### PR TITLE
updating instructions to update skaffold.yaml build artifact image location and name

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ You will need the following components to get started with Skaffold:
     cd examples/getting-started
     ```
 
+1. In the skaffold.yaml file, update the `build.artifacts.imageName` stanza to the `<registry/image:tag>` registry where your image will be pushed. For example `gcr.io/<your-project-ID>/your-image`, where `gcr.io/<your-project-ID>` is your GCP container registry location. As mentioned earlier, your docker client should be configured to push to this location.
+
 1. Run `skaffold dev`.
 
     ```console


### PR DESCRIPTION
Without instructing users on this step, at least in the intro getting-started example, they'll be pushing to a registry that they do not have access to. This field needs to be updated in order for the push to work.