### PR TITLE
Improve GCR docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -94,10 +94,7 @@ You will need the following components to get started with Skaffold:
 . Docker image registry
    -  Your docker client should be configured to push to an external docker image repository.
 If you're using a minikube or Docker for Desktop cluster, you can skip this requirement.
-   -  If you are using Google Container Registry (GCR), choose one of the following:
-        . Use `gcloud`'s Docker credential helper: Run link:https://cloud.google.com/sdk/gcloud/reference/auth/configure-docker[`gcloud auth configure-docker`]
-        . Install and configure GCR's standalone cred helper: link:https://github.com/GoogleCloudPlatform/docker-credential-gcr#installation-and-usage[`docker-credential-gcr`]
-        . Run `gcloud docker -a` before each development session.
+   -  If you are using Google Container Registry (GCR), you can use `gcloud` and run link:https://cloud.google.com/sdk/gcloud/reference/auth/configure-docker[`gcloud auth configure-docker`] to configure Docker with GCR credentials. If you don't have `gcloud`, you can install a standalone helper – link:https://github.com/GoogleCloudPlatform/docker-credential-gcr#installation-and-usage[`docker-credential-gcr`].
 
 == Iterative Development
 


### PR DESCRIPTION
The README looked weird on GitHub. It turns out Github doesn't support many list indentation levels for adoc, hence I put it does as one sentence...  Also, `gcloud docker` is deprecated, so I thought we shouldn't mention it.