### PR TITLE
Implements `skaffold find-configs -d <dir>` command

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -101,6 +101,7 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 	rootCmd.AddCommand(NewCmdConfig(out))
 	rootCmd.AddCommand(NewCmdInit(out))
 	rootCmd.AddCommand(NewCmdDiagnose(out))
+	rootCmd.AddCommand(NewCmdFindConfigs(out))
 
 	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", constants.DefaultLogLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 	rootCmd.PersistentFlags().IntVar(&defaultColor, "color", int(color.Default), "Specify the default output color in ANSI escape codes")

--- a/cmd/skaffold/app/cmd/find_configs.go
+++ b/cmd/skaffold/app/cmd/find_configs.go
@@ -76,7 +76,6 @@ func doFindConfigs(out io.Writer) error {
 		for p, v := range pathToVersion {
 			var c color.Color
 			if v == latest.Version {
-				v += " (LATEST)"
 				c = color.Default
 			} else {
 				c = color.Green
@@ -84,7 +83,7 @@ func doFindConfigs(out io.Writer) error {
 			c.Fprintf(out, fmt.Sprintf("%%-%ds\t%%-%ds\n", pathOutLen, versionOutLen), p, v)
 		}
 	default:
-		return errors.New("Unsupported template")
+		return errors.New("unsupported template")
 	}
 
 	return nil

--- a/cmd/skaffold/app/cmd/find_configs.go
+++ b/cmd/skaffold/app/cmd/find_configs.go
@@ -34,7 +34,7 @@ var (
 	directory string
 )
 
-// NewCmdInit describes the CLI command to generate a Skaffold configuration.
+// NewCmdFindConfigs list the skaffold config files in the specified directory.
 func NewCmdFindConfigs(out io.Writer) *cobra.Command {
 	return NewCmd(out, "find-configs").
 		WithDescription("Find in a given directory all skaffold yamls files that are parseable or upgradeable with their versions.").

--- a/cmd/skaffold/app/cmd/find_configs.go
+++ b/cmd/skaffold/app/cmd/find_configs.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	directory string
+)
+
+// NewCmdInit describes the CLI command to generate a Skaffold configuration.
+func NewCmdFindConfigs(out io.Writer) *cobra.Command {
+	return NewCmd(out, "find-configs").
+		WithDescription("Find in a given directory all skaffold yamls files that are parseable or upgradeable with their versions.").
+		WithFlags(func(f *pflag.FlagSet) {
+			// Default to current directory
+			f.StringVarP(&directory, "directory", "d", ".", "Root directory to lookup the config files.")
+		}).
+		NoArgs(doFindConfigs)
+}
+
+func doFindConfigs(out io.Writer) error {
+	pathOutLen, versionOutLen := 70, 20
+
+	return filepath.Walk(directory,
+		func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+
+			// Find files ending in ".yaml" and parseable to skaffold config in the specified root directory recursively.
+			if !info.IsDir() && strings.HasSuffix(path, ".yaml") {
+				cfg, err := schema.ParseConfig(path, false)
+				if err == nil {
+					if cfg.GetVersion() == latest.Version {
+						printColoredRow(out, pathOutLen, versionOutLen, path, "LATEST", color.Default)
+					} else {
+						printColoredRow(out, pathOutLen, versionOutLen, path, cfg.GetVersion(), color.Green)
+					}
+				}
+			}
+			return nil
+		})
+}
+
+func printColoredRow(out io.Writer, pathLen, versionLen int, path, version string, c color.Color) {
+	formatTemplate := fmt.Sprintf("%%-%ds\t%%-%ds\n", pathLen, versionLen)
+	c.Fprintf(out, formatTemplate, path, version)
+}

--- a/cmd/skaffold/app/cmd/find_configs_test.go
+++ b/cmd/skaffold/app/cmd/find_configs_test.go
@@ -26,16 +26,16 @@ import (
 )
 
 var (
-	invalidFileName    = "invalid-skaffold.yaml"
-	validFileName      = "valid-skaffold.yaml"
-	upgradableFileName = "upgradable-skaffold.yaml"
+	invalidFileName     = "invalid-skaffold.yaml"
+	validFileName       = "valid-skaffold.yaml"
+	upgradeableFileName = "upgradeable-skaffold.yaml"
 )
 
 func TestFindConfigs(t *testing.T) {
 	testutil.Run(t, "", func(tt *testutil.T) {
 		latestVersion := latest.Version
-		upgradableVersion := v1beta7.Version
-		tmpDir1, tmpDir2 := setUpTempFiles(tt, latestVersion, upgradableVersion)
+		upgradeableVersion := v1beta7.Version
+		tmpDir1, tmpDir2 := setUpTempFiles(tt, latestVersion, upgradeableVersion)
 
 		tests := []struct {
 			flagDir                *testutil.TempDir
@@ -45,7 +45,7 @@ func TestFindConfigs(t *testing.T) {
 			{
 				flagDir:                tmpDir1,
 				resultCounts:           2,
-				shouldContainsMappings: map[string]string{validFileName: latestVersion, upgradableFileName: upgradableVersion},
+				shouldContainsMappings: map[string]string{validFileName: latestVersion, upgradeableFileName: upgradeableVersion},
 			},
 			{
 				flagDir:                tmpDir2,
@@ -71,13 +71,13 @@ This helper function will generate the following file tree for testing purpose
 ...
 ├── tmpDir1
 │   ├── valid-skaffold.yaml
-|   ├── upgradable-skaffold.yaml
+|   ├── upgradeable-skaffold.yaml
 │   └── invalid-skaffold.yaml
 └── tmpDir2
 	├── valid-skaffold.yaml
 	└── invalid-skaffold.yaml
 */
-func setUpTempFiles(tt *testutil.T, latestVersion, upgradableVersion string) (*testutil.TempDir, *testutil.TempDir) {
+func setUpTempFiles(tt *testutil.T, latestVersion, upgradeableVersion string) (*testutil.TempDir, *testutil.TempDir) {
 	validYaml := fmt.Sprintf(`apiVersion: %s
 kind: Config
 build:
@@ -86,14 +86,14 @@ build:
     docker:
       dockerfile: dockerfile.test
 `, latestVersion)
-	upgradableYaml := fmt.Sprintf(`apiVersion: %s
+	upgradeableYaml := fmt.Sprintf(`apiVersion: %s
 kind: Config
 build:
   artifacts:
   - image: docker/image
     docker:
       dockerfile: dockerfile.test
-`, upgradableVersion)
+`, upgradeableVersion)
 	invalidYaml := `This is invalid`
 
 	tmpDir1 := tt.NewTempDir()
@@ -115,8 +115,8 @@ build:
 			tmpDir:   tmpDir1,
 		},
 		{
-			fileName: upgradableFileName,
-			content:  upgradableYaml,
+			fileName: upgradeableFileName,
+			content:  upgradeableYaml,
 			tmpDir:   tmpDir1,
 		},
 		{

--- a/cmd/skaffold/app/cmd/find_configs_test.go
+++ b/cmd/skaffold/app/cmd/find_configs_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta7"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+var (
+	invalidFileName    string = "invalid-skaffold.yaml"
+	validFileName      string = "valid-skaffold.yaml"
+	upgradableFileName string = "upgradable-skaffold.yaml"
+)
+
+func TestFindConfigs(t *testing.T) {
+	testutil.Run(t, "", func(tt *testutil.T) {
+		latestVersion := latest.Version
+		upgradableVersion := v1beta7.Version
+		tmpDir1, tmpDir2 := setUpTempFiles(tt, latestVersion, upgradableVersion)
+
+		tests := []struct {
+			flagDir                string
+			resultCounts           int
+			shouldContainsFiles    []string
+			shouldContainsVersions []string
+		}{
+			{
+				flagDir:                tmpDir1,
+				resultCounts:           2,
+				shouldContainsFiles:    []string{validFileName, upgradableFileName},
+				shouldContainsVersions: []string{latestVersion, upgradableVersion},
+			},
+			{
+				flagDir:                tmpDir2,
+				resultCounts:           1,
+				shouldContainsFiles:    []string{validFileName},
+				shouldContainsVersions: []string{latestVersion},
+			},
+		}
+		for _, test := range tests {
+			var b bytes.Buffer
+			err := findConfigs(&b, test.flagDir)
+
+			for _, f := range test.shouldContainsFiles {
+				tt.CheckContains(fmt.Sprintf("%s/%s", test.flagDir, f), b.String())
+			}
+
+			for _, v := range test.shouldContainsVersions {
+				tt.CheckContains(v, b.String())
+			}
+
+			tt.CheckDeepEqual(test.resultCounts, strings.Count(b.String(), "\n"))
+			tt.CheckError(false, err)
+		}
+	})
+}
+
+/*
+This helper function will generate the following file tree for testing purpose
+...
+├── tmpDir1
+│   ├── valid-skaffold.yaml
+|   ├── upgradable-skaffold.yaml
+│   └── invalid-skaffold.yaml
+└── tmpDir2
+	├── valid-skaffold.yaml
+	└── invalid-skaffold.yaml
+*/
+func setUpTempFiles(tt *testutil.T, latestVersion, upgradableVersion string) (string, string) {
+	validYaml := fmt.Sprintf(`apiVersion: %s
+kind: Config
+build:
+  artifacts:
+  - image: docker/image
+    docker:
+      dockerfile: dockerfile.test
+`, latestVersion)
+	upgradableYaml := fmt.Sprintf(`apiVersion: %s
+kind: Config
+build:
+  artifacts:
+  - image: docker/image
+    docker:
+      dockerfile: dockerfile.test
+`, upgradableVersion)
+	invalidYaml := `This is invalid`
+
+	tmpDir1 := tt.NewTempDir()
+	tmpDir2 := tt.NewTempDir()
+
+	files := []struct {
+		fileName string
+		content  string
+		tmpDir   *testutil.TempDir
+	}{
+		{
+			fileName: invalidFileName,
+			content:  invalidYaml,
+			tmpDir:   tmpDir1,
+		},
+		{
+			fileName: validFileName,
+			content:  validYaml,
+			tmpDir:   tmpDir1,
+		},
+		{
+			fileName: upgradableFileName,
+			content:  upgradableYaml,
+			tmpDir:   tmpDir1,
+		},
+		{
+			fileName: invalidFileName,
+			content:  invalidYaml,
+			tmpDir:   tmpDir2,
+		},
+		{
+			fileName: validFileName,
+			content:  validYaml,
+			tmpDir:   tmpDir2,
+		},
+	}
+
+	for _, file := range files {
+		file.tmpDir.Write(file.fileName, file.content)
+	}
+
+	return tmpDir1.Root(), tmpDir2.Root()
+}

--- a/cmd/skaffold/app/cmd/find_configs_test.go
+++ b/cmd/skaffold/app/cmd/find_configs_test.go
@@ -40,7 +40,7 @@ func TestFindConfigs(t *testing.T) {
 		tmpDir1, tmpDir2 := setUpTempFiles(tt, latestVersion, upgradableVersion)
 
 		tests := []struct {
-			flagDir                string
+			flagDir                *testutil.TempDir
 			resultCounts           int
 			shouldContainsFiles    []string
 			shouldContainsVersions []string
@@ -60,10 +60,10 @@ func TestFindConfigs(t *testing.T) {
 		}
 		for _, test := range tests {
 			var b bytes.Buffer
-			err := findConfigs(&b, test.flagDir)
+			err := findConfigs(&b, test.flagDir.Root())
 
 			for _, f := range test.shouldContainsFiles {
-				tt.CheckContains(fmt.Sprintf("%s/%s", test.flagDir, f), b.String())
+				tt.CheckContains(test.flagDir.Path(f), b.String())
 			}
 
 			for _, v := range test.shouldContainsVersions {
@@ -87,7 +87,7 @@ This helper function will generate the following file tree for testing purpose
 	├── valid-skaffold.yaml
 	└── invalid-skaffold.yaml
 */
-func setUpTempFiles(tt *testutil.T, latestVersion, upgradableVersion string) (string, string) {
+func setUpTempFiles(tt *testutil.T, latestVersion, upgradableVersion string) (*testutil.TempDir, *testutil.TempDir) {
 	validYaml := fmt.Sprintf(`apiVersion: %s
 kind: Config
 build:
@@ -145,5 +145,5 @@ build:
 		file.tmpDir.Write(file.fileName, file.content)
 	}
 
-	return tmpDir1.Root(), tmpDir2.Root()
+	return tmpDir1, tmpDir2
 }

--- a/cmd/skaffold/app/cmd/find_configs_test.go
+++ b/cmd/skaffold/app/cmd/find_configs_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 var (
-	invalidFileName    string = "invalid-skaffold.yaml"
-	validFileName      string = "valid-skaffold.yaml"
-	upgradableFileName string = "upgradable-skaffold.yaml"
+	invalidFileName    = "invalid-skaffold.yaml"
+	validFileName      = "valid-skaffold.yaml"
+	upgradableFileName = "upgradable-skaffold.yaml"
 )
 
 func TestFindConfigs(t *testing.T) {

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -478,6 +478,7 @@ Usage:
 
 Flags:
   -d, --directory string   Root directory to lookup the config files. (default ".")
+  -o, --output string      Result format, default to table. [(-o|--output=)json|table] (default "table")
 
 Global Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -488,6 +489,7 @@ Global Flags:
 Env vars:
 
 * `SKAFFOLD_DIRECTORY` (same as `--directory`)
+* `SKAFFOLD_OUTPUT` (same as `--output`)
 
 ### skaffold fix
 

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -63,18 +63,19 @@ Usage:
   skaffold [command]
 
 Available Commands:
-  build       Builds the artifacts
-  completion  Output shell completion for the given shell (bash or zsh)
-  config      A set of commands for interacting with the Skaffold config.
-  debug       Runs a pipeline file in debug mode
-  delete      Delete the deployed resources
-  deploy      Deploys the artifacts
-  dev         Runs a pipeline file in development mode
-  diagnose    Run a diagnostic on Skaffold
-  fix         Converts old Skaffold config to newest schema version
-  init        Automatically generate Skaffold configuration for deploying an application
-  run         Runs a pipeline file
-  version     Print the version information
+  build        Builds the artifacts
+  completion   Output shell completion for the given shell (bash or zsh)
+  config       A set of commands for interacting with the Skaffold config.
+  debug        Runs a pipeline file in debug mode
+  delete       Delete the deployed resources
+  deploy       Deploys the artifacts
+  dev          Runs a pipeline file in development mode
+  diagnose     Run a diagnostic on Skaffold
+  find-configs Find in a given directory all skaffold yamls files that are parseable or upgradeable with their versions.
+  fix          Converts old Skaffold config to newest schema version
+  init         Automatically generate Skaffold configuration for deploying an application
+  run          Runs a pipeline file
+  version      Print the version information
 
 Flags:
       --color int          Specify the default output color in ANSI escape codes (default 34)
@@ -466,6 +467,27 @@ Env vars:
 
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
+
+### skaffold find-configs
+
+Find in a given directory all skaffold yamls files that are parseable or upgradeable with their versions.
+
+```
+Usage:
+  skaffold find-configs
+
+Flags:
+  -d, --directory string   Root directory to lookup the config files. (default ".")
+
+Global Flags:
+      --color int          Specify the default output color in ANSI escape codes (default 34)
+  -v, --verbosity string   Log level (debug, info, warn, error, fatal, panic) (default "warning")
+
+
+```
+Env vars:
+
+* `SKAFFOLD_DIRECTORY` (same as `--directory`)
 
 ### skaffold fix
 


### PR DESCRIPTION
Resolves #2229, which can be used to find in a given directory all files that are parseable or upgradeable.