### PR TITLE
Improve `skaffold init` performance by not walking hidden dirs.

### DIFF
--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -86,10 +86,11 @@ func doInit(out io.Writer) error {
 
 	var potentialConfigs, k8sConfigs, dockerfiles, images []string
 	err := filepath.Walk(rootDir, func(path string, f os.FileInfo, e error) error {
-		if f.IsDir() {
-			return nil
+		if f.IsDir() && util.IsHiddenDir(f.Name()) {
+			logrus.Debugf("skip walking hidden dir %s", f.Name())
+			return filepath.SkipDir
 		}
-		if strings.HasPrefix(path, ".") {
+		if f.IsDir() || util.IsHiddenFile(f.Name()) {
 			return nil
 		}
 		if util.IsSupportedKubernetesFormat(path) {

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -38,6 +38,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	hiddenPrefix string = "."
+)
+
 func RandomID() string {
 	b := make([]byte, 16)
 	_, err := rand.Read(b)
@@ -292,4 +296,23 @@ func AbsolutePaths(workspace string, paths []string) []string {
 		p = append(p, path)
 	}
 	return p
+}
+
+// IsHiddenDir returns if a directory is hidden.
+func IsHiddenDir(filename string) bool {
+	// Return false for current dir
+	if filename == hiddenPrefix {
+		return false
+	}
+	return hasHiddenPrefix(filename)
+}
+
+// IsHiddenFile returns if a file is hidden.
+// File is hidden if it starts with prefix "."
+func IsHiddenFile(filename string) bool {
+	return hasHiddenPrefix(filename)
+}
+
+func hasHiddenPrefix(s string) bool {
+	return strings.HasPrefix(s, hiddenPrefix)
 }

--- a/pkg/skaffold/util/util_test.go
+++ b/pkg/skaffold/util/util_test.go
@@ -235,3 +235,60 @@ func TestCloneThroughJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestIsHiddenDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		expected bool
+	}{
+		{
+			name:     "hidden dir",
+			filename: ".hidden",
+			expected: true,
+		},
+		{
+			name:     "not hidden dir",
+			filename: "not_hidden",
+			expected: false,
+		},
+		{
+			name:     "current dir",
+			filename: ".",
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if IsHiddenDir(test.filename) != test.expected {
+				t.Errorf("error want %t,  got %t", test.expected, !test.expected)
+			}
+		})
+	}
+}
+
+func TestIsHiddenFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		expected bool
+	}{
+		{
+			name:     "hidden file name",
+			filename: ".hidden",
+			expected: true,
+		},
+		{
+			name:     "not hidden file",
+			filename: "not_hidden",
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if IsHiddenDir(test.filename) != test.expected {
+				t.Errorf("error want %t,  got %t", test.expected, !test.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`skaffold init` should skip walking hidden directories like .git,
IDE config dirs like .vscode, .idea etc.

For a small github project with .git dir of 44K, the time improvement
was 1.3 ms or roughly 86%

Please see gist https://gist.github.com/tejal29/96958f32ea88cecd6cbe5edd26c68968