### PR TITLE
Add labels to podTemplates in helm deployments

### DIFF
--- a/pkg/skaffold/deploy/labels.go
+++ b/pkg/skaffold/deploy/labels.go
@@ -99,6 +99,15 @@ func addLabels(labels map[string]string, accessor metav1.Object) {
 	copyMap(kv, labels)
 
 	accessor.SetLabels(kv)
+
+	if podTpl := kubernetes.GetPodTemplateSpec(accessor); podTpl != nil {
+		dkv := make(map[string]string)
+
+		copyMap(dkv, podTpl.GetLabels())
+		copyMap(dkv, labels)
+
+		podTpl.SetLabels(dkv)
+	}
 }
 
 func updateRuntimeObject(client dynamic.Interface, disco discovery.DiscoveryInterface, labels map[string]string, res Artifact) error {

--- a/pkg/skaffold/kubernetes/util.go
+++ b/pkg/skaffold/kubernetes/util.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/apps/v1beta1"
+	"k8s.io/api/apps/v1beta2"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	extv1beta1 "k8s.io/api/extensions/v1beta1"
+)
+
+// GetPodTemplateSpec extracts the PodTemplateSpec from public k8s api-resources.
+// This list will need to be extended manually for new api-versions.
+func GetPodTemplateSpec(o interface{}) (podTpl *v1.PodTemplateSpec) {
+	switch o := o.(type) {
+	// ReplicationControllers
+	case *v1.ReplicationController:
+		podTpl = o.Spec.Template
+
+	// ReplicaSets
+	case *extv1beta1.ReplicaSet:
+		podTpl = &o.Spec.Template
+	case *v1beta2.ReplicaSet:
+		podTpl = &o.Spec.Template
+	case *appsv1.ReplicaSet:
+		podTpl = &o.Spec.Template
+
+	// StatefulSets
+	case *v1beta1.StatefulSet:
+		podTpl = &o.Spec.Template
+	case *v1beta2.StatefulSet:
+		podTpl = &o.Spec.Template
+	case *appsv1.StatefulSet:
+		podTpl = &o.Spec.Template
+
+	// Deployments
+	case *extv1beta1.Deployment:
+		podTpl = &o.Spec.Template
+	case *v1beta1.Deployment:
+		podTpl = &o.Spec.Template
+	case *v1beta2.Deployment:
+		podTpl = &o.Spec.Template
+	case *appsv1.Deployment:
+		podTpl = &o.Spec.Template
+
+	// DaemonSets
+	case *extv1beta1.DaemonSet:
+		podTpl = &o.Spec.Template
+	case *v1beta2.DaemonSet:
+		podTpl = &o.Spec.Template
+	case *appsv1.DaemonSet:
+		podTpl = &o.Spec.Template
+
+	// Job
+	case *batchv1.Job:
+		podTpl = &o.Spec.Template
+
+	// CronJob
+	case *batchv1beta1.CronJob:
+		podTpl = &o.Spec.JobTemplate.Spec.Template
+	}
+
+	return
+}

--- a/pkg/skaffold/kubernetes/util_test.go
+++ b/pkg/skaffold/kubernetes/util_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/apps/v1beta1"
+	"k8s.io/api/apps/v1beta2"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestGetPodTemplateSpec(t *testing.T) {
+	tests := []struct {
+		name        string
+		apiResource interface{}
+	}{
+		{
+			name: "v1.ReplicationController",
+			apiResource: &v1.ReplicationController{
+				Spec: v1.ReplicationControllerSpec{
+					Template: &v1.PodTemplateSpec{},
+				},
+			},
+		},
+		// ReplicaSets
+		{name: "extv1beta1.ReplicaSet", apiResource: &extv1beta1.ReplicaSet{}},
+		{name: "v1beta2.ReplicaSet", apiResource: &v1beta2.ReplicaSet{}},
+		{name: "appsv1.ReplicaSet", apiResource: &appsv1.ReplicaSet{}},
+
+		// StatefulSets
+		{name: "v1beta1.StatefulSet", apiResource: &v1beta1.StatefulSet{}},
+		{name: "v1beta2.StatefulSet", apiResource: &v1beta2.StatefulSet{}},
+		{name: "appsv1.StatefulSet", apiResource: &appsv1.StatefulSet{}},
+
+		// Deployments
+		{name: "extv1beta1.Deployment", apiResource: &extv1beta1.Deployment{}},
+		{name: "v1beta1.Deployment", apiResource: &v1beta1.Deployment{}},
+		{name: "v1beta2.Deployment", apiResource: &v1beta2.Deployment{}},
+		{name: "appsv1.Deployment", apiResource: &appsv1.Deployment{}},
+
+		// DaemonSets
+		{name: "extv1beta1.DaemonSet", apiResource: &extv1beta1.DaemonSet{}},
+		{name: "v1beta2.DaemonSet", apiResource: &v1beta2.DaemonSet{}},
+		{name: "appsv1.DaemonSet", apiResource: &appsv1.DaemonSet{}},
+
+		// Job
+		{name: "batchv1.Job", apiResource: &batchv1.Job{}},
+
+		// CronJob
+		{name: "batchv1beta1.CronJob", apiResource: &batchv1beta1.CronJob{}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clone := test.apiResource.(runtime.Object).DeepCopyObject()
+
+			actualPodTpl := GetPodTemplateSpec(clone)
+			testutil.CheckDeepEqual(t, false, actualPodTpl == nil)
+
+			actualPodTpl.Name = "some-change"
+			if diff := cmp.Diff(test.apiResource, clone); diff == "" {
+				t.Errorf("podTemplate should alias cloned object")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Helm deployments need to be labeled after they are created and live. For that, Skaffold fetches the live resources and adds its labels. However, Skaffold only adds its labels to the outer `metatdata.labels` field, but not to any pod templates, such as the `deployment.spec.template`.

This PR ensures that for all common public api-resources with pod templates, the labels are also live-patched to the pod-template.

Fix #2074 