### PR TITLE
Don’t fetch the same config twice

### DIFF
--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -20,11 +20,15 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -385,4 +389,52 @@ func TestInsecureRegistry(t *testing.T) {
 			called = false
 		})
 	}
+}
+
+func TestConfigFile(t *testing.T) {
+	api := &testutil.FakeAPIClient{
+		TagToImageID: map[string]string{
+			"gcr.io/image": "sha256:imageIDabcab",
+		},
+	}
+
+	localDocker := NewLocalDaemon(api, nil, false, nil)
+	cfg, err := localDocker.ConfigFile(context.Background(), "gcr.io/image")
+
+	testutil.CheckErrorAndDeepEqual(t, false, err, "sha256:imageIDabcab", cfg.Config.Image)
+}
+
+type APICallsCounter struct {
+	client.CommonAPIClient
+	calls int32
+}
+
+func (c *APICallsCounter) ImageInspectWithRaw(ctx context.Context, image string) (types.ImageInspect, []byte, error) {
+	atomic.AddInt32(&c.calls, 1)
+	return c.CommonAPIClient.ImageInspectWithRaw(ctx, image)
+}
+
+func TestConfigFileConcurrentCalls(t *testing.T) {
+	api := &APICallsCounter{
+		CommonAPIClient: &testutil.FakeAPIClient{
+			TagToImageID: map[string]string{
+				"gcr.io/image": "sha256:imageIDabcab",
+			},
+		},
+	}
+
+	localDocker := NewLocalDaemon(api, nil, false, nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			localDocker.ConfigFile(context.Background(), "gcr.io/image")
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+
+	// Check that the APIClient was called only once
+	testutil.CheckDeepEqual(t, int32(1), atomic.LoadInt32(&api.calls))
 }

--- a/testutil/fake_image_api.go
+++ b/testutil/fake_image_api.go
@@ -89,14 +89,17 @@ func (f *FakeAPIClient) ImageInspectWithRaw(_ context.Context, ref string) (type
 		return types.ImageInspect{}, nil, fmt.Errorf("")
 	}
 
-	if _, ok := f.TagToImageID[ref]; !ok {
+	id, ok := f.TagToImageID[ref]
+	if !ok {
 		return types.ImageInspect{}, nil, fmt.Errorf("")
 	}
 
+	rawConfig := []byte(fmt.Sprintf(`{"Config":{"Image":"%s"}}`, id))
+
 	return types.ImageInspect{
-		ID:          f.TagToImageID[ref],
+		ID:          id,
 		RepoDigests: f.RepoDigests,
-	}, nil, nil
+	}, rawConfig, nil
 }
 
 func (f *FakeAPIClient) ImageTag(_ context.Context, image, ref string) error {


### PR DESCRIPTION
Since this code is called from multiple go routines, we could end up fetching the config for the same image name multiple times.

Signed-off-by: David Gageot <david@gageot.net>