### PR TITLE
fixed a bug in dirtyTag which may leave extra whitespaces in changedPath

### DIFF
--- a/pkg/skaffold/build/tag/git_commit.go
+++ b/pkg/skaffold/build/tag/git_commit.go
@@ -169,7 +169,7 @@ func dirtyTag(root string, opts *Options, currentTag string, lines []string) (st
 			continue
 		}
 
-		changedPath := statusLine[2:]
+		changedPath := strings.Trim(statusLine[2:], " ")
 		f, err := os.Open(filepath.Join(root, changedPath))
 		if err != nil {
 			return "", errors.Wrap(err, "reading diff")


### PR DESCRIPTION
A `git status --porcelain` entry may have more one whitespaces between status character and the file path

-- snip --
DEBU[0000] Running command: [git status --porcelain]
DEBU[0000] Command output: stdout M  containers/go/go-http/Dockerfile
A  containers/go/go-http/k8s-deployment.yaml
A  containers/go/go-http/kubernetes/deployment.yaml
AM containers/go/go-http/skaffold.yaml
, stderr:
FATA[0000] build step: generating tag: reading diff: open /Users/xxx/projs/gke/ containers/go/go-http/Dockerfile: no such file or directory