### PR TITLE
Handle simple glob patterns when upgrading the sync patterns

### DIFF
--- a/docs/content/en/schemas/v1beta11.json
+++ b/docs/content/en/schemas/v1beta11.json
@@ -1674,8 +1674,8 @@
         },
         "src": {
           "type": "string",
-          "description": "a glob pattern to match local paths against.",
-          "x-intellij-html-description": "a glob pattern to match local paths against.",
+          "description": "a glob pattern to match local paths against. Directories should be delimited by `/` on all platforms.",
+          "x-intellij-html-description": "a glob pattern to match local paths against. Directories should be delimited by <code>/</code> on all platforms.",
           "examples": [
             "\"css/**/*.css\""
           ]

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -498,6 +498,7 @@ type Sync struct {
 // SyncRule specifies which local files to sync to remote folders.
 type SyncRule struct {
 	// Src is a glob pattern to match local paths against.
+	// Directories should be delimited by `/` on all platforms.
 	// For example: `"css/**/*.css"`.
 	Src string `yaml:"src,omitempty" yamltags:"required"`
 

--- a/pkg/skaffold/schema/v1beta9/upgrade_test.go
+++ b/pkg/skaffold/schema/v1beta9/upgrade_test.go
@@ -142,7 +142,7 @@ build:
   artifacts:
   - image: gcr.io/no-star-1
     sync:
-      '/public/A/B/a.html': /www
+      '/public/A/B/a.html': /public/A/B
   - image: gcr.io/no-star-2
     sync:
       '/b.html': /www
@@ -151,10 +151,10 @@ build:
       'c.html': /www
   - image: gcr.io/no-star-4
     sync:
-      'public/A/d.html': /www
+      'public/A/d.html': public/A/
   - image: gcr.io/single-star-1
     sync:
-      'public/*': /app
+      'public/*': /app/public/
   - image: gcr.io/single-star-2
     sync:
       'main*.js': /app
@@ -185,8 +185,7 @@ build:
     sync:
       manual:
       - src: /public/A/B/a.html
-        dest: /www
-        strip: /public/A/B/
+        dest: /
   - image: gcr.io/no-star-2
     sync:
       manual:
@@ -202,14 +201,12 @@ build:
     sync:
       manual:
       - src: public/A/d.html
-        dest: /www
-        strip: public/A/
+        dest: .
   - image: gcr.io/single-star-1
     sync:
       manual:
       - src: 'public/*'
-        dest: /app
-        strip: public/
+        dest: /app/
   - image: gcr.io/single-star-2
     sync:
       manual:

--- a/pkg/skaffold/schema/v1beta9/upgrade_test.go
+++ b/pkg/skaffold/schema/v1beta9/upgrade_test.go
@@ -140,10 +140,33 @@ apiVersion: skaffold/v1beta9
 kind: Config
 build:
   artifacts:
+  - image: gcr.io/no-star-1
+    sync:
+      '/public/A/B/a.html': /www
+  - image: gcr.io/no-star-2
+    sync:
+      '/b.html': /www
+  - image: gcr.io/no-star-3
+    sync:
+      'c.html': /www
+  - image: gcr.io/no-star-4
+    sync:
+      'public/A/d.html': /www
+  - image: gcr.io/single-star-1
+    sync:
+      'public/*': /app
+  - image: gcr.io/single-star-2
+    sync:
+      'main*.js': /app
+  - image: gcr.io/single-star-3
+    sync:
+      '/public/b/*.js': /app
+  - image: gcr.io/single-star-4
+    sync:
+      '/c/prefix-*': /app
   - image: gcr.io/k8s-skaffold/node-example
     sync:
       '**/*.js': .
-  - image: gcr.io/k8s-skaffold/leeroy
   - image: gcr.io/k8s-skaffold/react-reload
     sync:
       'src/***/*.js': app/
@@ -158,12 +181,57 @@ apiVersion: skaffold/v1beta10
 kind: Config
 build:
   artifacts:
+  - image: gcr.io/no-star-1
+    sync:
+      manual:
+      - src: /public/A/B/a.html
+        dest: /www
+        strip: /public/A/B/
+  - image: gcr.io/no-star-2
+    sync:
+      manual:
+      - src: /b.html
+        dest: /www
+        strip: /
+  - image: gcr.io/no-star-3
+    sync:
+      manual:
+      - src: c.html
+        dest: /www
+  - image: gcr.io/no-star-4
+    sync:
+      manual:
+      - src: public/A/d.html
+        dest: /www
+        strip: public/A/
+  - image: gcr.io/single-star-1
+    sync:
+      manual:
+      - src: 'public/*'
+        dest: /app
+        strip: public/
+  - image: gcr.io/single-star-2
+    sync:
+      manual:
+      - src: 'main*.js'
+        dest: /app
+  - image: gcr.io/single-star-3
+    sync:
+      manual:
+      - src: '/public/b/*.js'
+        dest: /app
+        strip: /public/b/
+  - image: gcr.io/single-star-4
+    sync:
+      manual:
+      - src: '/c/prefix-*'
+        dest: /app
+        strip: /c/
   - image: gcr.io/k8s-skaffold/node-example
     sync:
       manual:
       - src: '**/*.js'
         dest: .
-  - image: gcr.io/k8s-skaffold/leeroy
   - image: gcr.io/k8s-skaffold/react-reload
     sync:
       manual:


### PR DESCRIPTION
Also simple glob patterns are flattened at the destination. The translation to the new sync config was not handled correctly for cases such as:
```yaml
- public/*: /app/public
- public/index.html: /app/public
```

---

Now, for compatible source patterns, the `strip` field is correctly populated. For example:
IN:
```yaml
apiVersion: skaffold/v1beta8
kind: Config
build:
  artifacts:
  - image: myimage
    sync:
      public/*: /app/public
```

OUT (`skaffold fix`):
```yaml
apiVersion: skaffold/v1beta11
kind: Config
build:
  artifacts:
  - image: myimage
    sync:
      manual:
      - src: public/*
        dest: /app/
```
This requires also a simplification of the sync rule, if `strip` is a suffix of `dest`, which is now also applied to triple-star patterns.

Fix #2280 