### PR TITLE
Enhance hack/check-samples script

### DIFF
--- a/hack/check-samples.sh
+++ b/hack/check-samples.sh
@@ -21,6 +21,7 @@ INTEGRATION_EXAMPLES=$(find integration/examples -mindepth 1 -maxdepth 1 -type d
 
 if [[ "${EXAMPLES}" != "${INTEGRATION_EXAMPLES}" ]]; then
   echo "Every code sample that is in ./examples should also be in ./integration/examples"
+  diff <(printf "examples:\n${EXAMPLES}" ) <(printf "integration/examples:\n${INTEGRATION_EXAMPLES}")
   exit 1
 fi
 


### PR DESCRIPTION
Why?
Some of the files in the examples directory could be ignored by
git e.g. integration/examples/jib-multimodule/target if developers
.gitconfig ignore target dir everywhere.

Since this script does a file comparison, debugging failures in such
situation takes times.

To verify on this branch run:
```
 mkdir integration/examples/hack_script_check
touch integration/examples/hack_script_check/foo
./hack/check-samples.sh 
Every code sample that is in ./examples should also be in ./integration/examples
1c1
< examples:
---
> integration/examples:
4a5
> hack_script_check

```