### PR TITLE
Fix typo in option name for 'enable-rpc'

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -142,7 +142,7 @@ func AddRunDeployFlags(cmd *cobra.Command) {
 }
 
 func AddRunDevFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&opts.EnableRPC, "--enable-rpc", false, "Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)")
+	cmd.Flags().BoolVar(&opts.EnableRPC, "enable-rpc", false, "Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)")
 	cmd.Flags().StringVar(&opts.RPCPort, "rpc-port", ":50051", "tcp port to expose event API")
 	cmd.Flags().StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
 	cmd.Flags().BoolVar(&opts.Notification, "toot", false, "Emit a terminal beep after the deploy is complete")

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -63,11 +63,11 @@ Usage:
   skaffold build [flags]
 
 Flags:
-      ----enable-rpc skaffold dev    Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
   -b, --build-image stringArray      Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts
       --cache-artifacts              Set to true to enable caching of artifacts.
       --cache-file string            Specify the location of the cache file (default $HOME/.skaffold/cache)
   -d, --default-repo string          Default repository value (overrides global config)
+      --enable-rpc skaffold dev      Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
   -f, --filename string              Filename or URL to the pipeline file (default "skaffold.yaml")
   -n, --namespace string             Run deployments in the specified namespace
   -o, --output *flags.TemplateFlag   Format output with go-template. For full struct documentation, see https://godoc.org/github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd#BuildOutput (default {{range .Builds}}{{.ImageName}} -> {{.Tag}}
@@ -86,11 +86,11 @@ Global Flags:
 ```
 Env vars:
 
-* `SKAFFOLD___ENABLE_RPC` (same as ----enable-rpc)
 * `SKAFFOLD_BUILD_IMAGE` (same as --build-image)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as --cache-artifacts)
 * `SKAFFOLD_CACHE_FILE` (same as --cache-file)
 * `SKAFFOLD_DEFAULT_REPO` (same as --default-repo)
+* `SKAFFOLD_ENABLE_RPC` (same as --enable-rpc)
 * `SKAFFOLD_FILENAME` (same as --filename)
 * `SKAFFOLD_NAMESPACE` (same as --namespace)
 * `SKAFFOLD_OUTPUT` (same as --output)
@@ -150,16 +150,16 @@ Usage:
   skaffold delete [flags]
 
 Flags:
-      ----enable-rpc skaffold dev   Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-      --cache-artifacts             Set to true to enable caching of artifacts.
-      --cache-file string           Specify the location of the cache file (default $HOME/.skaffold/cache)
-  -d, --default-repo string         Default repository value (overrides global config)
-  -f, --filename string             Filename or URL to the pipeline file (default "skaffold.yaml")
-  -n, --namespace string            Run deployments in the specified namespace
-  -p, --profile stringArray         Activate profiles by name
-      --rpc-port string             tcp port to expose event API (default ":50051")
-      --skip-tests                  Whether to skip the tests after building
-      --toot                        Emit a terminal beep after the deploy is complete
+      --cache-artifacts           Set to true to enable caching of artifacts.
+      --cache-file string         Specify the location of the cache file (default $HOME/.skaffold/cache)
+  -d, --default-repo string       Default repository value (overrides global config)
+      --enable-rpc skaffold dev   Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+  -f, --filename string           Filename or URL to the pipeline file (default "skaffold.yaml")
+  -n, --namespace string          Run deployments in the specified namespace
+  -p, --profile stringArray       Activate profiles by name
+      --rpc-port string           tcp port to expose event API (default ":50051")
+      --skip-tests                Whether to skip the tests after building
+      --toot                      Emit a terminal beep after the deploy is complete
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -169,10 +169,10 @@ Global Flags:
 ```
 Env vars:
 
-* `SKAFFOLD___ENABLE_RPC` (same as ----enable-rpc)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as --cache-artifacts)
 * `SKAFFOLD_CACHE_FILE` (same as --cache-file)
 * `SKAFFOLD_DEFAULT_REPO` (same as --default-repo)
+* `SKAFFOLD_ENABLE_RPC` (same as --enable-rpc)
 * `SKAFFOLD_FILENAME` (same as --filename)
 * `SKAFFOLD_NAMESPACE` (same as --namespace)
 * `SKAFFOLD_PROFILE` (same as --profile)
@@ -189,19 +189,19 @@ Usage:
   skaffold deploy [flags]
 
 Flags:
-      ----enable-rpc skaffold dev   Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-      --cache-artifacts             Set to true to enable caching of artifacts.
-      --cache-file string           Specify the location of the cache file (default $HOME/.skaffold/cache)
-  -d, --default-repo string         Default repository value (overrides global config)
-  -f, --filename string             Filename or URL to the pipeline file (default "skaffold.yaml")
-      --images strings              A list of pre-built images to deploy
-  -l, --label stringArray           Add custom labels to deployed objects. Set multiple times for multiple labels.
-  -n, --namespace string            Run deployments in the specified namespace
-  -p, --profile stringArray         Activate profiles by name
-      --rpc-port string             tcp port to expose event API (default ":50051")
-      --skip-tests                  Whether to skip the tests after building
-      --tail                        Stream logs from deployed objects
-      --toot                        Emit a terminal beep after the deploy is complete
+      --cache-artifacts           Set to true to enable caching of artifacts.
+      --cache-file string         Specify the location of the cache file (default $HOME/.skaffold/cache)
+  -d, --default-repo string       Default repository value (overrides global config)
+      --enable-rpc skaffold dev   Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+  -f, --filename string           Filename or URL to the pipeline file (default "skaffold.yaml")
+      --images strings            A list of pre-built images to deploy
+  -l, --label stringArray         Add custom labels to deployed objects. Set multiple times for multiple labels.
+  -n, --namespace string          Run deployments in the specified namespace
+  -p, --profile stringArray       Activate profiles by name
+      --rpc-port string           tcp port to expose event API (default ":50051")
+      --skip-tests                Whether to skip the tests after building
+      --tail                      Stream logs from deployed objects
+      --toot                      Emit a terminal beep after the deploy is complete
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -211,10 +211,10 @@ Global Flags:
 ```
 Env vars:
 
-* `SKAFFOLD___ENABLE_RPC` (same as ----enable-rpc)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as --cache-artifacts)
 * `SKAFFOLD_CACHE_FILE` (same as --cache-file)
 * `SKAFFOLD_DEFAULT_REPO` (same as --default-repo)
+* `SKAFFOLD_ENABLE_RPC` (same as --enable-rpc)
 * `SKAFFOLD_FILENAME` (same as --filename)
 * `SKAFFOLD_IMAGES` (same as --images)
 * `SKAFFOLD_LABEL` (same as --label)
@@ -234,24 +234,24 @@ Usage:
   skaffold dev [flags]
 
 Flags:
-      ----enable-rpc skaffold dev   Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-      --cache-artifacts             Set to true to enable caching of artifacts.
-      --cache-file string           Specify the location of the cache file (default $HOME/.skaffold/cache)
-      --cleanup                     Delete deployments after dev mode is interrupted (default true)
-  -d, --default-repo string         Default repository value (overrides global config)
-      --experimental-gui            Experimental Graphical User Interface
-  -f, --filename string             Filename or URL to the pipeline file (default "skaffold.yaml")
-  -l, --label stringArray           Add custom labels to deployed objects. Set multiple times for multiple labels
-  -n, --namespace string            Run deployments in the specified namespace
-      --port-forward                Port-forward exposed container ports within pods (default true)
-  -p, --profile stringArray         Activate profiles by name
-      --rpc-port string             tcp port to expose event API (default ":50051")
-      --skip-tests                  Whether to skip the tests after building
-      --tail                        Stream logs from deployed objects (default true)
-      --toot                        Emit a terminal beep after the deploy is complete
-      --trigger string              How are changes detected? (polling, manual or notify) (default "polling")
-  -w, --watch-image stringArray     Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts
-  -i, --watch-poll-interval int     Interval (in ms) between two checks for file changes (default 1000)
+      --cache-artifacts           Set to true to enable caching of artifacts.
+      --cache-file string         Specify the location of the cache file (default $HOME/.skaffold/cache)
+      --cleanup                   Delete deployments after dev mode is interrupted (default true)
+  -d, --default-repo string       Default repository value (overrides global config)
+      --enable-rpc skaffold dev   Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+      --experimental-gui          Experimental Graphical User Interface
+  -f, --filename string           Filename or URL to the pipeline file (default "skaffold.yaml")
+  -l, --label stringArray         Add custom labels to deployed objects. Set multiple times for multiple labels
+  -n, --namespace string          Run deployments in the specified namespace
+      --port-forward              Port-forward exposed container ports within pods (default true)
+  -p, --profile stringArray       Activate profiles by name
+      --rpc-port string           tcp port to expose event API (default ":50051")
+      --skip-tests                Whether to skip the tests after building
+      --tail                      Stream logs from deployed objects (default true)
+      --toot                      Emit a terminal beep after the deploy is complete
+      --trigger string            How are changes detected? (polling, manual or notify) (default "polling")
+  -w, --watch-image stringArray   Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts
+  -i, --watch-poll-interval int   Interval (in ms) between two checks for file changes (default 1000)
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -261,11 +261,11 @@ Global Flags:
 ```
 Env vars:
 
-* `SKAFFOLD___ENABLE_RPC` (same as ----enable-rpc)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as --cache-artifacts)
 * `SKAFFOLD_CACHE_FILE` (same as --cache-file)
 * `SKAFFOLD_CLEANUP` (same as --cleanup)
 * `SKAFFOLD_DEFAULT_REPO` (same as --default-repo)
+* `SKAFFOLD_ENABLE_RPC` (same as --enable-rpc)
 * `SKAFFOLD_EXPERIMENTAL_GUI` (same as --experimental-gui)
 * `SKAFFOLD_FILENAME` (same as --filename)
 * `SKAFFOLD_LABEL` (same as --label)
@@ -365,19 +365,19 @@ Usage:
   skaffold run [flags]
 
 Flags:
-      ----enable-rpc skaffold dev   Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-      --cache-artifacts             Set to true to enable caching of artifacts.
-      --cache-file string           Specify the location of the cache file (default $HOME/.skaffold/cache)
-  -d, --default-repo string         Default repository value (overrides global config)
-  -f, --filename string             Filename or URL to the pipeline file (default "skaffold.yaml")
-  -l, --label stringArray           Add custom labels to deployed objects. Set multiple times for multiple labels.
-  -n, --namespace string            Run deployments in the specified namespace
-  -p, --profile stringArray         Activate profiles by name
-      --rpc-port string             tcp port to expose event API (default ":50051")
-      --skip-tests                  Whether to skip the tests after building
-  -t, --tag string                  The optional custom tag to use for images which overrides the current Tagger configuration
-      --tail                        Stream logs from deployed objects
-      --toot                        Emit a terminal beep after the deploy is complete
+      --cache-artifacts           Set to true to enable caching of artifacts.
+      --cache-file string         Specify the location of the cache file (default $HOME/.skaffold/cache)
+  -d, --default-repo string       Default repository value (overrides global config)
+      --enable-rpc skaffold dev   Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+  -f, --filename string           Filename or URL to the pipeline file (default "skaffold.yaml")
+  -l, --label stringArray         Add custom labels to deployed objects. Set multiple times for multiple labels.
+  -n, --namespace string          Run deployments in the specified namespace
+  -p, --profile stringArray       Activate profiles by name
+      --rpc-port string           tcp port to expose event API (default ":50051")
+      --skip-tests                Whether to skip the tests after building
+  -t, --tag string                The optional custom tag to use for images which overrides the current Tagger configuration
+      --tail                      Stream logs from deployed objects
+      --toot                      Emit a terminal beep after the deploy is complete
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -387,10 +387,10 @@ Global Flags:
 ```
 Env vars:
 
-* `SKAFFOLD___ENABLE_RPC` (same as ----enable-rpc)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as --cache-artifacts)
 * `SKAFFOLD_CACHE_FILE` (same as --cache-file)
 * `SKAFFOLD_DEFAULT_REPO` (same as --default-repo)
+* `SKAFFOLD_ENABLE_RPC` (same as --enable-rpc)
 * `SKAFFOLD_FILENAME` (same as --filename)
 * `SKAFFOLD_LABEL` (same as --label)
 * `SKAFFOLD_NAMESPACE` (same as --namespace)


### PR DESCRIPTION
Enable rcp has a very strange long option name, namely `----enable-rpc` (4! dashes). This is probably a typo?

This PR renames the flag `----enable-rpc` -> `--enable-rpc`