### PR TITLE
Remove container-friendly flags for Java 8

### DIFF
--- a/examples/jib-multimodule/project1/pom.xml
+++ b/examples/jib-multimodule/project1/pom.xml
@@ -33,9 +33,6 @@
                     <container>
                         <jvmFlags>
                             <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
-                            <!-- specific to Java 8 containers -->
-                            <jvmFlag>-XX:+UnlockExperimentalVMOptions</jvmFlag>
-                            <jvmFlag>-XX:+UseCGroupMemoryLimitForHeap</jvmFlag>
                         </jvmFlags>
                     </container>
                 </configuration>

--- a/examples/jib-multimodule/project2/pom.xml
+++ b/examples/jib-multimodule/project2/pom.xml
@@ -33,9 +33,6 @@
                     <container>
                         <jvmFlags>
                             <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
-                            <!-- specific to Java 8 containers -->
-                            <jvmFlag>-XX:+UnlockExperimentalVMOptions</jvmFlag>
-                            <jvmFlag>-XX:+UseCGroupMemoryLimitForHeap</jvmFlag>
                         </jvmFlags>
                     </container>
                 </configuration>

--- a/examples/jib/pom.xml
+++ b/examples/jib/pom.xml
@@ -39,9 +39,6 @@
                     <container>
                         <jvmFlags>
                             <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
-                            <!-- specific to Java 8 containers -->
-                            <jvmFlag>-XX:+UnlockExperimentalVMOptions</jvmFlag>
-                            <jvmFlag>-XX:+UseCGroupMemoryLimitForHeap</jvmFlag>
                         </jvmFlags>
                     </container>
                 </configuration>

--- a/integration/examples/jib-multimodule/project1/pom.xml
+++ b/integration/examples/jib-multimodule/project1/pom.xml
@@ -33,9 +33,6 @@
                     <container>
                         <jvmFlags>
                             <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
-                            <!-- specific to Java 8 containers -->
-                            <jvmFlag>-XX:+UnlockExperimentalVMOptions</jvmFlag>
-                            <jvmFlag>-XX:+UseCGroupMemoryLimitForHeap</jvmFlag>
                         </jvmFlags>
                     </container>
                 </configuration>

--- a/integration/examples/jib-multimodule/project2/pom.xml
+++ b/integration/examples/jib-multimodule/project2/pom.xml
@@ -33,9 +33,6 @@
                     <container>
                         <jvmFlags>
                             <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
-                            <!-- specific to Java 8 containers -->
-                            <jvmFlag>-XX:+UnlockExperimentalVMOptions</jvmFlag>
-                            <jvmFlag>-XX:+UseCGroupMemoryLimitForHeap</jvmFlag>
                         </jvmFlags>
                     </container>
                 </configuration>

--- a/integration/examples/jib/pom.xml
+++ b/integration/examples/jib/pom.xml
@@ -39,9 +39,6 @@
                     <container>
                         <jvmFlags>
                             <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
-                            <!-- specific to Java 8 containers -->
-                            <jvmFlag>-XX:+UnlockExperimentalVMOptions</jvmFlag>
-                            <jvmFlag>-XX:+UseCGroupMemoryLimitForHeap</jvmFlag>
                         </jvmFlags>
                     </container>
                 </configuration>

--- a/integration/testdata/jib/pom.xml
+++ b/integration/testdata/jib/pom.xml
@@ -39,9 +39,6 @@
                     <container>
                         <jvmFlags>
                             <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>
-                            <!-- specific to Java 8 containers -->
-                            <jvmFlag>-XX:+UnlockExperimentalVMOptions</jvmFlag>
-                            <jvmFlag>-XX:+UseCGroupMemoryLimitForHeap</jvmFlag>
                         </jvmFlags>
                     </container>
                 </configuration>


### PR DESCRIPTION
Distroless has now Java 1.8.0_212. Special container flags are unnecessary with 1.8.0_191 and beyond:

https://github.com/GoogleContainerTools/distroless/pull/330/files#diff-4ad938850c58b9cd9b2b90ca4d4a9d42L43