### PR TITLE
 Improves jib.getDependencies.

### DIFF
--- a/pkg/skaffold/jib/jib_test.go
+++ b/pkg/skaffold/jib/jib_test.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"sort"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -91,7 +93,8 @@ func TestGetDependencies(t *testing.T) {
 				nil,
 			)
 
-			deps, err := getDependencies(&exec.Cmd{Args: []string{"ignored"}})
+			deps, err := getDependencies(&exec.Cmd{Args: []string{"ignored"}, Dir: tmpDir.Root()})
+			sort.Strings(deps)
 			testutil.CheckErrorAndDeepEqual(t, false, err, test.expectedDeps, deps)
 		})
 	}

--- a/pkg/skaffold/jib/jib_test.go
+++ b/pkg/skaffold/jib/jib_test.go
@@ -63,6 +63,10 @@ func TestGetDependencies(t *testing.T) {
 			expectedDeps: []string{dep1, dep2},
 		},
 		{
+			stdout:       fmt.Sprintf("%s\n%s\n%s\n", dep1, dep2, tmpDir.Root()),
+			expectedDeps: []string{dep1, dep2},
+		},
+		{
 			stdout:       "\n\n\n",
 			expectedDeps: nil,
 		},


### PR DESCRIPTION
Resolves issues in #1096:

- Use `godirwalk.walk` (https://github.com/GoogleContainerTools/skaffold/pull/1097#discussion_r223378336)
- Don't walk dep if is workspace root

/cc @GoogleContainerTools/java-tools 