### PR TITLE
runContext is not created anywhere else but in runner

### DIFF
--- a/integration/testdata/plugin/gcb/skaffold.yaml
+++ b/integration/testdata/plugin/gcb/skaffold.yaml
@@ -14,6 +14,7 @@ build:
         target: targetStage
   executionEnvironment:
     name: googleCloudBuild
+
 deploy:
   kubectl:
     manifests:

--- a/pkg/skaffold/build/local/bazel.go
+++ b/pkg/skaffold/build/local/bazel.go
@@ -20,9 +20,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/plugin/builders/bazel"
-	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -30,19 +28,12 @@ func (b *Builder) buildBazel(ctx context.Context, out io.Writer, a *latest.Artif
 	builder := bazel.NewBuilder()
 	builder.LocalBuild = b.cfg
 	builder.LocalDocker = b.localDocker
-	builder.KubeContext = b.kubeContext
+	builder.KubeContext = b.runCtx.KubeContext
 	builder.PushImages = b.pushImages
 	builder.PluginMode = false
 
-	builder.Init(&runcontext.RunContext{
-		Opts: &config.SkaffoldOptions{
-			SkipTests: b.skipTests,
-		},
-		Cfg: &latest.Pipeline{
-			Build: latest.BuildConfig{
-				ExecutionEnvironment: &latest.ExecutionEnvironment{},
-			},
-		},
-	})
+	if err := builder.Init(b.runCtx); err != nil {
+		return "", err
+	}
 	return builder.BuildArtifact(ctx, out, a, tag)
 }

--- a/pkg/skaffold/build/local/docker.go
+++ b/pkg/skaffold/build/local/docker.go
@@ -20,9 +20,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/plugin/builders/docker"
-	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -30,19 +28,12 @@ func (b *Builder) buildDocker(ctx context.Context, out io.Writer, a *latest.Arti
 	builder := docker.NewBuilder()
 	builder.LocalBuild = b.cfg
 	builder.LocalDocker = b.localDocker
-	builder.KubeContext = b.kubeContext
+	builder.KubeContext = b.runCtx.KubeContext
 	builder.PushImages = b.pushImages
 	builder.PluginMode = false
 
-	builder.Init(&runcontext.RunContext{
-		Opts: &config.SkaffoldOptions{
-			SkipTests: b.skipTests,
-		},
-		Cfg: &latest.Pipeline{
-			Build: latest.BuildConfig{
-				ExecutionEnvironment: &latest.ExecutionEnvironment{},
-			},
-		},
-	})
+	if err := builder.Init(b.runCtx); err != nil {
+		return "", nil
+	}
 	return builder.BuildArtifact(ctx, out, a, tag)
 }

--- a/pkg/skaffold/build/local/jib_gradle.go
+++ b/pkg/skaffold/build/local/jib_gradle.go
@@ -37,7 +37,7 @@ func (b *Builder) buildJibGradle(ctx context.Context, out io.Writer, workspace s
 }
 
 func (b *Builder) buildJibGradleToDocker(ctx context.Context, out io.Writer, workspace string, artifact *latest.JibGradleArtifact, tag string) (string, error) {
-	args := jib.GenerateGradleArgs("jibDockerBuild", tag, artifact, b.skipTests)
+	args := jib.GenerateGradleArgs("jibDockerBuild", tag, artifact, b.runCtx.Opts.SkipTests)
 	if err := b.runGradleCommand(ctx, out, workspace, args); err != nil {
 		return "", err
 	}
@@ -46,7 +46,7 @@ func (b *Builder) buildJibGradleToDocker(ctx context.Context, out io.Writer, wor
 }
 
 func (b *Builder) buildJibGradleToRegistry(ctx context.Context, out io.Writer, workspace string, artifact *latest.JibGradleArtifact, tag string) (string, error) {
-	args := jib.GenerateGradleArgs("jib", tag, artifact, b.skipTests)
+	args := jib.GenerateGradleArgs("jib", tag, artifact, b.runCtx.Opts.SkipTests)
 	if err := b.runGradleCommand(ctx, out, workspace, args); err != nil {
 		return "", err
 	}

--- a/pkg/skaffold/build/local/jib_maven.go
+++ b/pkg/skaffold/build/local/jib_maven.go
@@ -44,7 +44,7 @@ func (b *Builder) buildJibMavenToDocker(ctx context.Context, out io.Writer, work
 		}
 	}
 
-	args := jib.GenerateMavenArgs("dockerBuild", tag, artifact, b.skipTests)
+	args := jib.GenerateMavenArgs("dockerBuild", tag, artifact, b.runCtx.Opts.SkipTests)
 	if err := b.runMavenCommand(ctx, out, workspace, args); err != nil {
 		return "", err
 	}
@@ -60,7 +60,7 @@ func (b *Builder) buildJibMavenToRegistry(ctx context.Context, out io.Writer, wo
 		}
 	}
 
-	args := jib.GenerateMavenArgs("build", tag, artifact, b.skipTests)
+	args := jib.GenerateMavenArgs("build", tag, artifact, b.runCtx.Opts.SkipTests)
 	if err := b.runMavenCommand(ctx, out, workspace, args); err != nil {
 		return "", err
 	}

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -38,7 +38,7 @@ import (
 // its checksum. It streams build progress to the writer argument.
 func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 	if b.localCluster {
-		color.Default.Fprintf(out, "Found [%s] context, using local docker daemon.\n", b.kubeContext)
+		color.Default.Fprintf(out, "Found [%s] context, using local docker daemon.\n", b.runCtx.KubeContext)
 	}
 	defer b.localDocker.Close()
 

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -21,6 +21,8 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
@@ -225,15 +227,27 @@ func TestLocalRun(t *testing.T) {
 				BuildType: latest.BuildType{
 					LocalBuild: &latest.LocalBuild{},
 				},
+				ExecutionEnvironment: &latest.ExecutionEnvironment{Name: constants.Local},
 			}
-			event.InitializeState(&runcontext.RunContext{
+			runContext := &runcontext.RunContext{
 				Cfg: &latest.Pipeline{
 					Build: cfg,
 				},
 				Opts: &config.SkaffoldOptions{},
-			})
+			}
+			cancel, err := event.InitializeState(runContext)
+			if err != nil {
+				t.Error(err)
+			}
+			defer func() {
+				if err := cancel(); err != nil {
+					t.Error(err)
+				}
+			}()
+
 			l := Builder{
 				cfg:         &latest.LocalBuild{},
+				runCtx:      runContext,
 				localDocker: docker.NewLocalDaemon(&test.api, nil, false),
 				pushImages:  test.pushImages,
 			}

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -223,15 +223,14 @@ func TestLocalRun(t *testing.T) {
 			defer func(w warnings.Warner) { warnings.Printf = w }(warnings.Printf)
 			fakeWarner := &warnings.Collect{}
 			warnings.Printf = fakeWarner.Warnf
-			cfg := latest.BuildConfig{
-				BuildType: latest.BuildType{
-					LocalBuild: &latest.LocalBuild{},
-				},
-				ExecutionEnvironment: &latest.ExecutionEnvironment{Name: constants.Local},
-			}
 			runContext := &runcontext.RunContext{
 				Cfg: &latest.Pipeline{
-					Build: cfg,
+					Build: latest.BuildConfig{
+						BuildType: latest.BuildType{
+							LocalBuild: &latest.LocalBuild{},
+						},
+						ExecutionEnvironment: &latest.ExecutionEnvironment{Name: constants.Local},
+					},
 				},
 				Opts: &config.SkaffoldOptions{},
 			}

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -32,15 +32,14 @@ import (
 
 // Builder uses the host docker daemon to build and tag the image.
 type Builder struct {
-	cfg *latest.LocalBuild
-
+	cfg          *latest.LocalBuild
 	localDocker  docker.LocalDaemon
 	localCluster bool
 	pushImages   bool
-	prune        bool
-	skipTests    bool
-	kubeContext  string
-	builtImages  []string
+
+	builtImages []string
+
+	runCtx *runcontext.RunContext
 }
 
 // NewBuilder returns an new instance of a local Builder.
@@ -64,13 +63,12 @@ func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
 	}
 
 	return &Builder{
-		cfg:          runCtx.Cfg.Build.LocalBuild,
-		kubeContext:  runCtx.KubeContext,
+		cfg: runCtx.Cfg.Build.LocalBuild,
+
 		localDocker:  localDocker,
 		localCluster: localCluster,
 		pushImages:   pushImages,
-		skipTests:    runCtx.Opts.SkipTests,
-		prune:        runCtx.Opts.Prune(),
+		runCtx:       runCtx,
 	}, nil
 }
 

--- a/pkg/skaffold/plugin/builders/docker/builder.go
+++ b/pkg/skaffold/plugin/builders/docker/builder.go
@@ -48,13 +48,15 @@ type Builder struct {
 	PluginMode  bool
 	KubeContext string
 	builtImages []string
+	runCtx      *runcontext.RunContext
 }
 
 // NewBuilder creates a new Builder that builds artifacts with Docker.
 func NewBuilder() *Builder {
-	return &Builder{
+	builder := &Builder{
 		PluginMode: true,
 	}
+	return builder
 }
 
 // Init stores skaffold options and the execution environment
@@ -66,6 +68,7 @@ func (b *Builder) Init(runCtx *runcontext.RunContext) error {
 			return err
 		}
 	}
+	b.runCtx = runCtx
 	b.opts = runCtx.Opts
 	b.env = runCtx.Cfg.Build.ExecutionEnvironment
 	logrus.Debugf("initialized plugin with %+v", runCtx)
@@ -128,17 +131,7 @@ func (b *Builder) googleCloudBuild(ctx context.Context, out io.Writer, tags tag.
 			return nil, err
 		}
 	}
-	runCtx := &runcontext.RunContext{
-		Opts: b.opts,
-		Cfg: &latest.Pipeline{
-			Build: latest.BuildConfig{
-				BuildType: latest.BuildType{
-					GoogleCloudBuild: g,
-				},
-			},
-		},
-	}
-	return gcb.NewBuilder(runCtx).Build(ctx, out, tags, artifacts)
+	return gcb.NewBuilder(b.runCtx).Build(ctx, out, tags, artifacts)
 }
 
 func setArtifact(artifact *latest.Artifact) error {

--- a/pkg/skaffold/plugin/environments/gcb/types.go
+++ b/pkg/skaffold/plugin/environments/gcb/types.go
@@ -21,6 +21,8 @@ import (
 	"io"
 	"time"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/jib"
@@ -65,12 +67,25 @@ type Builder struct {
 	skipTests bool
 }
 
-// NewBuilder creates a new Builder that builds artifacts with Google Cloud Build.
-func NewBuilder(runCtx *runcontext.RunContext) *Builder {
+// NewDeprecatedBuilder creates a new Builder that builds artifacts with Google Cloud Build.
+func NewDeprecatedBuilder(runCtx *runcontext.RunContext) *Builder {
 	return &Builder{
 		GoogleCloudBuild: runCtx.Cfg.Build.GoogleCloudBuild,
 		skipTests:        runCtx.Opts.SkipTests,
 	}
+}
+
+// NewEnvBuilder creates a new Builder that builds artifacts with Google Cloud Build.
+func NewEnvBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
+	var g *latest.GoogleCloudBuild
+	if err := util.CloneThroughJSON(runCtx.Cfg.Build.ExecutionEnvironment.Properties, &g); err != nil {
+		return nil, errors.Wrap(err, "converting execution environment to googleCloudBuild struct")
+	}
+	defaults.SetDefaultCloudBuildDockerImage(g)
+	return &Builder{
+		GoogleCloudBuild: g,
+		skipTests:        runCtx.Opts.SkipTests,
+	}, nil
 }
 
 // Labels are labels specific to Google Cloud Build.

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -143,7 +143,7 @@ func getBuilder(runCtx *runcontext.RunContext) (build.Builder, error) {
 
 	case runCtx.Cfg.Build.GoogleCloudBuild != nil:
 		logrus.Debugln("Using builder: google cloud")
-		return gcb.NewBuilder(runCtx), nil
+		return gcb.NewDeprecatedBuilder(runCtx), nil
 
 	case runCtx.Cfg.Build.Cluster != nil:
 		logrus.Debugln("Using builder: kaniko")

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -70,7 +70,7 @@ type BuildConfig struct {
 	TagPolicy TagPolicy `yaml:"tagPolicy,omitempty"`
 
 	// ExecutionEnvironment is the environment in which the build
-	// should run. Possible values: googleCloudBuild.
+	// should run. Possible values: googleCloudBuild, local.
 	ExecutionEnvironment *ExecutionEnvironment `yaml:"executionEnvironment,omitempty"`
 
 	BuildType `yaml:",inline"`


### PR DESCRIPTION
`RunContext` should not be created anywhere else but the `Runner` and tests. 
This PR clears up the plugin/builder code that was creating `RunContext`