### PR TITLE
Add --analyze flag to skaffold init

### DIFF
--- a/cmd/skaffold/app/cmd/init_test.go
+++ b/cmd/skaffold/app/cmd/init_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"testing"
 
@@ -59,4 +60,41 @@ deploy:
 	buf, err := generateSkaffoldPipeline(k8sConfigs, dockerfilePairs)
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, expectedYaml, string(buf))
+}
+
+func TestPrintAnalyzeJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		dockerfiles []string
+		images      []string
+		expected    string
+	}{
+		{
+			name:        "dockerfile and image",
+			dockerfiles: []string{"Dockerfile", "Dockerfile_2"},
+			images:      []string{"image1", "image2"},
+			expected:    "{\"dockerfiles\":[\"Dockerfile\",\"Dockerfile_2\"],\"images\":[\"image1\",\"image2\"]}",
+		},
+		{
+			name:     "no dockerfile",
+			images:   []string{"image1", "image2"},
+			expected: "{\"images\":[\"image1\",\"image2\"]}",
+		},
+		{
+			name:        "no images",
+			dockerfiles: []string{"Dockerfile", "Dockerfile_2"},
+			expected:    "{\"dockerfiles\":[\"Dockerfile\",\"Dockerfile_2\"]}",
+		},
+		{
+			name:     "no dockerfiles or images",
+			expected: "{}",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := bytes.NewBuffer([]byte{})
+			err := printAnalyzeJSON(out, test.dockerfiles, test.images)
+			testutil.CheckErrorAndDeepEqual(t, false, err, test.expected, out.String())
+		})
+	}
 }

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -335,6 +335,7 @@ Usage:
   skaffold init [flags]
 
 Flags:
+      --analyze                Print all discoverable Dockerfiles and images in JSON format to stdout
   -a, --artifact stringArray   '='-delimited dockerfile/image pair to generate build artifact
                                (example: --artifact=/web/Dockerfile.web=gcr.io/web-project/image)
       --compose-file string    Initialize from a docker-compose file
@@ -350,6 +351,7 @@ Global Flags:
 ```
 Env vars:
 
+* `SKAFFOLD_ANALYZE` (same as --analyze)
 * `SKAFFOLD_ARTIFACT` (same as --artifact)
 * `SKAFFOLD_COMPOSE_FILE` (same as --compose-file)
 * `SKAFFOLD_FILENAME` (same as --filename)


### PR DESCRIPTION
The --analyze flag will print out all dockerfiles and images found in
the workspace in JSON format.

Should fix #1710