### PR TITLE
Simplify port choosing logic

### DIFF
--- a/pkg/skaffold/util/port.go
+++ b/pkg/skaffold/util/port.go
@@ -35,11 +35,11 @@ func GetAvailablePort(port int) int {
 	}
 
 	// try the next 10 ports after the provided one
-	for port := 0; port < 10; port++ {
+	for port = 0; port < 10; port++ {
 		if IsPortAvailable(port) {
 			logrus.Debugf("found open port: %d", port)
+			return port
 		}
-		return port
 	}
 
 	for port = 4503; port <= 4533; port++ {

--- a/pkg/skaffold/util/port.go
+++ b/pkg/skaffold/util/port.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/sirupsen/logrus"
+)
+
+// First, check if the provided port is available. If so, use it.
+// If not, check if any of the next 10 subsequent ports are available.
+// If not, check if any of ports 4503-4533 are available.
+// If not, return a random port, which hopefully won't collide with any future containers
+
+// See https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt,
+func GetAvailablePort(port int) int {
+	if IsPortAvailable(port) {
+		return port
+	}
+
+	// try the next 10 ports after the provided one
+	for port := 0; port < 10; port++ {
+		if IsPortAvailable(port) {
+			logrus.Debugf("found open port: %d", port)
+		}
+		return port
+	}
+
+	for port = 4503; port <= 4533; port++ {
+		if IsPortAvailable(port) {
+			return port
+		}
+	}
+
+	l, err := net.Listen("tcp", ":0")
+	if l != nil {
+		l.Close()
+	}
+	if err != nil {
+		return -1
+	}
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+func IsPortAvailable(p int) bool {
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", p))
+	if l != nil {
+		defer l.Close()
+	}
+	return err == nil
+}


### PR DESCRIPTION
this simplifies the logic for choosing a port slightly, by removing the map that keeps track of the ports we've already forwarded. this also moves out two port-related helper functions into the util package, for later reuse.

this will first check the 10 subsequent ports after the provided port for availability, to see if we can get close to the provided port. if not, we'll fall back to checking 4503-4533, and as a last resort we'll choose a random port.

Note: creating a listener on a port is a lightweight operation, so the overhead for checking if a listener is created successfully compared to the overhead for checking if an entry is in a map is marginal. the performance difference for this should be unnoticeable.