### PR TITLE
Add --tiller-namespace support to config

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -68,7 +68,12 @@ func (h *HelmDeployer) Cleanup(ctx context.Context, out io.Writer) error {
 }
 
 func (h *HelmDeployer) args(moreArgs ...string) []string {
-	return append([]string{"--kube-context", h.kubeContext}, moreArgs...)
+	args := []string{"--kube-context", h.kubeContext}
+
+	if h.HelmDeploy.TillerNamespace != "" {
+		args = append(args, []string{"--tiller-namespace", h.HelmDeploy.TillerNamespace}...)
+	}
+	return append(args, moreArgs...)
 }
 
 func (h *HelmDeployer) deployRelease(out io.Writer, r v1alpha2.HelmRelease, b *build.BuildResult) error {

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -114,7 +114,8 @@ type KubectlDeploy struct {
 
 // HelmDeploy contains the configuration needed for deploying with helm
 type HelmDeploy struct {
-	Releases []HelmRelease `yaml:"releases,omitempty"`
+	Releases        []HelmRelease `yaml:"releases,omitempty"`
+	TillerNamespace string        `yaml:"tillerNamespace,omitempty"`
 }
 
 type HelmRelease struct {


### PR DESCRIPTION
I have a cluster I need to deploy to that is using namespacing heavily for isolation.  While I can use an environment var before running skaffold to set the tiller namespace, it'd be nice to make it fully declarative in the config.  

If this has merit I can add some tests, but wanted to get thoughts first.