### PR TITLE
Allow `skaffold dev —watch image`

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -129,6 +129,7 @@ func setFlagsFromEnvVariables(commands []*cobra.Command) {
 
 func AddDevFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&opts.Cleanup, "cleanup", true, "Delete deployments after dev mode is interrupted")
+	cmd.Flags().StringArrayVarP(&opts.Watch, "watch-image", "w", nil, "Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts.")
 }
 
 func AddRunDeployFlags(cmd *cobra.Command) {

--- a/pkg/skaffold/build/gcb/cloud_build_test.go
+++ b/pkg/skaffold/build/gcb/cloud_build_test.go
@@ -69,5 +69,5 @@ func TestBuildDescription(t *testing.T) {
 		Timeout: "10m",
 	}
 
-	testutil.CheckErrorAndDeepEqual(t, false, nil, expected, *desc)
+	testutil.CheckDeepEqual(t, expected, *desc)
 }

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -30,6 +30,7 @@ type SkaffoldOptions struct {
 	Profiles          []string
 	CustomTag         string
 	Namespace         string
+	Watch             []string
 }
 
 // Labels returns a map of labels to be applied to all deployed

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -391,3 +391,53 @@ func TestBuildAndDeployAllArtifacts(t *testing.T) {
 		t.Errorf("Expected 2 artifacts to be deployed. Got %d", len(deployer.deployed))
 	}
 }
+
+func TestShouldWatch(t *testing.T) {
+	var tests = []struct {
+		description   string
+		watch         []string
+		expectedMatch bool
+	}{
+		{
+			description:   "match all",
+			watch:         nil,
+			expectedMatch: true,
+		},
+		{
+			description:   "match full name",
+			watch:         []string{"domain/image"},
+			expectedMatch: true,
+		},
+		{
+			description:   "match partial name",
+			watch:         []string{"image"},
+			expectedMatch: true,
+		},
+		{
+			description:   "match any",
+			watch:         []string{"other", "image"},
+			expectedMatch: true,
+		},
+		{
+			description:   "no match",
+			watch:         []string{"other"},
+			expectedMatch: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			runner := &SkaffoldRunner{
+				opts: &config.SkaffoldOptions{
+					Watch: test.watch,
+				},
+			}
+
+			match := runner.shouldWatch(&v1alpha2.Artifact{
+				ImageName: "domain/image",
+			})
+
+			testutil.CheckDeepEqual(t, test.expectedMatch, match)
+		})
+	}
+}

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -358,6 +358,7 @@ func TestBuildAndDeployAllArtifacts(t *testing.T) {
 	runner := &SkaffoldRunner{
 		Builder:  builder,
 		Deployer: deployer,
+		opts:     &config.SkaffoldOptions{},
 	}
 
 	ctx := context.Background()

--- a/pkg/skaffold/watch/changes_test.go
+++ b/pkg/skaffold/watch/changes_test.go
@@ -88,7 +88,7 @@ func TestHasChanged(t *testing.T) {
 
 			changed := hasChanged(prev, curr)
 
-			testutil.CheckErrorAndDeepEqual(t, false, nil, test.expectedChanged, changed)
+			testutil.CheckDeepEqual(t, test.expectedChanged, changed)
 		})
 	}
 }

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -42,6 +42,14 @@ type FakeReaderCloser struct {
 func (f FakeReaderCloser) Close() error             { return nil }
 func (f FakeReaderCloser) Read([]byte) (int, error) { return 0, f.Err }
 
+func CheckDeepEqual(t *testing.T, expected, actual interface{}) {
+	t.Helper()
+	if diff := cmp.Diff(actual, expected); diff != "" {
+		t.Errorf("%T differ (-got, +want): %s", expected, diff)
+		return
+	}
+}
+
 func CheckErrorAndDeepEqual(t *testing.T, shouldErr bool, err error, expected, actual interface{}) {
 	t.Helper()
 	if err := checkErr(shouldErr, err); err != nil {


### PR DESCRIPTION
The idea is to be able to run a dev loop that is focused on a few artifacts instead of all the artifacts. For eg, with the micro-services example, I could run `skaffold dev --watch-image app` to only watch the code for the `leeroy-app` part.

Signed-off-by: David Gageot <david@gageot.net>