### PR TITLE
Fix remoteManifests

### DIFF
--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -144,7 +144,7 @@ func (k *KubectlDeployer) Cleanup(ctx context.Context, out io.Writer) error {
 	}
 
 	// pull remote manifests
-	var rm kubectl.ManifestList
+	var rm deploy.ManifestList
 	for _, m := range k.RemoteManifests {
 		manifest, err := k.readRemoteManifest(ctx, m)
 		if err != nil {
@@ -224,14 +224,15 @@ func (k *KubectlDeployer) readManifests(ctx context.Context) (deploy.ManifestLis
 // context in the specified namespace and for the specified type
 func (k *KubectlDeployer) readRemoteManifest(ctx context.Context, name string) ([]byte, error) {
 	var args []string
+	ns := ""
 	if parts := strings.Split(name, ":"); len(parts) > 1 {
-		args = append(args, "--namespace", parts[0])
+		ns = parts[0]
 		name = parts[1]
 	}
 	args = append(args, name, "-o", "yaml")
 
 	var manifest bytes.Buffer
-	err := k.kubectl.Run(ctx, nil, &manifest, "get", nil, args...)
+	err := k.kubectl.RunInNamespace(ctx, nil, &manifest, "get", ns, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting manifest")
 	}

--- a/pkg/skaffold/deploy/kubectl/visitor.go
+++ b/pkg/skaffold/deploy/kubectl/visitor.go
@@ -18,7 +18,7 @@ package kubectl
 
 import (
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // Replacer is used to replace portions of yaml manifests that match a given key.

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -271,38 +271,59 @@ func TestKubectlCleanup(t *testing.T) {
 }
 
 func TestKubectlDeployerRemoteCleanup(t *testing.T) {
-	cfg := &latest.KubectlDeploy{
-		RemoteManifests: []string{"pod/leeroy-web"},
+	tests := []struct {
+		description string
+		cfg         *latest.KubectlDeploy
+		command     util.Command
+		shouldErr   bool
+	}{
+		{
+			description: "cleanup success",
+			cfg: &latest.KubectlDeploy{
+			 RemoteManifests: []string{"pod/leeroy-web"},
+			},
+			command: testutil.NewFakeCmd(t).
+				WithRun("kubectl --context kubecontext --namespace testNamespace get pod/leeroy-web -o yaml").
+				WithRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true -f -").
+				WithRunInput("kubectl --context kubecontext --namespace testNamespace apply -f -", deploymentWebYAML),
+		},
+		{
+			description: "cleanup error",
+			cfg: &latest.KubectlDeploy{
+				RemoteManifests: []string{"anotherNamespace:pod/leeroy-web"},
+			},
+			command: testutil.NewFakeCmd(t).
+				WithRun("kubectl --context kubecontext --namespace anotherNamespace get pod/leeroy-web -o yaml").
+				WithRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true -f -").
+				WithRunInput("kubectl --context kubecontext --namespace anotherNamespace apply -f -", deploymentWebYAML),
+		},
 	}
+	for _, test := range tests {
+		testutil.Run(t, "cleanup remote", func(t *testutil.T) {
+			t.Override(&util.DefaultExecCommand, test.command)
+			t.NewTempDir().
+				Write("deployment.yaml", deploymentWebYAML).
+				Chdir()
 
-	testutil.Run(t, "cleanup remote", func(t *testutil.T) {
-		command := t.FakeRun("kubectl --context kubecontext --namespace testNamespace get pod/leeroy-web -o yaml").
-			WithRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true -f -").
-			WithRunInput("kubectl --context kubecontext --namespace testNamespace apply -f -", deploymentWebYAML)
-
-		t.Override(&util.DefaultExecCommand, command)
-		t.NewTempDir().
-			Write("deployment.yaml", deploymentWebYAML).
-			Chdir()
-
-		k := NewKubectlDeployer(&runcontext.RunContext{
-			WorkingDir: ".",
-			Cfg: &latest.Pipeline{
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KubectlDeploy: cfg,
+			k := NewKubectlDeployer(&runcontext.RunContext{
+				WorkingDir: ".",
+				Cfg: latest.Pipeline{
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							KubectlDeploy: test.cfg,
+						},
 					},
 				},
-			},
-			KubeContext: testKubeContext,
-			Opts: &config.SkaffoldOptions{
-				Namespace: testNamespace,
-			},
-		})
-		err := k.Cleanup(context.Background(), ioutil.Discard)
+				KubeContext: testKubeContext,
+				Opts: config.SkaffoldOptions{
+					Namespace: testNamespace,
+				},
+			})
+			err := k.Cleanup(context.Background(), ioutil.Discard)
 
-		t.CheckError(false, err)
-	})
+			t.CheckError(false, err)
+		})
+	}
 }
 
 func TestKubectlRedeploy(t *testing.T) {

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -275,12 +275,11 @@ func TestKubectlDeployerRemoteCleanup(t *testing.T) {
 		description string
 		cfg         *latest.KubectlDeploy
 		command     util.Command
-		shouldErr   bool
 	}{
 		{
 			description: "cleanup success",
 			cfg: &latest.KubectlDeploy{
-			 RemoteManifests: []string{"pod/leeroy-web"},
+				RemoteManifests: []string{"pod/leeroy-web"},
 			},
 			command: testutil.NewFakeCmd(t).
 				WithRun("kubectl --context kubecontext --namespace testNamespace get pod/leeroy-web -o yaml").

--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -91,8 +91,7 @@ func (c *CLI) args(command string, namespace string, arg ...string) []string {
 	return args
 }
 
-
-func (c *CLI) resolveNamespace(ns string) string{
+func (c *CLI) resolveNamespace(ns string) string {
 	if ns != "" {
 		return ns
 	}


### PR DESCRIPTION
This commit address issue #2160. Remote manifests in the config are
properly pulled again.

This also addresses another unmentioned issue: when using a remote
manifest with `skaffold dev`, the remote manifest will have its image
updated to include the new tag. When shutting down, the remote manifest
will be left the same, including the updated tag. This causes further
runs of `skaffold dev` to no longer match the image, and not update it
properly.

This is addressed by saving all of the images in the manifests found the
first time apply is ran, and then on cleanup replacing the images with
those initially found.