### PR TITLE
Add k8 style managed by label to skaffold deployed pods

### DIFF
--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -84,11 +84,7 @@ var Labels = struct {
 	Deployer         string
 	Builder          string
 	DockerAPIVersion string
-	DefaultLabels    map[string]string
 }{
-	DefaultLabels: map[string]string{
-		"deployed-with": "skaffold",
-	},
 	TagPolicy:        "skaffold-tag-policy",
 	Deployer:         "skaffold-deployer",
 	Builder:          "skaffold-builder",

--- a/pkg/skaffold/deploy/labels.go
+++ b/pkg/skaffold/deploy/labels.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/pkg/errors"
@@ -96,7 +95,6 @@ func labelDeployResults(labels map[string]string, results []Artifact) {
 func addLabels(labels map[string]string, accessor metav1.Object) {
 	kv := make(map[string]string)
 
-	copyMap(kv, constants.Labels.DefaultLabels)
 	copyMap(kv, accessor.GetLabels())
 	copyMap(kv, labels)
 

--- a/pkg/skaffold/runner/labeller.go
+++ b/pkg/skaffold/runner/labeller.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"fmt"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
+)
+
+const (
+	K8_MANAGED_BY_LABEL = "app.kubernetes.io/managed-by"
+)
+
+// DefaultLabeller adds K9 style managed-by label
+type DefaultLabeller struct {
+	version string
+}
+
+func NewLabeller(verStr string) *DefaultLabeller {
+	if verStr == "" {
+		verStr = version.Get().Version
+	}
+	return &DefaultLabeller{
+		version: verStr,
+	}
+}
+
+func (d *DefaultLabeller) Labels() map[string]string {
+	return map[string]string{
+		K8_MANAGED_BY_LABEL: fmt.Sprintf("skaffold-%s", d.version),
+	}
+}

--- a/pkg/skaffold/runner/labeller.go
+++ b/pkg/skaffold/runner/labeller.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	K8_MANAGED_BY_LABEL = "app.kubernetes.io/managed-by"
+	K8ManagedByLabel = "app.kubernetes.io/managed-by"
 )
 
 // DefaultLabeller adds K9 style managed-by label
@@ -42,6 +42,6 @@ func NewLabeller(verStr string) *DefaultLabeller {
 
 func (d *DefaultLabeller) Labels() map[string]string {
 	return map[string]string{
-		K8_MANAGED_BY_LABEL: fmt.Sprintf("skaffold-%s", d.version),
+		K8ManagedByLabel: fmt.Sprintf("skaffold-%s", d.version),
 	}
 }

--- a/pkg/skaffold/runner/labeller_test.go
+++ b/pkg/skaffold/runner/labeller_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDEfaultLabeller(t *testing.T) {
+	var tests = []struct {
+		description string
+		version     string
+		expected    string
+	}{
+		{
+			description: "version mentioned",
+			version:     "1.0",
+			expected:    "skaffold-1.0",
+		},
+		{
+			description: "no version",
+			expected:    fmt.Sprintf("skaffold-%s", version.Get().Version),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			l := &DefaultLabeller{
+				version: test.version,
+			}
+			expected := map[string]string{
+				"app.kubernetes.io/managed-by": test.expected,
+			}
+			testutil.CheckDeepEqual(t, expected, l.Labels())
+		})
+	}
+}

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -91,7 +91,8 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldConfig) (*Sk
 		return nil, errors.Wrap(err, "parsing deploy config")
 	}
 
-	labellers := []deploy.Labeller{opts, builder, deployer, tagger}
+	defaultLabeller := NewLabeller("")
+	labellers := []deploy.Labeller{opts, builder, deployer, tagger, defaultLabeller}
 
 	builder, tester, deployer = WithTimings(builder, tester, deployer, opts.CacheArtifacts)
 	if opts.Notification {

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	pkgkubernetes "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -464,8 +463,10 @@ func fakeCmd(ctx context.Context, p v1.Pod, c v1.Container, files map[string]str
 
 var pod = &v1.Pod{
 	ObjectMeta: meta_v1.ObjectMeta{
-		Name:   "podname",
-		Labels: constants.Labels.DefaultLabels,
+		Name: "podname",
+		Labels: map[string]string{
+			"app.kubernetes.io/managed-by": "skaffold-dirty",
+		},
 	},
 	Status: v1.PodStatus{
 		Phase: v1.PodRunning,


### PR DESCRIPTION
Fixes #2045 

This PR will works with internal metrics gathering logic.

Summary of Changes:
1. Add a labeller to deployer in the Runner so that all the labeller will be propagated to all the deployers.
2. Remove the existing default labels which was only added in deploying with helm deployer.