### PR TITLE
Fix error in flag refactoring for `skaffold run --tail`

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -148,7 +148,7 @@ var FlagRegistry = []Flag{
 	// when registering the flag twice.
 	{
 		Name:          "tail",
-		Usage:         "Stream logs from deployed objects. (default false)",
+		Usage:         "Stream logs from deployed objects (default false)",
 		Value:         &opts.Tail,
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -152,7 +152,7 @@ var FlagRegistry = []Flag{
 		Value:         &opts.Tail,
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",
-		DefinedOn:     []string{"deploy"},
+		DefinedOn:     []string{"deploy", "run"},
 	},
 	{
 		Name:          "tail",
@@ -160,7 +160,7 @@ var FlagRegistry = []Flag{
 		Value:         &opts.TailDev,
 		DefValue:      true,
 		FlagAddMethod: "BoolVar",
-		DefinedOn:     []string{"dev", "run", "debug"},
+		DefinedOn:     []string{"dev", "debug"},
 	},
 	// We need opts.Force and opts.ForceDev since cobra, overwrites the default value
 	// when registering the flag twice.

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -356,7 +356,7 @@ Flags:
   -p, --profile strings                              Activate profiles by name
       --rpc-http-port int                            tcp port to expose event REST API over HTTP (default 50052)
       --rpc-port int                                 tcp port to expose event API (default 50051)
-      --tail                                         Stream logs from deployed objects. (default false)
+      --tail                                         Stream logs from deployed objects (default false)
       --toot                                         Emit a terminal beep after the deploy is complete
 
 Global Flags:
@@ -548,7 +548,7 @@ Flags:
       --rpc-port int                tcp port to expose event API (default 50051)
       --skip-tests                  Whether to skip the tests after building
   -t, --tag string                  The optional custom tag to use for images which overrides the current Tagger configuration
-      --tail                        Stream logs from deployed objects (default true)
+      --tail                        Stream logs from deployed objects (default false)
       --toot                        Emit a terminal beep after the deploy is complete
 
 Global Flags:


### PR DESCRIPTION
pkg/skaffold/runner/run.go:27 clearly checks for `opts.Tail`, but the log-tailing for `skaffold run` used `opts.TailDev`.

Fix #2167 