### PR TITLE
Pass --recreate-pods to helm by default in dev mode

### DIFF
--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -151,6 +151,7 @@ deploy:
     #     image: skaffold-helm
     #   namespace: skaffold
     #   version: ""
+    #   recreatePods: false
     #
     #   # setValues get appended to the helm deploy with --set.
     #   setValues:

--- a/examples/helm-deployment/skaffold.yaml
+++ b/examples/helm-deployment/skaffold.yaml
@@ -14,6 +14,8 @@ deploy:
       #valuesFilePath: helm-skaffold-values.yaml
       values:
         image: gcr.io/k8s-skaffold/skaffold-helm
+      #recreatePods will pass --recreate-pods to helm upgrade
+      #recreatePods: true
       #overrides builds an override values.yaml file to run with the helm deploy
       #overrides:
       # some:

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -149,6 +149,9 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r v1alp
 		args = append(args, "install", "--name", releaseName)
 	} else {
 		args = append(args, "upgrade", releaseName)
+		if r.RecreatePods {
+			args = append(args, "--recreate-pods")
+		}
 	}
 
 	// There are 2 strategies:

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -66,6 +66,25 @@ var testDeployConfig = &v1alpha2.HelmDeploy{
 	},
 }
 
+var testDeployRecreatePodsConfig = &v1alpha2.HelmDeploy{
+	Releases: []v1alpha2.HelmRelease{
+		{
+			Name:      "skaffold-helm",
+			ChartPath: "examples/test",
+			Values: map[string]string{
+				"image": "skaffold-helm",
+			},
+			Overrides: map[string]interface{}{
+				"foo": "bar",
+			},
+			SetValues: map[string]string{
+				"some.key": "somevalue",
+			},
+			RecreatePods: true,
+		},
+	},
+}
+
 var testDeployHelmStyleConfig = &v1alpha2.HelmDeploy{
 	Releases: []v1alpha2.HelmRelease{
 		{
@@ -233,6 +252,12 @@ func TestHelmDeploy(t *testing.T) {
 			description: "deploy success",
 			cmd:         &MockHelm{t: t},
 			deployer:    NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace),
+			builds:      testBuilds,
+		},
+		{
+			description: "deploy success with recreatePods",
+			cmd:         &MockHelm{t: t},
+			deployer:    NewHelmDeployer(testDeployRecreatePodsConfig, testKubeContext, testNamespace),
 			builds:      testBuilds,
 		},
 		{

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -153,6 +153,7 @@ type HelmRelease struct {
 	SetValues         map[string]string      `yaml:"setValues"`
 	SetValueTemplates map[string]string      `yaml:"setValueTemplates"`
 	Wait              bool                   `yaml:"wait"`
+	RecreatePods      bool                   `yaml:"recreatePods"`
 	Overrides         map[string]interface{} `yaml:"overrides"`
 	Packaged          *HelmPackaged          `yaml:"packaged"`
 	ImageStrategy     HelmImageStrategy      `yaml:"imageStrategy"`


### PR DESCRIPTION
It is common in development to just rebuild a Docker image with the same tag, which will not trigger a rolling update of the deployment because the pod spec does not change. Passing `--recreate-pods` will forcibly terminate the running pods and allow new ones to be spawned with the new image.

This change only applies in dev mode because it would be harmful for production deployments, which should push an image with a new tag and allow the usual rolling update process to replace the old pods.

This change would resolve https://github.com/GoogleContainerTools/skaffold/issues/289, without requiring an additional configuration option. (This behaviour can be disabled at runtime with `--recreate-pods=false` if needed for some reason.)

For now, I have only added a test to verify that a helm deployment works if `recreatePods == true`. Developing a test for the behaviour of actually recreating pods would be a little more involved, and I'm not sure it's worth including in this PR.