### PR TITLE
Fix push scopes in docker.AddTag

### DIFF
--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -123,7 +123,7 @@ func AddTag(src, target string) error {
 }
 
 func addTag(ref name.Reference, targetRef name.Reference, auth authn.Authenticator, t http.RoundTripper) error {
-	tr, err := transport.New(ref.Context().Registry, auth, t, []string{transport.PushScope})
+	tr, err := transport.New(ref.Context().Registry, auth, t, []string{targetRef.Scope(transport.PushScope)})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #577. This was introduced by #548.

This is go-containerregistry leaking a bit too much detail that we
should fix upstream.