### PR TITLE
Revert "Improve output for docker push"

### DIFF
--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -199,9 +199,10 @@ func (l *localDaemon) Build(ctx context.Context, out io.Writer, workspace string
 }
 
 // streamDockerMessages streams formatted json output from the docker daemon
+// TODO(@r2d4): Make this output much better, this is the bare minimum
 func streamDockerMessages(dst io.Writer, src io.Reader, auxCallback func(jsonmessage.JSONMessage)) error {
-	fd, isTerm := term.GetFdInfo(dst)
-	return jsonmessage.DisplayJSONMessagesStream(src, dst, fd, isTerm, auxCallback)
+	fd, _ := term.GetFdInfo(dst)
+	return jsonmessage.DisplayJSONMessagesStream(src, dst, fd, false, auxCallback)
 }
 
 // Push pushes an image reference to a registry. Returns the image digest.


### PR DESCRIPTION
This reverts commit 948189ae10dc4078357d404b0514bb8450d3aa73.
That change panics on gLinux + Docker 18.09.3:

````
skaffold dev 
Generating tags...
 - gcr.io/balintp-gcp-lab/gcr.io/k8s-skaffold/skaffold-example -> gcr.io/balintp-gcp-lab/gcr.io/k8s-skaffold/skaffold-example:v0.30.0-62-g81a56b1be
Tags generated in 34.831474ms
Starting build...
Building [gcr.io/balintp-gcp-lab/gcr.io/k8s-skaffold/skaffold-example]...
Sending build context to Docker daemon  3.072kB
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/GoogleContainerTools/skaffold/vendor/github.com/Nvveen/Gotty.readTermInfo(0xc000478ec0, 0x1e, 0x0, 0x0, 0x0)
	vendor/github.com/Nvveen/Gotty/gotty.go:232 +0xd12
github.com/GoogleContainerTools/skaffold/vendor/github.com/Nvveen/Gotty.OpenTermInfo(0xc000042245, 0xe, 0xc000042245, 0xe, 0x0)
	vendor/github.com/Nvveen/Gotty/gotty.go:45 +0x276
github.com/GoogleContainerTools/skaffold/vendor/github.com/docker/docker/pkg/jsonmessage.DisplayJSONMessagesStream(0x1a05160, 0xc00054e980, 0x1a05420, 0xc000010018, 0x1, 0x160de01, 0xc0005451e0, 0x0, 0x1a05160)
	vendor/github.com/docker/docker/pkg/jsonmessage/jsonmessage.go:263 +0x5d9
github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker.streamDockerMessages(0x1a05420, 0xc000010018, 0x1a05160, 0xc00054e980, 0xc0005451e0, 0xc0004247c0, 0x1)
	pkg/skaffold/docker/image.go:204 +0x8f
github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker.(*localDaemon).Build(0xc0002eec80, 0x1a3e3c0, 0xc000392100, 0x1a05420, 0xc000010018, 0x17cf2e5, 0x1, 0xc0002841e0, 0xc00055c960, 0x51, ...)
	pkg/skaffold/docker/image.go:185 +0x6e9
github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/local.(*Builder).buildDocker(0xc0002eed20, 0x1a3e3c0, 0xc000392100, 0x1a05420, 0xc000010018, 0xc000267420, 0xc00055c960, 0x51, 0x53, 0x60, ...)
	pkg/skaffold/build/local/docker.go:44 +0x2bd
github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/local.(*Builder).runBuildForArtifact(0xc0002eed20, 0x1a3e3c0, 0xc000392100, 0x1a05420, 0xc000010018, 0xc000267420, 0xc00055c960, 0x51, 0x30, 0xc000476a50, ...)
	pkg/skaffold/build/local/local.go:89 +0x493
github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/local.(*Builder).buildArtifact(0xc0002eed20, 0x1a3e3c0, 0xc000392100, 0x1a05420, 0xc000010018, 0xc000267420, 0xc00055c960, 0x51, 0x1878948, 0xc00032cf80, ...)
	pkg/skaffold/build/local/local.go:51 +0x9b
github.com/GoogleContainerTools/skaffold/pkg/skaffold/build.InSequence(0x1a3e3c0, 0xc000392100, 0x1a05420, 0xc000010018, 0xc0004767b0, 0xc000390060, 0x1, 0x1, 0xc000545768, 0x0, ...)
	pkg/skaffold/build/sequence.go:45 +0x25c
github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/local.(*Builder).Build(0xc0002eed20, 0x1a3e3c0, 0xc000392100, 0x1a05420, 0xc000010018, 0xc0004767b0, 0xc000390060, 0x1, 0x1, 0x0, ...)
	pkg/skaffold/build/local/local.go:47 +0x12f
github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner.withTimings.Build(0x1a3e6c0, 0xc0002eed20, 0x1a1fda0, 0xc0001cc4b0, 0x1a3e740, 0xc00044ae00, 0x0, 0x1a3e3c0, 0xc000392100, 0x1a05420, ...)
	pkg/skaffold/runner/timings.go:64 +0x169
github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner.(*SkaffoldRunner).BuildAndTest(0xc000388fc0, 0x1a3e3c0, 0xc000392100, 0x1a05420, 0xc000010018, 0xc000390060, 0x1, 0x1, 0x16cb4a0, 0xc0004f68a0, ...)
	pkg/skaffold/runner/build.go:42 +0x1ff
github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner.(*SkaffoldRunner).buildTestDeploy(0xc000388fc0, 0x1a3e3c0, 0xc000392100, 0x1a05420, 0xc000010018, 0xc000390060, 0x1, 0x1, 0x1a3e6c0, 0xc0002eed20)
	pkg/skaffold/runner/runner.go:251 +0x9b
github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner.(*SkaffoldRunner).Dev(0xc000388fc0, 0x1a3e3c0, 0xc000392100, 0x1a05420, 0xc000010018, 0xc000390060, 0x1, 0x1, 0x0, 0x0)
	pkg/skaffold/runner/dev.go:131 +0x8ab
github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd.doDev(0x1a3e3c0, 0xc000392100, 0x1a05420, 0xc000010018, 0x0, 0x0)
	cmd/skaffold/app/cmd/dev.go:71 +0x148
github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd.cancelWithCtrlC.func1(0x1a05420, 0xc000010018, 0x0, 0x0)
	cmd/skaffold/app/cmd/signals.go:33 +0xba
github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd.(*builder).NoArgs.func1(0xc0003dd690, 0xc00000e540, 0x0, 0x2, 0x0, 0x0)
	cmd/skaffold/app/cmd/commands.go:82 +0x3a
github.com/GoogleContainerTools/skaffold/vendor/github.com/spf13/cobra.(*Command).execute(0xc0003dd690, 0xc00000e500, 0x2, 0x2, 0xc0003dd690, 0xc00000e500)
	vendor/github.com/spf13/cobra/command.go:762 +0x465
github.com/GoogleContainerTools/skaffold/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc0003dc000, 0xc000010018, 0x1a05420, 0xc000010020)
	vendor/github.com/spf13/cobra/command.go:852 +0x2ec
github.com/GoogleContainerTools/skaffold/vendor/github.com/spf13/cobra.(*Command).Execute(...)
	vendor/github.com/spf13/cobra/command.go:800
github.com/GoogleContainerTools/skaffold/cmd/skaffold/app.Run(0x1a05420, 0xc000010018, 0x1a05420, 0xc000010020, 0xc0004f7f88, 0x51bddf)
	cmd/skaffold/app/skaffold.go:27 +0x58
main.main()
	cmd/skaffold/skaffold.go:30 +0x4e
````