### PR TITLE
Update golangci-lint to v1.9.3 and enable misspell+unparam modules

### DIFF
--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -20,15 +20,17 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if ! [ -x "$(command -v golangci-lint)" ]; then
 	echo "Installing GolangCI-Lint"
-	${DIR}/install_golint.sh -b $GOPATH/bin v1.8.1
+	${DIR}/install_golint.sh -b $GOPATH/bin v1.9.3
 fi
 
 golangci-lint run \
 	--no-config \
-	-E goimports \
-	-E interfacer \
-	-E golint \
-	-E unconvert \
 	-E goconst \
+	-E goimports \
+	-E golint \
+	-E interfacer \
 	-E maligned \
+	-E misspell \
+	-E unconvert \
+	-E unparam \
 	-D errcheck


### PR DESCRIPTION
Requires the following PR's to be submitted first to avoid test failures:

#883 "misspell" and "unparam" lint issues
#880 Add missing filename to error message