### PR TITLE
feat(deploy): support timeout flag for helm

### DIFF
--- a/examples/helm-deployment/skaffold.yaml
+++ b/examples/helm-deployment/skaffold.yaml
@@ -11,6 +11,7 @@ deploy:
     - name: skaffold-helm
       chartPath: skaffold-helm
       #wait: true
+      #timeout: 300
       #valuesFiles:
       #- helm-skaffold-values.yaml
       values:
@@ -21,6 +22,6 @@ deploy:
       #overrides:
       # some:
       #   key: someValue
-      #setValues get appended to the helm deploy with --set.  
+      #setValues get appended to the helm deploy with --set.
       #setValues:
         #some.key: someValue

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -261,6 +261,10 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 	}
 	if r.Wait {
 		args = append(args, "--wait")
+		if r.Timeout > 0 {
+			timeoutInSeconds := r.Timeout
+			args = append(args, fmt.Sprintf("--timeout=%v", timeoutInSeconds))
+		}
 	}
 	args = append(args, setOpts...)
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -196,6 +196,7 @@ type HelmRelease struct {
 	SetValues         map[string]string      `yaml:"setValues,omitempty"`
 	SetValueTemplates map[string]string      `yaml:"setValueTemplates,omitempty"`
 	Wait              bool                   `yaml:"wait,omitempty"`
+	Timeout			  int64					 `yaml:"timeout,omitempty"`
 	RecreatePods      bool                   `yaml:"recreatePods,omitempty"`
 	Overrides         map[string]interface{} `yaml:"overrides,omitempty"`
 	Packaged          *HelmPackaged          `yaml:"packaged,omitempty"`


### PR DESCRIPTION
I was playing with this and had trouble getting it to work with some large umbrella charts. The default timeout is 5 minutes with helm (300 seconds) and this provides you with the built-in helm way of changing that. This replaces #1443 I needed to open the PR from my org. Sorry!