### PR TITLE
Allow flags to be passed to kustomize

### DIFF
--- a/integration/examples/annotated-skaffold.yaml
+++ b/integration/examples/annotated-skaffold.yaml
@@ -161,9 +161,14 @@ deploy:
  # kustomize:
     # path: .
     # kustomize deploys manifests with kubectl.
+    # kustomize can be passed additional option flags either on every command (Global)
+    # or on builds (Build).
+    # flags:
+    #   global: [""]
+    #   build: [""]
     # kubectl can be passed additional option flags either on every command (Global),
     # on creations (Apply) or deletions (Delete).
-    # flags:
+    # kubectlFlags:
     #   global: [""]
     #   apply: [""]
     #   delete: [""]

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -66,7 +66,7 @@ func NewKustomizeDeployer(cfg *latest.KustomizeDeploy, kubeContext string, names
 		kubectl: kubectl.CLI{
 			Namespace:   namespace,
 			KubeContext: kubeContext,
-			Flags:       cfg.Flags,
+			Flags:       cfg.KubectlFlags,
 		},
 		defaultRepo: defaultRepo,
 	}
@@ -173,7 +173,10 @@ func (k *KustomizeDeployer) Dependencies() ([]string, error) {
 }
 
 func (k *KustomizeDeployer) readManifests(ctx context.Context) (kubectl.ManifestList, error) {
-	cmd := exec.CommandContext(ctx, "kustomize", "build", k.KustomizePath)
+	args := []string{"build", k.KustomizePath}
+	args = append(args, k.Flags.Global...)
+	args = append(args, k.Flags.Build...)
+	cmd := exec.CommandContext(ctx, "kustomize", args...)
 	out, err := util.RunCmdOut(cmd)
 	if err != nil {
 		return nil, errors.Wrap(err, "kustomize build")

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -176,8 +176,16 @@ type HelmDeploy struct {
 
 // KustomizeDeploy contains the configuration needed for deploying with kustomize.
 type KustomizeDeploy struct {
-	KustomizePath string       `yaml:"path,omitempty"`
-	Flags         KubectlFlags `yaml:"flags,omitempty"`
+	KustomizePath string         `yaml:"path,omitempty"`
+	KubectlFlags  KubectlFlags   `yaml:"kubectlFlags,omitempty"`
+	Flags         KustomizeFlags `yaml:"flags,omitempty"`
+}
+
+// KustomizeFlags describes additional options flags that are passed on the command
+// line to kustomize either on every command (Global) or on builds (Build).
+type KustomizeFlags struct {
+	Global []string `yaml:"global,omitempty"`
+	Build  []string `yaml:"build,omitempty"`
 }
 
 type HelmRelease struct {


### PR DESCRIPTION
:wave:

`kustomize build` accepts a `--transformer-config` argument, but skaffold didn't expose a mechanism for adding flags there.

`KustomizeDeploy` already had a `flags` field that added flags to kubectl invocations, so I renamed it to `kubectlFlags` and co-opted the `flags` field for kustomize flags; not sure if that's kosher.