### PR TITLE
Fix bugs in custom builder

### DIFF
--- a/pkg/skaffold/build/custom/custom.go
+++ b/pkg/skaffold/build/custom/custom.go
@@ -54,17 +54,30 @@ func NewArtifactBuilder(pushImages bool, additionalEnv []string) *ArtifactBuilde
 // Build builds a custom artifact
 // It returns true if the image is expected to exist remotely, or false if it is expected to exist locally
 func (b *ArtifactBuilder) Build(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) error {
+	cmd, err := b.retrieveCmd(a, tag)
+	if err != nil {
+		return errors.Wrap(err, "retrieving cmd")
+	}
+	return cmd.Run()
+}
+
+func (b *ArtifactBuilder) retrieveCmd(a *latest.Artifact, tag string) (*exec.Cmd, error) {
 	artifact := a.CustomArtifact
-	cmd := exec.Command(artifact.BuildCommand)
+	split := strings.Split(artifact.BuildCommand, " ")
+	cmd := exec.Command(split[0], split[1:]...)
 	env, err := b.retrieveEnv(a, tag)
 	if err != nil {
-		return errors.Wrapf(err, "retrieving env variables for %s", a.ImageName)
+		return nil, errors.Wrapf(err, "retrieving env variables for %s", a.ImageName)
 	}
 	cmd.Env = env
+	dir, err := buildContext(a.Workspace)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting context for artifact")
+	}
+	cmd.Dir = dir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-
-	return cmd.Run()
+	return cmd, nil
 }
 
 func (b *ArtifactBuilder) retrieveEnv(a *latest.Artifact, tag string) ([]string, error) {


### PR DESCRIPTION
This PR fixes the following bugs in the custom builder:

  1. The build command should be run in the artifact context (fixes #2125)
  2. The build command should be split into executable+arguments so that
  flags can be passed in

This PR also adds a unit test for each of these bugs.