### PR TITLE
Add K8sManagedBy function to labeller

### DIFF
--- a/pkg/skaffold/runner/labeller.go
+++ b/pkg/skaffold/runner/labeller.go
@@ -51,3 +51,7 @@ func (d *DefaultLabeller) Labels() map[string]string {
 		K8ManagedByLabel: fmt.Sprintf("skaffold-%s", version),
 	}
 }
+
+func (d *DefaultLabeller) K8sMangedByLabel() string {
+	return fmt.Sprintf("%s=skaffold-%s", K8ManagedByLabel, d.version)
+}

--- a/pkg/skaffold/runner/labeller.go
+++ b/pkg/skaffold/runner/labeller.go
@@ -23,9 +23,9 @@ import (
 )
 
 const (
-	K8ManagedByLabel = "app.kubernetes.io/managed-by"
-	UnknownVersion   = "unknown"
-	Empty            = ""
+	K8ManagedByLabelKey = "app.kubernetes.io/managed-by"
+	UnknownVersion      = "unknown"
+	Empty               = ""
 )
 
 // DefaultLabeller adds K9 style managed-by label
@@ -37,21 +37,24 @@ func NewLabeller(verStr string) *DefaultLabeller {
 	if verStr == Empty {
 		verStr = version.Get().Version
 	}
+	if verStr == Empty {
+		verStr = UnknownVersion
+	}
 	return &DefaultLabeller{
 		version: verStr,
 	}
 }
 
 func (d *DefaultLabeller) Labels() map[string]string {
-	version := d.version
-	if version == Empty {
-		version = UnknownVersion
-	}
 	return map[string]string{
-		K8ManagedByLabel: fmt.Sprintf("skaffold-%s", version),
+		K8ManagedByLabelKey: d.skaffoldVersion(),
 	}
 }
 
-func (d *DefaultLabeller) K8sMangedByLabel() string {
-	return fmt.Sprintf("%s=skaffold-%s", K8ManagedByLabel, d.version)
+func (d *DefaultLabeller) K8sManagedByLabelKeyValueString() string {
+	return fmt.Sprintf("%s=%s", K8ManagedByLabelKey, d.skaffoldVersion())
+}
+
+func (d *DefaultLabeller) skaffoldVersion() string {
+	return fmt.Sprintf("skaffold-%s", d.version)
 }

--- a/pkg/skaffold/runner/labeller_test.go
+++ b/pkg/skaffold/runner/labeller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package runner
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -36,14 +35,12 @@ func TestDefaultLabeller(t *testing.T) {
 		},
 		{
 			description: "empty version should add postfix unknown",
-			expected:    fmt.Sprintf("skaffold-unknown"),
+			expected:    "skaffold-unknown",
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			l := &DefaultLabeller{
-				version: test.version,
-			}
+			l := NewLabeller(test.version)
 			labels := l.Labels()
 
 			expected := map[string]string{"app.kubernetes.io/managed-by": test.expected}
@@ -52,12 +49,12 @@ func TestDefaultLabeller(t *testing.T) {
 	}
 }
 
-func TestK8sMangedByLabel(t *testing.T) {
+func TestK8sManagedByLabelKeyValueString(t *testing.T) {
 	defaultLabeller := &DefaultLabeller{
 		version: "version",
 	}
 	expected := "app.kubernetes.io/managed-by=skaffold-version"
-	actual := defaultLabeller.K8sMangedByLabel()
+	actual := defaultLabeller.K8sManagedByLabelKeyValueString()
 	if actual != expected {
 		t.Fatalf("actual label not equal to expected label. Actual: \n %s \n Expected: \n %s", actual, expected)
 	}

--- a/pkg/skaffold/runner/labeller_test.go
+++ b/pkg/skaffold/runner/labeller_test.go
@@ -51,3 +51,14 @@ func TestDefaultLabeller(t *testing.T) {
 		})
 	}
 }
+
+func TestK8sMangedByLabel(t *testing.T) {
+	defaultLabeller := &DefaultLabeller{
+		version: "version",
+	}
+	expected := "app.kubernetes.io/managed-by=skaffold-version"
+	actual := defaultLabeller.K8sMangedByLabel()
+	if actual != expected {
+		t.Fatalf("actual label not equal to expected label. Actual: \n %s \n Expected: \n %s", actual, expected)
+	}
+}

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -57,6 +57,7 @@ type SkaffoldRunner struct {
 	cache             *cache.Cache
 	runCtx            *runcontext.RunContext
 	labellers         []deploy.Labeller
+	defaultLabeller   *DefaultLabeller
 	builds            []build.Artifact
 	hasBuilt          bool
 	hasDeployed       bool
@@ -118,6 +119,7 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *latest.SkaffoldConfig) (*Sk
 		Syncer:            kubectl.NewSyncer(runCtx.Namespaces),
 		Watcher:           watch.NewWatcher(trigger),
 		labellers:         labellers,
+		defaultLabeller:   defaultLabeller,
 		imageList:         kubernetes.NewImageList(),
 		cache:             artifactCache,
 		runCtx:            runCtx,


### PR DESCRIPTION
This function will be used by the port forwarder to parse out deployed services to automatically port forward. I've added the defaultLabeller to the runner so that the label can be passed in to the port forwarder in an upcoming PR.