### PR TITLE
Extract yaml used in documentation into files

### DIFF
--- a/docs/content/en/docs/how-tos/builders/_index.md
+++ b/docs/content/en/docs/how-tos/builders/_index.md
@@ -50,21 +50,7 @@ of `skaffold.yaml`. The `local` type offers the following options:
 The following `build` section, for example, instructs Skaffold to build a
 Docker image `gcr.io/k8s-skaffold/example` with the local Docker daemon: 
 
-```yaml
-build:
-    artifacts:
-    - image: gcr.io/k8s-skaffold/example
-    # Use local Docker daemon to build artifacts
-    local:
-        push: true
-        useDockerCLI: false
-        useBuildkit: false
-# The build section above is equal to
-# build:
-#   artifacts:
-#   - image: gcr.io/k8s-skaffold/example
-#   local: {}
-```
+{{% readfile file="samples/builders/local.yaml" %}}
 
 ## Dockerfile remotely with Google Cloud Build
 
@@ -95,14 +81,7 @@ options:
 The following `build` section, for example, instructs Skaffold to build a
 Docker image `gcr.io/k8s-skaffold/example` with Google Cloud Build: 
 
-```yaml
-build:
-    artifacts:
-    - image: gcr.io/k8s-skaffold/example
-    # Use Google Cloud Build to build artifacts
-    googleCloudBuild:
-        projectId: YOUR-GCP-PROJECT
-```
+{{% readfile file="samples/builders/gcb.yaml" %}}
 
 ## Dockerfile in-cluster with Kaniko  
 
@@ -127,15 +106,7 @@ To use Kaniko, add build type `kaniko` to the `build` section of
 The following `build` section, for example, instructs Skaffold to build a
 Docker image `gcr.io/k8s-skaffold/example` with Kaniko: 
 
-```yaml
-build:
-    artifacts:
-    - image: gcr.io/k8s-skaffold/example
-    # Use Kaniko to build artifacts
-    kaniko:
-        buildContext:
-          gcsBucket: YOUR-BUCKET
-```
+{{% readfile file="samples/builders/kaniko.yaml" %}}
 
 ## Jib Maven and Gradle locally 
 
@@ -161,11 +132,4 @@ specification, which Skaffold will use to load the image to the Docker daemon.
 The following `build` section, for example, instructs Skaffold to build a
 Docker image `gcr.io/k8s-skaffold/example` with Bazel:
 
-```yaml
-build:
-    artifacts:
-    - image: gcr.io/k8s-skaffold/example
-      bazel:
-        target: //:example.tar
-```
-
+{{% readfile file="samples/builders/bazel.yaml" %}}

--- a/docs/content/en/docs/how-tos/deployers/_index.md
+++ b/docs/content/en/docs/how-tos/deployers/_index.md
@@ -48,22 +48,7 @@ To use `kubectl`, add deploy type `kubectl` to the `deploy` section of
 The following `deploy` section, for example, instructs Skaffold to deploy
 artifacts using `kubectl`:
 
-```yaml
-deploy:
-    kubectl:
-      manifests:
-        - k8s-*
-    # Uncomment the following lines to add remote manifests and flags
-    # remoteManifests:
-    #    - YOUR-REMOTE-MANIFESTS
-    # flags:
-    #    global:
-    #    - YOUR-GLOBAL-FLAGS
-    #    apply:
-    #    - YOUR-APPLY-FLAGS
-    #    delete:
-    #    - YOUR-DELETE-FLAGS
-```
+{{% readfile file="samples/deployers/kubectl.yaml" %}}
 
 ## Deploying with Helm
 
@@ -98,38 +83,7 @@ Each release includes the following fields:
 The following `deploy` section, for example, instructs Skaffold to deploy
 artifacts using `helm`:
 
-```yaml
-deploy:
-  helm:
-    releases:
-    - name: skaffold-helm
-      chartPath: skaffold-helm
-      values:
-        image: gcr.io/k8s-skaffold/skaffold-helm
-      # Uncomment the following lines to specify more parameters
-      # valuesFilePath: YOUR-VALUES-FILE-PATH
-      # namespace: YOUR-NAMESPACE
-      # version: YOUR-VERSION
-      # setValues:
-      #     SOME-KEY: SOME-VALUE
-      # setValues:
-      #     SOME-KEY: SOME-VALUE-TEMPLATE
-      # setValueTemplates:
-      #     SOME-KEY: "{{.SOME-ENV-VARIABLE}}"
-      # wait: true
-      # recreatePods: true
-      # overrides:
-      #     SOME-KEY: SOME-VALUE
-      #     SOME-MORE-KEY:
-      #         SOME-KEY: SOME-VALUE
-      # packaged:
-      #     version: YOUR-VERSION
-      #     appVersion: YOUR-APP-VERSION
-      # imageStrategy:
-      #     helm: {}
-      # OR
-      #     fqn: {}
-```
+{{% readfile file="samples/deployers/helm.yaml" %}}
 
 ## Deploying with kustomize
 
@@ -148,11 +102,4 @@ section of `skaffold.yaml`. The `kustomize` type offers the following options:
 The following `deploy` section, for example, instructs Skaffold to deploy
 artifacts using kustomize:
 
-```yaml
-deploy:
-  kustomize:
-    path: "."
-# The deploy section above is equal to
-# deploy:
-#   kustomize: {}
-```
+{{% readfile file="samples/deployers/kustomize.yaml" %}}

--- a/docs/content/en/docs/how-tos/profiles/_index.md
+++ b/docs/content/en/docs/how-tos/profiles/_index.md
@@ -38,22 +38,7 @@ You can activate a profile with the `-p` (`--profile`) parameter in the
 The following example, showcases a `skaffold.yaml` with one profile, `gcb`,
 for building with Google Cloud Build:
 
-```yaml
-apiVersion: skaffold/v1beta2
-kind: Config
-build:
-  artifacts:
-  - image: gcr.io/k8s-skaffold/skaffold-example
-deploy:
-  kubectl:
-    manifests:
-    - k8s-pod
-profiles:
-- name: gcb
-  build:
-  googleCloudBuild:
-    projectId: k8s-skaffold
-```
+{{% readfile file="samples/profiles/profiles.yaml" %}}
 
 With no profile activated, Skaffold will build the artifact
 `gcr.io/k8s-skaffold/skaffold-example` using local Docker daemon and deploy it

--- a/docs/content/en/docs/how-tos/taggers/_index.md
+++ b/docs/content/en/docs/how-tos/taggers/_index.md
@@ -30,13 +30,7 @@ The following `build` section, for example, instructs Skaffold to build a
 Docker image `gcr.io/k8s-skaffold/example` with the `gitCommit` tag policy
 specified explicitly:
 
-```yaml
-build:
-    artifacts:
-    - image: gcr.io/k8s-skaffold/example
-    tagPolicy:
-        gitCommit: {}
-```
+{{% readfile file="samples/taggers/git.yaml" %}}
 
 `gitCommit` tag policy features no options.
 
@@ -54,13 +48,7 @@ it allows Kubernetes to re-deploy images every time your source code changes.
 The following `build` section, for example, instructs Skaffold to build a
 Docker image `gcr.io/k8s-skaffold/example` with the `sha256` tag policy:
 
-```yaml
-build:
-    artifacts:
-    - image: gcr.io/k8s-skaffold/example
-    tagPolicy:
-        sha256: {}
-```
+{{% readfile file="samples/taggers/sha256.yaml" %}}
 
 `sha256` tag policy features no options.
 
@@ -85,14 +73,7 @@ image.
 the <code>artifacts</code> part of the <code>build</code> section.
 {{< /alert >}}
 
-```yaml
-build:
-    artifacts:
-    - image: gcr.io/k8s-skaffold/example
-    tagPolicy:
-        envTemplate:
-            template: "{{.IMAGE_NAME}}:{{.FOO}}"
-```
+{{% readfile file="samples/taggers/envTemplate.yaml" %}}
 
 Suppose the value of the `FOO` environment variable is `v1`, the image built
 will be `gcr.io/k8s-skaffold/example:v1`.
@@ -112,22 +93,7 @@ The following `build` section, for example, instructs Skaffold to build a Docker
 image `gcr.io/k8s-skaffold/example` with the `dateTime`
 tag policy:
 
-```yaml
-build:
-    artifacts:
-    - image: gcr.io/k8s-skaffold/example
-    tagPolicy:
-        dateTime:
-            format: "2006-01-02_15-04-05.999_MST"
-            timezone: "Local"
-# The build section above is equal to
-# build:
-#   artifacts:
-#   - image: gcr.io/k8s-skaffold/example
-#   tagPolicy:
-#       dateTime: {}
-#   local: {}
-```
+{{% readfile file="samples/taggers/datetime.yaml" %}}
 
 Suppose current time is `15:04:09.999 January 2nd, 2006` and current time zone
 is `MST` (`US Mountain Standard Time`), the image built will

--- a/docs/content/en/docs/how-tos/templating/_index.md
+++ b/docs/content/en/docs/how-tos/templating/_index.md
@@ -8,15 +8,7 @@ weight: 90
 Skaffold config allows for certain fields to have values injected that are either environment variables or calculated by Skaffold.
 For example: 
 
-```yaml
-build:
-    artifacts:
-    - image: gcr.io/k8s-skaffold/example
-    tagPolicy:
-        envTemplate:
-            template: "{{.IMAGE_NAME}}:{{.FOO}}"
-    local: {}
-```
+{{% readfile file="samples/templating/env.yaml" %}}
 
 Suppose the value of the `FOO` environment variable is `v1`, the image built
 will be `gcr.io/k8s-skaffold/example:v1`.

--- a/docs/content/en/samples/builders/bazel.yaml
+++ b/docs/content/en/samples/builders/bazel.yaml
@@ -1,0 +1,5 @@
+build:
+  artifacts:
+  - image: gcr.io/k8s-skaffold/example
+    bazel:
+      target: //:example.tar

--- a/docs/content/en/samples/builders/gcb.yaml
+++ b/docs/content/en/samples/builders/gcb.yaml
@@ -1,0 +1,5 @@
+build:
+  artifacts:
+  - image: gcr.io/k8s-skaffold/example
+  googleCloudBuild:
+    projectId: YOUR-GCP-PROJECT

--- a/docs/content/en/samples/builders/kaniko.yaml
+++ b/docs/content/en/samples/builders/kaniko.yaml
@@ -1,0 +1,6 @@
+build:
+  artifacts:
+  - image: gcr.io/k8s-skaffold/example
+  kaniko:
+    buildContext:
+      gcsBucket: YOUR-BUCKET

--- a/docs/content/en/samples/builders/local.yaml
+++ b/docs/content/en/samples/builders/local.yaml
@@ -1,0 +1,13 @@
+build:
+  artifacts:
+  - image: gcr.io/k8s-skaffold/example
+  local: {}
+
+# The build section above is equal to
+# build:
+#   artifacts:
+#   - image: gcr.io/k8s-skaffold/example
+#   local:
+#     push: true
+#     useDockerCLI: false
+#     useBuildkit: false

--- a/docs/content/en/samples/deployers/helm.yaml
+++ b/docs/content/en/samples/deployers/helm.yaml
@@ -1,0 +1,30 @@
+deploy:
+  helm:
+    releases:
+    - name: skaffold-helm
+      chartPath: skaffold-helm
+      values:
+        image: gcr.io/k8s-skaffold/skaffold-helm
+      # Uncomment the following lines to specify more parameters
+      # valuesFilePath: YOUR-VALUES-FILE-PATH
+      # namespace: YOUR-NAMESPACE
+      # version: YOUR-VERSION
+      # setValues:
+      #     SOME-KEY: SOME-VALUE
+      # setValues:
+      #     SOME-KEY: SOME-VALUE-TEMPLATE
+      # setValueTemplates:
+      #     SOME-KEY: "{{.SOME-ENV-VARIABLE}}"
+      # wait: true
+      # recreatePods: true
+      # overrides:
+      #     SOME-KEY: SOME-VALUE
+      #     SOME-MORE-KEY:
+      #         SOME-KEY: SOME-VALUE
+      # packaged:
+      #     version: YOUR-VERSION
+      #     appVersion: YOUR-APP-VERSION
+      # imageStrategy:
+      #     helm: {}
+      # OR
+      #     fqn: {}

--- a/docs/content/en/samples/deployers/kubectl.yaml
+++ b/docs/content/en/samples/deployers/kubectl.yaml
@@ -1,0 +1,15 @@
+deploy:
+  kubectl:
+    manifests:
+    - k8s-*
+    # Uncomment the following lines to add remote manifests
+    # remoteManifests:
+    # - YOUR-REMOTE-MANIFESTS
+    # Uncomment the following lines to add flags
+    # flags:
+    # global:
+    # - YOUR-GLOBAL-FLAGS
+    # apply:
+    # - YOUR-APPLY-FLAGS
+    # delete:
+    # - YOUR-DELETE-FLAGS

--- a/docs/content/en/samples/deployers/kustomize.yaml
+++ b/docs/content/en/samples/deployers/kustomize.yaml
@@ -1,0 +1,6 @@
+deploy:
+  kustomize: {}
+# The deploy section above is equal to
+# deploy:
+#   kustomize: {}
+#     path: "."

--- a/docs/content/en/samples/profiles/profiles.yaml
+++ b/docs/content/en/samples/profiles/profiles.yaml
@@ -1,0 +1,14 @@
+apiVersion: skaffold/v1beta2
+kind: Config
+build:
+  artifacts:
+  - image: gcr.io/k8s-skaffold/skaffold-example
+deploy:
+  kubectl:
+    manifests:
+    - k8s-pod
+profiles:
+- name: gcb
+  build:
+    googleCloudBuild:
+      projectId: k8s-skaffold

--- a/docs/content/en/samples/taggers/dateTime.yaml
+++ b/docs/content/en/samples/taggers/dateTime.yaml
@@ -1,0 +1,10 @@
+build:
+  tagPolicy:
+    dateTime:
+      format: "2006-01-02_15-04-05.999_MST"
+      timezone: "Local"
+  artifacts:
+  - image: gcr.io/k8s-skaffold/example
+# The tagPolicy section above is equal to
+# tagPolicy:
+#   dateTime: {}

--- a/docs/content/en/samples/taggers/envTemplate.yaml
+++ b/docs/content/en/samples/taggers/envTemplate.yaml
@@ -1,0 +1,6 @@
+build:
+  tagPolicy:
+    envTemplate:
+      template: "{{.IMAGE_NAME}}:{{.FOO}}"
+  artifacts:
+  - image: gcr.io/k8s-skaffold/example

--- a/docs/content/en/samples/taggers/git.yaml
+++ b/docs/content/en/samples/taggers/git.yaml
@@ -1,0 +1,5 @@
+build:
+  tagPolicy:
+    gitCommit: {}
+  artifacts:
+  - image: gcr.io/k8s-skaffold/example

--- a/docs/content/en/samples/taggers/sha256.yaml
+++ b/docs/content/en/samples/taggers/sha256.yaml
@@ -1,0 +1,5 @@
+build:
+  tagPolicy:
+    sha256: {}
+  artifacts:
+  - image: gcr.io/k8s-skaffold/example

--- a/docs/content/en/samples/templating/env.yaml
+++ b/docs/content/en/samples/templating/env.yaml
@@ -1,0 +1,6 @@
+build:
+  tagPolicy:
+    envTemplate:
+      template: "{{.IMAGE_NAME}}:{{.FOO}}"
+  artifacts:
+  - image: gcr.io/k8s-skaffold/example

--- a/docs/layouts/shortcodes/readfile.html
+++ b/docs/layouts/shortcodes/readfile.html
@@ -1,0 +1,1 @@
+{{ (printf "```yaml\n%s\n```" ((.Get "file") | readFile)) | markdownify }}

--- a/pkg/skaffold/schema/samples_test.go
+++ b/pkg/skaffold/schema/samples_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2018 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schema
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+const samplesRoot = "../../../docs/content/en/samples"
+
+func TestParseSamples(t *testing.T) {
+	paths, err := findSamples(samplesRoot)
+	if err != nil {
+		t.Fatalf("unable to read sample files in %q", samplesRoot)
+	}
+
+	if len(paths) == 0 {
+		t.Fatalf("did not find sample files in %q", samplesRoot)
+	}
+
+	tmpDir, teardown := testutil.NewTempDir(t)
+	defer teardown()
+
+	for _, path := range paths {
+		name := filepath.Base(path)
+
+		t.Run(name, func(t *testing.T) {
+			buf, err := ioutil.ReadFile(path)
+			testutil.CheckError(t, false, err)
+
+			tmpDir.Write(name, addHeader(buf))
+
+			_, err = ParseConfig(tmpDir.Path(name), true)
+			testutil.CheckError(t, false, err)
+		})
+	}
+}
+
+func findSamples(root string) ([]string, error) {
+	var files []string
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			files = append(files, path)
+		}
+		return err
+	})
+
+	return files, err
+}
+
+func addHeader(buf []byte) string {
+	if bytes.HasPrefix(buf, []byte("apiVersion:")) {
+		return string(buf)
+	}
+	return fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latest.Version, buf)
+}


### PR DESCRIPTION
This creates a shortcode to embed yaml configuration fragments into the documentation.
The fragments are parsed by a unit test to ensure that each of them is a valid configuration.

This helped fix a bug in on of the yaml files.

Signed-off-by: David Gageot <david@gageot.net>