### PR TITLE
Remove docs check from test Makefile target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
 script:
   - make out/skaffold
   - make test
+  - make check-docs
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -189,3 +189,7 @@ build-docs-preview:
 .PHONY: generate-schemas
 generate-schemas:
 	go run hack/schemas/main.go
+
+.PHONY: check-docs
+check-docs: $(BUILD_DIR)
+	@ ./hack/check-docs.sh

--- a/hack/check-cli.sh
+++ b/hack/check-cli.sh
@@ -17,9 +17,9 @@
 cp docs/content/en/docs/references/cli/index_header docs/content/en/docs/references/cli/_index.md
 go run cmd/skaffold/man/man.go >> docs/content/en/docs/references/cli/_index.md
 
-readonly DOCS_CHANGES=`git diff --name-status master | grep "docs/" | wc -l`
+readonly CLI_CHANGES=`git status -s | grep "docs/" | wc -l`
 
-if [ $DOCS_CHANGES -gt 0 ]; then
-  echo "There are $DOCS_CHANGES changes in docs, testing site generation..."
-  make build-docs-preview
+if [ $CLI_CHANGES -gt 0 ]; then
+  echo "You have skaffold command changes; CLI reference docs should have just been generated. Make sure to commit the results!"
+  exit 1
 fi

--- a/test.sh
+++ b/test.sh
@@ -35,6 +35,7 @@ scripts=(
     "hack/linter.sh"
     "hack/dep.sh"
     "hack/check-samples.sh"
+    "hack/check-cli.sh"
 )
 fail=0
 for s in "${scripts[@]}"; do

--- a/test.sh
+++ b/test.sh
@@ -35,7 +35,6 @@ scripts=(
     "hack/linter.sh"
     "hack/dep.sh"
     "hack/check-samples.sh"
-    "hack/check-docs.sh"
 )
 fail=0
 for s in "${scripts[@]}"; do


### PR DESCRIPTION
This significantly shortens the amount of time it takes to run `make test` locally. The docs check will be done by travis.