### PR TITLE
annotated.yaml: fix gcb timeout format

### DIFF
--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -92,7 +92,7 @@ build:
   #   projectId: YOUR_PROJECT
   #   diskSizeGb: 200
   #   machineType: "N1_HIGHCPU_8"|"N1_HIGHCPU_32"
-  #   timeout: 10000S
+  #   timeout: 10000s
   #   dockerImage: gcr.io/cloud-builders/docker
 
   # Docker artifacts can be built on a Kubernetes cluster with Kaniko.


### PR DESCRIPTION
apparently gcb api requires lowercase s here:

    could not create build: googleapi: Error 400: Invalid value at
    'build.timeout' (type.googleapis.com/google.protobuf.Duration),
    Field 'timeout', Illegal duration format; duration must end with 's',
    badRequest