### PR TITLE
Apply default values upgraded configurations

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -58,7 +58,7 @@ func runBuild(out io.Writer) error {
 	defer cancel()
 	catchCtrlC(cancel)
 
-	runner, config, err := newRunner(out, opts)
+	runner, config, err := newRunner(opts)
 	if err != nil {
 		return errors.Wrap(err, "creating runner")
 	}

--- a/cmd/skaffold/app/cmd/delete.go
+++ b/cmd/skaffold/app/cmd/delete.go
@@ -43,7 +43,7 @@ func delete(out io.Writer) error {
 	defer cancel()
 	catchCtrlC(cancel)
 
-	runner, _, err := newRunner(out, opts)
+	runner, _, err := newRunner(opts)
 	if err != nil {
 		return errors.Wrap(err, "creating runner")
 	}

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -65,7 +65,7 @@ func dev(out io.Writer) error {
 		case <-ctx.Done():
 			return nil
 		default:
-			r, config, err := newRunner(out, opts)
+			r, config, err := newRunner(opts)
 			if err != nil {
 				return errors.Wrap(err, "creating runner")
 			}

--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -49,7 +49,7 @@ func NewCmdDiagnose(out io.Writer) *cobra.Command {
 }
 
 func doDiagnose(out io.Writer) error {
-	_, config, err := newRunner(out, opts)
+	_, config, err := newRunner(opts)
 	if err != nil {
 		return errors.Wrap(err, "creating runner")
 	}

--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -44,7 +44,7 @@ func NewCmdFix(out io.Writer) *cobra.Command {
 }
 
 func runFix(out io.Writer, configFile string, overwrite bool) error {
-	cfg, err := schema.ParseConfig(configFile, false)
+	cfg, err := schema.ParseConfig(configFile, false, false)
 	if err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func runFix(out io.Writer, configFile string, overwrite bool) error {
 		return nil
 	}
 
-	cfg, err = schema.UpgradeToLatest(out, cfg)
+	cfg, err = schema.ParseConfig(configFile, false, true)
 	if err != nil {
 		return err
 	}

--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -44,7 +44,7 @@ func NewCmdFix(out io.Writer) *cobra.Command {
 }
 
 func runFix(out io.Writer, configFile string, overwrite bool) error {
-	cfg, err := schema.ParseConfig(configFile, false, false)
+	cfg, err := schema.ParseConfig(configFile, false)
 	if err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func runFix(out io.Writer, configFile string, overwrite bool) error {
 		return nil
 	}
 
-	cfg, err = schema.ParseConfig(configFile, false, true)
+	cfg, err = schema.ParseConfig(configFile, true)
 	if err != nil {
 		return err
 	}

--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -20,36 +20,21 @@ import (
 	"io"
 	"io/ioutil"
 
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
-
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	yaml "gopkg.in/yaml.v2"
 )
 
 func NewCmdFix(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "fix",
 		Short: "Converts old skaffold.yaml to newest schema version",
-		Run: func(cmd *cobra.Command, args []string) {
-			cfg, err := schema.ParseConfig(opts.ConfigurationFile, false)
-			if err != nil {
-				logrus.Error(err)
-				return
-			}
-
-			if cfg.GetVersion() == latest.Version {
-				color.Default.Fprintln(out, "config is already latest version")
-				return
-			}
-
-			if err := runFix(out, cfg); err != nil {
-				logrus.Errorf("fix: %s", err)
-			}
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFix(out, opts.ConfigurationFile, overwrite)
 		},
 		Args: cobra.NoArgs,
 	}
@@ -58,8 +43,18 @@ func NewCmdFix(out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func runFix(out io.Writer, cfg schemautil.VersionedConfig) error {
-	cfg, err := schema.UpgradeToLatest(out, cfg)
+func runFix(out io.Writer, configFile string, overwrite bool) error {
+	cfg, err := schema.ParseConfig(configFile, false)
+	if err != nil {
+		return err
+	}
+
+	if cfg.GetVersion() == latest.Version {
+		color.Default.Fprintln(out, "config is already latest version")
+		return nil
+	}
+
+	cfg, err = schema.UpgradeToLatest(out, cfg)
 	if err != nil {
 		return err
 	}
@@ -70,7 +65,7 @@ func runFix(out io.Writer, cfg schemautil.VersionedConfig) error {
 	}
 
 	if overwrite {
-		if err := ioutil.WriteFile(opts.ConfigurationFile, newCfg, 0644); err != nil {
+		if err := ioutil.WriteFile(configFile, newCfg, 0644); err != nil {
 			return errors.Wrap(err, "writing config file")
 		}
 		color.Default.Fprintf(out, "New config at version %s generated and written to %s\n", cfg.GetVersion(), opts.ConfigurationFile)

--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -106,7 +106,7 @@ func doInit(out io.Writer) error {
 
 	for _, file := range potentialConfigs {
 		if !force {
-			config, err := schema.ParseConfig(file, true)
+			config, err := schema.ParseConfig(file, true, false)
 			if err == nil && config != nil {
 				return fmt.Errorf("pre-existing %s found", file)
 			}

--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -106,7 +106,7 @@ func doInit(out io.Writer) error {
 
 	for _, file := range potentialConfigs {
 		if !force {
-			config, err := schema.ParseConfig(file, true, false)
+			config, err := schema.ParseConfig(file, false)
 			if err == nil && config != nil {
 				return fmt.Errorf("pre-existing %s found", file)
 			}

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -46,7 +46,7 @@ func run(out io.Writer) error {
 	defer cancel()
 	catchCtrlC(cancel)
 
-	runner, config, err := newRunner(out, opts)
+	runner, config, err := newRunner(opts)
 	if err != nil {
 		return errors.Wrap(err, "creating runner")
 	}

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -28,9 +28,13 @@ import (
 
 // newRunner creates a SkaffoldRunner and returns the SkaffoldPipeline associated with it.
 func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.SkaffoldPipeline, error) {
-	parsed, err := schema.ParseConfig(opts.ConfigurationFile, true, true)
+	parsed, err := schema.ParseConfig(opts.ConfigurationFile, true)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "parsing skaffold config")
+	}
+
+	if err := parsed.SetDefaultValues(); err != nil {
+		return nil, nil, errors.Wrap(err, "setting default values")
 	}
 
 	config := parsed.(*latest.SkaffoldPipeline)

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"io"
-
 	configutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
@@ -29,16 +27,10 @@ import (
 )
 
 // newRunner creates a SkaffoldRunner and returns the SkaffoldPipeline associated with it.
-func newRunner(out io.Writer, opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.SkaffoldPipeline, error) {
-	parsed, err := schema.ParseConfig(opts.ConfigurationFile, true)
+func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.SkaffoldPipeline, error) {
+	parsed, err := schema.ParseConfig(opts.ConfigurationFile, true, true)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "parsing skaffold config")
-	}
-
-	// automatically upgrade older config
-	parsed, err = schema.UpgradeToLatest(out, parsed)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "invalid config")
 	}
 
 	config := parsed.(*latest.SkaffoldPipeline)

--- a/pkg/skaffold/schema/latest/defaults_test.go
+++ b/pkg/skaffold/schema/latest/defaults_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latest
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDetDefaults(t *testing.T) {
+	pipeline := SkaffoldPipeline{
+		Build: BuildConfig{
+			Artifacts: []*Artifact{
+				{ImageName: "image"},
+			},
+		},
+	}
+
+	err := pipeline.SetDefaultValues()
+
+	testutil.CheckError(t, false, err)
+}

--- a/pkg/skaffold/schema/v1alpha1/config.go
+++ b/pkg/skaffold/schema/v1alpha1/config.go
@@ -17,10 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
-
-	yaml "gopkg.in/yaml.v2"
 )
 
 const Version string = "skaffold/v1alpha1"
@@ -111,42 +108,4 @@ type Artifact struct {
 	DockerfilePath string             `yaml:"dockerfilePath,omitempty"`
 	Workspace      string             `yaml:"workspace"`
 	BuildArgs      map[string]*string `yaml:"buildArgs,omitempty"`
-}
-
-// DefaultDevSkaffoldPipeline is a partial set of defaults for the SkaffoldPipeline
-// when dev mode is specified.
-// Each API is responsible for setting its own defaults that are not top level.
-var defaultDevSkaffoldPipeline = &SkaffoldPipeline{
-	Build: BuildConfig{
-		TagPolicy: constants.DefaultDevTagStrategy,
-	},
-}
-
-// DefaultRunSkaffoldPipeline is a partial set of defaults for the SkaffoldPipeline
-// when run mode is specified.
-// Each API is responsible for setting its own defaults that are not top level.
-var defaultRunSkaffoldPipeline = &SkaffoldPipeline{
-	Build: BuildConfig{
-		TagPolicy: constants.DefaultRunTagStrategy,
-	},
-}
-
-// Parse reads from an io.Reader and unmarshals the result into a SkaffoldPipeline.
-// The default config argument provides default values for the config,
-// which can be overridden if present in the config file.
-func (config *SkaffoldPipeline) Parse(contents []byte, useDefault bool) error {
-	if useDefault {
-		*config = *config.getDefaultForMode(false)
-	} else {
-		*config = SkaffoldPipeline{}
-	}
-
-	return yaml.UnmarshalStrict(contents, config)
-}
-
-func (config *SkaffoldPipeline) getDefaultForMode(dev bool) *SkaffoldPipeline {
-	if dev {
-		return defaultDevSkaffoldPipeline
-	}
-	return defaultRunSkaffoldPipeline
 }

--- a/pkg/skaffold/schema/v1alpha1/defaults.go
+++ b/pkg/skaffold/schema/v1alpha1/defaults.go
@@ -14,10 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util
+package v1alpha1
 
-type VersionedConfig interface {
-	GetVersion() string
-	SetDefaultValues() error
-	Upgrade() (VersionedConfig, error)
+// SetDefaultValues makes sure default values are set.
+func (c *SkaffoldPipeline) SetDefaultValues() error {
+	return nil
 }

--- a/pkg/skaffold/schema/v1alpha1/upgrade.go
+++ b/pkg/skaffold/schema/v1alpha1/upgrade.go
@@ -53,7 +53,7 @@ func (config *SkaffoldPipeline) Upgrade() (util.VersionedConfig, error) {
 
 	var newHelmDeploy *next.HelmDeploy
 	if config.Deploy.DeployType.HelmDeploy != nil {
-		newReleases := make([]next.HelmRelease, 0)
+		var newReleases []next.HelmRelease
 		for _, release := range config.Deploy.DeployType.HelmDeploy.Releases {
 			newReleases = append(newReleases, next.HelmRelease{
 				Name:           release.Name,
@@ -70,7 +70,7 @@ func (config *SkaffoldPipeline) Upgrade() (util.VersionedConfig, error) {
 	}
 	var newKubectlDeploy *next.KubectlDeploy
 	if config.Deploy.DeployType.KubectlDeploy != nil {
-		newManifests := make([]string, 0)
+		var newManifests []string
 		logrus.Warn("Ignoring manifest parameters when transforming v1alpha1 config; check kubernetes yaml before running skaffold")
 		for _, manifest := range config.Deploy.DeployType.KubectlDeploy.Manifests {
 			newManifests = append(newManifests, manifest.Paths...)
@@ -80,7 +80,7 @@ func (config *SkaffoldPipeline) Upgrade() (util.VersionedConfig, error) {
 		}
 	}
 
-	var newArtifacts = make([]*next.Artifact, 0)
+	var newArtifacts []*next.Artifact
 	for _, artifact := range config.Build.Artifacts {
 		newArtifacts = append(newArtifacts, &next.Artifact{
 			ImageName: artifact.ImageName,

--- a/pkg/skaffold/schema/v1alpha1/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha1/upgrade_test.go
@@ -21,6 +21,7 @@ import (
 
 	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2"
 	"github.com/GoogleContainerTools/skaffold/testutil"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestPipelineUpgrade(t *testing.T) {
@@ -107,7 +108,7 @@ deploy:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pipeline := NewSkaffoldPipeline()
-			err := pipeline.Parse([]byte(tt.yaml), false)
+			err := yaml.UnmarshalStrict([]byte(tt.yaml), pipeline)
 			if err != nil {
 				t.Fatalf("unexpected error during parsing old config: %v", err)
 			}

--- a/pkg/skaffold/schema/v1alpha1/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha1/upgrade_test.go
@@ -44,7 +44,6 @@ build:
 					TagPolicy: next.TagPolicy{
 						GitTagger: &next.GitTagger{},
 					},
-					Artifacts: []*next.Artifact{},
 				},
 			},
 		},
@@ -62,7 +61,6 @@ build:
 					TagPolicy: next.TagPolicy{
 						ShaTagger: &next.ShaTagger{},
 					},
-					Artifacts: []*next.Artifact{},
 				},
 			},
 		},

--- a/pkg/skaffold/schema/v1alpha1/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha1/upgrade_test.go
@@ -82,9 +82,6 @@ deploy:
 				APIVersion: next.Version,
 				Kind:       "Config",
 				Build: next.BuildConfig{
-					TagPolicy: next.TagPolicy{
-						GitTagger: &next.GitTagger{},
-					},
 					Artifacts: []*next.Artifact{
 						{
 							ImageName: "gcr.io/k8s-skaffold/skaffold-example",
@@ -110,18 +107,14 @@ deploy:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pipeline := NewSkaffoldPipeline()
-			err := pipeline.Parse([]byte(tt.yaml), true)
+			err := pipeline.Parse([]byte(tt.yaml), false)
 			if err != nil {
 				t.Fatalf("unexpected error during parsing old config: %v", err)
 			}
 
 			upgraded, err := pipeline.Upgrade()
-			if err != nil {
-				t.Errorf("unexpected error during upgrade: %v", err)
-			}
 
-			upgradedPipeline := upgraded.(*next.SkaffoldPipeline)
-			testutil.CheckDeepEqual(t, tt.expected, upgradedPipeline)
+			testutil.CheckErrorAndDeepEqual(t, false, err, tt.expected, upgraded)
 		})
 	}
 }

--- a/pkg/skaffold/schema/v1alpha2/config.go
+++ b/pkg/skaffold/schema/v1alpha2/config.go
@@ -18,8 +18,6 @@ package v1alpha2
 
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
-	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const Version string = "skaffold/v1alpha2"
@@ -222,19 +220,4 @@ type DockerArtifact struct {
 
 type BazelArtifact struct {
 	BuildTarget string `yaml:"target"`
-}
-
-// Parse reads a SkaffoldPipeline from yaml.
-func (c *SkaffoldPipeline) Parse(contents []byte, useDefaults bool) error {
-	if err := yaml.UnmarshalStrict(contents, c); err != nil {
-		return err
-	}
-
-	if useDefaults {
-		if err := c.SetDefaultValues(); err != nil {
-			return errors.Wrap(err, "applying default values")
-		}
-	}
-
-	return nil
 }

--- a/pkg/skaffold/schema/v1alpha2/defaults_test.go
+++ b/pkg/skaffold/schema/v1alpha2/defaults_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDetDefaults(t *testing.T) {
+	pipeline := SkaffoldPipeline{
+		Build: BuildConfig{
+			Artifacts: []*Artifact{
+				{ImageName: "image"},
+			},
+		},
+	}
+
+	err := pipeline.SetDefaultValues()
+
+	testutil.CheckError(t, false, err)
+}

--- a/pkg/skaffold/schema/v1alpha2/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha2/upgrade_test.go
@@ -21,6 +21,7 @@ import (
 
 	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha3"
 	"github.com/GoogleContainerTools/skaffold/testutil"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestPipelineUpgrade(t *testing.T) {
@@ -139,7 +140,7 @@ profiles:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pipeline := NewSkaffoldPipeline()
-			err := pipeline.Parse([]byte(tt.yaml), false)
+			err := yaml.UnmarshalStrict([]byte(tt.yaml), pipeline)
 			if err != nil {
 				t.Fatalf("unexpected error during parsing old config: %v", err)
 			}

--- a/pkg/skaffold/schema/v1alpha2/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha2/upgrade_test.go
@@ -139,19 +139,14 @@ profiles:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pipeline := NewSkaffoldPipeline()
-			err := pipeline.Parse([]byte(tt.yaml), true)
+			err := pipeline.Parse([]byte(tt.yaml), false)
 			if err != nil {
 				t.Fatalf("unexpected error during parsing old config: %v", err)
 			}
 
 			upgraded, err := pipeline.Upgrade()
-			if err != nil {
-				t.Errorf("unexpected error during upgrade: %v", err)
-			}
 
-			upgradedPipeline := upgraded.(*next.SkaffoldPipeline)
-			tt.expected.SetDefaultValues()
-			testutil.CheckDeepEqual(t, tt.expected, upgradedPipeline)
+			testutil.CheckErrorAndDeepEqual(t, false, err, tt.expected, upgraded)
 		})
 	}
 }

--- a/pkg/skaffold/schema/v1alpha3/config.go
+++ b/pkg/skaffold/schema/v1alpha3/config.go
@@ -18,8 +18,6 @@ package v1alpha3
 
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
-	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const Version string = "skaffold/v1alpha3"
@@ -228,19 +226,4 @@ type DockerArtifact struct {
 
 type BazelArtifact struct {
 	BuildTarget string `yaml:"target"`
-}
-
-// Parse reads a SkaffoldPipeline from yaml.
-func (c *SkaffoldPipeline) Parse(contents []byte, useDefaults bool) error {
-	if err := yaml.UnmarshalStrict(contents, c); err != nil {
-		return err
-	}
-
-	if useDefaults {
-		if err := c.SetDefaultValues(); err != nil {
-			return errors.Wrap(err, "applying default values")
-		}
-	}
-
-	return nil
 }

--- a/pkg/skaffold/schema/v1alpha3/defaults_test.go
+++ b/pkg/skaffold/schema/v1alpha3/defaults_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDetDefaults(t *testing.T) {
+	pipeline := SkaffoldPipeline{
+		Build: BuildConfig{
+			Artifacts: []*Artifact{
+				{ImageName: "image"},
+			},
+		},
+	}
+
+	err := pipeline.SetDefaultValues()
+
+	testutil.CheckError(t, false, err)
+}

--- a/pkg/skaffold/schema/v1alpha3/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha3/upgrade_test.go
@@ -122,7 +122,7 @@ profiles:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pipeline := NewSkaffoldPipeline()
-			err := pipeline.Parse([]byte(tt.yaml), true)
+			err := pipeline.Parse([]byte(tt.yaml), false)
 			if err != nil {
 				t.Fatalf("unexpected error during parsing old config: %v", err)
 			}
@@ -133,7 +133,6 @@ profiles:
 			}
 
 			upgradedPipeline := upgraded.(*next.SkaffoldPipeline)
-			tt.expected.SetDefaultValues()
 			testutil.CheckDeepEqual(t, tt.expected, upgradedPipeline)
 		})
 	}
@@ -156,7 +155,7 @@ profiles:
         skipPush: false
 `
 	pipeline := NewSkaffoldPipeline()
-	err := pipeline.Parse([]byte(old), true)
+	err := pipeline.Parse([]byte(old), false)
 	if err != nil {
 		t.Errorf("unexpected error during parsing old config: %v", err)
 	}

--- a/pkg/skaffold/schema/v1alpha3/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha3/upgrade_test.go
@@ -21,6 +21,7 @@ import (
 
 	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha4"
 	"github.com/GoogleContainerTools/skaffold/testutil"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestPipelineUpgrade(t *testing.T) {
@@ -122,7 +123,7 @@ profiles:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pipeline := NewSkaffoldPipeline()
-			err := pipeline.Parse([]byte(tt.yaml), false)
+			err := yaml.UnmarshalStrict([]byte(tt.yaml), pipeline)
 			if err != nil {
 				t.Fatalf("unexpected error during parsing old config: %v", err)
 			}
@@ -155,7 +156,7 @@ profiles:
         skipPush: false
 `
 	pipeline := NewSkaffoldPipeline()
-	err := pipeline.Parse([]byte(old), false)
+	err := yaml.UnmarshalStrict([]byte(old), pipeline)
 	if err != nil {
 		t.Errorf("unexpected error during parsing old config: %v", err)
 	}

--- a/pkg/skaffold/schema/v1alpha4/config.go
+++ b/pkg/skaffold/schema/v1alpha4/config.go
@@ -18,8 +18,6 @@ package v1alpha4
 
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
-	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const Version string = "skaffold/v1alpha4"
@@ -263,19 +261,4 @@ type JibMavenArtifact struct {
 type JibGradleArtifact struct {
 	// Only multi-module
 	Project string `yaml:"project"`
-}
-
-// Parse reads a SkaffoldPipeline from yaml.
-func (c *SkaffoldPipeline) Parse(contents []byte, useDefaults bool) error {
-	if err := yaml.UnmarshalStrict(contents, c); err != nil {
-		return err
-	}
-
-	if useDefaults {
-		if err := c.SetDefaultValues(); err != nil {
-			return errors.Wrap(err, "applying default values")
-		}
-	}
-
-	return nil
 }

--- a/pkg/skaffold/schema/v1alpha4/defaults_test.go
+++ b/pkg/skaffold/schema/v1alpha4/defaults_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDetDefaults(t *testing.T) {
+	pipeline := SkaffoldPipeline{
+		Build: BuildConfig{
+			Artifacts: []*Artifact{
+				{ImageName: "image"},
+			},
+		},
+	}
+
+	err := pipeline.SetDefaultValues()
+
+	testutil.CheckError(t, false, err)
+}

--- a/pkg/skaffold/schema/v1alpha4/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha4/upgrade_test.go
@@ -21,6 +21,7 @@ import (
 
 	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha5"
 	"github.com/GoogleContainerTools/skaffold/testutil"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestPipelineUpgrade(t *testing.T) {
@@ -121,7 +122,7 @@ profiles:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pipeline := NewSkaffoldPipeline()
-			err := pipeline.Parse([]byte(tt.yaml), false)
+			err := yaml.UnmarshalStrict([]byte(tt.yaml), pipeline)
 			if err != nil {
 				t.Fatalf("unexpected error during parsing old config: %v", err)
 			}

--- a/pkg/skaffold/schema/v1alpha4/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha4/upgrade_test.go
@@ -121,19 +121,14 @@ profiles:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pipeline := NewSkaffoldPipeline()
-			err := pipeline.Parse([]byte(tt.yaml), true)
+			err := pipeline.Parse([]byte(tt.yaml), false)
 			if err != nil {
 				t.Fatalf("unexpected error during parsing old config: %v", err)
 			}
 
 			upgraded, err := pipeline.Upgrade()
-			if err != nil {
-				t.Errorf("unexpected error during upgrade: %v", err)
-			}
 
-			upgradedPipeline := upgraded.(*next.SkaffoldPipeline)
-			tt.expected.SetDefaultValues()
-			testutil.CheckDeepEqual(t, tt.expected, upgradedPipeline)
+			testutil.CheckErrorAndDeepEqual(t, false, err, tt.expected, upgraded)
 		})
 	}
 }

--- a/pkg/skaffold/schema/v1alpha5/config.go
+++ b/pkg/skaffold/schema/v1alpha5/config.go
@@ -18,8 +18,6 @@ package v1alpha5
 
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
-	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const Version string = "skaffold/v1alpha5"
@@ -273,19 +271,4 @@ type JibMavenArtifact struct {
 type JibGradleArtifact struct {
 	// Only multi-module
 	Project string `yaml:"project"`
-}
-
-// Parse reads a SkaffoldPipeline from yaml.
-func (c *SkaffoldPipeline) Parse(contents []byte, useDefaults bool) error {
-	if err := yaml.UnmarshalStrict(contents, c); err != nil {
-		return err
-	}
-
-	if useDefaults {
-		if err := c.SetDefaultValues(); err != nil {
-			return errors.Wrap(err, "applying default values")
-		}
-	}
-
-	return nil
 }

--- a/pkg/skaffold/schema/v1alpha5/defaults_test.go
+++ b/pkg/skaffold/schema/v1alpha5/defaults_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha5
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDetDefaults(t *testing.T) {
+	pipeline := SkaffoldPipeline{
+		Build: BuildConfig{
+			Artifacts: []*Artifact{
+				{ImageName: "image"},
+			},
+		},
+	}
+
+	err := pipeline.SetDefaultValues()
+
+	testutil.CheckError(t, false, err)
+}

--- a/pkg/skaffold/schema/v1alpha5/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha5/upgrade_test.go
@@ -21,6 +21,7 @@ import (
 
 	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestPipelineUpgrade(t *testing.T) {
@@ -155,7 +156,7 @@ profiles:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pipeline := NewSkaffoldPipeline()
-			err := pipeline.Parse([]byte(tt.yaml), false)
+			err := yaml.UnmarshalStrict([]byte(tt.yaml), pipeline)
 			if err != nil {
 				t.Fatalf("unexpected error during parsing old config: %v", err)
 			}

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -84,8 +84,14 @@ func ParseConfig(filename string, applyDefaults bool, upgrade bool) (util.Versio
 	}
 
 	cfg := factory()
-	if err := cfg.Parse(buf, applyDefaults); err != nil {
+	if err := yaml.UnmarshalStrict(buf, cfg); err != nil {
 		return nil, errors.Wrap(err, "unable to parse config")
+	}
+
+	if applyDefaults {
+		if err := cfg.SetDefaultValues(); err != nil {
+			return nil, errors.Wrap(err, "setting default values")
+		}
 	}
 
 	if err := yamltags.ProcessStruct(cfg); err != nil {

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -18,7 +18,6 @@ package schema
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -68,7 +67,7 @@ func (v *versions) Find(apiVersion string) (func() util.VersionedConfig, bool) {
 }
 
 // ParseConfig reads a configuration file.
-func ParseConfig(filename string, applyDefaults bool) (util.VersionedConfig, error) {
+func ParseConfig(filename string, applyDefaults bool, upgrade bool) (util.VersionedConfig, error) {
 	buf, err := misc.ReadConfiguration(filename)
 	if err != nil {
 		return nil, errors.Wrap(err, "read skaffold config")
@@ -93,11 +92,18 @@ func ParseConfig(filename string, applyDefaults bool) (util.VersionedConfig, err
 		return nil, errors.Wrap(err, "invalid config")
 	}
 
+	if upgrade && cfg.GetVersion() != latest.Version {
+		cfg, err = upgradeToLatest(cfg)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return cfg, nil
 }
 
-// UpgradeToLatest upgrades a configuration to the latest version.
-func UpgradeToLatest(out io.Writer, vc util.VersionedConfig) (util.VersionedConfig, error) {
+// upgradeToLatest upgrades a configuration to the latest version.
+func upgradeToLatest(vc util.VersionedConfig) (util.VersionedConfig, error) {
 	var err error
 
 	// first, check to make sure config version isn't too new

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -67,7 +67,7 @@ func (v *versions) Find(apiVersion string) (func() util.VersionedConfig, bool) {
 }
 
 // ParseConfig reads a configuration file.
-func ParseConfig(filename string, applyDefaults bool, upgrade bool) (util.VersionedConfig, error) {
+func ParseConfig(filename string, upgrade bool) (util.VersionedConfig, error) {
 	buf, err := misc.ReadConfiguration(filename)
 	if err != nil {
 		return nil, errors.Wrap(err, "read skaffold config")
@@ -86,12 +86,6 @@ func ParseConfig(filename string, applyDefaults bool, upgrade bool) (util.Versio
 	cfg := factory()
 	if err := yaml.UnmarshalStrict(buf, cfg); err != nil {
 		return nil, errors.Wrap(err, "unable to parse config")
-	}
-
-	if applyDefaults {
-		if err := cfg.SetDefaultValues(); err != nil {
-			return nil, errors.Wrap(err, "setting default values")
-		}
 	}
 
 	if err := yamltags.ProcessStruct(cfg); err != nil {

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -200,7 +200,12 @@ func TestParseConfig(t *testing.T) {
 			yaml := fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", test.apiVersion, test.config)
 			tmp.Write("skaffold.yaml", yaml)
 
-			cfg, err := ParseConfig(tmp.Path("skaffold.yaml"), true, true)
+			cfg, err := ParseConfig(tmp.Path("skaffold.yaml"), true)
+			if cfg != nil {
+				if err := cfg.SetDefaultValues(); err != nil {
+					t.Fatal("unable to set default values")
+				}
+			}
 
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, cfg)
 		})

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -115,6 +115,17 @@ func TestParseConfig(t *testing.T) {
 			),
 		},
 		{
+			apiVersion:  "skaffold/v1alpha1",
+			description: "Old minimal config",
+			config:      minimalConfig,
+			expected: config(
+				withLocalBuild(
+					withGitTagger(),
+				),
+				withKubectlDeploy("k8s/*.yaml"),
+			),
+		},
+		{
 			apiVersion:  latest.Version,
 			description: "Simple config",
 			config:      simpleConfig,
@@ -189,7 +200,7 @@ func TestParseConfig(t *testing.T) {
 			yaml := fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", test.apiVersion, test.config)
 			tmp.Write("skaffold.yaml", yaml)
 
-			cfg, err := ParseConfig(tmp.Path("skaffold.yaml"), true, false)
+			cfg, err := ParseConfig(tmp.Path("skaffold.yaml"), true, true)
 
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, cfg)
 		})

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -189,7 +189,7 @@ func TestParseConfig(t *testing.T) {
 			yaml := fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", test.apiVersion, test.config)
 			tmp.Write("skaffold.yaml", yaml)
 
-			cfg, err := ParseConfig(tmp.Path("skaffold.yaml"), true)
+			cfg, err := ParseConfig(tmp.Path("skaffold.yaml"), true, false)
 
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, cfg)
 		})


### PR DESCRIPTION
Default values need to be set after upgrade, not before. In fact, default values are only needed to simplify the code of the runner, so that it doesn't have to compensate missing fields.

I used this opportunity to:
 + improve the code and coverage for `skaffold fix`
 + Remove duplication in code and tests

Signed-off-by: David Gageot <david@gageot.net>