### PR TITLE
Print logs from init containers

### DIFF
--- a/pkg/skaffold/kubernetes/log.go
+++ b/pkg/skaffold/kubernetes/log.go
@@ -104,7 +104,7 @@ func (a *LogAggregator) Start(ctx context.Context) error {
 					continue
 				}
 
-				for _, container := range pod.Status.ContainerStatuses {
+				for _, container := range append(pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses...) {
 					if container.ContainerID == "" {
 						if container.State.Waiting != nil && container.State.Waiting.Message != "" {
 							color.Red.Fprintln(a.output, container.State.Waiting.Message)

--- a/pkg/skaffold/kubernetes/log.go
+++ b/pkg/skaffold/kubernetes/log.go
@@ -112,6 +112,11 @@ func (a *LogAggregator) Start(ctx context.Context) error {
 						continue
 					}
 
+					if container.State.Terminated != nil {
+						color.Purple.Fprintln(a.output, container.State.Terminated.Message)
+						continue
+					}
+
 					if !a.trackedContainers.add(container.ContainerID) {
 						go a.streamContainerLogs(cancelCtx, pod, container)
 					}


### PR DESCRIPTION
This is based on #1865, but now skips terminated containers.

Close #1865.
CC @tejal29  who raised this concern on #1865 and @ottonello who opened #1865 .