### PR TITLE
added support for manifest templating with environment variables and values key in skaffold.yaml

### DIFF
--- a/examples/manifest-templating/Dockerfile
+++ b/examples/manifest-templating/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.10.1-alpine3.7 as builder
+COPY main.go .
+RUN go build -o /app main.go
+
+FROM alpine:3.7  
+CMD ["./app"]
+COPY --from=builder /app .

--- a/examples/manifest-templating/README.adoc
+++ b/examples/manifest-templating/README.adoc
@@ -1,0 +1,33 @@
+=== Example: Getting started with a simple go app
+:icons: font
+
+This is a simple example based on
+
+* *building* a single go file app and with a multistage `Dockerfile` using local docker to build
+* *tagging* using the default tagPolicy (`gitCommit`)
+* *deploying* a single container pod using `kubectl`
+
+ifndef::env-github[]
+==== link:{github-repo-tree}/examples/getting-started[Example files icon:github[]]
+
+[source,yaml, indent=3, title=skaffold.yaml]
+----
+include::skaffold.yaml[]
+----
+
+[source,go, indent=3, title=main.go, syntax=go]
+----
+include::main.go[]
+----
+
+[source,docker, indent=3, title=Dockerfile]
+----
+include::Dockerfile[]
+----
+
+[source,yaml, indent=3, title=k8s-pod.yaml]
+----
+include::k8s-pod.yaml[]
+----
+
+endif::[]

--- a/examples/manifest-templating/k8s-pod.yaml
+++ b/examples/manifest-templating/k8s-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{.Name}}
+spec:
+  containers:
+  - name: getting-started
+    image: gcr.io/k8s-skaffold/skaffold-example

--- a/examples/manifest-templating/main.go
+++ b/examples/manifest-templating/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/examples/manifest-templating/skaffold.yaml
+++ b/examples/manifest-templating/skaffold.yaml
@@ -10,7 +10,10 @@ deploy:
     values:
       Name: my-pod
 profiles:
-  - name: gcb
-    build:
-      googleCloudBuild:
-        projectId: k8s-skaffold
+  - name: prod
+    deploy:
+      kubectl:
+        manifests:
+          - k8s-*
+        values:
+          Name: my-production-pod

--- a/examples/manifest-templating/skaffold.yaml
+++ b/examples/manifest-templating/skaffold.yaml
@@ -1,0 +1,16 @@
+apiVersion: skaffold/v1alpha2
+kind: Config
+build:
+  artifacts:
+  - imageName: gcr.io/k8s-skaffold/skaffold-example
+deploy:
+  kubectl:
+    manifests:
+      - k8s-*
+    values:
+      Name: my-pod
+profiles:
+  - name: gcb
+    build:
+      googleCloudBuild:
+        projectId: k8s-skaffold

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -119,9 +119,10 @@ type DeployType struct {
 
 // KubectlDeploy contains the configuration needed for deploying with `kubectl apply`
 type KubectlDeploy struct {
-	Manifests       []string     `yaml:"manifests,omitempty"`
-	RemoteManifests []string     `yaml:"remoteManifests,omitempty"`
-	Flags           KubectlFlags `yaml:"flags,omitempty"`
+	Manifests       []string          `yaml:"manifests,omitempty"`
+	RemoteManifests []string          `yaml:"remoteManifests,omitempty"`
+	Flags           KubectlFlags      `yaml:"flags,omitempty"`
+	Values          map[string]string `yaml:"values,omitempty"`
 }
 
 // KubectlFlags describes additional options flags that are passed on the command


### PR DESCRIPTION
Sorry for not communicating at all about this feature idea, I've been thinking this could be a great addition to the tool for awhile but I just never got around to creating a feature request. Then today I read #543 and wrote a response for this idea, thinking it might be a good solution.

After checking every open/closed issue I couldn't find anyone else talking about this feature so I decided to jump in and implement it myself (i'm a golang newbie).

I think the comment I wrote on #543 sums up the feature best so i'll copy it here (with a few minor edits):

---

It'd be nice if skaffold would allow you to defined variables that are rendered into your manifests. These ideally could be global or profile specific and could be sourced from environment variables e.g.

```yaml
apiVersion: skaffold/v1alpha2
kind: Config
profiles:
- name: prod
  # ...  
  deploy:
    kubectl:
      manifests: ./k8s/*
    values:
      namespace: "prod"
      domain: "myapp.com"
- name: feature-branch
  # ...  
  deploy:
    kubectl:
      manifests: ./k8s/*
    values:
      namespace: "{{.CI_ENVIRONMENT_SLUG}}"
      domain: "{{.CI_ENVIRONMENT_SLUG}}.myapp.com"
```

then your k8s manifests could have the following:
```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: myservice-ingress
  namespace: "{{.namespace}}"
spec:
  rules:
  - host: "myservice.{{.domain}}"
    http:
      paths:
      - path: /
        backend:
          serviceName: myservice
          servicePort: 80
```

I think this also allows skaffold to fill a nice middle ground between basic deployments with static manifests and helm deployments which adds a cluster component and multiple extra configuration files that feel like boilerplate when all you need is some basic template rendering.

---