### PR TITLE
Remove build dep for helm deploy

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -162,10 +162,7 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 		color.Red.Fprintf(out, "Helm release %s not installed. Installing...\n", releaseName)
 		isInstalled = false
 	}
-	params, err := h.joinTagsToBuildResult(builds, r.Values)
-	if err != nil {
-		return nil, errors.Wrap(err, "matching build results to chart values")
-	}
+	params := h.joinTagsToBuildResult(builds, r.Values)
 
 	var setOpts []string
 	for k, v := range params {
@@ -399,7 +396,7 @@ func (h *HelmDeployer) deleteRelease(ctx context.Context, out io.Writer, r lates
 	return nil
 }
 
-func (h *HelmDeployer) joinTagsToBuildResult(builds []build.Artifact, params map[string]string) (map[string]build.Artifact, error) {
+func (h *HelmDeployer) joinTagsToBuildResult(builds []build.Artifact, params map[string]string) map[string]build.Artifact {
 	imageToBuildResult := map[string]build.Artifact{}
 	for _, b := range builds {
 		imageToBuildResult[b.ImageName] = b
@@ -415,7 +412,7 @@ func (h *HelmDeployer) joinTagsToBuildResult(builds []build.Artifact, params map
 		}
 		paramToBuildResult[param] = b
 	}
-	return paramToBuildResult, nil
+	return paramToBuildResult
 }
 
 func evaluateReleaseName(nameTemplate string) (string, error) {

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -411,7 +411,7 @@ func (h *HelmDeployer) joinTagsToBuildResult(builds []build.Artifact, params map
 		b, ok := imageToBuildResult[newImageName]
 		if !ok {
 			if len(builds) == 0 {
-				logrus.Warnf("no build artifacts present. Assuming skaffold deploy. Continuing with %s", imageName)
+				logrus.Debugf("no build artifacts present. Assuming skaffold deploy. Continuing with %s", imageName)
 				b = build.Artifact{ImageName: imageName, Tag: imageName}
 			} else {
 				return nil, fmt.Errorf("no build present for %s", imageName)

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -401,18 +401,19 @@ func (h *HelmDeployer) deleteRelease(ctx context.Context, out io.Writer, r lates
 
 func (h *HelmDeployer) joinTagsToBuildResult(builds []build.Artifact, params map[string]string) (map[string]build.Artifact, error) {
 	imageToBuildResult := map[string]build.Artifact{}
-	for _, build := range builds {
-		imageToBuildResult[build.ImageName] = build
+	for _, b := range builds {
+		imageToBuildResult[b.ImageName] = b
 	}
 
 	paramToBuildResult := map[string]build.Artifact{}
 	for param, imageName := range params {
 		newImageName := util.SubstituteDefaultRepoIntoImage(h.defaultRepo, imageName)
-		build, ok := imageToBuildResult[newImageName]
+		b, ok := imageToBuildResult[newImageName]
 		if !ok {
-			return nil, fmt.Errorf("no build present for %s", imageName)
+			logrus.Warnf("no build present for %s. Continuing with %s", imageName, imageName)
+			b = build.Artifact{ImageName: imageName, Tag: imageName}
 		}
-		paramToBuildResult[param] = build
+		paramToBuildResult[param] = b
 	}
 	return paramToBuildResult, nil
 }

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -162,7 +162,10 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 		color.Red.Fprintf(out, "Helm release %s not installed. Installing...\n", releaseName)
 		isInstalled = false
 	}
-	params := h.joinTagsToBuildResult(builds, r.Values)
+	params, err := h.joinTagsToBuildResult(builds, r.Values)
+	if err != nil {
+		return nil, errors.Wrap(err, "matching build results to chart values")
+	}
 
 	var setOpts []string
 	for k, v := range params {
@@ -396,7 +399,7 @@ func (h *HelmDeployer) deleteRelease(ctx context.Context, out io.Writer, r lates
 	return nil
 }
 
-func (h *HelmDeployer) joinTagsToBuildResult(builds []build.Artifact, params map[string]string) map[string]build.Artifact {
+func (h *HelmDeployer) joinTagsToBuildResult(builds []build.Artifact, params map[string]string) (map[string]build.Artifact, error) {
 	imageToBuildResult := map[string]build.Artifact{}
 	for _, b := range builds {
 		imageToBuildResult[b.ImageName] = b
@@ -407,12 +410,16 @@ func (h *HelmDeployer) joinTagsToBuildResult(builds []build.Artifact, params map
 		newImageName := util.SubstituteDefaultRepoIntoImage(h.defaultRepo, imageName)
 		b, ok := imageToBuildResult[newImageName]
 		if !ok {
-			logrus.Warnf("no build present for %s. Continuing with %s", imageName, imageName)
-			b = build.Artifact{ImageName: imageName, Tag: imageName}
+			if len(builds) == 0 {
+				logrus.Warnf("no build artifacts present. Assuming skaffold deploy. Continuing with %s", imageName)
+				b = build.Artifact{ImageName: imageName, Tag: imageName}
+			} else {
+				return nil, fmt.Errorf("no build present for %s", imageName)
+			}
 		}
 		paramToBuildResult[param] = b
 	}
-	return paramToBuildResult
+	return paramToBuildResult, nil
 }
 
 func evaluateReleaseName(nameTemplate string) (string, error) {

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -212,7 +212,7 @@ spec:
       containers:
         - name: skaffold-helm
           image: gcr.io/nick-cloudbuild/skaffold-helm:f759510436c8fd6f7ffa13dd9e9d85e64bec8d2bfd12c5aa3fb9af1288eccdab
-          imagePullPolicy: 
+          imagePullPolicy:
           command: ["/bin/bash", "-c", "--" ]
           args: ["while true; do sleep 30; done;"]
           resources:
@@ -301,11 +301,10 @@ func TestHelmDeploy(t *testing.T) {
 			builds:      testBuilds,
 		},
 		{
-			description: "deploy error unmatched parameter",
+			description: "deploy should not error for unmatched parameter",
 			cmd:         &MockHelm{t: t},
 			runContext:  makeRunContext(testDeployConfigParameterUnmatched, false),
 			builds:      testBuilds,
-			shouldErr:   true,
 		},
 		{
 			description: "deploy success remote chart with skipBuildDependencies",

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -301,10 +301,17 @@ func TestHelmDeploy(t *testing.T) {
 			builds:      testBuilds,
 		},
 		{
-			description: "deploy should not error for unmatched parameter",
+			description: "deploy should not error for unmatched parameter when no builds present",
+			cmd:         &MockHelm{t: t},
+			runContext:  makeRunContext(testDeployConfigParameterUnmatched, false),
+			builds:      nil,
+		},
+		{
+			description: "deploy should error for unmatched parameter when builds present",
 			cmd:         &MockHelm{t: t},
 			runContext:  makeRunContext(testDeployConfigParameterUnmatched, false),
 			builds:      testBuilds,
+			shouldErr:   true,
 		},
 		{
 			description: "deploy success remote chart with skipBuildDependencies",


### PR DESCRIPTION
On master, skaffold deploy fails with following error.

```
skaffold deploy -f examples/helm-deployment/skaffold.yaml
Starting deploy...
Error: release: "skaffold-helm" not found
Helm release skaffold-helm not installed. Installing...
FATA[0002] deploying skaffold-helm: matching build results to chart values: no build present for gcr.io/k8s-skaffold/skaffold-helm
```
This is because in #922, we removed deploy triggering the build. Running
deploy should use the default tag i.e. "latest" when depoying images.