### PR TITLE
cmd: add skaffold deploy

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -58,6 +58,7 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 	rootCmd.AddCommand(NewCmdRun(out))
 	rootCmd.AddCommand(NewCmdDev(out))
 	rootCmd.AddCommand(NewCmdBuild(out))
+	rootCmd.AddCommand(NewCmdDeploy(out))
 	rootCmd.AddCommand(NewCmdDelete(out))
 	rootCmd.AddCommand(NewCmdFix(out))
 	rootCmd.AddCommand(NewCmdDocker(out))

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
+	"github.com/google/go-containerregistry/name"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	images []string
+)
+
+// NewCmdDeploy describes the CLI command to deploy artifacts.
+func NewCmdDeploy(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deploy",
+		Short: "Deploys the artifacts",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDeploy(out, filename)
+		},
+	}
+	AddRunDevFlags(cmd)
+	cmd.Flags().StringSliceVar(&images, "images", nil, "A list of images to deploy")
+	cmd.Flags().BoolVarP(&quietFlag, "quiet", "q", false, "Suppress the deploy output")
+	return cmd
+}
+
+func runDeploy(out io.Writer, filename string) error {
+	ctx := context.Background()
+
+	config, err := readConfiguration(filename)
+	if err != nil {
+		return errors.Wrap(err, "reading configuration")
+	}
+
+	runner, err := runner.NewForConfig(opts, config)
+	if err != nil {
+		return errors.Wrap(err, "creating runner")
+	}
+
+	deployOut := out
+	if quietFlag {
+		deployOut = ioutil.Discard
+	}
+
+	var builds []build.Build
+	for _, image := range images {
+		parsedTag, err := name.NewTag(image, name.WeakValidation)
+		if err != nil {
+			return err
+		}
+		builds = append(builds, build.Build{
+			ImageName: parsedTag.Context().String(),
+			Tag:       parsedTag.Name(),
+		})
+	}
+
+	if err := runner.Deploy(ctx, deployOut, builds); err != nil {
+		return errors.Wrap(err, "deploy step")
+	}
+
+	return nil
+}


### PR DESCRIPTION
I might be able to get rid of some of the redundancy in the build struct - it shouldn't really need anything other than the full image tag. Now that we have go-containerregistry, it becomes a lot easier to separate the parts (tag/context)