### PR TITLE
 Don’t assume bazel-bin is symlinked in workspace

### DIFF
--- a/pkg/skaffold/build/local/bazel_test.go
+++ b/pkg/skaffold/build/local/bazel_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestBazelBin(t *testing.T) {
+	defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
+	util.DefaultExecCommand = testutil.NewFakeCmdOut(
+		"bazel info bazel-bin",
+		"/absolute/path/bin\n",
+		nil,
+	)
+
+	bazelBin, err := bazelBin(context.Background(), ".")
+
+	testutil.CheckErrorAndDeepEqual(t, false, err, "/absolute/path/bin", bazelBin)
+}

--- a/pkg/skaffold/build/local/bazel_test.go
+++ b/pkg/skaffold/build/local/bazel_test.go
@@ -36,3 +36,19 @@ func TestBazelBin(t *testing.T) {
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, "/absolute/path/bin", bazelBin)
 }
+
+func TestBuildTarPath(t *testing.T) {
+	buildTarget := "//:skaffold_example.tar"
+
+	tarPath := buildTarPath(buildTarget)
+
+	testutil.CheckDeepEqual(t, "skaffold_example.tar", tarPath)
+}
+
+func TestBuildImageTag(t *testing.T) {
+	buildTarget := "//:skaffold_example.tar"
+
+	imageTag := buildImageTag(buildTarget)
+
+	testutil.CheckDeepEqual(t, ":skaffold_example", imageTag)
+}


### PR DESCRIPTION
Fix #1319 