### PR TITLE
Only go through images once for artifact caching

### DIFF
--- a/pkg/skaffold/build/cache.go
+++ b/pkg/skaffold/build/cache.go
@@ -236,21 +236,12 @@ func (c *Cache) retrieveCachedArtifactDetails(ctx context.Context, a *latest.Art
 }
 
 func (c *Cache) retrievePrebuiltImage(ctx context.Context, details ImageDetails) (string, error) {
-	// first, search for an image with the same image ID
-	img, err := c.client.FindImageByID(ctx, details.ID)
+	img, err := c.client.FindTaggedImage(ctx, details.ID, details.Digest)
 	if err != nil {
-		logrus.Debugf("error getting tagged image with id %s, checking digest: %v", details.ID, err)
-	}
-	if err == nil && img != "" {
-		return img, nil
-	}
-	// else, search for an image with the same digest
-	img, err = c.client.FindTaggedImageByDigest(ctx, details.Digest)
-	if err != nil {
-		return "", errors.Wrapf(err, "getting image from digest %s", details.Digest)
+		return "", errors.Wrap(err, "unable to find tagged image")
 	}
 	if img == "" {
-		return "", errors.New("no prebuilt image")
+		return img, errors.New("no prebuilt image")
 	}
 	return img, nil
 }

--- a/pkg/skaffold/build/cache_test.go
+++ b/pkg/skaffold/build/cache_test.go
@@ -18,6 +18,7 @@ package build
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -29,6 +30,10 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	"github.com/docker/docker/api/types"
 	yaml "gopkg.in/yaml.v2"
+)
+
+var (
+	digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
 )
 
 var defaultArtifactCache = ArtifactCache{"hash": ImageDetails{
@@ -313,16 +318,16 @@ func TestRetrieveCachedArtifactDetails(t *testing.T) {
 			api: testutil.FakeAPIClient{
 				ImageSummaries: []types.ImageSummary{
 					{
-						RepoDigests: []string{"digest"},
+						RepoDigests: []string{fmt.Sprintf("image@%s", digest)},
 						RepoTags:    []string{"anotherimage:hash"},
 					},
 				},
 			},
 			cache: &Cache{
 				useCache:      true,
-				artifactCache: ArtifactCache{"hash": ImageDetails{Digest: "digest"}},
+				artifactCache: ArtifactCache{"hash": ImageDetails{Digest: digest}},
 			},
-			digest: "digest",
+			digest: digest,
 			expected: &cachedArtifactDetails{
 				needsRetag:    true,
 				needsPush:     true,
@@ -338,16 +343,16 @@ func TestRetrieveCachedArtifactDetails(t *testing.T) {
 			api: testutil.FakeAPIClient{
 				ImageSummaries: []types.ImageSummary{
 					{
-						RepoDigests: []string{"digest"},
+						RepoDigests: []string{fmt.Sprintf("image@%s", digest)},
 						RepoTags:    []string{"anotherimage:hash"},
 					},
 				},
 			},
 			cache: &Cache{
 				useCache:      true,
-				artifactCache: ArtifactCache{"hash": ImageDetails{Digest: "digest"}},
+				artifactCache: ArtifactCache{"hash": ImageDetails{Digest: digest}},
 			},
-			digest: "digest",
+			digest: digest,
 			expected: &cachedArtifactDetails{
 				needsRetag:    true,
 				prebuiltImage: "anotherimage:hash",
@@ -362,7 +367,7 @@ func TestRetrieveCachedArtifactDetails(t *testing.T) {
 			api: testutil.FakeAPIClient{
 				ImageSummaries: []types.ImageSummary{
 					{
-						RepoDigests: []string{"digest"},
+						RepoDigests: []string{fmt.Sprintf("image@%s", digest)},
 						RepoTags:    []string{"anotherimage:hash"},
 					},
 				},
@@ -370,9 +375,9 @@ func TestRetrieveCachedArtifactDetails(t *testing.T) {
 			cache: &Cache{
 				useCache:      true,
 				needsPush:     true,
-				artifactCache: ArtifactCache{"hash": ImageDetails{Digest: "digest"}},
+				artifactCache: ArtifactCache{"hash": ImageDetails{Digest: digest}},
 			},
-			digest: "digest",
+			digest: digest,
 			expected: &cachedArtifactDetails{
 				needsRetag:    true,
 				needsPush:     true,

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -277,7 +277,7 @@ func TestFindTaggedImageByDigest(t *testing.T) {
 				apiClient: api,
 			}
 
-			actual, err := localDocker.FindTaggedImageByDigest(context.Background(), test.digest)
+			actual, err := localDocker.FindTaggedImage(context.Background(), "", test.digest)
 			testutil.CheckErrorAndDeepEqual(t, false, err, test.expected, actual)
 		})
 	}
@@ -381,7 +381,7 @@ func TestRepoDigest(t *testing.T) {
 		})
 	}
 }
-func TestFindImageByID(t *testing.T) {
+func TestFindTaggedImageByID(t *testing.T) {
 	tests := []struct {
 		name           string
 		id             string
@@ -444,7 +444,7 @@ func TestFindImageByID(t *testing.T) {
 				apiClient: api,
 			}
 
-			actual, err := localDocker.FindImageByID(context.Background(), test.id)
+			actual, err := localDocker.FindTaggedImage(context.Background(), test.id, "")
 			testutil.CheckErrorAndDeepEqual(t, false, err, test.expected, actual)
 		})
 	}


### PR DESCRIPTION
when looking for a prebuilt image in the cache.

Combines two functions to find a match for id and digest at the same
time.