### PR TITLE
Pass bazel args to `bazel info hazel-bin`

### DIFF
--- a/pkg/skaffold/build/local/bazel.go
+++ b/pkg/skaffold/build/local/bazel.go
@@ -43,7 +43,7 @@ func (b *Builder) buildBazel(ctx context.Context, out io.Writer, workspace strin
 		return "", errors.Wrap(err, "running command")
 	}
 
-	bazelBin, err := bazelBin(ctx, workspace)
+	bazelBin, err := bazelBin(ctx, workspace, a)
 	if err != nil {
 		return "", errors.Wrap(err, "getting path of bazel-bin")
 	}
@@ -65,8 +65,11 @@ func (b *Builder) buildBazel(ctx context.Context, out io.Writer, workspace strin
 	return imageID, nil
 }
 
-func bazelBin(ctx context.Context, workspace string) (string, error) {
-	cmd := exec.CommandContext(ctx, "bazel", "info", "bazel-bin")
+func bazelBin(ctx context.Context, workspace string, a *latest.BazelArtifact) (string, error) {
+	args := []string{"info", "bazel-bin"}
+	args = append(args, a.BuildArgs...)
+
+	cmd := exec.CommandContext(ctx, "bazel", args...)
 	cmd.Dir = workspace
 
 	buf, err := util.RunCmdOut(cmd)

--- a/pkg/skaffold/build/local/bazel_test.go
+++ b/pkg/skaffold/build/local/bazel_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -27,11 +28,13 @@ import (
 func TestBazelBin(t *testing.T) {
 	defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
 	util.DefaultExecCommand = testutil.NewFakeCmd(t).WithRunOut(
-		"bazel info bazel-bin",
+		"bazel info bazel-bin --arg1 --arg2",
 		"/absolute/path/bin\n",
 	)
 
-	bazelBin, err := bazelBin(context.Background(), ".")
+	bazelBin, err := bazelBin(context.Background(), ".", &latest.BazelArtifact{
+		BuildArgs: []string{"--arg1", "--arg2"},
+	})
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, "/absolute/path/bin", bazelBin)
 }


### PR DESCRIPTION
Fixes #1467

Signed-off-by: David Gageot <david@gageot.net>