### PR TITLE
Get namespace for updating objects from build artifact

### DIFF
--- a/pkg/skaffold/deploy/labels.go
+++ b/pkg/skaffold/deploy/labels.go
@@ -140,7 +140,7 @@ func updateRuntimeObject(client dynamic.Interface, disco discovery.DiscoveryInte
 		return errors.Wrap(err, "getting metadata accessor")
 	}
 	name := accessor.GetName()
-	namespace := accessor.GetNamespace()
+	namespace := res.Namespace
 	addLabels(labels, accessor)
 
 	modifiedJSON, _ := json.Marshal(modifiedObj)


### PR DESCRIPTION
When deploying with helm to a non-default namespace, we were seeing the warning "error adding label
to runtime object". This was because accessor.GetNamespace() always
returned an empty string rather than the specified namespace. It seems
the original object returned by helm doesn't have the namespace field specified.

To fix this problem, we can access the namespace from the build artifact
instead of the accessor.

Should fix #899