### PR TITLE
Add additional flags to kaniko builder

### DIFF
--- a/integration/examples/annotated-skaffold.yaml
+++ b/integration/examples/annotated-skaffold.yaml
@@ -124,12 +124,17 @@ build:
   # A cache repo can be specified to store cached layers, otherwise one will be inferred
   # from the image name. See https://github.com/GoogleContainerTools/kaniko#caching 
   #
+  # Additional flags can be specified as a list. To see all additional flags, visit:
+  # https://github.com/GoogleContainerTools/kaniko#additional-flags
+  # 
   # kaniko:
   #   buildContext:
   #     gcsBucket: k8s-skaffold
   #     localDir: {}
   #   cache:
   #     repo: gcr.io/my-project/skaffold/cache
+  #   flags:
+  #     - --aditional-flag
   #   pullSecret: /a/secret/path/serviceaccount.json
   #   pullSecretName: kaniko-secret
   #   namespace: default

--- a/integration/examples/kaniko-local/skaffold.yaml
+++ b/integration/examples/kaniko-local/skaffold.yaml
@@ -9,6 +9,8 @@ build:
     pullSecretName: e2esecret
     namespace: default
     cache: {}
+    flags: 
+      - --single-snapshot
 deploy:
   kubectl:
     manifests:

--- a/pkg/skaffold/build/kaniko/run.go
+++ b/pkg/skaffold/build/kaniko/run.go
@@ -51,8 +51,8 @@ func (b *Builder) run(ctx context.Context, out io.Writer, artifact *latest.Artif
 		fmt.Sprintf("--dockerfile=%s", artifact.DockerArtifact.DockerfilePath),
 		fmt.Sprintf("--context=%s", context),
 		fmt.Sprintf("--destination=%s", imageDst),
-		fmt.Sprintf("-v=%s", logLevel().String()),
-	}
+		fmt.Sprintf("-v=%s", logLevel().String())}
+	args = append(args, cfg.AdditionalFlags...)
 	args = append(args, docker.GetBuildArgs(artifact.DockerArtifact)...)
 
 	if cfg.Cache != nil {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -118,13 +118,14 @@ type KanikoCache struct {
 // KanikoBuild contains the fields needed to do a on-cluster build using
 // the kaniko image
 type KanikoBuild struct {
-	BuildContext   *KanikoBuildContext `yaml:"buildContext,omitempty"`
-	Cache          *KanikoCache        `yaml:"cache,omitempty"`
-	PullSecret     string              `yaml:"pullSecret,omitempty"`
-	PullSecretName string              `yaml:"pullSecretName,omitempty"`
-	Namespace      string              `yaml:"namespace,omitempty"`
-	Timeout        string              `yaml:"timeout,omitempty"`
-	Image          string              `yaml:"image,omitempty"`
+	BuildContext    *KanikoBuildContext `yaml:"buildContext,omitempty"`
+	Cache           *KanikoCache        `yaml:"cache,omitempty"`
+	AdditionalFlags []string            `yaml:"flags,omitempty"`
+	PullSecret      string              `yaml:"pullSecret,omitempty"`
+	PullSecretName  string              `yaml:"pullSecretName,omitempty"`
+	Namespace       string              `yaml:"namespace,omitempty"`
+	Timeout         string              `yaml:"timeout,omitempty"`
+	Image           string              `yaml:"image,omitempty"`
 }
 
 type TestConfig []*TestCase


### PR DESCRIPTION
This will allow users to pass in any additional flags to the kaniko
builder. This could include flags for insecure pulls/pushes, or the
--single-snapshot flag which speeds up snapshotting (which I added to
the local integration test).