### PR TITLE
Improve nodejs example to show subdirectories sync

### DIFF
--- a/examples/nodejs/backend/index.js
+++ b/examples/nodejs/backend/index.js
@@ -1,7 +1,0 @@
-const express = require('express')
-const app = express()
-const port = 3000
-
-app.get('/', (req, res) => res.send('Hello World!'))
-
-app.listen(port, () => console.log(`Example app listening on port ${port}!`))

--- a/examples/nodejs/backend/package.json
+++ b/examples/nodejs/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "nodemon index.js"
+    "dev": "nodemon src/index.js"
   },
   "dependencies": {
     "express": "^4.16.4"

--- a/examples/nodejs/backend/src/index.js
+++ b/examples/nodejs/backend/src/index.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const { echo } = require("./utils");
+const app = express();
+const port = 3000;
+
+app.get("/", (req, res) => res.send(echo("Hello World!")));
+
+app.listen(port, () => console.log(`Example app listening on port ${port}!`));

--- a/examples/nodejs/backend/src/utils/index.js
+++ b/examples/nodejs/backend/src/utils/index.js
@@ -1,0 +1,7 @@
+function echo(string) {
+  return string;
+}
+
+module.exports = {
+  echo
+};

--- a/examples/nodejs/skaffold.yaml
+++ b/examples/nodejs/skaffold.yaml
@@ -1,11 +1,13 @@
-apiVersion: skaffold/v1beta8
+apiVersion: skaffold/v1beta9
 kind: Config
 build:
   artifacts:
   - image: gcr.io/k8s-skaffold/node-example
     context: backend
     sync:
-      '*.js': .
+      # Sync all the javascript files that are in the src folder 
+      # with the container src folder
+      'src/***/*.js': src/
 deploy:
   kubectl:
     manifests:

--- a/integration/examples/nodejs/backend/package.json
+++ b/integration/examples/nodejs/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "nodemon index.js"
+    "dev": "nodemon src/index.js"
   },
   "dependencies": {
     "express": "^4.16.4"

--- a/integration/examples/nodejs/backend/src/index.js
+++ b/integration/examples/nodejs/backend/src/index.js
@@ -1,7 +1,8 @@
 const express = require('express')
+const { echo } = require('./utils');
 const app = express()
 const port = 3000
 
-app.get('/', (req, res) => res.send('Hello World!'))
+app.get('/', (req, res) => res.send(echo('Hello World!')))
 
 app.listen(port, () => console.log(`Example app listening on port ${port}!`))

--- a/integration/examples/nodejs/backend/src/utils/index.js
+++ b/integration/examples/nodejs/backend/src/utils/index.js
@@ -1,0 +1,7 @@
+function echo(string) {
+    return string;
+}
+
+module.exports = {
+    echo
+}

--- a/integration/examples/nodejs/skaffold.yaml
+++ b/integration/examples/nodejs/skaffold.yaml
@@ -5,7 +5,9 @@ build:
   - image: gcr.io/k8s-skaffold/node-example
     context: backend
     sync:
-      '*.js': .
+      # Sync all the javascript files that are in the src folder 
+      # with the container src folder
+      'src/***/*.js': src/
 deploy:
   kubectl:
     manifests:


### PR DESCRIPTION
I've updated the `nodejs` example to show the use of the undocumented `folder/***` sync feature that syncs subdirectories. My changes consist of just placing the javascript files in multiple folders and to get the attention of the developer learning `skaffold` to pay attention when checking the `skaffold.yaml` file on the difference between the `folder/**` and `folder/***` sync mechanisms.