### PR TITLE
Substitute build args from config into parsed Dockerfile before processing deps

### DIFF
--- a/cmd/skaffold/app/cmd/docker/context.go
+++ b/cmd/skaffold/app/cmd/docker/context.go
@@ -24,6 +24,7 @@ import (
 
 	cmdutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -46,7 +47,7 @@ func NewCmdContext(out io.Writer) *cobra.Command {
 func runContext(out io.Writer, filename, context string) error {
 	config, err := cmdutil.ParseConfig(filename)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "parsing skaffold config")
 	}
 	dockerFilePath, err := filepath.Abs(filename)
 	logrus.Info(filename)

--- a/cmd/skaffold/app/cmd/docker/context.go
+++ b/cmd/skaffold/app/cmd/docker/context.go
@@ -39,10 +39,7 @@ func NewCmdContext(out io.Writer) *cobra.Command {
 			return runContext(out, filename, context)
 		},
 	}
-	cmd.Flags().StringVarP(&filename, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
-	cmd.Flags().StringVarP(&dockerfile, "dockerfile", "d", "Dockerfile", "Dockerfile path")
-	cmd.Flags().StringVarP(&context, "context", "c", ".", "Dockerfile context path")
-	cmd.Flags().StringVarP(&output, "output", "o", "context.tar.gz", "Output filename.")
+	AddDockerFlags(cmd)
 	return cmd
 }
 

--- a/cmd/skaffold/app/cmd/docker/deps.go
+++ b/cmd/skaffold/app/cmd/docker/deps.go
@@ -60,7 +60,7 @@ func runDeps(out io.Writer, filename, dockerfile, context string) error {
 	}
 	config, err := cmdutil.ParseConfig(filename)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "parsing skaffold config")
 	}
 	// normalize the provided dockerfile path WRT to the context
 	normalizedPath, err := normalizeDockerfilePath(dockerfile, context)

--- a/cmd/skaffold/app/cmd/docker/flags.go
+++ b/cmd/skaffold/app/cmd/docker/flags.go
@@ -16,6 +16,17 @@ limitations under the License.
 
 package docker
 
+import (
+	"github.com/spf13/cobra"
+)
+
 var (
 	filename, dockerfile, context string
 )
+
+func AddDockerFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&filename, "filename", "f", "", "Filename or URL to the pipeline file")
+	cmd.Flags().StringVarP(&dockerfile, "dockerfile", "d", "Dockerfile", "Dockerfile path")
+	cmd.Flags().StringVarP(&context, "context", "c", "", "Dockerfile context path")
+	cmd.Flags().VarP(depsFormatFlag, "output", "o", depsFormatFlag.Usage())
+}

--- a/cmd/skaffold/app/cmd/docker/flags.go
+++ b/cmd/skaffold/app/cmd/docker/flags.go
@@ -17,5 +17,5 @@ limitations under the License.
 package docker
 
 var (
-	filename, context string
+	filename, dockerfile, context string
 )

--- a/cmd/skaffold/app/cmd/util/util.go
+++ b/cmd/skaffold/app/cmd/util/util.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/pkg/errors"
+)
+
+func ParseConfig(filename string) (*config.SkaffoldConfig, error) {
+	buf, err := util.ReadConfiguration(filename)
+	if err != nil {
+		return nil, errors.Wrap(err, "read skaffold config")
+	}
+
+	apiVersion := &config.APIVersion{}
+	if err := yaml.Unmarshal(buf, apiVersion); err != nil {
+		return nil, errors.Wrap(err, "parsing api version")
+	}
+
+	if apiVersion.Version != config.LatestVersion {
+		return nil, errors.New("Config version out of date: run `skaffold fix`")
+	}
+
+	cfg, err := config.GetConfig(buf, true)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing skaffold config")
+	}
+
+	// we already ensured that the versions match in the previous block,
+	// so this type assertion is safe.
+	return cfg.(*config.SkaffoldConfig), nil
+}

--- a/pkg/skaffold/build/deps.go
+++ b/pkg/skaffold/build/deps.go
@@ -30,7 +30,7 @@ var DependenciesForArtifact = dependenciesForArtifact
 func dependenciesForArtifact(a *v1alpha2.Artifact) ([]string, error) {
 	switch {
 	case a.DockerArtifact != nil:
-		return docker.GetDependencies(a.Workspace, a.DockerArtifact.DockerfilePath)
+		return docker.GetDependencies(map[string]*string{}, a.Workspace, a.DockerArtifact.DockerfilePath)
 
 	case a.BazelArtifact != nil:
 		return bazel.GetDependencies(a)

--- a/pkg/skaffold/docker/context.go
+++ b/pkg/skaffold/docker/context.go
@@ -25,8 +25,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-func CreateDockerTarContext(w io.Writer, context, dockerfilePath string) error {
-	paths, err := GetDependencies(context, dockerfilePath)
+func CreateDockerTarContext(buildArgs map[string]*string, w io.Writer, context, dockerfilePath string) error {
+	paths, err := GetDependencies(buildArgs, context, dockerfilePath)
 	if err != nil {
 		return errors.Wrap(err, "getting relative tar paths")
 	}
@@ -36,8 +36,8 @@ func CreateDockerTarContext(w io.Writer, context, dockerfilePath string) error {
 	return nil
 }
 
-func CreateDockerTarGzContext(w io.Writer, context, dockerfilePath string) error {
-	paths, err := GetDependencies(context, dockerfilePath)
+func CreateDockerTarGzContext(buildArgs map[string]*string, w io.Writer, context, dockerfilePath string) error {
+	paths, err := GetDependencies(buildArgs, context, dockerfilePath)
 	if err != nil {
 		return errors.Wrap(err, "getting relative tar paths")
 	}
@@ -55,7 +55,7 @@ func UploadContextToGCS(ctx context.Context, context, dockerfilePath, bucket, ob
 	defer c.Close()
 
 	w := c.Bucket(bucket).Object(objectName).NewWriter(ctx)
-	if err := CreateDockerTarGzContext(w, context, dockerfilePath); err != nil {
+	if err := CreateDockerTarGzContext(map[string]*string{}, w, context, dockerfilePath); err != nil {
 		return errors.Wrap(err, "uploading targz to google storage")
 	}
 	return w.Close()

--- a/pkg/skaffold/docker/context_test.go
+++ b/pkg/skaffold/docker/context_test.go
@@ -45,7 +45,7 @@ func TestDockerContext(t *testing.T) {
 	ioutil.WriteFile(filepath.Join(tmpDir, "alsoignored.txt"), []byte(""), 0644)
 	reader, writer := io.Pipe()
 	go func() {
-		err := CreateDockerTarContext(writer, tmpDir, "Dockerfile")
+		err := CreateDockerTarContext(map[string]*string{}, writer, tmpDir, "Dockerfile")
 		if err != nil {
 			writer.CloseWithError(err)
 		} else {

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -47,7 +47,7 @@ func RunBuild(ctx context.Context, out io.Writer, cli APIClient, workspace strin
 
 	buildCtx, buildCtxWriter := io.Pipe()
 	go func() {
-		err := CreateDockerTarContext(buildCtxWriter, workspace, opts.Dockerfile)
+		err := CreateDockerTarContext(opts.BuildArgs, buildCtxWriter, workspace, opts.Dockerfile)
 		if err != nil {
 			buildCtxWriter.CloseWithError(errors.Wrap(err, "creating docker context"))
 			return

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -39,7 +39,7 @@ import (
 // RetrieveImage is overriden for unit testing
 var RetrieveImage = retrieveImage
 
-func readDockerfile(buildArgs map[string]*string, workspace, absDockerfilePath string) ([]string, error) {
+func readDockerfile(workspace, absDockerfilePath string, buildArgs map[string]*string) ([]string, error) {
 	f, err := os.Open(absDockerfilePath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "opening dockerfile: %s", absDockerfilePath)
@@ -173,7 +173,7 @@ func GetDependencies(buildArgs map[string]*string, workspace, dockerfilePath str
 		absDockerfilePath = filepath.Join(workspace, dockerfilePath)
 	}
 
-	deps, err := readDockerfile(buildArgs, workspace, absDockerfilePath)
+	deps, err := readDockerfile(workspace, absDockerfilePath, buildArgs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/docker/parse_test.go
+++ b/pkg/skaffold/docker/parse_test.go
@@ -290,7 +290,7 @@ func TestGetDependencies(t *testing.T) {
 				ioutil.WriteFile(filepath.Join(workspace, ".dockerignore"), []byte(test.ignore), 0644)
 			}
 
-			deps, err := GetDependencies(workspace, "Dockerfile")
+			deps, err := GetDependencies(map[string]*string{}, workspace, "Dockerfile")
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, deps)
 		})
 	}

--- a/pkg/skaffold/docker/parse_test.go
+++ b/pkg/skaffold/docker/parse_test.go
@@ -113,6 +113,15 @@ FROM noimage:latest
 ADD ./file /etc/file
 `
 
+const copyServerGoBuildArg = `
+FROM ubuntu:14.04
+ARG FOO
+COPY $FOO .
+CMD $FOO
+`
+
+var fooArg = "server.go" // used for build args
+
 var ImageConfigs = map[string]*v1.ConfigFile{
 	"golang:onbuild": {
 		Config: v1.Config{
@@ -154,6 +163,7 @@ func TestGetDependencies(t *testing.T) {
 		dockerfile  string
 		workspace   string
 		ignore      string
+		buildArgs   map[string]*string
 
 		expected  []string
 		badReader bool
@@ -264,6 +274,13 @@ func TestGetDependencies(t *testing.T) {
 			workspace:   ".",
 			expected:    []string{"Dockerfile", "file"},
 		},
+		{
+			description: "build args",
+			dockerfile:  copyServerGoBuildArg,
+			workspace:   ".",
+			buildArgs:   map[string]*string{"FOO": &fooArg},
+			expected:    []string{"Dockerfile", "server.go"},
+		},
 	}
 
 	RetrieveImage = mockRetrieveImage
@@ -290,7 +307,7 @@ func TestGetDependencies(t *testing.T) {
 				ioutil.WriteFile(filepath.Join(workspace, ".dockerignore"), []byte(test.ignore), 0644)
 			}
 
-			deps, err := GetDependencies(map[string]*string{}, workspace, "Dockerfile")
+			deps, err := GetDependencies(test.buildArgs, workspace, "Dockerfile")
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, deps)
 		})
 	}


### PR DESCRIPTION
This PR passes the buildArgs from Docker artifacts in skaffold.yaml to the Docker dependency parser, which substitutes the args into the parsed Dockerfile AST before processing any other commands. This allows args to be substituted correctly when provided as a build arg and implicitly referenced in a Dockerfile, e.g.

skaffold.yaml
```yaml
build:
  artifacts:
  - imageName: foo/bar
    workspace: .
    docker:
      buildArgs:
        FOO: "bar"
```
Dockerfile
```
...
ARG FOO
COPY $FOO.txt /tmp/bar.txt
...
```
will now copy `bar.txt` to `/tmp/bar.txt`.

Fixes #777 