### PR TITLE
Refactor pod selection logic for log-tailing

### DIFF
--- a/pkg/skaffold/kubernetes/port_forward_test.go
+++ b/pkg/skaffold/kubernetes/port_forward_test.go
@@ -443,7 +443,7 @@ func TestPortForwardPod(t *testing.T) {
 				retrieveAvailablePort = originalGetAvailablePort
 			}()
 
-			p := NewPortForwarder(ioutil.Discard, NewImageList(), []string{""})
+			p := NewPortForwarder(ioutil.Discard, &TailLabelSelector{}, []string{""})
 			if test.forwarder == nil {
 				test.forwarder = newTestForwarder(nil)
 			}

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -35,10 +35,10 @@ var ErrorConfigurationChanged = errors.New("configuration changed")
 // Dev watches for changes and runs the skaffold build and deploy
 // config until interrupted by the user.
 func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) error {
-	logger := r.newLogger(out, artifacts)
+	logger := r.newLogger(out)
 	defer logger.Stop()
 
-	portForwarder := kubernetes.NewPortForwarder(out, r.imageList, r.runCtx.Namespaces)
+	portForwarder := kubernetes.NewPortForwarder(out, r.podSelector, r.runCtx.Namespaces)
 	defer portForwarder.Stop()
 
 	// Create watcher and register artifacts to build current state of files.

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -330,19 +330,3 @@ func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []
 	r.hasDeployed = true
 	return err
 }
-
-// todo(corneliusweig) function unused?
-// TailLogs prints the logs for deployed artifacts.
-func (r *SkaffoldRunner) TailLogs(ctx context.Context, out io.Writer, artifacts []*latest.Artifact, bRes []build.Artifact) error {
-	if !r.runCtx.Opts.Tail {
-		return nil
-	}
-
-	logger := r.newLogger(out, artifacts)
-	if err := logger.Start(ctx); err != nil {
-		return errors.Wrap(err, "starting logger")
-	}
-
-	<-ctx.Done()
-	return nil
-}


### PR DESCRIPTION
**Note**: Part of design proposal #1911

So far, pods were selected based on known image names in their container spec. This is restricting, because it does not allow to add additional pods for log-tailing, nor is it feasible to exclude uninteresting pods. Besides, the book-keeping code for the deployed images was scattered in the code.

Now, pods are selected for log-tailing by looking for a `tail=true` label on the pods. This is mainly a preparatory refactoring to implement more interesting label selectors in the future.

References #666, #588
Depends on #2074