### PR TITLE
Get builder, tagger and deployer info from config

### DIFF
--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -61,6 +61,20 @@ const (
 
 	// A regex matching valid repository names (https://github.com/docker/distribution/blob/master/reference/reference.go)
 	RepositoryComponentRegex string = `^[a-z\d]+(?:(?:[_.]|__|-+)[a-z\d]+)*$`
+
+	LocalBuilderName           = "Local"
+	KanikoBuilderName          = "Kaniko"
+	GoogleCloudBuilderName     = "GoogleCloudBuild"
+	AzureContainerRegistryName = "AzureContainerRegistry"
+
+	KubectlDeployerName   = "Kubectl"
+	HelmDeployerName      = "Helm"
+	KustomizeDeployerName = "Kustomize"
+
+	ShaTaggerName         = "ShaTagger"
+	GitTaggerName         = "GitTagger"
+	EnvTemplateTaggerName = "EnvTemplateTagger"
+	DateTimeTaggerName    = "DateTimeTagger"
 )
 
 var DefaultKubectlManifests = []string{"k8s/*.yaml"}

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -18,6 +18,7 @@ package latest
 
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
@@ -47,6 +48,48 @@ type SkaffoldPipeline struct {
 
 func (c *SkaffoldPipeline) GetVersion() string {
 	return c.APIVersion
+}
+
+// GetBuilderName returns the name of the chosen builder
+func (c *SkaffoldPipeline) GetBuilderName() string {
+	if c.Build.GoogleCloudBuild != nil {
+		return constants.GoogleCloudBuilderName
+	}
+	if c.Build.KanikoBuild != nil {
+		return constants.KanikoBuilderName
+	}
+	if c.Build.AzureContainerBuild != nil {
+		return constants.AzureContainerBuildName
+	}
+	// default
+	return constants.LocalBuilderName
+}
+
+// GetDeployerName returns the name of the chosen deployer
+func (c *SkaffoldPipeline) GetDeployerName() string {
+	if c.Deploy.HelmDeploy != nil {
+		return constants.HelmDeployerName
+	}
+	if c.Deploy.KustomizeDeploy != nil {
+		return constants.KustomizeDeployerName
+	}
+	// default
+	return constants.KubectlDeployerName
+}
+
+// GetTaggerName returns the name of the chosen tagger
+func (c *SkaffoldPipeline) GetTaggerName() string {
+	if c.Build.TagPolicy.EnvTemplateTagger != nil {
+		return constants.EnvTemplateTaggerName
+	}
+	if c.Build.TagPolicy.ShaTagger != nil {
+		return constants.ShaTaggerName
+	}
+	if c.Build.TagPolicy.DateTimeTagger != nil {
+		return constants.DateTimeTaggerName
+	}
+	// default
+	return constants.GitTaggerName
 }
 
 // BuildConfig contains all the configuration for the build steps

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -59,7 +59,7 @@ func (c *SkaffoldPipeline) GetBuilderName() string {
 		return constants.KanikoBuilderName
 	}
 	if c.Build.AzureContainerBuild != nil {
-		return constants.AzureContainerBuildName
+		return constants.AzureContainerRegistryName
 	}
 	// default
 	return constants.LocalBuilderName

--- a/pkg/skaffold/schema/util/util.go
+++ b/pkg/skaffold/schema/util/util.go
@@ -18,6 +18,9 @@ package util
 
 type VersionedConfig interface {
 	GetVersion() string
+	GetBuilderName() string
+	GetDeployerName() string
+	GetTaggerName() string
 	Parse([]byte, bool) error
 	Upgrade() (VersionedConfig, error)
 }

--- a/pkg/skaffold/schema/v1alpha1/config.go
+++ b/pkg/skaffold/schema/v1alpha1/config.go
@@ -44,6 +44,29 @@ func (config *SkaffoldPipeline) GetVersion() string {
 	return config.APIVersion
 }
 
+// GetBuilderName returns the name of the chosen builder
+func (config *SkaffoldPipeline) GetBuilderName() string {
+	if config.Build.GoogleCloudBuild != nil {
+		return constants.GoogleCloudBuilderName
+	}
+	// default
+	return constants.LocalBuilderName
+}
+
+// GetDeployerName returns the name of the chosen deployer
+func (config *SkaffoldPipeline) GetDeployerName() string {
+	if config.Deploy.HelmDeploy != nil {
+		return constants.HelmDeployerName
+	}
+	// default
+	return constants.KubectlDeployerName
+}
+
+// GetTaggerName returns the name of the chosen tagger
+func (config *SkaffoldPipeline) GetTaggerName() string {
+	return constants.ShaTaggerName
+}
+
 // BuildConfig contains all the configuration for the build steps
 type BuildConfig struct {
 	Artifacts []*Artifact `yaml:"artifacts"`

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha2
 
 import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
@@ -40,6 +41,45 @@ type SkaffoldPipeline struct {
 
 func (c *SkaffoldPipeline) GetVersion() string {
 	return c.APIVersion
+}
+
+// GetBuilderName returns the name of the chosen builder
+func (c *SkaffoldPipeline) GetBuilderName() string {
+	if c.Build.GoogleCloudBuild != nil {
+		return constants.GoogleCloudBuilderName
+	}
+	if c.Build.KanikoBuild != nil {
+		return constants.KanikoBuilderName
+	}
+	// default
+	return constants.LocalBuilderName
+}
+
+// GetDeployerName returns the name of the chosen deployer
+func (c *SkaffoldPipeline) GetDeployerName() string {
+	if c.Deploy.HelmDeploy != nil {
+		return constants.HelmDeployerName
+	}
+	if c.Deploy.KustomizeDeploy != nil {
+		return constants.KustomizeDeployerName
+	}
+	// default
+	return constants.KubectlDeployerName
+}
+
+// GetTaggerName returns the name of the chosen tagger
+func (c *SkaffoldPipeline) GetTaggerName() string {
+	if c.Build.TagPolicy.EnvTemplateTagger != nil {
+		return constants.EnvTemplateTaggerName
+	}
+	if c.Build.TagPolicy.ShaTagger != nil {
+		return constants.ShaTaggerName
+	}
+	if c.Build.TagPolicy.DateTimeTagger != nil {
+		return constants.DateTimeTaggerName
+	}
+	// default
+	return constants.GitTaggerName
 }
 
 // BuildConfig contains all the configuration for the build steps

--- a/pkg/skaffold/schema/v1alpha3/config.go
+++ b/pkg/skaffold/schema/v1alpha3/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha3
 
 import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
@@ -40,6 +41,45 @@ type SkaffoldPipeline struct {
 
 func (c *SkaffoldPipeline) GetVersion() string {
 	return c.APIVersion
+}
+
+// GetBuilderName returns the name of the chosen builder
+func (c *SkaffoldPipeline) GetBuilderName() string {
+	if c.Build.GoogleCloudBuild != nil {
+		return constants.GoogleCloudBuilderName
+	}
+	if c.Build.KanikoBuild != nil {
+		return constants.KanikoBuilderName
+	}
+	// default
+	return constants.LocalBuilderName
+}
+
+// GetDeployerName returns the name of the chosen deployer
+func (c *SkaffoldPipeline) GetDeployerName() string {
+	if c.Deploy.HelmDeploy != nil {
+		return constants.HelmDeployerName
+	}
+	if c.Deploy.KustomizeDeploy != nil {
+		return constants.KustomizeDeployerName
+	}
+	// default
+	return constants.KubectlDeployerName
+}
+
+// GetTaggerName returns the name of the chosen tagger
+func (c *SkaffoldPipeline) GetTaggerName() string {
+	if c.Build.TagPolicy.EnvTemplateTagger != nil {
+		return constants.EnvTemplateTaggerName
+	}
+	if c.Build.TagPolicy.ShaTagger != nil {
+		return constants.ShaTaggerName
+	}
+	if c.Build.TagPolicy.DateTimeTagger != nil {
+		return constants.DateTimeTaggerName
+	}
+	// default
+	return constants.GitTaggerName
 }
 
 // BuildConfig contains all the configuration for the build steps

--- a/pkg/skaffold/schema/v1alpha4/config.go
+++ b/pkg/skaffold/schema/v1alpha4/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha4
 
 import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
@@ -43,6 +44,45 @@ type TestConfig []TestCase
 
 func (c *SkaffoldPipeline) GetVersion() string {
 	return c.APIVersion
+}
+
+// GetBuilderName returns the name of the chosen builder
+func (c *SkaffoldPipeline) GetBuilderName() string {
+	if c.Build.GoogleCloudBuild != nil {
+		return constants.GoogleCloudBuilderName
+	}
+	if c.Build.KanikoBuild != nil {
+		return constants.KanikoBuilderName
+	}
+	// default
+	return constants.LocalBuilderName
+}
+
+// GetDeployerName returns the name of the chosen deployer
+func (c *SkaffoldPipeline) GetDeployerName() string {
+	if c.Deploy.HelmDeploy != nil {
+		return constants.HelmDeployerName
+	}
+	if c.Deploy.KustomizeDeploy != nil {
+		return constants.KustomizeDeployerName
+	}
+	// default
+	return constants.KubectlDeployerName
+}
+
+// GetTaggerName returns the name of the chosen tagger
+func (c *SkaffoldPipeline) GetTaggerName() string {
+	if c.Build.TagPolicy.EnvTemplateTagger != nil {
+		return constants.EnvTemplateTaggerName
+	}
+	if c.Build.TagPolicy.ShaTagger != nil {
+		return constants.ShaTaggerName
+	}
+	if c.Build.TagPolicy.DateTimeTagger != nil {
+		return constants.DateTimeTaggerName
+	}
+	// default
+	return constants.GitTaggerName
 }
 
 // BuildConfig contains all the configuration for the build steps


### PR DESCRIPTION
This change should help with two things:
  1. metrics collection
  2. the "skaffold status" command

For metrics, this will allow us to get data for each version of the
skaffold config (for example, which builders are most prevalent in v1alpha2
etc). 

For "skaffold status" we can get information about the config from the
config itself and display it for the user.