### PR TITLE
Preventing Kaniko log loss

### DIFF
--- a/pkg/skaffold/build/cluster/sources/sources.go
+++ b/pkg/skaffold/build/cluster/sources/sources.go
@@ -77,6 +77,12 @@ func podTemplate(clusterDetails *latest.ClusterDetails, artifact *latest.KanikoA
 					},
 					Resources: resourceRequirements(clusterDetails.Resources),
 				},
+				{
+                    Name:            "logger-container",
+                    Image:           constants.DefaultBusyboxImage,
+                    ImagePullPolicy: v1.PullIfNotPresent,
+                    Command: []string{"sh", "-c", "while [[ $(ps -ef | grep kaniko | wc -l) -gt 1 ]] ; do   sleep 1; done; sleep " + clusterDetails.PodGracePeriodSeconds},
+                },
 			},
 			RestartPolicy: v1.RestartPolicyNever,
 			Volumes: []v1.Volume{{

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -51,6 +51,7 @@ const (
 	DefaultKanikoCacheDirMountPath      = "/cache"
 	DefaultKanikoDockerConfigSecretName = "docker-cfg"
 	DefaultKanikoDockerConfigPath       = "/kaniko/.docker"
+	DefaultKanikoPodGracePeriodSeconds  = "2"
 
 	DefaultBusyboxImage = "busybox"
 

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -250,7 +250,7 @@ func setDefaultKanikoArtifactImage(artifact *latest.Artifact) {
 }
 
 func setDefaultKanikoPodGracePeriod(cluster *latest.ClusterDetails) error{
-	artifact.KanikoArtifact.PodGracePeriodSeconds = valueOrDefault(kanikoArtifact.PodGracePeriodSeconds, constants.DefaultKanikoPodGracePeriodSeconds)
+	cluster.PodGracePeriodSeconds = valueOrDefault(cluster.PodGracePeriodSeconds, constants.DefaultKanikoPodGracePeriodSeconds)
 	return nil
 }
 func valueOrDefault(v, def string) string {

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -56,6 +56,7 @@ func Set(c *latest.SkaffoldConfig) error {
 		setDefaultClusterTimeout,
 		setDefaultClusterPullSecret,
 		setDefaultClusterDockerConfigSecret,
+		setDefaultKanikoPodGracePeriod,
 	); err != nil {
 		return err
 	}
@@ -248,6 +249,10 @@ func setDefaultKanikoArtifactImage(artifact *latest.Artifact) {
 	artifact.KanikoArtifact.Image = valueOrDefault(kanikoArtifact.Image, constants.DefaultKanikoImage)
 }
 
+func setDefaultKanikoPodGracePeriod(cluster *latest.ClusterDetails) error{
+	artifact.KanikoArtifact.PodGracePeriodSeconds = valueOrDefault(kanikoArtifact.PodGracePeriodSeconds, constants.DefaultKanikoPodGracePeriodSeconds)
+	return nil
+}
 func valueOrDefault(v, def string) string {
 	if v != "" {
 		return v

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -275,6 +275,9 @@ type ClusterDetails struct {
 
 	// Resources define the resource requirements for the kaniko pod.
 	Resources *ResourceRequirements `yaml:"resources,omitempty"`
+
+	// Wait period for kaniko pod after it finishes of building and pushing the image
+	PodGracePeriodSeconds string `yaml:podGracePeriodSeconds, omitempty"`
 }
 
 // DockerConfig contains information about the docker `config.json` to mount.


### PR DESCRIPTION
Adding PodGracePeriodSecond for kaniko pod, to ensure all the logs are stream before it dies.