### PR TITLE
Get digest on push and imageID on build

### DIFF
--- a/pkg/skaffold/build/local/bazel.go
+++ b/pkg/skaffold/build/local/bazel.go
@@ -67,7 +67,7 @@ func (b *Builder) buildBazel(ctx context.Context, out io.Writer, workspace strin
 		return "", errors.Wrap(err, "reading from image load response")
 	}
 
-	return docker.Digest(ctx, b.api, buildImageTag(a.BuildTarget))
+	return docker.ImageID(ctx, b.api, buildImageTag(a.BuildTarget))
 }
 
 func bazelBin(ctx context.Context, workspace string) (string, error) {

--- a/pkg/skaffold/build/local/bazel.go
+++ b/pkg/skaffold/build/local/bazel.go
@@ -62,7 +62,7 @@ func (b *Builder) buildBazel(ctx context.Context, out io.Writer, workspace strin
 	}
 	defer resp.Body.Close()
 
-	err = docker.StreamDockerMessages(out, resp.Body)
+	err = docker.StreamDockerMessages(out, resp.Body, nil)
 	if err != nil {
 		return "", errors.Wrap(err, "reading from image load response")
 	}

--- a/pkg/skaffold/build/local/docker.go
+++ b/pkg/skaffold/build/local/docker.go
@@ -50,11 +50,9 @@ func (b *Builder) buildDocker(ctx context.Context, out io.Writer, workspace stri
 		if err := util.RunCmd(cmd); err != nil {
 			return "", errors.Wrap(err, "running build")
 		}
-	} else {
-		if err := docker.BuildArtifact(ctx, out, b.api, workspace, a, initialTag); err != nil {
-			return "", errors.Wrap(err, "running build")
-		}
+
+		return docker.ImageID(ctx, b.api, initialTag)
 	}
 
-	return docker.Digest(ctx, b.api, initialTag)
+	return docker.Build(ctx, out, b.api, workspace, a, initialTag)
 }

--- a/pkg/skaffold/build/local/jib_gradle.go
+++ b/pkg/skaffold/build/local/jib_gradle.go
@@ -44,7 +44,7 @@ func (b *Builder) buildJibGradleToDocker(ctx context.Context, out io.Writer, wor
 		return "", err
 	}
 
-	return docker.Digest(ctx, b.api, skaffoldImage)
+	return docker.ImageID(ctx, b.api, skaffoldImage)
 }
 
 func (b *Builder) buildJibGradleToRegistry(ctx context.Context, out io.Writer, workspace string, artifact *latest.Artifact) (string, error) {

--- a/pkg/skaffold/build/local/jib_maven.go
+++ b/pkg/skaffold/build/local/jib_maven.go
@@ -52,7 +52,7 @@ func (b *Builder) buildJibMavenToDocker(ctx context.Context, out io.Writer, work
 		return "", err
 	}
 
-	return docker.Digest(ctx, b.api, skaffoldImage)
+	return docker.ImageID(ctx, b.api, skaffoldImage)
 }
 
 func (b *Builder) buildJibMavenToRegistry(ctx context.Context, out io.Writer, workspace string, artifact *latest.Artifact) (string, error) {

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -103,7 +103,7 @@ func (b *Builder) retagAndPush(ctx context.Context, out io.Writer, initialTag st
 	}
 
 	if b.pushImages {
-		if err := docker.RunPush(ctx, out, b.api, newTag); err != nil {
+		if _, err := docker.RunPush(ctx, out, b.api, newTag); err != nil {
 			return errors.Wrap(err, "pushing")
 		}
 	}

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -18,6 +18,7 @@ package docker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,6 +39,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
+
+// PushResult gives the information on an image that has been pushed.
+type PushResult struct {
+	Digest string
+}
 
 // BuildArtifact performs a docker build and returns nothing
 func BuildArtifact(ctx context.Context, out io.Writer, cli APIClient, workspace string, a *latest.DockerArtifact, initialTag string) error {
@@ -73,29 +79,59 @@ func BuildArtifact(ctx context.Context, out io.Writer, cli APIClient, workspace 
 	}
 	defer resp.Body.Close()
 
-	return StreamDockerMessages(out, resp.Body)
+	return StreamDockerMessages(out, resp.Body, nil)
 }
 
 // StreamDockerMessages streams formatted json output from the docker daemon
 // TODO(@r2d4): Make this output much better, this is the bare minimum
-func StreamDockerMessages(dst io.Writer, src io.Reader) error {
+func StreamDockerMessages(dst io.Writer, src io.Reader, auxCallback func(jsonmessage.JSONMessage)) error {
 	fd, _ := term.GetFdInfo(dst)
-	return jsonmessage.DisplayJSONMessagesStream(src, dst, fd, false, nil)
+	return jsonmessage.DisplayJSONMessagesStream(src, dst, fd, false, auxCallback)
 }
 
-func RunPush(ctx context.Context, out io.Writer, cli APIClient, ref string) error {
+// RunPush pushes an image reference to a registry. Returns the image digest.
+func RunPush(ctx context.Context, out io.Writer, cli APIClient, ref string) (string, error) {
 	registryAuth, err := encodedRegistryAuth(ctx, cli, DefaultAuthHelper, ref)
 	if err != nil {
-		return errors.Wrapf(err, "getting auth config for %s", ref)
+		return "", errors.Wrapf(err, "getting auth config for %s", ref)
 	}
+
 	rc, err := cli.ImagePush(ctx, ref, types.ImagePushOptions{
 		RegistryAuth: registryAuth,
 	})
 	if err != nil {
-		return errors.Wrap(err, "pushing image to repository")
+		return "", errors.Wrap(err, "pushing image to repository")
 	}
 	defer rc.Close()
-	return StreamDockerMessages(out, rc)
+
+	var digest string
+	auxCallback := func(msg jsonmessage.JSONMessage) {
+		if msg.Aux == nil {
+			return
+		}
+
+		var result PushResult
+		if err := json.Unmarshal(*msg.Aux, &result); err != nil {
+			logrus.Debugln("Unable to parse push output:", err)
+			return
+		}
+		digest = result.Digest
+	}
+
+	if err := StreamDockerMessages(out, rc, auxCallback); err != nil {
+		return "", err
+	}
+
+	if digest == "" {
+		// Maybe this version of Docker doesn't return the digest of the image
+		// that has been pushed.
+		digest, err = RemoteDigest(ref)
+		if err != nil {
+			return "", errors.Wrap(err, "getting digest")
+		}
+	}
+
+	return digest, nil
 }
 
 func AddTag(src, target string) error {

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -80,7 +80,7 @@ func TestRunPush(t *testing.T) {
 	}
 }
 
-func TestRunBuildArtifact(t *testing.T) {
+func TestRunBuild(t *testing.T) {
 	var tests = []struct {
 		description string
 		expected    string
@@ -108,24 +108,24 @@ func TestRunBuildArtifact(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			err := BuildArtifact(context.Background(), ioutil.Discard, &test.api, ".", &latest.DockerArtifact{}, "finalimage")
+			_, err := Build(context.Background(), ioutil.Discard, &test.api, ".", &latest.DockerArtifact{}, "finalimage")
 
 			testutil.CheckError(t, test.shouldErr, err)
 		})
 	}
 }
 
-func TestDigest(t *testing.T) {
+func TestImageID(t *testing.T) {
 	var tests = []struct {
 		description string
-		imageName   string
+		ref         string
 		api         testutil.FakeAPIClient
 		expected    string
 		shouldErr   bool
 	}{
 		{
 			description: "get digest",
-			imageName:   "identifier:latest",
+			ref:         "identifier:latest",
 			api: testutil.FakeAPIClient{
 				TagToImageID: map[string]string{
 					"identifier:latest": "sha256:123abc",
@@ -135,7 +135,7 @@ func TestDigest(t *testing.T) {
 		},
 		{
 			description: "image inspect error",
-			imageName:   "test",
+			ref:         "test",
 			api: testutil.FakeAPIClient{
 				ErrImageInspect: true,
 			},
@@ -143,15 +143,15 @@ func TestDigest(t *testing.T) {
 		},
 		{
 			description: "not found",
-			imageName:   "somethingelse",
+			ref:         "somethingelse",
 			expected:    "",
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			digest, err := Digest(context.Background(), &test.api, test.imageName)
+			imageID, err := ImageID(context.Background(), &test.api, test.ref)
 
-			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, digest)
+			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, imageID)
 		})
 	}
 }


### PR DESCRIPTION
This code tried to retrieve the digest/imageID immediately after the push/build.

Will enabled a few simplifications in builders' code