### PR TITLE
Shell out docker build

### DIFF
--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -62,19 +62,27 @@ build:
 # This next section is where you'll put your specific builder configuration.
   # Valid builders are `local`, `googleCloudBuild` and `kaniko.
   # Defaults to `local: {}`
-  # Example
+
+  # Pushing the images can be skipped. If no value is specified, it'll default to
+  # `true` on minikube or Docker for Desktop, for even faster build and deploy cycles.
+  # `false` on other types of kubernetes clusters that require pushing the images.
+  # skaffold defers to your ~/.docker/config for authentication information.
+  # If you're using Google Container Registry, make sure that you have gcloud and
+  # docker-credentials-helper-gcr configured correctly.
+  #
+  # By default, the local builder connects to the Docker daemon with Go code to build
+  # images. If `useDockerCLI` is set, skaffold will simply shell out to the docker CLI.
+  # `useBuildkit` can also be set to activate the experimental BuildKit feature.
+  #
   # local:
-    # Pushing the images can be skipped. If no value is specified, it'll default to
-    # `true` on minikube or Docker for Desktop, for even faster build and deploy cycles.
-    # `false` on other types of kubernetes clusters that require pushing the images.
-    # Skaffold defers to your ~/.docker/config for authentication information.
-    # If you're using Google Container Registry, make sure that you have gcloud and
-    # docker-credentials-helper-gcr configured correctly.
-    # skipPush: true
+  #   skipPush: true
+  #   useDockerCLI: false
+  #   useBuildkit: false
 
   # Docker artifacts can be built on Google Container Builder. The projectId then needs
   # to be provided and the currently logged user should be given permissions to trigger
   # new builds on GCB.
+  #
   #  googleCloudBuild:
   #   projectId: YOUR_PROJECT
 
@@ -82,7 +90,7 @@ build:
   # Sources will be sent to a GCS bucket whose name is provided.
   # Kaniko also needs access to a service account to push the final image.
   # See https://github.com/GoogleContainerTools/kaniko#running-kaniko-in-a-kubernetes-cluster
-  # Example
+  #
   # kaniko:
   #   gcsBucket: k8s-skaffold
   #   pullSecret: /a/secret/path/serviceaccount.json

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -183,6 +183,7 @@ func TestLocalRun(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			l := Builder{
+				cfg:          test.config,
 				api:          test.api,
 				localCluster: test.localCluster,
 			}

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -29,6 +29,8 @@ import (
 
 // Builder uses the host docker daemon to build and tag the image.
 type Builder struct {
+	cfg *v1alpha2.LocalBuild
+
 	api          docker.APIClient
 	localCluster bool
 	pushImages   bool
@@ -54,6 +56,7 @@ func NewBuilder(cfg *v1alpha2.LocalBuild, kubeContext string) (*Builder, error) 
 	}
 
 	return &Builder{
+		cfg:          cfg,
 		kubeContext:  kubeContext,
 		api:          api,
 		localCluster: localCluster,

--- a/pkg/skaffold/docker/context.go
+++ b/pkg/skaffold/docker/context.go
@@ -19,11 +19,25 @@ package docker
 import (
 	"context"
 	"io"
+	"path/filepath"
+	"strings"
 
 	cstorage "cloud.google.com/go/storage"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
 )
+
+// NormalizeDockerfilePath returns the absolute path to the dockerfile.
+func NormalizeDockerfilePath(context, dockerfile string) (string, error) {
+	if filepath.IsAbs(dockerfile) {
+		return dockerfile, nil
+	}
+
+	if !strings.HasPrefix(dockerfile, context) {
+		dockerfile = filepath.Join(context, dockerfile)
+	}
+	return filepath.Abs(dockerfile)
+}
 
 func CreateDockerTarContext(buildArgs map[string]*string, w io.Writer, context, dockerfilePath string) error {
 	paths, err := GetDependencies(buildArgs, context, dockerfilePath)

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -18,9 +18,12 @@ package docker
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
+	"sort"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -162,4 +165,28 @@ func RemoteDigest(identifier string) (string, error) {
 	}
 
 	return h.String(), nil
+}
+
+// GetBuildArgs gives the build args flags for docker build.
+func GetBuildArgs(a *v1alpha2.DockerArtifact) []string {
+	var args []string
+
+	var keys []string
+	for k := range a.BuildArgs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		args = append(args, "--build-arg")
+
+		v := a.BuildArgs[k]
+		if v == nil {
+			args = append(args, k)
+		} else {
+			args = append(args, fmt.Sprintf("%s=%s", k, *v))
+		}
+	}
+
+	return args
 }

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -25,8 +25,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	"github.com/docker/docker/api/types"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestMain(m *testing.M) {
@@ -173,5 +176,22 @@ func TestDigest(t *testing.T) {
 
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, digest)
 		})
+	}
+}
+
+func TestGetBuildArgs(t *testing.T) {
+	artifact := &v1alpha2.DockerArtifact{
+		BuildArgs: map[string]*string{
+			"key1": util.StringPtr("value1"),
+			"key2": nil,
+		},
+	}
+
+	arg := GetBuildArgs(artifact)
+	expected := []string{"--build-arg", "key1=value1", "--build-arg", "key2"}
+
+	if diff := cmp.Diff(arg, expected); diff != "" {
+		t.Errorf("%T differ (-got, +want): %s", expected, diff)
+		return
 	}
 }

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -168,9 +168,9 @@ func readDockerfile(workspace, absDockerfilePath string, buildArgs map[string]*s
 }
 
 func GetDependencies(buildArgs map[string]*string, workspace, dockerfilePath string) ([]string, error) {
-	absDockerfilePath := dockerfilePath
-	if !filepath.IsAbs(dockerfilePath) {
-		absDockerfilePath = filepath.Join(workspace, dockerfilePath)
+	absDockerfilePath, err := NormalizeDockerfilePath(workspace, dockerfilePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "normalizing dockerfile path")
 	}
 
 	deps, err := readDockerfile(workspace, absDockerfilePath, buildArgs)

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -79,7 +79,9 @@ type BuildType struct {
 // LocalBuild contains the fields needed to do a build on the local docker daemon
 // and optionally push to a repository.
 type LocalBuild struct {
-	SkipPush *bool `yaml:"skipPush"`
+	SkipPush     *bool `yaml:"skipPush"`
+	UseDockerCLI bool  `yaml:"useDockerCLI"`
+	UseBuildkit  bool  `yaml:"useBuildkit"`
 }
 
 // GoogleCloudBuild contains the fields needed to do a remote build on

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -127,6 +127,12 @@ func BoolPtr(b bool) *bool {
 	return &o
 }
 
+// StringPtr returns a pointer to a string
+func StringPtr(s string) *string {
+	o := s
+	return &o
+}
+
 func ReadConfiguration(filename string) ([]byte, error) {
 	switch {
 	case filename == "":


### PR DESCRIPTION
Support an alternative way of building locally by running `docker build` directly. This is also a good opportunity to let the user enable experimental buildkit.