### PR TITLE
Fix flaky test

### DIFF
--- a/pkg/skaffold/docker/context_test.go
+++ b/pkg/skaffold/docker/context_test.go
@@ -31,6 +31,11 @@ func TestDockerContext(t *testing.T) {
 	tmpDir, cleanup := testutil.TempDir(t)
 	defer cleanup()
 
+	RetrieveImage = mockRetrieveImage
+	defer func() {
+		RetrieveImage = retrieveImage
+	}()
+
 	os.Mkdir(filepath.Join(tmpDir, "files"), 0750)
 	ioutil.WriteFile(filepath.Join(tmpDir, "files", "ignored.txt"), []byte(""), 0644)
 	ioutil.WriteFile(filepath.Join(tmpDir, "files", "included.txt"), []byte(""), 0644)


### PR DESCRIPTION
The test shouldn’t depend on Docker being available

Fixes #593

Signed-off-by: David Gageot <david@gageot.net>