### PR TITLE
Add ability to pass an explicit registry value to Helm charts

### DIFF
--- a/docs/content/en/schemas/v1beta13.json
+++ b/docs/content/en/schemas/v1beta13.json
@@ -871,8 +871,8 @@
       "properties": {
         "explicitRegistry": {
           "type": "boolean",
-          "description": "enables passing a value for `registry` to Helm.",
-          "x-intellij-html-description": "enables passing a value for <code>registry</code> to Helm.",
+          "description": "separates `image.registry` to the image config syntax. Useful for some charts e.g. `postgresql`.",
+          "x-intellij-html-description": "separates <code>image.registry</code> to the image config syntax. Useful for some charts e.g. <code>postgresql</code>.",
           "default": "false"
         }
       },

--- a/docs/content/en/schemas/v1beta13.json
+++ b/docs/content/en/schemas/v1beta13.json
@@ -868,6 +868,18 @@
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
     "HelmConventionConfig": {
+      "properties": {
+        "explicitRegistry": {
+          "type": "boolean",
+          "description": "enables passing a value for `registry` to Helm.",
+          "x-intellij-html-description": "enables passing a value for <code>registry</code> to Helm.",
+          "default": "false"
+        }
+      },
+      "preferredOrder": [
+        "explicitRegistry"
+      ],
+      "additionalProperties": false,
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -176,12 +176,24 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 	var setOpts []string
 	for k, v := range params {
 		setOpts = append(setOpts, "--set")
-		if r.ImageStrategy.HelmImageConfig.HelmConventionConfig != nil {
+		helmConventionConfig := r.ImageStrategy.HelmImageConfig.HelmConventionConfig
+		if helmConventionConfig != nil {
 			dockerRef, err := docker.ParseReference(v.Tag)
 			if err != nil {
 				return nil, errors.Wrapf(err, "cannot parse the docker image reference %s", v.Tag)
 			}
-			imageRepositoryTag := fmt.Sprintf("%s.repository=%s,%s.tag=%s", k, dockerRef.BaseName, k, dockerRef.Tag)
+			var imageRepositoryTag string
+			if helmConventionConfig.ExplicitRegistry {
+				if dockerRef.Domain == "" {
+					return nil, errors.Wrapf(err, "cannot parse the docker image reference %s into parts", v.Tag)
+				}
+				imageRepositoryTag = fmt.Sprintf(
+					"%s.registry=%s,%s.repository=%s,%s.tag=%s",
+					k, dockerRef.Domain, k, dockerRef.Path, k, dockerRef.Tag,
+				)
+			} else {
+				imageRepositoryTag = fmt.Sprintf("%s.repository=%s,%s.tag=%s", k, dockerRef.BaseName, k, dockerRef.Tag)
+			}
 			setOpts = append(setOpts, imageRepositoryTag)
 		} else {
 			setOpts = append(setOpts, fmt.Sprintf("%s=%s", k, v.Tag))

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -381,12 +381,7 @@ func TestHelmDeploy(t *testing.T) {
 				t:         t,
 				getResult: fmt.Errorf("not found"),
 				installMatcher: func(cmd *exec.Cmd) bool {
-					dockerRef, err := docker.ParseReference(testBuilds[0].Tag)
-					if err != nil {
-						return false
-					}
-
-					expected := fmt.Sprintf("image.registry=%s,image.repository=%s,image.tag=%s", dockerRef.Domain, dockerRef.Path, dockerRef.Tag)
+					expected := fmt.Sprintf("image.registry=%s,image.repository=%s,image.tag=%s", "docker.io:5000", "skaffold-helm", "3605e7bc17cf46e53f4d81c4cbc24e5b4c495184")
 					for _, arg := range cmd.Args {
 						if expected == arg {
 							return true

--- a/pkg/skaffold/docker/reference.go
+++ b/pkg/skaffold/docker/reference.go
@@ -21,6 +21,8 @@ import "github.com/docker/distribution/reference"
 // ImageReference is a parsed image name.
 type ImageReference struct {
 	BaseName       string
+	Domain         string
+	Path           string
 	Tag            string
 	Digest         string
 	FullyQualified bool
@@ -34,8 +36,12 @@ func ParseReference(image string) (*ImageReference, error) {
 	}
 
 	baseName := image
+	var domain string
+	var path string
 	if n, ok := r.(reference.Named); ok {
 		baseName = n.Name()
+		domain = reference.Domain(n)
+		path = reference.Path(n)
 	}
 
 	fullyQualified := false
@@ -53,6 +59,8 @@ func ParseReference(image string) (*ImageReference, error) {
 
 	return &ImageReference{
 		BaseName:       baseName,
+		Domain:         domain,
+		Path:           path,
 		Tag:            tag,
 		Digest:         digest,
 		FullyQualified: fullyQualified,

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -505,7 +505,7 @@ type HelmFQNConfig struct {
 
 // HelmConventionConfig is the image config in the syntax of image.repository and image.tag.
 type HelmConventionConfig struct {
-	// ExplicitRegistry enables passing a value for `registry` to Helm.
+	// ExplicitRegistry separates `image.registry` to the image config syntax. Useful for some charts e.g. `postgresql`.
 	ExplicitRegistry bool `yaml:"explicitRegistry,omitempty"`
 }
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -505,6 +505,8 @@ type HelmFQNConfig struct {
 
 // HelmConventionConfig is the image config in the syntax of image.repository and image.tag.
 type HelmConventionConfig struct {
+	// ExplicitRegistry enables passing a value for `registry` to Helm.
+	ExplicitRegistry bool `yaml:"explicitRegistry,omitempty"`
 }
 
 // Artifact are the items that need to be built, along with the context in which


### PR DESCRIPTION
I've run into a problem deploying a chart based on [stable/postgresql](https://github.com/helm/charts/tree/master/stable/postgresql#configuration) where an explicit `registry` value is expected when the templates are rendered. I'm not sure how common this pattern is amongst other charts but given that Postgres uses it and it seems reasonable in general, it seemed ok to me to add it as an option to Skaffold.