### PR TITLE
Add a touch after sync.

### DIFF
--- a/pkg/skaffold/sync/kubectl/kubectl.go
+++ b/pkg/skaffold/sync/kubectl/kubectl.go
@@ -73,5 +73,8 @@ func copyFileFn(ctx context.Context, pod v1.Pod, container v1.Container, src, ds
 		syncedDirs[dir] = struct{}{}
 	}
 	copy := exec.CommandContext(ctx, "kubectl", "cp", src, fmt.Sprintf("%s/%s:%s", pod.Namespace, pod.Name, dst), "-c", container.Name)
-	return append(cmds, copy)
+
+	// Run a touch in the pod to let inotify/dnotify know of our presence.
+	touch := exec.CommandContext(ctx, "kubectl", "exec", pod.Name, "-c", container.Name, "-n", pod.Namespace, "--", "touch", dst)
+	return append(cmds, copy, touch)
 }


### PR DESCRIPTION
Adding a `kubectl exec ... touch $dst` during sync is enough to tickle the kernel into realising there's an updated file, so it sends out inotify/dnotify as usual.  Without this change, inotify/dnotify don't notice the files updated with `kubectl cp`.

Fixes #1640 without needing special support from `CHOKIDAR_USEPOLLING`.
