### PR TITLE
Make the git tagger support dirty trees.

### DIFF
--- a/pkg/skaffold/build/tag/git_commit.go
+++ b/pkg/skaffold/build/tag/git_commit.go
@@ -17,6 +17,8 @@ limitations under the License.
 package tag
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -31,11 +33,33 @@ type GitCommit struct {
 
 // GenerateFullyQualifiedImageName tags an image with the supplied image name and the git commit.
 func (c *GitCommit) GenerateFullyQualifiedImageName(opts *TagOptions) (string, error) {
+	// If the repository state is dirty, we add a -dirty-unique-id suffix to work well with local iterations
+	dirtyCmd := exec.Command("git", "status", "--porcelain")
+	stdout, _, err := util.RunCommand(dirtyCmd, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "determining repo state")
+	}
+	suffix := ""
+	if string(stdout) != "" {
+		// The file state is dirty. To generate a unique suffix, let's hash the "git diff" output.
+		// It should be roughly content-addressable.
+		uniqueCmd := exec.Command("git", "diff")
+		stdout, _, err := util.RunCommand(uniqueCmd, nil)
+		if err != nil {
+			return "", errors.Wrap(err, "determining git diff")
+		}
+		sha := sha256.Sum256(stdout)
+		shaStr := hex.EncodeToString(sha[:])[:16]
+		suffix = fmt.Sprintf("dirty-%s", shaStr)
+	}
 	cmd := exec.Command("git", "rev-parse", "HEAD")
-	stdout, _, err := util.RunCommand(cmd, nil)
+	stdout, _, err = util.RunCommand(cmd, nil)
 	if err != nil {
 		return "", errors.Wrap(err, "determining current git commit")
 	}
 	commit := strings.TrimSuffix(string(stdout), "\n")
+	if suffix != "" {
+		return fmt.Sprintf("%s:%s-%s", opts.ImageName, commit, suffix), nil
+	}
 	return fmt.Sprintf("%s:%s", opts.ImageName, commit), nil
 }


### PR DESCRIPTION
We check the ditry status using "git status --porcelain", and if it's dirty we add on a -dirty- suffix with a "unique" sha generated from the output of "git diff".