### PR TITLE
skaffold debug: log unsupported objects or versions

### DIFF
--- a/docs/content/en/docs/how-tos/debug/_index.md
+++ b/docs/content/en/docs/how-tos/debug/_index.md
@@ -30,7 +30,12 @@ artifacts are transformed to enable the runtime technology's debugging functions
       
 `skaffold debug` uses a set of heuristics to identify the runtime technology.
 The Kubernetes manifests are transformed on-the-fly such that the on-disk
-representations are untouched. 
+representations are untouched.
+
+{{< alert title="Caution" >}}
+`skaffold debug` does not support deprecated versions of Workload API objects such as `apps/v1beta1`.
+{{< /alert >}}
+
 
 ## Limitations
 

--- a/pkg/skaffold/debug/transform_test.go
+++ b/pkg/skaffold/debug/transform_test.go
@@ -17,10 +17,15 @@ limitations under the License.
 package debug
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestAllocatePort(t *testing.T) {
@@ -98,6 +103,32 @@ func TestAllocatePort(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			result := allocatePort(&test.pod, test.desiredPort)
 			testutil.CheckDeepEqual(t, test.result, result)
+		})
+	}
+}
+
+func TestDescribe(t *testing.T) {
+	tests := []struct {
+		in     runtime.Object
+		result string
+	}{
+		{&v1.Pod{TypeMeta: metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.String(), Kind: "Pod"}, ObjectMeta: metav1.ObjectMeta{Name: "name"}}, "pod/name"},
+		{&v1.ReplicationController{TypeMeta: metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.String(), Kind: "ReplicationController"}, ObjectMeta: metav1.ObjectMeta{Name: "name"}}, "replicationcontroller/name"},
+		{&appsv1.Deployment{TypeMeta: metav1.TypeMeta{APIVersion: appsv1.SchemeGroupVersion.String(), Kind: "Deployment"}, ObjectMeta: metav1.ObjectMeta{Name: "name"}}, "deployment.apps/name"},
+		{&appsv1.ReplicaSet{TypeMeta: metav1.TypeMeta{APIVersion: appsv1.SchemeGroupVersion.String(), Kind: "ReplicaSet"}, ObjectMeta: metav1.ObjectMeta{Name: "name"}}, "replicaset.apps/name"},
+		{&appsv1.StatefulSet{TypeMeta: metav1.TypeMeta{APIVersion: appsv1.SchemeGroupVersion.String(), Kind: "StatefulSet"}, ObjectMeta: metav1.ObjectMeta{Name: "name"}}, "statefulset.apps/name"},
+		{&appsv1.DaemonSet{TypeMeta: metav1.TypeMeta{APIVersion: appsv1.SchemeGroupVersion.String(), Kind: "DaemonSet"}, ObjectMeta: metav1.ObjectMeta{Name: "name"}}, "daemonset.apps/name"},
+		{&batchv1.Job{TypeMeta: metav1.TypeMeta{APIVersion: batchv1.SchemeGroupVersion.String(), Kind: "Job"}, ObjectMeta: metav1.ObjectMeta{Name: "name"}}, "job.batch/name"},
+	}
+
+	for _, test := range tests {
+		t.Run(reflect.TypeOf(test.in).Name(), func(t *testing.T) {
+			gvk := test.in.GetObjectKind().GroupVersionKind()
+			group, version, kind, description := describe(test.in)
+			testutil.CheckDeepEqual(t, gvk.Group, group)
+			testutil.CheckDeepEqual(t, gvk.Kind, kind)
+			testutil.CheckDeepEqual(t, gvk.Version, version)
+			testutil.CheckDeepEqual(t, test.result, description)
 		})
 	}
 }


### PR DESCRIPTION
We don't support workload objects in `apps/v1beta1` or `apps/v1beta2`, which have been deprecated since Kubernetes 1.9.  Log these in a more visible manner:
```
ERRO[0003] deprecated versions not supported by debug: deployment.apps/web2 (v1beta1) 
DEBU[0004] no debug transformation for: service/web          
WARN[0005] no debug transformation for: foobar.apps/name
```
The warning should only be issued workload API objects (`apps` and `batch`) that aren't handled.
