### PR TITLE
Port forward pods automatically during `skaffold dev`

### DIFF
--- a/pkg/skaffold/kubernetes/log.go
+++ b/pkg/skaffold/kubernetes/log.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -64,18 +63,7 @@ func NewLogAggregator(out io.Writer, podSelector PodSelector, colorPicker ColorP
 func (a *LogAggregator) Start(ctx context.Context) error {
 	a.startTime = time.Now()
 
-	kubeclient, err := Client()
-	if err != nil {
-		return errors.Wrap(err, "getting k8s client")
-	}
-	client := kubeclient.CoreV1()
-
-	var forever int64 = 3600 * 24 * 365 * 100
-	watcher, err := client.Pods("").Watch(meta_v1.ListOptions{
-		IncludeUninitialized: true,
-		TimeoutSeconds:       &forever,
-	})
-
+	watcher, err := PodWatcher()
 	if err != nil {
 		return errors.Wrap(err, "initializing pod watcher")
 	}

--- a/pkg/skaffold/kubernetes/port_forward.go
+++ b/pkg/skaffold/kubernetes/port_forward.go
@@ -78,7 +78,7 @@ func (*kubectlForwader) Forward(pfe *portForwardEntry) error {
 	cmd.Stderr = buf
 
 	if err := cmd.Run(); err != nil && !IsTerminatedError(err) {
-		return errors.Wrapf(err, "port forwarding pod: %s, port: %s, err: %s", pfe.podName, portNumber, string(buf.Bytes()))
+		return errors.Wrapf(err, "port forwarding pod: %s, port: %s, err: %s", pfe.podName, portNumber, buf.String())
 	}
 	return nil
 }
@@ -149,7 +149,7 @@ func (p *PortForwarder) Start(ctx context.Context) error {
 				}
 				if p.podSelector.Select(pod) && pod.Status.Phase == v1.PodRunning && pod.DeletionTimestamp == nil {
 					go func() {
-						if err := p.portForwardPod(ctx, pod); err != nil {
+						if err := p.portForwardPod(pod); err != nil {
 							logrus.Warnf("port forwarding pod failed: %s", err)
 						}
 					}()
@@ -161,7 +161,7 @@ func (p *PortForwarder) Start(ctx context.Context) error {
 	return nil
 }
 
-func (p *PortForwarder) portForwardPod(ctx context.Context, pod *v1.Pod) error {
+func (p *PortForwarder) portForwardPod(pod *v1.Pod) error {
 	resourceVersion, err := strconv.Atoi(pod.ResourceVersion)
 	if err != nil {
 		return errors.Wrap(err, "converting resource version to integer")

--- a/pkg/skaffold/kubernetes/port_forward.go
+++ b/pkg/skaffold/kubernetes/port_forward.go
@@ -110,7 +110,7 @@ func (p *PortForwarder) cleanupPorts() {
 	p.forwardedPods.Range(func(k, v interface{}) bool {
 		entry := v.(*portForwardEntry)
 		if err := p.Stop(entry); err != nil {
-			logrus.Warnf("cleaning up port forwards", err)
+			logrus.Warnf("cleaning up port forwards: %s", err)
 		}
 		return false
 	})

--- a/pkg/skaffold/kubernetes/port_forward.go
+++ b/pkg/skaffold/kubernetes/port_forward.go
@@ -117,6 +117,7 @@ func (p *PortForwarder) cleanupPorts() {
 }
 
 // Start begins a pod watcher that port forwards any pods involving containers with exposed ports.
+// TODO(r2d4): merge this event loop with pod watcher from log writer
 func (p *PortForwarder) Start(ctx context.Context) error {
 	watcher, err := PodWatcher()
 	if err != nil {

--- a/pkg/skaffold/kubernetes/port_forward.go
+++ b/pkg/skaffold/kubernetes/port_forward.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strconv"
+	"sync"
+	"syscall"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type PortForwarder struct {
+	output      io.Writer
+	podSelector PodSelector
+
+	// forwardedPods is a map of portForwardEntry.key() (string) -> portForwardEntry
+	forwardedPods *sync.Map
+
+	// forwardedPorts is a map of port (int32) -> container name (string)
+	forwardedPorts *sync.Map
+}
+
+type portForwardEntry struct {
+	resourceVersion int
+	podName         string
+	containerName   string
+	port            int32
+
+	cmd *exec.Cmd
+}
+
+func NewPortForwarder(out io.Writer, podSelector PodSelector) *PortForwarder {
+	return &PortForwarder{
+		output:         out,
+		podSelector:    podSelector,
+		forwardedPods:  &sync.Map{},
+		forwardedPorts: &sync.Map{},
+	}
+}
+
+func (p *PortForwarder) cleanupPorts() {
+	p.forwardedPods.Range(func(k, v interface{}) bool {
+		entry := v.(*portForwardEntry)
+		if err := entry.stop(); err != nil {
+			logrus.Warnf("cleaning up port forwards", err)
+		}
+		return false
+	})
+}
+
+func (p *PortForwarder) Start(ctx context.Context) error {
+	watcher, err := PodWatcher()
+	if err != nil {
+		return errors.Wrap(err, "initializing pod watcher")
+	}
+
+	go func() {
+		defer watcher.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				p.cleanupPorts()
+				return
+			case evt, ok := <-watcher.ResultChan():
+				if !ok {
+					return
+				}
+
+				// Pods will never be "added" in a state that they are ready for port-forwarding
+				// so only watch "modified" events
+				if evt.Type != watch.Modified {
+					continue
+				}
+
+				pod, ok := evt.Object.(*v1.Pod)
+				if !ok {
+					continue
+				}
+				if p.podSelector.Select(pod) && pod.Status.Phase == v1.PodRunning && pod.DeletionTimestamp == nil {
+					go func() {
+						if err := p.portForwardPod(ctx, pod); err != nil {
+							logrus.Warnf("port forwarding pod failed: %s", err)
+						}
+					}()
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (p *PortForwarder) portForwardPod(ctx context.Context, pod *v1.Pod) error {
+	resourceVersion, err := strconv.Atoi(pod.ResourceVersion)
+	if err != nil {
+		return errors.Wrap(err, "converting resource version to integer")
+	}
+	for _, c := range pod.Spec.Containers {
+		for _, port := range c.Ports {
+			// If the port is already port-forwarded by another container,
+			// continue without port-forwarding
+			currentApp, ok := p.forwardedPorts.Load(port.ContainerPort)
+			if ok && currentApp != c.Name {
+				color.LightYellow.Fprintf(p.output, "Port %d for %s is already in use by container %s\n", port.ContainerPort, c.Name, currentApp)
+				continue
+			}
+
+			entry := &portForwardEntry{
+				resourceVersion: resourceVersion,
+				podName:         pod.Name,
+				containerName:   c.Name,
+				port:            port.ContainerPort,
+			}
+			v, ok := p.forwardedPods.Load(entry.key())
+
+			if ok {
+				prevEntry := v.(*portForwardEntry)
+
+				// Check if this is a new generation of pod
+				if entry.resourceVersion > prevEntry.resourceVersion {
+					if err := prevEntry.stop(); err != nil {
+						return errors.Wrap(err, "terminating port-forward process")
+					}
+				}
+			}
+
+			if err := p.forward(entry); err != nil {
+				return errors.Wrap(err, "port forwarding")
+			}
+		}
+	}
+
+	return nil
+}
+
+func (p *PortForwarder) forward(pfe *portForwardEntry) error {
+	portNumber := fmt.Sprintf("%d", pfe.port)
+	color.Default.Fprintln(p.output, fmt.Sprintf("Port Forwarding %s %d -> %d", pfe.podName, pfe.port, pfe.port))
+	cmd := exec.Command("kubectl", "port-forward", fmt.Sprintf("pod/%s", pfe.podName), portNumber, portNumber)
+	pfe.cmd = cmd
+
+	p.forwardedPods.Store(pfe.key(), pfe)
+	p.forwardedPorts.Store(pfe.port, pfe.containerName)
+
+	if err := util.RunCmd(cmd); err != nil && !IsTerminatedError(err) {
+		return errors.Wrapf(err, "port forwarding pod: %s, port: %s", pfe.podName, portNumber)
+	}
+	return nil
+}
+
+func IsTerminatedError(err error) bool {
+	exitError, ok := err.(*exec.ExitError)
+	if !ok {
+		return false
+	}
+	ws := exitError.Sys().(syscall.WaitStatus)
+	return ws.Signal() == syscall.SIGTERM
+}
+
+func (p *portForwardEntry) key() string {
+	return fmt.Sprintf("%s-%d", p.containerName, p.port)
+}
+
+func (p *portForwardEntry) String() string {
+	return fmt.Sprintf("%s/%s:%d", p.podName, p.containerName, p.port)
+}
+
+func (p *portForwardEntry) stop() error {
+	logrus.Debugf("Terminating port-forward %s", p.String())
+	if p.cmd == nil {
+		return fmt.Errorf("No port-forward command found for %s", p.String())
+	}
+	if err := p.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		return errors.Wrap(err, "terminating port-forward process")
+	}
+	return nil
+}

--- a/pkg/skaffold/kubernetes/port_forward_test.go
+++ b/pkg/skaffold/kubernetes/port_forward_test.go
@@ -1,28 +1,336 @@
 package kubernetes
 
 import (
+	"bytes"
+	"context"
+	"fmt"
+	"reflect"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+type testForwarder struct {
+	forwardedEntries map[string]*portForwardEntry
+	forwardedPorts   map[int32]bool
+
+	forwardErr error
+	stopErr    error
+}
+
+func (f *testForwarder) Forward(pfe *portForwardEntry) error {
+	f.forwardedEntries[pfe.key()] = pfe
+	f.forwardedPorts[pfe.port] = true
+	return f.forwardErr
+}
+
+func (f *testForwarder) Stop(pfe *portForwardEntry) error {
+	delete(f.forwardedEntries, pfe.key())
+	delete(f.forwardedPorts, pfe.port)
+	return f.stopErr
+}
+
+func newTestForwarder(forwardErr, stopErr error) *testForwarder {
+	return &testForwarder{
+		forwardedEntries: map[string]*portForwardEntry{},
+		forwardedPorts:   map[int32]bool{},
+		forwardErr:       forwardErr,
+		stopErr:          stopErr,
+	}
+}
 
 func TestPortForwardPod(t *testing.T) {
 	var tests = []struct {
-		description string
-		command     util.Command
-		shouldErr   bool
+		description     string
+		pods            []*v1.Pod
+		forwarder       *testForwarder
+		expectedPorts   map[int32]bool
+		expectedEntries map[string]*portForwardEntry
+		shouldErr       bool
 	}{
-		{},
+		{
+			description: "single container port",
+			expectedPorts: map[int32]bool{
+				8080: true,
+			},
+			expectedEntries: map[string]*portForwardEntry{
+				"containername-8080": &portForwardEntry{
+					resourceVersion: 1,
+					podName:         "podname",
+					containerName:   "containername",
+					port:            8080,
+				},
+			},
+			pods: []*v1.Pod{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "podname",
+						ResourceVersion: "1",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							v1.Container{
+								Name: "containername",
+								Ports: []v1.ContainerPort{
+									v1.ContainerPort{
+										ContainerPort: 8080,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description:     "bad resource version",
+			expectedPorts:   map[int32]bool{},
+			shouldErr:       true,
+			expectedEntries: map[string]*portForwardEntry{},
+			pods: []*v1.Pod{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "podname",
+						ResourceVersion: "10000000000a",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							v1.Container{
+								Name: "containername",
+								Ports: []v1.ContainerPort{
+									v1.ContainerPort{
+										ContainerPort: 8080,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "forward error",
+			expectedPorts: map[int32]bool{
+				8080: true,
+			},
+			forwarder: newTestForwarder(fmt.Errorf(""), nil),
+			shouldErr: true,
+			expectedEntries: map[string]*portForwardEntry{
+				"containername-8080": &portForwardEntry{
+					resourceVersion: 1,
+					podName:         "podname",
+					containerName:   "containername",
+					port:            8080,
+				},
+			},
+			pods: []*v1.Pod{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "podname",
+						ResourceVersion: "1",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							v1.Container{
+								Name: "containername",
+								Ports: []v1.ContainerPort{
+									v1.ContainerPort{
+										ContainerPort: 8080,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "two different container ports",
+			expectedPorts: map[int32]bool{
+				8080:  true,
+				50051: true,
+			},
+			expectedEntries: map[string]*portForwardEntry{
+				"containername-8080": &portForwardEntry{
+					resourceVersion: 1,
+					podName:         "podname",
+					containerName:   "containername",
+					port:            8080,
+				},
+				"containername2-50051": &portForwardEntry{
+					resourceVersion: 1,
+					podName:         "podname2",
+					containerName:   "containername2",
+					port:            50051,
+				},
+			},
+			pods: []*v1.Pod{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "podname",
+						ResourceVersion: "1",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							v1.Container{
+								Name: "containername",
+								Ports: []v1.ContainerPort{
+									v1.ContainerPort{
+										ContainerPort: 8080,
+									},
+								},
+							},
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "podname2",
+						ResourceVersion: "1",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							v1.Container{
+								Name: "containername2",
+								Ports: []v1.ContainerPort{
+									v1.ContainerPort{
+										ContainerPort: 50051,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "two same container ports",
+			expectedPorts: map[int32]bool{
+				8080: true,
+			},
+			expectedEntries: map[string]*portForwardEntry{
+				"containername-8080": &portForwardEntry{
+					resourceVersion: 1,
+					podName:         "podname",
+					containerName:   "containername",
+					port:            8080,
+				},
+			},
+			pods: []*v1.Pod{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "podname",
+						ResourceVersion: "1",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							v1.Container{
+								Name: "containername",
+								Ports: []v1.ContainerPort{
+									v1.ContainerPort{
+										ContainerPort: 8080,
+									},
+								},
+							},
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "podname2",
+						ResourceVersion: "1",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							v1.Container{
+								Name: "containername2",
+								Ports: []v1.ContainerPort{
+									v1.ContainerPort{
+										ContainerPort: 8080,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "updated pod gets port forwarded",
+			expectedPorts: map[int32]bool{
+				8080: true,
+			},
+			expectedEntries: map[string]*portForwardEntry{
+				"containername-8080": &portForwardEntry{
+					resourceVersion: 2,
+					podName:         "podname",
+					containerName:   "containername",
+					port:            8080,
+				},
+			},
+			pods: []*v1.Pod{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "podname",
+						ResourceVersion: "1",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							v1.Container{
+								Name: "containername",
+								Ports: []v1.ContainerPort{
+									v1.ContainerPort{
+										ContainerPort: 8080,
+									},
+								},
+							},
+						},
+					},
+				},
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "podname",
+						ResourceVersion: "2",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							v1.Container{
+								Name: "containername",
+								Ports: []v1.ContainerPort{
+									v1.ContainerPort{
+										ContainerPort: 8080,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			if test.command != nil {
-				defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
-				util.DefaultExecCommand = test.command
+			p := NewPortForwarder(&bytes.Buffer{}, NewImageList())
+			if test.forwarder == nil {
+				test.forwarder = newTestForwarder(nil, nil)
+			}
+			p.Forwarder = test.forwarder
+
+			for _, pod := range test.pods {
+				err := p.portForwardPod(context.Background(), pod)
+				testutil.CheckError(t, test.shouldErr, err)
+			}
+
+			// Error is already checked above
+			testutil.CheckErrorAndDeepEqual(t, false, nil, test.expectedPorts, test.forwarder.forwardedPorts)
+
+			// cmp.Diff cannot access unexported fields, so use reflect.DeepEqual here directly
+			if !reflect.DeepEqual(test.expectedEntries, test.forwarder.forwardedEntries) {
+				t.Errorf("Forwarded entries differs from expected entries. Expected: %s, Actual: %s", test.expectedEntries, test.forwarder.forwardedEntries)
 			}
 		})
 	}
-
-	return nil
 }

--- a/pkg/skaffold/kubernetes/port_forward_test.go
+++ b/pkg/skaffold/kubernetes/port_forward_test.go
@@ -1,0 +1,28 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+func TestPortForwardPod(t *testing.T) {
+	var tests = []struct {
+		description string
+		command     util.Command
+		shouldErr   bool
+	}{
+		{},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			if test.command != nil {
+				defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
+				util.DefaultExecCommand = test.command
+			}
+		})
+	}
+
+	return nil
+}

--- a/pkg/skaffold/kubernetes/port_forward_test.go
+++ b/pkg/skaffold/kubernetes/port_forward_test.go
@@ -18,7 +18,6 @@ package kubernetes
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -336,7 +335,7 @@ func TestPortForwardPod(t *testing.T) {
 			p.Forwarder = test.forwarder
 
 			for _, pod := range test.pods {
-				err := p.portForwardPod(context.Background(), pod)
+				err := p.portForwardPod(pod)
 				testutil.CheckError(t, test.shouldErr, err)
 			}
 

--- a/pkg/skaffold/kubernetes/port_forward_test.go
+++ b/pkg/skaffold/kubernetes/port_forward_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubernetes
 
 import (
@@ -56,7 +72,7 @@ func TestPortForwardPod(t *testing.T) {
 				8080: true,
 			},
 			expectedEntries: map[string]*portForwardEntry{
-				"containername-8080": &portForwardEntry{
+				"containername-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
@@ -64,17 +80,17 @@ func TestPortForwardPod(t *testing.T) {
 				},
 			},
 			pods: []*v1.Pod{
-				&v1.Pod{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "podname",
 						ResourceVersion: "1",
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
-							v1.Container{
+							{
 								Name: "containername",
 								Ports: []v1.ContainerPort{
-									v1.ContainerPort{
+									{
 										ContainerPort: 8080,
 									},
 								},
@@ -90,17 +106,17 @@ func TestPortForwardPod(t *testing.T) {
 			shouldErr:       true,
 			expectedEntries: map[string]*portForwardEntry{},
 			pods: []*v1.Pod{
-				&v1.Pod{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "podname",
 						ResourceVersion: "10000000000a",
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
-							v1.Container{
+							{
 								Name: "containername",
 								Ports: []v1.ContainerPort{
-									v1.ContainerPort{
+									{
 										ContainerPort: 8080,
 									},
 								},
@@ -118,7 +134,7 @@ func TestPortForwardPod(t *testing.T) {
 			forwarder: newTestForwarder(fmt.Errorf(""), nil),
 			shouldErr: true,
 			expectedEntries: map[string]*portForwardEntry{
-				"containername-8080": &portForwardEntry{
+				"containername-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
@@ -126,17 +142,17 @@ func TestPortForwardPod(t *testing.T) {
 				},
 			},
 			pods: []*v1.Pod{
-				&v1.Pod{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "podname",
 						ResourceVersion: "1",
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
-							v1.Container{
+							{
 								Name: "containername",
 								Ports: []v1.ContainerPort{
-									v1.ContainerPort{
+									{
 										ContainerPort: 8080,
 									},
 								},
@@ -153,13 +169,13 @@ func TestPortForwardPod(t *testing.T) {
 				50051: true,
 			},
 			expectedEntries: map[string]*portForwardEntry{
-				"containername-8080": &portForwardEntry{
+				"containername-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
 					port:            8080,
 				},
-				"containername2-50051": &portForwardEntry{
+				"containername2-50051": {
 					resourceVersion: 1,
 					podName:         "podname2",
 					containerName:   "containername2",
@@ -167,17 +183,17 @@ func TestPortForwardPod(t *testing.T) {
 				},
 			},
 			pods: []*v1.Pod{
-				&v1.Pod{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "podname",
 						ResourceVersion: "1",
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
-							v1.Container{
+							{
 								Name: "containername",
 								Ports: []v1.ContainerPort{
-									v1.ContainerPort{
+									{
 										ContainerPort: 8080,
 									},
 								},
@@ -185,17 +201,17 @@ func TestPortForwardPod(t *testing.T) {
 						},
 					},
 				},
-				&v1.Pod{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "podname2",
 						ResourceVersion: "1",
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
-							v1.Container{
+							{
 								Name: "containername2",
 								Ports: []v1.ContainerPort{
-									v1.ContainerPort{
+									{
 										ContainerPort: 50051,
 									},
 								},
@@ -211,7 +227,7 @@ func TestPortForwardPod(t *testing.T) {
 				8080: true,
 			},
 			expectedEntries: map[string]*portForwardEntry{
-				"containername-8080": &portForwardEntry{
+				"containername-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
@@ -219,17 +235,17 @@ func TestPortForwardPod(t *testing.T) {
 				},
 			},
 			pods: []*v1.Pod{
-				&v1.Pod{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "podname",
 						ResourceVersion: "1",
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
-							v1.Container{
+							{
 								Name: "containername",
 								Ports: []v1.ContainerPort{
-									v1.ContainerPort{
+									{
 										ContainerPort: 8080,
 									},
 								},
@@ -237,17 +253,17 @@ func TestPortForwardPod(t *testing.T) {
 						},
 					},
 				},
-				&v1.Pod{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "podname2",
 						ResourceVersion: "1",
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
-							v1.Container{
+							{
 								Name: "containername2",
 								Ports: []v1.ContainerPort{
-									v1.ContainerPort{
+									{
 										ContainerPort: 8080,
 									},
 								},
@@ -263,7 +279,7 @@ func TestPortForwardPod(t *testing.T) {
 				8080: true,
 			},
 			expectedEntries: map[string]*portForwardEntry{
-				"containername-8080": &portForwardEntry{
+				"containername-8080": {
 					resourceVersion: 2,
 					podName:         "podname",
 					containerName:   "containername",
@@ -271,17 +287,17 @@ func TestPortForwardPod(t *testing.T) {
 				},
 			},
 			pods: []*v1.Pod{
-				&v1.Pod{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "podname",
 						ResourceVersion: "1",
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
-							v1.Container{
+							{
 								Name: "containername",
 								Ports: []v1.ContainerPort{
-									v1.ContainerPort{
+									{
 										ContainerPort: 8080,
 									},
 								},
@@ -289,17 +305,17 @@ func TestPortForwardPod(t *testing.T) {
 						},
 					},
 				},
-				&v1.Pod{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "podname",
 						ResourceVersion: "2",
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
-							v1.Container{
+							{
 								Name: "containername",
 								Ports: []v1.ContainerPort{
-									v1.ContainerPort{
+									{
 										ContainerPort: 8080,
 									},
 								},

--- a/pkg/skaffold/kubernetes/watcher.go
+++ b/pkg/skaffold/kubernetes/watcher.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"github.com/pkg/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+// PodWatcher returns a watcher that will report on all Pod Events (additions, modifications, etc.)
+func PodWatcher() (watch.Interface, error) {
+	kubeclient, err := Client()
+	if err != nil {
+		return nil, errors.Wrap(err, "getting k8s client")
+	}
+	client := kubeclient.CoreV1()
+	var forever int64 = 3600 * 24 * 365 * 100
+	return client.Pods("").Watch(meta_v1.ListOptions{
+		IncludeUninitialized: true,
+		TimeoutSeconds:       &forever,
+	})
+}

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -38,6 +38,7 @@ import (
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/watch"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -202,6 +203,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*v1
 	imageList := kubernetes.NewImageList()
 	colorPicker := kubernetes.NewColorPicker(artifacts)
 	logger := kubernetes.NewLogAggregator(out, imageList, colorPicker)
+	portForwarder := kubernetes.NewPortForwarder(out, imageList)
 
 	// Create watcher and register artifacts to build current state of files.
 	changed := changes{}
@@ -266,6 +268,10 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*v1
 	// Start logs
 	if err := logger.Start(ctx); err != nil {
 		return nil, errors.Wrap(err, "starting logger")
+	}
+
+	if err := portForwarder.Start(ctx); err != nil {
+		return nil, errors.Wrap(err, "starting port-forwarder")
 	}
 
 	return nil, watcher.Run(ctx, PollInterval, onChange)


### PR DESCRIPTION
Skaffold dev will now automatically port-forward any pods that expose
container ports.

Ports are assigned on a first-come-first-serve basis,
and that container will hold the lock on that port for the remainder of the dev
cycle.

Updates to a container will trigger an update which replaces the
forwarded port with the newest version.

Scaling up a deployment will continue to port-forward the latest pod.
However, scaling down a deployment has the potential to kill the
port-forwarded pod without replacement - since we do not keep track of
candidates that are "waiting" on that port.