### PR TITLE
Support deploying remote helm charts

### DIFF
--- a/docs/content/en/schemas/v1beta10.json
+++ b/docs/content/en/schemas/v1beta10.json
@@ -1037,12 +1037,6 @@
           "x-intellij-html-description": "if <code>true</code>, Skaffold will send <code>--recreate-pods</code> flag to Helm CLI.",
           "default": "false"
         },
-        "remote": {
-          "type": "boolean",
-          "description": "specifies whether the chart path is remote, or exists on the host filesystem.",
-          "x-intellij-html-description": "specifies whether the chart path is remote, or exists on the host filesystem.",
-          "default": "false"
-        },
         "setValueTemplates": {
           "additionalProperties": {
             "type": "string"
@@ -1116,7 +1110,6 @@
         "recreatePods",
         "skipBuildDependencies",
         "useHelmSecrets",
-        "remote",
         "overrides",
         "packaged",
         "imageStrategy"

--- a/docs/content/en/schemas/v1beta10.json
+++ b/docs/content/en/schemas/v1beta10.json
@@ -1037,6 +1037,12 @@
           "x-intellij-html-description": "if <code>true</code>, Skaffold will send <code>--recreate-pods</code> flag to Helm CLI.",
           "default": "false"
         },
+        "remote": {
+          "type": "boolean",
+          "description": "specifies whether the chart path is remote, or exists on the host filesystem.",
+          "x-intellij-html-description": "specifies whether the chart path is remote, or exists on the host filesystem.",
+          "default": "false"
+        },
         "setValueTemplates": {
           "additionalProperties": {
             "type": "string"
@@ -1110,6 +1116,7 @@
         "recreatePods",
         "skipBuildDependencies",
         "useHelmSecrets",
+        "remote",
         "overrides",
         "packaged",
         "imageStrategy"

--- a/docs/content/en/schemas/v1beta11.json
+++ b/docs/content/en/schemas/v1beta11.json
@@ -1037,6 +1037,12 @@
           "x-intellij-html-description": "if <code>true</code>, Skaffold will send <code>--recreate-pods</code> flag to Helm CLI.",
           "default": "false"
         },
+        "remote": {
+          "type": "boolean",
+          "description": "specifies whether the chart path is remote, or exists on the host filesystem. `remote: true` implies `skipBuildDependencies: true`.",
+          "x-intellij-html-description": "specifies whether the chart path is remote, or exists on the host filesystem. <code>remote: true</code> implies <code>skipBuildDependencies: true</code>.",
+          "default": "false"
+        },
         "setValueTemplates": {
           "additionalProperties": {
             "type": "string"
@@ -1110,6 +1116,7 @@
         "recreatePods",
         "skipBuildDependencies",
         "useHelmSecrets",
+        "remote",
         "overrides",
         "packaged",
         "imageStrategy"

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -98,26 +98,29 @@ func (h *HelmDeployer) Dependencies() ([]string, error) {
 	var deps []string
 	for _, release := range h.Releases {
 		deps = append(deps, release.ValuesFiles...)
-		chartDepsDir := filepath.Join(release.ChartPath, "charts")
-		err := filepath.Walk(release.ChartPath, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return errors.Wrapf(err, "failure accessing path '%s'", path)
-			}
-
-			if !info.IsDir() {
-				if !strings.HasPrefix(path, chartDepsDir) || release.SkipBuildDependencies {
-					// We can always add a dependency if it is not contained in our chartDepsDir.
-					// However, if the file is in  our chartDepsDir, we can only include the file
-					// if we are not running the helm dep build phase, as that modifies files inside
-					// the chartDepsDir and results in an infinite build loop.
-					deps = append(deps, path)
+		// chart path is only a dependency if it exists on the local filesystem
+		if !release.Remote {
+			chartDepsDir := filepath.Join(release.ChartPath, "charts")
+			err := filepath.Walk(release.ChartPath, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return errors.Wrapf(err, "failure accessing path '%s'", path)
 				}
-			}
 
-			return nil
-		})
-		if err != nil {
-			return deps, errors.Wrap(err, "issue walking releases")
+				if !info.IsDir() {
+					if !strings.HasPrefix(path, chartDepsDir) || release.SkipBuildDependencies {
+						// We can always add a dependency if it is not contained in our chartDepsDir.
+						// However, if the file is in  our chartDepsDir, we can only include the file
+						// if we are not running the helm dep build phase, as that modifies files inside
+						// the chartDepsDir and results in an infinite build loop.
+						deps = append(deps, path)
+					}
+				}
+
+				return nil
+			})
+			if err != nil {
+				return deps, errors.Wrap(err, "issue walking releases")
+			}
 		}
 	}
 	sort.Strings(deps)
@@ -136,7 +139,6 @@ func (h *HelmDeployer) Cleanup(ctx context.Context, out io.Writer) error {
 }
 
 func (h *HelmDeployer) helm(ctx context.Context, out io.Writer, useSecrets bool, arg ...string) error {
-
 	args := append([]string{"--kube-context", h.kubeContext}, arg...)
 	args = append(args, h.Flags.Global...)
 
@@ -185,7 +187,8 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 	// Dependency builds should be skipped when trying to install a chart
 	// with local dependencies in the chart folder, e.g. the istio helm chart.
 	// This decision is left to the user.
-	if !r.SkipBuildDependencies {
+	// Dep builds should also be skipped whenever a remote chart path is specified.
+	if !r.SkipBuildDependencies && !r.Remote {
 		// First build dependencies.
 		logrus.Infof("Building helm dependencies...")
 		if err := h.helm(ctx, out, false, "dep", "build", r.ChartPath); err != nil {

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -573,6 +573,7 @@ func TestHelmDependencies(t *testing.T) {
 		files                 []string
 		valuesFiles           []string
 		skipBuildDependencies bool
+		remote                bool
 		expected              func(folder *testutil.TempDir) []string
 	}{
 		{
@@ -600,6 +601,15 @@ func TestHelmDependencies(t *testing.T) {
 				return []string{"/folder/values.yaml", folder.Path("Chart.yaml")}
 			},
 		},
+		{
+			description:           "no deps for remote chart path",
+			skipBuildDependencies: false,
+			files:                 []string{"Chart.yaml"},
+			remote:                true,
+			expected: func(folder *testutil.TempDir) []string {
+				return nil
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -619,6 +629,7 @@ func TestHelmDependencies(t *testing.T) {
 						Overrides:             schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
 						SetValues:             map[string]string{"some.key": "somevalue"},
 						SkipBuildDependencies: tt.skipBuildDependencies,
+						Remote:                tt.remote,
 					},
 				},
 			}, false))

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -375,9 +375,6 @@ type HelmRelease struct {
 	// ChartPath is the path to the Helm chart.
 	ChartPath string `yaml:"chartPath,omitempty" yamltags:"required"`
 
-	// Remote specifies whether the chart path is remote, or exists on the host filesystem.
-	Remote bool `yaml:"remote,omitempty"`
-
 	// ValuesFiles are the paths to the Helm `values` files.
 	ValuesFiles []string `yaml:"valuesFiles,omitempty"`
 
@@ -413,6 +410,9 @@ type HelmRelease struct {
 
 	// UseHelmSecrets instructs skaffold to use secrets plugin on deployment.
 	UseHelmSecrets bool `yaml:"useHelmSecrets,omitempty"`
+
+	// Remote specifies whether the chart path is remote, or exists on the host filesystem.
+	Remote bool `yaml:"remote,omitempty"`
 
 	// Overrides are key-value pairs.
 	// If present, Skaffold will build a Helm `values` file that overrides

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -411,7 +411,8 @@ type HelmRelease struct {
 	// UseHelmSecrets instructs skaffold to use secrets plugin on deployment.
 	UseHelmSecrets bool `yaml:"useHelmSecrets,omitempty"`
 
-	// Remote specifies whether the chart path is remote, or exists on the host filesystem.
+	// Remote specifies whether the chart path is remote, or exists on the host filesystem. 
+	// `remote: true` implies `skipBuildDependencies: true`.
 	Remote bool `yaml:"remote,omitempty"`
 
 	// Overrides are key-value pairs.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -411,7 +411,7 @@ type HelmRelease struct {
 	// UseHelmSecrets instructs skaffold to use secrets plugin on deployment.
 	UseHelmSecrets bool `yaml:"useHelmSecrets,omitempty"`
 
-	// Remote specifies whether the chart path is remote, or exists on the host filesystem. 
+	// Remote specifies whether the chart path is remote, or exists on the host filesystem.
 	// `remote: true` implies `skipBuildDependencies: true`.
 	Remote bool `yaml:"remote,omitempty"`
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -375,6 +375,9 @@ type HelmRelease struct {
 	// ChartPath is the path to the Helm chart.
 	ChartPath string `yaml:"chartPath,omitempty" yamltags:"required"`
 
+	// Remote specifies whether the chart path is remote, or exists on the host filesystem.
+	Remote bool `yaml:"remote,omitempty"`
+
 	// ValuesFiles are the paths to the Helm `values` files.
 	ValuesFiles []string `yaml:"valuesFiles,omitempty"`
 


### PR DESCRIPTION
Fixes #1615 

this adds a boolean `remote` field to the `releases` stanza of `helm` deploys in the skaffold config. it's used when computing the dependencies for a helm release: if a chart path is specified as `remote`, skaffold will skip it when listing the dependencies for the deploy.

```yaml
deploy:
  helm:
    releases:
      - name: redis
        chartPath: stable/redis
        remote: true
        skipBuildDependencies: true // not necessary when `remote:true` is specified
```

since dependency building doesn't make sense for remote helm charts (e.g. `helm dep build stable/redis` doesn't work), we skip this by default when `remote: true` is specified by the user.

`remote: true` ==> `skipBuildDependencies: true`