### PR TITLE
super hacky jkcfg proof-of-concept

### DIFF
--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -196,7 +196,7 @@ func (k *KustomizeDeployer) Dependencies() ([]string, error) {
 }
 
 func (k *KustomizeDeployer) readManifests(ctx context.Context) (kubectl.ManifestList, error) {
-	cmd := exec.CommandContext(ctx, "kustomize", "build", k.KustomizePath)
+	cmd := exec.CommandContext(ctx, "jk", "run", k.KustomizePath+"/install.js")
 	out, err := util.RunCmdOut(cmd)
 	if err != nil {
 		return nil, errors.Wrap(err, "kustomize build")


### PR DESCRIPTION
jkcfg is a data templating tool that uses plain old javascript.   Like kustomize
it's hermetic.  https://jkcfg.github.io

this PR is literally a single line change which runs `jk run <dir>/install.js`
instead of `kustomize build <dir>`.   Obviously not ready for merging, but it's
enough to actually be useful.

To use it, use the kustomize clause in your skaffold.yaml:

    deploy:
      kustomize:
        path: jk_dir

put a kustomization.yaml file in that directory.  It's fine if it's completely
empty, but skaffold will watch any files you list in the resources section.  The
files don't have to be valid for kustomize.

name your root jkcfg file 'install.js'.

install.js must write kubernetes files to stdout:

    std.write(k8s_manifests, '', {format: std.Format.YAMLStream});