### PR TITLE
Fix bug where dirty submodules broke hash generation

### DIFF
--- a/pkg/skaffold/build/tag/git_commit_test.go
+++ b/pkg/skaffold/build/tag/git_commit_test.go
@@ -80,7 +80,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			opts: &Options{
 				ImageName: "test",
 			},
-			expectedName: "test:eefe1b9-dirty-af8de1fde8be4367",
+			expectedName: "test:eefe1b9-dirty-8b8c4dad90faa822",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", []byte("code")).
@@ -95,7 +95,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 				ImageName: "test",
 				Digest:    "sha256:12345abcde",
 			},
-			expectedName: "test:eefe1b9-dirty-af8de1fde8be4367",
+			expectedName: "test:eefe1b9-dirty-8b8c4dad90faa822",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", []byte("code")).
@@ -110,7 +110,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			opts: &Options{
 				ImageName: "test",
 			},
-			expectedName: "test:eefe1b9-dirty-bfe9b4566c9d3fec",
+			expectedName: "test:eefe1b9-dirty-e0bc2923501f63b7",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", []byte("code")).
@@ -154,7 +154,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			opts: &Options{
 				ImageName: "test",
 			},
-			expectedName: "test:eefe1b9-dirty-9c858d88cc0bf792",
+			expectedName: "test:eefe1b9-dirty-c9417af5dc664b60",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", []byte("code")).
@@ -168,7 +168,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			opts: &Options{
 				ImageName: "test",
 			},
-			expectedName: "test:eefe1b9-dirty-6534adc17ccd1cf4", // Must be <> each time a new name is used
+			expectedName: "test:eefe1b9-dirty-91fd2028ff0a5cf3", // Must be <> each time a new name is used
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", []byte("code")).
@@ -195,7 +195,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			opts: &Options{
 				ImageName: "test",
 			},
-			expectedName: "test:a7b32a6-dirty-83715cdc64e43ee9",
+			expectedName: "test:a7b32a6-dirty-2dfb095d0f4830ad",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("sub/sub").


### PR DESCRIPTION
This is a proposal for a fix for https://github.com/GoogleContainerTools/skaffold/issues/685. Please let me know what you think of the approach! I'm new to the Skaffold code, so hopefully I'm not misunderstanding how this should work.

Regarding splitting the status lines: `??` isn't the only special case (two characters). `MM` is also a valid status, for example. If my understanding of the purpose of that code was correct, then my new implementation should be more robust. Ideally I would have split this out as a separate commit, but it's pretty tangled in there.

-------------

Instead of appending the entire contents of modified files to the sha256
input, we should only append the diff as computed by `git diff` in order
to handle all modifications properly, including submodules.

This also fixes a bug where the processing of the git status output was
too fragile. It makes it more generic by splitting the status string on
fields instead.

Signed-off-by: Matt Kelly <matt.kelly@containership.io>