### PR TITLE
Preserve sync subtree for '***'.

### DIFF
--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -152,7 +152,8 @@ func intersect(context string, syncMap map[string]string, files []string, workin
 		}
 
 		// Convert relative destinations to absolute via the workingDir.
-		if filepath.IsAbs(dst) {
+		// Note that we always use Unix-style paths in our destination.
+		if dst[0] == '/' {
 			dst = filepath.ToSlash(dst)
 		} else {
 			dst = filepath.ToSlash(filepath.Join(workingDir, dst))

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -148,7 +148,7 @@ func intersect(context string, syncMap map[string]string, files []string, workin
 					if isTripleStar {
 						// Map the paths as a tree from the prefix.
 						subtreePrefix := strings.Split(p, "***")[0]
-						subPath = strings.TrimPrefix(relPath, subtreePrefix)
+						subPath = strings.TrimPrefix(relPath, filepath.FromSlash(subtreePrefix))
 					} else {
 						// Collapse the paths.
 						subPath = filepath.Base(relPath)

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -275,6 +275,61 @@ func TestNewSyncItem(t *testing.T) {
 				Delete: map[string]string{},
 			},
 		},
+		{
+			description: "triple-stars mean subtrees",
+			artifact: &latest.Artifact{
+				ImageName: "test",
+				Sync: map[string]string{
+					"dir1/***/*.js": ".",
+				},
+				Workspace: ".",
+			},
+			workingDir: "/some/dir",
+			builds: []build.Artifact{
+				{
+					ImageName: "test",
+					Tag:       "test:123",
+				},
+			},
+			evt: watch.Events{
+				Added: []string{filepath.Join("dir1", "dir2/node.js")},
+			},
+			expected: &Item{
+				Image: "test:123",
+				Copy: map[string]string{
+					filepath.Join("dir1", "dir2/node.js"): "/some/dir/dir2/node.js",
+				},
+				Delete: map[string]string{},
+			},
+		},
+		{
+			description: "triple-stars take precedence",
+			artifact: &latest.Artifact{
+				ImageName: "test",
+				Sync: map[string]string{
+					"dir1/***/*.js":   ".",
+					"dir1/**/**/*.js": ".",
+				},
+				Workspace: ".",
+			},
+			workingDir: "/some/dir",
+			builds: []build.Artifact{
+				{
+					ImageName: "test",
+					Tag:       "test:123",
+				},
+			},
+			evt: watch.Events{
+				Added: []string{filepath.Join("dir1", "dir2/node.js")},
+			},
+			expected: &Item{
+				Image: "test:123",
+				Copy: map[string]string{
+					filepath.Join("dir1", "dir2/node.js"): "/some/dir/dir2/node.js",
+				},
+				Delete: map[string]string{},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -330,6 +330,38 @@ func TestNewSyncItem(t *testing.T) {
 				Delete: map[string]string{},
 			},
 		},
+		{
+			description: "stars work with absolute paths",
+			artifact: &latest.Artifact{
+				ImageName: "test",
+				Sync: map[string]string{
+					"dir1a/***/*.js": "/tstar",
+					"dir1b/**/*.js":  "/dstar",
+				},
+				Workspace: ".",
+			},
+			workingDir: "/some/dir",
+			builds: []build.Artifact{
+				{
+					ImageName: "test",
+					Tag:       "test:123",
+				},
+			},
+			evt: watch.Events{
+				Added: []string{
+					filepath.Join("dir1a", "dir2/dir3/node.js"),
+					filepath.Join("dir1b", "dir2/dir3/node.js"),
+				},
+			},
+			expected: &Item{
+				Image: "test:123",
+				Copy: map[string]string{
+					filepath.Join("dir1a", "dir2/dir3/node.js"): "/tstar/dir2/dir3/node.js",
+					filepath.Join("dir1b", "dir2/dir3/node.js"): "/dstar/node.js",
+				},
+				Delete: map[string]string{},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #1807 

This PR implements subtree syncing for '***' globs in the sync specification.

Given:
```yaml
    sync:
      'foo/***/*.js': /usr/src/app/
```

and changing `foo/baz/bot/test.js`, `test.js` will be synchronized to `/usr/src/app/baz/bot/test.js`.

Given:
```yaml
    sync:
      '***': subdir
```

and changing `my/src.txt`, `src.txt` will be synchronized to `${WORKDIR}/subdir/my/src.txt`.

All the existing sync specs in 0.25.0 mean the same as they did before this PR (i.e. they collapse the subPath, so all files in the subtree are synced to the same destination directory, not its children).  To allow for backward compatibility with 0.23.0's subtree syncing, you can use:

```yaml
    sync:
      '**': /usr/src/app/ # v0.23.0
      '***': /usr/src/app/ # this PR
```

The line marked `this PR` will take precedence over the `v0.23.0` line (triple-stars are matched first before other patterns), except when running a version of Skaffold before this PR.  In that case, the `v0.23.0` line will be used, and only `v0.23.0` will produce the same behaviour as this PR.

Hope this helps,
Michael.