### PR TITLE
upgrading hugo + unpinning webhook image

### DIFF
--- a/deploy/webhook/Dockerfile
+++ b/deploy/webhook/Dockerfile
@@ -25,7 +25,7 @@ RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-re
     chmod +x /usr/local/bin/kubectl
 
 
-ENV HUGO_VERSION=0.49.2
+ENV HUGO_VERSION=0.51
 RUN curl -LO https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
     tar -xzf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
     mv hugo /usr/local/bin/hugo

--- a/pkg/webhook/constants/constants.go
+++ b/pkg/webhook/constants/constants.go
@@ -45,5 +45,5 @@ const (
 	HugoPort = 1313
 
 	// DeploymentImage is the image the controller deploys, must contain hugo and git
-	DeploymentImage = "gcr.io/k8s-skaffold/docs-controller@sha256:e4b58adfdc59fd916092d6c30026e5e1a75095013fec5381d8e58a85161b9977"
+	DeploymentImage = "gcr.io/k8s-skaffold/docs-controller:latest"
 )


### PR DESCRIPTION
We need the latest version of hugo to work with the docsy site due to some SCSS feature:
```
Building sites … ERROR 2018/11/17 01:16:44 error: failed to transform resource: TOCSS: failed to transform "scss/main.scss" (text/x-scss): this feature is not available in your current Hugo version
```
Also I unpinned the webhook image so that after this merge the preview container actually picks up the  change - otherwise I'd have to raise 2 PRs for upgrading the webhook image. 