### PR TITLE
make: cgo_enabled=0 on go install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test: $(BUILD_DIR)/$(PROJECT)
 
 .PHONY: install
 install: $(GO_FILES) $(BUILD_DIR)
-	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go install -ldflags $(GO_LDFLAGS) $(BUILD_PACKAGE)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go install -ldflags $(GO_LDFLAGS) -tags $(GO_BUILD_TAGS) $(BUILD_PACKAGE)
 
 .PHONY: integration
 integration: $(BUILD_DIR)/$(PROJECT)


### PR DESCRIPTION
This requires go 1.10 if you don't have permissions to install the std
library packages that use cgo (os/user, net, crypto/x509).

https://github.com/golang/go/issues/18981