### PR TITLE
Revert "Rename kustomize.KustomizePath to kustomize.Path"

### DIFF
--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -133,7 +133,7 @@ deploy:
     # - namespace:deployment/web-app2
 
  # kustomize:
-    # path: .
+    # kustomizePath: .
     # kustomize deploys manifests with kubectl.
     # kubectl can be passed additional option flags either on every command (Global),
     # on creations (Apply) or deletions (Delete).

--- a/integration/examples/annotated-skaffold.yaml
+++ b/integration/examples/annotated-skaffold.yaml
@@ -133,7 +133,7 @@ deploy:
     # - namespace:deployment/web-app2
 
  # kustomize:
-    # path: .
+    # kustomizePath: "kustomization.yaml"
     # kustomize deploys manifests with kubectl.
     # kubectl can be passed additional option flags either on every command (Global),
     # on creations (Apply) or deletions (Delete).

--- a/integration/examples/annotated-skaffold.yaml
+++ b/integration/examples/annotated-skaffold.yaml
@@ -133,7 +133,7 @@ deploy:
     # - namespace:deployment/web-app2
 
  # kustomize:
-    # kustomizePath: "kustomization.yaml"
+    # kustomizePath: .
     # kustomize deploys manifests with kubectl.
     # kubectl can be passed additional option flags either on every command (Global),
     # on creations (Apply) or deletions (Delete).

--- a/pkg/skaffold/config/transform/transforms.go
+++ b/pkg/skaffold/config/transform/transforms.go
@@ -132,7 +132,6 @@ func ToV1Alpha3(vc util.VersionedConfig) (util.VersionedConfig, error) {
 	if err := convert(oldConfig.Deploy, &newDeploy); err != nil {
 		return nil, errors.Wrap(err, "converting deploy config")
 	}
-
 	// if the helm deploy config was set, then convert ValueFilePath to ValuesFiles
 	if oldHelmDeploy := oldConfig.Deploy.DeployType.HelmDeploy; oldHelmDeploy != nil {
 		for i, oldHelmRelease := range oldHelmDeploy.Releases {
@@ -140,12 +139,6 @@ func ToV1Alpha3(vc util.VersionedConfig) (util.VersionedConfig, error) {
 				newDeploy.DeployType.HelmDeploy.Releases[i].ValuesFiles = []string{oldHelmRelease.ValuesFilePath}
 			}
 		}
-	}
-
-	// the kustomize path parameter was renamed
-	kustomize := oldConfig.Deploy.KustomizeDeploy
-	if kustomize != nil {
-		newDeploy.KustomizeDeploy.Path = kustomize.KustomizePath
 	}
 
 	// convert v1alpha2.Profiles to v1alpha3.Profiles (should be the same)

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -164,11 +164,11 @@ func joinPaths(root string, paths []string) []string {
 
 // Dependencies lists all the files that can change what needs to be deployed.
 func (k *KustomizeDeployer) Dependencies() ([]string, error) {
-	return dependenciesForKustomization(k.Path)
+	return dependenciesForKustomization(k.KustomizePath)
 }
 
 func (k *KustomizeDeployer) readManifests(ctx context.Context) (kubectl.ManifestList, error) {
-	cmd := exec.CommandContext(ctx, "kustomize", "build", k.Path)
+	cmd := exec.CommandContext(ctx, "kustomize", "build", k.KustomizePath)
 	out, err := util.RunCmdOut(cmd)
 	if err != nil {
 		return nil, errors.Wrap(err, "kustomize build")

--- a/pkg/skaffold/schema/v1alpha3/config.go
+++ b/pkg/skaffold/schema/v1alpha3/config.go
@@ -144,10 +144,9 @@ type HelmDeploy struct {
 	Releases []HelmRelease `yaml:"releases,omitempty"`
 }
 
-// KustomizeDeploy contains the configuration needed for deploying with kustomize.
 type KustomizeDeploy struct {
-	Path  string       `yaml:"path,omitempty"`
-	Flags KubectlFlags `yaml:"flags,omitempty"`
+	KustomizePath string       `yaml:"kustomizePath,omitempty"`
+	Flags         KubectlFlags `yaml:"flags,omitempty"`
 }
 
 type HelmRelease struct {

--- a/pkg/skaffold/schema/v1alpha3/defaults.go
+++ b/pkg/skaffold/schema/v1alpha3/defaults.go
@@ -95,13 +95,8 @@ func (c *SkaffoldConfig) setDefaultTagger() {
 }
 
 func (c *SkaffoldConfig) setDefaultKustomizePath() {
-	kustomize := c.Deploy.KustomizeDeploy
-	if kustomize == nil {
-		return
-	}
-
-	if kustomize.Path == "" {
-		kustomize.Path = constants.DefaultKustomizationPath
+	if c.Deploy.KustomizeDeploy != nil && c.Deploy.KustomizeDeploy.KustomizePath == "" {
+		c.Deploy.KustomizeDeploy.KustomizePath = constants.DefaultKustomizationPath
 	}
 }
 


### PR DESCRIPTION
This needs to be reverted because it was not merged in time into the new v1alpha3 config format.

This reverts commit ceeb2472325394feb83bba28f567eb4ef4c6412d.