### PR TITLE
Rename test pkg to testutil

### DIFF
--- a/pkg/skaffold/build/local_test.go
+++ b/pkg/skaffold/build/local_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/config"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/docker"
-	testutil "github.com/GoogleCloudPlatform/skaffold/test"
+	"github.com/GoogleCloudPlatform/skaffold/testutil"
 	"github.com/docker/docker/api/types"
 	"github.com/moby/moby/client"
 )

--- a/pkg/skaffold/build/tag/git_commit_test.go
+++ b/pkg/skaffold/build/tag/git_commit_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/util"
-	testutil "github.com/GoogleCloudPlatform/skaffold/test"
+	"github.com/GoogleCloudPlatform/skaffold/testutil"
 )
 
 func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {

--- a/pkg/skaffold/build/tag/sha256_test.go
+++ b/pkg/skaffold/build/tag/sha256_test.go
@@ -19,7 +19,7 @@ package tag
 import (
 	"testing"
 
-	testutil "github.com/GoogleCloudPlatform/skaffold/test"
+	"github.com/GoogleCloudPlatform/skaffold/testutil"
 )
 
 func TestGenerateFullyQualifiedImageName(t *testing.T) {

--- a/pkg/skaffold/config/config_test.go
+++ b/pkg/skaffold/config/config_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	testutil "github.com/GoogleCloudPlatform/skaffold/test"
+	"github.com/GoogleCloudPlatform/skaffold/testutil"
 )
 
 const (

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/build"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/config"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/util"
-	testutil "github.com/GoogleCloudPlatform/skaffold/test"
+	"github.com/GoogleCloudPlatform/skaffold/testutil"
 	"github.com/spf13/afero"
 )
 

--- a/pkg/skaffold/docker/auth_test.go
+++ b/pkg/skaffold/docker/auth_test.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	testutil "github.com/GoogleCloudPlatform/skaffold/test"
+	"github.com/GoogleCloudPlatform/skaffold/testutil"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/docker/api/types"
 	"github.com/spf13/afero"

--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"testing"
 
-	testutil "github.com/GoogleCloudPlatform/skaffold/test"
+	"github.com/GoogleCloudPlatform/skaffold/testutil"
 )
 
 func TestNewEnvClient(t *testing.T) {

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"testing"
 
-	testutil "github.com/GoogleCloudPlatform/skaffold/test"
+	"github.com/GoogleCloudPlatform/skaffold/testutil"
 )
 
 func TestMain(m *testing.M) {

--- a/pkg/skaffold/docker/parse_test.go
+++ b/pkg/skaffold/docker/parse_test.go
@@ -23,7 +23,7 @@ import (
 
 	"sort"
 
-	testutil "github.com/GoogleCloudPlatform/skaffold/test"
+	"github.com/GoogleCloudPlatform/skaffold/testutil"
 	"github.com/spf13/afero"
 )
 

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/watch"
-	testutil "github.com/GoogleCloudPlatform/skaffold/test"
+	"github.com/GoogleCloudPlatform/skaffold/testutil"
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/skaffold/watch/watch_test.go
+++ b/pkg/skaffold/watch/watch_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/config"
-	testutil "github.com/GoogleCloudPlatform/skaffold/test"
+	"github.com/GoogleCloudPlatform/skaffold/testutil"
 	"github.com/sirupsen/logrus"
 
 	"github.com/spf13/afero"

--- a/testutil/cmd_helper.go
+++ b/testutil/cmd_helper.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package test
+package testutil
 
 import (
 	"io"

--- a/testutil/fake_image_api.go
+++ b/testutil/fake_image_api.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package test
+package testutil
 
 import (
 	"context"

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package test
+package testutil
 
 import (
 	"fmt"


### PR DESCRIPTION
Might as well just rename this package instead of alias it everywhere.