### PR TITLE
Fix watch git submodule and testing of watch

### DIFF
--- a/pkg/skaffold/watch/files.go
+++ b/pkg/skaffold/watch/files.go
@@ -29,7 +29,6 @@ import (
 )
 
 //TODO(@r2d4): Figure out best UX to support configuring this blacklist
-var ignoredFiles = []string{}
 var ignoredDirs = []string{"vendor", ".git"}
 
 // FileChangedFn is a function called when files where changed.
@@ -72,7 +71,7 @@ func walk(dirs []string) (fileMap, error) {
 				return err
 			}
 
-			if isIgnored(info.Name(), info.IsDir()) {
+			if info.IsDir() && isIgnored(info.Name()) {
 				return filepath.SkipDir
 			}
 
@@ -115,14 +114,8 @@ func computeDiff(prev, curr fileMap) []string {
 	return changes
 }
 
-func isIgnored(path string, isDir bool) bool {
-	var files []string
-	if isDir {
-		files = ignoredDirs
-	} else {
-		files = ignoredFiles
-	}
-	for _, i := range files {
+func isIgnored(path string) bool {
+	for _, i := range ignoredDirs {
 		if path == i {
 			return true
 		}

--- a/pkg/skaffold/watch/files.go
+++ b/pkg/skaffold/watch/files.go
@@ -29,7 +29,8 @@ import (
 )
 
 //TODO(@r2d4): Figure out best UX to support configuring this blacklist
-var ignored = []string{"vendor", ".git"}
+var ignoredFiles = []string{}
+var ignoredDirs = []string{"vendor", ".git"}
 
 // FileChangedFn is a function called when files where changed.
 type FileChangedFn func(changes []string) error
@@ -71,7 +72,7 @@ func walk(dirs []string) (fileMap, error) {
 				return err
 			}
 
-			if isIgnored(info.Name()) {
+			if isIgnored(info.Name(), info.IsDir()) {
 				return filepath.SkipDir
 			}
 
@@ -114,8 +115,14 @@ func computeDiff(prev, curr fileMap) []string {
 	return changes
 }
 
-func isIgnored(path string) bool {
-	for _, i := range ignored {
+func isIgnored(path string, isDir bool) bool {
+	var files []string
+	if isDir {
+		files = ignoredDirs
+	} else {
+		files = ignoredFiles
+	}
+	for _, i := range files {
 		if path == i {
 			return true
 		}


### PR DESCRIPTION
Resolve #859 

When using a git submodule as a workspace for build, any change done in it weren't picked by the watcher. This is because of `var ignored = []string{"vendor", ".git"}` and as soon as we walked over this [file|directory] name, a `filePath.SkipDir` was returned. This is legit in the case of a git repo, but on a submodule, `.git` is a file and there is no need to skip it.

I've split the ignore list in files and dir, but it could be a single list of directories.

Doing so, I've added a test to make sure it was working and discover that the watch test weren't doing enough. The `expectedChanges` list wasn't used and tested, because if the FileWatcher doesn't see any changes then it doesn't call the callback, and thus, the content of the diff is not tested.

I've added a test for assuring the callback is called.

I'm not sure though on how to allow the FileWatcher to run enough time to pick up the changes, maybe the Timer operations in watch_test need to be adapted 