### PR TITLE
Improve the logs

### DIFF
--- a/pkg/skaffold/kubernetes/log.go
+++ b/pkg/skaffold/kubernetes/log.go
@@ -111,7 +111,7 @@ func (a *LogAggregator) streamLogs(ctx context.Context, client corev1.CoreV1Inte
 
 		logrus.Infof("Stream logs from pod: %s container: %s", pod.Name, container.Name)
 
-		sinceSeconds := int64(time.Since(a.startTime).Seconds())
+		sinceSeconds := int64(time.Since(a.startTime).Seconds() + 0.5)
 		// 0s means all the logs
 		if sinceSeconds == 0 {
 			sinceSeconds = 1


### PR DESCRIPTION
Fixes #478

 + First second of logs can be lost
 + The code tries to reconnect to pods that are known to be terminated.

Signed-off-by: David Gageot <david@gageot.net>