### PR TITLE
Add support for multiple helm values files

### DIFF
--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -147,7 +147,9 @@ deploy:
     # releases:
     # - name: skaffold-helm
     #   chartPath: skaffold-helm
-    #   valuesFilePath: helm-skaffold-values.yaml
+    #   valuesFiles:
+    #   - first-values-file.yaml
+    #   - second-values-file.yaml
     #   values:
     #     image: skaffold-helm
     #   namespace: skaffold

--- a/examples/helm-deployment/README.adoc
+++ b/examples/helm-deployment/README.adoc
@@ -30,6 +30,8 @@ deploy:
       namespace: skaffold
       values:
         image: skaffold-helm
+      valuesFiles:
+        - helm-values-file.yaml
 ```
 
 This part tells skaffold to set the `image` parameter of the values file to the built skaffold-helm image and tag.

--- a/examples/helm-deployment/skaffold.yaml
+++ b/examples/helm-deployment/skaffold.yaml
@@ -11,7 +11,8 @@ deploy:
     - name: skaffold-helm
       chartPath: skaffold-helm
       #wait: true
-      #valuesFilePath: helm-skaffold-values.yaml
+      #valuesFiles:
+      #- helm-skaffold-values.yaml
       values:
         image: gcr.io/k8s-skaffold/skaffold-helm
       #recreatePods will pass --recreate-pods to helm upgrade

--- a/pkg/skaffold/config/transform/transforms.go
+++ b/pkg/skaffold/config/transform/transforms.go
@@ -132,6 +132,12 @@ func ToV1Alpha3(vc util.VersionedConfig) (util.VersionedConfig, error) {
 	if err := convert(oldConfig.Deploy, &newDeploy); err != nil {
 		return nil, errors.Wrap(err, "converting deploy config")
 	}
+	// if the helm deploy config was set, then convert ValueFilePath to ValuesFiles
+	if oldHelmDeploy := oldConfig.Deploy.DeployType.HelmDeploy; oldHelmDeploy != nil {
+		for i, oldHelmRelease := range oldHelmDeploy.Releases {
+			newDeploy.DeployType.HelmDeploy.Releases[i].ValuesFiles = []string{oldHelmRelease.ValuesFilePath}
+		}
+	}
 
 	// convert v1alpha2.Profiles to v1alpha3.Profiles (should be the same)
 	var newProfiles []v1alpha3.Profile

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -79,9 +79,7 @@ func (h *HelmDeployer) Deploy(ctx context.Context, out io.Writer, builds []build
 func (h *HelmDeployer) Dependencies() ([]string, error) {
 	var deps []string
 	for _, release := range h.Releases {
-		if release.ValuesFilePath != "" {
-			deps = append(deps, release.ValuesFilePath)
-		}
+		deps = append(deps, release.ValuesFiles...)
 		chartDepsDir := filepath.Join(release.ChartPath, "charts")
 		filepath.Walk(release.ChartPath, func(path string, info os.FileInfo, err error) error {
 			if !info.IsDir() && !strings.HasPrefix(path, chartDepsDir) {
@@ -206,8 +204,8 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r v1alp
 		}
 		args = append(args, "-f", constants.HelmOverridesFilename)
 	}
-	if r.ValuesFilePath != "" {
-		args = append(args, "-f", r.ValuesFilePath)
+	for _, valuesFile := range r.ValuesFiles {
+		args = append(args, "-f", valuesFile)
 	}
 
 	setValues := r.SetValues

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -491,10 +491,10 @@ func TestExtractChartFilename(t *testing.T) {
 
 func TestHelmDependencies(t *testing.T) {
 	var tests = []struct {
-		description    string
-		files          []string
-		valuesFilePath string
-		expected       func(folder *testutil.TempDir) []string
+		description string
+		files       []string
+		valuesFiles []string
+		expected    func(folder *testutil.TempDir) []string
 	}{
 		{
 			description: "charts dir is excluded",
@@ -504,9 +504,9 @@ func TestHelmDependencies(t *testing.T) {
 			},
 		},
 		{
-			description:    "values file is included",
-			files:          []string{"Chart.yaml"},
-			valuesFilePath: "/folder/values.yaml",
+			description: "values file is included",
+			files:       []string{"Chart.yaml"},
+			valuesFiles: []string{"/folder/values.yaml"},
 			expected: func(folder *testutil.TempDir) []string {
 				return []string{"/folder/values.yaml", folder.Path("Chart.yaml")}
 			},
@@ -524,12 +524,12 @@ func TestHelmDependencies(t *testing.T) {
 			deployer := NewHelmDeployer(&v1alpha3.HelmDeploy{
 				Releases: []v1alpha3.HelmRelease{
 					{
-						Name:           "skaffold-helm",
-						ChartPath:      folder.Root(),
-						ValuesFilePath: tt.valuesFilePath,
-						Values:         map[string]string{"image": "skaffold-helm"},
-						Overrides:      map[string]interface{}{"foo": "bar"},
-						SetValues:      map[string]string{"some.key": "somevalue"},
+						Name:        "skaffold-helm",
+						ChartPath:   folder.Root(),
+						ValuesFiles: tt.valuesFiles,
+						Values:      map[string]string{"image": "skaffold-helm"},
+						Overrides:   map[string]interface{}{"foo": "bar"},
+						SetValues:   map[string]string{"some.key": "somevalue"},
 					},
 				},
 			}, testKubeContext, testNamespace)

--- a/pkg/skaffold/schema/v1alpha3/config.go
+++ b/pkg/skaffold/schema/v1alpha3/config.go
@@ -152,7 +152,7 @@ type KustomizeDeploy struct {
 type HelmRelease struct {
 	Name              string                 `yaml:"name"`
 	ChartPath         string                 `yaml:"chartPath"`
-	ValuesFilePath    string                 `yaml:"valuesFilePath"`
+	ValuesFiles       []string               `yaml:"valuesFiles"`
 	Values            map[string]string      `yaml:"values,omitempty"`
 	Namespace         string                 `yaml:"namespace"`
 	Version           string                 `yaml:"version"`


### PR DESCRIPTION
This PR adds support for multiple helm values files in the skaffold config.

The helm deploy config the field `valuesFilePath` has been renamed to `valuesFiles` and now accepts a list of strings, instead of a string.
All valuesFiles are added to helm deploy using the `-f` option.

This PR was based on the changes and discussion in #677. 