### PR TITLE
Fix missing parenthesis

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -81,7 +81,7 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 	rootCmd.AddCommand(NewCmdConfig(out))
 	rootCmd.AddCommand(NewCmdInit(out))
 
-	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", constants.DefaultLogLevel.String(), "Log level (debug, info, warn, error, fatal, panic")
+	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", constants.DefaultLogLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 
 	setFlagsFromEnvVariables(rootCmd.Commands())
 


### PR DESCRIPTION
```
$ skaffold --help
...
Flags:
  -v, --verbosity string   Log level (debug, info, warn, error, fatal, panic (default "warning")
...
```

Add a parenthesis at the end




Signed-off-by: David Gageot <david@gageot.net>