### PR TITLE
Switch to gcr for the kaniko builder example.

### DIFF
--- a/examples/kaniko/Dockerfile
+++ b/examples/kaniko/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.1-alpine3.7
+FROM gcr.io/google-appengine/golang
 
 WORKDIR /go/src/github.com/GoogleCloudPlatform/skaffold
 CMD ["./app"]


### PR DESCRIPTION
The flake was a networking issue with Docker Hub. This might help.