### PR TITLE
Fix default-repo handling for images with non-alphabetic characters

### DIFF
--- a/pkg/skaffold/util/image.go
+++ b/pkg/skaffold/util/image.go
@@ -25,7 +25,7 @@ const maxLength = 255
 
 const gcr = "gcr.io"
 const escapeChars = "[/._:@]"
-const prefixRegexStr = "gcr.io/[a-zA-Z]+/"
+const prefixRegexStr = "gcr.io/[a-zA-Z0-9-_]+/"
 
 var escapeRegex = regexp.MustCompile(escapeChars)
 var prefixRegex = regexp.MustCompile(prefixRegexStr)

--- a/pkg/skaffold/util/image_test.go
+++ b/pkg/skaffold/util/image_test.go
@@ -64,6 +64,12 @@ func TestImageReplaceDefaultRepo(t *testing.T) {
 			defaultRepo:   "aws_account_id.dkr.ecr.region.amazonaws.com",
 			expectedImage: "aws_account_id.dkr.ecr.region.amazonaws.com/gcr_io_herewehaveanincrediblylongregistryname_herewealsohaveanabnormallylongimagename_doubtyouveseenanimagethislong_butyouneverknowdoyouimeanpeopledosomecrazystuffoutthere_goodluckpushingthistoanyregistrymyfrien",
 		},
+		{
+			name:          "normal GCR concatenation with numbers and other characters",
+			image:         "gcr.io/k8s-skaffold/skaffold-example",
+			defaultRepo:   "gcr.io/k8s-skaffold",
+			expectedImage: "gcr.io/k8s-skaffold/skaffold-example",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #1657 

This fixes an issue with the default-repo regex missing numeric characters, as well as hypens and underscores.