### PR TITLE
introduce v1beta1 config

### DIFF
--- a/examples/kaniko-local/skaffold.yaml
+++ b/examples/kaniko-local/skaffold.yaml
@@ -8,7 +8,6 @@ build:
       localDir: {}
     pullSecretName: e2esecret
     namespace: default
-    cache: {}
 deploy:
   kubectl:
     manifests:

--- a/examples/kaniko/skaffold.yaml
+++ b/examples/kaniko/skaffold.yaml
@@ -8,7 +8,6 @@ build:
       gcsBucket: skaffold-kaniko
     pullSecretName: e2esecret
     namespace: default
-    cache: {}
 deploy:
   kubectl:
     manifests:

--- a/integration/examples/acr/skaffold.yaml
+++ b/integration/examples/acr/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 build:
   artifacts:

--- a/integration/examples/annotated-skaffold.yaml
+++ b/integration/examples/annotated-skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 build:
   # tagPolicy determines how skaffold is going to tag your images.

--- a/integration/examples/bazel/skaffold.yaml
+++ b/integration/examples/bazel/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 build:
   artifacts:

--- a/integration/examples/getting-started/skaffold.yaml
+++ b/integration/examples/getting-started/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 build:
   artifacts:

--- a/integration/examples/helm-deployment/skaffold.yaml
+++ b/integration/examples/helm-deployment/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 build:
   tagPolicy:

--- a/integration/examples/hot-reload/skaffold.yaml
+++ b/integration/examples/hot-reload/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 build:
   artifacts:

--- a/integration/examples/jib/skaffold.yaml
+++ b/integration/examples/jib/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 build:
   artifacts:

--- a/integration/examples/kaniko-local/skaffold.yaml
+++ b/integration/examples/kaniko-local/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 build:
   artifacts:

--- a/integration/examples/kaniko-local/skaffold.yaml
+++ b/integration/examples/kaniko-local/skaffold.yaml
@@ -8,6 +8,7 @@ build:
       localDir: {}
     pullSecretName: e2esecret
     namespace: default
+    cache: {}
 deploy:
   kubectl:
     manifests:

--- a/integration/examples/kaniko/skaffold.yaml
+++ b/integration/examples/kaniko/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 build:
   artifacts:

--- a/integration/examples/kaniko/skaffold.yaml
+++ b/integration/examples/kaniko/skaffold.yaml
@@ -8,6 +8,7 @@ build:
       gcsBucket: skaffold-kaniko
     pullSecretName: e2esecret
     namespace: default
+    cache: {}
 deploy:
   kubectl:
     manifests:

--- a/integration/examples/kustomize/skaffold.yaml
+++ b/integration/examples/kustomize/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 deploy:
   kustomize: {}

--- a/integration/examples/microservices/skaffold.yaml
+++ b/integration/examples/microservices/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 build:
   artifacts:

--- a/integration/examples/nodejs/skaffold.yaml
+++ b/integration/examples/nodejs/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 build:
   artifacts:

--- a/integration/examples/structure-tests/skaffold.yaml
+++ b/integration/examples/structure-tests/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 build:
   artifacts:

--- a/integration/examples/tagging-with-environment-variables/skaffold.yaml
+++ b/integration/examples/tagging-with-environment-variables/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 build:
   artifacts:

--- a/integration/examples/test-dev-job/skaffold.yaml
+++ b/integration/examples/test-dev-job/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha5
+apiVersion: skaffold/v1beta1
 kind: Config
 build:
   artifacts:

--- a/pkg/skaffold/schema/v1alpha1/upgrade.go
+++ b/pkg/skaffold/schema/v1alpha1/upgrade.go
@@ -24,6 +24,21 @@ import (
 )
 
 // Upgrade upgrades a configuration to the next version.
+// Config changes from v1alpha1 to v1alpha2:
+// 1. Additions
+//  - Profiles
+//	- BuildType.KanikoBuild
+// 	- LocalBuild.useDockerCLI, useBuildkit
+//  - GoogleCloudBuild.	DiskSizeGb, MachineType, Timeout, DockerImage
+//  - DeployType.KustomizeDeploy
+//  - KubectlDeploy.RemoteManifests, Flags - KubectlFlags type
+//  - HelmRelease fields: setValues, setValueTemplates,wait,recreatePods,overrides,packaged,imageStrategy
+//  - BazelArtifact introduced
+//  - DockerArtifact fields: CacheFrom, Target
+// 2. No removal
+// 3. Updates
+//  - TagPolicy is a struct
+//
 func (config *SkaffoldPipeline) Upgrade() (util.VersionedConfig, error) {
 	var tagPolicy next.TagPolicy
 	if config.Build.TagPolicy == constants.TagStrategySha256 {

--- a/pkg/skaffold/schema/v1alpha2/upgrade.go
+++ b/pkg/skaffold/schema/v1alpha2/upgrade.go
@@ -25,6 +25,12 @@ import (
 )
 
 // Upgrade upgrades a configuration to the next version.
+// Config changes from v1alpha2 to v1alpha3:
+// 1. No additions
+// 2. No removal
+// 3. Updates
+//  - KanikoBuildContext instead of GCSBucket
+//  - HelmRelease.valuesFilePath -> valuesFiles in yaml
 func (config *SkaffoldPipeline) Upgrade() (util.VersionedConfig, error) {
 	// convert Deploy (should be the same)
 	var newDeploy next.DeployConfig

--- a/pkg/skaffold/schema/v1alpha3/upgrade.go
+++ b/pkg/skaffold/schema/v1alpha3/upgrade.go
@@ -25,6 +25,22 @@ import (
 )
 
 // Upgrade upgrades a configuration to the next version.
+// Config changes from v1alpha3 to v1alpha4:
+// 1. Additions:
+//   - SkaffoldPipeline.Test, Profile.Test, TestCase, TestConfig
+//   - KanikoBuildContext.LocalDir, LocalDir
+//   - KanikoBuild.Image
+//   - Artifact.Sync
+// 	 - JibMavenArtifact, JibGradleArtifact
+// 2. No removal
+// 3. Updates
+//    - EnvTemplate.Template is now optional in yaml
+//    - LocalBuild.SkipPush=false (v1alpha3) -> LocalBuild.Push=true (v1alpha4)_
+//    - kustomizePath -> path in yaml
+// 		- HelmRelease, HelmPackaged, HelmFQNConfig fields are optional in yaml,
+//    - Artifact.imageName -> image, workspace -> context in yaml
+//		- DockerArtifact.dockerfilePath -> dockerfile in yaml
+//    - BazelArtifact.BuildTarget is optional in yaml
 func (config *SkaffoldPipeline) Upgrade() (util.VersionedConfig, error) {
 	// convert Deploy (should be the same)
 	var newDeploy next.DeployConfig

--- a/pkg/skaffold/schema/v1alpha4/upgrade.go
+++ b/pkg/skaffold/schema/v1alpha4/upgrade.go
@@ -25,6 +25,12 @@ import (
 )
 
 // Upgrade upgrades a configuration to the next version.
+// Config changes from v1alpha4 to v1alpha5:
+// 1. Additions:
+//   - BuildType.AzureContainerBuild and AzureContainerBuild type
+// 2. No removal
+// 3. Updates
+//    - minor - []TestCase type aliased to TestConfig
 func (config *SkaffoldPipeline) Upgrade() (util.VersionedConfig, error) {
 	// convert Deploy (should be the same)
 	var newDeploy next.DeployConfig

--- a/pkg/skaffold/schema/v1alpha4/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha4/upgrade_test.go
@@ -36,6 +36,10 @@ kind: Config
 build:
   artifacts:
   - image: gcr.io/k8s-skaffold/skaffold-example
+test:
+  - image: gcr.io/k8s-skaffold/skaffold-example
+    structureTests:
+     - ./test/*
 deploy:
   kubectl:
     manifests:
@@ -45,6 +49,10 @@ profiles:
     build:
       artifacts:
       - image: gcr.io/k8s-skaffold/skaffold-example
+    test:
+     - image: gcr.io/k8s-skaffold/skaffold-example
+       structureTests:
+         - ./test/*
     deploy:
       kubectl:
         manifests:
@@ -60,6 +68,12 @@ profiles:
 							ImageName:    "gcr.io/k8s-skaffold/skaffold-example",
 							ArtifactType: next.ArtifactType{},
 						},
+					},
+				},
+				Test: []*next.TestCase{
+					{
+						ImageName:      "gcr.io/k8s-skaffold/skaffold-example",
+						StructureTests: []string{"./test/*"},
 					},
 				},
 				Deploy: next.DeployConfig{
@@ -81,6 +95,12 @@ profiles:
 									ImageName:    "gcr.io/k8s-skaffold/skaffold-example",
 									ArtifactType: next.ArtifactType{},
 								},
+							},
+						},
+						Test: []*next.TestCase{
+							{
+								ImageName:      "gcr.io/k8s-skaffold/skaffold-example",
+								StructureTests: []string{"./test/*"},
 							},
 						},
 						Deploy: next.DeployConfig{

--- a/pkg/skaffold/schema/v1alpha5/config.go
+++ b/pkg/skaffold/schema/v1alpha5/config.go
@@ -14,21 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package latest
+package v1alpha5
 
 import (
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
-	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 )
 
-const Version string = "skaffold/v1beta1"
-
-func Semver() semver.Version {
-	return apiversion.MustParse(Version)
-}
+const Version string = "skaffold/v1alpha5"
 
 // NewSkaffoldPipeline creates a SkaffoldPipeline
 func NewSkaffoldPipeline() util.VersionedConfig {
@@ -119,16 +113,10 @@ type KanikoBuildContext struct {
 	LocalDir  *LocalDir `yaml:"localDir,omitempty" yamltags:"oneOf=buildContext"`
 }
 
-// KanikoCache contains fields related to kaniko caching
-type KanikoCache struct {
-	Repo string `yaml:"repo,omitempty"`
-}
-
 // KanikoBuild contains the fields needed to do a on-cluster build using
 // the kaniko image
 type KanikoBuild struct {
 	BuildContext   *KanikoBuildContext `yaml:"buildContext,omitempty"`
-	Cache          *KanikoCache        `yaml:"cache,omitempty"`
 	PullSecret     string              `yaml:"pullSecret,omitempty"`
 	PullSecretName string              `yaml:"pullSecretName,omitempty"`
 	Namespace      string              `yaml:"namespace,omitempty"`
@@ -273,8 +261,7 @@ type DockerArtifact struct {
 
 // BazelArtifact describes an artifact built with Bazel.
 type BazelArtifact struct {
-	BuildTarget string   `yaml:"target,omitempty"`
-	BuildArgs   []string `yaml:"args,omitempty"`
+	BuildTarget string `yaml:"target,omitempty"`
 }
 
 type JibMavenArtifact struct {

--- a/pkg/skaffold/schema/v1alpha5/defaults.go
+++ b/pkg/skaffold/schema/v1alpha5/defaults.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha5
+
+import (
+	"fmt"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
+	homedir "github.com/mitchellh/go-homedir"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// SetDefaultValues makes sure default values are set.
+func (c *SkaffoldPipeline) SetDefaultValues() error {
+	c.defaultToLocalBuild()
+	c.defaultToKubectlDeploy()
+	c.setDefaultCloudBuildDockerImage()
+	c.setDefaultTagger()
+	c.setDefaultKustomizePath()
+	c.setDefaultKubectlManifests()
+
+	if err := c.withKanikoConfig(
+		setDefaultKanikoTimeout,
+		setDefaultKanikoImage,
+		setDefaultKanikoNamespace,
+		setDefaultKanikoSecret,
+		setDefaultKanikoBuildContext,
+	); err != nil {
+		return err
+	}
+
+	for _, a := range c.Build.Artifacts {
+		c.defaultToDockerArtifact(a)
+		c.setDefaultDockerfile(a)
+		c.setDefaultWorkspace(a)
+	}
+
+	return nil
+}
+
+func (c *SkaffoldPipeline) defaultToLocalBuild() {
+	if c.Build.BuildType != (BuildType{}) {
+		return
+	}
+
+	logrus.Debugf("Defaulting build type to local build")
+	c.Build.BuildType.LocalBuild = &LocalBuild{}
+}
+
+func (c *SkaffoldPipeline) defaultToKubectlDeploy() {
+	if c.Deploy.DeployType != (DeployType{}) {
+		return
+	}
+
+	logrus.Debugf("Defaulting deploy type to kubectl")
+	c.Deploy.DeployType.KubectlDeploy = &KubectlDeploy{}
+}
+
+func (c *SkaffoldPipeline) setDefaultCloudBuildDockerImage() {
+	cloudBuild := c.Build.BuildType.GoogleCloudBuild
+	if cloudBuild == nil {
+		return
+	}
+
+	cloudBuild.DockerImage = valueOrDefault(cloudBuild.DockerImage, constants.DefaultCloudBuildDockerImage)
+}
+
+func (c *SkaffoldPipeline) setDefaultTagger() {
+	if c.Build.TagPolicy != (TagPolicy{}) {
+		return
+	}
+
+	c.Build.TagPolicy = TagPolicy{GitTagger: &GitTagger{}}
+}
+
+func (c *SkaffoldPipeline) setDefaultKustomizePath() {
+	kustomize := c.Deploy.KustomizeDeploy
+	if kustomize == nil {
+		return
+	}
+
+	kustomize.KustomizePath = valueOrDefault(kustomize.KustomizePath, constants.DefaultKustomizationPath)
+}
+
+func (c *SkaffoldPipeline) setDefaultKubectlManifests() {
+	if c.Deploy.KubectlDeploy != nil && len(c.Deploy.KubectlDeploy.Manifests) == 0 {
+		c.Deploy.KubectlDeploy.Manifests = constants.DefaultKubectlManifests
+	}
+}
+
+func (c *SkaffoldPipeline) defaultToDockerArtifact(a *Artifact) {
+	if a.ArtifactType == (ArtifactType{}) {
+		a.ArtifactType = ArtifactType{
+			DockerArtifact: &DockerArtifact{},
+		}
+	}
+}
+
+func (c *SkaffoldPipeline) setDefaultDockerfile(a *Artifact) {
+	if a.DockerArtifact != nil {
+		a.DockerArtifact.DockerfilePath = valueOrDefault(a.DockerArtifact.DockerfilePath, constants.DefaultDockerfilePath)
+	}
+}
+
+func (c *SkaffoldPipeline) setDefaultWorkspace(a *Artifact) {
+	a.Workspace = valueOrDefault(a.Workspace, ".")
+}
+
+func (c *SkaffoldPipeline) withKanikoConfig(operations ...func(kaniko *KanikoBuild) error) error {
+	if kaniko := c.Build.KanikoBuild; kaniko != nil {
+		for _, operation := range operations {
+			if err := operation(kaniko); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func setDefaultKanikoNamespace(kaniko *KanikoBuild) error {
+	if kaniko.Namespace == "" {
+		ns, err := currentNamespace()
+		if err != nil {
+			return errors.Wrap(err, "getting current namespace")
+		}
+
+		kaniko.Namespace = ns
+	}
+
+	return nil
+}
+
+func setDefaultKanikoTimeout(kaniko *KanikoBuild) error {
+	kaniko.Timeout = valueOrDefault(kaniko.Timeout, constants.DefaultKanikoTimeout)
+	return nil
+}
+
+func setDefaultKanikoImage(kaniko *KanikoBuild) error {
+	kaniko.Image = valueOrDefault(kaniko.Image, constants.DefaultKanikoImage)
+	return nil
+}
+
+func setDefaultKanikoSecret(kaniko *KanikoBuild) error {
+	kaniko.PullSecretName = valueOrDefault(kaniko.PullSecretName, constants.DefaultKanikoSecretName)
+
+	if kaniko.PullSecret != "" {
+		absPath, err := homedir.Expand(kaniko.PullSecret)
+		if err != nil {
+			return fmt.Errorf("unable to expand pullSecret %s", kaniko.PullSecret)
+		}
+
+		kaniko.PullSecret = absPath
+		return nil
+	}
+
+	return nil
+}
+
+func setDefaultKanikoBuildContext(kaniko *KanikoBuild) error {
+	if kaniko.BuildContext == nil {
+		kaniko.BuildContext = &KanikoBuildContext{
+			LocalDir: &LocalDir{},
+		}
+	}
+	return nil
+}
+
+func valueOrDefault(v, def string) string {
+	if v != "" {
+		return v
+	}
+	return def
+}
+
+func currentNamespace() (string, error) {
+	cfg, err := kubectx.CurrentConfig()
+	if err != nil {
+		return "", err
+	}
+
+	current, present := cfg.Contexts[cfg.CurrentContext]
+	if present {
+		if current.Namespace != "" {
+			return current.Namespace, nil
+		}
+	}
+
+	return "default", nil
+}

--- a/pkg/skaffold/schema/v1alpha5/upgrade.go
+++ b/pkg/skaffold/schema/v1alpha5/upgrade.go
@@ -25,6 +25,12 @@ import (
 )
 
 // Upgrade upgrades a configuration to the next version.
+// Config changes from v1alpha5 to v1beta1:
+// 1. Additions:
+//   - KanikoCache struct, KanikoBuild.Cache
+//   - BazelArtifact.BuildArgs
+// 2. No removal
+// 3. No updates
 func (config *SkaffoldPipeline) Upgrade() (util.VersionedConfig, error) {
 	// convert Deploy (should be the same)
 	var newDeploy next.DeployConfig

--- a/pkg/skaffold/schema/v1alpha5/upgrade.go
+++ b/pkg/skaffold/schema/v1alpha5/upgrade.go
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha4
+package v1alpha5
 
 import (
 	"encoding/json"
 
+	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
-	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha5"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/skaffold/schema/v1alpha5/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha5/upgrade_test.go
@@ -31,11 +31,15 @@ func TestPipelineUpgrade(t *testing.T) {
 	}{
 		{
 			name: "normal skaffold yaml",
-			yaml: `apiVersion: skaffold/v1alpha5
+			yaml: `apiVersion: skaffold/v1alpha4
 kind: Config
 build:
   artifacts:
   - image: gcr.io/k8s-skaffold/skaffold-example
+test:
+  - image: gcr.io/k8s-skaffold/skaffold-example
+    structureTests:
+     - ./test/*
 deploy:
   kubectl:
     manifests:
@@ -45,6 +49,10 @@ profiles:
     build:
       artifacts:
       - image: gcr.io/k8s-skaffold/skaffold-example
+    test:
+     - image: gcr.io/k8s-skaffold/skaffold-example
+       structureTests:
+         - ./test/*
     deploy:
       kubectl:
         manifests:
@@ -60,6 +68,12 @@ profiles:
 							ImageName:    "gcr.io/k8s-skaffold/skaffold-example",
 							ArtifactType: next.ArtifactType{},
 						},
+					},
+				},
+				Test: []*next.TestCase{
+					{
+						ImageName:      "gcr.io/k8s-skaffold/skaffold-example",
+						StructureTests: []string{"./test/*"},
 					},
 				},
 				Deploy: next.DeployConfig{
@@ -81,6 +95,12 @@ profiles:
 									ImageName:    "gcr.io/k8s-skaffold/skaffold-example",
 									ArtifactType: next.ArtifactType{},
 								},
+							},
+						},
+						Test: []*next.TestCase{
+							{
+								ImageName:      "gcr.io/k8s-skaffold/skaffold-example",
+								StructureTests: []string{"./test/*"},
 							},
 						},
 						Deploy: next.DeployConfig{

--- a/pkg/skaffold/schema/v1alpha5/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha5/upgrade_test.go
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha4
+package v1alpha5
 
 import (
 	"testing"
 
-	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha5"
+	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -31,7 +31,7 @@ func TestPipelineUpgrade(t *testing.T) {
 	}{
 		{
 			name: "normal skaffold yaml",
-			yaml: `apiVersion: skaffold/v1alpha4
+			yaml: `apiVersion: skaffold/v1alpha5
 kind: Config
 build:
   artifacts:

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	yaml "gopkg.in/yaml.v2"
 
 	apiversion "github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -32,7 +33,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha4"
 	misc "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags"
-	"gopkg.in/yaml.v2"
 )
 
 type APIVersion struct {


### PR DESCRIPTION
As we already have a config change (kaniko cache) since v1alpha5 was released, I will use those changes to do the version upgrade to v1beta1.

- [X] move kaniko cache example changes to integration test examples
- [x] move kaniko cache config changes to v1beta1
- [x] write basic tests

cc #1283 
cc #1275 && #1287