### PR TITLE
Implement packaging for helm deployment

### DIFF
--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -106,15 +106,27 @@ deploy:
     # helm releases to deploy.
     # releases:
     # - name: skaffold-helm
-    #  chartPath: skaffold-helm
-    #  valuesFilePath: helm-skaffold-values.yaml
-    #  values:
-    #    image: skaffold-helm
-    #  namespace: skaffold
-    #  version: ""
-      # setValues get appended to the helm deploy with --set.
-    #  setValues:
+    #   chartPath: skaffold-helm
+    #   valuesFilePath: helm-skaffold-values.yaml
+    #   values:
+    #     image: skaffold-helm
+    #   namespace: skaffold
+    #   version: ""
+    #
+    #   # setValues get appended to the helm deploy with --set.
+    #   setValues:
     #    key: "value"
+    #
+    #   # packaged section allows to package chart setting specific version
+    #   # and/or appVersion using "helm package" command.
+    #   packaged:
+    #     # version is passed to "helm package --version" flag.
+    #     # Note that you can specify both static string or dynamic template.
+    #     version: {{ .CHART_VERSION }}-dirty
+    #     # appVersion is passed to "helm package --app-version" flag.
+    #     # Note that you can specify both static string or dynamic template.
+    #     appVersion: {{ .CHART_VERSION }}-dirty
+
 # profiles section has all the profile information which can be used to override any build or deploy configuration
 profiles:
   - name: gcb

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -295,3 +295,29 @@ func TestParseHelmRelease(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractChartFilename(t *testing.T) {
+	testCases := map[string]struct {
+		input     string
+		tmp       string
+		output    string
+		shouldErr bool
+	}{
+		"1": {
+			input:     "Successfully packaged chart and saved it to: /var/folders/gm/rrs_712142x8vymmd7xq7h340000gn/T/foo-1.2.3-dirty.tgz\n",
+			tmp:       "/var/folders/gm/rrs_712142x8vymmd7xq7h340000gn/T/",
+			output:    "foo-1.2.3-dirty.tgz",
+			shouldErr: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			out, err := extractChartFilename(tc.input, tc.tmp)
+			testutil.CheckError(t, tc.shouldErr, err)
+			if out != tc.output {
+				t.Errorf("Expected output to be %q but got %q", tc.output, out)
+			}
+		})
+	}
+}

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -137,6 +137,16 @@ type HelmRelease struct {
 	SetValues      map[string]string      `yaml:"setValues"`
 	Wait           bool                   `yaml:"wait"`
 	Overrides      map[string]interface{} `yaml:"overrides"`
+	Packaged       *HelmPackaged          `yaml:"packaged"`
+}
+
+// HelmPackaged represents parameters for packaging helm chart.
+type HelmPackaged struct {
+	// Version sets the version on the chart to this semver version.
+	Version string `yaml:"version"`
+
+	// AppVersion set the appVersion on the chart to this version
+	AppVersion string `yaml:"appVersion"`
 }
 
 // Artifact represents items that need to be built, along with the context in which


### PR DESCRIPTION
**A note for reviewers**: this is a proposal. If you give the green light to it, I will add required tests and documentation.

---

This commit adds a possibility to package a helm chart before deployment
using `helm package` command. This can be useful to set a specific version
for a chart.

---

One of the workflows that skaffold assumes is to deploy a Helm chart that
resides within some directory in the project folder. `Chart.yaml` file in
that folder is basically static file, and `--version` flag in
`helm install ./path/to/chart --version` command actually does nothing,
so does "version:" field in helm section of **skaffold.yaml**.

To set a chart version dynamically, we have to use `helm package` command
setting `--version` (and optionally `--app-version`) flags accordingly.

This commit adds a new section `packaged:` to helm section **skaffold.yaml**
that can be used to configure dynamic chart versions.