### PR TITLE
Default to kubectl deploy

### DIFF
--- a/pkg/skaffold/config/config_test.go
+++ b/pkg/skaffold/config/config_test.go
@@ -117,6 +117,7 @@ func TestParseConfig(t *testing.T) {
 				withLocalBuild(
 					withTagPolicy(v1alpha2.TagPolicy{GitTagger: &v1alpha2.GitTagger{}}),
 				),
+				withKubectlDeploy("k8s/*.yaml"),
 			),
 		},
 		{
@@ -149,6 +150,7 @@ func TestParseConfig(t *testing.T) {
 				withKanikoBuild("demo", "kaniko-secret", "default", "", "20m",
 					withTagPolicy(v1alpha2.TagPolicy{GitTagger: &v1alpha2.GitTagger{}}),
 				),
+				withKubectlDeploy("k8s/*.yaml"),
 			),
 		},
 		{
@@ -158,6 +160,7 @@ func TestParseConfig(t *testing.T) {
 				withKanikoBuild("demo", "secret-name", "nskaniko", "/secret.json", "120m",
 					withTagPolicy(v1alpha2.TagPolicy{GitTagger: &v1alpha2.GitTagger{}}),
 				),
+				withKubectlDeploy("k8s/*.yaml"),
 			),
 		},
 		{

--- a/pkg/skaffold/config/config_test.go
+++ b/pkg/skaffold/config/config_test.go
@@ -115,7 +115,7 @@ func TestParseConfig(t *testing.T) {
 			config:      minimalConfig,
 			expected: config(
 				withLocalBuild(
-					withTagPolicy(v1alpha2.TagPolicy{GitTagger: &v1alpha2.GitTagger{}}),
+					withGitTagger(),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
 			),
@@ -125,7 +125,7 @@ func TestParseConfig(t *testing.T) {
 			config:      simpleConfig,
 			expected: config(
 				withLocalBuild(
-					withTagPolicy(v1alpha2.TagPolicy{GitTagger: &v1alpha2.GitTagger{}}),
+					withGitTagger(),
 					withDockerArtifact("example", ".", "Dockerfile"),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
@@ -136,7 +136,7 @@ func TestParseConfig(t *testing.T) {
 			config:      completeConfig,
 			expected: config(
 				withGoogleCloudBuild("ID",
-					withTagPolicy(v1alpha2.TagPolicy{ShaTagger: &v1alpha2.ShaTagger{}}),
+					withShaTagger(),
 					withDockerArtifact("image1", "./examples/app1", "Dockerfile.dev"),
 					withBazelArtifact("image2", "./examples/app2", "//:example.tar"),
 				),
@@ -148,7 +148,7 @@ func TestParseConfig(t *testing.T) {
 			config:      minimalKanikoConfig,
 			expected: config(
 				withKanikoBuild("demo", "kaniko-secret", "default", "", "20m",
-					withTagPolicy(v1alpha2.TagPolicy{GitTagger: &v1alpha2.GitTagger{}}),
+					withGitTagger(),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
 			),
@@ -158,7 +158,7 @@ func TestParseConfig(t *testing.T) {
 			config:      completeKanikoConfig,
 			expected: config(
 				withKanikoBuild("demo", "secret-name", "nskaniko", "/secret.json", "120m",
-					withTagPolicy(v1alpha2.TagPolicy{GitTagger: &v1alpha2.GitTagger{}}),
+					withGitTagger(),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
 			),
@@ -242,6 +242,16 @@ func withKubectlDeploy(manifests ...string) func(*SkaffoldConfig) {
 	}
 }
 
+func withHelmDeploy() func(*SkaffoldConfig) {
+	return func(cfg *SkaffoldConfig) {
+		cfg.Deploy = v1alpha2.DeployConfig{
+			DeployType: v1alpha2.DeployType{
+				HelmDeploy: &v1alpha2.HelmDeploy{},
+			},
+		}
+	}
+}
+
 func withDockerArtifact(image, workspace, dockerfile string) func(*v1alpha2.BuildConfig) {
 	return func(cfg *v1alpha2.BuildConfig) {
 		cfg.Artifacts = append(cfg.Artifacts, &v1alpha2.Artifact{
@@ -272,4 +282,18 @@ func withBazelArtifact(image, workspace, target string) func(*v1alpha2.BuildConf
 
 func withTagPolicy(tagPolicy v1alpha2.TagPolicy) func(*v1alpha2.BuildConfig) {
 	return func(cfg *v1alpha2.BuildConfig) { cfg.TagPolicy = tagPolicy }
+}
+
+func withGitTagger() func(*v1alpha2.BuildConfig) {
+	return withTagPolicy(v1alpha2.TagPolicy{GitTagger: &v1alpha2.GitTagger{}})
+}
+
+func withShaTagger() func(*v1alpha2.BuildConfig) {
+	return withTagPolicy(v1alpha2.TagPolicy{ShaTagger: &v1alpha2.ShaTagger{}})
+}
+
+func withProfiles(profiles ...v1alpha2.Profile) func(*SkaffoldConfig) {
+	return func(cfg *SkaffoldConfig) {
+		cfg.Profiles = profiles
+	}
 }

--- a/pkg/skaffold/config/profile_test.go
+++ b/pkg/skaffold/config/profile_test.go
@@ -50,7 +50,13 @@ func TestApplyProfiles(t *testing.T) {
 						LocalBuild: &v1alpha2.LocalBuild{},
 					},
 				},
-				Deploy: v1alpha2.DeployConfig{},
+				Deploy: v1alpha2.DeployConfig{
+					DeployType: v1alpha2.DeployType{
+						KubectlDeploy: &v1alpha2.KubectlDeploy{
+							Manifests: []string{"k8s/*.yaml"},
+						},
+					},
+				},
 				Profiles: []v1alpha2.Profile{
 					{
 						Name: "profile",
@@ -84,7 +90,13 @@ func TestApplyProfiles(t *testing.T) {
 						GitTagger: &v1alpha2.GitTagger{},
 					},
 				},
-				Deploy: v1alpha2.DeployConfig{},
+				Deploy: v1alpha2.DeployConfig{
+					DeployType: v1alpha2.DeployType{
+						KubectlDeploy: &v1alpha2.KubectlDeploy{
+							Manifests: []string{"k8s/*.yaml"},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -97,7 +109,13 @@ func TestApplyProfiles(t *testing.T) {
 					},
 					TagPolicy: v1alpha2.TagPolicy{GitTagger: &v1alpha2.GitTagger{}},
 				},
-				Deploy: v1alpha2.DeployConfig{},
+				Deploy: v1alpha2.DeployConfig{
+					DeployType: v1alpha2.DeployType{
+						KubectlDeploy: &v1alpha2.KubectlDeploy{
+							Manifests: []string{"k8s/*.yaml"},
+						},
+					},
+				},
 				Profiles: []v1alpha2.Profile{
 					{
 						Name: "dev",
@@ -125,7 +143,13 @@ func TestApplyProfiles(t *testing.T) {
 						LocalBuild: &v1alpha2.LocalBuild{},
 					},
 				},
-				Deploy: v1alpha2.DeployConfig{},
+				Deploy: v1alpha2.DeployConfig{
+					DeployType: v1alpha2.DeployType{
+						KubectlDeploy: &v1alpha2.KubectlDeploy{
+							Manifests: []string{"k8s/*.yaml"},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -138,7 +162,13 @@ func TestApplyProfiles(t *testing.T) {
 					},
 					TagPolicy: v1alpha2.TagPolicy{GitTagger: &v1alpha2.GitTagger{}},
 				},
-				Deploy: v1alpha2.DeployConfig{},
+				Deploy: v1alpha2.DeployConfig{
+					DeployType: v1alpha2.DeployType{
+						KubectlDeploy: &v1alpha2.KubectlDeploy{
+							Manifests: []string{"k8s/*.yaml"},
+						},
+					},
+				},
 				Profiles: []v1alpha2.Profile{
 					{
 						Name: "profile",
@@ -178,7 +208,13 @@ func TestApplyProfiles(t *testing.T) {
 						LocalBuild: &v1alpha2.LocalBuild{},
 					},
 				},
-				Deploy: v1alpha2.DeployConfig{},
+				Deploy: v1alpha2.DeployConfig{
+					DeployType: v1alpha2.DeployType{
+						KubectlDeploy: &v1alpha2.KubectlDeploy{
+							Manifests: []string{"k8s/*.yaml"},
+						},
+					},
+				},
 			},
 		},
 		{

--- a/pkg/skaffold/config/profile_test.go
+++ b/pkg/skaffold/config/profile_test.go
@@ -33,226 +33,114 @@ func TestApplyProfiles(t *testing.T) {
 	}{
 		{
 			description: "unknown profile",
-			config:      &SkaffoldConfig{},
+			config:      config(),
 			profile:     "profile",
-			expected:    &SkaffoldConfig{},
+			expected:    config(),
 			shouldErr:   true,
 		},
 		{
 			description: "build type",
 			profile:     "profile",
-			config: &SkaffoldConfig{
-				Build: v1alpha2.BuildConfig{
-					Artifacts: []*v1alpha2.Artifact{
-						{ImageName: "image"},
-					},
-					BuildType: v1alpha2.BuildType{
-						LocalBuild: &v1alpha2.LocalBuild{},
-					},
-				},
-				Deploy: v1alpha2.DeployConfig{
-					DeployType: v1alpha2.DeployType{
-						KubectlDeploy: &v1alpha2.KubectlDeploy{
-							Manifests: []string{"k8s/*.yaml"},
-						},
-					},
-				},
-				Profiles: []v1alpha2.Profile{
-					{
-						Name: "profile",
-						Build: v1alpha2.BuildConfig{
-							BuildType: v1alpha2.BuildType{
-								GoogleCloudBuild: &v1alpha2.GoogleCloudBuild{},
+			config: config(
+				withLocalBuild(
+					withGitTagger(),
+					withDockerArtifact("image", ".", "Dockerfile"),
+				),
+				withKubectlDeploy("k8s/*.yaml"),
+				withProfiles(v1alpha2.Profile{
+					Name: "profile",
+					Build: v1alpha2.BuildConfig{
+						BuildType: v1alpha2.BuildType{
+							GoogleCloudBuild: &v1alpha2.GoogleCloudBuild{
+								ProjectID: "my-project",
 							},
 						},
 					},
-				},
-			},
-			expected: &SkaffoldConfig{
-				Build: v1alpha2.BuildConfig{
-					Artifacts: []*v1alpha2.Artifact{
-						{
-							ImageName: "image",
-							Workspace: ".",
-							ArtifactType: v1alpha2.ArtifactType{
-								DockerArtifact: &v1alpha2.DockerArtifact{
-									DockerfilePath: "Dockerfile",
-								},
-							},
-						},
-					},
-					BuildType: v1alpha2.BuildType{
-						GoogleCloudBuild: &v1alpha2.GoogleCloudBuild{
-							DockerImage: "gcr.io/cloud-builders/docker",
-						},
-					},
-					TagPolicy: v1alpha2.TagPolicy{
-						GitTagger: &v1alpha2.GitTagger{},
-					},
-				},
-				Deploy: v1alpha2.DeployConfig{
-					DeployType: v1alpha2.DeployType{
-						KubectlDeploy: &v1alpha2.KubectlDeploy{
-							Manifests: []string{"k8s/*.yaml"},
-						},
-					},
-				},
-			},
+				}),
+			),
+			expected: config(
+				withGoogleCloudBuild("my-project",
+					withGitTagger(),
+					withDockerArtifact("image", ".", "Dockerfile"),
+				),
+				withKubectlDeploy("k8s/*.yaml"),
+			),
 		},
 		{
 			description: "tag policy",
 			profile:     "dev",
-			config: &SkaffoldConfig{
-				Build: v1alpha2.BuildConfig{
-					Artifacts: []*v1alpha2.Artifact{
-						{ImageName: "image"},
+			config: config(
+				withLocalBuild(
+					withGitTagger(),
+					withDockerArtifact("image", ".", "Dockerfile"),
+				),
+				withKubectlDeploy("k8s/*.yaml"),
+				withProfiles(v1alpha2.Profile{
+					Name: "dev",
+					Build: v1alpha2.BuildConfig{
+						TagPolicy: v1alpha2.TagPolicy{ShaTagger: &v1alpha2.ShaTagger{}},
 					},
-					TagPolicy: v1alpha2.TagPolicy{GitTagger: &v1alpha2.GitTagger{}},
-				},
-				Deploy: v1alpha2.DeployConfig{
-					DeployType: v1alpha2.DeployType{
-						KubectlDeploy: &v1alpha2.KubectlDeploy{
-							Manifests: []string{"k8s/*.yaml"},
-						},
-					},
-				},
-				Profiles: []v1alpha2.Profile{
-					{
-						Name: "dev",
-						Build: v1alpha2.BuildConfig{
-							TagPolicy: v1alpha2.TagPolicy{ShaTagger: &v1alpha2.ShaTagger{}},
-						},
-					},
-				},
-			},
-			expected: &SkaffoldConfig{
-				Build: v1alpha2.BuildConfig{
-					Artifacts: []*v1alpha2.Artifact{
-						{
-							ImageName: "image",
-							Workspace: ".",
-							ArtifactType: v1alpha2.ArtifactType{
-								DockerArtifact: &v1alpha2.DockerArtifact{
-									DockerfilePath: "Dockerfile",
-								},
-							},
-						},
-					},
-					TagPolicy: v1alpha2.TagPolicy{ShaTagger: &v1alpha2.ShaTagger{}},
-					BuildType: v1alpha2.BuildType{
-						LocalBuild: &v1alpha2.LocalBuild{},
-					},
-				},
-				Deploy: v1alpha2.DeployConfig{
-					DeployType: v1alpha2.DeployType{
-						KubectlDeploy: &v1alpha2.KubectlDeploy{
-							Manifests: []string{"k8s/*.yaml"},
-						},
-					},
-				},
-			},
+				}),
+			),
+			expected: config(
+				withLocalBuild(
+					withShaTagger(),
+					withDockerArtifact("image", ".", "Dockerfile"),
+				),
+				withKubectlDeploy("k8s/*.yaml"),
+			),
 		},
 		{
 			description: "artifacts",
 			profile:     "profile",
-			config: &SkaffoldConfig{
-				Build: v1alpha2.BuildConfig{
-					Artifacts: []*v1alpha2.Artifact{
-						{ImageName: "image"},
-					},
-					TagPolicy: v1alpha2.TagPolicy{GitTagger: &v1alpha2.GitTagger{}},
-				},
-				Deploy: v1alpha2.DeployConfig{
-					DeployType: v1alpha2.DeployType{
-						KubectlDeploy: &v1alpha2.KubectlDeploy{
-							Manifests: []string{"k8s/*.yaml"},
+			config: config(
+				withLocalBuild(
+					withGitTagger(),
+					withDockerArtifact("image", ".", "Dockerfile"),
+				),
+				withKubectlDeploy("k8s/*.yaml"),
+				withProfiles(v1alpha2.Profile{
+					Name: "profile",
+					Build: v1alpha2.BuildConfig{
+						Artifacts: []*v1alpha2.Artifact{
+							{ImageName: "image"},
+							{ImageName: "imageProd"},
 						},
 					},
-				},
-				Profiles: []v1alpha2.Profile{
-					{
-						Name: "profile",
-						Build: v1alpha2.BuildConfig{
-							Artifacts: []*v1alpha2.Artifact{
-								{ImageName: "image"},
-								{ImageName: "imageProd"},
-							},
-						},
-					},
-				},
-			},
-			expected: &SkaffoldConfig{
-				Build: v1alpha2.BuildConfig{
-					Artifacts: []*v1alpha2.Artifact{
-						{
-							ImageName: "image",
-							Workspace: ".",
-							ArtifactType: v1alpha2.ArtifactType{
-								DockerArtifact: &v1alpha2.DockerArtifact{
-									DockerfilePath: "Dockerfile",
-								},
-							},
-						},
-						{
-							ImageName: "imageProd",
-							Workspace: ".",
-							ArtifactType: v1alpha2.ArtifactType{
-								DockerArtifact: &v1alpha2.DockerArtifact{
-									DockerfilePath: "Dockerfile",
-								},
-							},
-						},
-					},
-					TagPolicy: v1alpha2.TagPolicy{GitTagger: &v1alpha2.GitTagger{}},
-					BuildType: v1alpha2.BuildType{
-						LocalBuild: &v1alpha2.LocalBuild{},
-					},
-				},
-				Deploy: v1alpha2.DeployConfig{
-					DeployType: v1alpha2.DeployType{
-						KubectlDeploy: &v1alpha2.KubectlDeploy{
-							Manifests: []string{"k8s/*.yaml"},
-						},
-					},
-				},
-			},
+				}),
+			),
+			expected: config(
+				withLocalBuild(
+					withGitTagger(),
+					withDockerArtifact("image", ".", "Dockerfile"),
+					withDockerArtifact("imageProd", ".", "Dockerfile"),
+				),
+				withKubectlDeploy("k8s/*.yaml"),
+			),
 		},
 		{
 			description: "deploy",
 			profile:     "profile",
-			config: &SkaffoldConfig{
-				Build: v1alpha2.BuildConfig{},
-				Deploy: v1alpha2.DeployConfig{
-					DeployType: v1alpha2.DeployType{
-						KubectlDeploy: &v1alpha2.KubectlDeploy{},
-					},
-				},
-				Profiles: []v1alpha2.Profile{
-					{
-						Name: "profile",
-						Deploy: v1alpha2.DeployConfig{
-							DeployType: v1alpha2.DeployType{
-								HelmDeploy: &v1alpha2.HelmDeploy{},
-							},
+			config: config(
+				withLocalBuild(
+					withGitTagger(),
+				),
+				withKubectlDeploy("k8s/*.yaml"),
+				withProfiles(v1alpha2.Profile{
+					Name: "profile",
+					Deploy: v1alpha2.DeployConfig{
+						DeployType: v1alpha2.DeployType{
+							HelmDeploy: &v1alpha2.HelmDeploy{},
 						},
 					},
-				},
-			},
-			expected: &SkaffoldConfig{
-				Build: v1alpha2.BuildConfig{
-					TagPolicy: v1alpha2.TagPolicy{
-						GitTagger: &v1alpha2.GitTagger{},
-					},
-					BuildType: v1alpha2.BuildType{
-						LocalBuild: &v1alpha2.LocalBuild{},
-					},
-				},
-				Deploy: v1alpha2.DeployConfig{
-					DeployType: v1alpha2.DeployType{
-						HelmDeploy: &v1alpha2.HelmDeploy{},
-					},
-				},
-			},
+				}),
+			),
+			expected: config(
+				withLocalBuild(
+					withGitTagger(),
+				),
+				withHelmDeploy(),
+			),
 		},
 	}
 

--- a/pkg/skaffold/schema/v1alpha2/defaults.go
+++ b/pkg/skaffold/schema/v1alpha2/defaults.go
@@ -28,6 +28,7 @@ import (
 
 func (c *SkaffoldConfig) setDefaultValues() error {
 	c.defaultToLocalBuild()
+	c.defaultToKubectlDeploy()
 	c.setDefaultCloudBuildDockerImage()
 	c.setDefaultTagger()
 	c.setDefaultKustomizePath()
@@ -56,6 +57,15 @@ func (c *SkaffoldConfig) defaultToLocalBuild() {
 
 	logrus.Debugf("Defaulting build type to local build")
 	c.Build.BuildType.LocalBuild = &LocalBuild{}
+}
+
+func (c *SkaffoldConfig) defaultToKubectlDeploy() {
+	if c.Deploy.DeployType != (DeployType{}) {
+		return
+	}
+
+	logrus.Debugf("Defaulting deploy type to kubectl")
+	c.Deploy.DeployType.KubectlDeploy = &KubectlDeploy{}
 }
 
 func (c *SkaffoldConfig) setDefaultCloudBuildDockerImage() {


### PR DESCRIPTION
Makes it possible to have an even shorter default skaffold.yaml to fit most cases.

Also simplified tests related to configuration.