### PR TITLE
Handle pointers in profile overlay

### DIFF
--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -233,6 +233,12 @@ func overlayProfileField(config interface{}, profile interface{}) interface{} {
 			return config
 		}
 		return v.Interface()
+	case reflect.Ptr:
+		// either return the values provided in the profile, or the original values if none were provided.
+		if v.IsNil() {
+			return config
+		}
+		return v.Interface()
 	default:
 		logrus.Warnf("unknown field type in profile overlay: %s. falling back to original config values", v.Kind())
 		return config

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	cfg "github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	yamlpatch "github.com/krishicks/yaml-patch"
@@ -265,6 +266,72 @@ func TestApplyProfiles(t *testing.T) {
 					ImageName:      "image",
 					StructureTests: []string{"test/*"},
 				}),
+			),
+		},
+		{
+			description: "execution environment",
+			profile:     "profile",
+			config: config(
+				withLocalBuild(
+					withGitTagger(),
+					withExecutionEnvironment(constants.Local),
+				),
+				withProfiles(latest.Profile{
+					Name: "profile",
+					Build: latest.BuildConfig{
+						ExecutionEnvironment: &latest.ExecutionEnvironment{
+							Name: constants.GoogleCloudBuild,
+						},
+					},
+				}),
+			),
+			expected: config(
+				withLocalBuild(
+					withGitTagger(),
+					withExecutionEnvironment(constants.GoogleCloudBuild),
+				),
+			),
+		},
+		{
+			description: "existing execution environment",
+			profile:     "profile",
+			config: config(
+				withLocalBuild(
+					withGitTagger(),
+					withExecutionEnvironment(constants.Local),
+				),
+				withProfiles(latest.Profile{
+					Name: "profile",
+				}),
+			),
+			expected: config(
+				withLocalBuild(
+					withGitTagger(),
+					withExecutionEnvironment(constants.Local),
+				),
+			),
+		},
+		{
+			description: "no original execution environment",
+			profile:     "profile",
+			config: config(
+				withLocalBuild(
+					withGitTagger(),
+				),
+				withProfiles(latest.Profile{
+					Name: "profile",
+					Build: latest.BuildConfig{
+						ExecutionEnvironment: &latest.ExecutionEnvironment{
+							Name: constants.GoogleCloudBuild,
+						},
+					},
+				}),
+			),
+			expected: config(
+				withLocalBuild(
+					withGitTagger(),
+					withExecutionEnvironment(constants.GoogleCloudBuild),
+				),
 			),
 		},
 	}

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -353,6 +353,13 @@ func withTests(testCases ...*latest.TestCase) func(*latest.SkaffoldPipeline) {
 	}
 }
 
+func withExecutionEnvironment(name latest.ExecEnvironment) func(*latest.BuildConfig) {
+	return func(cfg *latest.BuildConfig) {
+		cfg.ExecutionEnvironment = &latest.ExecutionEnvironment{
+			Name: name,
+		}
+	}
+}
 func TestUpgradeToNextVersion(t *testing.T) {
 	for i, schemaVersion := range SchemaVersions[0 : len(SchemaVersions)-2] {
 		from := schemaVersion


### PR DESCRIPTION
Return original values, or values in profile, upon encoutering a
pointer. This should fix a warning generated by the new
*ExecutionEnvironment pointer in the BuildConfig. Also adds unit tests
to check this functionality.

Fixes #1688