### PR TITLE
Multiple small improvements to unit tests

### DIFF
--- a/integration/skaffold/helper.go
+++ b/integration/skaffold/helper.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -202,7 +203,7 @@ func (b *RunBuilder) cmd(ctx context.Context) *exec.Cmd {
 	args = append(args, b.args...)
 
 	cmd := exec.CommandContext(ctx, "skaffold", args...)
-	cmd.Env = append(removeSkaffoldEnvVariables(os.Environ()), b.env...)
+	cmd.Env = append(removeSkaffoldEnvVariables(util.OSEnviron()), b.env...)
 	if b.stdin != nil {
 		cmd.Stdin = bytes.NewReader(b.stdin)
 	}

--- a/pkg/skaffold/build/bazel/dependencies_test.go
+++ b/pkg/skaffold/build/bazel/dependencies_test.go
@@ -26,11 +26,11 @@ import (
 )
 
 func TestGetDependenciesWithWorkspace(t *testing.T) {
-	defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
-	util.DefaultExecCommand = testutil.NewFakeCmd(t).WithRunOut(
+	reset := testutil.Override(t, &util.DefaultExecCommand, testutil.NewFakeCmd(t).WithRunOut(
 		"bazel query kind('source file', deps('target')) union buildfiles('target') --noimplicit_deps --order_output=no",
 		"@ignored\n//external/ignored\n\n//:dep1\n//:dep2\n",
-	)
+	))
+	defer reset()
 
 	tmpDir, cleanup := testutil.NewTempDir(t)
 	defer cleanup()
@@ -44,11 +44,11 @@ func TestGetDependenciesWithWorkspace(t *testing.T) {
 }
 
 func TestGetDependenciesWithoutWorkspace(t *testing.T) {
-	defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
-	util.DefaultExecCommand = testutil.NewFakeCmd(t).WithRunOut(
+	reset := testutil.Override(t, &util.DefaultExecCommand, testutil.NewFakeCmd(t).WithRunOut(
 		"bazel query kind('source file', deps('target2')) union buildfiles('target2') --noimplicit_deps --order_output=no",
 		"@ignored\n//external/ignored\n\n//:dep3\n",
-	)
+	))
+	defer reset()
 
 	deps, err := GetDependencies(context.Background(), ".", &latest.BazelArtifact{
 		BuildTarget: "target2",

--- a/pkg/skaffold/build/cache/cache_test.go
+++ b/pkg/skaffold/build/cache/cache_test.go
@@ -148,10 +148,10 @@ func Test_NewCache(t *testing.T) {
 			}
 			test.opts.CacheFile = cacheFile
 
-			defer func(c func(bool, map[string]bool) (docker.LocalDaemon, error)) { newDockerClient = c }(newDockerClient)
-			newDockerClient = func(forceRemove bool, insecureRegistries map[string]bool) (docker.LocalDaemon, error) {
+			reset := testutil.Override(t, &newDockerClient, func(forceRemove bool, insecureRegistries map[string]bool) (docker.LocalDaemon, error) {
 				return docker.NewLocalDaemon(test.api, nil, forceRemove, test.insecureRegistries), nil
-			}
+			})
+			defer reset()
 
 			if test.updateClient {
 				test.expectedCache.client = docker.NewLocalDaemon(test.api, nil, false, test.insecureRegistries)

--- a/pkg/skaffold/build/cache/hash_test.go
+++ b/pkg/skaffold/build/cache/hash_test.go
@@ -67,8 +67,8 @@ func TestGetHashForArtifact(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			defer func(h func(string) (string, error)) { hashFunction = h }(hashFunction)
-			hashFunction = mockCacheHasher
+			reset := testutil.Override(t, &hashFunction, mockCacheHasher)
+			defer reset()
 
 			for _, d := range test.dependencies {
 				builder := &mockBuilder{dependencies: d}

--- a/pkg/skaffold/build/custom/custom.go
+++ b/pkg/skaffold/build/custom/custom.go
@@ -28,12 +28,12 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
 )
 
 var (
 	// For testing
-	environ      = os.Environ
 	buildContext = retrieveBuildContext
 )
 
@@ -93,7 +93,7 @@ func (b *ArtifactBuilder) retrieveEnv(a *latest.Artifact, tag string) ([]string,
 		fmt.Sprintf("%s=%s", constants.BuildContext, buildContext),
 	}
 	envs = append(envs, b.additionalEnv...)
-	envs = append(envs, environ()...)
+	envs = append(envs, util.OSEnviron()...)
 	sort.Strings(envs)
 	return envs, nil
 }

--- a/pkg/skaffold/build/custom/custom_test.go
+++ b/pkg/skaffold/build/custom/custom_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -65,7 +66,7 @@ func TestRetrieveEnv(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			resetEnv := testutil.Override(t, &environ, func() []string {
+			resetEnv := testutil.Override(t, &util.OSEnviron, func() []string {
 				return test.environ
 			})
 			defer resetEnv()
@@ -118,7 +119,7 @@ func TestRetrieveCmd(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			resetEnv := testutil.Override(t, &environ, func() []string {
+			resetEnv := testutil.Override(t, &util.OSEnviron, func() []string {
 				return nil
 			})
 			defer resetEnv()

--- a/pkg/skaffold/build/custom/custom_test.go
+++ b/pkg/skaffold/build/custom/custom_test.go
@@ -65,18 +65,19 @@ func TestRetrieveEnv(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			defer func(e func() []string) { environ = e }(environ)
-			environ = func() []string {
+			resetEnv := testutil.Override(t, &environ, func() []string {
 				return test.environ
-			}
+			})
+			defer resetEnv()
 
-			defer func(bc func(string) (string, error)) { buildContext = bc }(buildContext)
-			buildContext = func(string) (string, error) {
+			reset := testutil.Override(t, &buildContext, func(string) (string, error) {
 				return test.buildContext, nil
-			}
+			})
+			defer reset()
 
 			artifactBuilder := NewArtifactBuilder(test.pushImages, test.additionalEnv)
 			actual, err := artifactBuilder.retrieveEnv(&latest.Artifact{}, test.tag)
+
 			testutil.CheckErrorAndDeepEqual(t, false, err, test.expected, actual)
 		})
 	}
@@ -117,16 +118,17 @@ func TestRetrieveCmd(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			builder := NewArtifactBuilder(false, nil)
+			resetEnv := testutil.Override(t, &environ, func() []string {
+				return nil
+			})
+			defer resetEnv()
 
-			defer func(e func() []string) { environ = e }(environ)
-			environ = func() []string { return nil }
-
-			defer func(bc func(string) (string, error)) { buildContext = bc }(buildContext)
-			buildContext = func(string) (string, error) {
+			reset := testutil.Override(t, &buildContext, func(string) (string, error) {
 				return test.artifact.Workspace, nil
-			}
+			})
+			defer reset()
 
+			builder := NewArtifactBuilder(false, nil)
 			cmd, err := builder.retrieveCmd(test.artifact, test.tag)
 			if err != nil {
 				t.Fatalf("error retrieving command: %v", err)

--- a/pkg/skaffold/build/custom/dependencies_test.go
+++ b/pkg/skaffold/build/custom/dependencies_test.go
@@ -60,12 +60,11 @@ func TestGetDependenciesDockerfile(t *testing.T) {
 }
 
 func TestGetDependenciesCommand(t *testing.T) {
-
-	defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
-	util.DefaultExecCommand = testutil.NewFakeCmd(t).WithRunOut(
+	reset := testutil.Override(t, &util.DefaultExecCommand, testutil.NewFakeCmd(t).WithRunOut(
 		"echo [\"file1\",\"file2\",\"file3\"]",
 		"[\"file1\",\"file2\",\"file3\"]",
-	)
+	))
+	defer reset()
 
 	customArtifact := &latest.CustomArtifact{
 		Dependencies: &latest.CustomDependencies{

--- a/pkg/skaffold/build/local/bazel_test.go
+++ b/pkg/skaffold/build/local/bazel_test.go
@@ -26,11 +26,11 @@ import (
 )
 
 func TestBazelBin(t *testing.T) {
-	defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
-	util.DefaultExecCommand = testutil.NewFakeCmd(t).WithRunOut(
+	reset := testutil.Override(t, &util.DefaultExecCommand, testutil.NewFakeCmd(t).WithRunOut(
 		"bazel info bazel-bin --arg1 --arg2",
 		"/absolute/path/bin\n",
-	)
+	))
+	defer reset()
 
 	bazelBin, err := bazelBin(context.Background(), ".", &latest.BazelArtifact{
 		BuildArgs: []string{"--arg1", "--arg2"},

--- a/pkg/skaffold/build/local/docker.go
+++ b/pkg/skaffold/build/local/docker.go
@@ -19,7 +19,6 @@ package local
 import (
 	"context"
 	"io"
-	"os"
 	"os/exec"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
@@ -75,7 +74,7 @@ func (b *Builder) dockerCLIBuild(ctx context.Context, out io.Writer, workspace s
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	if b.cfg.UseBuildkit {
-		cmd.Env = append(os.Environ(), "DOCKER_BUILDKIT=1")
+		cmd.Env = append(util.OSEnviron(), "DOCKER_BUILDKIT=1")
 	}
 	cmd.Stdout = out
 	cmd.Stderr = out

--- a/pkg/skaffold/build/local/jib_gradle.go
+++ b/pkg/skaffold/build/local/jib_gradle.go
@@ -19,7 +19,6 @@ package local
 import (
 	"context"
 	"io"
-	"os"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/jib"
@@ -56,7 +55,7 @@ func (b *Builder) buildJibGradleToRegistry(ctx context.Context, out io.Writer, w
 
 func (b *Builder) runGradleCommand(ctx context.Context, out io.Writer, workspace string, args []string) error {
 	cmd := jib.GradleCommand.CreateCommand(ctx, workspace, args)
-	cmd.Env = append(os.Environ(), b.localDocker.ExtraEnv()...)
+	cmd.Env = append(util.OSEnviron(), b.localDocker.ExtraEnv()...)
 	cmd.Stdout = out
 	cmd.Stderr = out
 

--- a/pkg/skaffold/build/local/jib_maven.go
+++ b/pkg/skaffold/build/local/jib_maven.go
@@ -19,7 +19,6 @@ package local
 import (
 	"context"
 	"io"
-	"os"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/jib"
@@ -96,7 +95,7 @@ func verifyJibPackageGoal(ctx context.Context, requiredGoal string, workspace st
 
 func (b *Builder) runMavenCommand(ctx context.Context, out io.Writer, workspace string, args []string) error {
 	cmd := jib.MavenCommand.CreateCommand(ctx, workspace, args)
-	cmd.Env = append(os.Environ(), b.localDocker.ExtraEnv()...)
+	cmd.Env = append(util.OSEnviron(), b.localDocker.ExtraEnv()...)
 	cmd.Stdout = out
 	cmd.Stderr = out
 

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -41,8 +41,8 @@ func (t testAuthHelper) GetAuthConfig(string) (types.AuthConfig, error) {
 func (t testAuthHelper) GetAllAuthConfigs() (map[string]types.AuthConfig, error) { return nil, nil }
 
 func TestLocalRun(t *testing.T) {
-	defer func(h docker.AuthConfigHelper) { docker.DefaultAuthHelper = h }(docker.DefaultAuthHelper)
-	docker.DefaultAuthHelper = testAuthHelper{}
+	reset := testutil.Override(t, &docker.DefaultAuthHelper, testAuthHelper{})
+	defer reset()
 
 	var tests = []struct {
 		description      string
@@ -218,9 +218,10 @@ func TestLocalRun(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			defer func(w warnings.Warner) { warnings.Printf = w }(warnings.Printf)
 			fakeWarner := &warnings.Collect{}
-			warnings.Printf = fakeWarner.Warnf
+			reset := testutil.Override(t, &warnings.Printf, fakeWarner.Warnf)
+			defer reset()
+
 			cfg := latest.BuildConfig{
 				BuildType: latest.BuildType{
 					LocalBuild: &latest.LocalBuild{},

--- a/pkg/skaffold/build/tag/env_template_test.go
+++ b/pkg/skaffold/build/tag/env_template_test.go
@@ -95,9 +95,9 @@ func TestEnvTemplateTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 				return test.env
 			}
 
-			defer func(w warnings.Warner) { warnings.Printf = w }(warnings.Printf)
 			fakeWarner := &warnings.Collect{}
-			warnings.Printf = fakeWarner.Warnf
+			reset := testutil.Override(t, &warnings.Printf, fakeWarner.Warnf)
+			defer reset()
 
 			c, err := NewEnvTemplateTagger(test.template)
 			testutil.CheckError(t, false, err)

--- a/pkg/skaffold/color/formatter_test.go
+++ b/pkg/skaffold/color/formatter_test.go
@@ -38,33 +38,33 @@ func compareText(t *testing.T, expected, actual string, expectedN int, actualN i
 }
 
 func TestFprint(t *testing.T) {
-	defer func(f func(io.Writer) bool) { IsTerminal = f }(IsTerminal)
-	IsTerminal = func(io.Writer) bool { return true }
+	reset := testutil.Override(t, &IsTerminal, func(io.Writer) bool { return true })
+	defer reset()
 
 	var b bytes.Buffer
 	n, err := Green.Fprint(&b, "It's not easy being")
-	expected := "\033[32mIt's not easy being\033[0m"
-	compareText(t, expected, b.String(), 28, n, err)
+
+	compareText(t, "\033[32mIt's not easy being\033[0m", b.String(), 28, n, err)
 }
 
 func TestFprintln(t *testing.T) {
-	defer func(f func(io.Writer) bool) { IsTerminal = f }(IsTerminal)
-	IsTerminal = func(io.Writer) bool { return true }
+	reset := testutil.Override(t, &IsTerminal, func(io.Writer) bool { return true })
+	defer reset()
 
 	var b bytes.Buffer
 	n, err := Green.Fprintln(&b, "2", "less", "chars!")
-	expected := "\033[32m2 less chars!\033[0m\n"
-	compareText(t, expected, b.String(), 23, n, err)
+
+	compareText(t, "\033[32m2 less chars!\033[0m\n", b.String(), 23, n, err)
 }
 
 func TestFprintf(t *testing.T) {
-	defer func(f func(io.Writer) bool) { IsTerminal = f }(IsTerminal)
-	IsTerminal = func(io.Writer) bool { return true }
+	reset := testutil.Override(t, &IsTerminal, func(io.Writer) bool { return true })
+	defer reset()
 
 	var b bytes.Buffer
 	n, err := Green.Fprintf(&b, "It's been %d %s", 1, "week")
-	expected := "\033[32mIt's been 1 week\033[0m"
-	compareText(t, expected, b.String(), 25, n, err)
+
+	compareText(t, "\033[32mIt's been 1 week\033[0m", b.String(), 25, n, err)
 }
 
 func TestFprintNoTTY(t *testing.T) {

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -456,10 +456,10 @@ func TestHelmDeploy(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			event.InitializeState(tt.runContext)
-			defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
-			util.DefaultExecCommand = tt.cmd
+			reset := testutil.Override(t, &util.DefaultExecCommand, tt.cmd)
+			defer reset()
 
+			event.InitializeState(tt.runContext)
 			err := NewHelmDeployer(tt.runContext).Deploy(context.Background(), ioutil.Discard, tt.builds, nil)
 
 			testutil.CheckError(t, tt.shouldErr, err)

--- a/pkg/skaffold/deploy/kubectl/images_test.go
+++ b/pkg/skaffold/deploy/kubectl/images_test.go
@@ -86,9 +86,9 @@ spec:
   - image: in valid
 `)}
 
-	defer func(w warnings.Warner) { warnings.Printf = w }(warnings.Printf)
 	fakeWarner := &warnings.Collect{}
-	warnings.Printf = fakeWarner.Warnf
+	reset := testutil.Override(t, &warnings.Printf, fakeWarner.Warnf)
+	defer reset()
 
 	resultManifest, err := manifests.ReplaceImages(builds, "")
 

--- a/pkg/skaffold/deploy/kubectl/version_test.go
+++ b/pkg/skaffold/deploy/kubectl/version_test.go
@@ -62,12 +62,12 @@ func TestCheckVersion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			defer func(w warnings.Warner) { warnings.Printf = w }(warnings.Printf)
 			fakeWarner := &warnings.Collect{}
-			warnings.Printf = fakeWarner.Warnf
+			reset := testutil.Override(t, &warnings.Printf, fakeWarner.Warnf)
+			defer reset()
 
-			defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
-			util.DefaultExecCommand = test.command
+			resetCmd := testutil.Override(t, &util.DefaultExecCommand, test.command)
+			defer resetCmd()
 
 			cli := CLI{}
 			err := cli.CheckVersion(context.Background())

--- a/pkg/skaffold/deploy/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize_test.go
@@ -70,8 +70,8 @@ func TestKustomizeDeploy(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
-			util.DefaultExecCommand = test.command
+			reset := testutil.Override(t, &util.DefaultExecCommand, test.command)
+			defer reset()
 
 			k := NewKustomizeDeployer(&runcontext.RunContext{
 				WorkingDir: tmpDir.Root(),
@@ -136,8 +136,8 @@ func TestKustomizeCleanup(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
-			util.DefaultExecCommand = test.command
+			reset := testutil.Override(t, &util.DefaultExecCommand, test.command)
+			defer reset()
 
 			k := NewKustomizeDeployer(&runcontext.RunContext{
 				WorkingDir: tmpDir.Root(),

--- a/pkg/skaffold/docker/auth_test.go
+++ b/pkg/skaffold/docker/auth_test.go
@@ -75,8 +75,8 @@ func TestGetEncodedRegistryAuth(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			defer func(h AuthConfigHelper) { DefaultAuthHelper = h }(DefaultAuthHelper)
-			DefaultAuthHelper = test.authType
+			reset := testutil.Override(t, &DefaultAuthHelper, test.authType)
+			defer reset()
 
 			l := &localDaemon{}
 			out, err := l.encodedRegistryAuth(context.Background(), test.authType, test.image)

--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -115,8 +115,11 @@ DOCKER_API_VERSION=1.23`,
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
-			util.DefaultExecCommand = testutil.NewFakeCmd(t).WithRunOut("minikube docker-env --shell none", test.env)
+			reset := testutil.Override(t, &util.DefaultExecCommand, testutil.NewFakeCmd(t).WithRunOut(
+				"minikube docker-env --shell none",
+				test.env,
+			))
+			defer reset()
 
 			env, _, err := newMinikubeAPIClient()
 

--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -48,15 +48,14 @@ func TestNewEnvClient(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			unsetEnvs := testutil.SetEnvs(t, test.envs)
+			reset := testutil.SetEnvs(t, test.envs)
+			defer reset()
 
 			env, _, err := newEnvAPIClient()
 
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, []string(nil), env)
-			unsetEnvs(t)
 		})
 	}
-
 }
 
 func TestNewMinikubeImageAPIClient(t *testing.T) {

--- a/pkg/skaffold/docker/context_test.go
+++ b/pkg/skaffold/docker/context_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
 func TestDockerContext(t *testing.T) {
@@ -33,9 +32,9 @@ func TestDockerContext(t *testing.T) {
 			tmpDir, cleanup := testutil.NewTempDir(t)
 			defer cleanup()
 
-			defer func(f func(string, map[string]bool) (*v1.ConfigFile, error)) { RetrieveImage = f }(RetrieveImage)
 			imageFetcher := fakeImageFetcher{}
-			RetrieveImage = imageFetcher.fetch
+			reset := testutil.Override(t, &RetrieveImage, imageFetcher.fetch)
+			defer reset()
 
 			artifact := &latest.DockerArtifact{
 				DockerfilePath: "Dockerfile",
@@ -48,8 +47,8 @@ func TestDockerContext(t *testing.T) {
 			tmpDir.Write(dir+"/ignored.txt", "")
 			tmpDir.Write(dir+"/alsoignored.txt", "")
 
-			reset := testutil.Chdir(t, tmpDir.Root())
-			defer reset()
+			resetDir := testutil.Chdir(t, tmpDir.Root())
+			defer resetDir()
 
 			reader, writer := io.Pipe()
 			go func() {

--- a/pkg/skaffold/docker/parse_test.go
+++ b/pkg/skaffold/docker/parse_test.go
@@ -513,9 +513,9 @@ func TestGetDependencies(t *testing.T) {
 			tmpDir, cleanup := testutil.NewTempDir(t)
 			defer cleanup()
 
-			defer func(f func(string, map[string]bool) (*v1.ConfigFile, error)) { RetrieveImage = f }(RetrieveImage)
 			imageFetcher := fakeImageFetcher{}
-			RetrieveImage = imageFetcher.fetch
+			reset := testutil.Override(t, &RetrieveImage, imageFetcher.fetch)
+			defer reset()
 
 			for _, file := range []string{"docker/nginx.conf", "docker/bar", "server.go", "test.conf", "worker.go", "bar", "file", ".dot"} {
 				tmpDir.Write(file, "")

--- a/pkg/skaffold/gcp/auth_test.go
+++ b/pkg/skaffold/gcp/auth_test.go
@@ -105,7 +105,7 @@ func TestAutoConfigureGCRCredentialHelper(t *testing.T) {
 			reset := testutil.SetEnvs(t, map[string]string{
 				"PATH": tmp.Root(),
 			})
-			defer reset(t)
+			defer reset()
 
 			if test.helperInPath {
 				tmp.Write("docker-credential-gcloud", "")

--- a/pkg/skaffold/jib/jib_gradle_test.go
+++ b/pkg/skaffold/jib/jib_gradle_test.go
@@ -86,12 +86,12 @@ func TestGetDependenciesGradle(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
-			util.DefaultExecCommand = testutil.NewFakeCmd(t).WithRunOutErr(
+			reset := testutil.Override(t, &util.DefaultExecCommand, testutil.NewFakeCmd(t).WithRunOutErr(
 				strings.Join(getCommandGradle(ctx, tmpDir.Root(), &latest.JibGradleArtifact{Project: "gradle-test"}).Args, " "),
 				test.stdout,
 				test.err,
-			)
+			))
+			defer reset()
 
 			// Change build file mod time
 			os.Chtimes(build, test.modTime, test.modTime)

--- a/pkg/skaffold/jib/jib_maven_test.go
+++ b/pkg/skaffold/jib/jib_maven_test.go
@@ -86,12 +86,12 @@ func TestGetDependenciesMaven(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
-			util.DefaultExecCommand = testutil.NewFakeCmd(t).WithRunOutErr(
+			reset := testutil.Override(t, &util.DefaultExecCommand, testutil.NewFakeCmd(t).WithRunOutErr(
 				strings.Join(getCommandMaven(ctx, tmpDir.Root(), &latest.JibMavenArtifact{Module: "maven-test"}).Args, " "),
 				test.stdout,
 				test.err,
-			)
+			))
+			defer reset()
 
 			// Change build file mod time
 			os.Chtimes(build, test.modTime, test.modTime)

--- a/pkg/skaffold/jib/jib_test.go
+++ b/pkg/skaffold/jib/jib_test.go
@@ -82,11 +82,11 @@ func TestGetDependencies(t *testing.T) {
 		watchedFiles = map[string]filesLists{}
 
 		t.Run("getDependencies", func(t *testing.T) {
-			defer func(c util.Command) { util.DefaultExecCommand = c }(util.DefaultExecCommand)
-			util.DefaultExecCommand = testutil.NewFakeCmd(t).WithRunOut(
+			reset := testutil.Override(t, &util.DefaultExecCommand, testutil.NewFakeCmd(t).WithRunOut(
 				"ignored",
 				test.stdout,
-			)
+			))
+			defer reset()
 
 			results, err := getDependencies(tmpDir.Root(), &exec.Cmd{Args: []string{"ignored"}, Dir: tmpDir.Root()}, "test")
 

--- a/pkg/skaffold/kubernetes/port_forward_test.go
+++ b/pkg/skaffold/kubernetes/port_forward_test.go
@@ -437,8 +437,8 @@ func TestPortForwardPod(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			taken := map[int]struct{}{}
 
-			defer func(r func(int, *sync.Map) int) { retrieveAvailablePort = r }(retrieveAvailablePort)
-			retrieveAvailablePort = mockRetrieveAvailablePort(taken, test.availablePorts)
+			reset := testutil.Override(t, &retrieveAvailablePort, mockRetrieveAvailablePort(taken, test.availablePorts))
+			defer reset()
 
 			p := NewPortForwarder(ioutil.Discard, NewImageList(), []string{""})
 			if test.forwarder == nil {

--- a/pkg/skaffold/runner/dev_test.go
+++ b/pkg/skaffold/runner/dev_test.go
@@ -330,10 +330,10 @@ func TestDevSync(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			defer func(s func(string, map[string]bool) (string, error)) { sync.WorkingDir = s }(sync.WorkingDir)
-			sync.WorkingDir = func(string, map[string]bool) (string, error) {
+			reset := testutil.Override(t, &sync.WorkingDir, func(string, map[string]bool) (string, error) {
 				return "/", nil
-			}
+			})
+			defer reset()
 
 			runner := createRunner(t, test.testBench)
 			runner.Watcher = &TestWatcher{

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -349,8 +349,8 @@ func TestValidateNetworkMode(t *testing.T) {
 	}
 
 	// disable yamltags validation
-	defer func(v func(interface{}) error) { validateYamltags = v }(validateYamltags)
-	validateYamltags = func(interface{}) error { return nil }
+	reset := testutil.Override(t, &validateYamltags, func(interface{}) error { return nil })
+	defer reset()
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -459,8 +459,8 @@ func TestValidateSyncRules(t *testing.T) {
 	}
 
 	// disable yamltags validation
-	defer func(v func(interface{}) error) { validateYamltags = v }(validateYamltags)
-	validateYamltags = func(interface{}) error { return nil }
+	reset := testutil.Override(t, &validateYamltags, func(interface{}) error { return nil })
+	defer reset()
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/pkg/skaffold/util/env_template.go
+++ b/pkg/skaffold/util/env_template.go
@@ -23,12 +23,14 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
-var OSEnviron = os.Environ
+// For testing
+var (
+	OSEnviron = os.Environ
+)
 
 // ParseEnvTemplate is a simple wrapper to parse an env template
 func ParseEnvTemplate(t string) (*template.Template, error) {

--- a/testutil/kubecontext.go
+++ b/testutil/kubecontext.go
@@ -36,6 +36,6 @@ func SetupFakeKubernetesContext(t *testing.T, config api.Config) func() {
 
 	return func() {
 		cleanup()
-		unsetEnvs(t)
+		unsetEnvs()
 	}
 }

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -126,7 +126,7 @@ func checkErr(shouldErr bool, err error) error {
 
 // SetEnvs takes a map of key values to set using os.Setenv and returns
 // a function that can be called to reset the envs to their previous values.
-func SetEnvs(t *testing.T, envs map[string]string) func(*testing.T) {
+func SetEnvs(t *testing.T, envs map[string]string) func() {
 	prevEnvs := map[string]string{}
 	for key, value := range envs {
 		prevEnv := os.Getenv(key)
@@ -136,7 +136,8 @@ func SetEnvs(t *testing.T, envs map[string]string) func(*testing.T) {
 			t.Error(err)
 		}
 	}
-	return func(t *testing.T) {
+
+	return func() {
 		for key, value := range prevEnvs {
 			err := os.Setenv(key, value)
 			if err != nil {


### PR DESCRIPTION
+ Simplify the `testutil.SetEnv()` helper
+ Use `testutil.Override` where possible
+ Use `util.OSEnviron()` everywhere