### PR TITLE
Add an http trigger

### DIFF
--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -38,7 +38,8 @@ func NewCmdDev(out io.Writer) *cobra.Command {
 	}
 	AddRunDevFlags(cmd)
 	cmd.Flags().BoolVar(&opts.TailDev, "tail", true, "Stream logs from deployed objects")
-	cmd.Flags().StringVar(&opts.Trigger, "trigger", "polling", "How are changes detected? (polling or manual)")
+	cmd.Flags().StringVar(&opts.Trigger, "trigger", "polling", "How are changes detected? (polling, manual or http)")
+	cmd.Flags().StringVar(&opts.HTTPTriggerAddr, "trigger-address", "tcp://0.0.0.0:45678", "Address used by the http trigger")
 	cmd.Flags().BoolVar(&opts.Cleanup, "cleanup", true, "Delete deployments after dev mode is interrupted")
 	cmd.Flags().StringArrayVarP(&opts.Watch, "watch-image", "w", nil, "Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts")
 	cmd.Flags().IntVarP(&opts.WatchPollInterval, "watch-poll-interval", "i", 1000, "Interval (in ms) between two checks for file changes")

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -213,7 +213,8 @@ Flags:
       --skip-tests                Whether to skip the tests after building
       --tail                      Stream logs from deployed objects (default true)
       --toot                      Emit a terminal beep after the deploy is complete
-      --trigger string            How are changes detected? (polling or manual) (default "polling")
+      --trigger string            How are changes detected? (polling, manual or http) (default "polling")
+      --trigger-address string    Address used by the http trigger (default "tcp://0.0.0.0:45678")
   -w, --watch-image stringArray   Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts
   -i, --watch-poll-interval int   Interval (in ms) between two checks for file changes (default 1000)
 
@@ -235,6 +236,7 @@ Env vars:
 * `SKAFFOLD_TAIL` (same as --tail)
 * `SKAFFOLD_TOOT` (same as --toot)
 * `SKAFFOLD_TRIGGER` (same as --trigger)
+* `SKAFFOLD_TRIGGER_ADDRESS` (same as --trigger-address)
 * `SKAFFOLD_WATCH_IMAGE` (same as --watch-image)
 * `SKAFFOLD_WATCH_POLL_INTERVAL` (same as --watch-poll-interval)
 

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -35,6 +35,7 @@ type SkaffoldOptions struct {
 	Namespace         string
 	Watch             []string
 	Trigger           string
+	HTTPTriggerAddr   string
 	CustomLabels      []string
 	WatchPollInterval int
 	DefaultRepo       string

--- a/pkg/skaffold/watch/triggers.go
+++ b/pkg/skaffold/watch/triggers.go
@@ -18,10 +18,12 @@ package watch
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
@@ -31,7 +33,7 @@ import (
 
 // Trigger describes a mechanism that triggers the watch.
 type Trigger interface {
-	Start() (<-chan bool, func())
+	Start(context.Context) (<-chan bool, error)
 	WatchForChanges(io.Writer)
 	Debounce() bool
 }
@@ -65,23 +67,26 @@ func (t *pollTrigger) WatchForChanges(out io.Writer) {
 }
 
 // Start starts a timer.
-func (t *pollTrigger) Start() (<-chan bool, func()) {
+func (t *pollTrigger) Start(ctx context.Context) (<-chan bool, error) {
 	trigger := make(chan bool)
 
 	ticker := time.NewTicker(t.interval)
 	go func() {
 		for {
-			<-ticker.C
-			trigger <- true
+			select {
+			case <-ticker.C:
+				trigger <- true
+			case <-ctx.Done():
+				ticker.Stop()
+			}
 		}
 	}()
 
-	return trigger, ticker.Stop
+	return trigger, nil
 }
 
 // manualTrigger watches for changes when the user presses a key.
-type manualTrigger struct {
-}
+type manualTrigger struct{}
 
 // Debounce tells the watcher to not debounce rapid sequence of changes.
 func (t *manualTrigger) Debounce() bool {
@@ -93,8 +98,14 @@ func (t *manualTrigger) WatchForChanges(out io.Writer) {
 }
 
 // Start starts listening to pressed keys.
-func (t *manualTrigger) Start() (<-chan bool, func()) {
+func (t *manualTrigger) Start(ctx context.Context) (<-chan bool, error) {
 	trigger := make(chan bool)
+
+	var stopped int32
+	go func() {
+		<-ctx.Done()
+		atomic.StoreInt32(&stopped, 1)
+	}()
 
 	reader := bufio.NewReader(os.Stdin)
 	go func() {
@@ -103,9 +114,14 @@ func (t *manualTrigger) Start() (<-chan bool, func()) {
 			if err != nil {
 				logrus.Debugf("manual trigger error: %s", err)
 			}
+
+			// Wait until the context is cancelled.
+			if atomic.LoadInt32(&stopped) == 1 {
+				return
+			}
 			trigger <- true
 		}
 	}()
 
-	return trigger, func() {}
+	return trigger, nil
 }

--- a/pkg/skaffold/watch/triggers.go
+++ b/pkg/skaffold/watch/triggers.go
@@ -41,7 +41,7 @@ func NewTrigger(opts *config.SkaffoldOptions) (Trigger, error) {
 	switch strings.ToLower(opts.Trigger) {
 	case "polling":
 		return &pollTrigger{
-			Interval: time.Duration(opts.WatchPollInterval) * time.Millisecond,
+			interval: time.Duration(opts.WatchPollInterval) * time.Millisecond,
 		}, nil
 	case "manual":
 		return &manualTrigger{}, nil
@@ -52,7 +52,7 @@ func NewTrigger(opts *config.SkaffoldOptions) (Trigger, error) {
 
 // pollTrigger watches for changes on a given interval of time.
 type pollTrigger struct {
-	Interval time.Duration
+	interval time.Duration
 }
 
 // Debounce tells the watcher to debounce rapid sequence of changes.
@@ -61,14 +61,14 @@ func (t *pollTrigger) Debounce() bool {
 }
 
 func (t *pollTrigger) WatchForChanges(out io.Writer) {
-	color.Yellow.Fprintf(out, "Watching for changes every %v...\n", t.Interval)
+	color.Yellow.Fprintf(out, "Watching for changes every %v...\n", t.interval)
 }
 
 // Start starts a timer.
 func (t *pollTrigger) Start() (<-chan bool, func()) {
 	trigger := make(chan bool)
 
-	ticker := time.NewTicker(t.Interval)
+	ticker := time.NewTicker(t.interval)
 	go func() {
 		for {
 			<-ticker.C

--- a/pkg/skaffold/watch/watch.go
+++ b/pkg/skaffold/watch/watch.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/pkg/errors"
 )
 
@@ -98,6 +99,10 @@ func (w *watchList) Run(ctx context.Context, out io.Writer, onChange func() erro
 					component.events = e
 					changed++
 				}
+			}
+
+			if changed == 0 {
+				color.Yellow.Fprintln(out, "No actual change was detected")
 			}
 
 			// Rapid file changes that are more frequent than the poll interval would trigger

--- a/pkg/skaffold/watch/watch.go
+++ b/pkg/skaffold/watch/watch.go
@@ -68,8 +68,13 @@ func (w *watchList) Register(deps func() ([]string, error), onChange func(Events
 
 // Run watches files until the context is cancelled or an error occurs.
 func (w *watchList) Run(ctx context.Context, out io.Writer, onChange func() error) error {
-	t, cleanup := w.trigger.Start()
-	defer cleanup()
+	ctxTrigger, cancelTrigger := context.WithCancel(ctx)
+	defer cancelTrigger()
+
+	t, err := w.trigger.Start(ctxTrigger)
+	if err != nil {
+		return errors.Wrap(err, "unable to start trigger")
+	}
 
 	changedComponents := map[int]bool{}
 

--- a/pkg/skaffold/watch/watch_test.go
+++ b/pkg/skaffold/watch/watch_test.go
@@ -72,7 +72,7 @@ func TestWatch(t *testing.T) {
 
 			// Watch folder
 			watcher := NewWatcher(&pollTrigger{
-				Interval: 10 * time.Millisecond,
+				interval: 10 * time.Millisecond,
 			})
 			err := watcher.Register(folder.List, folderChanged.call)
 			testutil.CheckError(t, false, err)


### PR DESCRIPTION
This is an additional trigger that makes it possible to drive `skaffold dev` from an outside such as a file watcher or an IDE.

**How-to**:

 + Run `skaffold dev --trigger=http`
 + Send a POST query to `http://localhost:45678/skaffold/v1/build`, for eg with: `curl -X POST http://localhost:45678/skaffold/v1/build`
 + If any file was actually changed, then Skaffold will rebuild what's necessary.
 + Skaffold stops watching for file changes but maintains a snapshot of file change dates, at startup and each time the trigger is called.
 + When the trigger is called rapidly, then Skaffold debounces events to not be flooded.

The address on which Skaffold listens can be changed with `--trigger-address tcp://0.0.0.0:45678` command line arg. It can also listen to a unix socket with `--trigger-address unix:///tmp/skaffold`.Named pipes are not yet implemented.

ping @briandealwis 
