### PR TITLE
Add global skaffold config with list/set commands

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -79,6 +79,7 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 	rootCmd.AddCommand(NewCmdDeploy(out))
 	rootCmd.AddCommand(NewCmdDelete(out))
 	rootCmd.AddCommand(NewCmdFix(out))
+	rootCmd.AddCommand(NewCmdConfig(out))
 
 	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", constants.DefaultLogLevel.String(), "Log level (debug, info, warn, error, fatal, panic")
 

--- a/cmd/skaffold/app/cmd/config.go
+++ b/cmd/skaffold/app/cmd/config.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
+	"github.com/spf13/cobra"
+)
+
+func NewCmdConfig(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "A set of commands for interacting with the skaffold config.",
+	}
+
+	cmd.AddCommand(config.NewCmdSet(out))
+	cmd.AddCommand(config.NewCmdList(out))
+	return cmd
+}

--- a/cmd/skaffold/app/cmd/config/config.go
+++ b/cmd/skaffold/app/cmd/config/config.go
@@ -24,5 +24,5 @@ type ContextConfig struct {
 }
 
 type ContextValues struct {
-	DefaultRepo string `yaml:"default-repo,omitempty"`
+	// config values are added here
 }

--- a/cmd/skaffold/app/cmd/config/config.go
+++ b/cmd/skaffold/app/cmd/config/config.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+type Config = []*ContextConfig
+
+type ContextConfig struct {
+	Context string        `yaml:"context"`
+	Values  ContextValues `yaml:"values"`
+}
+
+type ContextValues struct {
+	DefaultRepo string `yaml:"default-repo,omitempty"`
+}

--- a/cmd/skaffold/app/cmd/config/flags.go
+++ b/cmd/skaffold/app/cmd/config/flags.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var configFile, kubectx string
+
+func AddConfigFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&configFile, "config", "c", "", "path to skaffold config")
+	cmd.Flags().StringVarP(&kubectx, "kubectx", "k", "", "kubectl context to set values against")
+}

--- a/cmd/skaffold/app/cmd/config/list.go
+++ b/cmd/skaffold/app/cmd/config/list.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	yaml "gopkg.in/yaml.v2"
+	"io"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+const defaultConfigLocation = "~/.skaffold/config"
+
+func NewCmdList(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all values set in the global skaffold config",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolveKubectlContext()
+			return runList(out)
+		},
+	}
+	AddConfigFlags(cmd)
+	return cmd
+}
+
+func runList(out io.Writer) error {
+	configs, err := getConfigsForKubectx()
+	if err != nil {
+		return err
+	}
+	configYaml, err := yaml.Marshal(&configs)
+	if err != nil {
+		return errors.Wrap(err, "marshaling config")
+	}
+
+	out.Write(configYaml)
+	return nil
+}

--- a/cmd/skaffold/app/cmd/config/list.go
+++ b/cmd/skaffold/app/cmd/config/list.go
@@ -24,12 +24,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultConfigLocation = "~/.skaffold/config"
-
 func NewCmdList(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all values set in the global skaffold config",
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolveKubectlContext()
 			return runList(out)

--- a/cmd/skaffold/app/cmd/config/set.go
+++ b/cmd/skaffold/app/cmd/config/set.go
@@ -32,12 +32,7 @@ func NewCmdSet(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set",
 		Short: "Set a value in the global skaffold config",
-		Args: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 2 {
-				return errors.New("Please provide field name and value to set")
-			}
-			return nil
-		},
+		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolveKubectlContext()
 			return setConfigValue(args[0], args[1])

--- a/cmd/skaffold/app/cmd/config/set.go
+++ b/cmd/skaffold/app/cmd/config/set.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"reflect"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func NewCmdSet(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set",
+		Short: "Set a value in the global skaffold config",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return errors.New("Please provide field name and value to set")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			resolveKubectlContext()
+			return setConfigValue(args[0], args[1])
+		},
+	}
+	AddConfigFlags(cmd)
+	return cmd
+}
+
+func setConfigValue(name string, value interface{}) error {
+	configs, err := readConfig()
+	if err != nil {
+		return err
+	}
+	var cfg *ContextConfig
+	for _, contextCfg := range *configs {
+		if kubectx == "all" || contextCfg.Context == kubectx {
+			cfg = contextCfg
+			cfgValue := reflect.ValueOf(cfg.Values)
+			var fieldName string
+			for i := 0; i < cfgValue.NumField(); i++ {
+				fieldType := reflect.TypeOf(cfg.Values).Field(i)
+				for _, tag := range strings.Split(fieldType.Tag.Get("yaml"), ",") {
+					if tag == name {
+						fieldName = fieldType.Name
+					}
+				}
+			}
+			if fieldName == "" {
+				return fmt.Errorf("%s is not a valid config field", name)
+			}
+			fieldValue := cfgValue.FieldByName(fieldName)
+
+			fieldType := fieldValue.Type()
+			val := reflect.ValueOf(value)
+
+			if fieldType != val.Type() {
+				return fmt.Errorf("%s is not a valid value for field %s", value, fieldName)
+			}
+
+			reflect.ValueOf(&cfg.Values).Elem().FieldByName(fieldName).Set(val)
+		}
+	}
+	if cfg == nil {
+		return fmt.Errorf("no config entry found for kubectx %s", kubectx)
+	}
+
+	return writeConfig(configs)
+}
+
+func writeConfig(cfg *Config) error {
+	contents, err := yaml.Marshal(cfg)
+	if err != nil {
+		return errors.Wrap(err, "marshaling config")
+	}
+	err = ioutil.WriteFile(configFile, contents, 0644)
+	if err != nil {
+		return errors.Wrap(err, "writing config file")
+	}
+	return nil
+}

--- a/cmd/skaffold/app/cmd/config/util.go
+++ b/cmd/skaffold/app/cmd/config/util.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func resolveKubectlContext() {
+	if kubectx != "" {
+		return
+	}
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+	k := kubectl.CLI{}
+
+	if err := k.Run(nil, w, "config", nil, "current-context"); err != nil {
+		logrus.Warn(errors.Wrap(err, "retrieving current kubectl context"))
+		kubectx = "default"
+	}
+	kubectx = strings.Replace(buf.String(), "\n", "", -1)
+}
+
+func resolveConfigFile() error {
+	var err error
+	if configFile != "" {
+		// we had a config provided as a flag, expand it and return
+		if !filepath.IsAbs(configFile) {
+			absPath, err := filepath.Abs(configFile)
+			if err != nil {
+				return err
+			}
+			configFile = absPath
+		}
+	} else {
+		configFile, err = homedir.Expand(defaultConfigLocation)
+		if err != nil {
+			return err
+		}
+	}
+	_, err = os.Stat(configFile)
+	// TODO(nkubala): create default config?
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func readConfig() (*Config, error) {
+	if err := resolveConfigFile(); err != nil {
+		return nil, errors.Wrap(err, "resolving config file location")
+	}
+	contents, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading global config")
+	}
+	config := Config{}
+	if err := yaml.Unmarshal(contents, &config); err != nil {
+		return nil, errors.Wrap(err, "unmarshalling global skaffold config")
+	}
+	return &config, nil
+}
+
+func getConfigsForKubectx() (*Config, error) {
+	configs, err := readConfig()
+	if err != nil {
+		return nil, err
+	}
+	if kubectx == "all" {
+		return configs, nil
+	}
+	for _, cfg := range *configs {
+		if cfg.Context == kubectx {
+			return &[]*ContextConfig{cfg}, nil
+		}
+	}
+	return nil, fmt.Errorf("no config entry found for kubectx %s", kubectx)
+}


### PR DESCRIPTION
This change adds support for a skaffold properties file, which provides users with an easy way to set both global and context-specific parameters. This will be useful as a way to do context-specific skaffold.yaml templating, as well as repository introspection in the future

Values in the config will be set on a per-kubectx basis, so different groups of values can be set depending on the remote context the host is pointed to. Skaffold will attempt to use `kubectl` to determine the current context; if this fails, it will fall back to `default`. This can be configured through the `--kubectx (-k)` flag.

The default location of the skaffold config will be `~/.skaffold/config`, though this can be configured through the `--config (-c)` flag.

This change adds the `default-repo` config field as a first field, though this field is not currently used. More fields can (and will) be added later to the global `Config` struct.

Example config file:
```yaml
- context: default
  values:
    default-repo: gcr.io/staging-project
- context: gke_production-project_us-west1-a_production
  values:
    default-repo: gcr.io/production-project
```