### PR TITLE
Add gcb profile to example

### DIFF
--- a/examples/getting-started/skaffold.yaml
+++ b/examples/getting-started/skaffold.yaml
@@ -7,3 +7,8 @@ deploy:
   kubectl:
     manifests:
       - k8s-*
+profiles:
+  - name: gcb
+    build:
+      googleCloudBuild:
+        projectId: k8s-skaffold


### PR DESCRIPTION
This updates the Skaffold manifest to allow new users to follow
the Quick start for GKE document.