### PR TITLE
Add hugo and git to webhook image

### DIFF
--- a/deploy/skaffold/Dockerfile
+++ b/deploy/skaffold/Dockerfile
@@ -43,18 +43,11 @@ RUN curl -LO https://github.com/kubernetes-sigs/kustomize/releases/download/v${K
     chmod +x kustomize_${KUSTOMIZE_VERSION}_linux_amd64 && \
     mv kustomize_${KUSTOMIZE_VERSION}_linux_amd64 /usr/local/bin/kustomize
 
-ENV HUGO_VERSION=0.49.2
-RUN curl -LO https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
-    tar -xzf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
-    mv hugo /usr/local/bin/hugo
-
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
   && curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 
 RUN apt-get update \
-  && apt-get install -y \
-        bazel \
-        git && \
+  && apt-get install -y bazel && \
   rm -rf /var/lib/apt/lists/*
 
 ENV CONTAINER_STRUCTURE_TEST_VERSION=1.5.0

--- a/deploy/skaffold/Dockerfile
+++ b/deploy/skaffold/Dockerfile
@@ -43,11 +43,18 @@ RUN curl -LO https://github.com/kubernetes-sigs/kustomize/releases/download/v${K
     chmod +x kustomize_${KUSTOMIZE_VERSION}_linux_amd64 && \
     mv kustomize_${KUSTOMIZE_VERSION}_linux_amd64 /usr/local/bin/kustomize
 
+ENV HUGO_VERSION=0.49.2
+RUN curl -LO https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
+    tar -xzf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
+    mv hugo /usr/local/bin/hugo
+
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
   && curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 
 RUN apt-get update \
-  && apt-get install -y bazel && \
+  && apt-get install -y \
+        bazel \
+        git && \
   rm -rf /var/lib/apt/lists/*
 
 ENV CONTAINER_STRUCTURE_TEST_VERSION=1.5.0

--- a/deploy/webhook/Dockerfile
+++ b/deploy/webhook/Dockerfile
@@ -24,5 +24,12 @@ ENV KUBECTL_VERSION v1.12.0
 RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl  && \
     chmod +x /usr/local/bin/kubectl
 
+
+ENV HUGO_VERSION=0.49.2
+RUN curl -LO https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
+    tar -xzf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
+    mv hugo /usr/local/bin/hugo
+
+RUN apt-get update && apt-get install -y git
+
 COPY --from=0 /webhook /webhook
-ENTRYPOINT /webhook

--- a/deploy/webhook/deployment.yaml
+++ b/deploy/webhook/deployment.yaml
@@ -36,6 +36,7 @@ spec:
       containers:
       - name: docs-controller
         image: gcr.io/k8s-skaffold/docs-controller:latest
+        args: ["/webhook"]
         env:
         - name: GITHUB_ACCESS_TOKEN
           valueFrom:


### PR DESCRIPTION
Adding hugo and git to the skaffold image will allow the webhook to
deploy it and:

1. Use git to clone a user's branch with docs changes
2. Use hugo to set up a static website which will show those changes