### PR TITLE
Add React example app featuring hot module reload

### DIFF
--- a/examples/react-reload/README.adoc
+++ b/examples/react-reload/README.adoc
@@ -1,0 +1,16 @@
+=== Example: React app with hot-reload
+:icons: font
+
+Simple React app demonstrating the file synchronization mode in conjunction with webpack hot module reload.
+
+==== Init
+`skaffold dev`
+
+==== Workflow
+* Make some changes to `HelloWorld.js`:
+** The file will be synchronized to the cluster
+** `webpack` will perform hot module reloading
+* Make some changes to `package.json`:
+** The full build/push/deploy process will be triggered, fetching dependencies from `npm`
+
+

--- a/examples/react-reload/app/.babelrc
+++ b/examples/react-reload/app/.babelrc
@@ -1,0 +1,6 @@
+{
+    "presets": [
+        "@babel/preset-env",
+        "@babel/preset-react"
+    ]
+}

--- a/examples/react-reload/app/.dockerignore
+++ b/examples/react-reload/app/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+*.swp

--- a/examples/react-reload/app/.gitignore
+++ b/examples/react-reload/app/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/examples/react-reload/app/Dockerfile
+++ b/examples/react-reload/app/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:alpine
+
+WORKDIR /app
+COPY package.json ./
+RUN ["npm", "install"]
+
+FROM node:alpine
+
+WORKDIR /app
+
+COPY --from=0 /app/node_modules node_modules
+
+EXPOSE 8080
+CMD ["npm", "run", "dev"]
+
+COPY . .

--- a/examples/react-reload/app/k8s/pod.yaml
+++ b/examples/react-reload/app/k8s/pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: react
+spec:
+  containers:
+  - name: react
+    image: gcr.io/k8s-skaffold/react-reload
+    ports:
+    - containerPort: 8080

--- a/examples/react-reload/app/package.json
+++ b/examples/react-reload/app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "react-reload",
+  "version": "1.0.0",
+  "description": "A React demo application for skaffold",
+  "main": "index.js",
+  "scripts": {
+    "dev": "webpack-dev-server --mode development --hot"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.3.4",
+    "@babel/preset-env": "^7.3.4",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.5",
+    "css-loader": "^2.1.1",
+    "html-webpack-plugin": "^3.2.0",
+    "style-loader": "^0.23.1",
+    "webpack": "^4.29.6",
+    "webpack-cli": "^3.3.0",
+    "webpack-dev-server": "^3.2.1"
+  },
+  "dependencies": {
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
+  },
+  "browserslist": "> 2%, not dead"
+}

--- a/examples/react-reload/app/src/components/HelloWorld.js
+++ b/examples/react-reload/app/src/components/HelloWorld.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import '../styles/HelloWorld.css';
+
+export const HelloWorld = () => (
+	<div>
+		<h1>Hello world!</h1>
+	</div>
+);

--- a/examples/react-reload/app/src/index.html
+++ b/examples/react-reload/app/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>React demo app for skaffold</title>
+</head>
+<body>
+    <div id="root"/>
+</body>
+</html>

--- a/examples/react-reload/app/src/main.js
+++ b/examples/react-reload/app/src/main.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { HelloWorld } from './components/HelloWorld.js';
+
+ReactDOM.render( < HelloWorld/>, document.getElementById( 'root' ) );

--- a/examples/react-reload/app/src/styles/HelloWorld.css
+++ b/examples/react-reload/app/src/styles/HelloWorld.css
@@ -1,0 +1,6 @@
+h1 {
+    color: #27aedb;
+    text-align: center;
+    margin-top: 40vh;
+    font-size: 120pt;
+}

--- a/examples/react-reload/app/webpack.config.js
+++ b/examples/react-reload/app/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require( 'path' );
+const HtmlWebpackPlugin = require( 'html-webpack-plugin' );
+
+module.exports = {
+	entry: './src/main.js',
+	output: {
+		path: path.join( __dirname, '/dist' ),
+		filename: 'main.js'
+	},
+	devServer:{
+		host: '0.0.0.0'
+	},
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				exclude: /node_modules/,
+				use: [ 'babel-loader' ]
+			},
+			{
+				test: /\.css$/,
+				use: [ 'style-loader', 'css-loader' ]
+			}
+		]
+	},
+	plugins: [ new HtmlWebpackPlugin( { template: './src/index.html' } ) ]
+};

--- a/examples/react-reload/skaffold.yaml
+++ b/examples/react-reload/skaffold.yaml
@@ -1,0 +1,13 @@
+apiVersion: skaffold/v1beta7
+kind: Config
+build:
+  artifacts:
+  - image: gcr.io/k8s-skaffold/react-reload
+    context: app
+    sync:
+      'src/components/*': src/components/
+      'src/styles/*': src/styles/
+deploy:
+  kubectl:
+    manifests:
+    - 'app/k8s/**'

--- a/integration/examples/react-reload/README.adoc
+++ b/integration/examples/react-reload/README.adoc
@@ -1,0 +1,16 @@
+=== Example: React app with hot-reload
+:icons: font
+
+Simple React app demonstrating the file synchronization mode in conjunction with webpack hot module reload.
+
+==== Init
+`skaffold dev`
+
+==== Workflow
+* Make some changes to `HelloWorld.js`:
+** The file will be synchronized to the cluster
+** `webpack` will perform hot module reloading
+* Make some changes to `package.json`:
+** The full build/push/deploy process will be triggered, fetching dependencies from `npm`
+
+

--- a/integration/examples/react-reload/app/.babelrc
+++ b/integration/examples/react-reload/app/.babelrc
@@ -1,0 +1,6 @@
+{
+    "presets": [
+        "@babel/preset-env",
+        "@babel/preset-react"
+    ]
+}

--- a/integration/examples/react-reload/app/.dockerignore
+++ b/integration/examples/react-reload/app/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+*.swp

--- a/integration/examples/react-reload/app/.gitignore
+++ b/integration/examples/react-reload/app/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/integration/examples/react-reload/app/Dockerfile
+++ b/integration/examples/react-reload/app/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:alpine
+
+WORKDIR /app
+COPY package.json ./
+RUN ["npm", "install"]
+
+FROM node:alpine
+
+WORKDIR /app
+
+COPY --from=0 /app/node_modules node_modules
+
+EXPOSE 8080
+CMD ["npm", "run", "dev"]
+
+COPY . .

--- a/integration/examples/react-reload/app/k8s/pod.yaml
+++ b/integration/examples/react-reload/app/k8s/pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: react
+spec:
+  containers:
+  - name: react
+    image: gcr.io/k8s-skaffold/react-reload
+    ports:
+    - containerPort: 8080

--- a/integration/examples/react-reload/app/package.json
+++ b/integration/examples/react-reload/app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "react-reload",
+  "version": "1.0.0",
+  "description": "A React demo application for skaffold",
+  "main": "index.js",
+  "scripts": {
+    "dev": "webpack-dev-server --mode development --hot"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.3.4",
+    "@babel/preset-env": "^7.3.4",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.5",
+    "css-loader": "^2.1.1",
+    "html-webpack-plugin": "^3.2.0",
+    "style-loader": "^0.23.1",
+    "webpack": "^4.29.6",
+    "webpack-cli": "^3.3.0",
+    "webpack-dev-server": "^3.2.1"
+  },
+  "dependencies": {
+    "react": "^16.8.4",
+    "react-dom": "^16.8.4"
+  },
+  "browserslist": "> 2%, not dead"
+}

--- a/integration/examples/react-reload/app/src/components/HelloWorld.js
+++ b/integration/examples/react-reload/app/src/components/HelloWorld.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import '../styles/HelloWorld.css';
+
+export const HelloWorld = () => (
+	<div>
+		<h1>Hello world!</h1>
+	</div>
+);

--- a/integration/examples/react-reload/app/src/index.html
+++ b/integration/examples/react-reload/app/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>React demo app for skaffold</title>
+</head>
+<body>
+    <div id="root"/>
+</body>
+</html>

--- a/integration/examples/react-reload/app/src/main.js
+++ b/integration/examples/react-reload/app/src/main.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { HelloWorld } from './components/HelloWorld.js';
+
+ReactDOM.render( < HelloWorld/>, document.getElementById( 'root' ) );

--- a/integration/examples/react-reload/app/src/styles/HelloWorld.css
+++ b/integration/examples/react-reload/app/src/styles/HelloWorld.css
@@ -1,0 +1,6 @@
+h1 {
+    color: #27aedb;
+    text-align: center;
+    margin-top: 40vh;
+    font-size: 120pt;
+}

--- a/integration/examples/react-reload/app/webpack.config.js
+++ b/integration/examples/react-reload/app/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require( 'path' );
+const HtmlWebpackPlugin = require( 'html-webpack-plugin' );
+
+module.exports = {
+	entry: './src/main.js',
+	output: {
+		path: path.join( __dirname, '/dist' ),
+		filename: 'main.js'
+	},
+	devServer:{
+		host: '0.0.0.0'
+	},
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				exclude: /node_modules/,
+				use: [ 'babel-loader' ]
+			},
+			{
+				test: /\.css$/,
+				use: [ 'style-loader', 'css-loader' ]
+			}
+		]
+	},
+	plugins: [ new HtmlWebpackPlugin( { template: './src/index.html' } ) ]
+};

--- a/integration/examples/react-reload/skaffold.yaml
+++ b/integration/examples/react-reload/skaffold.yaml
@@ -1,0 +1,13 @@
+apiVersion: skaffold/v1beta7
+kind: Config
+build:
+  artifacts:
+  - image: gcr.io/k8s-skaffold/react-reload
+    context: app
+    sync:
+      'src/components/*': src/components/
+      'src/styles/*': src/styles/
+deploy:
+  kubectl:
+    manifests:
+    - 'app/k8s/**'


### PR DESCRIPTION
Close #1173

I checked that hot module reloading is working with version v0.25.0. In other words, I cannot reproduce #1640 with this example.

Note that the sync spec quickly becomes unwieldy with many subfolders. #1812 and #1813 should fix this when merged.