### PR TITLE
Remove duplication between run and deploy

### DIFF
--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -17,16 +17,10 @@ limitations under the License.
 package cmd
 
 import (
-	"context"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
-
-var images []string
 
 // NewCmdDeploy describes the CLI command to deploy artifacts.
 func NewCmdDeploy(out io.Writer) *cobra.Command {
@@ -35,40 +29,12 @@ func NewCmdDeploy(out io.Writer) *cobra.Command {
 		Short: "Deploys the artifacts",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDeploy(out)
+			// Same actions as `skaffold run`, but with pre-built images.
+			return run(out)
 		},
 	}
 	AddRunDevFlags(cmd)
 	AddRunDeployFlags(cmd)
-	cmd.Flags().StringSliceVar(&images, "images", nil, "A list of images to deploy")
+	cmd.Flags().StringSliceVar(&opts.PreBuiltImages, "images", nil, "A list of pre-built images to deploy")
 	return cmd
-}
-
-func runDeploy(out io.Writer) error {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	catchCtrlC(cancel)
-
-	r, config, err := newRunner(out, opts)
-	if err != nil {
-		return errors.Wrap(err, "creating runner")
-	}
-
-	var builds []build.Artifact
-	for _, image := range images {
-		parsed, err := docker.ParseReference(image)
-		if err != nil {
-			return err
-		}
-		builds = append(builds, build.Artifact{
-			ImageName: parsed.BaseName,
-			Tag:       image,
-		})
-	}
-
-	if _, err := r.Deploy(ctx, out, builds); err != nil {
-		return err
-	}
-
-	return r.TailLogs(ctx, out, config.Build.Artifacts, builds)
 }

--- a/pkg/skaffold/build/prebuilt.go
+++ b/pkg/skaffold/build/prebuilt.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"context"
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/pkg/errors"
+)
+
+// NewPreBuiltImagesBuilder returns an new instance a Builder that assumes images are
+// already built with given fully qualified names.
+func NewPreBuiltImagesBuilder(images []string) Builder {
+	return &prebuiltImagesBuilder{
+		images: images,
+	}
+}
+
+type prebuiltImagesBuilder struct {
+	images []string
+}
+
+// Labels are labels applied to deployed resources.
+func (b *prebuiltImagesBuilder) Labels() map[string]string {
+	return map[string]string{
+		constants.Labels.Builder: "pre-built",
+	}
+}
+
+func (b *prebuiltImagesBuilder) Build(ctx context.Context, out io.Writer, tagger tag.Tagger, artifacts []*latest.Artifact) ([]Artifact, error) {
+	tags := make(map[string]string)
+
+	for _, tag := range b.images {
+		parsed, err := docker.ParseReference(tag)
+		if err != nil {
+			return nil, err
+		}
+
+		tags[parsed.BaseName] = tag
+	}
+
+	var builds []Artifact
+
+	for _, artifact := range artifacts {
+		tag, present := tags[artifact.ImageName]
+		if !present {
+			return nil, errors.Errorf("unable to find image tag for %s", artifact.ImageName)
+		}
+		delete(tags, artifact.ImageName)
+
+		builds = append(builds, Artifact{
+			ImageName: artifact.ImageName,
+			Tag:       tag,
+		})
+	}
+
+	for image, tag := range tags {
+		builds = append(builds, Artifact{
+			ImageName: image,
+			Tag:       tag,
+		})
+	}
+
+	return builds, nil
+}

--- a/pkg/skaffold/build/prebuilt_test.go
+++ b/pkg/skaffold/build/prebuilt_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestPreBuiltImagesBuilder(t *testing.T) {
+	var tests = []struct {
+		description string
+		images      []string
+		artifacts   []*latest.Artifact
+		expected    []Artifact
+		shouldErr   bool
+	}{
+		{
+			description: "images in same order",
+			images: []string{
+				"skaffold/image1:tag1",
+				"skaffold/image2:tag2",
+			},
+			artifacts: []*latest.Artifact{
+				{ImageName: "skaffold/image1"},
+				{ImageName: "skaffold/image2"},
+			},
+			expected: []Artifact{
+				{ImageName: "skaffold/image1", Tag: "skaffold/image1:tag1"},
+				{ImageName: "skaffold/image2", Tag: "skaffold/image2:tag2"},
+			},
+		},
+		{
+			description: "images in reverse order",
+			images: []string{
+				"skaffold/image2:tag2",
+				"skaffold/image1:tag1",
+			},
+			artifacts: []*latest.Artifact{
+				{ImageName: "skaffold/image1"},
+				{ImageName: "skaffold/image2"},
+			},
+			expected: []Artifact{
+				{ImageName: "skaffold/image1", Tag: "skaffold/image1:tag1"},
+				{ImageName: "skaffold/image2", Tag: "skaffold/image2:tag2"},
+			},
+		},
+		{
+			description: "missing image",
+			images: []string{
+				"skaffold/image1:tag1",
+			},
+			artifacts: []*latest.Artifact{
+				{ImageName: "skaffold/image1"},
+				{ImageName: "skaffold/image2"},
+			},
+			shouldErr: true,
+		},
+		{
+			// Should we support that? It is used in kustomize example.
+			description: "additional image",
+			images: []string{
+				"busybox:1",
+				"skaffold/image1:tag1",
+			},
+			artifacts: []*latest.Artifact{
+				{ImageName: "skaffold/image1"},
+			},
+			expected: []Artifact{
+				{ImageName: "skaffold/image1", Tag: "skaffold/image1:tag1"},
+				{ImageName: "busybox", Tag: "busybox:1"},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			builder := NewPreBuiltImagesBuilder(test.images)
+
+			bRes, err := builder.Build(context.Background(), ioutil.Discard, nil, test.artifacts)
+
+			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, bRes)
+		})
+	}
+}

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -37,6 +37,7 @@ type SkaffoldOptions struct {
 	CustomLabels      []string
 	WatchPollInterval int
 	DefaultRepo       string
+	PreBuiltImages    []string
 }
 
 // Labels returns a map of labels to be applied to all deployed

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -80,12 +80,12 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldPipeline) (*
 		return nil, errors.Wrap(err, "parsing tag config")
 	}
 
-	builder, err := getBuilder(&cfg.Build, kubeContext)
+	builder, err := getBuilder(&cfg.Build, kubeContext, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing build config")
 	}
 
-	tester, err := getTester(&cfg.Test)
+	tester, err := getTester(&cfg.Test, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing test config")
 	}
@@ -119,8 +119,12 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldPipeline) (*
 	}, nil
 }
 
-func getBuilder(cfg *latest.BuildConfig, kubeContext string) (build.Builder, error) {
+func getBuilder(cfg *latest.BuildConfig, kubeContext string, opts *config.SkaffoldOptions) (build.Builder, error) {
 	switch {
+	case len(opts.PreBuiltImages) > 0:
+		logrus.Debugln("Using pre-built images")
+		return build.NewPreBuiltImagesBuilder(opts.PreBuiltImages), nil
+
 	case cfg.LocalBuild != nil:
 		logrus.Debugln("Using builder: local")
 		return local.NewBuilder(cfg.LocalBuild, kubeContext)
@@ -138,8 +142,14 @@ func getBuilder(cfg *latest.BuildConfig, kubeContext string) (build.Builder, err
 	}
 }
 
-func getTester(cfg *latest.TestConfig) (test.Tester, error) {
-	return test.NewTester(cfg)
+func getTester(cfg *latest.TestConfig, opts *config.SkaffoldOptions) (test.Tester, error) {
+	switch {
+	case len(opts.PreBuiltImages) > 0:
+		logrus.Debugln("Skipping tests")
+		return test.NewTester(&latest.TestConfig{})
+	default:
+		return test.NewTester(cfg)
+	}
 }
 
 func getDeployer(cfg *latest.DeployConfig, kubeContext string, namespace string, defaultRepo string) (deploy.Deployer, error) {
@@ -197,23 +207,46 @@ func (r *SkaffoldRunner) newLogger(out io.Writer, artifacts []*latest.Artifact) 
 	return kubernetes.NewLogAggregator(out, imageNames, r.imageList)
 }
 
-// Run builds artifacts, runs tests on built artifacts, and then deploys them.
-func (r *SkaffoldRunner) Run(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) error {
+func (r *SkaffoldRunner) buildTestDeploy(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) error {
 	bRes, err := r.Build(ctx, out, r.Tagger, artifacts)
 	if err != nil {
-		return errors.Wrap(err, "build step")
+		return errors.Wrap(err, "build failed")
 	}
 
-	if err = r.Test(ctx, out, bRes); err != nil {
-		return errors.Wrap(err, "test step")
+	if err := r.Test(ctx, out, bRes); err != nil {
+		return errors.Wrap(err, "test failed")
 	}
 
-	_, err = r.Deploy(ctx, out, bRes)
-	if err != nil {
-		return errors.Wrap(err, "deploy step")
+	// Update which images are logged.
+	for _, build := range bRes {
+		r.imageList.Add(build.Tag)
 	}
 
-	return r.TailLogs(ctx, out, artifacts, bRes)
+	// Make sure all artifacts are redeployed. Not only those that were just built.
+	r.builds = mergeWithPreviousBuilds(bRes, r.builds)
+
+	if _, err := r.Deploy(ctx, out, r.builds); err != nil {
+		return errors.Wrap(err, "deploy failed")
+	}
+
+	return nil
+}
+
+// Run builds artifacts, runs tests on built artifacts, and then deploys them.
+func (r *SkaffoldRunner) Run(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) error {
+	if err := r.buildTestDeploy(ctx, out, artifacts); err != nil {
+		return err
+	}
+
+	if r.opts.Tail {
+		logger := r.newLogger(out, artifacts)
+		if err := logger.Start(ctx); err != nil {
+			return errors.Wrap(err, "starting logger")
+		}
+		<-ctx.Done()
+	}
+
+	return nil
 }
 
 // TailLogs prints the logs for deployed artifacts.
@@ -276,20 +309,8 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 				}
 			}
 		case len(changed.needsRebuild) > 0:
-			bRes, err := r.Build(ctx, out, r.Tagger, changed.needsRebuild)
-			if err != nil {
-				logrus.Warnln("Skipping Deploy due to build error:", err)
-				return nil
-			}
-
-			r.trackBuiltImages(bRes)
-			if err := r.Test(ctx, out, bRes); err != nil {
-				logrus.Warnln("Skipping Deploy due to failed tests:", err)
-				return nil
-			}
-
-			if _, err = r.Deploy(ctx, out, r.builds); err != nil {
-				logrus.Warnln("Skipping Deploy due to error:", err)
+			if err := r.buildTestDeploy(ctx, out, changed.needsRebuild); err != nil {
+				logrus.Warnln("Skipping deploy due to errors:", err)
 				return nil
 			}
 		case changed.needsRedeploy:
@@ -346,19 +367,8 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	}
 
 	// First run
-	bRes, err := r.Build(ctx, out, r.Tagger, artifacts)
-	if err != nil {
-		return nil, errors.Wrap(err, "exiting dev mode because the first build failed")
-	}
-
-	r.trackBuiltImages(bRes)
-	if err := r.Test(ctx, out, bRes); err != nil {
-		return nil, errors.Wrap(err, "exiting dev mode because the first test run failed")
-	}
-
-	_, err = r.Deploy(ctx, out, r.builds)
-	if err != nil {
-		return nil, errors.Wrap(err, "exiting dev mode because the first deploy failed")
+	if err := r.buildTestDeploy(ctx, out, artifacts); err != nil {
+		return nil, errors.Wrap(err, "exiting dev mode because first run failed")
 	}
 
 	// Start logs
@@ -392,16 +402,6 @@ func (r *SkaffoldRunner) shouldWatch(artifact *latest.Artifact) bool {
 	}
 
 	return false
-}
-
-func (r *SkaffoldRunner) trackBuiltImages(bRes []build.Artifact) {
-	// Update which images are logged.
-	for _, build := range bRes {
-		r.imageList.Add(build.Tag)
-	}
-
-	// Make sure all artifacts are redeployed. Not only those that were just rebuilt.
-	r.builds = mergeWithPreviousBuilds(bRes, r.builds)
 }
 
 func mergeWithPreviousBuilds(builds, previous []build.Artifact) []build.Artifact {


### PR DESCRIPTION
This is the final part of #1204

Both commands should follow the same path except `deploy` will work with pre-built images.
Removes a lot of duplication.

Signed-off-by: David Gageot <david@gageot.net>