### PR TITLE
add support for helm image convention vs fqn setting

### DIFF
--- a/examples/helm-deployment/skaffold-helm/templates/deployment.yaml
+++ b/examples/helm-deployment/skaffold-helm/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           command: ["/bin/bash", "-c", "--" ]
           args: ["while true; do sleep 30; done;"]

--- a/examples/helm-deployment/skaffold-helm/templates/deployment.yaml
+++ b/examples/helm-deployment/skaffold-helm/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: {{ .Chart.Name }}
-          image: {{ .Values.image }}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           command: ["/bin/bash", "-c", "--" ]
           args: ["while true; do sleep 30; done;"]

--- a/examples/helm-deployment/skaffold-helm/values.yaml
+++ b/examples/helm-deployment/skaffold-helm/values.yaml
@@ -2,10 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
-image:
-  repository: nginx
-  tag: stable
-  pullPolicy: IfNotPresent
+image: nginx:stable
+# This is the helm convention on declaring images
+# image:
+#   repository: nginx
+#   tag: stable
+#   pullPolicy: IfNotPresent
 service:
   name: nginx
   type: ClusterIP

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -128,12 +128,12 @@ func (h *HelmDeployer) deployRelease(out io.Writer, r v1alpha2.HelmRelease, buil
 	var setOpts []string
 	for k, v := range params {
 		setOpts = append(setOpts, "--set")
-		if r.ImageStrategy.HelmImageConfig.HelmFQNConfig != nil {
-			setOpts = append(setOpts, fmt.Sprintf("%s=%s", k, v.Tag))
-		} else {
+		if r.ImageStrategy.HelmImageConfig.HelmConventionConfig != nil {
 			tagSplit := strings.Split(v.Tag, ":")
 			imageRepositoryTag := fmt.Sprintf("%s.repository=%s,%s.tag=%s", k, tagSplit[0], k, tagSplit[1])
 			setOpts = append(setOpts, imageRepositoryTag)
+		} else {
+			setOpts = append(setOpts, fmt.Sprintf("%s=%s", k, v.Tag))
 		}
 	}
 

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -128,7 +128,14 @@ func (h *HelmDeployer) deployRelease(out io.Writer, r v1alpha2.HelmRelease, buil
 	var setOpts []string
 	for k, v := range params {
 		setOpts = append(setOpts, "--set")
-		setOpts = append(setOpts, fmt.Sprintf("%s=%s", k, v.Tag))
+		if r.ImageStrategy.HelmImageConfig.HelmFQNConfig != nil {
+			setOpts = append(setOpts, fmt.Sprintf("%s=%s", k, v.Tag))
+		} else {
+			tagSplit := strings.Split(v.Tag, ":")
+			imageRepository := fmt.Sprintf("%s.repository=%s", k, tagSplit[0])
+			imageTag := fmt.Sprintf("%s.tag=%s", k, tagSplit[1])
+			setOpts = append(setOpts, imageRepository, imageTag)
+		}
 	}
 
 	// First build dependencies.

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -132,9 +132,8 @@ func (h *HelmDeployer) deployRelease(out io.Writer, r v1alpha2.HelmRelease, buil
 			setOpts = append(setOpts, fmt.Sprintf("%s=%s", k, v.Tag))
 		} else {
 			tagSplit := strings.Split(v.Tag, ":")
-			imageRepository := fmt.Sprintf("%s.repository=%s", k, tagSplit[0])
-			imageTag := fmt.Sprintf("%s.tag=%s", k, tagSplit[1])
-			setOpts = append(setOpts, imageRepository, imageTag)
+			imageRepositoryTag := fmt.Sprintf("%s.repository=%s,%s.tag=%s", k, tagSplit[0], k, tagSplit[1])
+			setOpts = append(setOpts, imageRepositoryTag)
 		}
 	}
 

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -63,7 +63,7 @@ var testDeployConfig = &v1alpha2.HelmDeploy{
 				"some.key": "somevalue",
 			},
 			ImageStrategy: v1alpha2.HelmImageStrategy{
-				v1alpha2.HelmImageConfig{
+				HelmImageConfig: v1alpha2.HelmImageConfig{
 					HelmFQNConfig: &v1alpha2.HelmFQNConfig{},
 				},
 			},

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -62,11 +62,6 @@ var testDeployConfig = &v1alpha2.HelmDeploy{
 			SetValues: map[string]string{
 				"some.key": "somevalue",
 			},
-			ImageStrategy: v1alpha2.HelmImageStrategy{
-				HelmImageConfig: v1alpha2.HelmImageConfig{
-					HelmFQNConfig: &v1alpha2.HelmFQNConfig{},
-				},
-			},
 		},
 	},
 }
@@ -84,6 +79,11 @@ var testDeployHelmStyleConfig = &v1alpha2.HelmDeploy{
 			},
 			SetValues: map[string]string{
 				"some.key": "somevalue",
+			},
+			ImageStrategy: v1alpha2.HelmImageStrategy{
+				HelmImageConfig: v1alpha2.HelmImageConfig{
+					HelmConventionConfig: &v1alpha2.HelmConventionConfig{},
+				},
 			},
 		},
 	},

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -53,7 +54,30 @@ var testDeployConfig = &v1alpha2.HelmDeploy{
 			Name:      "skaffold-helm",
 			ChartPath: "examples/test",
 			Values: map[string]string{
-				"image.tag": "skaffold-helm",
+				"image": "skaffold-helm",
+			},
+			Overrides: map[string]interface{}{
+				"foo": "bar",
+			},
+			SetValues: map[string]string{
+				"some.key": "somevalue",
+			},
+			ImageStrategy: v1alpha2.HelmImageStrategy{
+				v1alpha2.HelmImageConfig{
+					HelmFQNConfig: &v1alpha2.HelmFQNConfig{},
+				},
+			},
+		},
+	},
+}
+
+var testDeployHelmStyleConfig = &v1alpha2.HelmDeploy{
+	Releases: []v1alpha2.HelmRelease{
+		{
+			Name:      "skaffold-helm",
+			ChartPath: "examples/test",
+			Values: map[string]string{
+				"image": "skaffold-helm",
 			},
 			Overrides: map[string]interface{}{
 				"foo": "bar",
@@ -71,7 +95,7 @@ var testDeployConfigParameterUnmatched = &v1alpha2.HelmDeploy{
 			Name:      "skaffold-helm",
 			ChartPath: "examples/test",
 			Values: map[string]string{
-				"image.tag": "skaffold-helm-unmatched",
+				"image": "skaffold-helm-unmatched",
 			},
 		},
 	},
@@ -83,7 +107,7 @@ var testDeployFooWithPackaged = &v1alpha2.HelmDeploy{
 			Name:      "foo",
 			ChartPath: "testdata/foo",
 			Values: map[string]string{
-				"image.tag": "foo",
+				"image": "foo",
 			},
 			Packaged: &v1alpha2.HelmPackaged{
 				Version:    "0.1.2",
@@ -203,11 +227,40 @@ func TestHelmDeploy(t *testing.T) {
 		{
 			description: "get failure should install not upgrade",
 			cmd: &MockHelm{
-				t:             t,
-				getResult:     fmt.Errorf("not found"),
+				t:         t,
+				getResult: fmt.Errorf("not found"),
+				installMatcher: func(cmd *exec.Cmd) bool {
+					expected := map[string]bool{fmt.Sprintf("image=%s", testBuilds[0].Tag): true}
+					for _, arg := range cmd.Args {
+						if expected[arg] {
+							return true
+						}
+					}
+					return false
+				},
 				upgradeResult: fmt.Errorf("should not have called upgrade"),
 			},
 			deployer: NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace),
+			builds:   testBuilds,
+		},
+		{
+			description: "get failure should install not upgrade with helm image strategy",
+			cmd: &MockHelm{
+				t:         t,
+				getResult: fmt.Errorf("not found"),
+				installMatcher: func(cmd *exec.Cmd) bool {
+					builds := strings.Split(testBuilds[0].Tag, ":")
+					expected := map[string]bool{fmt.Sprintf("image.repository=%s,image.tag=%s", builds[0], builds[1]): true}
+					for _, arg := range cmd.Args {
+						if expected[arg] {
+							return true
+						}
+					}
+					return false
+				},
+				upgradeResult: fmt.Errorf("should not have called upgrade"),
+			},
+			deployer: NewHelmDeployer(testDeployHelmStyleConfig, testKubeContext, testNamespace),
 			builds:   testBuilds,
 		},
 		{
@@ -280,13 +333,18 @@ func TestHelmDeploy(t *testing.T) {
 	}
 }
 
+type CommandMatcher func(*exec.Cmd) bool
+
 type MockHelm struct {
 	t *testing.T
 
-	getResult     error
-	installResult error
-	upgradeResult error
-	depResult     error
+	getResult      error
+	getMatcher     CommandMatcher
+	installResult  error
+	installMatcher CommandMatcher
+	upgradeResult  error
+	upgradeMatcher CommandMatcher
+	depResult      error
 
 	packageOut    io.Reader
 	packageResult error
@@ -308,10 +366,19 @@ func (m *MockHelm) RunCmd(c *exec.Cmd) error {
 
 	switch c.Args[3] {
 	case "get":
+		if m.getMatcher != nil && !m.getMatcher(c) {
+			m.t.Errorf("get matcher failed to match cmd")
+		}
 		return m.getResult
 	case "install":
+		if m.installMatcher != nil && !m.installMatcher(c) {
+			m.t.Errorf("install matcher failed to match cmd")
+		}
 		return m.installResult
 	case "upgrade":
+		if m.upgradeMatcher != nil && !m.upgradeMatcher(c) {
+			m.t.Errorf("upgrade matcher failed to match cmd")
+		}
 		return m.upgradeResult
 	case "dep":
 		return m.depResult

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -150,6 +150,7 @@ type HelmRelease struct {
 	Wait              bool                   `yaml:"wait"`
 	Overrides         map[string]interface{} `yaml:"overrides"`
 	Packaged          *HelmPackaged          `yaml:"packaged"`
+	ImageStrategy     HelmImageStrategy      `yaml:"imageStrategy"`
 }
 
 // HelmPackaged represents parameters for packaging helm chart.
@@ -159,6 +160,24 @@ type HelmPackaged struct {
 
 	// AppVersion set the appVersion on the chart to this version
 	AppVersion string `yaml:"appVersion"`
+}
+
+type HelmImageStrategy struct {
+	HelmImageConfig `yaml:",inline"`
+}
+
+type HelmImageConfig struct {
+	HelmFQNConfig        *HelmFQNConfig        `yaml:"fqn"`
+	HelmConventionConfig *HelmConventionConfig `yaml:"helm"`
+}
+
+// HelmFQNConfig represents image config to use the FullyQualifiedImageName as param to set
+type HelmFQNConfig struct {
+	Property string `yaml:"property"`
+}
+
+// HelmConventionConfig represents image config in the syntax of image.repository and image.tag
+type HelmConventionConfig struct {
 }
 
 // Artifact represents items that need to be built, along with the context in which


### PR DESCRIPTION
This addresses the issue described in #360 
It will enable the user to determine if the image setup schema is using fully qualified named vs the Helm standard of `image.repository` and `image.tag`