### PR TITLE
Version parsing v2

### DIFF
--- a/cmd/skaffold/app/cmd/util/util.go
+++ b/cmd/skaffold/app/cmd/util/util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
@@ -35,8 +36,17 @@ func ParseConfig(filename string) (*config.SkaffoldConfig, error) {
 		return nil, errors.Wrap(err, "parsing api version")
 	}
 
-	if apiVersion.Version != config.LatestVersion {
+	parsedVersion, err := apiversion.Parse(apiVersion.Version)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing api version")
+	}
+
+	if parsedVersion.LT(config.LatestAPIVersion) {
 		return nil, errors.New("Config version out of date: run `skaffold fix`")
+	}
+
+	if parsedVersion.GT(config.LatestAPIVersion) {
+		return nil, errors.New("Config version is too new for this version of skaffold: upgrade skaffold")
 	}
 
 	cfg, err := config.GetConfig(buf, true)

--- a/cmd/skaffold/app/cmd/util/util_test.go
+++ b/cmd/skaffold/app/cmd/util/util_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha1"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+)
+
+func TestParseConfig(t *testing.T) {
+	type args struct {
+		apiVersion string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "good api version",
+			args: args{
+				apiVersion: config.LatestVersion,
+			},
+			wantErr: false,
+		},
+		{
+			name: "old api version",
+			args: args{
+				apiVersion: v1alpha1.Version,
+			},
+			wantErr: true,
+		},
+		{
+			name: "new api version",
+			args: args{
+				apiVersion: "skaffold/v9",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := config.NewConfig()
+			if err != nil {
+				t.Fatalf("error generating config: %s", err)
+			}
+			cfg.APIVersion = tt.args.apiVersion
+			cfgStr, err := yaml.Marshal(cfg)
+			if err != nil {
+				t.Fatalf("error marshalling config: %s", err)
+			}
+
+			p := writeTestConfig(t, cfgStr)
+			defer os.Remove(p)
+
+			_, err = ParseConfig(p)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}
+
+func writeTestConfig(t *testing.T, cfg []byte) string {
+	t.Helper()
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatalf("error getting temp file: %s", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(cfg); err != nil {
+		t.Fatalf("error writing config: %s", err)
+	}
+	return f.Name()
+}

--- a/pkg/skaffold/apiversion/apiversion.go
+++ b/pkg/skaffold/apiversion/apiversion.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package apiversion
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/blang/semver"
+)
+
+var re = regexp.MustCompile(`^skaffold/v(\d)(?:(alpha|beta)(\d))?$`)
+
+// Parse parses a string into a Version.
+func Parse(v string) (semver.Version, error) {
+	res := re.FindStringSubmatch(v)
+	if res == nil {
+		return semver.Version{}, fmt.Errorf("%s is an invalid api version", v)
+	}
+	if res[2] == "" || res[3] == "" {
+		return semver.Parse(fmt.Sprintf("%s.0.0", res[1]))
+	}
+	return semver.Parse(fmt.Sprintf("%s.0.0-%s.%s", res[1], res[2], res[3]))
+}
+
+// MustParse is like Parse but panics if the version cannot be parsed.
+func MustParse(s string) semver.Version {
+	v, err := Parse(s)
+	if err != nil {
+		panic(`semver: Parse(` + s + `): ` + err.Error())
+	}
+	return v
+}

--- a/pkg/skaffold/apiversion/apiversion_test.go
+++ b/pkg/skaffold/apiversion/apiversion_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package apiversion
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/blang/semver"
+)
+
+func TestMustParse(t *testing.T) {
+	_ = MustParse("skaffold/v1alpha4")
+}
+
+func TestMustParse_panic(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Errorf("Should have panicked")
+		}
+	}()
+	_ = MustParse("invalid version")
+}
+
+func TestParseVersion(t *testing.T) {
+	type args struct {
+		v string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    semver.Version
+		wantErr bool
+	}{
+		{
+			name: "full",
+			args: args{
+				v: "skaffold/v7alpha3",
+			},
+			want: semver.Version{
+				Major: 7,
+				Pre: []semver.PRVersion{
+					{
+						VersionStr: "alpha",
+					},
+					{
+						VersionNum: 3,
+						IsNum:      true,
+					},
+				},
+			},
+		},
+		{
+			name: "ga",
+			args: args{
+				v: "skaffold/v4",
+			},
+			want: semver.Version{
+				Major: 4,
+			},
+		},
+		{
+			name: "incorrect",
+			args: args{
+				v: "apps/v1",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.args.v)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Parse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/skaffold/config/config.go
+++ b/pkg/skaffold/config/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion"
 	latest "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha4"
 )
 
@@ -24,6 +25,8 @@ import (
 type SkaffoldConfig = latest.SkaffoldConfig
 
 const LatestVersion string = latest.Version
+
+var LatestAPIVersion = apiversion.MustParse(LatestVersion)
 
 func NewConfig() (*SkaffoldConfig, error) {
 	return latest.NewConfig()


### PR DESCRIPTION
just to test out https://github.com/GoogleContainerTools/skaffold/pull/1020/files#r220053214

1. about 50% less code
2. more functionality (from blang/semver)
3. 100% test coverage apiversion.go + relying on a tested version library (blang/semver) vs. a custom one

