### PR TITLE
Refactor the envTemplate code to make it reusable

### DIFF
--- a/pkg/skaffold/build/tag/env_template_test.go
+++ b/pkg/skaffold/build/tag/env_template_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -76,7 +77,7 @@ func TestEnvTemplateTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 			c := &EnvTemplateTagger{
 				Template: template.Must(template.New("").Parse(test.template)),
 			}
-			environ = func() []string {
+			util.OSEnviron = func() []string {
 				return test.env
 			}
 

--- a/pkg/skaffold/util/env_template.go
+++ b/pkg/skaffold/util/env_template.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/pkg/errors"
+)
+
+var OSEnviron = os.Environ
+
+// Simple wrapper to parse an env template
+func ParseEnvTemplate(t string) (*template.Template, error) {
+	tmpl, err := template.New("envTemplate").Parse(t)
+	return tmpl, err
+}
+
+// Executes an envTemplate based on OS environment variables and a custom map
+func ExecuteEnvTemplate(envTemplate *template.Template, customMap map[string]string) (string, error) {
+	var buf bytes.Buffer
+	envMap := map[string]string{}
+	for _, env := range OSEnviron() {
+		kvp := strings.SplitN(env, "=", 2)
+		if len(kvp) != 2 {
+			return "", fmt.Errorf("error parsing environment variables, %s does not contain an =", kvp)
+		}
+		envMap[kvp[0]] = kvp[1]
+	}
+
+	for k, v := range customMap {
+		envMap[k] = v
+	}
+
+	logrus.Debugf("Executing template %v with environment %v", envTemplate, envMap)
+	if err := envTemplate.Execute(&buf, envMap); err != nil {
+		return "", errors.Wrap(err, "executing template")
+	}
+	return buf.String(), nil
+}


### PR DESCRIPTION
The env_template tagger includes code that can be re-used by other
parts of skaffold to introduce templates elsewhere (e.g. helm
values, helm release name). Refactor the common code out to
a env_template module under util.