### PR TITLE
Capture digest at build

### DIFF
--- a/pkg/skaffold/build/local_test.go
+++ b/pkg/skaffold/build/local_test.go
@@ -97,7 +97,7 @@ func TestLocalRun(t *testing.T) {
 				},
 			},
 			tagger: &tag.ChecksumTagger{},
-			api:    testutil.NewFakeImageAPIClient(map[string]string{}, &testutil.FakeImageAPIOptions{}),
+			api:    testutil.NewFakeImageAPIClient(map[string]string{}, nil),
 			expectedBuild: &BuildResult{
 				[]Build{
 					{
@@ -144,7 +144,7 @@ func TestLocalRun(t *testing.T) {
 					},
 				},
 			},
-			api: testutil.NewFakeImageAPIClient(map[string]string{}, &testutil.FakeImageAPIOptions{}),
+			api: testutil.NewFakeImageAPIClient(map[string]string{}, nil),
 			expectedBuild: &BuildResult{
 				[]Build{
 					{
@@ -208,7 +208,7 @@ func TestLocalRun(t *testing.T) {
 				},
 			},
 			tagger:    &tag.ChecksumTagger{},
-			api:       testutil.NewFakeImageAPIClient(map[string]string{}, &testutil.FakeImageAPIOptions{}),
+			api:       testutil.NewFakeImageAPIClient(map[string]string{}, nil),
 			shouldErr: true,
 		},
 		{
@@ -239,7 +239,7 @@ func TestLocalRun(t *testing.T) {
 				},
 			},
 			tagger:    &FakeTagger{Err: fmt.Errorf("")},
-			api:       testutil.NewFakeImageAPIClient(map[string]string{}, &testutil.FakeImageAPIOptions{}),
+			api:       testutil.NewFakeImageAPIClient(map[string]string{}, nil),
 			shouldErr: true,
 		},
 	}

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -119,10 +119,9 @@ func TestRunBuild(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			api := testutil.NewFakeImageAPIClient(test.tagToImageID, test.testOpts)
-			err := RunBuild(context.Background(), api, &BuildOptions{
+			_, err := RunBuild(context.Background(), api, &BuildOptions{
 				Dockerfile: "Dockerfile",
 				ContextDir: "../../../testdata/docker",
-				ImageName:  "finalimage",
 			})
 			testutil.CheckError(t, test.shouldErr, err)
 		})


### PR DESCRIPTION
+ Don’t use random id anymore
+ Directly capture digest from build output

This simplifies the output of the build in the most common case