### PR TITLE
Add support for pushing/pulling to insecure registries

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -325,13 +325,14 @@
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:f25f0ba1157af718c239c7ea37fae2d5d1b929f9227c56d410ebc6ac8c957a6d"
+  digest = "1:7cbe4d240970406dcd35a4451848b906d2584c62d84845a7ad02217cc0770705"
   name = "github.com/google/go-containerregistry"
   packages = [
     "pkg/authn",
     "pkg/name",
     "pkg/v1",
     "pkg/v1/partial",
+    "pkg/v1/random",
     "pkg/v1/remote",
     "pkg/v1/remote/transport",
     "pkg/v1/stream",
@@ -340,7 +341,7 @@
     "pkg/v1/v1util",
   ]
   pruneopts = "NUT"
-  revision = "16d6587b5a87052c861b30443f31c588a319e8d4"
+  revision = "8d4083db9aa0d2fae6588c1acdbe6a1f5db461e3"
 
 [[projects]]
   digest = "1:f4f203acd8b11b8747bdcd91696a01dbc95ccb9e2ca2db6abf81c3a4f5e950ce"
@@ -1342,6 +1343,7 @@
     "github.com/google/go-containerregistry/pkg/authn",
     "github.com/google/go-containerregistry/pkg/name",
     "github.com/google/go-containerregistry/pkg/v1",
+    "github.com/google/go-containerregistry/pkg/v1/random",
     "github.com/google/go-containerregistry/pkg/v1/remote",
     "github.com/google/go-containerregistry/pkg/v1/tarball",
     "github.com/google/go-github/github",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -9,7 +9,7 @@
 
 [[constraint]]
   name = "github.com/google/go-containerregistry"
-  revision = "16d6587b5a87052c861b30443f31c588a319e8d4"
+  revision = "8d4083db9aa0d2fae6588c1acdbe6a1f5db461e3"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -156,6 +156,7 @@ func AddRunDevFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&opts.SkipTests, "skip-tests", false, "Whether to skip the tests after building")
 	cmd.Flags().BoolVar(&opts.CacheArtifacts, "cache-artifacts", false, "Set to true to enable caching of artifacts.")
 	cmd.Flags().StringVarP(&opts.CacheFile, "cache-file", "", "", "Specify the location of the cache file (default $HOME/.skaffold/cache)")
+	cmd.Flags().StringArrayVar(&opts.InsecureRegistries, "insecure-registry", nil, "Target registries for built images which are not secure")
 }
 
 func SetUpLogs(out io.Writer, level string) error {

--- a/cmd/skaffold/app/cmd/config/config.go
+++ b/cmd/skaffold/app/cmd/config/config.go
@@ -26,7 +26,8 @@ type Config struct {
 // ContextConfig is the context-specific config information provided in
 // the global Skaffold config.
 type ContextConfig struct {
-	Kubecontext  string `yaml:"kube-context,omitempty"`
-	DefaultRepo  string `yaml:"default-repo,omitempty"`
-	LocalCluster *bool  `yaml:"local-cluster,omitempty"`
+	Kubecontext        string   `yaml:"kube-context,omitempty"`
+	DefaultRepo        string   `yaml:"default-repo,omitempty"`
+	LocalCluster       *bool    `yaml:"local-cluster,omitempty"`
+	InsecureRegistries []string `yaml:"insecure-registries,omitempty"`
 }

--- a/cmd/skaffold/app/cmd/config/config_test.go
+++ b/cmd/skaffold/app/cmd/config/config_test.go
@@ -177,6 +177,19 @@ func TestSetAndUnsetConfig(t *testing.T) {
 				ContextConfigs: []*ContextConfig{},
 			},
 		},
+		{
+			name:  "set insecure registries",
+			key:   "insecure-registries",
+			value: "my.insecure.registry",
+			expectedSetCfg: &Config{
+				ContextConfigs: []*ContextConfig{
+					{
+						Kubecontext:        dummyContext,
+						InsecureRegistries: []string{"my.insecure.registry"},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/skaffold/app/cmd/config/config_test.go
+++ b/cmd/skaffold/app/cmd/config/config_test.go
@@ -178,14 +178,22 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			},
 		},
 		{
-			name:  "set insecure registries",
-			key:   "insecure-registries",
-			value: "my.insecure.registry",
+			name:        "set insecure registries",
+			key:         "insecure-registries",
+			value:       "my.insecure.registry",
+			kubecontext: "this_is_a_context",
 			expectedSetCfg: &Config{
 				ContextConfigs: []*ContextConfig{
 					{
-						Kubecontext:        dummyContext,
+						Kubecontext:        "this_is_a_context",
 						InsecureRegistries: []string{"my.insecure.registry"},
+					},
+				},
+			},
+			expectedUnsetCfg: &Config{
+				ContextConfigs: []*ContextConfig{
+					{
+						Kubecontext: "this_is_a_context",
 					},
 				},
 			},

--- a/cmd/skaffold/app/cmd/config/set.go
+++ b/cmd/skaffold/app/cmd/config/set.go
@@ -59,7 +59,7 @@ func setConfigValue(name string, value string) error {
 	}
 
 	field := reflect.Indirect(reflect.ValueOf(cfg)).FieldByName(fieldName)
-	val, err := parseAsType(value, field.Type())
+	val, err := parseAsType(value, field)
 	if err != nil {
 		return fmt.Errorf("%s is not a valid value for field %s", value, name)
 	}
@@ -83,10 +83,16 @@ func getFieldName(cfg *ContextConfig, name string) string {
 	return fieldName
 }
 
-func parseAsType(value string, fieldType reflect.Type) (reflect.Value, error) {
+func parseAsType(value string, field reflect.Value) (reflect.Value, error) {
+	fieldType := field.Type()
 	switch fieldType.String() {
 	case "string":
 		return reflect.ValueOf(value), nil
+	case "[]string":
+		if value == "" {
+			return reflect.Zero(fieldType), nil
+		}
+		return reflect.Append(field, reflect.ValueOf(value)), nil
 	case "*bool":
 		if value == "" {
 			return reflect.Zero(fieldType), nil

--- a/cmd/skaffold/app/cmd/config/util.go
+++ b/cmd/skaffold/app/cmd/config/util.go
@@ -33,10 +33,6 @@ import (
 const defaultConfigDir = ".skaffold"
 const defaultConfigFile = "config"
 
-var cachedLocalCluster *bool
-var cachedDefaultRepo *string
-var cachedInsecureRegistries *[]string
-
 func resolveKubectlContext() {
 	if kubecontext != "" {
 		return
@@ -150,19 +146,14 @@ func getOrCreateConfigForKubectx() (*ContextConfig, error) {
 }
 
 func GetDefaultRepo(cliValue string) (string, error) {
-	if cachedDefaultRepo != nil {
-		return *cachedDefaultRepo, nil
-	}
 	// CLI flag takes precedence. If no default-repo specified from a flag,
 	// retrieve the value from the global config.
 	if cliValue != "" {
-		cachedDefaultRepo = &cliValue
 		return cliValue, nil
 	}
 	cfg, err := GetConfigForKubectx()
 	if err != nil {
 		empty := ""
-		cachedDefaultRepo = &empty
 		return empty, errors.Wrap(err, "retrieving global config")
 	}
 	var defaultRepo string
@@ -174,26 +165,19 @@ func GetDefaultRepo(cliValue string) (string, error) {
 		// retrieve the global config and use this value as a fallback
 		cfg, err := GetGlobalConfig()
 		if err != nil {
-			empty := ""
-			cachedDefaultRepo = &empty
 			return "", errors.Wrap(err, "retrieving global config")
 		}
 		if cfg != nil {
 			defaultRepo = cfg.DefaultRepo
 		}
 	}
-	cachedDefaultRepo = &defaultRepo
 	return defaultRepo, nil
 }
 
 func GetLocalCluster() (bool, error) {
-	if cachedLocalCluster != nil {
-		return *cachedLocalCluster, nil
-	}
 	cfg, err := GetConfigForKubectx()
 	localCluster := isDefaultLocal(kubecontext)
 	if err != nil {
-		cachedLocalCluster = &localCluster
 		return localCluster, errors.Wrap(err, "retrieving global config")
 	}
 
@@ -205,7 +189,6 @@ func GetLocalCluster() (bool, error) {
 		// if no value is set for this cluster, fall back to the global setting
 		globalCfg, err := GetGlobalConfig()
 		if err != nil {
-			cachedLocalCluster = &localCluster
 			return localCluster, errors.Wrap(err, "retrieving global config")
 		}
 		if globalCfg != nil && globalCfg.LocalCluster != nil {
@@ -213,18 +196,13 @@ func GetLocalCluster() (bool, error) {
 		}
 	}
 
-	cachedLocalCluster = &localCluster
 	return localCluster, nil
 }
 
 func GetInsecureRegistries() ([]string, error) {
-	if cachedInsecureRegistries != nil {
-		return *cachedInsecureRegistries, nil
-	}
 	cfg, err := GetConfigForKubectx()
 	registries := []string{}
 	if err != nil {
-		cachedInsecureRegistries = &registries
 		return registries, errors.Wrap(err, "retrieving global config")
 	}
 
@@ -236,7 +214,6 @@ func GetInsecureRegistries() ([]string, error) {
 		// if no value is set for this cluster, fall back to the global setting
 		globalCfg, err := GetGlobalConfig()
 		if err != nil {
-			cachedInsecureRegistries = &registries
 			return registries, errors.Wrap(err, "retrieving global config")
 		}
 		if globalCfg != nil && globalCfg.InsecureRegistries != nil {
@@ -244,7 +221,6 @@ func GetInsecureRegistries() ([]string, error) {
 		}
 	}
 
-	cachedInsecureRegistries = &registries
 	return registries, nil
 }
 

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -63,21 +63,22 @@ Usage:
   skaffold build
 
 Flags:
-  -b, --build-image stringArray      Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts
-      --cache-artifacts              Set to true to enable caching of artifacts.
-      --cache-file string            Specify the location of the cache file (default $HOME/.skaffold/cache)
-  -d, --default-repo string          Default repository value (overrides global config)
-      --enable-rpc skaffold dev      Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-  -f, --filename string              Filename or URL to the pipeline file (default "skaffold.yaml")
-  -n, --namespace string             Run deployments in the specified namespace
-  -o, --output *flags.TemplateFlag   Format output with go-template. For full struct documentation, see https://godoc.org/github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd#BuildOutput (default {{range .Builds}}{{.ImageName}} -> {{.Tag}}
-                                     {{end}})
-  -p, --profile stringArray          Activate profiles by name
-  -q, --quiet                        Suppress the build output and print image built on success
-      --rpc-http-port int            tcp port to expose event REST API over HTTP (default 50052)
-      --rpc-port int                 tcp port to expose event API (default 50051)
-      --skip-tests                   Whether to skip the tests after building
-      --toot                         Emit a terminal beep after the deploy is complete
+  -b, --build-image stringArray         Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts
+      --cache-artifacts                 Set to true to enable caching of artifacts.
+      --cache-file string               Specify the location of the cache file (default $HOME/.skaffold/cache)
+  -d, --default-repo string             Default repository value (overrides global config)
+      --enable-rpc skaffold dev         Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+  -f, --filename string                 Filename or URL to the pipeline file (default "skaffold.yaml")
+      --insecure-registry stringArray   Target registries for built images which are not secure
+  -n, --namespace string                Run deployments in the specified namespace
+  -o, --output *flags.TemplateFlag      Format output with go-template. For full struct documentation, see https://godoc.org/github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd#BuildOutput (default {{range .Builds}}{{.ImageName}} -> {{.Tag}}
+                                        {{end}})
+  -p, --profile stringArray             Activate profiles by name
+  -q, --quiet                           Suppress the build output and print image built on success
+      --rpc-http-port int               tcp port to expose event REST API over HTTP (default 50052)
+      --rpc-port int                    tcp port to expose event API (default 50051)
+      --skip-tests                      Whether to skip the tests after building
+      --toot                            Emit a terminal beep after the deploy is complete
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -192,17 +193,18 @@ Usage:
   skaffold delete
 
 Flags:
-      --cache-artifacts           Set to true to enable caching of artifacts.
-      --cache-file string         Specify the location of the cache file (default $HOME/.skaffold/cache)
-  -d, --default-repo string       Default repository value (overrides global config)
-      --enable-rpc skaffold dev   Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-  -f, --filename string           Filename or URL to the pipeline file (default "skaffold.yaml")
-  -n, --namespace string          Run deployments in the specified namespace
-  -p, --profile stringArray       Activate profiles by name
-      --rpc-http-port int         tcp port to expose event REST API over HTTP (default 50052)
-      --rpc-port int              tcp port to expose event API (default 50051)
-      --skip-tests                Whether to skip the tests after building
-      --toot                      Emit a terminal beep after the deploy is complete
+      --cache-artifacts                 Set to true to enable caching of artifacts.
+      --cache-file string               Specify the location of the cache file (default $HOME/.skaffold/cache)
+  -d, --default-repo string             Default repository value (overrides global config)
+      --enable-rpc skaffold dev         Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+  -f, --filename string                 Filename or URL to the pipeline file (default "skaffold.yaml")
+      --insecure-registry stringArray   Target registries for built images which are not secure
+  -n, --namespace string                Run deployments in the specified namespace
+  -p, --profile stringArray             Activate profiles by name
+      --rpc-http-port int               tcp port to expose event REST API over HTTP (default 50052)
+      --rpc-port int                    tcp port to expose event API (default 50051)
+      --skip-tests                      Whether to skip the tests after building
+      --toot                            Emit a terminal beep after the deploy is complete
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -220,20 +222,21 @@ Usage:
   skaffold deploy
 
 Flags:
-      --cache-artifacts           Set to true to enable caching of artifacts.
-      --cache-file string         Specify the location of the cache file (default $HOME/.skaffold/cache)
-  -d, --default-repo string       Default repository value (overrides global config)
-      --enable-rpc skaffold dev   Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-  -f, --filename string           Filename or URL to the pipeline file (default "skaffold.yaml")
-      --images strings            A list of pre-built images to deploy
-  -l, --label stringArray         Add custom labels to deployed objects. Set multiple times for multiple labels.
-  -n, --namespace string          Run deployments in the specified namespace
-  -p, --profile stringArray       Activate profiles by name
-      --rpc-http-port int         tcp port to expose event REST API over HTTP (default 50052)
-      --rpc-port int              tcp port to expose event API (default 50051)
-      --skip-tests                Whether to skip the tests after building
-      --tail                      Stream logs from deployed objects
-      --toot                      Emit a terminal beep after the deploy is complete
+      --cache-artifacts                 Set to true to enable caching of artifacts.
+      --cache-file string               Specify the location of the cache file (default $HOME/.skaffold/cache)
+  -d, --default-repo string             Default repository value (overrides global config)
+      --enable-rpc skaffold dev         Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+  -f, --filename string                 Filename or URL to the pipeline file (default "skaffold.yaml")
+      --images strings                  A list of pre-built images to deploy
+      --insecure-registry stringArray   Target registries for built images which are not secure
+  -l, --label stringArray               Add custom labels to deployed objects. Set multiple times for multiple labels.
+  -n, --namespace string                Run deployments in the specified namespace
+  -p, --profile stringArray             Activate profiles by name
+      --rpc-http-port int               tcp port to expose event REST API over HTTP (default 50052)
+      --rpc-port int                    tcp port to expose event API (default 50051)
+      --skip-tests                      Whether to skip the tests after building
+      --tail                            Stream logs from deployed objects
+      --toot                            Emit a terminal beep after the deploy is complete
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -251,25 +254,26 @@ Usage:
   skaffold dev
 
 Flags:
-      --cache-artifacts           Set to true to enable caching of artifacts.
-      --cache-file string         Specify the location of the cache file (default $HOME/.skaffold/cache)
-      --cleanup                   Delete deployments after dev mode is interrupted (default true)
-  -d, --default-repo string       Default repository value (overrides global config)
-      --enable-rpc skaffold dev   Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-      --experimental-gui          Experimental Graphical User Interface
-  -f, --filename string           Filename or URL to the pipeline file (default "skaffold.yaml")
-  -l, --label stringArray         Add custom labels to deployed objects. Set multiple times for multiple labels
-  -n, --namespace string          Run deployments in the specified namespace
-      --port-forward              Port-forward exposed container ports within pods (default true)
-  -p, --profile stringArray       Activate profiles by name
-      --rpc-http-port int         tcp port to expose event REST API over HTTP (default 50052)
-      --rpc-port int              tcp port to expose event API (default 50051)
-      --skip-tests                Whether to skip the tests after building
-      --tail                      Stream logs from deployed objects (default true)
-      --toot                      Emit a terminal beep after the deploy is complete
-      --trigger string            How are changes detected? (polling, manual or notify) (default "polling")
-  -w, --watch-image stringArray   Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts
-  -i, --watch-poll-interval int   Interval (in ms) between two checks for file changes (default 1000)
+      --cache-artifacts                 Set to true to enable caching of artifacts.
+      --cache-file string               Specify the location of the cache file (default $HOME/.skaffold/cache)
+      --cleanup                         Delete deployments after dev mode is interrupted (default true)
+  -d, --default-repo string             Default repository value (overrides global config)
+      --enable-rpc skaffold dev         Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+      --experimental-gui                Experimental Graphical User Interface
+  -f, --filename string                 Filename or URL to the pipeline file (default "skaffold.yaml")
+      --insecure-registry stringArray   Target registries for built images which are not secure
+  -l, --label stringArray               Add custom labels to deployed objects. Set multiple times for multiple labels
+  -n, --namespace string                Run deployments in the specified namespace
+      --port-forward                    Port-forward exposed container ports within pods (default true)
+  -p, --profile stringArray             Activate profiles by name
+      --rpc-http-port int               tcp port to expose event REST API over HTTP (default 50052)
+      --rpc-port int                    tcp port to expose event API (default 50051)
+      --skip-tests                      Whether to skip the tests after building
+      --tail                            Stream logs from deployed objects (default true)
+      --toot                            Emit a terminal beep after the deploy is complete
+      --trigger string                  How are changes detected? (polling, manual or notify) (default "polling")
+  -w, --watch-image stringArray         Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts
+  -i, --watch-poll-interval int         Interval (in ms) between two checks for file changes (default 1000)
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -349,20 +353,21 @@ Usage:
   skaffold run
 
 Flags:
-      --cache-artifacts           Set to true to enable caching of artifacts.
-      --cache-file string         Specify the location of the cache file (default $HOME/.skaffold/cache)
-  -d, --default-repo string       Default repository value (overrides global config)
-      --enable-rpc skaffold dev   Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-  -f, --filename string           Filename or URL to the pipeline file (default "skaffold.yaml")
-  -l, --label stringArray         Add custom labels to deployed objects. Set multiple times for multiple labels.
-  -n, --namespace string          Run deployments in the specified namespace
-  -p, --profile stringArray       Activate profiles by name
-      --rpc-http-port int         tcp port to expose event REST API over HTTP (default 50052)
-      --rpc-port int              tcp port to expose event API (default 50051)
-      --skip-tests                Whether to skip the tests after building
-  -t, --tag string                The optional custom tag to use for images which overrides the current Tagger configuration
-      --tail                      Stream logs from deployed objects
-      --toot                      Emit a terminal beep after the deploy is complete
+      --cache-artifacts                 Set to true to enable caching of artifacts.
+      --cache-file string               Specify the location of the cache file (default $HOME/.skaffold/cache)
+  -d, --default-repo string             Default repository value (overrides global config)
+      --enable-rpc skaffold dev         Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+  -f, --filename string                 Filename or URL to the pipeline file (default "skaffold.yaml")
+      --insecure-registry stringArray   Target registries for built images which are not secure
+  -l, --label stringArray               Add custom labels to deployed objects. Set multiple times for multiple labels.
+  -n, --namespace string                Run deployments in the specified namespace
+  -p, --profile stringArray             Activate profiles by name
+      --rpc-http-port int               tcp port to expose event REST API over HTTP (default 50052)
+      --rpc-port int                    tcp port to expose event API (default 50051)
+      --skip-tests                      Whether to skip the tests after building
+  -t, --tag string                      The optional custom tag to use for images which overrides the current Tagger configuration
+      --tail                            Stream logs from deployed objects
+      --toot                            Emit a terminal beep after the deploy is complete
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)

--- a/docs/content/en/schemas/v1beta7.json
+++ b/docs/content/en/schemas/v1beta7.json
@@ -424,6 +424,15 @@
               "description": "environment in which the build should run. Possible values: googleCloudBuild.",
               "x-intellij-html-description": "environment in which the build should run. Possible values: googleCloudBuild."
             },
+            "insecureRegistries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "x-intellij-html-description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "default": "[]"
+            },
             "tagPolicy": {
               "$ref": "#/definitions/TagPolicy",
               "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {}`.",
@@ -432,6 +441,7 @@
           },
           "preferredOrder": [
             "artifacts",
+            "insecureRegistries",
             "tagPolicy",
             "executionEnvironment"
           ],
@@ -452,6 +462,15 @@
               "description": "environment in which the build should run. Possible values: googleCloudBuild.",
               "x-intellij-html-description": "environment in which the build should run. Possible values: googleCloudBuild."
             },
+            "insecureRegistries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "x-intellij-html-description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "default": "[]"
+            },
             "local": {
               "$ref": "#/definitions/LocalBuild",
               "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
@@ -465,6 +484,7 @@
           },
           "preferredOrder": [
             "artifacts",
+            "insecureRegistries",
             "tagPolicy",
             "executionEnvironment",
             "local"
@@ -491,6 +511,15 @@
               "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/).",
               "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/\">Google Cloud Build</a>."
             },
+            "insecureRegistries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "x-intellij-html-description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "default": "[]"
+            },
             "tagPolicy": {
               "$ref": "#/definitions/TagPolicy",
               "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {}`.",
@@ -499,6 +528,7 @@
           },
           "preferredOrder": [
             "artifacts",
+            "insecureRegistries",
             "tagPolicy",
             "executionEnvironment",
             "googleCloudBuild"
@@ -525,6 +555,15 @@
               "description": "environment in which the build should run. Possible values: googleCloudBuild.",
               "x-intellij-html-description": "environment in which the build should run. Possible values: googleCloudBuild."
             },
+            "insecureRegistries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "x-intellij-html-description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "default": "[]"
+            },
             "tagPolicy": {
               "$ref": "#/definitions/TagPolicy",
               "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {}`.",
@@ -533,6 +572,7 @@
           },
           "preferredOrder": [
             "artifacts",
+            "insecureRegistries",
             "tagPolicy",
             "executionEnvironment",
             "cluster"

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -163,7 +163,7 @@ type imageLocation struct {
 
 func (c *Cache) imageLocation(ctx context.Context, imageDetails ImageDetails, tag string) (*imageLocation, error) {
 	// Check if tagged image exists remotely with the same digest
-	existsRemotely := imgExistsRemotely(tag, imageDetails.Digest)
+	existsRemotely := imgExistsRemotely(tag, imageDetails.Digest, c.insecureRegistries)
 	existsLocally := false
 	if c.client != nil {
 		// See if this image exists in the local daemon
@@ -254,12 +254,12 @@ func getDigest(img string) string {
 	return ref.DigestStr()
 }
 
-func imageExistsRemotely(image, digest string) bool {
+func imageExistsRemotely(image, digest string, insecureRegistries map[string]bool) bool {
 	if digest == "" {
 		logrus.Debugf("Checking if %s exists remotely, but digest is empty", image)
 		return false
 	}
-	d, err := remoteDigest(image)
+	d, err := remoteDigest(image, insecureRegistries)
 	if err != nil {
 		logrus.Debugf("Checking if %s exists remotely, can't get digest: %v", image, err)
 		return false

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -130,7 +130,7 @@ func Test_RetrieveCachedArtifacts(t *testing.T) {
 				hashForArtifact = originalHash
 			}()
 
-			test.cache.client = docker.NewLocalDaemon(&test.api, nil)
+			test.cache.client = docker.NewLocalDaemon(&test.api, nil, map[string]bool{})
 
 			actualArtifacts, actualBuildResults, err := test.cache.RetrieveCachedArtifacts(context.Background(), os.Stdout, test.artifacts)
 			sort.Sort(&artifactSorter{artifacts: actualArtifacts})
@@ -314,7 +314,7 @@ func TestRetrieveCachedArtifactDetails(t *testing.T) {
 			}()
 
 			originalRemoteDigest := remoteDigest
-			remoteDigest = func(string) (string, error) {
+			remoteDigest = func(string, map[string]bool) (string, error) {
 				return test.digest, nil
 			}
 			defer func() {
@@ -322,7 +322,7 @@ func TestRetrieveCachedArtifactDetails(t *testing.T) {
 			}()
 
 			originalImgExistsRemotely := imgExistsRemotely
-			imgExistsRemotely = func(_, _ string) bool {
+			imgExistsRemotely = func(_, _ string, _ map[string]bool) bool {
 				return test.targetImageExistsRemotely
 			}
 			defer func() {
@@ -330,7 +330,7 @@ func TestRetrieveCachedArtifactDetails(t *testing.T) {
 			}()
 
 			if test.api != nil {
-				test.cache.client = docker.NewLocalDaemon(test.api, nil)
+				test.cache.client = docker.NewLocalDaemon(test.api, nil, map[string]bool{})
 			}
 			actual, err := test.cache.retrieveCachedArtifactDetails(context.Background(), test.artifact)
 			if err != nil {
@@ -452,7 +452,7 @@ func TestRetrievePrebuiltImage(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			test.cache.client = docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil)
+			test.cache.client = docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, map[string]bool{})
 			actual, err := test.cache.retrievePrebuiltImage(test.imageDetails)
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, actual)
 		})

--- a/pkg/skaffold/build/cache/save.go
+++ b/pkg/skaffold/build/cache/save.go
@@ -103,11 +103,11 @@ func (c *Cache) CacheArtifacts(ctx context.Context, artifacts []*latest.Artifact
 func (c *Cache) retrieveImageDigest(ctx context.Context, img string) (string, error) {
 	if c.client == nil {
 		// Check for remote digest
-		return docker.RemoteDigest(img)
+		return docker.RemoteDigest(img, c.insecureRegistries)
 	}
 	repoDigest, err := c.client.RepoDigest(ctx, img)
 	if err != nil {
-		return docker.RemoteDigest(img)
+		return docker.RemoteDigest(img, c.insecureRegistries)
 	}
 	ref, err := name.NewDigest(repoDigest, name.WeakValidation)
 	return ref.DigestStr(), err

--- a/pkg/skaffold/build/kaniko/run.go
+++ b/pkg/skaffold/build/kaniko/run.go
@@ -100,7 +100,7 @@ func (b *Builder) run(ctx context.Context, out io.Writer, artifact *latest.Artif
 
 	waitForLogs()
 
-	return docker.RemoteDigest(tag)
+	return docker.RemoteDigest(tag, b.insecureRegistries)
 }
 
 func appendCacheIfExists(args []string, cache *latest.KanikoCache) []string {

--- a/pkg/skaffold/build/kaniko/types.go
+++ b/pkg/skaffold/build/kaniko/types.go
@@ -31,19 +31,21 @@ import (
 type Builder struct {
 	*latest.ClusterDetails
 
-	timeout time.Duration
+	timeout            time.Duration
+	insecureRegistries map[string]bool
 }
 
 // NewBuilder creates a new Builder that builds artifacts with Kaniko.
-func NewBuilder(clusterDetails *latest.ClusterDetails) (*Builder, error) {
+func NewBuilder(clusterDetails *latest.ClusterDetails, insecureRegistries map[string]bool) (*Builder, error) {
 	timeout, err := time.ParseDuration(clusterDetails.Timeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing timeout")
 	}
 
 	return &Builder{
-		ClusterDetails: clusterDetails,
-		timeout:        timeout,
+		ClusterDetails:     clusterDetails,
+		timeout:            timeout,
+		insecureRegistries: insecureRegistries,
 	}, nil
 }
 
@@ -56,7 +58,7 @@ func (b *Builder) Labels() map[string]string {
 
 // DependenciesForArtifact returns the Dockerfile dependencies for this kaniko artifact
 func (b *Builder) DependenciesForArtifact(ctx context.Context, a *latest.Artifact) ([]string, error) {
-	paths, err := docker.GetDependencies(ctx, a.Workspace, a.KanikoArtifact.DockerfilePath, a.KanikoArtifact.BuildArgs)
+	paths, err := docker.GetDependencies(ctx, a.Workspace, a.KanikoArtifact.DockerfilePath, a.KanikoArtifact.BuildArgs, b.insecureRegistries)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting dependencies for %s", a.ImageName)
 	}

--- a/pkg/skaffold/build/local/bazel.go
+++ b/pkg/skaffold/build/local/bazel.go
@@ -36,6 +36,6 @@ func (b *Builder) buildBazel(ctx context.Context, out io.Writer, a *latest.Artif
 	opts := &config.SkaffoldOptions{
 		SkipTests: b.skipTests,
 	}
-	builder.Init(opts, &latest.ExecutionEnvironment{})
+	builder.Init(opts, &latest.ExecutionEnvironment{}, b.insecureRegistries)
 	return builder.BuildArtifact(ctx, out, a, tag)
 }

--- a/pkg/skaffold/build/local/docker.go
+++ b/pkg/skaffold/build/local/docker.go
@@ -36,6 +36,6 @@ func (b *Builder) buildDocker(ctx context.Context, out io.Writer, a *latest.Arti
 	opts := &config.SkaffoldOptions{
 		SkipTests: b.skipTests,
 	}
-	builder.Init(opts, &latest.ExecutionEnvironment{})
+	builder.Init(opts, &latest.ExecutionEnvironment{}, b.insecureRegistries)
 	return builder.BuildArtifact(ctx, out, a, tag)
 }

--- a/pkg/skaffold/build/local/jib_gradle.go
+++ b/pkg/skaffold/build/local/jib_gradle.go
@@ -51,7 +51,7 @@ func (b *Builder) buildJibGradleToRegistry(ctx context.Context, out io.Writer, w
 		return "", err
 	}
 
-	return docker.RemoteDigest(tag)
+	return docker.RemoteDigest(tag, b.insecureRegistries)
 }
 
 func (b *Builder) runGradleCommand(ctx context.Context, out io.Writer, workspace string, args []string) error {

--- a/pkg/skaffold/build/local/jib_maven.go
+++ b/pkg/skaffold/build/local/jib_maven.go
@@ -65,7 +65,7 @@ func (b *Builder) buildJibMavenToRegistry(ctx context.Context, out io.Writer, wo
 		return "", err
 	}
 
-	return docker.RemoteDigest(tag)
+	return docker.RemoteDigest(tag, b.insecureRegistries)
 }
 
 // verifyJibPackageGoal verifies that the referenced module has `package` bound to a single jib goal.

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -97,7 +97,7 @@ func (b *Builder) DependenciesForArtifact(ctx context.Context, a *latest.Artifac
 
 	switch {
 	case a.DockerArtifact != nil:
-		paths, err = docker.GetDependencies(ctx, a.Workspace, a.DockerArtifact.DockerfilePath, a.DockerArtifact.BuildArgs)
+		paths, err = docker.GetDependencies(ctx, a.Workspace, a.DockerArtifact.DockerfilePath, a.DockerArtifact.BuildArgs, b.insecureRegistries)
 
 	case a.BazelArtifact != nil:
 		paths, err = bazel.GetDependencies(ctx, a.Workspace, a.BazelArtifact)

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -228,7 +228,7 @@ func TestLocalRun(t *testing.T) {
 			event.InitializeState(cfg, nil, &config.SkaffoldOptions{})
 			l := Builder{
 				cfg:         &latest.LocalBuild{},
-				localDocker: docker.NewLocalDaemon(&test.api, nil),
+				localDocker: docker.NewLocalDaemon(&test.api, nil, map[string]bool{}),
 				pushImages:  test.pushImages,
 			}
 

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -32,16 +32,17 @@ import (
 type Builder struct {
 	cfg *latest.LocalBuild
 
-	localDocker  docker.LocalDaemon
-	localCluster bool
-	pushImages   bool
-	skipTests    bool
-	kubeContext  string
+	localDocker        docker.LocalDaemon
+	localCluster       bool
+	pushImages         bool
+	skipTests          bool
+	kubeContext        string
+	insecureRegistries map[string]bool
 }
 
 // NewBuilder returns an new instance of a local Builder.
-func NewBuilder(cfg *latest.LocalBuild, kubeContext string, skipTests bool) (*Builder, error) {
-	localDocker, err := docker.NewAPIClient()
+func NewBuilder(cfg *latest.LocalBuild, kubeContext string, skipTests bool, insecureRegistries map[string]bool) (*Builder, error) {
+	localDocker, err := docker.NewAPIClient(insecureRegistries)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting docker client")
 	}
@@ -60,12 +61,13 @@ func NewBuilder(cfg *latest.LocalBuild, kubeContext string, skipTests bool) (*Bu
 	}
 
 	return &Builder{
-		cfg:          cfg,
-		kubeContext:  kubeContext,
-		localDocker:  localDocker,
-		localCluster: localCluster,
-		pushImages:   pushImages,
-		skipTests:    skipTests,
+		cfg:                cfg,
+		kubeContext:        kubeContext,
+		localDocker:        localDocker,
+		localCluster:       localCluster,
+		pushImages:         pushImages,
+		skipTests:          skipTests,
+		insecureRegistries: insecureRegistries,
 	}, nil
 }
 

--- a/pkg/skaffold/build/plugin/plugin.go
+++ b/pkg/skaffold/build/plugin/plugin.go
@@ -41,7 +41,7 @@ var (
 )
 
 // NewPluginBuilder initializes and returns all required plugin builders
-func NewPluginBuilder(cfg *latest.BuildConfig, opts *config.SkaffoldOptions) (shared.PluginBuilder, error) {
+func NewPluginBuilder(cfg *latest.BuildConfig, opts *config.SkaffoldOptions, insecureRegistries map[string]bool) (shared.PluginBuilder, error) {
 	// We're a host. Start by launching the plugin process.
 	logrus.SetOutput(os.Stdout)
 
@@ -91,7 +91,7 @@ func NewPluginBuilder(cfg *latest.BuildConfig, opts *config.SkaffoldOptions) (sh
 	b := &Builder{
 		Builders: builders,
 	}
-	b.Init(opts, cfg.ExecutionEnvironment)
+	b.Init(opts, cfg.ExecutionEnvironment, insecureRegistries)
 	return b, nil
 }
 
@@ -99,9 +99,9 @@ type Builder struct {
 	Builders map[string]shared.PluginBuilder
 }
 
-func (b *Builder) Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnvironment) {
+func (b *Builder) Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnvironment, insecureRegistries map[string]bool) {
 	for _, builder := range b.Builders {
-		builder.Init(opts, env)
+		builder.Init(opts, env, insecureRegistries)
 	}
 }
 

--- a/pkg/skaffold/build/plugin/plugin_test.go
+++ b/pkg/skaffold/build/plugin/plugin_test.go
@@ -34,7 +34,7 @@ type mockBuilder struct {
 	artifacts []build.Artifact
 }
 
-func (b *mockBuilder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+func (b *mockBuilder) Build(_ context.Context, _ io.Writer, _ tag.ImageTags, _ []*latest.Artifact) ([]build.Artifact, error) {
 	return b.artifacts, nil
 }
 
@@ -42,9 +42,10 @@ func (b *mockBuilder) Labels() map[string]string {
 	return b.labels
 }
 
-func (b *mockBuilder) Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnvironment) {}
+func (b *mockBuilder) Init(_ *config.SkaffoldOptions, _ *latest.ExecutionEnvironment, _ map[string]bool) {
+}
 
-func (b *mockBuilder) DependenciesForArtifact(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
+func (b *mockBuilder) DependenciesForArtifact(_ context.Context, _ *latest.Artifact) ([]string, error) {
 	return nil, nil
 }
 

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -30,29 +30,30 @@ type Output struct {
 // SkaffoldOptions are options that are set by command line arguments not included
 // in the config file itself
 type SkaffoldOptions struct {
-	ConfigurationFile string
-	Cleanup           bool
-	Notification      bool
-	Tail              bool
-	TailDev           bool
-	PortForward       bool
-	SkipTests         bool
-	CacheArtifacts    bool
-	ExperimentalGUI   bool
-	EnableRPC         bool
-	Profiles          []string
-	CustomTag         string
-	Namespace         string
-	CacheFile         string
-	TargetImages      []string
-	Trigger           string
-	CustomLabels      []string
-	WatchPollInterval int
-	DefaultRepo       string
-	PreBuiltImages    []string
-	Command           string
-	RPCPort           int
-	RPCHTTPPort       int
+	ConfigurationFile  string
+	Cleanup            bool
+	Notification       bool
+	Tail               bool
+	TailDev            bool
+	PortForward        bool
+	SkipTests          bool
+	CacheArtifacts     bool
+	ExperimentalGUI    bool
+	EnableRPC          bool
+	WatchPollInterval  int
+	RPCPort            int
+	RPCHTTPPort        int
+	CustomTag          string
+	Namespace          string
+	CacheFile          string
+	Trigger            string
+	DefaultRepo        string
+	Command            string
+	Profiles           []string
+	InsecureRegistries []string
+	PreBuiltImages     []string
+	TargetImages       []string
+	CustomLabels       []string
 }
 
 // Labels returns a map of labels to be applied to all deployed

--- a/pkg/skaffold/docker/auth.go
+++ b/pkg/skaffold/docker/auth.go
@@ -93,9 +93,8 @@ func (l *localDaemon) encodedRegistryAuth(ctx context.Context, a AuthConfigHelpe
 		return "", err
 	}
 
-	index := repoInfo.Index
-	configKey := index.Name
-	if index.Official {
+	configKey := repoInfo.Index.Name
+	if repoInfo.Index.Official {
 		configKey = l.officialRegistry(ctx)
 	}
 

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -47,7 +47,7 @@ var (
 )
 
 // NewAPIClient guesses the docker client to use based on current kubernetes context.
-func NewAPIClient() (LocalDaemon, error) {
+func NewAPIClient(insecureRegistries map[string]bool) (LocalDaemon, error) {
 	dockerAPIClientOnce.Do(func() {
 		kubeContext, err := kubectx.CurrentContext()
 		if err != nil {
@@ -56,7 +56,7 @@ func NewAPIClient() (LocalDaemon, error) {
 		}
 
 		env, apiClient, err := newAPIClient(kubeContext)
-		dockerAPIClient = NewLocalDaemon(apiClient, env)
+		dockerAPIClient = NewLocalDaemon(apiClient, env, insecureRegistries)
 		dockerAPIClientErr = err
 	})
 

--- a/pkg/skaffold/docker/context.go
+++ b/pkg/skaffold/docker/context.go
@@ -26,8 +26,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-func CreateDockerTarContext(ctx context.Context, w io.Writer, workspace string, a *latest.DockerArtifact) error {
-	paths, err := GetDependencies(ctx, workspace, a.DockerfilePath, a.BuildArgs)
+func CreateDockerTarContext(ctx context.Context, w io.Writer, workspace string, a *latest.DockerArtifact, insecureRegistries map[string]bool) error {
+	paths, err := GetDependencies(ctx, workspace, a.DockerfilePath, a.BuildArgs, insecureRegistries)
 	if err != nil {
 		return errors.Wrap(err, "getting relative tar paths")
 	}

--- a/pkg/skaffold/docker/context_test.go
+++ b/pkg/skaffold/docker/context_test.go
@@ -52,7 +52,7 @@ func TestDockerContext(t *testing.T) {
 
 			reader, writer := io.Pipe()
 			go func() {
-				err := CreateDockerTarContext(context.Background(), writer, dir, artifact)
+				err := CreateDockerTarContext(context.Background(), writer, dir, artifact, map[string]bool{})
 				if err != nil {
 					writer.CloseWithError(err)
 				} else {

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -26,6 +26,9 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
 )
 
 func TestMain(m *testing.M) {
@@ -313,6 +316,73 @@ func TestRepoDigest(t *testing.T) {
 				return
 			}
 			testutil.CheckErrorAndDeepEqual(t, false, err, test.expected, actual)
+		})
+	}
+}
+
+func TestInsecureRegistry(t *testing.T) {
+	called := false // variable to make sure we've called our getInsecureRegistry function
+	getInsecureRegistryImpl = func(reg string) (name.Registry, error) {
+		called = true
+		return name.Registry{}, nil
+	}
+	getRemoteImageImpl = func(ref name.Reference, reg name.Registry) (v1.Image, error) {
+		return random.Image(0, 0)
+	}
+
+	tests := []struct {
+		name               string
+		image              string
+		insecureRegistries map[string]bool
+		insecure           bool
+		shouldErr          bool
+	}{
+		{
+			name:               "secure image",
+			image:              "gcr.io/secure/image",
+			insecureRegistries: map[string]bool{},
+		},
+		{
+			name:  "insecure image",
+			image: "my.insecure.registry/image",
+			insecureRegistries: map[string]bool{
+				"my.insecure.registry": true,
+			},
+			insecure: true,
+		},
+		{
+			name:      "insecure image not provided by user",
+			image:     "my.insecure.registry/image",
+			insecure:  true,
+			shouldErr: true,
+		},
+		{
+			name:  "secure image provided in insecure registries list",
+			image: "gcr.io/secure/image",
+			insecureRegistries: map[string]bool{
+				"gcr.io": true,
+			},
+			shouldErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := remoteImage(test.image, test.insecureRegistries)
+			if err != nil {
+				t.Errorf("error calling remoteImage: %s", err.Error())
+			}
+			if test.insecure && !called { // error condition
+				if !test.shouldErr {
+					t.Errorf("getInsecureRegistry not called for insecure registry")
+				}
+			}
+			if !test.insecure && called { // error condition
+				if !test.shouldErr {
+					t.Errorf("getInsecureRegistry called for secure registry")
+				}
+			}
+			called = false
 		})
 	}
 }

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -100,7 +100,7 @@ func fromInstruction(node *parser.Node) from {
 	}
 }
 
-func onbuildInstructions(nodes []*parser.Node) ([]*parser.Node, error) {
+func onbuildInstructions(nodes []*parser.Node, insecureRegistries map[string]bool) ([]*parser.Node, error) {
 	var instructions []string
 
 	stages := map[string]bool{}
@@ -121,7 +121,7 @@ func onbuildInstructions(nodes []*parser.Node) ([]*parser.Node, error) {
 		logrus.Debugf("Checking base image %s for ONBUILD triggers.", from.image)
 
 		// Image names are case SENSITIVE
-		img, err := RetrieveImage(from.image)
+		img, err := RetrieveImage(from.image, insecureRegistries)
 		if err != nil {
 			logrus.Warnf("Error processing base image (%s) for ONBUILD triggers: %s. Dependencies may be incomplete.", from.image, err)
 			continue
@@ -167,7 +167,7 @@ func copiedFiles(nodes []*parser.Node) ([][]string, error) {
 	return copied, nil
 }
 
-func readDockerfile(workspace, absDockerfilePath string, buildArgs map[string]*string) ([]string, error) {
+func readDockerfile(workspace, absDockerfilePath string, buildArgs map[string]*string, insecureRegistries map[string]bool) ([]string, error) {
 	f, err := os.Open(absDockerfilePath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "opening dockerfile: %s", absDockerfilePath)
@@ -183,7 +183,7 @@ func readDockerfile(workspace, absDockerfilePath string, buildArgs map[string]*s
 
 	expandBuildArgs(dockerfileLines, buildArgs)
 
-	instructions, err := onbuildInstructions(dockerfileLines)
+	instructions, err := onbuildInstructions(dockerfileLines, insecureRegistries)
 	if err != nil {
 		return nil, errors.Wrap(err, "listing ONBUILD instructions")
 	}
@@ -256,13 +256,13 @@ func NormalizeDockerfilePath(context, dockerfile string) (string, error) {
 
 // GetDependencies finds the sources dependencies for the given docker artifact.
 // All paths are relative to the workspace.
-func GetDependencies(ctx context.Context, workspace string, dockerfilePath string, buildArgs map[string]*string) ([]string, error) {
+func GetDependencies(ctx context.Context, workspace string, dockerfilePath string, buildArgs map[string]*string, insecureRegistries map[string]bool) ([]string, error) {
 	absDockerfilePath, err := NormalizeDockerfilePath(workspace, dockerfilePath)
 	if err != nil {
 		return nil, errors.Wrap(err, "normalizing dockerfile path")
 	}
 
-	deps, err := readDockerfile(workspace, absDockerfilePath, buildArgs)
+	deps, err := readDockerfile(workspace, absDockerfilePath, buildArgs, insecureRegistries)
 	if err != nil {
 		return nil, err
 	}
@@ -362,8 +362,8 @@ func GetDependencies(ctx context.Context, workspace string, dockerfilePath strin
 	return dependencies, nil
 }
 
-func retrieveImage(image string) (*v1.ConfigFile, error) {
-	localDaemon, err := NewAPIClient() // Cached after first call
+func retrieveImage(image string, insecureRegistries map[string]bool) (*v1.ConfigFile, error) {
+	localDaemon, err := NewAPIClient(insecureRegistries) // Cached after first call
 	if err != nil {
 		return nil, errors.Wrap(err, "getting docker client")
 	}

--- a/pkg/skaffold/docker/parse_test.go
+++ b/pkg/skaffold/docker/parse_test.go
@@ -199,7 +199,7 @@ type fakeImageFetcher struct {
 	fetched []string
 }
 
-func (f *fakeImageFetcher) fetch(image string) (*v1.ConfigFile, error) {
+func (f *fakeImageFetcher) fetch(image string, _ map[string]bool) (*v1.ConfigFile, error) {
 	f.fetched = append(f.fetched, image)
 
 	switch image {
@@ -510,7 +510,7 @@ func TestGetDependencies(t *testing.T) {
 			}
 
 			workspace := tmpDir.Path(test.workspace)
-			deps, err := GetDependencies(context.Background(), workspace, "Dockerfile", test.buildArgs)
+			deps, err := GetDependencies(context.Background(), workspace, "Dockerfile", test.buildArgs, map[string]bool{})
 
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, deps)
 			testutil.CheckDeepEqual(t, test.fetched, imageFetcher.fetched)

--- a/pkg/skaffold/docker/remote_test.go
+++ b/pkg/skaffold/docker/remote_test.go
@@ -28,7 +28,7 @@ func TestRemoteDigest(t *testing.T) {
 	}
 
 	for _, ref := range validReferences {
-		_, err := RemoteDigest(ref)
+		_, err := RemoteDigest(ref, map[string]bool{})
 
 		// Ignore networking errors
 		if err != nil && strings.Contains(err.Error(), "could not parse") {

--- a/pkg/skaffold/plugin/builders/bazel/builder.go
+++ b/pkg/skaffold/plugin/builders/bazel/builder.go
@@ -38,11 +38,12 @@ type Builder struct {
 	opts *config.SkaffoldOptions
 	env  *latest.ExecutionEnvironment
 	*latest.LocalBuild
-	LocalDocker  docker.LocalDaemon
-	LocalCluster bool
-	PushImages   bool
-	PluginMode   bool
-	KubeContext  string
+	LocalDocker        docker.LocalDaemon
+	LocalCluster       bool
+	PushImages         bool
+	PluginMode         bool
+	KubeContext        string
+	insecureRegistries map[string]bool
 }
 
 // NewBuilder creates a new Builder that builds artifacts with Bazel.
@@ -53,7 +54,7 @@ func NewBuilder() *Builder {
 }
 
 // Init stores skaffold options and the execution environment
-func (b *Builder) Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnvironment) {
+func (b *Builder) Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnvironment, insecureRegistries map[string]bool) {
 	if b.PluginMode {
 		if err := event.SetupRPCClient(opts); err != nil {
 			logrus.Warn("error establishing gRPC connection to skaffold process; events will not be handled correctly")
@@ -62,6 +63,7 @@ func (b *Builder) Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnviro
 	}
 	b.opts = opts
 	b.env = env
+	b.insecureRegistries = insecureRegistries
 }
 
 // Labels are labels specific to Bazel.

--- a/pkg/skaffold/plugin/builders/docker/builder.go
+++ b/pkg/skaffold/plugin/builders/docker/builder.go
@@ -44,8 +44,9 @@ type Builder struct {
 	LocalCluster bool
 	PushImages   bool
 	// TODO: remove once old docker build functionality is removed (priyawadhwa@)
-	PluginMode  bool
-	KubeContext string
+	PluginMode         bool
+	KubeContext        string
+	insecureRegistries map[string]bool
 }
 
 // NewBuilder creates a new Builder that builds artifacts with Docker.
@@ -56,7 +57,7 @@ func NewBuilder() *Builder {
 }
 
 // Init stores skaffold options and the execution environment
-func (b *Builder) Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnvironment) {
+func (b *Builder) Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnvironment, insecureRegistries map[string]bool) {
 	if b.PluginMode {
 		if err := event.SetupRPCClient(opts); err != nil {
 			logrus.Warn("error establishing gRPC connection to skaffold process; events will not be handled correctly")
@@ -66,6 +67,7 @@ func (b *Builder) Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnviro
 
 	b.opts = opts
 	b.env = env
+	b.insecureRegistries = insecureRegistries
 }
 
 // Labels are labels specific to Docker.
@@ -80,7 +82,7 @@ func (b *Builder) DependenciesForArtifact(ctx context.Context, artifact *latest.
 	if err := setArtifact(artifact); err != nil {
 		return nil, err
 	}
-	paths, err := docker.GetDependencies(ctx, artifact.Workspace, artifact.DockerArtifact.DockerfilePath, artifact.DockerArtifact.BuildArgs)
+	paths, err := docker.GetDependencies(ctx, artifact.Workspace, artifact.DockerArtifact.DockerfilePath, artifact.DockerArtifact.BuildArgs, b.insecureRegistries)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting dependencies for %s", artifact.ImageName)
 	}
@@ -112,7 +114,7 @@ func (b *Builder) googleCloudBuild(ctx context.Context, out io.Writer, tags tag.
 			return nil, err
 		}
 	}
-	return gcb.NewBuilder(g, b.opts.SkipTests).Build(ctx, out, tags, artifacts)
+	return gcb.NewBuilder(g, b.opts.SkipTests, b.insecureRegistries).Build(ctx, out, tags, artifacts)
 }
 
 func setArtifact(artifact *latest.Artifact) error {

--- a/pkg/skaffold/plugin/builders/docker/local.go
+++ b/pkg/skaffold/plugin/builders/docker/local.go
@@ -50,7 +50,7 @@ func (b *Builder) local(ctx context.Context, out io.Writer, tags tag.ImageTags, 
 		return nil, errors.Wrap(err, "getting current cluster context")
 	}
 	b.KubeContext = kubeContext
-	localDocker, err := docker.NewAPIClient()
+	localDocker, err := docker.NewAPIClient(b.insecureRegistries)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting docker client")
 	}

--- a/pkg/skaffold/plugin/environments/gcb/types.go
+++ b/pkg/skaffold/plugin/environments/gcb/types.go
@@ -60,14 +60,16 @@ const (
 // Builder builds artifacts with Google Cloud Build.
 type Builder struct {
 	*latest.GoogleCloudBuild
-	skipTests bool
+	skipTests          bool
+	insecureRegistries map[string]bool
 }
 
 // NewBuilder creates a new Builder that builds artifacts with Google Cloud Build.
-func NewBuilder(cfg *latest.GoogleCloudBuild, skipTests bool) *Builder {
+func NewBuilder(cfg *latest.GoogleCloudBuild, skipTests bool, insecureRegistries map[string]bool) *Builder {
 	return &Builder{
-		GoogleCloudBuild: cfg,
-		skipTests:        skipTests,
+		GoogleCloudBuild:   cfg,
+		skipTests:          skipTests,
+		insecureRegistries: insecureRegistries,
 	}
 }
 
@@ -83,7 +85,7 @@ func (b *Builder) DependenciesForArtifact(ctx context.Context, a *latest.Artifac
 	var paths []string
 	var err error
 	if a.DockerArtifact != nil {
-		paths, err = docker.GetDependencies(ctx, a.Workspace, a.DockerArtifact.DockerfilePath, a.DockerArtifact.BuildArgs)
+		paths, err = docker.GetDependencies(ctx, a.Workspace, a.DockerArtifact.DockerfilePath, a.DockerArtifact.BuildArgs, b.insecureRegistries)
 		if err != nil {
 			return nil, errors.Wrapf(err, "getting dependencies for %s", a.ImageName)
 		}

--- a/pkg/skaffold/plugin/shared/build.go
+++ b/pkg/skaffold/plugin/shared/build.go
@@ -23,6 +23,6 @@ import (
 )
 
 type PluginBuilder interface {
-	Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnvironment)
+	Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnvironment, insecureRegistries map[string]bool)
 	build.Builder
 }

--- a/pkg/skaffold/plugin/shared/server.go
+++ b/pkg/skaffold/plugin/shared/server.go
@@ -37,12 +37,13 @@ type BuilderRPC struct {
 	client *rpc.Client
 }
 
-func (b *BuilderRPC) Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnvironment) {
+func (b *BuilderRPC) Init(opts *config.SkaffoldOptions, env *latest.ExecutionEnvironment, insecureRegistries map[string]bool) {
 	// We don't expect a response, so we can just use interface{}
 	var resp interface{}
 	args := InitArgs{
-		Opts: opts,
-		Env:  env,
+		Opts:               opts,
+		Env:                env,
+		InsecureRegistries: insecureRegistries,
 	}
 	b.client.Call("Plugin.Init", args, &resp)
 }
@@ -108,7 +109,7 @@ type BuilderRPCServer struct {
 }
 
 func (s *BuilderRPCServer) Init(args InitArgs, resp *interface{}) error {
-	s.Impl.Init(args.Opts, args.Env)
+	s.Impl.Init(args.Opts, args.Env, args.InsecureRegistries)
 	return nil
 }
 
@@ -142,8 +143,9 @@ type DependencyArgs struct {
 
 // InitArgs are args passed via rpc to the builder plugin on Init()
 type InitArgs struct {
-	Opts *config.SkaffoldOptions
-	Env  *latest.ExecutionEnvironment
+	Opts               *config.SkaffoldOptions
+	Env                *latest.ExecutionEnvironment
+	InsecureRegistries map[string]bool
 }
 
 // BuildArgs are the args passed via rpc to the builder plugin on Build()

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -50,7 +50,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, output *config.Output, artifac
 		logger.Mute()
 
 		for _, a := range changed.dirtyArtifacts {
-			s, err := sync.NewItem(a.artifact, a.events, r.builds)
+			s, err := sync.NewItem(a.artifact, a.events, r.builds, r.InsecureRegistries)
 			if err != nil {
 				return errors.Wrap(err, "sync")
 			}

--- a/pkg/skaffold/runner/dev_test.go
+++ b/pkg/skaffold/runner/dev_test.go
@@ -339,7 +339,7 @@ func TestDevSync(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			originalWorkingDir := sync.WorkingDir
-			sync.WorkingDir = func(tagged string) (string, error) {
+			sync.WorkingDir = func(_ string, _ map[string]bool) (string, error) {
 				return "/", nil
 			}
 			defer func() {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -58,6 +58,10 @@ type BuildConfig struct {
 	// Artifacts lists the images you're going to be building.
 	Artifacts []*Artifact `yaml:"artifacts,omitempty"`
 
+	// InsecureRegistries is a list of registries declared by the user to be insecure.
+	// These registries will be connected to via HTTP instead of HTTPS.
+	InsecureRegistries []string `yaml:"insecureRegistries,omitempty"`
+
 	// TagPolicy *beta* determines how images are tagged.
 	// A few strategies are provided here, although you most likely won't need to care!
 	// If not specified, it defaults to `gitCommit: {}`.

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -367,13 +367,13 @@ func TestNewSyncItem(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			originalWorkingDir := WorkingDir
-			WorkingDir = func(tagged string) (string, error) {
+			WorkingDir = func(_ string, _ map[string]bool) (string, error) {
 				return test.workingDir, nil
 			}
 			defer func() {
 				WorkingDir = originalWorkingDir
 			}()
-			actual, err := NewItem(test.artifact, test.evt, test.builds)
+			actual, err := NewItem(test.artifact, test.evt, test.builds, map[string]bool{})
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, actual)
 		})
 	}

--- a/vendor/github.com/google/go-containerregistry/pkg/name/digest.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/name/digest.go
@@ -73,14 +73,9 @@ func NewDigest(name string, strict Strictness) (Digest, error) {
 	base := parts[0]
 	digest := parts[1]
 
-	// We don't require a digest, but if we get one check it's valid,
-	// even when not being strict.
-	// If we are being strict, we want to validate the digest regardless in case
-	// it's empty.
-	if digest != "" || strict == StrictValidation {
-		if err := checkDigest(digest); err != nil {
-			return Digest{}, err
-		}
+	// Always check that the digest is valid.
+	if err := checkDigest(digest); err != nil {
+		return Digest{}, err
 	}
 
 	tag, err := NewTag(base, strict)

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/image.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/image.go
@@ -24,9 +24,6 @@ type Image interface {
 	// The order of the list is oldest/base layer first, and most-recent/top layer last.
 	Layers() ([]Layer, error)
 
-	// BlobSet returns an unordered collection of all the blobs in the image.
-	BlobSet() (map[Hash]struct{}, error)
-
 	// MediaType of this image's manifest.
 	MediaType() (types.MediaType, error)
 

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/manifest.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/manifest.go
@@ -23,7 +23,7 @@ import (
 
 // Manifest represents the OCI image manifest in a structured way.
 type Manifest struct {
-	SchemaVersion int64             `json:"schemaVersion"`
+	SchemaVersion int64             `json:"schemaVersion,omitempty"`
 	MediaType     types.MediaType   `json:"mediaType"`
 	Config        Descriptor        `json:"config"`
 	Layers        []Descriptor      `json:"layers"`

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/partial/compressed.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/partial/compressed.go
@@ -91,11 +91,6 @@ type compressedImageExtender struct {
 // Assert that our extender type completes the v1.Image interface
 var _ v1.Image = (*compressedImageExtender)(nil)
 
-// BlobSet implements v1.Image
-func (i *compressedImageExtender) BlobSet() (map[v1.Hash]struct{}, error) {
-	return BlobSet(i)
-}
-
 // Digest implements v1.Image
 func (i *compressedImageExtender) Digest() (v1.Hash, error) {
 	return Digest(i)

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/partial/uncompressed.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/partial/uncompressed.go
@@ -112,11 +112,6 @@ type uncompressedImageExtender struct {
 // Assert that our extender type completes the v1.Image interface
 var _ v1.Image = (*uncompressedImageExtender)(nil)
 
-// BlobSet implements v1.Image
-func (i *uncompressedImageExtender) BlobSet() (map[v1.Hash]struct{}, error) {
-	return BlobSet(i)
-}
-
 // Digest implements v1.Image
 func (i *uncompressedImageExtender) Digest() (v1.Hash, error) {
 	return Digest(i)

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/partial/with.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/partial/with.go
@@ -191,20 +191,6 @@ func FSLayers(i WithManifest) ([]v1.Hash, error) {
 	return fsl, nil
 }
 
-// BlobSet is a helper for implementing v1.Image
-func BlobSet(i WithManifest) (map[v1.Hash]struct{}, error) {
-	m, err := i.Manifest()
-	if err != nil {
-		return nil, err
-	}
-	bs := make(map[v1.Hash]struct{})
-	for _, l := range m.Layers {
-		bs[l.Digest] = struct{}{}
-	}
-	bs[m.Config.Digest] = struct{}{}
-	return bs, nil
-}
-
 // BlobSize is a helper for implementing v1.Image
 func BlobSize(i WithManifest, h v1.Hash) (int64, error) {
 	m, err := i.Manifest()

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/random/doc.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/random/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package random provides a facility for synthesizing pseudo-random images.
+package random

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/random/image.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/random/image.go
@@ -1,0 +1,135 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package random
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"time"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+// uncompressedLayer implements partial.UncompressedLayer from raw bytes.
+// TODO(mattmoor): Consider moving this into a library.
+type uncompressedLayer struct {
+	diffID  v1.Hash
+	content []byte
+}
+
+// DiffID implements partial.UncompressedLayer
+func (ul *uncompressedLayer) DiffID() (v1.Hash, error) {
+	return ul.diffID, nil
+}
+
+// Uncompressed implements partial.UncompressedLayer
+func (ul *uncompressedLayer) Uncompressed() (io.ReadCloser, error) {
+	return ioutil.NopCloser(bytes.NewBuffer(ul.content)), nil
+}
+
+var _ partial.UncompressedLayer = (*uncompressedLayer)(nil)
+
+// Image returns a pseudo-randomly generated Image.
+func Image(byteSize, layers int64) (v1.Image, error) {
+	layerz := make(map[v1.Hash]partial.UncompressedLayer)
+	for i := int64(0); i < layers; i++ {
+		var b bytes.Buffer
+		tw := tar.NewWriter(&b)
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     fmt.Sprintf("random_file_%d.txt", i),
+			Size:     byteSize,
+			Typeflag: tar.TypeRegA,
+		}); err != nil {
+			return nil, err
+		}
+		if _, err := io.CopyN(tw, rand.Reader, byteSize); err != nil {
+			return nil, err
+		}
+		if err := tw.Close(); err != nil {
+			return nil, err
+		}
+		bts := b.Bytes()
+		h, _, err := v1.SHA256(bytes.NewReader(bts))
+		if err != nil {
+			return nil, err
+		}
+		layerz[h] = &uncompressedLayer{
+			diffID:  h,
+			content: bts,
+		}
+	}
+
+	cfg := &v1.ConfigFile{}
+
+	// Some clients check this.
+	cfg.RootFS.Type = "layers"
+
+	// It is ok that iteration order is random in Go, because this is the random image anyways.
+	for k := range layerz {
+		cfg.RootFS.DiffIDs = append(cfg.RootFS.DiffIDs, k)
+	}
+
+	for i := int64(0); i < layers; i++ {
+		cfg.History = append(cfg.History, v1.History{
+			Author:    "random.Image",
+			Comment:   fmt.Sprintf("this is a random history %d", i),
+			CreatedBy: "random",
+			Created:   v1.Time{time.Now()},
+		})
+	}
+
+	return partial.UncompressedToImage(&image{
+		config: cfg,
+		layers: layerz,
+	})
+}
+
+// image is pseudo-randomly generated.
+type image struct {
+	config *v1.ConfigFile
+	layers map[v1.Hash]partial.UncompressedLayer
+}
+
+var _ partial.UncompressedImageCore = (*image)(nil)
+
+// RawConfigFile implements partial.UncompressedImageCore
+func (i *image) RawConfigFile() ([]byte, error) {
+	return partial.RawConfigFile(i)
+}
+
+// ConfigFile implements v1.Image
+func (i *image) ConfigFile() (*v1.ConfigFile, error) {
+	return i.config, nil
+}
+
+// MediaType implements partial.UncompressedImageCore
+func (i *image) MediaType() (types.MediaType, error) {
+	return types.DockerManifestSchema2, nil
+}
+
+// LayerByDiffID implements partial.UncompressedImageCore
+func (i *image) LayerByDiffID(diffID v1.Hash) (partial.UncompressedLayer, error) {
+	l, ok := i.layers[diffID]
+	if !ok {
+		return nil, fmt.Errorf("unknown diff_id: %v", diffID)
+	}
+	return l, nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/random/index.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/random/index.go
@@ -1,0 +1,106 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package random
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+type randomIndex struct {
+	images   map[v1.Hash]v1.Image
+	manifest *v1.IndexManifest
+}
+
+// Index returns a pseudo-randomly generated ImageIndex with count images, each
+// having the given number of layers of size byteSize.
+func Index(byteSize, layers, count int64) (v1.ImageIndex, error) {
+	manifest := v1.IndexManifest{
+		SchemaVersion: 2,
+		Manifests:     []v1.Descriptor{},
+	}
+
+	images := make(map[v1.Hash]v1.Image)
+	for i := int64(0); i < count; i++ {
+		img, err := Image(byteSize, layers)
+		if err != nil {
+			return nil, err
+		}
+
+		rawManifest, err := img.RawManifest()
+		if err != nil {
+			return nil, err
+		}
+		digest, size, err := v1.SHA256(bytes.NewReader(rawManifest))
+		if err != nil {
+			return nil, err
+		}
+		mediaType, err := img.MediaType()
+		if err != nil {
+			return nil, err
+		}
+
+		manifest.Manifests = append(manifest.Manifests, v1.Descriptor{
+			Digest:    digest,
+			Size:      size,
+			MediaType: mediaType,
+		})
+
+		images[digest] = img
+	}
+
+	return &randomIndex{
+		images:   images,
+		manifest: &manifest,
+	}, nil
+}
+
+func (i *randomIndex) MediaType() (types.MediaType, error) {
+	return types.OCIImageIndex, nil
+}
+
+func (i *randomIndex) Digest() (v1.Hash, error) {
+	return partial.Digest(i)
+}
+
+func (i *randomIndex) IndexManifest() (*v1.IndexManifest, error) {
+	return i.manifest, nil
+}
+
+func (i *randomIndex) RawManifest() ([]byte, error) {
+	m, err := i.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(m)
+}
+
+func (i *randomIndex) Image(h v1.Hash) (v1.Image, error) {
+	if img, ok := i.images[h]; ok {
+		return img, nil
+	}
+
+	return nil, fmt.Errorf("image not found: %v", h)
+}
+
+func (i *randomIndex) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
+	// This is a single level index (for now?).
+	return nil, fmt.Errorf("image not found: %v", h)
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/check.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/check.go
@@ -1,0 +1,56 @@
+package remote
+
+import (
+	"net/http"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+)
+
+// CheckPushPermission returns an error if the given keychain cannot authorize
+// a push operation to the given ref.
+//
+// This can be useful to check whether the caller has permission to push an
+// image before doing work to construct the image.
+//
+// TODO(#412): Remove the need for this method.
+func CheckPushPermission(ref name.Reference, kc authn.Keychain, t http.RoundTripper) error {
+	auth, err := kc.Resolve(ref.Context().Registry)
+	if err != nil {
+		return err
+	}
+
+	scopes := []string{ref.Scope(transport.PushScope)}
+	tr, err := transport.New(ref.Context().Registry, auth, t, scopes)
+	if err != nil {
+		return err
+	}
+	// TODO(jasonhall): Against GCR, just doing the token handshake is
+	// enough, but this doesn't extend to Dockerhub
+	// (https://github.com/docker/hub-feedback/issues/1771), so we actually
+	// need to initiate an upload to tell whether the credentials can
+	// authorize a push. Figure out how to return early here when we can,
+	// to avoid a roundtrip for spec-compliant registries.
+	w := writer{
+		ref:    ref,
+		client: &http.Client{Transport: tr},
+	}
+	loc, _, err := w.initiateUpload("", "")
+	if loc != "" {
+		// Since we're only initiating the upload to check whether we
+		// can, we should attempt to cancel it, in case initiating
+		// reserves some resources on the server. We shouldn't wait for
+		// cancelling to complete, and we don't care if it fails.
+		go w.cancelUpload(loc)
+	}
+	return err
+}
+
+func (w *writer) cancelUpload(loc string) {
+	req, err := http.NewRequest(http.MethodDelete, loc, nil)
+	if err != nil {
+		return
+	}
+	_, _ = w.client.Do(req)
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/descriptor.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/descriptor.go
@@ -1,0 +1,271 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+var defaultPlatform = v1.Platform{
+	Architecture: "amd64",
+	OS:           "linux",
+}
+
+// ErrSchema1 indicates that we received a schema1 manifest from the registry.
+// This library doesn't have plans to support this legacy image format:
+// https://github.com/google/go-containerregistry/issues/377
+var ErrSchema1 = errors.New("unsupported MediaType: https://github.com/google/go-containerregistry/issues/377")
+
+// Descriptor provides access to metadata about remote artifact and accessors
+// for efficiently converting it into a v1.Image or v1.ImageIndex.
+type Descriptor struct {
+	fetcher
+	v1.Descriptor
+	Manifest []byte
+
+	// So we can share this implementation with Image..
+	platform v1.Platform
+}
+
+type imageOpener struct {
+	auth      authn.Authenticator
+	transport http.RoundTripper
+	ref       name.Reference
+	client    *http.Client
+	platform  v1.Platform
+}
+
+// Get returns a remote.Descriptor for the given reference. The response from
+// the registry is left un-interpreted, for the most part. This is useful for
+// querying what kind of artifact a reference represents.
+func Get(ref name.Reference, options ...ImageOption) (*Descriptor, error) {
+	acceptable := []types.MediaType{
+		types.DockerManifestSchema2,
+		types.OCIManifestSchema1,
+		types.DockerManifestList,
+		types.OCIImageIndex,
+		// Just to look at them.
+		types.DockerManifestSchema1,
+		types.DockerManifestSchema1Signed,
+	}
+	return get(ref, acceptable, options...)
+}
+
+// Handle options and fetch the manifest with the acceptable MediaTypes in the
+// Accept header.
+func get(ref name.Reference, acceptable []types.MediaType, options ...ImageOption) (*Descriptor, error) {
+	i := &imageOpener{
+		auth:      authn.Anonymous,
+		transport: http.DefaultTransport,
+		ref:       ref,
+		platform:  defaultPlatform,
+	}
+
+	for _, option := range options {
+		if err := option(i); err != nil {
+			return nil, err
+		}
+	}
+	tr, err := transport.New(i.ref.Context().Registry, i.auth, i.transport, []string{i.ref.Scope(transport.PullScope)})
+	if err != nil {
+		return nil, err
+	}
+
+	f := fetcher{
+		Ref:    i.ref,
+		Client: &http.Client{Transport: tr},
+	}
+
+	b, desc, err := f.fetchManifest(ref, acceptable)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Descriptor{
+		fetcher:    f,
+		Manifest:   b,
+		Descriptor: *desc,
+		platform:   i.platform,
+	}, nil
+}
+
+// Image converts the Descriptor into a v1.Image.
+//
+// If the fetched artifact is already an image, it will just return it.
+//
+// If the fetched artifact is an index, it will attempt to resolve the index to
+// a child image with the appropriate platform.
+//
+// See WithPlatform to set the desired platform.
+func (d *Descriptor) Image() (v1.Image, error) {
+	switch d.MediaType {
+	case types.DockerManifestSchema1, types.DockerManifestSchema1Signed:
+		// We don't care to support schema 1 images:
+		// https://github.com/google/go-containerregistry/issues/377
+		return nil, ErrSchema1
+	case types.OCIImageIndex, types.DockerManifestList:
+		// We want an image but the registry has an index, resolve it to an image.
+		return d.remoteIndex().imageByPlatform(d.platform)
+	case types.OCIManifestSchema1, types.DockerManifestSchema2:
+		// These are expected. Enumerated here to allow a default case.
+	default:
+		// We could just return an error here, but some registries (e.g. static
+		// registries) don't set the Content-Type headers correctly, so instead...
+		// TODO(#390): Log a warning.
+	}
+
+	// Wrap the v1.Layers returned by this v1.Image in a hint for downstream
+	// remote.Write calls to facilitate cross-repo "mounting".
+	imgCore, err := partial.CompressedToImage(d.remoteImage())
+	if err != nil {
+		return nil, err
+	}
+	return &mountableImage{
+		Image:     imgCore,
+		Reference: d.Ref,
+	}, nil
+}
+
+// ImageIndex converts the Descriptor into a v1.ImageIndex.
+func (d *Descriptor) ImageIndex() (v1.ImageIndex, error) {
+	switch d.MediaType {
+	case types.DockerManifestSchema1, types.DockerManifestSchema1Signed:
+		// We don't care to support schema 1 images:
+		// https://github.com/google/go-containerregistry/issues/377
+		return nil, ErrSchema1
+	case types.OCIManifestSchema1, types.DockerManifestSchema2:
+		// We want an index but the registry has an image, nothing we can do.
+		return nil, fmt.Errorf("unexpected media type for ImageIndex(): %s; call Image() instead", d.MediaType)
+	case types.OCIImageIndex, types.DockerManifestList:
+		// These are expected.
+	default:
+		// We could just return an error here, but some registries (e.g. static
+		// registries) don't set the Content-Type headers correctly, so instead...
+		// TODO(#390): Log a warning.
+	}
+	return d.remoteIndex(), nil
+}
+
+func (d *Descriptor) remoteImage() *remoteImage {
+	return &remoteImage{
+		fetcher: fetcher{
+			Ref:    d.Ref,
+			Client: d.Client,
+		},
+		manifest:  d.Manifest,
+		mediaType: d.MediaType,
+	}
+}
+
+func (d *Descriptor) remoteIndex() *remoteIndex {
+	return &remoteIndex{
+		fetcher: fetcher{
+			Ref:    d.Ref,
+			Client: d.Client,
+		},
+		manifest:  d.Manifest,
+		mediaType: d.MediaType,
+	}
+}
+
+// fetcher implements methods for reading from a registry.
+type fetcher struct {
+	Ref    name.Reference
+	Client *http.Client
+}
+
+// url returns a url.Url for the specified path in the context of this remote image reference.
+func (f *fetcher) url(resource, identifier string) url.URL {
+	return url.URL{
+		Scheme: f.Ref.Context().Registry.Scheme(),
+		Host:   f.Ref.Context().RegistryStr(),
+		Path:   fmt.Sprintf("/v2/%s/%s/%s", f.Ref.Context().RepositoryStr(), resource, identifier),
+	}
+}
+
+func (f *fetcher) fetchManifest(ref name.Reference, acceptable []types.MediaType) ([]byte, *v1.Descriptor, error) {
+	u := f.url("manifests", ref.Identifier())
+	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	accept := []string{}
+	for _, mt := range acceptable {
+		accept = append(accept, string(mt))
+	}
+	req.Header.Set("Accept", strings.Join(accept, ","))
+
+	resp, err := f.Client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+
+	if err := transport.CheckError(resp, http.StatusOK); err != nil {
+		return nil, nil, err
+	}
+
+	manifest, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	digest, size, err := v1.SHA256(bytes.NewReader(manifest))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mediaType := types.MediaType(resp.Header.Get("Content-Type"))
+
+	// Validate the digest matches what we asked for, if pulling by digest.
+	if dgst, ok := ref.(name.Digest); ok {
+		if mediaType == types.DockerManifestSchema1Signed {
+			// Digests for this are stupid to calculate, ignore it.
+		} else if digest.String() != dgst.DigestStr() {
+			return nil, nil, fmt.Errorf("manifest digest: %q does not match requested digest: %q for %q", digest, dgst.DigestStr(), f.Ref)
+		}
+	} else {
+		// Do nothing for tags; I give up.
+		//
+		// We'd like to validate that the "Docker-Content-Digest" header matches what is returned by the registry,
+		// but so many registries implement this incorrectly that it's not worth checking.
+		//
+		// For reference:
+		// https://github.com/docker/distribution/issues/2395
+		// https://github.com/GoogleContainerTools/kaniko/issues/298
+	}
+
+	// Return all this info since we have to calculate it anyway.
+	desc := v1.Descriptor{
+		Digest:    digest,
+		Size:      size,
+		MediaType: mediaType,
+	}
+
+	return manifest, &desc, nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/image.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/image.go
@@ -15,16 +15,11 @@
 package remote
 
 import (
-	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"net/url"
-	"strings"
 	"sync"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
@@ -43,129 +38,25 @@ type remoteImage struct {
 	mediaType    types.MediaType
 }
 
-// ImageOption is a functional option for Image.
-type ImageOption func(*imageOpener) error
-
 var _ partial.CompressedImageCore = (*remoteImage)(nil)
-
-type imageOpener struct {
-	auth      authn.Authenticator
-	transport http.RoundTripper
-	ref       name.Reference
-	client    *http.Client
-}
-
-func (i *imageOpener) Open() (v1.Image, error) {
-	tr, err := transport.New(i.ref.Context().Registry, i.auth, i.transport, []string{i.ref.Scope(transport.PullScope)})
-	if err != nil {
-		return nil, err
-	}
-	ri := &remoteImage{
-		fetcher: fetcher{
-			Ref:    i.ref,
-			Client: &http.Client{Transport: tr},
-		},
-	}
-	imgCore, err := partial.CompressedToImage(ri)
-	if err != nil {
-		return imgCore, err
-	}
-	// Wrap the v1.Layers returned by this v1.Image in a hint for downstream
-	// remote.Write calls to facilitate cross-repo "mounting".
-	return &mountableImage{
-		Image:     imgCore,
-		Reference: i.ref,
-	}, nil
-}
 
 // Image provides access to a remote image reference, applying functional options
 // to the underlying imageOpener before resolving the reference into a v1.Image.
 func Image(ref name.Reference, options ...ImageOption) (v1.Image, error) {
-	img := &imageOpener{
-		auth:      authn.Anonymous,
-		transport: http.DefaultTransport,
-		ref:       ref,
+	acceptable := []types.MediaType{
+		types.DockerManifestSchema2,
+		types.OCIManifestSchema1,
+		// We resolve these to images later.
+		types.DockerManifestList,
+		types.OCIImageIndex,
 	}
 
-	for _, option := range options {
-		if err := option(img); err != nil {
-			return nil, err
-		}
-	}
-	return img.Open()
-}
-
-// fetcher implements methods for reading from a remote image.
-type fetcher struct {
-	Ref    name.Reference
-	Client *http.Client
-}
-
-// url returns a url.Url for the specified path in the context of this remote image reference.
-func (f *fetcher) url(resource, identifier string) url.URL {
-	return url.URL{
-		Scheme: f.Ref.Context().Registry.Scheme(),
-		Host:   f.Ref.Context().RegistryStr(),
-		Path:   fmt.Sprintf("/v2/%s/%s/%s", f.Ref.Context().RepositoryStr(), resource, identifier),
-	}
-}
-
-func (f *fetcher) fetchManifest(acceptable []types.MediaType) ([]byte, *v1.Descriptor, error) {
-	u := f.url("manifests", f.Ref.Identifier())
-	req, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	desc, err := get(ref, acceptable, options...)
 	if err != nil {
-		return nil, nil, err
-	}
-	accept := []string{}
-	for _, mt := range acceptable {
-		accept = append(accept, string(mt))
-	}
-	req.Header.Set("Accept", strings.Join(accept, ","))
-
-	resp, err := f.Client.Do(req)
-	if err != nil {
-		return nil, nil, err
-	}
-	defer resp.Body.Close()
-
-	if err := transport.CheckError(resp, http.StatusOK); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	manifest, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	digest, size, err := v1.SHA256(bytes.NewReader(manifest))
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Validate the digest matches what we asked for, if pulling by digest.
-	if dgst, ok := f.Ref.(name.Digest); ok {
-		if digest.String() != dgst.DigestStr() {
-			return nil, nil, fmt.Errorf("manifest digest: %q does not match requested digest: %q for %q", digest, dgst.DigestStr(), f.Ref)
-		}
-	} else {
-		// Do nothing for tags; I give up.
-		//
-		// We'd like to validate that the "Docker-Content-Digest" header matches what is returned by the registry,
-		// but so many registries implement this incorrectly that it's not worth checking.
-		//
-		// For reference:
-		// https://github.com/docker/distribution/issues/2395
-		// https://github.com/GoogleContainerTools/kaniko/issues/298
-	}
-
-	// Return all this info since we have to calculate it anyway.
-	desc := v1.Descriptor{
-		Digest:    digest,
-		Size:      size,
-		MediaType: types.MediaType(resp.Header.Get("Content-Type")),
-	}
-
-	return manifest, &desc, nil
+	return desc.Image()
 }
 
 func (r *remoteImage) MediaType() (types.MediaType, error) {
@@ -175,7 +66,6 @@ func (r *remoteImage) MediaType() (types.MediaType, error) {
 	return types.DockerManifestSchema2, nil
 }
 
-// TODO(jonjohnsonjr): Handle manifest lists.
 func (r *remoteImage) RawManifest() ([]byte, error) {
 	r.manifestLock.Lock()
 	defer r.manifestLock.Unlock()
@@ -183,12 +73,14 @@ func (r *remoteImage) RawManifest() ([]byte, error) {
 		return r.manifest, nil
 	}
 
-	// TODO(jonjohnsonjr): Accept manifest list and image index?
+	// NOTE(jonjohnsonjr): We should never get here because the public entrypoints
+	// do type-checking via remote.Descriptor. I've left this here for tests that
+	// directly instantiate a remoteImage.
 	acceptable := []types.MediaType{
 		types.DockerManifestSchema2,
 		types.OCIManifestSchema1,
 	}
-	manifest, desc, err := r.fetchManifest(acceptable)
+	manifest, desc, err := r.fetchManifest(r.Ref, acceptable)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/index.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/index.go
@@ -17,14 +17,11 @@ package remote
 import (
 	"bytes"
 	"fmt"
-	"net/http"
 	"sync"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
-	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
 
@@ -39,27 +36,17 @@ type remoteIndex struct {
 // Index provides access to a remote index reference, applying functional options
 // to the underlying imageOpener before resolving the reference into a v1.ImageIndex.
 func Index(ref name.Reference, options ...ImageOption) (v1.ImageIndex, error) {
-	i := &imageOpener{
-		auth:      authn.Anonymous,
-		transport: http.DefaultTransport,
-		ref:       ref,
+	acceptable := []types.MediaType{
+		types.DockerManifestList,
+		types.OCIImageIndex,
 	}
 
-	for _, option := range options {
-		if err := option(i); err != nil {
-			return nil, err
-		}
-	}
-	tr, err := transport.New(i.ref.Context().Registry, i.auth, i.transport, []string{i.ref.Scope(transport.PullScope)})
+	desc, err := get(ref, acceptable, options...)
 	if err != nil {
 		return nil, err
 	}
-	return &remoteIndex{
-		fetcher: fetcher{
-			Ref:    i.ref,
-			Client: &http.Client{Transport: tr},
-		},
-	}, nil
+
+	return desc.ImageIndex()
 }
 
 func (r *remoteIndex) MediaType() (types.MediaType, error) {
@@ -80,11 +67,14 @@ func (r *remoteIndex) RawManifest() ([]byte, error) {
 		return r.manifest, nil
 	}
 
+	// NOTE(jonjohnsonjr): We should never get here because the public entrypoints
+	// do type-checking via remote.Descriptor. I've left this here for tests that
+	// directly instantiate a remoteIndex.
 	acceptable := []types.MediaType{
 		types.DockerManifestList,
 		types.OCIImageIndex,
 	}
-	manifest, desc, err := r.fetchManifest(acceptable)
+	manifest, desc, err := r.fetchManifest(r.Ref, acceptable)
 	if err != nil {
 		return nil, err
 	}
@@ -103,37 +93,93 @@ func (r *remoteIndex) IndexManifest() (*v1.IndexManifest, error) {
 }
 
 func (r *remoteIndex) Image(h v1.Hash) (v1.Image, error) {
-	imgRef, err := name.ParseReference(fmt.Sprintf("%s@%s", r.Ref.Context(), h), name.StrictValidation)
+	desc, err := r.childByHash(h)
 	if err != nil {
 		return nil, err
 	}
-	ri := &remoteImage{
-		fetcher: fetcher{
-			Ref:    imgRef,
-			Client: r.Client,
-		},
-	}
-	imgCore, err := partial.CompressedToImage(ri)
-	if err != nil {
-		return imgCore, err
-	}
-	// Wrap the v1.Layers returned by this v1.Image in a hint for downstream
-	// remote.Write calls to facilitate cross-repo "mounting".
-	return &mountableImage{
-		Image:     imgCore,
-		Reference: r.Ref,
-	}, nil
+
+	// Descriptor.Image will handle coercing nested indexes into an Image.
+	return desc.Image()
 }
 
 func (r *remoteIndex) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
-	idxRef, err := name.ParseReference(fmt.Sprintf("%s@%s", r.Ref.Context(), h), name.StrictValidation)
+	desc, err := r.childByHash(h)
 	if err != nil {
 		return nil, err
 	}
-	return &remoteIndex{
+	return desc.ImageIndex()
+}
+
+func (r *remoteIndex) imageByPlatform(platform v1.Platform) (v1.Image, error) {
+	desc, err := r.childByPlatform(platform)
+	if err != nil {
+		return nil, err
+	}
+
+	// Descriptor.Image will handle coercing nested indexes into an Image.
+	return desc.Image()
+}
+
+// This naively matches the first manifest with matching Architecture and OS.
+//
+// We should probably use this instead:
+//	 github.com/containerd/containerd/platforms
+//
+// But first we'd need to migrate to:
+//   github.com/opencontainers/image-spec/specs-go/v1
+func (r *remoteIndex) childByPlatform(platform v1.Platform) (*Descriptor, error) {
+	index, err := r.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+	for _, childDesc := range index.Manifests {
+		// If platform is missing from child descriptor, assume it's amd64/linux.
+		p := defaultPlatform
+		if childDesc.Platform != nil {
+			p = *childDesc.Platform
+		}
+
+		if platform.Architecture == p.Architecture && platform.OS == p.OS {
+			return r.childDescriptor(childDesc, platform)
+		}
+	}
+	return nil, fmt.Errorf("no child with platform %s/%s in index %s", platform.Architecture, platform.OS, r.Ref)
+}
+
+func (r *remoteIndex) childByHash(h v1.Hash) (*Descriptor, error) {
+	index, err := r.IndexManifest()
+	if err != nil {
+		return nil, err
+	}
+	for _, childDesc := range index.Manifests {
+		if h == childDesc.Digest {
+			return r.childDescriptor(childDesc, defaultPlatform)
+		}
+	}
+	return nil, fmt.Errorf("no child with digest %s in index %s", h, r.Ref)
+}
+
+func (r *remoteIndex) childRef(h v1.Hash) (name.Reference, error) {
+	return name.ParseReference(fmt.Sprintf("%s@%s", r.Ref.Context(), h), name.StrictValidation)
+}
+
+// Convert one of this index's child's v1.Descriptor into a remote.Descriptor, with the given platform option.
+func (r *remoteIndex) childDescriptor(child v1.Descriptor, platform v1.Platform) (*Descriptor, error) {
+	ref, err := r.childRef(child.Digest)
+	if err != nil {
+		return nil, err
+	}
+	manifest, desc, err := r.fetchManifest(ref, []types.MediaType{child.MediaType})
+	if err != nil {
+		return nil, err
+	}
+	return &Descriptor{
 		fetcher: fetcher{
-			Ref:    idxRef,
+			Ref:    ref,
 			Client: r.Client,
 		},
+		Manifest:   manifest,
+		Descriptor: *desc,
+		platform:   platform,
 	}, nil
 }

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/remote/options.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/remote/options.go
@@ -19,7 +19,11 @@ import (
 	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/authn"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
+
+// ImageOption is a functional option for Image, index, and Get.
+type ImageOption func(*imageOpener) error
 
 // WithTransport is a functional option for overriding the default transport
 // on a remote image
@@ -51,6 +55,16 @@ func WithAuthFromKeychain(keys authn.Keychain) ImageOption {
 			log.Println("No matching credentials were found, falling back on anonymous")
 		}
 		i.auth = auth
+		return nil
+	}
+}
+
+// WithPlatform is a functional option for overriding the default platform
+// that Image and Descriptor.Image use for resolving an index to an image.
+// The default platform is amd64/linux.
+func WithPlatform(p v1.Platform) ImageOption {
+	return func(i *imageOpener) error {
+		i.platform = p
 		return nil
 	}
 }

--- a/vendor/github.com/google/go-containerregistry/pkg/v1/tarball/layer.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/v1/tarball/layer.go
@@ -15,6 +15,7 @@
 package tarball
 
 import (
+	"bytes"
 	"compress/gzip"
 	"io"
 	"io/ioutil"
@@ -101,6 +102,18 @@ func LayerFromOpener(opener Opener) (v1.Layer, error) {
 		compressed: compressed,
 		opener:     opener,
 	}, nil
+}
+
+// LayerFromReader returns a v1.Layer given a io.Reader.
+func LayerFromReader(reader io.Reader) (v1.Layer, error) {
+	// Buffering due to Opener requiring multiple calls.
+	a, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	return LayerFromOpener(func() (io.ReadCloser, error) {
+		return ioutil.NopCloser(bytes.NewReader(a)), nil
+	})
 }
 
 func computeDigest(opener Opener, compressed bool) (v1.Hash, int64, error) {


### PR DESCRIPTION
This adds support for marking any number of registries as insecure during a skaffold run. When a registry is marked as insecure, skaffold will attempt to push to/pull from it via HTTP instead of HTTPS.

Insecure registries can be provided through any of 3 different ways
* Repeatable CLI flag (--insecure-registry)
* Global config (`skaffold config set insecure-registries <registry>`)
* skaffold.yaml, via the build config stanza:
```yaml
apiVersion: skaffold/v1beta7
kind: Config
build:
  insecureRegistries:
  - registry1
  - registry2
  artifacts:
...
```

Fixes #1732 