### PR TITLE
added some extra logging for test failures for easier feedback

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ GREEN='\033[0;32m'
 RESET='\033[0m'
 
 echo "Running go tests..."
-go test -cover -short -v -timeout 60s ./... | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
+go test -cover -short -timeout 60s ./... | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
 GO_TEST_EXIT_CODE=${PIPESTATUS[0]}
 if [[ $GO_TEST_EXIT_CODE -ne 0 ]]; then
     exit $GO_TEST_EXIT_CODE

--- a/test.sh
+++ b/test.sh
@@ -19,11 +19,16 @@ set -e
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 RESET='\033[0m'
+LOGFILE=`mktemp`
 
 echo "Running go tests..."
-go test -cover -short -v -timeout 60s ./... | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
+go test -cover -short -v -timeout 60s ./... 2>&1 | tee ${LOGFILE}  | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
 GO_TEST_EXIT_CODE=${PIPESTATUS[0]}
 if [[ $GO_TEST_EXIT_CODE -ne 0 ]]; then
+    echo "*****"
+    echo "***** 'go test' failed (log file: ${LOGFILE}) *****"
+    echo "*****"
+    grep "FAIL" ${LOGFILE} -C 2  | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
     exit $GO_TEST_EXIT_CODE
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -19,16 +19,11 @@ set -e
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 RESET='\033[0m'
-LOGFILE=`mktemp`
 
 echo "Running go tests..."
-go test -cover -short -v -timeout 60s ./... 2>&1 | tee ${LOGFILE}  | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
+go test -cover -short -v -timeout 60s ./... | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
 GO_TEST_EXIT_CODE=${PIPESTATUS[0]}
 if [[ $GO_TEST_EXIT_CODE -ne 0 ]]; then
-    echo "*****"
-    echo "***** 'go test' failed (log file: ${LOGFILE}) *****"
-    echo "*****"
-    grep "FAIL" ${LOGFILE} -C 2  | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
     exit $GO_TEST_EXIT_CODE
 fi
 


### PR DESCRIPTION
This adds some extra logging at the bottom of `make test` run and saves it in a temporary logfile so that you don't have to manually scroll through issues - as our test output is getting long. 

![image](https://user-images.githubusercontent.com/635073/54053792-42544280-419d-11e9-8025-c441678589c8.png)
