### PR TITLE
cmd: silence usage text

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -48,6 +48,7 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 		if err := SetUpLogs(err, v); err != nil {
 			return err
 		}
+		rootCmd.SilenceUsage = true
 		logrus.Infof("Skaffold %+v", version.Get())
 		return nil
 	}


### PR DESCRIPTION
This supresses usage test from the output when we have an application error OR usage error. I can't find out a clear way to use cobra's arg validation and toggle this.
https://github.com/spf13/cobra/issues/340

I'm a bit undecided about this. On one hand, we shouldn't output message error text on our application error, but on the other hand, for legitimate usage errors, the user needs to now run an additional `skaffold --help`