### PR TITLE
Remove pointer to runtime.Object interface

### DIFF
--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -27,7 +27,7 @@ import (
 
 // Artifact contains all information about a completed deployment
 type Artifact struct {
-	Obj       *runtime.Object
+	Obj       runtime.Object
 	Namespace string
 }
 

--- a/pkg/skaffold/deploy/labels.go
+++ b/pkg/skaffold/deploy/labels.go
@@ -124,8 +124,8 @@ func addLabels(labels map[string]string, accessor metav1.Object) {
 }
 
 func updateRuntimeObject(client dynamic.Interface, disco discovery.DiscoveryInterface, labels map[string]string, res Artifact) error {
-	originalJSON, _ := json.Marshal(*res.Obj)
-	modifiedObj := (*res.Obj).DeepCopyObject()
+	originalJSON, _ := json.Marshal(res.Obj)
+	modifiedObj := res.Obj.DeepCopyObject()
 	accessor, err := meta.Accessor(modifiedObj)
 	if err != nil {
 		return errors.Wrap(err, "getting metadata accessor")

--- a/pkg/skaffold/deploy/util.go
+++ b/pkg/skaffold/deploy/util.go
@@ -34,7 +34,7 @@ func parseRuntimeObject(namespace string, b []byte) (Artifact, error) {
 		return Artifact{}, fmt.Errorf("error decoding parsed yaml: %s", err.Error())
 	}
 	return Artifact{
-		Obj:       &obj,
+		Obj:       obj,
 		Namespace: namespace,
 	}, nil
 }


### PR DESCRIPTION
Removed pointer to an interface, because it makes no sence in this
case.
