### PR TITLE
Docker is case sensitive about networks

### DIFF
--- a/docs/content/en/schemas/v1beta10.json
+++ b/docs/content/en/schemas/v1beta10.json
@@ -689,8 +689,8 @@
         },
         "network": {
           "type": "string",
-          "description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Valid modes are `Host`: use the host's networking stack. `Bridge`: use the bridged network configuration. `None`: no networking in the container.",
-          "x-intellij-html-description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Valid modes are <code>Host</code>: use the host's networking stack. <code>Bridge</code>: use the bridged network configuration. <code>None</code>: no networking in the container."
+          "description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Valid modes are `host`: use the host's networking stack. `bridge`: use the bridged network configuration. `none`: no networking in the container.",
+          "x-intellij-html-description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Valid modes are <code>host</code>: use the host's networking stack. <code>bridge</code>: use the bridged network configuration. <code>none</code>: no networking in the container."
         },
         "noCache": {
           "type": "boolean",

--- a/docs/content/en/schemas/v1beta11.json
+++ b/docs/content/en/schemas/v1beta11.json
@@ -689,8 +689,8 @@
         },
         "network": {
           "type": "string",
-          "description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Valid modes are `Host`: use the host's networking stack. `Bridge`: use the bridged network configuration. `None`: no networking in the container.",
-          "x-intellij-html-description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Valid modes are <code>Host</code>: use the host's networking stack. <code>Bridge</code>: use the bridged network configuration. <code>None</code>: no networking in the container."
+          "description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Valid modes are `host`: use the host's networking stack. `bridge`: use the bridged network configuration. `none`: no networking in the container.",
+          "x-intellij-html-description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Valid modes are <code>host</code>: use the host's networking stack. <code>bridge</code>: use the bridged network configuration. <code>none</code>: no networking in the container."
         },
         "noCache": {
           "type": "boolean",

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -672,9 +672,9 @@ type DockerArtifact struct {
 	// NetworkMode is passed through to docker and overrides the
 	// network configuration of docker builder. If unset, use whatever
 	// is configured in the underlying docker daemon. Valid modes are
-	// `Host`: use the host's networking stack.
-	// `Bridge`: use the bridged network configuration.
-	// `None`: no networking in the container.
+	// `host`: use the host's networking stack.
+	// `bridge`: use the bridged network configuration.
+	// `none`: no networking in the container.
 	NetworkMode string `yaml:"network,omitempty"`
 
 	// CacheFrom lists the Docker images used as cache sources.

--- a/pkg/skaffold/schema/v1beta10/config.go
+++ b/pkg/skaffold/schema/v1beta10/config.go
@@ -660,9 +660,9 @@ type DockerArtifact struct {
 	// NetworkMode is passed through to docker and overrides the
 	// network configuration of docker builder. If unset, use whatever
 	// is configured in the underlying docker daemon. Valid modes are
-	// `Host`: use the host's networking stack.
-	// `Bridge`: use the bridged network configuration.
-	// `None`: no networking in the container.
+	// `host`: use the host's networking stack.
+	// `bridge`: use the bridged network configuration.
+	// `none`: no networking in the container.
 	NetworkMode string `yaml:"network,omitempty"`
 
 	// CacheFrom lists the Docker images used as cache sources.

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -48,7 +48,7 @@ func Process(config *latest.SkaffoldConfig) error {
 	return fmt.Errorf(strings.Join(messages, " | "))
 }
 
-// validateDockerNetworkMode makes sure that networkMode is one of `Bridge`, `None`, or `Host` if set.
+// validateDockerNetworkMode makes sure that networkMode is one of `bridge`, `none`, or `host` if set.
 func validateDockerNetworkMode(artifacts []*latest.Artifact) (errs []error) {
 	for _, a := range artifacts {
 		if a.DockerArtifact == nil || a.DockerArtifact.NetworkMode == "" {


### PR DESCRIPTION
host/bridge/none must be lower case or will be treated as network names.

This is a follow up on @tomaratyn’s work (https://github.com/GoogleContainerTools/skaffold/pull/2267)

Signed-off-by: David Gageot <david@gageot.net>