### PR TITLE
Improve cmd creation

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"time"
 
-	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/commands"
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
@@ -46,8 +45,7 @@ var (
 // NewCmdBuild describes the CLI command to build artifacts.
 func NewCmdBuild(out io.Writer) *cobra.Command {
 	cmdUse := "build"
-	return commands.
-		New(out, cmdUse).
+	return NewCmd(out, cmdUse).
 		WithDescription("Builds the artifacts").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.StringSliceVarP(&opts.TargetImages, "build-image", "b", nil, "Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts")

--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -44,14 +44,13 @@ var (
 
 // NewCmdBuild describes the CLI command to build artifacts.
 func NewCmdBuild(out io.Writer) *cobra.Command {
-	cmdUse := "build"
-	return NewCmd(out, cmdUse).
+	return NewCmd(out, "build").
 		WithDescription("Builds the artifacts").
+		WithCommonFlags().
 		WithFlags(func(f *pflag.FlagSet) {
 			f.StringSliceVarP(&opts.TargetImages, "build-image", "b", nil, "Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts")
 			f.BoolVarP(&quietFlag, "quiet", "q", false, "Suppress the build output and print image built on success. See --output to format output.")
 			f.VarP(buildFormatFlag, "output", "o", "Used in conjuction with --quiet flag. "+buildFormatFlag.Usage())
-			AddFlags(f, cmdUse)
 		}).
 		NoArgs(cancelWithCtrlC(context.Background(), doBuild))
 }

--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -47,8 +47,8 @@ var (
 func NewCmdBuild(out io.Writer) *cobra.Command {
 	cmdUse := "build"
 	return commands.
-		New(out).
-		WithDescription(cmdUse, "Builds the artifacts").
+		New(out, cmdUse).
+		WithDescription("Builds the artifacts").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.StringSliceVarP(&opts.TargetImages, "build-image", "b", nil, "Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts")
 			f.BoolVarP(&quietFlag, "quiet", "q", false, "Suppress the build output and print image built on success. See --output to format output.")

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -86,7 +86,6 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 		}
 	}
 
-	SetUpFlags()
 	rootCmd.SetOutput(out)
 	rootCmd.AddCommand(NewCmdCompletion(out))
 	rootCmd.AddCommand(NewCmdVersion(out))

--- a/cmd/skaffold/app/cmd/commands.go
+++ b/cmd/skaffold/app/cmd/commands.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package commands
+package cmd
 
 import (
 	"io"
@@ -36,7 +36,7 @@ type cmdBuilder struct {
 	cmd cobra.Command
 }
 
-func New(out io.Writer, use string) CmdBuilder {
+func NewCmd(out io.Writer, use string) CmdBuilder {
 	return &cmdBuilder{
 		out: out,
 		cmd: cobra.Command{

--- a/cmd/skaffold/app/cmd/commands.go
+++ b/cmd/skaffold/app/cmd/commands.go
@@ -26,6 +26,7 @@ import (
 type CmdBuilder interface {
 	WithDescription(description string) CmdBuilder
 	WithLongDescription(long string) CmdBuilder
+	WithCommonFlags() CmdBuilder
 	WithFlags(adder func(*pflag.FlagSet)) CmdBuilder
 	ExactArgs(argCount int, action func(io.Writer, []string) error) *cobra.Command
 	NoArgs(action func(io.Writer) error) *cobra.Command
@@ -52,6 +53,11 @@ func (c *cmdBuilder) WithDescription(description string) CmdBuilder {
 
 func (c *cmdBuilder) WithLongDescription(long string) CmdBuilder {
 	c.cmd.Long = long
+	return c
+}
+
+func (c *cmdBuilder) WithCommonFlags() CmdBuilder {
+	AddFlags(c.cmd.Flags(), c.cmd.Use)
 	return c
 }
 

--- a/cmd/skaffold/app/cmd/commands.go
+++ b/cmd/skaffold/app/cmd/commands.go
@@ -23,22 +23,22 @@ import (
 	"github.com/spf13/pflag"
 )
 
-type CmdBuilder interface {
-	WithDescription(description string) CmdBuilder
-	WithLongDescription(long string) CmdBuilder
-	WithCommonFlags() CmdBuilder
-	WithFlags(adder func(*pflag.FlagSet)) CmdBuilder
+type Builder interface {
+	WithDescription(description string) Builder
+	WithLongDescription(long string) Builder
+	WithCommonFlags() Builder
+	WithFlags(adder func(*pflag.FlagSet)) Builder
 	ExactArgs(argCount int, action func(io.Writer, []string) error) *cobra.Command
 	NoArgs(action func(io.Writer) error) *cobra.Command
 }
 
-type cmdBuilder struct {
+type builder struct {
 	out io.Writer
 	cmd cobra.Command
 }
 
-func NewCmd(out io.Writer, use string) CmdBuilder {
-	return &cmdBuilder{
+func NewCmd(out io.Writer, use string) Builder {
+	return &builder{
 		out: out,
 		cmd: cobra.Command{
 			Use: use,
@@ -46,27 +46,27 @@ func NewCmd(out io.Writer, use string) CmdBuilder {
 	}
 }
 
-func (c *cmdBuilder) WithDescription(description string) CmdBuilder {
+func (c *builder) WithDescription(description string) Builder {
 	c.cmd.Short = description
 	return c
 }
 
-func (c *cmdBuilder) WithLongDescription(long string) CmdBuilder {
+func (c *builder) WithLongDescription(long string) Builder {
 	c.cmd.Long = long
 	return c
 }
 
-func (c *cmdBuilder) WithCommonFlags() CmdBuilder {
+func (c *builder) WithCommonFlags() Builder {
 	AddFlags(c.cmd.Flags(), c.cmd.Use)
 	return c
 }
 
-func (c *cmdBuilder) WithFlags(adder func(*pflag.FlagSet)) CmdBuilder {
+func (c *builder) WithFlags(adder func(*pflag.FlagSet)) Builder {
 	adder(c.cmd.Flags())
 	return c
 }
 
-func (c *cmdBuilder) ExactArgs(argCount int, action func(io.Writer, []string) error) *cobra.Command {
+func (c *builder) ExactArgs(argCount int, action func(io.Writer, []string) error) *cobra.Command {
 	c.cmd.Args = cobra.ExactArgs(argCount)
 	c.cmd.RunE = func(cmd *cobra.Command, args []string) error {
 		return action(c.out, args)
@@ -74,7 +74,7 @@ func (c *cmdBuilder) ExactArgs(argCount int, action func(io.Writer, []string) er
 	return &c.cmd
 }
 
-func (c *cmdBuilder) NoArgs(action func(io.Writer) error) *cobra.Command {
+func (c *builder) NoArgs(action func(io.Writer) error) *cobra.Command {
 	c.cmd.Args = cobra.NoArgs
 	c.cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		return action(c.out)

--- a/cmd/skaffold/app/cmd/commands/commands.go
+++ b/cmd/skaffold/app/cmd/commands/commands.go
@@ -24,8 +24,8 @@ import (
 )
 
 type CmdBuilder interface {
-	WithDescription(use, description string) CmdBuilder
-	WithLongDescription(use, description, long string) CmdBuilder
+	WithDescription(description string) CmdBuilder
+	WithLongDescription(long string) CmdBuilder
 	WithFlags(adder func(*pflag.FlagSet)) CmdBuilder
 	ExactArgs(argCount int, action func(io.Writer, []string) error) *cobra.Command
 	NoArgs(action func(io.Writer) error) *cobra.Command
@@ -36,22 +36,23 @@ type cmdBuilder struct {
 	cmd cobra.Command
 }
 
-func New(out io.Writer) CmdBuilder {
+func New(out io.Writer, use string) CmdBuilder {
 	return &cmdBuilder{
 		out: out,
-		cmd: cobra.Command{},
+		cmd: cobra.Command{
+			Use: use,
+		},
 	}
 }
 
-func (c *cmdBuilder) WithDescription(use, description string) CmdBuilder {
-	c.cmd.Use = use
+func (c *cmdBuilder) WithDescription(description string) CmdBuilder {
 	c.cmd.Short = description
 	return c
 }
 
-func (c *cmdBuilder) WithLongDescription(use, description, long string) CmdBuilder {
+func (c *cmdBuilder) WithLongDescription(long string) CmdBuilder {
 	c.cmd.Long = long
-	return c.WithDescription(use, description)
+	return c
 }
 
 func (c *cmdBuilder) WithFlags(adder func(*pflag.FlagSet)) CmdBuilder {

--- a/cmd/skaffold/app/cmd/commands/commands_test.go
+++ b/cmd/skaffold/app/cmd/commands/commands_test.go
@@ -27,29 +27,28 @@ import (
 )
 
 func TestNewCommandDescription(t *testing.T) {
-	cmd := New(nil).WithDescription("help", "prints help").NoArgs(nil)
+	cmd := New(nil, "help").WithDescription("prints help").NoArgs(nil)
 
 	testutil.CheckDeepEqual(t, "help", cmd.Use)
 	testutil.CheckDeepEqual(t, "prints help", cmd.Short)
 }
 
 func TestNewCommandLongDescription(t *testing.T) {
-	cmd := New(nil).WithLongDescription("help", "prints help", "long description").NoArgs(nil)
+	cmd := New(nil, "help").WithLongDescription("long description").NoArgs(nil)
 
 	testutil.CheckDeepEqual(t, "help", cmd.Use)
-	testutil.CheckDeepEqual(t, "prints help", cmd.Short)
 	testutil.CheckDeepEqual(t, "long description", cmd.Long)
 }
 
 func TestNewCommandNoArgs(t *testing.T) {
-	cmd := New(nil).NoArgs(nil)
+	cmd := New(nil, "").NoArgs(nil)
 
 	testutil.CheckError(t, false, cmd.Args(cmd, []string{}))
 	testutil.CheckError(t, true, cmd.Args(cmd, []string{"extract arg"}))
 }
 
 func TestNewCommandExactArgs(t *testing.T) {
-	cmd := New(nil).ExactArgs(1, nil)
+	cmd := New(nil, "").ExactArgs(1, nil)
 
 	testutil.CheckError(t, true, cmd.Args(cmd, []string{}))
 	testutil.CheckError(t, false, cmd.Args(cmd, []string{"valid"}))
@@ -57,7 +56,7 @@ func TestNewCommandExactArgs(t *testing.T) {
 }
 
 func TestNewCommandError(t *testing.T) {
-	cmd := New(nil).NoArgs(func(out io.Writer) error {
+	cmd := New(nil, "").NoArgs(func(out io.Writer) error {
 		return errors.New("expected error")
 	})
 
@@ -69,7 +68,7 @@ func TestNewCommandError(t *testing.T) {
 func TestNewCommandOutput(t *testing.T) {
 	var buf bytes.Buffer
 
-	cmd := New(&buf).ExactArgs(1, func(out io.Writer, args []string) error {
+	cmd := New(&buf, "").ExactArgs(1, func(out io.Writer, args []string) error {
 		fmt.Fprintf(out, "test output: %v\n", args)
 		return nil
 	})

--- a/cmd/skaffold/app/cmd/commands_test.go
+++ b/cmd/skaffold/app/cmd/commands_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package commands
+package cmd
 
 import (
 	"bytes"
@@ -27,28 +27,28 @@ import (
 )
 
 func TestNewCommandDescription(t *testing.T) {
-	cmd := New(nil, "help").WithDescription("prints help").NoArgs(nil)
+	cmd := NewCmd(nil, "help").WithDescription("prints help").NoArgs(nil)
 
 	testutil.CheckDeepEqual(t, "help", cmd.Use)
 	testutil.CheckDeepEqual(t, "prints help", cmd.Short)
 }
 
 func TestNewCommandLongDescription(t *testing.T) {
-	cmd := New(nil, "help").WithLongDescription("long description").NoArgs(nil)
+	cmd := NewCmd(nil, "help").WithLongDescription("long description").NoArgs(nil)
 
 	testutil.CheckDeepEqual(t, "help", cmd.Use)
 	testutil.CheckDeepEqual(t, "long description", cmd.Long)
 }
 
 func TestNewCommandNoArgs(t *testing.T) {
-	cmd := New(nil, "").NoArgs(nil)
+	cmd := NewCmd(nil, "").NoArgs(nil)
 
 	testutil.CheckError(t, false, cmd.Args(cmd, []string{}))
 	testutil.CheckError(t, true, cmd.Args(cmd, []string{"extract arg"}))
 }
 
 func TestNewCommandExactArgs(t *testing.T) {
-	cmd := New(nil, "").ExactArgs(1, nil)
+	cmd := NewCmd(nil, "").ExactArgs(1, nil)
 
 	testutil.CheckError(t, true, cmd.Args(cmd, []string{}))
 	testutil.CheckError(t, false, cmd.Args(cmd, []string{"valid"}))
@@ -56,7 +56,7 @@ func TestNewCommandExactArgs(t *testing.T) {
 }
 
 func TestNewCommandError(t *testing.T) {
-	cmd := New(nil, "").NoArgs(func(out io.Writer) error {
+	cmd := NewCmd(nil, "").NoArgs(func(out io.Writer) error {
 		return errors.New("expected error")
 	})
 
@@ -68,7 +68,7 @@ func TestNewCommandError(t *testing.T) {
 func TestNewCommandOutput(t *testing.T) {
 	var buf bytes.Buffer
 
-	cmd := New(&buf, "").ExactArgs(1, func(out io.Writer, args []string) error {
+	cmd := NewCmd(&buf, "").ExactArgs(1, func(out io.Writer, args []string) error {
 		fmt.Fprintf(out, "test output: %v\n", args)
 		return nil
 	})

--- a/cmd/skaffold/app/cmd/config.go
+++ b/cmd/skaffold/app/cmd/config.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func NewCmdConfig(out io.Writer) *cobra.Command {
@@ -29,8 +30,38 @@ func NewCmdConfig(out io.Writer) *cobra.Command {
 		Short: "A set of commands for interacting with the Skaffold config.",
 	}
 
-	cmd.AddCommand(config.NewCmdSet(out))
-	cmd.AddCommand(config.NewCmdUnset(out))
-	cmd.AddCommand(config.NewCmdList(out))
+	cmd.AddCommand(NewCmdSet(out))
+	cmd.AddCommand(NewCmdUnset(out))
+	cmd.AddCommand(NewCmdList(out))
 	return cmd
+}
+
+func NewCmdSet(out io.Writer) *cobra.Command {
+	return NewCmd(out, "set").
+		WithDescription("Set a value in the global Skaffold config").
+		WithFlags(func(f *pflag.FlagSet) {
+			config.AddCommonFlags(f)
+			config.AddSetUnsetFlags(f)
+		}).
+		ExactArgs(2, config.Set)
+}
+
+func NewCmdUnset(out io.Writer) *cobra.Command {
+	return NewCmd(out, "unset").
+		WithDescription("Unset a value in the global Skaffold config").
+		WithFlags(func(f *pflag.FlagSet) {
+			config.AddCommonFlags(f)
+			config.AddSetUnsetFlags(f)
+		}).
+		ExactArgs(1, config.Unset)
+}
+
+func NewCmdList(out io.Writer) *cobra.Command {
+	return NewCmd(out, "list").
+		WithDescription("List all values set in the global Skaffold config").
+		WithFlags(func(f *pflag.FlagSet) {
+			config.AddCommonFlags(f)
+			config.AddListFlags(f)
+		}).
+		NoArgs(config.List)
 }

--- a/cmd/skaffold/app/cmd/config/flags.go
+++ b/cmd/skaffold/app/cmd/config/flags.go
@@ -18,14 +18,20 @@ package config
 
 import "github.com/spf13/pflag"
 
-var configFile, kubecontext string
-var showAll, global bool
+var (
+	configFile, kubecontext string
+	showAll, global         bool
+)
 
-func AddConfigFlags(f *pflag.FlagSet) {
+func AddCommonFlags(f *pflag.FlagSet) {
 	f.StringVarP(&configFile, "config", "c", "", "Path to Skaffold config")
 	f.StringVarP(&kubecontext, "kube-context", "k", "", "Kubectl context to set values against")
 }
 
-func AddSetFlags(f *pflag.FlagSet) {
+func AddListFlags(f *pflag.FlagSet) {
+	f.BoolVarP(&showAll, "all", "a", false, "Show values for all kubecontexts")
+}
+
+func AddSetUnsetFlags(f *pflag.FlagSet) {
 	f.BoolVarP(&global, "global", "g", false, "Set value for global config")
 }

--- a/cmd/skaffold/app/cmd/config/list.go
+++ b/cmd/skaffold/app/cmd/config/list.go
@@ -20,25 +20,11 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/commands"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	yaml "gopkg.in/yaml.v2"
 )
 
-func NewCmdList(out io.Writer) *cobra.Command {
-	return commands.
-		New(out, "list").
-		WithDescription("List all values set in the global Skaffold config").
-		WithFlags(func(f *pflag.FlagSet) {
-			f.BoolVarP(&showAll, "all", "a", false, "Show values for all kubecontexts")
-			AddConfigFlags(f)
-		}).
-		NoArgs(doList)
-}
-
-func doList(out io.Writer) error {
+func List(out io.Writer) error {
 	var configYaml []byte
 	if showAll {
 		cfg, err := readConfig()

--- a/cmd/skaffold/app/cmd/config/list.go
+++ b/cmd/skaffold/app/cmd/config/list.go
@@ -29,8 +29,8 @@ import (
 
 func NewCmdList(out io.Writer) *cobra.Command {
 	return commands.
-		New(out).
-		WithDescription("list", "List all values set in the global Skaffold config").
+		New(out, "list").
+		WithDescription("List all values set in the global Skaffold config").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.BoolVarP(&showAll, "all", "a", false, "Show values for all kubecontexts")
 			AddConfigFlags(f)

--- a/cmd/skaffold/app/cmd/config/set.go
+++ b/cmd/skaffold/app/cmd/config/set.go
@@ -33,8 +33,8 @@ import (
 
 func NewCmdSet(out io.Writer) *cobra.Command {
 	return commands.
-		New(out).
-		WithDescription("set", "Set a value in the global Skaffold config").
+		New(out, "set").
+		WithDescription("Set a value in the global Skaffold config").
 		WithFlags(func(f *pflag.FlagSet) {
 			AddConfigFlags(f)
 			AddSetFlags(f)

--- a/cmd/skaffold/app/cmd/config/set.go
+++ b/cmd/skaffold/app/cmd/config/set.go
@@ -24,25 +24,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/commands"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	yaml "gopkg.in/yaml.v2"
 )
 
-func NewCmdSet(out io.Writer) *cobra.Command {
-	return commands.
-		New(out, "set").
-		WithDescription("Set a value in the global Skaffold config").
-		WithFlags(func(f *pflag.FlagSet) {
-			AddConfigFlags(f)
-			AddSetFlags(f)
-		}).
-		ExactArgs(2, doSet)
-}
-
-func doSet(out io.Writer, args []string) error {
+func Set(out io.Writer, args []string) error {
 	if err := setConfigValue(args[0], args[1]); err != nil {
 		return err
 	}

--- a/cmd/skaffold/app/cmd/config/unset.go
+++ b/cmd/skaffold/app/cmd/config/unset.go
@@ -19,24 +19,9 @@ package config
 import (
 	"fmt"
 	"io"
-
-	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/commands"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
-func NewCmdUnset(out io.Writer) *cobra.Command {
-	return commands.
-		New(out, "unset").
-		WithDescription("Unset a value in the global Skaffold config").
-		WithFlags(func(f *pflag.FlagSet) {
-			AddConfigFlags(f)
-			AddSetFlags(f)
-		}).
-		ExactArgs(1, doUnset)
-}
-
-func doUnset(out io.Writer, args []string) error {
+func Unset(out io.Writer, args []string) error {
 	resolveKubectlContext()
 	if err := unsetConfigValue(args[0]); err != nil {
 		return err

--- a/cmd/skaffold/app/cmd/config/unset.go
+++ b/cmd/skaffold/app/cmd/config/unset.go
@@ -27,8 +27,8 @@ import (
 
 func NewCmdUnset(out io.Writer) *cobra.Command {
 	return commands.
-		New(out).
-		WithDescription("unset", "Unset a value in the global Skaffold config").
+		New(out, "unset").
+		WithDescription("Unset a value in the global Skaffold config").
 		WithFlags(func(f *pflag.FlagSet) {
 			AddConfigFlags(f)
 			AddSetFlags(f)

--- a/cmd/skaffold/app/cmd/debug.go
+++ b/cmd/skaffold/app/cmd/debug.go
@@ -31,8 +31,9 @@ import (
 func NewCmdDebug(out io.Writer) *cobra.Command {
 	cmdUse := "debug"
 	return commands.
-		New(out).
-		WithLongDescription(cmdUse, "Runs a pipeline file in debug mode", "Similar to `dev`, but configures the pipeline for debugging.").
+		New(out, cmdUse).
+		WithDescription("Runs a pipeline file in debug mode").
+		WithLongDescription("Similar to `dev`, but configures the pipeline for debugging.").
 		WithFlags(func(f *pflag.FlagSet) {
 			AddFlags(f, cmdUse)
 		}).

--- a/cmd/skaffold/app/cmd/debug.go
+++ b/cmd/skaffold/app/cmd/debug.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/commands"
 	debugging "github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/spf13/cobra"
@@ -30,8 +29,7 @@ import (
 // NewCmdDebug describes the CLI command to run a pipeline in debug mode.
 func NewCmdDebug(out io.Writer) *cobra.Command {
 	cmdUse := "debug"
-	return commands.
-		New(out, cmdUse).
+	return NewCmd(out, cmdUse).
 		WithDescription("Runs a pipeline file in debug mode").
 		WithLongDescription("Similar to `dev`, but configures the pipeline for debugging.").
 		WithFlags(func(f *pflag.FlagSet) {

--- a/cmd/skaffold/app/cmd/debug.go
+++ b/cmd/skaffold/app/cmd/debug.go
@@ -23,18 +23,14 @@ import (
 	debugging "github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 // NewCmdDebug describes the CLI command to run a pipeline in debug mode.
 func NewCmdDebug(out io.Writer) *cobra.Command {
-	cmdUse := "debug"
-	return NewCmd(out, cmdUse).
+	return NewCmd(out, "debug").
 		WithDescription("Runs a pipeline file in debug mode").
 		WithLongDescription("Similar to `dev`, but configures the pipeline for debugging.").
-		WithFlags(func(f *pflag.FlagSet) {
-			AddFlags(f, cmdUse)
-		}).
+		WithCommonFlags().
 		NoArgs(cancelWithCtrlC(context.Background(), doDebug))
 }
 

--- a/cmd/skaffold/app/cmd/delete.go
+++ b/cmd/skaffold/app/cmd/delete.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/commands"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/spf13/cobra"
@@ -30,8 +29,7 @@ import (
 // NewCmdDelete describes the CLI command to delete deployed resources.
 func NewCmdDelete(out io.Writer) *cobra.Command {
 	cmdUse := "delete"
-	return commands.
-		New(out, cmdUse).
+	return NewCmd(out, cmdUse).
 		WithDescription("Delete the deployed resources").
 		WithFlags(func(f *pflag.FlagSet) {
 			AddFlags(f, cmdUse)

--- a/cmd/skaffold/app/cmd/delete.go
+++ b/cmd/skaffold/app/cmd/delete.go
@@ -23,17 +23,13 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 // NewCmdDelete describes the CLI command to delete deployed resources.
 func NewCmdDelete(out io.Writer) *cobra.Command {
-	cmdUse := "delete"
-	return NewCmd(out, cmdUse).
+	return NewCmd(out, "delete").
 		WithDescription("Delete the deployed resources").
-		WithFlags(func(f *pflag.FlagSet) {
-			AddFlags(f, cmdUse)
-		}).
+		WithCommonFlags().
 		NoArgs(cancelWithCtrlC(context.Background(), doDelete))
 }
 

--- a/cmd/skaffold/app/cmd/delete.go
+++ b/cmd/skaffold/app/cmd/delete.go
@@ -31,8 +31,8 @@ import (
 func NewCmdDelete(out io.Writer) *cobra.Command {
 	cmdUse := "delete"
 	return commands.
-		New(out).
-		WithDescription(cmdUse, "Delete the deployed resources").
+		New(out, cmdUse).
+		WithDescription("Delete the deployed resources").
 		WithFlags(func(f *pflag.FlagSet) {
 			AddFlags(f, cmdUse)
 		}).

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -35,14 +35,13 @@ var (
 
 // NewCmdDeploy describes the CLI command to deploy artifacts.
 func NewCmdDeploy(out io.Writer) *cobra.Command {
-	cmdUse := "deploy"
-	return NewCmd(out, cmdUse).
+	return NewCmd(out, "deploy").
 		WithDescription("Deploys the artifacts").
+		WithCommonFlags().
 		WithFlags(func(f *pflag.FlagSet) {
 			f.VarP(&preBuiltImages, "images", "i", "A list of pre-built images to deploy")
 			f.VarP(&buildOutputFile, "build-artifacts", "a", `Filepath containing build output.
 E.g. build.out created by running skaffold build --quiet {{json .}} > build.out`)
-			AddFlags(f, cmdUse)
 		}).
 		NoArgs(cancelWithCtrlC(context.Background(), doDeploy))
 }

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/commands"
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
@@ -37,8 +36,7 @@ var (
 // NewCmdDeploy describes the CLI command to deploy artifacts.
 func NewCmdDeploy(out io.Writer) *cobra.Command {
 	cmdUse := "deploy"
-	return commands.
-		New(out, cmdUse).
+	return NewCmd(out, cmdUse).
 		WithDescription("Deploys the artifacts").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.VarP(&preBuiltImages, "images", "i", "A list of pre-built images to deploy")

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -38,8 +38,8 @@ var (
 func NewCmdDeploy(out io.Writer) *cobra.Command {
 	cmdUse := "deploy"
 	return commands.
-		New(out).
-		WithDescription(cmdUse, "Deploys the artifacts").
+		New(out, cmdUse).
+		WithDescription("Deploys the artifacts").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.VarP(&preBuiltImages, "images", "i", "A list of pre-built images to deploy")
 			f.VarP(&buildOutputFile, "build-artifacts", "a", `Filepath containing build output.

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -32,8 +32,8 @@ import (
 func NewCmdDev(out io.Writer) *cobra.Command {
 	cmdUse := "dev"
 	return commands.
-		New(out).
-		WithDescription(cmdUse, "Runs a pipeline file in development mode").
+		New(out, cmdUse).
+		WithDescription("Runs a pipeline file in development mode").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.StringVar(&opts.Trigger, "trigger", "polling", "How are changes detected? (polling, manual or notify)")
 			f.StringSliceVarP(&opts.TargetImages, "watch-image", "w", nil, "Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts")

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/commands"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -31,8 +30,7 @@ import (
 // NewCmdDev describes the CLI command to run a pipeline in development mode.
 func NewCmdDev(out io.Writer) *cobra.Command {
 	cmdUse := "dev"
-	return commands.
-		New(out, cmdUse).
+	return NewCmd(out, cmdUse).
 		WithDescription("Runs a pipeline file in development mode").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.StringVar(&opts.Trigger, "trigger", "polling", "How are changes detected? (polling, manual or notify)")

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -32,11 +32,11 @@ func NewCmdDev(out io.Writer) *cobra.Command {
 	cmdUse := "dev"
 	return NewCmd(out, cmdUse).
 		WithDescription("Runs a pipeline file in development mode").
+		WithCommonFlags().
 		WithFlags(func(f *pflag.FlagSet) {
 			f.StringVar(&opts.Trigger, "trigger", "polling", "How are changes detected? (polling, manual or notify)")
 			f.StringSliceVarP(&opts.TargetImages, "watch-image", "w", nil, "Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts")
 			f.IntVarP(&opts.WatchPollInterval, "watch-poll-interval", "i", 1000, "Interval (in ms) between two checks for file changes")
-			AddFlags(f, cmdUse)
 		}).
 		NoArgs(cancelWithCtrlC(context.Background(), doDev))
 }

--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/commands"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -34,8 +33,7 @@ import (
 
 // NewCmdDiagnose describes the CLI command to diagnose skaffold.
 func NewCmdDiagnose(out io.Writer) *cobra.Command {
-	return commands.
-		New(out, "diagnose").
+	return NewCmd(out, "diagnose").
 		WithDescription("Run a diagnostic on Skaffold").
 		WithFlags(func(f *pflag.FlagSet) {
 			AddFlags(f, "diagnose")

--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -35,8 +35,8 @@ import (
 // NewCmdDiagnose describes the CLI command to diagnose skaffold.
 func NewCmdDiagnose(out io.Writer) *cobra.Command {
 	return commands.
-		New(out).
-		WithDescription("diagnose", "Run a diagnostic on Skaffold").
+		New(out, "diagnose").
+		WithDescription("Run a diagnostic on Skaffold").
 		WithFlags(func(f *pflag.FlagSet) {
 			AddFlags(f, "diagnose")
 		}).

--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -38,8 +38,7 @@ func NewCmdDiagnose(out io.Writer) *cobra.Command {
 		New(out).
 		WithDescription("diagnose", "Run a diagnostic on Skaffold").
 		WithFlags(func(f *pflag.FlagSet) {
-			f.StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
-			f.StringSliceVarP(&opts.Profiles, "profile", "p", nil, "Activate profiles by name")
+			AddFlags(f, "diagnose")
 		}).
 		NoArgs(doDiagnose)
 }

--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -35,9 +34,7 @@ import (
 func NewCmdDiagnose(out io.Writer) *cobra.Command {
 	return NewCmd(out, "diagnose").
 		WithDescription("Run a diagnostic on Skaffold").
-		WithFlags(func(f *pflag.FlagSet) {
-			AddFlags(f, "diagnose")
-		}).
+		WithCommonFlags().
 		NoArgs(doDiagnose)
 }
 

--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -33,9 +33,9 @@ import (
 func NewCmdFix(out io.Writer) *cobra.Command {
 	return NewCmd(out, "fix").
 		WithDescription("Converts old Skaffold config to newest schema version").
+		WithCommonFlags().
 		WithFlags(func(f *pflag.FlagSet) {
 			f.BoolVar(&overwrite, "overwrite", false, "Overwrite original config with fixed config")
-			AddFlags(f, "fix")
 		}).
 		NoArgs(doFix)
 }

--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -36,8 +36,8 @@ func NewCmdFix(out io.Writer) *cobra.Command {
 		New(out).
 		WithDescription("fix", "Converts old Skaffold config to newest schema version").
 		WithFlags(func(f *pflag.FlagSet) {
-			f.StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
 			f.BoolVar(&overwrite, "overwrite", false, "Overwrite original config with fixed config")
+			AddFlags(f, "fix")
 		}).
 		NoArgs(doFix)
 }

--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/commands"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -32,8 +31,7 @@ import (
 )
 
 func NewCmdFix(out io.Writer) *cobra.Command {
-	return commands.
-		New(out, "fix").
+	return NewCmd(out, "fix").
 		WithDescription("Converts old Skaffold config to newest schema version").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.BoolVar(&overwrite, "overwrite", false, "Overwrite original config with fixed config")

--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -33,8 +33,8 @@ import (
 
 func NewCmdFix(out io.Writer) *cobra.Command {
 	return commands.
-		New(out).
-		WithDescription("fix", "Converts old Skaffold config to newest schema version").
+		New(out, "fix").
+		WithDescription("Converts old Skaffold config to newest schema version").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.BoolVar(&overwrite, "overwrite", false, "Overwrite original config with fixed config")
 			AddFlags(f, "fix")

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -59,7 +59,7 @@ var FlagRegistry = []Flag{
 		Value:         &opts.Profiles,
 		DefValue:      []string{},
 		FlagAddMethod: "StringSliceVar",
-		DefinedOn:     []string{"all"},
+		DefinedOn:     []string{"dev", "build", "run", "debug", "deploy", "delete", "diagnose"},
 	},
 	{
 		Name:          "namespace",
@@ -68,7 +68,7 @@ var FlagRegistry = []Flag{
 		Value:         &opts.Namespace,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",
-		DefinedOn:     []string{"all"},
+		DefinedOn:     []string{"dev", "build", "run", "debug", "deploy", "delete"},
 	},
 	{
 		Name:          "default-repo",
@@ -77,11 +77,11 @@ var FlagRegistry = []Flag{
 		Value:         &opts.DefaultRepo,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",
-		DefinedOn:     []string{"all"},
+		DefinedOn:     []string{"dev", "build", "run", "debug", "deploy", "delete"},
 	},
 	{
 		Name:          "cache-artifacts",
-		Usage:         "Set to true to enable caching of artifacts.",
+		Usage:         "Set to true to enable caching of artifacts",
 		Value:         &opts.CacheArtifacts,
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",

--- a/cmd/skaffold/app/cmd/flags_test.go
+++ b/cmd/skaffold/app/cmd/flags_test.go
@@ -62,6 +62,6 @@ func TestAddFlagsSmoke(t *testing.T) {
 		Use:   "test",
 		Short: "Test commanf for smoke testing",
 	}
-	SetUpFlags()
+
 	AddFlags(testCmd.Flags(), "test")
 }

--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -39,12 +39,12 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 		New(out).
 		WithDescription("init", "Automatically generate Skaffold configuration for deploying an application").
 		WithFlags(func(f *pflag.FlagSet) {
-			f.StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
 			f.BoolVar(&skipBuild, "skip-build", false, "Skip generating build artifacts in Skaffold config")
 			f.BoolVar(&force, "force", false, "Force the generation of the Skaffold config")
 			f.StringVar(&composeFile, "compose-file", "", "Initialize from a docker-compose file")
 			f.StringSliceVarP(&cliArtifacts, "artifact", "a", nil, "'='-delimited dockerfile/image pair to generate build artifact\n(example: --artifact=/web/Dockerfile.web=gcr.io/web-project/image)")
 			f.BoolVar(&analyze, "analyze", false, "Print all discoverable Dockerfiles and images in JSON format to stdout")
+			AddFlags(f, "init")
 		}).
 		NoArgs(doInit)
 }

--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -36,8 +36,8 @@ var (
 // NewCmdInit describes the CLI command to generate a Skaffold configuration.
 func NewCmdInit(out io.Writer) *cobra.Command {
 	return commands.
-		New(out).
-		WithDescription("init", "Automatically generate Skaffold configuration for deploying an application").
+		New(out, "init").
+		WithDescription("Automatically generate Skaffold configuration for deploying an application").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.BoolVar(&skipBuild, "skip-build", false, "Skip generating build artifacts in Skaffold config")
 			f.BoolVar(&force, "force", false, "Force the generation of the Skaffold config")

--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/commands"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -35,8 +34,7 @@ var (
 
 // NewCmdInit describes the CLI command to generate a Skaffold configuration.
 func NewCmdInit(out io.Writer) *cobra.Command {
-	return commands.
-		New(out, "init").
+	return NewCmd(out, "init").
 		WithDescription("Automatically generate Skaffold configuration for deploying an application").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.BoolVar(&skipBuild, "skip-build", false, "Skip generating build artifacts in Skaffold config")

--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -36,13 +36,13 @@ var (
 func NewCmdInit(out io.Writer) *cobra.Command {
 	return NewCmd(out, "init").
 		WithDescription("Automatically generate Skaffold configuration for deploying an application").
+		WithCommonFlags().
 		WithFlags(func(f *pflag.FlagSet) {
 			f.BoolVar(&skipBuild, "skip-build", false, "Skip generating build artifacts in Skaffold config")
 			f.BoolVar(&force, "force", false, "Force the generation of the Skaffold config")
 			f.StringVar(&composeFile, "compose-file", "", "Initialize from a docker-compose file")
 			f.StringSliceVarP(&cliArtifacts, "artifact", "a", nil, "'='-delimited dockerfile/image pair to generate build artifact\n(example: --artifact=/web/Dockerfile.web=gcr.io/web-project/image)")
 			f.BoolVar(&analyze, "analyze", false, "Print all discoverable Dockerfiles and images in JSON format to stdout")
-			AddFlags(f, "init")
 		}).
 		NoArgs(doInit)
 }

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -32,8 +32,8 @@ import (
 func NewCmdRun(out io.Writer) *cobra.Command {
 	cmdUse := "run"
 	return commands.
-		New(out).
-		WithDescription(cmdUse, "Runs a pipeline file").
+		New(out, cmdUse).
+		WithDescription("Runs a pipeline file").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.StringVarP(&opts.CustomTag, "tag", "t", "", "The optional custom tag to use for images which overrides the current Tagger configuration")
 			AddFlags(f, cmdUse)

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/commands"
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -31,8 +30,7 @@ import (
 // NewCmdRun describes the CLI command to run a pipeline.
 func NewCmdRun(out io.Writer) *cobra.Command {
 	cmdUse := "run"
-	return commands.
-		New(out, cmdUse).
+	return NewCmd(out, cmdUse).
 		WithDescription("Runs a pipeline file").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.StringVarP(&opts.CustomTag, "tag", "t", "", "The optional custom tag to use for images which overrides the current Tagger configuration")

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -29,12 +29,11 @@ import (
 
 // NewCmdRun describes the CLI command to run a pipeline.
 func NewCmdRun(out io.Writer) *cobra.Command {
-	cmdUse := "run"
-	return NewCmd(out, cmdUse).
+	return NewCmd(out, "run").
 		WithDescription("Runs a pipeline file").
+		WithCommonFlags().
 		WithFlags(func(f *pflag.FlagSet) {
 			f.StringVarP(&opts.CustomTag, "tag", "t", "", "The optional custom tag to use for images which overrides the current Tagger configuration")
-			AddFlags(f, cmdUse)
 		}).
 		NoArgs(cancelWithCtrlC(context.Background(), doRun))
 }

--- a/cmd/skaffold/app/cmd/version.go
+++ b/cmd/skaffold/app/cmd/version.go
@@ -30,8 +30,8 @@ var versionFlag = flags.NewTemplateFlag("{{.Version}}\n", version.Info{})
 
 func NewCmdVersion(out io.Writer) *cobra.Command {
 	return commands.
-		New(out).
-		WithDescription("version", "Print the version information").
+		New(out, "version").
+		WithDescription("Print the version information").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.VarP(versionFlag, "output", "o", versionFlag.Usage())
 		}).

--- a/cmd/skaffold/app/cmd/version.go
+++ b/cmd/skaffold/app/cmd/version.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/commands"
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 	"github.com/spf13/cobra"
@@ -29,8 +28,7 @@ import (
 var versionFlag = flags.NewTemplateFlag("{{.Version}}\n", version.Info{})
 
 func NewCmdVersion(out io.Writer) *cobra.Command {
-	return commands.
-		New(out, "version").
+	return NewCmd(out, "version").
 		WithDescription("Print the version information").
 		WithFlags(func(f *pflag.FlagSet) {
 			f.VarP(versionFlag, "output", "o", versionFlag.Usage())

--- a/cmd/skaffold/man/man_test.go
+++ b/cmd/skaffold/man/man_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"io/ioutil"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -28,11 +29,23 @@ func TestPrintMan(t *testing.T) {
 	var stderr bytes.Buffer
 
 	err := printMan(&stdout, &stderr)
+	output := stdout.String()
 
+	// Sanity checks
 	testutil.CheckError(t, false, err)
-	testutil.CheckContains(t, "skaffold build", stdout.String())
-	testutil.CheckContains(t, "skaffold run", stdout.String())
-	testutil.CheckContains(t, "skaffold dev", stdout.String())
-	testutil.CheckContains(t, "Env vars", stdout.String())
 	testutil.CheckDeepEqual(t, "", stderr.String())
+	testutil.CheckContains(t, "skaffold build", output)
+	testutil.CheckContains(t, "skaffold run", output)
+	testutil.CheckContains(t, "skaffold dev", output)
+	testutil.CheckContains(t, "Env vars", output)
+
+	// Compare to current man page
+	header, err := ioutil.ReadFile("../../../docs/content/en/docs/references/cli/index_header")
+	testutil.CheckError(t, false, err)
+
+	expected, err := ioutil.ReadFile("../../../docs/content/en/docs/references/cli/_index.md")
+	testutil.CheckError(t, false, err)
+	if string(expected) != string(header)+output {
+		t.Error("You have skaffold command changes but haven't generated the CLI reference docs. Please run ./hack/generate-man.sh and commit the results!")
+	}
 }

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -100,7 +100,7 @@ Usage:
 
 Flags:
   -b, --build-image strings          Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts
-      --cache-artifacts              Set to true to enable caching of artifacts.
+      --cache-artifacts              Set to true to enable caching of artifacts
       --cache-file string            Specify the location of the cache file (default $HOME/.skaffold/cache)
   -d, --default-repo string          Default repository value (overrides global config)
       --enable-rpc skaffold dev      Enable gRPC for exposing Skaffold events (true by default for skaffold dev)
@@ -260,7 +260,7 @@ Usage:
   skaffold debug
 
 Flags:
-      --cache-artifacts             Set to true to enable caching of artifacts.
+      --cache-artifacts             Set to true to enable caching of artifacts
       --cache-file string           Specify the location of the cache file (default $HOME/.skaffold/cache)
       --cleanup                     Delete deployments after dev or debug mode is interrupted (default true)
   -d, --default-repo string         Default repository value (overrides global config)
@@ -390,7 +390,7 @@ Usage:
   skaffold dev
 
 Flags:
-      --cache-artifacts             Set to true to enable caching of artifacts.
+      --cache-artifacts             Set to true to enable caching of artifacts
       --cache-file string           Specify the location of the cache file (default $HOME/.skaffold/cache)
       --cleanup                     Delete deployments after dev or debug mode is interrupted (default true)
   -d, --default-repo string         Default repository value (overrides global config)
@@ -531,7 +531,7 @@ Usage:
   skaffold run
 
 Flags:
-      --cache-artifacts             Set to true to enable caching of artifacts.
+      --cache-artifacts             Set to true to enable caching of artifacts
       --cache-file string           Specify the location of the cache file (default $HOME/.skaffold/cache)
       --cleanup                     Delete deployments after dev or debug mode is interrupted (default true)
   -d, --default-repo string         Default repository value (overrides global config)

--- a/hack/generate-man.sh
+++ b/hack/generate-man.sh
@@ -14,9 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-readonly DOCS_CHANGES=`git diff --name-status master | grep "docs/" | wc -l`
-
-if [ $DOCS_CHANGES -gt 0 ]; then
-  echo "There are $DOCS_CHANGES changes in docs, testing site generation..."
-  make build-docs-preview
-fi
+cat \
+  docs/content/en/docs/references/cli/index_header \
+  <(go run cmd/skaffold/man/man.go) \
+  > docs/content/en/docs/references/cli/_index.md


### PR DESCRIPTION
 + Make sure a command name is always passed to the Builder
 + Remove a few duplicate flags
 + Make it easier to add common flags
