### PR TITLE
fixes `skaffold version` in the released docker image

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -146,6 +146,13 @@ To test a release on your own project:
 gcloud builds submit --config deploy/cloudbuild-release.yaml --substitutions=_RELEASE_BUCKET=<personal-bucket>,TAG_NAME=testrelease_v1234
 ```                                                      
 
+Note: if gcloud submit fails with something similar to the error message below, run `dep ensure && dep prune` to remove the broken symlinks   
+```
+ERROR: gcloud crashed (OSError): [Errno 2] No such file or directory: './vendor/github.com/karrick/godirwalk/testdata/symlinks/file-symlink'
+
+```
+
+
 To just run a release without Google Cloud Build only using your local Docker daemon, you can run: 
 
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -124,6 +124,34 @@ Once PRs with doc changes are merged, they will get automatically published to t
 for [the latest build](https://storage.googleapis.com/skaffold/builds/latest/docs/index.html)
 which at release time will be published with [the latest release](https://storage.googleapis.com/skaffold/releases/latest/docs/index.html).
 
+## Testing and contributing to the Skaffold release process 
+
+Skaffold release process works with Google Cloud Build within our own project `k8s-skaffold` and the skaffold release bucket, `gs://skaffold`. 
+
+In order to be able to iterate/fix the release process you can pass in your own project and bucket as parameters to the build. 
+
+We continuously release **builds** under `gs://skaffold/builds`. This is done by triggering `cloudbuild.yaml` on every push to master. 
+
+To run a build on your own project: 
+
+```
+gcloud builds submit --config deploy/cloudbuild.yaml --substitutions=_RELEASE_BUCKET=<personal-bucket>,COMMIT_SHA=$(git rev-parse HEAD)
+```  
+
+We **release** stable versions under `gs://skaffold/releases`. This is done by triggering `cloudbuild-release.yaml` on every new tag in our Github repo.
+
+To test a release on your own project:
+                                                          
+```
+gcloud builds submit --config deploy/cloudbuild-release.yaml --substitutions=_RELEASE_BUCKET=<personal-bucket>,TAG_NAME=testrelease_v1234
+```                                                      
+
+To just run a release without Google Cloud Build only using your local Docker daemon, you can run: 
+
+```
+make -j release GCP_PROJECT=<personalproject> RELEASE_BUCKET=<personal-bucket>
+``` 
+
 ## Creating a PR
 
 When you have changes you would like to propose to skaffold, you will need to:

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,7 @@ release: cross docs $(BUILD_DIR)/VERSION
 	docker build \
         		-f deploy/skaffold/Dockerfile \
         		--cache-from gcr.io/$(GCP_PROJECT)/skaffold-builder \
+        		--build-arg VERSION=$(VERSION) \
         		-t gcr.io/$(GCP_PROJECT)/skaffold:$(VERSION) .
 	gsutil -m cp $(BUILD_DIR)/$(PROJECT)-* $(GSC_RELEASE_PATH)/
 	gsutil -m cp $(BUILD_DIR)/VERSION $(GSC_RELEASE_PATH)/VERSION
@@ -107,7 +108,7 @@ release-in-docker:
 	docker run \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(HOME)/.config/gcloud:/root/.config/gcloud \
-		gcr.io/$(GCP_PROJECT)/skaffold-builder make -j release RELEASE_BUCKET=$(RELEASE_BUCKET) GCP_PROJECT=$(GCP_PROJECT)
+		gcr.io/$(GCP_PROJECT)/skaffold-builder make -j release VERSION=$(VERSION) RELEASE_BUCKET=$(RELEASE_BUCKET) GCP_PROJECT=$(GCP_PROJECT)
 
 .PHONY: release-build
 release-build: cross docs

--- a/deploy/skaffold/Dockerfile
+++ b/deploy/skaffold/Dockerfile
@@ -90,8 +90,9 @@ WORKDIR /go/src/github.com/GoogleContainerTools/skaffold
 COPY . .
 
 FROM builder as integration
+ARG VERSION
 
-RUN make out/skaffold-linux-amd64 && mv out/skaffold-linux-amd64 /usr/bin/skaffold
+RUN make out/skaffold-linux-amd64 VERSION=$VERSION && mv out/skaffold-linux-amd64 /usr/bin/skaffold
 
 CMD ["make", "integration"]
 


### PR DESCRIPTION
proof by manual testing, that I also added to the DEVELOPMENT.md

```
$ docker run gcr.io/<myproject>/skaffold:testrelease_v2 skaffold version
testrelease_v2
```

fixes #906.