### PR TITLE
Check for new skaffold version when skaffold.yaml parsing fails

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -97,11 +97,11 @@ func updateCheck(ch chan string) error {
 		logrus.Debugf("Update check not enabled, skipping.")
 		return nil
 	}
-	latest, isAhead, err := update.VersionCheck()
+	latest, current, err := update.GetLatestAndCurrentVersion()
 	if err != nil {
-		return errors.Wrap(err, "version check")
+		return errors.Wrap(err, "get latest and current Skaffold version")
 	}
-	if isAhead {
+	if latest.GT(current) {
 		ch <- fmt.Sprintf("There is a new version (%s) of Skaffold available. Download it at %s\n", latest, constants.LatestDownloadURL)
 	}
 	return nil

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -98,15 +97,11 @@ func updateCheck(ch chan string) error {
 		logrus.Debugf("Update check not enabled, skipping.")
 		return nil
 	}
-	current, err := version.ParseVersion(version.Get().Version)
+	latest, isAhead, err := update.VersionCheck()
 	if err != nil {
-		return errors.Wrap(err, "parsing current semver, skipping update check")
+		return errors.Wrap(err, "version check")
 	}
-	latest, err := update.GetLatestVersion(context.Background())
-	if err != nil {
-		return errors.Wrap(err, "getting latest version")
-	}
-	if latest.GT(current) {
+	if isAhead {
 		ch <- fmt.Sprintf("There is a new version (%s) of Skaffold available. Download it at %s\n", latest, constants.LatestDownloadURL)
 	}
 	return nil

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -19,18 +19,25 @@ package cmd
 import (
 	configutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // newRunner creates a SkaffoldRunner and returns the SkaffoldPipeline associated with it.
 func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.SkaffoldPipeline, error) {
 	parsed, err := schema.ParseConfig(opts.ConfigurationFile, true)
 	if err != nil {
+		version, isAhead, versionErr := update.VersionCheck()
+		if versionErr == nil && isAhead {
+			logrus.Warnf("Your Skaffold version might be too old. Download the latest version (%s) at %s\n", version, constants.LatestDownloadURL)
+		}
 		return nil, nil, errors.Wrap(err, "parsing skaffold config")
 	}
 

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -34,9 +34,9 @@ import (
 func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.SkaffoldPipeline, error) {
 	parsed, err := schema.ParseConfig(opts.ConfigurationFile, true)
 	if err != nil {
-		version, isAhead, versionErr := update.VersionCheck()
-		if versionErr == nil && isAhead {
-			logrus.Warnf("Your Skaffold version might be too old. Download the latest version (%s) at %s\n", version, constants.LatestDownloadURL)
+		latest, current, versionErr := update.GetLatestAndCurrentVersion()
+		if versionErr == nil && latest.GT(current) {
+			logrus.Warnf("Your Skaffold version might be too old. Download the latest version (%s) at %s\n", latest, constants.LatestDownloadURL)
 		}
 		return nil, nil, errors.Wrap(err, "parsing skaffold config")
 	}

--- a/pkg/skaffold/update/update.go
+++ b/pkg/skaffold/update/update.go
@@ -17,7 +17,6 @@ limitations under the License.
 package update
 
 import (
-	"context"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -43,23 +42,27 @@ func IsUpdateCheckEnabled() bool {
 	return v == "" || strings.ToLower(v) == "true"
 }
 
-// GetLatestVersion uses a VERSION file stored on GCS to determine the latest released version of skaffold
-func GetLatestVersion(ctx context.Context) (semver.Version, error) {
+// VersionCheck uses a VERSION file stored on GCS to determine the latest released version of skaffold
+func VersionCheck() (semver.Version, bool, error) {
 	resp, err := http.Get(latestVersionURL)
 	if err != nil {
-		return semver.Version{}, errors.Wrap(err, "getting latest version info from GCS")
+		return semver.Version{}, false, errors.Wrap(err, "getting latest version info from GCS")
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return semver.Version{}, errors.Wrapf(err, "http %d, error: %s", resp.StatusCode, resp.Status)
+		return semver.Version{}, false, errors.Wrapf(err, "http %d, error: %s", resp.StatusCode, resp.Status)
 	}
 	versionBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return semver.Version{}, errors.Wrap(err, "reading version file from GCS")
+		return semver.Version{}, false, errors.Wrap(err, "reading version file from GCS")
 	}
-	v, err := version.ParseVersion(string(versionBytes))
+	latest, err := version.ParseVersion(string(versionBytes))
 	if err != nil {
-		return semver.Version{}, errors.Wrap(err, "parsing latest version from GCS")
+		return semver.Version{}, false, errors.Wrap(err, "parsing latest version from GCS")
 	}
-	return v, nil
+	current, err := version.ParseVersion(version.Get().Version)
+	if err != nil {
+		return semver.Version{}, false, errors.Wrap(err, "parsing current semver, skipping update check")
+	}
+	return latest, latest.GT(current), nil
 }

--- a/pkg/webhook/kubernetes/deployment.go
+++ b/pkg/webhook/kubernetes/deployment.go
@@ -139,6 +139,7 @@ func WaitForDeploymentToStabilize(d *appsv1.Deployment, ip string) error {
 		if err != nil {
 			return false, nil
 		}
+		defer resp.Body.Close()
 		return resp.StatusCode == http.StatusOK, nil
 	})
 }


### PR DESCRIPTION
Re-uses the already existing asynchronous version check. Now, if parsing fails, the check is repeated synchronously and an appropriate warning is shown.

Fixes #1570