### PR TITLE
brew: remove version from formula

### DIFF
--- a/installers/brew/skaffold.rb
+++ b/installers/brew/skaffold.rb
@@ -2,7 +2,6 @@ class Skaffold < Formula
   desc "A tool that facilitates continuous development for Kubernetes applications."
   head "https://github.com/GoogleContainerTools/skaffold.git"
   url "https://github.com/GoogleContainerTools/skaffold.git"
-  version "v0.6.0"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
We could also just remove this. Useful if people wanted to check formula and but install manually with brew