### PR TITLE
Add back tracking of forwarded ports to avoid race condition

### DIFF
--- a/pkg/skaffold/event/server.go
+++ b/pkg/skaffold/event/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/proto"
@@ -69,7 +70,7 @@ func newStatusServer(originalPort int) (func() error, error) {
 	if originalPort == -1 {
 		return func() error { return nil }, nil
 	}
-	port := util.GetAvailablePort(originalPort)
+	port := util.GetAvailablePort(originalPort, &sync.Map{})
 	if port != originalPort && originalPort != constants.DefaultRPCPort {
 		logrus.Warnf("provided port %d already in use: using %d instead", originalPort, port)
 	}


### PR DESCRIPTION
This code adds tracking of which ports we've forwarded in the port forwarder. The motivation for this is to avoid a race condition where skaffold searches for open ports for two services in a very short period of time: kubectl doesn't have enough time to forward either of the ports, so skaffold thinks the provided port is available for both services, and the first one wins while the second one is not forwarded correctly.

This also adds the pod name and the namespace to the key we're using the track forwardedPods, which fixes a potential latent issue with two containers that share the same name.

cc @briandealwis 