### PR TITLE
Note JVM flags specific to Java 8 in examples/jib

### DIFF
--- a/examples/jib/pom.xml
+++ b/examples/jib/pom.xml
@@ -39,6 +39,7 @@
                     <container>
                         <jvmFlags>
                             <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
+                            <!-- specific to Java 8 containers -->
                             <jvmFlag>-XX:+UnlockExperimentalVMOptions</jvmFlag>
                             <jvmFlag>-XX:+UseCGroupMemoryLimitForHeap</jvmFlag>
                         </jvmFlags>

--- a/integration/examples/jib/pom.xml
+++ b/integration/examples/jib/pom.xml
@@ -39,6 +39,7 @@
                     <container>
                         <jvmFlags>
                             <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
+                            <!-- specific to Java 8 containers -->
                             <jvmFlag>-XX:+UnlockExperimentalVMOptions</jvmFlag>
                             <jvmFlag>-XX:+UseCGroupMemoryLimitForHeap</jvmFlag>
                         </jvmFlags>


### PR DESCRIPTION
The JVM flags used in `examples/jib/pom.xml` are unsupported in OpenJDK 11.