### PR TITLE
Handle private docker registries with explicit port numbers

### DIFF
--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -333,8 +334,6 @@ func recursiveReplaceImage(i interface{}, replacements map[string]*replacement) 
 }
 
 func removeTag(image string) string {
-	if strings.Contains(image, ":") {
-		return strings.Split(image, ":")[0]
-	}
-	return image
+	re := regexp.MustCompile(":[^/]+$")
+	return re.ReplaceAllString(image, "")
 }

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -405,3 +405,20 @@ spec:
         ports:
         - containerPort: 80`, manifests.String())
 }
+
+func TestRemoveTag(t *testing.T) {
+	removed := removeTag("host:1234/user/container:tag")
+	if removed != "host:1234/user/container" {
+		t.Errorf("Tag vas not removed from an image name with port: %s ", removed)
+	}
+
+	removed = removeTag("host/user/container:tag")
+	if removed != "host/user/container" {
+		t.Errorf("Tag vas not removed from an image name with port: %s ", removed)
+	}
+
+	removed = removeTag("host:1234/user/container")
+	if removed != "host:1234/user/container" {
+		t.Errorf("Image without tag and port is changed during tag removal: %s ", removed)
+	}
+}


### PR DESCRIPTION
The current tag removal in the kubernetes deployment can't handle private registries with custom ports, such as `registry.intranet:8000/user/image:tag`. This small patch address this issue.