### PR TITLE
Fix Helm example

### DIFF
--- a/examples/helm-deployment/skaffold.yaml
+++ b/examples/helm-deployment/skaffold.yaml
@@ -13,7 +13,7 @@ deploy:
       namespace: skaffold
       #valuesFilePath: helm-skaffold-values.yaml
       values:
-        image: skaffold-helm
+        image.tag: skaffold-helm
       #setValues get appended to the helm deploy with --set.  
       #setValues:
         #some.key: someValue


### PR DESCRIPTION
I had trouble getting this example to work until I used "image.tag" instead of "image". This is also the value that is checked for in the test for Helm deploys: https://github.com/GoogleContainerTools/skaffold/blob/master/pkg/skaffold/deploy/helm_test.go#L47

So I think the example is just wrong.