### PR TITLE
Fix kaniko default behaviour

### DIFF
--- a/pkg/skaffold/build/kaniko/sources/sources.go
+++ b/pkg/skaffold/build/kaniko/sources/sources.go
@@ -35,7 +35,7 @@ type BuildContextSource interface {
 
 // Retrieve returns the correct build context based on the config
 func Retrieve(cfg *latest.KanikoBuild) (BuildContextSource, error) {
-	if cfg.BuildContext == nil || cfg.BuildContext.LocalDir != nil {
+	if cfg.BuildContext.LocalDir != nil {
 		return &LocalDir{}, nil
 	}
 	return &GCSBucket{}, nil

--- a/pkg/skaffold/build/kaniko/sources/sources.go
+++ b/pkg/skaffold/build/kaniko/sources/sources.go
@@ -35,7 +35,7 @@ type BuildContextSource interface {
 
 // Retrieve returns the correct build context based on the config
 func Retrieve(cfg *latest.KanikoBuild) (BuildContextSource, error) {
-	if cfg.BuildContext.LocalDir != nil {
+	if cfg.BuildContext == nil || cfg.BuildContext.LocalDir != nil {
 		return &LocalDir{}, nil
 	}
 	return &GCSBucket{}, nil

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -115,12 +115,12 @@ type KanikoBuildContext struct {
 // KanikoBuild contains the fields needed to do a on-cluster build using
 // the kaniko image
 type KanikoBuild struct {
-	BuildContext   KanikoBuildContext `yaml:"buildContext,omitempty"`
-	PullSecret     string             `yaml:"pullSecret,omitempty"`
-	PullSecretName string             `yaml:"pullSecretName,omitempty"`
-	Namespace      string             `yaml:"namespace,omitempty"`
-	Timeout        string             `yaml:"timeout,omitempty"`
-	Image          string             `yaml:"image,omitempty"`
+	BuildContext   *KanikoBuildContext `yaml:"buildContext,omitempty"`
+	PullSecret     string              `yaml:"pullSecret,omitempty"`
+	PullSecretName string              `yaml:"pullSecretName,omitempty"`
+	Namespace      string              `yaml:"namespace,omitempty"`
+	Timeout        string              `yaml:"timeout,omitempty"`
+	Image          string              `yaml:"image,omitempty"`
 }
 
 // TestCase is a struct containing all the specified test

--- a/pkg/skaffold/schema/latest/defaults.go
+++ b/pkg/skaffold/schema/latest/defaults.go
@@ -41,6 +41,7 @@ func (c *SkaffoldPipeline) SetDefaultValues() error {
 		setDefaultKanikoImage,
 		setDefaultKanikoNamespace,
 		setDefaultKanikoSecret,
+		setDefaultKanikoBuildContext,
 	); err != nil {
 		return err
 	}
@@ -170,6 +171,15 @@ func setDefaultKanikoSecret(kaniko *KanikoBuild) error {
 		return nil
 	}
 
+	return nil
+}
+
+func setDefaultKanikoBuildContext(kaniko *KanikoBuild) error {
+	if kaniko.BuildContext == nil {
+		kaniko.BuildContext = &KanikoBuildContext{
+			LocalDir: &LocalDir{},
+		}
+	}
 	return nil
 }
 

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -217,7 +217,7 @@ func withGoogleCloudBuild(id string, ops ...func(*latest.BuildConfig)) func(*lat
 func withKanikoBuild(bucket, secretName, namespace, secret string, timeout string, ops ...func(*latest.BuildConfig)) func(*latest.SkaffoldPipeline) {
 	return func(cfg *latest.SkaffoldPipeline) {
 		b := latest.BuildConfig{BuildType: latest.BuildType{KanikoBuild: &latest.KanikoBuild{
-			BuildContext: latest.KanikoBuildContext{
+			BuildContext: &latest.KanikoBuildContext{
 				GCSBucket: bucket,
 			},
 			PullSecretName: secretName,


### PR DESCRIPTION
If buildcontext isn't specified or localdir is specified, return localdir as the source
context. Otherwise, return a GCS bucket. If no value is passed in for
the bucket, one will be inferred from the project ID.