### PR TITLE
don't watch to vendor folder

### DIFF
--- a/pkg/skaffold/watch/watch.go
+++ b/pkg/skaffold/watch/watch.go
@@ -22,6 +22,8 @@ import (
 	"sort"
 	"time"
 
+	"strings"
+
 	"github.com/fsnotify/fsnotify"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -57,6 +59,9 @@ func NewWatcher(paths []string) (Watcher, error) {
 
 	sort.Strings(paths)
 	for _, p := range paths {
+		if strings.HasPrefix(p, "vendor") {
+			continue
+		}
 		files[p] = true
 		logrus.Infof("Added watch for %s", p)
 


### PR DESCRIPTION
Watcher crash with error `To many files` if you have a medium size of vendor folder.
In common case we user don't change code in vendor folder and not needed watch for each file.


P.S. Maybe need add watch_exclude_folders settings, because if you have big folders like node_modules it's huge or watcher crash