### PR TITLE
Faster code to get image digest

### DIFF
--- a/pkg/skaffold/build/local_test.go
+++ b/pkg/skaffold/build/local_test.go
@@ -160,12 +160,12 @@ func TestLocalRun(t *testing.T) {
 			shouldErr:   true,
 		},
 		{
-			description: "error image list",
+			description: "error image inspect",
 			out:         &testutil.BadWriter{},
 			artifacts:   []*v1alpha2.Artifact{{}},
 			tagger:      &tag.ChecksumTagger{},
 			api: testutil.NewFakeImageAPIClient(map[string]string{}, &testutil.FakeImageAPIOptions{
-				ErrImageList: true,
+				ErrImageInspect: true,
 			}),
 			shouldErr: true,
 		},

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -146,13 +146,13 @@ func TestDigest(t *testing.T) {
 			expected: "sha256:123abc",
 		},
 		{
-			description: "image list error",
+			description: "image inspect error",
 			imageName:   "test",
 			tagToImageID: map[string]string{
 				"test:latest": "sha256:123abc",
 			},
 			testOpts: &testutil.FakeImageAPIOptions{
-				ErrImageList: true,
+				ErrImageInspect: true,
 			},
 			shouldErr: true,
 		},
@@ -168,7 +168,9 @@ func TestDigest(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			api := testutil.NewFakeImageAPIClient(test.tagToImageID, test.testOpts)
+
 			digest, err := Digest(context.Background(), api, test.imageName)
+
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, digest)
 		})
 	}


### PR DESCRIPTION
Takes 3ms instead of 75ms of my machine

Since it’s done each time an image is built, that makes a difference!

Signed-off-by: David Gageot <david@gageot.net>