### PR TITLE
New code to watch file changes

### DIFF
--- a/pkg/skaffold/build/deps.go
+++ b/pkg/skaffold/build/deps.go
@@ -29,9 +29,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// DependencyMapFactory can build DependencyMaps from a list of artifacts.
-type DependencyMapFactory func(artifacts []*v1alpha2.Artifact) (*DependencyMap, error)
-
 // DependencyMap is a bijection between artifacts and the files they depend on.
 type DependencyMap struct {
 	artifacts       []*v1alpha2.Artifact

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -63,6 +63,21 @@ func StrSliceContains(sl []string, s string) bool {
 	return false
 }
 
+func UniqueStrSlice(values []string) []string {
+	var unique []string
+
+	m := make(map[string]bool)
+	for _, value := range values {
+		m[value] = true
+	}
+	for value := range m {
+		unique = append(unique, value)
+	}
+
+	sort.Strings(unique)
+	return unique
+}
+
 // ExpandPathsGlob expands paths according to filepath.Glob patterns
 // Returns a list of unique files that match the glob patterns passed in.
 func ExpandPathsGlob(workingDir string, paths []string) ([]string, error) {

--- a/pkg/skaffold/watch/artifacts.go
+++ b/pkg/skaffold/watch/artifacts.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// ArtifactChangedFn is a function called when artifacts where changed.
+type ArtifactChangedFn func(changes []*v1alpha2.Artifact) error
+
+// ArtifactWatcher watches for artifacts changes.
+type ArtifactWatcher interface {
+	Run(ctx context.Context, callback ArtifactChangedFn) error
+}
+
+type artifactWatcher struct {
+	artifacts   []*v1alpha2.Artifact
+	fileWatcher FileWatcher
+}
+
+// NewArtifactWatcher creates an ArtifactWatcher for a list of artifacts.
+func NewArtifactWatcher(artifacts []*v1alpha2.Artifact, pollInterval time.Duration) (ArtifactWatcher, error) {
+	fileWatcher, err := NewFileWatcher(workingDirs(artifacts), pollInterval)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating file watcher")
+	}
+
+	return &artifactWatcher{
+		artifacts:   artifacts,
+		fileWatcher: fileWatcher,
+	}, nil
+}
+
+func workingDirs(artifacts []*v1alpha2.Artifact) []string {
+	var workingDirs []string
+
+	for _, artifact := range artifacts {
+		workingDirs = append(workingDirs, artifact.Workspace)
+	}
+
+	return workingDirs
+}
+
+func (w *artifactWatcher) Run(ctx context.Context, callback ArtifactChangedFn) error {
+	return w.fileWatcher.Run(ctx, func(changes []string) error {
+		artifacts, err := w.artifactsForFiles(changes)
+		if err != nil {
+			logrus.Warnln("Skipping build. Dependencies couldn't be listed", err)
+			return nil
+		}
+
+		if len(artifacts) == 0 {
+			return nil
+		}
+
+		err = callback(artifacts)
+		if err != nil {
+			return errors.Wrap(err, "applying changes to artifacts")
+		}
+
+		return nil
+	})
+}
+
+func (w *artifactWatcher) artifactsForFiles(files []string) ([]*v1alpha2.Artifact, error) {
+	var artifacts []*v1alpha2.Artifact
+
+	for _, artifact := range w.artifacts {
+		matches, err := matchesAny(artifact, files)
+		if err != nil {
+			return nil, errors.Wrap(err, "matching path to artifact")
+		}
+
+		if matches {
+			artifacts = append(artifacts, artifact)
+		}
+	}
+
+	return artifacts, nil
+}
+
+func matchesAny(artifact *v1alpha2.Artifact, files []string) (bool, error) {
+	inWorkspace, err := inWorkspace(artifact, files)
+	if err != nil {
+		return false, errors.Wrap(err, "getting files in workspace")
+	}
+
+	if len(inWorkspace) == 0 {
+		return false, nil
+	}
+
+	deps, err := build.DependenciesForArtifact(artifact)
+	if err != nil {
+		return false, errors.Wrap(err, "getting dependencies for artifact")
+	}
+
+	for _, path := range inWorkspace {
+		for _, dep := range deps {
+			if path == filepath.Join(artifact.Workspace, dep) {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
+}
+
+// inWorkspace filters out the paths that are not in the artifact's workspace.
+func inWorkspace(artifact *v1alpha2.Artifact, files []string) ([]string, error) {
+	var inWorkspace []string
+
+	for _, file := range files {
+		p1, err := filepath.Abs(file)
+		if err != nil {
+			return nil, errors.Wrapf(err, "getting absolute path for %s", file)
+		}
+
+		p2, _ := filepath.Abs(artifact.Workspace)
+		if err != nil {
+			return nil, errors.Wrapf(err, "getting absolute path for %s", artifact.Workspace)
+		}
+
+		if strings.HasPrefix(p1, p2) {
+			inWorkspace = append(inWorkspace, file)
+		}
+	}
+
+	return inWorkspace, nil
+}

--- a/pkg/skaffold/watch/files.go
+++ b/pkg/skaffold/watch/files.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package watch
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+//TODO(@r2d4): Figure out best UX to support configuring this blacklist
+var ignored = []string{"vendor", ".git"}
+
+// FileChangedFn is a function called when files where changed.
+type FileChangedFn func(changes []string) error
+
+// FileWatcher watches for file changes.
+type FileWatcher interface {
+	Run(ctx context.Context, callback FileChangedFn) error
+}
+
+type fileMap map[string]os.FileInfo
+
+type fileWatcher struct {
+	dirs         []string
+	pollInterval time.Duration
+	files        fileMap
+}
+
+// NewFileWatcher creates a FileWatcher for a list of directories.
+func NewFileWatcher(dirs []string, pollInterval time.Duration) (FileWatcher, error) {
+	files, err := walk(dirs)
+	if err != nil {
+		return nil, errors.Wrap(err, "listing files in folders")
+	}
+
+	return &fileWatcher{
+		dirs:         dirs,
+		files:        files,
+		pollInterval: pollInterval,
+	}, nil
+}
+
+func uniqueDirs(dirs []string) []string {
+	var unique []string
+
+	m := make(map[string]bool)
+	for _, dir := range dirs {
+		m[dir] = true
+	}
+	for dir := range m {
+		unique = append(unique, dir)
+	}
+
+	sort.Strings(unique)
+	return unique
+}
+
+func walk(dirs []string) (fileMap, error) {
+	m := make(fileMap)
+
+	for _, dir := range uniqueDirs(dirs) {
+		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			if isIgnored(info.Name()) {
+				return filepath.SkipDir
+			}
+
+			m[path] = info
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return m, nil
+}
+
+func computeDiff(prev, curr fileMap) []string {
+	var changes []string
+
+	for k, prevV := range prev {
+		currV, ok := curr[k]
+		if !ok {
+			// Deleted
+			changes = append(changes, k)
+		} else if prevV.ModTime() != currV.ModTime() {
+			if currV.IsDir() && currV.IsDir() == prevV.IsDir() {
+				// Ignore directory time changes
+			} else {
+				// Changed mtime
+				changes = append(changes, k)
+			}
+		}
+	}
+	for k := range curr {
+		if _, ok := prev[k]; !ok {
+			// Created
+			changes = append(changes, k)
+		}
+	}
+
+	sort.Strings(changes)
+	return changes
+}
+
+func isIgnored(path string) bool {
+	for _, i := range ignored {
+		if path == i {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (w *fileWatcher) Run(ctx context.Context, callback FileChangedFn) error {
+	ticker := time.NewTicker(w.pollInterval)
+	defer ticker.Stop()
+
+	var previousDiff []string
+	previousFiles := w.files
+
+	for {
+		select {
+		case <-ticker.C:
+			files, err := walk(w.dirs)
+			if err != nil {
+				return errors.Wrap(err, "listing files in folders")
+			}
+
+			changesSinceLastTick := computeDiff(previousFiles, files)
+			if len(changesSinceLastTick) > 0 {
+				// fmt.Println("First change detected")
+			} else if len(previousDiff) > 0 {
+				diff := computeDiff(w.files, files)
+				if len(diff) > 0 {
+					if err := callback(diff); err != nil {
+						return errors.Wrap(err, "watcher callback")
+					}
+				}
+
+				w.files = files
+			}
+
+			previousFiles = files
+			previousDiff = changesSinceLastTick
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}


### PR DESCRIPTION
 + This uses the mTime based polling to watch artifacts and deployment files.
 + It now supports adding and deleting files
 + It also supports changing Dockerfiles and Bazel files.
 + Extract the cleanup code to support changing the skaffold.yaml

Fixes #617, #287 and #341
