### PR TITLE
Correctly parse env-var for multi-valued flags

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -51,7 +51,7 @@ func NewCmdBuild(out io.Writer) *cobra.Command {
 		},
 	}
 	AddRunDevFlags(cmd)
-	cmd.Flags().StringArrayVarP(&opts.TargetImages, "build-image", "b", nil, "Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts")
+	cmd.Flags().StringSliceVarP(&opts.TargetImages, "build-image", "b", nil, "Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts")
 	cmd.Flags().BoolVarP(&quietFlag, "quiet", "q", false, "Suppress the build output and print image built on success. See --output to format output.")
 	cmd.Flags().VarP(buildFormatFlag, "output", "o", "Used in conjuction with --quiet flag. "+buildFormatFlag.Usage())
 	return cmd

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -148,17 +148,17 @@ func AddRunCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&opts.RPCHTTPPort, "rpc-http-port", constants.DefaultRPCHTTPPort, "tcp port to expose event REST API over HTTP")
 	cmd.Flags().StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
 	cmd.Flags().BoolVar(&opts.Notification, "toot", false, "Emit a terminal beep after the deploy is complete")
-	cmd.Flags().StringArrayVarP(&opts.Profiles, "profile", "p", nil, "Activate profiles by name")
+	cmd.Flags().StringSliceVarP(&opts.Profiles, "profile", "p", nil, "Activate profiles by name")
 	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "", "Run deployments in the specified namespace")
 	cmd.Flags().StringVarP(&opts.DefaultRepo, "default-repo", "d", "", "Default repository value (overrides global config)")
 	cmd.Flags().BoolVar(&opts.NoPrune, "no-prune", false, "Skip removing images and containers built by Skaffold")
-	cmd.Flags().StringArrayVar(&opts.InsecureRegistries, "insecure-registry", nil, "Target registries for built images which are not secure")
+	cmd.Flags().StringSliceVar(&opts.InsecureRegistries, "insecure-registry", nil, "Target registries for built images which are not secure")
 }
 
 func AddRunDeployFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&opts.Tail, "tail", false, "Stream logs from deployed objects")
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "Recreate kubernetes resources if necessary for deployment (default: false, warning: might cause downtime!)")
-	cmd.Flags().StringArrayVarP(&opts.CustomLabels, "label", "l", nil, "Add custom labels to deployed objects. Set multiple times for multiple labels.")
+	cmd.Flags().StringSliceVarP(&opts.CustomLabels, "label", "l", nil, "Add custom labels to deployed objects. Set multiple times for multiple labels.")
 }
 
 func AddRunDevFlags(cmd *cobra.Command) {
@@ -172,7 +172,7 @@ func AddDevDebugFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&opts.TailDev, "tail", true, "Stream logs from deployed objects")
 	cmd.Flags().BoolVar(&opts.Cleanup, "cleanup", true, "Delete deployments after dev mode is interrupted")
 	cmd.Flags().BoolVar(&opts.PortForward, "port-forward", true, "Port-forward exposed container ports within pods")
-	cmd.Flags().StringArrayVarP(&opts.CustomLabels, "label", "l", nil, "Add custom labels to deployed objects. Set multiple times for multiple labels")
+	cmd.Flags().StringSliceVarP(&opts.CustomLabels, "label", "l", nil, "Add custom labels to deployed objects. Set multiple times for multiple labels")
 }
 
 func SetUpLogs(out io.Writer, level string) error {

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -39,7 +39,7 @@ func NewCmdDev(out io.Writer) *cobra.Command {
 	AddRunDevFlags(cmd)
 	AddDevDebugFlags(cmd)
 	cmd.Flags().StringVar(&opts.Trigger, "trigger", "polling", "How are changes detected? (polling, manual or notify)")
-	cmd.Flags().StringArrayVarP(&opts.TargetImages, "watch-image", "w", nil, "Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts")
+	cmd.Flags().StringSliceVarP(&opts.TargetImages, "watch-image", "w", nil, "Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts")
 	cmd.Flags().IntVarP(&opts.WatchPollInterval, "watch-poll-interval", "i", 1000, "Interval (in ms) between two checks for file changes")
 	return cmd
 }

--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -39,7 +39,7 @@ func NewCmdDiagnose(out io.Writer) *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
-	cmd.Flags().StringArrayVarP(&opts.Profiles, "profile", "p", nil, "Activate profiles by name")
+	cmd.Flags().StringSliceVarP(&opts.Profiles, "profile", "p", nil, "Activate profiles by name")
 	return cmd
 }
 

--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -53,7 +53,7 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&skipBuild, "skip-build", false, "Skip generating build artifacts in Skaffold config")
 	cmd.Flags().BoolVar(&force, "force", false, "Force the generation of the Skaffold config")
 	cmd.Flags().StringVar(&composeFile, "compose-file", "", "Initialize from a docker-compose file")
-	cmd.Flags().StringArrayVarP(&cliArtifacts, "artifact", "a", nil, "'='-delimited dockerfile/image pair to generate build artifact\n(example: --artifact=/web/Dockerfile.web=gcr.io/web-project/image)")
+	cmd.Flags().StringSliceVarP(&cliArtifacts, "artifact", "a", nil, "'='-delimited dockerfile/image pair to generate build artifact\n(example: --artifact=/web/Dockerfile.web=gcr.io/web-project/image)")
 	cmd.Flags().BoolVar(&analyze, "analyze", false, "Print all discoverable Dockerfiles and images in JSON format to stdout")
 	return cmd
 }

--- a/docs/content/en/docs/concepts/_index.md
+++ b/docs/content/en/docs/concepts/_index.md
@@ -142,7 +142,7 @@ There are several levels of granularity to allow insecure communication with som
 1. Per Skaffold run via `SKAFFOLD_INSECURE_REGISTRY` environment variable
 
     ```bash
-    SKAFFOLD_INSECURE_REGISTRY='insecure.io' skaffold dev
+    SKAFFOLD_INSECURE_REGISTRY='insecure1.io,insecure2.io' skaffold dev
     ```
     
 1. Per project via the Skaffold pipeline config `skaffold.yaml`

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -63,22 +63,22 @@ Usage:
   skaffold build
 
 Flags:
-  -b, --build-image stringArray         Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts
-      --cache-artifacts                 Set to true to enable caching of artifacts.
-      --cache-file string               Specify the location of the cache file (default $HOME/.skaffold/cache)
-  -d, --default-repo string             Default repository value (overrides global config)
-      --enable-rpc skaffold dev         Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-  -f, --filename string                 Filename or URL to the pipeline file (default "skaffold.yaml")
-      --insecure-registry stringArray   Target registries for built images which are not secure
-  -n, --namespace string                Run deployments in the specified namespace
-      --no-prune                        Skip removing images and containers built by Skaffold
-  -o, --output *flags.TemplateFlag      Used in conjuction with --quiet flag. Format output with go-template. For full struct documentation, see https://godoc.org/github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd#BuildOutput (default {{.}})
-  -p, --profile stringArray             Activate profiles by name
-  -q, --quiet                           Suppress the build output and print image built on success. See --output to format output.
-      --rpc-http-port int               tcp port to expose event REST API over HTTP (default 50052)
-      --rpc-port int                    tcp port to expose event API (default 50051)
-      --skip-tests                      Whether to skip the tests after building
-      --toot                            Emit a terminal beep after the deploy is complete
+  -b, --build-image strings          Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts
+      --cache-artifacts              Set to true to enable caching of artifacts.
+      --cache-file string            Specify the location of the cache file (default $HOME/.skaffold/cache)
+  -d, --default-repo string          Default repository value (overrides global config)
+      --enable-rpc skaffold dev      Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+  -f, --filename string              Filename or URL to the pipeline file (default "skaffold.yaml")
+      --insecure-registry strings    Target registries for built images which are not secure
+  -n, --namespace string             Run deployments in the specified namespace
+      --no-prune                     Skip removing images and containers built by Skaffold
+  -o, --output *flags.TemplateFlag   Used in conjuction with --quiet flag. Format output with go-template. For full struct documentation, see https://godoc.org/github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd#BuildOutput (default {{.}})
+  -p, --profile strings              Activate profiles by name
+  -q, --quiet                        Suppress the build output and print image built on success. See --output to format output.
+      --rpc-http-port int            tcp port to expose event REST API over HTTP (default 50052)
+      --rpc-port int                 tcp port to expose event API (default 50051)
+      --skip-tests                   Whether to skip the tests after building
+      --toot                         Emit a terminal beep after the deploy is complete
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -226,23 +226,23 @@ Usage:
   skaffold debug
 
 Flags:
-      --cache-artifacts                 Set to true to enable caching of artifacts.
-      --cache-file string               Specify the location of the cache file (default $HOME/.skaffold/cache)
-      --cleanup                         Delete deployments after dev mode is interrupted (default true)
-  -d, --default-repo string             Default repository value (overrides global config)
-      --enable-rpc skaffold dev         Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-  -f, --filename string                 Filename or URL to the pipeline file (default "skaffold.yaml")
-      --insecure-registry stringArray   Target registries for built images which are not secure
-  -l, --label stringArray               Add custom labels to deployed objects. Set multiple times for multiple labels
-  -n, --namespace string                Run deployments in the specified namespace
-      --no-prune                        Skip removing images and containers built by Skaffold
-      --port-forward                    Port-forward exposed container ports within pods (default true)
-  -p, --profile stringArray             Activate profiles by name
-      --rpc-http-port int               tcp port to expose event REST API over HTTP (default 50052)
-      --rpc-port int                    tcp port to expose event API (default 50051)
-      --skip-tests                      Whether to skip the tests after building
-      --tail                            Stream logs from deployed objects (default true)
-      --toot                            Emit a terminal beep after the deploy is complete
+      --cache-artifacts             Set to true to enable caching of artifacts.
+      --cache-file string           Specify the location of the cache file (default $HOME/.skaffold/cache)
+      --cleanup                     Delete deployments after dev mode is interrupted (default true)
+  -d, --default-repo string         Default repository value (overrides global config)
+      --enable-rpc skaffold dev     Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+  -f, --filename string             Filename or URL to the pipeline file (default "skaffold.yaml")
+      --insecure-registry strings   Target registries for built images which are not secure
+  -l, --label strings               Add custom labels to deployed objects. Set multiple times for multiple labels
+  -n, --namespace string            Run deployments in the specified namespace
+      --no-prune                    Skip removing images and containers built by Skaffold
+      --port-forward                Port-forward exposed container ports within pods (default true)
+  -p, --profile strings             Activate profiles by name
+      --rpc-http-port int           tcp port to expose event REST API over HTTP (default 50052)
+      --rpc-port int                tcp port to expose event API (default 50051)
+      --skip-tests                  Whether to skip the tests after building
+      --tail                        Stream logs from deployed objects (default true)
+      --toot                        Emit a terminal beep after the deploy is complete
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -279,16 +279,16 @@ Usage:
   skaffold delete
 
 Flags:
-  -d, --default-repo string             Default repository value (overrides global config)
-      --enable-rpc skaffold dev         Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-  -f, --filename string                 Filename or URL to the pipeline file (default "skaffold.yaml")
-      --insecure-registry stringArray   Target registries for built images which are not secure
-  -n, --namespace string                Run deployments in the specified namespace
-      --no-prune                        Skip removing images and containers built by Skaffold
-  -p, --profile stringArray             Activate profiles by name
-      --rpc-http-port int               tcp port to expose event REST API over HTTP (default 50052)
-      --rpc-port int                    tcp port to expose event API (default 50051)
-      --toot                            Emit a terminal beep after the deploy is complete
+  -d, --default-repo string         Default repository value (overrides global config)
+      --enable-rpc skaffold dev     Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+  -f, --filename string             Filename or URL to the pipeline file (default "skaffold.yaml")
+      --insecure-registry strings   Target registries for built images which are not secure
+  -n, --namespace string            Run deployments in the specified namespace
+      --no-prune                    Skip removing images and containers built by Skaffold
+  -p, --profile strings             Activate profiles by name
+      --rpc-http-port int           tcp port to expose event REST API over HTTP (default 50052)
+      --rpc-port int                tcp port to expose event API (default 50051)
+      --toot                        Emit a terminal beep after the deploy is complete
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -318,23 +318,23 @@ Usage:
   skaffold deploy
 
 Flags:
-      --cache-artifacts                 Set to true to enable caching of artifacts.
-      --cache-file string               Specify the location of the cache file (default $HOME/.skaffold/cache)
-  -d, --default-repo string             Default repository value (overrides global config)
-      --enable-rpc skaffold dev         Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-  -f, --filename string                 Filename or URL to the pipeline file (default "skaffold.yaml")
-      --force                           Recreate kubernetes resources if necessary for deployment (default: false, warning: might cause downtime!)
-      --images strings                  A list of pre-built images to deploy
-      --insecure-registry stringArray   Target registries for built images which are not secure
-  -l, --label stringArray               Add custom labels to deployed objects. Set multiple times for multiple labels.
-  -n, --namespace string                Run deployments in the specified namespace
-      --no-prune                        Skip removing images and containers built by Skaffold
-  -p, --profile stringArray             Activate profiles by name
-      --rpc-http-port int               tcp port to expose event REST API over HTTP (default 50052)
-      --rpc-port int                    tcp port to expose event API (default 50051)
-      --skip-tests                      Whether to skip the tests after building
-      --tail                            Stream logs from deployed objects
-      --toot                            Emit a terminal beep after the deploy is complete
+      --cache-artifacts             Set to true to enable caching of artifacts.
+      --cache-file string           Specify the location of the cache file (default $HOME/.skaffold/cache)
+  -d, --default-repo string         Default repository value (overrides global config)
+      --enable-rpc skaffold dev     Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+  -f, --filename string             Filename or URL to the pipeline file (default "skaffold.yaml")
+      --force                       Recreate kubernetes resources if necessary for deployment (default: false, warning: might cause downtime!)
+      --images strings              A list of pre-built images to deploy
+      --insecure-registry strings   Target registries for built images which are not secure
+  -l, --label strings               Add custom labels to deployed objects. Set multiple times for multiple labels.
+  -n, --namespace string            Run deployments in the specified namespace
+      --no-prune                    Skip removing images and containers built by Skaffold
+  -p, --profile strings             Activate profiles by name
+      --rpc-http-port int           tcp port to expose event REST API over HTTP (default 50052)
+      --rpc-port int                tcp port to expose event API (default 50051)
+      --skip-tests                  Whether to skip the tests after building
+      --tail                        Stream logs from deployed objects
+      --toot                        Emit a terminal beep after the deploy is complete
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -371,26 +371,26 @@ Usage:
   skaffold dev
 
 Flags:
-      --cache-artifacts                 Set to true to enable caching of artifacts.
-      --cache-file string               Specify the location of the cache file (default $HOME/.skaffold/cache)
-      --cleanup                         Delete deployments after dev mode is interrupted (default true)
-  -d, --default-repo string             Default repository value (overrides global config)
-      --enable-rpc skaffold dev         Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-  -f, --filename string                 Filename or URL to the pipeline file (default "skaffold.yaml")
-      --insecure-registry stringArray   Target registries for built images which are not secure
-  -l, --label stringArray               Add custom labels to deployed objects. Set multiple times for multiple labels
-  -n, --namespace string                Run deployments in the specified namespace
-      --no-prune                        Skip removing images and containers built by Skaffold
-      --port-forward                    Port-forward exposed container ports within pods (default true)
-  -p, --profile stringArray             Activate profiles by name
-      --rpc-http-port int               tcp port to expose event REST API over HTTP (default 50052)
-      --rpc-port int                    tcp port to expose event API (default 50051)
-      --skip-tests                      Whether to skip the tests after building
-      --tail                            Stream logs from deployed objects (default true)
-      --toot                            Emit a terminal beep after the deploy is complete
-      --trigger string                  How are changes detected? (polling, manual or notify) (default "polling")
-  -w, --watch-image stringArray         Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts
-  -i, --watch-poll-interval int         Interval (in ms) between two checks for file changes (default 1000)
+      --cache-artifacts             Set to true to enable caching of artifacts.
+      --cache-file string           Specify the location of the cache file (default $HOME/.skaffold/cache)
+      --cleanup                     Delete deployments after dev mode is interrupted (default true)
+  -d, --default-repo string         Default repository value (overrides global config)
+      --enable-rpc skaffold dev     Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+  -f, --filename string             Filename or URL to the pipeline file (default "skaffold.yaml")
+      --insecure-registry strings   Target registries for built images which are not secure
+  -l, --label strings               Add custom labels to deployed objects. Set multiple times for multiple labels
+  -n, --namespace string            Run deployments in the specified namespace
+      --no-prune                    Skip removing images and containers built by Skaffold
+      --port-forward                Port-forward exposed container ports within pods (default true)
+  -p, --profile strings             Activate profiles by name
+      --rpc-http-port int           tcp port to expose event REST API over HTTP (default 50052)
+      --rpc-port int                tcp port to expose event API (default 50051)
+      --skip-tests                  Whether to skip the tests after building
+      --tail                        Stream logs from deployed objects (default true)
+      --toot                        Emit a terminal beep after the deploy is complete
+      --trigger string              How are changes detected? (polling, manual or notify) (default "polling")
+  -w, --watch-image strings         Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts
+  -i, --watch-poll-interval int     Interval (in ms) between two checks for file changes (default 1000)
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -430,8 +430,8 @@ Usage:
   skaffold diagnose
 
 Flags:
-  -f, --filename string       Filename or URL to the pipeline file (default "skaffold.yaml")
-  -p, --profile stringArray   Activate profiles by name
+  -f, --filename string   Filename or URL to the pipeline file (default "skaffold.yaml")
+  -p, --profile strings   Activate profiles by name
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -476,13 +476,13 @@ Usage:
   skaffold init
 
 Flags:
-      --analyze                Print all discoverable Dockerfiles and images in JSON format to stdout
-  -a, --artifact stringArray   '='-delimited dockerfile/image pair to generate build artifact
-                               (example: --artifact=/web/Dockerfile.web=gcr.io/web-project/image)
-      --compose-file string    Initialize from a docker-compose file
-  -f, --filename string        Filename or URL to the pipeline file (default "skaffold.yaml")
-      --force                  Force the generation of the Skaffold config
-      --skip-build             Skip generating build artifacts in Skaffold config
+      --analyze               Print all discoverable Dockerfiles and images in JSON format to stdout
+  -a, --artifact strings      '='-delimited dockerfile/image pair to generate build artifact
+                              (example: --artifact=/web/Dockerfile.web=gcr.io/web-project/image)
+      --compose-file string   Initialize from a docker-compose file
+  -f, --filename string       Filename or URL to the pipeline file (default "skaffold.yaml")
+      --force                 Force the generation of the Skaffold config
+      --skip-build            Skip generating build artifacts in Skaffold config
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -508,23 +508,23 @@ Usage:
   skaffold run
 
 Flags:
-      --cache-artifacts                 Set to true to enable caching of artifacts.
-      --cache-file string               Specify the location of the cache file (default $HOME/.skaffold/cache)
-  -d, --default-repo string             Default repository value (overrides global config)
-      --enable-rpc skaffold dev         Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
-  -f, --filename string                 Filename or URL to the pipeline file (default "skaffold.yaml")
-      --force                           Recreate kubernetes resources if necessary for deployment (default: false, warning: might cause downtime!)
-      --insecure-registry stringArray   Target registries for built images which are not secure
-  -l, --label stringArray               Add custom labels to deployed objects. Set multiple times for multiple labels.
-  -n, --namespace string                Run deployments in the specified namespace
-      --no-prune                        Skip removing images and containers built by Skaffold
-  -p, --profile stringArray             Activate profiles by name
-      --rpc-http-port int               tcp port to expose event REST API over HTTP (default 50052)
-      --rpc-port int                    tcp port to expose event API (default 50051)
-      --skip-tests                      Whether to skip the tests after building
-  -t, --tag string                      The optional custom tag to use for images which overrides the current Tagger configuration
-      --tail                            Stream logs from deployed objects
-      --toot                            Emit a terminal beep after the deploy is complete
+      --cache-artifacts             Set to true to enable caching of artifacts.
+      --cache-file string           Specify the location of the cache file (default $HOME/.skaffold/cache)
+  -d, --default-repo string         Default repository value (overrides global config)
+      --enable-rpc skaffold dev     Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
+  -f, --filename string             Filename or URL to the pipeline file (default "skaffold.yaml")
+      --force                       Recreate kubernetes resources if necessary for deployment (default: false, warning: might cause downtime!)
+      --insecure-registry strings   Target registries for built images which are not secure
+  -l, --label strings               Add custom labels to deployed objects. Set multiple times for multiple labels.
+  -n, --namespace string            Run deployments in the specified namespace
+      --no-prune                    Skip removing images and containers built by Skaffold
+  -p, --profile strings             Activate profiles by name
+      --rpc-http-port int           tcp port to expose event REST API over HTTP (default 50052)
+      --rpc-port int                tcp port to expose event API (default 50051)
+      --skip-tests                  Whether to skip the tests after building
+  -t, --tag string                  The optional custom tag to use for images which overrides the current Tagger configuration
+      --tail                        Stream logs from deployed objects
+      --toot                        Emit a terminal beep after the deploy is complete
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)


### PR DESCRIPTION
Before, multi-valued env-vars were not parsed correctly. For example
```
SKAFFOLD_INSECURE_REGISTRY="insecure1.io,insecure2.io" skaffold run
```
resulted in _one_ entry in the string array `["insecure1.io,insecure2.io"]`. This is because the cobra flag type `StringArrayVar` does not split its argument on commas.

This PR switches all string array flags to the cobra flag type `StringSliceVar`, which _does_ split its argument on commas. For example, the following is now possible:
```
SKAFFOLD_INSECURE_REGISTRY="insecure1.io,insecure2.io" skaffold run \
  --insecure-registry xyz.io \
  --insecure-registry abc.io,def.io  
# results in ["insecure1.io", "insecure2.io", "xyz.io", "abc.io", "def.io"]
```

See #2031