### PR TITLE
prevent watcher failure if helm valuesFilePath not set

### DIFF
--- a/pkg/skaffold/config/transform/transforms.go
+++ b/pkg/skaffold/config/transform/transforms.go
@@ -135,7 +135,9 @@ func ToV1Alpha3(vc util.VersionedConfig) (util.VersionedConfig, error) {
 	// if the helm deploy config was set, then convert ValueFilePath to ValuesFiles
 	if oldHelmDeploy := oldConfig.Deploy.DeployType.HelmDeploy; oldHelmDeploy != nil {
 		for i, oldHelmRelease := range oldHelmDeploy.Releases {
-			newDeploy.DeployType.HelmDeploy.Releases[i].ValuesFiles = []string{oldHelmRelease.ValuesFilePath}
+			if oldHelmRelease.ValuesFilePath != "" {
+				newDeploy.DeployType.HelmDeploy.Releases[i].ValuesFiles = []string{oldHelmRelease.ValuesFilePath}
+			}
 		}
 	}
 


### PR DESCRIPTION
If the Helm deployment section's valuesFilePath is not set, the helm deployer in dev mode will fail due to the watcher observing a non-existent blank filename.

```
$ skaffold dev                                                          
Cleaning up...
Error: release: "unified-k8s-repo" not found
Cleanup complete in 1.251887709s
FATA[0001] watching files for deployer: listing files: unable to stat file : stat : no such file or directory
```

Example pipeline file:

```
apiVersion: skaffold/v1alpha2
kind: Config
build:
  tagPolicy:
    # Tag the image with the git commit of your current repository.
    gitCommit: {}

  artifacts:
  - imageName: my-registry.com/rsanders/unified-k8s-repo
    docker:
      # Dockerfile's location relative to workspace. Defaults to "Dockerfile"
      dockerfilePath: docker/Dockerfile

deploy:
  helm:
    releases:
    - name: unified-k8s-repo
      chartPath: deploy/helm/unified-k8s-repo
      wait: true
      #valuesFilePath: helm-skaffold-values.yaml
      values:
        image: my-registry.com/rsanders/unified-k8s-repo
```
