### PR TITLE
Revert commits

### DIFF
--- a/pkg/skaffold/build/local.go
+++ b/pkg/skaffold/build/local.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -91,9 +92,11 @@ func (l *LocalBuilder) Build(ctx context.Context, out io.Writer, tagger tag.Tagg
 
 		digest, err := docker.Digest(ctx, l.api, initialTag)
 		if err != nil {
-			return nil, errors.Wrap(err, "finding digest")
+			return nil, errors.Wrapf(err, "build and tag: %s", initialTag)
 		}
-
+		if digest == "" {
+			return nil, fmt.Errorf("digest not found")
+		}
 		tag, err := tagger.GenerateFullyQualifiedImageName(artifact.Workspace, &tag.TagOptions{
 			ImageName: artifact.ImageName,
 			Digest:    digest,
@@ -101,8 +104,7 @@ func (l *LocalBuilder) Build(ctx context.Context, out io.Writer, tagger tag.Tagg
 		if err != nil {
 			return nil, errors.Wrap(err, "generating tag")
 		}
-
-		if err := l.api.ImageTag(ctx, digest, tag); err != nil {
+		if err := l.api.ImageTag(ctx, initialTag, tag); err != nil {
 			return nil, errors.Wrap(err, "tagging image")
 		}
 		if _, err := io.WriteString(out, fmt.Sprintf("Successfully tagged %s\n", tag)); err != nil {
@@ -124,9 +126,10 @@ func (l *LocalBuilder) Build(ctx context.Context, out io.Writer, tagger tag.Tagg
 	return res, nil
 }
 
-// buildDocker return the imageID (sha256 digest) of the built image.
 func (l *LocalBuilder) buildDocker(ctx context.Context, out io.Writer, a *v1alpha2.Artifact) (string, error) {
-	imageID, err := docker.RunBuild(ctx, l.api, &docker.BuildOptions{
+	initialTag := util.RandomID()
+	err := docker.RunBuild(ctx, l.api, &docker.BuildOptions{
+		ImageName:   initialTag,
 		Dockerfile:  a.DockerArtifact.DockerfilePath,
 		ContextDir:  a.Workspace,
 		ProgressBuf: out,
@@ -136,6 +139,5 @@ func (l *LocalBuilder) buildDocker(ctx context.Context, out io.Writer, a *v1alph
 	if err != nil {
 		return "", errors.Wrap(err, "running build")
 	}
-
-	return imageID, nil
+	return fmt.Sprintf("%s:latest", initialTag), nil
 }

--- a/pkg/skaffold/build/local_test.go
+++ b/pkg/skaffold/build/local_test.go
@@ -97,7 +97,7 @@ func TestLocalRun(t *testing.T) {
 				},
 			},
 			tagger: &tag.ChecksumTagger{},
-			api:    testutil.NewFakeImageAPIClient(map[string]string{}, nil),
+			api:    testutil.NewFakeImageAPIClient(map[string]string{}, &testutil.FakeImageAPIOptions{}),
 			expectedBuild: &BuildResult{
 				[]Build{
 					{
@@ -144,7 +144,7 @@ func TestLocalRun(t *testing.T) {
 					},
 				},
 			},
-			api: testutil.NewFakeImageAPIClient(map[string]string{}, nil),
+			api: testutil.NewFakeImageAPIClient(map[string]string{}, &testutil.FakeImageAPIOptions{}),
 			expectedBuild: &BuildResult{
 				[]Build{
 					{
@@ -208,7 +208,7 @@ func TestLocalRun(t *testing.T) {
 				},
 			},
 			tagger:    &tag.ChecksumTagger{},
-			api:       testutil.NewFakeImageAPIClient(map[string]string{}, nil),
+			api:       testutil.NewFakeImageAPIClient(map[string]string{}, &testutil.FakeImageAPIOptions{}),
 			shouldErr: true,
 		},
 		{
@@ -239,7 +239,7 @@ func TestLocalRun(t *testing.T) {
 				},
 			},
 			tagger:    &FakeTagger{Err: fmt.Errorf("")},
-			api:       testutil.NewFakeImageAPIClient(map[string]string{}, nil),
+			api:       testutil.NewFakeImageAPIClient(map[string]string{}, &testutil.FakeImageAPIOptions{}),
 			shouldErr: true,
 		},
 	}

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -19,10 +19,8 @@ package docker
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/google/go-containerregistry/authn"
 	"github.com/google/go-containerregistry/name"
@@ -40,6 +38,7 @@ import (
 )
 
 type BuildOptions struct {
+	ImageName   string
 	Dockerfile  string
 	ContextDir  string
 	ProgressBuf io.Writer
@@ -48,14 +47,15 @@ type BuildOptions struct {
 }
 
 // RunBuild performs a docker build and returns nothing
-func RunBuild(ctx context.Context, cli DockerAPIClient, opts *BuildOptions) (string, error) {
+func RunBuild(ctx context.Context, cli DockerAPIClient, opts *BuildOptions) error {
 	logrus.Debugf("Running docker build: context: %s, dockerfile: %s", opts.ContextDir, opts.Dockerfile)
 	authConfigs, err := DefaultAuthHelper.GetAllAuthConfigs()
 	if err != nil {
-		return "", errors.Wrap(err, "read auth configs")
+		return errors.Wrap(err, "read auth configs")
 	}
 
 	imageBuildOpts := types.ImageBuildOptions{
+		Tags:        []string{opts.ImageName},
 		Dockerfile:  opts.Dockerfile,
 		BuildArgs:   opts.BuildArgs,
 		AuthConfigs: authConfigs,
@@ -76,26 +76,11 @@ func RunBuild(ctx context.Context, cli DockerAPIClient, opts *BuildOptions) (str
 
 	resp, err := cli.ImageBuild(ctx, body, imageBuildOpts)
 	if err != nil {
-		return "", errors.Wrap(err, "docker build")
+		return errors.Wrap(err, "docker build")
 	}
 	defer resp.Body.Close()
 
-	imageID := ""
-	aux := func(auxJSON *json.RawMessage) {
-		var result types.BuildResult
-		if err := json.Unmarshal(*auxJSON, &result); err != nil {
-			logrus.Errorln("Failed to parse aux message:", err)
-		} else {
-			imageID = result.ID
-		}
-	}
-
-	err = StreamDockerMessages(opts.BuildBuf, resp.Body, aux)
-	if err != nil {
-		return "", errors.Wrap(err, "streaming messages")
-	}
-
-	return imageID, nil
+	return StreamDockerMessages(opts.BuildBuf, resp.Body, nil)
 }
 
 // StreamDockerMessages prints docker messages to the console.
@@ -160,11 +145,6 @@ func addTag(ref name.Reference, targetRef name.Reference, auth authn.Authenticat
 // The digest is of the form
 // sha256:<image_id>
 func Digest(ctx context.Context, cli DockerAPIClient, ref string) (string, error) {
-	if strings.HasPrefix(ref, "sha256:") {
-		parts := strings.Split(ref, ":")
-		return fmt.Sprintf("%s:%s", parts[0], parts[1]), nil
-	}
-
 	args := filters.KeyValuePair{Key: "reference", Value: ref}
 	filters := filters.NewArgs(args)
 	imageList, err := cli.ImageList(ctx, types.ImageListOptions{

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -119,9 +119,10 @@ func TestRunBuild(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			api := testutil.NewFakeImageAPIClient(test.tagToImageID, test.testOpts)
-			_, err := RunBuild(context.Background(), api, &BuildOptions{
+			err := RunBuild(context.Background(), api, &BuildOptions{
 				Dockerfile: "Dockerfile",
 				ContextDir: "../../../testdata/docker",
+				ImageName:  "finalimage",
 			})
 			testutil.CheckError(t, test.shouldErr, err)
 		})


### PR DESCRIPTION
"Better streaming of docker messages" causes skaffold to panic on gotty.go. I think we can just update our docker/cli dependency here, but it might be better to just revert this.

I believe its this issue
https://github.com/moby/moby/pull/32401

Capture digest at build fails for me on all platforms. I'm not sure why it was passing CI. I tried this on docker 17.09-ce.  