### PR TITLE
make initContainer in localDir type of kaniko build param

### DIFF
--- a/docs/content/en/schemas/v1beta6.json
+++ b/docs/content/en/schemas/v1beta6.json
@@ -1424,6 +1424,17 @@
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
     "LocalDir": {
+      "properties": {
+        "initImage": {
+          "type": "string",
+          "description": "image used to run init container which mounts kaniko context.",
+          "x-intellij-html-description": "image used to run init container which mounts kaniko context."
+        }
+      },
+      "preferredOrder": [
+        "initImage"
+      ],
+      "additionalProperties": false,
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },

--- a/pkg/skaffold/build/kaniko/sources/localdir.go
+++ b/pkg/skaffold/build/kaniko/sources/localdir.go
@@ -79,7 +79,7 @@ func (g *LocalDir) Pod(args []string) *v1.Pod {
 	// Generate the init container, which will run until the /tmp/complete file is created
 	ic := v1.Container{
 		Name:         initContainer,
-		Image:        constants.DefaultBusyboxImage,
+		Image:        g.cfg.BuildContext.LocalDir.InitImage,
 		Command:      []string{"sh", "-c", "while [ ! -f /tmp/complete ]; do sleep 1; done"},
 		VolumeMounts: []v1.VolumeMount{vm},
 	}

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -50,6 +50,7 @@ func Set(c *latest.SkaffoldPipeline) error {
 	if err := withKanikoConfig(c,
 		setDefaultKanikoTimeout,
 		setDefaultKanikoImage,
+		setDefaultKanikoInitImage,
 		setDefaultKanikoNamespace,
 		setDefaultKanikoSecret,
 		setDefaultKanikoBuildContext,
@@ -57,7 +58,6 @@ func Set(c *latest.SkaffoldPipeline) error {
 	); err != nil {
 		return err
 	}
-	setDefaultKanikoInitImage(c.Build.KanikoBuild.BuildContext.LocalDir)
 
 	if pluginsDefined(c) {
 		return nil
@@ -217,8 +217,11 @@ func setDefaultKanikoTimeout(kaniko *latest.KanikoBuild) error {
 	return nil
 }
 
-func setDefaultKanikoInitImage(localDir *latest.LocalDir) error {
-	localDir.InitImage = valueOrDefault(localDir.InitImage, constants.DefaultBusyboxImage)
+func setDefaultKanikoInitImage(kaniko *latest.KanikoBuild) error {
+	if kaniko.BuildContext != nil && kaniko.BuildContext.LocalDir != nil {
+		localDir := kaniko.BuildContext.LocalDir
+		localDir.InitImage = valueOrDefault(localDir.InitImage, constants.DefaultBusyboxImage)
+	}
 	return nil
 }
 

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -57,6 +57,7 @@ func Set(c *latest.SkaffoldPipeline) error {
 	); err != nil {
 		return err
 	}
+	setDefaultKanikoInitImage(c.Build.KanikoBuild.BuildContext.LocalDir)
 
 	if pluginsDefined(c) {
 		return nil
@@ -213,6 +214,11 @@ func setDefaultKanikoNamespace(kaniko *latest.KanikoBuild) error {
 
 func setDefaultKanikoTimeout(kaniko *latest.KanikoBuild) error {
 	kaniko.Timeout = valueOrDefault(kaniko.Timeout, constants.DefaultKanikoTimeout)
+	return nil
+}
+
+func setDefaultKanikoInitImage(localDir *latest.LocalDir) error {
+	localDir.InitImage = valueOrDefault(localDir.InitImage, constants.DefaultBusyboxImage)
 	return nil
 }
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -211,8 +211,8 @@ type GoogleCloudBuild struct {
 }
 
 // LocalDir configures how Kaniko mounts sources directly via an `emptyDir` volume.
-type LocalDir struct{
-	// Image used to run init container which mounts kaniko context
+type LocalDir struct {
+	// InitImage is the image used to run init container which mounts kaniko context.
 	InitImage string `yaml:"initImage,omitempty"`
 }
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -211,7 +211,10 @@ type GoogleCloudBuild struct {
 }
 
 // LocalDir configures how Kaniko mounts sources directly via an `emptyDir` volume.
-type LocalDir struct{}
+type LocalDir struct{
+	// Image used to run init container which mounts kaniko context
+	InitImage string `yaml:"initImage,omitempty"`
+}
 
 // KanikoBuildContext contains the different fields available to specify
 // a Kaniko build context.


### PR DESCRIPTION
This is to parameterize the InitContainer Image in LocalDir build of kaniko, so we can use custom one apart from busybox, especially useful in private clouds where public repos are not accessible