### PR TITLE
:sparkles: Add support for regexp in profile activation kubeContext

### DIFF
--- a/docs/content/en/docs/how-tos/profiles/_index.md
+++ b/docs/content/en/docs/how-tos/profiles/_index.md
@@ -47,7 +47,7 @@ You can activate a profile two ways: CLI flag or skaffold.yaml activations.
 
 **Activations in skaffold.yaml**: You can auto-activate a profile based on
 
-* kubecontext
+* kubecontext (could be either a string or a regexp: prefixing with `!` will negate the match)
 * environment variable value
 * skaffold command (dev/run/build/deploy)
 

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	re "regexp"
 	"strings"
 
 	cfg "github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
@@ -124,7 +125,13 @@ func satisfies(expected, actual string) bool {
 	if strings.HasPrefix(expected, "!") {
 		return actual != expected[1:]
 	}
-	return actual == expected
+	matcher, err := re.Compile(expected)
+	if err != nil {
+		logrus.Infof("Not a regexp: %s, falling back to string equals", expected)
+		return actual == expected
+	}
+
+	return matcher.MatchString(actual)
 }
 
 func applyProfile(config *latest.SkaffoldConfig, profile latest.Profile) error {

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -123,11 +123,19 @@ func isKubeContext(kubeContext string) (bool, error) {
 
 func satisfies(expected, actual string) bool {
 	if strings.HasPrefix(expected, "!") {
-		return actual != expected[1:]
+		notExpected := expected[1:]
+
+		return !matches(notExpected, actual)
 	}
+
+	return matches(expected, actual)
+}
+
+func matches(expected, actual string) bool {
 	matcher, err := re.Compile(expected)
+
 	if err != nil {
-		logrus.Infof("profile activation criteria '%s' is not a valid regexp, falling back to string equals", expected)
+		logrus.Infof("profile activation criteria '%s' is not a valid regexp, falling back to string", expected)
 		return actual == expected
 	}
 

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -127,7 +127,7 @@ func satisfies(expected, actual string) bool {
 	}
 	matcher, err := re.Compile(expected)
 	if err != nil {
-		logrus.Infof("Not a regexp: %s, falling back to string equals", expected)
+		logrus.Infof("profile activation criteria '%s' is not a valid regexp, falling back to string equals", expected)
 		return actual == expected
 	}
 

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -379,9 +379,8 @@ func TestActivatedProfiles(t *testing.T) {
 				{Name: "also-activated", Activation: []latest.Activation{{KubeContext: "!dev-context"}}},
 				{Name: "activated-regexp", Activation: []latest.Activation{{KubeContext: "prod-.*"}}},
 				{Name: "not-activated-regexp", Activation: []latest.Activation{{KubeContext: "dev-.*"}}},
-				{Name: "also-activated-regexp", Activation: []latest.Activation{{KubeContext: "!dev-.*"}}},
 			},
-			expected: []string{"activated", "also-activated", "activated-regexp", "also-activated-regexp"},
+			expected: []string{"activated", "also-activated", "activated-regexp"},
 		}, {
 			description: "AND between activation criteria",
 			opts: &cfg.SkaffoldOptions{

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -377,8 +377,11 @@ func TestActivatedProfiles(t *testing.T) {
 				{Name: "activated", Activation: []latest.Activation{{KubeContext: "prod-context"}}},
 				{Name: "not-activated", Activation: []latest.Activation{{KubeContext: "dev-context"}}},
 				{Name: "also-activated", Activation: []latest.Activation{{KubeContext: "!dev-context"}}},
+				{Name: "activated-regexp", Activation: []latest.Activation{{KubeContext: "prod-.*"}}},
+				{Name: "not-activated-regexp", Activation: []latest.Activation{{KubeContext: "dev-.*"}}},
+				{Name: "also-activated-regexp", Activation: []latest.Activation{{KubeContext: "!dev-.*"}}},
 			},
-			expected: []string{"activated", "also-activated"},
+			expected: []string{"activated", "also-activated", "activated-regexp", "also-activated-regexp"},
 		}, {
 			description: "AND between activation criteria",
 			opts: &cfg.SkaffoldOptions{


### PR DESCRIPTION
Hi 👋

This PR adds support for regexp in profile activation via kubeContext as specified in #1677 
I tried to avoid breaking any existing behaviour.

Thanks for your review 🙏 

PS: thanks @pyaillet for his help 😄 