### PR TITLE
Allow passing arguments to bazel build

### DIFF
--- a/pkg/skaffold/build/local/bazel.go
+++ b/pkg/skaffold/build/local/bazel.go
@@ -31,7 +31,11 @@ import (
 )
 
 func (b *Builder) buildBazel(ctx context.Context, out io.Writer, workspace string, a *latest.BazelArtifact) (string, error) {
-	cmd := exec.CommandContext(ctx, "bazel", "build", a.BuildTarget)
+	args := []string{"build"}
+	args = append(args, a.BuildArgs...)
+	args = append(args, a.BuildTarget)
+
+	cmd := exec.CommandContext(ctx, "bazel", args...)
 	cmd.Dir = workspace
 	cmd.Stdout = out
 	cmd.Stderr = out

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -267,7 +267,8 @@ type DockerArtifact struct {
 
 // BazelArtifact describes an artifact built with Bazel.
 type BazelArtifact struct {
-	BuildTarget string `yaml:"target,omitempty"`
+	BuildTarget string   `yaml:"target,omitempty"`
+	BuildArgs   []string `yaml:"args,omitempty"`
 }
 
 type JibMavenArtifact struct {


### PR DESCRIPTION
To make a container capable of being used by skaffold I need to be able
to provide additional parameters on the command line. Add an args:
element to the bazel build configuration that is a list of strings that
will be passed to the build command.