### PR TITLE
WIP Sync: infer destination from Dockerfile

### DIFF
--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"sort"
 	"time"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -118,8 +119,16 @@ func diagnoseArtifacts(out io.Writer, builder build.Builder, artifacts []*latest
 
 func timeToListDependencies(ctx context.Context, builder build.Builder, a *latest.Artifact) (time.Duration, []string, error) {
 	start := time.Now()
-	paths, err := builder.DependenciesForArtifact(ctx, a)
-	return time.Since(start), paths, err
+	dependencies, err := builder.DependenciesForArtifact(ctx, a)
+	duration := time.Since(start)
+
+	paths := make([]string, 0, len(dependencies))
+	for path := range dependencies {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	return duration, paths, err
 }
 
 func timeToComputeMTimes(deps []string) (time.Duration, error) {

--- a/docs/content/en/schemas/v1beta7.json
+++ b/docs/content/en/schemas/v1beta7.json
@@ -70,16 +70,10 @@
               "x-intellij-html-description": "plugin used to build this artifact."
             },
             "sync": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object",
-              "description": "*alpha* local files synced to pods instead of triggering an image build when modified. This is a mapping of local files to sync to remote folders.",
-              "x-intellij-html-description": "<em>alpha</em> local files synced to pods instead of triggering an image build when modified. This is a mapping of local files to sync to remote folders.",
-              "default": "{}",
-              "examples": [
-                "{\"*.py\": \".\", \"css/**/*.css\": \"app/css\"}"
-              ]
+              "type": "boolean",
+              "description": "*alpha* local files synced to pods instead of triggering an image build when modified.",
+              "x-intellij-html-description": "<em>alpha</em> local files synced to pods instead of triggering an image build when modified.",
+              "default": "false"
             }
           },
           "preferredOrder": [
@@ -117,16 +111,10 @@
               "x-intellij-html-description": "plugin used to build this artifact."
             },
             "sync": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object",
-              "description": "*alpha* local files synced to pods instead of triggering an image build when modified. This is a mapping of local files to sync to remote folders.",
-              "x-intellij-html-description": "<em>alpha</em> local files synced to pods instead of triggering an image build when modified. This is a mapping of local files to sync to remote folders.",
-              "default": "{}",
-              "examples": [
-                "{\"*.py\": \".\", \"css/**/*.css\": \"app/css\"}"
-              ]
+              "type": "boolean",
+              "description": "*alpha* local files synced to pods instead of triggering an image build when modified.",
+              "x-intellij-html-description": "<em>alpha</em> local files synced to pods instead of triggering an image build when modified.",
+              "default": "false"
             }
           },
           "preferredOrder": [
@@ -165,16 +153,10 @@
               "x-intellij-html-description": "plugin used to build this artifact."
             },
             "sync": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object",
-              "description": "*alpha* local files synced to pods instead of triggering an image build when modified. This is a mapping of local files to sync to remote folders.",
-              "x-intellij-html-description": "<em>alpha</em> local files synced to pods instead of triggering an image build when modified. This is a mapping of local files to sync to remote folders.",
-              "default": "{}",
-              "examples": [
-                "{\"*.py\": \".\", \"css/**/*.css\": \"app/css\"}"
-              ]
+              "type": "boolean",
+              "description": "*alpha* local files synced to pods instead of triggering an image build when modified.",
+              "x-intellij-html-description": "<em>alpha</em> local files synced to pods instead of triggering an image build when modified.",
+              "default": "false"
             }
           },
           "preferredOrder": [
@@ -213,16 +195,10 @@
               "x-intellij-html-description": "plugin used to build this artifact."
             },
             "sync": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object",
-              "description": "*alpha* local files synced to pods instead of triggering an image build when modified. This is a mapping of local files to sync to remote folders.",
-              "x-intellij-html-description": "<em>alpha</em> local files synced to pods instead of triggering an image build when modified. This is a mapping of local files to sync to remote folders.",
-              "default": "{}",
-              "examples": [
-                "{\"*.py\": \".\", \"css/**/*.css\": \"app/css\"}"
-              ]
+              "type": "boolean",
+              "description": "*alpha* local files synced to pods instead of triggering an image build when modified.",
+              "x-intellij-html-description": "<em>alpha</em> local files synced to pods instead of triggering an image build when modified.",
+              "default": "false"
             }
           },
           "preferredOrder": [
@@ -261,16 +237,10 @@
               "x-intellij-html-description": "plugin used to build this artifact."
             },
             "sync": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object",
-              "description": "*alpha* local files synced to pods instead of triggering an image build when modified. This is a mapping of local files to sync to remote folders.",
-              "x-intellij-html-description": "<em>alpha</em> local files synced to pods instead of triggering an image build when modified. This is a mapping of local files to sync to remote folders.",
-              "default": "{}",
-              "examples": [
-                "{\"*.py\": \".\", \"css/**/*.css\": \"app/css\"}"
-              ]
+              "type": "boolean",
+              "description": "*alpha* local files synced to pods instead of triggering an image build when modified.",
+              "x-intellij-html-description": "<em>alpha</em> local files synced to pods instead of triggering an image build when modified.",
+              "default": "false"
             }
           },
           "preferredOrder": [
@@ -309,16 +279,10 @@
               "x-intellij-html-description": "plugin used to build this artifact."
             },
             "sync": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object",
-              "description": "*alpha* local files synced to pods instead of triggering an image build when modified. This is a mapping of local files to sync to remote folders.",
-              "x-intellij-html-description": "<em>alpha</em> local files synced to pods instead of triggering an image build when modified. This is a mapping of local files to sync to remote folders.",
-              "default": "{}",
-              "examples": [
-                "{\"*.py\": \".\", \"css/**/*.css\": \"app/css\"}"
-              ]
+              "type": "boolean",
+              "description": "*alpha* local files synced to pods instead of triggering an image build when modified.",
+              "x-intellij-html-description": "<em>alpha</em> local files synced to pods instead of triggering an image build when modified.",
+              "default": "false"
             }
           },
           "preferredOrder": [

--- a/examples/hot-reload/skaffold.yaml
+++ b/examples/hot-reload/skaffold.yaml
@@ -4,12 +4,10 @@ build:
   artifacts:
   - image: gcr.io/k8s-skaffold/node-example
     context: node
-    sync:
-      '**/*.js': .
+    sync: true
   - image: gcr.io/k8s-skaffold/python-reload
     context: python
-    sync:
-      '**/*.py': .
+    sync: true
 deploy:
   kubectl:
     manifests:

--- a/examples/nodejs/skaffold.yaml
+++ b/examples/nodejs/skaffold.yaml
@@ -4,8 +4,7 @@ build:
   artifacts:
   - image: gcr.io/k8s-skaffold/node-example
     context: backend
-    sync:
-      '*.js': .
+    sync: true
 deploy:
   kubectl:
     manifests:

--- a/integration/examples/hot-reload/skaffold.yaml
+++ b/integration/examples/hot-reload/skaffold.yaml
@@ -4,12 +4,10 @@ build:
   artifacts:
   - image: gcr.io/k8s-skaffold/node-example
     context: node
-    sync:
-      '**/*.js': .
+    sync: true
   - image: gcr.io/k8s-skaffold/python-reload
     context: python
-    sync:
-      '**/*.py': .
+    sync: true
 deploy:
   kubectl:
     manifests:

--- a/integration/examples/nodejs/skaffold.yaml
+++ b/integration/examples/nodejs/skaffold.yaml
@@ -4,8 +4,7 @@ build:
   artifacts:
   - image: gcr.io/k8s-skaffold/node-example
     context: backend
-    sync:
-      '*.js': .
+    sync: true
 deploy:
   kubectl:
     manifests:

--- a/integration/testdata/file-sync/skaffold.yaml
+++ b/integration/testdata/file-sync/skaffold.yaml
@@ -6,8 +6,7 @@ build:
   artifacts:
   - image: gcr.io/k8s-skaffold/test-file-sync
     context: .
-    sync:
-      '**/foo*' : /test
+    sync: true
 deploy:
  kubectl:
    manifests:

--- a/pkg/skaffold/build/build.go
+++ b/pkg/skaffold/build/build.go
@@ -39,5 +39,5 @@ type Builder interface {
 
 	Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]Artifact, error)
 
-	DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) ([]string, error)
+	DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) (map[string][]string, error)
 }

--- a/pkg/skaffold/build/cache/hash.go
+++ b/pkg/skaffold/build/cache/hash.go
@@ -38,11 +38,17 @@ var (
 )
 
 func getHashForArtifact(ctx context.Context, builder build.Builder, a *latest.Artifact) (string, error) {
-	deps, err := builder.DependenciesForArtifact(ctx, a)
+	dependencies, err := builder.DependenciesForArtifact(ctx, a)
 	if err != nil {
 		return "", errors.Wrapf(err, "getting dependencies for %s", a.ImageName)
 	}
+
+	deps := make([]string, 0, len(dependencies))
+	for path := range dependencies {
+		deps = append(deps, path)
+	}
 	sort.Strings(deps)
+
 	var hashes []string
 	for _, d := range deps {
 		h, err := hashFunction(d)

--- a/pkg/skaffold/build/cache/hash_test.go
+++ b/pkg/skaffold/build/cache/hash_test.go
@@ -37,8 +37,13 @@ func (m *mockBuilder) Build(ctx context.Context, out io.Writer, tags tag.ImageTa
 	return nil, nil
 }
 
-func (m *mockBuilder) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
-	return m.dependencies, nil
+func (m *mockBuilder) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) (map[string][]string, error) {
+	noDst := []string{""}
+	dependencies := map[string][]string{}
+	for _, path := range m.dependencies {
+		dependencies[path] = noDst
+	}
+	return dependencies, nil
 }
 
 var mockCacheHasher = func(s string) (string, error) {

--- a/pkg/skaffold/build/kaniko/sources/gcs.go
+++ b/pkg/skaffold/build/kaniko/sources/gcs.go
@@ -37,7 +37,7 @@ type GCSBucket struct {
 }
 
 // Setup uploads the context to the provided GCS bucket
-func (g *GCSBucket) Setup(ctx context.Context, out io.Writer, artifact *latest.Artifact, initialTag string, dependencies []string) (string, error) {
+func (g *GCSBucket) Setup(ctx context.Context, out io.Writer, artifact *latest.Artifact, initialTag string, dependencies map[string][]string) (string, error) {
 	bucket := g.artifact.BuildContext.GCSBucket
 	if bucket == "" {
 		guessedProjectID, err := gcp.ExtractProjectID(artifact.ImageName)

--- a/pkg/skaffold/build/kaniko/sources/localdir.go
+++ b/pkg/skaffold/build/kaniko/sources/localdir.go
@@ -48,7 +48,7 @@ type LocalDir struct {
 }
 
 // Setup for LocalDir creates a tarball of the buildcontext and stores it in /tmp
-func (g *LocalDir) Setup(ctx context.Context, out io.Writer, artifact *latest.Artifact, initialTag string, dependencies []string) (string, error) {
+func (g *LocalDir) Setup(ctx context.Context, out io.Writer, artifact *latest.Artifact, initialTag string, dependencies map[string][]string) (string, error) {
 	g.tarPath = filepath.Join(os.TempDir(), fmt.Sprintf("context-%s.tar.gz", initialTag))
 	color.Default.Fprintln(out, "Storing build context at", g.tarPath)
 

--- a/pkg/skaffold/build/kaniko/sources/sources.go
+++ b/pkg/skaffold/build/kaniko/sources/sources.go
@@ -28,7 +28,7 @@ import (
 
 // BuildContextSource is the generic type for the different build context sources the kaniko builder can use
 type BuildContextSource interface {
-	Setup(ctx context.Context, out io.Writer, artifact *latest.Artifact, initialTag string, dependencies []string) (string, error)
+	Setup(ctx context.Context, out io.Writer, artifact *latest.Artifact, initialTag string, dependencies map[string][]string) (string, error)
 	Pod(args []string) *v1.Pod
 	ModifyPod(ctx context.Context, p *v1.Pod) error
 	Cleanup(ctx context.Context) error

--- a/pkg/skaffold/build/kaniko/types.go
+++ b/pkg/skaffold/build/kaniko/types.go
@@ -54,8 +54,7 @@ func (b *Builder) Labels() map[string]string {
 	}
 }
 
-// DependenciesForArtifact returns the Dockerfile dependencies for this kaniko artifact
-func (b *Builder) DependenciesForArtifact(ctx context.Context, a *latest.Artifact) ([]string, error) {
+func (b *Builder) DependenciesForArtifact(ctx context.Context, a *latest.Artifact) (map[string][]string, error) {
 	paths, err := docker.GetDependencies(ctx, a.Workspace, a.KanikoArtifact.DockerfilePath, a.KanikoArtifact.BuildArgs)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting dependencies for %s", a.ImageName)

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -89,9 +89,9 @@ func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, artifa
 	}
 }
 
-func (b *Builder) DependenciesForArtifact(ctx context.Context, a *latest.Artifact) ([]string, error) {
+func (b *Builder) DependenciesForArtifact(ctx context.Context, a *latest.Artifact) (map[string][]string, error) {
 	var (
-		paths []string
+		paths map[string][]string
 		err   error
 	)
 
@@ -100,7 +100,7 @@ func (b *Builder) DependenciesForArtifact(ctx context.Context, a *latest.Artifac
 		paths, err = docker.GetDependencies(ctx, a.Workspace, a.DockerArtifact.DockerfilePath, a.DockerArtifact.BuildArgs)
 
 	case a.BazelArtifact != nil:
-		paths, err = bazel.GetDependencies(ctx, a.Workspace, a.BazelArtifact)
+		paths, err = bazel.GetDependencyMap(ctx, a.Workspace, a.BazelArtifact)
 
 	case a.JibMavenArtifact != nil:
 		paths, err = jib.GetDependenciesMaven(ctx, a.Workspace, a.JibMavenArtifact)

--- a/pkg/skaffold/build/plugin/plugin.go
+++ b/pkg/skaffold/build/plugin/plugin.go
@@ -137,8 +137,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, 
 	return builtArtifacts, nil
 }
 
-func (b *Builder) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
-	// Group artifacts by builder
+func (b *Builder) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) (map[string][]string, error) {
 	for name, builder := range b.Builders {
 		if name != artifact.BuilderPlugin.Name {
 			continue

--- a/pkg/skaffold/build/plugin/plugin_test.go
+++ b/pkg/skaffold/build/plugin/plugin_test.go
@@ -44,7 +44,7 @@ func (b *mockBuilder) Labels() map[string]string {
 
 func (b *mockBuilder) Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnvironment) {}
 
-func (b *mockBuilder) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
+func (b *mockBuilder) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) (map[string][]string, error) {
 	return nil, nil
 }
 

--- a/pkg/skaffold/build/prebuilt.go
+++ b/pkg/skaffold/build/prebuilt.go
@@ -84,6 +84,6 @@ func (b *prebuiltImagesBuilder) Build(ctx context.Context, out io.Writer, _ tag.
 }
 
 // DependenciesForArtifact returns nil since a prebuilt image should have no dependencies
-func (b *prebuiltImagesBuilder) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
+func (b *prebuiltImagesBuilder) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) (map[string][]string, error) {
 	return nil, nil
 }

--- a/pkg/skaffold/docker/context.go
+++ b/pkg/skaffold/docker/context.go
@@ -27,14 +27,14 @@ import (
 )
 
 func CreateDockerTarContext(ctx context.Context, w io.Writer, workspace string, a *latest.DockerArtifact) error {
-	paths, err := GetDependencies(ctx, workspace, a.DockerfilePath, a.BuildArgs)
+	dependencies, err := GetDependencies(ctx, workspace, a.DockerfilePath, a.BuildArgs)
 	if err != nil {
 		return errors.Wrap(err, "getting relative tar paths")
 	}
 
-	var p []string
-	for _, path := range paths {
-		p = append(p, filepath.Join(workspace, path))
+	p := map[string][]string{}
+	for path, dsts := range dependencies {
+		p[filepath.Join(workspace, path)] = dsts
 	}
 
 	if err := util.CreateTar(w, workspace, p); err != nil {

--- a/pkg/skaffold/docker/context.go
+++ b/pkg/skaffold/docker/context.go
@@ -32,9 +32,10 @@ func CreateDockerTarContext(ctx context.Context, w io.Writer, workspace string, 
 		return errors.Wrap(err, "getting relative tar paths")
 	}
 
+	defaultDst := []string{""}
 	p := map[string][]string{}
-	for path, dsts := range dependencies {
-		p[filepath.Join(workspace, path)] = dsts
+	for path := range dependencies {
+		p[filepath.Join(workspace, path)] = defaultDst
 	}
 
 	if err := util.CreateTar(w, workspace, p); err != nil {

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -223,7 +223,11 @@ func copiedFiles(nodes []*parser.Node) (map[cDest][]string, error) {
 			}
 
 			if len(files) > 0 {
-				copied[dest] = files
+				if otherFiles, ok := copied[dest]; ok {
+					copied[dest] = append(otherFiles, files...)
+				} else {
+					copied[dest] = files
+				}
 			}
 		case command.Env:
 			// one env command may define multiple variables
@@ -505,6 +509,7 @@ func retrieveWorkingDir(tagged string) (string, error) {
 	}
 
 	if cf.Config.WorkingDir == "" {
+		logrus.Debugf("Using default workdir '/' for %s", tagged)
 		return "/", nil
 	}
 	return cf.Config.WorkingDir, nil

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -165,7 +165,7 @@ func onbuildInstructions(nodes []*parser.Node) ([]*parser.Node, error) {
 func copiedFiles(nodes []*parser.Node) ([][]string, error) {
 	var copied [][]string
 
-	envs := map[string]string{}
+	envs := make([]string, 0)
 	for _, node := range nodes {
 		switch node.Value {
 		case command.Add, command.Copy:
@@ -180,7 +180,7 @@ func copiedFiles(nodes []*parser.Node) ([][]string, error) {
 		case command.Env:
 			// one env command may define multiple variables
 			for node := node.Next; node != nil && node.Next != nil; node = node.Next.Next {
-				envs[node.Value] = node.Next.Value
+				envs = append(envs, fmt.Sprintf("%s=%s", node.Value, node.Next.Value))
 			}
 		}
 	}
@@ -392,7 +392,7 @@ func retrieveImage(image string) (*v1.ConfigFile, error) {
 	return localDaemon.ConfigFile(context.Background(), image)
 }
 
-func processCopy(value *parser.Node, envs map[string]string) ([]string, error) {
+func processCopy(value *parser.Node, envs []string) ([]string, error) {
 	var copied []string
 
 	slex := shell.NewLex('\\')
@@ -401,7 +401,7 @@ func processCopy(value *parser.Node, envs map[string]string) ([]string, error) {
 		if value.Next.Next == nil || strings.HasPrefix(value.Next.Next.Value, "#") {
 			break
 		}
-		src, err := processShellWord(slex, value.Next.Value, envs)
+		src, err := slex.ProcessWord(value.Next.Value, envs)
 		if err != nil {
 			return nil, errors.Wrap(err, "processing word")
 		}
@@ -420,14 +420,6 @@ func processCopy(value *parser.Node, envs map[string]string) ([]string, error) {
 	}
 
 	return copied, nil
-}
-
-func processShellWord(lex *shell.Lex, word string, envs map[string]string) (string, error) {
-	envSlice := []string{}
-	for envKey, envVal := range envs {
-		envSlice = append(envSlice, fmt.Sprintf("%s=%s", envKey, envVal))
-	}
-	return lex.ProcessWord(word, envSlice)
 }
 
 func hasMultiStageFlag(flags []string) bool {

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -497,6 +497,10 @@ func retrieveWorkingDir(tagged string) (string, error) {
 	var cf *registry_v1.ConfigFile
 	var err error
 
+	if strings.ToLower(tagged) == "scratch" {
+		return "/", nil
+	}
+
 	localDocker, err := NewAPIClient()
 	if err != nil {
 		// No local Docker is available

--- a/pkg/skaffold/docker/parse_test.go
+++ b/pkg/skaffold/docker/parse_test.go
@@ -51,6 +51,12 @@ WORKDIR /app
 COPY server.go /bar
 `
 
+const copySameDest = `
+FROM ubuntu:14.04
+COPY server.go .
+COPY test.conf .
+`
+
 const copyWorkdirAbsDestDir = `
 FROM ubuntu:14.04
 WORKDIR /app
@@ -306,6 +312,13 @@ func TestGetDependencies(t *testing.T) {
 			dockerfile:  copyWorkdirAbsDest,
 			workspace:   ".",
 			expected:    map[string][]string{"Dockerfile": nil, "server.go": {"/bar"}},
+			fetched:     []string{"ubuntu:14.04"},
+		},
+		{
+			description: "two copy commands with same destination",
+			dockerfile:  copySameDest,
+			workspace:   ".",
+			expected:    map[string][]string{"Dockerfile": nil, "server.go": {"/server.go"}, "test.conf": {"/test.conf"}},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{

--- a/pkg/skaffold/docker/parse_test.go
+++ b/pkg/skaffold/docker/parse_test.go
@@ -500,6 +500,13 @@ func TestGetDependencies(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			tmpDir, cleanup := testutil.NewTempDir(t)
 			defer cleanup()
+			originalWorkingDir := WorkingDir
+			WorkingDir = func(tagged string) (string, error) {
+				return "/", nil
+			}
+			defer func() {
+				WorkingDir = originalWorkingDir
+			}()
 
 			imageFetcher := fakeImageFetcher{}
 			RetrieveImage = imageFetcher.fetch

--- a/pkg/skaffold/docker/parse_test.go
+++ b/pkg/skaffold/docker/parse_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
-	"github.com/google/go-containerregistry/pkg/v1"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 const copyServerGo = `
@@ -235,21 +235,21 @@ func TestGetDependencies(t *testing.T) {
 			description: "copy dependency",
 			dockerfile:  copyServerGo,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, "server.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "server.go": {""}},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
 			description: "add dependency",
 			dockerfile:  addNginx,
 			workspace:   "docker",
-			expected:    map[string][]string{"Dockerfile": {""}, "nginx.conf": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "nginx.conf": {""}},
 			fetched:     []string{"nginx"},
 		},
 		{
 			description: "wildcards",
 			dockerfile:  wildcards,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, "server.go": {""}, "worker.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "server.go": {""}, "worker.go": {""}},
 			fetched:     []string{"nginx"},
 		},
 		{
@@ -263,7 +263,7 @@ func TestGetDependencies(t *testing.T) {
 			description: "one wilcard matches none",
 			dockerfile:  oneWilcardMatchesNone,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, "server.go": {""}, "worker.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "server.go": {""}, "worker.go": {""}},
 			fetched:     []string{"nginx"},
 		},
 		{
@@ -275,42 +275,42 @@ func TestGetDependencies(t *testing.T) {
 			// https://github.com/GoogleContainerTools/skaffold/issues/158
 			description: "no dependencies on remote files",
 			dockerfile:  remoteFileAdd,
-			expected:    map[string][]string{"Dockerfile": {""}},
+			expected:    map[string][]string{"Dockerfile": nil},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
 			description: "multistage dockerfile",
 			dockerfile:  multiStageDockerfile,
 			workspace:   "",
-			expected:    map[string][]string{"Dockerfile": {""}, "worker.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "worker.go": {""}},
 			fetched:     []string{"golang:1.9.2", "gcr.io/distroless/base"},
 		},
 		{
 			description: "copy twice",
 			dockerfile:  multiCopy,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, "test.conf": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "test.conf": {""}},
 			fetched:     []string{"nginx"},
 		},
 		{
 			description: "env test",
 			dockerfile:  envTest,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, "bar": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "bar": {""}},
 			fetched:     []string{"busybox"},
 		},
 		{
 			description: "multiple env test",
 			dockerfile:  multiEnvTest,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, filepath.Join("docker", "nginx.conf"): {""}},
+			expected:    map[string][]string{"Dockerfile": nil, filepath.Join("docker", "nginx.conf"): {""}},
 			fetched:     []string{"busybox"},
 		},
 		{
 			description: "multi file copy",
 			dockerfile:  multiFileCopy,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, "file": {""}, "server.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "file": {""}, "server.go": {""}},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
@@ -326,7 +326,7 @@ func TestGetDependencies(t *testing.T) {
 			dockerfile:  copyServerGo,
 			ignore:      "Dockerfile",
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, "server.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "server.go": {""}},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
@@ -387,7 +387,7 @@ func TestGetDependencies(t *testing.T) {
 			description: "onbuild error",
 			dockerfile:  onbuildError,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, "file": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "file": {""}},
 			fetched:     []string{"noimage:latest"},
 		},
 		{
@@ -395,7 +395,7 @@ func TestGetDependencies(t *testing.T) {
 			dockerfile:  copyServerGoBuildArg,
 			workspace:   ".",
 			buildArgs:   map[string]*string{"FOO": util.StringPtr("server.go")},
-			expected:    map[string][]string{"Dockerfile": {""}, "server.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "server.go": {""}},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
@@ -403,7 +403,7 @@ func TestGetDependencies(t *testing.T) {
 			dockerfile:  copyWorkerGoBuildArgSamePrefix,
 			workspace:   ".",
 			buildArgs:   map[string]*string{"FOO2": util.StringPtr("worker.go")},
-			expected:    map[string][]string{"Dockerfile": {""}, "worker.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "worker.go": {""}},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
@@ -411,7 +411,7 @@ func TestGetDependencies(t *testing.T) {
 			dockerfile:  copyServerGoBuildArgCurlyBraces,
 			workspace:   ".",
 			buildArgs:   map[string]*string{"FOO": util.StringPtr("server.go")},
-			expected:    map[string][]string{"Dockerfile": {""}, "server.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "server.go": {""}},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
@@ -419,28 +419,28 @@ func TestGetDependencies(t *testing.T) {
 			dockerfile:  copyServerGoBuildArgExtraWhitespace,
 			workspace:   ".",
 			buildArgs:   map[string]*string{"FOO": util.StringPtr("server.go")},
-			expected:    map[string][]string{"Dockerfile": {""}, "server.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "server.go": {""}},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
 			description: "build args with default value",
 			dockerfile:  copyServerGoBuildArgDefaultValue,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, "server.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "server.go": {""}},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
 			description: "build args with redefined default value",
 			dockerfile:  copyWorkerGoBuildArgRedefinedDefaultValue,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, "worker.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "worker.go": {""}},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
 			description: "build args all defined a the top",
 			dockerfile:  copyServerGoBuildArgsAtTheTop,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, "server.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "server.go": {""}},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
@@ -448,7 +448,7 @@ func TestGetDependencies(t *testing.T) {
 			dockerfile:  copyServerGoBuildArgDefaultValue,
 			workspace:   ".",
 			buildArgs:   map[string]*string{"FOO": util.StringPtr("worker.go")},
-			expected:    map[string][]string{"Dockerfile": {""}, "worker.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "worker.go": {""}},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
@@ -456,42 +456,42 @@ func TestGetDependencies(t *testing.T) {
 			dockerfile:  copyServerGoBuildArgDefaultValue,
 			workspace:   ".",
 			buildArgs:   map[string]*string{"FOO": nil},
-			expected:    map[string][]string{"Dockerfile": {""}, "server.go": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "server.go": {""}},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
 			description: "from base stage",
 			dockerfile:  fromStage,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}},
+			expected:    map[string][]string{"Dockerfile": nil},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
 			description: "from base stage, ignoring case",
 			dockerfile:  fromStageIgnoreCase,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}},
+			expected:    map[string][]string{"Dockerfile": nil},
 			fetched:     []string{"ubuntu:14.04"},
 		},
 		{
 			description: "from scratch",
 			dockerfile:  fromScratch,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, "file": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "file": {""}},
 			fetched:     nil,
 		},
 		{
 			description: "from scratch, ignoring case",
 			dockerfile:  fromScratchUppercase,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, "file": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "file": {""}},
 			fetched:     nil,
 		},
 		{
 			description: "case sensitive",
 			dockerfile:  fromImageCaseSensitive,
 			workspace:   ".",
-			expected:    map[string][]string{"Dockerfile": {""}, "file": {""}},
+			expected:    map[string][]string{"Dockerfile": nil, "file": {""}},
 			fetched:     []string{"jboss/wildfly:14.0.1.Final"},
 		},
 	}

--- a/pkg/skaffold/docker/parse_test.go
+++ b/pkg/skaffold/docker/parse_test.go
@@ -376,6 +376,14 @@ func TestGetDependencies(t *testing.T) {
 			fetched:     []string{"golang:onbuild"},
 		},
 		{
+			description: "onbuild with dockerignore",
+			dockerfile:  onbuild,
+			workspace:   ".",
+			ignore:      "bar\ndocker/*",
+			expected:    []string{".dot", "Dockerfile", "file", "server.go", "test.conf", "worker.go"},
+			fetched:     []string{"golang:onbuild"},
+		},
+		{
 			description: "onbuild error",
 			dockerfile:  onbuildError,
 			workspace:   ".",

--- a/pkg/skaffold/jib/jib_gradle.go
+++ b/pkg/skaffold/jib/jib_gradle.go
@@ -31,9 +31,8 @@ var GradleCommand = util.CommandWrapper{Executable: "gradle", Wrapper: "gradlew"
 
 // GetDependenciesGradle finds the source dependencies for the given jib-gradle artifact.
 // All paths are absolute.
-func GetDependenciesGradle(ctx context.Context, workspace string, a *latest.JibGradleArtifact) ([]string, error) {
-	cmd := getCommandGradle(ctx, workspace, a)
-	deps, err := getDependencies(cmd)
+func GetDependenciesGradle(ctx context.Context, workspace string, a *latest.JibGradleArtifact) (map[string][]string, error) {
+	deps, err := getDependencies(getCommandGradle(ctx, workspace, a))
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting jibGradle dependencies")
 	}

--- a/pkg/skaffold/jib/jib_gradle_test.go
+++ b/pkg/skaffold/jib/jib_gradle_test.go
@@ -77,7 +77,7 @@ func TestGetDependenciesGradle(t *testing.T) {
 			if test.err != nil {
 				testutil.CheckErrorAndDeepEqual(t, true, err, "getting jibGradle dependencies: "+test.err.Error(), err.Error())
 			} else {
-				testutil.CheckDeepEqual(t, []string{dep1, dep2}, deps)
+				testutil.CheckDeepEqual(t, map[string][]string{dep1: {""}, dep2: {""}}, deps)
 			}
 		})
 	}

--- a/pkg/skaffold/jib/jib_maven.go
+++ b/pkg/skaffold/jib/jib_maven.go
@@ -30,7 +30,7 @@ var MavenCommand = util.CommandWrapper{Executable: "mvn", Wrapper: "mvnw"}
 
 // GetDependenciesMaven finds the source dependencies for the given jib-maven artifact.
 // All paths are absolute.
-func GetDependenciesMaven(ctx context.Context, workspace string, a *latest.JibMavenArtifact) ([]string, error) {
+func GetDependenciesMaven(ctx context.Context, workspace string, a *latest.JibMavenArtifact) (map[string][]string, error) {
 	deps, err := getDependencies(getCommandMaven(ctx, workspace, a))
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting jibMaven dependencies")

--- a/pkg/skaffold/jib/jib_maven_test.go
+++ b/pkg/skaffold/jib/jib_maven_test.go
@@ -49,13 +49,13 @@ func TestGetDependenciesMaven(t *testing.T) {
 	var tests = []struct {
 		description string
 		stdout      string
-		expected    []string
+		expected    map[string][]string
 		err         error
 	}{
 		{
 			description: "success",
 			stdout:      fmt.Sprintf("%s\n%s\n\n\n", dep1, dep2),
-			expected:    []string{dep1, dep2},
+			expected:    map[string][]string{dep1: {""}, dep2: {""}},
 		},
 		{
 			description: "failure",

--- a/pkg/skaffold/jib/jib_test.go
+++ b/pkg/skaffold/jib/jib_test.go
@@ -43,44 +43,44 @@ func TestGetDependencies(t *testing.T) {
 	dep3SubPathFileB := tmpDir.Path("dep3/sub/path/fileB")
 
 	var tests = []struct {
-		stdout       string
-		expectedDeps []string
+		stdout        string
+		expectedPaths []string
 	}{
 		{
-			stdout:       "",
-			expectedDeps: nil,
+			stdout:        "",
+			expectedPaths: nil,
 		},
 		{
-			stdout:       fmt.Sprintf("%s\n%s", dep1, dep2),
-			expectedDeps: []string{dep1, dep2},
+			stdout:        fmt.Sprintf("%s\n%s", dep1, dep2),
+			expectedPaths: []string{dep1, dep2},
 		},
 		{
-			stdout:       fmt.Sprintf("%s\n%s\n", dep1, dep2),
-			expectedDeps: []string{dep1, dep2},
+			stdout:        fmt.Sprintf("%s\n%s\n", dep1, dep2),
+			expectedPaths: []string{dep1, dep2},
 		},
 		{
-			stdout:       fmt.Sprintf("%s\n%s\n%s\n", dep1, dep2, tmpDir.Root()),
-			expectedDeps: []string{dep1, dep2},
+			stdout:        fmt.Sprintf("%s\n%s\n%s\n", dep1, dep2, tmpDir.Root()),
+			expectedPaths: []string{dep1, dep2},
 		},
 		{
-			stdout:       "\n\n\n",
-			expectedDeps: nil,
+			stdout:        "\n\n\n",
+			expectedPaths: nil,
 		},
 		{
-			stdout:       fmt.Sprintf("\n\n%s\n\n%s\n\n\n", dep1, dep2),
-			expectedDeps: []string{dep1, dep2},
+			stdout:        fmt.Sprintf("\n\n%s\n\n%s\n\n\n", dep1, dep2),
+			expectedPaths: []string{dep1, dep2},
 		},
 		{
-			stdout:       dep3,
-			expectedDeps: []string{dep3, dep3FileA, dep3Sub, dep3SubPath, dep3SubPathFileB},
+			stdout:        dep3,
+			expectedPaths: []string{dep3, dep3FileA, dep3Sub, dep3SubPath, dep3SubPathFileB},
 		},
 		{
-			stdout:       fmt.Sprintf("%s\n%s\n%s\n", dep1, dep2, dep3),
-			expectedDeps: []string{dep1, dep2, dep3, dep3FileA, dep3Sub, dep3SubPath, dep3SubPathFileB},
+			stdout:        fmt.Sprintf("%s\n%s\n%s\n", dep1, dep2, dep3),
+			expectedPaths: []string{dep1, dep2, dep3, dep3FileA, dep3Sub, dep3SubPath, dep3SubPathFileB},
 		},
 		{
-			stdout:       fmt.Sprintf("%s\nnonexistent\n%s\n%s\n", dep1, dep2, dep3),
-			expectedDeps: []string{dep1, dep2, dep3, dep3FileA, dep3Sub, dep3SubPath, dep3SubPathFileB},
+			stdout:        fmt.Sprintf("%s\nnonexistent\n%s\n%s\n", dep1, dep2, dep3),
+			expectedPaths: []string{dep1, dep2, dep3, dep3FileA, dep3Sub, dep3SubPath, dep3SubPathFileB},
 		},
 	}
 
@@ -94,7 +94,12 @@ func TestGetDependencies(t *testing.T) {
 
 			deps, err := getDependencies(&exec.Cmd{Args: []string{"ignored"}, Dir: tmpDir.Root()})
 
-			testutil.CheckErrorAndDeepEqual(t, false, err, test.expectedDeps, deps)
+			expectedDependencies := map[string][]string{}
+			for _, path := range test.expectedPaths {
+				expectedDependencies[path] = []string{""}
+			}
+
+			testutil.CheckErrorAndDeepEqual(t, false, err, expectedDependencies, deps)
 		})
 	}
 }

--- a/pkg/skaffold/plugin/builders/bazel/builder.go
+++ b/pkg/skaffold/plugin/builders/bazel/builder.go
@@ -30,7 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // Builder builds artifacts with Bazel.
@@ -71,15 +71,14 @@ func (b *Builder) Labels() map[string]string {
 	}
 }
 
-// DependenciesForArtifact returns the dependencies for this bazel artifact
-func (b *Builder) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
+func (b *Builder) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) (map[string][]string, error) {
 	if err := setArtifact(artifact); err != nil {
 		return nil, err
 	}
 	if artifact.BazelArtifact == nil {
 		return nil, errors.New("bazel artifact is nil")
 	}
-	paths, err := GetDependencies(ctx, artifact.Workspace, artifact.BazelArtifact)
+	paths, err := GetDependencyMap(ctx, artifact.Workspace, artifact.BazelArtifact)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting bazel dependencies")
 	}

--- a/pkg/skaffold/plugin/builders/bazel/dependencies.go
+++ b/pkg/skaffold/plugin/builders/bazel/dependencies.go
@@ -80,6 +80,21 @@ func GetDependencies(ctx context.Context, workspace string, a *latest.BazelArtif
 	return deps, nil
 }
 
+func GetDependencyMap(ctx context.Context, workspace string, a *latest.BazelArtifact) (map[string][]string, error) {
+	deps, err := GetDependencies(ctx, workspace, a)
+	if err != nil {
+		return nil, err
+	}
+
+	dependencies := map[string][]string{}
+	noDst := make([]string, 0)
+	for _, p := range deps {
+		dependencies[p] = noDst
+	}
+
+	return dependencies, nil
+}
+
 func depToPath(dep string) string {
 	return strings.TrimPrefix(strings.Replace(strings.TrimPrefix(dep, "//"), ":", "/", 1), "/")
 }

--- a/pkg/skaffold/plugin/builders/docker/builder.go
+++ b/pkg/skaffold/plugin/builders/docker/builder.go
@@ -32,7 +32,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // Builder builds artifacts with Docker.
@@ -75,8 +75,7 @@ func (b *Builder) Labels() map[string]string {
 	}
 }
 
-// DependenciesForArtifact returns the dependencies for this docker artifact
-func (b *Builder) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
+func (b *Builder) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) (map[string][]string, error) {
 	if err := setArtifact(artifact); err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/plugin/environments/gcb/types.go
+++ b/pkg/skaffold/plugin/environments/gcb/types.go
@@ -79,8 +79,8 @@ func (b *Builder) Labels() map[string]string {
 }
 
 // DependenciesForArtifact returns the dependencies for this artifact
-func (b *Builder) DependenciesForArtifact(ctx context.Context, a *latest.Artifact) ([]string, error) {
-	var paths []string
+func (b *Builder) DependenciesForArtifact(ctx context.Context, a *latest.Artifact) (map[string][]string, error) {
+	var paths map[string][]string
 	var err error
 	if a.DockerArtifact != nil {
 		paths, err = docker.GetDependencies(ctx, a.Workspace, a.DockerArtifact.DockerfilePath, a.DockerArtifact.BuildArgs)

--- a/pkg/skaffold/plugin/shared/server.go
+++ b/pkg/skaffold/plugin/shared/server.go
@@ -47,8 +47,8 @@ func (b *BuilderRPC) Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnv
 	b.client.Call("Plugin.Init", args, &resp)
 }
 
-func (b *BuilderRPC) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
-	var resp []string
+func (b *BuilderRPC) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) (map[string][]string, error) {
+	var resp map[string][]string
 	if err := convertPropertiesToBytes([]*latest.Artifact{artifact}); err != nil {
 		return nil, errors.Wrapf(err, "converting properties to bytes")
 	}
@@ -126,10 +126,10 @@ func (s *BuilderRPCServer) Build(b BuildArgs, resp *[]build.Artifact) error {
 	return nil
 }
 
-func (s *BuilderRPCServer) DependenciesForArtifact(d DependencyArgs, resp *[]string) error {
+func (s *BuilderRPCServer) DependenciesForArtifact(d DependencyArgs, resp *map[string][]string) error {
 	dependencies, err := s.Impl.DependenciesForArtifact(context.Background(), d.Artifact)
 	if err != nil {
-		return errors.Wrapf(err, "getting dependencies for %s", d.Artifact.ImageName)
+		return errors.Wrapf(err, "getting dependency map for %s", d.Artifact.ImageName)
 	}
 	*resp = dependencies
 	return nil

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -51,7 +51,8 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, output *config.Output, artifac
 		logger.Mute()
 
 		for _, a := range changed.dirtyArtifacts {
-			s, err := sync.NewItem(a.artifact, a.events, r.builds)
+			depsResolver := func() (map[string][]string, error) { return r.Builder.DependenciesForArtifact(ctx, a.artifact) }
+			s, err := sync.NewItem(a.artifact, a.events, r.builds, depsResolver)
 			if err != nil {
 				return errors.Wrap(err, "sync")
 			}

--- a/pkg/skaffold/runner/dev_test.go
+++ b/pkg/skaffold/runner/dev_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/watch"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -298,7 +297,9 @@ func TestDevSync(t *testing.T) {
 	}{
 		{
 			description: "sync",
-			testBench:   &TestBench{},
+			testBench: &TestBench{
+				dependencies: map[string][]string{"file1": {}},
+			},
 			watchEvents: []watch.Events{
 				{Modified: []string{"file1"}},
 			},
@@ -315,7 +316,9 @@ func TestDevSync(t *testing.T) {
 		},
 		{
 			description: "sync twice",
-			testBench:   &TestBench{},
+			testBench: &TestBench{
+				dependencies: map[string][]string{"file1": {}},
+			},
 			watchEvents: []watch.Events{
 				{Modified: []string{"file1"}},
 				{Modified: []string{"file1"}},
@@ -338,13 +341,6 @@ func TestDevSync(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			originalWorkingDir := sync.WorkingDir
-			sync.WorkingDir = func(tagged string) (string, error) {
-				return "/", nil
-			}
-			defer func() {
-				sync.WorkingDir = originalWorkingDir
-			}()
 			runner := createRunner(t, test.testBench)
 			runner.Watcher = &TestWatcher{
 				events:    test.watchEvents,

--- a/pkg/skaffold/runner/dev_test.go
+++ b/pkg/skaffold/runner/dev_test.go
@@ -350,9 +350,7 @@ func TestDevSync(t *testing.T) {
 			err := runner.Dev(context.Background(), discardOutput(), []*latest.Artifact{
 				{
 					ImageName: "img1",
-					Sync: map[string]string{
-						"file1": "file1",
-					},
+					Sync:      true,
 				},
 				{
 					ImageName: "img2",

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -60,7 +60,7 @@ func (t *TestBench) Labels() map[string]string                        { return m
 func (t *TestBench) TestDependencies() ([]string, error)              { return nil, nil }
 func (t *TestBench) Dependencies() ([]string, error)                  { return nil, nil }
 func (t *TestBench) Cleanup(ctx context.Context, out io.Writer) error { return nil }
-func (t *TestBench) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
+func (t *TestBench) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) (map[string][]string, error) {
 	return nil, nil
 }
 

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -51,6 +51,7 @@ type TestBench struct {
 	testErrors   []error
 	deployErrors []error
 
+	dependencies   map[string][]string
 	currentActions Actions
 	actions        []Actions
 	tag            int
@@ -61,7 +62,7 @@ func (t *TestBench) TestDependencies() ([]string, error)              { return n
 func (t *TestBench) Dependencies() ([]string, error)                  { return nil, nil }
 func (t *TestBench) Cleanup(ctx context.Context, out io.Writer) error { return nil }
 func (t *TestBench) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) (map[string][]string, error) {
-	return nil, nil
+	return t.dependencies, nil
 }
 
 func (t *TestBench) enterNewCycle() {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -459,9 +459,7 @@ type Artifact struct {
 
 	// Sync *alpha* lists local files synced to pods instead
 	// of triggering an image build when modified.
-	// This is a mapping of local files to sync to remote folders.
-	// For example: `{"*.py": ".", "css/**/*.css": "app/css"}`.
-	Sync map[string]string `yaml:"sync,omitempty"`
+	Sync bool `yaml:"sync,omitempty"`
 
 	// ArtifactType describes how to build an artifact.
 	ArtifactType `yaml:",inline"`

--- a/pkg/skaffold/schema/v1beta6/upgrade_test.go
+++ b/pkg/skaffold/schema/v1beta6/upgrade_test.go
@@ -142,6 +142,37 @@ deploy:
 	verifyUpgrade(t, yaml, expected)
 }
 
+func TestUpgradeSync(t *testing.T) {
+	yaml := `
+apiVersion: skaffold/v1beta6
+kind: Config
+build:
+  artifacts:
+  - image: gcr.io/k8s-skaffold/node-example
+    sync:
+      '*.js': .
+  - image: nginx
+deploy:
+  kubectl:
+    manifests:
+    - "backend/k8s/**"
+`
+	expected := `
+apiVersion: skaffold/v1beta7
+kind: Config
+build:
+  artifacts:
+  - image: gcr.io/k8s-skaffold/node-example
+    sync: true
+  - image: nginx
+deploy:
+  kubectl:
+    manifests:
+    - "backend/k8s/**"
+`
+	verifyUpgrade(t, yaml, expected)
+}
+
 func verifyUpgrade(t *testing.T, input, output string) {
 	pipeline := NewSkaffoldPipeline()
 	err := yaml.UnmarshalStrict([]byte(input), pipeline)

--- a/pkg/skaffold/sources/upload.go
+++ b/pkg/skaffold/sources/upload.go
@@ -27,7 +27,7 @@ import (
 )
 
 // TarGz creates a .tgz archive of the artifact's sources.
-func TarGz(ctx context.Context, w io.Writer, a *latest.Artifact, dependencies []string) error {
+func TarGz(ctx context.Context, w io.Writer, a *latest.Artifact, dependencies map[string][]string) error {
 	if err := util.CreateTarGz(w, a.Workspace, dependencies); err != nil {
 		return errors.Wrap(err, "creating tar gz")
 	}
@@ -36,7 +36,7 @@ func TarGz(ctx context.Context, w io.Writer, a *latest.Artifact, dependencies []
 }
 
 // UploadToGCS uploads the artifact's sources to a GCS bucket.
-func UploadToGCS(ctx context.Context, a *latest.Artifact, bucket, objectName string, dependencies []string) error {
+func UploadToGCS(ctx context.Context, a *latest.Artifact, bucket, objectName string, dependencies map[string][]string) error {
 	c, err := cstorage.NewClient(ctx)
 	if err != nil {
 		return errors.Wrap(err, "creating GCS client")

--- a/pkg/skaffold/sync/kubectl/kubectl.go
+++ b/pkg/skaffold/sync/kubectl/kubectl.go
@@ -58,7 +58,7 @@ func (k *Syncer) Sync(ctx context.Context, s *sync.Item) error {
 	return nil
 }
 
-func deleteFileFn(ctx context.Context, pod v1.Pod, container v1.Container, files map[string]string) []*exec.Cmd {
+func deleteFileFn(ctx context.Context, pod v1.Pod, container v1.Container, files map[string]string) *exec.Cmd {
 	// "kubectl" is below...
 	deleteCmd := []string{"exec", pod.Name, "--namespace", pod.Namespace, "-c", container.Name, "--", "rm", "-rf"}
 	args := make([]string, 0, len(deleteCmd)+len(files))
@@ -66,11 +66,10 @@ func deleteFileFn(ctx context.Context, pod v1.Pod, container v1.Container, files
 	for _, dst := range files {
 		args = append(args, dst)
 	}
-	delete := exec.CommandContext(ctx, "kubectl", args...)
-	return []*exec.Cmd{delete}
+	return exec.CommandContext(ctx, "kubectl", args...)
 }
 
-func copyFileFn(ctx context.Context, pod v1.Pod, container v1.Container, files map[string]string) []*exec.Cmd {
+func copyFileFn(ctx context.Context, pod v1.Pod, container v1.Container, files map[string]string) *exec.Cmd {
 	// Use "m" flag to touch the files as they are copied.
 	reader, writer := io.Pipe()
 	copy := exec.CommandContext(ctx, "kubectl", "exec", pod.Name, "--namespace", pod.Namespace, "-c", container.Name, "-i",
@@ -83,5 +82,5 @@ func copyFileFn(ctx context.Context, pod v1.Pod, container v1.Container, files m
 			logrus.Errorln("Error creating tar archive:", err)
 		}
 	}()
-	return []*exec.Cmd{copy}
+	return copy
 }

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -47,7 +47,7 @@ type DependencyResolver func() (map[string][]string, error)
 
 func NewItem(a *latest.Artifact, e watch.Events, builds []build.Artifact, deps DependencyResolver) (*Item, error) {
 	// If there are no changes, short circuit and don't sync anything
-	if !e.HasChanged() || len(a.Sync) == 0 {
+	if !e.HasChanged() || !a.Sync {
 		return nil, nil
 	}
 

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -365,14 +365,11 @@ func (t *TestCmdRecorder) RunCmdOut(cmd *exec.Cmd) ([]byte, error) {
 	return nil, t.RunCmd(cmd)
 }
 
-func fakeCmd(ctx context.Context, p v1.Pod, c v1.Container, files map[string]string) []*exec.Cmd {
-	cmds := make([]*exec.Cmd, len(files))
-	i := 0
+func fakeCmd(ctx context.Context, p v1.Pod, c v1.Container, files map[string]string) *exec.Cmd {
 	for src, dst := range files {
-		cmds[i] = exec.CommandContext(ctx, "copy", src, dst)
-		i++
+		return exec.CommandContext(ctx, "copy", src, dst)
 	}
-	return cmds
+	return nil
 }
 
 var pod = &v1.Pod{
@@ -398,7 +395,7 @@ func TestPerform(t *testing.T) {
 		description string
 		image       string
 		files       map[string]string
-		cmdFn       func(context.Context, v1.Pod, v1.Container, map[string]string) []*exec.Cmd
+		cmdFn       func(context.Context, v1.Pod, v1.Container, map[string]string) *exec.Cmd
 		cmdErr      error
 		clientErr   error
 		expected    []string
@@ -425,13 +422,6 @@ func TestPerform(t *testing.T) {
 			files:       map[string]string{"test.go": "/test.go"},
 			cmdFn:       fakeCmd,
 			clientErr:   fmt.Errorf(""),
-			shouldErr:   true,
-		},
-		{
-			description: "no copy",
-			image:       "gcr.io/different-pod:123",
-			files:       map[string]string{"test.go": "/test.go"},
-			cmdFn:       fakeCmd,
 			shouldErr:   true,
 		},
 	}

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -51,9 +51,7 @@ func TestNewSyncItem(t *testing.T) {
 			description: "match copy",
 			artifact: &latest.Artifact{
 				ImageName: "test",
-				Sync: map[string]string{
-					"*.html": ".",
-				},
+				Sync:      true,
 				Workspace: ".",
 			},
 			dependencies: map[string][]string{
@@ -77,12 +75,31 @@ func TestNewSyncItem(t *testing.T) {
 			},
 		},
 		{
+			description: "no sync when disabled",
+			artifact: &latest.Artifact{
+				ImageName: "test",
+				Sync:      false, // !
+				Workspace: ".",
+			},
+			dependencies: map[string][]string{
+				"index.html": {"index.html"},
+			},
+			builds: []build.Artifact{
+				{
+					ImageName: "test",
+					Tag:       "test:123",
+				},
+			},
+			evt: watch.Events{
+				Added: []string{"index.html"},
+			},
+			expected: nil,
+		},
+		{
 			description: "no tag for image",
 			artifact: &latest.Artifact{
 				ImageName: "notbuildyet",
-				Sync: map[string]string{
-					"*.html": ".",
-				},
+				Sync:      true,
 				Workspace: ".",
 			},
 			dependencies: map[string][]string{
@@ -103,11 +120,7 @@ func TestNewSyncItem(t *testing.T) {
 			description: "multiple sync patterns",
 			artifact: &latest.Artifact{
 				ImageName: "test",
-				Sync: map[string]string{
-					"*.js":   ".",
-					"*.html": ".",
-					"*.json": ".",
-				},
+				Sync:      true,
 				Workspace: "node",
 			},
 			dependencies: map[string][]string{
@@ -140,9 +153,7 @@ func TestNewSyncItem(t *testing.T) {
 		{
 			description: "not copy syncable",
 			artifact: &latest.Artifact{
-				Sync: map[string]string{
-					"*.html": ".",
-				},
+				Sync:      true,
 				Workspace: ".",
 			},
 			dependencies: map[string][]string{
@@ -161,9 +172,7 @@ func TestNewSyncItem(t *testing.T) {
 		{
 			description: "not delete syncable",
 			artifact: &latest.Artifact{
-				Sync: map[string]string{
-					"*.html": "/static",
-				},
+				Sync:      true,
 				Workspace: ".",
 			},
 			dependencies: map[string][]string{
@@ -182,9 +191,7 @@ func TestNewSyncItem(t *testing.T) {
 		{
 			description: "no change no sync",
 			artifact: &latest.Artifact{
-				Sync: map[string]string{
-					"*.html": "*",
-				},
+				Sync:      true,
 				Workspace: ".",
 			},
 			dependencies: map[string][]string{

--- a/pkg/skaffold/util/tar.go
+++ b/pkg/skaffold/util/tar.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// TODO(corneliusweig) This should be unused when auto-sync is done
 func CreateMappedTar(w io.Writer, root string, pathMap map[string]string) error {
 	tw := tar.NewWriter(w)
 	defer tw.Close()
@@ -40,20 +41,22 @@ func CreateMappedTar(w io.Writer, root string, pathMap map[string]string) error 
 	return nil
 }
 
-func CreateTar(w io.Writer, root string, paths []string) error {
+func CreateTar(w io.Writer, root string, paths map[string][]string) error {
 	tw := tar.NewWriter(w)
 	defer tw.Close()
 
-	for _, path := range paths {
-		if err := addFileToTar(root, path, "", tw); err != nil {
-			return err
+	for path, dsts := range paths {
+		for _, dst := range dsts {
+			if err := addFileToTar(root, path, dst, tw); err != nil {
+				return err
+			}
 		}
 	}
 
 	return nil
 }
 
-func CreateTarGz(w io.Writer, root string, paths []string) error {
+func CreateTarGz(w io.Writer, root string, paths map[string][]string) error {
 	gw := gzip.NewWriter(w)
 	defer gw.Close()
 	return CreateTar(gw, root, paths)

--- a/pkg/skaffold/util/tar.go
+++ b/pkg/skaffold/util/tar.go
@@ -27,20 +27,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// TODO(corneliusweig) This should be unused when auto-sync is done
-func CreateMappedTar(w io.Writer, root string, pathMap map[string]string) error {
-	tw := tar.NewWriter(w)
-	defer tw.Close()
-
-	for src, dst := range pathMap {
-		if err := addFileToTar(root, src, dst, tw); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func CreateTar(w io.Writer, root string, paths map[string][]string) error {
 	tw := tar.NewWriter(w)
 	defer tw.Close()

--- a/pkg/skaffold/util/tar_test.go
+++ b/pkg/skaffold/util/tar_test.go
@@ -35,10 +35,10 @@ func TestCreateTar(t *testing.T) {
 		"bar/bat": "baz2",
 		"bar/baz": "baz3",
 	}
-	var paths []string
+	paths := map[string][]string{}
 	for path, content := range files {
 		tmpDir.Write(path, content)
-		paths = append(paths, path)
+		paths[path] = []string{""}
 	}
 
 	reset := testutil.Chdir(t, tmpDir.Root())
@@ -76,10 +76,10 @@ func TestCreateTarSubDirectory(t *testing.T) {
 		"sub/bar/bat": "baz2",
 		"sub/bar/baz": "baz3",
 	}
-	var paths []string
+	paths := map[string][]string{}
 	for path, content := range files {
 		tmpDir.Write(path, content)
-		paths = append(paths, path)
+		paths[path] = []string{""}
 	}
 
 	reset := testutil.Chdir(t, tmpDir.Root())
@@ -117,10 +117,10 @@ func TestCreateTarWithAbsolutePaths(t *testing.T) {
 		"bar/bat": "baz2",
 		"bar/baz": "baz3",
 	}
-	var paths []string
+	paths := map[string][]string{}
 	for path, content := range files {
 		tmpDir.Write(path, content)
-		paths = append(paths, tmpDir.Path(path))
+		paths[path] = []string{""}
 	}
 
 	reset := testutil.Chdir(t, tmpDir.Root())
@@ -147,4 +147,57 @@ func TestCreateTarWithAbsolutePaths(t *testing.T) {
 	}
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, files, tarFiles)
+}
+
+func TestCreateTarWithExplicitDestination(t *testing.T) {
+	tmpDir, cleanup := testutil.NewTempDir(t)
+	defer cleanup()
+
+	contentByName := map[string]string{
+		"foo":     "baz1",
+		"bar/bat": "baz2",
+		"bar/baz": "baz3",
+	}
+	paths := map[string][]string{
+		"foo":     {"f1", "d1/f1"},
+		"bar/bat": {"d2/f2", "d3/f2"},
+		"bar/baz": {"d2/f3", "f2", "d1/f2"},
+	}
+	for path, content := range contentByName {
+		tmpDir.Write(path, content)
+	}
+	expected := map[string]string{
+		"f1":    "baz1",
+		"d1/f1": "baz1",
+		"d2/f2": "baz2",
+		"d3/f2": "baz2",
+		"d2/f3": "baz3",
+		"d1/f2": "baz3",
+		"f2":    "baz3",
+	}
+
+	reset := testutil.Chdir(t, tmpDir.Root())
+	defer reset()
+
+	var b bytes.Buffer
+	err := CreateTar(&b, ".", paths)
+	testutil.CheckError(t, false, err)
+
+	// Make sure the contents match.
+	tarFiles := make(map[string]string)
+	tr := tar.NewReader(&b)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		testutil.CheckError(t, false, err)
+
+		content, err := ioutil.ReadAll(tr)
+		testutil.CheckError(t, false, err)
+
+		tarFiles[hdr.Name] = string(content)
+	}
+
+	testutil.CheckErrorAndDeepEqual(t, false, err, expected, tarFiles)
 }

--- a/pkg/skaffold/util/tar_test.go
+++ b/pkg/skaffold/util/tar_test.go
@@ -120,7 +120,7 @@ func TestCreateTarWithAbsolutePaths(t *testing.T) {
 	paths := map[string][]string{}
 	for path, content := range files {
 		tmpDir.Write(path, content)
-		paths[path] = []string{""}
+		paths[tmpDir.Path(path)] = []string{""}
 	}
 
 	reset := testutil.Chdir(t, tmpDir.Root())

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -286,14 +286,14 @@ func CloneThroughJSON(old interface{}, new interface{}) error {
 }
 
 // AbsolutePaths prepends each path in paths with workspace if the path isn't absolute
-func AbsolutePaths(workspace string, paths []string) []string {
-	var p []string
-	for _, path := range paths {
+func AbsolutePaths(workspace string, dependencies map[string][]string) map[string][]string {
+	p := map[string][]string{}
+	for path, dests := range dependencies {
 		// TODO(dgageot): this is only done for jib builder.
 		if !filepath.IsAbs(path) {
 			path = filepath.Join(workspace, path)
 		}
-		p = append(p, path)
+        p[path] = dests
 	}
 	return p
 }

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -293,7 +293,7 @@ func AbsolutePaths(workspace string, dependencies map[string][]string) map[strin
 		if !filepath.IsAbs(path) {
 			path = filepath.Join(workspace, path)
 		}
-        p[path] = dests
+		p[path] = dests
 	}
 	return p
 }


### PR DESCRIPTION
**On hold until #1847 is resolved**
## Context
So far, artifact sync required a specification of sync patterns like
```
sync:
  '*.js': app/
```
This is error prone and unnecessarily hard to use, because the destination is already contained in the Dockerfile (see #1166, #1581). In addition, the syncing needs to handle special cases for globbing and often requires a long list of sync patterns (#1807)


## Changes
This PR extracts the destination location from the Dockerfile and uses that information to infer the sync location. For example
```
FROM nginx
WORKDIR /var
COPY static *.html www/
ADD nginx.conf .
```
will infer sync destinations according to docker rules such as
- `nginx.conf -> /var/nginx.conf`
- `static/page1.html -> /var/www/page1.html` (! no `static` folder at destination !)
- `static/assets/style.css -> /var/www/assets/style.css`
- `index.html -> /var/www/index.html`

#### Possible issues
- I did not consider how to resolve overlapping copies to the same destination. For example
   ```
   COPY foo /foo
   COPY bar/ /   # bar contains a file called "foo"
   ```
   In that case it is indeterminate what the content of `/foo` will be. However, simpler cases such as
   ```
   COPY foo baz
   COPY bar baz
   ```
   guarantee that `baz` has content from `bar`. 
- Transitive copies across stages of multi-stage dockerfiles are not resolved:
   ```
   FROM scratch
   ADD foo .
   FROM scratch
   COPY --from=0 foo bar
   ```
   The current implementation will resolve `foo -> foo` and not `foo -> bar`. In practice, this should not be a problem, because this does not really make sense and can easily be circumvented.

#### Simplified pipeline config
Since the pipeline config sync map competes with the sync inference, and it is not clear to me how we can handle preference, I also changed the config field to a boolean:
```
sync: true # false
```
This means however, that sync can no longer be used with Dockerfile-less builders (i.e. only kaniko and docker, right?). I think
- for jib syncing does not make sense IMHO, so this should be fine.
- for bazel, I also don't see the use-case. Also, I'm not a bazel expert and maybe there is a way to get the file destination.

For me, this is reason enough to avoid the complexity of maintaining the original sync map and bother about preference. Let me know your thoughts..

Fixes #1166, #1581 
Related #1180, #1807 
See #1844 for a design discussion