### PR TITLE
removing unnecessary exit from plugin processes

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -22,6 +22,8 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/hashicorp/go-plugin"
+
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
@@ -66,6 +68,7 @@ func runBuild(out io.Writer) error {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	defer plugin.CleanupClients()
 	catchCtrlC(cancel)
 
 	runner, config, err := newRunner(opts)

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/hashicorp/go-plugin"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
@@ -97,7 +99,6 @@ func dev(out io.Writer, ui bool) error {
 			if err != nil {
 				return errors.Wrap(err, "creating runner")
 			}
-			defer r.RPCServerShutdown()
 
 			err = r.Dev(ctx, output, config.Build.Artifacts)
 			if r.HasDeployed() {
@@ -109,9 +110,13 @@ func dev(out io.Writer, ui bool) error {
 			}
 			if err != nil {
 				if errors.Cause(err) != runner.ErrorConfigurationChanged {
+					plugin.CleanupClients()
+					r.RPCServerShutdown()
 					return err
 				}
 			}
+			plugin.CleanupClients()
+			r.RPCServerShutdown()
 		}
 	}
 }

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
+	plugin "github.com/hashicorp/go-plugin"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -49,6 +50,7 @@ func NewCmdRun(out io.Writer) *cobra.Command {
 
 func run(out io.Writer) error {
 	ctx, cancel := context.WithCancel(context.Background())
+	defer plugin.CleanupClients()
 	defer cancel()
 	catchCtrlC(cancel)
 

--- a/cmd/skaffold/app/skaffold.go
+++ b/cmd/skaffold/app/skaffold.go
@@ -23,11 +23,14 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/plugin"
 )
 
-func Run(out, err io.Writer) error {
-	if plugin.ShouldExecuteCorePlugin() {
-		return plugin.Execute()
+func Run(out, stderr io.Writer) error {
+	corePlugin, err := plugin.GetCorePluginFromEnv()
+	if err != nil {
+		return err
 	}
-
-	c := cmd.NewSkaffoldCommand(out, err)
+	if corePlugin != "" {
+		return plugin.Execute(corePlugin)
+	}
+	c := cmd.NewSkaffoldCommand(out, stderr)
 	return c.Execute()
 }

--- a/pkg/skaffold/plugin/builders/bazel/bazel.go
+++ b/pkg/skaffold/plugin/builders/bazel/bazel.go
@@ -17,25 +17,27 @@ limitations under the License.
 package bazel
 
 import (
-	pkgplugin "github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/plugin"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/plugin/shared"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
 )
 
 // Execute an image build with docker
-func Execute() error {
-	// pluginMap is the map of plugins we can dispense.
-	var pluginMap = map[string]plugin.Plugin{
-		"bazel": &shared.BuilderPlugin{Impl: NewBuilder()},
-	}
+func Execute(pluginLogLevel hclog.Level) func() error {
+	return func() error {
+		// pluginMap is the map of plugins we can dispense.
+		var pluginMap = map[string]plugin.Plugin{
+			"bazel": &shared.BuilderPlugin{Impl: NewBuilder()},
+		}
 
-	plugin.Serve(&plugin.ServeConfig{
-		Logger: hclog.New(&hclog.LoggerOptions{
-			Level: pkgplugin.DefaultPluginLogLevel,
-		}),
-		HandshakeConfig: shared.Handshake,
-		Plugins:         pluginMap,
-	})
-	return nil
+		plugin.Serve(&plugin.ServeConfig{
+			Logger: hclog.New(&hclog.LoggerOptions{
+				Level: pluginLogLevel,
+			}),
+			HandshakeConfig: shared.Handshake,
+			Plugins:         pluginMap,
+		})
+
+		return nil
+	}
 }

--- a/pkg/skaffold/plugin/builders/bazel/bazel.go
+++ b/pkg/skaffold/plugin/builders/bazel/bazel.go
@@ -17,8 +17,10 @@ limitations under the License.
 package bazel
 
 import (
+	pkgplugin "github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/plugin"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/plugin/shared"
-	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-plugin"
 )
 
 // Execute an image build with docker
@@ -29,6 +31,9 @@ func Execute() error {
 	}
 
 	plugin.Serve(&plugin.ServeConfig{
+		Logger: hclog.New(&hclog.LoggerOptions{
+			Level: pkgplugin.DefaultPluginLogLevel,
+		}),
 		HandshakeConfig: shared.Handshake,
 		Plugins:         pluginMap,
 	})

--- a/pkg/skaffold/plugin/builders/docker/docker.go
+++ b/pkg/skaffold/plugin/builders/docker/docker.go
@@ -17,25 +17,27 @@ limitations under the License.
 package docker
 
 import (
-	pkgplugin "github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/plugin"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/plugin/shared"
 	"github.com/hashicorp/go-hclog"
-	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/go-plugin"
 )
 
 // Execute an image build with docker
-func Execute() error {
-	// pluginMap is the map of plugins we can dispense.
-	var pluginMap = map[string]plugin.Plugin{
-		"docker": &shared.BuilderPlugin{Impl: NewBuilder()},
-	}
+func Execute(pluginLogLevel hclog.Level) func() error {
+	return func() error {
+		// pluginMap is the map of plugins we can dispense.
+		var pluginMap = map[string]plugin.Plugin{
+			"docker": &shared.BuilderPlugin{Impl: NewBuilder()},
+		}
 
-	plugin.Serve(&plugin.ServeConfig{
-		Logger: hclog.New(&hclog.LoggerOptions{
-			Level: pkgplugin.DefaultPluginLogLevel,
-		}),
-		HandshakeConfig: shared.Handshake,
-		Plugins:         pluginMap,
-	})
-	return nil
+		plugin.Serve(&plugin.ServeConfig{
+			Logger: hclog.New(&hclog.LoggerOptions{
+				Level: pluginLogLevel,
+			}),
+			HandshakeConfig: shared.Handshake,
+			Plugins:         pluginMap,
+		})
+
+		return nil
+	}
 }

--- a/pkg/skaffold/plugin/builders/docker/docker.go
+++ b/pkg/skaffold/plugin/builders/docker/docker.go
@@ -17,7 +17,9 @@ limitations under the License.
 package docker
 
 import (
+	pkgplugin "github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/plugin"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/plugin/shared"
+	"github.com/hashicorp/go-hclog"
 	plugin "github.com/hashicorp/go-plugin"
 )
 
@@ -29,6 +31,9 @@ func Execute() error {
 	}
 
 	plugin.Serve(&plugin.ServeConfig{
+		Logger: hclog.New(&hclog.LoggerOptions{
+			Level: pkgplugin.DefaultPluginLogLevel,
+		}),
 		HandshakeConfig: shared.Handshake,
 		Plugins:         pluginMap,
 	})


### PR DESCRIPTION
We thought that the default warning message means something is wrong when we saw it by default from hashicorps go-plugin after a Ctrl+C signal is received: 

```
{"@level":"debug","@message":"plugin received interrupt signal, ignoring","@timestamp":"2019-03-20T16:40:56.592099-07:00","count":1}
2019-03-20T16:40:56.593-0700 [DEBUG] plugin.skaffold: plugin received interrupt signal, ignoring: count=1 timestamp=2019-03-20T16:40:56.592-0700

```

It turns out it behaves exactly what it needs to: it swallows the signal and ignores it - leaving the chance for the main process to cleanup. 

The `plugins.CleanupPlugins()` call should be called from the main process which is now implemented there. 

The logging level for plugins can be configured via the `DefaultPluginLogLevel` that is now set to `Info` instead of `Debug`. A follow-up PR could be to get this from an environment variable that the main process sets for the plugin to set the same level of debugging as the main process. 