### PR TITLE
Use kubectl to read the manifests

### DIFF
--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -21,8 +21,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
-	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
@@ -150,58 +148,10 @@ func parseManifestsForDeploys(namespace string, manifests kubectl.ManifestList) 
 
 // readManifests reads the manifests to deploy/delete.
 func (k *KubectlDeployer) readManifests(ctx context.Context) (kubectl.ManifestList, error) {
-	files, err := k.manifestFiles(k.Manifests)
+	manifests, err := k.Dependencies()
 	if err != nil {
-		return nil, errors.Wrap(err, "expanding user manifest list")
+		return nil, errors.Wrap(err, "listing manifests")
 	}
 
-	var manifests kubectl.ManifestList
-	for _, manifest := range files {
-		buf, err := ioutil.ReadFile(manifest)
-		if err != nil {
-			return nil, errors.Wrap(err, "reading manifest")
-		}
-
-		manifests.Append(buf)
-	}
-
-	for _, manifest := range k.Manifests {
-		if util.IsURL(manifest) {
-			buf, err := util.Download(manifest)
-			if err != nil {
-				return nil, errors.Wrap(err, "downloading manifest")
-			}
-			manifests.Append(buf)
-		}
-	}
-
-	for _, m := range k.RemoteManifests {
-		manifest, err := k.readRemoteManifest(ctx, m)
-		if err != nil {
-			return nil, errors.Wrap(err, "get remote manifests")
-		}
-
-		manifests = append(manifests, manifest)
-	}
-
-	logrus.Debugln("manifests", manifests.String())
-
-	return manifests, nil
-}
-
-func (k *KubectlDeployer) readRemoteManifest(ctx context.Context, name string) ([]byte, error) {
-	var args []string
-	if parts := strings.Split(name, ":"); len(parts) > 1 {
-		args = append(args, "--namespace", parts[0])
-		name = parts[1]
-	}
-	args = append(args, name, "-o", "yaml")
-
-	var manifest bytes.Buffer
-	err := k.kubectl.Run(ctx, nil, &manifest, "get", nil, args...)
-	if err != nil {
-		return nil, errors.Wrap(err, "getting manifest")
-	}
-
-	return manifest.Bytes(), nil
+	return k.kubectl.ReadManifests(ctx, manifests)
 }

--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -153,5 +153,9 @@ func (k *KubectlDeployer) readManifests(ctx context.Context) (kubectl.ManifestLi
 		return nil, errors.Wrap(err, "listing manifests")
 	}
 
+	if len(manifests) == 0 {
+		return kubectl.ManifestList{}, nil
+	}
+
 	return k.kubectl.ReadManifests(ctx, manifests)
 }

--- a/pkg/skaffold/deploy/kubectl/manifests.go
+++ b/pkg/skaffold/deploy/kubectl/manifests.go
@@ -19,6 +19,7 @@ package kubectl
 import (
 	"bytes"
 	"io"
+	"regexp"
 	"strings"
 )
 
@@ -38,7 +39,13 @@ func (l *ManifestList) String() string {
 
 // Append appends the yaml manifests defined in the given buffer.
 func (l *ManifestList) Append(buf []byte) {
-	parts := bytes.Split(buf, []byte("\n---"))
+	// `kubectl create --dry-run -oyaml` outputs manifests without --- separator
+	// But we can rely on `apiVersion:` being here as a "separator".
+	buf = regexp.
+		MustCompile("\n(|---\n)apiVersion: ").
+		ReplaceAll(buf, []byte("\n---\napiVersion: "))
+
+	parts := bytes.Split(buf, []byte("\n---\n"))
 	for _, part := range parts {
 		*l = append(*l, part)
 	}

--- a/pkg/skaffold/deploy/kubectl/manifests_test.go
+++ b/pkg/skaffold/deploy/kubectl/manifests_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+const pod1 = `apiVersion: v1
+kind: Pod
+metadata:
+  name: leeroy-web
+spec:
+  containers:
+  - name: leeroy-web
+    image: leeroy-web`
+
+const pod2 = `apiVersion: v1
+kind: Pod
+metadata:
+  name: leeroy-app
+spec:
+  containers:
+  - name: leeroy-app
+	image: leeroy-app`
+
+func TestAppend(t *testing.T) {
+	var manifests ManifestList
+
+	manifests.Append([]byte(pod1 + "\n---\n" + pod2))
+
+	testutil.CheckDeepEqual(t, 2, len(manifests))
+	testutil.CheckDeepEqual(t, pod1, string(manifests[0]))
+	testutil.CheckDeepEqual(t, pod2, string(manifests[1]))
+}
+
+func TestAppendWithoutSeperator(t *testing.T) {
+	var manifests ManifestList
+
+	manifests.Append([]byte(pod1 + "\n" + pod2))
+
+	testutil.CheckDeepEqual(t, 2, len(manifests))
+	testutil.CheckDeepEqual(t, pod1, string(manifests[0]))
+	testutil.CheckDeepEqual(t, pod2, string(manifests[1]))
+}


### PR DESCRIPTION
 + Adds support for json manifests
 + Should help when kustomize is built into kubectl

Fixes #921

Signed-off-by: David Gageot <david@gageot.net>