### PR TITLE
Add support to the kaniko builder for secrets that already exist.

### DIFF
--- a/examples/kaniko/k8s-pod.yaml
+++ b/examples/kaniko/k8s-pod.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: getting-started
+  name: getting-started-kaniko
 spec:
   containers:
   - name: getting-started

--- a/examples/kaniko/skaffold.yaml
+++ b/examples/kaniko/skaffold.yaml
@@ -4,8 +4,8 @@ build:
   artifacts:
   - imageName: gcr.io/k8s-skaffold/skaffold-example
   kaniko:
-    gcsBucket: k8s-skaffold
-    pullSecret: ~/secrets/kaniko/kaniko.json
+    gcsBucket: skaffold-debug
+    pullSecretName: e2esecret
 deploy:
   kubectl:
     manifests:

--- a/examples/kaniko/skaffold.yaml
+++ b/examples/kaniko/skaffold.yaml
@@ -4,7 +4,7 @@ build:
   artifacts:
   - imageName: gcr.io/k8s-skaffold/skaffold-example
   kaniko:
-    gcsBucket: skaffold-debug
+    gcsBucket: skaffold-kaniko
     pullSecretName: e2esecret
 deploy:
   kubectl:

--- a/examples/kaniko/skaffold.yaml
+++ b/examples/kaniko/skaffold.yaml
@@ -6,6 +6,7 @@ build:
   kaniko:
     gcsBucket: skaffold-kaniko
     pullSecretName: e2esecret
+    namespace: default
 deploy:
   kubectl:
     manifests:

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -165,7 +165,7 @@ func TestRun(t *testing.T) {
 			args:        []string{"run"},
 			pods: []testObject{
 				{
-					name: "getting-started",
+					name: "getting-started-kaniko",
 				},
 			},
 			dir:        "../examples/kaniko",

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -160,6 +160,17 @@ func TestRun(t *testing.T) {
 			},
 			dir: "../examples/kustomize",
 		},
+		{
+			description: "kaniko example",
+			args:        []string{"run"},
+			pods: []testObject{
+				{
+					name: "getting-started",
+				},
+			},
+			dir:        "../examples/kaniko",
+			remoteOnly: true,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/skaffold/build/kaniko.go
+++ b/pkg/skaffold/build/kaniko.go
@@ -24,7 +24,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
@@ -68,7 +67,7 @@ func (k *KanikoBuilder) Build(ctx context.Context, out io.Writer, tagger tag.Tag
 			return nil, errors.Wrap(err, "reading secret")
 		}
 
-		_, err = client.CoreV1().Secrets(k.KanikoBuild.Namespace).Create(&v1.Secret{
+		if _, err := client.CoreV1().Secrets(k.KanikoBuild.Namespace).Create(&v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   k.KanikoBuild.PullSecretName,
 				Labels: map[string]string{"skaffold-kaniko": "skaffold-kaniko"},
@@ -76,8 +75,7 @@ func (k *KanikoBuilder) Build(ctx context.Context, out io.Writer, tagger tag.Tag
 			Data: map[string][]byte{
 				constants.DefaultKanikoSecretName: secretData,
 			},
-		})
-		if err != nil {
+		}); err != nil {
 			logrus.Warnf("creating secret: %s", err)
 		}
 		defer func() {

--- a/pkg/skaffold/build/kaniko.go
+++ b/pkg/skaffold/build/kaniko.go
@@ -76,7 +76,7 @@ func (k *KanikoBuilder) Build(ctx context.Context, out io.Writer, tagger tag.Tag
 				constants.DefaultKanikoSecretName: secretData,
 			},
 		}); err != nil {
-			logrus.Warnf("creating secret: %s", err)
+			return nil, errors.Wrapf(err, "creating secret: %s", err)
 		}
 		defer func() {
 			if err := client.CoreV1().Secrets(k.KanikoBuild.Namespace).Delete(k.KanikoBuild.PullSecretName, &metav1.DeleteOptions{}); err != nil {

--- a/pkg/skaffold/build/kaniko.go
+++ b/pkg/skaffold/build/kaniko.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
@@ -69,10 +71,10 @@ func (k *KanikoBuilder) Build(ctx context.Context, out io.Writer, tagger tag.Tag
 		_, err = client.CoreV1().Secrets(k.KanikoBuild.Namespace).Create(&v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   k.KanikoBuild.PullSecretName,
-				Labels: map[string]string{"kaniko": "kaniko"},
+				Labels: map[string]string{"skaffold-kaniko": "skaffold-kaniko"},
 			},
 			Data: map[string][]byte{
-				"kaniko-secret": secretData,
+				constants.DefaultKanikoSecretName: secretData,
 			},
 		})
 		if err != nil {

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -44,7 +44,8 @@ const (
 	DefaultKustomizationPath = "."
 
 	// DefaultKanikoImage is v0.1.0
-	DefaultKanikoImage = "gcr.io/kaniko-project/executor:v0.1.0@sha256:501056bf52f3a96f151ccbeb028715330d5d5aa6647e7572ce6c6c55f91ab374"
+	DefaultKanikoImage      = "gcr.io/kaniko-project/executor:v0.1.0@sha256:501056bf52f3a96f151ccbeb028715330d5d5aa6647e7572ce6c6c55f91ab374"
+	DefaultKanikoSecretName = "kaniko-secret"
 )
 
 var Labels = struct {

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -29,7 +29,7 @@ import (
 	"sync"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/client"
@@ -51,7 +51,7 @@ var (
 // NewAPIClient guesses the docker client to use based on current kubernetes context.
 func NewAPIClient() (APIClient, error) {
 	dockerAPIClientOnce.Do(func() {
-		kubeContext, err := kubernetes.CurrentContext()
+		kubeContext, err := kubectx.CurrentContext()
 		if err != nil {
 			dockerAPIClientErr = errors.Wrap(err, "getting current cluster context")
 			return

--- a/pkg/skaffold/kaniko/kaniko.go
+++ b/pkg/skaffold/kaniko/kaniko.go
@@ -57,7 +57,7 @@ func RunKanikoBuild(ctx context.Context, out io.Writer, artifact *v1alpha2.Artif
 	p, err := client.CoreV1().Pods(cfg.Namespace).Create(&v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kaniko",
-			Labels:    map[string]string{"kaniko": "kaniko"},
+			Labels:    map[string]string{"skaffold-kaniko": "skaffold-kaniko"},
 			Namespace: cfg.Namespace,
 		},
 		Spec: v1.PodSpec{
@@ -74,7 +74,7 @@ func RunKanikoBuild(ctx context.Context, out io.Writer, artifact *v1alpha2.Artif
 					},
 					VolumeMounts: []v1.VolumeMount{
 						{
-							Name:      "kaniko-secret",
+							Name:      constants.DefaultKanikoSecretName,
 							MountPath: "/secret",
 						},
 					},
@@ -88,7 +88,7 @@ func RunKanikoBuild(ctx context.Context, out io.Writer, artifact *v1alpha2.Artif
 			},
 			Volumes: []v1.Volume{
 				{
-					Name: "kaniko-secret",
+					Name: constants.DefaultKanikoSecretName,
 					VolumeSource: v1.VolumeSource{
 						Secret: &v1.SecretVolumeSource{
 							SecretName: cfg.PullSecretName,

--- a/pkg/skaffold/kubernetes/context/context_test.go
+++ b/pkg/skaffold/kubernetes/context/context_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package context
 
 import (
 	"os"

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/label"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/watch"
@@ -75,7 +76,7 @@ func (r *SkaffoldRunner) Labels() map[string]string {
 
 // NewForConfig returns a new SkaffoldRunner for a SkaffoldConfig
 func NewForConfig(opts *config.SkaffoldOptions, cfg *config.SkaffoldConfig) (*SkaffoldRunner, error) {
-	kubeContext, err := kubernetes.CurrentContext()
+	kubeContext, err := kubectx.CurrentContext()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting current cluster context")
 	}

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -202,8 +202,8 @@ func (c *SkaffoldConfig) setDefaultValues() error {
 	c.setDefaultTagger()
 	c.setDefaultDockerfiles()
 	c.setDefaultWorkspaces()
-	c.setDefaultNamespace()
-	return c.setDefaultSecret()
+	c.setDefaultKanikoNamespace()
+	return c.setDefaultKanikoSecret()
 }
 
 func (c *SkaffoldConfig) defaultToLocalBuild() {
@@ -251,7 +251,7 @@ func (c *SkaffoldConfig) setDefaultWorkspaces() {
 	}
 }
 
-func (c *SkaffoldConfig) setDefaultNamespace() {
+func (c *SkaffoldConfig) setDefaultKanikoNamespace() {
 	if c.Build.KanikoBuild == nil {
 		return
 	}
@@ -260,7 +260,7 @@ func (c *SkaffoldConfig) setDefaultNamespace() {
 	}
 }
 
-func (c *SkaffoldConfig) setDefaultSecret() error {
+func (c *SkaffoldConfig) setDefaultKanikoSecret() error {
 	if c.Build.KanikoBuild == nil {
 		return nil
 	}

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -202,7 +202,6 @@ func (c *SkaffoldConfig) setDefaultValues() error {
 	c.setDefaultTagger()
 	c.setDefaultDockerfiles()
 	c.setDefaultWorkspaces()
-	c.setDefaultKanikoNamespace()
 	return c.setDefaultKanikoSecret()
 }
 
@@ -251,15 +250,6 @@ func (c *SkaffoldConfig) setDefaultWorkspaces() {
 	}
 }
 
-func (c *SkaffoldConfig) setDefaultKanikoNamespace() {
-	if c.Build.KanikoBuild == nil {
-		return
-	}
-	if c.Build.KanikoBuild.Namespace == "" {
-		c.Build.KanikoBuild.Namespace = "default"
-	}
-}
-
 func (c *SkaffoldConfig) setDefaultKanikoSecret() error {
 	if c.Build.KanikoBuild == nil {
 		return nil
@@ -274,7 +264,7 @@ func (c *SkaffoldConfig) setDefaultKanikoSecret() error {
 		return nil
 	}
 	if c.Build.KanikoBuild.PullSecretName == "" {
-		c.Build.KanikoBuild.PullSecret = "kaniko-secret"
+		c.Build.KanikoBuild.PullSecret = constants.DefaultKanikoSecretName
 	}
 	return nil
 }

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	homedir "github.com/mitchellh/go-homedir"
 
 	"github.com/pkg/errors"
@@ -202,6 +203,9 @@ func (c *SkaffoldConfig) setDefaultValues() error {
 	c.setDefaultTagger()
 	c.setDefaultDockerfiles()
 	c.setDefaultWorkspaces()
+	if err := c.setDefaultKanikoNamespace(); err != nil {
+		return err
+	}
 	return c.setDefaultKanikoSecret()
 }
 
@@ -248,6 +252,20 @@ func (c *SkaffoldConfig) setDefaultWorkspaces() {
 			artifact.Workspace = "."
 		}
 	}
+}
+
+func (c *SkaffoldConfig) setDefaultKanikoNamespace() error {
+	if c.Build.KanikoBuild == nil {
+		return nil
+	}
+	if c.Build.KanikoBuild.Namespace == "" {
+		cfg, err := kubectx.CurrentConfig()
+		if err != nil {
+			return err
+		}
+		c.Build.KanikoBuild.Namespace = cfg.Contexts[cfg.CurrentContext].Namespace
+	}
+	return nil
 }
 
 func (c *SkaffoldConfig) setDefaultKanikoSecret() error {


### PR DESCRIPTION
Specifying secrets via local files is a bit burdensome. This PR adds initial support for secrets that already exist in the cluster (the kaniko-secret). We should probably make the name of this configurable.