### PR TITLE
Use git binary or fallback to go-git

### DIFF
--- a/pkg/skaffold/build/tag/git_commit.go
+++ b/pkg/skaffold/build/tag/git_commit.go
@@ -17,15 +17,21 @@ limitations under the License.
 package tag
 
 import (
+	"bufio"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	git "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 )
@@ -42,6 +48,44 @@ func (c *GitCommit) Labels() map[string]string {
 
 // GenerateFullyQualifiedImageName tags an image with the supplied image name and the git commit.
 func (c *GitCommit) GenerateFullyQualifiedImageName(workingDir string, opts *Options) (string, error) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return generateNameGitShellOut(workingDir, opts)
+	}
+
+	logrus.Warn("git binary not found. Falling back on a go git implementation. Some features might not work.")
+	return generateNameGoGit(workingDir, opts)
+}
+
+func generateNameGitShellOut(workingDir string, opts *Options) (string, error) {
+	root, err := runGit(workingDir, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", errors.Wrap(err, "getting git root")
+	}
+
+	revision, err := runGit(root, "rev-parse", "HEAD")
+	if err != nil {
+		return "", errors.Wrap(err, "getting current revision")
+	}
+
+	status, err := runGit(root, "status", "--porcelain")
+	if err != nil {
+		return "", errors.Wrap(err, "getting git status")
+	}
+
+	currentTag := revision[0:7]
+	if status == "" {
+		tags, err := runGit(root, "describe", "--tags", "--always")
+		if err != nil {
+			return "", errors.Wrap(err, "getting tags")
+		}
+
+		return commitOrTag(currentTag, lines(tags), opts), nil
+	}
+
+	return dirtyTag(root, opts, currentTag, lines(status))
+}
+
+func generateNameGoGit(workingDir string, opts *Options) (string, error) {
 	repo, err := git.PlainOpenWithOptions(workingDir, &git.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
 		return "", errors.Wrap(err, "opening git repo")
@@ -51,11 +95,7 @@ func (c *GitCommit) GenerateFullyQualifiedImageName(workingDir string, opts *Opt
 	if err != nil {
 		return "", errors.Wrap(err, "reading worktree")
 	}
-
-	status, err := w.Status()
-	if err != nil {
-		return "", errors.Wrap(err, "reading status")
-	}
+	root := w.Filesystem.Root()
 
 	head, err := repo.Head()
 	if err != nil {
@@ -65,38 +105,72 @@ func (c *GitCommit) GenerateFullyQualifiedImageName(workingDir string, opts *Opt
 	commitHash := head.Hash().String()
 	currentTag := commitHash[0:7]
 
+	status, err := w.Status()
+	if err != nil {
+		return "", errors.Wrap(err, "reading status")
+	}
+
 	if status.IsClean() {
-		tagrefs, _ := repo.Tags()
-		err = tagrefs.ForEach(func(t *plumbing.Reference) error {
-			if t.Hash() == head.Hash() {
-				currentTag = t.Name().Short()
-			}
-			return nil
-		})
+		tagrefs, err := repo.Tags()
 		if err != nil {
 			return "", errors.Wrap(err, "determining git tag")
 		}
 
-		fqn := fmt.Sprintf("%s:%s", opts.ImageName, currentTag)
-		return fqn, nil
+		var tags []string
+		if err = tagrefs.ForEach(func(t *plumbing.Reference) error {
+			if t.Hash() == head.Hash() {
+				tags = append(tags, t.Name().Short())
+			}
+			return nil
+		}); err != nil {
+			return "", errors.Wrap(err, "determining git tag")
+		}
+
+		return commitOrTag(currentTag, tags, opts), nil
 	}
 
-	// The file state is dirty. To generate a unique suffix, let's hash all the modified files.
-	// We add a -dirty-unique-id suffix to work well with local iterations.
-	h := sha256.New()
-	for _, changedPath := range changedPaths(status) {
-		status := status[changedPath].Worktree
+	return dirtyTag(root, opts, currentTag, changes(status))
+}
 
-		statusLine := fmt.Sprintf("%c %s", status, changedPath)
+func runGit(workingDir string, arg ...string) (string, error) {
+	cmd := exec.Command("git", arg...)
+	cmd.Dir = workingDir
+
+	out, err := util.RunCmdOut(cmd)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+func commitOrTag(currentTag string, tags []string, opts *Options) string {
+	if len(tags) > 0 {
+		currentTag = tags[0]
+	}
+
+	return fmt.Sprintf("%s:%s", opts.ImageName, currentTag)
+}
+
+// The file state is dirty. To generate a unique suffix, let's hash all the modified files.
+// We add a -dirty-unique-id suffix to work well with local iterations.
+func dirtyTag(root string, opts *Options, currentTag string, lines []string) (string, error) {
+	h := sha256.New()
+	for _, statusLine := range lines {
+		if strings.HasPrefix(statusLine, "??") {
+			statusLine = statusLine[1:]
+		}
+
 		if _, err := h.Write([]byte(statusLine)); err != nil {
 			return "", errors.Wrap(err, "adding deleted file to diff")
 		}
 
-		if status == git.Deleted {
+		if strings.HasPrefix(statusLine, "D") {
 			continue
 		}
 
-		f, err := w.Filesystem.Open(changedPath)
+		changedPath := statusLine[2:]
+		f, err := os.Open(filepath.Join(root, changedPath))
 		if err != nil {
 			return "", errors.Wrap(err, "reading diff")
 		}
@@ -115,9 +189,23 @@ func (c *GitCommit) GenerateFullyQualifiedImageName(workingDir string, opts *Opt
 	return fqn, nil
 }
 
-// changedPaths returns the changed paths in a consistent order.
+func lines(text string) []string {
+	var lines []string
+
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+
+	return lines
+}
+
+// changes returns the same output as git status --porcelain.
 // The order is important because we generate a sha256 out of it.
-func changedPaths(status git.Status) []string {
+func changes(status git.Status) []string {
 	var changes []string
 
 	for path, change := range status {
@@ -127,5 +215,12 @@ func changedPaths(status git.Status) []string {
 	}
 
 	sort.Strings(changes)
-	return changes
+
+	var lines []string
+	for _, changedPath := range changes {
+		status := status[changedPath].Worktree
+		lines = append(lines, fmt.Sprintf("%c %s", status, changedPath))
+	}
+
+	return lines
 }


### PR DESCRIPTION
The idea is to rollback to using `git` binary by default because go-git doesn't support sa few corner cases. If git is not found it will fallback to using go-git with should be ok 99% of the time

Fixes #323, #563 and #623

Signed-off-by: David Gageot <david@gageot.net>