### PR TITLE
Improve `make test`

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ GREEN='\033[0;32m'
 RESET='\033[0m'
 
 echo "Running go tests..."
-go test -count=1 -cover -short -timeout 60s ./... | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
+go test -count=1 -cover -short -timeout 60s ./... | grep -v 'no test files' | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
 GO_TEST_EXIT_CODE=${PIPESTATUS[0]}
 if [[ $GO_TEST_EXIT_CODE -ne 0 ]]; then
     exit $GO_TEST_EXIT_CODE

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ GREEN='\033[0;32m'
 RESET='\033[0m'
 
 echo "Running go tests..."
-go test -cover -short -timeout 60s ./... | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
+go test -count=1 -cover -short -timeout 60s ./... | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
 GO_TEST_EXIT_CODE=${PIPESTATUS[0]}
 if [[ $GO_TEST_EXIT_CODE -ne 0 ]]; then
     exit $GO_TEST_EXIT_CODE


### PR DESCRIPTION
 + Make sure test results are not cached
 + Remove packages that are not tested from the output

```
make test
Running go tests...
ok  	github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd	0.866s	coverage: 9.0% of statements
ok  	github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config	0.409s	coverage: 36.9% of statements
ok  	github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags	0.091s	coverage: 52.2% of statements
ok  	github.com/GoogleContainerTools/skaffold/hack/schemas	0.435s	coverage: 90.6% of statements
ok  	github.com/GoogleContainerTools/skaffold/integration	0.826s	coverage: 0.0% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion	0.064s	coverage: 100.0% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/bazel	0.325s	coverage: 88.5% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/build	0.455s	coverage: 68.9% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/bazel	0.354s	coverage: 18.2% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/docker	0.373s	coverage: 16.0% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko	0.700s	coverage: 3.3% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/local	0.409s	coverage: 32.8% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/plugin	0.505s	coverage: 12.8% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag	1.896s	coverage: 82.8% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/color	0.342s	coverage: 82.4% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/config	0.244s	coverage: 93.8% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy	0.917s	coverage: 56.2% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl	0.375s	coverage: 54.3% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker	3.181s	coverage: 70.3% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/gcp	0.367s	coverage: 92.0% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/jib	0.358s	coverage: 95.5% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes	2.276s	coverage: 23.1% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context	0.335s	coverage: 76.9% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/plugin/environments/gcb	0.426s	coverage: 11.7% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner	3.930s	coverage: 61.6% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema	0.541s	coverage: 90.9% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults	0.440s	coverage: 37.5% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha1	0.562s	coverage: 78.1% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2	0.358s	coverage: 75.0% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha3	0.343s	coverage: 80.8% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha4	0.340s	coverage: 72.7% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha5	0.348s	coverage: 77.8% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta1	0.349s	coverage: 72.7% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta2	0.334s	coverage: 72.7% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta3	0.366s	coverage: 72.7% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta4	0.365s	coverage: 72.7% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta5	0.336s	coverage: 75.0% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta6	0.369s	coverage: 75.0% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync	0.448s	coverage: 77.0% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/util	0.418s	coverage: 52.4% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/version	0.228s	coverage: 71.4% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/watch	0.261s	coverage: 67.9% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags	0.068s	coverage: 92.8% of statements
ok  	github.com/GoogleContainerTools/skaffold/pkg/webhook/labels	0.197s	coverage: 100.0% of statements```
