### PR TITLE
build: added head config to brew installer

### DIFF
--- a/installers/brew/skaffold.rb
+++ b/installers/brew/skaffold.rb
@@ -1,6 +1,7 @@
 class Skaffold < Formula
   desc "A tool that facilitates continuous development for Kubernetes applications."
   url "https://github.com/GoogleContainerTools/skaffold.git"
+  head "https://github.com/GoogleContainerTools/skaffold.git"
   version "v0.6.0"
 
   depends_on "go" => :build


### PR DESCRIPTION
a simple test i ran locally after editing the local formulae via `brew edit`...


```
➜  brew install skaffold --HEAD
Error: skaffold 0.6.0 is already installed
To install HEAD, first run `brew unlink skaffold`
➜  brew unlink skaffold
Unlinking /usr/local/Cellar/skaffold/0.6.0... 1 symlinks removed
➜  brew install skaffold --HEAD
==> Cloning https://github.com/GoogleContainerTools/skaffold.git
Cloning into '/Users/shimmerjs/Library/Caches/Homebrew/skaffold--git'...
remote: Counting objects: 3400, done.
remote: Compressing objects: 100% (2513/2513), done.
remote: Total 3400 (delta 780), reused 2689 (delta 625), pack-reused 0
Receiving objects: 100% (3400/3400), 8.00 MiB | 20.63 MiB/s, done.
Resolving deltas: 100% (780/780), done.
==> Checking out branch master
==> make
🍺  /usr/local/Cellar/skaffold/HEAD-73d0a65: 6 files, 48.8MB, built in 23 seconds
➜  skaffold version -v debug
INFO[0000] Skaffold &{Version:v0.6.0 GitVersion: GitCommit:73d0a6526b949c62ed073932f3058480cc63c9c5 GitTreeState:clean BuildDate:2018-05-22T12:54:19Z GoVersion:go1.10.2 Compiler:gc Platform:darwin/amd64}
v0.6.0
```