### PR TITLE
Release latest version of docs controller image

### DIFF
--- a/deploy/webhook/cloudbuild.yaml
+++ b/deploy/webhook/cloudbuild.yaml
@@ -20,3 +20,15 @@ steps:
   - 'run'
   - '--tag'
   - '${COMMIT_SHA}'
+# Build and push latest version of the docs-controller image
+- name: gcr.io/cloud-builders/docker
+  args:
+  - 'build'
+  - '-t'
+  - 'gcr.io/k8s-skaffold/docs-controller:latest'
+  - '-f'
+  - 'deploy/webhook/Dockerfile'
+  - '.'
+images: [
+  'gcr.io/k8s-skaffold/docs-controller:latest'
+]


### PR DESCRIPTION
PR #1288 pinned the deployment image to gcr.io/k8s-skaffold/docs-controller:latest, but that image hasn't been updated in a long time. This change will release the latest image each time a change is made, which should fix one bug in the webhook.