### PR TITLE
Full validation for `required` and `oneOf` config fields

### DIFF
--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -59,7 +59,7 @@ func runFix(out io.Writer, configFile string, overwrite bool) error {
 		return err
 	}
 
-	if err := validation.ValidateSchema(cfg.(*latest.SkaffoldConfig)); err != nil {
+	if err := validation.Process(cfg.(*latest.SkaffoldConfig)); err != nil {
 		return errors.Wrap(err, "validating upgraded config")
 	}
 

--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/validation"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	yaml "gopkg.in/yaml.v2"
@@ -56,6 +57,10 @@ func runFix(out io.Writer, configFile string, overwrite bool) error {
 	cfg, err = schema.ParseConfig(configFile, true)
 	if err != nil {
 		return err
+	}
+
+	if err := validation.ValidateSchema(cfg.(*latest.SkaffoldConfig)); err != nil {
+		return errors.Wrap(err, "validating upgraded config")
 	}
 
 	newCfg, err := yaml.Marshal(cfg)

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -52,7 +52,7 @@ func newRunner(opts *config.SkaffoldOptions) (*runner.SkaffoldRunner, *latest.Sk
 		return nil, nil, errors.Wrap(err, "setting default values")
 	}
 
-	if err := validation.ValidateSchema(config); err != nil {
+	if err := validation.Process(config); err != nil {
 		return nil, nil, errors.Wrap(err, "invalid skaffold config")
 	}
 

--- a/docs/content/en/schemas/v1beta8.json
+++ b/docs/content/en/schemas/v1beta8.json
@@ -1536,6 +1536,10 @@
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
     "SkaffoldConfig": {
+      "required": [
+        "apiVersion",
+        "kind"
+      ],
       "properties": {
         "apiVersion": {
           "type": "string",

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -31,10 +31,10 @@ func NewSkaffoldConfig() util.VersionedConfig {
 // SkaffoldConfig holds the fields parsed from the Skaffold configuration file (skaffold.yaml).
 type SkaffoldConfig struct {
 	// APIVersion is the version of the configuration.
-	APIVersion string `yaml:"apiVersion"`
+	APIVersion string `yaml:"apiVersion" yamltags:"required"`
 
 	// Kind is always `Config`. Defaults to `Config`.
-	Kind string `yaml:"kind"`
+	Kind string `yaml:"kind" yamltags:"required"`
 
 	// Pipeline defines the Build/Test/Deploy phases.
 	Pipeline `yaml:",inline"`

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -49,7 +49,7 @@ func visitStructs(s interface{}, visitor func(interface{}) error) []error {
 	case reflect.Struct:
 		var errs []error
 		if err := visitor(v.Interface()); err != nil {
-			errs = []error{err}
+			errs = append(errs, err)
 		}
 
 		// also check all fields of the current struct

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -25,8 +25,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags"
 )
 
-// ValidateSchema checks if the Skaffold pipeline is valid and returns all encountered errors as a concatenated string
-func ValidateSchema(config *latest.SkaffoldConfig) error {
+// Process checks if the Skaffold pipeline is valid and returns all encountered errors as a concatenated string
+func Process(config *latest.SkaffoldConfig) error {
 	errs := visitStructs(config, yamltags.ValidateStruct)
 
 	if len(errs) == 0 {

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -81,7 +81,7 @@ func TestValidateSchema(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateSchema(tt.cfg)
+			err := Process(tt.cfg)
 			testutil.CheckError(t, tt.shouldErr, err)
 		})
 	}

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -53,80 +54,151 @@ var (
 )
 
 func TestValidateSchema(t *testing.T) {
-	err := ValidateSchema(cfgWithErrors)
-	testutil.CheckError(t, true, err)
-
-	err = ValidateSchema(&latest.SkaffoldConfig{})
-	testutil.CheckError(t, false, err)
-}
-
-func TestValidateOneOf(t *testing.T) {
 	tests := []struct {
 		name      string
-		input     interface{}
+		cfg       *latest.SkaffoldConfig
 		shouldErr bool
-		expected  []string
 	}{
 		{
-			name: "only one field set",
-			input: &latest.BuildType{
-				Cluster: &latest.ClusterDetails{},
+			name:      "config with errors",
+			cfg:       cfgWithErrors,
+			shouldErr: true,
+		},
+		{
+			name:      "empty config",
+			cfg:       &latest.SkaffoldConfig{},
+			shouldErr: true,
+		},
+		{
+			name: "minimal config",
+			cfg: &latest.SkaffoldConfig{
+				APIVersion: "foo",
+				Kind:       "bar",
 			},
 			shouldErr: false,
 		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSchema(tt.cfg)
+			testutil.CheckError(t, tt.shouldErr, err)
+		})
+	}
+}
+
+func alwaysErr(_ interface{}) error {
+	return fmt.Errorf("always fail")
+}
+
+type emptyStruct struct{}
+type nestedEmptyStruct struct {
+	N emptyStruct
+}
+
+func TestVisitStructs(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        interface{}
+		expectedErrs int
+	}{
 		{
-			name: "two colliding buildTypes",
-			input: &latest.BuildType{
-				GoogleCloudBuild: &latest.GoogleCloudBuild{},
-				Cluster:          &latest.ClusterDetails{},
+			name:         "single struct to validate",
+			input:        emptyStruct{},
+			expectedErrs: 1,
+		},
+		{
+			name:         "recurse into nested struct",
+			input:        nestedEmptyStruct{},
+			expectedErrs: 2,
+		},
+		{
+			name: "check all slice items",
+			input: struct {
+				A []emptyStruct
+			}{
+				A: []emptyStruct{{}, {}},
 			},
-			shouldErr: true,
-			expected:  []string{"googleCloudBuild cluster"},
+			expectedErrs: 3,
 		},
 		{
-			name: "deployType with two fields",
-			input: &latest.DeployType{
-				HelmDeploy:    &latest.HelmDeploy{},
-				KubectlDeploy: &latest.KubectlDeploy{},
+			name: "recurse into slices",
+			input: struct {
+				A []nestedEmptyStruct
+			}{
+				A: []nestedEmptyStruct{
+					{
+						N: emptyStruct{},
+					},
+				},
 			},
-			shouldErr: true,
-			expected:  []string{"helm kubectl"},
+			expectedErrs: 3,
 		},
 		{
-			name: "deployType with three fields",
-			input: &latest.DeployType{
-				HelmDeploy:      &latest.HelmDeploy{},
-				KubectlDeploy:   &latest.KubectlDeploy{},
-				KustomizeDeploy: &latest.KustomizeDeploy{},
+			name: "recurse into ptr slices",
+			input: struct {
+				A []*nestedEmptyStruct
+			}{
+				A: []*nestedEmptyStruct{
+					{
+						N: emptyStruct{},
+					},
+				},
 			},
-			shouldErr: true,
-			expected:  []string{"helm kubectl kustomize"},
+			expectedErrs: 3,
 		},
 		{
-			name:      "empty struct should not fail",
-			input:     &latest.GitTagger{},
-			shouldErr: false,
+			name: "ignore empty slices",
+			input: struct {
+				A []emptyStruct
+			}{},
+			expectedErrs: 1,
 		},
 		{
-			name:      "full Skaffold pipeline",
-			input:     cfgWithErrors,
-			shouldErr: true,
-			expected:  []string{"docker bazel", "bazel kaniko", "helm kubectl"},
+			name: "ignore nil pointers",
+			input: struct {
+				A *struct{}
+			}{},
+			expectedErrs: 1,
+		},
+		{
+			name: "recurse into members",
+			input: struct {
+				A, B emptyStruct
+			}{
+				A: emptyStruct{},
+				B: emptyStruct{},
+			},
+			expectedErrs: 3,
+		},
+		{
+			name: "recurse into ptr members",
+			input: struct {
+				A, B *emptyStruct
+			}{
+				A: &emptyStruct{},
+				B: &emptyStruct{},
+			},
+			expectedErrs: 3,
+		},
+		{
+			name: "ignore other fields",
+			input: struct {
+				A emptyStruct
+				C int
+			}{
+				A: emptyStruct{},
+				C: 2,
+			},
+			expectedErrs: 2,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := validateOneOf(test.input)
+			actual := visitStructs(test.input, alwaysErr)
 
-			if test.shouldErr {
-				testutil.CheckDeepEqual(t, len(test.expected), len(actual))
-				for i, message := range test.expected {
-					testutil.CheckContains(t, message, actual[i].Error())
-				}
-			} else {
-				testutil.CheckDeepEqual(t, []error(nil), actual)
-			}
+			testutil.CheckDeepEqual(t, test.expectedErrs, len(actual))
 		})
 	}
 }

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -19,11 +19,7 @@ package schema
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v2"
-
-	apiversion "github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha1"
@@ -39,7 +35,9 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta6"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta7"
 	misc "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 type APIVersion struct {
@@ -100,10 +98,6 @@ func ParseConfig(filename string, upgrade bool) (util.VersionedConfig, error) {
 	cfg := factory()
 	if err := yaml.UnmarshalStrict(buf, cfg); err != nil {
 		return nil, errors.Wrap(err, "unable to parse config")
-	}
-
-	if err := yamltags.ProcessStruct(cfg); err != nil {
-		return nil, errors.Wrap(err, "invalid config")
 	}
 
 	if upgrade && cfg.GetVersion() != latest.Version {

--- a/pkg/skaffold/yamltags/tags.go
+++ b/pkg/skaffold/yamltags/tags.go
@@ -61,6 +61,8 @@ func processTags(yamltags string, val reflect.Value, parentStruct reflect.Value,
 				Field:  field,
 				Parent: parentStruct,
 			}
+		default:
+			logrus.Fatalf("unknown yaml tag in %s", yamltags)
 		}
 		if err := yt.Load(tagParts); err != nil {
 			return err

--- a/pkg/skaffold/yamltags/tags.go
+++ b/pkg/skaffold/yamltags/tags.go
@@ -62,7 +62,7 @@ func processTags(yamltags string, val reflect.Value, parentStruct reflect.Value,
 				Parent: parentStruct,
 			}
 		default:
-			logrus.Fatalf("unknown yaml tag in %s", yamltags)
+			logrus.Panicf("unknown yaml tag in %s", yamltags)
 		}
 		if err := yt.Load(tagParts); err != nil {
 			return err

--- a/pkg/skaffold/yamltags/tags.go
+++ b/pkg/skaffold/yamltags/tags.go
@@ -19,7 +19,6 @@ package yamltags
 import (
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
 )
 
@@ -58,8 +57,6 @@ func ProcessTags(yamltags string, val reflect.Value, parentStruct reflect.Value,
 			yt = &RequiredTag{
 				Field: field,
 			}
-		case "default":
-			yt = &DefaultTag{}
 		case "oneOf":
 			yt = &OneOfTag{
 				Field:  field,
@@ -95,36 +92,6 @@ func (rt *RequiredTag) Process(val reflect.Value) error {
 			return fmt.Errorf("required value not set: %s", strings.Split(tags, ",")[0])
 		}
 		return fmt.Errorf("required value not set: %s", rt.Field.Name)
-	}
-	return nil
-}
-
-type DefaultTag struct {
-	dv string
-}
-
-func (dt *DefaultTag) Load(s []string) error {
-	if len(s) != 2 {
-		return fmt.Errorf("invalid default tag: %v, expected key=value", s)
-	}
-	dt.dv = s[1]
-	return nil
-}
-
-func (dt *DefaultTag) Process(val reflect.Value) error {
-	if !isZeroValue(val) {
-		return nil
-	}
-
-	switch val.Kind() {
-	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64:
-		i, err := strconv.ParseInt(dt.dv, 0, 0)
-		if err != nil {
-			return err
-		}
-		val.SetInt(i)
-	case reflect.String:
-		val.SetString(dt.dv)
 	}
 	return nil
 }

--- a/pkg/skaffold/yamltags/tags.go
+++ b/pkg/skaffold/yamltags/tags.go
@@ -20,14 +20,17 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 type FieldSet map[string]struct{}
 
-// ProcessStruct validates and processes the provided pointer to a struct.
-func ProcessStruct(s interface{}) error {
-	parentStruct := reflect.ValueOf(s).Elem()
+// ValidateStruct validates and processes the provided pointer to a struct.
+func ValidateStruct(s interface{}) error {
+	parentStruct := reflect.Indirect(reflect.ValueOf(s))
 	t := parentStruct.Type()
+	logrus.Debugf("validating yamltags of struct %s", t.Name())
 
 	// Loop through the fields on the struct, looking for tags.
 	for i := 0; i < t.NumField(); i++ {
@@ -36,12 +39,6 @@ func ProcessStruct(s interface{}) error {
 		field := parentStruct.Type().Field(i)
 		if tags, ok := f.Tag.Lookup("yamltags"); ok {
 			if err := ProcessTags(tags, val, parentStruct, field); err != nil {
-				return err
-			}
-		}
-		// Recurse down the struct
-		if val.Kind() == reflect.Struct {
-			if err := ProcessStruct(val.Addr().Interface()); err != nil {
 				return err
 			}
 		}

--- a/pkg/skaffold/yamltags/tags_test.go
+++ b/pkg/skaffold/yamltags/tags_test.go
@@ -33,7 +33,7 @@ type required struct {
 	C otherstruct
 }
 
-func TestProcessStructRequired(t *testing.T) {
+func TestValidateStructRequired(t *testing.T) {
 	type args struct {
 		s interface{}
 	}
@@ -97,7 +97,7 @@ type nested struct {
 	F string
 }
 
-func TestOneOf(t *testing.T) {
+func TestValidateStructOneOf(t *testing.T) {
 	type args struct {
 		s interface{}
 	}
@@ -155,6 +155,20 @@ func TestOneOf(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateStructInvalid(t *testing.T) {
+	invalidYamlTags := struct {
+		A string `yamltags:"invalidTag"`
+	}{A: "whatever"}
+
+	defer func() {
+		if recover() == nil {
+			t.Errorf("should have panicked")
+		}
+	}()
+
+	_ = ValidateStruct(invalidYamlTags)
 }
 
 func TestIsZeroValue(t *testing.T) {

--- a/pkg/skaffold/yamltags/tags_test.go
+++ b/pkg/skaffold/yamltags/tags_test.go
@@ -95,59 +95,6 @@ func TestProcessStructRequired(t *testing.T) {
 	}
 }
 
-type defaultTags struct {
-	A string `yamltags:"default=foo"`
-	B int    `yamltags:"default=3"`
-}
-
-func TestProcessStructDefault(t *testing.T) {
-	type args struct {
-		s interface{}
-	}
-
-	tests := []struct {
-		name    string
-		args    args
-		want    interface{}
-		wantErr bool
-	}{
-		{
-			name: "missing all",
-			args: args{
-				s: &defaultTags{},
-			},
-			want:    &defaultTags{A: "foo", B: 3},
-			wantErr: false,
-		},
-		{
-			name: "all set",
-			args: args{
-				s: &defaultTags{A: "yo", B: 1},
-			},
-			want:    &defaultTags{A: "yo", B: 1},
-			wantErr: false,
-		},
-		{
-			name: "some set",
-			args: args{
-				s: &defaultTags{A: "yo"},
-			},
-			want:    &defaultTags{A: "yo", B: 3},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := ProcessStruct(tt.args.s); (err != nil) != tt.wantErr {
-				t.Errorf("ProcessStruct() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if !reflect.DeepEqual(tt.args.s, tt.want) {
-				t.Errorf("Got %v, want %v", tt.args.s, tt.want)
-			}
-		})
-	}
-}
-
 type oneOfStruct struct {
 	A string  `yamltags:"oneOf=set1"`
 	B string  `yamltags:"oneOf=set1"`

--- a/pkg/skaffold/yamltags/tags_test.go
+++ b/pkg/skaffold/yamltags/tags_test.go
@@ -64,7 +64,7 @@ func TestProcessStructRequired(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "missng some",
+			name: "missing some",
 			args: args{
 				s: &required{
 					A: "hey",
@@ -75,21 +75,11 @@ func TestProcessStructRequired(t *testing.T) {
 			},
 			wantErr: true,
 		},
-		{
-			name: "missng nested",
-			args: args{
-				s: &required{
-					A: "hey",
-					B: 3,
-				},
-			},
-			wantErr: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := ProcessStruct(tt.args.s); (err != nil) != tt.wantErr {
-				t.Errorf("ProcessStruct() error = %v, wantErr %v", err, tt.wantErr)
+			if err := ValidateStruct(tt.args.s); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateStruct() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -157,24 +147,11 @@ func TestOneOf(t *testing.T) {
 				}},
 			wantErr: true,
 		},
-		{
-			name: "different instances may set other fields",
-			args: args{
-				s: []*oneOfStruct{
-					{
-						A: "foo",
-					},
-					{
-						B: "baz",
-					},
-				}},
-			wantErr: false,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := ProcessStruct(tt.args.s); (err != nil) != tt.wantErr {
-				t.Errorf("ProcessStruct() error = %v, wantErr %v", err, tt.wantErr)
+			if err := ValidateStruct(tt.args.s); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateStruct() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/skaffold/yamltags/tags_test.go
+++ b/pkg/skaffold/yamltags/tags_test.go
@@ -157,6 +157,19 @@ func TestOneOf(t *testing.T) {
 				}},
 			wantErr: true,
 		},
+		{
+			name: "different instances may set other fields",
+			args: args{
+				s: []*oneOfStruct{
+					{
+						A: "foo",
+					},
+					{
+						B: "baz",
+					},
+				}},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
As outlined in #1920, the current validation of the Skaffold config was quite inconsistent:
- validation for `yamltags=oneOf` was duplicated in packages `yamltags` and `validation`
- validation for `yamltags=required` was broken and not doing much
- `yamltags=default` had the same problem as `yamltags=required` but it cannot be fixed
- the original yamltags validation was done before applying profiles, iow too early

This PR fixes the abovementioned problems. Validation still remains in the `validation` package, so that there will be a good location to add further validation in the future. The implementation of `yamltags` validation is now taken from the `yamltags` package.

Close #1920