### PR TITLE
fix version in released docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ integration: install $(BUILD_DIR)/$(PROJECT)
 release: cross docs $(BUILD_DIR)/VERSION
 	docker build \
         		-f deploy/skaffold/Dockerfile \
+        		-e VERSION=$(VERSION)		  \
         		--cache-from gcr.io/$(GCP_PROJECT)/skaffold-builder \
         		-t gcr.io/$(GCP_PROJECT)/skaffold:$(VERSION) .
 	gsutil -m cp $(BUILD_DIR)/$(PROJECT)-* $(GSC_RELEASE_PATH)/


### PR DESCRIPTION
since the build happens inside docker, we have to pass through the overridden version info

https://kubernetes.slack.com/archives/CABQMSZA6/p1533571310000477?thread_ts=1533292054.000118&cid=CABQMSZA6

