### PR TITLE
Add Go container debugging support

### DIFF
--- a/docs/content/en/docs/how-tos/debug/_index.md
+++ b/docs/content/en/docs/how-tos/debug/_index.md
@@ -66,9 +66,15 @@ Go-based applications are configured to run under [Delve](https://github.com/go-
     or `GOTRACEBACK`. `GOTRACEBACK=all` is a generally useful configuration.
   - Go applications should be built without optimizations, so your build should be capable of building with
     `-gcflags='all=-N -l'`. Skaffold [_Profiles_](../profiles/) are a useful option.
+
+{{< alert title="Caution" >}}
+Delve always stops the execution of the application.  You must connect to the
+Delve instance and continue the execution.
+{{< /alert >}}
+
     
 Note for users of [VS Code's debug adapter for Go](https://github.com/Microsoft/vscode-go): Delve seems
-to treat the source location for headless launches as relative to `/go`.  The following
+to treat the source location for headless launches as being relative to `/go`.  The following
 [remote launch configuration](https://github.com/Microsoft/vscode-go/wiki/Debugging-Go-code-using-VS-Code#remote-debugging) was useful:
 ```json
 {

--- a/docs/content/en/docs/how-tos/debug/_index.md
+++ b/docs/content/en/docs/how-tos/debug/_index.md
@@ -8,26 +8,27 @@ This page describes `skaffold debug`, a zero-configuration solution for
 setting up containers for debugging on a Kubernetes cluster. 
 
 {{< alert title="Note" >}}
-This functionality is in an alpha state and may change without warning.
+The `debug` functionality is in an alpha state and may change without warning.
 {{< /alert >}}
 
 ## Debugging with Skaffold
 
 `skaffold debug` acts like `skaffold dev`, but it configures containers in pods
 for debugging as required for each container's runtime technology.
-The associated debugging ports are exposed and labelled and port-forwarded to the
+The associated debugging ports are exposed and labelled so that they can be port-forwarded to the
 local machine.  Helper metadata is also added to allow IDEs to detect the debugging
 configuration parameters.
  
 ## How it works
 
 `skaffold debug` examines the built artifacts to determine the underlying runtime technology
-(currently supported: Java, NodeJS, and Python).  Any Kubernetes manifest that references these
+(currently supported: Go, JVM, NodeJS, and Python).  Any Kubernetes manifest that references these
 artifacts are transformed to enable the runtime technology's debugging functions:
 
-  - a JDWP agent is configured for Java applications,
-  - the Chrome DevTools inspector is configured for NodeJS applications,
-  - Python applications are configured to use [`ptvsd`](https://github.com/microsoft/ptvsd/).
+  - Go: the application is run using [Delve](https://github.com/go-delve/delve) in its headless-server mode
+  - JVM: the JVM is configured to use a JDWP agent
+  - NodeJS: the interpreter is configured to use the Chrome DevTools inspector
+  - Python: the interpreter is configured to use [`ptvsd`](https://github.com/microsoft/ptvsd/).
 
 `skaffold debug` uses a set of heuristics to identify the runtime
 technology.  The Kubernetes manifests are transformed on-the-fly
@@ -45,7 +46,13 @@ such that the on-disk representations are untouched.
   - Only the `kubectl` and `kustomize` deployers are supported at the moment: support for
     the Helm deployer is not yet available.
   - File sync is disabled for all artifacts.
-  - Only JVM, NodeJS, and Python applications are supported:
+  - Only Go, JVM, NodeJS, and Python applications are supported:
+      - Go applications:
+          - Go application should self-identify by setting one of the [standard Go runtime
+            environment variables](https://godoc.org/runtime) such as `GODEBUG`, `GOGC`, `GOMAXPROCS`,
+            or `GOTRACEBACK`. `GOTRACEBACK=all` is a generally useful configuration.
+          - Go applications should be built without optimizations, so your build should be capable of building with
+            `-gcflags='all=-N -l'`. Skaffold [_Profiles_](../profiles/) are a useful option.
       - JVM applications are configured using the `JAVA_TOOL_OPTIONS` environment variable
         which causes extra debugging output on launch.
       - NodeJS applications must be launched using `node` or `nodemon`, or `npm`
@@ -54,11 +61,9 @@ such that the on-disk representations are untouched.
       - Python applications are configured to use [`ptvsd`](https://github.com/microsoft/ptvsd/),
         a wrapper around `pydevd` that uses the
         [_debug adapter protocol_ (DAP)](https://microsoft.github.io/debug-adapter-protocol/). 
-        The DAP is supported by Visual Studio Code,
+        DAP is supported by Visual Studio Code,
         [Eclipse LSP4e](https://projects.eclipse.org/projects/technology.lsp4e),
         [and other editors and IDEs](https://microsoft.github.io/debug-adapter-protocol/implementors/tools/).
         DAP is not yet supported by JetBrains IDEs like PyCharm.
-      - Go apps should be built without optimizations, so your build should be capable of building with
-        `-gcflags='all=-N -l'`
   
  Support for additional language runtimes will be forthcoming.

--- a/docs/content/en/docs/how-tos/debug/_index.md
+++ b/docs/content/en/docs/how-tos/debug/_index.md
@@ -58,5 +58,7 @@ such that the on-disk representations are untouched.
         [Eclipse LSP4e](https://projects.eclipse.org/projects/technology.lsp4e),
         [and other editors and IDEs](https://microsoft.github.io/debug-adapter-protocol/implementors/tools/).
         DAP is not yet supported by JetBrains IDEs like PyCharm.
+      - Go apps should be built without optimizations, so your build should be capable of building with
+        `-gcflags='all=-N -l'`
   
  Support for additional language runtimes will be forthcoming.

--- a/docs/content/en/docs/how-tos/debug/_index.md
+++ b/docs/content/en/docs/how-tos/debug/_index.md
@@ -21,22 +21,92 @@ configuration parameters.
  
 ## How it works
 
-`skaffold debug` examines the built artifacts to determine the underlying runtime technology
-(currently supported: Go, JVM, NodeJS, and Python).  Any Kubernetes manifest that references these
-artifacts are transformed to enable the runtime technology's debugging functions:
+`skaffold debug` examines the built artifacts to determine the underlying runtime technology.
+Any Kubernetes manifest that references these artifacts are transformed to enable the runtime technology's
+debugging functions.
 
-  - Go: the application is run using [Delve](https://github.com/go-delve/delve) in its headless-server mode
-  - JVM: the JVM is configured to use a JDWP agent
-  - NodeJS: the interpreter is configured to use the Chrome DevTools inspector
-  - Python: the interpreter is configured to use [`ptvsd`](https://github.com/microsoft/ptvsd/).
+`skaffold debug` uses a set of heuristics to identify the runtime technology.  
+The Kubernetes manifests are transformed on-the-fly such that the on-disk representations
+are untouched.
 
-`skaffold debug` uses a set of heuristics to identify the runtime
-technology.  The Kubernetes manifests are transformed on-the-fly
-such that the on-disk representations are untouched.
+Each Pod will have an `debug.cloud.google.com/config` annotation with a JSON object
+describing the debug configurations for the pod's containers (linebreaks for readability):
+```  
+	debug.cloud.google.com/config={
+		"<containerName>":{"runtime":"<runtimeId>",...},
+		"<containerName>":{"runtime":"<runtimeId>",...},
+		}
+```
+
+For example the following annotation indicates that the container named `web` is a Go application
+that is being debugged by a headless Delve session on port `56268`:
+```
+debug.cloud.google.com/config={"web":{"dlv":56268,"runtime":"go"}}
+```
+
+Some language runtimes require additional support files to enable debugging.
+For these languages, a special set of [runtime-specific images](https://github.com/GoogleContainerTools/container-debug-support)
+are configured as _init-containers_ to populate a shared-volume that is mounted into
+each of the appropriate containers.  These images are hosted at `gcr.io/gcp-dev-tools/duct-tape`.
 
 {{< alert title="Caution" >}}
 `skaffold debug` does not support deprecated versions of Workload API objects such as `apps/v1beta1`.
 {{< /alert >}}
+
+### Supported Language Runtimes
+
+Debugging is currently supported for Go, Java (and JVM languages), NodeJS, and Python.
+
+#### Go
+
+Go-based applications are configured to run under [Delve](https://github.com/go-delve/delve) in its headless-server mode.
+
+  - Go application should self-identify by setting one of the [standard Go runtime
+    environment variables](https://godoc.org/runtime) such as `GODEBUG`, `GOGC`, `GOMAXPROCS`,
+    or `GOTRACEBACK`. `GOTRACEBACK=all` is a generally useful configuration.
+  - Go applications should be built without optimizations, so your build should be capable of building with
+    `-gcflags='all=-N -l'`. Skaffold [_Profiles_](../profiles/) are a useful option.
+    
+Note for users of [VS Code's debug adapter for Go](https://github.com/Microsoft/vscode-go): Delve seems
+to treat the source location for headless launches as relative to `/go`.  The following
+[remote launch configuration](https://github.com/Microsoft/vscode-go/wiki/Debugging-Go-code-using-VS-Code#remote-debugging) was useful:
+```json
+{
+  "name": "Skaffold Debug",
+  "type": "go",
+  "request": "launch",
+  "mode": "remote",
+  "host": "localhost",
+  "port": 56268,
+  "remotePath": "/go/",
+  "program": "/Users/login/go/src/github.com/GoogleContainerTools/skaffold/integration/testdata/debug/go/",
+}
+```
+
+#### Java and other JVM languages
+
+Java/JVM applications are configured to expose the JDWP agent using the `JAVA_TOOL_OPTIONS`
+environment variable.  
+Note that the use of `JAVA_TOOL_OPTIONS` causes extra debugging output from the JVM on launch.
+
+#### NodeJS
+
+NodeJS applications are configured to use the Chrome DevTools inspector.  
+NodeJS applications must be launched using `node` or `nodemon`, or `npm`.
+Note that `npm` scripts should not then invoke `nodemon` as the DevTools inspector
+configuration will be picked up by `nodemon` rather than the actual application.
+
+Note that the client must first obtain [the inspector UUID](https://github.com/nodejs/node/issues/9185#issuecomment-254872466).
+  
+#### Python
+
+Python applications are configured to use [`ptvsd`](https://github.com/microsoft/ptvsd/), a
+wrapper around [`pydevd`](https://github.com/fabioz/PyDev.Debugger) that uses the
+[_debug adapter protocol_ (DAP)](https://microsoft.github.io/debug-adapter-protocol/). 
+
+The DAP is supported by Visual Studio Code, [Eclipse LSP4e](https://projects.eclipse.org/projects/technology.lsp4e),
+[and other editors and IDEs](https://microsoft.github.io/debug-adapter-protocol/implementors/tools/).
+DAP is not yet supported by JetBrains IDEs like PyCharm.
 
 
 ## Limitations
@@ -46,24 +116,4 @@ such that the on-disk representations are untouched.
   - Only the `kubectl` and `kustomize` deployers are supported at the moment: support for
     the Helm deployer is not yet available.
   - File sync is disabled for all artifacts.
-  - Only Go, JVM, NodeJS, and Python applications are supported:
-      - Go applications:
-          - Go application should self-identify by setting one of the [standard Go runtime
-            environment variables](https://godoc.org/runtime) such as `GODEBUG`, `GOGC`, `GOMAXPROCS`,
-            or `GOTRACEBACK`. `GOTRACEBACK=all` is a generally useful configuration.
-          - Go applications should be built without optimizations, so your build should be capable of building with
-            `-gcflags='all=-N -l'`. Skaffold [_Profiles_](../profiles/) are a useful option.
-      - JVM applications are configured using the `JAVA_TOOL_OPTIONS` environment variable
-        which causes extra debugging output on launch.
-      - NodeJS applications must be launched using `node` or `nodemon`, or `npm`
-          - `npm` scripts shouldn't then invoke `nodemon` as the DevTools inspector
-            configuration will be picked up by `nodemon` rather than the actual application
-      - Python applications are configured to use [`ptvsd`](https://github.com/microsoft/ptvsd/),
-        a wrapper around `pydevd` that uses the
-        [_debug adapter protocol_ (DAP)](https://microsoft.github.io/debug-adapter-protocol/). 
-        DAP is supported by Visual Studio Code,
-        [Eclipse LSP4e](https://projects.eclipse.org/projects/technology.lsp4e),
-        [and other editors and IDEs](https://microsoft.github.io/debug-adapter-protocol/implementors/tools/).
-        DAP is not yet supported by JetBrains IDEs like PyCharm.
-  
- Support for additional language runtimes will be forthcoming.
+    

--- a/integration/testdata/debug/go/.dockerignore
+++ b/integration/testdata/debug/go/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+*.swp

--- a/integration/testdata/debug/go/.gitignore
+++ b/integration/testdata/debug/go/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+*.swp

--- a/integration/testdata/debug/go/Dockerfile
+++ b/integration/testdata/debug/go/Dockerfile
@@ -1,11 +1,14 @@
 FROM golang:1.12 as builder
 
 COPY app.go .
-# disable optimizations for debugging
-RUN go build -gcflags='all=-N -l' -o /app .
+# Seemingly must assign the ARG to an environment variable for proper handling
+# of args with spaces like `-gcflags='all=-N -l'`
+ARG GOBUILDFLAGS
+ENV GOBUILDFLAGS=${GOBUILDARGS}
+RUN go build ${GOBUILDFLAGS} -o /app .
 
 FROM gcr.io/distroless/base
-# add GOTRACEBACK=all to trigger `skaffold debug`
+# use GOTRACEBACK=all to trigger `skaffold debug`
 ENV GOTRACEBACK=all
 EXPOSE 8080
 COPY --from=builder /app .

--- a/integration/testdata/debug/go/Dockerfile
+++ b/integration/testdata/debug/go/Dockerfile
@@ -1,11 +1,9 @@
 FROM golang:1.12 as builder
 
 COPY app.go .
-# Seemingly must assign the ARG to an environment variable for proper handling
-# of args with spaces like `-gcflags='all=-N -l'`
-ARG GOBUILDFLAGS
-ENV GOBUILDFLAGS=${GOBUILDARGS}
-RUN go build ${GOBUILDFLAGS} -o /app .
+# Must use eval to handle GOGCFLAGS with spaces like `-gcflags='all=-N -l'`
+ARG GOGCFLAGS
+RUN eval go build "${GOGCFLAGS}" -o /app .
 
 FROM gcr.io/distroless/base
 # use GOTRACEBACK=all to trigger `skaffold debug`

--- a/integration/testdata/debug/go/Dockerfile
+++ b/integration/testdata/debug/go/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.12 as builder
+
+COPY app.go .
+# disable optimizations for debugging
+RUN go build -gcflags='all=-N -l' -o /app .
+
+FROM gcr.io/distroless/base
+# add GOTRACEBACK=all to trigger `skaffold debug`
+ENV GOTRACEBACK=all
+EXPOSE 8080
+COPY --from=builder /app .
+CMD ["/app"]

--- a/integration/testdata/debug/go/app.go
+++ b/integration/testdata/debug/go/app.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"html"
+	"log"
+	"net/http"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
+}
+
+func main() {
+	log.Print("example web app ready on port 8080")
+	http.HandleFunc("/", handler)
+	http.ListenAndServe(":8080", nil)
+}

--- a/integration/testdata/debug/go/k8s/pod.yaml
+++ b/integration/testdata/debug/go/k8s/pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: go
+spec:
+  containers:
+  - name: web
+    image: gcr.io/k8s-skaffold/skaffold-debug-go
+    ports:
+    - containerPort: 8080

--- a/integration/testdata/debug/kustomization.yaml
+++ b/integration/testdata/debug/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
   - nodejs/k8s/pod.yaml
   - npm/k8s/pod.yaml
   - python3/k8s/pod.yaml
+  - go/k8s/pod.yaml

--- a/integration/testdata/debug/skaffold.yaml
+++ b/integration/testdata/debug/skaffold.yaml
@@ -13,6 +13,8 @@ build:
     context: nodejs
   - image: gcr.io/k8s-skaffold/skaffold-debug-python3
     context: python3
+  - image: gcr.io/k8s-skaffold/skaffold-debug-go
+    context: go
 deploy:
   kubectl:
     manifests:
@@ -20,6 +22,7 @@ deploy:
     - nodejs/k8s/pod.yaml
     - npm/k8s/pod.yaml
     - python3/k8s/pod.yaml
+    - go/k8s/pod.yaml
 profiles:
   - name: kustomize
     deploy:

--- a/integration/testdata/debug/skaffold.yaml
+++ b/integration/testdata/debug/skaffold.yaml
@@ -15,6 +15,10 @@ build:
     context: python3
   - image: gcr.io/k8s-skaffold/skaffold-debug-go
     context: go
+    docker:
+      buildArgs:
+        GOBUILDFLAGS: "-gcflags='all=-N -l'"
+
 deploy:
   kubectl:
     manifests:

--- a/integration/testdata/debug/skaffold.yaml
+++ b/integration/testdata/debug/skaffold.yaml
@@ -17,7 +17,7 @@ build:
     context: go
     docker:
       buildArgs:
-        GOBUILDFLAGS: "-gcflags='all=-N -l'"
+        GOGCFLAGS: "-gcflags='all=-N -l'"
 
 deploy:
   kubectl:

--- a/pkg/skaffold/debug/transform_go.go
+++ b/pkg/skaffold/debug/transform_go.go
@@ -94,7 +94,7 @@ func (t dlvTransformer) Apply(container *v1.Container, config imageConfiguration
 			container.Args = rewriteDlvCommandLine(config.arguments, *spec)
 
 		default:
-			logrus.Warnf("Skipping %q as does not appear to be go", container.Name)
+			logrus.Warnf("Skipping %q as does not appear to be Go-based", container.Name)
 			return nil
 		}
 	}
@@ -187,5 +187,8 @@ func (spec dlvSpec) asArguments() []string {
 	if spec.log {
 		args = append(args, "--log")
 	}
+
+	// indicate end of Delve arguments
+	args = append(args, "--")
 	return args
 }

--- a/pkg/skaffold/debug/transform_go.go
+++ b/pkg/skaffold/debug/transform_go.go
@@ -34,7 +34,7 @@ func init() {
 const (
 	// dlv defaults to port 56268
 	defaultDlvPort    = 56268
-	defaultApiVersion = 2
+	defaultAPIVersion = 2
 )
 
 // dlvSpec captures the useful nodejs devtools options
@@ -42,13 +42,13 @@ type dlvSpec struct {
 	mode       string
 	host       string
 	port       uint16
-	apiVersion int
 	headless   bool
 	log        bool
+	apiVersion int
 }
 
 func newDlvSpec(port uint16) dlvSpec {
-	return dlvSpec{mode: "exec", host: "localhost", port: port, apiVersion: defaultApiVersion, headless: true}
+	return dlvSpec{mode: "exec", host: "localhost", port: port, apiVersion: defaultAPIVersion, headless: true}
 }
 
 // isLaunchingDlv determines if the arguments seems to be invoking Delve

--- a/pkg/skaffold/debug/transform_go.go
+++ b/pkg/skaffold/debug/transform_go.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+)
+
+type dlvTransformer struct{}
+
+func init() {
+	containerTransforms = append(containerTransforms, dlvTransformer{})
+}
+
+const (
+	// dlv defaults to port 56268
+	defaultDlvPort    = 56268
+	defaultApiVersion = 2
+)
+
+// dlvSpec captures the useful nodejs devtools options
+type dlvSpec struct {
+	mode       string
+	host       string
+	port       uint16
+	apiVersion int
+	headless   bool
+	log        bool
+}
+
+func newDlvSpec(port uint16) dlvSpec {
+	return dlvSpec{mode: "exec", host: "localhost", port: port, apiVersion: defaultApiVersion, headless: true}
+}
+
+// isLaunchingDlv determines if the arguments seems to be invoking Delve
+func isLaunchingDlv(args []string) bool {
+	return len(args) > 0 && (args[0] == "dlv" || strings.HasSuffix(args[0], "/dlv"))
+}
+
+func (t dlvTransformer) IsApplicable(config imageConfiguration) bool {
+	for _, name := range []string{"GODEBUG", "GOGC", "GOMAXPROCS", "GOTRACEBACK"} {
+		if _, found := config.env[name]; found {
+			return true
+		}
+	}
+	if config.labels["skaffold.dev/debug/runtime"] == "go" {
+		return true
+	}
+	if len(config.entrypoint) > 0 {
+		return isLaunchingDlv(config.entrypoint)
+	} else if len(config.arguments) > 0 {
+		return isLaunchingDlv(config.arguments)
+	}
+	return false
+}
+
+func (t dlvTransformer) RuntimeSupportImage() string {
+	return "go"
+}
+
+// Apply configures a container definition for Go with Delve.
+// Returns a simple map describing the debug configuration details.
+func (t dlvTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) map[string]interface{} {
+	logrus.Infof("Configuring %q for Go/Delve debugging", container.Name)
+
+	// try to find existing `dlv` command
+	spec := retrieveDlvSpec(config)
+	// todo: find existing containerPort "dap" (debug-adapter protocol) and use port. But what if it conflicts with command-line spec?
+
+	if spec == nil {
+		newSpec := newDlvSpec(uint16(portAlloc(defaultDlvPort)))
+		spec = &newSpec
+		switch {
+		case len(config.entrypoint) > 0:
+			container.Command = rewriteDlvCommandLine(config.entrypoint, *spec)
+
+		case len(config.entrypoint) == 0 && len(config.arguments) > 0:
+			container.Args = rewriteDlvCommandLine(config.arguments, *spec)
+
+		default:
+			logrus.Warnf("Skipping %q as does not appear to be go", container.Name)
+			return nil
+		}
+	}
+
+	dlvPort := v1.ContainerPort{
+		Name:          "dlv",
+		ContainerPort: int32(spec.port),
+	}
+	container.Ports = append(container.Ports, dlvPort)
+
+	return map[string]interface{}{
+		"runtime": "go",
+		"dlv":     spec.port,
+		//"dap":     spec.port,
+	}
+}
+
+func retrieveDlvSpec(config imageConfiguration) *dlvSpec {
+	if spec := extractDlvSpec(config.entrypoint); spec != nil {
+		return spec
+	}
+	if spec := extractDlvSpec(config.arguments); spec != nil {
+		return spec
+	}
+	return nil
+}
+
+func extractDlvSpec(args []string) *dlvSpec {
+	if !isLaunchingDlv(args) {
+		return nil
+	}
+	spec := dlvSpec{apiVersion: 2, log: false, headless: false}
+	for _, arg := range args {
+		switch {
+		case arg == "debug" || arg == "test" || arg == "exec":
+			spec.mode = arg
+		case arg == "--headless":
+			spec.headless = true
+		case arg == "--log":
+			spec.log = true
+		case strings.Index(arg, "--listen=") == 0:
+			address := strings.SplitN(arg, "=", 2)[1]
+			split := strings.SplitN(address, ":", 2)
+			switch len(split) {
+			// port only
+			case 1:
+				p, _ := strconv.ParseUint(split[0], 10, 16)
+				spec.port = uint16(p)
+
+			// host and port
+			case 2:
+				spec.host = split[0]
+				p, _ := strconv.ParseUint(split[1], 10, 16)
+				spec.port = uint16(p)
+			}
+		case strings.Index(arg, "--api-version=") == 0:
+			address := strings.SplitN(arg, "=", 2)[1]
+			version, _ := strconv.ParseInt(address, 10, 16)
+			spec.apiVersion = int(version)
+		}
+	}
+	return &spec
+}
+
+// rewriteDlvCommandLine rewrites a go command-line to insert a `dlv`
+func rewriteDlvCommandLine(commandLine []string, spec dlvSpec) []string {
+	// todo: parse off dlv commands if present
+	return append(spec.asArguments(), commandLine...)
+}
+
+func (spec dlvSpec) asArguments() []string {
+	args := []string{"/dbg/go/bin/dlv"}
+	args = append(args, spec.mode)
+	if spec.headless {
+		args = append(args, "--headless")
+	}
+	host := "localhost"
+	if spec.host != "" {
+		host = spec.host
+	}
+	if spec.port > 0 {
+		args = append(args, fmt.Sprintf("--listen=%s:%d", host, spec.port))
+		//args = append(args, ":", strconv.FormatInt(int64(spec.port), 10))
+	} else {
+		args = append(args, fmt.Sprintf("--listen=%s", host))
+	}
+	if spec.apiVersion > 0 {
+		args = append(args, fmt.Sprintf("--api-version=%d", spec.apiVersion))
+	}
+	if spec.log {
+		args = append(args, "--log")
+	}
+	return args
+}

--- a/pkg/skaffold/debug/transform_go.go
+++ b/pkg/skaffold/debug/transform_go.go
@@ -62,9 +62,6 @@ func (t dlvTransformer) IsApplicable(config imageConfiguration) bool {
 			return true
 		}
 	}
-	if config.labels["skaffold.dev/debug/runtime"] == "go" {
-		return true
-	}
 	if len(config.entrypoint) > 0 {
 		return isLaunchingDlv(config.entrypoint)
 	} else if len(config.arguments) > 0 {

--- a/pkg/skaffold/debug/transform_go_test.go
+++ b/pkg/skaffold/debug/transform_go_test.go
@@ -88,16 +88,6 @@ func TestDlvTransformer_IsApplicable(t *testing.T) {
 			result:      true,
 		},
 		{
-			description: "skaffold runtime label with go",
-			source:      imageConfiguration{labels: map[string]string{"skaffold.dev/debug/runtime": "go"}},
-			result:      true,
-		},
-		{
-			description: "skaffold runtime label without go",
-			source:      imageConfiguration{labels: map[string]string{"skaffold.dev/debug/runtime": "java"}},
-			result:      false,
-		},
-		{
 			description: "entrypoint with dlv",
 			source:      imageConfiguration{entrypoint: []string{"dlv", "exec", "--headless"}},
 			result:      true,

--- a/pkg/skaffold/debug/transform_go_test.go
+++ b/pkg/skaffold/debug/transform_go_test.go
@@ -1,0 +1,564 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestNewDlvSpecDefaults(t *testing.T) {
+	spec := newDlvSpec(20)
+	expected := dlvSpec{mode: "exec", host: "localhost", port: 20, apiVersion: 2, headless: true, log: false}
+	testutil.CheckDeepEqual(t, expected, spec, cmp.AllowUnexported(spec))
+}
+
+func TestExtractDlvArg(t *testing.T) {
+	tests := []struct {
+		in     []string
+		result *dlvSpec
+	}{
+		{nil, nil},
+		{[]string{"foo"}, nil},
+		{[]string{"foo", "--foo"}, nil},
+		{[]string{"dlv", "debug", "--headless"}, &dlvSpec{mode: "debug", headless: true, apiVersion: 2, log: false}},
+		{[]string{"dlv", "--headless", "exec"}, &dlvSpec{mode: "exec", headless: true, apiVersion: 2, log: false}},
+		{[]string{"dlv", "test", "--headless", "--listen=host:4345"}, &dlvSpec{mode: "test", host: "host", port: 4345, headless: true, apiVersion: 2, log: false}},
+		{[]string{"dlv", "debug", "--headless", "--api-version=1"}, &dlvSpec{mode: "debug", headless: true, apiVersion: 1, log: false}},
+		{[]string{"dlv", "debug", "--listen=host:4345", "--headless", "--api-version=2", "--log"}, &dlvSpec{mode: "debug", host: "host", port: 4345, headless: true, apiVersion: 2, log: true}},
+	}
+	for _, test := range tests {
+		t.Run(strings.Join(test.in, " "), func(t *testing.T) {
+			if test.result == nil {
+				testutil.CheckDeepEqual(t, test.result, extractDlvSpec(test.in))
+			} else {
+				testutil.CheckDeepEqual(t, *test.result, *extractDlvSpec(test.in), cmp.AllowUnexported(dlvSpec{}))
+			}
+		})
+	}
+}
+
+func TestDlvTransformer_IsApplicable(t *testing.T) {
+	tests := []struct {
+		description string
+		source      imageConfiguration
+		result      bool
+	}{
+		{
+			description: "GOMAXPROCS",
+			source:      imageConfiguration{env: map[string]string{"GOMAXPROCS": "2"}},
+			result:      true,
+		},
+		{
+			description: "GOGC",
+			source:      imageConfiguration{env: map[string]string{"GOGC": "off"}},
+			result:      true,
+		},
+		{
+			description: "GODEBUG",
+			source:      imageConfiguration{env: map[string]string{"GODEBUG": "efence=1"}},
+			result:      true,
+		},
+		{
+			description: "GOTRACEBACK",
+			source:      imageConfiguration{env: map[string]string{"GOTRACEBACK": "off"}},
+			result:      true,
+		},
+		{
+			description: "skaffold runtime label with go",
+			source:      imageConfiguration{labels: map[string]string{"skaffold.dev/debug/runtime": "go"}},
+			result:      true,
+		},
+		{
+			description: "skaffold runtime label without go",
+			source:      imageConfiguration{labels: map[string]string{"skaffold.dev/debug/runtime": "java"}},
+			result:      false,
+		},
+		{
+			description: "entrypoint with dlv",
+			source:      imageConfiguration{entrypoint: []string{"dlv", "exec", "--headless"}},
+			result:      true,
+		},
+		{
+			description: "entrypoint /bin/sh",
+			source:      imageConfiguration{entrypoint: []string{"/bin/sh"}},
+			result:      false,
+		},
+		{
+			description: "nothing",
+			source:      imageConfiguration{},
+			result:      false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			result := dlvTransformer{}.IsApplicable(test.source)
+			testutil.CheckDeepEqual(t, test.result, result)
+		})
+	}
+}
+
+func TestDlvTransformer_RuntimeSupportImage(t *testing.T) {
+	testutil.CheckDeepEqual(t, "go", dlvTransformer{}.RuntimeSupportImage())
+}
+
+func TestDlvTransformerApply(t *testing.T) {
+	tests := []struct {
+		description   string
+		containerSpec v1.Container
+		configuration imageConfiguration
+		result        v1.Container
+	}{
+		{
+			description:   "empty",
+			containerSpec: v1.Container{},
+			configuration: imageConfiguration{},
+			result:        v1.Container{},
+		},
+		{
+			description:   "basic",
+			containerSpec: v1.Container{},
+			configuration: imageConfiguration{entrypoint: []string{"app"}},
+			result: v1.Container{
+				Command: []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2","app"},
+				Ports:   []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
+			},
+		},
+		{
+			description: "existing port",
+			containerSpec: v1.Container{
+				Ports: []v1.ContainerPort{{Name: "http-server", ContainerPort: 8080}},
+			},
+			configuration: imageConfiguration{entrypoint: []string{"app"}},
+			result: v1.Container{
+				Command: []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2","app"},
+				Ports:   []v1.ContainerPort{{Name: "http-server", ContainerPort: 8080}, {Name: "dlv", ContainerPort: 56268}},
+			},
+		},
+		{
+			description:   "command not entrypoint",
+			containerSpec: v1.Container{},
+			configuration: imageConfiguration{arguments: []string{"app"}},
+			result: v1.Container{
+				Args:  []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2","app"},
+				Ports: []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
+			},
+		},
+	}
+	var identity portAllocator = func(port int32) int32 {
+		return port
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			dlvTransformer{}.Apply(&test.containerSpec, test.configuration, identity)
+			testutil.CheckDeepEqual(t, test.result, test.containerSpec)
+		})
+	}
+}
+
+func TestTransformManifestDelve(t *testing.T) {
+	int32p := func(x int32) *int32 { return &x }
+	tests := []struct {
+		description string
+		in          runtime.Object
+		transformed bool
+		out         runtime.Object
+	}{
+		{
+			"Pod with no transformable container",
+			&v1.Pod{
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{
+						Name:    "test",
+						Command: []string{"echo", "Hello World"},
+					},
+				}}},
+			false,
+			&v1.Pod{
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{
+						Name:    "test",
+						Command: []string{"echo", "Hello World"},
+					},
+				}}},
+		},
+		{
+			"Pod with Go container with GOMAXPROCS",
+			&v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:    "test",
+						Command: []string{"app"},
+						Env:     []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+					}},
+				}},
+			true,
+			&v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:         "test",
+						Command:      []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2", "app"},
+						Ports:        []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
+						Env:          []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+						VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+					}},
+					InitContainers: []v1.Container{{
+						Name:         "install-go-support",
+						Image:        "gcr.io/gcp-dev-tools/duct-tape/go",
+						VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+					}},
+					Volumes: []v1.Volume{{
+						Name:         "debugging-support-files",
+						VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+					}},
+				}},
+		},
+		{
+			"Deployment with Go container",
+			&appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Replicas: int32p(2),
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:    "test",
+								Command: []string{"app"},
+								Env:     []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+							}},
+						}}}},
+			true,
+			&appsv1.Deployment{
+				//ObjectMeta: metav1.ObjectMeta{
+				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
+				//},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: int32p(1),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:         "test",
+								Command:      []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2", "app"},
+								Ports:        []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
+								Env:          []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+							}},
+							InitContainers: []v1.Container{{
+								Name:         "install-go-support",
+								Image:        "gcr.io/gcp-dev-tools/duct-tape/go",
+								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+							}},
+							Volumes: []v1.Volume{{
+								Name:         "debugging-support-files",
+								VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+							}},
+						}}}},
+		},
+		{
+			"ReplicaSet with Go container",
+			&appsv1.ReplicaSet{
+				Spec: appsv1.ReplicaSetSpec{
+					Replicas: int32p(2),
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:    "test",
+								Command: []string{"app"},
+								Env:     []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+							}},
+						}}}},
+			true,
+			&appsv1.ReplicaSet{
+				//ObjectMeta: metav1.ObjectMeta{
+				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
+				//},
+				Spec: appsv1.ReplicaSetSpec{
+					Replicas: int32p(1),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:         "test",
+								Command:      []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2", "app"},
+								Ports:        []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
+								Env:          []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+							}},
+							InitContainers: []v1.Container{{
+								Name:         "install-go-support",
+								Image:        "gcr.io/gcp-dev-tools/duct-tape/go",
+								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+							}},
+							Volumes: []v1.Volume{{
+								Name:         "debugging-support-files",
+								VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+							}},
+						}}}},
+		},
+		{
+			"StatefulSet with Go container",
+			&appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: int32p(2),
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:    "test",
+								Command: []string{"app"},
+								Env:     []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+							}},
+						}}}},
+			true,
+			&appsv1.StatefulSet{
+				//ObjectMeta: metav1.ObjectMeta{
+				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
+				//},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: int32p(1),
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:         "test",
+								Command:      []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2", "app"},
+								Ports:        []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
+								Env:          []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+							}},
+							InitContainers: []v1.Container{{
+								Name:         "install-go-support",
+								Image:        "gcr.io/gcp-dev-tools/duct-tape/go",
+								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+							}},
+							Volumes: []v1.Volume{{
+								Name:         "debugging-support-files",
+								VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+							}},
+						}}}},
+		},
+		{
+			"DaemonSet with Go container",
+			&appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:    "test",
+								Command: []string{"app"},
+								Env:     []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+							}},
+						}}}},
+			true,
+			&appsv1.DaemonSet{
+				//ObjectMeta: metav1.ObjectMeta{
+				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
+				//},
+				Spec: appsv1.DaemonSetSpec{
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:         "test",
+								Command:      []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2", "app"},
+								Ports:        []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
+								Env:          []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+							}},
+							InitContainers: []v1.Container{{
+								Name:         "install-go-support",
+								Image:        "gcr.io/gcp-dev-tools/duct-tape/go",
+								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+							}},
+							Volumes: []v1.Volume{{
+								Name:         "debugging-support-files",
+								VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+							}},
+						}}}},
+		},
+		{
+			"Job with Go container",
+			&batchv1.Job{
+				Spec: batchv1.JobSpec{
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:    "test",
+								Command: []string{"app"},
+								Env:     []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+							}},
+						}}}},
+			true,
+			&batchv1.Job{
+				//ObjectMeta: metav1.ObjectMeta{
+				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
+				//},
+				Spec: batchv1.JobSpec{
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:         "test",
+								Command:      []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2", "app"},
+								Ports:        []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
+								Env:          []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+							}},
+							InitContainers: []v1.Container{{
+								Name:         "install-go-support",
+								Image:        "gcr.io/gcp-dev-tools/duct-tape/go",
+								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+							}},
+							Volumes: []v1.Volume{{
+								Name:         "debugging-support-files",
+								VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+							}},
+						}}}},
+		},
+		{
+			"ReplicationController with Go container",
+			&v1.ReplicationController{
+				Spec: v1.ReplicationControllerSpec{
+					Replicas: int32p(2),
+					Template: &v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:    "test",
+								Command: []string{"app"},
+								Env:     []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+							}},
+						}}}},
+			true,
+			&v1.ReplicationController{
+				//ObjectMeta: metav1.ObjectMeta{
+				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
+				//},
+				Spec: v1.ReplicationControllerSpec{
+					Replicas: int32p(1),
+					Template: &v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:         "test",
+								Command:      []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2", "app"},
+								Ports:        []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
+								Env:          []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+							}},
+							InitContainers: []v1.Container{{
+								Name:         "install-go-support",
+								Image:        "gcr.io/gcp-dev-tools/duct-tape/go",
+								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+							}},
+							Volumes: []v1.Volume{{
+								Name:         "debugging-support-files",
+								VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+							}},
+						}}}},
+		},
+		{
+			"PodList with Go and non-Go container",
+			&v1.PodList{
+				Items: []v1.Pod{
+					{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:    "echo",
+								Command: []string{"echo", "Hello World"},
+							}},
+						}},
+					{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:    "test",
+								Command: []string{"app"},
+								Env:     []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+							}},
+						}},
+				}},
+			true,
+			&v1.PodList{
+				Items: []v1.Pod{
+					{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:    "echo",
+								Command: []string{"echo", "Hello World"},
+							}},
+						}},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+						},
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{
+								Name:         "test",
+								Command:      []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2", "app"},
+								Ports:        []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
+								Env:          []v1.EnvVar{{Name: "GOMAXPROCS", Value: "1"}},
+								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+							}},
+							InitContainers: []v1.Container{{
+								Name:         "install-go-support",
+								Image:        "gcr.io/gcp-dev-tools/duct-tape/go",
+								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
+							}},
+							Volumes: []v1.Volume{{
+								Name:         "debugging-support-files",
+								VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}},
+							}},
+						}},
+				}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			value := test.in.DeepCopyObject()
+
+			retriever := func(image string) (imageConfiguration, error) {
+				return imageConfiguration{}, nil
+			}
+			result := transformManifest(value, retriever)
+			testutil.CheckDeepEqual(t, test.transformed, result)
+			testutil.CheckDeepEqual(t, test.out, value)
+		})
+	}
+}

--- a/pkg/skaffold/debug/transform_go_test.go
+++ b/pkg/skaffold/debug/transform_go_test.go
@@ -144,7 +144,7 @@ func TestDlvTransformerApply(t *testing.T) {
 			containerSpec: v1.Container{},
 			configuration: imageConfiguration{entrypoint: []string{"app"}},
 			result: v1.Container{
-				Command: []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2","app"},
+				Command: []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2", "app"},
 				Ports:   []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
 			},
 		},
@@ -155,7 +155,7 @@ func TestDlvTransformerApply(t *testing.T) {
 			},
 			configuration: imageConfiguration{entrypoint: []string{"app"}},
 			result: v1.Container{
-				Command: []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2","app"},
+				Command: []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2", "app"},
 				Ports:   []v1.ContainerPort{{Name: "http-server", ContainerPort: 8080}, {Name: "dlv", ContainerPort: 56268}},
 			},
 		},
@@ -164,7 +164,7 @@ func TestDlvTransformerApply(t *testing.T) {
 			containerSpec: v1.Container{},
 			configuration: imageConfiguration{arguments: []string{"app"}},
 			result: v1.Container{
-				Args:  []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2","app"},
+				Args:  []string{"/dbg/go/bin/dlv", "exec", "--headless", "--listen=localhost:56268", "--api-version=2", "app"},
 				Ports: []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
 			},
 		},


### PR DESCRIPTION
This patch adds support to `skaffold debug` for Go debugging.  Go requires some additional support files for debugging, which are fetched and installed using an `initContainer` base.

These debugging runtime support files are installed via `initContainers` from images defined in https://github.com/GoogleContainerTools/container-debug-support/. These images are currently manually pushed to `gcr.io/gcp-dev-tools/duct-tape/XXX` where XXX is a runtime-specific identifier like `go`.

The Go image installs the [`dlv`](https://github.com/go-delve/delve) debugger for Go.  The debug support launches Delve in headless mode, and configured it to listen to a port.

**BEWARE** Unlike the other languages, but in the spirit of gdb, dlv currently stops on launch, and requires attaching and "continue"ing the application.

## Manual Testing

For manual testing, you'll need to connect directly to the Delve debug port (`dlv connect host:port`).  dlv normally listens on port 56678.

VS Code does have a debug adapter for Go/dlv, which can be used from other DAP-compatible systems (`node $HOME/.vscode/extensions/ms-vscode.go-0.10.2/out/src/debugAdapter/goDebug.js`), and I added some notes to `docs/content/en/docs/how-tos/debug/_index.md` on configuration.

Fixes #2173