### PR TITLE
Don’t break pages that reference `annotated-skaffold.yaml`

### DIFF
--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -1,0 +1,1 @@
+# This documentation has been moved to https://skaffold.dev/docs/references/yaml/


### PR DESCRIPTION
Fixes #1768

Signed-off-by: David Gageot <david@gageot.net>