### PR TITLE
Add --label flag to specify custom labels for deployments

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -136,10 +136,12 @@ func AddDevFlags(cmd *cobra.Command) {
 	cmd.Flags().StringArrayVarP(&opts.Watch, "watch-image", "w", nil, "Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts.")
 	cmd.Flags().IntVarP(&opts.WatchPollInterval, "watch-poll-interval", "i", 1000, "Interval (in ms) between two checks for file changes.")
 	cmd.Flags().BoolVar(&opts.PortForward, "port-forward", true, "Port-forward exposed container ports within pods")
+	cmd.Flags().StringArrayVarP(&opts.CustomLabels, "label", "l", nil, "Add custom labels to deployed objects. Set multiple times for multiple labels.")
 }
 
 func AddRunDeployFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&opts.Tail, "tail", false, "Stream logs from deployed objects")
+	cmd.Flags().StringArrayVarP(&opts.CustomLabels, "label", "l", nil, "Add custom labels to deployed objects. Set multiple times for multiple labels.")
 }
 
 func AddRunDevFlags(cmd *cobra.Command) {

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -34,6 +34,7 @@ type SkaffoldOptions struct {
 	Namespace         string
 	Watch             []string
 	Trigger           string
+	CustomLabels      []string
 	WatchPollInterval int
 }
 
@@ -53,6 +54,14 @@ func (opts *SkaffoldOptions) Labels() map[string]string {
 	}
 	if len(opts.Profiles) > 0 {
 		labels["profiles"] = strings.Join(opts.Profiles, ",")
+	}
+	for _, cl := range opts.CustomLabels {
+		l := strings.SplitN(cl, "=", 2)
+		if len(l) == 1 {
+			labels[l[0]] = ""
+			continue
+		}
+		labels[l[0]] = l[1]
 	}
 	return labels
 }

--- a/pkg/skaffold/config/options_test.go
+++ b/pkg/skaffold/config/options_test.go
@@ -65,6 +65,25 @@ func TestLabels(t *testing.T) {
 				"profiles":  "p1,p2",
 			},
 		},
+		{
+			description: "custom labels",
+			options: SkaffoldOptions{
+				Cleanup: true,
+				CustomLabels: []string{
+					"one=first",
+					"two=second",
+					"three=",
+					"four",
+				},
+			},
+			expectedLabels: map[string]string{
+				"cleanup": "true",
+				"one":     "first",
+				"two":     "second",
+				"three":   "",
+				"four":    "",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This should work for skaffold run, dev, and deploy to help support external tools/scripts provide their own labels. 

e.g. skaffold run --label firstlabel=one --label secondlabel=two