### PR TITLE
Only get images list once for caching

### DIFF
--- a/docs/content/en/schemas/v1beta6.json
+++ b/docs/content/en/schemas/v1beta6.json
@@ -1424,17 +1424,6 @@
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
     "LocalDir": {
-      "properties": {
-        "initImage": {
-          "type": "string",
-          "description": "image used to run init container which mounts kaniko context.",
-          "x-intellij-html-description": "image used to run init container which mounts kaniko context."
-        }
-      },
-      "preferredOrder": [
-        "initImage"
-      ],
-      "additionalProperties": false,
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },

--- a/docs/content/en/schemas/v1beta7.json
+++ b/docs/content/en/schemas/v1beta7.json
@@ -1424,6 +1424,17 @@
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
     "LocalDir": {
+      "properties": {
+        "initImage": {
+          "type": "string",
+          "description": "image used to run init container which mounts kaniko context.",
+          "x-intellij-html-description": "image used to run init container which mounts kaniko context."
+        }
+      },
+      "preferredOrder": [
+        "initImage"
+      ],
+      "additionalProperties": false,
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },

--- a/pkg/skaffold/build/cache.go
+++ b/pkg/skaffold/build/cache.go
@@ -180,7 +180,7 @@ func (c *Cache) resolveCachedArtifact(ctx context.Context, out io.Writer, a *lat
 		color.Green.Fprint(out, ". Retagging")
 	}
 	if details.needsPush {
-		color.Green.Fprint(out, ". Pushing")
+		color.Green.Fprint(out, ". Pushing.")
 	}
 	color.Default.Fprintln(out)
 

--- a/pkg/skaffold/build/cache_test.go
+++ b/pkg/skaffold/build/cache_test.go
@@ -35,7 +35,10 @@ import (
 )
 
 var (
-	digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	digest    = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	digestOne = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	image     = fmt.Sprintf("image@%s", digest)
+	imageOne  = fmt.Sprintf("image1@%s", digestOne)
 )
 
 var defaultArtifactCache = ArtifactCache{"hash": ImageDetails{
@@ -50,16 +53,14 @@ func mockHashForArtifact(hashes map[string]string) func(context.Context, Builder
 }
 
 func Test_NewCache(t *testing.T) {
-	client, err := docker.NewAPIClient()
-	if err != nil {
-		t.Fatalf("error gettting docker api client: %v", err)
-	}
 	tests := []struct {
 		updateCacheFile   bool
 		needsPush         bool
+		updateClient      bool
 		name              string
 		opts              *config.SkaffoldOptions
 		expectedCache     *Cache
+		api               *testutil.FakeAPIClient
 		cacheFileContents interface{}
 	}{
 		{
@@ -69,10 +70,22 @@ func Test_NewCache(t *testing.T) {
 			opts: &config.SkaffoldOptions{
 				CacheArtifacts: true,
 			},
+			updateClient: true,
+			api: &testutil.FakeAPIClient{
+				ImageSummaries: []types.ImageSummary{
+					{
+						ID: "image",
+					},
+				},
+			},
 			expectedCache: &Cache{
 				artifactCache: defaultArtifactCache,
 				useCache:      true,
-				client:        client,
+				imageList: []types.ImageSummary{
+					{
+						ID: "image",
+					},
+				},
 			},
 		},
 		{
@@ -80,19 +93,21 @@ func Test_NewCache(t *testing.T) {
 			cacheFileContents: defaultArtifactCache,
 			needsPush:         true,
 			updateCacheFile:   true,
+			updateClient:      true,
 			opts: &config.SkaffoldOptions{
 				CacheArtifacts: true,
 			},
+			api: &testutil.FakeAPIClient{},
 			expectedCache: &Cache{
 				artifactCache: defaultArtifactCache,
 				useCache:      true,
-				client:        client,
 				needsPush:     true,
 			},
 		},
 		{
 			name:              "valid cache file exists, but useCache is false",
 			cacheFileContents: defaultArtifactCache,
+			api:               &testutil.FakeAPIClient{},
 			opts:              &config.SkaffoldOptions{},
 			expectedCache:     &Cache{},
 		},
@@ -111,12 +126,24 @@ func Test_NewCache(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			cacheFile := createTempCacheFile(t, test.cacheFileContents)
-
 			if test.updateCacheFile {
 				test.expectedCache.cacheFile = cacheFile
 			}
 			test.opts.CacheFile = cacheFile
-			actualCache := NewCache(nil, test.opts, test.needsPush)
+
+			originalDockerClient := newDockerCilent
+			newDockerCilent = func() (docker.LocalDaemon, error) {
+				return docker.NewLocalDaemon(test.api, nil), nil
+			}
+			defer func() {
+				newDockerCilent = originalDockerClient
+			}()
+
+			if test.updateClient {
+				test.expectedCache.client = docker.NewLocalDaemon(test.api, nil)
+			}
+
+			actualCache := NewCache(context.Background(), nil, test.opts, test.needsPush)
 
 			// cmp.Diff cannot access unexported fields, so use reflect.DeepEqual here directly
 			if !reflect.DeepEqual(test.expectedCache, actualCache) {
@@ -317,17 +344,15 @@ func TestRetrieveCachedArtifactDetails(t *testing.T) {
 			name:     "image in cache, prebuilt image exists, remote cluster",
 			artifact: &latest.Artifact{ImageName: "image"},
 			hashes:   map[string]string{"image": "hash"},
-			api: testutil.FakeAPIClient{
-				ImageSummaries: []types.ImageSummary{
+			cache: &Cache{
+				useCache:      true,
+				artifactCache: ArtifactCache{"hash": ImageDetails{Digest: digest}},
+				imageList: []types.ImageSummary{
 					{
 						RepoDigests: []string{fmt.Sprintf("image@%s", digest)},
 						RepoTags:    []string{"anotherimage:hash"},
 					},
 				},
-			},
-			cache: &Cache{
-				useCache:      true,
-				artifactCache: ArtifactCache{"hash": ImageDetails{Digest: digest}},
 			},
 			digest: digest,
 			expected: &cachedArtifactDetails{
@@ -342,17 +367,15 @@ func TestRetrieveCachedArtifactDetails(t *testing.T) {
 			artifact:     &latest.Artifact{ImageName: "image"},
 			hashes:       map[string]string{"image": "hash"},
 			localCluster: true,
-			api: testutil.FakeAPIClient{
-				ImageSummaries: []types.ImageSummary{
+			cache: &Cache{
+				useCache:      true,
+				artifactCache: ArtifactCache{"hash": ImageDetails{Digest: digest}},
+				imageList: []types.ImageSummary{
 					{
 						RepoDigests: []string{fmt.Sprintf("image@%s", digest)},
 						RepoTags:    []string{"anotherimage:hash"},
 					},
 				},
-			},
-			cache: &Cache{
-				useCache:      true,
-				artifactCache: ArtifactCache{"hash": ImageDetails{Digest: digest}},
 			},
 			digest: digest,
 			expected: &cachedArtifactDetails{
@@ -366,18 +389,16 @@ func TestRetrieveCachedArtifactDetails(t *testing.T) {
 			artifact:     &latest.Artifact{ImageName: "image"},
 			hashes:       map[string]string{"image": "hash"},
 			localCluster: true,
-			api: testutil.FakeAPIClient{
-				ImageSummaries: []types.ImageSummary{
+			cache: &Cache{
+				useCache:      true,
+				needsPush:     true,
+				artifactCache: ArtifactCache{"hash": ImageDetails{Digest: digest}},
+				imageList: []types.ImageSummary{
 					{
 						RepoDigests: []string{fmt.Sprintf("image@%s", digest)},
 						RepoTags:    []string{"anotherimage:hash"},
 					},
 				},
-			},
-			cache: &Cache{
-				useCache:      true,
-				needsPush:     true,
-				artifactCache: ArtifactCache{"hash": ImageDetails{Digest: digest}},
 			},
 			digest: digest,
 			expected: &cachedArtifactDetails{
@@ -549,6 +570,120 @@ func TestCacheHasher(t *testing.T) {
 			if !test.differentHash && oldHash != newHash {
 				t.Fatalf("expected hashes to be the same but they were different:\n oldHash: %s\n newHash: %s", oldHash, newHash)
 			}
+		})
+	}
+}
+
+func TestRetrievePrebuiltImage(t *testing.T) {
+	tests := []struct {
+		name         string
+		cache        *Cache
+		imageDetails ImageDetails
+		shouldErr    bool
+		expected     string
+	}{
+		{
+			name: "one image id exists",
+			cache: &Cache{
+				imageList: []types.ImageSummary{
+					{
+						RepoTags:    []string{"image:mytag"},
+						RepoDigests: []string{image},
+					},
+					{
+						RepoTags:    []string{"image1:latest"},
+						RepoDigests: []string{imageOne},
+					},
+				},
+			},
+			imageDetails: ImageDetails{
+				Digest: digest,
+			},
+			expected: "image:mytag",
+		},
+		{
+			name: "no image id exists",
+			cache: &Cache{
+				imageList: []types.ImageSummary{
+					{
+						RepoTags:    []string{"image:mytag"},
+						RepoDigests: []string{image},
+					},
+					{
+						RepoTags:    []string{"image:mytag"},
+						RepoDigests: []string{image},
+					},
+				},
+			},
+			shouldErr: true,
+			imageDetails: ImageDetails{
+				Digest: "dne",
+			},
+			expected: "",
+		},
+		{
+			name: "one image id exists",
+			cache: &Cache{
+				imageList: []types.ImageSummary{
+					{
+						RepoTags: []string{"image1", "image2"},
+						ID:       "something",
+					},
+					{
+						RepoTags: []string{"image3"},
+						ID:       "imageid",
+					},
+				},
+			},
+			imageDetails: ImageDetails{
+				ID: "imageid",
+			},
+			expected: "image3",
+		},
+		{
+			name: "multiple image ids exist",
+			cache: &Cache{
+				imageList: []types.ImageSummary{
+					{
+						RepoTags: []string{"image1", "image2"},
+						ID:       "something",
+					},
+					{
+						RepoTags: []string{"image3", "image4"},
+						ID:       "imageid",
+					},
+				},
+			},
+			imageDetails: ImageDetails{
+				ID: "imageid",
+			},
+			expected: "image3",
+		},
+		{
+			name: "no image id exists",
+			cache: &Cache{
+				imageList: []types.ImageSummary{
+					{
+						RepoTags: []string{"image1", "image2"},
+						ID:       "something",
+					},
+					{
+						RepoTags: []string{"image3"},
+						ID:       "somethingelse",
+					},
+				},
+			},
+			imageDetails: ImageDetails{
+				ID: "imageid",
+			},
+			shouldErr: true,
+			expected:  "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := test.cache.retrievePrebuiltImage(test.imageDetails)
+			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, actual)
 		})
 	}
 }

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -31,7 +31,6 @@ import (
 	"github.com/docker/docker/pkg/progress"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/term"
-	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -50,7 +49,7 @@ type LocalDaemon interface {
 	Tag(ctx context.Context, image, ref string) error
 	ImageID(ctx context.Context, ref string) (string, error)
 	RepoDigest(ctx context.Context, ref string) (string, error)
-	FindTaggedImage(ctx context.Context, id, digest string) (string, error)
+	ImageList(ctx context.Context, options types.ImageListOptions) ([]types.ImageSummary, error)
 	ImageExists(ctx context.Context, ref string) bool
 }
 
@@ -288,32 +287,9 @@ func (l *localDaemon) ImageID(ctx context.Context, ref string) (string, error) {
 	return image.ID, nil
 }
 
-// FindTaggedImage returns the name of an image with a matching id or digest
-func (l *localDaemon) FindTaggedImage(ctx context.Context, id, digest string) (string, error) {
-	resp, err := l.apiClient.ImageList(ctx, types.ImageListOptions{})
-	if err != nil {
-		return "", errors.Wrap(err, "listing images")
-	}
-	for _, r := range resp {
-		if r.ID == id && id != "" {
-			if len(r.RepoTags) == 0 {
-				return "", nil
-			}
-			return r.RepoTags[0], nil
-		}
-		if digest == "" {
-			continue
-		}
-		for _, d := range r.RepoDigests {
-			if getDigest(d) == digest {
-				// Return a tagged version of this image, since we can't retag an image in the image@sha256: format
-				if len(r.RepoTags) > 0 {
-					return r.RepoTags[0], nil
-				}
-			}
-		}
-	}
-	return "", nil
+// ImageList returns a list of all images in the local daemon
+func (l *localDaemon) ImageList(ctx context.Context, options types.ImageListOptions) ([]types.ImageSummary, error) {
+	return l.apiClient.ImageList(ctx, options)
 }
 
 // RepoDigest returns a repo digest for the given ref
@@ -331,11 +307,6 @@ func (l *localDaemon) RepoDigest(ctx context.Context, ref string) (string, error
 func (l *localDaemon) ImageExists(ctx context.Context, ref string) bool {
 	_, _, err := l.apiClient.ImageInspectWithRaw(ctx, ref)
 	return err == nil
-}
-
-func getDigest(img string) string {
-	ref, _ := name.NewDigest(img, name.WeakValidation)
-	return ref.DigestStr()
 }
 
 // GetBuildArgs gives the build args flags for docker build.

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -324,7 +324,7 @@ func (r *SkaffoldRunner) BuildAndTest(ctx context.Context, out io.Writer, artifa
 		return nil, errors.Wrap(err, "generating tag")
 	}
 
-	artifactCache := build.NewCache(r.Builder, r.opts, r.needsPush)
+	artifactCache := build.NewCache(ctx, r.Builder, r.opts, r.needsPush)
 	artifactsToBuild, res := artifactCache.RetrieveCachedArtifacts(ctx, out, artifacts)
 	bRes, err := r.Build(ctx, out, tags, artifactsToBuild)
 	if err != nil {


### PR DESCRIPTION
Only get image list from docker daemon once per build loop and save it in memory so that we aren't getting a list of all images per artifact.

Continues work on #1740 