### PR TITLE
Support system's LDFLAGS, make compilation reproducible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,11 @@ VERSION_PACKAGE = $(REPOPATH)/pkg/skaffold/version
 COMMIT = $(shell git rev-parse HEAD)
 VERSION ?= $(shell git describe --always --tags --dirty)
 
+GO_GCFLAGS := "all=-trimpath=${PWD}"
+GO_ASMFLAGS := "all=-trimpath=${PWD}"
+
 GO_LDFLAGS :="
+GO_LDFLAGS += -extldflags \"${LDFLAGS}\"
 GO_LDFLAGS += -X $(VERSION_PACKAGE).version=$(VERSION)
 GO_LDFLAGS += -X $(VERSION_PACKAGE).buildDate=$(shell date +'%Y-%m-%dT%H:%M:%SZ')
 GO_LDFLAGS += -X $(VERSION_PACKAGE).gitCommit=$(COMMIT)
@@ -50,7 +54,7 @@ $(BUILD_DIR)/$(PROJECT): $(BUILD_DIR)/$(PROJECT)-$(GOOS)-$(GOARCH)
 	cp $(BUILD_DIR)/$(PROJECT)-$(GOOS)-$(GOARCH) $@
 
 $(BUILD_DIR)/$(PROJECT)-%-$(GOARCH): $(GO_FILES) $(BUILD_DIR)
-	GOOS=$* GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -tags $(GO_BUILD_TAGS) -o $@ $(BUILD_PACKAGE)
+	GOOS=$* GOARCH=$(GOARCH) CGO_ENABLED=0 go build -ldflags $(GO_LDFLAGS) -gcflags $(GO_GCFLAGS) -asmflags $(GO_ASMFLAGS) -tags $(GO_BUILD_TAGS) -o $@ $(BUILD_PACKAGE)
 
 %.sha256: %
 	shasum -a 256 $< > $@
@@ -76,7 +80,7 @@ test:
 
 .PHONY: install
 install: $(GO_FILES) $(BUILD_DIR)
-	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go install -ldflags $(GO_LDFLAGS) -tags $(GO_BUILD_TAGS) $(BUILD_PACKAGE)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go install -ldflags $(GO_LDFLAGS) -gcflags $(GO_GCFLAGS) -asmflags $(GO_ASMFLAGS) -tags $(GO_BUILD_TAGS) $(BUILD_PACKAGE)
 
 .PHONY: integration
 integration: install $(BUILD_DIR)/$(PROJECT)


### PR DESCRIPTION
* Supporting `$LDFLAGS` provided by the build system for example allows [enabling RELRO](https://medium.com/@HockeyInJune/relro-relocation-read-only-c8d0933faef3).
* Using `-trimpath` in `-gcflags` and `-asmflags` makes your application [reproducible](https://reproducible-builds.org/).