### PR TITLE
Attaching os standard error and out stream to the copy command

### DIFF
--- a/pkg/skaffold/sync/kubectl/kubectl.go
+++ b/pkg/skaffold/sync/kubectl/kubectl.go
@@ -19,7 +19,6 @@ package kubectl
 import (
 	"context"
 	"io"
-	"os"
 	"os/exec"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
@@ -77,9 +76,6 @@ func copyFileFn(ctx context.Context, pod v1.Pod, container v1.Container, files m
 	copy := exec.CommandContext(ctx, "kubectl", "exec", pod.Name, "--namespace", pod.Namespace, "-c", container.Name, "-i",
 		"--", "tar", "xmf", "-", "-C", "/", "--no-same-owner")
 	copy.Stdin = reader
-	copy.Stdout = os.Stdout
-	copy.Stderr = os.Stderr
-
 	go func() {
 		defer writer.Close()
 

--- a/pkg/skaffold/sync/kubectl/kubectl.go
+++ b/pkg/skaffold/sync/kubectl/kubectl.go
@@ -19,6 +19,7 @@ package kubectl
 import (
 	"context"
 	"io"
+	"os"
 	"os/exec"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
@@ -76,6 +77,9 @@ func copyFileFn(ctx context.Context, pod v1.Pod, container v1.Container, files m
 	copy := exec.CommandContext(ctx, "kubectl", "exec", pod.Name, "--namespace", pod.Namespace, "-c", container.Name, "-i",
 		"--", "tar", "xmf", "-", "-C", "/", "--no-same-owner")
 	copy.Stdin = reader
+	copy.Stdout = os.Stdout
+	copy.Stderr = os.Stderr
+
 	go func() {
 		defer writer.Close()
 

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -247,7 +247,7 @@ func Perform(ctx context.Context, image string, files map[string]string, cmdFn f
 
 				cmds := cmdFn(ctx, p, c, files)
 				for _, cmd := range cmds {
-					if err := util.RunCmdOut(cmd); err != nil {
+					if _,err := util.RunCmdOut(cmd); err != nil {
 						return err
 					}
 					numSynced++

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sync
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os/exec"

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -247,7 +247,11 @@ func Perform(ctx context.Context, image string, files map[string]string, cmdFn f
 
 				cmds := cmdFn(ctx, p, c, files)
 				for _, cmd := range cmds {
+					buf := &bytes.Buffer{}
+					cmd.Stdout = buf
+					cmd.Stderr = buf
 					if err := util.RunCmd(cmd); err != nil {
+						logrus.Warnf("Sync failed: %s", buf.String())
 						return err
 					}
 					numSynced++

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -248,7 +248,6 @@ func Perform(ctx context.Context, image string, files map[string]string, cmdFn f
 				cmds := cmdFn(ctx, p, c, files)
 				for _, cmd := range cmds {
 					if err := util.RunCmdOut(cmd); err != nil {
-						logrus.Warnf("Sync failed: %s", buf.String())
 						return err
 					}
 					numSynced++

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -17,7 +17,6 @@ limitations under the License.
 package sync
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"os/exec"
@@ -248,10 +247,7 @@ func Perform(ctx context.Context, image string, files map[string]string, cmdFn f
 
 				cmds := cmdFn(ctx, p, c, files)
 				for _, cmd := range cmds {
-					buf := &bytes.Buffer{}
-					cmd.Stdout = buf
-					cmd.Stderr = buf
-					if err := util.RunCmd(cmd); err != nil {
+					if err := util.RunCmdOut(cmd); err != nil {
 						logrus.Warnf("Sync failed: %s", buf.String())
 						return err
 					}

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -247,7 +247,7 @@ func Perform(ctx context.Context, image string, files map[string]string, cmdFn f
 
 				cmds := cmdFn(ctx, p, c, files)
 				for _, cmd := range cmds {
-					if _,err := util.RunCmdOut(cmd); err != nil {
+					if _, err := util.RunCmdOut(cmd); err != nil {
 						return err
 					}
 					numSynced++


### PR DESCRIPTION
Copy command doesn't output the logs to the user, hence attaching logs to stderr and stdout.