### PR TITLE
installer: add brew installer

### DIFF
--- a/installers/brew/skaffold.rb
+++ b/installers/brew/skaffold.rb
@@ -1,0 +1,20 @@
+class Skaffold < Formula
+  desc "A tool that makes the onboarding of existing applications to Kubernetes simple and repeatable."
+  url "https://github.com/GoogleCloudPlatform/skaffold.git"
+  version "v0.1.0"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/GoogleCloudPlatform").mkpath
+
+    ln_s buildpath, buildpath/"src/github.com/GoogleCloudPlatform/skaffold"
+    system "make"
+    bin.install "out/skaffold"
+  end
+
+  test do
+    system "#{bin}skaffold", "--version"
+  end
+end


### PR DESCRIPTION
this isn't really useful yet while the repository is still private, but I'd like to ship this as soon as possible to when we flip the bit to public.

we have some machinery in minikube that we use to automatically update the brew formula
https://github.com/kubernetes/minikube/blob/master/hack/jenkins/release_update_installers.sh

I'll move over some of that once we figure out how we're going to run the integration tests
