### PR TITLE
Omit empty strings in jib sections of the config

### DIFF
--- a/pkg/skaffold/schema/v1beta1/config.go
+++ b/pkg/skaffold/schema/v1beta1/config.go
@@ -261,11 +261,11 @@ type BazelArtifact struct {
 
 type JibMavenArtifact struct {
 	// Only multi-module
-	Module  string `yaml:"module"`
-	Profile string `yaml:"profile"`
+	Module  string `yaml:"module,omitempty"`
+	Profile string `yaml:"profile,omitempty"`
 }
 
 type JibGradleArtifact struct {
 	// Only multi-module
-	Project string `yaml:"project"`
+	Project string `yaml:"project,omitempty"`
 }


### PR DESCRIPTION
This will prevent `skaffold fix` from displaying these empty strings in the generated config.