### PR TITLE
Slightly improve the Dockerfile

### DIFF
--- a/examples/getting-started/Dockerfile
+++ b/examples/getting-started/Dockerfile
@@ -1,5 +1,6 @@
-FROM golang:1.9.2
+FROM golang:1.9.4-alpine3.7
+
 WORKDIR /go/src/github.com/GoogleCloudPlatform/skaffold/examples/getting-started
+CMD ["./app"]
 COPY main.go .
 RUN go build -o app main.go
-CMD ["./app"]


### PR DESCRIPTION
+ Smaller base image
+ Replace `CMD` with `ENTRYPOINT`
+ Move `ENTRYPOINT` to before the code copy to improve caching

Signed-off-by: David Gageot <david@gageot.net>