### PR TITLE
adding JIB codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,7 @@
+# Global owners
+
+* @balopat @dgageot @nkubala @priyawadhwa @tejal29
+
+# JIB owners
+
+**/**jib** @GoogleContainerTools/java-tools

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 
 # JIB owners
 
-**/**jib** @GoogleContainerTools/java-tools
+**/**jib** @briandealwis @loosebazooka @TadCordle @chanseokoh


### PR DESCRIPTION
This PR introduces code ownership. 

@GoogleContainerTools/java-tools has now merge permission (write permission) to Skaffold repo, i.e. they can hit the Merge button on approved PRs. 
 
I also changed the definition of an approved PR (protected branch settings for `master`): a PR is approved if it has at least one code owner review from the touched files. 

This means: 

- if JIB related files change, the java-tools team must give a review - after which it can be merged. 
- In case non-JIB related changes, at least 1 review must come from the skaffold team, after which it can be merged