### PR TITLE
Correctly parse build tags that contain port numbers

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -135,13 +135,15 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r v1alp
 	for k, v := range params {
 		setOpts = append(setOpts, "--set")
 		if r.ImageStrategy.HelmImageConfig.HelmConventionConfig != nil {
-			tagSplit := strings.Split(v.Tag, ":")
-			imageRepositoryTag := fmt.Sprintf("%s.repository=%s,%s.tag=%s", k, tagSplit[0], k, tagSplit[1])
+			tagIndex := strings.LastIndex(v.Tag, ":")
+
+			imageRepositoryTag := fmt.Sprintf("%s.repository=%s,%s.tag=%s", k, v.Tag[0:tagIndex], k, v.Tag[tagIndex+1:len(v.Tag)-1])
 			setOpts = append(setOpts, imageRepositoryTag)
 		} else {
 			setOpts = append(setOpts, fmt.Sprintf("%s=%s", k, v.Tag))
 		}
 	}
+
 
 	// First build dependencies.
 	logrus.Infof("Building helm dependencies...")

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -37,7 +37,7 @@ import (
 var testBuilds = []build.Artifact{
 	{
 		ImageName: "skaffold-helm",
-		Tag:       "skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184",
+		Tag:       "docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184",
 	},
 }
 
@@ -292,8 +292,10 @@ func TestHelmDeploy(t *testing.T) {
 				t:         t,
 				getResult: fmt.Errorf("not found"),
 				installMatcher: func(cmd *exec.Cmd) bool {
-					builds := strings.Split(testBuilds[0].Tag, ":")
-					expected := map[string]bool{fmt.Sprintf("image.repository=%s,image.tag=%s", builds[0], builds[1]): true}
+					buildTag := testBuilds[0].Tag
+					tagIndex := strings.LastIndex(buildTag, ":")
+
+					expected := map[string]bool{fmt.Sprintf("image.repository=%s,image.tag=%s", buildTag[0:tagIndex], buildTag[tagIndex+1:len(buildTag)-1]): true}
 					for _, arg := range cmd.Args {
 						if expected[arg] {
 							return true


### PR DESCRIPTION
Fixes issue #994 

When a build tag contains a port number i.e. docker.io:5000/skaffold-helm:my-tag the Helm Strategy was incorrectly performing a basic split and ending up with repository=docker.io,tag=5000/skaffold-helm:my-tag.

This PR fixes the parsing so that the repository is correctly extracted, i.e. repository=docker.io:5000/skaffold-helm,image=my-tag