### PR TITLE
Add functionality to toggle the `--wait` flag on helm install/upgrade

### DIFF
--- a/examples/helm-deployment/skaffold.yaml
+++ b/examples/helm-deployment/skaffold.yaml
@@ -11,6 +11,7 @@ deploy:
     - name: skaffold-helm
       chartPath: skaffold-helm
       namespace: skaffold
+      #wait: true
       #valuesFilePath: helm-skaffold-values.yaml
       values:
         image: skaffold-helm

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -135,6 +135,9 @@ func (h *HelmDeployer) deployRelease(out io.Writer, r v1alpha2.HelmRelease, buil
 			setOpts = append(setOpts, fmt.Sprintf("%s=%s", k, v))
 		}
 	}
+	if r.Wait {
+		args = append(args, "--wait")
+	}
 	args = append(args, setOpts...)
 
 	return h.helm(out, args...)

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -132,6 +132,7 @@ type HelmRelease struct {
 	Namespace      string            `yaml:"namespace"`
 	Version        string            `yaml:"version"`
 	SetValues      map[string]string `yaml:"setValues"`
+	Wait           bool              `yaml:"wait"`
 }
 
 // Artifact represents items that need to be built, along with the context in which


### PR DESCRIPTION
Added a flag `wait` to the possible fields of a helm release to support adding the `--wait` flag onto `helm install` / `helm upgrade`. Mentioned in #631 #176 