### PR TITLE
cluster builder fails to detect insecure registries

### DIFF
--- a/pkg/skaffold/build/cluster/types.go
+++ b/pkg/skaffold/build/cluster/types.go
@@ -49,6 +49,7 @@ func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
 	return &Builder{
 		ClusterDetails: runCtx.Cfg.Build.Cluster,
 		timeout:        timeout,
+		insecureRegistries: runCtx.InsecureRegistries,
 	}, nil
 }
 

--- a/pkg/skaffold/build/cluster/types.go
+++ b/pkg/skaffold/build/cluster/types.go
@@ -47,8 +47,8 @@ func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
 	}
 
 	return &Builder{
-		ClusterDetails: runCtx.Cfg.Build.Cluster,
-		timeout:        timeout,
+		ClusterDetails:     runCtx.Cfg.Build.Cluster,
+		timeout:            timeout,
 		insecureRegistries: runCtx.InsecureRegistries,
 	}, nil
 }


### PR DESCRIPTION
inject insecure registries from context to builder, was lost in pulling #1870