### PR TITLE
Add support for helm --force flag

### DIFF
--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -183,6 +183,7 @@ deploy:
 
  # helm:
     # helm releases to deploy.
+    # Uses "helm install" if not installed yet, otherwise "helm upgrade" is executed
     # releases:
     # - name: skaffold-helm
     #   chartPath: skaffold-helm
@@ -193,9 +194,11 @@ deploy:
     #     image: skaffold-helm
     #   namespace: skaffold
     #   version: ""
-    #   recreatePods: false
+    #   # use --recreate-pods for helm upgrade
+    #   recreatePods: true
     #   wait: false
-    #   force: false
+    #   # use --force for helm upgrade
+    #   force: true
     #
     #   # setValues get appended to the helm deploy with --set.
     #   setValues:

--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -194,6 +194,8 @@ deploy:
     #   namespace: skaffold
     #   version: ""
     #   recreatePods: false
+    #   wait: false
+    #   force: false
     #
     #   # setValues get appended to the helm deploy with --set.
     #   setValues:

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -173,6 +173,9 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 		if r.RecreatePods {
 			args = append(args, "--recreate-pods")
 		}
+		if r.Force {
+			args = append(args, "--force")
+		}
 	}
 
 	// There are 2 strategies:
@@ -261,9 +264,6 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 	}
 	if r.Wait {
 		args = append(args, "--wait")
-	}
-	if r.Force {
-		args = append(args, "--force")
 	}
 	args = append(args, setOpts...)
 

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -262,6 +262,9 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 	if r.Wait {
 		args = append(args, "--wait")
 	}
+	if r.Force {
+		args = append(args, "--force")
+	}
 	args = append(args, setOpts...)
 
 	helmErr := h.helm(ctx, out, args...)

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -177,7 +177,7 @@ type KubectlFlags struct {
 
 // HelmDeploy contains the configuration needed for deploying with helm
 type HelmDeploy struct {
-	Releases [] `yaml:"releases,omitempty"`
+	Releases []HelmRelease `yaml:"releases,omitempty"`
 }
 
 // KustomizeDeploy contains the configuration needed for deploying with kustomize.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -177,8 +177,7 @@ type KubectlFlags struct {
 
 // HelmDeploy contains the configuration needed for deploying with helm
 type HelmDeploy struct {
-	Releases []
-	`yaml:"releases,omitempty"`
+	Releases [] `yaml:"releases,omitempty"`
 }
 
 // KustomizeDeploy contains the configuration needed for deploying with kustomize.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -177,7 +177,8 @@ type KubectlFlags struct {
 
 // HelmDeploy contains the configuration needed for deploying with helm
 type HelmDeploy struct {
-	Releases []HelmRelease `yaml:"releases,omitempty"`
+	Releases []
+	`yaml:"releases,omitempty"`
 }
 
 // KustomizeDeploy contains the configuration needed for deploying with kustomize.
@@ -196,6 +197,7 @@ type HelmRelease struct {
 	SetValues         map[string]string      `yaml:"setValues,omitempty"`
 	SetValueTemplates map[string]string      `yaml:"setValueTemplates,omitempty"`
 	Wait              bool                   `yaml:"wait,omitempty"`
+	Force             bool                   `yaml:"force,omitempty"`
 	RecreatePods      bool                   `yaml:"recreatePods,omitempty"`
 	Overrides         map[string]interface{} `yaml:"overrides,omitempty"`
 	Packaged          *HelmPackaged          `yaml:"packaged,omitempty"`


### PR DESCRIPTION
We're using skaffold and helm to deploy. In our ci-cluster deploys sometimes fail,
but then skaffold cannot install it anymore if it finds a failed helm installation.
The --force flag solves this. 

See the --force functionailtiy added in helm 2.5.0:
https://github.com/helm/helm/pull/2280

Potential solution for #1328 
Makes it more easy to use skaffold in a ci-pipeline. (deploy from a clean sheet)