### PR TITLE
Add Git Repository Watcher

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -68,6 +68,7 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 }
 
 func AddDevFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&opts.GitRepository, "git-repository", "", "Watch a git repository instead of local files")
 	cmd.Flags().BoolVar(&opts.Cleanup, "cleanup", true, "Delete deployments after dev mode is interrupted")
 }
 

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -19,12 +19,15 @@ package cmd
 import (
 	"context"
 	"io"
+	"io/ioutil"
 	"os"
+	"os/exec"
 	"os/signal"
 	"sync"
 	"syscall"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/watch"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -52,6 +55,14 @@ func dev(out io.Writer, filename string) error {
 
 	if opts.Cleanup {
 		catchCtrlC(cancel)
+	}
+
+	if opts.GitRepository != "" {
+		cleanup, err := initGit(opts.GitRepository)
+		if err != nil {
+			return errors.Wrap(err, "cloning git repository")
+		}
+		defer cleanup()
 	}
 
 	errDev := devLoop(ctx, cancel, out, filename)
@@ -136,4 +147,27 @@ func catchCtrlC(cancel context.CancelFunc) {
 		<-signals
 		cancel()
 	}()
+}
+
+func initGit(url string) (func(), error) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return nil, errors.Wrap(err, "getting working directory")
+	}
+	tmpDir, err := ioutil.TempDir("", "skaffold-dev")
+	if err != nil {
+		return nil, errors.Wrap(err, "getting temp directory for git repo ")
+	}
+	//TODO(r2d4): We are unfortunately using os.Getwd in some of the code, so we have to actually switch directories here.
+	if err := os.Chdir(tmpDir); err != nil {
+		return nil, errors.Wrap(err, "changing dir to temp dir")
+	}
+	cmd := exec.Command("git", "clone", url, ".")
+	if err := util.RunCmd(cmd); err != nil {
+		return nil, errors.Wrapf(err, "cloning repository %s into %s", url, tmpDir)
+	}
+	return func() {
+		os.Chdir(currentDir)
+		os.RemoveAll(tmpDir)
+	}, nil
 }

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -45,5 +45,8 @@ func (opts *SkaffoldOptions) Labels() map[string]string {
 	if len(opts.Profiles) > 0 {
 		labels["profiles"] = strings.Join(opts.Profiles, ",")
 	}
+	if opts.GitRepository != "" {
+		labels["git-repo"] = opts.GitRepository
+	}
 	return labels
 }

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -23,11 +23,12 @@ import (
 // SkaffoldOptions are options that are set by command line arguments not included
 // in the config file itself
 type SkaffoldOptions struct {
-	Cleanup      bool
-	Notification bool
-	Profiles     []string
-	CustomTag    string
-	Namespace    string
+	Cleanup       bool
+	Notification  bool
+	Profiles      []string
+	CustomTag     string
+	Namespace     string
+	GitRepository string
 }
 
 // Labels returns a map of labels to be applied to all deployed

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -45,6 +45,7 @@ type SkaffoldRunner struct {
 
 	watchFactory watch.Factory
 	builds       []build.Artifact
+	opts         *config.SkaffoldOptions
 }
 
 // NewForConfig returns a new SkaffoldRunner for a SkaffoldConfig
@@ -81,6 +82,7 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *config.SkaffoldConfig) (*Sk
 		Deployer:     deployer,
 		Tagger:       tagger,
 		watchFactory: watch.NewCompositeWatcher,
+		opts:         opts,
 	}, nil
 }
 
@@ -206,7 +208,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*v1
 		return nil, errors.Wrap(err, "starting logger")
 	}
 
-	watcher := r.watchFactory(deployDeps, artifacts, PollInterval)
+	watcher := r.watchFactory(deployDeps, artifacts, PollInterval, r.opts)
 	return nil, watcher.Run(ctx, onDeploymentsChange, onArtifactChange)
 }
 

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -101,7 +101,7 @@ type TestWatcher struct {
 }
 
 func NewWatcherFactory(err error, changes ...[]*v1alpha2.Artifact) watch.Factory {
-	return func(files []string, artifacts []*v1alpha2.Artifact, pollInterval time.Duration) watch.CompositeWatcher {
+	return func(files []string, artifacts []*v1alpha2.Artifact, pollInterval time.Duration, opts *config.SkaffoldOptions) watch.CompositeWatcher {
 		return &TestWatcher{
 			changes: changes,
 			err:     err,

--- a/pkg/skaffold/watch/artifacts.go
+++ b/pkg/skaffold/watch/artifacts.go
@@ -42,10 +42,16 @@ type artifactWatcher struct {
 }
 
 // NewArtifactWatcher creates an ArtifactWatcher for a list of artifacts.
-func NewArtifactWatcher(artifacts []*v1alpha2.Artifact, pollInterval time.Duration) (ArtifactWatcher, error) {
-	fileWatcher, err := NewFileWatcher(workingDirs(artifacts), pollInterval)
-	if err != nil {
-		return nil, errors.Wrap(err, "creating file watcher")
+func NewArtifactWatcher(artifacts []*v1alpha2.Artifact, pollInterval time.Duration, gitRepository string) (ArtifactWatcher, error) {
+	var fileWatcher FileWatcher
+	var err error
+	if gitRepository != "" {
+		fileWatcher = NewGitFileWatcher(gitRepository, pollInterval)
+	} else {
+		fileWatcher, err = NewFileWatcher(workingDirs(artifacts), pollInterval)
+		if err != nil {
+			return nil, errors.Wrap(err, "creating file watcher")
+		}
 	}
 
 	return &artifactWatcher{

--- a/pkg/skaffold/watch/git_repo.go
+++ b/pkg/skaffold/watch/git_repo.go
@@ -1,0 +1,104 @@
+package watch
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+const masterRef = "refs/heads/master"
+
+type GitFileWatcher struct {
+	url          string
+	pollInterval time.Duration
+
+	// TODO(r2d4): watch pulls and tags
+}
+
+func NewGitFileWatcher(url string, pollInterval time.Duration) FileWatcher {
+	logrus.Infof("Using git file watcher: %s", url)
+	return &GitFileWatcher{
+		url:          url,
+		pollInterval: pollInterval,
+	}
+}
+
+func (g *GitFileWatcher) Run(ctx context.Context, callback FileChangedFn) error {
+	ticker := time.NewTicker(g.pollInterval)
+	defer ticker.Stop()
+	lastCommit, err := getHeadRef()
+	if err != nil {
+		return errors.Wrap(err, "getting initial head ref")
+	}
+	for {
+		select {
+		case <-ticker.C:
+			currentCommit, err := getCurrentCommit(g.url)
+			if err != nil {
+				return errors.Wrap(err, "getting current commit")
+			}
+			logrus.Debugf("Current commit %s, Last commit built: %s", currentCommit, lastCommit)
+			if lastCommit == currentCommit {
+				continue
+			}
+
+			fetchCmd := exec.Command("git", "fetch", "origin", "master")
+			if err := util.RunCmd(fetchCmd); err != nil {
+				return errors.Wrap(err, "fetching head")
+			}
+
+			diff, err := computeGitDiff(lastCommit, currentCommit)
+			if err != nil {
+				return errors.Wrap(err, "computing diff")
+			}
+
+			checkoutCmd := exec.Command("git", "checkout", "-f", currentCommit)
+			if err := util.RunCmd(checkoutCmd); err != nil {
+				return errors.Wrap(err, "checking out latest commit")
+			}
+
+			lastCommit = currentCommit
+
+			if len(diff) > 0 {
+				if err := callback(diff); err != nil {
+					return errors.Wrap(err, "git watcher callback")
+				}
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func computeGitDiff(srcRef, targetRef string) ([]string, error) {
+	cmd := exec.Command("git", "diff", "--name-only", srcRef, targetRef)
+	out, err := util.RunCmdOut(cmd)
+	if err != nil {
+		return nil, errors.Wrap(err, "diffing revisions")
+	}
+	return strings.Split(strings.TrimSpace(string(out)), "\n"), nil
+}
+
+func getCurrentCommit(url string) (string, error) {
+	cmd := exec.Command("git", "ls-remote", url, masterRef)
+	lsRemoteOutput, err := util.RunCmdOut(cmd)
+	if err != nil {
+		return "", errors.Wrap(err, "getting latest commit reference")
+	}
+	commitAndRef := strings.Split(string(lsRemoteOutput), "\t")
+	return strings.TrimSpace(commitAndRef[0]), nil
+}
+
+func getHeadRef() (string, error) {
+	headCmd := exec.Command("git", "rev-parse", "master")
+	head, err := util.RunCmdOut(headCmd)
+	if err != nil {
+		return "", errors.Wrap(err, "getting initial head ref")
+	}
+	return strings.TrimSpace(string(head)), nil
+}

--- a/pkg/skaffold/watch/git_repo.go
+++ b/pkg/skaffold/watch/git_repo.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package watch
 
 import (

--- a/pkg/skaffold/watch/git_repo_test.go
+++ b/pkg/skaffold/watch/git_repo_test.go
@@ -1,0 +1,130 @@
+package watch
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestGetCurrentCommit(t *testing.T) {
+	var tests = []struct {
+		description string
+		url         string
+		command     util.Command
+		expected    string
+		shouldErr   bool
+	}{
+		{
+			description: "correct",
+			url:         "https://test.git",
+			expected:    "a143d3841fa9d981ab242bb2c1b09f27e5da05bc",
+			command: testutil.NewFakeCmdOut("git ls-remote https://test.git refs/heads/master", "a143d3841fa9d981ab242bb2c1b09f27e5da05bc	refs/heads/master\n", nil),
+		},
+		{
+			description: "error",
+			url:         "https://test.git",
+			shouldErr:   true,
+			command: testutil.NewFakeCmdOut("git ls-remote https://test.git refs/heads/master", "a143d3841fa9d981ab242bb2c1b09f27e5da05bc	refs/heads/master\n", fmt.Errorf("")),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			if test.command != nil {
+				defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
+				util.DefaultExecCommand = test.command
+			}
+
+			actual, err := getCurrentCommit(test.url)
+			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, actual)
+		})
+	}
+}
+
+func TestGetHeadRef(t *testing.T) {
+	var tests = []struct {
+		description string
+		url         string
+		command     util.Command
+		expected    string
+		shouldErr   bool
+	}{
+		{
+			description: "correct",
+			expected:    "a143d3841fa9d981ab242bb2c1b09f27e5da05bc",
+			command:     testutil.NewFakeCmdOut("git rev-parse master", "a143d3841fa9d981ab242bb2c1b09f27e5da05bc", nil),
+		},
+		{
+			description: "error",
+			shouldErr:   true,
+			command:     testutil.NewFakeCmdOut("git rev-parse master", "a143d3841fa9d981ab242bb2c1b09f27e5da05bc", fmt.Errorf("")),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			if test.command != nil {
+				defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
+				util.DefaultExecCommand = test.command
+			}
+
+			actual, err := getHeadRef()
+			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, actual)
+		})
+	}
+}
+
+const diffOutput = `cmd/skaffold/app/cmd/cmd.go
+pkg/skaffold/config/options.go
+pkg/skaffold/runner/runner.go
+pkg/skaffold/watch/artifacts.go
+pkg/skaffold/watch/watch.go
+`
+
+var expectedDiffOutput = []string{
+	"cmd/skaffold/app/cmd/cmd.go",
+	"pkg/skaffold/config/options.go",
+	"pkg/skaffold/runner/runner.go",
+	"pkg/skaffold/watch/artifacts.go",
+	"pkg/skaffold/watch/watch.go",
+}
+
+func TestComputeGitDiff(t *testing.T) {
+	var tests = []struct {
+		description string
+		srcRef      string
+		targetRef   string
+		url         string
+		command     util.Command
+		expected    []string
+		shouldErr   bool
+	}{
+		{
+			description: "correct",
+			srcRef:      "a143d3841fa9d981ab242bb2c1b09f27e5da05bc",
+			targetRef:   "d779f0e0558998943c9bd45970513e7408fa9c64",
+			expected:    expectedDiffOutput,
+			command:     testutil.NewFakeCmdOut("git diff --name-only a143d3841fa9d981ab242bb2c1b09f27e5da05bc d779f0e0558998943c9bd45970513e7408fa9c64", diffOutput, nil),
+		},
+		{
+			description: "error",
+			srcRef:      "a143d3841fa9d981ab242bb2c1b09f27e5da05bc",
+			targetRef:   "d779f0e0558998943c9bd45970513e7408fa9c64",
+			shouldErr:   true,
+			command:     testutil.NewFakeCmdOut("git diff --name-only a143d3841fa9d981ab242bb2c1b09f27e5da05bc d779f0e0558998943c9bd45970513e7408fa9c64", diffOutput, fmt.Errorf(""))},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			if test.command != nil {
+				defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
+				util.DefaultExecCommand = test.command
+			}
+
+			actual, err := computeGitDiff(test.srcRef, test.targetRef)
+			fmt.Println(actual)
+			sort.Strings(actual)
+			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, actual)
+		})
+	}
+}

--- a/pkg/skaffold/watch/git_repo_test.go
+++ b/pkg/skaffold/watch/git_repo_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package watch
 
 import (


### PR DESCRIPTION
Adds another implementation of the filewatcher interface that watches a remote git repository and runs the normal `skaffold dev` workflow off that.

Works exactly like the `skaffold dev` workflow except changes are triggered by new commits instead of file change events.

UX:

`$ skaffold dev --git-repository https://github.com/r2d4/saffold`

Behavior:
* Clones repository into a temporary directory
* Watches for new commits (only to master for now)
* Computes the file diff between last build and current commit
* Conditionally rebuilds artifacts/redeploys based on the rules already computed by skaffold

