### PR TITLE
Add smoke test for `skaffold diagnose`

### DIFF
--- a/integration/diagnose_test.go
+++ b/integration/diagnose_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
+)
+
+func TestDiagnose(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tests := []struct {
+		name string
+		dir  string
+		args []string
+	}{
+		{name: "kaniko builder", dir: "examples/kaniko"},
+		{name: "docker builder", dir: "examples/nodejs"},
+		{name: "jib maven builder", dir: "examples/jib-multimodule"},
+		{name: "bazel builder", dir: "examples/bazel"},
+		// todo add test cases for "jib gradle builder" and "custom builder"
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			skaffold.Diagnose(test.args...).InDir(test.dir).RunOrFailOutput(t)
+		})
+	}
+}

--- a/integration/skaffold/helper.go
+++ b/integration/skaffold/helper.go
@@ -86,6 +86,11 @@ func Init(args ...string) *RunBuilder {
 	return &RunBuilder{command: "init", args: args}
 }
 
+// Diagnose runs `skaffold diagnose` with the given arguments.
+func Diagnose(args ...string) *RunBuilder {
+	return &RunBuilder{command: "diagnose", args: args}
+}
+
 // InDir sets the directory in which skaffold is running.
 func (b *RunBuilder) InDir(dir string) *RunBuilder {
 	b.dir = dir


### PR DESCRIPTION
The `skaffold diagnose` command has bad test coverage (both integration and unit tests). There are reasons why it may not make sense to have full unit test coverage there. However, basic test coverage should be there to check whether the subcommand runs at all.

This PR adds basic smoke tests which check if `skaffold diagnose` runs successfully. It covers all artifact types that have an example.