### PR TITLE
Fix skaffold build templating output and add tests

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -98,15 +98,15 @@ func runBuild(out io.Writer) error {
 
 func createRunnerAndBuild(ctx context.Context, buildOut io.Writer) ([]build.Artifact, error) {
 	runner, config, err := newRunner(opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating runner")
+	}
+	defer runner.RPCServerShutdown()
 	var targetArtifacts []*latest.Artifact
 	for _, artifact := range config.Build.Artifacts {
 		if runner.IsTargetImage(artifact) {
 			targetArtifacts = append(targetArtifacts, artifact)
 		}
 	}
-	if err != nil {
-		return nil, errors.Wrap(err, "creating runner")
-	}
-	defer runner.RPCServerShutdown()
 	return runner.BuildAndTest(ctx, buildOut, targetArtifacts)
 }

--- a/cmd/skaffold/app/cmd/build_test.go
+++ b/cmd/skaffold/app/cmd/build_test.go
@@ -30,17 +30,17 @@ import (
 )
 
 func TestQuietFlag(t *testing.T) {
-	mockCreateRunner := func(c context.Context, buildOut io.Writer) ([]build.Artifact, error) {
+	mockCreateRunner := func(context.Context, io.Writer) ([]build.Artifact, error) {
 		return []build.Artifact{{
 			ImageName: "gcr.io/skaffold/example",
 			Tag:       "test",
 		}}, nil
 	}
 
-	orginalCreateRunner := createRunnerAndBuildFunc
-	defer func(f func(c context.Context, buildOut io.Writer) ([]build.Artifact, error)) {
+	defer func(f func(context.Context, io.Writer) ([]build.Artifact, error)) {
 		createRunnerAndBuildFunc = f
-	}(orginalCreateRunner)
+	}(createRunnerAndBuildFunc)
+
 	var tests = []struct {
 		description    string
 		template       string
@@ -87,19 +87,18 @@ func TestQuietFlag(t *testing.T) {
 }
 
 func TestRunBuild(t *testing.T) {
-	errRunner := func(c context.Context, buildOut io.Writer) ([]build.Artifact, error) {
+	errRunner := func(context.Context, io.Writer) ([]build.Artifact, error) {
 		return nil, errors.New("some error")
 	}
-	mockCreateRunner := func(c context.Context, buildOut io.Writer) ([]build.Artifact, error) {
+	mockCreateRunner := func(context.Context, io.Writer) ([]build.Artifact, error) {
 		return []build.Artifact{{
 			ImageName: "gcr.io/skaffold/example",
 			Tag:       "test",
 		}}, nil
 	}
-	orginalCreateRunner := createRunnerAndBuildFunc
-	defer func(f func(c context.Context, buildOut io.Writer) ([]build.Artifact, error)) {
+	defer func(f func(context.Context, io.Writer) ([]build.Artifact, error)) {
 		createRunnerAndBuildFunc = f
-	}(orginalCreateRunner)
+	}(createRunnerAndBuildFunc)
 
 	var tests = []struct {
 		description string

--- a/cmd/skaffold/app/cmd/build_test.go
+++ b/cmd/skaffold/app/cmd/build_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestQuietFlag(t *testing.T) {
+	mockCreateRunner := func(buildOut io.Writer) ([]build.Artifact, error) {
+		return []build.Artifact{{
+			ImageName: "gcr.io/skaffold/example",
+			Tag:       "test",
+		}}, nil
+	}
+
+	orginalCreateRunner := createRunnerAndBuildFunc
+	defer func(c func(buildOut io.Writer) ([]build.Artifact, error)) { createRunnerAndBuildFunc = c }(orginalCreateRunner)
+	var tests = []struct {
+		name           string
+		template       string
+		expectedOutput []byte
+		mock           func(io.Writer) ([]build.Artifact, error)
+		shdErr         bool
+	}{
+		{
+			name:           "quiet flag print build images with no template",
+			expectedOutput: []byte("gcr.io/skaffold/example -> test\n"),
+			shdErr:         false,
+			mock:           mockCreateRunner,
+		},
+		{
+			name:           "quiet flag print build images applies pattern specified in template ",
+			template:       "{{.}}",
+			expectedOutput: []byte("{[{gcr.io/skaffold/example test}]}"),
+			shdErr:         false,
+			mock:           mockCreateRunner,
+		},
+		{
+			name:           "build errors out when incorrect template specified",
+			template:       "{{.Incorrect}}",
+			expectedOutput: nil,
+			shdErr:         true,
+			mock:           mockCreateRunner,
+		},
+	}
+
+	for _, test := range tests {
+		quietFlag = true
+		if test.template != "" {
+			buildFormatFlag = flags.NewTemplateFlag(test.template, BuildOutput{})
+		}
+		createRunnerAndBuildFunc = test.mock
+		var output bytes.Buffer
+		err := runBuild(&output)
+		testutil.CheckErrorAndDeepEqual(t, test.shdErr, err, string(test.expectedOutput), output.String())
+	}
+}
+
+func TestRunBuild(t *testing.T) {
+	mockCreateRunner := func(buildOut io.Writer) ([]build.Artifact, error) {
+		return []build.Artifact{{
+			ImageName: "gcr.io/skaffold/example",
+			Tag:       "test",
+		}}, nil
+	}
+	errRunner := func(buildOut io.Writer) ([]build.Artifact, error) {
+		return nil, errors.New("some error")
+	}
+
+	orginalCreateRunner := createRunnerAndBuildFunc
+	defer func(c func(buildOut io.Writer) ([]build.Artifact, error)) { createRunnerAndBuildFunc = c }(orginalCreateRunner)
+
+	var tests = []struct {
+		name   string
+		mock   func(io.Writer) ([]build.Artifact, error)
+		shdErr bool
+	}{
+		{
+			name:   "buod should return successfully when runner is successful.",
+			shdErr: false,
+			mock:   mockCreateRunner,
+		},
+		{
+			name:   "build errors out when there was runner error.",
+			shdErr: true,
+			mock:   errRunner,
+		},
+	}
+	for _, test := range tests {
+		createRunnerAndBuildFunc = test.mock
+		err := runBuild(ioutil.Discard)
+		testutil.CheckError(t, test.shdErr, err)
+	}
+
+}

--- a/cmd/skaffold/app/cmd/build_test.go
+++ b/cmd/skaffold/app/cmd/build_test.go
@@ -69,9 +69,11 @@ func TestQuietFlag(t *testing.T) {
 
 	for _, test := range tests {
 		quietFlag = true
+		defer func() { quietFlag = false }()
 		if test.template != "" {
 			buildFormatFlag = flags.NewTemplateFlag(test.template, BuildOutput{})
 		}
+		defer func() { buildFormatFlag = nil }()
 		createRunnerAndBuildFunc = test.mock
 		var output bytes.Buffer
 		err := runBuild(&output)

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -70,10 +70,10 @@ Flags:
       --enable-rpc skaffold dev      Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
   -f, --filename string              Filename or URL to the pipeline file (default "skaffold.yaml")
   -n, --namespace string             Run deployments in the specified namespace
-  -o, --output *flags.TemplateFlag   Format output with go-template. For full struct documentation, see https://godoc.org/github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd#BuildOutput (default {{range .Builds}}{{.ImageName}} -> {{.Tag}}
+  -o, --output *flags.TemplateFlag   Used in conjuction with --quiet flag. Format output with go-template. For full struct documentation, see https://godoc.org/github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd#BuildOutput (default {{range .Builds}}{{.ImageName}} -> {{.Tag}}
                                      {{end}})
   -p, --profile stringArray          Activate profiles by name
-  -q, --quiet                        Suppress the build output and print image built on success
+  -q, --quiet                        Suppress the build output and print image built on success. See --output to format output.
       --rpc-http-port int            tcp port to expose event REST API over HTTP (default 50052)
       --rpc-port int                 tcp port to expose event API (default 50051)
       --skip-tests                   Whether to skip the tests after building

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -70,8 +70,7 @@ Flags:
       --enable-rpc skaffold dev      Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
   -f, --filename string              Filename or URL to the pipeline file (default "skaffold.yaml")
   -n, --namespace string             Run deployments in the specified namespace
-  -o, --output *flags.TemplateFlag   Used in conjuction with --quiet flag. Format output with go-template. For full struct documentation, see https://godoc.org/github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd#BuildOutput (default {{range .Builds}}{{.ImageName}} -> {{.Tag}}
-                                     {{end}})
+  -o, --output *flags.TemplateFlag   Used in conjuction with --quiet flag. Format output with go-template. For full struct documentation, see https://godoc.org/github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd#BuildOutput (default {{.}})
   -p, --profile stringArray          Activate profiles by name
   -q, --quiet                        Suppress the build output and print image built on success. See --output to format output.
       --rpc-http-port int            tcp port to expose event REST API over HTTP (default 50052)

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -72,7 +72,7 @@ Flags:
   -n, --namespace string             Run deployments in the specified namespace
   -o, --output *flags.TemplateFlag   Used in conjuction with --quiet flag. Format output with go-template. For full struct documentation, see https://godoc.org/github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd#BuildOutput (default {{.}})
   -p, --profile stringArray          Activate profiles by name
-  -q, --quiet                        Suppress the build output and print image built on success. See --output to format output.
+  -q, --quiet                        Suppress the build output and print image built on success. See --output to format output. 
       --rpc-http-port int            tcp port to expose event REST API over HTTP (default 50052)
       --rpc-port int                 tcp port to expose event API (default 50051)
       --skip-tests                   Whether to skip the tests after building


### PR DESCRIPTION
fixes #1839 

In this commit

- Add better description on flags so its clear, `skaffold build -o` is only useful with --quiet.
- suppress "Complete in " line with --quiet flag so that  `skaffold build --quiet > build.out` output can consumed to by `skaffold deploy` to correctly parse and construct a build.Artifacts object.
- Refactor runBuild to move creating a runner and actually building artifacts to another function, so it can be mocked in tests.
- add tests for --quiet flag and make sure output is as expected when a template is specified vs when its not.
- change default template to "{{.}}"