### PR TITLE
Don't expose ports to the outside and fix a race condition

### DIFF
--- a/pkg/skaffold/event/server.go
+++ b/pkg/skaffold/event/server.go
@@ -25,14 +25,13 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/proto"
+	gw "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/proto"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	empty "github.com/golang/protobuf/ptypes/empty"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-
-	gw "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/proto"
 )
 
 type server struct{}
@@ -93,7 +92,7 @@ func newStatusServer(originalRPCPort, originalHTTPPort int) (func() error, error
 }
 
 func newGRPCServer(port int) (func() error, error) {
-	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", util.Loopback, port))
 	if err != nil {
 		return func() error { return nil }, errors.Wrap(err, "creating listener")
 	}
@@ -116,12 +115,12 @@ func newGRPCServer(port int) (func() error, error) {
 func newHTTPServer(port, proxyPort int) (func() error, error) {
 	mux := runtime.NewServeMux()
 	opts := []grpc.DialOption{grpc.WithInsecure()}
-	err := gw.RegisterSkaffoldServiceHandlerFromEndpoint(context.Background(), mux, fmt.Sprintf("127.0.0.1:%d", proxyPort), opts)
+	err := gw.RegisterSkaffoldServiceHandlerFromEndpoint(context.Background(), mux, fmt.Sprintf("%s:%d", util.Loopback, proxyPort), opts)
 	if err != nil {
 		return func() error { return nil }, err
 	}
 
-	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", util.Loopback, port))
 	if err != nil {
 		return func() error { return nil }, errors.Wrap(err, "creating listener")
 	}

--- a/pkg/skaffold/event/server.go
+++ b/pkg/skaffold/event/server.go
@@ -93,7 +93,7 @@ func newStatusServer(originalRPCPort, originalHTTPPort int) (func() error, error
 }
 
 func newGRPCServer(port int) (func() error, error) {
-	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		return func() error { return nil }, errors.Wrap(err, "creating listener")
 	}
@@ -116,12 +116,12 @@ func newGRPCServer(port int) (func() error, error) {
 func newHTTPServer(port, proxyPort int) (func() error, error) {
 	mux := runtime.NewServeMux()
 	opts := []grpc.DialOption{grpc.WithInsecure()}
-	err := gw.RegisterSkaffoldServiceHandlerFromEndpoint(context.Background(), mux, fmt.Sprintf(":%d", proxyPort), opts)
+	err := gw.RegisterSkaffoldServiceHandlerFromEndpoint(context.Background(), mux, fmt.Sprintf("127.0.0.1:%d", proxyPort), opts)
 	if err != nil {
 		return func() error { return nil }, err
 	}
 
-	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		return func() error { return nil }, errors.Wrap(err, "creating listener")
 	}

--- a/pkg/skaffold/util/port.go
+++ b/pkg/skaffold/util/port.go
@@ -24,6 +24,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Loopback network address. Skaffold should not bind to 0.0.0.0
+// unless we really want to expose something to the network.
+const Loopback = "127.0.0.1"
+
 // First, check if the provided port is available. If so, use it.
 // If not, check if any of the next 10 subsequent ports are available.
 // If not, check if any of ports 4503-4533 are available.
@@ -50,7 +54,7 @@ func GetAvailablePort(port int, forwardedPorts *sync.Map) int {
 		}
 	}
 
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	l, err := net.Listen("tcp", fmt.Sprintf("%s:0", Loopback))
 	if err != nil {
 		return -1
 	}
@@ -68,7 +72,7 @@ func getPortIfAvailable(p int, forwardedPorts *sync.Map) bool {
 		return false
 	}
 
-	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", p))
+	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", Loopback, p))
 	if err != nil {
 		return false
 	}

--- a/pkg/skaffold/util/port.go
+++ b/pkg/skaffold/util/port.go
@@ -53,7 +53,7 @@ func GetAvailablePort(port int, forwardedPorts *sync.Map) int {
 		}
 	}
 
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if l != nil {
 		l.Close()
 	}
@@ -69,7 +69,7 @@ func isPortAvailable(p int, forwardedPorts *sync.Map) bool {
 	if _, ok := forwardedPorts.Load(p); ok {
 		return false
 	}
-	l, err := net.Listen("tcp", fmt.Sprintf(":%d", p))
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", p))
 	if l != nil {
 		defer l.Close()
 	}

--- a/pkg/skaffold/util/port_test.go
+++ b/pkg/skaffold/util/port_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+)
+
+func TestGetAvailablePort(t *testing.T) {
+	var ports sync.Map
+
+	port := GetAvailablePort(4503, &ports)
+
+	l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("Unable to listen on port that is supposed to be available: %d", port)
+	}
+	l.Close()
+}

--- a/pkg/skaffold/util/port_test.go
+++ b/pkg/skaffold/util/port_test.go
@@ -38,7 +38,7 @@ func TestGetAvailablePort(t *testing.T) {
 		go func() {
 			port := GetAvailablePort(4503, &ports)
 
-			l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+			l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", Loopback, port))
 			if err != nil {
 				atomic.AddInt32(&errors, 1)
 			} else {


### PR DESCRIPTION
Ports used for eventing shouldn't be exposed to the outside world. Also this removed an alert on OSX each time a port needs to be opened on the firewall.

I also took the opportunity to fix a race condition where a port could be said available when it is not.