### PR TITLE
Remove podname from port forward key

### DIFF
--- a/pkg/skaffold/kubernetes/port_forward.go
+++ b/pkg/skaffold/kubernetes/port_forward.go
@@ -243,7 +243,7 @@ func (p *PortForwarder) forward(ctx context.Context, entry *portForwardEntry) er
 
 // Key is an identifier for the lock on a port during the skaffold dev cycle.
 func (p *portForwardEntry) key() string {
-	return fmt.Sprintf("%s-%s-%s-%s-%d", p.containerName, p.podName, p.namespace, p.portName, p.port)
+	return fmt.Sprintf("%s-%s-%s-%d", p.containerName, p.namespace, p.portName, p.port)
 }
 
 // String is a utility function that returns the port forward entry as a user-readable string

--- a/pkg/skaffold/kubernetes/port_forward_test.go
+++ b/pkg/skaffold/kubernetes/port_forward_test.go
@@ -87,7 +87,7 @@ func TestPortForwardPod(t *testing.T) {
 			},
 			availablePorts: []int{8080},
 			expectedEntries: map[string]*portForwardEntry{
-				"containername-podname-namespace-portname-8080": {
+				"containername-namespace-portname-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
@@ -126,7 +126,7 @@ func TestPortForwardPod(t *testing.T) {
 				9000: true,
 			},
 			expectedEntries: map[string]*portForwardEntry{
-				"containername-podname-namespace-portname-8080": {
+				"containername-namespace-portname-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
@@ -198,7 +198,7 @@ func TestPortForwardPod(t *testing.T) {
 			shouldErr:      true,
 			availablePorts: []int{8080},
 			expectedEntries: map[string]*portForwardEntry{
-				"containername-podname-namespace-portname-8080": {
+				"containername-namespace-portname-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
@@ -239,7 +239,7 @@ func TestPortForwardPod(t *testing.T) {
 			},
 			availablePorts: []int{8080, 50051},
 			expectedEntries: map[string]*portForwardEntry{
-				"containername-podname-namespace-portname-8080": {
+				"containername-namespace-portname-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
@@ -248,7 +248,7 @@ func TestPortForwardPod(t *testing.T) {
 					port:            8080,
 					localPort:       8080,
 				},
-				"containername2-podname2-namespace2-portname2-50051": {
+				"containername2-namespace2-portname2-50051": {
 					resourceVersion: 1,
 					podName:         "podname2",
 					containerName:   "containername2",
@@ -309,7 +309,7 @@ func TestPortForwardPod(t *testing.T) {
 			},
 			availablePorts: []int{8080, 9000},
 			expectedEntries: map[string]*portForwardEntry{
-				"containername-podname-namespace-portname-8080": {
+				"containername-namespace-portname-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
@@ -318,7 +318,7 @@ func TestPortForwardPod(t *testing.T) {
 					port:            8080,
 					localPort:       8080,
 				},
-				"containername2-podname2-namespace2-portname2-8080": {
+				"containername2-namespace2-portname2-8080": {
 					resourceVersion: 1,
 					podName:         "podname2",
 					containerName:   "containername2",
@@ -378,7 +378,7 @@ func TestPortForwardPod(t *testing.T) {
 			},
 			availablePorts: []int{8080},
 			expectedEntries: map[string]*portForwardEntry{
-				"containername-podname-namespace-portname-8080": {
+				"containername-namespace-portname-8080": {
 					resourceVersion: 2,
 					podName:         "podname",
 					containerName:   "containername",


### PR DESCRIPTION
This way, when pods are regenerated, they will be mapped to the same
port.

This should fix some of the issues users have been facing in #1815 and #1594.