### PR TITLE
Add global helm deploy flags

### DIFF
--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -169,6 +169,9 @@ deploy:
     #   delete: [""]
 
  # helm:
+    # helm can be passed additional option flags on every command (Global)
+    # flags:
+    #   global: [""]
     # helm releases to deploy.
     # releases:
     # - name: skaffold-helm

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -108,6 +108,7 @@ func (h *HelmDeployer) Cleanup(ctx context.Context, out io.Writer) error {
 
 func (h *HelmDeployer) helm(ctx context.Context, out io.Writer, arg ...string) error {
 	args := append([]string{"--kube-context", h.kubeContext}, arg...)
+	args = append(args, h.Flags.Global...)
 
 	cmd := exec.CommandContext(ctx, "helm", args...)
 	cmd.Stdout = out

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -180,6 +180,13 @@ type KubectlFlags struct {
 // HelmDeploy contains the configuration needed for deploying with helm
 type HelmDeploy struct {
 	Releases []HelmRelease `yaml:"releases,omitempty"`
+	Flags    HelmFlags     `yaml:"flags,omitempty"`
+}
+
+// HelmFlags describes additional options flags that are passed on the command
+// line to helm on every command (Global)
+type HelmFlags struct {
+	Global []string `yaml:"global,omitempty"`
 }
 
 // KustomizeDeploy contains the configuration needed for deploying with kustomize.


### PR DESCRIPTION
I added the option to add global arguments to helm deploy, similar to `kubectl`. 

```yaml
deploy:
  helm:
    flags:
      global: [""]
```

This allows you to add any of:

```
Flags:
      --debug                           enable verbose output
  -h, --help                            help for helm
      --home string                     location of your Helm config. Overrides $HELM_HOME (default "~/.helm")
      --host string                     address of Tiller. Overrides $HELM_HOST
      --kube-context string             name of the kubeconfig context to use
      --kubeconfig string               absolute path to the kubeconfig file to use
      --tiller-connection-timeout int   the duration (in seconds) Helm will wait to establish a connection to tiller (default 300)
      --tiller-namespace string         namespace of Tiller (default "kube-system")
```

This should resolve #1183, #785 and also #529 