### PR TITLE
Add support for urls in deploy.kubectl.manifests

### DIFF
--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -161,6 +161,16 @@ func (k *KubectlDeployer) readManifests(ctx context.Context) (kubectl.ManifestLi
 		manifests.Append(buf)
 	}
 
+	for _, manifest := range k.Manifests {
+		if util.IsURL(manifest) {
+			buf, err := util.Download(manifest)
+			if err != nil {
+				return nil, errors.Wrap(err, "downloading manifest")
+			}
+			manifests.Append(buf)
+		}
+	}
+
 	for _, m := range k.RemoteManifests {
 		manifest, err := k.readRemoteManifest(ctx, m)
 		if err != nil {

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -84,9 +84,6 @@ func ExpandPathsGlob(workingDir string, paths []string) ([]string, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "glob")
 		}
-		if files == nil {
-			return nil, fmt.Errorf("file pattern must match at least one file %s", path)
-		}
 
 		for _, f := range files {
 			err := filepath.Walk(f, func(path string, info os.FileInfo, err error) error {
@@ -139,8 +136,8 @@ func ReadConfiguration(filename string) ([]byte, error) {
 		return nil, errors.New("filename not specified")
 	case filename == "-":
 		return ioutil.ReadAll(os.Stdin)
-	case strings.HasPrefix(filename, "http://") || strings.HasPrefix(filename, "https://"):
-		return download(filename)
+	case IsURL(filename):
+		return Download(filename)
 	default:
 		directory := filepath.Dir(filename)
 		baseName := filepath.Base(filename)
@@ -157,7 +154,11 @@ func ReadConfiguration(filename string) ([]byte, error) {
 	}
 }
 
-func download(url string) ([]byte, error) {
+func IsURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}
+
+func Download(url string) ([]byte, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return nil, err

--- a/pkg/skaffold/util/util_test.go
+++ b/pkg/skaffold/util/util_test.go
@@ -89,11 +89,6 @@ func TestExpandPathsGlob(t *testing.T) {
 			in:          []string{"dir*"},
 			out:         []string{tmpDir.Path("dir/sub_dir/file"), tmpDir.Path("dir_b/sub_dir_b/file")},
 		},
-		{
-			description: "error unmatched glob",
-			in:          []string{"dir/sub_dir_c/*"},
-			shouldErr:   true,
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
```
apiVersion: skaffold/v1alpha5
kind: Config
build:
  artifacts:
  - image: gcr.io/k8s-skaffold/skaffold-example
deploy:
  kubectl:
    manifests:
      - https://raw.githubusercontent.com/GoogleContainerTools/skaffold/master/examples/getting-started/k8s-pod.yaml
```
