### PR TITLE
Initialize LocalCluster in docker local builder plugin

### DIFF
--- a/pkg/skaffold/plugin/builders/docker/local.go
+++ b/pkg/skaffold/plugin/builders/docker/local.go
@@ -59,6 +59,7 @@ func (b *Builder) local(ctx context.Context, out io.Writer, tags tag.ImageTags, 
 	if err != nil {
 		return nil, errors.Wrap(err, "getting localCluster")
 	}
+	b.LocalCluster = localCluster
 	var pushImages bool
 	if b.LocalBuild.Push == nil {
 		pushImages = !localCluster


### PR DESCRIPTION
I see `LocalCluster` is used in line 80 but seems not initialized.