### PR TITLE
Add godoc help generation for templateFlag.

### DIFF
--- a/cmd/skaffold/app/cmd/docker/deps.go
+++ b/cmd/skaffold/app/cmd/docker/deps.go
@@ -33,7 +33,7 @@ var (
 	output            flags.TemplateFlag
 )
 
-var depsFormatFlag = flags.NewTemplateFlag("{{range .Deps}}{{.}} {{end}}\n")
+var depsFormatFlag = flags.NewTemplateFlag("{{range .Deps}}{{.}} {{end}}\n", DepsOutput{})
 
 func NewCmdDeps(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
@@ -47,7 +47,7 @@ func NewCmdDeps(out io.Writer) *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&filename, "filename", "f", "Dockerfile", "Dockerfile path")
 	cmd.Flags().StringVarP(&context, "context", "c", ".", "Dockerfile context path")
-	cmd.Flags().VarP(depsFormatFlag, "output", "o", "Format output with go-template")
+	cmd.Flags().VarP(depsFormatFlag, "output", "o", depsFormatFlag.Usage())
 	return cmd
 }
 

--- a/cmd/skaffold/app/flags/template.go
+++ b/cmd/skaffold/app/flags/template.go
@@ -18,6 +18,7 @@ package flags
 
 import (
 	"fmt"
+	"reflect"
 	"text/template"
 
 	"github.com/pkg/errors"
@@ -26,10 +27,21 @@ import (
 type TemplateFlag struct {
 	rawTemplate string
 	template    *template.Template
+	context     interface{}
 }
 
 func (t *TemplateFlag) String() string {
 	return t.rawTemplate
+}
+
+func (t *TemplateFlag) Usage() string {
+	defaultUsage := "Format output with go-template."
+	if t.context != nil {
+		goType := reflect.TypeOf(t.context)
+		url := fmt.Sprintf("https://godoc.org/%s#%s", goType.PkgPath(), goType.Name())
+		defaultUsage += fmt.Sprintf(" For full struct documentation, see %s", url)
+	}
+	return defaultUsage
 }
 
 func (t *TemplateFlag) Set(value string) error {
@@ -50,9 +62,10 @@ func (t *TemplateFlag) Template() *template.Template {
 	return t.template
 }
 
-func NewTemplateFlag(value string) *TemplateFlag {
+func NewTemplateFlag(value string, context interface{}) *TemplateFlag {
 	return &TemplateFlag{
 		template:    template.Must(template.New("flagtemplate").Parse(value)),
 		rawTemplate: value,
+		context:     context,
 	}
 }

--- a/cmd/skaffold/app/flags/template_test.go
+++ b/cmd/skaffold/app/flags/template_test.go
@@ -36,7 +36,7 @@ func TestNewTemplateFlag(t *testing.T) {
 	actual := &bytes.Buffer{}
 	expected := &bytes.Buffer{}
 
-	flag := NewTemplateFlag(rawTemplate)
+	flag := NewTemplateFlag(rawTemplate, nil)
 	if err := flag.Template().Execute(actual, &data); err != nil {
 		t.Errorf("Error parsing template from flag: %s", err)
 	}
@@ -61,7 +61,7 @@ func TestTemplateSet(t *testing.T) {
 }
 
 func TestTemplateString(t *testing.T) {
-	flag := NewTemplateFlag(rawTemplate)
+	flag := NewTemplateFlag(rawTemplate, nil)
 	if rawTemplate != flag.String() {
 		t.Errorf("Flag String() does not match. Expected %s, Actual %s", rawTemplate, flag.String())
 	}


### PR DESCRIPTION
This makes the help text look like:

```shell
  -o, --output *flags.TemplateFlag   Format output with go-template. For full struct documentation, see https://godoc.org/github.com/GoogleCloudPlatform/skaffold/cmd/skaffold/app/cmd/docker#DepsOutput (default {{range .Deps}}{{.}} {{end}}
```