### PR TITLE
[wip] Add --port flag to skaffold dev

### DIFF
--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -44,6 +44,7 @@ func NewCmdDev(out io.Writer) *cobra.Command {
 	cmd.Flags().IntVarP(&opts.WatchPollInterval, "watch-poll-interval", "i", 1000, "Interval (in ms) between two checks for file changes")
 	cmd.Flags().BoolVar(&opts.PortForward, "port-forward", true, "Port-forward exposed container ports within pods")
 	cmd.Flags().StringArrayVarP(&opts.CustomLabels, "label", "l", nil, "Add custom labels to deployed objects. Set multiple times for multiple labels")
+	cmd.Flags().StringArrayVarP(&opts.Ports, "port", "", nil, "Specify a port to forward of the form pod/container:localPort:containerPort. Set multiple times for multiple ports.")
 	return cmd
 }
 

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -44,7 +44,7 @@ func NewCmdDev(out io.Writer) *cobra.Command {
 	cmd.Flags().IntVarP(&opts.WatchPollInterval, "watch-poll-interval", "i", 1000, "Interval (in ms) between two checks for file changes")
 	cmd.Flags().BoolVar(&opts.PortForward, "port-forward", true, "Port-forward exposed container ports within pods")
 	cmd.Flags().StringArrayVarP(&opts.CustomLabels, "label", "l", nil, "Add custom labels to deployed objects. Set multiple times for multiple labels")
-	cmd.Flags().StringArrayVarP(&opts.Ports, "port", "", nil, "Specify a port to forward of the form pod/container:localPort:containerPort. Set multiple times for multiple ports.")
+	cmd.Flags().StringArrayVarP(&opts.Ports, "port", "", nil, "Specify a port to forward to in the form pod/container:localPort:containerPort. Set multiple times for multiple ports.")
 	return cmd
 }
 

--- a/docs/content/en/docs/how-tos/portforward/_index.md
+++ b/docs/content/en/docs/how-tos/portforward/_index.md
@@ -5,6 +5,46 @@ linkTitle: "Using port forwarding"
 weight: 50
 ---
 
-This page discusses how to set up Skaffold to setup port forwarding for container ports from pods.
- 
-{{% todo 1076 %}} 
+This page discusses how to set up Skaffold to setup port forwarding for container ports from pods with `skaffold dev`.
+
+### Flags
+
+|Flag|Description|
+|-----|-----|
+|`port-forward`| OPTIONAL. Set to false to disable automatic port-forwarding. |                    
+|`port`| OPTIONAL. Specify a port to forward to in the form pod/container:localPort:containerPort. Set multiple times for multiple ports. |                    
+
+
+### Background
+
+Given the following pod definition: 
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+spec:
+  containers:
+  - name: hello
+    image: gcr.io/k8s-skaffold/hello-port-forward
+    ports:
+    - containerPort: 8080
+```
+
+skaffold will automatically attempt to forward container port 8080 to port 8080 on your local machine using `kubectl port-forward`.
+If the port is unavailable locally, skaffold will forward to a random open port.
+
+Similarly, upon a port collision, skaffold will forward any colliding ports to a random open port.
+
+### Specifying a Local Port
+
+To specify which local port a container port should be forwarded too, pass in the `--port` flag with arguments formatted as follows:
+
+```
+skaffold dev --port <my pod name>/<my container name>:localPort:containerPort
+```
+
+where the containerPort will be forwarded to the localPort on your machine. 
+You can set this flag multiple times to specify multiple ports. 
+

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -208,6 +208,7 @@ Flags:
   -f, --filename string           Filename or URL to the pipeline file (default "skaffold.yaml")
   -l, --label stringArray         Add custom labels to deployed objects. Set multiple times for multiple labels
   -n, --namespace string          Run deployments in the specified namespace
+      --port stringArray          Specify a port to forward to in the form pod/container:localPort:containerPort. Set multiple times for multiple ports.
       --port-forward              Port-forward exposed container ports within pods (default true)
   -p, --profile stringArray       Activate profiles by name
       --skip-tests                Whether to skip the tests after building
@@ -229,6 +230,7 @@ Env vars:
 * `SKAFFOLD_FILENAME` (same as --filename)
 * `SKAFFOLD_LABEL` (same as --label)
 * `SKAFFOLD_NAMESPACE` (same as --namespace)
+* `SKAFFOLD_PORT` (same as --port)
 * `SKAFFOLD_PORT_FORWARD` (same as --port-forward)
 * `SKAFFOLD_PROFILE` (same as --profile)
 * `SKAFFOLD_SKIP_TESTS` (same as --skip-tests)

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -31,6 +31,7 @@ type SkaffoldOptions struct {
 	PortForward       bool
 	SkipTests         bool
 	Profiles          []string
+	Ports             []string
 	CustomTag         string
 	Namespace         string
 	Watch             []string

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -40,7 +40,10 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	logger := r.newLogger(out, artifacts)
 	defer logger.Stop()
 
-	portForwarder := kubernetes.NewPortForwarder(out, r.imageList)
+	portForwarder, err := kubernetes.NewPortForwarder(out, r.imageList, r.opts.Ports)
+	if err != nil {
+		return err
+	}
 	defer portForwarder.Stop()
 
 	// Create watcher and register artifacts to build current state of files.


### PR DESCRIPTION
I added a --port flag to skaffold dev so users could specify additional ports they want to port forward, to be used with Java debugging (#1480) . This will also allow users to specify local ports as well (right now, skaffold randomly forwards to an open port in the event of a collision), which should fix #1311.

The flag takes in strings in the form `pod/container:localPort:containerPort`. When a pod event happens, skaffold first goes through the user defined ports and forwards any ports assigned to that pod. It then goes through the ports specified in the manifest file and forwards any additional ports there.

We could also add a field to the skaffold.yaml, which should be pretty easy to add:

```yaml
deploy:
  portForward:
  - pod: mypod
    container: mycontainer
    containerPort: 8080 
    localPort: 9000
```

cc @etanshaul