### PR TITLE
Add zsh completion

### DIFF
--- a/cmd/skaffold/app/cmd/completion.go
+++ b/cmd/skaffold/app/cmd/completion.go
@@ -24,30 +24,46 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// completionCmd represents the completion command
+const longDescription = `
+	Outputs skaffold shell completion for the given shell (bash or zsh)
+
+	This depends on the bash-completion binary.  Example installation instructions:
+	OS X:
+		$ brew install bash-completion
+		$ source $(brew --prefix)/etc/bash_completion
+		$ skaffold completion bash > ~/.skaffold-completion  # for bash users
+		$ skaffold completion zsh > ~/.skaffold-completion   # for zsh users
+		$ source ~/.skaffold-completion
+	Ubuntu:
+		$ apt-get install bash-completion
+		$ source /etc/bash-completion
+		$ source <(skaffold completion bash) # for bash users
+		$ source <(skaffold completion zsh)  # for zsh users
+
+	Additionally, you may want to output the completion to a file and source in your .bashrc
+`
+
 var completionCmd = &cobra.Command{
-	// Only bash is supported for now. However, having args after
-	// "completion" will help when supporting multiple shells
-	Use: "completion bash",
+	Use: "completion SHELL",
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
 			return fmt.Errorf("requires 1 arg, found %d", len(args))
 		}
 		return cobra.OnlyValidArgs(cmd, args)
 	},
-	ValidArgs: []string{"bash"},
-	Short:     "Output command completion script for the bash shell",
-	Long: `To enable command completion run
+	ValidArgs: []string{"bash", "zsh"},
+	Short:     "Output skaffold shell completion for the given shell (bash or zsh)",
+	Long:      longDescription,
+	Run:       completion,
+}
 
-eval "$(skaffold completion bash)"
-
-To configure bash shell completion for all your sessions, add the following to your
-~/.bashrc or ~/.bash_profile:
-
-eval "$(skaffold completion bash)"`,
-	Run: func(cmd *cobra.Command, args []string) {
+func completion(_cmd *cobra.Command, args []string) {
+	switch args[0] {
+	case "bash":
 		rootCmd.GenBashCompletion(os.Stdout)
-	},
+	case "zsh":
+		rootCmd.GenZshCompletion(os.Stdout)
+	}
 }
 
 // NewCmdCompletion returns the cobra command that outputs shell completion code

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -91,11 +91,11 @@ Env vars:
 
 ### skaffold completion
 
-Output command completion script for the bash shell
+Output skaffold shell completion for the given shell (bash or zsh)
 
 ```
 Usage:
-  skaffold completion bash [flags]
+  skaffold completion SHELL [flags]
 
 Global Flags:
   -v, --verbosity string   Log level (debug, info, warn, error, fatal, panic) (default "warning")


### PR DESCRIPTION
This PR adds command completion for skaffold in zsh. It uses the cobra zsh completion generator. Cobra has only limited support for completion in zsh, for example options are not included in the completion unlike for bash completion. However, a revised completion generator is in the works (https://github.com/spf13/cobra/pull/646), so that it didn't seem reasonable to build a custom temporary solution. Therefore, this zsh completion for skaffold is still a bit basic, but hopefully will improve soon.

Fixes #1012