### PR TITLE
Tail logs for init containers

### DIFF
--- a/pkg/skaffold/kubernetes/log.go
+++ b/pkg/skaffold/kubernetes/log.go
@@ -104,7 +104,7 @@ func (a *LogAggregator) Start(ctx context.Context) error {
 					continue
 				}
 
-				for _, container := range pod.Status.ContainerStatuses {
+				for _, container := range append(pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses...) {
 					if container.ContainerID == "" {
 						if container.State.Waiting != nil && container.State.Waiting.Message != "" {
 							color.Red.Fprintln(a.output, container.State.Waiting.Message)


### PR DESCRIPTION
This PR makes output for init containers to be tailed together with the rest of the containers in the pods. So far these logs were being ignored. 