### PR TITLE
Use `RunOrFailOutput` instead of `RunOrFail` to see the error logs in test

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -130,7 +130,7 @@ func TestRun(t *testing.T) {
 			ns, client, deleteNs := SetupNamespace(t)
 			defer deleteNs()
 
-			skaffold.Run().WithConfig(test.filename).InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunOrFailOutput(t)
+			skaffold.Run(test.args...).WithConfig(test.filename).InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunOrFailOutput(t)
 
 			client.WaitForPodsReady(test.pods...)
 			client.WaitForDeploymentsToStabilize(test.deployments...)

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -70,7 +70,7 @@ func TestRun(t *testing.T) {
 			pods:        []string{"getting-started"},
 			remoteOnly:  true,
 		}, {
-			description: "Google Cloud Build - sub folder",
+			description: "Google Cloud Build with sub folder",
 			dir:         "testdata/gcb-sub-folder",
 			pods:        []string{"getting-started"},
 			remoteOnly:  true,
@@ -85,7 +85,7 @@ func TestRun(t *testing.T) {
 			pods:        []string{"getting-started-kaniko"},
 			remoteOnly:  true,
 		}, {
-			description: "kaniko local - sub folder",
+			description: "kaniko local with sub folder",
 			dir:         "testdata/kaniko-sub-folder",
 			pods:        []string{"getting-started-kaniko"},
 			remoteOnly:  true,

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -130,7 +130,7 @@ func TestRun(t *testing.T) {
 			ns, client, deleteNs := SetupNamespace(t)
 			defer deleteNs()
 
-			skaffold.Run().WithConfig(test.filename).InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunOrFail(t)
+			skaffold.Run().WithConfig(test.filename).InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunOrFailOutput(t)
 
 			client.WaitForPodsReady(test.pods...)
 			client.WaitForDeploymentsToStabilize(test.deployments...)


### PR DESCRIPTION
… test.

Use `RunOrFailOutput` instead of `RunOrFail` to see the error logs in test.