### PR TITLE
Allow user to specify custom kaniko image

### DIFF
--- a/pkg/skaffold/build/kaniko/sources/sources.go
+++ b/pkg/skaffold/build/kaniko/sources/sources.go
@@ -58,7 +58,7 @@ func podTemplate(cfg *latest.KanikoBuild, args []string) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:            constants.DefaultKanikoContainerName,
-					Image:           constants.DefaultKanikoImage,
+					Image:           cfg.Image,
 					Args:            args,
 					ImagePullPolicy: v1.PullIfNotPresent,
 					Env: []v1.EnvVar{{


### PR DESCRIPTION
fixes #1586, previously we were using the default image instead of the image passed in through the config.