### PR TITLE
Add folders to tarballs

### DIFF
--- a/pkg/skaffold/util/tar.go
+++ b/pkg/skaffold/util/tar.go
@@ -93,6 +93,16 @@ func addFileToTar(root string, src string, dst string, tw *tar.Writer) error {
 		return err
 	}
 	switch mode := fi.Mode(); {
+	case mode.IsDir():
+		tarHeader, err := tar.FileInfoHeader(fi, tarPath)
+		if err != nil {
+			return err
+		}
+		tarHeader.Name = tarPath
+
+		if err := tw.WriteHeader(tarHeader); err != nil {
+			return err
+		}
 	case mode.IsRegular():
 		tarHeader, err := tar.FileInfoHeader(fi, tarPath)
 		if err != nil {
@@ -103,6 +113,7 @@ func addFileToTar(root string, src string, dst string, tw *tar.Writer) error {
 		if err := tw.WriteHeader(tarHeader); err != nil {
 			return err
 		}
+
 		f, err := os.Open(absPath)
 		if err != nil {
 			return err

--- a/pkg/skaffold/util/tar_test.go
+++ b/pkg/skaffold/util/tar_test.go
@@ -108,6 +108,37 @@ func TestCreateTarSubDirectory(t *testing.T) {
 	testutil.CheckErrorAndDeepEqual(t, false, err, files, tarFiles)
 }
 
+func TestCreateTarEmptyFolder(t *testing.T) {
+	tmpDir, cleanup := testutil.NewTempDir(t)
+	defer cleanup()
+
+	tmpDir.Mkdir("empty")
+
+	reset := testutil.Chdir(t, tmpDir.Root())
+	defer reset()
+
+	var b bytes.Buffer
+	err := CreateTar(&b, ".", []string{"empty"})
+	testutil.CheckError(t, false, err)
+
+	// Make sure the contents match.
+	var tarFolders []string
+	tr := tar.NewReader(&b)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		testutil.CheckError(t, false, err)
+
+		if hdr.FileInfo().IsDir() {
+			tarFolders = append(tarFolders, hdr.Name)
+		}
+	}
+
+	testutil.CheckErrorAndDeepEqual(t, false, err, []string{"empty"}, tarFolders)
+}
+
 func TestCreateTarWithAbsolutePaths(t *testing.T) {
 	tmpDir, cleanup := testutil.NewTempDir(t)
 	defer cleanup()


### PR DESCRIPTION
If `CreateTar` is passed a folder, it shouldn't complain. The code currently complains on Jib projects built with GCB because Jib list folders as dependencies.

Signed-off-by: David Gageot <david@gageot.net>