### PR TITLE
Automatically fix old configs by default

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -58,7 +58,7 @@ func runBuild(out io.Writer) error {
 	defer cancel()
 	catchCtrlC(cancel)
 
-	runner, config, err := newRunner(opts)
+	runner, config, err := newRunner(out, opts)
 	if err != nil {
 		return errors.Wrap(err, "creating runner")
 	}

--- a/cmd/skaffold/app/cmd/delete.go
+++ b/cmd/skaffold/app/cmd/delete.go
@@ -43,7 +43,7 @@ func delete(out io.Writer) error {
 	defer cancel()
 	catchCtrlC(cancel)
 
-	runner, _, err := newRunner(opts)
+	runner, _, err := newRunner(out, opts)
 	if err != nil {
 		return errors.Wrap(err, "creating runner")
 	}

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -53,7 +53,7 @@ func runDeploy(out io.Writer) error {
 	defer cancel()
 	catchCtrlC(cancel)
 
-	r, config, err := newRunner(opts)
+	r, config, err := newRunner(out, opts)
 	if err != nil {
 		return errors.Wrap(err, "creating runner")
 	}

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -65,7 +65,7 @@ func dev(out io.Writer) error {
 		case <-ctx.Done():
 			return nil
 		default:
-			r, config, err := newRunner(opts)
+			r, config, err := newRunner(out, opts)
 			if err != nil {
 				return errors.Wrap(err, "creating runner")
 			}

--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -49,7 +49,7 @@ func NewCmdDiagnose(out io.Writer) *cobra.Command {
 }
 
 func doDiagnose(out io.Writer) error {
-	_, config, err := newRunner(opts)
+	_, config, err := newRunner(out, opts)
 	if err != nil {
 		return errors.Wrap(err, "creating runner")
 	}

--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -59,7 +59,7 @@ func NewCmdFix(out io.Writer) *cobra.Command {
 }
 
 func runFix(out io.Writer, cfg schemautil.VersionedConfig) error {
-	cfg, err := schema.UpgradeToLatest(cfg)
+	cfg, err := schema.UpgradeToLatest(out, cfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/skaffold/app/cmd/fix_test.go
+++ b/cmd/skaffold/app/cmd/fix_test.go
@@ -51,8 +51,7 @@ deploy:
     manifests:
     - k8s/deployment.yaml
 `,
-			outputYaml: fmt.Sprintf(`config version skaffold/v1alpha4 out of date: upgrading to latest (%s)
-apiVersion: %s
+			outputYaml: fmt.Sprintf(`apiVersion: %s
 kind: Config
 build:
   artifacts:
@@ -67,7 +66,7 @@ deploy:
   kubectl:
     manifests:
     - k8s/deployment.yaml
-`, latest.Version, latest.Version),
+`, latest.Version),
 		},
 		{
 			name: "v1alpha1 to latest",
@@ -83,8 +82,7 @@ deploy:
     - paths:
       - k8s/deployment.yaml
 `,
-			outputYaml: fmt.Sprintf(`config version skaffold/v1alpha1 out of date: upgrading to latest (%s)
-apiVersion: %s
+			outputYaml: fmt.Sprintf(`apiVersion: %s
 kind: Config
 build:
   artifacts:
@@ -95,7 +93,7 @@ deploy:
   kubectl:
     manifests:
     - k8s/deployment.yaml
-`, latest.Version, latest.Version),
+`, latest.Version),
 		},
 	}
 

--- a/cmd/skaffold/app/cmd/fix_test.go
+++ b/cmd/skaffold/app/cmd/fix_test.go
@@ -51,7 +51,8 @@ deploy:
     manifests:
     - k8s/deployment.yaml
 `,
-			outputYaml: fmt.Sprintf(`apiVersion: %s
+			outputYaml: fmt.Sprintf(`config version skaffold/v1alpha4 out of date: upgrading to latest (%s)
+apiVersion: %s
 kind: Config
 build:
   artifacts:
@@ -66,7 +67,7 @@ deploy:
   kubectl:
     manifests:
     - k8s/deployment.yaml
-`, latest.Version),
+`, latest.Version, latest.Version),
 		},
 		{
 			name: "v1alpha1 to latest",
@@ -82,7 +83,8 @@ deploy:
     - paths:
       - k8s/deployment.yaml
 `,
-			outputYaml: fmt.Sprintf(`apiVersion: %s
+			outputYaml: fmt.Sprintf(`config version skaffold/v1alpha1 out of date: upgrading to latest (%s)
+apiVersion: %s
 kind: Config
 build:
   artifacts:
@@ -93,7 +95,7 @@ deploy:
   kubectl:
     manifests:
     - k8s/deployment.yaml
-`, latest.Version),
+`, latest.Version, latest.Version),
 		},
 	}
 

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -46,7 +46,7 @@ func run(out io.Writer) error {
 	defer cancel()
 	catchCtrlC(cancel)
 
-	runner, config, err := newRunner(opts)
+	runner, config, err := newRunner(out, opts)
 	if err != nil {
 		return errors.Wrap(err, "creating runner")
 	}

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"io"
+
 	configutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
@@ -27,14 +29,14 @@ import (
 )
 
 // newRunner creates a SkaffoldRunner and returns the SkaffoldPipeline associated with it.
-func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.SkaffoldPipeline, error) {
+func newRunner(out io.Writer, opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.SkaffoldPipeline, error) {
 	parsed, err := schema.ParseConfig(opts.ConfigurationFile, true)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "parsing skaffold config")
 	}
 
 	// automatically upgrade older config
-	parsed, err = schema.UpgradeToLatest(parsed)
+	parsed, err = schema.UpgradeToLatest(out, parsed)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "invalid config")
 	}

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -33,7 +33,9 @@ func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.Sk
 		return nil, nil, errors.Wrap(err, "parsing skaffold config")
 	}
 
-	if err := schema.CheckVersionIsLatest(parsed.GetVersion()); err != nil {
+	// automatically upgrade older config
+	parsed, err = schema.UpgradeToLatest(parsed)
+	if err != nil {
 		return nil, nil, errors.Wrap(err, "invalid config")
 	}
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -17,12 +17,18 @@ limitations under the License.
 package latest
 
 import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
+	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 )
 
 const Version string = "skaffold/v1alpha5"
+
+func Semver() semver.Version {
+	return apiversion.MustParse(Version)
+}
 
 // NewSkaffoldPipeline creates a SkaffoldPipeline
 func NewSkaffoldPipeline() util.VersionedConfig {

--- a/pkg/skaffold/schema/v1alpha1/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha1/upgrade_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestPipelineUpgrade(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		expected *next.SkaffoldPipeline
+	}{
+		{
+			name: "git tagger",
+			yaml: `apiVersion: skaffold/v1alpha1
+kind: Config
+build:
+  tagPolicy: gitCommit
+`,
+			expected: &next.SkaffoldPipeline{
+				APIVersion: next.Version,
+				Kind:       "Config",
+				Build: next.BuildConfig{
+					TagPolicy: next.TagPolicy{
+						GitTagger: &next.GitTagger{},
+					},
+					Artifacts: []*next.Artifact{},
+				},
+			},
+		},
+		{
+			name: "sha tagger",
+			yaml: `apiVersion: skaffold/v1alpha1
+kind: Config
+build:
+  tagPolicy: sha256
+`,
+			expected: &next.SkaffoldPipeline{
+				APIVersion: next.Version,
+				Kind:       "Config",
+				Build: next.BuildConfig{
+					TagPolicy: next.TagPolicy{
+						ShaTagger: &next.ShaTagger{},
+					},
+					Artifacts: []*next.Artifact{},
+				},
+			},
+		},
+		{
+			name: "normal skaffold yaml",
+			yaml: `apiVersion: skaffold/v1alpha1
+kind: Config
+build:
+  artifacts:
+  - imageName: gcr.io/k8s-skaffold/skaffold-example
+deploy:
+  kubectl:
+    manifests:
+    - paths:
+      - k8s-*
+`,
+			expected: &next.SkaffoldPipeline{
+				APIVersion: next.Version,
+				Kind:       "Config",
+				Build: next.BuildConfig{
+					TagPolicy: next.TagPolicy{
+						GitTagger: &next.GitTagger{},
+					},
+					Artifacts: []*next.Artifact{
+						&next.Artifact{
+							ImageName: "gcr.io/k8s-skaffold/skaffold-example",
+							ArtifactType: next.ArtifactType{
+								DockerArtifact: &next.DockerArtifact{},
+							},
+						},
+					},
+				},
+				Deploy: next.DeployConfig{
+					DeployType: next.DeployType{
+						KubectlDeploy: &next.KubectlDeploy{
+							Manifests: []string{
+								"k8s-*",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pipeline := NewSkaffoldPipeline()
+			err := pipeline.Parse([]byte(tt.yaml), true)
+			if err != nil {
+				t.Fatalf("unexpected error during parsing old config: %v", err)
+			}
+
+			upgraded, err := pipeline.Upgrade()
+			if err != nil {
+				t.Errorf("unexpected error during upgrade: %v", err)
+			}
+
+			upgradedPipeline := upgraded.(*next.SkaffoldPipeline)
+			testutil.CheckDeepEqual(t, tt.expected, upgradedPipeline)
+		})
+	}
+}

--- a/pkg/skaffold/schema/v1alpha1/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha1/upgrade_test.go
@@ -86,7 +86,7 @@ deploy:
 						GitTagger: &next.GitTagger{},
 					},
 					Artifacts: []*next.Artifact{
-						&next.Artifact{
+						{
 							ImageName: "gcr.io/k8s-skaffold/skaffold-example",
 							ArtifactType: next.ArtifactType{
 								DockerArtifact: &next.DockerArtifact{},

--- a/pkg/skaffold/schema/v1alpha2/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha2/upgrade_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"testing"
+
+	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha3"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestPipelineUpgrade(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		expected *next.SkaffoldPipeline
+	}{
+		{
+			name: "helm release values file",
+			yaml: `apiVersion: skaffold/v1alpha2
+kind: Config
+deploy:
+  helm:
+    releases:
+    - name: test release
+      valuesFilePath: values.yaml
+`,
+			expected: &next.SkaffoldPipeline{
+				APIVersion: next.Version,
+				Kind:       "Config",
+				Deploy: next.DeployConfig{
+					DeployType: next.DeployType{
+						HelmDeploy: &next.HelmDeploy{
+							Releases: []next.HelmRelease{
+								next.HelmRelease{
+									Name:        "test release",
+									ValuesFiles: []string{"values.yaml"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "normal skaffold yaml with kaniko",
+			yaml: `apiVersion: skaffold/v1alpha2
+kind: Config
+build:
+  artifacts:
+  - imageName: gcr.io/k8s-skaffold/skaffold-example
+  kaniko:
+    gcsBucket: k8s-skaffold
+    pullSecret: /a/secret/path/kaniko.json
+deploy:
+  kubectl:
+    manifests:
+    - k8s-*
+profiles:
+  - name: test profile
+    build:
+      artifacts:
+      - imageName: gcr.io/k8s-skaffold/skaffold-example
+    deploy:
+      kubectl:
+        manifests:
+        - k8s-*
+`,
+			expected: &next.SkaffoldPipeline{
+				APIVersion: next.Version,
+				Kind:       "Config",
+				Build: next.BuildConfig{
+					TagPolicy: next.TagPolicy{},
+					Artifacts: []*next.Artifact{
+						&next.Artifact{
+							ImageName:    "gcr.io/k8s-skaffold/skaffold-example",
+							ArtifactType: next.ArtifactType{},
+						},
+					},
+					BuildType: next.BuildType{
+						KanikoBuild: &next.KanikoBuild{
+							PullSecret: "/a/secret/path/kaniko.json",
+							BuildContext: next.KanikoBuildContext{
+								GCSBucket: "k8s-skaffold",
+							},
+						},
+					},
+				},
+				Deploy: next.DeployConfig{
+					DeployType: next.DeployType{
+						KubectlDeploy: &next.KubectlDeploy{
+							Manifests: []string{
+								"k8s-*",
+							},
+						},
+					},
+				},
+				Profiles: []next.Profile{
+					next.Profile{
+						Name: "test profile",
+						Build: next.BuildConfig{
+							TagPolicy: next.TagPolicy{},
+							Artifacts: []*next.Artifact{
+								&next.Artifact{
+									ImageName:    "gcr.io/k8s-skaffold/skaffold-example",
+									ArtifactType: next.ArtifactType{},
+								},
+							},
+						},
+						Deploy: next.DeployConfig{
+							DeployType: next.DeployType{
+								KubectlDeploy: &next.KubectlDeploy{
+									Manifests: []string{
+										"k8s-*",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pipeline := NewSkaffoldPipeline()
+			err := pipeline.Parse([]byte(tt.yaml), true)
+			if err != nil {
+				t.Fatalf("unexpected error during parsing old config: %v", err)
+			}
+
+			upgraded, err := pipeline.Upgrade()
+			if err != nil {
+				t.Errorf("unexpected error during upgrade: %v", err)
+			}
+
+			upgradedPipeline := upgraded.(*next.SkaffoldPipeline)
+			tt.expected.SetDefaultValues()
+			testutil.CheckDeepEqual(t, tt.expected, upgradedPipeline)
+		})
+	}
+}

--- a/pkg/skaffold/schema/v1alpha2/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha2/upgrade_test.go
@@ -46,7 +46,7 @@ deploy:
 					DeployType: next.DeployType{
 						HelmDeploy: &next.HelmDeploy{
 							Releases: []next.HelmRelease{
-								next.HelmRelease{
+								{
 									Name:        "test release",
 									ValuesFiles: []string{"values.yaml"},
 								},
@@ -86,7 +86,7 @@ profiles:
 				Build: next.BuildConfig{
 					TagPolicy: next.TagPolicy{},
 					Artifacts: []*next.Artifact{
-						&next.Artifact{
+						{
 							ImageName:    "gcr.io/k8s-skaffold/skaffold-example",
 							ArtifactType: next.ArtifactType{},
 						},
@@ -110,12 +110,12 @@ profiles:
 					},
 				},
 				Profiles: []next.Profile{
-					next.Profile{
+					{
 						Name: "test profile",
 						Build: next.BuildConfig{
 							TagPolicy: next.TagPolicy{},
 							Artifacts: []*next.Artifact{
-								&next.Artifact{
+								{
 									ImageName:    "gcr.io/k8s-skaffold/skaffold-example",
 									ArtifactType: next.ArtifactType{},
 								},

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -18,6 +18,7 @@ package schema
 
 import (
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	apiversion "github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -90,27 +91,23 @@ func ParseConfig(filename string, applyDefaults bool) (util.VersionedConfig, err
 	return cfg, nil
 }
 
-// CheckVersionIsLatest checks that a given version is the most recent.
-func CheckVersionIsLatest(apiVersion string) error {
-	parsedVersion, err := apiversion.Parse(apiVersion)
-	if err != nil {
-		return errors.Wrap(err, "parsing api version")
-	}
-
-	if parsedVersion.LT(apiversion.MustParse(latest.Version)) {
-		return errors.New("config version out of date: run `skaffold fix`")
-	}
-
-	if parsedVersion.GT(apiversion.MustParse(latest.Version)) {
-		return errors.New("config version is too new for this version of skaffold: upgrade skaffold")
-	}
-
-	return nil
-}
-
 // UpgradeToLatest upgrades a configuration to the latest version.
 func UpgradeToLatest(vc util.VersionedConfig) (util.VersionedConfig, error) {
 	var err error
+
+	// first, check to make sure config version isn't too new
+	version, err := apiversion.Parse(vc.GetVersion())
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing api version")
+	}
+	latestVersion := apiversion.MustParse(latest.Version)
+	if version.GT(latestVersion) {
+		return nil, errors.New("config version is too new for this version of skaffold: upgrade skaffold")
+	}
+
+	if version.LT(latestVersion) {
+		logrus.Infof("config version %s out of date: upgrading to latest (%s)", vc.GetVersion(), latest.Version)
+	}
 
 	for vc.GetVersion() != latest.Version {
 		vc, err = vc.Upgrade()

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	apiversion "github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -109,7 +110,7 @@ func UpgradeToLatest(out io.Writer, vc util.VersionedConfig) (util.VersionedConf
 		return nil, fmt.Errorf("config version %s is too new for this version of skaffold: upgrade skaffold", vc.GetVersion())
 	}
 
-	out.Write([]byte(fmt.Sprintf("config version %s out of date: upgrading to latest (%s)\n", vc.GetVersion(), latest.Version)))
+	logrus.Warnf("config version %s out of date: upgrading to latest (%s)\n", vc.GetVersion(), latest.Version)
 
 	for vc.GetVersion() != latest.Version {
 		vc, err = vc.Upgrade()

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	"k8s.io/client-go/tools/clientcmd/api"
 )
@@ -315,36 +314,6 @@ func withProfiles(profiles ...latest.Profile) func(*latest.SkaffoldPipeline) {
 	}
 }
 
-func TestCheckVersionIsLatest(t *testing.T) {
-	tests := []struct {
-		name      string
-		version   string
-		shouldErr bool
-	}{
-		{
-			name:    "latest api version",
-			version: latest.Version,
-		},
-		{
-			name:      "old api version",
-			version:   v1alpha1.Version,
-			shouldErr: true,
-		},
-		{
-			name:      "new api version",
-			version:   "skaffold/v9",
-			shouldErr: true,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			err := CheckVersionIsLatest(test.version)
-
-			testutil.CheckError(t, test.shouldErr, err)
-		})
-	}
-}
-
 func TestUpgradeToNextVersion(t *testing.T) {
 	for i, schemaVersion := range schemaVersions[0 : len(schemaVersions)-2] {
 		from := schemaVersion
@@ -360,7 +329,7 @@ func TestUpgradeToNextVersion(t *testing.T) {
 	}
 }
 
-func TestCantUpgradeFromLastestVersion(t *testing.T) {
+func TestCantUpgradeFromLatestVersion(t *testing.T) {
 	factory, present := schemaVersions.Find(latest.Version)
 	testutil.CheckDeepEqual(t, true, present)
 


### PR DESCRIPTION
This adds a hook in the runner to automatically try and upgrade older configs to the latest version before running skaffold. This means users with older configs will no longer be required to run `skaffold fix` to run skaffold as we upgrade the config.

I'll leave `skaffold fix` in, in case anybody wants to use it to upgrade their config and overwrite it in their repo.

Fixes #1257 