### PR TITLE
Add labels to all k8s objects deployed by skaffold

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -50,7 +50,7 @@ func NewCmdBuild(out io.Writer) *cobra.Command {
 
 // BuildOutput is the output of `skaffold build`.
 type BuildOutput struct {
-	Builds []build.Build
+	Builds []build.Artifact
 }
 
 func runBuild(out io.Writer, filename string) error {

--- a/pkg/skaffold/build/build.go
+++ b/pkg/skaffold/build/build.go
@@ -24,8 +24,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
 )
 
-// Build is the result corresponding to each Artifact built.
-type Build struct {
+// Artifact is the result corresponding to each successful build.
+type Artifact struct {
 	ImageName string
 	Tag       string
 }
@@ -35,5 +35,7 @@ type Build struct {
 // This could include pushing to a authorized repository or loading the nodes with the image.
 // If artifacts is supplied, the builder should only rebuild those artifacts.
 type Builder interface {
-	Build(ctx context.Context, out io.Writer, tagger tag.Tagger, artifacts []*v1alpha2.Artifact) ([]Build, error)
+	Labels() map[string]string
+
+	Build(ctx context.Context, out io.Writer, tagger tag.Tagger, artifacts []*v1alpha2.Artifact) ([]Artifact, error)
 }

--- a/pkg/skaffold/build/local_test.go
+++ b/pkg/skaffold/build/local_test.go
@@ -42,6 +42,10 @@ func (f *FakeTagger) GenerateFullyQualifiedImageName(workingDir string, tagOpts 
 	return f.Out, f.Err
 }
 
+func (f *FakeTagger) Labels() map[string]string {
+	return map[string]string{}
+}
+
 type testAuthHelper struct{}
 
 func (t testAuthHelper) GetAuthConfig(string) (types.AuthConfig, error) {
@@ -70,7 +74,7 @@ func TestLocalRun(t *testing.T) {
 		api          docker.APIClient
 		tagger       tag.Tagger
 		artifacts    []*v1alpha2.Artifact
-		expected     []Build
+		expected     []Artifact
 		localCluster bool
 		shouldErr    bool
 	}{
@@ -95,7 +99,7 @@ func TestLocalRun(t *testing.T) {
 			},
 			tagger: &tag.ChecksumTagger{},
 			api:    testutil.NewFakeImageAPIClient(map[string]string{}, &testutil.FakeImageAPIOptions{}),
-			expected: []Build{
+			expected: []Artifact{
 				{
 					ImageName: "gcr.io/test/image",
 					Tag:       "gcr.io/test/image:imageid",
@@ -139,7 +143,7 @@ func TestLocalRun(t *testing.T) {
 				},
 			},
 			api: testutil.NewFakeImageAPIClient(map[string]string{}, &testutil.FakeImageAPIOptions{}),
-			expected: []Build{
+			expected: []Artifact{
 				{
 					ImageName: "gcr.io/test/image",
 					Tag:       "gcr.io/test/image:imageid",

--- a/pkg/skaffold/build/tag/custom.go
+++ b/pkg/skaffold/build/tag/custom.go
@@ -18,10 +18,18 @@ package tag
 
 import (
 	"fmt"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 )
 
 type CustomTag struct {
 	Tag string
+}
+
+func (c *CustomTag) Labels() map[string]string {
+	return map[string]string{
+		constants.Labels.TagPolicy: "custom",
+	}
 }
 
 // GenerateFullyQualifiedImageName tags an image with the custom tag

--- a/pkg/skaffold/build/tag/date_time.go
+++ b/pkg/skaffold/build/tag/date_time.go
@@ -19,6 +19,8 @@ package tag
 import (
 	"fmt"
 	"time"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 )
 
 const tagTime = "2006-01-02_15-04-05.999_MST"
@@ -37,6 +39,12 @@ func NewDateTimeTagger(format, timezone string) Tagger {
 		Format:   format,
 		TimeZone: timezone,
 		timeFn:   func() time.Time { return time.Now() },
+	}
+}
+
+func (tagger *dateTimeTagger) Labels() map[string]string {
+	return map[string]string{
+		constants.Labels.TagPolicy: "dateTimeTagger",
 	}
 }
 

--- a/pkg/skaffold/build/tag/env_template.go
+++ b/pkg/skaffold/build/tag/env_template.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
 )
@@ -40,8 +41,14 @@ func NewEnvTemplateTagger(t string) (Tagger, error) {
 	}, nil
 }
 
+func (t *envTemplateTagger) Labels() map[string]string {
+	return map[string]string{
+		constants.Labels.TagPolicy: "envTemplateTagger",
+	}
+}
+
 // GenerateFullyQualifiedImageName tags an image with the custom tag
-func (c *envTemplateTagger) GenerateFullyQualifiedImageName(workingDir string, opts *Options) (string, error) {
+func (t *envTemplateTagger) GenerateFullyQualifiedImageName(workingDir string, opts *Options) (string, error) {
 	customMap := map[string]string{}
 
 	customMap["IMAGE_NAME"] = opts.ImageName
@@ -55,5 +62,5 @@ func (c *envTemplateTagger) GenerateFullyQualifiedImageName(workingDir string, o
 		}
 	}
 
-	return util.ExecuteEnvTemplate(c.Template, customMap)
+	return util.ExecuteEnvTemplate(t.Template, customMap)
 }

--- a/pkg/skaffold/build/tag/git_commit.go
+++ b/pkg/skaffold/build/tag/git_commit.go
@@ -23,6 +23,8 @@ import (
 	"io"
 	"sort"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+
 	"github.com/pkg/errors"
 	git "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -30,6 +32,12 @@ import (
 
 // GitCommit tags an image by the git commit it was built at.
 type GitCommit struct {
+}
+
+func (c *GitCommit) Labels() map[string]string {
+	return map[string]string{
+		constants.Labels.TagPolicy: "git-commit",
+	}
 }
 
 // GenerateFullyQualifiedImageName tags an image with the supplied image name and the git commit.

--- a/pkg/skaffold/build/tag/sha256.go
+++ b/pkg/skaffold/build/tag/sha256.go
@@ -19,10 +19,18 @@ package tag
 import (
 	"fmt"
 	"strings"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 )
 
 // ChecksumTagger tags an image by the sha256 of the image tarball
 type ChecksumTagger struct {
+}
+
+func (c *ChecksumTagger) Labels() map[string]string {
+	return map[string]string{
+		constants.Labels.TagPolicy: "sha256",
+	}
 }
 
 // GenerateFullyQualifiedImageName tags an image with the supplied image name and the sha256 checksum of the image

--- a/pkg/skaffold/build/tag/tag.go
+++ b/pkg/skaffold/build/tag/tag.go
@@ -19,6 +19,7 @@ package tag
 // Tagger is an interface for tag strategies to be implemented against
 type Tagger interface {
 	GenerateFullyQualifiedImageName(workingDir string, tagOpts *Options) (string, error)
+	Labels() map[string]string
 }
 
 type Options struct {

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package config
 
+import (
+	"fmt"
+)
+
 // SkaffoldOptions are options that are set by command line arguments not included
 // in the config file itself
 type SkaffoldOptions struct {
@@ -24,4 +28,16 @@ type SkaffoldOptions struct {
 	Profiles     []string
 	CustomTag    string
 	Namespace    string
+}
+
+// Labels returns a map of labels to be applied to all deployed
+// k8s objects during the duration of the run
+func (opts *SkaffoldOptions) Labels() map[string]string {
+	labels := map[string]string{
+		"cleanup": fmt.Sprintf("%t", opts.Cleanup),
+	}
+	if opts.Namespace != "" {
+		labels["namespace"] = opts.Namespace
+	}
+	return labels
 }

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -44,3 +44,19 @@ const (
 	// DefaultKanikoImage is v0.1.0
 	DefaultKanikoImage = "gcr.io/kaniko-project/executor:v0.1.0@sha256:501056bf52f3a96f151ccbeb028715330d5d5aa6647e7572ce6c6c55f91ab374"
 )
+
+var Labels = struct {
+	TagPolicy        string
+	Deployer         string
+	Builder          string
+	DockerAPIVersion string
+	DefaultLabels    map[string]string
+}{
+	DefaultLabels: map[string]string{
+		"deployed-with": "skaffold",
+	},
+	TagPolicy:        "skaffold-tag-policy",
+	Deployer:         "skaffold-deployer",
+	Builder:          "skaffold-builder",
+	DockerAPIVersion: "docker-api-version",
+}

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -60,7 +60,7 @@ func TestKubectlDeploy(t *testing.T) {
 	var tests = []struct {
 		description string
 		cfg         *v1alpha2.DeployConfig
-		builds      []build.Build
+		builds      []build.Artifact
 		command     util.Command
 		shouldErr   bool
 	}{
@@ -74,7 +74,7 @@ func TestKubectlDeploy(t *testing.T) {
 					},
 				},
 			},
-			builds: []build.Build{
+			builds: []build.Artifact{
 				{
 					ImageName: "leeroy-web",
 					Tag:       "leeroy-web:v1",
@@ -91,7 +91,7 @@ func TestKubectlDeploy(t *testing.T) {
 					},
 				},
 			},
-			builds: []build.Build{
+			builds: []build.Artifact{
 				{
 					ImageName: "leeroy-web",
 					Tag:       "leeroy-web:123",
@@ -108,7 +108,7 @@ func TestKubectlDeploy(t *testing.T) {
 				},
 			},
 			command: testutil.NewFakeCmd("kubectl --context kubecontext apply -f -", nil),
-			builds: []build.Build{
+			builds: []build.Artifact{
 				{
 					ImageName: "leeroy-web",
 					Tag:       "leeroy-web:123",
@@ -126,7 +126,7 @@ func TestKubectlDeploy(t *testing.T) {
 				},
 			},
 			command: testutil.NewFakeCmd("kubectl --context kubecontext apply -f -", fmt.Errorf("")),
-			builds: []build.Build{
+			builds: []build.Artifact{
 				{
 					ImageName: "leeroy-web",
 					Tag:       "leeroy-web:123",
@@ -149,7 +149,7 @@ func TestKubectlDeploy(t *testing.T) {
 			}
 
 			k := NewKubectlDeployer(tmp, test.cfg, testKubeContext)
-			err := k.Deploy(context.Background(), &bytes.Buffer{}, test.builds)
+			_, err := k.Deploy(context.Background(), &bytes.Buffer{}, test.builds)
 
 			testutil.CheckError(t, test.shouldErr, err)
 		})
@@ -229,7 +229,7 @@ spec:
     name: digest
 `)}
 
-	builds := []build.Build{{
+	builds := []build.Artifact{{
 		ImageName: "gcr.io/k8s-skaffold/example",
 		Tag:       "gcr.io/k8s-skaffold/example:TAG",
 	}, {

--- a/pkg/skaffold/deploy/util.go
+++ b/pkg/skaffold/deploy/util.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deploy
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+
+	"github.com/sirupsen/logrus"
+
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func parseRuntimeObject(namespace string, b []byte) (Artifact, error) {
+	d := scheme.Codecs.UniversalDeserializer()
+	obj, _, err := d.Decode(b, nil, nil)
+	if err != nil {
+		return Artifact{}, fmt.Errorf("error decoding parsed yaml: %s", err.Error())
+	}
+	return Artifact{
+		Obj:       &obj,
+		Namespace: namespace,
+	}, nil
+}
+
+func parseReleaseInfo(namespace string, b *bufio.Reader) []Artifact {
+	results := []Artifact{}
+	r := k8syaml.NewYAMLReader(b)
+	for {
+		doc, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			logrus.Infof("error parsing object from string: %s", err.Error())
+			continue
+		}
+		obj, err := parseRuntimeObject(namespace, doc)
+		if err != nil {
+			logrus.Infof(err.Error())
+		} else {
+			results = append(results, obj)
+		}
+	}
+	return results
+}

--- a/pkg/skaffold/runner/label/label.go
+++ b/pkg/skaffold/runner/label/label.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package label
+
+import (
+	"time"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	"github.com/sirupsen/logrus"
+
+	clientgo "k8s.io/client-go/kubernetes"
+
+	appsv1 "k8s.io/api/apps/v1"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	corev1 "k8s.io/api/core/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// retry 3 times to give the object time to propagate to the API server
+const tries int = 3
+const sleeptime time.Duration = 300 * time.Millisecond
+
+//nolint
+func LabelDeployResults(labels map[string]string, results []deploy.Artifact) {
+	// use the kubectl client to update all k8s objects with a skaffold watermark
+	client, err := kubernetes.Client()
+	if err != nil {
+		logrus.Warnf("error retrieving kubernetes client: %s", err.Error())
+		return
+	}
+	for _, res := range results {
+		err = nil
+		for i := 0; i < tries; i++ {
+			if err = updateRuntimeObject(client, labels, res); err == nil {
+				break
+			}
+			time.Sleep(sleeptime)
+		}
+		if err != nil {
+			logrus.Warnf("error adding label to runtime object: %s", err.Error())
+		}
+	}
+}
+
+func addSkaffoldLabels(labels map[string]string, m *metav1.ObjectMeta) {
+	if m.Labels == nil {
+		m.Labels = map[string]string{}
+	}
+	for k, v := range labels {
+		m.Labels[k] = v
+	}
+}
+
+func retrieveNamespace(ns string, m metav1.ObjectMeta) string {
+	if ns != "" {
+		return ns
+	}
+	if m.Namespace != "" {
+		return m.Namespace
+	}
+	return "default"
+}
+
+// TODO(nkubala): change this to use the client-go dynamic client or something equally clean
+func updateRuntimeObject(client clientgo.Interface, labels map[string]string, res deploy.Artifact) error {
+	for k, v := range constants.Labels.DefaultLabels {
+		labels[k] = v
+	}
+	var err error
+	obj := *res.Obj
+	switch obj.(type) {
+	case *corev1.Pod:
+		p := obj.(*corev1.Pod)
+		addSkaffoldLabels(labels, &p.ObjectMeta)
+		pods := client.CoreV1().Pods(retrieveNamespace(res.Namespace, p.ObjectMeta))
+		_, err = pods.UpdateStatus(p)
+	case *appsv1.Deployment:
+		d := obj.(*appsv1.Deployment)
+		addSkaffoldLabels(labels, &d.ObjectMeta)
+		deployments := client.AppsV1().Deployments(retrieveNamespace(res.Namespace, d.ObjectMeta))
+		_, err = deployments.Update(d)
+	case *appsv1beta1.Deployment:
+		d := obj.(*appsv1beta1.Deployment)
+		addSkaffoldLabels(labels, &d.ObjectMeta)
+		deployments := client.AppsV1beta1().Deployments(retrieveNamespace(res.Namespace, d.ObjectMeta))
+		_, err = deployments.Update(d)
+	case *appsv1beta2.Deployment:
+		d := obj.(*appsv1beta2.Deployment)
+		addSkaffoldLabels(labels, &d.ObjectMeta)
+		deployments := client.AppsV1beta2().Deployments(retrieveNamespace(res.Namespace, d.ObjectMeta))
+		_, err = deployments.Update(d)
+	case *extensionsv1beta1.Deployment:
+		d := obj.(*extensionsv1beta1.Deployment)
+		addSkaffoldLabels(labels, &d.ObjectMeta)
+		deployments := client.ExtensionsV1beta1().Deployments(retrieveNamespace(res.Namespace, d.ObjectMeta))
+		_, err = deployments.Update(d)
+	case *corev1.Service:
+		s := obj.(*corev1.Service)
+		addSkaffoldLabels(labels, &s.ObjectMeta)
+		services := client.CoreV1().Services(retrieveNamespace(res.Namespace, s.ObjectMeta))
+		_, err = services.UpdateStatus(s)
+	case *appsv1.StatefulSet:
+		s := obj.(*appsv1.StatefulSet)
+		addSkaffoldLabels(labels, &s.ObjectMeta)
+		sets := client.AppsV1().StatefulSets(retrieveNamespace(res.Namespace, s.ObjectMeta))
+		_, err = sets.UpdateStatus(s)
+	case *appsv1beta1.StatefulSet:
+		s := obj.(*appsv1beta1.StatefulSet)
+		addSkaffoldLabels(labels, &s.ObjectMeta)
+		sets := client.AppsV1beta1().StatefulSets(retrieveNamespace(res.Namespace, s.ObjectMeta))
+		_, err = sets.UpdateStatus(s)
+	case *appsv1beta2.StatefulSet:
+		s := obj.(*appsv1beta2.StatefulSet)
+		addSkaffoldLabels(labels, &s.ObjectMeta)
+		sets := client.AppsV1beta2().StatefulSets(retrieveNamespace(res.Namespace, s.ObjectMeta))
+		_, err = sets.UpdateStatus(s)
+	case *extensionsv1beta1.DaemonSet:
+		s := obj.(*extensionsv1beta1.DaemonSet)
+		addSkaffoldLabels(labels, &s.ObjectMeta)
+		sets := client.ExtensionsV1beta1().DaemonSets(retrieveNamespace(res.Namespace, s.ObjectMeta))
+		_, err = sets.UpdateStatus(s)
+	case *appsv1.ReplicaSet:
+		rs := obj.(*appsv1.ReplicaSet)
+		addSkaffoldLabels(labels, &rs.ObjectMeta)
+		sets := client.AppsV1().ReplicaSets(retrieveNamespace(res.Namespace, rs.ObjectMeta))
+		_, err = sets.UpdateStatus(rs)
+	case *appsv1beta2.ReplicaSet:
+		rs := obj.(*appsv1beta2.ReplicaSet)
+		addSkaffoldLabels(labels, &rs.ObjectMeta)
+		sets := client.AppsV1beta2().ReplicaSets(retrieveNamespace(res.Namespace, rs.ObjectMeta))
+		_, err = sets.UpdateStatus(rs)
+	default:
+		logrus.Infof("unknown runtime.Object, skipping label")
+		return nil
+	}
+	return err
+}

--- a/pkg/skaffold/runner/notification.go
+++ b/pkg/skaffold/runner/notification.go
@@ -41,13 +41,13 @@ type withNotification struct {
 	deploy.Deployer
 }
 
-func (w withNotification) Deploy(ctx context.Context, out io.Writer, builds []build.Build) error {
-	err := w.Deployer.Deploy(ctx, out, builds)
+func (w withNotification) Deploy(ctx context.Context, out io.Writer, builds []build.Artifact) ([]deploy.Artifact, error) {
+	res, err := w.Deployer.Deploy(ctx, out, builds)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	fmt.Fprint(out, terminalBell)
 
-	return nil
+	return res, nil
 }

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -36,21 +36,25 @@ import (
 )
 
 type TestBuilder struct {
-	built  []build.Build
+	built  []build.Artifact
 	errors []error
 }
 
-func (t *TestBuilder) Build(ctx context.Context, w io.Writer, tagger tag.Tagger, artifacts []*v1alpha2.Artifact) ([]build.Build, error) {
+func (t *TestBuilder) Labels() map[string]string {
+	return map[string]string{}
+}
+
+func (t *TestBuilder) Build(ctx context.Context, w io.Writer, tagger tag.Tagger, artifacts []*v1alpha2.Artifact) ([]build.Artifact, error) {
 	if len(t.errors) > 0 {
 		err := t.errors[0]
 		t.errors = t.errors[1:]
 		return nil, err
 	}
 
-	var builds []build.Build
+	var builds []build.Artifact
 
 	for _, artifact := range artifacts {
-		builds = append(builds, build.Build{
+		builds = append(builds, build.Artifact{
 			ImageName: artifact.ImageName,
 		})
 	}
@@ -60,21 +64,25 @@ func (t *TestBuilder) Build(ctx context.Context, w io.Writer, tagger tag.Tagger,
 }
 
 type TestDeployer struct {
-	deployed []build.Build
+	deployed []build.Artifact
 	err      error
+}
+
+func (t *TestDeployer) Labels() map[string]string {
+	return map[string]string{}
 }
 
 func (t *TestDeployer) Dependencies() ([]string, error) {
 	return nil, nil
 }
 
-func (t *TestDeployer) Deploy(ctx context.Context, out io.Writer, builds []build.Build) error {
+func (t *TestDeployer) Deploy(ctx context.Context, out io.Writer, builds []build.Artifact) ([]deploy.Artifact, error) {
 	if t.err != nil {
-		return t.err
+		return nil, t.err
 	}
 
 	t.deployed = builds
-	return nil
+	return nil, nil
 }
 
 func (t *TestDeployer) Cleanup(ctx context.Context, out io.Writer) error {


### PR DESCRIPTION
This adds labels to all kubernetes objects deployed by Skaffold. ~By default, the label `deployed_with:skaffold` is added to all objects, as well as a `skaffold_deploy_client:<client>` with the deployer used in skaffold. We can add more labels or change these as we see fit.~
Each `Builder`, `Deployer`, and `Tagger` implementation now exposes its own set of labels to the `Runner`, which will aggregate all labels and send those to the deployed objects on each run.

We should consider adding labels for individual profiles as well, possibly in a follow-up PR.

Also, as a small non-functional change, I changed `build.Build` to `build.BuildArtifact` to match `deploy.DeployArtifact`.

Fixes #98 