### PR TITLE
Add caching to kaniko builder

### DIFF
--- a/examples/kaniko-local/skaffold.yaml
+++ b/examples/kaniko-local/skaffold.yaml
@@ -8,6 +8,7 @@ build:
       localDir: {}
     pullSecretName: e2esecret
     namespace: default
+    cache: {}
 deploy:
   kubectl:
     manifests:

--- a/examples/kaniko/skaffold.yaml
+++ b/examples/kaniko/skaffold.yaml
@@ -8,6 +8,7 @@ build:
       gcsBucket: skaffold-kaniko
     pullSecretName: e2esecret
     namespace: default
+    cache: {}
 deploy:
   kubectl:
     manifests:

--- a/integration/examples/annotated-skaffold.yaml
+++ b/integration/examples/annotated-skaffold.yaml
@@ -111,11 +111,16 @@ build:
   # If gcsBucket is specified, skaffold will send sources to the GCS bucket provided
   # Kaniko also needs access to a service account to push the final image.
   # See https://github.com/GoogleContainerTools/kaniko#running-kaniko-in-a-kubernetes-cluster
+  # If cache is specified, kaniko will use a remote cache which will speed up builds.
+  # A cache repo can be specified to store cached layers, otherwise one will be inferred
+  # from the image name. See https://github.com/GoogleContainerTools/kaniko#caching 
   #
   # kaniko:
   #   buildContext:
   #     gcsBucket: k8s-skaffold
   #     localDir: {}
+  #   cache:
+  #     repo: gcr.io/my-project/skaffold/cache
   #   pullSecret: /a/secret/path/serviceaccount.json
   #   namespace: default
   #   timeout: 20m

--- a/pkg/skaffold/build/kaniko/run.go
+++ b/pkg/skaffold/build/kaniko/run.go
@@ -55,6 +55,13 @@ func (b *Builder) run(ctx context.Context, out io.Writer, artifact *latest.Artif
 	}
 	args = append(args, docker.GetBuildArgs(artifact.DockerArtifact)...)
 
+	if cfg.Cache != nil {
+		args = append(args, "--cache=true")
+		if cfg.Cache.Repo != "" {
+			args = append(args, fmt.Sprintf("--cache-repo=%s", cfg.Cache.Repo))
+		}
+	}
+
 	pods := client.CoreV1().Pods(cfg.Namespace)
 	p, err := pods.Create(s.Pod(args))
 	if err != nil {

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -46,7 +46,7 @@ const (
 
 	DefaultKustomizationPath = "."
 
-	DefaultKanikoImage             = "gcr.io/kaniko-project/executor:v0.4.0@sha256:0bbaa4859eec9796d32ab45e6c1627562dbc7796e40450295b9604cd3f4197af"
+	DefaultKanikoImage             = "gcr.io/kaniko-project/executor@sha256:434bbb1d998ba1bd8ebc04c90d93afa859fd5c7ff93326bca9f6e7da0d6277ff"
 	DefaultKanikoSecretName        = "kaniko-secret"
 	DefaultKanikoTimeout           = "20m"
 	DefaultKanikoContainerName     = "kaniko"

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -119,10 +119,16 @@ type KanikoBuildContext struct {
 	LocalDir  *LocalDir `yaml:"localDir,omitempty" yamltags:"oneOf=buildContext"`
 }
 
+// KanikoCache contains fields related to kaniko caching
+type KanikoCache struct {
+	Repo string `yaml:"repo,omitempty"`
+}
+
 // KanikoBuild contains the fields needed to do a on-cluster build using
 // the kaniko image
 type KanikoBuild struct {
 	BuildContext   *KanikoBuildContext `yaml:"buildContext,omitempty"`
+	Cache          *KanikoCache        `yaml:"cache,omitempty"`
 	PullSecret     string              `yaml:"pullSecret,omitempty"`
 	PullSecretName string              `yaml:"pullSecretName,omitempty"`
 	Namespace      string              `yaml:"namespace,omitempty"`


### PR DESCRIPTION
I updated the version of the kaniko image so that I could add caching.
To use caching, the user has to specify 'cache' in their skaffold.yaml,
with an optional field for 'repo', which is where cached layers will be
stored.

Fixes #1275 