### PR TITLE
Canonicalizes paths when attempting to compensate for odd `mvnw` working-directory echo bug

### DIFF
--- a/pkg/skaffold/jib/jib.go
+++ b/pkg/skaffold/jib/jib.go
@@ -39,7 +39,7 @@ func getDependencies(cmd *exec.Cmd) ([]string, error) {
 	lines := strings.Split(string(stdout), "\n")
 
 	// TODO(coollog): Remove this once Jib deps are prepended with special sequence.
-	// The dependencies from `jib:_skaffold-files` have been canonicalized 
+	// The dependencies from `jib:_skaffold-files` have been canonicalized
 	cmdDir := util.Canonical(cmd.Dir)
 
 	var deps []string

--- a/pkg/skaffold/jib/jib.go
+++ b/pkg/skaffold/jib/jib.go
@@ -38,6 +38,9 @@ func getDependencies(cmd *exec.Cmd) ([]string, error) {
 	// Parses stdout for the dependencies, one per line
 	lines := strings.Split(string(stdout), "\n")
 
+	// TODO(coollog): Remove this once Jib deps are prepended with special sequence.
+	cmdDir := util.Canonical(cmd.Dir)
+
 	var deps []string
 	for _, dep := range lines {
 		if dep == "" {
@@ -46,7 +49,7 @@ func getDependencies(cmd *exec.Cmd) ([]string, error) {
 
 		// TODO(coollog): Remove this once Jib deps are prepended with special sequence.
 		// Skips the project directory itself. This is necessary as some wrappers print the project directory for some reason.
-		if dep == cmd.Dir {
+		if dep == cmdDir {
 			continue
 		}
 

--- a/pkg/skaffold/jib/jib.go
+++ b/pkg/skaffold/jib/jib.go
@@ -39,6 +39,7 @@ func getDependencies(cmd *exec.Cmd) ([]string, error) {
 	lines := strings.Split(string(stdout), "\n")
 
 	// TODO(coollog): Remove this once Jib deps are prepended with special sequence.
+	// The dependencies from `jib:_skaffold-files` have been canonicalized 
 	cmdDir := util.Canonical(cmd.Dir)
 
 	var deps []string

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -227,3 +227,20 @@ func AbsFile(workspace string, filename string) (string, error) {
 	}
 	return filepath.Abs(file)
 }
+
+// Canonical returns the canonical location of the given path,
+// making it absolute and resolving any symlinks.
+// Return the best path possible if there are failures.
+// This implementation does not attempt to be thorough for paths
+// that do not actually exist (e.g., /tmp/does/not/exist).
+func Canonical(path string) string {
+	abspath, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	fullpath, err := filepath.EvalSymlinks(abspath)
+	if err != nil {
+		return abspath
+	}
+	return fullpath
+}

--- a/pkg/skaffold/util/util_unix_test.go
+++ b/pkg/skaffold/util/util_unix_test.go
@@ -1,0 +1,40 @@
+// +build !windows
+
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"os"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestCanonical(t *testing.T) {
+		tmpDir, cleanup := testutil.NewTempDir(t)
+	defer cleanup()
+
+	tmpDir.Write("skaffold.yml", "foo")
+	err := os.Symlink(tmpDir.Path("skaffold.yml"), tmpDir.Path("newfile"))
+	testutil.CheckError(t, false, err)
+	
+	// must canonicalize both as the tmpDir may be a symlinked directory
+	var filepath = Canonical(tmpDir.Path("skaffold.yml"))
+	var canonical = Canonical(tmpDir.Path("newfile"))
+	testutil.CheckDeepEqual(t, filepath, canonical) 
+}

--- a/pkg/skaffold/util/util_unix_test.go
+++ b/pkg/skaffold/util/util_unix_test.go
@@ -26,15 +26,15 @@ import (
 )
 
 func TestCanonical(t *testing.T) {
-		tmpDir, cleanup := testutil.NewTempDir(t)
+	tmpDir, cleanup := testutil.NewTempDir(t)
 	defer cleanup()
 
 	tmpDir.Write("skaffold.yml", "foo")
 	err := os.Symlink(tmpDir.Path("skaffold.yml"), tmpDir.Path("newfile"))
 	testutil.CheckError(t, false, err)
-	
+
 	// must canonicalize both as the tmpDir may be a symlinked directory
 	var filepath = Canonical(tmpDir.Path("skaffold.yml"))
 	var canonical = Canonical(tmpDir.Path("newfile"))
-	testutil.CheckDeepEqual(t, filepath, canonical) 
+	testutil.CheckDeepEqual(t, filepath, canonical)
 }


### PR DESCRIPTION
There is an odd bug in some `mvnw` wrappers (particularly the one generated by the Spring Initializr) where it prints out the current directory name.  This bug affects the Scaffold-Jib integration as Skaffold requests `mvnw jib:_skaffold-files`.  For example:
```
$ pwd
/Users/bsd/Projects/skaffold-jib/spring-boot-logging

$ ./mvnw -q jib:_skaffold-files
/Users/bsd/Projects/skaffold-jib/spring-boot-logging
/Users/bsd/Manumitting/Projects/skaffold-jib/spring-boot-logging/pom.xml
/Users/bsd/Manumitting/Projects/skaffold-jib/spring-boot-logging/src/main/java
/Users/bsd/Manumitting/Projects/skaffold-jib/spring-boot-logging/src/main/resources
/Users/bsd/Manumitting/Projects/skaffold-jib/spring-boot-logging/src/main/resources
/Users/bsd/Manumitting/Projects/skaffold-jib/spring-boot-logging/src/main/jib
```
A consequence is that Skaffold then monitors the entire source directory and picks up files from the build, and continuously triggers new builds.

To compensate, the Scaffold-Jib dependencies parser [compares each path to the workspace directory](https://github.com/GoogleContainerTools/skaffold/blob/master/pkg/skaffold/jib/jib.go#L49).  But there are two problems:
   1. The workspace directory is the `context` field value and is usually relative to the current working directory, whereas the files reported by `jib:_skaffold-files` are absolute.
   2. I have a symlink from `/Users/bsd/Projects/skaffold-jib` to `/Users/bsd/Manumitting/Projects/skaffold-jib`. So just using `filepath.Abs` is insufficient as it does not expand symlinks.

This patch adds a `util.Canonical(path)` method that attempts to expand a provided path, and uses this new method to compare canonicalized paths.