### PR TITLE
Get credentials before releasing docs controller image

### DIFF
--- a/deploy/webhook/cloudbuild.yaml
+++ b/deploy/webhook/cloudbuild.yaml
@@ -1,4 +1,16 @@
 steps:
+# Get cluster credentials
+- name: gcr.io/k8s-skaffold/skaffold:v0.16.0
+  args:
+  - 'gcloud'
+  - 'container'
+  - 'clusters'
+  - 'get-credentials'
+  - 'docs'
+  - '--zone'
+  - 'us-west2-a'
+  - '--project'
+  - 'k8s-skaffold'
   # Build and push the image with the :commit_sha tag
 - name: gcr.io/k8s-skaffold/skaffold:v0.16.0
   args:


### PR DESCRIPTION
The build trigger for releasing the docs-controller-image failed with this error:

`error retrieving kubernetes dynamic client: getting client config for
dynamic client: Error creating kubeConfig: invalid configuration: no
configuration has been provided`

Explicitly getting the credentials should generate the correct
kubeconfig for skaffold. I tested locally with cloud-build-local and
this should work now.