### PR TITLE
Fix image release process: master -> edge, tag -> latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,10 @@ BUILD_PACKAGE = $(REPOPATH)/cmd/skaffold
 
 VERSION_PACKAGE = $(REPOPATH)/pkg/skaffold/version
 COMMIT = $(shell git rev-parse HEAD)
-VERSION ?= $(shell git describe --always --tags --dirty)
+
+ifeq "$(strip $(VERSION))" ""
+ override VERSION = $(shell git describe --always --tags --dirty)
+endif
 
 GO_GCFLAGS := "all=-trimpath=${PWD}"
 GO_ASMFLAGS := "all=-trimpath=${PWD}"

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ release: cross $(BUILD_DIR)/VERSION
         		-f deploy/skaffold/Dockerfile \
         		--cache-from gcr.io/$(GCP_PROJECT)/skaffold-builder \
         		--build-arg VERSION=$(VERSION) \
+        		-t gcr.io/$(GCP_PROJECT)/skaffold:latest \
         		-t gcr.io/$(GCP_PROJECT)/skaffold:$(VERSION) .
 	gsutil -m cp $(BUILD_DIR)/$(PROJECT)-* $(GSC_RELEASE_PATH)/
 	gsutil -m cp $(BUILD_DIR)/VERSION $(GSC_RELEASE_PATH)/VERSION
@@ -122,7 +123,7 @@ release-build: cross
 	docker build \
     		-f deploy/skaffold/Dockerfile \
     		--cache-from gcr.io/$(GCP_PROJECT)/skaffold-builder \
-    		-t gcr.io/$(GCP_PROJECT)/skaffold:latest \
+    		-t gcr.io/$(GCP_PROJECT)/skaffold:edge \
     		-t gcr.io/$(GCP_PROJECT)/skaffold:$(COMMIT) .
 	gsutil -m cp $(BUILD_DIR)/$(PROJECT)-* $(GSC_BUILD_PATH)/
 	gsutil -m cp -r $(GSC_BUILD_PATH)/* $(GSC_BUILD_LATEST)

--- a/deploy/cloudbuild-release.yaml
+++ b/deploy/cloudbuild-release.yaml
@@ -37,6 +37,7 @@ steps:
 
 images:
 - 'gcr.io/$PROJECT_ID/skaffold-builder:latest'
+- 'gcr.io/$PROJECT_ID/skaffold:latest'
 - 'gcr.io/$PROJECT_ID/skaffold:$TAG_NAME'
 
 options:

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -36,7 +36,7 @@ steps:
 
 images:
 - 'gcr.io/$PROJECT_ID/skaffold-builder:latest'
-- 'gcr.io/$PROJECT_ID/skaffold:latest'
+- 'gcr.io/$PROJECT_ID/skaffold:edge'
 - 'gcr.io/$PROJECT_ID/skaffold:$COMMIT_SHA'
 
 options:

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -121,11 +121,30 @@ For the latest **stable** release download and place it in your `PATH` as `skaff
 
 https://storage.googleapis.com/skaffold/releases/latest/skaffold-windows-amd64.exe
 
+### Bleeding edge binary
+
 For the latest **bleeding edge** build, download and place it in your `PATH` as `skaffold.exe`:
 
 https://storage.googleapis.com/skaffold/builds/latest/skaffold-windows-amd64.exe
 
 {{% /tab %}}
+
+{{% tab "DOCKER" %}}
+
+### Stable binary
+
+For the latest **stable** release, you can use: 
+
+`docker run gcr.io/k8s-skaffold/skaffold:latest skaffold <command>`
+
+### Bleeding edge binary
+
+For the latest **bleeding edge** build:
+
+`docker run gcr.io/k8s-skaffold/skaffold:edge skaffold <command>`
+
+{{% /tab %}}
+
 {{% /tabs %}}
 
 ## Downloading the sample app


### PR DESCRIPTION
Also fixes a bug that caused sometimes the version to disappear - now if the Makefile receives an empty string, it will still override the `VERSION` variable with the abbreviated git commit. 