### PR TITLE
Handle env commands with multiple variable definitions (#1625)

### DIFF
--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -179,7 +179,10 @@ func copiedFiles(nodes []*parser.Node) ([][]string, error) {
 				copied = append(copied, files)
 			}
 		case command.Env:
-			envs[node.Next.Value] = node.Next.Next.Value
+			// one env command may define multiple variables
+			for node := node.Next; node != nil && node.Next != nil; node = node.Next.Next {
+				envs[node.Value] = node.Next.Value
+			}
 		}
 	}
 

--- a/pkg/skaffold/docker/parse_test.go
+++ b/pkg/skaffold/docker/parse_test.go
@@ -80,6 +80,13 @@ WORKDIR ${foo}   # WORKDIR /bar
 COPY $foo /quux # COPY bar /quux
 `
 
+const multiEnvTest = `
+FROM busybox
+ENV baz=bar \
+    foo=docker
+COPY $foo/nginx.conf . # COPY docker/nginx.conf .
+`
+
 const copyDirectory = `
 FROM nginx
 ADD . /etc/
@@ -328,6 +335,13 @@ func TestGetDependencies(t *testing.T) {
 			dockerfile:  envTest,
 			workspace:   ".",
 			expected:    []string{"Dockerfile", "bar"},
+			fetched:     []string{"busybox"},
+		},
+		{
+			description: "multiple env test",
+			dockerfile:  multiEnvTest,
+			workspace:   ".",
+			expected:    []string{"Dockerfile", filepath.Join("docker", "nginx.conf")},
 			fetched:     []string{"busybox"},
 		},
 		{


### PR DESCRIPTION
The docker `ENV` command allows to define one or many variables. So far, Skaffold only handled the case, where the `ENV` command defined exactly one variable. This small fix also handles the case with multiple variable definitions.

Fixes #1625 