### PR TITLE
Cleanup step

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -65,6 +65,10 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 	return rootCmd
 }
 
+func AddDevFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&opts.Cleanup, "cleanup", true, "Delete deployments after dev mode is interrupted")
+}
+
 func AddRunDevFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&filename, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
 	cmd.Flags().BoolVar(&opts.Notification, "toot", false, "Emit a terminal beep after the deploy is complete")

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"io"
 
 	yaml "gopkg.in/yaml.v2"
@@ -86,6 +87,8 @@ func SetUpLogs(out io.Writer, level string) error {
 }
 
 func runSkaffold(out io.Writer, dev bool, filename string) error {
+	ctx := context.Background()
+
 	buf, err := util.ReadConfiguration(filename)
 	if err != nil {
 		return errors.Wrap(err, "read skaffold config")
@@ -121,7 +124,7 @@ func runSkaffold(out io.Writer, dev bool, filename string) error {
 		return errors.Wrap(err, "getting skaffold config")
 	}
 
-	if err := r.Run(); err != nil {
+	if err := r.Run(ctx); err != nil {
 		return errors.Wrap(err, "running skaffold steps")
 	}
 

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -32,5 +32,6 @@ func NewCmdDev(out io.Writer) *cobra.Command {
 		},
 	}
 	AddRunDevFlags(cmd)
+	AddDevFlags(cmd)
 	return cmd
 }

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -22,6 +22,7 @@ import "io"
 // in the config file itself
 type SkaffoldOptions struct {
 	DevMode      bool
+	Cleanup      bool
 	Notification bool
 	Profiles     []string
 	CustomTag    string

--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -34,6 +34,9 @@ type Deployer interface {
 	// Deploy should ensure that the build results are deployed to the Kubernetes
 	// cluster.
 	Deploy(context.Context, io.Writer, *build.BuildResult) (*Result, error)
+
+	// Cleanup deletes what was deployed by calling Deploy.
+	Cleanup(context.Context, io.Writer) error
 }
 
 func JoinTagsToBuildResult(b []build.Build, params map[string]string) (map[string]build.Build, error) {

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -134,7 +134,10 @@ func newTaggerForConfig(t v1alpha2.TagPolicy) (tag.Tagger, error) {
 // Run runs the skaffold build and deploy pipeline.
 func (r *SkaffoldRunner) Run(ctx context.Context) error {
 	if r.opts.DevMode {
-		return cleanUpOnCtrlC(ctx, r.dev, r.cleanup)
+		if r.opts.Cleanup {
+			return cleanUpOnCtrlC(ctx, r.dev, r.cleanup)
+		}
+		return r.dev(ctx)
 	}
 
 	_, _, err := r.buildAndDeploy(ctx, r.config.Build.Artifacts, nil)

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -19,6 +19,9 @@ package runner
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -129,18 +132,18 @@ func newTaggerForConfig(t v1alpha2.TagPolicy) (tag.Tagger, error) {
 }
 
 // Run runs the skaffold build and deploy pipeline.
-func (r *SkaffoldRunner) Run() error {
-	ctx := context.Background()
-
+func (r *SkaffoldRunner) Run(ctx context.Context) error {
 	if r.opts.DevMode {
-		return r.dev(ctx, r.config.Build.Artifacts)
+		return cleanUpOnCtrlC(ctx, r.dev, r.cleanup)
 	}
 
 	_, _, err := r.buildAndDeploy(ctx, r.config.Build.Artifacts, nil)
 	return err
 }
 
-func (r *SkaffoldRunner) dev(ctx context.Context, artifacts []*v1alpha2.Artifact) error {
+func (r *SkaffoldRunner) dev(ctx context.Context) error {
+	artifacts := r.config.Build.Artifacts
+
 	var err error
 	r.depMap, err = build.NewDependencyMap(artifacts)
 	if err != nil {
@@ -243,6 +246,35 @@ func (r *SkaffoldRunner) deploy(ctx context.Context, bRes *build.BuildResult) (*
 	fmt.Fprintln(r.opts.Output, "Deploy complete in", time.Since(start))
 
 	return dRes, nil
+}
+
+func cleanUpOnCtrlC(ctx context.Context, runDevMode func(context.Context) error, cleanup func(context.Context)) error {
+	ctx, cancel := context.WithCancel(ctx)
+
+	signals := make(chan os.Signal, 2)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		<-signals
+		cancel()
+	}()
+
+	errRun := runDevMode(ctx)
+	cleanup(ctx)
+	return errRun
+}
+
+func (r *SkaffoldRunner) cleanup(ctx context.Context) {
+	start := time.Now()
+	fmt.Fprintln(r.opts.Output, "Cleaning up...")
+
+	err := r.Deployer.Cleanup(ctx, r.opts.Output)
+	if err != nil {
+		logrus.Warnf("cleanup: %s", err)
+		return
+	}
+
+	fmt.Fprintln(r.opts.Output, "Cleanup complete in", time.Since(start))
 }
 
 func mergeWithPreviousBuilds(builds, previous []build.Build) []build.Build {

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -70,6 +70,10 @@ func (t *TestDeployer) Deploy(context.Context, io.Writer, *build.BuildResult) (*
 	return t.res, t.err
 }
 
+func (t *TestDeployer) Cleanup(ctx context.Context, out io.Writer) error {
+	return nil
+}
+
 type TestDeployAll struct {
 	deployed *build.BuildResult
 }
@@ -77,6 +81,10 @@ type TestDeployAll struct {
 func (t *TestDeployAll) Deploy(ctx context.Context, w io.Writer, bRes *build.BuildResult) (*deploy.Result, error) {
 	t.deployed = bRes
 	return &deploy.Result{}, nil
+}
+
+func (t *TestDeployAll) Cleanup(ctx context.Context, out io.Writer) error {
+	return nil
 }
 
 type TestTagger struct {
@@ -347,7 +355,8 @@ func TestRun(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			err := test.runner.Run()
+			err := test.runner.Run(context.Background())
+
 			testutil.CheckError(t, test.shouldErr, err)
 		})
 	}


### PR DESCRIPTION
This PR adds a Cleanup step on top of https://github.com/GoogleContainerTools/skaffold/pull/405

Run a cleanup step when the dev step is interrupted by the user:

+ [x] Implement Cleanup for kubectl deployer
+ [x] Implement Cleanup for helm deployer
+ [x] Can a local build be interrupted?
+ [x] Can a GCB build be interrupted?

Fixes #61