### PR TITLE
Run tests in skaffold build, add flag to skip tests

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -68,9 +68,9 @@ func runBuild(out io.Writer) error {
 		buildOut = ioutil.Discard
 	}
 
-	bRes, err := runner.Build(ctx, buildOut, runner.Tagger, config.Build.Artifacts)
+	bRes, err := runner.RunBuild(ctx, buildOut, config.Build.Artifacts)
 	if err != nil {
-		return errors.Wrap(err, "build step")
+		return err
 	}
 
 	cmdOut := BuildOutput{Builds: bRes}

--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -68,7 +68,7 @@ func runBuild(out io.Writer) error {
 		buildOut = ioutil.Discard
 	}
 
-	bRes, err := runner.RunBuild(ctx, buildOut, config.Build.Artifacts)
+	bRes, err := runner.BuildAndTest(ctx, buildOut, config.Build.Artifacts)
 	if err != nil {
 		return err
 	}

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -143,6 +143,7 @@ func AddRunDevFlags(cmd *cobra.Command) {
 	cmd.Flags().StringArrayVarP(&opts.Profiles, "profile", "p", nil, "Activate profiles by name")
 	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "", "Run deployments in the specified namespace")
 	cmd.Flags().StringVarP(&opts.DefaultRepo, "default-repo", "d", "", "Default repository value (overrides global config)")
+	cmd.Flags().BoolVar(&opts.SkipTests, "skip-tests", false, "whether to skip the tests after building")
 }
 
 func SetUpLogs(out io.Writer, level string) error {

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -143,7 +143,7 @@ func AddRunDevFlags(cmd *cobra.Command) {
 	cmd.Flags().StringArrayVarP(&opts.Profiles, "profile", "p", nil, "Activate profiles by name")
 	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "", "Run deployments in the specified namespace")
 	cmd.Flags().StringVarP(&opts.DefaultRepo, "default-repo", "d", "", "Default repository value (overrides global config)")
-	cmd.Flags().BoolVar(&opts.SkipTests, "skip-tests", false, "whether to skip the tests after building")
+	cmd.Flags().BoolVar(&opts.SkipTests, "skip-tests", false, "Whether to skip the tests after building")
 }
 
 func SetUpLogs(out io.Writer, level string) error {

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -29,6 +29,7 @@ type SkaffoldOptions struct {
 	Tail              bool
 	TailDev           bool
 	PortForward       bool
+	SkipTests         bool
 	Profiles          []string
 	CustomTag         string
 	Namespace         string

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -208,15 +208,9 @@ func (r *SkaffoldRunner) newLogger(out io.Writer, artifacts []*latest.Artifact) 
 }
 
 func (r *SkaffoldRunner) buildTestDeploy(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) error {
-	bRes, err := r.Build(ctx, out, r.Tagger, artifacts)
+	bRes, err := r.RunBuild(ctx, out, artifacts)
 	if err != nil {
-		return errors.Wrap(err, "build failed")
-	}
-
-	if !r.opts.SkipTests {
-		if err = r.Test(ctx, out, bRes); err != nil {
-			return errors.Wrap(err, "test failed")
-		}
+		return err
 	}
 
 	// Update which images are logged.
@@ -249,6 +243,21 @@ func (r *SkaffoldRunner) Run(ctx context.Context, out io.Writer, artifacts []*la
 	}
 
 	return nil
+}
+
+// RunBuild builds artifacts and runs tests on built artifacts
+func (r *SkaffoldRunner) RunBuild(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+	bRes, err := r.Build(ctx, out, r.Tagger, artifacts)
+	if err != nil {
+		return nil, errors.Wrap(err, "build failed")
+	}
+
+	if !r.opts.SkipTests {
+		if err = r.Test(ctx, out, bRes); err != nil {
+			return nil, errors.Wrap(err, "test failed")
+		}
+	}
+	return bRes, err
 }
 
 // TailLogs prints the logs for deployed artifacts.

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -213,8 +213,10 @@ func (r *SkaffoldRunner) buildTestDeploy(ctx context.Context, out io.Writer, art
 		return errors.Wrap(err, "build failed")
 	}
 
-	if err := r.Test(ctx, out, bRes); err != nil {
-		return errors.Wrap(err, "test failed")
+	if !r.opts.SkipTests {
+		if err = r.Test(ctx, out, bRes); err != nil {
+			return errors.Wrap(err, "test failed")
+		}
 	}
 
 	// Update which images are logged.

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -208,7 +208,7 @@ func (r *SkaffoldRunner) newLogger(out io.Writer, artifacts []*latest.Artifact) 
 }
 
 func (r *SkaffoldRunner) buildTestDeploy(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) error {
-	bRes, err := r.RunBuild(ctx, out, artifacts)
+	bRes, err := r.BuildAndTest(ctx, out, artifacts)
 	if err != nil {
 		return err
 	}
@@ -245,8 +245,8 @@ func (r *SkaffoldRunner) Run(ctx context.Context, out io.Writer, artifacts []*la
 	return nil
 }
 
-// RunBuild builds artifacts and runs tests on built artifacts
-func (r *SkaffoldRunner) RunBuild(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+// BuildAndTest builds artifacts and runs tests on built artifacts
+func (r *SkaffoldRunner) BuildAndTest(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 	bRes, err := r.Build(ctx, out, r.Tagger, artifacts)
 	if err != nil {
 		return nil, errors.Wrap(err, "build failed")


### PR DESCRIPTION
This adds support for running tests during a `skaffold build`. Additionally, it adds a way for users to skip running tests with a CLI flag.

Fixes #1078 