### PR TITLE
 Handles Jib build directly to registry when push=true.

### DIFF
--- a/pkg/skaffold/build/local/jib_gradle.go
+++ b/pkg/skaffold/build/local/jib_gradle.go
@@ -35,11 +35,12 @@ func (b *Builder) buildJibGradle(ctx context.Context, out io.Writer, workspace s
 	cmd := jib.GradleCommand.CreateCommand(ctx, workspace, commandLine)
 	cmd.Stdout = out
 	cmd.Stderr = out
+
 	logrus.Infof("Building %s: %s, %v", workspace, cmd.Path, cmd.Args)
-	err := util.RunCmd(cmd)
-	if err != nil {
+	if err := util.RunCmd(cmd); err != nil {
 		return "", errors.Wrap(err, "gradle build failed")
 	}
+
 	return skaffoldImage, nil
 }
 
@@ -47,13 +48,13 @@ func (b *Builder) buildJibGradle(ctx context.Context, out io.Writer, workspace s
 // project in `workspace`.  The resulting image is added to the local docker daemon
 // and called `skaffoldImage`.
 func generateGradleCommand(_ /*workspace*/ string, skaffoldImage string, a *latest.JibGradleArtifact) []string {
-	var command []string
+	var command string
 	if a.Project == "" {
-		command = []string{":jibDockerBuild"}
+		command = ":jibDockerBuild"
 	} else {
 		// multi-module
-		command = []string{fmt.Sprintf(":%s:jibDockerBuild", a.Project)}
+		command = fmt.Sprintf(":%s:jibDockerBuild", a.Project)
 	}
-	command = append(command, "--image="+skaffoldImage)
-	return command
+
+	return []string{command, "--image=" + skaffoldImage}
 }

--- a/pkg/skaffold/build/local/jib_gradle.go
+++ b/pkg/skaffold/build/local/jib_gradle.go
@@ -28,33 +28,51 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (b *Builder) buildJibGradle(ctx context.Context, out io.Writer, workspace string, a *latest.JibGradleArtifact) (string, error) {
+func (b *Builder) buildJibGradleToDocker(ctx context.Context, out io.Writer, workspace string, a *latest.JibGradleArtifact) (string, error) {
 	skaffoldImage := generateJibImageRef(workspace, a.Project)
-	commandLine := generateGradleCommand(workspace, skaffoldImage, a)
+	args := generateGradleArgs("jibDockerBuild", skaffoldImage, a)
 
-	cmd := jib.GradleCommand.CreateCommand(ctx, workspace, commandLine)
-	cmd.Stdout = out
-	cmd.Stderr = out
-
-	logrus.Infof("Building %s: %s, %v", workspace, cmd.Path, cmd.Args)
-	if err := util.RunCmd(cmd); err != nil {
-		return "", errors.Wrap(err, "gradle build failed")
+	if err := runGradleCommand(ctx, out, workspace, args); err != nil {
+		return "", err
 	}
 
 	return skaffoldImage, nil
 }
 
-// generateGradleCommand generates the command-line to pass to gradle for building an
-// project in `workspace`.  The resulting image is added to the local docker daemon
-// and called `skaffoldImage`.
-func generateGradleCommand(_ /*workspace*/ string, skaffoldImage string, a *latest.JibGradleArtifact) []string {
+func (b *Builder) buildJibGradleToRegistry(ctx context.Context, out io.Writer, workspace string, artifact *latest.Artifact) (string, error) {
+	initialTag := util.RandomID()
+	skaffoldImage := fmt.Sprintf("%s:%s", artifact.ImageName, initialTag)
+	args := generateGradleArgs("jib", skaffoldImage, artifact.JibGradleArtifact)
+
+	if err := runGradleCommand(ctx, out, workspace, args); err != nil {
+		return "", err
+	}
+
+	return skaffoldImage, nil
+}
+
+// generateGradleArgs generates the arguments to Gradle for building the project as an image called `skaffoldImage`.
+func generateGradleArgs(task string, skaffoldImage string, a *latest.JibGradleArtifact) []string {
 	var command string
 	if a.Project == "" {
-		command = ":jibDockerBuild"
+		command = ":" + task
 	} else {
 		// multi-module
-		command = fmt.Sprintf(":%s:jibDockerBuild", a.Project)
+		command = fmt.Sprintf(":%s:%s", a.Project, task)
 	}
 
 	return []string{command, "--image=" + skaffoldImage}
+}
+
+func runGradleCommand(ctx context.Context, out io.Writer, workspace string, args []string) error {
+	cmd := jib.GradleCommand.CreateCommand(ctx, workspace, args)
+	cmd.Stdout = out
+	cmd.Stderr = out
+
+	logrus.Infof("Building %s: %s, %v", workspace, cmd.Path, cmd.Args)
+	if err := util.RunCmd(cmd); err != nil {
+		return errors.Wrap(err, "gradle build failed")
+	}
+
+	return nil
 }

--- a/pkg/skaffold/build/local/jib_maven.go
+++ b/pkg/skaffold/build/local/jib_maven.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"fmt"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/jib"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"

--- a/pkg/skaffold/build/local/jib_test.go
+++ b/pkg/skaffold/build/local/jib_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package local
 
 import (
+	"context"
+	"io/ioutil"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -33,16 +35,18 @@ func TestGenerateMavenCommand(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		commandLine, err := generateMavenCommand(".", "image", &tt.in)
+		command := generateMavenCommand(".", "image", &tt.in)
 
-		testutil.CheckError(t, false, err)
-		testutil.CheckDeepEqual(t, tt.out, commandLine)
+		testutil.CheckDeepEqual(t, tt.out, command)
 	}
 }
 
-func TestGenerateMavenCommand_errorWithModule(t *testing.T) {
-	a := latest.JibMavenArtifact{Module: "module"}
-	_, err := generateMavenCommand(".", "image", &a)
+func TestMultiModulesNotSupported(t *testing.T) {
+	builder := &Builder{}
+
+	_, err := builder.buildJibMaven(context.Background(), ioutil.Discard, ".", &latest.JibMavenArtifact{
+		Module: "module",
+	})
 
 	testutil.CheckError(t, true, err)
 }
@@ -57,9 +61,9 @@ func TestGenerateGradleCommand(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		commandLine := generateGradleCommand(".", "image", &tt.in)
+		command := generateGradleCommand(".", "image", &tt.in)
 
-		testutil.CheckDeepEqual(t, tt.out, commandLine)
+		testutil.CheckDeepEqual(t, tt.out, command)
 	}
 }
 
@@ -77,8 +81,7 @@ func TestGenerateJibImageRef(t *testing.T) {
 
 	for _, tt := range testCases {
 		computed := generateJibImageRef(tt.workspace, tt.project)
-		if tt.out != computed {
-			t.Errorf("Expected '%s' for '%s'/'%s': '%s'", tt.out, tt.workspace, tt.project, computed)
-		}
+
+		testutil.CheckDeepEqual(t, tt.out, computed)
 	}
 }

--- a/pkg/skaffold/build/local/jib_test.go
+++ b/pkg/skaffold/build/local/jib_test.go
@@ -25,43 +25,43 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestGenerateMavenCommand(t *testing.T) {
+func TestGenerateMavenArgs(t *testing.T) {
 	var testCases = []struct {
 		in  latest.JibMavenArtifact
 		out []string
 	}{
-		{latest.JibMavenArtifact{}, []string{"prepare-package", "jib:dockerBuild", "-Dimage=image"}},
-		{latest.JibMavenArtifact{Profile: "profile"}, []string{"prepare-package", "jib:dockerBuild", "-Dimage=image", "-Pprofile"}},
+		{latest.JibMavenArtifact{}, []string{"prepare-package", "jib:goal", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Profile: "profile"}, []string{"prepare-package", "jib:goal", "-Dimage=image", "-Pprofile"}},
 	}
 
 	for _, tt := range testCases {
-		command := generateMavenCommand(".", "image", &tt.in)
+		args := generateMavenArgs("goal", "image", &tt.in)
 
-		testutil.CheckDeepEqual(t, tt.out, command)
+		testutil.CheckDeepEqual(t, tt.out, args)
 	}
 }
 
 func TestMultiModulesNotSupported(t *testing.T) {
 	builder := &Builder{}
 
-	_, err := builder.buildJibMaven(context.Background(), ioutil.Discard, ".", &latest.JibMavenArtifact{
+	_, err := builder.buildJibMavenToDocker(context.Background(), ioutil.Discard, ".", &latest.JibMavenArtifact{
 		Module: "module",
 	})
 
 	testutil.CheckError(t, true, err)
 }
 
-func TestGenerateGradleCommand(t *testing.T) {
+func TestGenerateGradleArgs(t *testing.T) {
 	var testCases = []struct {
 		in  latest.JibGradleArtifact
 		out []string
 	}{
-		{latest.JibGradleArtifact{}, []string{":jibDockerBuild", "--image=image"}},
-		{latest.JibGradleArtifact{Project: "project"}, []string{":project:jibDockerBuild", "--image=image"}},
+		{latest.JibGradleArtifact{}, []string{":task", "--image=image"}},
+		{latest.JibGradleArtifact{Project: "project"}, []string{":project:task", "--image=image"}},
 	}
 
 	for _, tt := range testCases {
-		command := generateGradleCommand(".", "image", &tt.in)
+		command := generateGradleArgs("task", "image", &tt.in)
 
 		testutil.CheckDeepEqual(t, tt.out, command)
 	}

--- a/pkg/skaffold/jib/jib_gradle_test.go
+++ b/pkg/skaffold/jib/jib_gradle_test.go
@@ -18,12 +18,10 @@ package jib
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
-
-	"fmt"
-	"path/filepath"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -32,12 +30,8 @@ import (
 )
 
 func TestGradleWrapperDefinition(t *testing.T) {
-	if GradleCommand.Executable != "gradle" {
-		t.Error("GradleCommand executable should be 'gradle'")
-	}
-	if GradleCommand.Wrapper != "gradlew" {
-		t.Error("GradleCommand wrapper should be 'gradlew'")
-	}
+	testutil.CheckDeepEqual(t, "gradle", GradleCommand.Executable)
+	testutil.CheckDeepEqual(t, "gradlew", GradleCommand.Wrapper)
 }
 
 func TestGetDependenciesGradle(t *testing.T) {
@@ -47,20 +41,21 @@ func TestGetDependenciesGradle(t *testing.T) {
 	tmpDir.Write("dep1", "")
 	tmpDir.Write("dep2", "")
 
-	dep1 := filepath.Join(tmpDir.Root(), "dep1")
-	dep2 := filepath.Join(tmpDir.Root(), "dep2")
+	dep1 := tmpDir.Path("dep1")
+	dep2 := tmpDir.Path("dep2")
 
-	ctx := context.TODO()
+	ctx := context.Background()
 
 	var tests = []struct {
 		description string
 		stdout      string
+		expected    []string
 		err         error
 	}{
 		{
 			description: "success",
 			stdout:      fmt.Sprintf("%s\n%s\n\n\n", dep1, dep2),
-			err:         nil,
+			expected:    []string{dep1, dep2},
 		},
 		{
 			description: "failure",
@@ -71,9 +66,6 @@ func TestGetDependenciesGradle(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			tmpDir, cleanup := testutil.NewTempDir(t)
-			defer cleanup()
-
 			defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
 			util.DefaultExecCommand = testutil.NewFakeCmdOut(
 				strings.Join(getCommandGradle(ctx, tmpDir.Root(), &latest.JibGradleArtifact{}).Args, " "),
@@ -92,7 +84,7 @@ func TestGetDependenciesGradle(t *testing.T) {
 }
 
 func TestGetCommandGradle(t *testing.T) {
-	ctx := context.TODO()
+	ctx := context.Background()
 
 	var tests = []struct {
 		description       string

--- a/pkg/skaffold/jib/jib_test.go
+++ b/pkg/skaffold/jib/jib_test.go
@@ -17,13 +17,9 @@ limitations under the License.
 package jib
 
 import (
+	"fmt"
 	"os/exec"
 	"testing"
-
-	"fmt"
-	"path/filepath"
-
-	"sort"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -38,13 +34,13 @@ func TestGetDependencies(t *testing.T) {
 	tmpDir.Write("dep3/fileA", "")
 	tmpDir.Write("dep3/sub/path/fileB", "")
 
-	dep1 := filepath.Join(tmpDir.Root(), "dep1")
-	dep2 := filepath.Join(tmpDir.Root(), "dep2")
-	dep3 := filepath.Join(tmpDir.Root(), "dep3")
-	dep3FileA := filepath.Join(tmpDir.Root(), "dep3/fileA")
-	dep3Sub := filepath.Join(tmpDir.Root(), "dep3/sub")
-	dep3SubPath := filepath.Join(tmpDir.Root(), "dep3/sub/path")
-	dep3SubPathFileB := filepath.Join(tmpDir.Root(), "dep3/sub/path/fileB")
+	dep1 := tmpDir.Path("dep1")
+	dep2 := tmpDir.Path("dep2")
+	dep3 := tmpDir.Path("dep3")
+	dep3FileA := tmpDir.Path("dep3/fileA")
+	dep3Sub := tmpDir.Path("dep3/sub")
+	dep3SubPath := tmpDir.Path("dep3/sub/path")
+	dep3SubPathFileB := tmpDir.Path("dep3/sub/path/fileB")
 
 	var tests = []struct {
 		stdout       string
@@ -98,7 +94,7 @@ func TestGetDependencies(t *testing.T) {
 			)
 
 			deps, err := getDependencies(&exec.Cmd{Args: []string{"ignored"}, Dir: tmpDir.Root()})
-			sort.Strings(deps)
+
 			testutil.CheckErrorAndDeepEqual(t, false, err, test.expectedDeps, deps)
 		})
 	}


### PR DESCRIPTION
Builds off of #1130, so will merge master once that is merged.

Fixes #1124 and implements the logic proposed in https://github.com/GoogleContainerTools/skaffold/issues/1124#issuecomment-428201600. This required adding some more per-artifact-type logic that should probably be refactored into separate implementations in `docker.go`/`bazel.go`/`jib-*.go`. Let me know how this looks and whether or not I should do that refactoring. I will add tests once the structure is more finalized.