### PR TITLE
Implement checksum computation for sha256 tagger (fix issue #2290)

### DIFF
--- a/pkg/skaffold/build/tag/sha256_test.go
+++ b/pkg/skaffold/build/tag/sha256_test.go
@@ -17,6 +17,11 @@ limitations under the License.
 package tag
 
 import (
+	"crypto/md5"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -24,22 +29,45 @@ import (
 
 func TestGenerateFullyQualifiedImageName(t *testing.T) {
 	c := &ChecksumTagger{}
+	var checksum []byte
 
-	tag, err := c.GenerateFullyQualifiedImageName(".", "img:tag")
+	//Creates temporary directory containing 1 file.
+	wd, cleanUp := testutil.NewTempDir(t)
+	defer cleanUp()
+
+	wd.Write("test1", "code")
+	checksum = computeTmpChecksum(wd.Path("test1"), checksum)
+
+	tag, err := c.GenerateFullyQualifiedImageName(wd.Root(), "img")
+	testutil.CheckErrorAndDeepEqual(t, false, err, fmt.Sprintf("img:%x", md5.Sum(checksum)), tag)
+
+	tag, err = c.GenerateFullyQualifiedImageName(wd.Root(), "registry.example.com:8080/img")
+	testutil.CheckErrorAndDeepEqual(t, false, err, fmt.Sprintf("registry.example.com:8080/img:%x", md5.Sum(checksum)), tag)
+
+	tag, err = c.GenerateFullyQualifiedImageName(wd.Root(), "registry.example.com/img")
+	testutil.CheckErrorAndDeepEqual(t, false, err, fmt.Sprintf("registry.example.com/img:%x", md5.Sum(checksum)), tag)
+
+	//Add 1 file to the already created directory
+	wd.Write("test2", "code in a new file")
+	checksum = computeTmpChecksum(wd.Path("test2"), checksum)
+	tag, err = c.GenerateFullyQualifiedImageName(wd.Root(), "img")
+	testutil.CheckErrorAndDeepEqual(t, false, err, fmt.Sprintf("img:%x", md5.Sum(checksum)), tag)
+
+	tag, err = c.GenerateFullyQualifiedImageName(".", "img:tag")
 	testutil.CheckErrorAndDeepEqual(t, false, err, "img:tag", tag)
-
-	tag, err = c.GenerateFullyQualifiedImageName(".", "img")
-	testutil.CheckErrorAndDeepEqual(t, false, err, "img:latest", tag)
 
 	tag, err = c.GenerateFullyQualifiedImageName(".", "registry.example.com:8080/img:tag")
 	testutil.CheckErrorAndDeepEqual(t, false, err, "registry.example.com:8080/img:tag", tag)
 
-	tag, err = c.GenerateFullyQualifiedImageName(".", "registry.example.com:8080/img")
-	testutil.CheckErrorAndDeepEqual(t, false, err, "registry.example.com:8080/img:latest", tag)
-
-	tag, err = c.GenerateFullyQualifiedImageName(".", "registry.example.com/img")
-	testutil.CheckErrorAndDeepEqual(t, false, err, "registry.example.com/img:latest", tag)
-
 	tag, err = c.GenerateFullyQualifiedImageName(".", "registry.example.com:8080:garbage")
 	testutil.CheckErrorAndDeepEqual(t, true, err, "", tag)
+}
+
+func computeTmpChecksum(path string, checksum []byte) []byte {
+	f, _ := os.Open(path)
+	defer f.Close()
+
+	h := sha256.New()
+	io.Copy(h, f)
+	return h.Sum(checksum)
 }


### PR DESCRIPTION
fix #2290 

Instead of returning a `latest` tag by default the tagger will now
return a checksum based on the sha256 of the working dir.

The function walk across all files and directories of the working dir,
sum the sha256 of each and compute a checksum of the resulting sum.

Errors on some files only are ignored. If the directory cannot be walk
at all, then the default tag is `latest`.