### PR TITLE
[442] - fixing incorrect position of tarPath argument

### DIFF
--- a/pkg/skaffold/docker/context_test.go
+++ b/pkg/skaffold/docker/context_test.go
@@ -43,7 +43,6 @@ func TestDockerContext(t *testing.T) {
 	ioutil.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte("FROM alpine\nCOPY ./files /files"), 0644)
 	ioutil.WriteFile(filepath.Join(tmpDir, "ignored.txt"), []byte(""), 0644)
 	ioutil.WriteFile(filepath.Join(tmpDir, "alsoignored.txt"), []byte(""), 0644)
-
 	reader, writer := io.Pipe()
 	go func() {
 		err := CreateDockerTarContext(writer, "Dockerfile", tmpDir)

--- a/pkg/skaffold/util/tar.go
+++ b/pkg/skaffold/util/tar.go
@@ -34,7 +34,7 @@ func CreateTar(w io.Writer, root string, paths []string) error {
 	for _, p := range paths {
 		tarPath := filepath.ToSlash(filepath.Join(root, p))
 
-		if err := addFileToTar(tarPath, p, tw); err != nil {
+		if err := addFileToTar(p, tarPath, tw); err != nil {
 			return err
 		}
 
@@ -56,6 +56,7 @@ func addFileToTar(p string, tarPath string, tw *tar.Writer) error {
 	switch mode := fi.Mode(); {
 	case mode.IsRegular():
 		tarHeader, err := tar.FileInfoHeader(fi, tarPath)
+		
 		if err != nil {
 			return err
 		}

--- a/pkg/skaffold/util/tar.go
+++ b/pkg/skaffold/util/tar.go
@@ -32,8 +32,8 @@ func CreateTar(w io.Writer, root string, paths []string) error {
 	defer tw.Close()
 
 	for _, p := range paths {
-		tarPath := filepath.ToSlash(filepath.Join(root, p))
-
+		tarPath := filepath.ToSlash(p)
+		p := filepath.Join(root, p)
 		if err := addFileToTar(p, tarPath, tw); err != nil {
 			return err
 		}
@@ -56,7 +56,6 @@ func addFileToTar(p string, tarPath string, tw *tar.Writer) error {
 	switch mode := fi.Mode(); {
 	case mode.IsRegular():
 		tarHeader, err := tar.FileInfoHeader(fi, tarPath)
-		
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This was tested on windows 7. Previously the header in the tar contained windows file separators and failed to extract properly on docker, creating files instead of the directory structure. 
E.G. instead of /src/main/app.java directory structure, one would see \src\main\app.java file.
Fixes 
https://github.com/GoogleContainerTools/skaffold/issues/442
https://github.com/GoogleContainerTools/skaffold/pull/489