### PR TITLE
test: add color output to go test

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,11 @@ GREEN='\033[0;32m'
 RESET='\033[0m'
 
 echo "Running go tests..."
-go test -cover -v -timeout 60s `go list ./... | grep -v vendor`
+go test -cover -v -timeout 60s `go list ./... | grep -v vendor` | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
+GO_TEST_EXIT_CODE=${PIPESTATUS[0]}
+if [[ $GO_TEST_EXIT_CODE -ne 0 ]]; then
+    exit $GO_TEST_EXIT_CODE
+fi
 
 echo "Running validation scripts..."
 scripts=(


### PR DESCRIPTION
the tests are greener on the other side

this actually makes it a lot easier to spot the failed tests through all the test and logging output