### PR TITLE
Exclude helm dependency chart packages from watched files

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -79,8 +79,9 @@ func (h *HelmDeployer) Dependencies() ([]string, error) {
 	var deps []string
 	for _, release := range h.Releases {
 		deps = append(deps, release.ValuesFilePath)
+		chart_deps_dir := filepath.Join(release.ChartPath, "charts")
 		filepath.Walk(release.ChartPath, func(path string, info os.FileInfo, err error) error {
-			if !info.IsDir() {
+			if !info.IsDir() && !strings.HasPrefix(path, chart_deps_dir) {
 				deps = append(deps, path)
 			}
 			return nil

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -79,9 +79,9 @@ func (h *HelmDeployer) Dependencies() ([]string, error) {
 	var deps []string
 	for _, release := range h.Releases {
 		deps = append(deps, release.ValuesFilePath)
-		chart_deps_dir := filepath.Join(release.ChartPath, "charts")
+		chartDepsDir := filepath.Join(release.ChartPath, "charts")
 		filepath.Walk(release.ChartPath, func(path string, info os.FileInfo, err error) error {
-			if !info.IsDir() && !strings.HasPrefix(path, chart_deps_dir) {
+			if !info.IsDir() && !strings.HasPrefix(path, chartDepsDir) {
 				deps = append(deps, path)
 			}
 			return nil

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -78,7 +78,9 @@ func (h *HelmDeployer) Deploy(ctx context.Context, out io.Writer, builds []build
 func (h *HelmDeployer) Dependencies() ([]string, error) {
 	var deps []string
 	for _, release := range h.Releases {
-		deps = append(deps, release.ValuesFilePath)
+		if release.ValuesFilePath != "" {
+			deps = append(deps, release.ValuesFilePath)
+		}
 		chartDepsDir := filepath.Join(release.ChartPath, "charts")
 		filepath.Walk(release.ChartPath, func(path string, info os.FileInfo, err error) error {
 			if !info.IsDir() && !strings.HasPrefix(path, chartDepsDir) {


### PR DESCRIPTION
Fixes #931 

This excludes files located in the `charts` subdirectory within a chart package from the list of watched files. This does mean that if someone manually does a `helm dep update`, the watcher won't pick up the change. However, a dependency version bump would require a change to `requirements.yaml`, which the watcher will detect.