### PR TITLE
Don't run GCB example on structure tests

### DIFF
--- a/examples/google-cloud-build/Dockerfile
+++ b/examples/google-cloud-build/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.10.1-alpine3.7 as builder
+COPY main.go .
+RUN go build -o /app main.go
+
+FROM alpine:3.7  
+CMD ["./app"]
+COPY --from=builder /app .

--- a/examples/google-cloud-build/README.adoc
+++ b/examples/google-cloud-build/README.adoc
@@ -1,0 +1,33 @@
+=== Example: Getting started with a simple go app
+:icons: font
+
+This is a simple example based on
+
+* *building* a single go file app and with a multistage `Dockerfile` using Google Cloud Build
+* *tagging* using the default tagPolicy (`gitCommit`)
+* *deploying* a single container pod using `kubectl`
+
+ifndef::env-github[]
+==== link:{github-repo-tree}/examples/getting-started[Example files icon:github[]]
+
+[source,yaml, indent=3, title=skaffold.yaml]
+----
+include::skaffold.yaml[]
+----
+
+[source,go, indent=3, title=main.go, syntax=go]
+----
+include::main.go[]
+----
+
+[source,docker, indent=3, title=Dockerfile]
+----
+include::Dockerfile[]
+----
+
+[source,yaml, indent=3, title=k8s-pod.yaml]
+----
+include::k8s-pod.yaml[]
+----
+
+endif::[]

--- a/examples/google-cloud-build/k8s-pod.yaml
+++ b/examples/google-cloud-build/k8s-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+  - name: getting-started
+    image: gcr.io/k8s-skaffold/skaffold-example

--- a/examples/google-cloud-build/main.go
+++ b/examples/google-cloud-build/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/examples/google-cloud-build/skaffold.yaml
+++ b/examples/google-cloud-build/skaffold.yaml
@@ -1,0 +1,12 @@
+apiVersion: skaffold/v1beta8
+kind: Config
+build:
+  googleCloudBuild:
+    projectId: k8s-skaffold
+  artifacts:
+  - image: gcr.io/k8s-skaffold/skaffold-example
+
+deploy:
+  kubectl:
+    manifests:
+      - k8s-*

--- a/integration/examples/google-cloud-build/Dockerfile
+++ b/integration/examples/google-cloud-build/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.10.1-alpine3.7 as builder
+COPY main.go .
+RUN go build -o /app main.go
+
+FROM alpine:3.7  
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/examples/google-cloud-build/README.adoc
+++ b/integration/examples/google-cloud-build/README.adoc
@@ -1,0 +1,33 @@
+=== Example: Getting started with a simple go app
+:icons: font
+
+This is a simple example based on
+
+* *building* a single go file app and with a multistage `Dockerfile` using Google Cloud Build
+* *tagging* using the default tagPolicy (`gitCommit`)
+* *deploying* a single container pod using `kubectl`
+
+ifndef::env-github[]
+==== link:{github-repo-tree}/examples/getting-started[Example files icon:github[]]
+
+[source,yaml, indent=3, title=skaffold.yaml]
+----
+include::skaffold.yaml[]
+----
+
+[source,go, indent=3, title=main.go, syntax=go]
+----
+include::main.go[]
+----
+
+[source,docker, indent=3, title=Dockerfile]
+----
+include::Dockerfile[]
+----
+
+[source,yaml, indent=3, title=k8s-pod.yaml]
+----
+include::k8s-pod.yaml[]
+----
+
+endif::[]

--- a/integration/examples/google-cloud-build/k8s-pod.yaml
+++ b/integration/examples/google-cloud-build/k8s-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+  - name: getting-started
+    image: gcr.io/k8s-skaffold/skaffold-example

--- a/integration/examples/google-cloud-build/main.go
+++ b/integration/examples/google-cloud-build/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/examples/google-cloud-build/skaffold.yaml
+++ b/integration/examples/google-cloud-build/skaffold.yaml
@@ -1,0 +1,11 @@
+apiVersion: skaffold/v1beta8
+kind: Config
+build:
+  googleCloudBuild:
+    projectId: k8s-skaffold
+  artifacts:
+  - image: gcr.io/k8s-skaffold/skaffold-example
+deploy:
+  kubectl:
+    manifests:
+      - k8s-*

--- a/integration/examples/structure-tests/skaffold.yaml
+++ b/integration/examples/structure-tests/skaffold.yaml
@@ -12,10 +12,6 @@ deploy:
     manifests:
       - k8s-*
 profiles:
-  - name: gcb
-    build:
-      googleCloudBuild:
-        projectId: k8s-skaffold
   - name: test
     test:
       - image: gcr.io/k8s-skaffold/skaffold-example

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -65,8 +65,7 @@ func TestRun(t *testing.T) {
 			pods:        []string{"bazel"},
 		}, {
 			description: "Google Cloud Build",
-			dir:         "examples/structure-tests",
-			args:        []string{"-p", "gcb"},
+			dir:         "examples/google-cloud-build",
 			pods:        []string{"getting-started"},
 			remoteOnly:  true,
 		}, {


### PR DESCRIPTION
running structure tests through GCB doesn't currently work (since the structure tests are run locally but the image was built directly to a registry), so let's just run this in a different directory until that problem is fixed.