### PR TITLE
Add support for Kaniko AWS secret

### DIFF
--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -147,6 +147,9 @@ build:
   #   dockerConfig:
   #     path: path to the docker config.json
   #     secretName: docker-cfg
+  #   awsSecret:
+  #     path: path to the AWS credentials
+  #     secretName: aws-secret
 
 # The test section has all the information needed to test images.
 test:

--- a/pkg/skaffold/build/kaniko/kaniko.go
+++ b/pkg/skaffold/build/kaniko/kaniko.go
@@ -41,6 +41,13 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, 
 		}
 		defer teardownDockerConfigSecret()
 	}
+	if b.AWSSecret != nil {
+		teardownAWSSecret, err := b.setupAWSSecretSecret(out)
+		if err != nil {
+			return nil, errors.Wrap(err, "setting up AWS secret")
+		}
+		defer teardownAWSSecret()
+	}
 
 	return build.InParallel(ctx, out, tags, artifacts, b.buildArtifactWithKaniko)
 }

--- a/pkg/skaffold/build/kaniko/sources/sources.go
+++ b/pkg/skaffold/build/kaniko/sources/sources.go
@@ -90,14 +90,22 @@ func podTemplate(cfg *latest.KanikoBuild, args []string) *v1.Pod {
 		return pod
 	}
 
-	volumeMount := v1.VolumeMount{
+	dockerConfigVolumeMount := v1.VolumeMount{
 		Name:      constants.DefaultKanikoDockerConfigSecretName,
 		MountPath: constants.DefaultKanikoDockerConfigPath,
 	}
+	awsSecretVolumeMount := v1.VolumeMount{
+		Name:      constants.DefaultKanikoAWSSecretName,
+		MountPath: constants.DefaultKanikoAWSSecretPath,
+	}
 
-	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, volumeMount)
+	pod.Spec.Containers[0].VolumeMounts = append(
+		pod.Spec.Containers[0].VolumeMounts,
+		dockerConfigVolumeMount,
+		awsSecretVolumeMount,
+	)
 
-	volume := v1.Volume{
+	dockerConfigVolume := v1.Volume{
 		Name: constants.DefaultKanikoDockerConfigSecretName,
 		VolumeSource: v1.VolumeSource{
 			Secret: &v1.SecretVolumeSource{
@@ -105,8 +113,20 @@ func podTemplate(cfg *latest.KanikoBuild, args []string) *v1.Pod {
 			},
 		},
 	}
+	awsSecretVolume := v1.Volume{
+		Name: constants.DefaultKanikoAWSSecretName,
+		VolumeSource: v1.VolumeSource{
+			Secret: &v1.SecretVolumeSource{
+				SecretName: cfg.AWSSecret.SecretName,
+			},
+		},
+	}
 
-	pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
+	pod.Spec.Volumes = append(
+		pod.Spec.Volumes,
+		dockerConfigVolume,
+		awsSecretVolume,
+	)
 
 	return pod
 }

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -52,6 +52,8 @@ const (
 	DefaultKanikoEmptyDirMountPath      = "/kaniko/buildcontext"
 	DefaultKanikoDockerConfigSecretName = "docker-cfg"
 	DefaultKanikoDockerConfigPath       = "/kaniko/.docker"
+	DefaultKanikoAWSSecretName          = "aws-secret"
+	DefaultKanikoAWSSecretPath          = "/root/.aws"
 
 	DefaultBusyboxImage = "busybox"
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -236,6 +236,9 @@ type KanikoBuild struct {
 
 	// DockerConfig
 	DockerConfig *DockerConfig `yaml:"dockerConfig,omitempty"`
+
+	// AWSSecret
+	AWSSecret *AWSSecret `yaml:"awsSecret,omitempty"`
 }
 
 // DockerConfig contains information about the docker config.json to mount
@@ -243,6 +246,13 @@ type DockerConfig struct {
 	// Path path to the docker `config.json`
 	Path string `yaml:"path,omitempty"`
 
+	SecretName string `yaml:"secretName,omitempty"`
+}
+
+// AWSSecret contains information about the AWS credentials to mount
+type AWSSecret struct {
+	// Path to the AWS `credentials`
+	Path       string `yaml:"path,omitempty"`
 	SecretName string `yaml:"secretName,omitempty"`
 }
 

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -91,6 +91,9 @@ build:
     dockerConfig:
       secretName: config-name
       path: /kaniko/.docker
+    awsSecret:
+      secretName: aws-secret-name
+      path: /root/.aws
 `
 	badConfig = "bad config"
 )
@@ -173,6 +176,7 @@ func TestParseConfig(t *testing.T) {
 				withKanikoBuild("demo", "secret-name", "nskaniko", "/secret.json", "120m",
 					withGitTagger(),
 					withDockerConfig("config-name", "/kaniko/.docker"),
+					withAWSSecret("aws-secret-name", "/root/.aws"),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
 			),
@@ -273,6 +277,15 @@ func withKanikoBuild(bucket, secretName, namespace, secret string, timeout strin
 func withDockerConfig(secretName string, path string) func(*latest.BuildConfig) {
 	return func(cfg *latest.BuildConfig) {
 		cfg.KanikoBuild.DockerConfig = &latest.DockerConfig{
+			SecretName: secretName,
+			Path:       path,
+		}
+	}
+}
+
+func withAWSSecret(secretName string, path string) func(*latest.BuildConfig) {
+	return func(cfg *latest.BuildConfig) {
+		cfg.KanikoBuild.AWSSecret = &latest.AWSSecret{
 			SecretName: secretName,
 			Path:       path,
 		}


### PR DESCRIPTION
Kaniko supports an AWS secret used to push/pull from ECR repositories.
This adds support for it to Skaffold.
I'm happy to review the design if necessary.
I tested this end to end in a custom build of mine against our internal ECR repository and it works fine.
CLA is in progress (we want to sign it as a company, so it's taking a bit more time).