### PR TITLE
Add logic for finding next available port for gRPC if provided one is in use

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -143,7 +143,7 @@ func AddRunDeployFlags(cmd *cobra.Command) {
 
 func AddRunDevFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&opts.EnableRPC, "enable-rpc", false, "Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)")
-	cmd.Flags().StringVar(&opts.RPCPort, "rpc-port", ":50051", "tcp port to expose event API")
+	cmd.Flags().StringVar(&opts.RPCPort, "rpc-port", constants.DefaultRPCPort, "tcp port to expose event API")
 	cmd.Flags().StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
 	cmd.Flags().BoolVar(&opts.Notification, "toot", false, "Emit a terminal beep after the deploy is complete")
 	cmd.Flags().StringArrayVarP(&opts.Profiles, "profile", "p", nil, "Activate profiles by name")

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -71,6 +71,8 @@ const (
 	SkaffoldPluginValue     = "1337"
 	SkaffoldPluginName      = "SKAFFOLD_PLUGIN_NAME"
 	DockerBuilderPluginName = "docker"
+
+	DefaultRPCPort = ":50051"
 )
 
 var (


### PR DESCRIPTION
Fixes #1733 

this adds a small function that makes skaffold a bit smarter about the port it uses for starting the gRPC event server. if the provided port is in use, it will attempt to parse out the port number and increment it until it finds a free port, or if the parsing fails, simply choose a random (valid) port and make sure it's free.

this will also issue a small warning to the user that their specified port is in use, if they provided a non-default port through the CLI.