### PR TITLE
Add dockerfile to custom dependencies

### DIFF
--- a/docs/content/en/schemas/v1beta10.json
+++ b/docs/content/en/schemas/v1beta10.json
@@ -595,6 +595,11 @@
     },
     "CustomDependencies": {
       "properties": {
+        "dockerfile": {
+          "$ref": "#/definitions/DockerfileDependency",
+          "description": "should be set if the artifact is built from a Dockerfile, from which skaffold can determine dependencies.",
+          "x-intellij-html-description": "should be set if the artifact is built from a Dockerfile, from which skaffold can determine dependencies."
+        },
         "ignore": {
           "items": {
             "type": "string"
@@ -615,12 +620,13 @@
         }
       },
       "preferredOrder": [
+        "dockerfile",
         "paths",
         "ignore"
       ],
       "additionalProperties": false,
-      "description": "*alpha* used to specify dependencies for an artifact built by a custom build script.",
-      "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a custom build script."
+      "description": "*alpha* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
+      "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
     "DateTimeTagger": {
       "properties": {
@@ -766,6 +772,40 @@
       "additionalProperties": false,
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
+    },
+    "DockerfileDependency": {
+      "properties": {
+        "buildArgs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "arguments passed to the docker build. It also accepts environment variables via the go template syntax.",
+          "x-intellij-html-description": "arguments passed to the docker build. It also accepts environment variables via the go template syntax.",
+          "default": "{}",
+          "examples": [
+            "{\"key1\": \"value1\", \"key2\": \"value2\", \"key3\": \"{{.ENV_VARIABLE}}\"}"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "description": "locates the Dockerfile relative to workspace.",
+          "x-intellij-html-description": "locates the Dockerfile relative to workspace."
+        },
+        "target": {
+          "type": "string",
+          "description": "Dockerfile target name to build.",
+          "x-intellij-html-description": "Dockerfile target name to build."
+        }
+      },
+      "preferredOrder": [
+        "path",
+        "target",
+        "buildArgs"
+      ],
+      "additionalProperties": false,
+      "description": "*alpha* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
+      "x-intellij-html-description": "<em>alpha</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
     "EnvTemplateTagger": {
       "required": [

--- a/docs/content/en/schemas/v1beta10.json
+++ b/docs/content/en/schemas/v1beta10.json
@@ -791,16 +791,10 @@
           "type": "string",
           "description": "locates the Dockerfile relative to workspace.",
           "x-intellij-html-description": "locates the Dockerfile relative to workspace."
-        },
-        "target": {
-          "type": "string",
-          "description": "Dockerfile target name to build.",
-          "x-intellij-html-description": "Dockerfile target name to build."
         }
       },
       "preferredOrder": [
         "path",
-        "target",
         "buildArgs"
       ],
       "additionalProperties": false,

--- a/pkg/skaffold/build/custom/dependencies_test.go
+++ b/pkg/skaffold/build/custom/dependencies_test.go
@@ -25,7 +25,40 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestGetDependencies(t *testing.T) {
+func TestGetDependenciesDockerfile(t *testing.T) {
+	tmpDir, cleanup := testutil.NewTempDir(t)
+	defer cleanup()
+
+	// Directory structure:
+	//   foo
+	//   bar
+	// - baz
+	//     file
+	//   Dockerfile
+	tmpDir.Write("foo", "")
+	tmpDir.Write("bar", "")
+	tmpDir.Mkdir("baz")
+	tmpDir.Write("baz/file", "")
+	tmpDir.Write("Dockerfile", "FROM scratch \n ARG file \n COPY $file baz/file .")
+
+	customArtifact := &latest.CustomArtifact{
+		Dependencies: &latest.CustomDependencies{
+			Dockerfile: &latest.DockerfileDependency{
+				Path: "Dockerfile",
+				BuildArgs: map[string]*string{
+					"file": stringPointer("foo"),
+				},
+			},
+		},
+	}
+
+	expected := []string{"Dockerfile", filepath.FromSlash("baz/file"), "foo"}
+	deps, err := GetDependencies(context.Background(), tmpDir.Root(), customArtifact, nil)
+
+	testutil.CheckErrorAndDeepEqual(t, false, err, expected, deps)
+}
+
+func TestGetDependenciesPaths(t *testing.T) {
 	tmpDir, cleanup := testutil.NewTempDir(t)
 	defer cleanup()
 
@@ -66,9 +99,13 @@ func TestGetDependencies(t *testing.T) {
 					Paths:  test.paths,
 					Ignore: test.ignore,
 				},
-			})
+			}, nil)
 			testutil.CheckErrorAndDeepEqual(t, false, err, test.expected, deps)
 		})
 	}
 
+}
+
+func stringPointer(s string) *string {
+	return &s
 }

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -124,7 +124,7 @@ func (b *Builder) DependenciesForArtifact(ctx context.Context, a *latest.Artifac
 		paths, err = jib.GetDependenciesGradle(ctx, a.Workspace, a.JibGradleArtifact)
 
 	case a.CustomArtifact != nil:
-		paths, err = custom.GetDependencies(ctx, a.Workspace, a.CustomArtifact)
+		paths, err = custom.GetDependencies(ctx, a.Workspace, a.CustomArtifact, b.insecureRegistries)
 
 	default:
 		return nil, fmt.Errorf("undefined artifact type: %+v", a.ArtifactType)

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -566,12 +566,29 @@ type CustomArtifact struct {
 }
 
 // CustomDependencies *alpha* is used to specify dependencies for an artifact built by a custom build script.
+// Either `dockerfile` or `paths` should be specified for file watching to work as expected.
 type CustomDependencies struct {
+	// Dockerfile should be set if the artifact is built from a Dockerfile, from which skaffold can determine dependencies.
+	Dockerfile *DockerfileDependency `yaml:"dockerfile,omitempty" yamltags:"oneOf=dependency"`
 	// Paths should be set to the file dependencies for this artifact, so that the skaffold file watcher knows when to rebuild and perform file synchronization.
 	Paths []string `yaml:"paths,omitempty" yamltags:"oneOf=dependency"`
 	// Ignore specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both `paths` and in `ignore`, it will be ignored, and will be excluded from both rebuilds and file synchronization.
 	// Will only work in conjunction with `paths`.
 	Ignore []string `yaml:"ignore,omitempty"`
+}
+
+// DockerfileDependency *alpha* is used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.
+type DockerfileDependency struct {
+	// Path locates the Dockerfile relative to workspace.
+	Path string `yaml:"path,omitempty"`
+
+	// Target is the Dockerfile target name to build.
+	Target string `yaml:"target,omitempty"`
+
+	// BuildArgs are arguments passed to the docker build.
+	// It also accepts environment variables via the go template syntax.
+	// For example: `{"key1": "value1", "key2": "value2", "key3": "{{.ENV_VARIABLE}}"}`.
+	BuildArgs map[string]*string `yaml:"buildArgs,omitempty"`
 }
 
 // KanikoArtifact *alpha* describes an artifact built from a Dockerfile,

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -582,9 +582,6 @@ type DockerfileDependency struct {
 	// Path locates the Dockerfile relative to workspace.
 	Path string `yaml:"path,omitempty"`
 
-	// Target is the Dockerfile target name to build.
-	Target string `yaml:"target,omitempty"`
-
 	// BuildArgs are arguments passed to the docker build.
 	// It also accepts environment variables via the go template syntax.
 	// For example: `{"key1": "value1", "key2": "value2", "key3": "{{.ENV_VARIABLE}}"}`.

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -34,6 +34,7 @@ var (
 func Process(config *latest.SkaffoldConfig) error {
 	errs := visitStructs(config, validateYamltags)
 	errs = append(errs, validateDockerNetworkMode(config.Build.Artifacts)...)
+	errs = append(errs, validateCustomDependencies(config.Build.Artifacts)...)
 
 	if len(errs) == 0 {
 		return nil
@@ -57,6 +58,22 @@ func validateDockerNetworkMode(artifacts []*latest.Artifact) (errs []error) {
 			continue
 		}
 		errs = append(errs, fmt.Errorf("artifact %s has invalid networkMode '%s'", a.ImageName, mode))
+	}
+	return
+}
+
+// validateCustomDependencies makes sure that dependencies.ignore is only used in conjunction with dependencies.paths
+func validateCustomDependencies(artifacts []*latest.Artifact) (errs []error) {
+	for _, a := range artifacts {
+		if a.CustomArtifact == nil {
+			continue
+		}
+		if a.CustomArtifact.Dependencies.Ignore == nil {
+			continue
+		}
+		if a.CustomArtifact.Dependencies.Dockerfile != nil {
+			errs = append(errs, fmt.Errorf("artifact %s has invalid dependencies; dependencies.ignore can only be used in conjunction with dependencies.paths", a.ImageName))
+		}
 	}
 	return
 }

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -366,3 +366,45 @@ func TestValidateNetworkMode(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCustomDependencies(t *testing.T) {
+	tests := []struct {
+		description    string
+		dependencies   *latest.CustomDependencies
+		expectedErrors int
+	}{
+		{
+			description: "no errors",
+			dependencies: &latest.CustomDependencies{
+				Paths:  []string{"somepath"},
+				Ignore: []string{"anotherpath"},
+			},
+		}, {
+			description: "ignore in conjunction with dockerfile",
+			dependencies: &latest.CustomDependencies{
+				Dockerfile: &latest.DockerfileDependency{
+					Path: "some/path",
+				},
+				Ignore: []string{"ignoreme"},
+			},
+			expectedErrors: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			artifact := &latest.Artifact{
+				ArtifactType: latest.ArtifactType{
+					CustomArtifact: &latest.CustomArtifact{
+						Dependencies: test.dependencies,
+					},
+				},
+			}
+
+			errs := validateCustomDependencies([]*latest.Artifact{artifact})
+			if len(errs) != test.expectedErrors {
+				t.Fatalf("got incorrect number of errors. got: %d \n expected: %d \n", len(errs), test.expectedErrors)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Allows users to say something like:

```yaml
- image: my image
  custom:
     buildCommand: ./build.sh
     dependencies:
        dockerfile:
           path: path/to/Dockerfile
           buildArgs:
             - file:foo
           target: secondStage
```