### PR TITLE
integration: run tests in separate namespaces

### DIFF
--- a/examples/environment-variables/k8s-pod.yaml
+++ b/examples/environment-variables/k8s-pod.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
   - name: getting-started
-    image: gcr.io/k8s-skaffold/skaffold-example-foo
+    image: gcr.io/k8s-skaffold/skaffold-example

--- a/examples/environment-variables/skaffold.yaml
+++ b/examples/environment-variables/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.IMAGE_NAME}}-{{.FOO}}"
+      template: "{{.IMAGE_NAME}}:{{.FOO}}"
   artifacts:
   - imageName: gcr.io/k8s-skaffold/skaffold-example
     workspace: .

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -207,6 +207,9 @@ func setupNamespace(t *testing.T) (*v1.Namespace, func()) {
 			Namespace: namespaceName,
 		},
 	})
+	if err != nil {
+		t.Fatalf("creating namespace: %s", err)
+	}
 
 	kubectlCmd := exec.Command("kubectl", "config", "set-context", context.Cluster, "--namespace", ns.Name)
 	out, outerr, err := util.RunCommand(kubectlCmd, nil)
@@ -228,7 +231,7 @@ func TestFix(t *testing.T) {
 	}
 	runCmd := exec.Command("skaffold", "run", "-f", "-")
 	runCmd.Dir = "testdata/old-config"
-	out, _, err = util.RunCommand(runCmd, bytes.NewReader(out))
+	_, _, err = util.RunCommand(runCmd, bytes.NewReader(out))
 	if err != nil {
 		t.Fatalf("testing error: %s", err.Error())
 	}

--- a/integration/testdata/old-config/skaffold.yaml
+++ b/integration/testdata/old-config/skaffold.yaml
@@ -2,7 +2,7 @@ apiVersion: skaffold/v1alpha1
 kind: Config
 build:
   artifacts:
-  - imageName: gcr.io/k8s-skaffold/skaffold
+  - imageName: gcr.io/k8s-skaffold/skaffold-example
     workspace: .
   local: {}
   tagPolicy: sha256


### PR DESCRIPTION
* runs each integration test in a separate namespace, and then tears down that namespace
* fixes the fix integration test to not modify the skaffold.yaml in place and leave the repo dirty

future work:
we can run these integration tests in parallel if we copy the kubeconfig for each test, and set KUBECONFIG env var for each skaffold run invocation 