### PR TITLE
Add namespace CLI flag to run

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -75,6 +75,7 @@ func AddRunDevFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&filename, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
 	cmd.Flags().BoolVar(&opts.Notification, "toot", false, "Emit a terminal beep after the deploy is complete")
 	cmd.Flags().StringArrayVarP(&opts.Profiles, "profile", "p", nil, "Activate profiles by name")
+	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "", "Run Helm deployments in the specified namespace")
 }
 
 func AddFixFlags(cmd *cobra.Command) {

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -23,4 +23,5 @@ type SkaffoldOptions struct {
 	Notification bool
 	Profiles     []string
 	CustomTag    string
+	Namespace    string
 }

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -33,14 +33,16 @@ import (
 type HelmDeployer struct {
 	*v1alpha2.DeployConfig
 	kubeContext string
+	namespace   string
 }
 
 // NewHelmDeployer returns a new HelmDeployer for a DeployConfig filled
 // with the needed configuration for `helm`
-func NewHelmDeployer(cfg *v1alpha2.DeployConfig, kubeContext string) *HelmDeployer {
+func NewHelmDeployer(cfg *v1alpha2.DeployConfig, kubeContext string, namespace string) *HelmDeployer {
 	return &HelmDeployer{
 		DeployConfig: cfg,
 		kubeContext:  kubeContext,
+		namespace:    namespace,
 	}
 }
 
@@ -115,8 +117,12 @@ func (h *HelmDeployer) deployRelease(out io.Writer, r v1alpha2.HelmRelease, buil
 		args = append(args, "upgrade", releaseName, r.ChartPath)
 	}
 
-	ns := r.Namespace
-	if ns == "" {
+	var ns string
+	if h.namespace != "" {
+		ns = h.namespace
+	} else if r.Namespace != "" {
+		ns = r.Namespace
+	} else {
 		ns = os.Getenv("SKAFFOLD_DEPLOY_NAMESPACE")
 	}
 	if ns != "" {

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -71,6 +71,8 @@ var testDeployConfigParameterUnmatched = &v1alpha2.DeployConfig{
 	},
 }
 
+var testNamespace = "testNamespace"
+
 func TestHelmDeploy(t *testing.T) {
 	var tests = []struct {
 		description string
@@ -82,13 +84,13 @@ func TestHelmDeploy(t *testing.T) {
 		{
 			description: "deploy success",
 			cmd:         &MockHelm{t: t},
-			deployer:    NewHelmDeployer(testDeployConfig, testKubeContext),
+			deployer:    NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace),
 			builds:      testBuilds,
 		},
 		{
 			description: "deploy error unmatched parameter",
 			cmd:         &MockHelm{t: t},
-			deployer:    NewHelmDeployer(testDeployConfigParameterUnmatched, testKubeContext),
+			deployer:    NewHelmDeployer(testDeployConfigParameterUnmatched, testKubeContext, testNamespace),
 			builds:      testBuilds,
 			shouldErr:   true,
 		},
@@ -99,7 +101,7 @@ func TestHelmDeploy(t *testing.T) {
 				getResult:     fmt.Errorf("not found"),
 				upgradeResult: fmt.Errorf("should not have called upgrade"),
 			},
-			deployer: NewHelmDeployer(testDeployConfig, testKubeContext),
+			deployer: NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace),
 			builds:   testBuilds,
 		},
 		{
@@ -108,7 +110,7 @@ func TestHelmDeploy(t *testing.T) {
 				t:             t,
 				installResult: fmt.Errorf("should not have called install"),
 			},
-			deployer: NewHelmDeployer(testDeployConfig, testKubeContext),
+			deployer: NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace),
 			builds:   testBuilds,
 		},
 		{
@@ -118,7 +120,7 @@ func TestHelmDeploy(t *testing.T) {
 				upgradeResult: fmt.Errorf("unexpected error"),
 			},
 			shouldErr: true,
-			deployer:  NewHelmDeployer(testDeployConfig, testKubeContext),
+			deployer:  NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace),
 			builds:    testBuilds,
 		},
 		{
@@ -128,7 +130,7 @@ func TestHelmDeploy(t *testing.T) {
 				depResult: fmt.Errorf("unexpected error"),
 			},
 			shouldErr: true,
-			deployer:  NewHelmDeployer(testDeployConfig, testKubeContext),
+			deployer:  NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace),
 			builds:    testBuilds,
 		},
 	}

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -62,7 +62,7 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *config.SkaffoldConfig) (*Sk
 		return nil, errors.Wrap(err, "parsing skaffold build config")
 	}
 
-	deployer, err := getDeployer(&cfg.Deploy, kubeContext)
+	deployer, err := getDeployer(&cfg.Deploy, kubeContext, opts.Namespace)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing skaffold deploy config")
 	}
@@ -106,7 +106,7 @@ func getBuilder(cfg *v1alpha2.BuildConfig, kubeContext string) (build.Builder, e
 	}
 }
 
-func getDeployer(cfg *v1alpha2.DeployConfig, kubeContext string) (deploy.Deployer, error) {
+func getDeployer(cfg *v1alpha2.DeployConfig, kubeContext string, namespace string) (deploy.Deployer, error) {
 	switch {
 	case cfg.KubectlDeploy != nil:
 		// TODO(dgageot): this should be the folder containing skaffold.yaml. Should also be moved elsewhere.
@@ -117,7 +117,7 @@ func getDeployer(cfg *v1alpha2.DeployConfig, kubeContext string) (deploy.Deploye
 		return deploy.NewKubectlDeployer(cwd, cfg, kubeContext), nil
 
 	case cfg.HelmDeploy != nil:
-		return deploy.NewHelmDeployer(cfg, kubeContext), nil
+		return deploy.NewHelmDeployer(cfg, kubeContext, namespace), nil
 
 	default:
 		return nil, fmt.Errorf("Unknown deployer for config %+v", cfg)


### PR DESCRIPTION
Add a CLI flag "namespace" to the run command to override the
namespace for all helm deployments defined in the pipeline.

Fixes #496