### PR TITLE
Add --compose-file option to skaffold init

### DIFF
--- a/deploy/skaffold/Dockerfile
+++ b/deploy/skaffold/Dockerfile
@@ -43,6 +43,11 @@ RUN curl -LO https://github.com/kubernetes-sigs/kustomize/releases/download/v${K
     chmod +x kustomize_${KUSTOMIZE_VERSION}_linux_amd64 && \
     mv kustomize_${KUSTOMIZE_VERSION}_linux_amd64 /usr/local/bin/kustomize
 
+ENV KOMPOSE_VERSION=1.17.0
+RUN curl -L https://github.com/kubernetes/kompose/releases/download/v${KOMPOSE_VERSION}/kompose-linux-amd64 -o kompose && \
+    chmod +x kompose-linux-amd64 && \
+    mv kompose-linux-amd64 /usr/local/bin/kompose
+
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
   && curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 

--- a/deploy/skaffold/Dockerfile
+++ b/deploy/skaffold/Dockerfile
@@ -45,8 +45,8 @@ RUN curl -LO https://github.com/kubernetes-sigs/kustomize/releases/download/v${K
 
 ENV KOMPOSE_VERSION=1.17.0
 RUN curl -L https://github.com/kubernetes/kompose/releases/download/v${KOMPOSE_VERSION}/kompose-linux-amd64 -o kompose && \
-    chmod +x kompose-linux-amd64 && \
-    mv kompose-linux-amd64 /usr/local/bin/kompose
+    chmod +x kompose && \
+    mv kompose /usr/local/bin
 
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
   && curl https://bazel.build/bazel-release.pub.gpg | apt-key add -

--- a/examples/compose/Dockerfile
+++ b/examples/compose/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.10.1-alpine3.7 as builder
+COPY main.go .
+RUN go build -o /app main.go
+
+FROM alpine:3.7  
+CMD ["./app"]
+COPY --from=builder /app .

--- a/examples/compose/README.adoc
+++ b/examples/compose/README.adoc
@@ -1,0 +1,10 @@
+=== Example: Running skaffold with docker-compose files
+:icons: font
+
+This example provides a simple application set up to run with 
+https://docs.docker.com/compose/[docker-compose].
+Notice there is no skaffold configuration present: to run this example,
+first run `skaffold init --compose-file docker-compose.yaml`, which will
+invoke the https://github.com/kubernetes/kompose[kompose] binary to generate
+kubernetes manifests based off of the docker-compose configuration, and then run
+`skaffold init` to generate the skaffold configuration.

--- a/examples/compose/docker-compose.yaml
+++ b/examples/compose/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  compose:
+    build: .
+    image: "gcr.io/k8s-skaffold/compose"
+    ports:
+     - "5000:5000"

--- a/examples/compose/main.go
+++ b/examples/compose/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/examples/compose/Dockerfile
+++ b/integration/examples/compose/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.10.1-alpine3.7 as builder
+COPY main.go .
+RUN go build -o /app main.go
+
+FROM alpine:3.7  
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/examples/compose/README.adoc
+++ b/integration/examples/compose/README.adoc
@@ -1,0 +1,10 @@
+=== Example: Running skaffold with docker-compose files
+:icons: font
+
+This example provides a simple application set up to run with 
+https://docs.docker.com/compose/[docker-compose].
+Notice there is no skaffold configuration present: to run this example,
+first run `skaffold init --compose-file docker-compose.yaml`, which will
+invoke the https://github.com/kubernetes/kompose[kompose] binary to generate
+kubernetes manifests based off of the docker-compose configuration, and then run
+`skaffold init` to generate the skaffold configuration.

--- a/integration/examples/compose/docker-compose.yaml
+++ b/integration/examples/compose/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  compose:
+    build: .
+    image: "gcr.io/k8s-skaffold/compose"
+    ports:
+     - "5000:5000"

--- a/integration/examples/compose/main.go
+++ b/integration/examples/compose/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -408,9 +408,10 @@ func TestListConfig(t *testing.T) {
 
 func TestInit(t *testing.T) {
 	type testCase struct {
-		name string
-		dir  string
-		args []string
+		name             string
+		dir              string
+		args             []string
+		skipSkaffoldYaml bool
 	}
 
 	tests := []testCase{
@@ -426,16 +427,24 @@ func TestInit(t *testing.T) {
 				"-a", "leeroy-web/Dockerfile=gcr.io/k8s-skaffold/leeroy-web",
 			},
 		},
+		{
+			name:             "compose",
+			dir:              "../examples/compose",
+			args:             []string{"--compose-file", "docker-compose.yaml"},
+			skipSkaffoldYaml: true,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			oldYamlPath := filepath.Join(test.dir, "skaffold.yaml")
-			oldYaml, err := removeOldSkaffoldYaml(oldYamlPath)
-			if err != nil {
-				t.Fatalf("removing original skaffold.yaml: %s", err)
+			if !test.skipSkaffoldYaml {
+				oldYamlPath := filepath.Join(test.dir, "skaffold.yaml")
+				oldYaml, err := removeOldSkaffoldYaml(oldYamlPath)
+				if err != nil {
+					t.Fatalf("removing original skaffold.yaml: %s", err)
+				}
+				defer restoreOldSkaffoldYaml(oldYaml, oldYamlPath)
 			}
-			defer restoreOldSkaffoldYaml(oldYaml, oldYamlPath)
 
 			generatedYaml := "skaffold.yaml.out"
 			defer func() {


### PR DESCRIPTION
This adds a `--compose-file` flag to `skaffold init`, which enables users to quickly get started with skaffold with a docker-compose application. The flag simply runs `kompose convert` on the docker-compose file, which generates kubernetes manifests in the application directory, and then runs `skaffold init` as normal to generate a skaffold.yaml.

#674 already took a stab at adding direct compose file support, and was closed since there wasn't consensus around the implementation. I also had issues vendoring in `kubernetes/kompose`, but the precedent for shelling out to k8s-related binaries has already been set with kustomize, so I think this is ok.

We can also extend this to a `ComposeDeployer` (a la what @r2d4 had in #674) if we want to go that route, depending on what people want, but I think at the very least it makes sense in `init`.

Fixes #1195 