### PR TITLE
docker: fallback to host docker when minikube env fails

### DIFF
--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/moby/moby/client"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // NewImageAPIClient returns a docker client based on the environment variables set.
@@ -50,7 +51,8 @@ func NewImageAPIClient() (client.ImageAPIClient, io.Closer, error) {
 func NewMinikubeImageAPIClient() (client.ImageAPIClient, io.Closer, error) {
 	env, err := getMinikubeDockerEnv()
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "getting minikube docker env")
+		logrus.Warnf("Could not get minikube docker env, falling back to local docker daemon")
+		return NewImageAPIClient()
 	}
 
 	var httpclient *http.Client

--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package docker
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/util"
@@ -74,11 +73,6 @@ DOCKER_CERT_PATH=testdata
 DOCKER_API_VERSION=1.23`, "", nil),
 		},
 		{
-			description: "bad env client",
-			cmd:         testutil.NewFakeRunCommand("", "", fmt.Errorf("")),
-			shouldErr:   true,
-		},
-		{
 			description: "correct client",
 			cmd: testutil.NewFakeRunCommand(`DOCKER_TLS_VERIFY=1
 DOCKER_HOST=http://127.0.0.1:8080
@@ -107,23 +101,11 @@ DOCKER_API_VERSION=1.23`, "", nil),
 			shouldErr: true,
 		},
 		{
-			description: "bad env output, too many key value pairs",
+			description: "bad env output, should fallback to host docker",
 			cmd: testutil.NewFakeRunCommand(`DOCKER_TLS_VERIFY=1
 DOCKER_HOST=http://127.0.0.1:8080=toomanyvalues
 DOCKER_CERT_PATH=testdata
 DOCKER_API_VERSION=1.23`, "", nil),
-			shouldErr: true,
-		},
-		{
-			description: "newlines ignored, no error",
-			cmd: testutil.NewFakeRunCommand(`
-			
-DOCKER_TLS_VERIFY=1
-DOCKER_HOST=http://127.0.0.1:8080
-
-DOCKER_CERT_PATH=testdata
-DOCKER_API_VERSION=1.23`, "", nil),
-			shouldErr: true,
 		},
 	}
 


### PR DESCRIPTION
fixes #112 

Not the greatest solution, but we don't have any way of telling that minikube is running the none driver. We fall back to the host docker daemon (which is what the none driver uses) when the env output fails (which is probably correct, since the minikube configuration wouldn't work anyways)