### PR TITLE
Handle `eu.gcr.io` like `gcr.io` when replacing default image

### DIFF
--- a/pkg/skaffold/util/image.go
+++ b/pkg/skaffold/util/image.go
@@ -23,30 +23,30 @@ import (
 
 const maxLength = 255
 
-const gcr = "gcr.io"
-const escapeChars = "[/._:@]"
-const prefixRegexStr = "gcr.io/[a-zA-Z0-9-_]+/"
-
-var escapeRegex = regexp.MustCompile(escapeChars)
-var prefixRegex = regexp.MustCompile(prefixRegexStr)
+var (
+	escapeRegex = regexp.MustCompile(`[/._:@]`)
+	prefixRegex = regexp.MustCompile(`(.*\.)?gcr.io/[a-zA-Z0-9-_]+/?`)
+)
 
 func SubstituteDefaultRepoIntoImage(defaultRepo string, originalImage string) string {
 	if defaultRepo == "" {
 		return originalImage
 	}
-	if strings.HasPrefix(defaultRepo, gcr) {
-		originalPrefix := prefixRegex.FindString(originalImage)
-		defaultRepoPrefix := prefixRegex.FindString(defaultRepo)
 
+	originalPrefix := prefixRegex.FindString(originalImage)
+	defaultRepoPrefix := prefixRegex.FindString(defaultRepo)
+	if originalPrefix != "" && defaultRepoPrefix != "" {
+		// prefixes match
 		if originalPrefix == defaultRepoPrefix {
-			// prefixes match
 			return defaultRepo + "/" + originalImage[len(originalPrefix):]
-		} else if strings.HasPrefix(originalImage, defaultRepo) {
+		}
+		if strings.HasPrefix(originalImage, defaultRepo) {
 			return originalImage
 		}
 		// prefixes don't match, concatenate and truncate
 		return truncate(defaultRepo + "/" + originalImage)
 	}
+
 	return truncate(defaultRepo + "/" + escapeRegex.ReplaceAllString(originalImage, "_"))
 }
 

--- a/pkg/skaffold/util/image_test.go
+++ b/pkg/skaffold/util/image_test.go
@@ -47,6 +47,12 @@ func TestImageReplaceDefaultRepo(t *testing.T) {
 			expectedImage: "gcr.io/default/registry",
 		},
 		{
+			description:   "provided image has defaultRepo eu prefix",
+			image:         "eu.gcr.io/project/registry",
+			defaultRepo:   "eu.gcr.io/project",
+			expectedImage: "eu.gcr.io/project/registry",
+		},
+		{
 			description:   "image has shared prefix with defaultRepo",
 			image:         "gcr.io/default/example/registry",
 			defaultRepo:   "gcr.io/default/repository",


### PR DESCRIPTION
Fix #2185

Signed-off-by: David Gageot <david@gageot.net>