### PR TITLE
Refactor port forwarding

### DIFF
--- a/pkg/skaffold/kubernetes/port_forward.go
+++ b/pkg/skaffold/kubernetes/port_forward.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os/exec"
 	"strconv"
 
@@ -42,7 +43,7 @@ type PortForwarder struct {
 	// forwardedPods is a map of portForwardEntry.key() (string) -> portForwardEntry
 	forwardedPods map[string]*portForwardEntry
 
-	// forwardedPorts is a map of port (int32) -> container name (string)
+	// forwardedPorts is a map of local port (int32) -> container name (string)
 	forwardedPorts map[int32]string
 }
 
@@ -52,6 +53,7 @@ type portForwardEntry struct {
 	namespace       string
 	containerName   string
 	port            int32
+	localPort       int32
 
 	cancel context.CancelFunc
 }
@@ -64,6 +66,11 @@ type Forwarder interface {
 
 type kubectlForwarder struct{}
 
+var (
+	// For testing
+	retrieveAvailablePort = getAvailablePort
+)
+
 // Forward port-forwards a pod using kubectl port-forward
 // It returns an error only if the process fails or was terminated by a signal other than SIGTERM
 func (*kubectlForwarder) Forward(parentCtx context.Context, pfe *portForwardEntry) error {
@@ -72,9 +79,7 @@ func (*kubectlForwarder) Forward(parentCtx context.Context, pfe *portForwardEntr
 	ctx, cancel := context.WithCancel(parentCtx)
 	pfe.cancel = cancel
 
-	portNumber := fmt.Sprintf("%d", pfe.port)
-
-	cmd := exec.CommandContext(ctx, "kubectl", "port-forward", pfe.podName, portNumber, portNumber, "--namespace", pfe.namespace)
+	cmd := exec.CommandContext(ctx, "kubectl", "port-forward", pfe.podName, fmt.Sprintf("%d:%d", pfe.localPort, pfe.port), "--namespace", pfe.namespace)
 	buf := &bytes.Buffer{}
 	cmd.Stdout = buf
 	cmd.Stderr = buf
@@ -83,7 +88,7 @@ func (*kubectlForwarder) Forward(parentCtx context.Context, pfe *portForwardEntr
 		if errors.Cause(err) == context.Canceled {
 			return nil
 		}
-		return errors.Wrapf(err, "port forwarding pod: %s/%s, port: %s, err: %s", pfe.namespace, pfe.podName, portNumber, buf.String())
+		return errors.Wrapf(err, "port forwarding pod: %s/%s, port: %d to local port: %d, err: %s", pfe.namespace, pfe.podName, pfe.port, pfe.localPort, buf.String())
 	}
 
 	go cmd.Wait()
@@ -175,40 +180,99 @@ func (p *PortForwarder) portForwardPod(ctx context.Context, pod *v1.Pod) error {
 
 	for _, c := range pod.Spec.Containers {
 		for _, port := range c.Ports {
-			// If the port is already port-forwarded by another container,
-			// continue without port-forwarding
-			currentApp, ok := p.forwardedPorts[port.ContainerPort]
-			if ok && currentApp != c.Name {
-				color.LightYellow.Fprintf(p.output, "Port %d for %s is already in use by container %s\n", port.ContainerPort, c.Name, currentApp)
+			// get current entry for this container
+			entry, err := p.getCurrentEntry(pod, c, port, resourceVersion)
+			if err != nil {
+				color.Red.Fprintf(p.output, "Unable to get port for %s, skipping port-forward: %v", c.Name, err)
 				continue
 			}
-
-			entry := &portForwardEntry{
-				resourceVersion: resourceVersion,
-				podName:         pod.Name,
-				namespace:       pod.Namespace,
-				containerName:   c.Name,
-				port:            port.ContainerPort,
+			if entry.port != entry.localPort {
+				color.Yellow.Fprintf(p.output, "Forwarding container %s to local port %d.\n", c.Name, entry.localPort)
 			}
-
-			if prevEntry, ok := p.forwardedPods[entry.key()]; ok {
-				// Check if this is a new generation of pod
-				if entry.resourceVersion > prevEntry.resourceVersion {
-					p.Terminate(prevEntry)
-				}
-			}
-
-			color.Default.Fprintln(p.output, fmt.Sprintf("Port Forwarding %s %d -> %d", entry.podName, entry.port, entry.port))
-			p.forwardedPods[entry.key()] = entry
-			p.forwardedPorts[entry.port] = entry.containerName
-
-			if err := p.Forward(ctx, entry); err != nil {
-				return errors.Wrap(err, "port forwarding failed")
+			if err := p.forward(ctx, entry); err != nil {
+				return errors.Wrap(err, "failed to forward port")
 			}
 		}
 	}
-
 	return nil
+}
+
+func (p *PortForwarder) getCurrentEntry(pod *v1.Pod, c v1.Container, port v1.ContainerPort, resourceVersion int) (*portForwardEntry, error) {
+	// determine if we have seen this before
+	entry := &portForwardEntry{
+		resourceVersion: resourceVersion,
+		podName:         pod.Name,
+		namespace:       pod.Namespace,
+		containerName:   c.Name,
+		port:            port.ContainerPort,
+	}
+	// If we have, return the current entry
+	oldEntry, ok := p.forwardedPods[entry.key()]
+	if ok {
+		entry.localPort = oldEntry.localPort
+		return entry, nil
+	}
+	// If another container isn't using this port...
+	if _, exists := p.forwardedPorts[port.ContainerPort]; !exists {
+		// ...Then make sure the port is availble
+		if available, err := isPortAvailable(port.ContainerPort); available && err == nil {
+			entry.localPort = port.ContainerPort
+			return entry, nil
+		}
+	}
+	// Else, determine a new local port
+	localPort, err := retrieveAvailablePort()
+	if err != nil {
+		return nil, errors.Wrap(err, "getting random available port")
+	}
+	entry.localPort = localPort
+	p.forwardedPorts[localPort] = ""
+	return entry, nil
+}
+
+func (p *PortForwarder) forward(ctx context.Context, entry *portForwardEntry) error {
+	if prevEntry, ok := p.forwardedPods[entry.key()]; ok {
+		// Check if this is a new generation of pod
+		if entry.resourceVersion > prevEntry.resourceVersion {
+			p.Terminate(prevEntry)
+		}
+	}
+
+	color.Default.Fprintln(p.output, fmt.Sprintf("Port Forwarding %s %d -> %d", entry.podName, entry.port, entry.localPort))
+	p.forwardedPods[entry.key()] = entry
+	p.forwardedPorts[entry.localPort] = entry.containerName
+
+	if err := p.Forward(ctx, entry); err != nil {
+		return errors.Wrap(err, "port forwarding failed")
+	}
+	return nil
+}
+
+// From https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt,
+// ports 4503-4533 are unassigned user ports; first check if any of these are available
+// If not, return a random port, which hopefully won't collide with any future containers
+func getAvailablePort() (int32, error) {
+	for i := 4503; i <= 4533; i++ {
+		ok, err := isPortAvailable(int32(i))
+		if ok {
+			return int32(i), err
+		}
+	}
+
+	// get random port
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return -1, err
+	}
+	return int32(l.Addr().(*net.TCPAddr).Port), l.Close()
+}
+
+func isPortAvailable(p int32) (bool, error) {
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", p))
+	if l != nil {
+		defer l.Close()
+	}
+	return err == nil, nil
 }
 
 // Key is an identifier for the lock on a port during the skaffold dev cycle.

--- a/pkg/skaffold/kubernetes/port_forward.go
+++ b/pkg/skaffold/kubernetes/port_forward.go
@@ -69,6 +69,7 @@ type kubectlForwarder struct{}
 var (
 	// For testing
 	retrieveAvailablePort = getAvailablePort
+	isPortAvailable       = portAvailable
 )
 
 // Forward port-forwards a pod using kubectl port-forward
@@ -267,7 +268,7 @@ func getAvailablePort() (int32, error) {
 	return int32(l.Addr().(*net.TCPAddr).Port), l.Close()
 }
 
-func isPortAvailable(p int32) (bool, error) {
+func portAvailable(p int32) (bool, error) {
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", p))
 	if l != nil {
 		defer l.Close()

--- a/pkg/skaffold/kubernetes/port_forward.go
+++ b/pkg/skaffold/kubernetes/port_forward.go
@@ -215,7 +215,7 @@ func (p *PortForwarder) getCurrentEntry(pod *v1.Pod, c v1.Container, port v1.Con
 	}
 	// If another container isn't using this port...
 	if _, exists := p.forwardedPorts[port.ContainerPort]; !exists {
-		// ...Then make sure the port is availble
+		// ...Then make sure the port is available
 		if available, err := isPortAvailable(port.ContainerPort); available && err == nil {
 			entry.localPort = port.ContainerPort
 			return entry, nil

--- a/pkg/skaffold/kubernetes/port_forward_test.go
+++ b/pkg/skaffold/kubernetes/port_forward_test.go
@@ -46,6 +46,10 @@ func (f *testForwarder) Terminate(pfe *portForwardEntry) {
 	delete(f.forwardedPorts, pfe.port)
 }
 
+func mockRetrieveAvailablePort() (int32, error) {
+	return int32(8080), nil
+}
+
 func newTestForwarder(forwardErr error) *testForwarder {
 	return &testForwarder{
 		forwardedEntries: map[string]*portForwardEntry{},
@@ -74,6 +78,7 @@ func TestPortForwardPod(t *testing.T) {
 					podName:         "podname",
 					containerName:   "containername",
 					port:            8080,
+					localPort:       8080,
 				},
 			},
 			pods: []*v1.Pod{
@@ -136,6 +141,7 @@ func TestPortForwardPod(t *testing.T) {
 					podName:         "podname",
 					containerName:   "containername",
 					port:            8080,
+					localPort:       8080,
 				},
 			},
 			pods: []*v1.Pod{
@@ -171,12 +177,14 @@ func TestPortForwardPod(t *testing.T) {
 					podName:         "podname",
 					containerName:   "containername",
 					port:            8080,
+					localPort:       8080,
 				},
 				"containername2-50051": {
 					resourceVersion: 1,
 					podName:         "podname2",
 					containerName:   "containername2",
 					port:            50051,
+					localPort:       50051,
 				},
 			},
 			pods: []*v1.Pod{
@@ -229,6 +237,14 @@ func TestPortForwardPod(t *testing.T) {
 					podName:         "podname",
 					containerName:   "containername",
 					port:            8080,
+					localPort:       8080,
+				},
+				"containername2-8080": {
+					resourceVersion: 1,
+					podName:         "podname2",
+					containerName:   "containername2",
+					port:            8080,
+					localPort:       8080,
 				},
 			},
 			pods: []*v1.Pod{
@@ -281,6 +297,7 @@ func TestPortForwardPod(t *testing.T) {
 					podName:         "podname",
 					containerName:   "containername",
 					port:            8080,
+					localPort:       8080,
 				},
 			},
 			pods: []*v1.Pod{
@@ -325,6 +342,13 @@ func TestPortForwardPod(t *testing.T) {
 	}
 
 	for _, test := range tests {
+
+		originalGetAvailablePort := getAvailablePort
+		retrieveAvailablePort = mockRetrieveAvailablePort
+		defer func() {
+			retrieveAvailablePort = originalGetAvailablePort
+		}()
+
 		t.Run(test.description, func(t *testing.T) {
 			p := NewPortForwarder(ioutil.Discard, NewImageList())
 			if test.forwarder == nil {


### PR DESCRIPTION
Refactored port-forwarding to account for cases where:

1. Two containers map to the same port
2. Ports are already allocated on the machine

Now, when the port forwarder comes upon a new container, it follows
these steps:

1. It checks if the port is available on the machine. If so, then it
marks that port as taken.
2. If the port is unavailable, skaffold will find a new open port to map
to. It checks ports 4503-4533, which are unassigned user ports, first. If
none of those are open (which seems unlikely), then skaffold will find a
random open port.

Starts to fix #969 