### PR TITLE
Fix edge cases in build arg processing

### DIFF
--- a/pkg/skaffold/docker/parse_test.go
+++ b/pkg/skaffold/docker/parse_test.go
@@ -121,6 +121,27 @@ COPY $FOO .
 CMD $FOO
 `
 
+const copyServerGoBuildArgCurlyBraces = `
+FROM ubuntu:14.04
+ARG FOO
+COPY ${FOO} .
+CMD ${FOO}
+`
+
+const copyServerGoBuildArgExtraWhitespace = `
+FROM ubuntu:14.04
+ARG  FOO
+COPY $FOO .
+CMD $FOO
+`
+
+const copyServerGoBuildArgDefaultValue = `
+FROM ubuntu:14.04
+ARG FOO=server.go
+COPY $FOO .
+CMD $FOO
+`
+
 var fooArg = "server.go" // used for build args
 
 var ImageConfigs = map[string]*v1.ConfigFile{
@@ -278,6 +299,33 @@ func TestGetDependencies(t *testing.T) {
 		{
 			description: "build args",
 			dockerfile:  copyServerGoBuildArg,
+			workspace:   ".",
+			buildArgs:   map[string]*string{"FOO": &fooArg},
+			expected:    []string{"Dockerfile", "server.go"},
+		},
+		{
+			description: "build args with curly braces",
+			dockerfile:  copyServerGoBuildArgCurlyBraces,
+			workspace:   ".",
+			buildArgs:   map[string]*string{"FOO": &fooArg},
+			expected:    []string{"Dockerfile", "server.go"},
+		},
+		{
+			description: "build args with extra whitespace",
+			dockerfile:  copyServerGoBuildArgExtraWhitespace,
+			workspace:   ".",
+			buildArgs:   map[string]*string{"FOO": &fooArg},
+			expected:    []string{"Dockerfile", "server.go"},
+		},
+		{
+			description: "build args with default value and buildArgs unset",
+			dockerfile:  copyServerGoBuildArgDefaultValue,
+			workspace:   ".",
+			expected:    []string{"Dockerfile", "server.go"},
+		},
+		{
+			description: "build args with default value and buildArgs set",
+			dockerfile:  copyServerGoBuildArgDefaultValue,
 			workspace:   ".",
 			buildArgs:   map[string]*string{"FOO": &fooArg},
 			expected:    []string{"Dockerfile", "server.go"},


### PR DESCRIPTION
With #828 recently merged I tested in some Dockerfiles where we are using build args.

The current implementation misses some functionality and does not handle a couple of edge cases mostly detailed in the documentation here https://docs.docker.com/engine/reference/builder/#arg

* Build Args support default values: `ARG <name>[=<default value>]`
* Docker parses instructions even when there is more than one space between the command and the value.  EX: `ARG  FOO` is valid
* Usage of the build arg can be done with curly braces eg: `COPY ${FOO}`

There are also two additional issues that I didn't have in my files, but should be handled to match the behavior of `docker build`... that are not currently handled by this PR

* Inline defaults: `COPY ${FOO:-server.go}`
* Args are scoped to replace values only below where they are declared in the Dockerfile: 
  For example if we have a build arg FOO set to `start`
   
  ```
  FROM ubuntu:14.04 
  COPY ${FOO:-server.go} .
  ARG  FOO
  CMD $FOO
  ```

  will evaluate to:

  ``` 
  FROM ubuntu:14.04
  COPY server.go .
  ARG  FOO
  CMD start
  ```

Additional tests have been added for the variations handled by this PR and pass for me.