### PR TITLE
Change SkaffoldOption Labeller to not include a comma in the label value

### DIFF
--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -53,7 +53,7 @@ func (opts *SkaffoldOptions) Labels() map[string]string {
 		labels["namespace"] = opts.Namespace
 	}
 	if len(opts.Profiles) > 0 {
-		labels["profiles"] = strings.Join(opts.Profiles, ",")
+		labels["profiles"] = strings.Join(opts.Profiles, "__")
 	}
 	for _, cl := range opts.CustomLabels {
 		l := strings.SplitN(cl, "=", 2)

--- a/pkg/skaffold/config/options_test.go
+++ b/pkg/skaffold/config/options_test.go
@@ -50,7 +50,7 @@ func TestLabels(t *testing.T) {
 		{
 			description:    "profiles",
 			options:        SkaffoldOptions{Profiles: []string{"profile1", "profile2"}},
-			expectedLabels: map[string]string{"profiles": "profile1,profile2"},
+			expectedLabels: map[string]string{"profiles": "profile1__profile2"},
 		},
 		{
 			description: "all labels",
@@ -62,7 +62,7 @@ func TestLabels(t *testing.T) {
 			expectedLabels: map[string]string{
 				"cleanup":   "true",
 				"namespace": "namespace",
-				"profiles":  "p1,p2",
+				"profiles":  "p1__p2",
 			},
 		},
 		{


### PR DESCRIPTION
When running skaffold to deploy to my cluster, I get tens of errors like this:

```
time="2018-10-16T10:03:34Z" level=warning msg="error adding label to runtime object: patching resource nlx-test-haarlem/txlog-ui: Ingress.extensions \"txlog-ui\" is invalid: metadata.labels: Invalid value: \"release,deploy-test\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')"
```

Comma's are not allowed in label values. Skaffold uses them when multiple profiles are used.

This simple fix changes the separator from comma to a double underscore.