### PR TITLE
Fix minor lint errors surfaced by the 'misspell' and 'unparam' lint modules

### DIFF
--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -44,7 +44,7 @@ func GetConfig(contents []byte, useDefault bool) (util.VersionedConfig, error) {
 		cfg := schemaVersions[version]()
 		err := cfg.Parse(contents, useDefault)
 		if cfg.GetVersion() == version {
-			// Versions are same hence propogate the parse error.
+			// Versions are same hence propagate the parse error.
 			return cfg, err
 		}
 	}

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -38,7 +38,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// RetrieveImage is overriden for unit testing
+// RetrieveImage is overridden for unit testing
 var RetrieveImage = retrieveImage
 
 func readDockerfile(workspace, absDockerfilePath string, buildArgs map[string]*string) ([]string, error) {

--- a/pkg/skaffold/kubernetes/log.go
+++ b/pkg/skaffold/kubernetes/log.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 // Client is for tests
@@ -105,7 +104,7 @@ func (a *LogAggregator) Start(ctx context.Context) error {
 					}
 
 					if a.podSelector.Select(pod) {
-						go a.streamLogs(ctx, client, pod)
+						go a.streamLogs(ctx, pod)
 					}
 				}
 			}
@@ -115,7 +114,7 @@ func (a *LogAggregator) Start(ctx context.Context) error {
 	return nil
 }
 
-func (a *LogAggregator) streamLogs(ctx context.Context, client corev1.PodsGetter, pod *v1.Pod) error {
+func (a *LogAggregator) streamLogs(ctx context.Context, pod *v1.Pod) {
 	for _, container := range pod.Status.ContainerStatuses {
 		containerID := container.ContainerID
 		if containerID == "" || !container.Ready {
@@ -151,8 +150,6 @@ func (a *LogAggregator) streamLogs(ctx context.Context, client corev1.PodsGetter
 			a.trackedContainers.remove(containerID)
 		}()
 	}
-
-	return nil
 }
 
 func prefix(pod *v1.Pod, container v1.ContainerStatus) string {


### PR DESCRIPTION
- Remove unused client and error from streamLogs
- Fix minor spelling errors in comments

NOTE: The linter modules ("misspell" and "unparam") which found these are not yet enabled in Skaffold, but will be proposed in a subsequent PR.