### PR TITLE
Add files to the context tarball with Unix separators.

### DIFF
--- a/pkg/skaffold/util/tar.go
+++ b/pkg/skaffold/util/tar.go
@@ -46,7 +46,7 @@ func CreateTar(w io.Writer, root string, paths []string) error {
 			return err
 		}
 
-		if err := addFileToTar(p, tarPath, tw); err != nil {
+		if err := addFileToTar(p, filepath.ToSlash(tarPath), tw); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This should fix #442. I can't think of a good way to test this, since it would require running unit tests on Windows.

Any ideas?