### PR TITLE
Change getting started to emojinetes

### DIFF
--- a/examples/getting-started/main.go
+++ b/examples/getting-started/main.go
@@ -5,9 +5,30 @@ import (
 	"time"
 )
 
+const (
+	startingEmoji = '🐰'
+	maxEmoji      = 200
+
+	colorReset = "\u001b[0m"
+)
+
+var colors = []string{
+	"\u001b[31;1m", // red bold
+	"\u001b[33;1m", // yellow bold
+	"\u001b[32;1m", // green bold
+	"\u001b[34;1m", // blue bold
+	"\u001b[36;1m", // cyan bold
+	"\u001b[35;1m", // magenta bold
+}
+
 func main() {
 	for {
-		fmt.Println("Hello world!")
+		s := ""
+		for i := 0; i < maxEmoji; i++ {
+			s += fmt.Sprintf("%c%sHELLO WORLD%s", startingEmoji+i, colors[i%len(colors)], colorReset)
+		}
+
+		fmt.Println(s)
 
 		time.Sleep(time.Second * 1)
 	}


### PR DESCRIPTION
Instead of displaying "hello world", with this change the example will cycle through emojis and a rainbow of terminal colors.

Not sure if we should make this the default example, since the terminal escape colors will look terrible if looking at logs directly (e.g. piping into a file, offloading them somewhere), so feel free to reject this :D It looks pretty fun though:

![image](https://user-images.githubusercontent.com/432502/50178163-a101d280-02b8-11e9-8832-f0947b202862.png)

_This is based on the Google skaffold OSS ecosystem booth demo from Kubecon Seattle 2018_