### PR TITLE
Don't prefix pod names when port forwarding

### DIFF
--- a/pkg/skaffold/kubernetes/port_forward.go
+++ b/pkg/skaffold/kubernetes/port_forward.go
@@ -70,7 +70,7 @@ type kubectlForwader struct{}
 func (*kubectlForwader) Forward(pfe *portForwardEntry) error {
 	logrus.Debugf("Port forwarding %s", pfe)
 	portNumber := fmt.Sprintf("%d", pfe.port)
-	cmd := exec.Command("kubectl", "port-forward", fmt.Sprintf("pod/%s", pfe.podName), portNumber, portNumber)
+	cmd := exec.Command("kubectl", "port-forward", pfe.podName, portNumber, portNumber)
 	pfe.cmd = cmd
 
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
Older versions of kubectl (`1.9.x`) don't support port forwarding deployments as well as pods, so the `pod/` prefix isn't recognized when port forwarding. From testing newer versions (`1.11.x`) removing this prefix seems to work correctly, so it should be safe to remove this.

Fixes #974 