### PR TITLE
Make Deploy flags more relevant

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -156,6 +156,7 @@ func AddRunCommonFlags(cmd *cobra.Command) {
 }
 
 func AddRunDeployCommonFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&opts.Tail, "tail", false, "Stream logs from deployed objects")
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "Recreate kubernetes resources if necessary for deployment (default: false, warning: might cause downtime!)")
 	cmd.Flags().StringArrayVarP(&opts.CustomLabels, "label", "l", nil, "Add custom labels to deployed objects. Set multiple times for multiple labels.")
 }

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -155,10 +155,20 @@ func AddRunCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().StringArrayVar(&opts.InsecureRegistries, "insecure-registry", nil, "Target registries for built images which are not secure")
 }
 
-func AddRunDeployFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&opts.Tail, "tail", false, "Stream logs from deployed objects")
+func AddRunDeployCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "Recreate kubernetes resources if necessary for deployment (default: false, warning: might cause downtime!)")
 	cmd.Flags().StringArrayVarP(&opts.CustomLabels, "label", "l", nil, "Add custom labels to deployed objects. Set multiple times for multiple labels.")
+}
+
+func AddRunDeployOnlyFlags(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&opts.EnableRPC, "enable-rpc", false, "Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)")
+	cmd.Flags().IntVar(&opts.RPCPort, "rpc-port", constants.DefaultRPCPort, "tcp port to expose event API")
+	cmd.Flags().IntVar(&opts.RPCHTTPPort, "rpc-http-port", constants.DefaultRPCHTTPPort, "tcp port to expose event REST API over HTTP")
+	cmd.Flags().StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
+	cmd.Flags().BoolVar(&opts.Notification, "toot", false, "Emit a terminal beep after the deploy is complete")
+	cmd.Flags().StringArrayVarP(&opts.Profiles, "profile", "p", nil, "Activate profiles by name")
+	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "", "Run deployments in the specified namespace")
+	cmd.Flags().StringVarP(&opts.DefaultRepo, "default-repo", "d", "", "Default repository value (overrides global config)")
 }
 
 func AddRunDevFlags(cmd *cobra.Command) {

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -33,8 +33,8 @@ func NewCmdDeploy(out io.Writer) *cobra.Command {
 			return run(out)
 		},
 	}
-	AddRunDevFlags(cmd)
-	AddRunDeployFlags(cmd)
+	AddRunDeployCommonFlags(cmd)
+	AddRunDeployOnlyFlags(cmd)
 	cmd.Flags().StringSliceVar(&opts.PreBuiltImages, "images", nil, "A list of pre-built images to deploy")
 	return cmd
 }

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -41,8 +41,9 @@ func NewCmdRun(out io.Writer) *cobra.Command {
 		},
 	}
 	AddRunDevFlags(cmd)
-	AddRunDeployFlags(cmd)
+	AddRunDeployCommonFlags(cmd)
 
+	cmd.Flags().BoolVar(&opts.Tail, "tail", false, "Stream logs from deployed objects")
 	cmd.Flags().StringVarP(&opts.CustomTag, "tag", "t", "", "The optional custom tag to use for images which overrides the current Tagger configuration")
 	return cmd
 }

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -43,7 +43,6 @@ func NewCmdRun(out io.Writer) *cobra.Command {
 	AddRunDevFlags(cmd)
 	AddRunDeployCommonFlags(cmd)
 
-	cmd.Flags().BoolVar(&opts.Tail, "tail", false, "Stream logs from deployed objects")
 	cmd.Flags().StringVarP(&opts.CustomTag, "tag", "t", "", "The optional custom tag to use for images which overrides the current Tagger configuration")
 	return cmd
 }

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -318,23 +318,17 @@ Usage:
   skaffold deploy
 
 Flags:
-      --cache-artifacts                 Set to true to enable caching of artifacts.
-      --cache-file string               Specify the location of the cache file (default $HOME/.skaffold/cache)
-  -d, --default-repo string             Default repository value (overrides global config)
-      --enable-rpc skaffold dev         Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-  -f, --filename string                 Filename or URL to the pipeline file (default "skaffold.yaml")
-      --force                           Recreate kubernetes resources if necessary for deployment (default: false, warning: might cause downtime!)
-      --images strings                  A list of pre-built images to deploy
-      --insecure-registry stringArray   Target registries for built images which are not secure
-  -l, --label stringArray               Add custom labels to deployed objects. Set multiple times for multiple labels.
-  -n, --namespace string                Run deployments in the specified namespace
-      --no-prune                        Skip removing images and containers built by Skaffold
-  -p, --profile stringArray             Activate profiles by name
-      --rpc-http-port int               tcp port to expose event REST API over HTTP (default 50052)
-      --rpc-port int                    tcp port to expose event API (default 50051)
-      --skip-tests                      Whether to skip the tests after building
-      --tail                            Stream logs from deployed objects
-      --toot                            Emit a terminal beep after the deploy is complete
+  -d, --default-repo string       Default repository value (overrides global config)
+      --enable-rpc skaffold dev   Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+  -f, --filename string           Filename or URL to the pipeline file (default "skaffold.yaml")
+      --force                     Recreate kubernetes resources if necessary for deployment (default: false, warning: might cause downtime!)
+      --images strings            A list of pre-built images to deploy
+  -l, --label stringArray         Add custom labels to deployed objects. Set multiple times for multiple labels.
+  -n, --namespace string          Run deployments in the specified namespace
+  -p, --profile stringArray       Activate profiles by name
+      --rpc-http-port int         tcp port to expose event REST API over HTTP (default 50052)
+      --rpc-port int              tcp port to expose event API (default 50051)
+      --toot                      Emit a terminal beep after the deploy is complete
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -344,22 +338,16 @@ Global Flags:
 ```
 Env vars:
 
-* `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
-* `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)
 * `SKAFFOLD_IMAGES` (same as `--images`)
-* `SKAFFOLD_INSECURE_REGISTRY` (same as `--insecure-registry`)
 * `SKAFFOLD_LABEL` (same as `--label`)
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)
-* `SKAFFOLD_NO_PRUNE` (same as `--no-prune`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
-* `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
-* `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
 
 ### skaffold dev

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -328,6 +328,7 @@ Flags:
   -p, --profile stringArray       Activate profiles by name
       --rpc-http-port int         tcp port to expose event REST API over HTTP (default 50052)
       --rpc-port int              tcp port to expose event API (default 50051)
+      --tail                      Stream logs from deployed objects
       --toot                      Emit a terminal beep after the deploy is complete
 
 Global Flags:
@@ -348,6 +349,7 @@ Env vars:
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
+* `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
 
 ### skaffold dev


### PR DESCRIPTION
When rewriting `skaffold deploy` i realized `skaffold deploy` has `--tail` option which is not required.
`skaffold run` uses `--tail`

Some of the `skaffold deploy` flags are not relevant like `--insecure-registries`, `--no-prune`.
Please let me know if this is incorrect.

Please see https://github.com/GoogleContainerTools/skaffold/compare/master...tejal29:make_sane_deploy_flags?expand=1#diff-2e110939e227b787655acb75b7eea64f to see the flag difference.

Flags removed:

|  Flag | Reason   |  
|---|---|
|   --cache-artifacts    |  Relevant to Build |   
| --cache-file  |  Same as above  |  
|--insecure-registry   | Relevant to Build, deploy does not pull or push.  |   
|    --no-prune  | deploy does not invoke delete flow. Relevant to dev, run |
|      --skip-tests  | deploy does not run tests |
|     --tail            |  I think this is more relevant to run and dev. Deploy should only deploy and return |
