### PR TITLE
docs: correct header name for jump.

### DIFF
--- a/cmd/skaffold/app/cmd/completion.go
+++ b/cmd/skaffold/app/cmd/completion.go
@@ -230,7 +230,7 @@ func completion(cmd *cobra.Command, args []string) {
 // NewCmdCompletion returns the cobra command that outputs shell completion code
 func NewCmdCompletion(out io.Writer) *cobra.Command {
 	return &cobra.Command{
-		Use: "completion",
+		Use: "completion SHELL",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return fmt.Errorf("requires 1 arg, found %d", len(args))

--- a/cmd/skaffold/app/cmd/completion.go
+++ b/cmd/skaffold/app/cmd/completion.go
@@ -230,7 +230,7 @@ func completion(cmd *cobra.Command, args []string) {
 // NewCmdCompletion returns the cobra command that outputs shell completion code
 func NewCmdCompletion(out io.Writer) *cobra.Command {
 	return &cobra.Command{
-		Use: "completion SHELL",
+		Use: "completion",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return fmt.Errorf("requires 1 arg, found %d", len(args))

--- a/cmd/skaffold/man/man.go
+++ b/cmd/skaffold/man/man.go
@@ -51,7 +51,7 @@ func printSubCommands(out io.Writer, command *cobra.Command) error {
 func printCommand(out io.Writer, command *cobra.Command) error {
 	command.DisableFlagsInUseLine = true
 
-	fmt.Fprintf(out, "\n### %s\n", command.UseLine())
+	fmt.Fprintf(out, "\n### %s\n", command.CommandPath())
 	fmt.Fprintf(out, "\n%s\n", command.Short)
 	fmt.Fprintf(out, "\n```\n%s\n\n```\n", command.UsageString())
 

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -105,13 +105,13 @@ Env vars:
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
 
-### skaffold completion SHELL
+### skaffold completion
 
 Output shell completion for the given shell (bash or zsh)
 
 ```
 Usage:
-  skaffold completion SHELL
+  skaffold completion
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -111,7 +111,7 @@ Output shell completion for the given shell (bash or zsh)
 
 ```
 Usage:
-  skaffold completion
+  skaffold completion SHELL
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)


### PR DESCRIPTION
Origin problem:
![image](https://user-images.githubusercontent.com/3402811/57274643-74ffb600-70ce-11e9-9ecb-751b5df4bbd8.png)

when I click `skaffold completion`, it does not work as expected.

I think i should change the header name to `skaffold completion`, but the usage is changed too. And the command's description is not clarified.

I wonder the `SHELL` is arguments or sub command, if sub command is better?

Thank you~