### PR TITLE
Faster doc preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ docs/firebase-debug*
 docs/public
 docs/resources
 docs/node_modules
+docs/themes
 docs/package-lock.json
 pkg/skaffold/color/debug.test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,0 @@
-[submodule "docsy"]
-	active = true
-	path = docs/themes/docsy
-	url = https://github.com/google/docsy
-	commit = a7141a2eac26cb598b707cab87d224f9105c315d

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ BUILD_PACKAGE = $(REPOPATH)/cmd/skaffold
 
 VERSION_PACKAGE = $(REPOPATH)/pkg/skaffold/version
 COMMIT = $(shell git rev-parse HEAD)
-BASE_URL ?= https://skaffold.dev
 VERSION ?= $(shell git describe --always --tags --dirty)
 
 GO_GCFLAGS := "all=-trimpath=${PWD}"
@@ -179,29 +178,13 @@ submit-release-trigger:
 
 #utilities for skaffold site - not used anywhere else
 
-.PHONY: docs-controller-image
-docs-controller-image:
-	docker build -t gcr.io/$(GCP_PROJECT)/docs-controller -f deploy/webhook/Dockerfile .
-
-
 .PHONY: preview-docs
-preview-docs: start-docs-preview clean-docs-preview
-
-.PHONY: docs-preview-image
-docs-preview-image:
-	docker build -t skaffold-docs-previewer -f deploy/webhook/Dockerfile --target runtime_deps .
-
-.PHONY: start-docs-preview
-start-docs-preview:	docs-preview-image
-	docker run --rm -ti -v $(PWD):/app --workdir /app/ -p 1313:1313 skaffold-docs-previewer bash -xc deploy/docs/preview.sh
+preview-docs:
+	./deploy/docs/local-preview.sh hugo serve -D --bind=0.0.0.0
 
 .PHONY: build-docs-preview
-build-docs-preview:	docs-preview-image
-	docker run --rm -ti -v $(PWD):/app --workdir /app/ -p 1313:1313 skaffold-docs-previewer bash -xc deploy/docs/build.sh
-
-.PHONY: clean-docs-preview
-clean-docs-preview: docs-preview-image
-	docker run --rm -ti -v $(PWD):/app --workdir /app/ -p 1313:1313 skaffold-docs-previewer bash -xc deploy/docs/clean.sh
+build-docs-preview:
+	./deploy/docs/local-preview.sh hugo --baseURL=https://skaffold.dev
 
 # schema generation
 

--- a/deploy/docs/build.sh
+++ b/deploy/docs/build.sh
@@ -19,7 +19,7 @@ set -exu
 readonly BASE_URL=${1}
 
 cd docs
-mkdir themes
+mkdir -p themes
 ln -s /app/docs/themes/docsy ./themes/docsy
 ln -s /app/docs/node_modules ./node_modules
 hugo --baseURL=${BASE_URL}

--- a/deploy/docs/build.sh
+++ b/deploy/docs/build.sh
@@ -19,7 +19,7 @@ set -exu
 readonly BASE_URL=${1}
 
 cd docs
-mkdir -p themes
+mkdir themes
 ln -s /app/docs/themes/docsy ./themes/docsy
 ln -s /app/docs/node_modules ./node_modules
 hugo --baseURL=${BASE_URL}

--- a/deploy/docs/build.sh
+++ b/deploy/docs/build.sh
@@ -14,21 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -exu
 
-## This script builds the Skaffold site assuming it's ran from a
-## cloned Skaffold repo with no submodules initialized. The script initializes the git submodules for
-## the site's theme in a standard manner, thus this script can be used locally as well as for the PR review flow.
-set -x
+readonly BASE_URL=${1}
 
-readonly DOCSY_COMMIT=$(git config -f .gitmodules submodule.docsy.commit)
-readonly REPO_DIR=$(pwd)
-readonly BASE_URL=${1:-"http://localhost:1313"}
-
-git submodule init && \
-git submodule update --init && \
-cd  docs/themes/docsy && \
-git checkout ${DOCSY_COMMIT} && \
-git submodule update --init --recursive && \
-cd  ${REPO_DIR}/docs && \
-npm i -D autoprefixer && \
+cd docs
+mkdir themes
+ln -s /app/docs/themes/docsy ./themes/docsy
+ln -s /app/docs/node_modules ./node_modules
 hugo --baseURL=${BASE_URL}

--- a/deploy/docs/cloudbuild-release.yaml
+++ b/deploy/docs/cloudbuild-release.yaml
@@ -17,9 +17,9 @@ steps:
   - 'gcr.io/$PROJECT_ID/docs-controller:latest'
   - '--cache-from'
   - 'gcr.io/$PROJECT_ID/docs-controller:latest'
-  - '-f'
-  - 'deploy/webhook/Dockerfile'
-  - '.'
+  - '--target'
+  - 'runtime_deps'
+  - 'deploy/webhook'
 
 - name: gcr.io/$PROJECT_ID/docs-controller:latest
   env:

--- a/deploy/docs/cloudbuild.yaml
+++ b/deploy/docs/cloudbuild.yaml
@@ -17,9 +17,9 @@ steps:
   - 'gcr.io/$PROJECT_ID/docs-controller:latest'
   - '--cache-from'
   - 'gcr.io/$PROJECT_ID/docs-controller:latest'
-  - '-f'
-  - 'deploy/webhook/Dockerfile'
-  - '.'
+  - '--target'
+  - 'runtime_deps'
+  - 'deploy/webhook'
 
 - name: gcr.io/$PROJECT_ID/docs-controller:latest
   env:

--- a/deploy/docs/preview.sh
+++ b/deploy/docs/preview.sh
@@ -19,7 +19,7 @@ set -exu
 readonly BASE_URL=${1}
 
 cd docs
-mkdir themes
+mkdir -p themes
 ln -s /app/docs/themes/docsy ./themes/docsy
 ln -s /app/docs/node_modules ./node_modules
 hugo serve --bind=0.0.0.0 -D --baseURL=${BASE_URL}

--- a/deploy/docs/preview.sh
+++ b/deploy/docs/preview.sh
@@ -19,7 +19,7 @@ set -exu
 readonly BASE_URL=${1}
 
 cd docs
-mkdir -p themes
+mkdir themes
 ln -s /app/docs/themes/docsy ./themes/docsy
 ln -s /app/docs/node_modules ./node_modules
 hugo serve --bind=0.0.0.0 -D --baseURL=${BASE_URL}

--- a/deploy/docs/preview.sh
+++ b/deploy/docs/preview.sh
@@ -14,16 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-## This script starts a preview of the Skaffold site assuming it's ran from a
-## cloned Skaffold repo with no submodules initialized. The script initializes the git submodules for
-## the site's theme in a standard manner, thus this script can be used locally as well as for the PR review flow.
-set -x
+set -exu
 
-readonly REPO_DIR=$(pwd)
-readonly BASE_URL=${1:-"http://localhost:1313"}
+readonly BASE_URL=${1}
 
-bash ${REPO_DIR}/deploy/docs/build.sh ${BASE_URL}
-
-cd ${REPO_DIR}/docs
-
+cd docs
+mkdir themes
+ln -s /app/docs/themes/docsy ./themes/docsy
+ln -s /app/docs/node_modules ./node_modules
 hugo serve --bind=0.0.0.0 -D --baseURL=${BASE_URL}

--- a/deploy/webhook/Dockerfile
+++ b/deploy/webhook/Dockerfile
@@ -39,6 +39,14 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - &&  \
                        # required for releasing the docs
                        firebase-tools
 
+WORKDIR /app/docs/themes/docsy
+RUN git clone https://github.com/google/docsy.git . \
+    && git reset --hard a7141a2eac26cb598b707cab87d224f9105c315d \
+    && git submodule update --init --recursive
+
+WORKDIR /app/docs
+RUN npm i -D autoprefixer
+
 FROM golang:1.10 as webhook
 WORKDIR $GOPATH/src/github.com/GoogleContainerTools/skaffold
 COPY . .


### PR DESCRIPTION
Clone the docs theme inside a Docker image, not on the developer's machine.
Instead of mounting the whole workspace, we mount only the relevant doc sources.

This makes working on the documentation much faster, gets rid of the submodules, doesn't require a cleanup phase...

Signed-off-by: David Gageot <david@gageot.net>