### PR TITLE
Use os.SameFile() to check for mvnw working-dir echo bug

### DIFF
--- a/pkg/skaffold/jib/jib.go
+++ b/pkg/skaffold/jib/jib.go
@@ -35,18 +35,17 @@ func getDependencies(cmd *exec.Cmd) ([]string, error) {
 		return nil, err
 	}
 
+	cmdDirInfo, err := os.Stat(cmd.Dir)
+	if err != nil {
+		return nil, err
+	}
+
 	// Parses stdout for the dependencies, one per line
 	lines := strings.Split(string(stdout), "\n")
 
 	var deps []string
 	for _, dep := range lines {
 		if dep == "" {
-			continue
-		}
-
-		// TODO(coollog): Remove this once Jib deps are prepended with special sequence.
-		// Skips the project directory itself. This is necessary as some wrappers print the project directory for some reason.
-		if dep == cmd.Dir {
 			continue
 		}
 
@@ -58,6 +57,12 @@ func getDependencies(cmd *exec.Cmd) ([]string, error) {
 				continue // Ignore files that don't exist
 			}
 			return nil, errors.Wrapf(err, "unable to stat file %s", dep)
+		}
+
+		// TODO(coollog): Remove this once Jib deps are prepended with special sequence.
+		// Skips the project directory itself. This is necessary as some wrappers print the project directory for some reason.
+		if os.SameFile(cmdDirInfo, info) {
+			continue
 		}
 
 		if !info.IsDir() {


### PR DESCRIPTION
Alternative implementation to workaround the `mvnw` bug described in #1155.  Instead of canonicalizing each file to compare with the working directory, use `os.SameFile()` to compare the `os.Stat()` structures.  Since we were obtaining the stat structures already, this should have minimal overhead.