### PR TITLE
Improve artifact caching

### DIFF
--- a/pkg/skaffold/build/cache_test.go
+++ b/pkg/skaffold/build/cache_test.go
@@ -18,11 +18,13 @@ package build
 
 import (
 	"context"
+	"io"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -414,6 +416,133 @@ func TestRetrieveCachedArtifactDetails(t *testing.T) {
 			// cmp.Diff cannot access unexported fields, so use reflect.DeepEqual here directly
 			if !reflect.DeepEqual(test.expected, actual) {
 				t.Errorf("Expected: %v, Actual: %v", test.expected, actual)
+			}
+		})
+	}
+}
+
+type mockBuilder struct {
+	dependencies []string
+}
+
+func (m *mockBuilder) Labels() map[string]string { return nil }
+
+func (m *mockBuilder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]Artifact, error) {
+	return nil, nil
+}
+
+func (m *mockBuilder) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
+	return m.dependencies, nil
+}
+
+var mockCacheHasher = func(s string) (string, error) {
+	return s, nil
+}
+
+func TestGetHashForArtifact(t *testing.T) {
+	tests := []struct {
+		name         string
+		dependencies [][]string
+		expected     string
+	}{
+		{
+			name: "check dependencies in different orders",
+			dependencies: [][]string{
+				{"a", "b"},
+				{"b", "a"},
+			},
+			expected: "eb394fd4559b1d9c383f4359667a508a615b82a74e1b160fce539f86ae0842e8",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			originalHasher := cacheHasher
+			hashFunction = mockCacheHasher
+			defer func() {
+				hashFunction = originalHasher
+			}()
+
+			for _, d := range test.dependencies {
+				builder := &mockBuilder{dependencies: d}
+				actual, err := getHashForArtifact(context.Background(), builder, nil)
+				testutil.CheckErrorAndDeepEqual(t, false, err, test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestCacheHasher(t *testing.T) {
+	tests := []struct {
+		name          string
+		differentHash bool
+		newFilename   string
+		update        func(oldFile string, folder *testutil.TempDir)
+	}{
+		{
+			name:          "change filename",
+			differentHash: true,
+			newFilename:   "newfoo",
+			update: func(oldFile string, folder *testutil.TempDir) {
+				folder.Rename(oldFile, "newfoo")
+			},
+		},
+		{
+			name:          "change file contents",
+			differentHash: true,
+			update: func(oldFile string, folder *testutil.TempDir) {
+				folder.Write(oldFile, "newcontents")
+			},
+		},
+		{
+			name:          "change both",
+			differentHash: true,
+			newFilename:   "newfoo",
+			update: func(oldFile string, folder *testutil.TempDir) {
+				folder.Rename(oldFile, "newfoo")
+				folder.Write(oldFile, "newcontents")
+			},
+		},
+		{
+			name:          "change nothing",
+			differentHash: false,
+			update:        func(oldFile string, folder *testutil.TempDir) {},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			originalFile := "foo"
+			originalContents := "contents"
+
+			folder, cleanup := testutil.NewTempDir(t)
+			defer cleanup()
+			folder.Write(originalFile, originalContents)
+
+			path := originalFile
+			builder := &mockBuilder{dependencies: []string{folder.Path(originalFile)}}
+
+			oldHash, err := getHashForArtifact(context.Background(), builder, nil)
+			if err != nil {
+				t.Errorf("error getting hash for artifact: %v", err)
+			}
+
+			test.update(originalFile, folder)
+			if test.newFilename != "" {
+				path = test.newFilename
+			}
+
+			builder.dependencies = []string{folder.Path(path)}
+			newHash, err := getHashForArtifact(context.Background(), builder, nil)
+			if err != nil {
+				t.Errorf("error getting hash for artifact: %v", err)
+			}
+
+			if test.differentHash && oldHash == newHash {
+				t.Fatalf("expected hashes to be different but they were the same:\n oldHash: %s\n newHash: %s", oldHash, newHash)
+			}
+			if !test.differentHash && oldHash != newHash {
+				t.Fatalf("expected hashes to be the same but they were different:\n oldHash: %s\n newHash: %s", oldHash, newHash)
 			}
 		})
 	}

--- a/testutil/tmp.go
+++ b/testutil/tmp.go
@@ -95,6 +95,11 @@ func (h *TempDir) Write(file, content string) *TempDir {
 	return h.failIfErr(ioutil.WriteFile(h.Path(file), []byte(content), os.ModePerm))
 }
 
+// Rename renames a file from oldname to newname
+func (h *TempDir) Rename(oldName, newName string) *TempDir {
+	return h.failIfErr(os.Rename(h.Path(oldName), h.Path(newName)))
+}
+
 // List lists all the files in the temp directory.
 func (h *TempDir) List() ([]string, error) {
 	var files []string


### PR DESCRIPTION
some improvements to artifact caching:

1. Include filename in the cache key generation
2. Sort dependencies to ensure the key is reproducible
3. Add unit tests for both of these additions

Also, simplify the cache hasher function

begins to fix #1740 