### PR TITLE
fixing logs for plugins

### DIFF
--- a/pkg/skaffold/build/plugin/core.go
+++ b/pkg/skaffold/build/plugin/core.go
@@ -18,22 +18,21 @@ package plugin
 
 import (
 	"fmt"
-	"os"
-
+	"github.com/GoogleContainerTools/skaffold/integration/examples/bazel/bazel-bazel/external/go_sdk/src/strconv"
 	"github.com/hashicorp/go-hclog"
+	"os"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/plugin/builders/bazel"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/plugin/builders/docker"
 )
 
-//TODO(this should be rather wired through an env var from the skaffold process)
 const DefaultPluginLogLevel = hclog.Info
 
 // SkaffoldCorePluginExecutionMap maps the core plugin name to the execution function
-var SkaffoldCorePluginExecutionMap = map[string]func() error{
-	"docker": docker.Execute(DefaultPluginLogLevel),
-	"bazel":  bazel.Execute(DefaultPluginLogLevel),
+var SkaffoldCorePluginExecutionMap = map[string]func(level hclog.Level) error{
+	"docker": docker.Execute,
+	"bazel":  bazel.Execute,
 }
 
 // GetCorePluginFromEnv returns the core plugin name if env variables for plugins are set properly
@@ -51,5 +50,14 @@ func GetCorePluginFromEnv() (string, error) {
 
 // Execute executes a plugin - does not validate
 func Execute(plugin string) error {
-	return SkaffoldCorePluginExecutionMap[plugin]()
+	return SkaffoldCorePluginExecutionMap[plugin](logLevel())
+}
+
+func logLevel() hclog.Level {
+	logLevel := DefaultPluginLogLevel
+	level, err := strconv.Atoi(os.Getenv(constants.SkaffoldPluginLogLevel))
+	if err == nil {
+		logLevel = hclog.Level(level)
+	}
+	return logLevel
 }

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -70,6 +70,7 @@ const (
 	SkaffoldPluginKey       = "SKAFFOLD_PLUGIN_KEY"
 	SkaffoldPluginValue     = "1337"
 	SkaffoldPluginName      = "SKAFFOLD_PLUGIN_NAME"
+	SkaffoldPluginLogLevel  = "SKAFFOLD_PLUGIN_LOGLEVEL"
 	DockerBuilderPluginName = "docker"
 
 	DefaultRPCPort     = 50051

--- a/pkg/skaffold/plugin/builders/bazel/bazel.go
+++ b/pkg/skaffold/plugin/builders/bazel/bazel.go
@@ -23,8 +23,7 @@ import (
 )
 
 // Execute an image build with docker
-func Execute(pluginLogLevel hclog.Level) func() error {
-	return func() error {
+func Execute(pluginLogLevel hclog.Level) error {
 		// pluginMap is the map of plugins we can dispense.
 		var pluginMap = map[string]plugin.Plugin{
 			"bazel": &shared.BuilderPlugin{Impl: NewBuilder()},
@@ -39,5 +38,4 @@ func Execute(pluginLogLevel hclog.Level) func() error {
 		})
 
 		return nil
-	}
 }

--- a/pkg/skaffold/plugin/builders/docker/docker.go
+++ b/pkg/skaffold/plugin/builders/docker/docker.go
@@ -23,8 +23,7 @@ import (
 )
 
 // Execute an image build with docker
-func Execute(pluginLogLevel hclog.Level) func() error {
-	return func() error {
+func Execute(pluginLogLevel hclog.Level) error {
 		// pluginMap is the map of plugins we can dispense.
 		var pluginMap = map[string]plugin.Plugin{
 			"docker": &shared.BuilderPlugin{Impl: NewBuilder()},
@@ -39,5 +38,4 @@ func Execute(pluginLogLevel hclog.Level) func() error {
 		})
 
 		return nil
-	}
 }

--- a/vendor/github.com/hashicorp/go-plugin/rpc_server.go
+++ b/vendor/github.com/hashicorp/go-plugin/rpc_server.go
@@ -45,7 +45,10 @@ func (s *RPCServer) Serve(lis net.Listener) {
 	for {
 		conn, err := lis.Accept()
 		if err != nil {
-			log.Printf("[ERR] plugin: plugin server: %s", err)
+			//vendor-patch: removing unneccessary noise
+			//this happens currently when the Client is closed gracefully
+
+			//log.Printf("[ERR] plugin: plugin server: %s", err)
 			return
 		}
 


### PR DESCRIPTION
- the logging for plugins can now take an env var 
- I found a very annoying thing in hashicorp/go-plugin: https://github.com/hashicorp/go-plugin/issues/72 - so I added a [vendor patch](https://github.com/GoogleContainerTools/skaffold/compare/master...balopat:fix_plugin_logging?expand=1#diff-875bc989767973182d8a9e1faf2bf0c7L48) to remove the bogus error message...
- found a bunch of issues with Event API closing handling - this makes it better.

comments are welcome what to cherry-pick out of this PR. 