### PR TITLE
[ DRAFT] Add two new flag types and Inputfilepath, Outputfilepath

### DIFF
--- a/cmd/skaffold/app/flags/filepath.go
+++ b/cmd/skaffold/app/flags/filepath.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"os"
+)
+
+type filepathFlag struct {
+	path        string
+	shouldExist bool
+}
+
+func (f *filepathFlag) SetIfValid(value string) error {
+	copy := f
+	copy.path = value
+	if err := copy.isValid(); err != nil {
+		return err
+	}
+	f = copy
+	return nil
+}
+
+func newFilepathFlag(value string, exists bool) filepathFlag {
+	return filepathFlag{
+		path:        value,
+		shouldExist: exists,
+	}
+}
+
+func (f filepathFlag) isValid() error {
+	if !f.shouldExist {
+		// Currently no validation implemented for output files.
+		return nil
+	}
+	if _, err := os.Stat(f.path); os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/cmd/skaffold/app/flags/filepath.go
+++ b/cmd/skaffold/app/flags/filepath.go
@@ -26,20 +26,13 @@ type filepathFlag struct {
 }
 
 func (f *filepathFlag) SetIfValid(value string) error {
-	copy := f
+	copy := *f
 	copy.path = value
 	if err := copy.isValid(); err != nil {
 		return err
 	}
-	f = copy
+	*f = copy
 	return nil
-}
-
-func newFilepathFlag(value string, exists bool) filepathFlag {
-	return filepathFlag{
-		path:        value,
-		shouldExist: exists,
-	}
 }
 
 func (f filepathFlag) isValid() error {

--- a/cmd/skaffold/app/flags/filepath.go
+++ b/cmd/skaffold/app/flags/filepath.go
@@ -26,12 +26,12 @@ type filepathFlag struct {
 }
 
 func (f *filepathFlag) SetIfValid(value string) error {
-	copy := *f
-	copy.path = value
-	if err := copy.isValid(); err != nil {
+	clone := *f
+	clone.path = value
+	if err := clone.isValid(); err != nil {
 		return err
 	}
-	*f = copy
+	*f = clone
 	return nil
 }
 

--- a/cmd/skaffold/app/flags/inputfilepath.go
+++ b/cmd/skaffold/app/flags/inputfilepath.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"fmt"
+)
+
+// InputFilepath represents a input file command line argument
+// InputFilepath type makes sure the file exists.
+type InputFilepath struct {
+	filepathFlag
+}
+
+func NewInputFilepath(value string) *InputFilepath {
+	return &InputFilepath{
+		filepathFlag{
+			path:        value,
+			shouldExist: true,
+		}}
+}
+
+func (f *InputFilepath) Usage() string {
+	return "Path to an input file."
+}
+
+func (f *InputFilepath) Type() string {
+	return fmt.Sprintf("%T", f)
+}
+
+func (f *InputFilepath) Set(value string) error {
+	return f.SetIfValid(value)
+}
+
+func (f *InputFilepath) String() string {
+	return f.path
+}

--- a/cmd/skaffold/app/flags/inputfilepath.go
+++ b/cmd/skaffold/app/flags/inputfilepath.go
@@ -24,18 +24,21 @@ import (
 // InputFilepath type makes sure the file exists.
 type InputFilepath struct {
 	filepathFlag
+	usage string
 }
 
-func NewInputFilepath(value string) *InputFilepath {
+func NewInputFilepath(value string, usage string) *InputFilepath {
 	return &InputFilepath{
-		filepathFlag{
+		filepathFlag: filepathFlag{
 			path:        value,
 			shouldExist: true,
-		}}
+		},
+		usage: usage,
+	}
 }
 
 func (f *InputFilepath) Usage() string {
-	return "Path to an input file."
+	return f.usage
 }
 
 func (f *InputFilepath) Type() string {

--- a/cmd/skaffold/app/flags/inputfilepath_test.go
+++ b/cmd/skaffold/app/flags/inputfilepath_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestNewInputFile(t *testing.T) {
+	flag := NewInputFilepath("test.in")
+	expectedFlag := InputFilepath{filepathFlag{
+		path:        "test.in",
+		shouldExist: true,
+	}}
+	if *flag != expectedFlag {
+		t.Errorf("expected %s, actual %s", &expectedFlag, flag)
+	}
+}
+
+func TestInputFileFlagSet(t *testing.T) {
+	dir, cleanUp := testutil.NewTempDir(t)
+	defer cleanUp()
+	filename := "exists.in"
+	dir.Write(filename, "some input")
+
+	var tests = []struct {
+		description string
+		filename    string
+		shouldErr   bool
+	}{
+		{
+			description: "should not error when file is present",
+			filename:    dir.Path(filename),
+		},
+		{
+			description: "should error when file is present",
+			filename:    "does_not_exist.in",
+			shouldErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		flag := NewInputFilepath("")
+		err := flag.Set(test.filename)
+		expectedFlag := NewInputFilepath(test.filename)
+		testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, expectedFlag.String(), flag.String())
+	}
+}
+
+func TestInputFilepathType(t *testing.T) {
+	flag := NewInputFilepath("test.in")
+	expectedFlagType := "*flags.InputFilepath"
+	if flag.Type() != expectedFlagType {
+		t.Errorf("Flag returned wrong type. Expected %s, Actual %s", expectedFlagType, flag.Type())
+	}
+}

--- a/cmd/skaffold/app/flags/inputfilepath_test.go
+++ b/cmd/skaffold/app/flags/inputfilepath_test.go
@@ -41,24 +41,27 @@ func TestInputFileFlagSet(t *testing.T) {
 
 	var tests = []struct {
 		description string
-		filename    string
+		setValue    string
 		shouldErr   bool
 	}{
 		{
-			description: "should not error when file is present",
-			filename:    dir.Path(filename),
+			description: "set should not error when file is present and new flag set",
+			setValue:    dir.Path(filename),
 		},
 		{
-			description: "should error when file is present",
-			filename:    "does_not_exist.in",
+			description: "set should error when file is not present with original flag value",
+			setValue:    "does_not_exist.in",
 			shouldErr:   true,
 		},
 	}
 
 	for _, test := range tests {
 		flag := NewInputFilepath("")
-		err := flag.Set(test.filename)
-		expectedFlag := NewInputFilepath(test.filename)
+		err := flag.Set(test.setValue)
+		expectedFlag := flag
+		if !test.shouldErr {
+			expectedFlag = NewInputFilepath(test.setValue)
+		}
 		testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, expectedFlag.String(), flag.String())
 	}
 }

--- a/cmd/skaffold/app/flags/inputfilepath_test.go
+++ b/cmd/skaffold/app/flags/inputfilepath_test.go
@@ -23,11 +23,14 @@ import (
 )
 
 func TestNewInputFile(t *testing.T) {
-	flag := NewInputFilepath("test.in")
-	expectedFlag := InputFilepath{filepathFlag{
-		path:        "test.in",
-		shouldExist: true,
-	}}
+	flag := NewInputFilepath("test.in", "test input file")
+	expectedFlag := InputFilepath{
+		filepathFlag: filepathFlag{
+			path:        "test.in",
+			shouldExist: true,
+		},
+		usage: "test input file",
+	}
 	if *flag != expectedFlag {
 		t.Errorf("expected %s, actual %s", &expectedFlag, flag)
 	}
@@ -56,18 +59,18 @@ func TestInputFileFlagSet(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		flag := NewInputFilepath("")
+		flag := NewInputFilepath("", "")
 		err := flag.Set(test.setValue)
 		expectedFlag := flag
 		if !test.shouldErr {
-			expectedFlag = NewInputFilepath(test.setValue)
+			expectedFlag = NewInputFilepath(test.setValue, "")
 		}
 		testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, expectedFlag.String(), flag.String())
 	}
 }
 
 func TestInputFilepathType(t *testing.T) {
-	flag := NewInputFilepath("test.in")
+	flag := NewInputFilepath("test.in", "")
 	expectedFlagType := "*flags.InputFilepath"
 	if flag.Type() != expectedFlagType {
 		t.Errorf("Flag returned wrong type. Expected %s, Actual %s", expectedFlagType, flag.Type())

--- a/cmd/skaffold/app/flags/outputfilepath.go
+++ b/cmd/skaffold/app/flags/outputfilepath.go
@@ -24,20 +24,24 @@ import (
 // OutputFilepath currently does not provide any validation.
 type OutputFilepath struct {
 	filepathFlag
+	usage string
 }
 
-func NewOutputFilepath(value string) *OutputFilepath {
-	return &OutputFilepath{filepathFlag{
-		path: value,
-	}}
+func NewOutputFilepath(value string, usage string) *OutputFilepath {
+	return &OutputFilepath{
+		filepathFlag: filepathFlag{
+			path: value,
+		},
+		usage: usage,
+	}
+}
+
+func (f *OutputFilepath) Usage() string {
+	return f.usage
 }
 
 func (f *OutputFilepath) Type() string {
 	return fmt.Sprintf("%T", f)
-}
-
-func (f *OutputFilepath) Usage() string {
-	return "Path to an output filepath."
 }
 
 func (f *OutputFilepath) Set(value string) error {

--- a/cmd/skaffold/app/flags/outputfilepath.go
+++ b/cmd/skaffold/app/flags/outputfilepath.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"fmt"
+)
+
+// OutputFilepath represents a output file command line argument.
+// OutputFilepath currently does not provide any validation.
+type OutputFilepath struct {
+	filepathFlag
+}
+
+func NewOutputFilepath(value string) *OutputFilepath {
+	return &OutputFilepath{filepathFlag{
+		path: value,
+	}}
+}
+
+func (f *OutputFilepath) Type() string {
+	return fmt.Sprintf("%T", f)
+}
+
+func (f *OutputFilepath) Usage() string {
+	return "Path to an output filepath."
+}
+
+func (f *OutputFilepath) Set(value string) error {
+	return f.SetIfValid(value)
+}
+
+func (f *OutputFilepath) String() string {
+	return f.path
+}

--- a/cmd/skaffold/app/flags/outputfilepath_test.go
+++ b/cmd/skaffold/app/flags/outputfilepath_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"testing"
+)
+
+func TestNewOutputFilepathType(t *testing.T) {
+	flag := NewOutputFilepath("test.out")
+	expectedFlag := OutputFilepath{filepathFlag{
+		path: "test.out",
+	}}
+	if *flag != expectedFlag {
+		t.Errorf("expected %s, actual %s", &expectedFlag, flag)
+	}
+}
+
+func TestOutputFileFlagSet(t *testing.T) {
+	flag := NewOutputFilepath("")
+	if err := flag.Set("test.out"); err != nil {
+		t.Errorf("Error setting flag value: %s", err)
+	}
+}

--- a/cmd/skaffold/app/flags/outputfilepath_test.go
+++ b/cmd/skaffold/app/flags/outputfilepath_test.go
@@ -21,17 +21,20 @@ import (
 )
 
 func TestNewOutputFilepathType(t *testing.T) {
-	flag := NewOutputFilepath("test.out")
-	expectedFlag := OutputFilepath{filepathFlag{
-		path: "test.out",
-	}}
+	flag := NewOutputFilepath("test.out", "test output file")
+	expectedFlag := OutputFilepath{
+		filepathFlag: filepathFlag{
+			path: "test.out",
+		},
+		usage: "test output file",
+	}
 	if *flag != expectedFlag {
 		t.Errorf("expected %s, actual %s", &expectedFlag, flag)
 	}
 }
 
 func TestOutputFileFlagSet(t *testing.T) {
-	flag := NewOutputFilepath("")
+	flag := NewOutputFilepath("", "")
 	if err := flag.Set("test.out"); err != nil {
 		t.Errorf("Error setting flag value: %s", err)
 	}


### PR DESCRIPTION
 Add two new flags, Inputfilepath, Outputfilepath
    1. Inputfilepath:
            Inputfilepath flag, makes sure the file present exists.
    2. Outputfilepath:
            Outputfilepath flag does not do any validation right now.
    
Motivation:
For, #922 I am going to add `--build-output` as new flag to `skaffold build` to
 dump all artifacts built with with their tags.
    
Similarly, the deploy will have additional flag `--build-artifacts` which will point to the output written by `skaffold build --build-output <file>`
   
 The Inputfilepath, can also be used to replace all the places where we
 expect an input file without repeating validation.
    
    ```
    (add_flag_to_deploy)$ git grep 'Filename or URL to the pipeline'
    cmd/skaffold/app/cmd/cmd.go:    cmd.Flags().StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
    cmd/skaffold/app/cmd/diagnose.go:       cmd.Flags().StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
    cmd/skaffold/app/cmd/fix.go:    cmd.Flags().StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
    cmd/skaffold/app/cmd/init.go:   cmd.Flags().StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
    ```

TODO
1. What validation for outputfile path?
1.  Find all flag which expect to read to write file and replace them with these new files ( will done in a follow up Pr)

