### PR TITLE
Handle broken symlink when watch files

### DIFF
--- a/pkg/skaffold/watch/changes.go
+++ b/pkg/skaffold/watch/changes.go
@@ -49,7 +49,7 @@ func lastModified(paths []string) (time.Time, error) {
 	var last time.Time
 
 	for _, path := range paths {
-		stat, err := os.Stat(path)
+		stat, err := os.Lstat(path)
 		if err != nil {
 			return last, errors.Wrapf(err, "unable to stat file %s", path)
 		}

--- a/pkg/skaffold/watch/changes_test.go
+++ b/pkg/skaffold/watch/changes_test.go
@@ -67,6 +67,12 @@ func TestHasChanged(t *testing.T) {
 			update:          func(tmp *testutil.TempDir) { tmp.Chtimes("dir", time.Now().Add(2*time.Second)) },
 			expectedChanged: false,
 		},
+		{
+			description:     "broken symlink is handled",
+			setup:           func(tmp *testutil.TempDir) { tmp.WriteSymlink("symlink", "") },
+			update:          func(tmp *testutil.TempDir) { tmp.Remove("symlink") },
+			expectedChanged: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/testutil/tmp.go
+++ b/testutil/tmp.go
@@ -95,6 +95,15 @@ func (h *TempDir) Write(file, content string) *TempDir {
 	return h.failIfErr(ioutil.WriteFile(h.Path(file), []byte(content), os.ModePerm))
 }
 
+// WriteSymlink writes content to a file in the temp directory.
+func (h *TempDir) WriteSymlink(file, content string) *TempDir {
+	h.failIfErr(os.MkdirAll(filepath.Dir(h.Path(file)), os.ModePerm))
+	h.failIfErr(ioutil.WriteFile(h.Path(file), []byte(content), os.ModePerm))
+	symlink := filepath.Join(filepath.Dir(h.Path(file)), "link")
+	target := h.Path(file)
+	return h.failIfErr(os.Symlink(target, symlink))
+}
+
 // List lists all the files in the temp directory.
 func (h *TempDir) List() ([]string, error) {
 	var files []string


### PR DESCRIPTION
This is a fix for  #970.  `dep ensure` does some clean up on files which leaves behind a broken symlink in the vendor folder.  By using `os.Lstat()`  the watcher code doesn't die on the broken symlink.  Added a test case for a broken symlink.
