### PR TITLE
Improve test coverage

### DIFF
--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -44,27 +44,6 @@ type from struct {
 // RetrieveImage is overridden for unit testing
 var RetrieveImage = retrieveImage
 
-func ValidateDockerfile(path string) bool {
-	f, err := os.Open(path)
-	if err != nil {
-		logrus.Warnf("opening file %s: %s", path, err.Error())
-		return false
-	}
-	res, err := parser.Parse(f)
-	if err != nil || res == nil || len(res.AST.Children) == 0 {
-		return false
-	}
-	// validate each node contains valid dockerfile directive
-	for _, child := range res.AST.Children {
-		_, ok := command.Commands[child.Value]
-		if !ok {
-			return false
-		}
-	}
-
-	return true
-}
-
 func expandBuildArgs(nodes []*parser.Node, buildArgs map[string]*string) {
 	for i, node := range nodes {
 		if node.Value != command.Arg {

--- a/pkg/skaffold/docker/validate.go
+++ b/pkg/skaffold/docker/validate.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"os"
+
+	"github.com/moby/buildkit/frontend/dockerfile/command"
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+	"github.com/sirupsen/logrus"
+)
+
+// ValidateDockerfile makes sure the given Dockerfile is
+// existing and valid.
+func ValidateDockerfile(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		logrus.Warnf("opening file %s: %s", path, err.Error())
+		return false
+	}
+
+	res, err := parser.Parse(f)
+	if err != nil || res == nil || len(res.AST.Children) == 0 {
+		return false
+	}
+
+	// validate each node contains valid dockerfile directive
+	for _, child := range res.AST.Children {
+		_, ok := command.Commands[child.Value]
+		if !ok {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/skaffold/docker/validate_test.go
+++ b/pkg/skaffold/docker/validate_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestValidateDockerfile(t *testing.T) {
+	var tests = []struct {
+		description    string
+		content        string
+		fileToValidate string
+		expectedValid  bool
+	}{
+		{
+			description:    "valid",
+			content:        "FROM scratch",
+			fileToValidate: "Dockerfile",
+			expectedValid:  true,
+		},
+		{
+			description:    "invalid command",
+			content:        "GARBAGE",
+			fileToValidate: "Dockerfile",
+			expectedValid:  false,
+		},
+		{
+			description:    "not found",
+			fileToValidate: "Unknown",
+			expectedValid:  false,
+		},
+		{
+			description:    "invalid file",
+			content:        "#escape",
+			fileToValidate: "Dockerfile",
+			expectedValid:  false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			tmp, delete := testutil.NewTempDir(t)
+			defer delete()
+
+			tmp.Write("Dockerfile", test.content)
+
+			valid := ValidateDockerfile(tmp.Path(test.fileToValidate))
+
+			testutil.CheckDeepEqual(t, test.expectedValid, valid)
+		})
+	}
+}

--- a/pkg/skaffold/plugin/environments/gcb/desc_test.go
+++ b/pkg/skaffold/plugin/environments/gcb/desc_test.go
@@ -37,3 +37,14 @@ func TestBuildBazelDescriptionFail(t *testing.T) {
 
 	testutil.CheckError(t, true, err)
 }
+
+func TestBuildUnknownDescriptionFail(t *testing.T) {
+	artifact := &latest.Artifact{}
+
+	builder := Builder{
+		GoogleCloudBuild: &latest.GoogleCloudBuild{},
+	}
+	_, err := builder.buildDescription(artifact, "tag", "bucket", "object")
+
+	testutil.CheckError(t, true, err)
+}

--- a/pkg/skaffold/plugin/environments/gcb/jib_test.go
+++ b/pkg/skaffold/plugin/environments/gcb/jib_test.go
@@ -33,7 +33,11 @@ func TestJibMavenBuildSteps(t *testing.T) {
 		{true, []string{"--non-recursive", "-DskipTests=true", "prepare-package", "jib:dockerBuild", "-Dimage=img"}},
 	}
 	for _, tt := range testCases {
-		artifact := &latest.JibMavenArtifact{}
+		artifact := &latest.Artifact{
+			ArtifactType: latest.ArtifactType{
+				JibMavenArtifact: &latest.JibMavenArtifact{},
+			},
+		}
 
 		builder := Builder{
 			GoogleCloudBuild: &latest.GoogleCloudBuild{
@@ -41,7 +45,9 @@ func TestJibMavenBuildSteps(t *testing.T) {
 			},
 			skipTests: tt.skipTests,
 		}
-		steps := builder.jibMavenBuildSteps(artifact, "img")
+
+		steps, err := builder.buildSteps(artifact, []string{"img"})
+		testutil.CheckError(t, false, err)
 
 		expected := []*cloudbuild.BuildStep{{
 			Name: "maven:3.6.0",
@@ -61,7 +67,11 @@ func TestJibGradleBuildSteps(t *testing.T) {
 		{true, []string{":jibDockerBuild", "--image=img", "-x", "test"}},
 	}
 	for _, tt := range testCases {
-		artifact := &latest.JibGradleArtifact{}
+		artifact := &latest.Artifact{
+			ArtifactType: latest.ArtifactType{
+				JibGradleArtifact: &latest.JibGradleArtifact{},
+			},
+		}
 
 		builder := Builder{
 			GoogleCloudBuild: &latest.GoogleCloudBuild{
@@ -69,7 +79,9 @@ func TestJibGradleBuildSteps(t *testing.T) {
 			},
 			skipTests: tt.skipTests,
 		}
-		steps := builder.jibGradleBuildSteps(artifact, "img")
+
+		steps, err := builder.buildSteps(artifact, []string{"img"})
+		testutil.CheckError(t, false, err)
 
 		expected := []*cloudbuild.BuildStep{{
 			Name: "gradle:5.1.1",

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ GREEN='\033[0;32m'
 RESET='\033[0m'
 
 echo "Running go tests..."
-go test -count=1 -race -cover -short -timeout=60s -coverprofile=out/coverage.txt -covermode=atomic ./... | awk -v FAIL="${RED}FAIL${RESET}" '! /no test files/ { gsub("FAIL", FAIL, $0); print $0 }'
+go test -count=1 -race -cover -short -timeout=60s -coverprofile=out/coverage.txt ./... | awk -v FAIL="${RED}FAIL${RESET}" '! /no test files/ { gsub("FAIL", FAIL, $0); print $0 }'
 
 GO_TEST_EXIT_CODE=${PIPESTATUS[0]}
 if [[ $GO_TEST_EXIT_CODE -ne 0 ]]; then

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,7 @@ GREEN='\033[0;32m'
 RESET='\033[0m'
 
 echo "Running go tests..."
-go test -count=1 -race -cover -short -timeout=60s -coverprofile=out/coverage.txt ./... | awk -v FAIL="${RED}FAIL${RESET}" '! /no test files/ { gsub("FAIL", FAIL, $0); print $0 }'
+go test -count=1 -race -cover -short -timeout=60s -coverprofile=out/coverage.txt -coverpkg="./pkg/...,./cmd/..." ./... | awk -v FAIL="${RED}FAIL${RESET}" '! /no test files/ { gsub("FAIL", FAIL, $0); print $0 }'
 
 GO_TEST_EXIT_CODE=${PIPESTATUS[0]}
 if [[ $GO_TEST_EXIT_CODE -ne 0 ]]; then

--- a/test.sh
+++ b/test.sh
@@ -21,7 +21,8 @@ GREEN='\033[0;32m'
 RESET='\033[0m'
 
 echo "Running go tests..."
-go test -count=1 -race -cover -short -timeout 60s -coverprofile=out/coverage.txt -covermode=atomic ./... | grep -v 'no test files' | sed ''/PASS/s//$(printf "${GREEN}PASS${RESET}")/'' | sed ''/FAIL/s//$(printf "${RED}FAIL${RESET}")/''
+go test -count=1 -race -cover -short -timeout=60s -coverprofile=out/coverage.txt -covermode=atomic ./... | awk -v FAIL="${RED}FAIL${RESET}" '! /no test files/ { gsub("FAIL", FAIL, $0); print $0 }'
+
 GO_TEST_EXIT_CODE=${PIPESTATUS[0]}
 if [[ $GO_TEST_EXIT_CODE -ne 0 ]]; then
     exit $GO_TEST_EXIT_CODE


### PR DESCRIPTION
This improves the coverage of a few pieces of code.

It also configures `go test` so that test coverage is counted on every package, not the package that the test belongs to. This should show our real test coverage.