### PR TITLE
Profiles syntax version dependency

### DIFF
--- a/docs/content/en/docs/how-tos/profiles/_index.md
+++ b/docs/content/en/docs/how-tos/profiles/_index.md
@@ -16,6 +16,8 @@ For a detailed discussion on Skaffold configuration, see
 
 ## Profiles (`profiles`)
 
+**NOTE:** To use profiles you should use the skaffold apiVersion: `skaffold/v1beta10`
+
 Each profile has six parts:
 
 * Name (`name`): The name of the profile


### PR DESCRIPTION
Trying out profiles with an earlier apiVersion: v1beta7 and realized that this needs v1beta10. Wanted to make sure that this is captured in the documentation.