### PR TITLE
TarGZ

### DIFF
--- a/pkg/skaffold/util/tar.go
+++ b/pkg/skaffold/util/tar.go
@@ -28,9 +28,6 @@ import (
 )
 
 func CreateDockerTarContext(dockerfilePath, context string, paths []string, w io.Writer) error {
-	// Write everything to memory, then flush to disk at the end.
-	// This prevents recursion problems, where the output file can end up
-	// in the context itself during creation.
 	gw := gzip.NewWriter(w)
 	defer gw.Close()
 


### PR DESCRIPTION
GCB was complaining the tar.gz wasn't actually gzipped.  The tar writer should take in the gzip writer.

before
```
file out/context.tar.gz
out/context.tar.gz: POSIX tar archive
```

after
```
$ file out/context.tar.gz
out/context.tar.gz: gzip compressed data
```