### PR TITLE
[Refactor] Move gRPC and HTTP server logic out of event package

### DIFF
--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -35,6 +35,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/server"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/test"
@@ -101,10 +102,11 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldConfig) (*Sk
 		return nil, errors.Wrap(err, "creating watch trigger")
 	}
 
-	shutdown, err := event.InitializeState(runCtx)
+	shutdown, err := server.Initialize(runCtx)
 	if err != nil {
-		return nil, errors.Wrap(err, "initializing skaffold event handler")
+		return nil, errors.Wrap(err, "initializing skaffold server")
 	}
+	event.InitializeState(runCtx)
 
 	event.LogSkaffoldMetadata(version.Get())
 

--- a/pkg/skaffold/server/endpoints.go
+++ b/pkg/skaffold/server/endpoints.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/proto"
+	"github.com/golang/protobuf/ptypes/empty"
+)
+
+func (s *server) GetState(context.Context, *empty.Empty) (*proto.State, error) {
+	return event.GetState()
+}
+
+func (s *server) EventLog(stream proto.SkaffoldService_EventLogServer) error {
+	return event.ForEachEvent(stream.Send)
+}
+
+func (s *server) Handle(ctx context.Context, e *proto.Event) (*empty.Empty, error) {
+	event.Handle(e)
+	return &empty.Empty{}, nil
+}

--- a/pkg/skaffold/server/server_test.go
+++ b/pkg/skaffold/server/server_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package event
+package server
 
 import (
 	"fmt"
@@ -32,7 +32,7 @@ var (
 
 func TestServerStartup(t *testing.T) {
 	// start up servers
-	newStatusServer(rpcAddr, httpAddr)
+	initialize(rpcAddr, httpAddr)
 
 	// create gRPC client and ensure we can connect
 	conn, err := grpc.Dial(fmt.Sprintf(":%d", rpcAddr), grpc.WithInsecure())


### PR DESCRIPTION
This moves the server creation logic out of the event package. No functional change.