### PR TITLE
README.md should point to annotated-skaffold.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ $ skaffold run
 * [Deploying with Helm](./examples/helm-deployment)
 * [Microservices/Multiple applications](./examples/microservices)
 * [Deploying with no Kubernetes manifests](./examples/no-manifest)
+* [Annotated skaffold.yaml](./examples/annotated-skaffold.yaml)
 
 ## Community
 - [skaffold-users mailing list](https://groups.google.com/forum/#!forum/skaffold-users)


### PR DESCRIPTION
annotated-skaffold.yaml appears to be the closest thing to detailed documentation this project has, so it'd be nice to point to it from the README.