### PR TITLE
Use lstat to check for symlink without following

### DIFF
--- a/pkg/skaffold/watch/watch.go
+++ b/pkg/skaffold/watch/watch.go
@@ -117,11 +117,12 @@ func addDepsForArtifact(a *config.Artifact, depsToArtifact map[string][]*config.
 		return errors.Wrap(err, "getting dockerfile dependencies")
 	}
 	for _, dep := range deps {
-		fi, err := os.Stat(dep)
+		fi, err := os.Lstat(dep)
 		if err != nil {
 			return errors.Wrapf(err, "stat %s", dep)
 		}
 		if fi.Mode() == os.ModeSymlink {
+			logrus.Debugf("%s is a symlink", dep)
 			// nothing to do for symlinks
 			continue
 		}


### PR DESCRIPTION
os.Stat will follow the link and throw an error if its a broken
symlink. We want to ignore both symlinks and broken symlinks.