### PR TITLE
Use deep copy instead of yaml.Unmarshal to overlay profile onto config

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -419,6 +419,14 @@
   revision = "d14ea06fba99483203c19d92cfcd13ebe73135f4"
 
 [[projects]]
+  branch = "master"
+  digest = "1:6c2f939d99ad2074a4113c36aa93fa792ede8ff0b8cdb97634b41b9c5da7fab6"
+  name = "github.com/jinzhu/copier"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "7e38e58719c33e0d44d585c4ab477a30f8cb82dd"
+
+[[projects]]
   digest = "1:0243cffa4a3410f161ee613dfdd903a636d07e838a42d341da95d81f42cd1d41"
   name = "github.com/json-iterator/go"
   packages = ["."]
@@ -1143,6 +1151,7 @@
     "github.com/google/go-containerregistry/pkg/v1/remote",
     "github.com/google/go-containerregistry/pkg/v1/remote/transport",
     "github.com/google/go-github/github",
+    "github.com/jinzhu/copier",
     "github.com/karrick/godirwalk",
     "github.com/mitchellh/go-homedir",
     "github.com/moby/buildkit/frontend/dockerfile/command",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -74,3 +74,7 @@
 [[constraint]]
   name = "github.com/google/go-github"
   version = "15.0.0"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/jinzhu/copier"

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -211,7 +211,7 @@ func GetDependencies(workspace string, a *v1alpha2.DockerArtifact) ([]string, er
 
 		fi, err := os.Stat(absDep)
 		if err != nil {
-			return nil, errors.Wrapf(err, "stating file %s")
+			return nil, errors.Wrapf(err, "stating file %s", absDep)
 		}
 
 		switch mode := fi.Mode(); {

--- a/pkg/skaffold/schema/v1alpha2/profiles.go
+++ b/pkg/skaffold/schema/v1alpha2/profiles.go
@@ -36,7 +36,7 @@ func (c *SkaffoldConfig) ApplyProfiles(profiles []string) error {
 			return fmt.Errorf("couldn't find profile %s", name)
 		}
 
-		err = applyProfile(c, &profile)
+		err = applyProfile(c, profile)
 		if err != nil {
 			return errors.Wrapf(err, "applying profile %s", name)
 		}
@@ -50,7 +50,7 @@ func (c *SkaffoldConfig) ApplyProfiles(profiles []string) error {
 	return nil
 }
 
-func applyProfile(config *SkaffoldConfig, profile *Profile) error {
+func applyProfile(config *SkaffoldConfig, profile Profile) error {
 	logrus.Infof("Applying profile: %s", profile.Name)
 
 	// artifacts are preserved from original config, so add them to the profile if they're not already there

--- a/vendor/github.com/jinzhu/copier/License
+++ b/vendor/github.com/jinzhu/copier/License
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Jinzhu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/jinzhu/copier/copier.go
+++ b/vendor/github.com/jinzhu/copier/copier.go
@@ -1,0 +1,185 @@
+package copier
+
+import (
+	"database/sql"
+	"errors"
+	"reflect"
+)
+
+// Copy copy things
+func Copy(toValue interface{}, fromValue interface{}) (err error) {
+	var (
+		isSlice bool
+		amount  = 1
+		from    = indirect(reflect.ValueOf(fromValue))
+		to      = indirect(reflect.ValueOf(toValue))
+	)
+
+	if !to.CanAddr() {
+		return errors.New("copy to value is unaddressable")
+	}
+
+	// Return is from value is invalid
+	if !from.IsValid() {
+		return
+	}
+
+	// Just set it if possible to assign
+	if from.Type().AssignableTo(to.Type()) {
+		to.Set(from)
+		return
+	}
+
+	fromType := indirectType(from.Type())
+	toType := indirectType(to.Type())
+
+	if fromType.Kind() != reflect.Struct || toType.Kind() != reflect.Struct {
+		return
+	}
+
+	if to.Kind() == reflect.Slice {
+		isSlice = true
+		if from.Kind() == reflect.Slice {
+			amount = from.Len()
+		}
+	}
+
+	for i := 0; i < amount; i++ {
+		var dest, source reflect.Value
+
+		if isSlice {
+			// source
+			if from.Kind() == reflect.Slice {
+				source = indirect(from.Index(i))
+			} else {
+				source = indirect(from)
+			}
+
+			// dest
+			dest = indirect(reflect.New(toType).Elem())
+		} else {
+			source = indirect(from)
+			dest = indirect(to)
+		}
+
+		// Copy from field to field or method
+		for _, field := range deepFields(fromType) {
+			name := field.Name
+
+			if fromField := source.FieldByName(name); fromField.IsValid() {
+				// has field
+				if toField := dest.FieldByName(name); toField.IsValid() {
+					if toField.CanSet() {
+						if !set(toField, fromField) {
+							if err := Copy(toField.Addr().Interface(), fromField.Interface()); err != nil {
+								return err
+							}
+						}
+					}
+				} else {
+					// try to set to method
+					var toMethod reflect.Value
+					if dest.CanAddr() {
+						toMethod = dest.Addr().MethodByName(name)
+					} else {
+						toMethod = dest.MethodByName(name)
+					}
+
+					if toMethod.IsValid() && toMethod.Type().NumIn() == 1 && fromField.Type().AssignableTo(toMethod.Type().In(0)) {
+						toMethod.Call([]reflect.Value{fromField})
+					}
+				}
+			}
+		}
+
+		// Copy from method to field
+		for _, field := range deepFields(toType) {
+			name := field.Name
+
+			var fromMethod reflect.Value
+			if source.CanAddr() {
+				fromMethod = source.Addr().MethodByName(name)
+			} else {
+				fromMethod = source.MethodByName(name)
+			}
+
+			if fromMethod.IsValid() && fromMethod.Type().NumIn() == 0 && fromMethod.Type().NumOut() == 1 {
+				if toField := dest.FieldByName(name); toField.IsValid() && toField.CanSet() {
+					values := fromMethod.Call([]reflect.Value{})
+					if len(values) >= 1 {
+						set(toField, values[0])
+					}
+				}
+			}
+		}
+
+		if isSlice {
+			if dest.Addr().Type().AssignableTo(to.Type().Elem()) {
+				to.Set(reflect.Append(to, dest.Addr()))
+			} else if dest.Type().AssignableTo(to.Type().Elem()) {
+				to.Set(reflect.Append(to, dest))
+			}
+		}
+	}
+	return
+}
+
+func deepFields(reflectType reflect.Type) []reflect.StructField {
+	var fields []reflect.StructField
+
+	if reflectType = indirectType(reflectType); reflectType.Kind() == reflect.Struct {
+		for i := 0; i < reflectType.NumField(); i++ {
+			v := reflectType.Field(i)
+			if v.Anonymous {
+				fields = append(fields, deepFields(v.Type)...)
+			} else {
+				fields = append(fields, v)
+			}
+		}
+	}
+
+	return fields
+}
+
+func indirect(reflectValue reflect.Value) reflect.Value {
+	for reflectValue.Kind() == reflect.Ptr {
+		reflectValue = reflectValue.Elem()
+	}
+	return reflectValue
+}
+
+func indirectType(reflectType reflect.Type) reflect.Type {
+	for reflectType.Kind() == reflect.Ptr || reflectType.Kind() == reflect.Slice {
+		reflectType = reflectType.Elem()
+	}
+	return reflectType
+}
+
+func set(to, from reflect.Value) bool {
+	if from.IsValid() {
+		if to.Kind() == reflect.Ptr {
+			//set `to` to nil if from is nil
+			if from.Kind() == reflect.Ptr && from.IsNil() {
+				to.Set(reflect.Zero(to.Type()))
+				return true
+			} else if to.IsNil() {
+				to.Set(reflect.New(to.Type().Elem()))
+			}
+			to = to.Elem()
+		}
+
+		if from.Type().ConvertibleTo(to.Type()) {
+			to.Set(from.Convert(to.Type()))
+		} else if scanner, ok := to.Addr().Interface().(sql.Scanner); ok {
+			err := scanner.Scan(from.Interface())
+			if err != nil {
+				return false
+			}
+		} else if from.Kind() == reflect.Ptr {
+			return set(to, from.Elem())
+		} else {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
This changes the code that applies config profiles to actually copy the profile values into the config using a deep copy, rather than unmarshalling the profile yaml over the config yaml. Two reasons why we should do this:

1)  Will allow us to use `yaml:omitEmpty` tags on the config fields more liberally, which makes printing out the marshalled yaml to the user nicer.
2) Gives us more control over the actual processing of the profile. If there are fields we want to explicitly persist or ignore from the original config, we can add exceptions for those here.