### PR TITLE
Show duplication in jib code

### DIFF
--- a/pkg/skaffold/build/local/jib_maven.go
+++ b/pkg/skaffold/build/local/jib_maven.go
@@ -46,7 +46,7 @@ func (b *Builder) buildJibMavenToDocker(ctx context.Context, out io.Writer, work
 	}
 
 	skaffoldImage := generateJibImageRef(workspace, artifact.Module)
-	args := generateMavenArgs("dockerBuild", skaffoldImage, artifact)
+	args := jib.GenerateMavenArgs("dockerBuild", skaffoldImage, artifact)
 
 	if err := runMavenCommand(ctx, out, workspace, args); err != nil {
 		return "", err
@@ -65,31 +65,13 @@ func (b *Builder) buildJibMavenToRegistry(ctx context.Context, out io.Writer, wo
 
 	initialTag := util.RandomID()
 	skaffoldImage := fmt.Sprintf("%s:%s", artifact.ImageName, initialTag)
-	args := generateMavenArgs("build", skaffoldImage, artifact.JibMavenArtifact)
+	args := jib.GenerateMavenArgs("build", skaffoldImage, artifact.JibMavenArtifact)
 
 	if err := runMavenCommand(ctx, out, workspace, args); err != nil {
 		return "", err
 	}
 
 	return docker.RemoteDigest(skaffoldImage)
-}
-
-// generateMavenArgs generates the arguments to Maven for building the project as an image called `skaffoldImage`.
-func generateMavenArgs(goal string, imageName string, artifact *latest.JibMavenArtifact) []string {
-	var command []string
-	if artifact.Module == "" {
-		// single-module project
-		command = []string{"--non-recursive", "prepare-package", "jib:" + goal}
-	} else {
-		// multi-module project: we assume `package` is bound to `jib:<goal>`
-		command = []string{"--projects", artifact.Module, "--also-make", "package"}
-	}
-	command = append(command, "-Dimage="+imageName)
-	if artifact.Profile != "" {
-		command = append(command, "--activate-profiles", artifact.Profile)
-	}
-
-	return command
 }
 
 // verifyJibPackageGoal verifies that the referenced module has `package` bound to a single jib goal.

--- a/pkg/skaffold/build/local/jib_test.go
+++ b/pkg/skaffold/build/local/jib_test.go
@@ -25,24 +25,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestGenerateMavenArgs(t *testing.T) {
-	var testCases = []struct {
-		in  latest.JibMavenArtifact
-		out []string
-	}{
-		{latest.JibMavenArtifact{}, []string{"--non-recursive", "prepare-package", "jib:goal", "-Dimage=image"}},
-		{latest.JibMavenArtifact{Profile: "profile"}, []string{"--non-recursive", "prepare-package", "jib:goal", "-Dimage=image", "--activate-profiles", "profile"}},
-		{latest.JibMavenArtifact{Module: "module"}, []string{"--projects", "module", "--also-make", "package", "-Dimage=image"}},
-		{latest.JibMavenArtifact{Module: "module", Profile: "profile"}, []string{"--projects", "module", "--also-make", "package", "-Dimage=image", "--activate-profiles", "profile"}},
-	}
-
-	for _, tt := range testCases {
-		args := generateMavenArgs("goal", "image", &tt.in)
-
-		testutil.CheckDeepEqual(t, tt.out, args)
-	}
-}
-
 func TestMavenVerifyJibPackageGoal(t *testing.T) {
 	var testCases = []struct {
 		requiredGoal string
@@ -68,22 +50,6 @@ func TestMavenVerifyJibPackageGoal(t *testing.T) {
 		if hasError := err != nil; tt.shouldError != hasError {
 			t.Error("Unexpected return result")
 		}
-	}
-}
-
-func TestGenerateGradleArgs(t *testing.T) {
-	var testCases = []struct {
-		in  latest.JibGradleArtifact
-		out []string
-	}{
-		{latest.JibGradleArtifact{}, []string{":task", "--image=image"}},
-		{latest.JibGradleArtifact{Project: "project"}, []string{":project:task", "--image=image"}},
-	}
-
-	for _, tt := range testCases {
-		command := generateGradleArgs("task", "image", &tt.in)
-
-		testutil.CheckDeepEqual(t, tt.out, command)
 	}
 }
 

--- a/pkg/skaffold/jib/jib_gradle.go
+++ b/pkg/skaffold/jib/jib_gradle.go
@@ -42,22 +42,28 @@ func GetDependenciesGradle(ctx context.Context, workspace string, a *latest.JibG
 }
 
 func getCommandGradle(ctx context.Context, workspace string, a *latest.JibGradleArtifact) *exec.Cmd {
-	args := []string{"_jibSkaffoldFiles", "-q"}
-	if a.Project != "" {
+	task := "_jibSkaffoldFiles"
+
+	var command string
+	if a.Project == "" {
+		command = task
+	} else {
 		// multi-module
-		args[0] = fmt.Sprintf(":%s:%s", a.Project, args[0])
+		command = fmt.Sprintf(":%s:%s", a.Project, task)
 	}
+	args := []string{command, "-q"}
+
 	return GradleCommand.CreateCommand(ctx, workspace, args)
 }
 
 // GenerateGradleArgs generates the arguments to Gradle for building the project as an image.
-func GenerateGradleArgs(task string, imageName string, artifact *latest.JibGradleArtifact) []string {
+func GenerateGradleArgs(task string, imageName string, a *latest.JibGradleArtifact) []string {
 	var command string
-	if artifact.Project == "" {
+	if a.Project == "" {
 		command = ":" + task
 	} else {
 		// multi-module
-		command = fmt.Sprintf(":%s:%s", artifact.Project, task)
+		command = fmt.Sprintf(":%s:%s", a.Project, task)
 	}
 
 	return []string{command, "--image=" + imageName}

--- a/pkg/skaffold/jib/jib_gradle.go
+++ b/pkg/skaffold/jib/jib_gradle.go
@@ -49,3 +49,16 @@ func getCommandGradle(ctx context.Context, workspace string, a *latest.JibGradle
 	}
 	return GradleCommand.CreateCommand(ctx, workspace, args)
 }
+
+// GenerateGradleArgs generates the arguments to Gradle for building the project as an image.
+func GenerateGradleArgs(task string, imageName string, artifact *latest.JibGradleArtifact) []string {
+	var command string
+	if artifact.Project == "" {
+		command = ":" + task
+	} else {
+		// multi-module
+		command = fmt.Sprintf(":%s:%s", artifact.Project, task)
+	}
+
+	return []string{command, "--image=" + imageName}
+}

--- a/pkg/skaffold/jib/jib_gradle_test.go
+++ b/pkg/skaffold/jib/jib_gradle_test.go
@@ -143,3 +143,19 @@ func TestGetCommandGradle(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateGradleArgs(t *testing.T) {
+	var testCases = []struct {
+		in  latest.JibGradleArtifact
+		out []string
+	}{
+		{latest.JibGradleArtifact{}, []string{":task", "--image=image"}},
+		{latest.JibGradleArtifact{Project: "project"}, []string{":project:task", "--image=image"}},
+	}
+
+	for _, tt := range testCases {
+		command := GenerateGradleArgs("task", "image", &tt.in)
+
+		testutil.CheckDeepEqual(t, tt.out, command)
+	}
+}

--- a/pkg/skaffold/jib/jib_maven.go
+++ b/pkg/skaffold/jib/jib_maven.go
@@ -40,7 +40,11 @@ func GetDependenciesMaven(ctx context.Context, workspace string, a *latest.JibMa
 }
 
 func getCommandMaven(ctx context.Context, workspace string, a *latest.JibMavenArtifact) *exec.Cmd {
-	args := []string{"--quiet"}
+	var args []string
+	args = append(args, "--quiet")
+	if a.Profile != "" {
+		args = append(args, "--activate-profiles", a.Profile)
+	}
 	if a.Module == "" {
 		// single-module project
 		args = append(args, "--non-recursive")
@@ -49,27 +53,26 @@ func getCommandMaven(ctx context.Context, workspace string, a *latest.JibMavenAr
 		args = append(args, "--projects", a.Module, "--also-make")
 	}
 	args = append(args, "jib:_skaffold-files")
-	if a.Profile != "" {
-		args = append(args, "--activate-profiles", a.Profile)
-	}
 
 	return MavenCommand.CreateCommand(ctx, workspace, args)
 }
 
 // GenerateMavenArgs generates the arguments to Maven for building the project as an image.
-func GenerateMavenArgs(goal string, imageName string, artifact *latest.JibMavenArtifact) []string {
-	var command []string
-	if artifact.Module == "" {
+func GenerateMavenArgs(goal string, imageName string, a *latest.JibMavenArtifact) []string {
+	var args []string
+	if a.Profile != "" {
+		args = append(args, "--activate-profiles", a.Profile)
+	}
+	if a.Module == "" {
 		// single-module project
-		command = []string{"--non-recursive", "prepare-package", "jib:" + goal}
+		args = append(args, "--non-recursive")
+		args = append(args, "prepare-package", "jib:"+goal)
 	} else {
 		// multi-module project: we assume `package` is bound to `jib:<goal>`
-		command = []string{"--projects", artifact.Module, "--also-make", "package"}
+		args = append(args, "--projects", a.Module, "--also-make")
+		args = append(args, "package")
 	}
-	command = append(command, "-Dimage="+imageName)
-	if artifact.Profile != "" {
-		command = append(command, "--activate-profiles", artifact.Profile)
-	}
+	args = append(args, "-Dimage="+imageName)
 
-	return command
+	return args
 }

--- a/pkg/skaffold/jib/jib_maven.go
+++ b/pkg/skaffold/jib/jib_maven.go
@@ -55,3 +55,21 @@ func getCommandMaven(ctx context.Context, workspace string, a *latest.JibMavenAr
 
 	return MavenCommand.CreateCommand(ctx, workspace, args)
 }
+
+// GenerateMavenArgs generates the arguments to Maven for building the project as an image.
+func GenerateMavenArgs(goal string, imageName string, artifact *latest.JibMavenArtifact) []string {
+	var command []string
+	if artifact.Module == "" {
+		// single-module project
+		command = []string{"--non-recursive", "prepare-package", "jib:" + goal}
+	} else {
+		// multi-module project: we assume `package` is bound to `jib:<goal>`
+		command = []string{"--projects", artifact.Module, "--also-make", "package"}
+	}
+	command = append(command, "-Dimage="+imageName)
+	if artifact.Profile != "" {
+		command = append(command, "--activate-profiles", artifact.Profile)
+	}
+
+	return command
+}

--- a/pkg/skaffold/jib/jib_maven_test.go
+++ b/pkg/skaffold/jib/jib_maven_test.go
@@ -158,3 +158,21 @@ func TestGetCommandMaven(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateMavenArgs(t *testing.T) {
+	var testCases = []struct {
+		in  latest.JibMavenArtifact
+		out []string
+	}{
+		{latest.JibMavenArtifact{}, []string{"--non-recursive", "prepare-package", "jib:goal", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Profile: "profile"}, []string{"--non-recursive", "prepare-package", "jib:goal", "-Dimage=image", "--activate-profiles", "profile"}},
+		{latest.JibMavenArtifact{Module: "module"}, []string{"--projects", "module", "--also-make", "package", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Module: "module", Profile: "profile"}, []string{"--projects", "module", "--also-make", "package", "-Dimage=image", "--activate-profiles", "profile"}},
+	}
+
+	for _, tt := range testCases {
+		args := GenerateMavenArgs("goal", "image", &tt.in)
+
+		testutil.CheckDeepEqual(t, tt.out, args)
+	}
+}

--- a/pkg/skaffold/jib/jib_maven_test.go
+++ b/pkg/skaffold/jib/jib_maven_test.go
@@ -104,7 +104,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibMavenArtifact: latest.JibMavenArtifact{Profile: "profile"},
 			filesInWorkspace: []string{},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"--quiet", "--non-recursive", "jib:_skaffold-files", "--activate-profiles", "profile"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"--quiet", "--activate-profiles", "profile", "--non-recursive", "jib:_skaffold-files"})
 			},
 		},
 		{
@@ -128,7 +128,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibMavenArtifact: latest.JibMavenArtifact{Profile: "profile"},
 			filesInWorkspace: []string{"mvnw", "mvnw.bat"},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"--quiet", "--non-recursive", "jib:_skaffold-files", "--activate-profiles", "profile"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"--quiet", "--activate-profiles", "profile", "--non-recursive", "jib:_skaffold-files"})
 			},
 		},
 		{
@@ -165,9 +165,9 @@ func TestGenerateMavenArgs(t *testing.T) {
 		out []string
 	}{
 		{latest.JibMavenArtifact{}, []string{"--non-recursive", "prepare-package", "jib:goal", "-Dimage=image"}},
-		{latest.JibMavenArtifact{Profile: "profile"}, []string{"--non-recursive", "prepare-package", "jib:goal", "-Dimage=image", "--activate-profiles", "profile"}},
+		{latest.JibMavenArtifact{Profile: "profile"}, []string{"--activate-profiles", "profile", "--non-recursive", "prepare-package", "jib:goal", "-Dimage=image"}},
 		{latest.JibMavenArtifact{Module: "module"}, []string{"--projects", "module", "--also-make", "package", "-Dimage=image"}},
-		{latest.JibMavenArtifact{Module: "module", Profile: "profile"}, []string{"--projects", "module", "--also-make", "package", "-Dimage=image", "--activate-profiles", "profile"}},
+		{latest.JibMavenArtifact{Module: "module", Profile: "profile"}, []string{"--activate-profiles", "profile", "--projects", "module", "--also-make", "package", "-Dimage=image"}},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
There's some duplication in jib code with regards to maven/gradle args.
This PR moves similar code fragments next to one another to make them easier to maintain.

Ideally, this duplication can be removed but I don't know enough jib to ensure I'm not breaking something.