### PR TITLE
Configure Jib builds to use plain progress updates

### DIFF
--- a/pkg/skaffold/jib/jib_gradle.go
+++ b/pkg/skaffold/jib/jib_gradle.go
@@ -42,13 +42,13 @@ func GetDependenciesGradle(ctx context.Context, workspace string, a *latest.JibG
 }
 
 func getCommandGradle(ctx context.Context, workspace string, a *latest.JibGradleArtifact) *exec.Cmd {
-	args := []string{gradleCommand(a, "_jibSkaffoldFiles"), "-q"}
+	args := append(gradleCommand(a, "_jibSkaffoldFiles"), "-q")
 	return GradleCommand.CreateCommand(ctx, workspace, args)
 }
 
 // GenerateGradleArgs generates the arguments to Gradle for building the project as an image.
 func GenerateGradleArgs(task string, imageName string, a *latest.JibGradleArtifact, skipTests bool) []string {
-	args := []string{gradleCommand(a, task), "--image=" + imageName}
+	args := append(gradleCommand(a, task), "--image="+imageName)
 	if skipTests {
 		args = append(args, "-x", "test")
 	}
@@ -56,11 +56,14 @@ func GenerateGradleArgs(task string, imageName string, a *latest.JibGradleArtifa
 	return args
 }
 
-func gradleCommand(a *latest.JibGradleArtifact, task string) string {
+func gradleCommand(a *latest.JibGradleArtifact, task string) []string {
+	// disable jib's rich progress footer; we could use `--console=plain`
+	// but it also disables colour which can be helpful
+	args := []string{"-Djib.console=plain"}
 	if a.Project == "" {
-		return ":" + task
+		return append(args, ":"+task)
 	}
 
 	// multi-module
-	return fmt.Sprintf(":%s:%s", a.Project, task)
+	return append(args, fmt.Sprintf(":%s:%s", a.Project, task))
 }

--- a/pkg/skaffold/jib/jib_gradle_test.go
+++ b/pkg/skaffold/jib/jib_gradle_test.go
@@ -97,7 +97,7 @@ func TestGetCommandGradle(t *testing.T) {
 			jibGradleArtifact: latest.JibGradleArtifact{},
 			filesInWorkspace:  []string{},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return GradleCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", ":_jibSkaffoldFiles", "-q"})
+				return GradleCommand.CreateCommand(ctx, workspace, []string{":_jibSkaffoldFiles", "-q"})
 			},
 		},
 		{
@@ -105,7 +105,7 @@ func TestGetCommandGradle(t *testing.T) {
 			jibGradleArtifact: latest.JibGradleArtifact{Project: "project"},
 			filesInWorkspace:  []string{},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return GradleCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", ":project:_jibSkaffoldFiles", "-q"})
+				return GradleCommand.CreateCommand(ctx, workspace, []string{":project:_jibSkaffoldFiles", "-q"})
 			},
 		},
 		{
@@ -113,7 +113,7 @@ func TestGetCommandGradle(t *testing.T) {
 			jibGradleArtifact: latest.JibGradleArtifact{},
 			filesInWorkspace:  []string{"gradlew", "gradlew.cmd"},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return GradleCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", ":_jibSkaffoldFiles", "-q"})
+				return GradleCommand.CreateCommand(ctx, workspace, []string{":_jibSkaffoldFiles", "-q"})
 			},
 		},
 		{
@@ -121,7 +121,7 @@ func TestGetCommandGradle(t *testing.T) {
 			jibGradleArtifact: latest.JibGradleArtifact{Project: "project"},
 			filesInWorkspace:  []string{"gradlew", "gradlew.cmd"},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return GradleCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", ":project:_jibSkaffoldFiles", "-q"})
+				return GradleCommand.CreateCommand(ctx, workspace, []string{":project:_jibSkaffoldFiles", "-q"})
 			},
 		},
 	}

--- a/pkg/skaffold/jib/jib_gradle_test.go
+++ b/pkg/skaffold/jib/jib_gradle_test.go
@@ -97,7 +97,7 @@ func TestGetCommandGradle(t *testing.T) {
 			jibGradleArtifact: latest.JibGradleArtifact{},
 			filesInWorkspace:  []string{},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return GradleCommand.CreateCommand(ctx, workspace, []string{":_jibSkaffoldFiles", "-q"})
+				return GradleCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", ":_jibSkaffoldFiles", "-q"})
 			},
 		},
 		{
@@ -105,7 +105,7 @@ func TestGetCommandGradle(t *testing.T) {
 			jibGradleArtifact: latest.JibGradleArtifact{Project: "project"},
 			filesInWorkspace:  []string{},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return GradleCommand.CreateCommand(ctx, workspace, []string{":project:_jibSkaffoldFiles", "-q"})
+				return GradleCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", ":project:_jibSkaffoldFiles", "-q"})
 			},
 		},
 		{
@@ -113,7 +113,7 @@ func TestGetCommandGradle(t *testing.T) {
 			jibGradleArtifact: latest.JibGradleArtifact{},
 			filesInWorkspace:  []string{"gradlew", "gradlew.cmd"},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return GradleCommand.CreateCommand(ctx, workspace, []string{":_jibSkaffoldFiles", "-q"})
+				return GradleCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", ":_jibSkaffoldFiles", "-q"})
 			},
 		},
 		{
@@ -121,7 +121,7 @@ func TestGetCommandGradle(t *testing.T) {
 			jibGradleArtifact: latest.JibGradleArtifact{Project: "project"},
 			filesInWorkspace:  []string{"gradlew", "gradlew.cmd"},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return GradleCommand.CreateCommand(ctx, workspace, []string{":project:_jibSkaffoldFiles", "-q"})
+				return GradleCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", ":project:_jibSkaffoldFiles", "-q"})
 			},
 		},
 	}
@@ -150,11 +150,11 @@ func TestGenerateGradleArgs(t *testing.T) {
 		skipTests bool
 		out       []string
 	}{
-		{latest.JibGradleArtifact{}, false, []string{":task", "--image=image"}},
-		{latest.JibGradleArtifact{Flags: []string{"-extra", "args"}}, false, []string{":task", "--image=image", "-extra", "args"}},
-		{latest.JibGradleArtifact{}, true, []string{":task", "--image=image", "-x", "test"}},
-		{latest.JibGradleArtifact{Project: "project"}, false, []string{":project:task", "--image=image"}},
-		{latest.JibGradleArtifact{Project: "project"}, true, []string{":project:task", "--image=image", "-x", "test"}},
+		{latest.JibGradleArtifact{}, false, []string{"-Djib.console=plain", ":task", "--image=image"}},
+		{latest.JibGradleArtifact{Flags: []string{"-extra", "args"}}, false, []string{"-Djib.console=plain", ":task", "--image=image", "-extra", "args"}},
+		{latest.JibGradleArtifact{}, true, []string{"-Djib.console=plain", ":task", "--image=image", "-x", "test"}},
+		{latest.JibGradleArtifact{Project: "project"}, false, []string{"-Djib.console=plain", ":project:task", "--image=image"}},
+		{latest.JibGradleArtifact{Project: "project"}, true, []string{"-Djib.console=plain", ":project:task", "--image=image", "-x", "test"}},
 	}
 
 	for _, tt := range testCases {

--- a/pkg/skaffold/jib/jib_maven.go
+++ b/pkg/skaffold/jib/jib_maven.go
@@ -48,7 +48,10 @@ func getCommandMaven(ctx context.Context, workspace string, a *latest.JibMavenAr
 
 // GenerateMavenArgs generates the arguments to Maven for building the project as an image.
 func GenerateMavenArgs(goal string, imageName string, a *latest.JibMavenArtifact, skipTests bool) []string {
-	args := mavenArgs(a)
+	// disable jib's rich progress footer on builds; we could use --batch-mode
+	// but it also disables colour which can be helpful
+	args := []string{"-Djib.console=plain"}
+	args = append(args, mavenArgs(a)...)
 
 	if skipTests {
 		args = append(args, "-DskipTests=true")
@@ -68,9 +71,7 @@ func GenerateMavenArgs(goal string, imageName string, a *latest.JibMavenArtifact
 }
 
 func mavenArgs(a *latest.JibMavenArtifact) []string {
-	// disable jib's rich progress footer; we could use --batch-mode
-	// but it also disables colour which can be helpful
-	args := []string{"-Djib.console=plain"}
+	var args []string
 
 	args = append(args, a.Flags...)
 

--- a/pkg/skaffold/jib/jib_maven.go
+++ b/pkg/skaffold/jib/jib_maven.go
@@ -68,7 +68,9 @@ func GenerateMavenArgs(goal string, imageName string, a *latest.JibMavenArtifact
 }
 
 func mavenArgs(a *latest.JibMavenArtifact) []string {
-	var args []string
+	// disable jib's rich progress footer; we could use --batch-mode
+	// but it also disables colour which can be helpful
+	args := []string{"-Djib.console=plain"}
 
 	args = append(args, a.Flags...)
 

--- a/pkg/skaffold/jib/jib_maven_test.go
+++ b/pkg/skaffold/jib/jib_maven_test.go
@@ -96,7 +96,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibMavenArtifact: latest.JibMavenArtifact{},
 			filesInWorkspace: []string{},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", "--non-recursive", "jib:_skaffold-files", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"--non-recursive", "jib:_skaffold-files", "--quiet"})
 			},
 		},
 		{
@@ -106,7 +106,7 @@ func TestGetCommandMaven(t *testing.T) {
 			},
 			filesInWorkspace: []string{},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", "-DskipTests", "-x", "--non-recursive", "jib:_skaffold-files", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"-DskipTests", "-x", "--non-recursive", "jib:_skaffold-files", "--quiet"})
 			},
 		},
 		{
@@ -114,7 +114,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibMavenArtifact: latest.JibMavenArtifact{Profile: "profile"},
 			filesInWorkspace: []string{},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", "--activate-profiles", "profile", "--non-recursive", "jib:_skaffold-files", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"--activate-profiles", "profile", "--non-recursive", "jib:_skaffold-files", "--quiet"})
 			},
 		},
 		{
@@ -122,7 +122,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibMavenArtifact: latest.JibMavenArtifact{},
 			filesInWorkspace: []string{"mvnw", "mvnw.bat"},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", "--non-recursive", "jib:_skaffold-files", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"--non-recursive", "jib:_skaffold-files", "--quiet"})
 			},
 		},
 		{
@@ -130,7 +130,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibMavenArtifact: latest.JibMavenArtifact{},
 			filesInWorkspace: []string{"mvnw", "mvnw.cmd"},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", "--non-recursive", "jib:_skaffold-files", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"--non-recursive", "jib:_skaffold-files", "--quiet"})
 			},
 		},
 		{
@@ -138,7 +138,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibMavenArtifact: latest.JibMavenArtifact{Profile: "profile"},
 			filesInWorkspace: []string{"mvnw", "mvnw.bat"},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", "--activate-profiles", "profile", "--non-recursive", "jib:_skaffold-files", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"--activate-profiles", "profile", "--non-recursive", "jib:_skaffold-files", "--quiet"})
 			},
 		},
 		{
@@ -146,7 +146,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibMavenArtifact: latest.JibMavenArtifact{Module: "module"},
 			filesInWorkspace: []string{"mvnw", "mvnw.bat"},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", "--projects", "module", "--also-make", "jib:_skaffold-files", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"--projects", "module", "--also-make", "jib:_skaffold-files", "--quiet"})
 			},
 		},
 	}

--- a/pkg/skaffold/jib/jib_maven_test.go
+++ b/pkg/skaffold/jib/jib_maven_test.go
@@ -96,7 +96,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibMavenArtifact: latest.JibMavenArtifact{},
 			filesInWorkspace: []string{},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"--non-recursive", "jib:_skaffold-files", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", "--non-recursive", "jib:_skaffold-files", "--quiet"})
 			},
 		},
 		{
@@ -106,7 +106,7 @@ func TestGetCommandMaven(t *testing.T) {
 			},
 			filesInWorkspace: []string{},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"-DskipTests", "-x", "--non-recursive", "jib:_skaffold-files", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", "-DskipTests", "-x", "--non-recursive", "jib:_skaffold-files", "--quiet"})
 			},
 		},
 		{
@@ -114,7 +114,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibMavenArtifact: latest.JibMavenArtifact{Profile: "profile"},
 			filesInWorkspace: []string{},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"--activate-profiles", "profile", "--non-recursive", "jib:_skaffold-files", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", "--activate-profiles", "profile", "--non-recursive", "jib:_skaffold-files", "--quiet"})
 			},
 		},
 		{
@@ -122,7 +122,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibMavenArtifact: latest.JibMavenArtifact{},
 			filesInWorkspace: []string{"mvnw", "mvnw.bat"},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"--non-recursive", "jib:_skaffold-files", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", "--non-recursive", "jib:_skaffold-files", "--quiet"})
 			},
 		},
 		{
@@ -130,7 +130,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibMavenArtifact: latest.JibMavenArtifact{},
 			filesInWorkspace: []string{"mvnw", "mvnw.cmd"},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"--non-recursive", "jib:_skaffold-files", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", "--non-recursive", "jib:_skaffold-files", "--quiet"})
 			},
 		},
 		{
@@ -138,7 +138,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibMavenArtifact: latest.JibMavenArtifact{Profile: "profile"},
 			filesInWorkspace: []string{"mvnw", "mvnw.bat"},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"--activate-profiles", "profile", "--non-recursive", "jib:_skaffold-files", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", "--activate-profiles", "profile", "--non-recursive", "jib:_skaffold-files", "--quiet"})
 			},
 		},
 		{
@@ -146,7 +146,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibMavenArtifact: latest.JibMavenArtifact{Module: "module"},
 			filesInWorkspace: []string{"mvnw", "mvnw.bat"},
 			expectedCmd: func(workspace string) *exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"--projects", "module", "--also-make", "jib:_skaffold-files", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"-Djib.console=plain", "--projects", "module", "--also-make", "jib:_skaffold-files", "--quiet"})
 			},
 		},
 	}
@@ -175,14 +175,14 @@ func TestGenerateMavenArgs(t *testing.T) {
 		skipTests bool
 		out       []string
 	}{
-		{latest.JibMavenArtifact{}, false, []string{"--non-recursive", "prepare-package", "jib:goal", "-Dimage=image"}},
-		{latest.JibMavenArtifact{}, true, []string{"--non-recursive", "-DskipTests=true", "prepare-package", "jib:goal", "-Dimage=image"}},
-		{latest.JibMavenArtifact{Profile: "profile"}, false, []string{"--activate-profiles", "profile", "--non-recursive", "prepare-package", "jib:goal", "-Dimage=image"}},
-		{latest.JibMavenArtifact{Profile: "profile"}, true, []string{"--activate-profiles", "profile", "--non-recursive", "-DskipTests=true", "prepare-package", "jib:goal", "-Dimage=image"}},
-		{latest.JibMavenArtifact{Module: "module"}, false, []string{"--projects", "module", "--also-make", "package", "-Dimage=image"}},
-		{latest.JibMavenArtifact{Module: "module"}, true, []string{"--projects", "module", "--also-make", "-DskipTests=true", "package", "-Dimage=image"}},
-		{latest.JibMavenArtifact{Module: "module", Profile: "profile"}, false, []string{"--activate-profiles", "profile", "--projects", "module", "--also-make", "package", "-Dimage=image"}},
-		{latest.JibMavenArtifact{Module: "module", Profile: "profile"}, true, []string{"--activate-profiles", "profile", "--projects", "module", "--also-make", "-DskipTests=true", "package", "-Dimage=image"}},
+		{latest.JibMavenArtifact{}, false, []string{"-Djib.console=plain", "--non-recursive", "prepare-package", "jib:goal", "-Dimage=image"}},
+		{latest.JibMavenArtifact{}, true, []string{"-Djib.console=plain", "--non-recursive", "-DskipTests=true", "prepare-package", "jib:goal", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Profile: "profile"}, false, []string{"-Djib.console=plain", "--activate-profiles", "profile", "--non-recursive", "prepare-package", "jib:goal", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Profile: "profile"}, true, []string{"-Djib.console=plain", "--activate-profiles", "profile", "--non-recursive", "-DskipTests=true", "prepare-package", "jib:goal", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Module: "module"}, false, []string{"-Djib.console=plain", "--projects", "module", "--also-make", "package", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Module: "module"}, true, []string{"-Djib.console=plain", "--projects", "module", "--also-make", "-DskipTests=true", "package", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Module: "module", Profile: "profile"}, false, []string{"-Djib.console=plain", "--activate-profiles", "profile", "--projects", "module", "--also-make", "package", "-Dimage=image"}},
+		{latest.JibMavenArtifact{Module: "module", Profile: "profile"}, true, []string{"-Djib.console=plain", "--activate-profiles", "profile", "--projects", "module", "--also-make", "-DskipTests=true", "package", "-Dimage=image"}},
 	}
 
 	for _, tt := range testCases {

--- a/pkg/skaffold/plugin/environments/gcb/jib_test.go
+++ b/pkg/skaffold/plugin/environments/gcb/jib_test.go
@@ -29,8 +29,8 @@ func TestJibMavenBuildSteps(t *testing.T) {
 		skipTests bool
 		args      []string
 	}{
-		{false, []string{"--non-recursive", "prepare-package", "jib:dockerBuild", "-Dimage=img"}},
-		{true, []string{"--non-recursive", "-DskipTests=true", "prepare-package", "jib:dockerBuild", "-Dimage=img"}},
+		{false, []string{"-Djib.console=plain", "--non-recursive", "prepare-package", "jib:dockerBuild", "-Dimage=img"}},
+		{true, []string{"-Djib.console=plain", "--non-recursive", "-DskipTests=true", "prepare-package", "jib:dockerBuild", "-Dimage=img"}},
 	}
 	for _, tt := range testCases {
 		artifact := &latest.Artifact{
@@ -63,8 +63,8 @@ func TestJibGradleBuildSteps(t *testing.T) {
 		skipTests bool
 		args      []string
 	}{
-		{false, []string{":jibDockerBuild", "--image=img"}},
-		{true, []string{":jibDockerBuild", "--image=img", "-x", "test"}},
+		{false, []string{"-Djib.console=plain", ":jibDockerBuild", "--image=img"}},
+		{true, []string{"-Djib.console=plain", ":jibDockerBuild", "--image=img", "-x", "test"}},
 	}
 	for _, tt := range testCases {
 		artifact := &latest.Artifact{


### PR DESCRIPTION
Fixes GoogleContainerTools/jib#1430

This PR changes Skaffold's Jib binding to invoke Maven and Gradle with `-Djib.console=plain` to cause Jib to use its impoverished plain progress updater.

Jib provides a _rich_ progress updater that uses ANSI cursor sequences to provide a more GUI-like  build monitor.  Although we attempt to log these sequence strings as a single output, there can be interference if there is simultaneous output.  This rich progress updater is automatically disabled on Jib-Maven when invoked from Skaffold, and this patch explicitly disables Jib's rich progress updater on Jib-Gradle too.

The use of `jib.console` is a compromise.  Although Maven and Gradle provide options to run in a batch mode, doing so disables all colour output which is actually very useful. These batch modes can be enabled from the `args` field in the `skaffold.yaml`, and are automatically set when console output is redirected to a log file.