### PR TITLE
calculate version from git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,14 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Bump these on release
-VERSION_MAJOR ?= 0
-VERSION_MINOR ?= 9
-VERSION_BUILD ?= 0
-
-VERSION ?= v$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUILD)
-
 GOOS ?= $(shell go env GOOS)
 GOARCH = amd64
 BUILD_DIR ?= ./out
@@ -42,6 +34,7 @@ BUILD_PACKAGE = $(REPOPATH)/cmd/skaffold
 
 VERSION_PACKAGE = $(REPOPATH)/pkg/skaffold/version
 COMMIT = $(shell git rev-parse HEAD)
+VERSION = $(shell git describe --always --tags --dirty)
 
 GO_LDFLAGS :="
 GO_LDFLAGS += -X $(VERSION_PACKAGE).version=$(VERSION)


### PR DESCRIPTION
I think this should be fine now that we have all the release binaries automated triggered by git tag.

Fixes #813 