### PR TITLE
Propagate --skip-tests to builders

### DIFF
--- a/pkg/skaffold/build/gcb/jib.go
+++ b/pkg/skaffold/build/gcb/jib.go
@@ -26,13 +26,13 @@ import (
 func (b *Builder) jibMavenBuildSteps(imageName string, artifact *latest.JibMavenArtifact) []*cloudbuild.BuildStep {
 	return []*cloudbuild.BuildStep{{
 		Name: b.MavenImage,
-		Args: jib.GenerateMavenArgs("dockerBuild", imageName, artifact),
+		Args: jib.GenerateMavenArgs("dockerBuild", imageName, artifact, b.skipTests),
 	}}
 }
 
 func (b *Builder) jibGradleBuildSteps(imageName string, artifact *latest.JibGradleArtifact) []*cloudbuild.BuildStep {
 	return []*cloudbuild.BuildStep{{
 		Name: b.GradleImage,
-		Args: jib.GenerateGradleArgs("jibDockerBuild", imageName, artifact),
+		Args: jib.GenerateGradleArgs("jibDockerBuild", imageName, artifact, b.skipTests),
 	}}
 }

--- a/pkg/skaffold/build/gcb/jib_test.go
+++ b/pkg/skaffold/build/gcb/jib_test.go
@@ -25,37 +25,57 @@ import (
 )
 
 func TestJibMavenBuildSteps(t *testing.T) {
-	artifact := &latest.JibMavenArtifact{}
-
-	builder := Builder{
-		GoogleCloudBuild: &latest.GoogleCloudBuild{
-			MavenImage: "maven:3.6.0",
-		},
+	var testCases = []struct {
+		skipTests bool
+		args      []string
+	}{
+		{false, []string{"--non-recursive", "prepare-package", "jib:dockerBuild", "-Dimage=img"}},
+		{true, []string{"--non-recursive", "-DskipTests=true", "prepare-package", "jib:dockerBuild", "-Dimage=img"}},
 	}
-	steps := builder.jibMavenBuildSteps("img", artifact)
+	for _, tt := range testCases {
+		artifact := &latest.JibMavenArtifact{}
 
-	expected := []*cloudbuild.BuildStep{{
-		Name: "maven:3.6.0",
-		Args: []string{"--non-recursive", "prepare-package", "jib:dockerBuild", "-Dimage=img"},
-	}}
+		builder := Builder{
+			GoogleCloudBuild: &latest.GoogleCloudBuild{
+				MavenImage: "maven:3.6.0",
+			},
+			skipTests: tt.skipTests,
+		}
+		steps := builder.jibMavenBuildSteps("img", artifact)
 
-	testutil.CheckDeepEqual(t, expected, steps)
+		expected := []*cloudbuild.BuildStep{{
+			Name: "maven:3.6.0",
+			Args: tt.args,
+		}}
+
+		testutil.CheckDeepEqual(t, expected, steps)
+	}
 }
 
 func TestJibGradleBuildSteps(t *testing.T) {
-	artifact := &latest.JibGradleArtifact{}
-
-	builder := Builder{
-		GoogleCloudBuild: &latest.GoogleCloudBuild{
-			GradleImage: "gradle:5.1.1",
-		},
+	var testCases = []struct {
+		skipTests bool
+		args      []string
+	}{
+		{false, []string{":jibDockerBuild", "--image=img"}},
+		{true, []string{":jibDockerBuild", "--image=img", "-x", "test"}},
 	}
-	steps := builder.jibGradleBuildSteps("img", artifact)
+	for _, tt := range testCases {
+		artifact := &latest.JibGradleArtifact{}
 
-	expected := []*cloudbuild.BuildStep{{
-		Name: "gradle:5.1.1",
-		Args: []string{":jibDockerBuild", "--image=img"},
-	}}
+		builder := Builder{
+			GoogleCloudBuild: &latest.GoogleCloudBuild{
+				GradleImage: "gradle:5.1.1",
+			},
+			skipTests: tt.skipTests,
+		}
+		steps := builder.jibGradleBuildSteps("img", artifact)
 
-	testutil.CheckDeepEqual(t, expected, steps)
+		expected := []*cloudbuild.BuildStep{{
+			Name: "gradle:5.1.1",
+			Args: tt.args,
+		}}
+
+		testutil.CheckDeepEqual(t, expected, steps)
+	}
 }

--- a/pkg/skaffold/build/gcb/types.go
+++ b/pkg/skaffold/build/gcb/types.go
@@ -55,12 +55,14 @@ const (
 // Builder builds artifacts with Google Cloud Build.
 type Builder struct {
 	*latest.GoogleCloudBuild
+	skipTests bool
 }
 
 // NewBuilder creates a new Builder that builds artifacts with Google Cloud Build.
-func NewBuilder(cfg *latest.GoogleCloudBuild) *Builder {
+func NewBuilder(cfg *latest.GoogleCloudBuild, skipTests bool) *Builder {
 	return &Builder{
 		GoogleCloudBuild: cfg,
+		skipTests:        skipTests,
 	}
 }
 

--- a/pkg/skaffold/build/local/bazel.go
+++ b/pkg/skaffold/build/local/bazel.go
@@ -41,6 +41,7 @@ func (b *Builder) buildBazel(ctx context.Context, out io.Writer, workspace strin
 	args = append(args, a.BazelArtifact.BuildArgs...)
 	args = append(args, a.BazelArtifact.BuildTarget)
 
+	// FIXME: is it possible to apply b.skipTests?
 	cmd := exec.CommandContext(ctx, "bazel", args...)
 	cmd.Dir = workspace
 	cmd.Stdout = out

--- a/pkg/skaffold/build/local/jib_gradle.go
+++ b/pkg/skaffold/build/local/jib_gradle.go
@@ -39,7 +39,7 @@ func (b *Builder) buildJibGradle(ctx context.Context, out io.Writer, workspace s
 
 func (b *Builder) buildJibGradleToDocker(ctx context.Context, out io.Writer, workspace string, artifact *latest.JibGradleArtifact) (string, error) {
 	skaffoldImage := generateJibImageRef(workspace, artifact.Project)
-	args := jib.GenerateGradleArgs("jibDockerBuild", skaffoldImage, artifact)
+	args := jib.GenerateGradleArgs("jibDockerBuild", skaffoldImage, artifact, b.skipTests)
 
 	if err := b.runGradleCommand(ctx, out, workspace, args); err != nil {
 		return "", err
@@ -51,7 +51,7 @@ func (b *Builder) buildJibGradleToDocker(ctx context.Context, out io.Writer, wor
 func (b *Builder) buildJibGradleToRegistry(ctx context.Context, out io.Writer, workspace string, artifact *latest.Artifact) (string, error) {
 	initialTag := util.RandomID()
 	skaffoldImage := fmt.Sprintf("%s:%s", artifact.ImageName, initialTag)
-	args := jib.GenerateGradleArgs("jib", skaffoldImage, artifact.JibGradleArtifact)
+	args := jib.GenerateGradleArgs("jib", skaffoldImage, artifact.JibGradleArtifact, b.skipTests)
 
 	if err := b.runGradleCommand(ctx, out, workspace, args); err != nil {
 		return "", err

--- a/pkg/skaffold/build/local/jib_maven.go
+++ b/pkg/skaffold/build/local/jib_maven.go
@@ -46,7 +46,7 @@ func (b *Builder) buildJibMavenToDocker(ctx context.Context, out io.Writer, work
 	}
 
 	skaffoldImage := generateJibImageRef(workspace, artifact.Module)
-	args := jib.GenerateMavenArgs("dockerBuild", skaffoldImage, artifact)
+	args := jib.GenerateMavenArgs("dockerBuild", skaffoldImage, artifact, b.skipTests)
 
 	if err := b.runMavenCommand(ctx, out, workspace, args); err != nil {
 		return "", err
@@ -65,7 +65,7 @@ func (b *Builder) buildJibMavenToRegistry(ctx context.Context, out io.Writer, wo
 
 	initialTag := util.RandomID()
 	skaffoldImage := fmt.Sprintf("%s:%s", artifact.ImageName, initialTag)
-	args := jib.GenerateMavenArgs("build", skaffoldImage, artifact.JibMavenArtifact)
+	args := jib.GenerateMavenArgs("build", skaffoldImage, artifact.JibMavenArtifact, b.skipTests)
 
 	if err := b.runMavenCommand(ctx, out, workspace, args); err != nil {
 		return "", err

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -35,13 +35,14 @@ type Builder struct {
 	localDocker  docker.LocalDaemon
 	localCluster bool
 	pushImages   bool
+	skipTests    bool
 	kubeContext  string
 
 	alreadyTagged map[string]string
 }
 
 // NewBuilder returns an new instance of a local Builder.
-func NewBuilder(cfg *latest.LocalBuild, kubeContext string) (*Builder, error) {
+func NewBuilder(cfg *latest.LocalBuild, kubeContext string, skipTests bool) (*Builder, error) {
 	localDocker, err := docker.NewAPIClient()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting docker client")
@@ -66,6 +67,7 @@ func NewBuilder(cfg *latest.LocalBuild, kubeContext string) (*Builder, error) {
 		localDocker:  localDocker,
 		localCluster: localCluster,
 		pushImages:   pushImages,
+		skipTests:    skipTests,
 	}, nil
 }
 

--- a/pkg/skaffold/jib/jib_gradle.go
+++ b/pkg/skaffold/jib/jib_gradle.go
@@ -47,8 +47,12 @@ func getCommandGradle(ctx context.Context, workspace string, a *latest.JibGradle
 }
 
 // GenerateGradleArgs generates the arguments to Gradle for building the project as an image.
-func GenerateGradleArgs(task string, imageName string, a *latest.JibGradleArtifact) []string {
-	return []string{gradleCommand(a, task), "--image=" + imageName}
+func GenerateGradleArgs(task string, imageName string, a *latest.JibGradleArtifact, skipTests bool) []string {
+	args := []string{gradleCommand(a, task), "--image=" + imageName}
+	if skipTests {
+		args = append(args, "-x", "test")
+	}
+	return args
 }
 
 func gradleCommand(a *latest.JibGradleArtifact, task string) string {

--- a/pkg/skaffold/jib/jib_gradle_test.go
+++ b/pkg/skaffold/jib/jib_gradle_test.go
@@ -146,15 +146,18 @@ func TestGetCommandGradle(t *testing.T) {
 
 func TestGenerateGradleArgs(t *testing.T) {
 	var testCases = []struct {
-		in  latest.JibGradleArtifact
-		out []string
+		in        latest.JibGradleArtifact
+		skipTests bool
+		out       []string
 	}{
-		{latest.JibGradleArtifact{}, []string{":task", "--image=image"}},
-		{latest.JibGradleArtifact{Project: "project"}, []string{":project:task", "--image=image"}},
+		{latest.JibGradleArtifact{}, false, []string{":task", "--image=image"}},
+		{latest.JibGradleArtifact{}, true, []string{":task", "--image=image", "-x", "test"}},
+		{latest.JibGradleArtifact{Project: "project"}, false, []string{":project:task", "--image=image"}},
+		{latest.JibGradleArtifact{Project: "project"}, true, []string{":project:task", "--image=image", "-x", "test"}},
 	}
 
 	for _, tt := range testCases {
-		command := GenerateGradleArgs("task", "image", &tt.in)
+		command := GenerateGradleArgs("task", "image", &tt.in, tt.skipTests)
 
 		testutil.CheckDeepEqual(t, tt.out, command)
 	}

--- a/pkg/skaffold/jib/jib_maven.go
+++ b/pkg/skaffold/jib/jib_maven.go
@@ -47,8 +47,12 @@ func getCommandMaven(ctx context.Context, workspace string, a *latest.JibMavenAr
 }
 
 // GenerateMavenArgs generates the arguments to Maven for building the project as an image.
-func GenerateMavenArgs(goal string, imageName string, a *latest.JibMavenArtifact) []string {
+func GenerateMavenArgs(goal string, imageName string, a *latest.JibMavenArtifact, skipTests bool) []string {
 	args := mavenArgs(a)
+
+	if skipTests {
+		args = append(args, "-DskipTests=true")
+	}
 
 	if a.Module == "" {
 		// single-module project

--- a/pkg/skaffold/jib/jib_maven_test.go
+++ b/pkg/skaffold/jib/jib_maven_test.go
@@ -161,17 +161,22 @@ func TestGetCommandMaven(t *testing.T) {
 
 func TestGenerateMavenArgs(t *testing.T) {
 	var testCases = []struct {
-		in  latest.JibMavenArtifact
-		out []string
+		in        latest.JibMavenArtifact
+		skipTests bool
+		out       []string
 	}{
-		{latest.JibMavenArtifact{}, []string{"--non-recursive", "prepare-package", "jib:goal", "-Dimage=image"}},
-		{latest.JibMavenArtifact{Profile: "profile"}, []string{"--activate-profiles", "profile", "--non-recursive", "prepare-package", "jib:goal", "-Dimage=image"}},
-		{latest.JibMavenArtifact{Module: "module"}, []string{"--projects", "module", "--also-make", "package", "-Dimage=image"}},
-		{latest.JibMavenArtifact{Module: "module", Profile: "profile"}, []string{"--activate-profiles", "profile", "--projects", "module", "--also-make", "package", "-Dimage=image"}},
+		{latest.JibMavenArtifact{}, false, []string{"--non-recursive", "prepare-package", "jib:goal", "-Dimage=image"}},
+		{latest.JibMavenArtifact{}, true, []string{"--non-recursive", "-DskipTests=true", "prepare-package", "jib:goal", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Profile: "profile"}, false, []string{"--activate-profiles", "profile", "--non-recursive", "prepare-package", "jib:goal", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Profile: "profile"}, true, []string{"--activate-profiles", "profile", "--non-recursive", "-DskipTests=true", "prepare-package", "jib:goal", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Module: "module"}, false, []string{"--projects", "module", "--also-make", "package", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Module: "module"}, true, []string{"--projects", "module", "--also-make", "-DskipTests=true", "package", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Module: "module", Profile: "profile"}, false, []string{"--activate-profiles", "profile", "--projects", "module", "--also-make", "package", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Module: "module", Profile: "profile"}, true, []string{"--activate-profiles", "profile", "--projects", "module", "--also-make", "-DskipTests=true", "package", "-Dimage=image"}},
 	}
 
 	for _, tt := range testCases {
-		args := GenerateMavenArgs("goal", "image", &tt.in)
+		args := GenerateMavenArgs("goal", "image", &tt.in, tt.skipTests)
 
 		testutil.CheckDeepEqual(t, tt.out, args)
 	}

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -131,11 +131,11 @@ func getBuilder(cfg *latest.BuildConfig, kubeContext string, opts *config.Skaffo
 
 	case cfg.LocalBuild != nil:
 		logrus.Debugln("Using builder: local")
-		return local.NewBuilder(cfg.LocalBuild, kubeContext)
+		return local.NewBuilder(cfg.LocalBuild, kubeContext, opts.SkipTests)
 
 	case cfg.GoogleCloudBuild != nil:
 		logrus.Debugln("Using builder: google cloud")
-		return gcb.NewBuilder(cfg.GoogleCloudBuild), nil
+		return gcb.NewBuilder(cfg.GoogleCloudBuild, opts.SkipTests), nil
 
 	case cfg.KanikoBuild != nil:
 		logrus.Debugln("Using builder: kaniko")


### PR DESCRIPTION
Rewrites Jib Gradle commands to include "-x test" to exclude test tasks.
Rewrites Jib Maven commands to include "-DskipTests=true" to disable surefire tests.

Fix #1596