### PR TITLE
Turn port forwarding off by default

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -178,7 +178,7 @@ func AddRunDevFlags(cmd *cobra.Command) {
 func AddDevDebugFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&opts.TailDev, "tail", true, "Stream logs from deployed objects")
 	cmd.Flags().BoolVar(&opts.Cleanup, "cleanup", true, "Delete deployments after dev mode is interrupted")
-	cmd.Flags().BoolVar(&opts.PortForward, "port-forward", true, "Port-forward exposed container ports within pods")
+	cmd.Flags().BoolVar(&opts.PortForward, "port-forward", false, "Port-forward exposed container ports within pods")
 	cmd.Flags().StringSliceVarP(&opts.CustomLabels, "label", "l", nil, "Add custom labels to deployed objects. Set multiple times for multiple labels")
 }
 

--- a/docs/content/en/docs/how-tos/portforward/_index.md
+++ b/docs/content/en/docs/how-tos/portforward/_index.md
@@ -4,7 +4,9 @@ linkTitle: "Port forwarding"
 weight: 50
 ---
 
-This page discusses how Skaffold sets up port forwarding for container ports from pods. When Skaffold deploys an application, it will automatically forward any ports mentioned in the pod spec.
+This page discusses how Skaffold sets up port forwarding for container ports from pods. 
+Port forwarding is set to false by default; you can enable it with the `--port-forward` flag for `skaffold dev` and `skaffold debug`. 
+When this flag is set, skaffold will automatically forward any ports mentioned in the pod spec.
 
 ### Example
 

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -236,7 +236,7 @@ Flags:
   -l, --label strings               Add custom labels to deployed objects. Set multiple times for multiple labels
   -n, --namespace string            Run deployments in the specified namespace
       --no-prune                    Skip removing images and containers built by Skaffold
-      --port-forward                Port-forward exposed container ports within pods (default true)
+      --port-forward                Port-forward exposed container ports within pods
   -p, --profile strings             Activate profiles by name
       --rpc-http-port int           tcp port to expose event REST API over HTTP (default 50052)
       --rpc-port int                tcp port to expose event API (default 50051)
@@ -384,7 +384,7 @@ Flags:
   -l, --label strings               Add custom labels to deployed objects. Set multiple times for multiple labels
   -n, --namespace string            Run deployments in the specified namespace
       --no-prune                    Skip removing images and containers built by Skaffold
-      --port-forward                Port-forward exposed container ports within pods (default true)
+      --port-forward                Port-forward exposed container ports within pods
   -p, --profile strings             Activate profiles by name
       --rpc-http-port int           tcp port to expose event REST API over HTTP (default 50052)
       --rpc-port int                tcp port to expose event API (default 50051)


### PR DESCRIPTION
This PR turns port forwarding off by default and updates associated
docs. Port forwarding should stay off by default at least until it is
stabilized as described in #969, in this [comment](https://github.com/GoogleContainerTools/skaffold/issues/969#issuecomment-491918991).