### PR TITLE
Suppress fatal error reporting when ^C skaffold with jib

### DIFF
--- a/pkg/skaffold/jib/jib.go
+++ b/pkg/skaffold/jib/jib.go
@@ -31,6 +31,10 @@ import (
 func getDependencies(cmd *exec.Cmd) ([]string, error) {
 	stdout, err := util.RunCmdOut(cmd)
 	if err != nil {
+		// if terminated because of ^C then act as if all is well
+		if util.IsTerminatedError(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/pkg/skaffold/kubernetes/port_forward.go
+++ b/pkg/skaffold/kubernetes/port_forward.go
@@ -27,6 +27,7 @@ import (
 	"syscall"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
@@ -78,7 +79,7 @@ func (*kubectlForwarder) Forward(pfe *portForwardEntry) error {
 	cmd.Stdout = buf
 	cmd.Stderr = buf
 
-	if err := cmd.Run(); err != nil && !IsTerminatedError(err) {
+	if err := cmd.Run(); err != nil && !util.IsTerminatedError(err) {
 		return errors.Wrapf(err, "port forwarding pod: %s/%s, port: %s, err: %s", pfe.namespace, pfe.podName, portNumber, buf.String())
 	}
 	return nil
@@ -206,17 +207,6 @@ func (p *PortForwarder) portForwardPod(pod *v1.Pod) error {
 	}
 
 	return nil
-}
-
-// IsTerminatedError returns true if the error is type exec.ExitError and the corresponding process was terminated by SIGTERM
-// This error is given when a exec.Command is ran and terminated with a SIGTERM.
-func IsTerminatedError(err error) bool {
-	exitError, ok := err.(*exec.ExitError)
-	if !ok {
-		return false
-	}
-	ws := exitError.Sys().(syscall.WaitStatus)
-	return ws.Signal() == syscall.SIGTERM
 }
 
 // Key is an identifier for the lock on a port during the skaffold dev cycle.

--- a/pkg/skaffold/util/process.go
+++ b/pkg/skaffold/util/process.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"os/exec"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+// IsTerminatedError returns true if the error is type exec.ExitError and the corresponding process was terminated by SIGTERM
+// This error is given when a exec.Command is ran and terminated with a SIGTERM.
+func IsTerminatedError(err error) bool {
+	// unwrap to discover original cause
+	err = errors.Cause(err)
+	exitError, ok := err.(*exec.ExitError)
+	if !ok {
+		return false
+	}
+	ws := exitError.Sys().(syscall.WaitStatus)
+	signal := ws.Signal()
+	return signal == syscall.SIGTERM || signal == syscall.SIGKILL
+}


### PR DESCRIPTION
Move `kubernetes.IsTerminatedError()` into `util` and make it more general-purpose.  Use this new helper to suppress fatal error when the Jib `skaffoldFiles` target is killed.

Fixes #1198 