### PR TITLE
Try to guess GCB projectID from the image name

### DIFF
--- a/pkg/skaffold/build/container_builder_test.go
+++ b/pkg/skaffold/build/container_builder_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestGuessProjectID(t *testing.T) {
+	var tests = []struct {
+		description string
+		config      *v1alpha2.GoogleCloudBuild
+		artifact    *v1alpha2.Artifact
+		expected    string
+		shouldErr   bool
+	}{
+		{
+			description: "fixed projectId",
+			config:      &v1alpha2.GoogleCloudBuild{ProjectID: "fixed"},
+			artifact:    &v1alpha2.Artifact{ImageName: "any"},
+			expected:    "fixed",
+		},
+		{
+			description: "gcr.io",
+			config:      &v1alpha2.GoogleCloudBuild{},
+			artifact:    &v1alpha2.Artifact{ImageName: "gcr.io/project/image"},
+			expected:    "project",
+		},
+		{
+			description: "eu.gcr.io",
+			config:      &v1alpha2.GoogleCloudBuild{},
+			artifact:    &v1alpha2.Artifact{ImageName: "gcr.io/project/image"},
+			expected:    "project",
+		},
+		{
+			description: "docker hub",
+			config:      &v1alpha2.GoogleCloudBuild{},
+			artifact:    &v1alpha2.Artifact{ImageName: "project/image"},
+			shouldErr:   true,
+		},
+		{
+			description: "invalid GCR image",
+			config:      &v1alpha2.GoogleCloudBuild{},
+			artifact:    &v1alpha2.Artifact{ImageName: "gcr.io"},
+			shouldErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			builder := NewGoogleCloudBuilder(test.config)
+
+			projectID, err := builder.guessProjectID(test.artifact)
+
+			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, projectID)
+		})
+	}
+}


### PR DESCRIPTION
If a GCB projectId is not provided, we try to get the project from the names of the images.

That helps writing skaffold that are a bit more portable.

Signed-off-by: David Gageot <david@gageot.net>