### PR TITLE
Use docker CLI code to read the config

### DIFF
--- a/pkg/skaffold/docker/auth.go
+++ b/pkg/skaffold/docker/auth.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/distribution/reference"
@@ -64,7 +63,7 @@ type credsHelper struct {
 }
 
 func (credsHelper) GetAuthConfig(registry string) (types.AuthConfig, error) {
-	cf, err := load()
+	cf, err := config.Load(configDir)
 	if err != nil {
 		return types.AuthConfig{}, errors.Wrap(err, "docker config")
 	}
@@ -72,7 +71,7 @@ func (credsHelper) GetAuthConfig(registry string) (types.AuthConfig, error) {
 }
 
 func (credsHelper) GetAllAuthConfigs() (map[string]types.AuthConfig, error) {
-	cf, err := load()
+	cf, err := config.Load(configDir)
 	if err != nil {
 		return nil, errors.Wrap(err, "docker config")
 	}
@@ -125,18 +124,4 @@ func officialRegistry(ctx context.Context, cli DockerAPIClient) string {
 	}
 
 	return serverAddress
-}
-
-func load() (*configfile.ConfigFile, error) {
-	filename := filepath.Join(configDir, config.ConfigFileName)
-	f, err := util.Fs.Open(filename)
-	if err != nil {
-		return nil, errors.Wrap(err, "opening docker config")
-	}
-	defer f.Close()
-	cf := configfile.New("")
-	if err := cf.LoadFromReader(f); err != nil {
-		return nil, errors.Wrap(err, "loading docker config file")
-	}
-	return cf, nil
 }

--- a/pkg/skaffold/docker/auth_test.go
+++ b/pkg/skaffold/docker/auth_test.go
@@ -19,62 +19,11 @@ package docker
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"path/filepath"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
-	"github.com/docker/cli/cli/config"
 	"github.com/docker/docker/api/types"
 )
-
-const dockerCfg = `{
-	"auths": {
-			"https://appengine.gcr.io": {},
-			"https://asia.gcr.io": {},
-			"https://b.gcr.io": {},
-			"https://beta.gcr.io": {},
-			"https://bucket.gcr.io": {},
-			"https://eu.gcr.io": {},
-			"https://gcr.io": {},
-			"https://gcr.kubernetes.io": {},
-			"https://us.gcr.io": {}
-	},
-	"credsStore": "gcr",
-	"credHelpers": {
-			"appengine.gcr.io": "gcr",
-			"asia.gcr.io": "gcr",
-			"eu.gcr.io": "gcr",
-			"gcr.io": "gcr",
-			"gcr.kubernetes.io": "gcr",
-			"us.gcr.io": "gcr"
-	}
-}`
-
-func TestLoad(t *testing.T) {
-	tempDir, cleanup := testutil.TempDir(t)
-	defer cleanup()
-
-	defer func(d string) { configDir = d }(configDir)
-	configDir = tempDir
-
-	ioutil.WriteFile(filepath.Join(configDir, config.ConfigFileName), []byte(dockerCfg), 0650)
-
-	_, err := load()
-	if err != nil {
-		t.Errorf("Couldn't load docker config: %s", err)
-	}
-}
-
-func TestLoadNotARealPath(t *testing.T) {
-	defer func(d string) { configDir = d }(configDir)
-	configDir = "not a real path"
-
-	cf, err := load()
-	if err == nil {
-		t.Errorf("Expected error loading from bad path, but got none: %+v", cf)
-	}
-}
 
 type testAuthHelper struct {
 	getAuthConfigErr     error


### PR DESCRIPTION
 + Support non-existing config file
 + Support config in old format

Signed-off-by: David Gageot <david@gageot.net>