### PR TITLE
fix: allow an environment variable to default the deploy namespace

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -106,8 +107,12 @@ func (h *HelmDeployer) deployRelease(out io.Writer, r v1alpha2.HelmRelease, b *b
 		args = append(args, "upgrade", r.Name, r.ChartPath)
 	}
 
-	if r.Namespace != "" {
-		args = append(args, "--namespace", r.Namespace)
+	ns := r.Namespace
+	if ns == "" {
+		ns = os.Getenv("SKAFFOLD_DEPLOY_NAMESPACE")
+	}
+	if ns != "" {
+		args = append(args, "--namespace", ns)
 	}
 	if r.ValuesFilePath != "" {
 		args = append(args, "-f", r.ValuesFilePath)


### PR DESCRIPTION
lets allow an environment variable to be used to define the helm deploy namespace
fixes #496