### PR TITLE
Fix regression from port forwarding

### DIFF
--- a/pkg/skaffold/kubernetes/port_forward.go
+++ b/pkg/skaffold/kubernetes/port_forward.go
@@ -286,7 +286,7 @@ func portAvailable(p int32, forwardedPorts map[int32]string) (bool, error) {
 
 // Key is an identifier for the lock on a port during the skaffold dev cycle.
 func (p *portForwardEntry) key() string {
-	return fmt.Sprintf("%s-%s-%d", p.podName, p.containerName, p.port)
+	return fmt.Sprintf("%s-%d", p.containerName, p.port)
 }
 
 // String is a utility function that returns the port forward entry as a user-readable string

--- a/pkg/skaffold/kubernetes/port_forward_test.go
+++ b/pkg/skaffold/kubernetes/port_forward_test.go
@@ -101,7 +101,7 @@ func TestPortForwardPod(t *testing.T) {
 			},
 			availablePorts: []int32{8080},
 			expectedEntries: map[string]*portForwardEntry{
-				"podname-containername-8080": {
+				"containername-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
@@ -136,7 +136,7 @@ func TestPortForwardPod(t *testing.T) {
 				9000: true,
 			},
 			expectedEntries: map[string]*portForwardEntry{
-				"podname-containername-8080": {
+				"containername-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
@@ -202,7 +202,7 @@ func TestPortForwardPod(t *testing.T) {
 			shouldErr:      true,
 			availablePorts: []int32{8080},
 			expectedEntries: map[string]*portForwardEntry{
-				"podname-containername-8080": {
+				"containername-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
@@ -239,14 +239,14 @@ func TestPortForwardPod(t *testing.T) {
 			},
 			availablePorts: []int32{8080, 50051},
 			expectedEntries: map[string]*portForwardEntry{
-				"podname-containername-8080": {
+				"containername-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
 					port:            8080,
 					localPort:       8080,
 				},
-				"podname2-containername2-50051": {
+				"containername2-50051": {
 					resourceVersion: 1,
 					podName:         "podname2",
 					containerName:   "containername2",
@@ -301,14 +301,14 @@ func TestPortForwardPod(t *testing.T) {
 			},
 			availablePorts: []int32{8080, 9000},
 			expectedEntries: map[string]*portForwardEntry{
-				"podname-containername-8080": {
+				"containername-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
 					port:            8080,
 					localPort:       8080,
 				},
-				"podname2-containername2-8080": {
+				"containername2-8080": {
 					resourceVersion: 1,
 					podName:         "podname2",
 					containerName:   "containername2",
@@ -362,7 +362,7 @@ func TestPortForwardPod(t *testing.T) {
 			},
 			availablePorts: []int32{8080},
 			expectedEntries: map[string]*portForwardEntry{
-				"podname-containername-8080": {
+				"containername-8080": {
 					resourceVersion: 2,
 					podName:         "podname",
 					containerName:   "containername",


### PR DESCRIPTION
I introduced this regression when adding "pod name" to they port forward
entry key -- whenever a pod was replaced, it's name would change and it
would be mapped to a new port.

This should fix that issue, but I initally introduced "pod name" so that
replicated pods would map to different ports. I'll work on finding a
solution for that in another PR.

Fix #1594 