### PR TITLE
Fix Broken link to references/config in documentation

### DIFF
--- a/docs/content/en/docs/concepts/_index.md
+++ b/docs/content/en/docs/concepts/_index.md
@@ -28,7 +28,7 @@ read the configuration file from the current directory.
 | `profiles`|  Profile is a set of settings that, when activated, overrides the current configuration. You can use Profile to override the `build` and the`deploy`> section. |
 
 You can learn more about the syntax of `skaffold.yaml` at
-[`skaffold.yaml References`](/docs/references/config).
+[`skaffold.yaml References`](https://github.com/GoogleContainerTools/skaffold/blob/master/examples/annotated-skaffold.yaml).
 
 ## Workflow
 

--- a/docs/content/en/docs/how-tos/builders/_index.md
+++ b/docs/content/en/docs/how-tos/builders/_index.md
@@ -22,7 +22,7 @@ controls how Skaffold builds artifacts. To use a specific tool for building
 artifacts, add the value representing the tool and options for using the tool
 to the `build` section. For a detailed discussion on Skaffold configuration,
 see [Skaffold Concepts: Configuration](/docs/concepts/#configuration) and
-[skaffold.yaml References](/docs/references/config).
+[skaffold.yaml References](https://github.com/GoogleContainerTools/skaffold/blob/master/examples/annotated-skaffold.yaml).
 
 ## Dockerfile locally with Docker
 

--- a/docs/content/en/docs/how-tos/deployers/_index.md
+++ b/docs/content/en/docs/how-tos/deployers/_index.md
@@ -25,7 +25,7 @@ controls how Skaffold builds artifacts. To use a specific tool for deploying
 artifacts, add the value representing the tool and options for using the tool
 to the `build` section. For a detailed discussion on Skaffold configuration,
 see [Skaffold Concepts: Configuration](/docs/concepts/#configuration) and
-[Skaffold.yaml References](/docs/references/config).
+[Skaffold.yaml References](https://github.com/GoogleContainerTools/skaffold/blob/master/examples/annotated-skaffold.yaml).
 
 ## Deploying with kubectl
 

--- a/docs/content/en/docs/how-tos/profiles/_index.md
+++ b/docs/content/en/docs/how-tos/profiles/_index.md
@@ -13,7 +13,7 @@ configurations for different contexts. Different contexts are typically differen
 You can create profiles in the `profiles` section of `skaffold.yaml`. For a
 detailed discussion on Skaffold configuration,
 see [Skaffold Concepts: Configuration](/docs/concepts/#configuration) and
-[skaffold.yaml References](/docs/references/config).
+[skaffold.yaml References](https://github.com/GoogleContainerTools/skaffold/blob/master/examples/annotated-skaffold.yaml).
 
 ## Profiles (`profiles`)
 

--- a/docs/content/en/docs/how-tos/taggers/_index.md
+++ b/docs/content/en/docs/how-tos/taggers/_index.md
@@ -18,7 +18,7 @@ Tag policy is specified in the `tagPolicy` field of the `build` section of the
 Skaffold configuration file, `skaffold.yaml`. For a detailed discussion on
 Skaffold configuration,
 see [Skaffold Concepts: Configuration](/docs/concepts/#configuration) and
-[skaffold.yaml References](/docs/references/config).
+[skaffold.yaml References](https://github.com/GoogleContainerTools/skaffold/blob/master/examples/annotated-skaffold.yaml).
 
 ## `gitCommit`: using Git commit IDs as tags
 


### PR DESCRIPTION
Fix #1476

Signed-off-by: David Gageot <david@gageot.net>