### PR TITLE
Return full tag in gitcommit tagger

### DIFF
--- a/pkg/skaffold/build/tag/git_commit.go
+++ b/pkg/skaffold/build/tag/git_commit.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -36,5 +37,5 @@ func (c *GitCommit) GenerateFullyQualifiedImageName(opts *TagOptions) (string, e
 		return "", errors.Wrap(err, "determining current git commit")
 	}
 	commit := strings.TrimSuffix(string(stdout), "\n")
-	return commit, nil
+	return fmt.Sprintf("%s:%s", opts.ImageName, commit), nil
 }

--- a/pkg/skaffold/build/tag/git_commit_test.go
+++ b/pkg/skaffold/build/tag/git_commit_test.go
@@ -29,13 +29,18 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 	tests := []struct {
 		name    string
 		want    string
+		opts    *TagOptions
 		wantErr bool
 		command util.Command
 	}{
 		{
 			name:    "success",
 			command: testutil.NewFakeRunCommand("somecommit", "", nil),
-			want:    "somecommit",
+			opts: &TagOptions{
+				ImageName: "test",
+				Digest:    "sha256:12345abcde",
+			},
+			want:    "test:somecommit",
 			wantErr: false,
 		},
 		{
@@ -52,7 +57,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			defer util.ResetDefaultExecCommand()
 
 			c := &GitCommit{}
-			got, err := c.GenerateFullyQualifiedImageName(nil)
+			got, err := c.GenerateFullyQualifiedImageName(tt.opts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GitCommit.GenerateFullyQualifiedImageName() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
We could also change the interface to only return the tag instead of image name + tag.