### PR TITLE
Use kind to run integration tests on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,10 @@ jobs:
       script:
         - go build -o out/skaffold.exe cmd/skaffold/skaffold.go
         - go test -short -timeout 60s ./...
+    - stage: integration
+      os: linux
+      go: "1.11.x"
+      before_install:
+        - curl -Lo ${HOME}/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.3.0/kind-linux-amd64
+        - chmod +x ${HOME}/bin/kind
+      script: make integration-in-kind

--- a/cmd/skaffold/app/cmd/config/util.go
+++ b/cmd/skaffold/app/cmd/config/util.go
@@ -19,6 +19,7 @@ package config
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
@@ -226,5 +227,10 @@ func GetInsecureRegistries() ([]string, error) {
 func isDefaultLocal(kubeContext string) bool {
 	return kubeContext == constants.DefaultMinikubeContext ||
 		kubeContext == constants.DefaultDockerForDesktopContext ||
-		kubeContext == constants.DefaultDockerDesktopContext
+		kubeContext == constants.DefaultDockerDesktopContext ||
+		IsKindCluster(kubeContext)
+}
+
+func IsKindCluster(kubeContext string) bool {
+	return strings.HasSuffix(kubeContext, "@kind")
 }

--- a/deploy/skaffold/Dockerfile
+++ b/deploy/skaffold/Dockerfile
@@ -96,6 +96,11 @@ COPY . .
 FROM builder as integration
 ARG VERSION
 
+ENV KIND_VERSION=v0.3.0
+RUN curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64 && \
+  chmod +x kind && \
+  mv kind /usr/local/bin/
+
 RUN make out/skaffold-linux-amd64 VERSION=$VERSION && mv out/skaffold-linux-amd64 /usr/bin/skaffold
 
 CMD ["make", "integration"]

--- a/hack/kokoro/presubmit.sh
+++ b/hack/kokoro/presubmit.sh
@@ -18,6 +18,6 @@ export DOCKER_NAMESPACE=gcr.io/k8s-skaffold
 source $KOKORO_GFILE_DIR/common.sh
 
 pushd $KOKORO_ARTIFACTS_DIR/github/skaffold >/dev/null
-    make integration-in-docker
+    REMOTE_INTEGRATION=true make integration-in-docker
 popd
 

--- a/hack/kokoro/presubmit.sh
+++ b/hack/kokoro/presubmit.sh
@@ -18,6 +18,6 @@ export DOCKER_NAMESPACE=gcr.io/k8s-skaffold
 source $KOKORO_GFILE_DIR/common.sh
 
 pushd $KOKORO_ARTIFACTS_DIR/github/skaffold >/dev/null
-    REMOTE_INTEGRATION=true make integration-in-docker
+    GCP_ONLY=true make integration-in-docker
 popd
 

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -36,6 +36,9 @@ func TestBuild(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
 
 	tests := []struct {
 		description string

--- a/integration/config_test.go
+++ b/integration/config_test.go
@@ -27,6 +27,9 @@ func TestConfigListForContext(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
 
 	out := skaffold.Config("list", "-c", "testdata/config/config.yaml", "-k", "test-context").RunOrFailOutput(t)
 
@@ -36,6 +39,9 @@ func TestConfigListForContext(t *testing.T) {
 func TestConfigListForAll(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
+	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
 	}
 
 	out := skaffold.Config("list", "-c", "testdata/config/config.yaml", "--all").RunOrFailOutput(t)
@@ -54,6 +60,9 @@ func TestFailToSetUnrecognizedValue(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
 
 	err := skaffold.Config("set", "doubt-this-will-ever-be-a-config-key", "VALUE", "-c", "testdata/config/config.yaml", "--global").Run(t)
 
@@ -63,6 +72,9 @@ func TestFailToSetUnrecognizedValue(t *testing.T) {
 func TestSetDefaultRepoForContext(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
+	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
 	}
 
 	file, delete := testutil.TempFile(t, "config", nil)
@@ -77,6 +89,9 @@ func TestSetDefaultRepoForContext(t *testing.T) {
 func TestSetGlobalDefaultRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
+	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
 	}
 
 	file, delete := testutil.TempFile(t, "config", nil)

--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -26,6 +26,9 @@ func TestDebug(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
 
 	tests := []struct {
 		description string

--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -28,6 +28,9 @@ func TestBuildDeploy(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
 
 	ns, client, deleteNs := SetupNamespace(t)
 	defer deleteNs()
@@ -78,6 +81,9 @@ func TestBuildDeploy(t *testing.T) {
 func TestDeploy(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
+	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
 	}
 
 	ns, client, deleteNs := SetupNamespace(t)

--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -29,6 +29,9 @@ func TestDev(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
 
 	Run(t, "testdata/dev", "sh", "-c", "echo foo > foo")
 	defer Run(t, "testdata/dev", "rm", "foo")

--- a/integration/diagnose_test.go
+++ b/integration/diagnose_test.go
@@ -26,6 +26,9 @@ func TestDiagnose(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
 
 	tests := []struct {
 		name string

--- a/integration/fix_test.go
+++ b/integration/fix_test.go
@@ -26,6 +26,9 @@ func TestFix(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
 
 	ns, _, deleteNs := SetupNamespace(t)
 	defer deleteNs()

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -18,7 +18,6 @@ package integration
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
@@ -33,8 +32,8 @@ func TestHelmDeploy(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
-	if os.Getenv("REMOTE_INTEGRATION") != "true" {
-		t.Skip("skipping remote only test")
+	if !ShouldRunGCPOnlyTests() {
+		t.Skip("skipping gcp only test")
 	}
 
 	helmDir := "examples/helm-deployment"

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -26,6 +26,9 @@ func TestInit(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
 
 	tests := []struct {
 		name string

--- a/integration/rpc_test.go
+++ b/integration/rpc_test.go
@@ -47,6 +47,9 @@ func TestEventLogRPC(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
 
 	rpcAddr := randomPort()
 	teardown := setupSkaffoldWithArgs(t, "--rpc-port", rpcAddr)

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package integration
 
 import (
-	"os"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
@@ -36,7 +35,7 @@ func TestRun(t *testing.T) {
 		deployments []string
 		pods        []string
 		env         []string
-		remoteOnly  bool
+		gcpOnly     bool
 	}{
 		{
 			description: "getting-started",
@@ -67,38 +66,38 @@ func TestRun(t *testing.T) {
 			description: "Google Cloud Build",
 			dir:         "examples/google-cloud-build",
 			pods:        []string{"getting-started"},
-			remoteOnly:  true,
+			gcpOnly:     true,
 		}, {
 			description: "Google Cloud Build with sub folder",
 			dir:         "testdata/gcb-sub-folder",
 			pods:        []string{"getting-started"},
-			remoteOnly:  true,
+			gcpOnly:     true,
 		}, {
 			description: "kaniko",
 			dir:         "examples/kaniko",
 			pods:        []string{"getting-started-kaniko"},
-			remoteOnly:  true,
+			gcpOnly:     true,
 		}, {
 			description: "kaniko local",
 			dir:         "examples/kaniko-local",
 			pods:        []string{"getting-started-kaniko"},
-			remoteOnly:  true,
+			gcpOnly:     true,
 		}, {
 			description: "kaniko local with sub folder",
 			dir:         "testdata/kaniko-sub-folder",
 			pods:        []string{"getting-started-kaniko"},
-			remoteOnly:  true,
+			gcpOnly:     true,
 		}, {
 			description: "kaniko microservices",
 			dir:         "testdata/kaniko-microservices",
 			deployments: []string{"leeroy-app", "leeroy-web"},
-			remoteOnly:  true,
+			gcpOnly:     true,
 		}, {
 			description: "jib in googlecloudbuild",
 			dir:         "testdata/jib",
 			args:        []string{"-p", "gcb"},
 			deployments: []string{"web"},
-			remoteOnly:  true,
+			gcpOnly:     true,
 		}, {
 			description: "custom builder",
 			dir:         "testdata/custom",
@@ -107,8 +106,11 @@ func TestRun(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			if test.remoteOnly && os.Getenv("REMOTE_INTEGRATION") != "true" {
-				t.Skip("skipping remote only test")
+			if test.gcpOnly && !ShouldRunGCPOnlyTests() {
+				t.Skip("skipping gcp only test")
+			}
+			if !test.gcpOnly && ShouldRunGCPOnlyTests() {
+				t.Skip("skipping test that is not gcp only")
 			}
 
 			ns, client, deleteNs := SetupNamespace(t)

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -30,6 +30,9 @@ func TestDevSync(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
 
 	ns, client, deleteNs := SetupNamespace(t)
 	defer deleteNs()

--- a/integration/util.go
+++ b/integration/util.go
@@ -19,6 +19,7 @@ package integration
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -30,6 +31,10 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
+
+func ShouldRunGCPOnlyTests() bool {
+	return os.Getenv("GCP_ONLY") == "true"
+}
 
 func Run(t *testing.T, dir, command string, args ...string) {
 	cmd := exec.Command(command, args...)

--- a/pkg/skaffold/runner/build.go
+++ b/pkg/skaffold/runner/build.go
@@ -19,9 +19,12 @@ package runner
 import (
 	"context"
 	"io"
+	"os/exec"
 
+	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -53,5 +56,16 @@ func (r *SkaffoldRunner) BuildAndTest(ctx context.Context, out io.Writer, artifa
 			return nil, errors.Wrap(err, "test failed")
 		}
 	}
+
+	// With `kind`, docker images have to be loaded with the `kind` CLI.
+	if config.IsKindCluster(r.runCtx.KubeContext) {
+		for _, image := range bRes {
+			cmd := exec.CommandContext(ctx, "kind", "load", "docker-image", image.Tag)
+			if err := util.RunCmd(cmd); err != nil {
+				return nil, errors.Wrapf(err, "unable to load image with kind: %s", image.Tag)
+			}
+		}
+	}
+
 	return bRes, err
 }


### PR DESCRIPTION
This is a first try at using [kind](https://github.com/kubernetes-sigs/kind) for our integration tests.

+ It creates a kind cluster in Travis.
+ It runs the test suite in the same container that's currently used on kokoro.
+ I had to add a few lines of code in skaffold to handle kind clusters. The main change is that docker images have to be explicitly loaded before they are used by a k8s workload.