### PR TITLE
 Check for env variables for root cmd persistent flags

### DIFF
--- a/cmd/skaffold/man/man.go
+++ b/cmd/skaffold/man/man.go
@@ -34,8 +34,7 @@ func main() {
 
 func printMan(stdout, stderr io.Writer) error {
 	command := cmd.NewSkaffoldCommand(stdout, stderr)
-
-	return printSubCommands(stdout, command)
+	return printCommand(stdout, command)
 }
 
 func printSubCommands(out io.Writer, command *cobra.Command) error {

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -54,6 +54,42 @@ To edit this file above edit index_header - the rest of the file is autogenerate
 ******
 -->
 
+### skaffold
+
+A tool that facilitates continuous development for Kubernetes applications.
+
+```
+Usage:
+  skaffold [command]
+
+Available Commands:
+  build       Builds the artifacts
+  completion  Output shell completion for the given shell (bash or zsh)
+  config      A set of commands for interacting with the Skaffold config.
+  debug       Runs a pipeline file in debug mode
+  delete      Delete the deployed resources
+  deploy      Deploys the artifacts
+  dev         Runs a pipeline file in development mode
+  diagnose    Run a diagnostic on Skaffold
+  fix         Converts old Skaffold config to newest schema version
+  init        Automatically generate Skaffold configuration for deploying an application
+  run         Runs a pipeline file
+  version     Print the version information
+
+Flags:
+      --color int          Specify the default output color in ANSI escape codes (default 34)
+  -v, --verbosity string   Log level (debug, info, warn, error, fatal, panic) (default "warning")
+
+Use "skaffold [command] --help" for more information about a command.
+
+
+```
+Env vars:
+
+* `SKAFFOLD_COLOR` (same as `--color`)
+* `SKAFFOLD_FORCE_COLORS` (same as `--force-colors`)
+* `SKAFFOLD_VERBOSITY` (same as `--verbosity`)
+
 ### skaffold build
 
 Builds the artifacts


### PR DESCRIPTION
We were checking for environment variables for subcommands of
`skaffold`, but not the global flags that directly apply to the `skaffold`
root cmd.

This should allow us to also specify `SKAFFOLD_FORCE_COLORS` as an env
variable, fixing #2139.

I wasn't sure how to unit test this without changing the environment
variable locally, and I didn't want to risk messing up anyone's
configuration. However, I tested locally and the env variable seems to
be working now.

