### PR TITLE
updating instructions to update skaffold.yaml registry loc

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ You will need the following components to get started with Skaffold:
     cd examples/getting-started
     ```
 
+1. In the skaffold.yaml file, update the `build.artifacts.imageName` stanza to the registry where your image will be pushed (`<registry/image:tag>`). For example `gcr.io/<your-project-ID>/your-image`, where `gcr.io/<your-project-ID>` is your GCP container registry location. As mentioned earlier, your docker client should be configured to push to this location.
+
 1. Run `skaffold dev`.
 
     ```console


### PR DESCRIPTION
Currently the user will receive an error when the built image is pushed, as the default value is not a registry that users have access to.