### PR TITLE
delete hardcoded OSChoice linux

### DIFF
--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -232,17 +232,12 @@ func retrieveLocalImage(client DockerAPIClient, image string) ([]byte, error) {
 }
 
 func retrieveRemoteImage(image string) ([]byte, error) {
-	context := &types.SystemContext{
-		OSChoice:           "linux",
-		ArchitectureChoice: "amd64",
-	}
-
 	ref, err := docker.ParseReference("//" + image)
 	if err != nil {
 		return nil, err
 	}
 
-	img, err := ref.NewImage(context)
+	img, err := ref.NewImage(&types.SystemContext{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
delete hardcoded OSChoice linux
Not need to provide OSChoice,
```
        // If not "", overrides the use of platform.GOARCH when choosing an image or verifying architecture match.
	ArchitectureChoice string
	// If not "", overrides the use of platform.GOOS when choosing an image or verifying OS match.
	OSChoice string
```