### PR TITLE
Fix regression in sync

### DIFF
--- a/pkg/skaffold/sync/kubectl/kubectl.go
+++ b/pkg/skaffold/sync/kubectl/kubectl.go
@@ -74,7 +74,7 @@ func copyFileFn(ctx context.Context, pod v1.Pod, container v1.Container, files m
 	// Use "m" flag to touch the files as they are copied.
 	reader, writer := io.Pipe()
 	copy := exec.CommandContext(ctx, "kubectl", "exec", pod.Name, "--namespace", pod.Namespace, "-c", container.Name, "-i",
-		"--", "tar", "xmf", "-", "--no-same-owner")
+		"--", "tar", "xmf", "-", "-C", "/", "--no-same-owner")
 	copy.Stdin = reader
 	go func() {
 		defer writer.Close()


### PR DESCRIPTION
In #1709 I introduced a regression to sync by removing the "-C /" from
the tar extraction, which forced all files to be extracted at root. We
actually still want this, since now that we append the workdir for relative paths  all paths in the
tarball are absolute paths and so should be extracted at root.

This should fix #1721.