### PR TITLE
Embed Tagger in Builder

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -66,7 +66,7 @@ func runBuild(out io.Writer, filename string) error {
 		buildOut = ioutil.Discard
 	}
 
-	bRes, err := runner.Build(ctx, buildOut, runner.Tagger, config.Build.Artifacts)
+	bRes, err := runner.Build(ctx, buildOut, config.Build.Artifacts)
 	if err != nil {
 		return errors.Wrap(err, "build step")
 	}

--- a/pkg/skaffold/build/build.go
+++ b/pkg/skaffold/build/build.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
 )
 
@@ -37,5 +36,5 @@ type Artifact struct {
 type Builder interface {
 	Labels() map[string]string
 
-	Build(ctx context.Context, out io.Writer, tagger tag.Tagger, artifacts []*v1alpha2.Artifact) ([]Artifact, error)
+	Build(ctx context.Context, out io.Writer, artifacts []*v1alpha2.Artifact) ([]Artifact, error)
 }

--- a/pkg/skaffold/build/kaniko.go
+++ b/pkg/skaffold/build/kaniko.go
@@ -36,12 +36,14 @@ import (
 
 // KanikoBuilder can build docker artifacts on Kubernetes, using Kaniko.
 type KanikoBuilder struct {
+	tag.Tagger
 	*v1alpha2.KanikoBuild
 }
 
 // NewKanikoBuilder creates a KanikoBuilder.
-func NewKanikoBuilder(cfg *v1alpha2.KanikoBuild) *KanikoBuilder {
+func NewKanikoBuilder(t tag.Tagger, cfg *v1alpha2.KanikoBuild) *KanikoBuilder {
 	return &KanikoBuilder{
+		Tagger:      t,
 		KanikoBuild: cfg,
 	}
 }
@@ -54,7 +56,7 @@ func (k *KanikoBuilder) Labels() map[string]string {
 }
 
 // Build builds a list of artifacts with Kaniko.
-func (k *KanikoBuilder) Build(ctx context.Context, out io.Writer, tagger tag.Tagger, artifacts []*v1alpha2.Artifact) ([]Artifact, error) {
+func (k *KanikoBuilder) Build(ctx context.Context, out io.Writer, artifacts []*v1alpha2.Artifact) ([]Artifact, error) {
 	teardown, err := k.setupSecret()
 	if err != nil {
 		return nil, errors.Wrap(err, "setting up secret")
@@ -77,7 +79,7 @@ func (k *KanikoBuilder) Build(ctx context.Context, out io.Writer, tagger tag.Tag
 			return nil, errors.Wrap(err, "getting digest")
 		}
 
-		tag, err := tagger.GenerateFullyQualifiedImageName(artifact.Workspace, &tag.Options{
+		tag, err := k.Tagger.GenerateFullyQualifiedImageName(artifact.Workspace, &tag.Options{
 			ImageName: artifact.ImageName,
 			Digest:    digest,
 		})

--- a/pkg/skaffold/build/local_test.go
+++ b/pkg/skaffold/build/local_test.go
@@ -182,11 +182,12 @@ func TestLocalRun(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			l := LocalBuilder{
+				Tagger:       test.tagger,
 				api:          test.api,
 				localCluster: test.localCluster,
 			}
 
-			res, err := l.Build(context.Background(), test.out, test.tagger, test.artifacts)
+			res, err := l.Build(context.Background(), test.out, test.artifacts)
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, res)
 		})
 	}

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -37,6 +37,7 @@ import (
 )
 
 type TestBuilder struct {
+	tag.Tagger
 	built  []build.Artifact
 	errors []error
 }
@@ -45,7 +46,7 @@ func (t *TestBuilder) Labels() map[string]string {
 	return map[string]string{}
 }
 
-func (t *TestBuilder) Build(ctx context.Context, w io.Writer, tagger tag.Tagger, artifacts []*v1alpha2.Artifact) ([]build.Artifact, error) {
+func (t *TestBuilder) Build(ctx context.Context, w io.Writer, artifacts []*v1alpha2.Artifact) ([]build.Artifact, error) {
 	if len(t.errors) > 0 {
 		err := t.errors[0]
 		t.errors = t.errors[1:]
@@ -242,7 +243,9 @@ func TestRun(t *testing.T) {
 					},
 				},
 			},
-			builder: &TestBuilder{},
+			builder: &TestBuilder{
+				Tagger: &tag.ChecksumTagger{},
+			},
 			deployer: &TestDeployer{
 				errors: []error{fmt.Errorf("")},
 			},
@@ -255,7 +258,6 @@ func TestRun(t *testing.T) {
 			runner := &SkaffoldRunner{
 				Builder:  test.builder,
 				Deployer: test.deployer,
-				Tagger:   &tag.ChecksumTagger{},
 			}
 			err := runner.Run(context.Background(), ioutil.Discard, test.config.Build.Artifacts)
 
@@ -323,7 +325,6 @@ func TestDev(t *testing.T) {
 			runner := &SkaffoldRunner{
 				Builder:      test.builder,
 				Deployer:     test.deployer,
-				Tagger:       &tag.ChecksumTagger{},
 				watchFactory: test.watcherFactory,
 			}
 			_, err := runner.Dev(context.Background(), ioutil.Discard, nil)

--- a/pkg/skaffold/runner/timings.go
+++ b/pkg/skaffold/runner/timings.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
 )
@@ -43,11 +42,11 @@ type withTimings struct {
 	deploy.Deployer
 }
 
-func (w withTimings) Build(ctx context.Context, out io.Writer, tagger tag.Tagger, artifacts []*v1alpha2.Artifact) ([]build.Artifact, error) {
+func (w withTimings) Build(ctx context.Context, out io.Writer, artifacts []*v1alpha2.Artifact) ([]build.Artifact, error) {
 	start := time.Now()
 	fmt.Fprintln(out, "Starting build...")
 
-	bRes, err := w.Builder.Build(ctx, out, tagger, artifacts)
+	bRes, err := w.Builder.Build(ctx, out, artifacts)
 	if err == nil {
 		fmt.Fprintln(out, "Build complete in", time.Since(start))
 	}


### PR DESCRIPTION
Tags are never resolved without build context, so rather than passing around the `Runner`'s `Tagger` to `Build`, we can just embed the `Tagger` into the `Builder` itself.