### PR TITLE
Add tests for skaffold init walk flow.

### DIFF
--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -77,7 +77,7 @@ func TestWalk(t *testing.T) {
 		err                 bool
 	}{
 		{
-			name: "shd return correct k8 configs and dockerfiles",
+			name: "should return correct k8 configs and dockerfiles",
 			filesWithContents: map[string][]byte{
 				"config/test.yaml":  emptyFile,
 				"k8pod.yml":         emptyFile,
@@ -97,7 +97,7 @@ func TestWalk(t *testing.T) {
 			err: false,
 		},
 		{
-			name: "shd skip hidden dir",
+			name: "should skip hidden dir",
 			filesWithContents: map[string][]byte{
 				".hidden/test.yaml":  emptyFile,
 				"k8pod.yml":          emptyFile,
@@ -115,7 +115,7 @@ func TestWalk(t *testing.T) {
 			err: false,
 		},
 		{
-			name: "shd not error when skaffold.config present and force = true",
+			name: "should not error when skaffold.config present and force = true",
 			filesWithContents: map[string][]byte{
 				"skaffold.yaml": []byte(`apiVersion: skaffold/v1beta6
 kind: Config
@@ -139,7 +139,7 @@ deploy:
 			err: false,
 		},
 		{
-			name: "shd  error when skaffold.config present and force = false",
+			name: "should  error when skaffold.config present and force = false",
 			filesWithContents: map[string][]byte{
 				"config/test.yaml":  emptyFile,
 				"k8pod.yml":         emptyFile,

--- a/testutil/tmp.go
+++ b/testutil/tmp.go
@@ -128,3 +128,12 @@ func (h *TempDir) failIfErr(err error) *TempDir {
 	}
 	return h
 }
+
+// Paths returns the paths to a list of files in the temp directory.
+func (h *TempDir) Paths(files []string) []string {
+	var paths []string
+	for _, file := range files {
+		paths = append(paths, h.Path(file))
+	}
+	return paths
+}


### PR DESCRIPTION
As we support other helm and kustomize deployers in `skaffold init` flow, walk will become more complex.
Refactoring it out and adding some tests.