### PR TITLE
Faster integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_script:
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 script:
   - make out/skaffold test
-  - make coverage
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,9 @@ clean:
 
 .PHONY: integration-in-docker
 integration-in-docker:
+	-docker pull gcr.io/$(GCP_PROJECT)/skaffold-builder
 	docker build \
+		--cache-from gcr.io/$(GCP_PROJECT)/skaffold-builder \
 		-f deploy/skaffold/Dockerfile \
 		--target integration \
 		-t gcr.io/$(GCP_PROJECT)/skaffold-integration .

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ $(BUILD_DIR):
 cross: $(foreach platform, $(SUPPORTED_PLATFORMS), $(BUILD_DIR)/$(PROJECT)-$(platform).sha256)
 
 .PHONY: test
-test:
+test: $(BUILD_DIR)
 	@ ./test.sh
 
 .PHONY: install
@@ -93,10 +93,6 @@ ifeq ($(REMOTE_INTEGRATION),true)
 		--project $(GCP_PROJECT)
 endif
 	REMOTE_INTEGRATION=$(REMOTE_INTEGRATION) go test -v $(REPOPATH)/integration -timeout 10m
-
-.PHONY: coverage
-coverage: $(BUILD_DIR)
-	go test -short -coverprofile=$(BUILD_DIR)/coverage.txt -covermode=atomic ./...
 
 .PHONY: release
 release: cross $(BUILD_DIR)/VERSION

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ GREEN='\033[0;32m'
 RESET='\033[0m'
 
 echo "Running go tests..."
-go test -count=1 -cover -short -timeout 60s ./... | grep -v 'no test files' | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
+go test -count=1 -cover -short -timeout 60s -coverprofile=out/coverage.txt -covermode=atomic ./... | grep -v 'no test files' | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
 GO_TEST_EXIT_CODE=${PIPESTATUS[0]}
 if [[ $GO_TEST_EXIT_CODE -ne 0 ]]; then
     exit $GO_TEST_EXIT_CODE


### PR DESCRIPTION
+ Use `--cache-from` to build the integration tests Docker image.
+ Run `make test` and `make coverage` in a single step