### PR TITLE
Add support remote manifest from kubernetes(replace mode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 out/
 examples/bazel/bazel-*
 *.new
+.idea/

--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -54,7 +54,7 @@ deploy:
   # a client side `kubectl apply` to apply the manifests to the cluster. You'll
   # need a kubectl version installed that's compatible with your cluster.
   kubectl:
-    # Manifests is a list of manifests to deploy
+    # Manifests is a list of manifests to deploy from files
     manifests:
     # The path to where these manifests live.  path accepts a
     # filepath.Glob, so * can be used to deploy a whole folder.
@@ -64,3 +64,12 @@ deploy:
     # - /home/mrick/path/to/different/project/deploy/*
     #
     - ../examples/getting-started/k8s-*
+    # Manifests is a list of manifests to deploy from remote cluster
+    remoteManifests:
+    # The path to where these manifests live in remote kubernetes cluster
+    #
+    # Examples:
+    # project outside this repository
+    # - namespace1:deployment/web-app2
+    #
+    - default:deployment/web-app2

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -100,7 +100,8 @@ type DeployType struct {
 
 // KubectlDeploy contains the configuration needed for deploying with `kubectl apply`
 type KubectlDeploy struct {
-	Manifests []string `yaml:"manifests,omitempty"`
+	Manifests       []string `yaml:"manifests,omitempty"`
+	RemoteManifests []string `yaml:"remoteManifests,omitempty"`
 }
 
 // HelmDeploy contains the configuration needed for deploying with helm


### PR DESCRIPTION
This PR adds support replace exist deployment with new image.
You can set up your deployment in cluster(namespace/deployment/deployment_name) in skaffold.yaml
After this skaffold on the build get deployment yaml from a cluster and replace only image URL with a new tag and after this deploy again to cluster.
It's a good case if you have many namespaces and very complicate deployment with a lot of env params generate by namespace. Now you can replace the only code in an existing deployment.
