### PR TITLE
Add sync test and refactor InParallel

### DIFF
--- a/pkg/skaffold/build/parallel.go
+++ b/pkg/skaffold/build/parallel.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
@@ -42,10 +43,8 @@ func InParallel(ctx context.Context, out io.Writer, tags tag.ImageTags, artifact
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	n := len(artifacts)
-	finalTags := make([]string, n)
-	errs := make([]error, n)
-	outputs := make([]chan []byte, n)
+	results := new(sync.Map)
+	outputs := make([]chan []byte, len(artifacts))
 
 	// Run builds in //
 	for index := range artifacts {
@@ -54,46 +53,64 @@ func InParallel(ctx context.Context, out io.Writer, tags tag.ImageTags, artifact
 		outputs[i] = lines
 
 		r, w := io.Pipe()
+		cw := setUpColorWriter(w, out)
 
-		// Log to the pipe, output will be collected and printed later
-		go func() {
-			// Make sure logs are printed in colors
-			var cw io.WriteCloser
-			if color.IsTerminal(out) {
-				cw = color.ColoredWriteCloser{WriteCloser: w}
-			} else {
-				cw = w
-			}
+		// Run build and write output/logs to piped writer and store build result in
+		// sync.Map
+		go runBuild(ctx, cw, artifacts[i], tags, results, buildArtifact)
+		// Read build output/logs and write to buffered channel
+		go readOutputAndWriteToChannel(r, lines)
 
-			color.Default.Fprintf(cw, "Building [%s]...\n", artifacts[i].ImageName)
-
-			event.BuildInProgress(artifacts[i].ImageName)
-
-			tag, present := tags[artifacts[i].ImageName]
-			if !present {
-				errs[i] = fmt.Errorf("unable to find tag for image %s", artifacts[i].ImageName)
-				event.BuildFailed(artifacts[i].ImageName, errs[i])
-			} else {
-				finalTags[i], errs[i] = buildArtifact(ctx, cw, artifacts[i], tag)
-				if errs[i] != nil {
-					event.BuildFailed(artifacts[i].ImageName, errs[i])
-				}
-			}
-
-			event.BuildComplete(artifacts[i].ImageName)
-			cw.Close()
-		}()
-
-		go func() {
-			scanner := bufio.NewScanner(r)
-			for scanner.Scan() {
-				lines <- scanner.Bytes()
-			}
-			close(lines)
-		}()
 	}
 
 	// Print logs and collect results in order.
+	return printAndCollectResults(out, artifacts, outputs, results)
+}
+
+func runBuild(ctx context.Context, cw io.WriteCloser, artifact *latest.Artifact, tags tag.ImageTags, results *sync.Map, build artifactBuilder) {
+	color.Default.Fprintf(cw, "Building [%s]...\n", artifact.ImageName)
+
+	event.BuildInProgress(artifact.ImageName)
+
+	finalTag, err := getBuildResult(ctx, cw, artifact, tags, build)
+	if err != nil {
+		event.BuildFailed(artifact.ImageName, err)
+		results.Store(artifact.ImageName, err)
+	} else {
+		results.Store(artifact.ImageName, finalTag)
+	}
+
+	event.BuildComplete(artifact.ImageName)
+	cw.Close()
+}
+
+func readOutputAndWriteToChannel(r *io.PipeReader, lines chan []byte) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		lines <- scanner.Bytes()
+	}
+	close(lines)
+}
+
+func setUpColorWriter(w *io.PipeWriter, out io.Writer) io.WriteCloser {
+	var cw io.WriteCloser
+	if color.IsTerminal(out) {
+		cw = color.ColoredWriteCloser{WriteCloser: w}
+	} else {
+		cw = w
+	}
+	return cw
+}
+
+func getBuildResult(ctx context.Context, cw io.WriteCloser, artifact *latest.Artifact, tags tag.ImageTags, build artifactBuilder) (string, error) {
+	tag, present := tags[artifact.ImageName]
+	if !present {
+		return "", fmt.Errorf("unable to find tag for image %s", artifact.ImageName)
+	}
+	return build(ctx, cw, artifact, tag)
+}
+
+func printAndCollectResults(out io.Writer, artifacts []*latest.Artifact, outputs []chan []byte, results *sync.Map) ([]Artifact, error) {
 	var built []Artifact
 
 	for i, artifact := range artifacts {
@@ -102,15 +119,16 @@ func InParallel(ctx context.Context, out io.Writer, tags tag.ImageTags, artifact
 			fmt.Fprintln(out)
 		}
 
-		if errs[i] != nil {
-			return nil, errors.Wrapf(errs[i], "building [%s]", artifact.ImageName)
+		if v, ok := results.Load(artifact.ImageName); ok {
+			switch t := v.(type) {
+			case error:
+				return nil, errors.Wrapf(v.(error), "building [%s]", artifact.ImageName)
+			case string:
+				built = append(built, Artifact{ImageName: artifact.ImageName, Tag: v.(string)})
+			default:
+				return nil, fmt.Errorf("unknown type %T for %s", t, artifact.ImageName)
+			}
 		}
-
-		built = append(built, Artifact{
-			ImageName: artifact.ImageName,
-			Tag:       finalTags[i],
-		})
 	}
-
 	return built, nil
 }

--- a/pkg/skaffold/build/parallel_test.go
+++ b/pkg/skaffold/build/parallel_test.go
@@ -21,39 +21,37 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"sync"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
-	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/context"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestInParallel(t *testing.T) {
+func TestGetBuild(t *testing.T) {
 	var tests = []struct {
-		description       string
-		buildArtifact     artifactBuilder
-		tags              tag.ImageTags
-		expectedArtifacts []Artifact
-		expectedOut       string
-		shouldErr         bool
+		description   string
+		buildArtifact artifactBuilder
+		tags          tag.ImageTags
+		expectedTag   string
+		expectedOut   string
+		shouldErr     bool
 	}{
 		{
 			description: "build succeeds",
 			buildArtifact: func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+				out.Write([]byte("build succeeds"))
 				return fmt.Sprintf("%s@sha256:abac", tag), nil
 			},
 			tags: tag.ImageTags{
 				"skaffold/image1": "skaffold/image1:v0.0.1",
 				"skaffold/image2": "skaffold/image2:v0.0.2",
 			},
-			expectedArtifacts: []Artifact{
-				{ImageName: "skaffold/image1", Tag: "skaffold/image1:v0.0.1@sha256:abac"},
-				{ImageName: "skaffold/image2", Tag: "skaffold/image2:v0.0.2@sha256:abac"},
-			},
-			expectedOut: "Building [skaffold/image1]...\nBuilding [skaffold/image2]...\n",
+			expectedTag: "skaffold/image1:v0.0.1@sha256:abac",
+			expectedOut: "Building [skaffold/image1]...\nbuild succeeds",
 		},
 		{
 			description: "build fails",
@@ -75,28 +73,234 @@ func TestInParallel(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			initializeEvents()
+			out := new(bytes.Buffer)
+			artifact := &latest.Artifact{ImageName: "skaffold/image1"}
+			got, err := getBuildResult(context.Background(), out, test.tags, artifact, test.buildArtifact)
+			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expectedTag, got)
+			testutil.CheckDeepEqual(t, test.expectedOut, out.String())
+		})
+	}
+}
+
+func TestCollectResults(t *testing.T) {
+	var tests = []struct {
+		description string
+		artifacts   []*latest.Artifact
+		expected    []Artifact
+		results     map[string]interface{}
+		shouldErr   bool
+	}{
+		{
+			description: "all builds completely successfully",
+			artifacts: []*latest.Artifact{
+				{ImageName: "skaffold/image1"},
+				{ImageName: "skaffold/image2"},
+			},
+			expected: []Artifact{
+				{ImageName: "skaffold/image1", Tag: "skaffold/image1:v0.0.1@sha256:abac"},
+				{ImageName: "skaffold/image2", Tag: "skaffold/image2:v0.0.2@sha256:abac"},
+			},
+			results: map[string]interface{}{
+				"skaffold/image1": "skaffold/image1:v0.0.1@sha256:abac",
+				"skaffold/image2": "skaffold/image2:v0.0.2@sha256:abac",
+			},
+		},
+		{
+			description: "first build errors",
+			artifacts: []*latest.Artifact{
+				{ImageName: "skaffold/image1"},
+				{ImageName: "skaffold/image2"},
+			},
+			expected: nil,
+			results: map[string]interface{}{
+				"skaffold/image1": fmt.Errorf("Could not build image skaffold/image1"),
+				"skaffold/image2": "skaffold/image2:v0.0.2@sha256:abac",
+			},
+			shouldErr: true,
+		},
+		{
+			description: "arbitrary image build failure",
+			artifacts: []*latest.Artifact{
+				{ImageName: "skaffold/image1"},
+				{ImageName: "skaffold/image2"},
+				{ImageName: "skaffold/image3"},
+			},
+			expected: nil,
+			results: map[string]interface{}{
+				"skaffold/image1": "skaffold/image1:v0.0.1@sha256:abac",
+				"skaffold/image2": fmt.Errorf("Could not build image skaffold/image1"),
+				"skaffold/image3": "skaffold/image3:v0.0.1@sha256:abac",
+			},
+			shouldErr: true,
+		},
+		{
+			description: "no build result produced for a build",
+			artifacts: []*latest.Artifact{
+				{ImageName: "skaffold/image1"},
+				{ImageName: "skaffold/image2"},
+			},
+			expected: nil,
+			results: map[string]interface{}{
+				"skaffold/image1": "skaffold/image1:v0.0.1@sha256:abac",
+			},
+			shouldErr: true,
+		},
+		{
+			description: "build produced an incorrect value type",
+			artifacts: []*latest.Artifact{
+				{ImageName: "skaffold/image1"},
+				{ImageName: "skaffold/image2"},
+			},
+			expected: nil,
+			results: map[string]interface{}{
+				"skaffold/image1": 1,
+			},
+			shouldErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			resultMap := new(sync.Map)
+			for k, v := range test.results {
+				resultMap.Store(k, v)
+			}
+			got, err := collectResults(test.artifacts, resultMap)
+			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, got)
+		})
+	}
+}
+
+func TestInParallel(t *testing.T) {
+	var tests = []struct {
+		description string
+		buildFunc   artifactBuilder
+		expected    string
+	}{
+		{
+			description: "short and nice build log",
+			expected:    "Building [skaffold/image1]...\nshort\nBuilding [skaffold/image2]...\nshort\n",
+			buildFunc: func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+				out.Write([]byte("short"))
+				return fmt.Sprintf("%s:tag", artifact.ImageName), nil
+			},
+		},
+		{
+			description: "long build log gets printed correctly",
+			expected: `Building [skaffold/image1]...
+This is a long string more than 10 bytes.
+And new lines
+Building [skaffold/image2]...
+This is a long string more than 10 bytes.
+And new lines
+`,
+			buildFunc: func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+				out.Write([]byte("This is a long string more than 10 bytes.\nAnd new lines"))
+				return fmt.Sprintf("%s:tag", artifact.ImageName), nil
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
 			out := new(bytes.Buffer)
 			artifacts := []*latest.Artifact{
 				{ImageName: "skaffold/image1"},
 				{ImageName: "skaffold/image2"},
 			}
-			cfg := latest.BuildConfig{
-				BuildType: latest.BuildType{
-					LocalBuild: &latest.LocalBuild{},
-				},
+			tags := tag.ImageTags{
+				"skaffold/image1": "skaffold/image1:v0.0.1",
+				"skaffold/image2": "skaffold/image2:v0.0.2",
 			}
-			event.InitializeState(&runcontext.RunContext{
-				Cfg: &latest.Pipeline{
-					Build: cfg,
-				},
-				Opts: &config.SkaffoldOptions{},
-			})
-
-			got, err := InParallel(context.Background(), out, test.tags, artifacts, test.buildArtifact)
-
-			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expectedArtifacts, got)
-			testutil.CheckDeepEqual(t, test.expectedOut, out.String())
+			initializeEvents()
+			InParallel(context.Background(), out, tags, artifacts, test.buildFunc)
+			testutil.CheckDeepEqual(t, test.expected, out.String())
 		})
 	}
+}
+
+func TestInParallelForArgs(t *testing.T) {
+	var tests = []struct {
+		description   string
+		inSeqFunc     func(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, artifactBuilder) ([]Artifact, error)
+		buildArtifact artifactBuilder
+		artifactLen   int
+		expected      []Artifact
+	}{
+		{
+			description: "runs in sequence for 1 artifact",
+			inSeqFunc: func(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, artifactBuilder) ([]Artifact, error) {
+				return []Artifact{{ImageName: "singleArtifact", Tag: "one"}}, nil
+			},
+			artifactLen: 1,
+			expected:    []Artifact{{ImageName: "singleArtifact", Tag: "one"}},
+		},
+		{
+			description: "runs in sequence for 2 artifacts",
+			buildArtifact: func(_ context.Context, _ io.Writer, _ *latest.Artifact, tag string) (string, error) {
+				return tag, nil
+			},
+			artifactLen: 2,
+			expected: []Artifact{
+				{ImageName: "artifact1", Tag: "artifact1@tag1"},
+				{ImageName: "artifact2", Tag: "artifact2@tag2"},
+			},
+		},
+		{
+			description: "runs in parallel should return for 0 artifacts",
+			artifactLen: 0,
+			expected:    nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			artifacts := make([]*latest.Artifact, test.artifactLen)
+			tags := tag.ImageTags{}
+			for i := 0; i < test.artifactLen; i++ {
+				a := fmt.Sprintf("artifact%d", i+1)
+				artifacts[i] = &latest.Artifact{ImageName: a}
+				tags[a] = fmt.Sprintf("%s@tag%d", a, i+1)
+			}
+			if test.inSeqFunc != nil {
+				originalInSeq := runInSequence
+				defer func() { runInSequence = originalInSeq }()
+				runInSequence = test.inSeqFunc
+			}
+			initializeEvents()
+			actual, _ := InParallel(context.Background(), ioutil.Discard, tags, artifacts, test.buildArtifact)
+			testutil.CheckDeepEqual(t, test.expected, actual)
+		})
+	}
+
+}
+
+func TestColoredOutput(t *testing.T) {
+	var tests = []struct {
+		description   string
+		isTerminal    func(w io.Writer) bool
+		exceptedColor bool
+	}{
+		{
+			description:   "setUpColorWriter returns color out writer for terminal",
+			isTerminal:    func(w io.Writer) bool { return true },
+			exceptedColor: true,
+		},
+		{
+			description:   "setUpColorWriter returns color out writer if not terminal",
+			isTerminal:    func(w io.Writer) bool { return false },
+			exceptedColor: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			originalIsColor := color.IsTerminal
+			defer func() { color.IsTerminal = originalIsColor }()
+			color.IsTerminal = test.isTerminal
+			_, w := io.Pipe()
+			actual := setUpColorWriter(w, ioutil.Discard)
+			if _, ok := actual.(color.ColoredWriteCloser); ok != test.exceptedColor {
+				t.Errorf("got %t, expected %t", ok, test.exceptedColor)
+			}
+		})
+	}
+
 }

--- a/pkg/skaffold/build/parallel_test.go
+++ b/pkg/skaffold/build/parallel_test.go
@@ -75,6 +75,7 @@ func TestInParallel(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
+			initializeEvents()
 			out := new(bytes.Buffer)
 			artifacts := []*latest.Artifact{
 				{ImageName: "skaffold/image1"},

--- a/pkg/skaffold/build/sequence_test.go
+++ b/pkg/skaffold/build/sequence_test.go
@@ -107,7 +107,6 @@ func TestInSequenceResultsOrder(t *testing.T) {
 				{ImageName: "d", Tag: "d:abcd"},
 			},
 		},
-		// Add test when artifact has an error
 	}
 
 	for _, test := range tests {
@@ -122,22 +121,21 @@ func TestInSequenceResultsOrder(t *testing.T) {
 				}
 				tags[image] = image
 			}
-
 			builder := concatTagger{}
 			got, err := InSequence(context.Background(), out, tags, artifacts, builder.doBuild)
-
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, got)
 		})
 	}
 }
 
-// summer builder sums all the numbers
+// concatTagger builder sums all the numbers
 type concatTagger struct {
 	tag string
 }
 
 // doBuild calculate the tag based by concatinating the tag values for artifact
-// builds seen so far.
+// builds seen so far. It mimics artifact dependency where the next build result
+// depends on the previous build result.
 func (t *concatTagger) doBuild(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
 	t.tag += tag
 	return fmt.Sprintf("%s:%s", artifact.ImageName, t.tag), nil


### PR DESCRIPTION
Some work from #2091 

-  Added a test to make sure InSequence builds are run in sequence.
- Cleaned up parallel.go by adding functions.
- Used [sync.Map ](https://golang.org/pkg/sync/#Map)to collect parallel build results which are safe to use since as per the docs
``
The Map type is optimized for two common use cases: (1) when the entry for a given key is only ever written once but read many times, as in caches that only grow, or (2) when multiple goroutines read, write, and overwrite entries for disjoint sets of keys. In these two cases, use of a Map may significantly reduce lock contention compared to a Go map paired with a separate Mutex or RWMutex.
``
In our case, one go subroutine adds exactly one key and they are always disjoint. 
- Added Individual unit tests.
- Test cases cover code branches and not just errors.

