### PR TITLE
Improve manual installation instruction for windows

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Issues without logs and details are more complicated to fix.
   Please help us by filling the template below!
 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,20 @@
 # v0.25.0 Release - 3/15/2019
 
-*Note*: This release comes with a new config version `v1beta7`. 
-        To upgrade your `skaffold.yaml`, use `skaffold fix`. If you don't upgrade, skaffold will auto-upgrade in memory as best it can, and print a warning message. 
+*Note*: This release comes with a new config version `v1beta7`.
+        To upgrade your `skaffold.yaml`, use `skaffold fix`. If you don't upgrade, skaffold will auto-upgrade in memory as best it can, and print a warning message.
         See [deprecation-policy.md](/deprecation-policy.md) for details on what beta means.
 
 
 *Deprecation notice*: With this release we mark for deprecation the `flags` (KanikoArtifact.AdditionalFlags) field in kaniko; instead Kaniko's additional flags will now be represented as unique fields under `kaniko` per artifact (`KanikoArtifact` type).
-This flag will be removed earliest 06/15/2019. 
+This flag will be removed earliest 06/15/2019.
 
-New features: 
+New features:
 
 * Config upgrade: handle helm overrides [#1646](https://github.com/GoogleContainerTools/skaffold/pull/1646)
 * Enable custom InitContainer image in LocalDir build of kaniko [#1727](https://github.com/GoogleContainerTools/skaffold/pull/1727)
 * Add --analyze flag to skaffold init [#1725](https://github.com/GoogleContainerTools/skaffold/pull/1725)
 
-Fixes: 
+Fixes:
 
 * Initialize Artifact.Workspace to "." by default in plugin case too [#1804](https://github.com/GoogleContainerTools/skaffold/pull/1804)
 * Fix race conditions and run tests with a race detector [#1801](https://github.com/GoogleContainerTools/skaffold/pull/1801)
@@ -72,7 +72,7 @@ Docs updates:
 * Updated Install section [#1716](https://github.com/GoogleContainerTools/skaffold/pull/1716)
 
 
-Huge thanks goes out to all of our contributors for this release: 
+Huge thanks goes out to all of our contributors for this release:
 
 - Balint Pato
 - Chanseok Oh
@@ -91,8 +91,8 @@ Huge thanks goes out to all of our contributors for this release:
 
 # v0.24.0 Release - 3/1/2019
 
-*Note*: This release comes with a new config version `v1beta6`. 
-To upgrade your `skaffold.yaml`, use `skaffold fix`. If you don't upgrade, skaffold will auto-upgrade in memory as best it can, and print a warning message. 
+*Note*: This release comes with a new config version `v1beta6`.
+To upgrade your `skaffold.yaml`, use `skaffold fix`. If you don't upgrade, skaffold will auto-upgrade in memory as best it can, and print a warning message.
 See [deprecation-policy.md](/deprecation-policy.md) for details on what beta means.
 
 New Features:
@@ -130,7 +130,7 @@ Docs updates:
 * Improve documentation [#1713](https://github.com/GoogleContainerTools/skaffold/pull/1713)
 * Improve docs [#1682](https://github.com/GoogleContainerTools/skaffold/pull/1682)
 
-Huge thanks goes out to all of our contributors for this release: 
+Huge thanks goes out to all of our contributors for this release:
 
 - Balint Pato
 - Brian de Alwis
@@ -144,16 +144,16 @@ Huge thanks goes out to all of our contributors for this release:
 
 # v0.23.0 Release - 2/14/2019
 
-*Note*: This release comes with a new config version `v1beta5`. 
-        To upgrade your `skaffold.yaml`, use `skaffold fix`. If you don't upgrade, skaffold will auto-upgrade in memory as best it can, and print a warning message. 
+*Note*: This release comes with a new config version `v1beta5`.
+        To upgrade your `skaffold.yaml`, use `skaffold fix`. If you don't upgrade, skaffold will auto-upgrade in memory as best it can, and print a warning message.
         See [deprecation-policy.md](/deprecation-policy.md) for details on what beta means.
 
 *Deprecation notice*: With this release we mark for deprecation the following env variables in the `envTemplate` tagger:
 - `DIGEST`
 - `DIGEST_ALGO`
-- `DIGEST_HEX` 
-Currently these variables resolve to `_DEPRECATED_<envvar>_`, and the new tagging mechanism adds a digest to the image name thus it shouldn't break existing configurations. 
-This backward compatibility behavior will be removed earliest 05/14/2019. 
+- `DIGEST_HEX`
+Currently these variables resolve to `_DEPRECATED_<envvar>_`, and the new tagging mechanism adds a digest to the image name thus it shouldn't break existing configurations.
+This backward compatibility behavior will be removed earliest 05/14/2019.
 
 New features:
 * Builder plugin for docker in GCB [#1577](https://github.com/GoogleContainerTools/skaffold/pull/1577)
@@ -193,7 +193,7 @@ Updates & refactorings:
 * Add missing tests for build/sequence.go [#1575](https://github.com/GoogleContainerTools/skaffold/pull/1575)
 * Extract yaml used in documentation into files [#1593](https://github.com/GoogleContainerTools/skaffold/pull/1593)
 
-Docs updates: 
+Docs updates:
 * Improve comments and schema [#1652](https://github.com/GoogleContainerTools/skaffold/pull/1652)
 * Add `required` tags [#1642](https://github.com/GoogleContainerTools/skaffold/pull/1642)
 * Add more comments to the Config structs [#1630](https://github.com/GoogleContainerTools/skaffold/pull/1630)
@@ -202,7 +202,7 @@ Docs updates:
 * Fix DEVELOPMENT.md fragment [#1576](https://github.com/GoogleContainerTools/skaffold/pull/1576)
 * Improve the Skaffold.dev documentation [#1579](https://github.com/GoogleContainerTools/skaffold/pull/1579)
 
-Huge thanks goes out to all of our contributors for this release: 
+Huge thanks goes out to all of our contributors for this release:
 
 - Balint Pato
 - Brian de Alwis
@@ -217,25 +217,25 @@ Huge thanks goes out to all of our contributors for this release:
 
 # v0.22.0 Release - 1/31/2019
 
-*Note*: This release comes with a new config version `v1beta4`. 
-        To upgrade your `skaffold.yaml`, use `skaffold fix`. If you don't upgrade, skaffold will auto-upgrade in memory as best it can, and print a warning message. 
+*Note*: This release comes with a new config version `v1beta4`.
+        To upgrade your `skaffold.yaml`, use `skaffold fix`. If you don't upgrade, skaffold will auto-upgrade in memory as best it can, and print a warning message.
         See [deprecation-policy.md](/deprecation-policy.md) for details on what beta means.
 
-New features: 
+New features:
 * Introduce configuration option to configure image pushing per kube-context [#1355](https://github.com/GoogleContainerTools/skaffold/pull/1355)
 * Better support for docker build with a target [#1497](https://github.com/GoogleContainerTools/skaffold/pull/1497)
 * Reintroduce the fsNotify trigger [#1562](https://github.com/GoogleContainerTools/skaffold/pull/1562)
 * Add zsh completion [#1531](https://github.com/GoogleContainerTools/skaffold/pull/1531)
 * `#296` Support remote helm chart repositories [#1254](https://github.com/GoogleContainerTools/skaffold/pull/1254)
 
-Fixes: 
+Fixes:
 * Fix bug in port forwarding [#1529](https://github.com/GoogleContainerTools/skaffold/pull/1529)
 * Fix doc for Kustomize deploy: path option [#1527](https://github.com/GoogleContainerTools/skaffold/pull/1527)
 * Fix broken links in Getting Started [#1523](https://github.com/GoogleContainerTools/skaffold/pull/1523)
 * Use configured namespace for pod watcher. [#1473](https://github.com/GoogleContainerTools/skaffold/pull/1473)
 * Pass DOCKER* env variables for jib to connect to minikube [#1505](https://github.com/GoogleContainerTools/skaffold/pull/1505)
 
-Updates & Refactorings: 
+Updates & Refactorings:
 * Upgrade to jib 1.0.0 [#1512](https://github.com/GoogleContainerTools/skaffold/pull/1512)
 * Don’t use local Docker to push Bazel images [#1493](https://github.com/GoogleContainerTools/skaffold/pull/1493)
 * Use kubectl to read the manifests [#1451](https://github.com/GoogleContainerTools/skaffold/pull/1451)
@@ -245,7 +245,7 @@ Updates & Refactorings:
 * Improve triggers [#1561](https://github.com/GoogleContainerTools/skaffold/pull/1561)
 * Add tests for labels package [#1534](https://github.com/GoogleContainerTools/skaffold/pull/1534)
 
-Docs updates: 
+Docs updates:
 * Fix skaffold.dev indexing on Google [#1547](https://github.com/GoogleContainerTools/skaffold/pull/1547)
 * 2019 roadmap [#1530](https://github.com/GoogleContainerTools/skaffold/pull/1530)
 * Should be v1beta3 [#1515](https://github.com/GoogleContainerTools/skaffold/pull/1515)
@@ -254,7 +254,7 @@ Docs updates:
 * Add Priya as a maintainer [#1542](https://github.com/GoogleContainerTools/skaffold/pull/1542)
 * Note JVM flags specific to Java 8 in examples/jib [#1563](https://github.com/GoogleContainerTools/skaffold/pull/1563)
 
-Huge thanks goes out to all of our contributors for this release: 
+Huge thanks goes out to all of our contributors for this release:
 
 - Balint Pato
 - Brian de Alwis
@@ -297,7 +297,7 @@ Docs updates:
 * Update doc around local development [#1446](https://github.com/GoogleContainerTools/skaffold/pull/1446)
 * [doc] Fix default value for manifests [#1485](https://github.com/GoogleContainerTools/skaffold/pull/1485)
 
-Huge thanks goes out to all of our contributors for this release: 
+Huge thanks goes out to all of our contributors for this release:
 
 - David Gageot
 - Nick Kubala
@@ -307,8 +307,8 @@ Huge thanks goes out to all of our contributors for this release:
 
 # v0.21.0 Release - 1/17/2019
 
-*Note*: This release comes with a new config version `v1beta3`. 
-        To upgrade your `skaffold.yaml`, use `skaffold fix`. If you don't upgrade, skaffold will auto-upgrade in memory as best it can, and print a warning message. 
+*Note*: This release comes with a new config version `v1beta3`.
+        To upgrade your `skaffold.yaml`, use `skaffold fix`. If you don't upgrade, skaffold will auto-upgrade in memory as best it can, and print a warning message.
         See [deprecation-policy.md](/deprecation-policy.md) for details on what beta means.
 
 New Features:
@@ -381,15 +381,15 @@ Huge thank you for this release towards our contributors:
 
 # v0.20.0 Release - 12/21/2018
 
-*Note*: This release comes with a new config version `v1beta2`. 
-        To upgrade your `skaffold.yaml`, use `skaffold fix`. If you don't upgrade, skaffold will auto-upgrade in memory as best it can, and print a warning message. 
+*Note*: This release comes with a new config version `v1beta2`.
+        To upgrade your `skaffold.yaml`, use `skaffold fix`. If you don't upgrade, skaffold will auto-upgrade in memory as best it can, and print a warning message.
         See [deprecation-policy.md](/deprecation-policy.md) for details on what beta means.
 
-New Features: 
+New Features:
 
 * Add additional flags to kaniko builder [#1387](https://github.com/GoogleContainerTools/skaffold/pull/1387)
 
-Fixes: 
+Fixes:
 
 * Omit empty strings in jib sections of the config [#1399](https://github.com/GoogleContainerTools/skaffold/pull/1399)
 * Don’t panic if image field is not of type string [#1386](https://github.com/GoogleContainerTools/skaffold/pull/1386)
@@ -401,7 +401,7 @@ Fixes:
 * Don’t assume bazel-bin is symlinked in workspace [#1340](https://github.com/GoogleContainerTools/skaffold/pull/1340)
 
 
-Updates & refactorings: 
+Updates & refactorings:
 
 * Cleanup tagger tests [#1375](https://github.com/GoogleContainerTools/skaffold/pull/1375)
 * Local builders return a digest [#1374](https://github.com/GoogleContainerTools/skaffold/pull/1374)
@@ -419,15 +419,15 @@ Updates & refactorings:
 * Display usage tips to the user [#1361](https://github.com/GoogleContainerTools/skaffold/pull/1361)
 * Handle errors in release walking [#1356](https://github.com/GoogleContainerTools/skaffold/pull/1356)
 
-Docs updates: 
+Docs updates:
 
 * new skaffold site [#1338](https://github.com/GoogleContainerTools/skaffold/pull/1338)
 
-Utilities: 
+Utilities:
 
 * If webhook deployment fails, upload logs [#1348](https://github.com/GoogleContainerTools/skaffold/pull/1348)
 
-Huge thank you for this release towards our contributors: 
+Huge thank you for this release towards our contributors:
 
 - Balint Pato
 - David Gageot
@@ -441,12 +441,12 @@ Huge thank you for this release towards our contributors:
 
 # v0.19.0 Release - 11/29/2018
 
-*Note*: This release comes with a new config version `v1beta1`. 
-        To upgrade your `skaffold.yaml`, use `skaffold fix`. If you don't upgrade, skaffold will auto-upgrade in memory as best it can, and print a warning message. 
+*Note*: This release comes with a new config version `v1beta1`.
+        To upgrade your `skaffold.yaml`, use `skaffold fix`. If you don't upgrade, skaffold will auto-upgrade in memory as best it can, and print a warning message.
         See [deprecation-policy.md](/deprecation-policy.md) for details on what beta means.
 
 
-New features: 
+New features:
 
 * Run tests in skaffold build, add `skip-tests` flag to skip tests [#1326](https://github.com/GoogleContainerTools/skaffold/pull/1326)
 * Allow ** glob pattern in sync parameters [#1266](https://github.com/GoogleContainerTools/skaffold/pull/1266)
@@ -456,14 +456,14 @@ New features:
 * Automatically fix old configs by default [#1259](https://github.com/GoogleContainerTools/skaffold/pull/1259)
 * adding skaffold version to the docker push user agent [#1260](https://github.com/GoogleContainerTools/skaffold/pull/1260)
 
-Fixes: 
+Fixes:
 
 * Fix node security issue [#1323](https://github.com/GoogleContainerTools/skaffold/pull/1323)
 * Allow passing arguments to bazel build [#1289](https://github.com/GoogleContainerTools/skaffold/pull/1289)
 * Get tmp Directory from os env in kaniko local context storing [#1285](https://github.com/GoogleContainerTools/skaffold/pull/1285)
 
 
-Updates & refactorings: 
+Updates & refactorings:
 
 * Apply default values upgraded configurations [#1332](https://github.com/GoogleContainerTools/skaffold/pull/1332)
 * Remove duplication between run and deploy [#1331](https://github.com/GoogleContainerTools/skaffold/pull/1331)
@@ -480,12 +480,12 @@ Updates & refactorings:
 * removing the artifacts from appveyor [#1300](https://github.com/GoogleContainerTools/skaffold/pull/1300)
 * The multi-deployer feature is not working. Remove it [#1291](https://github.com/GoogleContainerTools/skaffold/pull/1291)
 
-Breaking changes: 
+Breaking changes:
 
 * Remove ACR builder [#1308](https://github.com/GoogleContainerTools/skaffold/pull/1308)
 * Remove `quiet` command line flag [#1292](https://github.com/GoogleContainerTools/skaffold/pull/1292)
 
-Docs updates: 
+Docs updates:
 
 * Clarify what manifest paths are relative to when specifying in skaffold yaml [#1336](https://github.com/GoogleContainerTools/skaffold/pull/1336)
 * adding deprecation policy and document component stability [#1324](https://github.com/GoogleContainerTools/skaffold/pull/1324)
@@ -494,7 +494,7 @@ Docs updates:
 * Lists indented in the installation section (minor fix) [#1298](https://github.com/GoogleContainerTools/skaffold/pull/1298)
 * Make usage messages look like the others. [#1267](https://github.com/GoogleContainerTools/skaffold/pull/1267)
 
-Utilities: 
+Utilities:
 
 * [docs-webhook] remove docs-modifications label from issue instead of deleting the label [#1306](https://github.com/GoogleContainerTools/skaffold/pull/1306)
 * [docs-webhook] hugo extended version + nodejs  [#1295](https://github.com/GoogleContainerTools/skaffold/pull/1295)
@@ -503,7 +503,7 @@ Utilities:
 * [lint] Golangci lint upgrade [#1281](https://github.com/GoogleContainerTools/skaffold/pull/1281)
 * [compilation] Support system's LDFLAGS, make compilation reproducible [#1270](https://github.com/GoogleContainerTools/skaffold/pull/1270)
 
-Huge thank you for this release towards our contributors: 
+Huge thank you for this release towards our contributors:
 - Balint Pato
 - Cedric Vidal
 - David Gageot
@@ -519,7 +519,7 @@ Huge thank you for this release towards our contributors:
 
 # v0.18.0 Release - 11/08/2018
 
-Bug Fixes: 
+Bug Fixes:
 
 * Don't lose test configuration when running skaffold fix [#1251](https://github.com/GoogleContainerTools/skaffold/pull/1251)
 * Fix jib errors on ctrl-c [#1248](https://github.com/GoogleContainerTools/skaffold/pull/1248)
@@ -530,20 +530,20 @@ Bug Fixes:
 * Fixed panic if skaffold.yaml is empty (#1216) [#1221](https://github.com/GoogleContainerTools/skaffold/pull/1221)
 * Suppress fatal error reporting when ^C skaffold with jib [#1228](https://github.com/GoogleContainerTools/skaffold/pull/1228)
 * portforward for resources with hardcoded namespace [#1223](https://github.com/GoogleContainerTools/skaffold/pull/1223)
- 
-Updates: 
+
+Updates:
 
 * Output config version in skaffold version [#1252](https://github.com/GoogleContainerTools/skaffold/pull/1252)
 * Port forward multiple ports [#1250](https://github.com/GoogleContainerTools/skaffold/pull/1250)
 * Improve errors [#1255](https://github.com/GoogleContainerTools/skaffold/pull/1255)
 * Move structure tests out of getting-started example [#1220](https://github.com/GoogleContainerTools/skaffold/pull/1220)
-* changes related to our docs review flow: 
+* changes related to our docs review flow:
   * Add github pkg to webhook [#1230](https://github.com/GoogleContainerTools/skaffold/pull/1230)
   * Allow webhook to create a deployment [#1227](https://github.com/GoogleContainerTools/skaffold/pull/1227)
   * Add hugo and git to webhook image [#1226](https://github.com/GoogleContainerTools/skaffold/pull/1226)
   * Add support for creating a service from webhook [#1213](https://github.com/GoogleContainerTools/skaffold/pull/1213)
 
-Huge thank you for this release towards our contributors: 
+Huge thank you for this release towards our contributors:
 - Balint Pato
 - Brian de Alwis
 - David Gageot
@@ -558,19 +558,19 @@ Huge thank you for this release towards our contributors:
 Note: This release comes with a config change, use `skaffold fix` to upgrade your config to `v1alpha5`.
 We 'skipped' `v1alpha4` due to an accidental merge: see [#1235](https://github.com/GoogleContainerTools/skaffold/issues/1235#issuecomment-436429009)
 
-New Features: 
+New Features:
 
 * Add support for setting default-repo in global config [#1057](https://github.com/GoogleContainerTools/skaffold/pull/1057)
 * Add support for building Maven multimodule projects [#1152](https://github.com/GoogleContainerTools/skaffold/pull/1152)
 * Azure Container Registry runner [#1107](https://github.com/GoogleContainerTools/skaffold/pull/1107)
 
-Bug fixes: 
+Bug fixes:
 
 * Improve Kaniko builder [#1168](https://github.com/GoogleContainerTools/skaffold/pull/1168)
 * Use os.SameFile() to check for mvnw working-dir echo bug [#1167](https://github.com/GoogleContainerTools/skaffold/pull/1167)
 * Fix kaniko default behaviour [#1139](https://github.com/GoogleContainerTools/skaffold/pull/1139)
 
-Updates: 
+Updates:
 
 * Change SkaffoldOption Labeller to not include a comma in the label value [#1169](https://github.com/GoogleContainerTools/skaffold/pull/1169)
 * Remove annoying log [#1163](https://github.com/GoogleContainerTools/skaffold/pull/1163)
@@ -579,7 +579,7 @@ Updates:
 * Jib sample [#1147](https://github.com/GoogleContainerTools/skaffold/pull/1147)
 * Node.js example with dependency handling and hot-reload [#1148](https://github.com/GoogleContainerTools/skaffold/pull/1148)
 
-Huge thank you for this release towards our contributors: 
+Huge thank you for this release towards our contributors:
 - Balint Pato
 - Brian de Alwis
 - Cedric Kring
@@ -646,7 +646,7 @@ Updates:
 # v0.15.1 Release - 10/02/2018
 
 This is a minor release to address an inconsistency in the `skaffold fix` upgrade:
- 
+
 * Transform values files in profiles to v1alpha3 [#1070](https://github.com/GoogleContainerTools/skaffold/pull/1070)
 
 
@@ -715,7 +715,7 @@ New Features:
 * Add --tail flag to stream logs with skaffold run [#914](https://github.com/GoogleContainerTools/skaffold/pull/914)
 * Add DEVELOPMENT.md [#901](https://github.com/GoogleContainerTools/skaffold/pull/901)
 
-Bug Fixes: 
+Bug Fixes:
 * fixes `skaffold version` in the released docker image [#933](https://github.com/GoogleContainerTools/skaffold/pull/933)
 
 Updates:
@@ -764,7 +764,7 @@ Updates:
 
 
 # v0.11.0 Release - 8/02/2018
-New Features: 
+New Features:
 * Pass buildArgs to Kaniko [#822](https://github.com/GoogleContainerTools/skaffold/pull/822)
 * Add pop of color to terminal output with a color formatter [#857](https://github.com/GoogleContainerTools/skaffold/pull/857)
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -69,11 +69,11 @@ dispute. If you are unable to resolve the matter for any reason, or if the
 behavior is threatening or harassing, report it. We are dedicated to providing
 an environment where participants feel welcome and safe.
 
-Reports should be directed to the maintainers, the Project Steward(s) for 
-Skaffold. It is the Project Steward’s duty to receive and address reported 
-violations of the code of conduct. They will then work with a committee 
-consisting of representatives from the Open Source Programs Office and the 
-Google Open Source Strategy team. If for any reason you are uncomfortable 
+Reports should be directed to the maintainers, the Project Steward(s) for
+Skaffold. It is the Project Steward’s duty to receive and address reported
+violations of the code of conduct. They will then work with a committee
+consisting of representatives from the Open Source Programs Office and the
+Google Open Source Strategy team. If for any reason you are uncomfortable
 reaching out the Project Steward, please email opensource@google.com.
 
 We will investigate every complaint, but you may not receive a direct response.

--- a/README.md
+++ b/README.md
@@ -16,26 +16,26 @@ provides building blocks and describe customizations for a CI/CD pipeline.
 * Fast local Kubernetes Development
   * **optimized source-to-k8s** - Skaffold detects changes in your source code and handles the pipeline to
   **build**, **push**, and **deploy** your application automatically with **policy based image tagging** and **highly optimized, fast local workflows**
-  * **continuous feedback** - Skaffold automatically manages logging and port-forwarding   
+  * **continuous feedback** - Skaffold automatically manages logging and port-forwarding
 * Skaffold projects work everywhere
   * **share with other developers** - Skaffold is the easiest way to **share your project** with the world: `git clone` and `skaffold run`
   * **context aware** - use Skaffold profiles, user level config, environment variables and flags to describe differences in environments
-  * **CI/CD building blocks** - use `skaffold run` end-to-end or just part of skaffold stages from build to deployment in your CI/CD system 
-* skaffold.yaml - a single pluggable, declarative configuration for your project  
+  * **CI/CD building blocks** - use `skaffold run` end-to-end or just part of skaffold stages from build to deployment in your CI/CD system
+* skaffold.yaml - a single pluggable, declarative configuration for your project
   * **skaffold init** - Skaffold discovers your files and generates its own config file
-  * **multi-component apps** - Skaffold supports applications consisting of multiple components 
+  * **multi-component apps** - Skaffold supports applications consisting of multiple components
   * **bring your own tools** - Skaffold has a pluggable architecture to allow for different implementations of the stages
-* Lightweight 
+* Lightweight
   * **client-side only** - Skaffold does not require maintaining a cluster-side component, so there is no overhead or maintenance burden to
   your cluster.
-  * **minimal pipeline** - Skaffold provides an opinionated, minimal pipeline to keep things simple  
+  * **minimal pipeline** - Skaffold provides an opinionated, minimal pipeline to keep things simple
 
 ## Install
 Installation methods can be found in the [Getting Started Guide](https://skaffold.dev/docs/getting-started/#installing-skaffold).
 
 See [Github Releases](https://github.com/GoogleContainerTools/skaffold/releases) for more information.
 
-## Demo 
+## Demo
 
 ![](docs/static/images/intro.gif)
 
@@ -45,18 +45,18 @@ Skaffold simplifies your development workflow by organizing common development
 stages into one simple command. Every time you run `skaffold dev`, the system
 
 1. Collects and watches your source code for changes
-1. Syncs files directly to pods if user marks them as syncable   
+1. Syncs files directly to pods if user marks them as syncable
 1. Builds artifacts from the source code
 1. Tests the built artifacts using container-structure-tests
 1. Tags the artifacts
 1. Pushes the artifacts
 1. Deploys the artifacts
 1. Monitors the deployed artifacts
-1. Cleans up deployed artifacts on exit (Ctrl+C) 
-   
+1. Cleans up deployed artifacts on exit (Ctrl+C)
+
 What's more, the pluggable architecture is central to Skaffold's design, allowing you to use
 the tool you prefer in each stage. Also, Skaffold's `profiles` feature grants
-you the freedom to switch tools as you see fit depending on the context. 
+you the freedom to switch tools as you see fit depending on the context.
 
 For example, if you are coding on a local machine, you can configure Skaffold to build artifacts
 with local Docker daemon and deploy them to minikube
@@ -72,25 +72,25 @@ Skaffold supports the following tools:
   * Dockerfile on cloud (Google Cloud Build)
   * Bazel locally
   * Jib Maven/Gradle locally
-* Test 
+* Test
   * with container-structure-test
-* Deploy 
+* Deploy
   * Kubernetes Command-Line Interface (`kubectl`)
   * Helm
   * kustomize
-* Tag 
+* Tag
   * tag by git commit
-  * tag by current date&time 
+  * tag by current date&time
   * tag by environment variables based template
   * tag by checksum of the source code
-* Push 
+* Push
     * don't push - keep the image on the local daemon
-    * push to registry 
+    * push to registry
 
 ![architecture](docs/static/images/architecture.png)
 
 
-Besides the above steps, skaffold also automatically manages the following utilities for you: 
+Besides the above steps, skaffold also automatically manages the following utilities for you:
 
 * forwards container ports to your local machine using `kubectl port-forward`
 * aggregates all the logs from the deployed pods
@@ -100,7 +100,7 @@ Besides the above steps, skaffold also automatically manages the following utili
 
 Documentation for latest release: http://skaffold.dev
 
-Documentation for latest build: http://skaffold-latest.firebaseapp.com  
+Documentation for latest build: http://skaffold-latest.firebaseapp.com
 
 ## More examples
 
@@ -111,8 +111,8 @@ Check out our [examples page](./examples)
 - [skaffold-users mailing list](https://groups.google.com/forum/#!forum/skaffold-users)
 - [#skaffold on Kubernetes Slack](https://kubernetes.slack.com/messages/CABQMSZA6/)
 
-There is a bi-weekly Skaffold users meeting at 9:30am-10am PST hosted on hangouts under "skaffold". 
-Everyone is welcome to add suggestions to the [agenda](https://docs.google.com/document/d/1mnCC_fAI3pmg3Vb2nMJyPk8Qtjjuapw_BTyqI_dX7sk/edit) and attend. 
+There is a bi-weekly Skaffold users meeting at 9:30am-10am PST hosted on hangouts under "skaffold".
+Everyone is welcome to add suggestions to the [agenda](https://docs.google.com/document/d/1mnCC_fAI3pmg3Vb2nMJyPk8Qtjjuapw_BTyqI_dX7sk/edit) and attend.
 Join the [skaffold-users mailing list](https://groups.google.com/forum/#!forum/skaffold-users) to get the calendar invite directly on your calendar.
 
 

--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -55,7 +55,7 @@ func NewCmdBuild(out io.Writer) *cobra.Command {
 	}
 	AddRunDevFlags(cmd)
 	cmd.Flags().StringArrayVarP(&opts.TargetImages, "build-image", "b", nil, "Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts")
-	cmd.Flags().BoolVarP(&quietFlag, "quiet", "q", false, "Suppress the build output and print image built on success. See --output to format output. ")
+	cmd.Flags().BoolVarP(&quietFlag, "quiet", "q", false, "Suppress the build output and print image built on success. See --output to format output.")
 	cmd.Flags().VarP(buildFormatFlag, "output", "o", "Used in conjuction with --quiet flag. "+buildFormatFlag.Usage())
 	return cmd
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Skaffold site 
+# Skaffold site
 
-The site for the last stable release is on: http://skaffold.dev 
-The site for the last build from master is on: http://skaffold-latest.firebaseapp.com 
+The site for the last stable release is on: http://skaffold.dev
+The site for the last build from master is on: http://skaffold-latest.firebaseapp.com

--- a/docs/content/en/docs/_index.md
+++ b/docs/content/en/docs/_index.md
@@ -18,21 +18,21 @@ provides building blocks and describe customizations for a CI/CD pipeline.
 * Fast local Kubernetes Development
   * **optimized "Source to Kubernetes"** - Skaffold detects changes in your source code and handles the pipeline to
   **build**, **push**, and **deploy** your application automatically with **policy based image tagging** and **highly optimized, fast local workflows**
-  * **continuous feedback** - Skaffold automatically manages logging and port-forwarding   
+  * **continuous feedback** - Skaffold automatically manages logging and port-forwarding
 * Skaffold projects work everywhere
   * **share with other developers** - Skaffold is the easiest way to **share your project** with the world: `git clone` and `skaffold run`
   * **context aware** - use Skaffold profiles, user level config, environment variables and flags to describe differences in environments
-  * **CI/CD building blocks** - use `skaffold run` end-to-end or just part of Skaffold stages from build to deployment in your CI/CD system 
-* skaffold.yaml - a single pluggable, declarative configuration for your project  
+  * **CI/CD building blocks** - use `skaffold run` end-to-end or just part of Skaffold stages from build to deployment in your CI/CD system
+* skaffold.yaml - a single pluggable, declarative configuration for your project
   * **skaffold init** - Skaffold discovers your files and generates its own config file
-  * **multi-component apps** - Skaffold supports applications consisting of multiple components 
+  * **multi-component apps** - Skaffold supports applications consisting of multiple components
   * **bring your own tools** - Skaffold has a pluggable architecture to allow for different implementations of the stages
-* Lightweight 
+* Lightweight
   * **client-side only** - Skaffold does not require maintaining a cluster-side component, so there is no overhead or maintenance burden to
   your cluster.
-  * **minimal pipeline** - Skaffold provides an opinionated, minimal pipeline to keep things simple  
+  * **minimal pipeline** - Skaffold provides an opinionated, minimal pipeline to keep things simple
 
-## Demo 
+## Demo
 
 ![architecture](/images/intro.gif)
 
@@ -42,22 +42,22 @@ Skaffold simplifies your development workflow by organizing common development
 stages into one simple command. Every time you run `skaffold dev`, the system
 
 1. Collects and watches your source code for changes
-1. Syncs files directly to pods if user marks them as syncable   
+1. Syncs files directly to pods if user marks them as syncable
 1. Builds artifacts from the source code
 1. Tests the built artifacts using [container-structure-tests](https://github.com/GoogleContainerTools/container-structure-test)
 1. Tags the artifacts
 1. Pushes the artifacts
 1. Deploys the artifacts
 1. Monitors the deployed artifacts
-1. Cleans up deployed artifacts on exit (Ctrl+C) 
+1. Cleans up deployed artifacts on exit (Ctrl+C)
 
 {{< alert title="Note" >}}
-Skaffold also supports skipping stages if you want to. 
+Skaffold also supports skipping stages if you want to.
 {{< /alert >}}
-   
+
 What's more, the pluggable architecture is central to Skaffold's design, allowing you to use
 the tool you prefer in each stage. Also, Skaffold's `profiles` feature grants
-you the freedom to switch tools as you see fit depending on the context. 
+you the freedom to switch tools as you see fit depending on the context.
 
 For example, if you are coding on a local machine, you can configure Skaffold to build artifacts
 with local Docker daemon and deploy them to minikube
@@ -89,22 +89,22 @@ Skaffold supports the following tools:
 
 {{% tab "TAG POLICIES" %}}
 * tag by git commit
-* tag by current date&time 
+* tag by current date&time
 * tag by environment variables based template
 * tag by digest of the Docker image
 {{% /tab %}}
 
 {{% tab "PUSH STRATEGIES" %}}
 * don't push - keep the image on the local daemon
-* push to registry 
-{{% /tab %}} 
+* push to registry
+{{% /tab %}}
 {{% /tabs %}}
 
 
 ![architecture](/images/architecture.png)
 
 
-Besides the above steps, Skaffold also automatically manages the following utilities for you: 
+Besides the above steps, Skaffold also automatically manages the following utilities for you:
 
 * forward container ports to your local machine using `kubectl port-forward`
 * aggregate all the logs from the deployed pods

--- a/docs/content/en/docs/concepts/_index.md
+++ b/docs/content/en/docs/concepts/_index.md
@@ -60,11 +60,11 @@ Skaffold allows you to skip stages. If, for example, you run Kubernetes
 locally with [Minikube](https://kubernetes.io/docs/setup/minikube/), Skaffold
 will not push artifacts to a remote repository.
 
-## Image repository handling 
+## Image repository handling
 
 Skaffold allows for automatically rewriting image names to your repository.
-This way you can grab a Skaffold project and just `skaffold run` it to deploy to your cluster.  
-The way to achieve this is the `default-repo` functionality: 
+This way you can grab a Skaffold project and just `skaffold run` it to deploy to your cluster.
+The way to achieve this is the `default-repo` functionality:
 
 1. Via `default-repo` flag
 
@@ -75,25 +75,25 @@ The way to achieve this is the `default-repo` functionality:
 1. Via `SKAFFOLD_DEFAULT_REPO` environment variable
 
     ```bash
-    SKAFFOLD_DEFAULT_REPO=<myrepo> skaffold dev  
+    SKAFFOLD_DEFAULT_REPO=<myrepo> skaffold dev
     ```
 
-1. Via Skaffold's global config           
+1. Via Skaffold's global config
 
     ```bash
     skaffold config set default-repo <myrepo>
     ```
 
-If Skaffold doesn't find `default-repo`, there is no automated image name rewriting. 
+If Skaffold doesn't find `default-repo`, there is no automated image name rewriting.
 
-The image name rewriting strategies are designed to be *conflict-free*: 
+The image name rewriting strategies are designed to be *conflict-free*:
 the full image name is rewritten on top of the default-repo so similar image names don't collide in the base namespace (e.g.: repo1/example and repo2/example would collide in the target_namespace/example without this)
 
-Automated image name rewriting strategies are determined based on the default-repo and the original image repository: 
+Automated image name rewriting strategies are determined based on the default-repo and the original image repository:
 
 * default-repo does not begin with gcr.io
   * **strategy**: 		escape & concat & truncate to 256
-  
+
     ```
      original image: 	gcr.io/k8s-skaffold/skaffold-example1
      default-repo:      aws_account_id.dkr.ecr.region.amazonaws.com
@@ -103,21 +103,21 @@ Automated image name rewriting strategies are determined based on the default-re
 * default-repo begins with "gcr.io" (special case - as GCR allows for infinite deep image repo names)
   * **strategy**: concat unless prefix matches
   * **example1**: prefix doesn't match:
-    
+
     ```
       original image: 	gcr.io/k8s-skaffold/skaffold-example1
       default-repo: 	gcr.io/myproject/myimage
       rewritten image:  gcr.io/myproject/myimage/gcr.io/k8s-skaffold/skaffold-example1
     ```
   * **example2**: prefix matches:
-    
+
     ```
       original image: 	gcr.io/k8s-skaffold/skaffold-example1
       default-repo: 	gcr.io/k8s-skaffold
       rewritten image:  gcr.io/k8s-skaffold/skaffold-example1	
     ```
   * **example3**: shared prefix:
-    
+
     ```
       original image: 	gcr.io/k8s-skaffold/skaffold-example1
       default-repo: 	gcr.io/k8s-skaffold/myimage
@@ -135,20 +135,20 @@ provides built-in support for the following tools:
 
 * **Build**
   * Dockerfile locally, in-cluster with kaniko or using Google Cloud Build
-  * Bazel locally 
+  * Bazel locally
   * Jib Maven and Jib Gradle locally or using Google Cloud Build
 * **Test**
   * [container-structure-test](https://github.com/GoogleContainerTools/container-structure-test)
 * **Tag**
-  * Git tagger 
+  * Git tagger
   * Sha256 tagger
-  * Env Template tagger 
+  * Env Template tagger
   * DateTime tagger
 * **Deploy**
   * Kubernetes Command-Line Interface (`kubectl`)
   * [Helm](https://helm.sh/)
   * [kustomize](https://github.com/kubernetes-sigs/kustomize)
- 
+
 And you can combine the tools as you see fit in Skaffold. For experimental
 projects, you may want to use local Docker daemon for building artifacts, and
 deploy them to a Minikube local Kubernetes cluster with `kubectl`:

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -117,13 +117,13 @@ choco install skaffold
 
 ### Stable binary
 
-For the latest **stable** release download and place it in your `PATH`: 
+For the latest **stable** release download and place it in your `PATH` as `skaffold.exe`:
 
 https://storage.googleapis.com/skaffold/releases/latest/skaffold-windows-amd64.exe 
 
-For the latest **bleeding edge** build, download and place it in your `PATH`: 
+For the latest **bleeding edge** build, download and place it in your `PATH` as `skaffold.exe`:
 
-https://storage.googleapis.com/skaffold/builds/latest/skaffold-windows-amd64.exe 
+https://storage.googleapis.com/skaffold/builds/latest/skaffold-windows-amd64.exe
 
 {{% /tab %}}
 {{% /tabs %}}

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -42,13 +42,13 @@ Docker with Google Container Registry, see <a href=https://cloud.google.com/cont
 
 {{% tabs %}}
 {{% tab "LINUX" %}}
-### Stable binary 
-For the latest **stable** release download and place it in your `PATH`: 
+### Stable binary
+For the latest **stable** release download and place it in your `PATH`:
 
-https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64 
+https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
 
-Run these commands to download and place the binary in your /usr/local/bin folder: 
- 
+Run these commands to download and place the binary in your /usr/local/bin folder:
+
 ```bash
 curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
 chmod +x skaffold
@@ -57,7 +57,7 @@ sudo mv skaffold /usr/local/bin
 
 ### Latest bleeding edge binary
 
-For the latest **bleeding edge** build, download and place it in your `PATH`: 
+For the latest **bleeding edge** build, download and place it in your `PATH`:
 
 https://storage.googleapis.com/skaffold/builds/latest/skaffold-linux-amd64
 
@@ -80,12 +80,12 @@ brew install skaffold
 ```
 
 ### Stable binary
-For the latest **stable** release download and place it in your `PATH`: 
+For the latest **stable** release download and place it in your `PATH`:
 
-https://storage.googleapis.com/skaffold/releases/latest/skaffold-darwin-amd64 
+https://storage.googleapis.com/skaffold/releases/latest/skaffold-darwin-amd64
 
-Run these commands to download and place the binary in your /usr/local/bin folder: 
- 
+Run these commands to download and place the binary in your /usr/local/bin folder:
+
 ```bash
 curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-darwin-amd64
 chmod +x skaffold
@@ -94,7 +94,7 @@ sudo mv skaffold /usr/local/bin
 
 ### Bleeding edge binary
 
-For the latest **bleeding edge** build, download and place it in your `PATH`: 
+For the latest **bleeding edge** build, download and place it in your `PATH`:
 
 https://storage.googleapis.com/skaffold/builds/latest/skaffold-darwin-amd64
 
@@ -109,7 +109,7 @@ sudo mv skaffold /usr/local/bin
 
 {{% tab "WINDOWS" %}}
 
-### Chocolatey 
+### Chocolatey
 
 ```bash
 choco install skaffold
@@ -119,7 +119,7 @@ choco install skaffold
 
 For the latest **stable** release download and place it in your `PATH` as `skaffold.exe`:
 
-https://storage.googleapis.com/skaffold/releases/latest/skaffold-windows-amd64.exe 
+https://storage.googleapis.com/skaffold/releases/latest/skaffold-windows-amd64.exe
 
 For the latest **bleeding edge** build, download and place it in your `PATH` as `skaffold.exe`:
 
@@ -144,8 +144,8 @@ https://storage.googleapis.com/skaffold/builds/latest/skaffold-windows-amd64.exe
 
 ## `skaffold dev`: Build and deploy your app every time your code changes
 
-Run `skaffold dev --default-repo <myrepo>` to build and deploy your app continuously. 
-The `--default-repo` functionality enables pushing images to your own repository instead of the default `gcr.io/k8s-skaffold` repo. 
+Run `skaffold dev --default-repo <myrepo>` to build and deploy your app continuously.
+The `--default-repo` functionality enables pushing images to your own repository instead of the default `gcr.io/k8s-skaffold` repo.
 You should see some outputs similar to the following entries:
 
 ```
@@ -192,7 +192,7 @@ workflow, which, in this example, is
 For skaffold dev, if `imagePullPolicy` is set to `Always` in your Kubernetes manifest, it will expect the image to exist in a remote registry.
 {{< /alert >}}
 
-Let's re-trigger the workflow just by a single code change! 
+Let's re-trigger the workflow just by a single code change!
 Update `main.go` as follows:
 
 ```go
@@ -231,7 +231,7 @@ Skaffold will perform the workflow described in `skaffold.yaml` exactly once.
 For more in-depth topics of Skaffold, explore [Skaffold Concepts: Configuration](/docs/concepts/#configuration),
 [Skaffold Concepts: Workflow](/docs/concepts/#workflow), and [Skaffold Concepts: Architecture](/docs/concepts/#architecture).
 
-To learn more about how Skaffold builds, tags, and deploys your app, see the How-to Guides on 
+To learn more about how Skaffold builds, tags, and deploys your app, see the How-to Guides on
 using [Builders](/docs/how-tos/builders), [Taggers](/docs/how-tos/taggers), and [Deployers](/docs/how-tos/deployers).
 
 [Skaffold Tutorials](/docs/tutorials) details some of the common use cases of Skaffold.

--- a/docs/content/en/docs/how-tos/builders/_index.md
+++ b/docs/content/en/docs/how-tos/builders/_index.md
@@ -29,7 +29,7 @@ For a detailed discussion on Skaffold configuration, see
 
 If you have [Docker Desktop](https://www.docker.com/products/docker-desktop)
 installed, Skaffold can be configured to build artifacts with the local
-Docker daemon. 
+Docker daemon.
 
 By default, Skaffold connects to the local Docker daemon using
 [Docker Engine APIs](https://docs.docker.com/develop/sdk/). Skaffold can, however,
@@ -50,7 +50,7 @@ of `skaffold.yaml`. The following options can optionally be configured:
 ### Example
 
 The following `build` section instructs Skaffold to build a
-Docker image `gcr.io/k8s-skaffold/example` with the local Docker daemon: 
+Docker image `gcr.io/k8s-skaffold/example` with the local Docker daemon:
 
 {{% readfile file="samples/builders/local.yaml" %}}
 
@@ -62,7 +62,7 @@ Which is equivalent to:
 
 [Google Cloud Build](https://cloud.google.com/cloud-build/) is a
 [Google Cloud Platform](https://cloud.google.com) service that executes
-your builds using Google infrastructure. To get started with Google 
+your builds using Google infrastructure. To get started with Google
 Build, see [Cloud Build Quickstart](https://cloud.google.com/cloud-build/docs/quickstart-docker).
 
 Skaffold can automatically connect to Cloud Build, and run your builds
@@ -80,11 +80,11 @@ section of `skaffold.yaml`. The following options can optionally be configured:
 ### Example
 
 The following `build` section, instructs Skaffold to build a
-Docker image `gcr.io/k8s-skaffold/example` with Google Cloud Build: 
+Docker image `gcr.io/k8s-skaffold/example` with Google Cloud Build:
 
 {{% readfile file="samples/builders/gcb.yaml" %}}
 
-## Dockerfile in-cluster with Kaniko  
+## Dockerfile in-cluster with Kaniko
 
 [Kaniko](https://github.com/GoogleContainerTools/kaniko) is a Google-developed
 open-source tool for building images from a Dockerfile inside a container or
@@ -108,14 +108,14 @@ The `buildContext` can be either:
 ### Example
 
 The following `build` section, instructs Skaffold to build a
-Docker image `gcr.io/k8s-skaffold/example` with Kaniko: 
+Docker image `gcr.io/k8s-skaffold/example` with Kaniko:
 
 {{% readfile file="samples/builders/kaniko.yaml" %}}
 
-## Jib Maven and Gradle locally 
+## Jib Maven and Gradle locally
 
 [Jib](https://github.com/GoogleContainerTools/jib#jib) is a set of plugins for
-[Maven](https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin) and 
+[Maven](https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin) and
 [Gradle](https://github.com/GoogleContainerTools/jib/blob/master/jib-gradle-plugin)
 for building optimized Docker and OCI images for Java applications
 without a Docker daemon.
@@ -160,7 +160,7 @@ specifying either the module's `:artifactId`, `groupId:artifactId`, or the relat
 to the module _within the project_. Each artifact's `context` field
 should point to the root project location.
 
-Building multi-module projects with Skaffold-Jib has one additional requirement: 
+Building multi-module projects with Skaffold-Jib has one additional requirement:
 a Jib goal must be explicitly bound to the `package` phase for each specific
 module that produces a container image.
 
@@ -171,14 +171,14 @@ Skaffold artifact. For each artifact, add a `jibGradle` field with a `project` f
 containing the sub-project's name (the directory, by default). Each artifact's `context` field
 should point to the root project location.
 
-## Jib Maven and Gradle remotely with Google Cloud Build 
+## Jib Maven and Gradle remotely with Google Cloud Build
 
-{{% todo 1299 %}} 
+{{% todo 1299 %}}
 
 ## Bazel locally
 
 [Bazel](https://bazel.build/) is a fast, scalable, multi-language, and
-extensible build system. 
+extensible build system.
 
 Skaffold can help build artifacts using Bazel; after Bazel finishes building
 container images, they will be loaded into the local Docker daemon.

--- a/docs/content/en/docs/how-tos/deployers/_index.md
+++ b/docs/content/en/docs/how-tos/deployers/_index.md
@@ -7,24 +7,24 @@ weight: 30
 This page discusses how to set up Skaffold to use the tool of your choice
 to deploy your app to a Kubernetes cluster.
 
-When Skaffold deploys an application the following steps happen: 
+When Skaffold deploys an application the following steps happen:
 
-* the Skaffold deployer _renders_ the final kubernetes manifests: Skaffold replaces the image names in the kubernetes manifests with the final tagged image names. 
-Also, in case of the more complicated deployers the rendering step involves expanding templates (in case of helm) or calculating overlays (in case of kustomize). 
+* the Skaffold deployer _renders_ the final kubernetes manifests: Skaffold replaces the image names in the kubernetes manifests with the final tagged image names.
+Also, in case of the more complicated deployers the rendering step involves expanding templates (in case of helm) or calculating overlays (in case of kustomize).
 * the Skaffold deployer _deploys_ the final kubernetes manifests to the cluster
 
 ### Supported deployers
 
 Skaffold supports the following tools for deploying applications:
 
-* [`kubectl`](#deploying-with-kubectl) 
-* [helm](#deploying-with-helm) 
+* [`kubectl`](#deploying-with-kubectl)
+* [helm](#deploying-with-helm)
 * [kustomize](#deploying-with-kustomize)
 
 The `deploy` section in the Skaffold configuration file, `skaffold.yaml`,
 controls how Skaffold builds artifacts. To use a specific tool for deploying
 artifacts, add the value representing the tool and options for using the tool
-to the `deploy` section. 
+to the `deploy` section.
 
 For a detailed discussion on Skaffold configuration, see
 [Skaffold Concepts](/docs/concepts/#configuration) and

--- a/docs/content/en/docs/how-tos/filesync/_index.md
+++ b/docs/content/en/docs/how-tos/filesync/_index.md
@@ -6,4 +6,4 @@ weight: 40
 
 This page discusses how to set up file sync for files that don't require full rebuild.
 
-{{% todo 1076 %}} 
+{{% todo 1076 %}}

--- a/docs/content/en/docs/how-tos/profiles/_index.md
+++ b/docs/content/en/docs/how-tos/profiles/_index.md
@@ -6,7 +6,7 @@ weight: 70
 
 Skaffold profiles allow you to define build, test and deployment
 configurations for different contexts. Different contexts are typically different
-environments in your app's lifecycle, like Production or Development. 
+environments in your app's lifecycle, like Production or Development.
 
 You can create profiles in the `profiles` section of `skaffold.yaml`.
 
@@ -31,13 +31,13 @@ in the main section of `skaffold.yaml`. The `build`, `test` and `deploy` configu
 section use the same syntax as the `build`, `test` and `deploy` sections of
 `skaffold.yaml`; for more information, see [Builders](/docs/how-tos/builders),
 [Testers](/docs/how-tos/testers), [Deployers](/docs/how-tos/deployers) and you can always refer to
- [skaffold.yaml reference](/docs/references/yaml/) for an overview of the syntax. 
- Alternatively, you can override the main configuration with finer grained control using `patches`.  
+ [skaffold.yaml reference](/docs/references/yaml/) for an overview of the syntax.
+ Alternatively, you can override the main configuration with finer grained control using `patches`.
 
 
-### Activation 
+### Activation
 
-You can activate a profile two ways: CLI flag or skaffold.yaml activations. 
+You can activate a profile two ways: CLI flag or skaffold.yaml activations.
 
 **CLI flag**: You can activate profiles with the `-p` (`--profile`) parameter in the
 `skaffold dev` and `skaffold run` commands.
@@ -48,25 +48,25 @@ You can activate a profile two ways: CLI flag or skaffold.yaml activations.
 **Activations in skaffold.yaml**: You can auto-activate a profile based on
 
 * kubecontext
-* environment variable value 
+* environment variable value
 * skaffold command (dev/run/build/deploy)
- 
-A profile is auto-activated if any one of the activations under it are triggered. 
+
+A profile is auto-activated if any one of the activations under it are triggered.
 An activation is triggered if all of the criteria (`env`, `kubeContext`, `command`) are triggered.
- 
+
 
 In the example below:
 
  * `profile1` is activated if `MAGIC_VAR` is 42
- * `profile2` is activated if `MAGIC_VAR` is 1337 or we are running `skaffold dev` while kubecontext is set to `minikube`. 
-    
+ * `profile2` is activated if `MAGIC_VAR` is 1337 or we are running `skaffold dev` while kubecontext is set to `minikube`.
+
 {{% readfile file="samples/profiles/activations.yaml" %}}
 
 
-### Override via replacement 
+### Override via replacement
 
-The `build`, `test` and `deploy` sections defined in the profile will completely replace the main configuration. 
-The default values are the same in profiles as in the main config.  
+The `build`, `test` and `deploy` sections defined in the profile will completely replace the main configuration.
+The default values are the same in profiles as in the main config.
 
 The following example showcases a `skaffold.yaml` with one profile named `gcb`,
 for building with Google Cloud Build:
@@ -83,7 +83,7 @@ However, if you run Skaffold with the following command:
 skaffold dev -p gcb
 ```
 
-Skaffold will switch to Google Cloud Build for building artifacts. 
+Skaffold will switch to Google Cloud Build for building artifacts.
 
 Note that
 since the `gcb` profile does not specify a deploy configuration, Skaffold will
@@ -92,10 +92,10 @@ continue using `kubectl` for deployments.
 
 ### Override via patches
 
-Patches are a more verbose way of overriding your config, but they provide a powerful, fine-grained way 
-to override individual values in your yaml config. They are based on [JSON Patch](http://jsonpatch.com/) under the hood. 
+Patches are a more verbose way of overriding your config, but they provide a powerful, fine-grained way
+to override individual values in your yaml config. They are based on [JSON Patch](http://jsonpatch.com/) under the hood.
 
-In the example below instead of overriding the whole `build` section, the `dev` profile specifically 
-defines a different Dockerfile to use for the first artifact.    
+In the example below instead of overriding the whole `build` section, the `dev` profile specifically
+defines a different Dockerfile to use for the first artifact.
 
 {{% readfile file="samples/profiles/patches.yaml" %}}

--- a/docs/content/en/docs/how-tos/taggers/_index.md
+++ b/docs/content/en/docs/how-tos/taggers/_index.md
@@ -28,7 +28,7 @@ to tag artifacts.
 
 The `gitCommit` tagger will look at the Git workspace that contains
 the artifact's `context` directory and tag according to those rules:
- 
+
  + If the workspace is on a Git tag, that tag is used to tag images
  + If the workspace is on a Git commit, the short commit is used
  + It the workspace has uncommited changes, a `-dirty` suffix is appended to the image tag
@@ -76,7 +76,7 @@ variables in the system for the variable `FOO`, and use its value to tag the
 image.
 
 {{< alert >}}
-<b>Note</b><br> 
+<b>Note</b><br>
 
 <code>IMAGE_NAME</code> is a built-in variable whose value is the <code>imageName</code> field in
 the <code>artifacts</code> part of the <code>build</code> section.

--- a/docs/content/en/docs/how-tos/templating/_index.md
+++ b/docs/content/en/docs/how-tos/templating/_index.md
@@ -5,19 +5,19 @@ weight: 90
 ---
 
 Skaffold config allows for certain fields to have values injected that are either environment variables or calculated by Skaffold.
-For example: 
+For example:
 
 {{% readfile file="samples/templating/env.yaml" %}}
 
 Suppose the value of the `FOO` environment variable is `v1`, the image built
 will be `gcr.io/k8s-skaffold/example:v1`.
 
-List of fields that support templating: 
+List of fields that support templating:
 
 * `build.tagPolicy.envTemplate.template` (see [envTemplate tagger](/docs/how-tos/taggers/##envtemplate-using-values-of-environment-variables-as-tags))
 * `deploy.helm.releases.setValueTemplates` (see [Deploying with helm](/docs/how-tos/deployers/#deploying-with-helm))
 
-List of variables that are available for templating: 
+List of variables that are available for templating:
 
-* all environment variables passed to the Skaffold process at startup 
+* all environment variables passed to the Skaffold process at startup
 * `IMAGE_NAME` - the artifacts' image name - the [image name rewriting](/docs/concepts/#image-repository-handling) acts after the template is calculated

--- a/docs/content/en/docs/how-tos/testers/_index.md
+++ b/docs/content/en/docs/how-tos/testers/_index.md
@@ -6,4 +6,4 @@ weight: 15
 
 This page discusses how to set up Skaffold to run container structure tests after building an artifact.
 
-{{% todo 1076 %}} 
+{{% todo 1076 %}}

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -72,7 +72,7 @@ Flags:
   -n, --namespace string             Run deployments in the specified namespace
   -o, --output *flags.TemplateFlag   Used in conjuction with --quiet flag. Format output with go-template. For full struct documentation, see https://godoc.org/github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd#BuildOutput (default {{.}})
   -p, --profile stringArray          Activate profiles by name
-  -q, --quiet                        Suppress the build output and print image built on success. See --output to format output. 
+  -q, --quiet                        Suppress the build output and print image built on success. See --output to format output.
       --rpc-http-port int            tcp port to expose event REST API over HTTP (default 50052)
       --rpc-port int                 tcp port to expose event API (default 50051)
       --skip-tests                   Whether to skip the tests after building

--- a/docs/content/en/docs/tutorials/_index.md
+++ b/docs/content/en/docs/tutorials/_index.md
@@ -4,11 +4,11 @@ linkTitle: "Tutorials"
 weight: 90
 ---
 
-See the [Github Examples page](https://github.com/GoogleContainerTools/skaffold/tree/master/examples) for examples. 
+See the [Github Examples page](https://github.com/GoogleContainerTools/skaffold/tree/master/examples) for examples.
 
-As we have gcr.io/k8s-skaffold in our image names, to run the examples, you have two options: 
+As we have gcr.io/k8s-skaffold in our image names, to run the examples, you have two options:
 
-1. manually replace the image repositories in skaffold.yaml from gcr.io/k8s-skaffold to yours 
+1. manually replace the image repositories in skaffold.yaml from gcr.io/k8s-skaffold to yours
 1. you can point skaffold to your default image repository in one of the four ways:
     1. flag: `skaffold dev --default-repo <myrepo>`
     1. env var: `SKAFFOLD_DEFAULT_REPO=<myrepo> skaffold dev`

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2019 The Skaffold Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -23,7 +23,7 @@ go run ${DIR}/release_notes/listpullreqs.go
 rm -rf ${EXAMPLES_DIR} && rm -rf ${INTEGRATION_EXAMPLES_DIR}/bazel/bazel-* && cp -r ${INTEGRATION_EXAMPLES_DIR} ${EXAMPLES_DIR} && rm -rf ${EXAMPLES_DIR}/test-*
 
 echo
-echo "Huge thanks goes out to all of our contributors for this release: "
+echo "Huge thanks goes out to all of our contributors for this release:"
 echo
 git log "$(git describe  --abbrev=0)".. --format="%aN" --reverse | sort | uniq | awk '{printf "- %s\n", $0 }'
 echo


### PR DESCRIPTION
Also
* remove trailing whitespace in docs
* add shebang in `hack/release.sh`
* ensure generated doc has no trailing whitespace

Fixes #1762 
