### PR TITLE
 Bring helm integration test back

### DIFF
--- a/integration/examples/helm-deployment/skaffold-int.yaml
+++ b/integration/examples/helm-deployment/skaffold-int.yaml
@@ -1,3 +1,5 @@
+# This config should be used for running integration tests purpose only.
+# Please use to skaffold.yaml to run this example
 apiVersion: skaffold/v1beta10
 kind: Config
 build:
@@ -8,7 +10,8 @@ build:
 deploy:
   helm:
     releases:
-    - name: skaffold-helm
+    # seed test namespace in the release name.
+    - name: skaffold-helm-{{.TEST_NS}}
       chartPath: skaffold-helm
       #wait: true
       #valuesFiles:

--- a/integration/examples/helm-deployment/skaffold.yaml
+++ b/integration/examples/helm-deployment/skaffold.yaml
@@ -8,7 +8,7 @@ build:
 deploy:
   helm:
     releases:
-    - name: skaffold-helm
+    - name: skaffold-helm-{{.TEST_NS}}
       chartPath: skaffold-helm
       #wait: true
       #valuesFiles:

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -43,13 +43,16 @@ func TestHelmDeploy(t *testing.T) {
 	// To fix #1823, we make use of env variable templating for release name
 	env := []string{fmt.Sprintf("TEST_NS=%s", ns.Name)}
 	depName := fmt.Sprintf("skaffold-helm-%s", ns.Name)
-	fmt.Println(env)
+	overrideConfigArgs := []string{"-f", "skaffold.yaml"}
+
 	defer func() {
-		skaffold.Delete().InDir(helmDir).InNs(ns.Name).WithEnv(env).RunOrFail(t)
+		skaffold.Delete(overrideConfigArgs...).InDir(helmDir).InNs(ns.Name).WithEnv(env).RunOrFail(t)
 		deleteNs()
 	}()
 
-	skaffold.Deploy("--images", "gcr.io/k8s-skaffold/skaffold-helm").InDir(helmDir).InNs(ns.Name).WithEnv(env).RunOrFailOutput(t)
+	runArgs := append(overrideConfigArgs, "--images", "gcr.io/k8s-skaffold/skaffold-helm")
+
+	skaffold.Deploy(runArgs...).InDir(helmDir).InNs(ns.Name).WithEnv(env).RunOrFailOutput(t)
 
 	client.WaitForDeploymentsToStabilize(depName)
 

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -43,7 +43,9 @@ func TestHelmDeploy(t *testing.T) {
 	// To fix #1823, we make use of env variable templating for release name
 	env := []string{fmt.Sprintf("TEST_NS=%s", ns.Name)}
 	depName := fmt.Sprintf("skaffold-helm-%s", ns.Name)
-	overrideConfigArgs := []string{"-f", "skaffold.yaml"}
+	// Please make sure to make the same changes in skaffold.yaml if you make
+	// any changes to skaffold-int.yaml
+	overrideConfigArgs := []string{"-f", "skaffold-int.yaml"}
 
 	defer func() {
 		skaffold.Delete(overrideConfigArgs...).InDir(helmDir).InNs(ns.Name).WithEnv(env).RunOrFail(t)

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
+	"github.com/google/go-cmp/cmp"
+)
+
+const (
+	TestVersion = "vtest"
+)
+
+func TestHelmDeploy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	if os.Getenv("REMOTE_INTEGRATION") != "true" {
+		t.Skip("skipping remote only test")
+	}
+
+	helmDir := "examples/helm-deployment"
+
+	ns, client, deleteNs := SetupNamespace(t)
+	// To fix #1823, we make use of env variable templating for release name
+	env := []string{fmt.Sprintf("TEST_NS=%s", ns.Name)}
+	depName := fmt.Sprintf("skaffold-helm-%s", ns.Name)
+	fmt.Println(env)
+	defer func() {
+		skaffold.Delete().InDir(helmDir).InNs(ns.Name).WithEnv(env).RunOrFail(t)
+		deleteNs()
+	}()
+
+	skaffold.Deploy("--images", "gcr.io/k8s-skaffold/skaffold-helm").InDir(helmDir).InNs(ns.Name).WithEnv(env).RunOrFailOutput(t)
+
+	client.WaitForDeploymentsToStabilize(depName)
+
+	expectedLabels := map[string]string{
+		"app.kubernetes.io/managed-by": TestVersion,
+		"release":                      depName,
+		"skaffold.dev/deployer":        "helm",
+	}
+
+	// check if labels are set correctly for deploument
+	dep := client.GetDeployment(depName)
+	if d := diffLabels(expectedLabels, dep.ObjectMeta.Labels); d != "" {
+		t.Errorf("did not find expected labels for dep %s: %s", depName, d)
+	}
+}
+
+func diffLabels(expected map[string]string, actual map[string]string) string {
+	extracted := map[string]string{}
+	for k, v := range actual {
+		switch k {
+		case "app.kubernetes.io/managed-by":
+			extracted[k] = TestVersion // ignore version since its runtime
+		case "release":
+			extracted[k] = v
+		case "skaffold.dev/deployer":
+			extracted[k] = v
+		default:
+			continue
+		}
+	}
+	return cmp.Diff(extracted, expected)
+}

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -94,11 +94,6 @@ func TestRun(t *testing.T) {
 			dir:         "testdata/kaniko-microservices",
 			deployments: []string{"leeroy-app", "leeroy-web"},
 			remoteOnly:  true,
-			// }, {
-			// 	description: "helm",
-			// 	dir:         "examples/helm-deployment",
-			// 	deployments: []string{"skaffold-helm"},
-			// 	remoteOnly:  true,
 		}, {
 			description: "jib in googlecloudbuild",
 			dir:         "testdata/jib",


### PR DESCRIPTION
Fixes #1823 Bring helm integration test back by adding namespace to release name