### PR TITLE
add option to generate override values.yaml based on data passed into skaffold.yaml

### DIFF
--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2018 Google LLC
+Copyright 2018 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/helm-deployment/skaffold.yaml
+++ b/examples/helm-deployment/skaffold.yaml
@@ -11,6 +11,7 @@ deploy:
     - name: skaffold-helm
       chartPath: skaffold-helm
       namespace: skaffold
+      #wait: true
       #valuesFilePath: helm-skaffold-values.yaml
       values:
         image: skaffold-helm

--- a/examples/helm-deployment/skaffold.yaml
+++ b/examples/helm-deployment/skaffold.yaml
@@ -15,6 +15,10 @@ deploy:
       #valuesFilePath: helm-skaffold-values.yaml
       values:
         image: skaffold-helm
+      #overrides builds an override values.yaml file to run with the helm deploy
+      #overrides:
+      # some:
+      #   key: someValue
       #setValues get appended to the helm deploy with --set.  
       #setValues:
         #some.key: someValue

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -135,6 +135,9 @@ func (h *HelmDeployer) deployRelease(out io.Writer, r v1alpha2.HelmRelease, buil
 			setOpts = append(setOpts, fmt.Sprintf("%s=%s", k, v))
 		}
 	}
+	if r.Wait {
+		args = append(args, "--wait")
+	}
 	args = append(args, setOpts...)
 
 	return h.helm(out, args...)

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -46,6 +46,9 @@ var testDeployConfig = &v1alpha2.DeployConfig{
 					Values: map[string]string{
 						"image.tag": "skaffold-helm",
 					},
+					Overrides: map[string]interface{}{
+						"foo": "bar",
+					},
 					SetValues: map[string]string{
 						"some.key": "somevalue",
 					},

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -132,6 +132,7 @@ type HelmRelease struct {
 	Namespace      string            `yaml:"namespace"`
 	Version        string            `yaml:"version"`
 	SetValues      map[string]string `yaml:"setValues"`
+	Wait           bool              `yaml:"wait"`
 }
 
 // Artifact represents items that need to be built, along with the context in which

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -125,14 +125,15 @@ type HelmDeploy struct {
 }
 
 type HelmRelease struct {
-	Name           string            `yaml:"name"`
-	ChartPath      string            `yaml:"chartPath"`
-	ValuesFilePath string            `yaml:"valuesFilePath"`
-	Values         map[string]string `yaml:"values,omitempty"`
-	Namespace      string            `yaml:"namespace"`
-	Version        string            `yaml:"version"`
-	SetValues      map[string]string `yaml:"setValues"`
-	Wait           bool              `yaml:"wait"`
+	Name           string                 `yaml:"name"`
+	ChartPath      string                 `yaml:"chartPath"`
+	ValuesFilePath string                 `yaml:"valuesFilePath"`
+	Values         map[string]string      `yaml:"values,omitempty"`
+	Namespace      string                 `yaml:"namespace"`
+	Version        string                 `yaml:"version"`
+	SetValues      map[string]string      `yaml:"setValues"`
+	Wait           bool                   `yaml:"wait"`
+	Overrides      map[string]interface{} `yaml:"overrides"`
 }
 
 // Artifact represents items that need to be built, along with the context in which


### PR DESCRIPTION
This is the implementation for #585.

When looking at the code more I saw the reason that `values` only contains images so I made a new field called `overrides` that will contain the contents of the generated override values.yaml.

I think the best course of action to clear up any confusion would be to rename the `values` section to something more image related like `artifacts` and then the `overrides` section I've implemented here would become `values`. I'd be happy to include that change in this PR but didn't want to introduce a breaking change without speaking about it first. Otherwise, it's just something to keep note of for the next major version bump 