### PR TITLE
[WIP] Use a pseudo json schema to generate the documentation

### DIFF
--- a/docs/content/en/docs/how-tos/builders/_index.md
+++ b/docs/content/en/docs/how-tos/builders/_index.md
@@ -42,11 +42,7 @@ of `skaffold.yaml`.
 
 The `local` type offers the following options:
 
-| Option        | Description | Default |
-|---------------|-------------|---------|
-| `push`        | Should images be pushed to a registry | `false` for local clusters, `true` for remote clusters. |
-| `useDockerCLI`| Uses `docker` command-line interface instead of Docker Engine APIs | `false` |
-| `useBuildkit` | Uses BuildKit to build Docker images | `false` |
+{{< schema root="build.local" >}}
 
 The following `build` section, for example, instructs Skaffold to build a
 Docker image `gcr.io/k8s-skaffold/example` with the local Docker daemon: 
@@ -70,15 +66,7 @@ section of `skaffold.yaml`.
 
 The `googleCloudBuild` type offers the following options:
 
-| Option        | Description | Default |
-|---------------|-------------|---------|
-| `projectId`   | **Required** The ID of your Google Cloud Platform Project | |
-| `diskSizeGb`  | The disk size of the VM that runs the build. See [Cloud Build API Reference: Build Options](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions) for more information | |
-| `machineType` | The type of the VM that runs the build. See [Cloud Build API Reference: Build Options](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions) for more information | |
-| `timeOut`     | The amount of time (in seconds) that this build should be allowed to run. See [Cloud Build API Reference: Resource/Build](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#resource-build) for more information. | |
-| `dockerImage` | The name of the image that will run a docker build. See [Cloud builders](https://cloud.google.com/cloud-build/docs/cloud-builders) for more information | `gcr.io/cloud-builders/docker` |
-| `gradleImage` | The name of the image that will run a gradle build. See [Cloud builders](https://cloud.google.com/cloud-build/docs/cloud-builders) for more information | `gcr.io/cloud-builders/gradle` |
-| `mavenImage`  | The name of the image that will run a maven build. See [Cloud builders](https://cloud.google.com/cloud-build/docs/cloud-builders) for more information | `gcr.io/cloud-builders/mvn` |
+{{< schema root="build.googleCloudBuild" >}}
 
 The following `build` section, for example, instructs Skaffold to build a
 Docker image `gcr.io/k8s-skaffold/example` with Google Cloud Build: 
@@ -99,13 +87,7 @@ To use Kaniko, add build type `kaniko` to the `build` section of
 
 The `kaniko` type offers the following options:
 
-| Option          | Description | Default |
-|-----------------|-------------|---------|
-| `buildContext`  | The Kaniko build context: `gcsBucket` or `localDir` | `localDir` |
-| `pullSecret`    | The path to the secret key file. See [Kaniko Documentation: Running Kaniko in a Kubernetes cluster](https://github.com/GoogleContainerTools/kaniko#running-kaniko-in-a-kubernetes-cluster) for more information | |
-| `pullSecretName`| The name of the Kubernetes secret for pulling the files from the build context and pushing the final image | `kaniko-secret` |
-| `namespace`     | The Kubernetes namespace | Current namespace in Kubernetes configuration |
-| `timeout`       | The amount of time (in seconds) that this build should be allowed to run | 20 minutes (`20m`) |
+{{< schema root="build.kaniko" >}}
 
 The following `build` section, for example, instructs Skaffold to build a
 Docker image `gcr.io/k8s-skaffold/example` with Kaniko: 
@@ -134,10 +116,7 @@ Bazel, `bazel` field to each artifact you specify in the
 
 The `bazel` type offers the following options:
 
-| Option    | Description |
-|-----------|-------------|
-| `target`  | **Required** The `bazel build` target to run |
-| `args`    | Additional args to pass to `bazel build` |
+{{< schema root="build.artifacts.bazel" >}}
 
 The following `build` section, for example, instructs Skaffold to build a
 Docker image `gcr.io/k8s-skaffold/example` with Bazel:

--- a/docs/content/en/docs/how-tos/deployers/_index.md
+++ b/docs/content/en/docs/how-tos/deployers/_index.md
@@ -43,11 +43,7 @@ To use `kubectl`, add deploy type `kubectl` to the `deploy` section of
 
 The `kubectl` type offers the following options:
 
-| Option | Description | Default |
-|--------|-------------|---------|
-|`manifests`| A list of paths to Kubernetes Manifests | `k8s/*.yaml` |
-|`remoteManifests`| A list of paths to Kubernetes Manifests in remote clusters | |
-|`flags`| Additional flags to pass to `kubectl`. You can specify three types of flags: <ul> <li>`global`: flags that apply to every command.</li> <li>`apply`: flags that apply to creation commands.</li> <li>`delete`: flags that apply to deletion commands.</li><ul>| |
+{{< schema root="deploy.kubectl" >}}
 
 The following `deploy` section, for example, instructs Skaffold to deploy
 artifacts using `kubectl`:
@@ -61,28 +57,15 @@ manage Kubernetes applications. Skaffold can work with Helm by calling its
 command-line interface.
 
 To use Helm with Skaffold, add deploy type `helm` to the `deploy` section
-of `skaffold.yaml`. The `helm` type offers the following options:
+of `skaffold.yaml`.
 
-| Option | Description |
-|--------|-------------|
-| `releases` | **Required** A list of Helm releases. See the table below for the schema of `releases`. |
+The `helm` type offers the following options:
+
+{{< schema root="deploy.helm" >}}
 
 Each release includes the following fields:
 
-| Option | Description |
-|--------|-------------|
-|`name`| **Required** The name of the Helm release.|
-|`chartPath`| **Required** The path to the Helm chart.|
-|`valuesFilePath`| The path to the Helm `values` file.|
-|`values`| A list of key-value pairs supplementing the Helm `values` file.|
-|`namespace`| The Kubernetes namespace.|
-|`version`| The version of the chart.|
-|`setValues`| A list of key-value pairs; if present, Skaffold will sent `--set` flag to Helm CLI and append all pairs after the flag.|
-|`setValueTemplates`| A list of key-value pairs; if present, Skaffold will try to parse the value part of each key-value pair using environment variables in the system, then send `--set` flag to Helm CLI and append all parsed pairs after the flag.|
-|`wait`| A boolean value; if `true`, Skaffold will send `--wait` flag to Helm CLI.|
-|`recreatePods`| A boolean value; if `true`, Skaffold will send `--recreate-pods` flag to Helm CLI.|
-|`overrides`| A list of key-value pairs; if present, Skaffold will build a Helm `values` file that overrides the original and use it to call Helm CLI (`--f` flag).|
-|`packaged`|Packages the chart (`helm package`) Includes two fields: <ul> <li>`version`: Version of the chart.</li> <li>`appVersion`: Version of the app.</li> </ul>| |`imageStrategy`|Add image configurations to the Helm `values` file. Includes one of the two following fields: <ul> <li> `fqn`: The image configuration uses the syntax `IMAGE-NAME=IMAGE-REPOSITORY:IMAGE-TAG`. </li> <li>`helm`: The image configuration uses the syntax `IMAGE-NAME.repository=IMAGE-REPOSITORY, IMAGE-NAME.tag=IMAGE-TAG`.</li> </ul> |
+{{< schema root="deploy.helm.releases" >}}
 
 The following `deploy` section, for example, instructs Skaffold to deploy
 artifacts using `helm`:
@@ -96,12 +79,11 @@ developers to customize raw, template-free YAML files for multiple purposes.
 Skaffold can work with `kustomize` by calling its command-line interface.
 
 To use kustomize with Skaffold, add deploy type `kustomize` to the `deploy`
-section of `skaffold.yaml`. The `kustomize` type offers the following options:
+section of `skaffold.yaml`. 
 
-| Option | Description | Default |
-|--------|-------------|---------|
-|`path`| Path to Kustomization files | `.` (current directory) |
-|`flags`| Additional flags to pass to `kubectl`. You can specify three types of flags: <ul> <li>`global`: flags that apply to every command.</li> <li>`apply`: flags that apply to creation commands.</li> <li>`delete`: flags that apply to deletion commands.</li> <ul> | |
+The `kustomize` type offers the following options:
+
+{{< schema root="deploy.kustomize" >}}
 
 The following `deploy` section, for example, instructs Skaffold to deploy
 artifacts using kustomize:

--- a/docs/layouts/shortcodes/schema.html
+++ b/docs/layouts/shortcodes/schema.html
@@ -1,0 +1,59 @@
+{{ $root := .Get "root" }}
+{{ if not $root}}
+    {{ errorf "missing value for param 'root': %s" .Position }}
+{{ end }}
+
+{{ $schema := getJSON "static/schema/v1beta4/schema.json" }}
+{{ if not $schema}}
+    {{ errorf "missing json schema: %s" .Position }}
+{{ end }}
+
+{{ $definition := $schema }}
+{{ range $part := split $root "." }}
+    {{ $found := false }}
+
+    {{ range $property := $definition.properties }}
+        {{ if eq $property.name $part }}
+            {{ $definition = $property }}
+            {{ $found = true }}
+        {{ end }}
+    {{ end }}
+
+    {{ range $property := $definition.oneOf }}
+        {{ if eq $property.name $part }}
+            {{ $definition = $property }}
+            {{ $found = true }}
+        {{ end }}
+    {{ end }}
+
+    {{ if not $found }}
+        {{ errorf "missing properties: %s" $root }}
+    {{ end }}
+{{end}}
+
+{{ $showDefaults := false }}
+{{ range $definition.properties }}
+    {{ if .default }}
+        {{ $showDefaults = true }}
+    {{ end }}
+{{ end }}
+
+<table>
+    <thead>
+        <tr>
+            <th>Option</th>
+            <th>Description</th>
+            {{ if $showDefaults }}<th>Default</th>{{ end }}
+        </tr>
+    </thead>
+    <tbody>
+        {{range $definition.properties}}
+        <tr>
+            <td><code>{{.name}}</code></td>
+            <td>{{if .required}}<strong>Required</strong> {{end}}{{.description | markdownify}}</td>
+            {{ if $showDefaults }}<td>{{.default | markdownify}}</td>{{ end }}
+        </tr>
+        {{end}}
+    </tbody>
+</table>
+    

--- a/docs/static/schema/v1beta4/schema.json
+++ b/docs/static/schema/v1beta4/schema.json
@@ -1,0 +1,295 @@
+{
+  "description": "TODO",
+  "properties": [
+    {
+      "name": "build",
+      "description": "TODO",
+      "properties": [
+        {
+          "name": "artifacts",
+          "description": "TODO",
+          "type": "[]interface",
+          "properties": [
+            {
+              "name": "image",
+              "description": "TODO",
+              "type": "string"
+            },
+            {
+              "name": "context",
+              "description": "TODO",
+              "type": "string"
+            },
+            {
+              "name": "sync",
+              "description": "TODO",
+              "type": "map[string]string"
+            }
+          ],
+          "oneOf": [
+            {
+              "name": "docker",
+              "description": "TODO"
+            },
+            {
+              "name": "bazel",
+              "description": "TODO",
+              "properties": [
+                {
+                  "name": "target",
+                  "description": "The `bazel build` target to run",
+                  "required": true,
+                  "type": "string"
+                },
+                {
+                  "name": "tags",
+                  "description": "Additional args to pass to `bazel build`",
+                  "type": "[]string"
+                }
+              ]
+            },
+            {
+              "name": "jibMaven",
+              "description": "TODO"
+            },
+            {
+              "name": "jibDocker",
+              "description": "TODO"
+            }
+          ]
+        }
+      ],
+      "oneOf": [
+        {
+          "name": "local",
+          "description": "TODO",
+          "properties": [
+            {
+              "name": "push",
+              "description": "Should images be pushed to a registry",
+              "default": "`false` for local clusters, `true` for remote clusters",
+              "type": "bool"
+            },
+            {
+              "name": "useDockerCLI",
+              "description": "Uses `docker` command-line interface instead of Docker Engine APIs",
+              "default": "`false`",
+              "type": "bool"
+            },
+            {
+              "name": "useBuildkit",
+              "description": "Uses BuildKit to build Docker images",
+              "default": "`false`",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "name": "googleCloudBuild",
+          "description": "TODO",
+          "properties": [
+            {
+              "name": "projectId",
+              "description": "The ID of your Google Cloud Platform Project",
+              "required": true,
+              "type": "string"
+            },
+            {
+              "name": "diskSizeGb",
+              "description": "The disk size of the VM that runs the build. See [Cloud Build API Reference: Build Options](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions) for more information",
+              "type": "string"
+            },
+            {
+              "name": "machineType",
+              "description": "The type of the VM that runs the build. See [Cloud Build API Reference: Build Options](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions) for more information",
+              "type": "string"
+            },
+            {
+              "name": "timeOut",
+              "description": "The amount of time (in seconds) that this build should be allowed to run. See [Cloud Build API Reference: Resource/Build](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#resource-build) for more information",
+              "type": "string"
+            },
+            {
+              "name": "dockerImage",
+              "description": "The name of the image that will run a docker build. See [Cloud builders](https://cloud.google.com/cloud-build/docs/cloud-builders) for more information",
+              "default": "`gcr.io/cloud-builders/docker`",
+              "type": "string"
+            },
+            {
+              "name": "gradleImage",
+              "description": "The name of the image that will run a gradle build. See [Cloud builders](https://cloud.google.com/cloud-build/docs/cloud-builders) for more information",
+              "default": "`gcr.io/cloud-builders/gradle`",
+              "type": "string"
+            },
+            {
+              "name": "mavenImage",
+              "description": "The name of the image that will run a maven build. See [Cloud builders](https://cloud.google.com/cloud-build/docs/cloud-builders) for more information",
+              "default": "`gcr.io/cloud-builders/mvn`",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "name": "kaniko",
+          "description": "TODO",
+          "properties": [
+            {
+              "name": "buildContext",
+              "description": "The Kaniko build context: `gcsBucket` or `localDir`",
+              "default": "`localDir`"
+            },
+            {
+              "name": "pullSecret",
+              "description": "The path to the secret key file. See [Kaniko Documentation: Running Kaniko in a Kubernetes cluster](https://github.com/GoogleContainerTools/kaniko#running-kaniko-in-a-kubernetes-cluster) for more information",
+              "type": "string"
+            },
+            {
+              "name": "pullSecretName",
+              "description": "The name of the Kubernetes secret for pulling the files from the build context and pushing the final image",
+              "default": "`kaniko-secret`",
+              "type": "string"
+            },
+            {
+              "name": "namespace",
+              "description": "The Kubernetes namespace",
+              "default": "Current namespace in Kubernetes configuration",
+              "type": "string"
+            },
+            {
+              "name": "timeout",
+              "description": "The amount of time (in seconds) that this build should be allowed to run",
+              "default": "20 minutes (`20m`)",
+              "type": "string"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "deploy",
+      "description": "TODO",
+      "properties": [
+      ],
+      "oneOf": [
+        {
+          "name": "kubectl",
+          "description": "TODO",
+          "properties": [
+            {
+              "name": "manifests",
+              "description": "A list of paths to Kubernetes Manifests",
+              "default": "`[\"k8s/*.yaml\"]`",
+              "type": "[]string"
+            },
+            {
+              "name": "remoteManifests",
+              "description": "A list of paths to Kubernetes Manifests in remote clusters",
+              "type": "[]string"
+            },
+            {
+              "name": "flags",
+              "description": "Additional flags to pass to `kubectl`. You can specify three types of flags: <ul> <li>`global`: flags that apply to every command.</li> <li>`apply`: flags that apply to creation commands.</li> <li>`delete`: flags that apply to deletion commands.</li><ul>"
+            }
+          ]
+        },
+        {
+          "name": "helm",
+          "description": "TODO",
+          "properties": [
+            {
+              "name": "releases",
+              "description": "A list of Helm releases",
+              "required": true,
+              "type": "[]interface",
+              "properties": [
+                {
+                  "name": "name",
+                  "description": "The name of the Helm release",
+                  "required": true,
+                  "type": "string"
+                },
+                {
+                  "name": "chartPath",
+                  "description": "The path to the Helm chart",
+                  "required": true,
+                  "type": "string"
+                },
+                {
+                  "name": "valuesFiles",
+                  "description": "The paths to the Helm `values` files",
+                  "type": "[]string"
+                },
+                {
+                  "name": "values",
+                  "description": "A list of key-value pairs supplementing the Helm `values` file",
+                  "type": "map[string]string"
+                },
+                {
+                  "name": "namespace",
+                  "description": "The Kubernetes namespace",
+                  "type": "string"
+                },
+                {
+                  "name": "version",
+                  "description": "The version of the chart",
+                  "type": "string"
+                },
+                {
+                  "name": "setValues",
+                  "description": "A list of key-value pairs; if present, Skaffold will sent `--set` flag to Helm CLI and append all pairs after the flag",
+                  "type": "map[string]string"
+                },
+                {
+                  "name": "setValueTemplates",
+                  "description": "A list of key-value pairs; if present, Skaffold will try to parse the value part of each key-value pair using environment variables in the system, then send `--set` flag to Helm CLI and append all parsed pairs after the flag",
+                  "type": "map[string]string"
+                },
+                {
+                  "name": "wait",
+                  "description": "if `true`, Skaffold will send `--wait` flag to Helm CLI",
+                  "default": "`false`",
+                  "type": "bool"
+                },
+                {
+                  "name": "recreatePods",
+                  "description": "if `true`, Skaffold will send `--recreate-pods` flag to Helm CLI",
+                  "default": "`false`",
+                  "type": "bool"
+                },
+                {
+                  "name": "overrides",
+                  "description": "A list of key-value pairs; if present, Skaffold will build a Helm `values` file that overrides the original and use it to call Helm CLI (`--f` flag)",
+                  "type": "map[string]interface{}"
+                },
+                {
+                  "name": "packaged",
+                  "description": "Packages the chart (`helm package`) Includes two fields: <ul> <li>`version`: Version of the chart.</li> <li>`appVersion`: Version of the app.</li> </ul>"
+                },
+                {
+                  "name": "imageStrategy",
+                  "description": "Add image configurations to the Helm `values` file. Includes one of the two following fields: <ul> <li> `fqn`: The image configuration uses the syntax `IMAGE-NAME=IMAGE-REPOSITORY:IMAGE-TAG`. </li> <li>`helm`: The image configuration uses the syntax `IMAGE-NAME.repository=IMAGE-REPOSITORY, IMAGE-NAME.tag=IMAGE-TAG`.</li> </ul>"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "kustomize",
+          "description": "TODO",
+          "properties": [
+            {
+              "name": "path",
+              "description": "Path to Kustomization files",
+              "default": "`.` (current directory)",
+              "type": "string"
+            },
+            {
+              "name": "flags",
+              "description": "Additional flags to pass to `kubectl`. You can specify three types of flags: <ul> <li>`global`: flags that apply to every command.</li> <li>`apply`: flags that apply to creation commands.</li> <li>`delete`: flags that apply to deletion commands.</li><ul>"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This is work in progress to improve our documentation.

The idea is to manually maintain a json file that serves as a schema for `skaffold.yaml`. That shema would help:
 1. Generate large portions of the documentation
 2. Generate the `annotated-skaffold.yaml`
 3. Generate schemas for IDEs to validate `skaffold.yaml` files

This PR currently achieves 1.

Next step is to make sure that this schema is in sync with the Go code with a unit test.

Why not generating this schema from Go code? I'm not sure every information can be put in Go comments (default values for example).