### PR TITLE
:sparkles: Add noPush field to kaniko

### DIFF
--- a/docs/content/en/schemas/v1beta10.json
+++ b/docs/content/en/schemas/v1beta10.json
@@ -1273,6 +1273,12 @@
           "description": "Docker image used by the Kaniko pod. Defaults to the latest released version of `gcr.io/kaniko-project/executor`.",
           "x-intellij-html-description": "Docker image used by the Kaniko pod. Defaults to the latest released version of <code>gcr.io/kaniko-project/executor</code>."
         },
+        "noPush": {
+          "type": "boolean",
+          "description": "used to pass in --no-push to kaniko build to prevent pushing to a registry.",
+          "x-intellij-html-description": "used to pass in --no-push to kaniko build to prevent pushing to a registry.",
+          "default": "false"
+        },
         "target": {
           "type": "string",
           "description": "Dockerfile target name to build.",
@@ -1286,7 +1292,8 @@
         "buildArgs",
         "buildContext",
         "image",
-        "cache"
+        "cache",
+        "noPush"
       ],
       "additionalProperties": false,
       "description": "*alpha* describes an artifact built from a Dockerfile, with kaniko.",

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -63,6 +63,10 @@ func (b *Builder) runKanikoBuild(ctx context.Context, out io.Writer, artifact *l
 	args = appendTargetIfExists(args, kanikoArtifact.Target)
 	args = appendCacheIfExists(args, kanikoArtifact.Cache)
 
+	if kanikoArtifact.NoPush {
+		args = append(args, "--no-push")
+	}
+
 	if artifact.WorkspaceHash != "" {
 		hashTag := cache.HashTag(artifact)
 		args = append(args, []string{"--destination", hashTag}...)

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -604,6 +604,9 @@ type KanikoArtifact struct {
 	// Cache configures Kaniko caching. If a cache is specified, Kaniko will
 	// use a remote cache which will speed up builds.
 	Cache *KanikoCache `yaml:"cache,omitempty"`
+
+	// NoPush used to pass in --no-push to kaniko build to prevent pushing to a registry.
+	NoPush bool `yaml:"noPush,omitempty"`
 }
 
 // DockerArtifact *beta* describes an artifact built from a Dockerfile,


### PR DESCRIPTION
Hi 👋 

This PR adds a `noPush` field to the `KanikoArtifact` type and append the flag `--no-push` as an argument to kaniko.
I preferred to name it `noPush` so it matches with [kaniko flags](https://github.com/GoogleContainerTools/kaniko#--no-push).
If you look at the `DockerArtifact` type you'll see that the same has been done for `noCache`.