### PR TITLE
Build before

### DIFF
--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -33,6 +33,8 @@ func TestDevSync(t *testing.T) {
 	ns, deleteNs := SetupNamespace(t)
 	defer deleteNs()
 
+	RunSkaffold(t, "build", "examples/test-file-sync", ns.Name, "", nil)
+
 	cancel := make(chan bool)
 	go RunSkaffoldNoFail(cancel, "dev", "examples/test-file-sync", ns.Name, "", nil)
 	defer func() { cancel <- true }()


### PR DESCRIPTION
This makes sure we don’t wait for the pod to start
while the image is building.

Can maybe fix a race condition

Signed-off-by: David Gageot <david@gageot.net>