### PR TITLE
extracting Pipeline from SkaffoldConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ examples/bazel/bazel-*
 integration/examples/bazel/bazel-*
 integration/testdata/plugin/local/bazel/bazel-*
 *.new
+*.iml
 .idea/
 docs/.firebase
 docs/firebase-debug*

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -30,8 +30,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// newRunner creates a SkaffoldRunner and returns the SkaffoldPipeline associated with it.
-func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.SkaffoldPipeline, error) {
+// newRunner creates a SkaffoldRunner and returns the SkaffoldConfig associated with it.
+func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.SkaffoldConfig, error) {
 	parsed, err := schema.ParseConfig(opts.ConfigurationFile, true)
 	if err != nil {
 		latest, current, versionErr := update.GetLatestAndCurrentVersion()
@@ -41,7 +41,7 @@ func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.Sk
 		return nil, nil, errors.Wrap(err, "parsing skaffold config")
 	}
 
-	config := parsed.(*latest.SkaffoldPipeline)
+	config := parsed.(*latest.SkaffoldConfig)
 
 	err = schema.ApplyProfiles(config, opts)
 	if err != nil {
@@ -67,7 +67,7 @@ func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.Sk
 	return runner, config, nil
 }
 
-func applyDefaultRepoSubstitution(config *latest.SkaffoldPipeline, defaultRepo string) {
+func applyDefaultRepoSubstitution(config *latest.SkaffoldConfig, defaultRepo string) {
 	if defaultRepo == "" {
 		// noop
 		return

--- a/docs/content/en/docs/references/yaml/main.js
+++ b/docs/content/en/docs/references/yaml/main.js
@@ -20,7 +20,6 @@ function* template(definitions, parentDefinition, ref, ident) {
   const allProperties = [];
   const seen = {};
 
-  console.log(name)
   const properties = definitions[name].properties;
   for (const key of (definitions[name].preferredOrder || [])) {
     allProperties.push([key, properties[key]]);

--- a/docs/content/en/docs/references/yaml/main.js
+++ b/docs/content/en/docs/references/yaml/main.js
@@ -11,7 +11,7 @@ var version;
   const table = document.getElementById("table");
 
   render(html`
-    ${template(json.definitions, undefined, '#/definitions/SkaffoldPipeline', 0)}
+    ${template(json.definitions, undefined, json.anyOf[0].$ref, 0)}
   `, table);
 })();
 
@@ -20,6 +20,7 @@ function* template(definitions, parentDefinition, ref, ident) {
   const allProperties = [];
   const seen = {};
 
+  console.log(name)
   const properties = definitions[name].properties;
   for (const key of (definitions[name].preferredOrder || [])) {
     allProperties.push([key, properties[key]]);

--- a/docs/content/en/schemas/v1beta7.json
+++ b/docs/content/en/schemas/v1beta7.json
@@ -2,7 +2,7 @@
   "type": "object",
   "anyOf": [
     {
-      "$ref": "#/definitions/SkaffoldPipeline"
+      "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
   "$schema": "http://json-schema-org/draft-07/schema#",

--- a/docs/content/en/schemas/v1beta7.json
+++ b/docs/content/en/schemas/v1beta7.json
@@ -1565,165 +1565,59 @@
       "required": [
         "name"
       ],
-      "anyOf": [
-        {
-          "properties": {
-            "activation": {
-              "items": {
-                "$ref": "#/definitions/Activation"
-              },
-              "type": "array",
-              "description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.",
-              "x-intellij-html-description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered."
-            },
-            "name": {
-              "type": "string",
-              "description": "a unique profile name.",
-              "x-intellij-html-description": "a unique profile name.",
-              "examples": [
-                "profile-prod"
-              ]
-            },
-            "patches": {
-              "items": {
-                "$ref": "#/definitions/JSONPatch"
-              },
-              "type": "array",
-              "description": "patches applied to the configuration. Patches use the JSON patch notation.",
-              "x-intellij-html-description": "patches applied to the configuration. Patches use the JSON patch notation."
-            }
+      "properties": {
+        "activation": {
+          "items": {
+            "$ref": "#/definitions/Activation"
           },
-          "preferredOrder": [
-            "name",
-            "patches",
-            "activation"
-          ],
-          "additionalProperties": false
+          "type": "array",
+          "description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.",
+          "x-intellij-html-description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered."
         },
-        {
-          "properties": {
-            "activation": {
-              "items": {
-                "$ref": "#/definitions/Activation"
-              },
-              "type": "array",
-              "description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.",
-              "x-intellij-html-description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered."
-            },
-            "build": {
-              "$ref": "#/definitions/BuildConfig",
-              "description": "describes how images are built.",
-              "x-intellij-html-description": "describes how images are built."
-            },
-            "name": {
-              "type": "string",
-              "description": "a unique profile name.",
-              "x-intellij-html-description": "a unique profile name.",
-              "examples": [
-                "profile-prod"
-              ]
-            },
-            "patches": {
-              "items": {
-                "$ref": "#/definitions/JSONPatch"
-              },
-              "type": "array",
-              "description": "patches applied to the configuration. Patches use the JSON patch notation.",
-              "x-intellij-html-description": "patches applied to the configuration. Patches use the JSON patch notation."
-            }
-          },
-          "preferredOrder": [
-            "name",
-            "patches",
-            "activation",
-            "build"
-          ],
-          "additionalProperties": false
+        "build": {
+          "$ref": "#/definitions/BuildConfig",
+          "description": "describes how images are built.",
+          "x-intellij-html-description": "describes how images are built."
         },
-        {
-          "properties": {
-            "activation": {
-              "items": {
-                "$ref": "#/definitions/Activation"
-              },
-              "type": "array",
-              "description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.",
-              "x-intellij-html-description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered."
-            },
-            "name": {
-              "type": "string",
-              "description": "a unique profile name.",
-              "x-intellij-html-description": "a unique profile name.",
-              "examples": [
-                "profile-prod"
-              ]
-            },
-            "patches": {
-              "items": {
-                "$ref": "#/definitions/JSONPatch"
-              },
-              "type": "array",
-              "description": "patches applied to the configuration. Patches use the JSON patch notation.",
-              "x-intellij-html-description": "patches applied to the configuration. Patches use the JSON patch notation."
-            },
-            "test": {
-              "items": {
-                "$ref": "#/definitions/TestCase"
-              },
-              "type": "array",
-              "description": "describes how images are tested.",
-              "x-intellij-html-description": "describes how images are tested."
-            }
-          },
-          "preferredOrder": [
-            "name",
-            "patches",
-            "activation",
-            "test"
-          ],
-          "additionalProperties": false
+        "deploy": {
+          "$ref": "#/definitions/DeployConfig",
+          "description": "describes how images are deployed.",
+          "x-intellij-html-description": "describes how images are deployed."
         },
-        {
-          "properties": {
-            "activation": {
-              "items": {
-                "$ref": "#/definitions/Activation"
-              },
-              "type": "array",
-              "description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.",
-              "x-intellij-html-description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered."
-            },
-            "deploy": {
-              "$ref": "#/definitions/DeployConfig",
-              "description": "describes how images are deployed.",
-              "x-intellij-html-description": "describes how images are deployed."
-            },
-            "name": {
-              "type": "string",
-              "description": "a unique profile name.",
-              "x-intellij-html-description": "a unique profile name.",
-              "examples": [
-                "profile-prod"
-              ]
-            },
-            "patches": {
-              "items": {
-                "$ref": "#/definitions/JSONPatch"
-              },
-              "type": "array",
-              "description": "patches applied to the configuration. Patches use the JSON patch notation.",
-              "x-intellij-html-description": "patches applied to the configuration. Patches use the JSON patch notation."
-            }
+        "name": {
+          "type": "string",
+          "description": "a unique profile name.",
+          "x-intellij-html-description": "a unique profile name.",
+          "examples": [
+            "profile-prod"
+          ]
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/definitions/JSONPatch"
           },
-          "preferredOrder": [
-            "name",
-            "patches",
-            "activation",
-            "deploy"
-          ],
-          "additionalProperties": false
+          "type": "array",
+          "description": "patches applied to the configuration. Patches use the JSON patch notation.",
+          "x-intellij-html-description": "patches applied to the configuration. Patches use the JSON patch notation."
+        },
+        "test": {
+          "items": {
+            "$ref": "#/definitions/TestCase"
+          },
+          "type": "array",
+          "description": "describes how images are tested.",
+          "x-intellij-html-description": "describes how images are tested."
         }
+      },
+      "preferredOrder": [
+        "name",
+        "patches",
+        "activation",
+        "build",
+        "test",
+        "deploy"
       ],
+      "additionalProperties": false,
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1732,147 +1626,56 @@
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
     "SkaffoldConfig": {
-      "anyOf": [
-        {
-          "properties": {
-            "apiVersion": {
-              "type": "string",
-              "description": "version of the configuration.",
-              "x-intellij-html-description": "version of the configuration."
-            },
-            "kind": {
-              "type": "string",
-              "description": "always `Config`.",
-              "x-intellij-html-description": "always <code>Config</code>.",
-              "default": "Config"
-            },
-            "profiles": {
-              "items": {
-                "$ref": "#/definitions/Profile"
-              },
-              "type": "array",
-              "description": "*beta* can override be used to `build`, `test` or `deploy` configuration.",
-              "x-intellij-html-description": "<em>beta</em> can override be used to <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
-            }
-          },
-          "preferredOrder": [
-            "apiVersion",
-            "kind",
-            "profiles"
-          ],
-          "additionalProperties": false
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "version of the configuration.",
+          "x-intellij-html-description": "version of the configuration."
         },
-        {
-          "properties": {
-            "apiVersion": {
-              "type": "string",
-              "description": "version of the configuration.",
-              "x-intellij-html-description": "version of the configuration."
-            },
-            "build": {
-              "$ref": "#/definitions/BuildConfig",
-              "description": "describes how images are built.",
-              "x-intellij-html-description": "describes how images are built."
-            },
-            "kind": {
-              "type": "string",
-              "description": "always `Config`.",
-              "x-intellij-html-description": "always <code>Config</code>.",
-              "default": "Config"
-            },
-            "profiles": {
-              "items": {
-                "$ref": "#/definitions/Profile"
-              },
-              "type": "array",
-              "description": "*beta* can override be used to `build`, `test` or `deploy` configuration.",
-              "x-intellij-html-description": "<em>beta</em> can override be used to <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
-            }
-          },
-          "preferredOrder": [
-            "apiVersion",
-            "kind",
-            "profiles",
-            "build"
-          ],
-          "additionalProperties": false
+        "build": {
+          "$ref": "#/definitions/BuildConfig",
+          "description": "describes how images are built.",
+          "x-intellij-html-description": "describes how images are built."
         },
-        {
-          "properties": {
-            "apiVersion": {
-              "type": "string",
-              "description": "version of the configuration.",
-              "x-intellij-html-description": "version of the configuration."
-            },
-            "kind": {
-              "type": "string",
-              "description": "always `Config`.",
-              "x-intellij-html-description": "always <code>Config</code>.",
-              "default": "Config"
-            },
-            "profiles": {
-              "items": {
-                "$ref": "#/definitions/Profile"
-              },
-              "type": "array",
-              "description": "*beta* can override be used to `build`, `test` or `deploy` configuration.",
-              "x-intellij-html-description": "<em>beta</em> can override be used to <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
-            },
-            "test": {
-              "items": {
-                "$ref": "#/definitions/TestCase"
-              },
-              "type": "array",
-              "description": "describes how images are tested.",
-              "x-intellij-html-description": "describes how images are tested."
-            }
-          },
-          "preferredOrder": [
-            "apiVersion",
-            "kind",
-            "profiles",
-            "test"
-          ],
-          "additionalProperties": false
+        "deploy": {
+          "$ref": "#/definitions/DeployConfig",
+          "description": "describes how images are deployed.",
+          "x-intellij-html-description": "describes how images are deployed."
         },
-        {
-          "properties": {
-            "apiVersion": {
-              "type": "string",
-              "description": "version of the configuration.",
-              "x-intellij-html-description": "version of the configuration."
-            },
-            "deploy": {
-              "$ref": "#/definitions/DeployConfig",
-              "description": "describes how images are deployed.",
-              "x-intellij-html-description": "describes how images are deployed."
-            },
-            "kind": {
-              "type": "string",
-              "description": "always `Config`.",
-              "x-intellij-html-description": "always <code>Config</code>.",
-              "default": "Config"
-            },
-            "profiles": {
-              "items": {
-                "$ref": "#/definitions/Profile"
-              },
-              "type": "array",
-              "description": "*beta* can override be used to `build`, `test` or `deploy` configuration.",
-              "x-intellij-html-description": "<em>beta</em> can override be used to <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
-            }
+        "kind": {
+          "type": "string",
+          "description": "always `Config`.",
+          "x-intellij-html-description": "always <code>Config</code>.",
+          "default": "Config"
+        },
+        "profiles": {
+          "items": {
+            "$ref": "#/definitions/Profile"
           },
-          "preferredOrder": [
-            "apiVersion",
-            "kind",
-            "profiles",
-            "deploy"
-          ],
-          "additionalProperties": false
+          "type": "array",
+          "description": "*beta* can override be used to `build`, `test` or `deploy` configuration.",
+          "x-intellij-html-description": "<em>beta</em> can override be used to <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
+        },
+        "test": {
+          "items": {
+            "$ref": "#/definitions/TestCase"
+          },
+          "type": "array",
+          "description": "describes how images are tested.",
+          "x-intellij-html-description": "describes how images are tested."
         }
+      },
+      "preferredOrder": [
+        "apiVersion",
+        "kind",
+        "profiles",
+        "build",
+        "test",
+        "deploy"
       ],
-      "description": "describes a Skaffold pipeline configuration file.",
-      "x-intellij-html-description": "describes a Skaffold pipeline configuration file."
+      "additionalProperties": false,
+      "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
+      "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
     "TagPolicy": {
       "properties": {

--- a/docs/content/en/schemas/v1beta7.json
+++ b/docs/content/en/schemas/v1beta7.json
@@ -1531,77 +1531,8 @@
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
-    "Profile": {
-      "required": [
-        "name"
-      ],
+    "Pipeline": {
       "properties": {
-        "activation": {
-          "items": {
-            "$ref": "#/definitions/Activation"
-          },
-          "type": "array",
-          "description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.",
-          "x-intellij-html-description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered."
-        },
-        "build": {
-          "$ref": "#/definitions/BuildConfig",
-          "description": "replaces the main `build` configuration.",
-          "x-intellij-html-description": "replaces the main <code>build</code> configuration."
-        },
-        "deploy": {
-          "$ref": "#/definitions/DeployConfig",
-          "description": "replaces the main `deploy` configuration.",
-          "x-intellij-html-description": "replaces the main <code>deploy</code> configuration."
-        },
-        "name": {
-          "type": "string",
-          "description": "a unique profile name.",
-          "x-intellij-html-description": "a unique profile name.",
-          "examples": [
-            "profile-prod"
-          ]
-        },
-        "patches": {
-          "items": {
-            "$ref": "#/definitions/JSONPatch"
-          },
-          "type": "array",
-          "description": "patches applied to the configuration. Patches use the JSON patch notation.",
-          "x-intellij-html-description": "patches applied to the configuration. Patches use the JSON patch notation."
-        },
-        "test": {
-          "items": {
-            "$ref": "#/definitions/TestCase"
-          },
-          "type": "array",
-          "description": "replaces the main `test` configuration.",
-          "x-intellij-html-description": "replaces the main <code>test</code> configuration."
-        }
-      },
-      "preferredOrder": [
-        "name",
-        "build",
-        "test",
-        "deploy",
-        "patches",
-        "activation"
-      ],
-      "additionalProperties": false,
-      "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
-      "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
-    },
-    "ShaTagger": {
-      "description": "*beta* tags images with their sha256 digest.",
-      "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
-    },
-    "SkaffoldPipeline": {
-      "properties": {
-        "apiVersion": {
-          "type": "string",
-          "description": "version of the configuration.",
-          "x-intellij-html-description": "version of the configuration."
-        },
         "build": {
           "$ref": "#/definitions/BuildConfig",
           "description": "describes how images are built.",
@@ -1611,20 +1542,6 @@
           "$ref": "#/definitions/DeployConfig",
           "description": "describes how images are deployed.",
           "x-intellij-html-description": "describes how images are deployed."
-        },
-        "kind": {
-          "type": "string",
-          "description": "always `Config`.",
-          "x-intellij-html-description": "always <code>Config</code>.",
-          "default": "Config"
-        },
-        "profiles": {
-          "items": {
-            "$ref": "#/definitions/Profile"
-          },
-          "type": "array",
-          "description": "*beta* can override be used to `build`, `test` or `deploy` configuration.",
-          "x-intellij-html-description": "<em>beta</em> can override be used to <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
         },
         "test": {
           "items": {
@@ -1636,16 +1553,326 @@
         }
       },
       "preferredOrder": [
-        "apiVersion",
-        "kind",
         "build",
         "test",
-        "deploy",
-        "profiles"
+        "deploy"
       ],
       "additionalProperties": false,
       "description": "describes a Skaffold pipeline.",
       "x-intellij-html-description": "describes a Skaffold pipeline."
+    },
+    "Profile": {
+      "required": [
+        "name"
+      ],
+      "anyOf": [
+        {
+          "properties": {
+            "activation": {
+              "items": {
+                "$ref": "#/definitions/Activation"
+              },
+              "type": "array",
+              "description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.",
+              "x-intellij-html-description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered."
+            },
+            "name": {
+              "type": "string",
+              "description": "a unique profile name.",
+              "x-intellij-html-description": "a unique profile name.",
+              "examples": [
+                "profile-prod"
+              ]
+            },
+            "patches": {
+              "items": {
+                "$ref": "#/definitions/JSONPatch"
+              },
+              "type": "array",
+              "description": "patches applied to the configuration. Patches use the JSON patch notation.",
+              "x-intellij-html-description": "patches applied to the configuration. Patches use the JSON patch notation."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "patches",
+            "activation"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "activation": {
+              "items": {
+                "$ref": "#/definitions/Activation"
+              },
+              "type": "array",
+              "description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.",
+              "x-intellij-html-description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered."
+            },
+            "build": {
+              "$ref": "#/definitions/BuildConfig",
+              "description": "describes how images are built.",
+              "x-intellij-html-description": "describes how images are built."
+            },
+            "name": {
+              "type": "string",
+              "description": "a unique profile name.",
+              "x-intellij-html-description": "a unique profile name.",
+              "examples": [
+                "profile-prod"
+              ]
+            },
+            "patches": {
+              "items": {
+                "$ref": "#/definitions/JSONPatch"
+              },
+              "type": "array",
+              "description": "patches applied to the configuration. Patches use the JSON patch notation.",
+              "x-intellij-html-description": "patches applied to the configuration. Patches use the JSON patch notation."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "patches",
+            "activation",
+            "build"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "activation": {
+              "items": {
+                "$ref": "#/definitions/Activation"
+              },
+              "type": "array",
+              "description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.",
+              "x-intellij-html-description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered."
+            },
+            "name": {
+              "type": "string",
+              "description": "a unique profile name.",
+              "x-intellij-html-description": "a unique profile name.",
+              "examples": [
+                "profile-prod"
+              ]
+            },
+            "patches": {
+              "items": {
+                "$ref": "#/definitions/JSONPatch"
+              },
+              "type": "array",
+              "description": "patches applied to the configuration. Patches use the JSON patch notation.",
+              "x-intellij-html-description": "patches applied to the configuration. Patches use the JSON patch notation."
+            },
+            "test": {
+              "items": {
+                "$ref": "#/definitions/TestCase"
+              },
+              "type": "array",
+              "description": "describes how images are tested.",
+              "x-intellij-html-description": "describes how images are tested."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "patches",
+            "activation",
+            "test"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "activation": {
+              "items": {
+                "$ref": "#/definitions/Activation"
+              },
+              "type": "array",
+              "description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.",
+              "x-intellij-html-description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered."
+            },
+            "deploy": {
+              "$ref": "#/definitions/DeployConfig",
+              "description": "describes how images are deployed.",
+              "x-intellij-html-description": "describes how images are deployed."
+            },
+            "name": {
+              "type": "string",
+              "description": "a unique profile name.",
+              "x-intellij-html-description": "a unique profile name.",
+              "examples": [
+                "profile-prod"
+              ]
+            },
+            "patches": {
+              "items": {
+                "$ref": "#/definitions/JSONPatch"
+              },
+              "type": "array",
+              "description": "patches applied to the configuration. Patches use the JSON patch notation.",
+              "x-intellij-html-description": "patches applied to the configuration. Patches use the JSON patch notation."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "patches",
+            "activation",
+            "deploy"
+          ],
+          "additionalProperties": false
+        }
+      ],
+      "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
+      "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
+    },
+    "ShaTagger": {
+      "description": "*beta* tags images with their sha256 digest.",
+      "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
+    },
+    "SkaffoldConfig": {
+      "anyOf": [
+        {
+          "properties": {
+            "apiVersion": {
+              "type": "string",
+              "description": "version of the configuration.",
+              "x-intellij-html-description": "version of the configuration."
+            },
+            "kind": {
+              "type": "string",
+              "description": "always `Config`.",
+              "x-intellij-html-description": "always <code>Config</code>.",
+              "default": "Config"
+            },
+            "profiles": {
+              "items": {
+                "$ref": "#/definitions/Profile"
+              },
+              "type": "array",
+              "description": "*beta* can override be used to `build`, `test` or `deploy` configuration.",
+              "x-intellij-html-description": "<em>beta</em> can override be used to <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
+            }
+          },
+          "preferredOrder": [
+            "apiVersion",
+            "kind",
+            "profiles"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "apiVersion": {
+              "type": "string",
+              "description": "version of the configuration.",
+              "x-intellij-html-description": "version of the configuration."
+            },
+            "build": {
+              "$ref": "#/definitions/BuildConfig",
+              "description": "describes how images are built.",
+              "x-intellij-html-description": "describes how images are built."
+            },
+            "kind": {
+              "type": "string",
+              "description": "always `Config`.",
+              "x-intellij-html-description": "always <code>Config</code>.",
+              "default": "Config"
+            },
+            "profiles": {
+              "items": {
+                "$ref": "#/definitions/Profile"
+              },
+              "type": "array",
+              "description": "*beta* can override be used to `build`, `test` or `deploy` configuration.",
+              "x-intellij-html-description": "<em>beta</em> can override be used to <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
+            }
+          },
+          "preferredOrder": [
+            "apiVersion",
+            "kind",
+            "profiles",
+            "build"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "apiVersion": {
+              "type": "string",
+              "description": "version of the configuration.",
+              "x-intellij-html-description": "version of the configuration."
+            },
+            "kind": {
+              "type": "string",
+              "description": "always `Config`.",
+              "x-intellij-html-description": "always <code>Config</code>.",
+              "default": "Config"
+            },
+            "profiles": {
+              "items": {
+                "$ref": "#/definitions/Profile"
+              },
+              "type": "array",
+              "description": "*beta* can override be used to `build`, `test` or `deploy` configuration.",
+              "x-intellij-html-description": "<em>beta</em> can override be used to <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
+            },
+            "test": {
+              "items": {
+                "$ref": "#/definitions/TestCase"
+              },
+              "type": "array",
+              "description": "describes how images are tested.",
+              "x-intellij-html-description": "describes how images are tested."
+            }
+          },
+          "preferredOrder": [
+            "apiVersion",
+            "kind",
+            "profiles",
+            "test"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "apiVersion": {
+              "type": "string",
+              "description": "version of the configuration.",
+              "x-intellij-html-description": "version of the configuration."
+            },
+            "deploy": {
+              "$ref": "#/definitions/DeployConfig",
+              "description": "describes how images are deployed.",
+              "x-intellij-html-description": "describes how images are deployed."
+            },
+            "kind": {
+              "type": "string",
+              "description": "always `Config`.",
+              "x-intellij-html-description": "always <code>Config</code>.",
+              "default": "Config"
+            },
+            "profiles": {
+              "items": {
+                "$ref": "#/definitions/Profile"
+              },
+              "type": "array",
+              "description": "*beta* can override be used to `build`, `test` or `deploy` configuration.",
+              "x-intellij-html-description": "<em>beta</em> can override be used to <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
+            }
+          },
+          "preferredOrder": [
+            "apiVersion",
+            "kind",
+            "profiles",
+            "deploy"
+          ],
+          "additionalProperties": false
+        }
+      ],
+      "description": "describes a Skaffold pipeline configuration file.",
+      "x-intellij-html-description": "describes a Skaffold pipeline configuration file."
     },
     "TagPolicy": {
       "properties": {

--- a/hack/schemas/main.go
+++ b/hack/schemas/main.go
@@ -357,7 +357,7 @@ func (g *schemaGenerator) Apply(inputPath string) ([]byte, error) {
 		Definition: &Definition{
 			Type: "object",
 			AnyOf: []*Definition{{
-				Ref: defPrefix + "SkaffoldPipeline",
+				Ref: defPrefix + preferredOrder[0],
 			}},
 		},
 		Definitions: definitions,

--- a/hack/schemas/testdata/inline-anyof/output.json
+++ b/hack/schemas/testdata/inline-anyof/output.json
@@ -2,7 +2,7 @@
   "type": "object",
   "anyOf": [
     {
-      "$ref": "#/definitions/SkaffoldPipeline"
+      "$ref": "#/definitions/TestStruct"
     }
   ],
   "$schema": "http://json-schema-org/draft-07/schema#",

--- a/hack/schemas/testdata/inline-hybrid/output.json
+++ b/hack/schemas/testdata/inline-hybrid/output.json
@@ -2,7 +2,7 @@
   "type": "object",
   "anyOf": [
     {
-      "$ref": "#/definitions/SkaffoldPipeline"
+      "$ref": "#/definitions/TestStruct"
     }
   ],
   "$schema": "http://json-schema-org/draft-07/schema#",

--- a/hack/schemas/testdata/inline/output.json
+++ b/hack/schemas/testdata/inline/output.json
@@ -2,7 +2,7 @@
   "type": "object",
   "anyOf": [
     {
-      "$ref": "#/definitions/SkaffoldPipeline"
+      "$ref": "#/definitions/TestStruct"
     }
   ],
   "$schema": "http://json-schema-org/draft-07/schema#",

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -242,7 +242,7 @@ func generateSkaffoldPipeline(k Initializer, dockerfilePairs []dockerfilePair) (
 	// if the user doesn't have any k8s yamls, generate one for each dockerfile
 	logrus.Info("generating skaffold config")
 
-	pipeline := &latest.SkaffoldPipeline{
+	pipeline := &latest.SkaffoldConfig{
 		APIVersion: latest.Version,
 		Kind:       "Config",
 	}

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -242,18 +242,18 @@ func generateSkaffoldPipeline(k Initializer, dockerfilePairs []dockerfilePair) (
 	// if the user doesn't have any k8s yamls, generate one for each dockerfile
 	logrus.Info("generating skaffold config")
 
-	pipeline := &latest.SkaffoldConfig{
+	cfg := &latest.SkaffoldConfig{
 		APIVersion: latest.Version,
 		Kind:       "Config",
 	}
-	if err := defaults.Set(pipeline); err != nil {
+	if err := defaults.Set(cfg); err != nil {
 		return nil, errors.Wrap(err, "generating default pipeline")
 	}
 
-	pipeline.Build = processBuildArtifacts(dockerfilePairs)
-	pipeline.Deploy = k.GenerateDeployConfig()
+	cfg.Build = processBuildArtifacts(dockerfilePairs)
+	cfg.Deploy = k.GenerateDeployConfig()
 
-	pipelineStr, err := yaml.Marshal(pipeline)
+	pipelineStr, err := yaml.Marshal(cfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshaling generated pipeline")
 	}

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -34,7 +34,7 @@ import (
 var ErrorConfigurationChanged = errors.New("configuration changed")
 
 // Dev watches for changes and runs the skaffold build and deploy
-// pipeline until interrupted by the user.
+// config until interrupted by the user.
 func (r *SkaffoldRunner) Dev(ctx context.Context, output *config.Output, artifacts []*latest.Artifact) error {
 	logger := r.newLogger(output.Logs, artifacts)
 	defer logger.Stop()

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -67,8 +67,8 @@ type SkaffoldRunner struct {
 	RPCServerShutdown func() error
 }
 
-// NewForConfig returns a new SkaffoldRunner for a SkaffoldPipeline
-func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldPipeline) (*SkaffoldRunner, error) {
+// NewForConfig returns a new SkaffoldRunner for a SkaffoldConfig
+func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldConfig) (*SkaffoldRunner, error) {
 	kubeContext, err := kubectx.CurrentContext()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting current cluster context")

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -48,7 +48,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/watch"
 )
 
-// SkaffoldRunner is responsible for running the skaffold build and deploy pipeline.
+// SkaffoldRunner is responsible for running the skaffold build and deploy config.
 type SkaffoldRunner struct {
 	build.Builder
 	deploy.Deployer

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -151,10 +151,10 @@ func createRunner(t *testing.T, testBench *TestBench) *SkaffoldRunner {
 		Trigger: "polling",
 	}
 
-	pipeline := &latest.SkaffoldConfig{}
-	defaults.Set(pipeline)
+	cfg := &latest.SkaffoldConfig{}
+	defaults.Set(cfg)
 
-	runner, err := NewForConfig(opts, pipeline)
+	runner, err := NewForConfig(opts, cfg)
 
 	testutil.CheckError(t, false, err)
 
@@ -172,7 +172,7 @@ func TestNewForConfig(t *testing.T) {
 
 	var tests = []struct {
 		description      string
-		pipeline         *latest.SkaffoldConfig
+		config           *latest.SkaffoldConfig
 		shouldErr        bool
 		cacheArtifacts   bool
 		expectedBuilder  build.Builder
@@ -181,7 +181,7 @@ func TestNewForConfig(t *testing.T) {
 	}{
 		{
 			description: "local builder config",
-			pipeline: &latest.SkaffoldConfig{
+			config: &latest.SkaffoldConfig{
 				Pipeline: latest.Pipeline{
 					Build: latest.BuildConfig{
 						TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
@@ -202,7 +202,7 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "bad tagger config",
-			pipeline: &latest.SkaffoldConfig{
+			config: &latest.SkaffoldConfig{
 				Pipeline: latest.Pipeline{
 					Build: latest.BuildConfig{
 						TagPolicy: latest.TagPolicy{},
@@ -221,7 +221,7 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "unknown builder",
-			pipeline: &latest.SkaffoldConfig{
+			config: &latest.SkaffoldConfig{
 				Pipeline: latest.Pipeline{
 					Build: latest.BuildConfig{},
 				},
@@ -233,7 +233,7 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "unknown tagger",
-			pipeline: &latest.SkaffoldConfig{
+			config: &latest.SkaffoldConfig{
 				Pipeline: latest.Pipeline{
 					Build: latest.BuildConfig{
 						TagPolicy: latest.TagPolicy{},
@@ -249,7 +249,7 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "unknown deployer",
-			pipeline: &latest.SkaffoldConfig{
+			config: &latest.SkaffoldConfig{
 				Pipeline: latest.Pipeline{
 					Build: latest.BuildConfig{
 						TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
@@ -263,7 +263,7 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "no artifacts, cache",
-			pipeline: &latest.SkaffoldConfig{
+			config: &latest.SkaffoldConfig{
 				Pipeline: latest.Pipeline{
 					Build: latest.BuildConfig{
 						TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
@@ -288,7 +288,7 @@ func TestNewForConfig(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			cfg, err := NewForConfig(&config.SkaffoldOptions{
 				Trigger: "polling",
-			}, test.pipeline)
+			}, test.config)
 
 			testutil.CheckError(t, test.shouldErr, err)
 			if cfg != nil {

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -150,7 +150,7 @@ func createRunner(t *testing.T, testBench *TestBench) *SkaffoldRunner {
 		Trigger: "polling",
 	}
 
-	pipeline := &latest.SkaffoldPipeline{}
+	pipeline := &latest.SkaffoldConfig{}
 	defaults.Set(pipeline)
 
 	runner, err := NewForConfig(opts, pipeline)
@@ -171,7 +171,7 @@ func TestNewForConfig(t *testing.T) {
 
 	var tests = []struct {
 		description      string
-		pipeline         *latest.SkaffoldPipeline
+		pipeline         *latest.SkaffoldConfig
 		shouldErr        bool
 		cacheArtifacts   bool
 		expectedBuilder  build.Builder
@@ -180,16 +180,18 @@ func TestNewForConfig(t *testing.T) {
 	}{
 		{
 			description: "local builder config",
-			pipeline: &latest.SkaffoldPipeline{
-				Build: latest.BuildConfig{
-					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
-					BuildType: latest.BuildType{
-						LocalBuild: &latest.LocalBuild{},
+			pipeline: &latest.SkaffoldConfig{
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{
+						TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
+						BuildType: latest.BuildType{
+							LocalBuild: &latest.LocalBuild{},
+						},
 					},
-				},
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KubectlDeploy: &latest.KubectlDeploy{},
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							KubectlDeploy: &latest.KubectlDeploy{},
+						},
 					},
 				},
 			},
@@ -199,16 +201,18 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "bad tagger config",
-			pipeline: &latest.SkaffoldPipeline{
-				Build: latest.BuildConfig{
-					TagPolicy: latest.TagPolicy{},
-					BuildType: latest.BuildType{
-						LocalBuild: &latest.LocalBuild{},
+			pipeline: &latest.SkaffoldConfig{
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{
+						TagPolicy: latest.TagPolicy{},
+						BuildType: latest.BuildType{
+							LocalBuild: &latest.LocalBuild{},
+						},
 					},
-				},
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KubectlDeploy: &latest.KubectlDeploy{},
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							KubectlDeploy: &latest.KubectlDeploy{},
+						},
 					},
 				},
 			},
@@ -216,8 +220,10 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "unknown builder",
-			pipeline: &latest.SkaffoldPipeline{
-				Build: latest.BuildConfig{},
+			pipeline: &latest.SkaffoldConfig{
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{},
+				},
 			},
 			shouldErr:        true,
 			expectedBuilder:  &local.Builder{},
@@ -226,11 +232,13 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "unknown tagger",
-			pipeline: &latest.SkaffoldPipeline{
-				Build: latest.BuildConfig{
-					TagPolicy: latest.TagPolicy{},
-					BuildType: latest.BuildType{
-						LocalBuild: &latest.LocalBuild{},
+			pipeline: &latest.SkaffoldConfig{
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{
+						TagPolicy: latest.TagPolicy{},
+						BuildType: latest.BuildType{
+							LocalBuild: &latest.LocalBuild{},
+						},
 					},
 				}},
 			shouldErr:        true,
@@ -240,11 +248,13 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "unknown deployer",
-			pipeline: &latest.SkaffoldPipeline{
-				Build: latest.BuildConfig{
-					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
-					BuildType: latest.BuildType{
-						LocalBuild: &latest.LocalBuild{},
+			pipeline: &latest.SkaffoldConfig{
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{
+						TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
+						BuildType: latest.BuildType{
+							LocalBuild: &latest.LocalBuild{},
+						},
 					},
 				},
 			},
@@ -252,16 +262,18 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "no artifacts, cache",
-			pipeline: &latest.SkaffoldPipeline{
-				Build: latest.BuildConfig{
-					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
-					BuildType: latest.BuildType{
-						LocalBuild: &latest.LocalBuild{},
+			pipeline: &latest.SkaffoldConfig{
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{
+						TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
+						BuildType: latest.BuildType{
+							LocalBuild: &latest.LocalBuild{},
+						},
 					},
-				},
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KubectlDeploy: &latest.KubectlDeploy{},
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							KubectlDeploy: &latest.KubectlDeploy{},
+						},
 					},
 				},
 			},

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -27,8 +27,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Set makes sure default values are set on a SkaffoldPipeline.
-func Set(c *latest.SkaffoldPipeline) error {
+// Set makes sure default values are set on a SkaffoldConfig.
+func Set(c *latest.SkaffoldConfig) error {
 	if pluginsDefined(c) {
 		defaultToLocalExecEnvironment(c)
 		defaultToEmptyProperties(c)
@@ -80,7 +80,7 @@ func Set(c *latest.SkaffoldPipeline) error {
 	return nil
 }
 
-func defaultToLocalExecEnvironment(c *latest.SkaffoldPipeline) {
+func defaultToLocalExecEnvironment(c *latest.SkaffoldConfig) {
 	if c.Build.ExecutionEnvironment == nil {
 		c.Build.ExecutionEnvironment = &latest.ExecutionEnvironment{
 			Name: constants.Local,
@@ -88,13 +88,13 @@ func defaultToLocalExecEnvironment(c *latest.SkaffoldPipeline) {
 	}
 }
 
-func defaultToEmptyProperties(c *latest.SkaffoldPipeline) {
+func defaultToEmptyProperties(c *latest.SkaffoldConfig) {
 	if c.Build.ExecutionEnvironment.Properties == nil {
 		c.Build.ExecutionEnvironment.Properties = map[string]interface{}{}
 	}
 }
 
-func pluginsDefined(c *latest.SkaffoldPipeline) bool {
+func pluginsDefined(c *latest.SkaffoldConfig) bool {
 	for _, a := range c.Build.Artifacts {
 		if a.BuilderPlugin != nil {
 			return true
@@ -103,7 +103,7 @@ func pluginsDefined(c *latest.SkaffoldPipeline) bool {
 	return false
 }
 
-func defaultToLocalBuild(c *latest.SkaffoldPipeline) {
+func defaultToLocalBuild(c *latest.SkaffoldConfig) {
 	if c.Build.BuildType != (latest.BuildType{}) {
 		return
 	}
@@ -112,7 +112,7 @@ func defaultToLocalBuild(c *latest.SkaffoldPipeline) {
 	c.Build.BuildType.LocalBuild = &latest.LocalBuild{}
 }
 
-func defaultToKubectlDeploy(c *latest.SkaffoldPipeline) {
+func defaultToKubectlDeploy(c *latest.SkaffoldConfig) {
 	if c.Deploy.DeployType != (latest.DeployType{}) {
 		return
 	}
@@ -121,7 +121,7 @@ func defaultToKubectlDeploy(c *latest.SkaffoldPipeline) {
 	c.Deploy.DeployType.KubectlDeploy = &latest.KubectlDeploy{}
 }
 
-func withCloudBuildConfig(c *latest.SkaffoldPipeline, operations ...func(kaniko *latest.GoogleCloudBuild)) {
+func withCloudBuildConfig(c *latest.SkaffoldConfig, operations ...func(kaniko *latest.GoogleCloudBuild)) {
 	if gcb := c.Build.GoogleCloudBuild; gcb != nil {
 		for _, operation := range operations {
 			operation(gcb)
@@ -142,7 +142,7 @@ func setDefaultCloudBuildGradleImage(gcb *latest.GoogleCloudBuild) {
 	gcb.GradleImage = valueOrDefault(gcb.GradleImage, constants.DefaultCloudBuildGradleImage)
 }
 
-func setDefaultTagger(c *latest.SkaffoldPipeline) {
+func setDefaultTagger(c *latest.SkaffoldConfig) {
 	if c.Build.TagPolicy != (latest.TagPolicy{}) {
 		return
 	}
@@ -150,7 +150,7 @@ func setDefaultTagger(c *latest.SkaffoldPipeline) {
 	c.Build.TagPolicy = latest.TagPolicy{GitTagger: &latest.GitTagger{}}
 }
 
-func setDefaultKustomizePath(c *latest.SkaffoldPipeline) {
+func setDefaultKustomizePath(c *latest.SkaffoldConfig) {
 	kustomize := c.Deploy.KustomizeDeploy
 	if kustomize == nil {
 		return
@@ -159,7 +159,7 @@ func setDefaultKustomizePath(c *latest.SkaffoldPipeline) {
 	kustomize.KustomizePath = valueOrDefault(kustomize.KustomizePath, constants.DefaultKustomizationPath)
 }
 
-func setDefaultKubectlManifests(c *latest.SkaffoldPipeline) {
+func setDefaultKubectlManifests(c *latest.SkaffoldConfig) {
 	if c.Deploy.KubectlDeploy != nil && len(c.Deploy.KubectlDeploy.Manifests) == 0 {
 		c.Deploy.KubectlDeploy.Manifests = constants.DefaultKubectlManifests
 	}
@@ -188,7 +188,7 @@ func setDefaultWorkspace(a *latest.Artifact) {
 	a.Workspace = valueOrDefault(a.Workspace, ".")
 }
 
-func withClusterConfig(c *latest.SkaffoldPipeline, opts ...func(cluster *latest.ClusterDetails) error) error {
+func withClusterConfig(c *latest.SkaffoldConfig, opts ...func(cluster *latest.ClusterDetails) error) error {
 	clusterDetails := c.Build.BuildType.Cluster
 	if clusterDetails == nil {
 		return nil

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -26,18 +26,20 @@ import (
 )
 
 func TestSetDefaults(t *testing.T) {
-	pipeline := &latest.SkaffoldPipeline{
-		Build: latest.BuildConfig{
-			Artifacts: []*latest.Artifact{
-				{
-					ImageName: "first",
-				},
-				{
-					ImageName: "second",
-					Workspace: "folder",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
-							DockerfilePath: "Dockerfile.second",
+	pipeline := &latest.SkaffoldConfig{
+		Pipeline: latest.Pipeline{
+			Build: latest.BuildConfig{
+				Artifacts: []*latest.Artifact{
+					{
+						ImageName: "first",
+					},
+					{
+						ImageName: "second",
+						Workspace: "folder",
+						ArtifactType: latest.ArtifactType{
+							DockerArtifact: &latest.DockerArtifact{
+								DockerfilePath: "Dockerfile.second",
+							},
 						},
 					},
 				},
@@ -67,13 +69,15 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 	})
 	defer restore()
 
-	pipeline := &latest.SkaffoldPipeline{
-		Build: latest.BuildConfig{
-			Artifacts: []*latest.Artifact{
-				{ImageName: "image"},
-			},
-			BuildType: latest.BuildType{
-				Cluster: &latest.ClusterDetails{},
+	pipeline := &latest.SkaffoldConfig{
+		Pipeline: latest.Pipeline{
+			Build: latest.BuildConfig{
+				Artifacts: []*latest.Artifact{
+					{ImageName: "image"},
+				},
+				BuildType: latest.BuildType{
+					Cluster: &latest.ClusterDetails{},
+				},
 			},
 		},
 	}
@@ -87,13 +91,15 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 }
 
 func TestSetDefaultsOnCloudBuild(t *testing.T) {
-	pipeline := &latest.SkaffoldPipeline{
-		Build: latest.BuildConfig{
-			Artifacts: []*latest.Artifact{
-				{ImageName: "image"},
-			},
-			BuildType: latest.BuildType{
-				GoogleCloudBuild: &latest.GoogleCloudBuild{},
+	pipeline := &latest.SkaffoldConfig{
+		Pipeline: latest.Pipeline{
+			Build: latest.BuildConfig{
+				Artifacts: []*latest.Artifact{
+					{ImageName: "image"},
+				},
+				BuildType: latest.BuildType{
+					GoogleCloudBuild: &latest.GoogleCloudBuild{},
+				},
 			},
 		},
 	}
@@ -107,12 +113,14 @@ func TestSetDefaultsOnCloudBuild(t *testing.T) {
 }
 
 func TestSetDefaultsOnPlugin(t *testing.T) {
-	pipeline := &latest.SkaffoldPipeline{
-		Build: latest.BuildConfig{
-			Artifacts: []*latest.Artifact{
-				{
-					ImageName:     "image",
-					BuilderPlugin: &latest.BuilderPlugin{},
+	pipeline := &latest.SkaffoldConfig{
+		Pipeline: latest.Pipeline{
+			Build: latest.BuildConfig{
+				Artifacts: []*latest.Artifact{
+					{
+						ImageName:     "image",
+						BuilderPlugin: &latest.BuilderPlugin{},
+					},
 				},
 			},
 		},

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestSetDefaults(t *testing.T) {
-	pipeline := &latest.SkaffoldConfig{
+	cfg := &latest.SkaffoldConfig{
 		Pipeline: latest.Pipeline{
 			Build: latest.BuildConfig{
 				Artifacts: []*latest.Artifact{
@@ -47,17 +47,17 @@ func TestSetDefaults(t *testing.T) {
 		},
 	}
 
-	err := Set(pipeline)
+	err := Set(cfg)
 
 	testutil.CheckError(t, false, err)
 
-	testutil.CheckDeepEqual(t, "first", pipeline.Build.Artifacts[0].ImageName)
-	testutil.CheckDeepEqual(t, ".", pipeline.Build.Artifacts[0].Workspace)
-	testutil.CheckDeepEqual(t, "Dockerfile", pipeline.Build.Artifacts[0].DockerArtifact.DockerfilePath)
+	testutil.CheckDeepEqual(t, "first", cfg.Build.Artifacts[0].ImageName)
+	testutil.CheckDeepEqual(t, ".", cfg.Build.Artifacts[0].Workspace)
+	testutil.CheckDeepEqual(t, "Dockerfile", cfg.Build.Artifacts[0].DockerArtifact.DockerfilePath)
 
-	testutil.CheckDeepEqual(t, "second", pipeline.Build.Artifacts[1].ImageName)
-	testutil.CheckDeepEqual(t, "folder", pipeline.Build.Artifacts[1].Workspace)
-	testutil.CheckDeepEqual(t, "Dockerfile.second", pipeline.Build.Artifacts[1].DockerArtifact.DockerfilePath)
+	testutil.CheckDeepEqual(t, "second", cfg.Build.Artifacts[1].ImageName)
+	testutil.CheckDeepEqual(t, "folder", cfg.Build.Artifacts[1].Workspace)
+	testutil.CheckDeepEqual(t, "Dockerfile.second", cfg.Build.Artifacts[1].DockerArtifact.DockerfilePath)
 }
 
 func TestSetDefaultsOnCluster(t *testing.T) {
@@ -69,7 +69,7 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 	})
 	defer restore()
 
-	pipeline := &latest.SkaffoldConfig{
+	cfg := &latest.SkaffoldConfig{
 		Pipeline: latest.Pipeline{
 			Build: latest.BuildConfig{
 				Artifacts: []*latest.Artifact{
@@ -82,16 +82,16 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 		},
 	}
 
-	err := Set(pipeline)
+	err := Set(cfg)
 
 	testutil.CheckError(t, false, err)
-	testutil.CheckDeepEqual(t, "ns", pipeline.Build.Cluster.Namespace)
-	testutil.CheckDeepEqual(t, constants.DefaultKanikoTimeout, pipeline.Build.Cluster.Timeout)
-	testutil.CheckDeepEqual(t, constants.DefaultKanikoSecretName, pipeline.Build.Cluster.PullSecretName)
+	testutil.CheckDeepEqual(t, "ns", cfg.Build.Cluster.Namespace)
+	testutil.CheckDeepEqual(t, constants.DefaultKanikoTimeout, cfg.Build.Cluster.Timeout)
+	testutil.CheckDeepEqual(t, constants.DefaultKanikoSecretName, cfg.Build.Cluster.PullSecretName)
 }
 
 func TestSetDefaultsOnCloudBuild(t *testing.T) {
-	pipeline := &latest.SkaffoldConfig{
+	cfg := &latest.SkaffoldConfig{
 		Pipeline: latest.Pipeline{
 			Build: latest.BuildConfig{
 				Artifacts: []*latest.Artifact{
@@ -104,16 +104,16 @@ func TestSetDefaultsOnCloudBuild(t *testing.T) {
 		},
 	}
 
-	err := Set(pipeline)
+	err := Set(cfg)
 
 	testutil.CheckError(t, false, err)
-	testutil.CheckDeepEqual(t, constants.DefaultCloudBuildDockerImage, pipeline.Build.GoogleCloudBuild.DockerImage)
-	testutil.CheckDeepEqual(t, constants.DefaultCloudBuildMavenImage, pipeline.Build.GoogleCloudBuild.MavenImage)
-	testutil.CheckDeepEqual(t, constants.DefaultCloudBuildGradleImage, pipeline.Build.GoogleCloudBuild.GradleImage)
+	testutil.CheckDeepEqual(t, constants.DefaultCloudBuildDockerImage, cfg.Build.GoogleCloudBuild.DockerImage)
+	testutil.CheckDeepEqual(t, constants.DefaultCloudBuildMavenImage, cfg.Build.GoogleCloudBuild.MavenImage)
+	testutil.CheckDeepEqual(t, constants.DefaultCloudBuildGradleImage, cfg.Build.GoogleCloudBuild.GradleImage)
 }
 
 func TestSetDefaultsOnPlugin(t *testing.T) {
-	pipeline := &latest.SkaffoldConfig{
+	cfg := &latest.SkaffoldConfig{
 		Pipeline: latest.Pipeline{
 			Build: latest.BuildConfig{
 				Artifacts: []*latest.Artifact{
@@ -126,11 +126,11 @@ func TestSetDefaultsOnPlugin(t *testing.T) {
 		},
 	}
 
-	err := Set(pipeline)
+	err := Set(cfg)
 
 	testutil.CheckError(t, false, err)
 	testutil.CheckDeepEqual(t, &latest.ExecutionEnvironment{
 		Name:       constants.Local,
 		Properties: map[string]interface{}{},
-	}, pipeline.Build.ExecutionEnvironment)
+	}, cfg.Build.ExecutionEnvironment)
 }

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -23,19 +23,28 @@ import (
 
 const Version string = "skaffold/v1beta7"
 
-// NewSkaffoldPipeline creates a SkaffoldPipeline
+// NewSkaffoldPipeline creates a SkaffoldConfig
 func NewSkaffoldPipeline() util.VersionedConfig {
-	return new(SkaffoldPipeline)
+	return new(SkaffoldConfig)
 }
 
-// SkaffoldPipeline describes a Skaffold pipeline.
-type SkaffoldPipeline struct {
+// SkaffoldConfig describes a Skaffold pipeline configuration file.
+type SkaffoldConfig struct {
 	// APIVersion is the version of the configuration.
 	APIVersion string `yaml:"apiVersion"`
 
 	// Kind is always `Config`. Defaults to `Config`.
 	Kind string `yaml:"kind"`
 
+	// Pipeline defines the Build/Test/Deploy phases
+	Pipeline `yaml:",inline"`
+
+	// Profiles *beta* can override be used to `build`, `test` or `deploy` configuration.
+	Profiles []Profile `yaml:"profiles,omitempty"`
+}
+
+// Pipeline describes a Skaffold pipeline.
+type Pipeline struct {
 	// Build describes how images are built.
 	Build BuildConfig `yaml:"build,omitempty"`
 
@@ -44,12 +53,9 @@ type SkaffoldPipeline struct {
 
 	// Deploy describes how images are deployed.
 	Deploy DeployConfig `yaml:"deploy,omitempty"`
-
-	// Profiles *beta* can override be used to `build`, `test` or `deploy` configuration.
-	Profiles []Profile `yaml:"profiles,omitempty"`
 }
 
-func (c *SkaffoldPipeline) GetVersion() string {
+func (c *SkaffoldConfig) GetVersion() string {
 	return c.APIVersion
 }
 
@@ -478,14 +484,8 @@ type Profile struct {
 	// For example: `profile-prod`.
 	Name string `yaml:"name,omitempty" yamltags:"required"`
 
-	// Build replaces the main `build` configuration.
-	Build BuildConfig `yaml:"build,omitempty"`
-
-	// Test replaces the main `test` configuration.
-	Test []*TestCase `yaml:"test,omitempty"`
-
-	// Deploy replaces the main `deploy` configuration.
-	Deploy DeployConfig `yaml:"deploy,omitempty"`
+	// Pipeline contains the definitions to replace the default pipeline with
+	Pipeline `yaml:",inline"`
 
 	// Patches lists patches applied to the configuration.
 	// Patches use the JSON patch notation.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -28,7 +28,7 @@ func NewSkaffoldConfig() util.VersionedConfig {
 	return new(SkaffoldConfig)
 }
 
-// SkaffoldConfig holds the fields parsed from the Skaffold configuration file (skaffold.yaml)
+// SkaffoldConfig holds the fields parsed from the Skaffold configuration file (skaffold.yaml).
 type SkaffoldConfig struct {
 	// APIVersion is the version of the configuration.
 	APIVersion string `yaml:"apiVersion"`
@@ -36,7 +36,7 @@ type SkaffoldConfig struct {
 	// Kind is always `Config`. Defaults to `Config`.
 	Kind string `yaml:"kind"`
 
-	// Pipeline defines the Build/Test/Deploy phases
+	// Pipeline defines the Build/Test/Deploy phases.
 	Pipeline `yaml:",inline"`
 
 	// Profiles *beta* can override be used to `build`, `test` or `deploy` configuration.
@@ -484,7 +484,7 @@ type Profile struct {
 	// For example: `profile-prod`.
 	Name string `yaml:"name,omitempty" yamltags:"required"`
 
-	// Pipeline contains the definitions to replace the default pipeline with
+	// Pipeline contains the definitions to replace the default skaffold pipeline.
 	Pipeline `yaml:",inline"`
 
 	// Patches lists patches applied to the configuration.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -23,12 +23,12 @@ import (
 
 const Version string = "skaffold/v1beta7"
 
-// NewSkaffoldPipeline creates a SkaffoldConfig
-func NewSkaffoldPipeline() util.VersionedConfig {
+// NewSkaffoldConfig creates a SkaffoldConfig
+func NewSkaffoldConfig() util.VersionedConfig {
 	return new(SkaffoldConfig)
 }
 
-// SkaffoldConfig describes a Skaffold pipeline configuration file.
+// SkaffoldConfig holds the fields parsed from the Skaffold configuration file (skaffold.yaml)
 type SkaffoldConfig struct {
 	// APIVersion is the version of the configuration.
 	APIVersion string `yaml:"apiVersion"`

--- a/pkg/skaffold/schema/latest/upgrade.go
+++ b/pkg/skaffold/schema/latest/upgrade.go
@@ -23,6 +23,6 @@ import (
 )
 
 // Upgrade upgrades a configuration to the next version.
-func (config *SkaffoldPipeline) Upgrade() (util.VersionedConfig, error) {
+func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
 	return nil, errors.New("not implemented yet")
 }

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -267,4 +267,3 @@ func overlayProfileField(config interface{}, profile interface{}) interface{} {
 		return config
 	}
 }
-

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -48,7 +48,7 @@ func ApplyProfiles(c *latest.SkaffoldConfig, opts *cfg.SkaffoldOptions) error {
 		}
 
 		if err := applyProfile(c, profile); err != nil {
-			return errors.Wrapf(err, "appying profile %s", name)
+			return errors.Wrapf(err, "applying profile %s", name)
 		}
 	}
 

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -33,7 +33,7 @@ import (
 
 // ApplyProfiles returns configuration modified by the application
 // of a list of profiles.
-func ApplyProfiles(c *latest.SkaffoldPipeline, opts *cfg.SkaffoldOptions) error {
+func ApplyProfiles(c *latest.SkaffoldConfig, opts *cfg.SkaffoldOptions) error {
 	byName := profilesByName(c.Profiles)
 
 	profiles, err := activatedProfiles(c.Profiles, opts)
@@ -126,16 +126,18 @@ func satisfies(expected, actual string) bool {
 	return actual == expected
 }
 
-func applyProfile(config *latest.SkaffoldPipeline, profile latest.Profile) error {
+func applyProfile(config *latest.SkaffoldConfig, profile latest.Profile) error {
 	logrus.Infof("applying profile: %s", profile.Name)
 
 	// this intentionally removes the Profiles field from the returned config
-	*config = latest.SkaffoldPipeline{
+	*config = latest.SkaffoldConfig{
 		APIVersion: config.APIVersion,
 		Kind:       config.Kind,
-		Build:      overlayProfileField(config.Build, profile.Build).(latest.BuildConfig),
-		Deploy:     overlayProfileField(config.Deploy, profile.Deploy).(latest.DeployConfig),
-		Test:       overlayProfileField(config.Test, profile.Test).([]*latest.TestCase),
+		Pipeline: latest.Pipeline{
+			Build:  overlayProfileField(config.Build, profile.Build).(latest.BuildConfig),
+			Deploy: overlayProfileField(config.Deploy, profile.Deploy).(latest.DeployConfig),
+			Test:   overlayProfileField(config.Test, profile.Test).([]*latest.TestCase),
+		},
 	}
 
 	if len(profile.Patches) == 0 {

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -245,7 +245,7 @@ func overlayProfileField(config interface{}, profile interface{}) interface{} {
 	switch v.Kind() {
 	case reflect.Struct:
 		// check the first field of the struct for a oneOf yamltag.
-		if isOneOf(t.Field(0)) {
+		if IsOneOf(t.Field(0)) {
 			return overlayOneOfField(config, profile)
 		}
 		return overlayStructField(config, profile)
@@ -267,7 +267,7 @@ func overlayProfileField(config interface{}, profile interface{}) interface{} {
 	}
 }
 
-func isOneOf(field reflect.StructField) bool {
+func IsOneOf(field reflect.StructField) bool {
 	for _, tag := range strings.Split(field.Tag.Get("yamltags"), ",") {
 		tagParts := strings.Split(tag, "=")
 

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -59,7 +59,7 @@ profiles:
 	parsed, err := ParseConfig(tmp.Path("skaffold.yaml"), false)
 	testutil.CheckError(t, false, err)
 
-	pipeline := parsed.(*latest.SkaffoldPipeline)
+	pipeline := parsed.(*latest.SkaffoldConfig)
 	err = ApplyProfiles(pipeline, &cfg.SkaffoldOptions{
 		Profiles: []string{"patches"},
 	})
@@ -90,7 +90,7 @@ profiles:
 	parsed, err := ParseConfig(tmp.Path("skaffold.yaml"), false)
 	testutil.CheckError(t, false, err)
 
-	pipeline := parsed.(*latest.SkaffoldPipeline)
+	pipeline := parsed.(*latest.SkaffoldConfig)
 	err = ApplyProfiles(pipeline, &cfg.SkaffoldOptions{
 		Profiles: []string{"patches"},
 	})
@@ -101,9 +101,9 @@ profiles:
 func TestApplyProfiles(t *testing.T) {
 	tests := []struct {
 		description string
-		config      *latest.SkaffoldPipeline
+		config      *latest.SkaffoldConfig
 		profile     string
-		expected    *latest.SkaffoldPipeline
+		expected    *latest.SkaffoldConfig
 		shouldErr   bool
 	}{
 		{
@@ -123,13 +123,15 @@ func TestApplyProfiles(t *testing.T) {
 				withKubectlDeploy("k8s/*.yaml"),
 				withProfiles(latest.Profile{
 					Name: "profile",
-					Build: latest.BuildConfig{
-						BuildType: latest.BuildType{
-							GoogleCloudBuild: &latest.GoogleCloudBuild{
-								ProjectID:   "my-project",
-								DockerImage: "gcr.io/cloud-builders/docker",
-								MavenImage:  "gcr.io/cloud-builders/mvn@sha256:0ec283f2ee1ab1d2ac779dcbb24bddaa46275aec7088cc10f2926b4ea0fcac9b",
-								GradleImage: "gcr.io/cloud-builders/gradle",
+					Pipeline: latest.Pipeline{
+						Build: latest.BuildConfig{
+							BuildType: latest.BuildType{
+								GoogleCloudBuild: &latest.GoogleCloudBuild{
+									ProjectID:   "my-project",
+									DockerImage: "gcr.io/cloud-builders/docker",
+									MavenImage:  "gcr.io/cloud-builders/mvn@sha256:0ec283f2ee1ab1d2ac779dcbb24bddaa46275aec7088cc10f2926b4ea0fcac9b",
+									GradleImage: "gcr.io/cloud-builders/gradle",
+								},
 							},
 						},
 					},
@@ -154,8 +156,10 @@ func TestApplyProfiles(t *testing.T) {
 				withKubectlDeploy("k8s/*.yaml"),
 				withProfiles(latest.Profile{
 					Name: "dev",
-					Build: latest.BuildConfig{
-						TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
+					Pipeline: latest.Pipeline{
+						Build: latest.BuildConfig{
+							TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
+						},
 					},
 				}),
 			),
@@ -178,18 +182,20 @@ func TestApplyProfiles(t *testing.T) {
 				withKubectlDeploy("k8s/*.yaml"),
 				withProfiles(latest.Profile{
 					Name: "profile",
-					Build: latest.BuildConfig{
-						Artifacts: []*latest.Artifact{
-							{ImageName: "image", Workspace: ".", ArtifactType: latest.ArtifactType{
-								DockerArtifact: &latest.DockerArtifact{
-									DockerfilePath: "Dockerfile.DEV",
-								},
-							}},
-							{ImageName: "imageProd", Workspace: ".", ArtifactType: latest.ArtifactType{
-								DockerArtifact: &latest.DockerArtifact{
-									DockerfilePath: "Dockerfile.DEV",
-								},
-							}},
+					Pipeline: latest.Pipeline{
+						Build: latest.BuildConfig{
+							Artifacts: []*latest.Artifact{
+								{ImageName: "image", Workspace: ".", ArtifactType: latest.ArtifactType{
+									DockerArtifact: &latest.DockerArtifact{
+										DockerfilePath: "Dockerfile.DEV",
+									},
+								}},
+								{ImageName: "imageProd", Workspace: ".", ArtifactType: latest.ArtifactType{
+									DockerArtifact: &latest.DockerArtifact{
+										DockerfilePath: "Dockerfile.DEV",
+									},
+								}},
+							},
 						},
 					},
 				}),
@@ -213,9 +219,11 @@ func TestApplyProfiles(t *testing.T) {
 				withKubectlDeploy("k8s/*.yaml"),
 				withProfiles(latest.Profile{
 					Name: "profile",
-					Deploy: latest.DeployConfig{
-						DeployType: latest.DeployType{
-							HelmDeploy: &latest.HelmDeploy{},
+					Pipeline: latest.Pipeline{
+						Deploy: latest.DeployConfig{
+							DeployType: latest.DeployType{
+								HelmDeploy: &latest.HelmDeploy{},
+							},
 						},
 					},
 				}),
@@ -280,10 +288,12 @@ func TestApplyProfiles(t *testing.T) {
 				),
 				withProfiles(latest.Profile{
 					Name: "profile",
-					Test: []*latest.TestCase{{
-						ImageName:      "image",
-						StructureTests: []string{"test/*"},
-					}},
+					Pipeline: latest.Pipeline{
+						Test: []*latest.TestCase{{
+							ImageName:      "image",
+							StructureTests: []string{"test/*"},
+						}},
+					},
 				}),
 			),
 			expected: config(
@@ -306,9 +316,11 @@ func TestApplyProfiles(t *testing.T) {
 				),
 				withProfiles(latest.Profile{
 					Name: "profile",
-					Build: latest.BuildConfig{
-						ExecutionEnvironment: &latest.ExecutionEnvironment{
-							Name: constants.GoogleCloudBuild,
+					Pipeline: latest.Pipeline{
+						Build: latest.BuildConfig{
+							ExecutionEnvironment: &latest.ExecutionEnvironment{
+								Name: constants.GoogleCloudBuild,
+							},
 						},
 					},
 				}),
@@ -348,9 +360,11 @@ func TestApplyProfiles(t *testing.T) {
 				),
 				withProfiles(latest.Profile{
 					Name: "profile",
-					Build: latest.BuildConfig{
-						ExecutionEnvironment: &latest.ExecutionEnvironment{
-							Name: constants.GoogleCloudBuild,
+					Pipeline: latest.Pipeline{
+						Build: latest.BuildConfig{
+							ExecutionEnvironment: &latest.ExecutionEnvironment{
+								Name: constants.GoogleCloudBuild,
+							},
 						},
 					},
 				}),

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -59,15 +59,15 @@ profiles:
 	parsed, err := ParseConfig(tmp.Path("skaffold.yaml"), false)
 	testutil.CheckError(t, false, err)
 
-	pipeline := parsed.(*latest.SkaffoldConfig)
-	err = ApplyProfiles(pipeline, &cfg.SkaffoldOptions{
+	skaffoldConfig := parsed.(*latest.SkaffoldConfig)
+	err = ApplyProfiles(skaffoldConfig, &cfg.SkaffoldOptions{
 		Profiles: []string{"patches"},
 	})
 	testutil.CheckError(t, false, err)
 
-	testutil.CheckDeepEqual(t, "replacement", pipeline.Build.Artifacts[0].ImageName)
-	testutil.CheckDeepEqual(t, "Dockerfile.DEV", pipeline.Build.Artifacts[0].DockerArtifact.DockerfilePath)
-	testutil.CheckDeepEqual(t, "Dockerfile.second", pipeline.Build.Artifacts[1].DockerArtifact.DockerfilePath)
+	testutil.CheckDeepEqual(t, "replacement", skaffoldConfig.Build.Artifacts[0].ImageName)
+	testutil.CheckDeepEqual(t, "Dockerfile.DEV", skaffoldConfig.Build.Artifacts[0].DockerArtifact.DockerfilePath)
+	testutil.CheckDeepEqual(t, "Dockerfile.second", skaffoldConfig.Build.Artifacts[1].DockerArtifact.DockerfilePath)
 }
 
 func TestApplyInvalidPatch(t *testing.T) {
@@ -90,8 +90,8 @@ profiles:
 	parsed, err := ParseConfig(tmp.Path("skaffold.yaml"), false)
 	testutil.CheckError(t, false, err)
 
-	pipeline := parsed.(*latest.SkaffoldConfig)
-	err = ApplyProfiles(pipeline, &cfg.SkaffoldOptions{
+	skaffoldConfig := parsed.(*latest.SkaffoldConfig)
+	err = ApplyProfiles(skaffoldConfig, &cfg.SkaffoldOptions{
 		Profiles: []string{"patches"},
 	})
 

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -95,7 +95,7 @@ profiles:
 		Profiles: []string{"patches"},
 	})
 
-	testutil.CheckErrorAndDeepEqual(t, true, err, "appying profile patches: invalid path: /build/artifacts/0/image/", err.Error())
+	testutil.CheckErrorAndDeepEqual(t, true, err, "applying profile patches: invalid path: /build/artifacts/0/image/", err.Error())
 }
 
 func TestApplyProfiles(t *testing.T) {

--- a/pkg/skaffold/schema/v1beta6/upgrade.go
+++ b/pkg/skaffold/schema/v1beta6/upgrade.go
@@ -68,13 +68,15 @@ func (config *SkaffoldPipeline) Upgrade() (util.VersionedConfig, error) {
 		return nil, errors.Wrap(err, "converting new test")
 	}
 
-	return &next.SkaffoldPipeline{
+	return &next.SkaffoldConfig{
 		APIVersion: next.Version,
 		Kind:       config.Kind,
-		Build:      newBuild,
-		Test:       newTest,
-		Deploy:     newDeploy,
-		Profiles:   newProfiles,
+		Pipeline: next.Pipeline{
+			Build:  newBuild,
+			Test:   newTest,
+			Deploy: newDeploy,
+		},
+		Profiles: newProfiles,
 	}, nil
 }
 

--- a/pkg/skaffold/schema/v1beta6/upgrade_test.go
+++ b/pkg/skaffold/schema/v1beta6/upgrade_test.go
@@ -150,7 +150,7 @@ func verifyUpgrade(t *testing.T, input, output string) {
 	upgraded, err := pipeline.Upgrade()
 	testutil.CheckError(t, false, err)
 
-	expected := latest.NewSkaffoldPipeline()
+	expected := latest.NewSkaffoldConfig()
 	err = yaml.UnmarshalStrict([]byte(output), expected)
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected, upgraded)

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -27,7 +27,7 @@ import (
 )
 
 // ValidateSchema checks if the Skaffold pipeline is valid and returns all encountered errors as a concatenated string
-func ValidateSchema(config *latest.SkaffoldPipeline) error {
+func ValidateSchema(config *latest.SkaffoldConfig) error {
 	errs := validateOneOf(config)
 	if errs == nil {
 		return nil

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -24,27 +24,29 @@ import (
 )
 
 var (
-	cfgWithErrors = &latest.SkaffoldPipeline{
-		Build: latest.BuildConfig{
-			Artifacts: []*latest.Artifact{
-				{
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{},
-						BazelArtifact:  &latest.BazelArtifact{},
+	cfgWithErrors = &latest.SkaffoldConfig{
+		Pipeline: latest.Pipeline{
+			Build: latest.BuildConfig{
+				Artifacts: []*latest.Artifact{
+					{
+						ArtifactType: latest.ArtifactType{
+							DockerArtifact: &latest.DockerArtifact{},
+							BazelArtifact:  &latest.BazelArtifact{},
+						},
 					},
-				},
-				{
-					ArtifactType: latest.ArtifactType{
-						BazelArtifact:  &latest.BazelArtifact{},
-						KanikoArtifact: &latest.KanikoArtifact{},
+					{
+						ArtifactType: latest.ArtifactType{
+							BazelArtifact:  &latest.BazelArtifact{},
+							KanikoArtifact: &latest.KanikoArtifact{},
+						},
 					},
 				},
 			},
-		},
-		Deploy: latest.DeployConfig{
-			DeployType: latest.DeployType{
-				HelmDeploy:    &latest.HelmDeploy{},
-				KubectlDeploy: &latest.KubectlDeploy{},
+			Deploy: latest.DeployConfig{
+				DeployType: latest.DeployType{
+					HelmDeploy:    &latest.HelmDeploy{},
+					KubectlDeploy: &latest.KubectlDeploy{},
+				},
 			},
 		},
 	}
@@ -54,7 +56,7 @@ func TestValidateSchema(t *testing.T) {
 	err := ValidateSchema(cfgWithErrors)
 	testutil.CheckError(t, true, err)
 
-	err = ValidateSchema(&latest.SkaffoldPipeline{})
+	err = ValidateSchema(&latest.SkaffoldConfig{})
 	testutil.CheckError(t, false, err)
 }
 

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -57,7 +57,7 @@ var SchemaVersions = Versions{
 	{v1beta4.Version, v1beta4.NewSkaffoldPipeline},
 	{v1beta5.Version, v1beta5.NewSkaffoldPipeline},
 	{v1beta6.Version, v1beta6.NewSkaffoldPipeline},
-	{latest.Version, latest.NewSkaffoldPipeline},
+	{latest.Version, latest.NewSkaffoldConfig},
 }
 
 type Version struct {

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -217,7 +217,7 @@ func TestParseConfig(t *testing.T) {
 
 			cfg, err := ParseConfig(tmp.Path("skaffold.yaml"), true)
 			if cfg != nil {
-				config := cfg.(*latest.SkaffoldPipeline)
+				config := cfg.(*latest.SkaffoldConfig)
 				if err := defaults.Set(config); err != nil {
 					t.Fatal("unable to set default values")
 				}
@@ -228,16 +228,16 @@ func TestParseConfig(t *testing.T) {
 	}
 }
 
-func config(ops ...func(*latest.SkaffoldPipeline)) *latest.SkaffoldPipeline {
-	cfg := &latest.SkaffoldPipeline{APIVersion: latest.Version, Kind: "Config"}
+func config(ops ...func(*latest.SkaffoldConfig)) *latest.SkaffoldConfig {
+	cfg := &latest.SkaffoldConfig{APIVersion: latest.Version, Kind: "Config"}
 	for _, op := range ops {
 		op(cfg)
 	}
 	return cfg
 }
 
-func withLocalBuild(ops ...func(*latest.BuildConfig)) func(*latest.SkaffoldPipeline) {
-	return func(cfg *latest.SkaffoldPipeline) {
+func withLocalBuild(ops ...func(*latest.BuildConfig)) func(*latest.SkaffoldConfig) {
+	return func(cfg *latest.SkaffoldConfig) {
 		b := latest.BuildConfig{BuildType: latest.BuildType{LocalBuild: &latest.LocalBuild{}}}
 		for _, op := range ops {
 			op(&b)
@@ -246,8 +246,8 @@ func withLocalBuild(ops ...func(*latest.BuildConfig)) func(*latest.SkaffoldPipel
 	}
 }
 
-func withGoogleCloudBuild(id string, ops ...func(*latest.BuildConfig)) func(*latest.SkaffoldPipeline) {
-	return func(cfg *latest.SkaffoldPipeline) {
+func withGoogleCloudBuild(id string, ops ...func(*latest.BuildConfig)) func(*latest.SkaffoldConfig) {
+	return func(cfg *latest.SkaffoldConfig) {
 		b := latest.BuildConfig{BuildType: latest.BuildType{GoogleCloudBuild: &latest.GoogleCloudBuild{
 			ProjectID:   id,
 			DockerImage: "gcr.io/cloud-builders/docker",
@@ -261,8 +261,8 @@ func withGoogleCloudBuild(id string, ops ...func(*latest.BuildConfig)) func(*lat
 	}
 }
 
-func withClusterBuild(secretName, namespace, secret string, timeout string, ops ...func(*latest.BuildConfig)) func(*latest.SkaffoldPipeline) {
-	return func(cfg *latest.SkaffoldPipeline) {
+func withClusterBuild(secretName, namespace, secret string, timeout string, ops ...func(*latest.BuildConfig)) func(*latest.SkaffoldConfig) {
+	return func(cfg *latest.SkaffoldConfig) {
 		b := latest.BuildConfig{BuildType: latest.BuildType{Cluster: &latest.ClusterDetails{
 			PullSecretName: secretName,
 			Namespace:      namespace,
@@ -285,8 +285,8 @@ func withDockerConfig(secretName string, path string) func(*latest.BuildConfig) 
 	}
 }
 
-func withKubectlDeploy(manifests ...string) func(*latest.SkaffoldPipeline) {
-	return func(cfg *latest.SkaffoldPipeline) {
+func withKubectlDeploy(manifests ...string) func(*latest.SkaffoldConfig) {
+	return func(cfg *latest.SkaffoldConfig) {
 		cfg.Deploy = latest.DeployConfig{
 			DeployType: latest.DeployType{
 				KubectlDeploy: &latest.KubectlDeploy{
@@ -297,8 +297,8 @@ func withKubectlDeploy(manifests ...string) func(*latest.SkaffoldPipeline) {
 	}
 }
 
-func withHelmDeploy() func(*latest.SkaffoldPipeline) {
-	return func(cfg *latest.SkaffoldPipeline) {
+func withHelmDeploy() func(*latest.SkaffoldConfig) {
+	return func(cfg *latest.SkaffoldConfig) {
 		cfg.Deploy = latest.DeployConfig{
 			DeployType: latest.DeployType{
 				HelmDeploy: &latest.HelmDeploy{},
@@ -372,14 +372,14 @@ func withShaTagger() func(*latest.BuildConfig) {
 	return withTagPolicy(latest.TagPolicy{ShaTagger: &latest.ShaTagger{}})
 }
 
-func withProfiles(profiles ...latest.Profile) func(*latest.SkaffoldPipeline) {
-	return func(cfg *latest.SkaffoldPipeline) {
+func withProfiles(profiles ...latest.Profile) func(*latest.SkaffoldConfig) {
+	return func(cfg *latest.SkaffoldConfig) {
 		cfg.Profiles = profiles
 	}
 }
 
-func withTests(testCases ...*latest.TestCase) func(*latest.SkaffoldPipeline) {
-	return func(cfg *latest.SkaffoldPipeline) {
+func withTests(testCases ...*latest.TestCase) func(*latest.SkaffoldConfig) {
+	return func(cfg *latest.SkaffoldConfig) {
 		cfg.Test = testCases
 	}
 }


### PR DESCRIPTION
This should be a functionally equivalent change, i.e refactoring, however it does change the generated schema for the skaffold config ~also wrongly generated due to #1900 :(~

Motivation: while introducing `RunContext` in https://github.com/GoogleContainerTools/skaffold/pull/1885, it would be beneficial to just share the `Pipeline` part of the configuration, as:
 - no further functionality depends on the profiles/apiVersion/kind fields anyway 
 - the profiles struct is not serializable by gob.encoder as it embeds `yamlpatch.Node` which does not have exported fields

Update: 
#1900 is fixed now, the schema changes are correct. 