### PR TITLE
Add support for setting default-repo in global config

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -180,5 +180,6 @@ func applyDefaultRepoSubstitution(config *config.SkaffoldConfig, globalConfig *c
 	for _, artifact := range config.Build.Artifacts {
 		artifact.ImageName = util.SubstituteDefaultRepoIntoImage(globalConfig.DefaultRepo, artifact.ImageName)
 	}
+	// TODO(nkubala): should we substitute into helm deploy values here?
 	return nil
 }

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -23,8 +23,11 @@ import (
 	"os"
 	"strings"
 
+	// configutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
+	cmdutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	// "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 	"github.com/pkg/errors"
@@ -153,3 +156,47 @@ func SetUpLogs(out io.Writer, level string) error {
 	logrus.SetLevel(lvl)
 	return nil
 }
+
+func readConfiguration(opts *config.SkaffoldOptions) (*config.SkaffoldConfig, error) {
+	config, err := cmdutil.ParseConfig(opts.ConfigurationFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing skaffold config")
+	}
+	err = config.ApplyProfiles(opts.Profiles)
+	if err != nil {
+		return nil, errors.Wrap(err, "applying profiles")
+	}
+	// globalConfig, err := configutil.GetConfigForKubectx()
+	// if err != nil {
+	// 	return nil, errors.Wrap(err, "retrieving global config")
+	// }
+	// if err = applyDefaultRepo(config, globalConfig); err != nil {
+	// 	return nil, errors.Wrap(err, "substituting default repos")
+	// }
+	return config, nil
+}
+
+// func applyDefaultRepo(config *config.SkaffoldConfig, globalConfig *configutil.ContextConfig) error {
+// 	fmt.Printf("default repo: %s\n", globalConfig.DefaultRepo)
+// 	for _, artifact := range config.Build.Artifacts {
+// 		fmt.Printf("artifact: %+v\n", artifact)
+// 		substituteRepoIntoArtifact(globalConfig.DefaultRepo, artifact)
+// 		fmt.Printf("artifact: %+v\n", artifact)
+// 	}
+// 	return nil
+// }
+
+// func substituteRepoIntoArtifact(repo string, artifact *v1alpha2.Artifact) error {
+// 	if strings.HasPrefix(repo, "gcr.io") {
+// 		if !strings.HasPrefix(artifact.ImageName, repo) {
+// 			artifact.ImageName = repo + "/" + artifact.ImageName
+// 		} else {
+// 			// TODO: this one is a little harder
+// 			return nil
+// 		}
+// 	} else {
+// 		// TODO: escape, concat, truncate to 256
+// 		return nil
+// 	}
+// 	return nil
+// }

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -181,5 +181,9 @@ func applyDefaultRepoSubstitution(config *config.SkaffoldConfig, globalConfig *c
 		artifact.ImageName = util.SubstituteDefaultRepoIntoImage(globalConfig.DefaultRepo, artifact.ImageName)
 	}
 	// TODO(nkubala): should we substitute into helm deploy values here?
+
+	// TODO(nkubala): do we also want to substitute into the deploy artifacts here? NO
+
+	//maybe we dont wanna do this at all here actually....
 	return nil
 }

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -180,10 +180,5 @@ func applyDefaultRepoSubstitution(config *config.SkaffoldConfig, globalConfig *c
 	for _, artifact := range config.Build.Artifacts {
 		artifact.ImageName = util.SubstituteDefaultRepoIntoImage(globalConfig.DefaultRepo, artifact.ImageName)
 	}
-	// TODO(nkubala): should we substitute into helm deploy values here?
-
-	// TODO(nkubala): do we also want to substitute into the deploy artifacts here? NO
-
-	//maybe we dont wanna do this at all here actually....
 	return nil
 }

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -142,6 +142,7 @@ func AddRunDevFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&opts.Notification, "toot", false, "Emit a terminal beep after the deploy is complete")
 	cmd.Flags().StringArrayVarP(&opts.Profiles, "profile", "p", nil, "Activate profiles by name")
 	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "", "Run deployments in the specified namespace")
+	cmd.Flags().StringVarP(&opts.DefaultRepo, "default-repo", "d", "", "Default repository value (overrides global config)")
 }
 
 func SetUpLogs(out io.Writer, level string) error {

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -23,12 +23,9 @@ import (
 	"os"
 	"strings"
 
-	configutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
-	cmdutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -154,31 +151,5 @@ func SetUpLogs(out io.Writer, level string) error {
 		return errors.Wrap(err, "parsing log level")
 	}
 	logrus.SetLevel(lvl)
-	return nil
-}
-
-func readConfiguration(opts *config.SkaffoldOptions) (*config.SkaffoldConfig, error) {
-	config, err := cmdutil.ParseConfig(opts.ConfigurationFile)
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing skaffold config")
-	}
-	err = config.ApplyProfiles(opts.Profiles)
-	if err != nil {
-		return nil, errors.Wrap(err, "applying profiles")
-	}
-	globalConfig, err := configutil.GetConfigForKubectx()
-	if err != nil {
-		return nil, errors.Wrap(err, "retrieving global config")
-	}
-	if err = applyDefaultRepoSubstitution(config, globalConfig); err != nil {
-		return nil, errors.Wrap(err, "substituting default repos")
-	}
-	return config, nil
-}
-
-func applyDefaultRepoSubstitution(config *config.SkaffoldConfig, globalConfig *configutil.ContextConfig) error {
-	for _, artifact := range config.Build.Artifacts {
-		artifact.ImageName = util.SubstituteDefaultRepoIntoImage(globalConfig.DefaultRepo, artifact.ImageName)
-	}
 	return nil
 }

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -23,12 +23,12 @@ import (
 	"os"
 	"strings"
 
-	// configutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
+	configutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
 	cmdutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-	// "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -166,37 +166,19 @@ func readConfiguration(opts *config.SkaffoldOptions) (*config.SkaffoldConfig, er
 	if err != nil {
 		return nil, errors.Wrap(err, "applying profiles")
 	}
-	// globalConfig, err := configutil.GetConfigForKubectx()
-	// if err != nil {
-	// 	return nil, errors.Wrap(err, "retrieving global config")
-	// }
-	// if err = applyDefaultRepo(config, globalConfig); err != nil {
-	// 	return nil, errors.Wrap(err, "substituting default repos")
-	// }
+	globalConfig, err := configutil.GetConfigForKubectx()
+	if err != nil {
+		return nil, errors.Wrap(err, "retrieving global config")
+	}
+	if err = applyDefaultRepoSubstitution(config, globalConfig); err != nil {
+		return nil, errors.Wrap(err, "substituting default repos")
+	}
 	return config, nil
 }
 
-// func applyDefaultRepo(config *config.SkaffoldConfig, globalConfig *configutil.ContextConfig) error {
-// 	fmt.Printf("default repo: %s\n", globalConfig.DefaultRepo)
-// 	for _, artifact := range config.Build.Artifacts {
-// 		fmt.Printf("artifact: %+v\n", artifact)
-// 		substituteRepoIntoArtifact(globalConfig.DefaultRepo, artifact)
-// 		fmt.Printf("artifact: %+v\n", artifact)
-// 	}
-// 	return nil
-// }
-
-// func substituteRepoIntoArtifact(repo string, artifact *v1alpha2.Artifact) error {
-// 	if strings.HasPrefix(repo, "gcr.io") {
-// 		if !strings.HasPrefix(artifact.ImageName, repo) {
-// 			artifact.ImageName = repo + "/" + artifact.ImageName
-// 		} else {
-// 			// TODO: this one is a little harder
-// 			return nil
-// 		}
-// 	} else {
-// 		// TODO: escape, concat, truncate to 256
-// 		return nil
-// 	}
-// 	return nil
-// }
+func applyDefaultRepoSubstitution(config *config.SkaffoldConfig, globalConfig *configutil.ContextConfig) error {
+	for _, artifact := range config.Build.Artifacts {
+		artifact.ImageName = util.SubstituteDefaultRepoIntoImage(globalConfig.DefaultRepo, artifact.ImageName)
+	}
+	return nil
+}

--- a/cmd/skaffold/app/cmd/config/config_test.go
+++ b/cmd/skaffold/app/cmd/config/config_test.go
@@ -103,7 +103,8 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			key:          "not_a_real_value",
 			shouldErrSet: true,
 			expectedSetCfg: &Config{
-				ContextConfigs: []*ContextConfig{{}},
+				Global:         &ContextConfig{},
+				ContextConfigs: []*ContextConfig{},
 			},
 		},
 		{

--- a/cmd/skaffold/app/cmd/config/config_test.go
+++ b/cmd/skaffold/app/cmd/config/config_test.go
@@ -67,6 +67,7 @@ func TestReadConfig(t *testing.T) {
 }
 
 func TestSetAndUnsetConfig(t *testing.T) {
+	dummyContext := "dummy_context"
 	var tests = []struct {
 		expectedSetCfg   *Config
 		expectedUnsetCfg *Config
@@ -103,8 +104,11 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			key:          "not_a_real_value",
 			shouldErrSet: true,
 			expectedSetCfg: &Config{
-				Global:         &ContextConfig{},
-				ContextConfigs: []*ContextConfig{},
+				ContextConfigs: []*ContextConfig{
+					{
+						Kubecontext: dummyContext,
+					},
+				},
 			},
 		},
 		{
@@ -131,8 +135,18 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			c, _ := yaml.Marshal(*emptyConfig)
 			cfg, teardown := testutil.TempFile(t, "config", c)
 
+			defer func() {
+				// reset all config context for next test
+				teardown()
+				kubecontext = dummyContext
+				configFile = ""
+				global = false
+			}()
+
 			// setup config context
-			kubecontext = test.kubecontext
+			if test.kubecontext != "" {
+				kubecontext = test.kubecontext
+			}
 			configFile = cfg
 			global = test.global
 
@@ -156,12 +170,6 @@ func TestSetAndUnsetConfig(t *testing.T) {
 				t.Error(cfgErr)
 			}
 			testutil.CheckErrorAndDeepEqual(t, false, err, test.expectedUnsetCfg, newConfig)
-
-			// reset all config context for next test
-			teardown()
-			kubecontext = ""
-			configFile = ""
-			global = false
 		})
 	}
 }

--- a/cmd/skaffold/app/cmd/config/list.go
+++ b/cmd/skaffold/app/cmd/config/list.go
@@ -55,7 +55,7 @@ func runList(out io.Writer) error {
 			return errors.Wrap(err, "marshaling config")
 		}
 	} else {
-		config, err := getConfigForKubectx()
+		config, err := GetConfigForKubectx()
 		if err != nil {
 			return err
 		}

--- a/cmd/skaffold/app/cmd/config/list.go
+++ b/cmd/skaffold/app/cmd/config/list.go
@@ -31,7 +31,6 @@ func NewCmdList(out io.Writer) *cobra.Command {
 		Short: "List all values set in the global skaffold config",
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			resolveKubectlContext()
 			return runList(out)
 		},
 	}

--- a/cmd/skaffold/app/cmd/config/set.go
+++ b/cmd/skaffold/app/cmd/config/set.go
@@ -34,7 +34,6 @@ func NewCmdSet(out io.Writer) *cobra.Command {
 		Short: "Set a value in the global skaffold config",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			resolveKubectlContext()
 			if err := setConfigValue(args[0], args[1]); err != nil {
 				return err
 			}

--- a/cmd/skaffold/app/cmd/config/util.go
+++ b/cmd/skaffold/app/cmd/config/util.go
@@ -83,8 +83,6 @@ func readConfig() (*Config, error) {
 // or the global config if that is specified (or if no current context is set).
 func GetConfigForKubectx() (*ContextConfig, error) {
 	resolveKubectlContext()
-	// TODO(nkubala): this call needs to be moved to its proper place
-	// currently doing it in the cmd handler for list(), this is not gonna work
 	cfg, err := readConfig()
 	if err != nil {
 		return nil, err
@@ -102,6 +100,7 @@ func GetConfigForKubectx() (*ContextConfig, error) {
 }
 
 func getOrCreateConfigForKubectx() (*ContextConfig, error) {
+	resolveKubectlContext()
 	cfg, err := readConfig()
 	if err != nil {
 		return nil, err

--- a/cmd/skaffold/app/cmd/config/util.go
+++ b/cmd/skaffold/app/cmd/config/util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 
@@ -62,6 +63,7 @@ func resolveConfigFile() error {
 // ReadConfigForFile reads the specified file and returns the contents
 // parsed into a Config struct.
 func ReadConfigForFile(filename string) (*Config, error) {
+	fmt.Printf("reading config for file %s\n", filename)
 	contents, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading global config")

--- a/cmd/skaffold/app/cmd/config/util.go
+++ b/cmd/skaffold/app/cmd/config/util.go
@@ -81,7 +81,10 @@ func readConfig() (*Config, error) {
 // return the specific config to be modified based on the provided kube context.
 // either returns the config corresponding to the provided or current context,
 // or the global config if that is specified (or if no current context is set).
-func getConfigForKubectx() (*ContextConfig, error) {
+func GetConfigForKubectx() (*ContextConfig, error) {
+	resolveKubectlContext()
+	// TODO(nkubala): this call needs to be moved to its proper place
+	// currently doing it in the cmd handler for list(), this is not gonna work
 	cfg, err := readConfig()
 	if err != nil {
 		return nil, err

--- a/cmd/skaffold/app/cmd/config/util.go
+++ b/cmd/skaffold/app/cmd/config/util.go
@@ -59,6 +59,8 @@ func resolveConfigFile() error {
 	return util.VerifyOrCreateFile(configFile)
 }
 
+// ReadConfigForFile reads the specified file and returns the contents
+// parsed into a Config struct.
 func ReadConfigForFile(filename string) (*Config, error) {
 	contents, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -78,8 +80,9 @@ func readConfig() (*Config, error) {
 	return ReadConfigForFile(configFile)
 }
 
-// return the specific config to be modified based on the provided kube context.
-// either returns the config corresponding to the provided or current context,
+// GetConfigForKubectx returns the specific config to be modified based on the
+// provided kube context.
+// Either returns the config corresponding to the provided or current context,
 // or the global config if that is specified (or if no current context is set).
 func GetConfigForKubectx() (*ContextConfig, error) {
 	resolveKubectlContext()
@@ -97,6 +100,15 @@ func GetConfigForKubectx() (*ContextConfig, error) {
 	}
 	logrus.Infof("no config entry found for kube-context %s", kubecontext)
 	return nil, nil
+}
+
+// GetGlobalConfig returns the global config values
+func GetGlobalConfig() (*ContextConfig, error) {
+	cfg, err := readConfig()
+	if err != nil {
+		return nil, err
+	}
+	return cfg.Global, nil
 }
 
 func getOrCreateConfigForKubectx() (*ContextConfig, error) {
@@ -130,4 +142,33 @@ func getOrCreateConfigForKubectx() (*ContextConfig, error) {
 	}
 
 	return newCfg, nil
+}
+
+func GetDefaultRepo(cliValue string) (string, error) {
+	// CLI flag takes precedence. If no default-repo specified from a flag,
+	// retrieve the value from the global config.
+	if cliValue != "" {
+		return cliValue, nil
+	}
+	cfg, err := GetConfigForKubectx()
+	if err != nil {
+		return "", errors.Wrap(err, "retrieving global config")
+	}
+	var defaultRepo string
+	if cfg != nil {
+		defaultRepo = cfg.DefaultRepo
+	}
+	if defaultRepo == "" {
+		// if we don't have a defaultRepo value set for the current context,
+		// retrieve the global config and use this value as a fallback
+		cfg, err := GetGlobalConfig()
+		if err != nil {
+			return "", errors.Wrap(err, "retrieving global config")
+		}
+		if cfg != nil {
+			defaultRepo = cfg.DefaultRepo
+		}
+	}
+
+	return defaultRepo, nil
 }

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -60,6 +60,10 @@ func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.Sk
 }
 
 func applyDefaultRepoSubstitution(config *latest.SkaffoldConfig, globalConfig *configutil.ContextConfig) error {
+	if globalConfig == nil {
+		// noop
+		return nil
+	}
 	for _, artifact := range config.Build.Artifacts {
 		artifact.ImageName = util.SubstituteDefaultRepoIntoImage(globalConfig.DefaultRepo, artifact.ImageName)
 	}

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -43,11 +43,12 @@ func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.Sk
 		return nil, nil, errors.Wrap(err, "applying profiles")
 	}
 
-	globalConfig, err := configutil.GetConfigForKubectx()
+	defaultRepo, err := configutil.GetDefaultRepo(opts.DefaultRepo)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "retrieving global config")
+		return nil, nil, errors.Wrap(err, "getting default repo")
 	}
-	if err = applyDefaultRepoSubstitution(config, globalConfig); err != nil {
+
+	if err = applyDefaultRepoSubstitution(config, defaultRepo); err != nil {
 		return nil, nil, errors.Wrap(err, "substituting default repos")
 	}
 
@@ -59,16 +60,16 @@ func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.Sk
 	return runner, config, nil
 }
 
-func applyDefaultRepoSubstitution(config *latest.SkaffoldConfig, globalConfig *configutil.ContextConfig) error {
-	if globalConfig == nil {
+func applyDefaultRepoSubstitution(config *latest.SkaffoldConfig, defaultRepo string) error {
+	if defaultRepo == "" {
 		// noop
 		return nil
 	}
 	for _, artifact := range config.Build.Artifacts {
-		artifact.ImageName = util.SubstituteDefaultRepoIntoImage(globalConfig.DefaultRepo, artifact.ImageName)
+		artifact.ImageName = util.SubstituteDefaultRepoIntoImage(defaultRepo, artifact.ImageName)
 	}
 	for _, testCase := range config.Test {
-		testCase.ImageName = util.SubstituteDefaultRepoIntoImage(globalConfig.DefaultRepo, testCase.ImageName)
+		testCase.ImageName = util.SubstituteDefaultRepoIntoImage(defaultRepo, testCase.ImageName)
 	}
 	return nil
 }

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -67,5 +67,8 @@ func applyDefaultRepoSubstitution(config *latest.SkaffoldConfig, globalConfig *c
 	for _, artifact := range config.Build.Artifacts {
 		artifact.ImageName = util.SubstituteDefaultRepoIntoImage(globalConfig.DefaultRepo, artifact.ImageName)
 	}
+	for _, testCase := range config.Test {
+		testCase.ImageName = util.SubstituteDefaultRepoIntoImage(globalConfig.DefaultRepo, testCase.ImageName)
+	}
 	return nil
 }

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -60,7 +60,7 @@ func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.Sk
 	return runner, config, nil
 }
 
-func applyDefaultRepoSubstitution(config *latest.SkaffoldConfig, defaultRepo string) error {
+func applyDefaultRepoSubstitution(config *latest.SkaffoldPipeline, defaultRepo string) error {
 	if defaultRepo == "" {
 		// noop
 		return nil

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -36,7 +36,7 @@ type SkaffoldOptions struct {
 	Trigger           string
 	CustomLabels      []string
 	WatchPollInterval int
-	DefaultRepo string
+	DefaultRepo       string
 }
 
 // Labels returns a map of labels to be applied to all deployed

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -36,6 +36,7 @@ type SkaffoldOptions struct {
 	Trigger           string
 	CustomLabels      []string
 	WatchPollInterval int
+	DefaultRepo string
 }
 
 // Labels returns a map of labels to be applied to all deployed

--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -111,20 +111,3 @@ func (m *multiDeployer) Cleanup(ctx context.Context, w io.Writer) error {
 
 	return nil
 }
-
-func joinTagsToBuildResult(builds []build.Artifact, params map[string]string) (map[string]build.Artifact, error) {
-	imageToBuildResult := map[string]build.Artifact{}
-	for _, build := range builds {
-		imageToBuildResult[build.ImageName] = build
-	}
-
-	paramToBuildResult := map[string]build.Artifact{}
-	for param, imageName := range params {
-		build, ok := imageToBuildResult[imageName]
-		if !ok {
-			return nil, fmt.Errorf("No build present for %s", imageName)
-		}
-		paramToBuildResult[param] = build
-	}
-	return paramToBuildResult, nil
-}

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -46,6 +46,7 @@ type HelmDeployer struct {
 
 	kubeContext string
 	namespace   string
+	defaultRepo string
 }
 
 // NewHelmDeployer returns a new HelmDeployer for a DeployConfig filled

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -51,11 +51,12 @@ type HelmDeployer struct {
 
 // NewHelmDeployer returns a new HelmDeployer for a DeployConfig filled
 // with the needed configuration for `helm`
-func NewHelmDeployer(cfg *latest.HelmDeploy, kubeContext string, namespace string) *HelmDeployer {
+func NewHelmDeployer(cfg *latest.HelmDeploy, kubeContext string, namespace string, defaultRepo string) *HelmDeployer {
 	return &HelmDeployer{
 		HelmDeploy:  cfg,
 		kubeContext: kubeContext,
 		namespace:   namespace,
+		defaultRepo: defaultRepo,
 	}
 }
 
@@ -126,7 +127,7 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 		color.Red.Fprintf(out, "Helm release %s not installed. Installing...\n", releaseName)
 		isInstalled = false
 	}
-	params, err := joinTagsToBuildResult(builds, r.Values)
+	params, err := h.joinTagsToBuildResult(builds, r.Values)
 	if err != nil {
 		return nil, errors.Wrap(err, "matching build results to chart values")
 	}
@@ -335,6 +336,24 @@ func (h *HelmDeployer) deleteRelease(ctx context.Context, out io.Writer, r lates
 	}
 
 	return nil
+}
+
+func (h *HelmDeployer) joinTagsToBuildResult(builds []build.Artifact, params map[string]string) (map[string]build.Artifact, error) {
+	imageToBuildResult := map[string]build.Artifact{}
+	for _, build := range builds {
+		imageToBuildResult[build.ImageName] = build
+	}
+
+	paramToBuildResult := map[string]build.Artifact{}
+	for param, imageName := range params {
+		newImageName := util.SubstituteDefaultRepoIntoImage(h.defaultRepo, imageName)
+		build, ok := imageToBuildResult[newImageName]
+		if !ok {
+			return nil, fmt.Errorf("No build present for %s", imageName)
+		}
+		paramToBuildResult[param] = build
+	}
+	return paramToBuildResult, nil
 }
 
 func evaluateReleaseName(nameTemplate string) (string, error) {

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -252,19 +252,19 @@ func TestHelmDeploy(t *testing.T) {
 		{
 			description: "deploy success",
 			cmd:         &MockHelm{t: t},
-			deployer:    NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace),
+			deployer:    NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace, ""),
 			builds:      testBuilds,
 		},
 		{
 			description: "deploy success with recreatePods",
 			cmd:         &MockHelm{t: t},
-			deployer:    NewHelmDeployer(testDeployRecreatePodsConfig, testKubeContext, testNamespace),
+			deployer:    NewHelmDeployer(testDeployRecreatePodsConfig, testKubeContext, testNamespace, ""),
 			builds:      testBuilds,
 		},
 		{
 			description: "deploy error unmatched parameter",
 			cmd:         &MockHelm{t: t},
-			deployer:    NewHelmDeployer(testDeployConfigParameterUnmatched, testKubeContext, testNamespace),
+			deployer:    NewHelmDeployer(testDeployConfigParameterUnmatched, testKubeContext, testNamespace, ""),
 			builds:      testBuilds,
 			shouldErr:   true,
 		},
@@ -284,7 +284,7 @@ func TestHelmDeploy(t *testing.T) {
 				},
 				upgradeResult: fmt.Errorf("should not have called upgrade"),
 			},
-			deployer: NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace),
+			deployer: NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace, ""),
 			builds:   testBuilds,
 		},
 		{
@@ -308,7 +308,7 @@ func TestHelmDeploy(t *testing.T) {
 				},
 				upgradeResult: fmt.Errorf("should not have called upgrade"),
 			},
-			deployer: NewHelmDeployer(testDeployHelmStyleConfig, testKubeContext, testNamespace),
+			deployer: NewHelmDeployer(testDeployHelmStyleConfig, testKubeContext, testNamespace, ""),
 			builds:   testBuilds,
 		},
 		{
@@ -317,7 +317,7 @@ func TestHelmDeploy(t *testing.T) {
 				t:             t,
 				installResult: fmt.Errorf("should not have called install"),
 			},
-			deployer: NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace),
+			deployer: NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace, ""),
 			builds:   testBuilds,
 		},
 		{
@@ -327,7 +327,7 @@ func TestHelmDeploy(t *testing.T) {
 				upgradeResult: fmt.Errorf("unexpected error"),
 			},
 			shouldErr: true,
-			deployer:  NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace),
+			deployer:  NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace, ""),
 			builds:    testBuilds,
 		},
 		{
@@ -337,7 +337,7 @@ func TestHelmDeploy(t *testing.T) {
 				depResult: fmt.Errorf("unexpected error"),
 			},
 			shouldErr: true,
-			deployer:  NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace),
+			deployer:  NewHelmDeployer(testDeployConfig, testKubeContext, testNamespace, ""),
 			builds:    testBuilds,
 		},
 		{
@@ -351,6 +351,7 @@ func TestHelmDeploy(t *testing.T) {
 				testDeployFooWithPackaged,
 				testKubeContext,
 				testNamespace,
+				"",
 			),
 			builds: testBuildsFoo,
 		},
@@ -365,13 +366,14 @@ func TestHelmDeploy(t *testing.T) {
 				testDeployFooWithPackaged,
 				testKubeContext,
 				testNamespace,
+				"",
 			),
 			builds: testBuildsFoo,
 		},
 		{
 			description: "deploy and get templated release name",
 			cmd:         &MockHelm{t: t},
-			deployer:    NewHelmDeployer(testDeployWithTemplatedName, testKubeContext, testNamespace),
+			deployer:    NewHelmDeployer(testDeployWithTemplatedName, testKubeContext, testNamespace, ""),
 			builds:      testBuilds,
 		},
 	}
@@ -537,7 +539,7 @@ func TestHelmDependencies(t *testing.T) {
 						SetValues:   map[string]string{"some.key": "somevalue"},
 					},
 				},
-			}, testKubeContext, testNamespace)
+			}, testKubeContext, testNamespace, "")
 
 			deps, err := deployer.Dependencies()
 

--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"strings"
@@ -82,17 +81,9 @@ func (k *KubectlDeployer) Deploy(ctx context.Context, out io.Writer, builds []bu
 		return nil, nil
 	}
 
-	for _, manifest := range manifests {
-		fmt.Printf("before replacing, manifest: %s", string(manifest))
-	}
-	// fmt.Printf("before replacing, manifests: %+v\n", manifests)
-
 	manifests, err = manifests.ReplaceImages(builds, k.defaultRepo)
 	if err != nil {
 		return nil, errors.Wrap(err, "replacing images in manifests")
-	}
-	for _, manifest := range manifests {
-		fmt.Printf("after replacing, manifest: %s", string(manifest))
 	}
 
 	updated, err := k.kubectl.Apply(ctx, out, manifests)

--- a/pkg/skaffold/deploy/kubectl/images.go
+++ b/pkg/skaffold/deploy/kubectl/images.go
@@ -70,8 +70,12 @@ func (r *imageReplacer) NewValue(old interface{}) (bool, interface{}) {
 	image := old.(string)
 	found, tag := r.parseAndReplace(image)
 	if !found {
+		subbedImage := r.substituteRepoIntoImage(image)
+		if image == subbedImage {
+			return found, tag
+		}
 		// no match, so try substituting in defaultRepo value
-		found, tag = r.parseAndReplace(r.substituteRepoIntoImage(image))
+		found, tag = r.parseAndReplace(subbedImage)
 	}
 	return found, tag
 }

--- a/pkg/skaffold/deploy/kubectl/images_test.go
+++ b/pkg/skaffold/deploy/kubectl/images_test.go
@@ -100,7 +100,7 @@ spec:
 	fakeWarner := &fakeWarner{}
 	warner = fakeWarner
 
-	resultManifest, err := manifests.ReplaceImages(builds)
+	resultManifest, err := manifests.ReplaceImages(builds, "")
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected.String(), resultManifest.String())
 	testutil.CheckErrorAndDeepEqual(t, false, err, []string{
@@ -114,7 +114,7 @@ func TestReplaceEmptyManifest(t *testing.T) {
 	manifests := ManifestList{[]byte(""), []byte("  ")}
 	expected := ManifestList{}
 
-	resultManifest, err := manifests.ReplaceImages(nil)
+	resultManifest, err := manifests.ReplaceImages(nil, "")
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected.String(), resultManifest.String())
 }
@@ -122,7 +122,7 @@ func TestReplaceEmptyManifest(t *testing.T) {
 func TestReplaceInvalidManifest(t *testing.T) {
 	manifests := ManifestList{[]byte("INVALID")}
 
-	_, err := manifests.ReplaceImages(nil)
+	_, err := manifests.ReplaceImages(nil, "")
 
 	testutil.CheckError(t, true, err)
 }

--- a/pkg/skaffold/deploy/kubectl/visitor.go
+++ b/pkg/skaffold/deploy/kubectl/visitor.go
@@ -25,7 +25,7 @@ import (
 type Replacer interface {
 	Matches(key string) bool
 
-	NewValue(key string, old interface{}) (bool, interface{})
+	NewValue(old interface{}) (bool, interface{})
 }
 
 // Visit recursively visits a list of manifests and applies transformations of them.
@@ -70,7 +70,7 @@ func recursiveVisit(i interface{}, replacer Replacer) {
 				continue
 			}
 
-			ok, newValue := replacer.NewValue(key, v)
+			ok, newValue := replacer.NewValue(v)
 			if ok {
 				t[k] = newValue
 			}

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -143,7 +143,7 @@ func TestKubectlDeploy(t *testing.T) {
 				util.DefaultExecCommand = test.command
 			}
 
-			k := NewKubectlDeployer(tmpDir.Root(), test.cfg, testKubeContext, testNamespace)
+			k := NewKubectlDeployer(tmpDir.Root(), test.cfg, testKubeContext, testNamespace, "")
 			_, err := k.Deploy(context.Background(), ioutil.Discard, test.builds)
 
 			testutil.CheckError(t, test.shouldErr, err)
@@ -199,7 +199,7 @@ func TestKubectlCleanup(t *testing.T) {
 				util.DefaultExecCommand = test.command
 			}
 
-			k := NewKubectlDeployer(tmpDir.Root(), test.cfg, testKubeContext, testNamespace)
+			k := NewKubectlDeployer(tmpDir.Root(), test.cfg, testKubeContext, testNamespace, "")
 			err := k.Cleanup(context.Background(), ioutil.Discard)
 
 			testutil.CheckError(t, test.shouldErr, err)
@@ -219,7 +219,7 @@ func TestKubectlRedeploy(t *testing.T) {
 	cfg := &latest.KubectlDeploy{
 		Manifests: []string{"deployment-web.yaml", "deployment-app.yaml"},
 	}
-	deployer := NewKubectlDeployer(tmpDir.Root(), cfg, testKubeContext, testNamespace)
+	deployer := NewKubectlDeployer(tmpDir.Root(), cfg, testKubeContext, testNamespace, "")
 
 	// Deploy one manifest
 	deployed, err := deployer.Deploy(context.Background(), ioutil.Discard, []build.Artifact{

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -18,6 +18,7 @@ package deploy
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os/exec"
@@ -92,6 +93,9 @@ func (k *KustomizeDeployer) Deploy(ctx context.Context, out io.Writer, builds []
 	manifests, err = manifests.ReplaceImages(builds, k.defaultRepo)
 	if err != nil {
 		return nil, errors.Wrap(err, "replacing images in manifests")
+	}
+	for _, manifest := range manifests {
+		fmt.Printf("manifest: %s\n", string(manifest))
 	}
 
 	updated, err := k.kubectl.Apply(ctx, out, manifests)

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -55,11 +55,11 @@ type configMapGenerator struct {
 type KustomizeDeployer struct {
 	*latest.KustomizeDeploy
 
-	kubectl kubectl.CLI
+	kubectl     kubectl.CLI
+	defaultRepo string
 }
 
-// NewKustomizeDeployer returns a new KustomizeDeployer.
-func NewKustomizeDeployer(cfg *latest.KustomizeDeploy, kubeContext string, namespace string) *KustomizeDeployer {
+func NewKustomizeDeployer(cfg *latest.KustomizeDeploy, kubeContext string, namespace string, defaultRepo string) *KustomizeDeployer {
 	return &KustomizeDeployer{
 		KustomizeDeploy: cfg,
 		kubectl: kubectl.CLI{
@@ -67,6 +67,7 @@ func NewKustomizeDeployer(cfg *latest.KustomizeDeploy, kubeContext string, names
 			KubeContext: kubeContext,
 			Flags:       cfg.Flags,
 		},
+		defaultRepo: defaultRepo,
 	}
 }
 
@@ -88,7 +89,7 @@ func (k *KustomizeDeployer) Deploy(ctx context.Context, out io.Writer, builds []
 		return nil, nil
 	}
 
-	manifests, err = manifests.ReplaceImages(builds)
+	manifests, err = manifests.ReplaceImages(builds, k.defaultRepo)
 	if err != nil {
 		return nil, errors.Wrap(err, "replacing images in manifests")
 	}

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -74,14 +74,9 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldPipeline) (*
 	}
 	logrus.Infof("Using kubectl context: %s", kubeContext)
 
-	globalConfig, err := configutil.GetConfigForKubectx()
+	defaultRepo, err := configutil.GetDefaultRepo(opts.DefaultRepo)
 	if err != nil {
-		return nil, errors.Wrap(err, "retrieving global config")
-	}
-
-	defaultRepo := ""
-	if globalConfig != nil {
-		defaultRepo = globalConfig.DefaultRepo
+		return nil, errors.Wrap(err, "getting default repo")
 	}
 
 	tagger, err := getTagger(cfg.Build.TagPolicy, opts.CustomTag)

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -156,7 +156,7 @@ func getDeployer(cfg *latest.DeployConfig, kubeContext string, namespace string,
 
 	// HelmDeploy first, in case there are resources in Kubectl that depend on these...
 	if cfg.HelmDeploy != nil {
-		deployers = append(deployers, deploy.NewHelmDeployer(cfg.HelmDeploy, kubeContext, namespace))
+		deployers = append(deployers, deploy.NewHelmDeployer(cfg.HelmDeploy, kubeContext, namespace, defaultRepo))
 	}
 
 	if cfg.KubectlDeploy != nil {

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -79,6 +79,11 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldPipeline) (*
 		return nil, errors.Wrap(err, "retrieving global config")
 	}
 
+	defaultRepo := ""
+	if globalConfig != nil {
+		defaultRepo = globalConfig.DefaultRepo
+	}
+
 	tagger, err := getTagger(cfg.Build.TagPolicy, opts.CustomTag)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing skaffold tag config")
@@ -94,7 +99,7 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldPipeline) (*
 		return nil, errors.Wrap(err, "parsing skaffold test config")
 	}
 
-	deployer, err := getDeployer(&cfg.Deploy, kubeContext, opts.Namespace, globalConfig.DefaultRepo)
+	deployer, err := getDeployer(&cfg.Deploy, kubeContext, opts.Namespace, defaultRepo)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing skaffold deploy config")
 	}

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -64,7 +64,6 @@ type SkaffoldRunner struct {
 	opts         *config.SkaffoldOptions
 	watchFactory watch.Factory
 	builds       []build.Artifact
-	// globalConfig *configutil.ContextConfig
 }
 
 // NewForConfig returns a new SkaffoldRunner for a SkaffoldPipeline
@@ -120,7 +119,6 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldPipeline) (*
 		Syncer:       &kubectl.Syncer{},
 		opts:         opts,
 		watchFactory: watch.NewWatcher,
-		// globalConfig: globalConfig,
 	}, nil
 }
 

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -150,7 +150,7 @@ func getBuilder(cfg *latest.BuildConfig, kubeContext string) (build.Builder, err
 	}
 }
 
-func getTester(cfg *[]latest.TestCase) (test.Tester, error) {
+func getTester(cfg *[]*latest.TestCase) (test.Tester, error) {
 	return test.NewTester(cfg)
 }
 

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -330,7 +330,7 @@ func TestRun(t *testing.T) {
 						},
 					},
 				},
-				Test: []latest.TestCase{
+				Test: []*latest.TestCase{
 					{
 						ImageName:      "test",
 						StructureTests: []string{"fake_file.yaml"},

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -34,7 +34,7 @@ type SkaffoldPipeline struct {
 	Kind       string `yaml:"kind"`
 
 	Build    BuildConfig  `yaml:"build,omitempty"`
-	Test     []TestCase   `yaml:"test,omitempty"`
+	Test     []*TestCase  `yaml:"test,omitempty"`
 	Deploy   DeployConfig `yaml:"deploy,omitempty"`
 	Profiles []Profile    `yaml:"profiles,omitempty"`
 }
@@ -237,7 +237,7 @@ type Artifact struct {
 type Profile struct {
 	Name   string       `yaml:"name,omitempty"`
 	Build  BuildConfig  `yaml:"build,omitempty"`
-	Test   []TestCase   `yaml:"test,omitempty"`
+	Test   []*TestCase  `yaml:"test,omitempty"`
 	Deploy DeployConfig `yaml:"deploy,omitempty"`
 }
 

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -55,7 +55,7 @@ func applyProfile(config *latest.SkaffoldPipeline, profile latest.Profile) {
 		Kind:       config.Kind,
 		Build:      overlayProfileField(config.Build, profile.Build).(latest.BuildConfig),
 		Deploy:     overlayProfileField(config.Deploy, profile.Deploy).(latest.DeployConfig),
-		Test:       overlayProfileField(config.Test, profile.Test).([]latest.TestCase),
+		Test:       overlayProfileField(config.Test, profile.Test).([]*latest.TestCase),
 	}
 }
 

--- a/pkg/skaffold/test/test.go
+++ b/pkg/skaffold/test/test.go
@@ -77,7 +77,7 @@ func (t FullTester) Test(ctx context.Context, out io.Writer, bRes []build.Artifa
 	return nil
 }
 
-func (t FullTester) runStructureTests(ctx context.Context, out io.Writer, bRes []build.Artifact, testCase latest.TestCase) error {
+func (t FullTester) runStructureTests(ctx context.Context, out io.Writer, bRes []build.Artifact, testCase *latest.TestCase) error {
 	if len(testCase.StructureTests) == 0 {
 		return nil
 	}

--- a/pkg/skaffold/test/test.go
+++ b/pkg/skaffold/test/test.go
@@ -32,7 +32,7 @@ import (
 // NewTester parses the provided test cases from the Skaffold config,
 // and returns a Tester instance with all the necessary test runners
 // to run all specified tests.
-func NewTester(testCases *[]latest.TestCase) (Tester, error) {
+func NewTester(testCases *[]*latest.TestCase) (Tester, error) {
 	// TODO(nkubala): copied this from runner.getDeployer(), this should be moved somewhere else
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/pkg/skaffold/test/types.go
+++ b/pkg/skaffold/test/types.go
@@ -42,7 +42,7 @@ type Tester interface {
 // FullTester should always be the ONLY implementation of the Tester interface;
 // newly added testing implementations should implement the Runner interface.
 type FullTester struct {
-	testCases  *[]latest.TestCase
+	testCases  *[]*latest.TestCase
 	workingDir string
 }
 

--- a/pkg/skaffold/util/image.go
+++ b/pkg/skaffold/util/image.go
@@ -21,6 +21,9 @@ import (
 )
 
 func SubstituteDefaultRepoIntoImage(defaultRepo string, originalImage string) string {
+	if defaultRepo == "" {
+		return originalImage
+	}
 	if strings.HasPrefix(defaultRepo, "gcr.io") {
 		if !strings.HasPrefix(originalImage, defaultRepo) {
 			return defaultRepo + "/" + originalImage

--- a/pkg/skaffold/util/image.go
+++ b/pkg/skaffold/util/image.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"strings"
+)
+
+func SubstituteDefaultRepoIntoImage(defaultRepo string, originalImage string) string {
+	if strings.HasPrefix(defaultRepo, "gcr.io") {
+		if !strings.HasPrefix(originalImage, defaultRepo) {
+			return defaultRepo + "/" + originalImage
+		} else {
+			// TODO: this one is a little harder
+			return originalImage
+		}
+	} else {
+		// TODO: escape, concat, truncate to 256
+		return originalImage
+	}
+	return originalImage
+}

--- a/pkg/skaffold/util/image_test.go
+++ b/pkg/skaffold/util/image_test.go
@@ -46,6 +46,24 @@ func TestImageReplaceDefaultRepo(t *testing.T) {
 			defaultRepo:   "gcr.io/default",
 			expectedImage: "gcr.io/default/registry",
 		},
+		{
+			name:          "image has shared prefix with defaultRepo",
+			image:         "gcr.io/default/example/registry",
+			defaultRepo:   "gcr.io/default/repository",
+			expectedImage: "gcr.io/default/repository/example/registry",
+		},
+		{
+			name:          "aws",
+			image:         "gcr.io/some/registry",
+			defaultRepo:   "aws_account_id.dkr.ecr.region.amazonaws.com",
+			expectedImage: "aws_account_id.dkr.ecr.region.amazonaws.com/gcr_io_some_registry",
+		},
+		{
+			name:          "aws over 255 chars",
+			image:         "gcr.io/herewehaveanincrediblylongregistryname/herewealsohaveanabnormallylongimagename/doubtyouveseenanimagethislong/butyouneverknowdoyouimeanpeopledosomecrazystuffoutthere/goodluckpushingthistoanyregistrymyfriend",
+			defaultRepo:   "aws_account_id.dkr.ecr.region.amazonaws.com",
+			expectedImage: "aws_account_id.dkr.ecr.region.amazonaws.com/gcr_io_herewehaveanincrediblylongregistryname_herewealsohaveanabnormallylongimagename_doubtyouveseenanimagethislong_butyouneverknowdoyouimeanpeopledosomecrazystuffoutthere_goodluckpushingthistoanyregistrymyfrien",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/skaffold/util/image_test.go
+++ b/pkg/skaffold/util/image_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestImageReplaceDefaultRepo(t *testing.T) {
+	tests := []struct {
+		name          string
+		image         string
+		defaultRepo   string
+		expectedImage string
+	}{
+		{
+			name:          "basic GCR concatenation",
+			image:         "gcr.io/some/registry",
+			defaultRepo:   "gcr.io/default",
+			expectedImage: "gcr.io/default/gcr.io/some/registry",
+		},
+		{
+			name:          "no default repo set",
+			image:         "gcr.io/some/registry",
+			expectedImage: "gcr.io/some/registry",
+		},
+		{
+			name:          "provided image has defaultRepo prefix",
+			image:         "gcr.io/default/registry",
+			defaultRepo:   "gcr.io/default",
+			expectedImage: "gcr.io/default/registry",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testutil.CheckDeepEqual(t, test.expectedImage, SubstituteDefaultRepoIntoImage(test.defaultRepo, test.image))
+		})
+	}
+}


### PR DESCRIPTION
This PR enables users to set the "default-repo" value in the skaffold
global config. This value will be substituted into all provided images
in the skaffold.yaml and k8s manifests according to certain
heuristics, allowing a better user experience for developing
applications against different image registries.