### PR TITLE
Use configured namespace for pod watcher.

### DIFF
--- a/pkg/skaffold/kubernetes/port_forward_test.go
+++ b/pkg/skaffold/kubernetes/port_forward_test.go
@@ -427,7 +427,7 @@ func TestPortForwardPod(t *testing.T) {
 				isPortAvailable = originalIsPortAvailable
 			}()
 
-			p := NewPortForwarder(ioutil.Discard, NewImageList())
+			p := NewPortForwarder(ioutil.Discard, NewImageList(), []string{""})
 			if test.forwarder == nil {
 				test.forwarder = newTestForwarder(nil)
 			}

--- a/pkg/skaffold/kubernetes/watcher.go
+++ b/pkg/skaffold/kubernetes/watcher.go
@@ -52,7 +52,7 @@ func AggregatePodWatcher(namespaces []string, aggregate chan watch.Event) (func(
 		}
 		watchers = append(watchers, watcher)
 		go func(w watch.Interface) {
-			for msg := range watcher.ResultChan() {
+			for msg := range w.ResultChan() {
 				aggregate <- msg
 			}
 		}(watcher)

--- a/pkg/skaffold/kubernetes/watcher.go
+++ b/pkg/skaffold/kubernetes/watcher.go
@@ -17,29 +17,45 @@ limitations under the License.
 package kubernetes
 
 import (
-	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/pkg/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
 // PodWatcher returns a watcher that will report on all Pod Events (additions, modifications, etc.)
-func PodWatcher() (watch.Interface, error) {
+func PodWatcher(namespace string) (watch.Interface, error) {
 	kubeclient, err := Client()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting k8s client")
 	}
 	client := kubeclient.CoreV1()
-	// Only watch the current namespace, or we get errors.
-	// FIXME: Should we override this with the --namespace option?
-	config, err := kubectx.CurrentConfig()
-	if err != nil {
-		return nil, errors.Wrap(err, "getting k8s namespace")
-	}
-	ns := config.Contexts[config.CurrentContext].Namespace
 	var forever int64 = 3600 * 24 * 365 * 100
-	return client.Pods(ns).Watch(meta_v1.ListOptions{
+	return client.Pods(namespace).Watch(meta_v1.ListOptions{
 		IncludeUninitialized: true,
 		TimeoutSeconds:       &forever,
 	})
+}
+
+// AggregatePodWatcher returns a watcher for multiple namespaces.
+func AggregatePodWatcher(namespaces []string, aggregate chan watch.Event) (func(), error) {
+	watchers := make([]watch.Interface, len(namespaces))
+	stopWatchers := func() {
+		for _, w := range watchers {
+			w.Stop()
+		}
+	}
+
+	for _, ns := range namespaces {
+		watcher, err := PodWatcher(ns)
+		if err != nil {
+			return stopWatchers, errors.Wrap(err, "initializing pod watcher for "+ns)
+		}
+		watchers = append(watchers, watcher)
+		go func(w watch.Interface) {
+			for msg := range watcher.ResultChan() {
+				aggregate <- msg
+			}
+		}(watcher)
+	}
+	return stopWatchers, nil
 }

--- a/pkg/skaffold/kubernetes/watcher.go
+++ b/pkg/skaffold/kubernetes/watcher.go
@@ -38,7 +38,7 @@ func PodWatcher(namespace string) (watch.Interface, error) {
 
 // AggregatePodWatcher returns a watcher for multiple namespaces.
 func AggregatePodWatcher(namespaces []string, aggregate chan watch.Event) (func(), error) {
-	watchers := make([]watch.Interface, len(namespaces))
+	watchers := make([]watch.Interface, 0, len(namespaces))
 	stopWatchers := func() {
 		for _, w := range watchers {
 			w.Stop()

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -40,7 +40,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	logger := r.newLogger(out, artifacts)
 	defer logger.Stop()
 
-	portForwarder := kubernetes.NewPortForwarder(out, r.imageList)
+	portForwarder := kubernetes.NewPortForwarder(out, r.imageList, r.namespaces)
 	defer portForwarder.Stop()
 
 	// Create watcher and register artifacts to build current state of files.

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -68,6 +68,9 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldPipeline) (*
 	logrus.Infof("Using kubectl context: %s", kubeContext)
 
 	namespaces, err := getAllPodNamespaces(opts.Namespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting namespace list")
+	}
 
 	defaultRepo, err := configutil.GetDefaultRepo(opts.DefaultRepo)
 	if err != nil {

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -97,11 +97,6 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldPipeline) (*
 		return nil, errors.Wrap(err, "parsing deploy config")
 	}
 
-	syncer, err := getSyncer(namespaces)
-	if err != nil {
-		return nil, errors.Wrap(err, "creating syncer")
-	}
-
 	labellers := []deploy.Labeller{opts, builder, deployer, tagger}
 
 	builder, tester, deployer = WithTimings(builder, tester, deployer)
@@ -119,7 +114,7 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldPipeline) (*
 		Tester:     tester,
 		Deployer:   deployer,
 		Tagger:     tagger,
-		Syncer:     syncer,
+		Syncer:     kubectl.NewSyncer(namespaces),
 		Watcher:    watch.NewWatcher(trigger),
 		opts:       opts,
 		labellers:  labellers,
@@ -159,10 +154,6 @@ func getTester(cfg *latest.TestConfig, opts *config.SkaffoldOptions) (test.Teste
 	default:
 		return test.NewTester(cfg)
 	}
-}
-
-func getSyncer(namespaces []string) (sync.Syncer, error) {
-	return kubectl.NewSyncer(namespaces), nil
 }
 
 func getDeployer(cfg *latest.DeployConfig, kubeContext string, namespace string, defaultRepo string) (deploy.Deployer, error) {

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -327,7 +327,7 @@ func getAllPodNamespaces(configNamespace string) ([]string, error) {
 	// FIXME: Set additional namespaces from the selected yamls.
 
 	// Collate the slice of namespaces.
-	namespaces := make([]string, len(nsMap))
+	namespaces := make([]string, 0, len(nsMap))
 	for ns := range nsMap {
 		namespaces = append(namespaces, ns)
 	}

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -318,8 +318,12 @@ func getAllPodNamespaces(configNamespace string) ([]string, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "getting k8s configuration")
 		}
-		ns := config.Contexts[config.CurrentContext].Namespace
-		nsMap[ns] = true
+		context, ok := config.Contexts[config.CurrentContext]
+		if ok {
+			nsMap[context.Namespace] = true
+		} else {
+			nsMap[""] = true
+		}
 	} else {
 		nsMap[configNamespace] = true
 	}

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -56,6 +56,7 @@ type SkaffoldRunner struct {
 	builds      []build.Artifact
 	hasDeployed bool
 	imageList   *kubernetes.ImageList
+	namespaces  []string
 }
 
 // NewForConfig returns a new SkaffoldRunner for a SkaffoldPipeline
@@ -65,6 +66,8 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldPipeline) (*
 		return nil, errors.Wrap(err, "getting current cluster context")
 	}
 	logrus.Infof("Using kubectl context: %s", kubeContext)
+
+	namespaces, err := getAllPodNamespaces(opts.Namespace)
 
 	defaultRepo, err := configutil.GetDefaultRepo(opts.DefaultRepo)
 	if err != nil {
@@ -104,15 +107,16 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldPipeline) (*
 	}
 
 	return &SkaffoldRunner{
-		Builder:   builder,
-		Tester:    tester,
-		Deployer:  deployer,
-		Tagger:    tagger,
-		Syncer:    &kubectl.Syncer{},
-		Watcher:   watch.NewWatcher(trigger),
-		opts:      opts,
-		labellers: labellers,
-		imageList: kubernetes.NewImageList(),
+		Builder:    builder,
+		Tester:     tester,
+		Deployer:   deployer,
+		Tagger:     tagger,
+		Syncer:     &kubectl.Syncer{},
+		Watcher:    watch.NewWatcher(trigger),
+		opts:       opts,
+		labellers:  labellers,
+		imageList:  kubernetes.NewImageList(),
+		namespaces: namespaces,
 	}, nil
 }
 
@@ -201,7 +205,7 @@ func (r *SkaffoldRunner) newLogger(out io.Writer, artifacts []*latest.Artifact) 
 		imageNames = append(imageNames, artifact.ImageName)
 	}
 
-	return kubernetes.NewLogAggregator(out, imageNames, r.imageList)
+	return kubernetes.NewLogAggregator(out, imageNames, r.imageList, r.namespaces)
 }
 
 // HasDeployed returns true if this runner has deployed something.
@@ -304,4 +308,28 @@ func mergeWithPreviousBuilds(builds, previous []build.Artifact) []build.Artifact
 	}
 
 	return merged
+}
+
+func getAllPodNamespaces(configNamespace string) ([]string, error) {
+	// We also get the default namespace.
+	nsMap := make(map[string]bool)
+	if configNamespace == "" {
+		config, err := kubectx.CurrentConfig()
+		if err != nil {
+			return nil, errors.Wrap(err, "getting k8s configuration")
+		}
+		ns := config.Contexts[config.CurrentContext].Namespace
+		nsMap[ns] = true
+	} else {
+		nsMap[configNamespace] = true
+	}
+
+	// FIXME: Set additional namespaces from the selected yamls.
+
+	// Collate the slice of namespaces.
+	namespaces := make([]string, len(nsMap))
+	for ns := range nsMap {
+		namespaces = append(namespaces, ns)
+	}
+	return namespaces, nil
 }

--- a/pkg/skaffold/sync/kubectl/kubectl.go
+++ b/pkg/skaffold/sync/kubectl/kubectl.go
@@ -28,15 +28,23 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-type Syncer struct{}
+type Syncer struct {
+	namespaces []string
+}
 
 var syncedDirs = map[string]struct{}{}
+
+func NewSyncer(namespaces []string) *Syncer {
+	return &Syncer{
+		namespaces: namespaces,
+	}
+}
 
 func (k *Syncer) Sync(ctx context.Context, s *sync.Item) error {
 	if len(s.Copy) > 0 {
 		logrus.Infoln("Copying files:", s.Copy, "to", s.Image)
 
-		if err := sync.Perform(ctx, s.Image, s.Copy, copyFileFn); err != nil {
+		if err := sync.Perform(ctx, s.Image, s.Copy, copyFileFn, k.namespaces); err != nil {
 			return errors.Wrap(err, "copying files")
 		}
 	}
@@ -44,7 +52,7 @@ func (k *Syncer) Sync(ctx context.Context, s *sync.Item) error {
 	if len(s.Delete) > 0 {
 		logrus.Infoln("Deleting files:", s.Delete, "from", s.Image)
 
-		if err := sync.Perform(ctx, s.Image, s.Delete, deleteFileFn); err != nil {
+		if err := sync.Perform(ctx, s.Image, s.Delete, deleteFileFn, k.namespaces); err != nil {
 			return errors.Wrap(err, "deleting files")
 		}
 	}

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -422,7 +422,7 @@ func TestPerform(t *testing.T) {
 
 			util.DefaultExecCommand = cmdRecord
 
-			err := Perform(context.Background(), test.image, test.files, test.cmdFn)
+			err := Perform(context.Background(), test.image, test.files, test.cmdFn, []string{""})
 
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, cmdRecord.cmds)
 		})


### PR DESCRIPTION
This is a first step towards working on my on-premises cluster.

Basically, the pod watcher was failing because it requests cluster-wide pod access, but my RBAC for the current user restricts it to just the `michael` namespace.

An enhancement would be to use the value of the `--namespace` flag to override the context's namespace if supplied.
