### PR TITLE
Add --tail flag to stream logs with skaffold run

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -130,7 +130,7 @@ func AddDevFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&opts.Cleanup, "cleanup", true, "Delete deployments after dev mode is interrupted")
 }
 
-func AddRunFlags(cmd *cobra.Command) {
+func AddRunDeployFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&opts.Tail, "tail", false, "Stream logs from deployed objects")
 }
 

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -130,6 +130,10 @@ func AddDevFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&opts.Cleanup, "cleanup", true, "Delete deployments after dev mode is interrupted")
 }
 
+func AddRunFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&opts.Tail, "tail", false, "Stream logs from deployed objects")
+}
+
 func AddRunDevFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
 	cmd.Flags().BoolVar(&opts.Notification, "toot", false, "Emit a terminal beep after the deploy is complete")

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -35,6 +35,7 @@ func NewCmdRun(out io.Writer) *cobra.Command {
 		},
 	}
 	AddRunDevFlags(cmd)
+	AddRunFlags(cmd)
 
 	cmd.Flags().StringVarP(&opts.CustomTag, "tag", "t", "", "The optional custom tag to use for images which overrides the current Tagger configuration")
 	return cmd

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -35,7 +35,7 @@ func NewCmdRun(out io.Writer) *cobra.Command {
 		},
 	}
 	AddRunDevFlags(cmd)
-	AddRunFlags(cmd)
+	AddRunDeployFlags(cmd)
 
 	cmd.Flags().StringVarP(&opts.CustomTag, "tag", "t", "", "The optional custom tag to use for images which overrides the current Tagger configuration")
 	return cmd

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -26,6 +26,7 @@ type SkaffoldOptions struct {
 	ConfigurationFile string
 	Cleanup           bool
 	Notification      bool
+	Tail              bool
 	Profiles          []string
 	CustomTag         string
 	Namespace         string

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -191,6 +191,8 @@ func (r *SkaffoldRunner) Run(ctx context.Context, out io.Writer, artifacts []*v1
 		select {
 		case <-ctx.Done():
 			return nil
+		default:
+			continue
 		}
 	}
 }

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -177,24 +177,17 @@ func (r *SkaffoldRunner) Run(ctx context.Context, out io.Writer, artifacts []*v1
 	}
 	// If tail is true, stream logs from deployed objects
 	imageList := kubernetes.NewImageList()
-	for _, build := range bRes {
-		imageList.Add(build.Tag)
+	for _, b := range bRes {
+		imageList.Add(b.Tag)
 	}
 	colorPicker := kubernetes.NewColorPicker(artifacts)
 	logger := kubernetes.NewLogAggregator(out, imageList, colorPicker)
-
 	if err := logger.Start(ctx); err != nil {
 		return errors.Wrap(err, "starting logger")
 	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		default:
-			continue
-		}
-	}
+	<-ctx.Done()
+	return nil
 }
 
 // Dev watches for changes and runs the skaffold build and deploy

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -266,6 +266,7 @@ func TestRun(t *testing.T) {
 				Builder:  test.builder,
 				Deployer: test.deployer,
 				Tagger:   &tag.ChecksumTagger{},
+				opts:     &config.SkaffoldOptions{},
 			}
 			err := runner.Run(context.Background(), ioutil.Discard, test.config.Build.Artifacts)
 


### PR DESCRIPTION
Shoulf fix #253. Adds option to stream logs from objects deployed by
skaffold run.