### PR TITLE
Fix Windows to Linux file sync by always converting path separators to *nix style

### DIFF
--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -112,11 +112,11 @@ func intersect(context string, syncMap map[string]string, files []string) (map[s
 				matches = true
 				// If the source has special match characters,
 				// the destination must be a directory
-				// The path package must be used here, since the destination is always
-				// a linux filesystem.
+				// The path package must be used here to enforce slashes,
+				// since the destination is always a linux filesystem.
 				if util.HasMeta(p) {
 					relPathDynamic := strings.TrimPrefix(relPath, staticPath)
-					dst = filepath.Join(dst, relPathDynamic)
+					dst = filepath.ToSlash(filepath.Join(dst, relPathDynamic))
 				}
 				ret[f] = dst
 			}

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -145,7 +145,7 @@ func TestNewSyncItem(t *testing.T) {
 			expected: &Item{
 				Image: "test:123",
 				Copy: map[string]string{
-					filepath.Join("node", "src/app/server/server.js"): filepath.Join("src", "app/server/server.js"),
+					filepath.Join("node", "src/app/server/server.js"): "src/app/server/server.js",
 				},
 				Delete: map[string]string{},
 			},
@@ -257,7 +257,7 @@ func TestNewSyncItem(t *testing.T) {
 			expected: &Item{
 				Image: "test:123",
 				Copy: map[string]string{
-					filepath.Join("dir1", "dir2/node.js"): filepath.Join("dir1", "dir2/node.js"),
+					filepath.Join("dir1", "dir2/node.js"): "dir1/dir2/node.js",
 				},
 				Delete: map[string]string{},
 			},
@@ -293,8 +293,8 @@ func TestIntersect(t *testing.T) {
 				filepath.Join("static", "*.html"): "/html",
 			},
 			expected: map[string]string{
-				filepath.Join("static", "index.html"): filepath.Join("/html", "index.html"),
-				filepath.Join("static", "test.html"):  filepath.Join("/html", "test.html"),
+				filepath.Join("static", "index.html"): "/html/index.html",
+				filepath.Join("static", "test.html"):  "/html/test.html",
 			},
 		},
 		{
@@ -305,7 +305,7 @@ func TestIntersect(t *testing.T) {
 				"*.js": "/",
 			},
 			expected: map[string]string{
-				filepath.Join("node", "server.js"): filepath.Join("/", "server.js"),
+				filepath.Join("node", "server.js"): "/server.js",
 			},
 		},
 		{


### PR DESCRIPTION
Fixes #1350.

Since there's a comment about the sync destination being always linux, I always convert to *nix directory style. Though, not quite sure if it would not interfere with upcoming windows containers in k8s support (should not, if it's a thing for skaffold at all), or even if it's a good way to tackle the problem.