### PR TITLE
Fix onbuild analysis

### DIFF
--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -145,7 +145,7 @@ func onbuildInstructions(nodes []*parser.Node) ([]*parser.Node, error) {
 		// Image names are case SENSITIVE
 		img, err := RetrieveImage(from.image)
 		if err != nil {
-			logrus.Warnf("Error processing base image for ONBUILD triggers: %s. Dependencies may be incomplete.", err)
+			logrus.Warnf("Error processing base image (%s) for ONBUILD triggers: %s. Dependencies may be incomplete.", from.image, err)
 			continue
 		}
 

--- a/pkg/skaffold/docker/remote.go
+++ b/pkg/skaffold/docker/remote.go
@@ -34,7 +34,7 @@ func AddTag(src, target string) error {
 		return errors.Wrap(err, "getting image")
 	}
 
-	targetRef, err := name.ParseReference(target, name.StrictValidation)
+	targetRef, err := name.ParseReference(target, name.WeakValidation)
 	if err != nil {
 		return errors.Wrap(err, "getting target reference")
 	}
@@ -71,7 +71,7 @@ func retrieveRemoteConfig(identifier string) (*v1.ConfigFile, error) {
 }
 
 func remoteImage(identifier string) (v1.Image, error) {
-	ref, err := name.ParseReference(identifier, name.StrictValidation)
+	ref, err := name.ParseReference(identifier, name.WeakValidation)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing initial ref")
 	}

--- a/pkg/skaffold/docker/remote_test.go
+++ b/pkg/skaffold/docker/remote_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRemoteDigest(t *testing.T) {
+	validReferences := []string{
+		"python",
+		"python:3-slim",
+	}
+
+	for _, ref := range validReferences {
+		_, err := RemoteDigest(ref)
+
+		// Ignore networking errors
+		if err != nil && strings.Contains(err.Error(), "could not parse") {
+			t.Errorf("unable to parse %q: %v", ref, err)
+		}
+	}
+}


### PR DESCRIPTION
Current code fails to retrieve remote image for `python:3-slim`