### PR TITLE
Improve documentation for kaniko

### DIFF
--- a/docs/content/en/docs/how-tos/builders/_index.md
+++ b/docs/content/en/docs/how-tos/builders/_index.md
@@ -114,9 +114,13 @@ The `buildContext` can be either:
 {{< schema root="KanikoBuildContext" >}}
 
 Since Kaniko must push images to a registry, it is required to set up cluster credentials.
-See the [kaniko docs](https://github.com/GoogleContainerTools/kaniko#kubernetes-secret) for details on how to set up a pull secret.
-The recommended way is to store the secret in Kubernetes and configure `pullSecretName`.
-Another option is to directly supply a path to a credentials file using `pullSecret`
+These credentials are configured in the `cluster` section with the following options:
+
+{{< schema root="ClusterDetails" >}}
+
+To set up the credentials for kaniko have a look at the [kaniko docs](https://github.com/GoogleContainerTools/kaniko#kubernetes-secret).
+The recommended way is to store the pull secret in Kubernetes and configure `pullSecretName`.
+Alternatively, the path to a credentials file can be set with the `pullSecret` option:
 ```yaml
 build:
   cluster:

--- a/docs/content/en/docs/how-tos/builders/_index.md
+++ b/docs/content/en/docs/how-tos/builders/_index.md
@@ -100,7 +100,7 @@ Kubernetes cluster. Kaniko enables building container images in environments
 that cannot easily or securely run a Docker daemon.
 
 Skaffold can help build artifacts in a Kubernetes cluster using the Kaniko
-image; after the artifacts are built, kaniko can push them to remote registries.
+image; after the artifacts are built, kaniko must push them to a registry.
 
 ### Configuration
 
@@ -112,6 +112,24 @@ To use Kaniko, add build type `kaniko` to the `build` section of
 The `buildContext` can be either:
 
 {{< schema root="KanikoBuildContext" >}}
+
+Since Kaniko must push images to a registry, it is required to set up cluster credentials.
+For example, Google Cloud Build requires a service account secret with push and pull access:
+```yaml
+build:
+  cluster:
+    pullSecret: path-to-service-account-key-file
+```
+Or when pushing to a docker registry:
+```yaml
+build:
+  cluster:
+    dockerConfig:
+      path: ~/.docker/config.json
+      # OR
+      secretName: docker-config-secret
+```
+Note that the kubernetes secret must not be of type `kubernetes.io/dockerconfigjson` which stores the config json under the key `".dockerconfigjson"`, but an opaque secret with the key `"config.json"`.
 
 ### Example
 

--- a/docs/content/en/docs/how-tos/builders/_index.md
+++ b/docs/content/en/docs/how-tos/builders/_index.md
@@ -107,7 +107,7 @@ image; after the artifacts are built, kaniko must push them to a registry.
 To use Kaniko, add build type `kaniko` to the `build` section of
 `skaffold.yaml`. The following options can optionally be configured:
 
-{{< schema root="KanikoBuild" >}}
+{{< schema root="KanikoArtifact" >}}
 
 The `buildContext` can be either:
 
@@ -124,7 +124,7 @@ build:
     # OR
     pullSecret: path-to-service-account-key-file
 ```
-Or when pushing to a docker registry:
+Similarly, when pushing to a docker registry:
 ```yaml
 build:
   cluster:

--- a/docs/content/en/docs/how-tos/builders/_index.md
+++ b/docs/content/en/docs/how-tos/builders/_index.md
@@ -114,10 +114,14 @@ The `buildContext` can be either:
 {{< schema root="KanikoBuildContext" >}}
 
 Since Kaniko must push images to a registry, it is required to set up cluster credentials.
-For example, Google Cloud Build requires a service account secret with push and pull access:
+See the [kaniko docs](https://github.com/GoogleContainerTools/kaniko#kubernetes-secret) for details on how to set up a pull secret.
+The recommended way is to store the secret in Kubernetes and configure `pullSecretName`.
+Another option is to directly supply a path to a credentials file using `pullSecret`
 ```yaml
 build:
   cluster:
+    pullSecretName: pull-secret-in-kubernetes
+    # OR
     pullSecret: path-to-service-account-key-file
 ```
 Or when pushing to a docker registry:
@@ -127,7 +131,7 @@ build:
     dockerConfig:
       path: ~/.docker/config.json
       # OR
-      secretName: docker-config-secret
+      secretName: docker-config-secret-in-kubernetes
 ```
 Note that the kubernetes secret must not be of type `kubernetes.io/dockerconfigjson` which stores the config json under the key `".dockerconfigjson"`, but an opaque secret with the key `"config.json"`.
 

--- a/docs/content/en/schemas/v1beta11.json
+++ b/docs/content/en/schemas/v1beta11.json
@@ -491,13 +491,13 @@
         },
         "pullSecret": {
           "type": "string",
-          "description": "path to the secret key file.",
-          "x-intellij-html-description": "path to the secret key file."
+          "description": "path to the Google Cloud service account secret key file.",
+          "x-intellij-html-description": "path to the Google Cloud service account secret key file."
         },
         "pullSecretName": {
           "type": "string",
-          "description": "name of the Kubernetes secret for pulling the files from the build context and pushing the final image.",
-          "x-intellij-html-description": "name of the Kubernetes secret for pulling the files from the build context and pushing the final image.",
+          "description": "name of the Kubernetes secret for pulling the files from the build context and pushing the final image. If given, the secret needs to contain the Google Cloud service account secret key under the key `kaniko-secret`.",
+          "x-intellij-html-description": "name of the Kubernetes secret for pulling the files from the build context and pushing the final image. If given, the secret needs to contain the Google Cloud service account secret key under the key <code>kaniko-secret</code>.",
           "default": "kaniko-secret"
         },
         "resources": {
@@ -725,8 +725,8 @@
         },
         "secretName": {
           "type": "string",
-          "description": "Kubernetes secret that will hold the Docker configuration.",
-          "x-intellij-html-description": "Kubernetes secret that will hold the Docker configuration."
+          "description": "Kubernetes secret that contains the `config.json` Docker configuration. Note that the expected secret type is not 'kubernetes.io/dockerconfigjson' but 'Opaque'.",
+          "x-intellij-html-description": "Kubernetes secret that contains the <code>config.json</code> Docker configuration. Note that the expected secret type is not 'kubernetes.io/dockerconfigjson' but 'Opaque'."
         }
       },
       "preferredOrder": [

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -228,11 +228,12 @@ type KanikoCache struct {
 
 // ClusterDetails *beta* describes how to do an on-cluster build.
 type ClusterDetails struct {
-	// PullSecret is the path to the secret key file.
+	// PullSecret is the path to the Google Cloud service account secret key file.
 	PullSecret string `yaml:"pullSecret,omitempty"`
 
 	// PullSecretName is the name of the Kubernetes secret for pulling the files
-	// from the build context and pushing the final image.
+	// from the build context and pushing the final image. If given, the secret needs to
+	// contain the Google Cloud service account secret key under the key `kaniko-secret`.
 	// Defaults to `kaniko-secret`.
 	PullSecretName string `yaml:"pullSecretName,omitempty"`
 
@@ -254,10 +255,11 @@ type ClusterDetails struct {
 // DockerConfig contains information about the docker `config.json` to mount.
 type DockerConfig struct {
 	// Path is the path to the docker `config.json`.
-	Path string `yaml:"path,omitempty"`
+	Path string `yaml:"path,omitempty" yamltags:"oneOf=dockerSecret"`
 
-	// SecretName is the Kubernetes secret that will hold the Docker configuration.
-	SecretName string `yaml:"secretName,omitempty"`
+	// SecretName is the Kubernetes secret that contains the `config.json` Docker configuration.
+	// Note that the expected secret type is not 'kubernetes.io/dockerconfigjson' but 'Opaque'.
+	SecretName string `yaml:"secretName,omitempty" yamltags:"oneOf=dockerSecret"`
 }
 
 // ResourceRequirements describes the resource requirements for the kaniko pod.


### PR DESCRIPTION
Today, I finally tried out kaniko, but it was harder to get it working than it should be. Please have a look and see if this is correct (which I'm not entirely sure of) and helpful.

Also, prevent users from specifying a docker-config by path and secret-name at the same time.