### PR TITLE
Add support for ECR pod specs for kaniko

### DIFF
--- a/docs/content/en/schemas/v1beta6.json
+++ b/docs/content/en/schemas/v1beta6.json
@@ -331,6 +331,16 @@
         "dockerConfig": {
           "$ref": "#/definitions/DockerConfig",
           "description": "describes how to mount the local Docker configuration into the Kaniko pod."
+        },
+        "isECR": {
+          "type": "boolean",
+          "description": "Specifies if kaniko pod would be configured with ECR secret settings in mind",
+          "default": "false"
+        },
+        "awsRegion": {
+          "type": "string",
+          "description": "Specifies AWS region where the ECR images will be pushed if ECR is enabled",
+          "default": "us-east-1"
         }
       },
       "additionalProperties": false,

--- a/pkg/skaffold/build/kaniko/sources/sources.go
+++ b/pkg/skaffold/build/kaniko/sources/sources.go
@@ -79,11 +79,34 @@ func podTemplate(cfg *latest.KanikoBuild, args []string) *v1.Pod {
 				VolumeSource: v1.VolumeSource{
 					Secret: &v1.SecretVolumeSource{
 						SecretName: cfg.PullSecretName,
+						Items: []v1.KeyToPath{
+							{
+								Key:  constants.DefaultKanikoSecretName,
+								Path: "./" + constants.DefaultKanikoSecretName,
+							},
+							{
+								Key:  constants.DefaultKanikoSecretName,
+								Path: "./credentials",
+							},
+						},
 					},
 				},
 			},
 			},
 		},
+	}
+
+	if cfg.IsECR == true {
+		volumeMountECR := v1.VolumeMount{
+			Name:      constants.DefaultKanikoSecretName,
+			MountPath: constants.DefaultKanikoECRSecretPath,
+		}
+		envVarECR := v1.EnvVar{
+							Name:  "AWS_DEFAULT_REGION",
+							Value: cfg.AwsRegion,
+		}
+		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, volumeMountECR)
+		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, envVarECR)
 	}
 
 	if cfg.DockerConfig == nil {

--- a/pkg/skaffold/build/kaniko/sources/sources.go
+++ b/pkg/skaffold/build/kaniko/sources/sources.go
@@ -96,14 +96,14 @@ func podTemplate(cfg *latest.KanikoBuild, args []string) *v1.Pod {
 		},
 	}
 
-	if cfg.IsECR == true {
+	if cfg.IsECR {
 		volumeMountECR := v1.VolumeMount{
 			Name:      constants.DefaultKanikoSecretName,
 			MountPath: constants.DefaultKanikoECRSecretPath,
 		}
 		envVarECR := v1.EnvVar{
-							Name:  "AWS_DEFAULT_REGION",
-							Value: cfg.AwsRegion,
+			Name:  "AWS_DEFAULT_REGION",
+			Value: cfg.AwsRegion,
 		}
 		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, volumeMountECR)
 		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, envVarECR)

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -53,6 +53,8 @@ const (
 	DefaultKanikoEmptyDirMountPath      = "/kaniko/buildcontext"
 	DefaultKanikoDockerConfigSecretName = "docker-cfg"
 	DefaultKanikoDockerConfigPath       = "/kaniko/.docker"
+	DefaultKanikoECRSecretPath          = "/root/.aws/"
+	DefaultKanikoAWSRegion              = "us-east-1"
 
 	DefaultBusyboxImage = "busybox"
 

--- a/pkg/skaffold/runner/timings.go
+++ b/pkg/skaffold/runner/timings.go
@@ -55,6 +55,7 @@ func (w withTimings) Labels() map[string]string {
 func (w withTimings) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 	start := time.Now()
 	color.Default.Fprintln(out, "Starting build...")
+	color.Default.Fprintln(out, "Tags of artifacts:", tags)
 
 	bRes, err := w.Builder.Build(ctx, out, tags, artifacts)
 	if err != nil {

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -54,6 +54,7 @@ func Set(c *latest.SkaffoldPipeline) error {
 		setDefaultKanikoSecret,
 		setDefaultKanikoBuildContext,
 		setDefaultDockerConfigSecret,
+		setDefaultKanikoAWSRegion,
 	); err != nil {
 		return err
 	}
@@ -234,6 +235,11 @@ func setDefaultKanikoSecret(kaniko *latest.KanikoBuild) error {
 		return nil
 	}
 
+	return nil
+}
+
+func setDefaultKanikoAWSRegion(kaniko *latest.KanikoBuild) error {
+	kaniko.AwsRegion = valueOrDefault(kaniko.AwsRegion, constants.DefaultKanikoAWSRegion)
 	return nil
 }
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -268,6 +268,13 @@ type KanikoBuild struct {
 	// DockerConfig describes how to mount the local Docker configuration into the
 	// Kaniko pod.
 	DockerConfig *DockerConfig `yaml:"dockerConfig,omitempty"`
+
+	// Specifies if kaniko pod would be configured with ECR secret settings in mind
+	IsECR bool `yaml:"isECR,omitempty"`
+
+	// Specifies AWS region where the ECR images will be pushed if ECR is enabled
+	// Defaults to `us-east-1`
+	AwsRegion string `yaml:"awsRegion,omitempty"`
 }
 
 // DockerConfig contains information about the docker `config.json` to mount.

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -262,6 +262,7 @@ func withKanikoBuild(bucket, secretName, namespace, secret string, timeout strin
 			PullSecret:     secret,
 			Timeout:        timeout,
 			Image:          constants.DefaultKanikoImage,
+			AwsRegion:      constants.DefaultKanikoAWSRegion,
 		}}}
 		for _, op := range ops {
 			op(&b)


### PR DESCRIPTION
This PR adds support for proper ECR pod specs for kaniko. Previously, Kaniko pod template didn't have proper environment variables and volume mounts to have it working properly.

Kinda related issue: https://github.com/GoogleContainerTools/skaffold/issues/731