### PR TITLE
completion: add wrapper code to transform bash to zsh completion

### DIFF
--- a/cmd/skaffold/app/cmd/completion.go
+++ b/cmd/skaffold/app/cmd/completion.go
@@ -14,6 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+NOTICE: The zsh wrapper code below is derived from the completion code
+in kubectl (k8s.io/kubernetes/pkg/kubectl/cmd/completion/completion.go),
+with the following license:
+
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmd
 
 import (

--- a/cmd/skaffold/app/cmd/completion.go
+++ b/cmd/skaffold/app/cmd/completion.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -24,7 +25,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const longDescription = `
+const (
+	longDescription = `
 	Outputs shell completion for the given shell (bash or zsh)
 
 	This depends on the bash-completion binary.  Example installation instructions:
@@ -42,6 +44,159 @@ const longDescription = `
 
 	Additionally, you may want to output the completion to a file and source in your .bashrc
 `
+
+	zshInitialization = `#compdef skaffold
+
+__skaffold_bash_source() {
+	alias shopt=':'
+	alias _expand=_bash_expand
+	alias _complete=_bash_comp
+	emulate -L sh
+	setopt kshglob noshglob braceexpand
+
+	source "$@"
+}
+
+__skaffold_type() {
+	# -t is not supported by zsh
+	if [ "$1" == "-t" ]; then
+		shift
+
+		# fake Bash 4 to disable "complete -o nospace". Instead
+		# "compopt +-o nospace" is used in the code to toggle trailing
+		# spaces. We don't support that, but leave trailing spaces on
+		# all the time
+		if [ "$1" = "__skaffold_compopt" ]; then
+			echo builtin
+			return 0
+		fi
+	fi
+	type "$@"
+}
+
+__skaffold_compgen() {
+	local completions w
+	completions=( $(compgen "$@") ) || return $?
+
+	# filter by given word as prefix
+	while [[ "$1" = -* && "$1" != -- ]]; do
+		shift
+		shift
+	done
+	if [[ "$1" == -- ]]; then
+		shift
+	fi
+	for w in "${completions[@]}"; do
+		if [[ "${w}" = "$1"* ]]; then
+			echo "${w}"
+		fi
+	done
+}
+
+__skaffold_compopt() {
+	true # don't do anything. Not supported by bashcompinit in zsh
+}
+
+__skaffold_ltrim_colon_completions()
+{
+	if [[ "$1" == *:* && "$COMP_WORDBREAKS" == *:* ]]; then
+		# Remove colon-word prefix from COMPREPLY items
+		local colon_word=${1%${1##*:}}
+		local i=${#COMPREPLY[*]}
+		while [[ $((--i)) -ge 0 ]]; do
+			COMPREPLY[$i]=${COMPREPLY[$i]#"$colon_word"}
+		done
+	fi
+}
+
+__skaffold_get_comp_words_by_ref() {
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[${COMP_CWORD}-1]}"
+	words=("${COMP_WORDS[@]}")
+	cword=("${COMP_CWORD[@]}")
+}
+
+__skaffold_filedir() {
+	local RET OLD_IFS w qw
+
+	__skaffold_debug "_filedir $@ cur=$cur"
+	if [[ "$1" = \~* ]]; then
+		# somehow does not work. Maybe, zsh does not call this at all
+		eval echo "$1"
+		return 0
+	fi
+
+	OLD_IFS="$IFS"
+	IFS=$'\n'
+	if [ "$1" = "-d" ]; then
+		shift
+		RET=( $(compgen -d) )
+	else
+		RET=( $(compgen -f) )
+	fi
+	IFS="$OLD_IFS"
+
+	IFS="," __skaffold_debug "RET=${RET[@]} len=${#RET[@]}"
+
+	for w in ${RET[@]}; do
+		if [[ ! "${w}" = "${cur}"* ]]; then
+			continue
+		fi
+		if eval "[[ \"\${w}\" = *.$1 || -d \"\${w}\" ]]"; then
+			qw="$(__skaffold_quote "${w}")"
+			if [ -d "${w}" ]; then
+				COMPREPLY+=("${qw}/")
+			else
+				COMPREPLY+=("${qw}")
+			fi
+		fi
+	done
+}
+
+__skaffold_quote() {
+    if [[ $1 == \'* || $1 == \"* ]]; then
+        # Leave out first character
+        printf %q "${1:1}"
+    else
+	printf %q "$1"
+    fi
+}
+
+autoload -U +X bashcompinit && bashcompinit
+
+# use word boundary patterns for BSD or GNU sed
+LWORD='[[:<:]]'
+RWORD='[[:>:]]'
+if sed --help 2>&1 | grep -q GNU; then
+	LWORD='\<'
+	RWORD='\>'
+fi
+
+__skaffold_convert_bash_to_zsh() {
+	sed \
+	-e 's/declare -F/whence -w/' \
+	-e 's/_get_comp_words_by_ref "\$@"/_get_comp_words_by_ref "\$*"/' \
+	-e 's/local \([a-zA-Z0-9_]*\)=/local \1; \1=/' \
+	-e 's/flags+=("\(--.*\)=")/flags+=("\1"); two_word_flags+=("\1")/' \
+	-e 's/must_have_one_flag+=("\(--.*\)=")/must_have_one_flag+=("\1")/' \
+	-e "s/${LWORD}_filedir${RWORD}/__skaffold_filedir/g" \
+	-e "s/${LWORD}_get_comp_words_by_ref${RWORD}/__skaffold_get_comp_words_by_ref/g" \
+	-e "s/${LWORD}__ltrim_colon_completions${RWORD}/__skaffold_ltrim_colon_completions/g" \
+	-e "s/${LWORD}compgen${RWORD}/__skaffold_compgen/g" \
+	-e "s/${LWORD}compopt${RWORD}/__skaffold_compopt/g" \
+	-e "s/${LWORD}declare${RWORD}/builtin declare/g" \
+	-e "s/\\\$(type${RWORD}/\$(__skaffold_type/g" \
+	<<'BASH_COMPLETION_EOF'
+`
+
+	zshTail = `
+BASH_COMPLETION_EOF
+}
+
+__skaffold_bash_source <(__skaffold_convert_bash_to_zsh)
+_complete skaffold 2>/dev/null
+`
+)
 
 var completionCmd = &cobra.Command{
 	Use: "completion SHELL",
@@ -62,11 +217,20 @@ func completion(_cmd *cobra.Command, args []string) {
 	case "bash":
 		rootCmd.GenBashCompletion(os.Stdout)
 	case "zsh":
-		rootCmd.GenZshCompletion(os.Stdout)
+		runCompletionZsh(os.Stdout)
 	}
 }
 
 // NewCmdCompletion returns the cobra command that outputs shell completion code
 func NewCmdCompletion(out io.Writer) *cobra.Command {
 	return completionCmd
+}
+
+func runCompletionZsh(out io.Writer) error {
+	io.WriteString(out, zshInitialization)
+	buf := new(bytes.Buffer)
+	rootCmd.GenBashCompletion(buf)
+	out.Write(buf.Bytes())
+	io.WriteString(out, zshTail)
+	return nil
 }


### PR DESCRIPTION
Cobra zsh completion is pretty broken. The idea is therefore, to use the working bash completion from cobra and wrap that with zsh adapter code. This code is based on the kubectl wrapper script.

I'm a bit unsure about the proper copyright notice. I left it as-is, but the beef of the logic comes from https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/completion/completion.go . Must I therefore include a proper attribution for the wrapper script?

Fixes #1671 
