### PR TITLE
Add logic for finding next available port for gRPC if provided one is in use

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -143,7 +143,7 @@ func AddRunDeployFlags(cmd *cobra.Command) {
 
 func AddRunDevFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&opts.EnableRPC, "enable-rpc", false, "Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)")
-	cmd.Flags().StringVar(&opts.RPCPort, "rpc-port", ":50051", "tcp port to expose event API")
+	cmd.Flags().IntVar(&opts.RPCPort, "rpc-port", constants.DefaultRPCPort, "tcp port to expose event API")
 	cmd.Flags().StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
 	cmd.Flags().BoolVar(&opts.Notification, "toot", false, "Emit a terminal beep after the deploy is complete")
 	cmd.Flags().StringArrayVarP(&opts.Profiles, "profile", "p", nil, "Activate profiles by name")

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -74,7 +74,7 @@ Flags:
                                      {{end}})
   -p, --profile stringArray          Activate profiles by name
   -q, --quiet                        Suppress the build output and print image built on success
-      --rpc-port string              tcp port to expose event API (default ":50051")
+      --rpc-port int                 tcp port to expose event API (default 50051)
       --skip-tests                   Whether to skip the tests after building
       --toot                         Emit a terminal beep after the deploy is complete
 
@@ -157,7 +157,7 @@ Flags:
   -f, --filename string           Filename or URL to the pipeline file (default "skaffold.yaml")
   -n, --namespace string          Run deployments in the specified namespace
   -p, --profile stringArray       Activate profiles by name
-      --rpc-port string           tcp port to expose event API (default ":50051")
+      --rpc-port int              tcp port to expose event API (default 50051)
       --skip-tests                Whether to skip the tests after building
       --toot                      Emit a terminal beep after the deploy is complete
 
@@ -198,7 +198,7 @@ Flags:
   -l, --label stringArray         Add custom labels to deployed objects. Set multiple times for multiple labels.
   -n, --namespace string          Run deployments in the specified namespace
   -p, --profile stringArray       Activate profiles by name
-      --rpc-port string           tcp port to expose event API (default ":50051")
+      --rpc-port int              tcp port to expose event API (default 50051)
       --skip-tests                Whether to skip the tests after building
       --tail                      Stream logs from deployed objects
       --toot                      Emit a terminal beep after the deploy is complete
@@ -245,7 +245,7 @@ Flags:
   -n, --namespace string          Run deployments in the specified namespace
       --port-forward              Port-forward exposed container ports within pods (default true)
   -p, --profile stringArray       Activate profiles by name
-      --rpc-port string           tcp port to expose event API (default ":50051")
+      --rpc-port int              tcp port to expose event API (default 50051)
       --skip-tests                Whether to skip the tests after building
       --tail                      Stream logs from deployed objects (default true)
       --toot                      Emit a terminal beep after the deploy is complete
@@ -375,7 +375,7 @@ Flags:
   -l, --label stringArray         Add custom labels to deployed objects. Set multiple times for multiple labels.
   -n, --namespace string          Run deployments in the specified namespace
   -p, --profile stringArray       Activate profiles by name
-      --rpc-port string           tcp port to expose event API (default ":50051")
+      --rpc-port int              tcp port to expose event API (default 50051)
       --skip-tests                Whether to skip the tests after building
   -t, --tag string                The optional custom tag to use for images which overrides the current Tagger configuration
       --tail                      Stream logs from deployed objects

--- a/integration/rpc_test.go
+++ b/integration/rpc_test.go
@@ -18,6 +18,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -50,7 +51,7 @@ func TestEventLog(t *testing.T) {
 	defer deleteNs()
 
 	cancel := make(chan bool)
-	addr := ":12345"
+	addr := "12345"
 	go RunSkaffoldNoFail(cancel, "dev", "testdata/dev", ns.Name, "", nil, "--rpc-port", addr)
 	defer func() { cancel <- true }()
 
@@ -60,7 +61,7 @@ func TestEventLog(t *testing.T) {
 	var client proto.SkaffoldServiceClient
 	attempts := 0
 	for {
-		conn, err = grpc.Dial(addr, grpc.WithInsecure())
+		conn, err = grpc.Dial(fmt.Sprintf(":%s", addr), grpc.WithInsecure())
 		if err != nil {
 			t.Logf("unable to establish skaffold grpc connection: retrying...")
 			attempts++
@@ -147,7 +148,7 @@ func TestGetState(t *testing.T) {
 
 	// start a skaffold dev loop on an example
 	cancel := make(chan bool)
-	addr := ":12345"
+	addr := "12345"
 	go RunSkaffoldNoFail(cancel, "dev", "testdata/dev", ns.Name, "", nil, "--rpc-port", addr)
 	defer func() { cancel <- true }()
 
@@ -157,7 +158,7 @@ func TestGetState(t *testing.T) {
 	var client proto.SkaffoldServiceClient
 	attempts := 0
 	for {
-		conn, err = grpc.Dial(addr, grpc.WithInsecure())
+		conn, err = grpc.Dial(fmt.Sprintf(":%s", addr), grpc.WithInsecure())
 		if err != nil {
 			t.Logf("unable to establish skaffold grpc connection: retrying...")
 			attempts++

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -51,7 +51,7 @@ type SkaffoldOptions struct {
 	DefaultRepo       string
 	PreBuiltImages    []string
 	Command           string
-	RPCPort           string
+	RPCPort           int
 }
 
 // Labels returns a map of labels to be applied to all deployed

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -71,6 +71,8 @@ const (
 	SkaffoldPluginValue     = "1337"
 	SkaffoldPluginName      = "SKAFFOLD_PLUGIN_NAME"
 	DockerBuilderPluginName = "docker"
+
+	DefaultRPCPort = 50051
 )
 
 var (

--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -112,7 +112,7 @@ func InitializeState(build *latest.BuildConfig, deploy *latest.DeployConfig, opt
 
 func SetupRPCClient(opts *config.SkaffoldOptions) error {
 	pluginMode = true
-	conn, err := grpc.Dial(opts.RPCPort, grpc.WithInsecure())
+	conn, err := grpc.Dial(fmt.Sprintf(":%d", opts.RPCPort), grpc.WithInsecure())
 	if err != nil {
 		return errors.Wrap(err, "opening gRPC connection to remote skaffold process")
 	}


### PR DESCRIPTION
Fixes #1733

this adds functionality in the gRPC event server logic to be smarter about finding an available port if the provided one is already in use.

this also changes the CLI flag to be an int instead of a string, for clarity.

this will also issue a small warning to the user that their specified port is in use, if they provided a non-default port through the CLI.