### PR TITLE
Add custom build arguments in jib artifacts

### DIFF
--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -76,14 +76,14 @@ build:
     # jibMaven:
     #  module: modulename     # selects which maven module to build, for a multimodule project
     #  profile: profilename   # selects which maven profile to activate
-    #  mavenArgs:             # additional arguments to pass to maven
+    #  args:             # additional arguments to pass to maven
     #  - "arg1"
     #  - "arg2"
 
     # jibGradle builds containers using the Jib plugin for Gradle.
     # jibGradle:
     #  project: projectname   # selects which gradle project to build
-    #  gradleArgs:            # additional arguments to pass to gradle
+    #  args:            # additional arguments to pass to gradle
     #  - "arg1"
     #  - "arg2"
 

--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -76,10 +76,16 @@ build:
     # jibMaven:
     #  module: modulename     # selects which maven module to build, for a multimodule project
     #  profile: profilename   # selects which maven profile to activate
+    #  mavenArgs:             # additional arguments to pass to maven
+    #  - "arg1"
+    #  - "arg2"
 
     # jibGradle builds containers using the Jib plugin for Gradle.
     # jibGradle:
     #  project: projectname   # selects which gradle project to build
+    #  gradleArgs:            # additional arguments to pass to gradle
+    #  - "arg1"
+    #  - "arg2"
 
 # This next section is where you'll put your specific builder configuration.
   # Valid builders are `local` (beta), `googleCloudBuild` (beta) and `kaniko` (beta).
@@ -120,17 +126,17 @@ build:
 
   # Docker artifacts can be built on a Kubernetes cluster with Kaniko.
   # Exactly one buildContext must be specified to use kaniko
-  # If localDir is specified, skaffold will mount sources directly via a emptyDir volume	
+  # If localDir is specified, skaffold will mount sources directly via a emptyDir volume
   # If gcsBucket is specified, skaffold will send sources to the GCS bucket provided
   # Kaniko also needs access to a service account to push the final image.
   # See https://github.com/GoogleContainerTools/kaniko#running-kaniko-in-a-kubernetes-cluster
   # If cache is specified, kaniko will use a remote cache which will speed up builds.
   # A cache repo can be specified to store cached layers, otherwise one will be inferred
-  # from the image name. See https://github.com/GoogleContainerTools/kaniko#caching 
+  # from the image name. See https://github.com/GoogleContainerTools/kaniko#caching
   #
   # Additional flags can be specified as a list. To see all additional flags, visit:
   # https://github.com/GoogleContainerTools/kaniko#additional-flags
-  # 
+  #
   # kaniko:
   #   buildContext:
   #     gcsBucket: k8s-skaffold

--- a/integration/examples/annotated-skaffold.yaml
+++ b/integration/examples/annotated-skaffold.yaml
@@ -73,14 +73,14 @@ build:
     # jibMaven:
     #  module: modulename     # selects which maven module to build, for a multimodule project
     #  profile: profilename   # selects which maven profile to activate
-    #  mavenArgs:             # additional arguments to pass to maven
+    #  args:             # additional arguments to pass to maven
     #  - "arg1"
     #  - "arg2"
 
     # jibGradle builds containers using the Jib plugin for Gradle.
     # jibGradle:
     #  project: projectname   # selects which gradle project to build
-    #  gradleArgs:            # additional arguments to pass to gradle
+    #  args:            # additional arguments to pass to gradle
     #  - "arg1"
     #  - "arg2"
 

--- a/integration/examples/annotated-skaffold.yaml
+++ b/integration/examples/annotated-skaffold.yaml
@@ -73,10 +73,16 @@ build:
     # jibMaven:
     #  module: modulename     # selects which maven module to build, for a multimodule project
     #  profile: profilename   # selects which maven profile to activate
+    #  mavenArgs:             # additional arguments to pass to maven
+    #  - "arg1"
+    #  - "arg2"
 
     # jibGradle builds containers using the Jib plugin for Gradle.
     # jibGradle:
     #  project: projectname   # selects which gradle project to build
+    #  gradleArgs:            # additional arguments to pass to gradle
+    #  - "arg1"
+    #  - "arg2"
 
 # This next section is where you'll put your specific builder configuration.
   # Valid builders are `local` (beta), `googleCloudBuild` (beta) and `kaniko` (beta).
@@ -117,17 +123,17 @@ build:
 
   # Docker artifacts can be built on a Kubernetes cluster with Kaniko.
   # Exactly one buildContext must be specified to use kaniko
-  # If localDir is specified, skaffold will mount sources directly via a emptyDir volume	
+  # If localDir is specified, skaffold will mount sources directly via a emptyDir volume
   # If gcsBucket is specified, skaffold will send sources to the GCS bucket provided
   # Kaniko also needs access to a service account to push the final image.
   # See https://github.com/GoogleContainerTools/kaniko#running-kaniko-in-a-kubernetes-cluster
   # If cache is specified, kaniko will use a remote cache which will speed up builds.
   # A cache repo can be specified to store cached layers, otherwise one will be inferred
-  # from the image name. See https://github.com/GoogleContainerTools/kaniko#caching 
+  # from the image name. See https://github.com/GoogleContainerTools/kaniko#caching
   #
   # Additional flags can be specified as a list. To see all additional flags, visit:
   # https://github.com/GoogleContainerTools/kaniko#additional-flags
-  # 
+  #
   # kaniko:
   #   buildContext:
   #     gcsBucket: k8s-skaffold

--- a/pkg/skaffold/jib/jib_gradle.go
+++ b/pkg/skaffold/jib/jib_gradle.go
@@ -52,7 +52,7 @@ func GenerateGradleArgs(task string, imageName string, a *latest.JibGradleArtifa
 	if skipTests {
 		args = append(args, "-x", "test")
 	}
-	args = append(args, a.Flags...)
+	args = append(args, a.BuildArgs...)
 	return args
 }
 

--- a/pkg/skaffold/jib/jib_gradle.go
+++ b/pkg/skaffold/jib/jib_gradle.go
@@ -52,6 +52,7 @@ func GenerateGradleArgs(task string, imageName string, a *latest.JibGradleArtifa
 	if skipTests {
 		args = append(args, "-x", "test")
 	}
+	args = append(args, a.Flags...)
 	return args
 }
 

--- a/pkg/skaffold/jib/jib_gradle_test.go
+++ b/pkg/skaffold/jib/jib_gradle_test.go
@@ -151,7 +151,7 @@ func TestGenerateGradleArgs(t *testing.T) {
 		out       []string
 	}{
 		{latest.JibGradleArtifact{}, false, []string{":task", "--image=image"}},
-		{latest.JibGradleArtifact{Flags: []string{"-extra", "args"}}, false, []string{":task", "--image=image", "-extra", "args"}},
+		{latest.JibGradleArtifact{BuildArgs: []string{"-extra", "args"}}, false, []string{":task", "--image=image", "-extra", "args"}},
 		{latest.JibGradleArtifact{}, true, []string{":task", "--image=image", "-x", "test"}},
 		{latest.JibGradleArtifact{Project: "project"}, false, []string{":project:task", "--image=image"}},
 		{latest.JibGradleArtifact{Project: "project"}, true, []string{":project:task", "--image=image", "-x", "test"}},

--- a/pkg/skaffold/jib/jib_gradle_test.go
+++ b/pkg/skaffold/jib/jib_gradle_test.go
@@ -151,6 +151,7 @@ func TestGenerateGradleArgs(t *testing.T) {
 		out       []string
 	}{
 		{latest.JibGradleArtifact{}, false, []string{":task", "--image=image"}},
+		{latest.JibGradleArtifact{Flags: []string{"-extra", "args"}}, false, []string{":task", "--image=image", "-extra", "args"}},
 		{latest.JibGradleArtifact{}, true, []string{":task", "--image=image", "-x", "test"}},
 		{latest.JibGradleArtifact{Project: "project"}, false, []string{":project:task", "--image=image"}},
 		{latest.JibGradleArtifact{Project: "project"}, true, []string{":project:task", "--image=image", "-x", "test"}},

--- a/pkg/skaffold/jib/jib_maven.go
+++ b/pkg/skaffold/jib/jib_maven.go
@@ -70,6 +70,8 @@ func GenerateMavenArgs(goal string, imageName string, a *latest.JibMavenArtifact
 func mavenArgs(a *latest.JibMavenArtifact) []string {
 	var args []string
 
+	args = append(args, a.Flags...)
+
 	if a.Profile != "" {
 		args = append(args, "--activate-profiles", a.Profile)
 	}

--- a/pkg/skaffold/jib/jib_maven.go
+++ b/pkg/skaffold/jib/jib_maven.go
@@ -70,7 +70,7 @@ func GenerateMavenArgs(goal string, imageName string, a *latest.JibMavenArtifact
 func mavenArgs(a *latest.JibMavenArtifact) []string {
 	var args []string
 
-	args = append(args, a.Flags...)
+	args = append(args, a.BuildArgs...)
 
 	if a.Profile != "" {
 		args = append(args, "--activate-profiles", a.Profile)

--- a/pkg/skaffold/jib/jib_maven_test.go
+++ b/pkg/skaffold/jib/jib_maven_test.go
@@ -102,7 +102,7 @@ func TestGetCommandMaven(t *testing.T) {
 		{
 			description: "maven with extra flags",
 			jibMavenArtifact: latest.JibMavenArtifact{
-				Flags: []string{"-DskipTests", "-x"},
+				BuildArgs: []string{"-DskipTests", "-x"},
 			},
 			filesInWorkspace: []string{},
 			expectedCmd: func(workspace string) *exec.Cmd {

--- a/pkg/skaffold/jib/jib_maven_test.go
+++ b/pkg/skaffold/jib/jib_maven_test.go
@@ -100,6 +100,16 @@ func TestGetCommandMaven(t *testing.T) {
 			},
 		},
 		{
+			description: "maven with extra flags",
+			jibMavenArtifact: latest.JibMavenArtifact{
+				Flags: []string{"-DskipTests", "-x"},
+			},
+			filesInWorkspace: []string{},
+			expectedCmd: func(workspace string) *exec.Cmd {
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"-DskipTests", "-x", "--non-recursive", "jib:_skaffold-files", "--quiet"})
+			},
+		},
+		{
 			description:      "maven with profile",
 			jibMavenArtifact: latest.JibMavenArtifact{Profile: "profile"},
 			filesInWorkspace: []string{},

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -504,10 +504,16 @@ type JibMavenArtifact struct {
 
 	// Profile selects which maven profile to activate.
 	Profile string `yaml:"profile"`
+
+	// Flags is passed as additional build flags to maven
+	Flags []string `yaml:"mavenArgs,omitempty"`
 }
 
 // JibGradleArtifact builds containers using the Jib plugin for Gradle.
 type JibGradleArtifact struct {
 	// Project selects which gradle project to build.
 	Project string `yaml:"project"`
+
+	// Flags is passed as additional build flags to gradle
+	Flags []string `yaml:"gradleArgs,omitempty"`
 }

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -506,7 +506,7 @@ type JibMavenArtifact struct {
 	Profile string `yaml:"profile"`
 
 	// Flags is passed as additional build flags to maven
-	Flags []string `yaml:"mavenArgs,omitempty"`
+	BuildArgs []string `yaml:"args,omitempty"`
 }
 
 // JibGradleArtifact builds containers using the Jib plugin for Gradle.
@@ -515,5 +515,5 @@ type JibGradleArtifact struct {
 	Project string `yaml:"project"`
 
 	// Flags is passed as additional build flags to gradle
-	Flags []string `yaml:"gradleArgs,omitempty"`
+	BuildArgs []string `yaml:"args,omitempty"`
 }


### PR DESCRIPTION
Before, there was no way to pass custom arguments to the jib artifacts.
Now, there is the `mavenArgs` and `gradleArgs` field which expect a list of strings which is forwarded to the maven and gradle builder, respectively.

Fixes #1565