### PR TITLE
Kaniko local and s3 build context

### DIFF
--- a/pkg/skaffold/build/kaniko/run.go
+++ b/pkg/skaffold/build/kaniko/run.go
@@ -40,64 +40,35 @@ import (
 const kanikoContainerName = "kaniko"
 
 func runKaniko(ctx context.Context, out io.Writer, artifact *v1alpha2.Artifact, cfg *v1alpha2.KanikoBuild) (string, error) {
-	dockerfilePath := artifact.DockerArtifact.DockerfilePath
-
 	initialTag := util.RandomID()
+	imageDst := fmt.Sprintf("%s:%s", artifact.ImageName, initialTag)
 	tarName := fmt.Sprintf("context-%s.tar.gz", initialTag)
-	if err := docker.UploadContextToGCS(ctx, artifact.Workspace, artifact.DockerArtifact, cfg.GCSBucket, tarName); err != nil {
-		return "", errors.Wrap(err, "uploading tar to gcs")
+	buildContext := ""
+
+	if cfg.GcsContext != nil {
+		if err := docker.UploadContextToGCS(ctx, artifact.Workspace, artifact.DockerArtifact, cfg.GcsContext.GCSBucket, tarName); err != nil {
+			return "", errors.Wrap(err, "uploading tar to gcs")
+		}
+		defer gcsDelete(ctx, cfg.GcsContext.GCSBucket, tarName)
+		buildContext = fmt.Sprintf("gs://%s/%s", cfg.GcsContext.GCSBucket, tarName)
+	} else if cfg.S3Context != nil {
+		if err := docker.UploadContextToS3(ctx, artifact.Workspace, artifact.DockerArtifact, cfg.S3Context.S3Bucket, tarName, cfg.S3Context.Region); err != nil {
+			return "", errors.Wrap(err, "uploading tar to s3")
+		}
+		buildContext = fmt.Sprintf("s3://%s/%s", cfg.S3Context.S3Bucket, tarName)
+	} else {
+		buildContext = cfg.LocalDirContext.Path
 	}
-	defer gcsDelete(ctx, cfg.GCSBucket, tarName)
 
 	client, err := kubernetes.GetClientset()
 	if err != nil {
 		return "", errors.Wrap(err, "")
 	}
+
+	podConfig := buildPodConfig(*artifact, *cfg, imageDst, initialTag, buildContext)
 	pods := client.CoreV1().Pods(cfg.Namespace)
+	p, err := pods.Create(podConfig)
 
-	imageDst := fmt.Sprintf("%s:%s", artifact.ImageName, initialTag)
-	args := []string{
-		fmt.Sprintf("--dockerfile=%s", dockerfilePath),
-		fmt.Sprintf("--context=gs://%s/%s", cfg.GCSBucket, tarName),
-		fmt.Sprintf("--destination=%s", imageDst),
-		fmt.Sprintf("-v=%s", logrus.GetLevel().String()),
-	}
-	args = append(args, docker.GetBuildArgs(artifact.DockerArtifact)...)
-
-	p, err := pods.Create(&v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "kaniko",
-			Labels:       map[string]string{"skaffold-kaniko": "skaffold-kaniko"},
-			Namespace:    cfg.Namespace,
-		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{
-					Name:            kanikoContainerName,
-					Image:           constants.DefaultKanikoImage,
-					ImagePullPolicy: v1.PullIfNotPresent,
-					Args:            args,
-					VolumeMounts: []v1.VolumeMount{{
-						Name:      constants.DefaultKanikoSecretName,
-						MountPath: "/secret",
-					}},
-					Env: []v1.EnvVar{{
-						Name:  "GOOGLE_APPLICATION_CREDENTIALS",
-						Value: "/secret/kaniko-secret",
-					}},
-				},
-			},
-			Volumes: []v1.Volume{{
-				Name: constants.DefaultKanikoSecretName,
-				VolumeSource: v1.VolumeSource{
-					Secret: &v1.SecretVolumeSource{
-						SecretName: cfg.PullSecretName,
-					},
-				},
-			}},
-			RestartPolicy: v1.RestartPolicyNever,
-		},
-	})
 	if err != nil {
 		return "", errors.Wrap(err, "creating kaniko pod")
 	}
@@ -124,6 +95,111 @@ func runKaniko(ctx context.Context, out io.Writer, artifact *v1alpha2.Artifact, 
 	waitForLogs()
 
 	return imageDst, nil
+}
+
+func buildPodConfig(artifact v1alpha2.Artifact, cfg v1alpha2.KanikoBuild, imageDst string, initialTag string, buildContext string) *v1.Pod {
+	containers := []v1.Container{}
+
+	args := []string{
+		fmt.Sprintf("--dockerfile=%s", artifact.DockerArtifact.DockerfilePath),
+		fmt.Sprintf("--context=%s", buildContext),
+		fmt.Sprintf("--destination=%s", imageDst),
+	}
+
+	args = append(args, docker.GetBuildArgs(artifact.DockerArtifact)...)
+
+	envVars := getEnvVars(cfg)
+	volumes := getVolumes(cfg)
+	volumeMounts := getVolumeMounts(cfg)
+
+	container := new(v1.Container)
+	container.Name = kanikoContainerName
+	container.Image = constants.DefaultKanikoImage
+	container.ImagePullPolicy = v1.PullIfNotPresent
+	container.Args = args
+	container.VolumeMounts = volumeMounts
+	container.Env = envVars
+
+	containers = append(containers, *container)
+
+	podConfig := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "kaniko-",
+			Labels:       map[string]string{"skaffold-kaniko": "skaffold-kaniko"},
+			Namespace:    cfg.Namespace,
+		},
+		Spec: v1.PodSpec{
+			Containers:    containers,
+			Volumes:       volumes,
+			RestartPolicy: v1.RestartPolicyNever,
+		},
+	}
+
+	return podConfig
+}
+
+func getVolumes(cfg v1alpha2.KanikoBuild) []v1.Volume {
+	volumes := []v1.Volume{}
+	volume := new(v1.Volume)
+
+	volume.Name = constants.DefaultKanikoSecretName
+	defaultSecretVolSource := &v1.SecretVolumeSource{
+		SecretName: cfg.PullSecretName}
+	volume.VolumeSource = v1.VolumeSource{
+		Secret: defaultSecretVolSource}
+
+	volumes = append(volumes, *volume)
+
+	for _, thisVolume := range cfg.Volumes {
+		volume.Name = thisVolume.Name
+
+		if thisVolume.HostPath != "" {
+			hostPathVolSource := &v1.HostPathVolumeSource{
+				Path: thisVolume.HostPath}
+			volume.VolumeSource = v1.VolumeSource{
+				HostPath: hostPathVolSource}
+		} else if thisVolume.Secret != "" {
+			secretVolSource := &v1.SecretVolumeSource{
+				SecretName: thisVolume.Secret}
+			volume.VolumeSource = v1.VolumeSource{
+				Secret: secretVolSource}
+		}
+		volumes = append(volumes, *volume)
+	}
+
+	return volumes
+}
+
+func getVolumeMounts(cfg v1alpha2.KanikoBuild) []v1.VolumeMount {
+	volMounts := []v1.VolumeMount{}
+
+	volMount := new(v1.VolumeMount)
+	volMount.Name = constants.DefaultKanikoSecretName
+	volMount.MountPath = "/secret"
+
+	volMounts = append(volMounts, *volMount)
+
+	for _, thisMount := range cfg.VolumeMounts {
+		volMount = new(v1.VolumeMount)
+		volMount.Name = thisMount.Name
+		volMount.MountPath = thisMount.MountPath
+		volMounts = append(volMounts, *volMount)
+	}
+
+	return volMounts
+}
+
+func getEnvVars(cfg v1alpha2.KanikoBuild) []v1.EnvVar {
+	envVars := []v1.EnvVar{}
+
+	for _, thisVar := range cfg.Env {
+		envVar := new(v1.EnvVar)
+		envVar.Name = thisVar.Name
+		envVar.Value = thisVar.Value
+		envVars = append(envVars, *envVar)
+	}
+
+	return envVars
 }
 
 func streamLogs(out io.Writer, name string, pods corev1.PodInterface) func() {

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -27,6 +27,8 @@ const (
 	// DefaultLogLevel is the default global verbosity
 	DefaultLogLevel = logrus.WarnLevel
 
+	DefaultAWSRegion = "us-west-2"
+
 	// DefaultDockerfilePath is the dockerfile path is given relative to the
 	// context directory
 	DefaultDockerfilePath = "Dockerfile"

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -97,11 +97,49 @@ type GoogleCloudBuild struct {
 // KanikoBuild contains the fields needed to do a on-cluster build using
 // the kaniko image
 type KanikoBuild struct {
-	GCSBucket      string `yaml:"gcsBucket,omitempty"`
-	PullSecret     string `yaml:"pullSecret,omitempty"`
-	PullSecretName string `yaml:"pullSecretName,omitempty"`
-	Namespace      string `yaml:"namespace,omitempty"`
-	Timeout        string `yaml:"timeout,omitempty"`
+	ContextType    `yaml:",inline"`
+	Env            []*Env         `yaml:"env,omitempty"`
+	Volumes        []*Volume      `yaml:"volumes,omitempty"`
+	VolumeMounts   []*VolumeMount `yaml:"volumeMounts,omitempty"`
+	PullSecret     string         `yaml:"pullSecret,omitempty"`
+	PullSecretName string         `yaml:"pullSecretName,omitempty"`
+	Namespace      string         `yaml:"namespace,omitempty"`
+	Timeout        string         `yaml:"timeout,omitempty"`
+}
+
+type ContextType struct {
+	GcsContext      *GcsContext      `yaml:"gcs" yamltags:"oneOf=context"`
+	LocalDirContext *LocalDirContext `yaml:"localDir" yamltags:"oneOf=context"`
+	S3Context       *S3Context       `yaml:"s3" yamltags:"oneOf=context"`
+}
+
+type Env struct {
+	Name  string `yaml:"name,omitempty"`
+	Value string `yaml:"value,omitempty"`
+}
+
+type VolumeMount struct {
+	Name      string `yaml:"name,omitempty"`
+	MountPath string `yaml:"mountPath,omitempty"`
+}
+
+type Volume struct {
+	Name     string `yaml:"name,omitempty"`
+	HostPath string `yaml:"hostPath,omitempty"`
+	Secret   string `yaml:"secret,omitempty"`
+}
+
+type GcsContext struct {
+	GCSBucket string `yaml:"bucket,omitempty"`
+}
+
+type S3Context struct {
+	S3Bucket string `yaml:"bucket,omitempty"`
+	Region string `yaml:"region,omitempty"`
+}
+
+type LocalDirContext struct {
+	Path string `yaml:"path,omitempty"`
 }
 
 // DeployConfig contains all the configuration needed by the deploy steps

--- a/pkg/skaffold/schema/v1alpha2/defaults.go
+++ b/pkg/skaffold/schema/v1alpha2/defaults.go
@@ -40,6 +40,7 @@ func (c *SkaffoldConfig) setDefaultValues() error {
 	if err := c.setDefaultKanikoSecret(); err != nil {
 		return err
 	}
+	c.setDefaultAWSRegion()
 
 	for _, a := range c.Build.Artifacts {
 		c.defaultToDockerArtifact(a)
@@ -165,6 +166,20 @@ func (c *SkaffoldConfig) setDefaultKanikoSecret() error {
 		}
 
 		kaniko.PullSecret = absPath
+		return nil
+	}
+
+	return nil
+}
+
+func (c *SkaffoldConfig) setDefaultAWSRegion() error {
+	kaniko := c.Build.KanikoBuild
+	if kaniko == nil {
+		return nil
+	}
+
+	if kaniko.ContextType.S3Context != nil {
+		kaniko.ContextType.S3Context.Region = constants.DefaultAWSRegion
 		return nil
 	}
 


### PR DESCRIPTION
The current version of skaffold only supports kaniko builds with a gcs build context.

skaffold.yaml for a local build context:

```
apiVersion: skaffold/v1alpha2
kind: Config
build:
  artifacts:
  - imageName: teakasahi/example-app
    workspace: /path/to/build/context
  kaniko:
    localDir:
      path: /build/
    pullSecretName: docker-hub-creds
    env:
    - name: DOCKER_CONFIG
      value: /secret/
    volumes:
    - name: mycode
      hostPath: /path/to/build/context
    volumeMounts:
    - name: mycode
      mountPath: /build/
deploy:
  kubectl:
    manifests:
      - k8s-*
```
example I used for a s3 build context:

```
apiVersion: skaffold/v1alpha2
kind: Config
build:
  artifacts:
  - imageName: teakasahi/example-app
  kaniko:
    s3:
      bucket: s3bucketnamehere
    pullSecretName: docker-hub-creds
    env:
    - name: DOCKER_CONFIG
      value: /secret/
    - name: AWS_REGION
      value: us-west-2
    - name: AWS_CONFIG_FILE
      value: /root/.aws/config
    volumes:
    - name: mycode
      hostPath: /path/to/build/context
    - name: aws-creds
      secret: aws-creds
    volumeMounts:
    - name: mycode
      mountPath: /build/
    - name: aws-creds
      mountPath: /root/.aws
deploy:
  kubectl:
    manifests:
      - k8s-*
```

I created two secrets:

```
kubectl create secret generic docker-hub-creds --from-file=/path/to/your/.docker/config.json
kubectl create secret generic aws-creds --from-file=/path/to/your/.aws/credentials
```