### PR TITLE
removing goroutine leak

### DIFF
--- a/pkg/skaffold/watch/triggers.go
+++ b/pkg/skaffold/watch/triggers.go
@@ -83,6 +83,7 @@ func (t *pollTrigger) Start(ctx context.Context) (<-chan bool, error) {
 				trigger <- true
 			case <-ctx.Done():
 				ticker.Stop()
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
Fixes #1867. 

We should add goroutine leak detection to our tests!  

It looks like this fix ran 7 times here without an issue - hopefully it will get up to 10: https://travis-ci.org/GoogleContainerTools/skaffold/builds/510176794
Before, this broke on the first 4 trials. 
