### PR TITLE
Local builders return a digest

### DIFF
--- a/pkg/skaffold/build/local/bazel.go
+++ b/pkg/skaffold/build/local/bazel.go
@@ -44,14 +44,12 @@ func (b *Builder) buildBazel(ctx context.Context, out io.Writer, workspace strin
 		return "", errors.Wrap(err, "running command")
 	}
 
-	tarPath := buildTarPath(a.BuildTarget)
-	imageTag := buildImageTag(a.BuildTarget)
-
 	bazelBin, err := bazelBin(ctx, workspace)
 	if err != nil {
 		return "", errors.Wrap(err, "getting path of bazel-bin")
 	}
 
+	tarPath := buildTarPath(a.BuildTarget)
 	imageTar, err := os.Open(filepath.Join(bazelBin, tarPath))
 	if err != nil {
 		return "", errors.Wrap(err, "opening image tarball")
@@ -69,7 +67,7 @@ func (b *Builder) buildBazel(ctx context.Context, out io.Writer, workspace strin
 		return "", errors.Wrap(err, "reading from image load response")
 	}
 
-	return fmt.Sprintf("bazel%s", imageTag), nil
+	return docker.Digest(ctx, b.api, buildImageTag(a.BuildTarget))
 }
 
 func bazelBin(ctx context.Context, workspace string) (string, error) {
@@ -108,8 +106,8 @@ func buildImageTag(buildTarget string) string {
 	imageTag = strings.TrimSuffix(imageTag, ".tar")
 
 	if strings.Contains(imageTag, ":") {
-		return fmt.Sprintf("/%s", imageTag)
+		return fmt.Sprintf("bazel/%s", imageTag)
 	}
 
-	return fmt.Sprintf(":%s", imageTag)
+	return fmt.Sprintf("bazel:%s", imageTag)
 }

--- a/pkg/skaffold/build/local/bazel_test.go
+++ b/pkg/skaffold/build/local/bazel_test.go
@@ -50,5 +50,5 @@ func TestBuildImageTag(t *testing.T) {
 
 	imageTag := buildImageTag(buildTarget)
 
-	testutil.CheckDeepEqual(t, ":skaffold_example", imageTag)
+	testutil.CheckDeepEqual(t, "bazel:skaffold_example", imageTag)
 }

--- a/pkg/skaffold/build/local/docker.go
+++ b/pkg/skaffold/build/local/docker.go
@@ -18,7 +18,6 @@ package local
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -57,5 +56,5 @@ func (b *Builder) buildDocker(ctx context.Context, out io.Writer, workspace stri
 		}
 	}
 
-	return fmt.Sprintf("%s:latest", initialTag), nil
+	return docker.Digest(ctx, b.api, initialTag)
 }

--- a/pkg/skaffold/build/local/jib_gradle.go
+++ b/pkg/skaffold/build/local/jib_gradle.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/jib"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -43,7 +44,7 @@ func (b *Builder) buildJibGradleToDocker(ctx context.Context, out io.Writer, wor
 		return "", err
 	}
 
-	return skaffoldImage, nil
+	return docker.Digest(ctx, b.api, skaffoldImage)
 }
 
 func (b *Builder) buildJibGradleToRegistry(ctx context.Context, out io.Writer, workspace string, artifact *latest.Artifact) (string, error) {
@@ -55,7 +56,7 @@ func (b *Builder) buildJibGradleToRegistry(ctx context.Context, out io.Writer, w
 		return "", err
 	}
 
-	return skaffoldImage, nil
+	return docker.RemoteDigest(skaffoldImage)
 }
 
 // generateGradleArgs generates the arguments to Gradle for building the project as an image called `skaffoldImage`.

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -44,17 +44,9 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, tagger tag.Tagger, a
 }
 
 func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, tagger tag.Tagger, artifact *latest.Artifact) (string, error) {
-	initialTag, err := b.runBuildForArtifact(ctx, out, artifact)
+	digest, err := b.runBuildForArtifact(ctx, out, artifact)
 	if err != nil {
 		return "", errors.Wrap(err, "build artifact")
-	}
-
-	digest, err := b.getDigestForArtifact(ctx, initialTag, artifact)
-	if err != nil {
-		return "", errors.Wrapf(err, "getting digest: %s", initialTag)
-	}
-	if digest == "" {
-		return "", fmt.Errorf("digest not found")
 	}
 
 	if b.alreadyTagged == nil {
@@ -98,13 +90,6 @@ func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, artifa
 	default:
 		return "", fmt.Errorf("undefined artifact type: %+v", artifact.ArtifactType)
 	}
-}
-
-func (b *Builder) getDigestForArtifact(ctx context.Context, initialTag string, artifact *latest.Artifact) (string, error) {
-	if b.pushImages && (artifact.JibMavenArtifact != nil || artifact.JibGradleArtifact != nil) {
-		return docker.RemoteDigest(initialTag)
-	}
-	return docker.Digest(ctx, b.api, initialTag)
 }
 
 func (b *Builder) retagAndPush(ctx context.Context, out io.Writer, initialTag string, newTag string, artifact *latest.Artifact) error {


### PR DESCRIPTION
Each builder is in charge of returning the digest of what it built. 
`digest` is still `digest|imageID` though.

Signed-off-by: David Gageot <david@gageot.net>