### PR TITLE
Add option to not tail logs in dev mode

### DIFF
--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -38,6 +38,7 @@ func NewCmdDev(out io.Writer) *cobra.Command {
 	}
 	AddRunDevFlags(cmd)
 	AddDevFlags(cmd)
+	AddRunDeployFlags(cmd)
 	return cmd
 }
 

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -38,7 +38,7 @@ func NewCmdDev(out io.Writer) *cobra.Command {
 	}
 	AddRunDevFlags(cmd)
 	AddDevFlags(cmd)
-	AddRunDeployFlags(cmd)
+	cmd.Flags().BoolVar(&opts.TailDev, "tail", true, "Stream logs from deployed objects")
 	return cmd
 }
 

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -27,6 +27,7 @@ type SkaffoldOptions struct {
 	Cleanup           bool
 	Notification      bool
 	Tail              bool
+	TailDev           bool
 	PortForward       bool
 	Profiles          []string
 	CustomTag         string
@@ -43,7 +44,7 @@ func (opts *SkaffoldOptions) Labels() map[string]string {
 	if opts.Cleanup {
 		labels["cleanup"] = "true"
 	}
-	if opts.Tail {
+	if opts.Tail || opts.TailDev {
 		labels["tail"] = "true"
 	}
 	if opts.Namespace != "" {

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -305,8 +305,10 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*v1
 	}
 
 	// Start logs
-	if err := logger.Start(ctx); err != nil {
-		return nil, errors.Wrap(err, "starting logger")
+	if r.opts.Tail {
+		if err := logger.Start(ctx); err != nil {
+			return nil, errors.Wrap(err, "starting logger")
+		}
 	}
 
 	if r.opts.PortForward {

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -305,7 +305,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*v1
 	}
 
 	// Start logs
-	if r.opts.Tail {
+	if r.opts.TailDev {
 		if err := logger.Start(ctx); err != nil {
 			return nil, errors.Wrap(err, "starting logger")
 		}


### PR DESCRIPTION
I need to able to not tail the logs of the containers in dev mode for demos.
It gives a much cleaner and more comprehensible look.