### PR TITLE
hugo extended version + nodejs 

### DIFF
--- a/deploy/webhook/Dockerfile
+++ b/deploy/webhook/Dockerfile
@@ -26,8 +26,8 @@ RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-re
 
 
 ENV HUGO_VERSION=0.51
-RUN curl -LO https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
-    tar -xzf hugo_${HUGO_VERSION}_Linux-64bit.tar.gz && \
+RUN curl -LO https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz && \
+    tar -xzf hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz && \
     mv hugo /usr/local/bin/hugo
 
 RUN apt-get update && apt-get install -y git

--- a/deploy/webhook/Dockerfile
+++ b/deploy/webhook/Dockerfile
@@ -30,6 +30,9 @@ RUN curl -LO https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}
     tar -xzf hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz && \
     mv hugo /usr/local/bin/hugo
 
-RUN apt-get update && apt-get install -y git
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    apt-get update && \
+    apt-get install -y git \
+                       nodejs
 
 COPY --from=0 /webhook /webhook


### PR DESCRIPTION
Required for the new site's theme, docsy - we need extended version with postcss-cli npm module and hence nodejs in the docs controller image. 