### PR TITLE
Git tagger variants (Tags, CommitSha, AbbrevCommitSha)

### DIFF
--- a/docs/content/en/schemas/v1beta9.json
+++ b/docs/content/en/schemas/v1beta9.json
@@ -805,8 +805,8 @@
       "properties": {
         "variant": {
           "type": "string",
-          "description": "determines the behavior of the git tagger. Valid variants are - Tags (default): use git tags or fall back to abbreviated commit hash. - CommitSha: use the full git commit sha. - AbbrevCommitSha: use the abbreviated git commit sha.",
-          "x-intellij-html-description": "determines the behavior of the git tagger. Valid variants are - Tags (default): use git tags or fall back to abbreviated commit hash. - CommitSha: use the full git commit sha. - AbbrevCommitSha: use the abbreviated git commit sha."
+          "description": "determines the behavior of the git tagger. Valid variants are `Tags` (default): use git tags or fall back to abbreviated commit hash. `CommitSha`: use the full git commit sha. `AbbrevCommitSha`: use the abbreviated git commit sha.",
+          "x-intellij-html-description": "determines the behavior of the git tagger. Valid variants are <code>Tags</code> (default): use git tags or fall back to abbreviated commit hash. <code>CommitSha</code>: use the full git commit sha. <code>AbbrevCommitSha</code>: use the abbreviated git commit sha."
         }
       },
       "preferredOrder": [

--- a/docs/content/en/schemas/v1beta9.json
+++ b/docs/content/en/schemas/v1beta9.json
@@ -802,6 +802,17 @@
       "x-intellij-html-description": "environment in which the build should run (ex. local or in-cluster, etc.)."
     },
     "GitTagger": {
+      "properties": {
+        "variant": {
+          "type": "string",
+          "description": "determines the behavior of the git tagger. Valid variants are - Tags (default): use git tags or fall back to abbreviated commit hash. - CommitSha: use the full git commit sha. - AbbrevCommitSha: use the abbreviated git commit sha.",
+          "x-intellij-html-description": "determines the behavior of the git tagger. Valid variants are - Tags (default): use git tags or fall back to abbreviated commit hash. - CommitSha: use the full git commit sha. - AbbrevCommitSha: use the abbreviated git commit sha."
+        }
+      },
+      "preferredOrder": [
+        "variant"
+      ],
+      "additionalProperties": false,
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },

--- a/docs/content/en/schemas/v1beta9.json
+++ b/docs/content/en/schemas/v1beta9.json
@@ -396,8 +396,8 @@
             },
             "tagPolicy": {
               "$ref": "#/definitions/TagPolicy",
-              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {}`.",
-              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {}</code>."
+              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {variant: Tags}`.",
+              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {variant: Tags}</code>."
             }
           },
           "preferredOrder": [
@@ -439,8 +439,8 @@
             },
             "tagPolicy": {
               "$ref": "#/definitions/TagPolicy",
-              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {}`.",
-              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {}</code>."
+              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {variant: Tags}`.",
+              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {variant: Tags}</code>."
             }
           },
           "preferredOrder": [
@@ -483,8 +483,8 @@
             },
             "tagPolicy": {
               "$ref": "#/definitions/TagPolicy",
-              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {}`.",
-              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {}</code>."
+              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {variant: Tags}`.",
+              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {variant: Tags}</code>."
             }
           },
           "preferredOrder": [
@@ -527,8 +527,8 @@
             },
             "tagPolicy": {
               "$ref": "#/definitions/TagPolicy",
-              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {}`.",
-              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {}</code>."
+              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {variant: Tags}`.",
+              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {variant: Tags}</code>."
             }
           },
           "preferredOrder": [

--- a/pkg/skaffold/build/tag/git_commit.go
+++ b/pkg/skaffold/build/tag/git_commit.go
@@ -39,6 +39,7 @@ type GitCommit struct {
 	variant int
 }
 
+// NewGitCommit creates a new git commit tagger. It fails if the tagger variant is invalid.
 func NewGitCommit(taggerVariant string) (*GitCommit, error) {
 	var variant int
 	switch strings.ToLower(taggerVariant) {
@@ -50,7 +51,7 @@ func NewGitCommit(taggerVariant string) (*GitCommit, error) {
 	case "abbrevcommitsha":
 		variant = abbrevCommitSha
 	default:
-		return nil, fmt.Errorf("%s is no valid git tagger variant", taggerVariant)
+		return nil, fmt.Errorf("%s is not a valid git tagger variant", taggerVariant)
 	}
 
 	return &GitCommit{variant: variant}, nil
@@ -94,7 +95,7 @@ func (c *GitCommit) makeGitTag(workingDir string) (string, error) {
 			args = append(args, "--abbrev-commit")
 		}
 	default:
-		return "", fmt.Errorf("this should not happen, please raise an issue")
+		return "", errors.New("invalid git tag variant: defaulting to 'dirty'")
 	}
 
 	return runGit(workingDir, args...)

--- a/pkg/skaffold/build/tag/git_commit.go
+++ b/pkg/skaffold/build/tag/git_commit.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -27,8 +28,33 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	tags = iota
+	commitSha
+	abbrevCommitSha
+)
+
 // GitCommit tags an image by the git commit it was built at.
-type GitCommit struct{}
+type GitCommit struct {
+	variant int
+}
+
+func NewGitCommit(taggerVariant string) (*GitCommit, error) {
+	var variant int
+	switch strings.ToLower(taggerVariant) {
+	case "", "tags":
+		// default to "tags" when unset
+		variant = tags
+	case "commitsha":
+		variant = commitSha
+	case "abbrevcommitsha":
+		variant = abbrevCommitSha
+	default:
+		return nil, fmt.Errorf("%s is no valid git tagger variant", taggerVariant)
+	}
+
+	return &GitCommit{variant: variant}, nil
+}
 
 // Labels are labels specific to the git tagger.
 func (c *GitCommit) Labels() map[string]string {
@@ -39,7 +65,7 @@ func (c *GitCommit) Labels() map[string]string {
 
 // GenerateFullyQualifiedImageName tags an image with the supplied image name and the git commit.
 func (c *GitCommit) GenerateFullyQualifiedImageName(workingDir string, imageName string) (string, error) {
-	ref, err := runGit(workingDir, "describe", "--tags", "--always")
+	ref, err := c.makeGitTag(workingDir)
 	if err != nil {
 		logrus.Warnln("Unable to find git commit:", err)
 		return fmt.Sprintf("%s:dirty", imageName), nil
@@ -55,6 +81,23 @@ func (c *GitCommit) GenerateFullyQualifiedImageName(workingDir string, imageName
 	}
 
 	return fmt.Sprintf("%s:%s", imageName, ref), nil
+}
+
+func (c *GitCommit) makeGitTag(workingDir string) (string, error) {
+	args := make([]string, 0, 4)
+	switch c.variant {
+	case tags:
+		args = append(args, "describe", "--tags", "--always")
+	case commitSha, abbrevCommitSha:
+		args = append(args, "rev-list", "-1", "HEAD")
+		if c.variant == abbrevCommitSha {
+			args = append(args, "--abbrev-commit")
+		}
+	default:
+		return "", fmt.Errorf("this should not happen, please raise an issue")
+	}
+
+	return runGit(workingDir, args...)
 }
 
 func runGit(workingDir string, arg ...string) (string, error) {

--- a/pkg/skaffold/build/tag/git_commit_test.go
+++ b/pkg/skaffold/build/tag/git_commit_test.go
@@ -35,15 +35,19 @@ import (
 // See: https://github.com/src-d/go-git/issues/378
 func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 	tests := []struct {
-		description   string
-		expectedName  string
-		createGitRepo func(string)
-		subDir        string
-		shouldErr     bool
+		description            string
+		variantTags            string
+		variantCommitSha       string
+		variantAbbrevCommitSha string
+		createGitRepo          func(string)
+		subDir                 string
+		shouldErr              bool
 	}{
 		{
-			description:  "success",
-			expectedName: "test:eefe1b9",
+			description:            "clean worktree without tag",
+			variantTags:            "test:eefe1b9",
+			variantCommitSha:       "test:eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed",
+			variantAbbrevCommitSha: "test:eefe1b9",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", []byte("code")).
@@ -52,8 +56,10 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			},
 		},
 		{
-			description:  "use tag over commit",
-			expectedName: "test:v2",
+			description:            "clean worktree with tags",
+			variantTags:            "test:v2",
+			variantCommitSha:       "test:aea33bcc86b5af8c8570ff45d8a643202d63c808",
+			variantAbbrevCommitSha: "test:aea33bc",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", []byte("code")).
@@ -67,8 +73,10 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			},
 		},
 		{
-			description:  "dirty",
-			expectedName: "test:eefe1b9-dirty",
+			description:            "dirty worktree without tag",
+			variantTags:            "test:eefe1b9-dirty",
+			variantCommitSha:       "test:eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed-dirty",
+			variantAbbrevCommitSha: "test:eefe1b9-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", []byte("code")).
@@ -78,8 +86,10 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			},
 		},
 		{
-			description:  "dirty tag",
-			expectedName: "test:v1-dirty",
+			description:            "dirty worktree with tag",
+			variantTags:            "test:v1-dirty",
+			variantCommitSha:       "test:eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed-dirty",
+			variantAbbrevCommitSha: "test:eefe1b9-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", []byte("code")).
@@ -90,8 +100,10 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			},
 		},
 		{
-			description:  "untracked",
-			expectedName: "test:eefe1b9-dirty",
+			description:            "untracked",
+			variantTags:            "test:eefe1b9-dirty",
+			variantCommitSha:       "test:eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed-dirty",
+			variantAbbrevCommitSha: "test:eefe1b9-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", []byte("code")).
@@ -101,8 +113,10 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			},
 		},
 		{
-			description:  "tag plus one commit",
-			expectedName: "test:v1-1-g3cec6b9",
+			description:            "tag plus one commit",
+			variantTags:            "test:v1-1-g3cec6b9",
+			variantCommitSha:       "test:3cec6b950895704a8a69b610a199b242a3bd370f",
+			variantAbbrevCommitSha: "test:3cec6b9",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", []byte("code")).
@@ -115,8 +129,10 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			},
 		},
 		{
-			description:  "deleted file",
-			expectedName: "test:279d53f-dirty",
+			description:            "deleted file",
+			variantTags:            "test:279d53f-dirty",
+			variantCommitSha:       "test:279d53fcc3ae34503aec382a49a41f6db6de9a66-dirty",
+			variantAbbrevCommitSha: "test:279d53f-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source1.go", []byte("code1")).
@@ -127,8 +143,10 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			},
 		},
 		{
-			description:  "rename",
-			expectedName: "test:eefe1b9-dirty",
+			description:            "rename",
+			variantTags:            "test:eefe1b9-dirty",
+			variantCommitSha:       "test:eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed-dirty",
+			variantAbbrevCommitSha: "test:eefe1b9-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", []byte("code")).
@@ -138,8 +156,10 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			},
 		},
 		{
-			description:  "sub directory",
-			expectedName: "test:a7b32a6",
+			description:            "sub directory",
+			variantTags:            "test:a7b32a6",
+			variantCommitSha:       "test:a7b32a69335a6daa51bd89cc1bf30bd31df228ba",
+			variantAbbrevCommitSha: "test:a7b32a6",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("sub/sub").
@@ -148,36 +168,42 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			subDir: "sub/sub",
 		},
 		{
-			description:  "clean artifact1 in tagged repo",
-			expectedName: "test:v1",
+			description:            "clean artifact1 in tagged repo",
+			variantTags:            "test:v1",
+			variantCommitSha:       "test:b610928dc27484cc56990bc77622aab0dbd67131",
+			variantAbbrevCommitSha: "test:b610928",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("artifact1").write("artifact1/source.go", []byte("code")).
-					mkdir("artifact2").write("artifact2/source.go", []byte("code")).
+					mkdir("artifact2").write("artifact2/source.go", []byte("other code")).
 					add("artifact1/source.go", "artifact2/source.go").
 					commit("initial").tag("v1")
 			},
-			subDir: "artifact1",
+			subDir: "artifact1/",
 		},
 		{
-			description:  "clean artifact2 in tagged repo",
-			expectedName: "test:v1",
+			description:            "clean artifact2 in tagged repo",
+			variantTags:            "test:v1",
+			variantCommitSha:       "test:b610928dc27484cc56990bc77622aab0dbd67131",
+			variantAbbrevCommitSha: "test:b610928",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("artifact1").write("artifact1/source.go", []byte("code")).
-					mkdir("artifact2").write("artifact2/source.go", []byte("code")).
+					mkdir("artifact2").write("artifact2/source.go", []byte("other code")).
 					add("artifact1/source.go", "artifact2/source.go").
 					commit("initial").tag("v1")
 			},
 			subDir: "artifact2",
 		},
 		{
-			description:  "clean artifact in dirty repo",
-			expectedName: "test:v1",
+			description:            "clean artifact in dirty repo",
+			variantTags:            "test:v1",
+			variantCommitSha:       "test:b610928dc27484cc56990bc77622aab0dbd67131",
+			variantAbbrevCommitSha: "test:b610928",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("artifact1").write("artifact1/source.go", []byte("code")).
-					mkdir("artifact2").write("artifact2/source.go", []byte("code")).
+					mkdir("artifact2").write("artifact2/source.go", []byte("other code")).
 					add("artifact1/source.go", "artifact2/source.go").
 					commit("initial").tag("v1").
 					write("artifact2/source.go", []byte("updated code"))
@@ -185,12 +211,14 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			subDir: "artifact1",
 		},
 		{
-			description:  "updated artifact in dirty repo",
-			expectedName: "test:v1-dirty",
+			description:            "updated artifact in dirty repo",
+			variantTags:            "test:v1-dirty",
+			variantCommitSha:       "test:b610928dc27484cc56990bc77622aab0dbd67131-dirty",
+			variantAbbrevCommitSha: "test:b610928-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("artifact1").write("artifact1/source.go", []byte("code")).
-					mkdir("artifact2").write("artifact2/source.go", []byte("code")).
+					mkdir("artifact2").write("artifact2/source.go", []byte("other code")).
 					add("artifact1/source.go", "artifact2/source.go").
 					commit("initial").tag("v1").
 					write("artifact2/source.go", []byte("updated code"))
@@ -198,20 +226,50 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			subDir: "artifact2",
 		},
 		{
-			description:  "non git repo",
-			expectedName: "test:dirty",
+			description:            "additional commit in other artifact",
+			variantTags:            "test:0d16f59",
+			variantCommitSha:       "test:0d16f59900bd63dd39425d6085d3f1333b66804f",
+			variantAbbrevCommitSha: "test:0d16f59",
+			createGitRepo: func(dir string) {
+				gitInit(t, dir).
+					mkdir("artifact1").write("artifact1/source.go", []byte("code")).
+					mkdir("artifact2").write("artifact2/source.go", []byte("other code")).
+					add("artifact1/source.go", "artifact2/source.go").
+					commit("initial").
+					write("artifact2/source.go", []byte("updated code")).
+					add("artifact2/source.go").
+					commit("update artifact2")
+			},
+			subDir: "artifact1",
+		},
+		{
+			description:            "non git repo",
+			variantTags:            "test:dirty",
+			variantCommitSha:       "test:dirty",
+			variantAbbrevCommitSha: "test:dirty",
 			createGitRepo: func(dir string) {
 				ioutil.WriteFile(filepath.Join(dir, "source.go"), []byte("code"), os.ModePerm)
 			},
 		},
 		{
-			description:  "git repo with no commit",
-			expectedName: "test:dirty",
+			description:            "git repo with no commit",
+			variantTags:            "test:dirty",
+			variantCommitSha:       "test:dirty",
+			variantAbbrevCommitSha: "test:dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir)
 			},
 		},
 	}
+
+	tTags, err := NewGitCommit("Tags")
+	testutil.CheckError(t, false, err)
+
+	tCommit, err := NewGitCommit("CommitSha")
+	testutil.CheckError(t, false, err)
+
+	tAbbrevC, err := NewGitCommit("AbbrevCommitSha")
+	testutil.CheckError(t, false, err)
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
@@ -221,11 +279,14 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			tt.createGitRepo(tmpDir.Root())
 			workspace := tmpDir.Path(tt.subDir)
 
-			c := &GitCommit{}
+			name, err := tTags.GenerateFullyQualifiedImageName(workspace, "test")
+			testutil.CheckErrorAndDeepEqual(t, tt.shouldErr, err, tt.variantTags, name)
 
-			name, err := c.GenerateFullyQualifiedImageName(workspace, "test")
+			name, err = tCommit.GenerateFullyQualifiedImageName(workspace, "test")
+			testutil.CheckErrorAndDeepEqual(t, tt.shouldErr, err, tt.variantCommitSha, name)
 
-			testutil.CheckErrorAndDeepEqual(t, tt.shouldErr, err, tt.expectedName, name)
+			name, err = tAbbrevC.GenerateFullyQualifiedImageName(workspace, "test")
+			testutil.CheckErrorAndDeepEqual(t, tt.shouldErr, err, tt.variantAbbrevCommitSha, name)
 		})
 	}
 }

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -188,7 +188,7 @@ func getTagger(t latest.TagPolicy, customTag string) (tag.Tagger, error) {
 		return &tag.ChecksumTagger{}, nil
 
 	case t.GitTagger != nil:
-		return &tag.GitCommit{}, nil
+		return tag.NewGitCommit(t.GitTagger.Variant)
 
 	case t.DateTimeTagger != nil:
 		return tag.NewDateTimeTagger(t.DateTimeTagger.Format, t.DateTimeTagger.TimeZone), nil

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -123,7 +123,13 @@ type TagPolicy struct {
 type ShaTagger struct{}
 
 // GitTagger *beta* tags images with the git tag or commit of the artifact's workspace.
-type GitTagger struct{}
+type GitTagger struct {
+	// Variant determines the behavior of the git tagger. Valid variants are
+	// - Tags (default): use git tags or fall back to abbreviated commit hash.
+	// - CommitSha: use the full git commit sha.
+	// - AbbrevCommitSha: use the abbreviated git commit sha.
+	Variant string `yaml:"variant,omitempty"`
+}
 
 // EnvTemplateTagger *beta* tags images with a configurable template string.
 type EnvTemplateTagger struct {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -125,9 +125,9 @@ type ShaTagger struct{}
 // GitTagger *beta* tags images with the git tag or commit of the artifact's workspace.
 type GitTagger struct {
 	// Variant determines the behavior of the git tagger. Valid variants are
-	// - Tags (default): use git tags or fall back to abbreviated commit hash.
-	// - CommitSha: use the full git commit sha.
-	// - AbbrevCommitSha: use the abbreviated git commit sha.
+	// `Tags` (default): use git tags or fall back to abbreviated commit hash.
+	// `CommitSha`: use the full git commit sha.
+	// `AbbrevCommitSha`: use the abbreviated git commit sha.
 	Variant string `yaml:"variant,omitempty"`
 }
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -70,7 +70,7 @@ type BuildConfig struct {
 
 	// TagPolicy *beta* determines how images are tagged.
 	// A few strategies are provided here, although you most likely won't need to care!
-	// If not specified, it defaults to `gitCommit: {}`.
+	// If not specified, it defaults to `gitCommit: {variant: Tags}`.
 	TagPolicy TagPolicy `yaml:"tagPolicy,omitempty"`
 
 	// ExecutionEnvironment is the environment in which the build

--- a/pkg/skaffold/schema/v1beta7/upgrade.go
+++ b/pkg/skaffold/schema/v1beta7/upgrade.go
@@ -26,6 +26,7 @@ import (
 // Upgrade upgrades a configuration to the next version.
 // Config changes from v1beta7 to v1beta8
 // 1. Additions:
+// kaniko/resource requirements
 // 2. No removals
 // 3. No updates
 func (config *SkaffoldPipeline) Upgrade() (util.VersionedConfig, error) {

--- a/pkg/skaffold/schema/v1beta7/upgrade.go
+++ b/pkg/skaffold/schema/v1beta7/upgrade.go
@@ -26,7 +26,7 @@ import (
 // Upgrade upgrades a configuration to the next version.
 // Config changes from v1beta7 to v1beta8
 // 1. Additions:
-// kaniko/resource requirements
+//    gitTagger/variant
 // 2. No removals
 // 3. No updates
 func (config *SkaffoldPipeline) Upgrade() (util.VersionedConfig, error) {

--- a/pkg/skaffold/schema/v1beta7/upgrade.go
+++ b/pkg/skaffold/schema/v1beta7/upgrade.go
@@ -26,7 +26,6 @@ import (
 // Upgrade upgrades a configuration to the next version.
 // Config changes from v1beta7 to v1beta8
 // 1. Additions:
-//    gitTagger/variant
 // 2. No removals
 // 3. No updates
 func (config *SkaffoldPipeline) Upgrade() (util.VersionedConfig, error) {

--- a/pkg/skaffold/schema/v1beta8/upgrade.go
+++ b/pkg/skaffold/schema/v1beta8/upgrade.go
@@ -25,7 +25,8 @@ import (
 
 // Upgrade upgrades a configuration to the next version.
 // Config changes from v1beta8 to v1beta9
-// 1. No additions
+// 1. Additions:
+//    gitTagger/variant
 // 2. No removals
 // 3. No updates
 func (config *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {


### PR DESCRIPTION
### Synopsis
Currently, the git tagger always uses git tags or abbreviated git hashes to generate image tags. Issue #407 suggests, to extends the git tagger with a few variants:

- Tags (default): use git tags or fall back to abbreviated commit hash
- CommitSha: use the full git commit sha
- AbbrevCommitSha: use the abbreviated git commit sha


### Config change
To switch between the different variants of the git tagger, the `GitTagger` config was changed to
```yaml
tagPolicy:
  #  before
  # gitCommit: {}

  # new
  gitCommit:
   # variant is an enum with valid values (case-insensitive)
   # - Tags
   # - CommitSha
   # - AbbrevCommitSha
    variant: Tags # default
```
See #407 


