### PR TITLE
Fix jib tagging

### DIFF
--- a/pkg/skaffold/docker/remote.go
+++ b/pkg/skaffold/docker/remote.go
@@ -25,10 +25,12 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 func AddTag(src, target string) error {
-	srcRef, err := name.ParseReference(src, name.WeakValidation)
+	logrus.Debugf("attempting to add tag %s to src %s", target, src)
+	srcRef, err := name.ParseReference(src, name.StrictValidation)
 	if err != nil {
 		return errors.Wrap(err, "getting source reference")
 	}
@@ -38,7 +40,7 @@ func AddTag(src, target string) error {
 		return err
 	}
 
-	targetRef, err := name.ParseReference(target, name.WeakValidation)
+	targetRef, err := name.ParseReference(target, name.StrictValidation)
 	if err != nil {
 		return errors.Wrap(err, "getting target reference")
 	}
@@ -84,7 +86,7 @@ func retrieveRemoteConfig(identifier string) (*v1.ConfigFile, error) {
 }
 
 func remoteImage(identifier string) (v1.Image, error) {
-	ref, err := name.ParseReference(identifier, name.WeakValidation)
+	ref, err := name.ParseReference(identifier, name.StrictValidation)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing initial ref")
 	}


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/skaffold/issues/1460

This fixes an issue when tagging a remote image built by jib directly to the registry.

Previously, the digest of the remote image was being passed to `docker.AddTag()`, which uses go-containerregistry's [`name.ParseReference()`](https://github.com/google/go-containerregistry/blob/master/pkg/name/ref.go#L41) to retrieve a remote image reference to add a new tag.

The issue was that Skaffold was using "WeakValidation", which tells the go-containerregistry to try and infer the remote registry in the event that we don't pass one in: so in trying to retrieve the remote image reference via image digest (e.g. `sha256:deadbeef...`), we were receiving back a "valid" remote reference to `index.docker.io/sha256:deadbeef....`.

This change prepends the remote registry specified in the artifact to the provided remote digest (where we retrieved it from anyway) before attempting to add the tag, ensuring that the remote image reference comes from the place we expect it to. This also changes the call to `name.ParseReference()` to use "StrictValidation", which requires that we pass in a fully-qualified remote, so we're not making any misleading assumptions about the remote registry target.