### PR TITLE
Issue #836: Use releaseName to get release info.

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -236,7 +236,7 @@ func (h *HelmDeployer) deployRelease(out io.Writer, r v1alpha2.HelmRelease, buil
 	args = append(args, setOpts...)
 
 	helmErr := h.helm(out, args...)
-	return h.getDeployResults(ns, r.Name), helmErr
+	return h.getDeployResults(ns, releaseName), helmErr
 }
 
 // imageName if the given string includes a fully qualified docker image name then lets trim just the tag part out


### PR DESCRIPTION
The helm release name can be templated so within the `deployRelease`
function the `releaseName` variable should be used any time the release
name is desired.

This commit updates the final call to `getDeployResults` to properly use
the `releaseName` variable.

#836 