### PR TITLE
kubectl: ignore glob matches that dont look right

### DIFF
--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -64,9 +64,12 @@ func deployManifest(b []build.Build, manifest config.Manifest) error {
 	}
 	logrus.Debugf("Expanded manifests %s", strings.Join(manifests, "\n"))
 	for _, fname := range manifests {
-		if !strings.HasSuffix(fname, ".yml") && !strings.HasSuffix(fname, ".yaml") {
-			logrus.Debugf("Refusing to deploy non yaml file %s", fname)
-			continue
+		if !util.IsSupportedKubernetesFormat(fname) {
+			if !util.StrSliceContains(manifest.Path, fname) {
+				logrus.Infof("Refusing to deploy non yaml file %s", fname)
+				logrus.Info("If you still wish to deploy this file, please specify it directly, outside a glob pattern.")
+				continue
+			}
 		}
 		logrus.Infof("Deploying %s", fname)
 		f, err := util.Fs.Open(fname)

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -22,9 +22,9 @@ import (
 	"os"
 	"path"
 	"sort"
+	"strings"
 
 	"github.com/docker/docker/builder/dockerignore"
-
 	"github.com/docker/docker/pkg/fileutils"
 
 	"github.com/pkg/errors"
@@ -45,6 +45,30 @@ func RandomID() string {
 		panic(err)
 	}
 	return fmt.Sprintf("%x", b)
+}
+
+// These are the supported file formats for kubernetes manifests
+var validSuffixes = []string{".yml", ".yaml", ".json"}
+
+// IsSupportedKubernetesFormat is for determining if a file under a glob pattern
+// is deployable file format. It makes no attempt to check whether or not the file
+// is actually deployable or has the correct contents.
+func IsSupportedKubernetesFormat(n string) bool {
+	for _, s := range validSuffixes {
+		if strings.HasSuffix(n, s) {
+			return true
+		}
+	}
+	return false
+}
+
+func StrSliceContains(sl []string, s string) bool {
+	for _, a := range sl {
+		if a == s {
+			return true
+		}
+	}
+	return false
 }
 
 // ExpandPaths uses a filepath.Match to expand paths according to wildcards.

--- a/pkg/skaffold/util/util_test.go
+++ b/pkg/skaffold/util/util_test.go
@@ -24,6 +24,44 @@ import (
 	"github.com/spf13/afero"
 )
 
+func TestSupportedKubernetesFormats(t *testing.T) {
+	var tests = []struct {
+		description string
+		in          string
+		out         bool
+	}{
+		{
+			description: "yaml",
+			in:          "filename.yaml",
+			out:         true,
+		},
+		{
+			description: "yml",
+			in:          "filename.yml",
+			out:         true,
+		},
+		{
+			description: "json",
+			in:          "filename.json",
+			out:         true,
+		},
+		{
+			description: "txt",
+			in:          "filename.txt",
+			out:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			actual := IsSupportedKubernetesFormat(tt.in)
+			if tt.out != actual {
+				t.Errorf("out: %t, actual: %t", tt.out, actual)
+			}
+		})
+	}
+}
+
 func TestExpandDeps(t *testing.T) {
 	var tests = []struct {
 		description string


### PR DESCRIPTION
If a glob match is not a .yml, .yaml, or .json, refuse to deploy it.
If the user really wants to deploy that file (since there are no
restrictions to what kubectl will accept), make them specifically
reference it.

