### PR TITLE
Remove Tagger from Builder interface

### DIFF
--- a/pkg/skaffold/build/build.go
+++ b/pkg/skaffold/build/build.go
@@ -37,5 +37,5 @@ type Artifact struct {
 type Builder interface {
 	Labels() map[string]string
 
-	Build(ctx context.Context, out io.Writer, tagger tag.Tagger, artifacts []*latest.Artifact) ([]Artifact, error)
+	Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]Artifact, error)
 }

--- a/pkg/skaffold/build/gcb/cloud_build.go
+++ b/pkg/skaffold/build/gcb/cloud_build.go
@@ -43,16 +43,11 @@ import (
 )
 
 // Build builds a list of artifacts with Google Cloud Build.
-func (b *Builder) Build(ctx context.Context, out io.Writer, tagger tag.Tagger, artifacts []*latest.Artifact) ([]build.Artifact, error) {
-	return build.InParallel(ctx, out, tagger, artifacts, b.buildArtifactWithCloudBuild)
+func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+	return build.InParallel(ctx, out, tags, artifacts, b.buildArtifactWithCloudBuild)
 }
 
-func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer, tagger tag.Tagger, artifact *latest.Artifact) (string, error) {
-	tag, err := tagger.GenerateFullyQualifiedImageName(artifact.Workspace, artifact.ImageName)
-	if err != nil {
-		return "", errors.Wrap(err, "generating tag")
-	}
-
+func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
 	client, err := google.DefaultClient(ctx, cloudbuild.CloudPlatformScope)
 	if err != nil {
 		return "", errors.Wrap(err, "getting google client")

--- a/pkg/skaffold/build/parallel_test.go
+++ b/pkg/skaffold/build/parallel_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestInSequence(t *testing.T) {
+func TestInParallel(t *testing.T) {
 	var tests = []struct {
 		description       string
 		buildArtifact     artifactBuilder
@@ -78,7 +78,7 @@ func TestInSequence(t *testing.T) {
 				{ImageName: "skaffold/image2"},
 			}
 
-			got, err := InSequence(context.Background(), out, test.tags, artifacts, test.buildArtifact)
+			got, err := InParallel(context.Background(), out, test.tags, artifacts, test.buildArtifact)
 
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expectedArtifacts, got)
 			testutil.CheckDeepEqual(t, test.expectedOut, out.String())

--- a/pkg/skaffold/build/prebuilt.go
+++ b/pkg/skaffold/build/prebuilt.go
@@ -46,7 +46,7 @@ func (b *prebuiltImagesBuilder) Labels() map[string]string {
 	}
 }
 
-func (b *prebuiltImagesBuilder) Build(ctx context.Context, out io.Writer, tagger tag.Tagger, artifacts []*latest.Artifact) ([]Artifact, error) {
+func (b *prebuiltImagesBuilder) Build(ctx context.Context, out io.Writer, _ tag.ImageTags, artifacts []*latest.Artifact) ([]Artifact, error) {
 	tags := make(map[string]string)
 
 	for _, tag := range b.images {

--- a/pkg/skaffold/build/sequence.go
+++ b/pkg/skaffold/build/sequence.go
@@ -18,6 +18,7 @@ package build
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
@@ -27,20 +28,25 @@ import (
 )
 
 // InSequence builds a list of artifacts in sequence.
-func InSequence(ctx context.Context, out io.Writer, tagger tag.Tagger, artifacts []*latest.Artifact, buildArtifact artifactBuilder) ([]Artifact, error) {
+func InSequence(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, buildArtifact artifactBuilder) ([]Artifact, error) {
 	var builds []Artifact
 
 	for _, artifact := range artifacts {
 		color.Default.Fprintf(out, "Building [%s]...\n", artifact.ImageName)
 
-		tag, err := buildArtifact(ctx, out, tagger, artifact)
+		tag, present := tags[artifact.ImageName]
+		if !present {
+			return nil, fmt.Errorf("unable to find tag for image %s", artifact.ImageName)
+		}
+
+		finalTag, err := buildArtifact(ctx, out, artifact, tag)
 		if err != nil {
 			return nil, errors.Wrapf(err, "building [%s]", artifact.ImageName)
 		}
 
 		builds = append(builds, Artifact{
 			ImageName: artifact.ImageName,
-			Tag:       tag,
+			Tag:       finalTag,
 		})
 	}
 

--- a/pkg/skaffold/build/tag/tag.go
+++ b/pkg/skaffold/build/tag/tag.go
@@ -16,6 +16,9 @@ limitations under the License.
 
 package tag
 
+// ImageTags maps image names to tags
+type ImageTags map[string]string
+
 // Tagger is an interface for tag strategies to be implemented against
 type Tagger interface {
 	Labels() map[string]string

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -66,7 +66,7 @@ func (t *TestBench) enterNewCycle() {
 	t.currentActions = Actions{}
 }
 
-func (t *TestBench) Build(ctx context.Context, w io.Writer, tagger tag.Tagger, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+func (t *TestBench) Build(ctx context.Context, w io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 	if len(t.buildErrors) > 0 {
 		err := t.buildErrors[0]
 		t.buildErrors = t.buildErrors[1:]
@@ -85,7 +85,7 @@ func (t *TestBench) Build(ctx context.Context, w io.Writer, tagger tag.Tagger, a
 		})
 	}
 
-	t.currentActions.Built = tags(builds)
+	t.currentActions.Built = findTags(builds)
 	return builds, nil
 }
 
@@ -111,7 +111,7 @@ func (t *TestBench) Test(ctx context.Context, out io.Writer, artifacts []build.A
 		}
 	}
 
-	t.currentActions.Tested = tags(artifacts)
+	t.currentActions.Tested = findTags(artifacts)
 	return nil
 }
 
@@ -124,7 +124,7 @@ func (t *TestBench) Deploy(ctx context.Context, out io.Writer, artifacts []build
 		}
 	}
 
-	t.currentActions.Deployed = tags(artifacts)
+	t.currentActions.Deployed = findTags(artifacts)
 	return nil
 }
 
@@ -132,7 +132,7 @@ func (t *TestBench) Actions() []Actions {
 	return append(t.actions, t.currentActions)
 }
 
-func tags(artifacts []build.Artifact) []string {
+func findTags(artifacts []build.Artifact) []string {
 	var tags []string
 	for _, artifact := range artifacts {
 		tags = append(tags, artifact.Tag)

--- a/pkg/skaffold/runner/timings.go
+++ b/pkg/skaffold/runner/timings.go
@@ -52,11 +52,11 @@ func (w withTimings) Labels() map[string]string {
 	return labels.Merge(w.Builder.Labels(), w.Deployer.Labels())
 }
 
-func (w withTimings) Build(ctx context.Context, out io.Writer, tagger tag.Tagger, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+func (w withTimings) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 	start := time.Now()
 	color.Default.Fprintln(out, "Starting build...")
 
-	bRes, err := w.Builder.Build(ctx, out, tagger, artifacts)
+	bRes, err := w.Builder.Build(ctx, out, tags, artifacts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Tags are now computed by the runner and passed as a `map` to the builder.
This makes it easier to transform builder into plugins that have basically no notion of tagging