### PR TITLE
Don’t always fail if some COPY patterns don't match any file

### DIFF
--- a/pkg/skaffold/docker/parse_test.go
+++ b/pkg/skaffold/docker/parse_test.go
@@ -56,6 +56,11 @@ FROM nginx
 ADD *.none /tmp
 `
 
+const oneWilcardMatchesNone = `
+FROM nginx
+ADD *.go *.none /tmp
+`
+
 const multiStageDockerfile = `
 FROM golang:1.9.2
 WORKDIR /go/src/github.com/r2d4/leeroy/
@@ -177,6 +182,12 @@ func TestGetDependencies(t *testing.T) {
 			dockerfile:  wildcardsMatchesNone,
 			workspace:   ".",
 			shouldErr:   true,
+		},
+		{
+			description: "one wilcard matches none",
+			dockerfile:  oneWilcardMatchesNone,
+			workspace:   ".",
+			expected:    []string{"Dockerfile", "server.go", "worker.go"},
 		},
 		{
 			description: "bad read",


### PR DESCRIPTION
Docker does not seem to mind if a wildcard matches no files so long as there is at least one file found on the statement to copy.

Fixes #741

Signed-off-by: David Gageot <david@gageot.net>