### PR TITLE
Transform values files in profiles to v1alpha3

### DIFF
--- a/pkg/skaffold/config/transform/transforms.go
+++ b/pkg/skaffold/config/transform/transforms.go
@@ -148,6 +148,16 @@ func ToV1Alpha3(vc util.VersionedConfig) (util.VersionedConfig, error) {
 			return nil, errors.Wrap(err, "converting new profile")
 		}
 	}
+	// if the helm deploy config was set for a profile, then convert ValueFilePath to ValuesFiles
+	for p, oldProfile := range oldConfig.Profiles {
+		if oldProfileHelmDeploy := oldProfile.Deploy.DeployType.HelmDeploy; oldProfileHelmDeploy != nil {
+			for i, oldProfileHelmRelease := range oldProfileHelmDeploy.Releases {
+				if oldProfileHelmRelease.ValuesFilePath != "" {
+					newProfiles[p].Deploy.DeployType.HelmDeploy.Releases[i].ValuesFiles = []string{oldProfileHelmRelease.ValuesFilePath}
+				}
+			}
+		}
+	}
 
 	// convert v1alpha2.Build to v1alpha3.Build (different only for kaniko)
 	oldKanikoBuilder := oldConfig.Build.KanikoBuild


### PR DESCRIPTION
I made a mistake in #985. With the v0.15.0 `skaffold fix` the `valuesFilePath` field in profiles is completely dropped. These changes fix that.

These changes are based on the `v0.15.0` tag. I think this PR shouldn't actually point to master but to a v0.15.x branch from which we may release v0.15.1

Apologies for the inconvenience. I hope it's possible to push out a hotfix release fast.