### PR TITLE
Add 'status' command for showing information about the skaffold runner

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -55,6 +55,14 @@ Use for:
 
 -  Continuous integration or continuous deployment pipelines
 -  Sanity checking after iterating on your application
+
+=== skaffold fix
+Automatically updates a older version of a skaffold config to the latest version, setting defaults where appropriate.
+Useful for running an updated version of skaffold on a repository which was set up with an older version.
+
+=== skaffold status
+Prints information about the skaffold runner to the console. Useful for sanity checking how skaffold is set up to run
+on a repository without actually building and deploying to a cluster, as well as debugging a skaffold config.
 //end::operatingmodes[]
 
 //tag::demo[]

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -61,6 +61,7 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 	rootCmd.AddCommand(NewCmdDeploy(out))
 	rootCmd.AddCommand(NewCmdDelete(out))
 	rootCmd.AddCommand(NewCmdFix(out))
+	rootCmd.AddCommand(NewCmdStatus(out))
 	rootCmd.AddCommand(NewCmdDocker(out))
 
 	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", constants.DefaultLogLevel.String(), "Log level (debug, info, warn, error, fatal, panic")

--- a/cmd/skaffold/app/cmd/status.go
+++ b/cmd/skaffold/app/cmd/status.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var statusTemplateFlag = flags.NewTemplateFlag(status.DefaultTemplate, status.Status{})
+
+// NewCmdStatus describes the CLI command to retrieve information about a skaffold run
+func NewCmdStatus(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Prints information about the builder/tagger/deployer associated with a skaffold run",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return GetStatus(out, filename)
+		},
+	}
+	AddRunDevFlags(cmd)
+
+	cmd.Flags().StringVarP(&opts.CustomTag, "tag", "t", "", "The optional custom tag to use for images which overrides the current Tagger configuration")
+	return cmd
+}
+
+func GetStatus(out io.Writer, filename string) error {
+	runner, _, err := newRunner(filename)
+	if err != nil {
+		return errors.Wrap(err, "creating runner")
+	}
+
+	status, err := runner.Status()
+	if err != nil {
+		return errors.Wrap(err, "retrieving status")
+	}
+
+	if err := statusTemplateFlag.Template().Execute(out, status); err != nil {
+		return errors.Wrap(err, "executing template")
+	}
+	return nil
+}

--- a/pkg/skaffold/build/build.go
+++ b/pkg/skaffold/build/build.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 )
 
 // Artifact is the result corresponding to each successful build.
@@ -38,4 +39,8 @@ type Builder interface {
 	Labels() map[string]string
 
 	Build(ctx context.Context, out io.Writer, tagger tag.Tagger, artifacts []*v1alpha2.Artifact) ([]Artifact, error)
+
+	// BuildInfo returns relevant attributes about the builder to be
+	// outputted to the user.
+	BuildInfo() status.BuilderInfo
 }

--- a/pkg/skaffold/build/container_builder.go
+++ b/pkg/skaffold/build/container_builder.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 	"github.com/docker/distribution/reference"
@@ -83,6 +84,13 @@ func NewGoogleCloudBuilder(cfg *v1alpha2.GoogleCloudBuild) *GoogleCloudBuilder {
 func (cb *GoogleCloudBuilder) Labels() map[string]string {
 	return map[string]string{
 		constants.Labels.Builder: "google-cloud-builder",
+	}
+}
+
+func (cb *GoogleCloudBuilder) BuildInfo() status.BuilderInfo {
+	return status.BuilderInfo{
+		Name:      "Google Cloud Builder",
+		ProjectID: cb.ProjectID,
 	}
 }
 

--- a/pkg/skaffold/build/kaniko.go
+++ b/pkg/skaffold/build/kaniko.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
@@ -50,6 +51,16 @@ func NewKanikoBuilder(cfg *v1alpha2.KanikoBuild) *KanikoBuilder {
 func (k *KanikoBuilder) Labels() map[string]string {
 	return map[string]string{
 		constants.Labels.Builder: "kaniko",
+	}
+}
+
+func (k *KanikoBuilder) BuildInfo() status.BuilderInfo {
+	return status.BuilderInfo{
+		Name:           "Kaniko",
+		Namespace:      k.Namespace,
+		GCSBucket:      k.GCSBucket,
+		PullSecretName: k.PullSecretName,
+		PullSecret:     k.PullSecret,
 	}
 }
 

--- a/pkg/skaffold/build/local.go
+++ b/pkg/skaffold/build/local.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -70,6 +71,13 @@ func (l *LocalBuilder) Labels() map[string]string {
 		labels[constants.Labels.DockerAPIVersion] = fmt.Sprintf("%v", v.APIVersion)
 	}
 	return labels
+}
+
+func (l *LocalBuilder) BuildInfo() status.BuilderInfo {
+	return status.BuilderInfo{
+		Name:        "Local Builder",
+		KubeContext: l.kubeContext,
+	}
 }
 
 // Build runs a docker build on the host and tags the resulting image with

--- a/pkg/skaffold/build/local_test.go
+++ b/pkg/skaffold/build/local_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	"github.com/docker/docker/api/types"
@@ -44,6 +45,10 @@ func (f *FakeTagger) GenerateFullyQualifiedImageName(workingDir string, tagOpts 
 
 func (f *FakeTagger) Labels() map[string]string {
 	return map[string]string{}
+}
+
+func (f *FakeTagger) TaggerInfo() status.TaggerInfo {
+	return status.TaggerInfo{}
 }
 
 type testAuthHelper struct{}

--- a/pkg/skaffold/build/tag/custom.go
+++ b/pkg/skaffold/build/tag/custom.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 )
 
 type CustomTag struct {
@@ -29,6 +30,13 @@ type CustomTag struct {
 func (c *CustomTag) Labels() map[string]string {
 	return map[string]string{
 		constants.Labels.TagPolicy: "custom",
+	}
+}
+
+func (c *CustomTag) TaggerInfo() status.TaggerInfo {
+	return status.TaggerInfo{
+		Name: "Custom",
+		Tag:  c.Tag,
 	}
 }
 

--- a/pkg/skaffold/build/tag/date_time.go
+++ b/pkg/skaffold/build/tag/date_time.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 )
 
 const tagTime = "2006-01-02_15-04-05.999_MST"
@@ -45,6 +46,12 @@ func NewDateTimeTagger(format, timezone string) Tagger {
 func (tagger *dateTimeTagger) Labels() map[string]string {
 	return map[string]string{
 		constants.Labels.TagPolicy: "dateTimeTagger",
+	}
+}
+
+func (tagger *dateTimeTagger) TaggerInfo() status.TaggerInfo {
+	return status.TaggerInfo{
+		Name: "Datetime Tagger",
 	}
 }
 

--- a/pkg/skaffold/build/tag/env_template.go
+++ b/pkg/skaffold/build/tag/env_template.go
@@ -17,10 +17,12 @@ limitations under the License.
 package tag
 
 import (
+	"fmt"
 	"strings"
 	"text/template"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
 )
@@ -44,6 +46,13 @@ func NewEnvTemplateTagger(t string) (Tagger, error) {
 func (t *envTemplateTagger) Labels() map[string]string {
 	return map[string]string{
 		constants.Labels.TagPolicy: "envTemplateTagger",
+	}
+}
+
+func (t *envTemplateTagger) TaggerInfo() status.TaggerInfo {
+	return status.TaggerInfo{
+		Name:     "Env Template Tagger",
+		Template: fmt.Sprintf("%+v", t.Template),
 	}
 }
 

--- a/pkg/skaffold/build/tag/git_commit.go
+++ b/pkg/skaffold/build/tag/git_commit.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -37,6 +38,12 @@ type GitCommit struct{}
 func (c *GitCommit) Labels() map[string]string {
 	return map[string]string{
 		constants.Labels.TagPolicy: "git-commit",
+	}
+}
+
+func (c *GitCommit) TaggerInfo() status.TaggerInfo {
+	return status.TaggerInfo{
+		Name: "Git Commit Tagger",
 	}
 }
 

--- a/pkg/skaffold/build/tag/sha256.go
+++ b/pkg/skaffold/build/tag/sha256.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 )
 
 // ChecksumTagger tags an image by the sha256 of the image tarball
@@ -30,6 +31,12 @@ type ChecksumTagger struct {
 func (c *ChecksumTagger) Labels() map[string]string {
 	return map[string]string{
 		constants.Labels.TagPolicy: "sha256",
+	}
+}
+
+func (c *ChecksumTagger) TaggerInfo() status.TaggerInfo {
+	return status.TaggerInfo{
+		Name: "Checksum Tagger",
 	}
 }
 

--- a/pkg/skaffold/build/tag/tag.go
+++ b/pkg/skaffold/build/tag/tag.go
@@ -16,11 +16,19 @@ limitations under the License.
 
 package tag
 
+import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
+)
+
 // Tagger is an interface for tag strategies to be implemented against
 type Tagger interface {
 	Labels() map[string]string
 
 	GenerateFullyQualifiedImageName(workingDir string, tagOpts *Options) (string, error)
+
+	// TaggerInfo prints relevant information about the tagger
+	// to the provided writer.
+	TaggerInfo() status.TaggerInfo
 }
 
 type Options struct {

--- a/pkg/skaffold/config/profile_test.go
+++ b/pkg/skaffold/config/profile_test.go
@@ -81,7 +81,8 @@ func TestApplyProfiles(t *testing.T) {
 						GitTagger: &v1alpha2.GitTagger{},
 					},
 				},
-				Deploy: v1alpha2.DeployConfig{},
+				Deploy:          v1alpha2.DeployConfig{},
+				AppliedProfiles: []string{"profile"},
 			},
 		},
 		{
@@ -122,7 +123,8 @@ func TestApplyProfiles(t *testing.T) {
 						LocalBuild: &v1alpha2.LocalBuild{},
 					},
 				},
-				Deploy: v1alpha2.DeployConfig{},
+				Deploy:          v1alpha2.DeployConfig{},
+				AppliedProfiles: []string{"dev"},
 			},
 		},
 		{
@@ -175,7 +177,8 @@ func TestApplyProfiles(t *testing.T) {
 						LocalBuild: &v1alpha2.LocalBuild{},
 					},
 				},
-				Deploy: v1alpha2.DeployConfig{},
+				Deploy:          v1alpha2.DeployConfig{},
+				AppliedProfiles: []string{"profile"},
 			},
 		},
 		{
@@ -213,6 +216,7 @@ func TestApplyProfiles(t *testing.T) {
 						HelmDeploy: &v1alpha2.HelmDeploy{},
 					},
 				},
+				AppliedProfiles: []string{"profile"},
 			},
 		},
 	}

--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -22,6 +22,7 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -46,6 +47,10 @@ type Deployer interface {
 
 	// Cleanup deletes what was deployed by calling Deploy.
 	Cleanup(context.Context, io.Writer) error
+
+	// DeployInfo returns relevant attributes about the deployer to be
+	// outputted to the user.
+	DeployInfo() status.DeployerInfo
 }
 
 func joinTagsToBuildResult(builds []build.Artifact, params map[string]string) (map[string]build.Artifact, error) {

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -32,6 +32,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -58,6 +59,14 @@ func NewHelmDeployer(cfg *v1alpha2.HelmDeploy, kubeContext string, namespace str
 func (h *HelmDeployer) Labels() map[string]string {
 	return map[string]string{
 		constants.Labels.Deployer: "helm",
+	}
+}
+
+func (h *HelmDeployer) DeployInfo() status.DeployerInfo {
+	return status.DeployerInfo{
+		Name:      "Helm",
+		Namespace: h.namespace,
+		Releases:  h.Releases,
 	}
 }
 

--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -62,9 +63,22 @@ func (k *KubectlDeployer) Labels() map[string]string {
 	}
 }
 
-// Deploy templates the provided manifests with a simple `find and replace` and
-// runs `kubectl apply` on those manifests
-func (k *KubectlDeployer) Deploy(ctx context.Context, out io.Writer, builds []build.Artifact) ([]Artifact, error) {
+func (k *KubectlDeployer) DeployInfo() status.DeployerInfo {
+	files, err := k.manifestFiles(k.Manifests)
+	if err != nil {
+		logrus.Warn(err.Error())
+	}
+
+	return status.DeployerInfo{
+		Name:                "Kubectl",
+		WorkingDir:          k.workingDir,
+		KubeContext:         k.kubeContext,
+		ManifestPaths:       files,
+		RemoteManifestPaths: k.RemoteManifests,
+	}
+}
+
+func (k *KubectlDeployer) processManifestsForDeploy(builds []build.Artifact) (manifestList, error) {
 	manifests, err := k.readManifests()
 	if err != nil {
 		return nil, errors.Wrap(err, "reading manifests")
@@ -73,6 +87,16 @@ func (k *KubectlDeployer) Deploy(ctx context.Context, out io.Writer, builds []bu
 	manifests, err = manifests.replaceImages(builds)
 	if err != nil {
 		return nil, errors.Wrap(err, "replacing images in manifests")
+	}
+	return manifests, nil
+}
+
+// Deploy templates the provided manifests with a simple `find and replace` and
+// runs `kubectl apply` on those manifests
+func (k *KubectlDeployer) Deploy(ctx context.Context, out io.Writer, builds []build.Artifact) ([]Artifact, error) {
+	manifests, err := k.processManifestsForDeploy(builds)
+	if err != nil {
+		return nil, err
 	}
 
 	err = kubectl(manifests.reader(), out, k.kubeContext, k.Flags.Global, "apply", k.Flags.Apply, "-f", "-")

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
 )
@@ -46,6 +47,14 @@ func NewKustomizeDeployer(cfg *v1alpha2.KustomizeDeploy, kubeContext string) *Ku
 func (k *KustomizeDeployer) Labels() map[string]string {
 	return map[string]string{
 		constants.Labels.Deployer: "kustomize",
+	}
+}
+
+func (k *KustomizeDeployer) DeployInfo() status.DeployerInfo {
+	return status.DeployerInfo{
+		Name:          "Kustomize",
+		KustomizePath: k.KustomizePath,
+		KubeContext:   k.kubeContext,
 	}
 }
 

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/watch"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -148,7 +149,7 @@ func getTagger(t v1alpha2.TagPolicy, customTag string) (tag.Tagger, error) {
 	}
 }
 
-// Run builds artifacts ad then deploys them.
+// Run builds artifacts and then deploys them.
 func (r *SkaffoldRunner) Run(ctx context.Context, out io.Writer, artifacts []*v1alpha2.Artifact) error {
 	bRes, err := r.Build(ctx, out, r.Tagger, artifacts)
 	if err != nil {
@@ -208,6 +209,15 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*v1
 
 	watcher := r.watchFactory(deployDeps, artifacts, PollInterval)
 	return nil, watcher.Run(ctx, onDeploymentsChange, onArtifactChange)
+}
+
+// Status returns information about the builder/tagger/deployer.
+func (r *SkaffoldRunner) Status() (*status.Status, error) {
+	return &status.Status{
+		BuilderInfo:  r.BuildInfo(),
+		TaggerInfo:   r.TaggerInfo(),
+		DeployerInfo: r.DeployInfo(),
+	}, nil
 }
 
 // buildAndDeploy builds a subset of the artifacts and deploys everything.

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -46,6 +46,7 @@ type SkaffoldRunner struct {
 
 	watchFactory watch.Factory
 	builds       []build.Artifact
+	status.ConfigInfo
 }
 
 // NewForConfig returns a new SkaffoldRunner for a SkaffoldConfig
@@ -78,6 +79,9 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *config.SkaffoldConfig) (*Sk
 	}
 
 	return &SkaffoldRunner{
+		ConfigInfo: status.ConfigInfo{
+			Profiles: cfg.AppliedProfiles,
+		},
 		Builder:      builder,
 		Deployer:     deployer,
 		Tagger:       tagger,
@@ -214,6 +218,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*v1
 // Status returns information about the builder/tagger/deployer.
 func (r *SkaffoldRunner) Status() (*status.Status, error) {
 	return &status.Status{
+		ConfigInfo:   r.ConfigInfo,
 		BuilderInfo:  r.BuildInfo(),
 		TaggerInfo:   r.TaggerInfo(),
 		DeployerInfo: r.DeployInfo(),

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/watch"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	clientgo "k8s.io/client-go/kubernetes"
@@ -43,6 +44,10 @@ type TestBuilder struct {
 
 func (t *TestBuilder) Labels() map[string]string {
 	return map[string]string{}
+}
+
+func (t *TestBuilder) BuildInfo() status.BuilderInfo {
+	return status.BuilderInfo{}
 }
 
 func (t *TestBuilder) Build(ctx context.Context, w io.Writer, tagger tag.Tagger, artifacts []*v1alpha2.Artifact) ([]build.Artifact, error) {
@@ -71,6 +76,10 @@ type TestDeployer struct {
 
 func (t *TestDeployer) Labels() map[string]string {
 	return map[string]string{}
+}
+
+func (t *TestDeployer) DeployInfo() status.DeployerInfo {
+	return status.DeployerInfo{}
 }
 
 func (t *TestDeployer) Dependencies() ([]string, error) {

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -30,6 +30,8 @@ type SkaffoldConfig struct {
 	Build    BuildConfig  `yaml:"build,omitempty"`
 	Deploy   DeployConfig `yaml:"deploy,omitempty"`
 	Profiles []Profile    `yaml:"profiles,omitempty"`
+
+	AppliedProfiles []string
 }
 
 func (c *SkaffoldConfig) GetVersion() string {

--- a/pkg/skaffold/schema/v1alpha2/profiles.go
+++ b/pkg/skaffold/schema/v1alpha2/profiles.go
@@ -58,7 +58,9 @@ func applyProfile(config *SkaffoldConfig, profile Profile) error {
 		return err
 	}
 
-	return yaml.Unmarshal(buf, config)
+	err = yaml.Unmarshal(buf, config)
+	config.AppliedProfiles = append(config.AppliedProfiles, profile.Name)
+	return err
 }
 
 func profilesByName(profiles []Profile) map[string]Profile {

--- a/pkg/skaffold/status/status.go
+++ b/pkg/skaffold/status/status.go
@@ -21,7 +21,8 @@ import (
 )
 
 const DefaultTemplate = `
---- Skaffold Status ---
+--- Skaffold Status ---{{if .ConfigInfo.Profiles}}
+Applied Profiles: {{range $prof := .ConfigInfo.Profiles}}{{$prof}} {{end}}{{end}}
 
 -- Builder
 Type: {{.BuilderInfo.Name}}{{if .BuilderInfo.ProjectID}}
@@ -65,9 +66,14 @@ Helm Releases:
 `
 
 type Status struct {
+	ConfigInfo
 	BuilderInfo
 	TaggerInfo
 	DeployerInfo
+}
+
+type ConfigInfo struct {
+	Profiles []string
 }
 
 type BuilderInfo struct {

--- a/pkg/skaffold/status/status.go
+++ b/pkg/skaffold/status/status.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+)
+
+const DefaultTemplate = `
+--- Skaffold Status ---
+
+-- Builder
+Type: {{.BuilderInfo.Name}}{{if .BuilderInfo.ProjectID}}
+Project ID: {{.BuilderInfo.ProjectID}}{{end}}{{if .BuilderInfo.Namespace}}
+Namespace: {{.BuilderInfo.Namespace}}{{end}}{{if .BuilderInfo.KubeContext}}
+KubeContext: {{.BuilderInfo.KubeContext}}{{end}}{{if .BuilderInfo.GCSBucket}}
+GCS Bucket: {{.BuilderInfo.GCSBucket}}{{end}}{{if .BuilderInfo.PullSecretName}}
+Pull Secret Name: {{.BuilderInfo.PullSecretName}}{{end}}{{if .BuilderInfo.PullSecret}}
+Pull Secret: {{.BuilderInfo.PullSecret}}{{end}}
+
+-- Tagger
+Type: {{.TaggerInfo.Name}}{{if .TaggerInfo.Tag}}
+Tag: {{.TaggerInfo.Tag}}{{end}}{{if .TaggerInfo.Template}}
+Template: {{.TaggerInfo.Template}}{{end}}
+
+-- Deployer
+Type: {{.DeployerInfo.Name}}{{if .DeployerInfo.KustomizePath}}
+Kustomize Path: {{.DeployerInfo.KustomizePath}}{{end}}{{if .DeployerInfo.Namespace}}
+Namespace: {{.DeployerInfo.Namespace}}{{end}}{{if .DeployerInfo.WorkingDir}}
+Working Dir: {{.DeployerInfo.WorkingDir}}{{end}}{{if .DeployerInfo.KubeContext}}
+KubeContext: {{.DeployerInfo.KubeContext}}{{end}}{{if .DeployerInfo.RemoteManifestPaths}}
+RemoteManifests:
+{{range $path := .DeployerInfo.RemoteManifestPaths}}  - {{$path}}
+{{end}}{{end}}{{if .DeployerInfo.ManifestPaths}}
+Manifests:
+{{range $path := .DeployerInfo.ManifestPaths}}  - {{$path}}
+{{end}}{{end}}{{if .DeployerInfo.Releases}}
+Helm Releases:
+{{range $release := .DeployerInfo.Releases}}{{if $release.Version}}  - Version: {{$.release.Version}}
+{{end}}{{if $release.ChartPath}}  - Chart Path: {{$release.ChartPath}}
+{{end}}{{if $release.ValuesFilePath}} - Values File Path: {{$release.ValuesFilePath}}
+{{end}}{{if $release.Values}}  - Values:
+{{range $key, $value := $release.Values}}   - {{$key}}: {{$value}}{{end}}
+{{end}}{{if $release.SetValues}}  - Set Values:
+{{range $key, $value := $release.SetValues}}   - {{$key}}: {{$value}}{{end}}
+{{end}}{{if $release.SetValueTemplates}}  - Set Value Templates:
+{{range $key, $value := $release.SetValueTemplates}}   - {{$key}}: {{$value}}{{end}}
+{{end}}{{if $release.Wait}}  - Wait: {{$release.Wait}}
+{{end}}{{if $release.Packaged}}  - App Packaging: {{$release.Packaged}}
+{{end}}{{end}}{{end}}
+`
+
+type Status struct {
+	BuilderInfo
+	TaggerInfo
+	DeployerInfo
+}
+
+type BuilderInfo struct {
+	Name string // required
+
+	// GCB
+	ProjectID   string
+	Namespace   string
+	KubeContext string
+
+	// Kaniko
+	GCSBucket      string
+	PullSecretName string
+	PullSecret     string
+}
+
+type TaggerInfo struct {
+	Name string // required
+	Tag  string
+
+	// Env Template
+	Template string
+}
+
+type DeployerInfo struct {
+	Name string // required
+
+	// helm
+	Namespace string
+	Releases  []v1alpha2.HelmRelease
+
+	// kubectl
+	WorkingDir          string
+	KubeContext         string
+	ManifestPaths       []string
+	RemoteManifestPaths []string
+
+	// kustomize
+	KustomizePath string
+}


### PR DESCRIPTION
This adds a new command, `status`, that prints information about the skaffold runner to the console without actually running skaffold. This can be used to gain information about the skaffold configuration prior to building or deploying any images.

Fixes #726 

Example output in the `examples/getting-started` directory:
```
--- Skaffold Status ---

-- Builder
Type: Local Builder
KubeContext: gke_test-project_us-west1-a_test

-- Tagger
Type: Git Commit Tagger

-- Deployer
Type: Kubectl
Working Dir: /Development/go/src/github.com/GoogleContainerTools/skaffold/examples/getting-started
KubeContext: gke_test-project_us-west1-a_test
Manifests:
  - /Development/go/src/github.com/GoogleContainerTools/skaffold/examples/getting-started/k8s-pod.yaml
```

and in the `examples/helm-deployment` directory:
```
--- Skaffold Status ---

-- Builder
Type: Local Builder
KubeContext: gke_test-project_us-west1-a_test

-- Tagger
Type: Checksum Tagger

-- Deployer
Type: Helm
Helm Releases:
  - Chart Path: skaffold-helm
  - Values:
   - image: gcr.io/k8s-skaffold/skaffold-helm
```

### Future Work
* ~Printing flag and options information (e.g. profiles)~

* `skaffold dev --dry-run`: We could take this one step further and actually do the image tag and registry resolution for the build and deploy runs, and print this information to the user. This could be really useful in determining what skaffold would actually do in a run, without executing that run.