### PR TITLE
Fix labeling cluster-wide resources

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1348,6 +1348,7 @@
     "gopkg.in/yaml.v2",
     "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
+    "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/meta",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
@@ -1361,6 +1362,7 @@
     "k8s.io/apimachinery/pkg/util/yaml",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
+    "k8s.io/client-go/discovery/fake",
     "k8s.io/client-go/dynamic",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
@@ -1368,6 +1370,7 @@
     "k8s.io/client-go/kubernetes/typed/core/v1",
     "k8s.io/client-go/plugin/pkg/client/auth",
     "k8s.io/client-go/rest",
+    "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/tools/clientcmd/api",
   ]

--- a/pkg/skaffold/deploy/labels_test.go
+++ b/pkg/skaffold/deploy/labels_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deploy
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	rbac_v1 "k8s.io/api/rbac/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	skaffold_kubernetes "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestLabelDeployResults_clusterWideResource(t *testing.T) {
+
+	// fake handler that does PATCH and saves merge result
+	ph := &patchHandler{
+		orig: clusterRole,
+		t:    t,
+	}
+
+	// fake server that will accept PATCH
+	srv := httptest.NewServer(ph)
+
+	// mocks
+	skaffold_kubernetes.Client = getFakeClientsetWithDiscovery([]*meta_v1.APIResourceList{
+		{
+			GroupVersion: rbac_v1.SchemeGroupVersion.String(),
+			APIResources: []meta_v1.APIResource{
+				{
+					Name:       "clusterroles",
+					Namespaced: false,
+					Kind:       "ClusterRole",
+				},
+			},
+		},
+	})
+	skaffold_kubernetes.DynamicClient = getFakeDynamicClientFunc(srv.URL)
+
+	// Run test target
+
+	labelDeployResults(
+		fooBarLabeller{}.Labels(),
+		deployArtifacts,
+	)
+
+	// asserts for original artifact
+
+	labels := deployArtifacts[0].Obj.(*rbac_v1.ClusterRole).GetLabels()
+	testutil.CheckDeepEqual(t, 1, len(labels))
+	testutil.CheckDeepEqual(t, "web-server", labels["app"])
+
+	// asserts for patched resource
+
+	var patchedClusterRole rbac_v1.ClusterRole
+	err := json.Unmarshal(ph.patchedData, &patchedClusterRole)
+	testutil.CheckError(t, false, err)
+
+	testutil.CheckDeepEqual(t, map[string]string{
+		"deployed-with": "skaffold",
+		"foo":           "bar",
+		"app":           "web-server",
+	}, patchedClusterRole.GetLabels())
+}
+
+var deployArtifacts = []Artifact{
+	{
+		Obj:       clusterRole,
+		Namespace: "does-not-matter",
+	},
+}
+
+var clusterRole = &rbac_v1.ClusterRole{
+	TypeMeta: meta_v1.TypeMeta{
+		Kind:       "ClusterRole",
+		APIVersion: "rbac.authorization.k8s.io/v1",
+	},
+	ObjectMeta: meta_v1.ObjectMeta{
+		Name:      "web-server",
+		Namespace: "", // Cluster-wide object has empty namespace.
+		Labels: map[string]string{
+			"app": "web-server",
+		},
+	},
+	Rules: []rbac_v1.PolicyRule{
+		{
+			Verbs:     []string{"get", "list", "watch"},
+			APIGroups: []string{""},
+			Resources: []string{"endpoints"},
+		},
+	},
+}
+
+type fooBarLabeller struct{}
+
+func (fooBarLabeller) Labels() map[string]string {
+	return map[string]string{"foo": "bar"}
+}

--- a/pkg/skaffold/deploy/testing_test.go
+++ b/pkg/skaffold/deploy/testing_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deploy
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/client-go/discovery"
+	fakedisco "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	fakekube "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+// getFakeClientsetWithDiscovery returns a function that creates Clientset with
+// a discovery using provided resources.
+func getFakeClientsetWithDiscovery(resources []*meta_v1.APIResourceList) func() (kubernetes.Interface, error) {
+	fakeDiscoveryClient := &fakedisco.FakeDiscovery{Fake: &clienttesting.Fake{}}
+	fakeDiscoveryClient.Resources = resources
+
+	return func() (kubernetes.Interface, error) {
+		return &fakeClientset{
+			Interface: fakekube.NewSimpleClientset(),
+			discovery: fakeDiscoveryClient,
+		}, nil
+	}
+}
+
+// fakeClientset is a fake Clientset that has configurable discovery.
+type fakeClientset struct {
+	kubernetes.Interface
+	discovery *fakedisco.FakeDiscovery
+}
+
+func (fc *fakeClientset) Discovery() discovery.DiscoveryInterface {
+	return fc.discovery
+}
+
+// getFakeDynamicClientFunc returns a function that creates dynamic client.
+func getFakeDynamicClientFunc(hostURL string) func() (dynamic.Interface, error) {
+	return func() (dynamic.Interface, error) {
+		return dynamic.NewForConfig(&rest.Config{
+			Host: hostURL,
+		})
+	}
+}
+
+// patchHandler is a http handler that processes PATCH request.
+type patchHandler struct {
+	t           *testing.T
+	orig        runtime.Object
+	patchedData []byte
+}
+
+func (h *patchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "PATCH" {
+		h.t.Errorf("Expected PATCH method, got %s", r.Method)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	content := r.Header.Get("Content-Type")
+	if content != string(types.StrategicMergePatchType) {
+		h.t.Errorf("Expected %s Content-Type, got %s", types.StrategicMergePatchType, content)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	patch, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		h.t.Errorf("Unexpected error reading body: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	orig := h.orig.DeepCopyObject()
+	origJSON, _ := json.Marshal(orig)
+	merged, err := strategicpatch.StrategicMergePatch(origJSON, patch, orig)
+	if err != nil {
+		h.t.Errorf("Unexpected error merging patch: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	// to assert further
+	h.patchedData = merged
+
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write(merged)
+	testutil.CheckError(h.t, false, err)
+}


### PR DESCRIPTION
This commit fixes the issue when skaffold labeler component tries to set labels on cluster-wide resource.

Because PATCH was applied through a specific namespace of deploy artifact, it always failed on cluster-wide resources like ClusterRole, ClusterRoleBinding and others with an error `WARN[xxxx] error adding label to runtime object: patching resource namespace-name/resource-name: the server could not find the requested resource`. Changes in this commit makes labeler check if a resource is namespaced or cluster-wide.
