### PR TITLE
[442] - fixing incorrect position of tarPath argument

### DIFF
--- a/pkg/skaffold/util/tar.go
+++ b/pkg/skaffold/util/tar.go
@@ -34,7 +34,7 @@ func CreateTar(w io.Writer, root string, paths []string) error {
 	for _, p := range paths {
 		tarPath := filepath.ToSlash(filepath.Join(root, p))
 
-		if err := addFileToTar(tarPath, p, tw); err != nil {
+		if err := addFileToTar(p, tarPath, tw); err != nil {
 			return err
 		}
 
@@ -56,6 +56,7 @@ func addFileToTar(p string, tarPath string, tw *tar.Writer) error {
 	switch mode := fi.Mode(); {
 	case mode.IsRegular():
 		tarHeader, err := tar.FileInfoHeader(fi, tarPath)
+		
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This was tested on windows 7 and works properly now.
Before this, the files created in the tar all had \\ as directory separator. I'm only guessing here since i dont understand the codebase fully but i suppose this was the intent of filePath.ToSlash.