### PR TITLE
upgrade go bazel rules to in examples to fix bazel breaking release 0.18.6

### DIFF
--- a/examples/bazel/.bazelrc
+++ b/examples/bazel/.bazelrc
@@ -1,0 +1,8 @@
+# The following flags are set to test use of new features for python toolchains
+# These flags will only work with Bazel 0.25.0 or above.
+build --incompatible_use_python_toolchains
+build --host_force_python=PY2
+test --incompatible_use_python_toolchains
+test --host_force_python=PY2
+run --incompatible_use_python_toolchains
+run --host_force_python=PY2

--- a/examples/bazel/WORKSPACE
+++ b/examples/bazel/WORKSPACE
@@ -11,8 +11,8 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz"],
-    sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz"],
+    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/examples/bazel/WORKSPACE
+++ b/examples/bazel/WORKSPACE
@@ -2,11 +2,12 @@ workspace(name = "skaffold")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+
 http_archive(
     name = "io_bazel_rules_docker",
-    strip_prefix = "rules_docker-0.7.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
-    sha256 = "aed1c249d4ec8f703edddf35cbe9dfaca0b5f5ea6e4cd9e83e99f3b0d1136c3d",
+    strip_prefix = "rules_docker-0.8.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.8.0.tar.gz"],
+    sha256 = "3556d4972571f288f8c43378295d84ed64fef5b1a875211ee1046f9f6b4258fa",
 )
 
 http_archive(
@@ -15,7 +16,7 @@ http_archive(
     sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
 
 go_rules_dependencies()
 go_register_toolchains(

--- a/integration/examples/bazel/.bazelrc
+++ b/integration/examples/bazel/.bazelrc
@@ -1,0 +1,8 @@
+# The following flags are set to test use of new features for python toolchains
+# These flags will only work with Bazel 0.25.0 or above.
+build --incompatible_use_python_toolchains
+build --host_force_python=PY2
+test --incompatible_use_python_toolchains
+test --host_force_python=PY2
+run --incompatible_use_python_toolchains
+run --host_force_python=PY2

--- a/integration/examples/bazel/WORKSPACE
+++ b/integration/examples/bazel/WORKSPACE
@@ -11,8 +11,8 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz"],
-    sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz"],
+    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/integration/examples/bazel/WORKSPACE
+++ b/integration/examples/bazel/WORKSPACE
@@ -2,11 +2,12 @@ workspace(name = "skaffold")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+
 http_archive(
     name = "io_bazel_rules_docker",
-    strip_prefix = "rules_docker-0.7.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
-    sha256 = "aed1c249d4ec8f703edddf35cbe9dfaca0b5f5ea6e4cd9e83e99f3b0d1136c3d",
+    strip_prefix = "rules_docker-0.8.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.8.0.tar.gz"],
+    sha256 = "3556d4972571f288f8c43378295d84ed64fef5b1a875211ee1046f9f6b4258fa",
 )
 
 http_archive(
@@ -15,7 +16,7 @@ http_archive(
     sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
 
 go_rules_dependencies()
 go_register_toolchains(

--- a/integration/testdata/custom/.bazelrc
+++ b/integration/testdata/custom/.bazelrc
@@ -1,0 +1,8 @@
+# The following flags are set to test use of new features for python toolchains
+# These flags will only work with Bazel 0.25.0 or above.
+build --incompatible_use_python_toolchains
+build --host_force_python=PY2
+test --incompatible_use_python_toolchains
+test --host_force_python=PY2
+run --incompatible_use_python_toolchains
+run --host_force_python=PY2

--- a/integration/testdata/custom/WORKSPACE
+++ b/integration/testdata/custom/WORKSPACE
@@ -11,8 +11,8 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz"],
-    sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.18.6/rules_go-0.18.6.tar.gz"],
+    sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/integration/testdata/custom/WORKSPACE
+++ b/integration/testdata/custom/WORKSPACE
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_docker",
-    strip_prefix = "rules_docker-0.7.0",
-    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.7.0.tar.gz"],
-    sha256 = "aed1c249d4ec8f703edddf35cbe9dfaca0b5f5ea6e4cd9e83e99f3b0d1136c3d",
+    strip_prefix = "rules_docker-0.8.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.8.0.tar.gz"],
+    sha256 = "3556d4972571f288f8c43378295d84ed64fef5b1a875211ee1046f9f6b4258fa",
 )
 
 http_archive(
@@ -15,7 +15,7 @@ http_archive(
     sha256 = "f04d2373bcaf8aa09bccb08a98a57e721306c8f6043a2a0ee610fd6853dcde3d",
 )
 
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
 
 go_rules_dependencies()
 go_register_toolchains(


### PR DESCRIPTION


One of the integration tests failed with following error:

The issue is : https://github.com/bazelbuild/bazel/issues/7793
Upgrading example should fix this.
```
ERROR: /root/.cache/bazel/_bazel_root/763bd7ff73f8885b0a98ed87a918afef/external/io_bazel_rules_go/BUILD.bazel:65:1: in go_context_data rule @io_bazel_rules_go//:go_context_data:
            Traceback (most recent call last):
            	File "/root/.cache/bazel/_bazel_root/763bd7ff73f8885b0a98ed87a918afef/external/io_bazel_rules_go/BUILD.bazel", line 65
            		go_context_data(name = 'go_context_data')
            	File "/root/.cache/bazel/_bazel_root/763bd7ff73f8885b0a98ed87a918afef/external/io_bazel_rules_go/go/private/context.bzl", line 396, in _go_context_data_impl
            		cc_common.configure_features(cc_toolchain = cc_toolchain, reque..., ...)
            Incompatible flag --incompatible_require_ctx_in_configure_features has been flipped, and the mandatory parameter 'ctx' of cc_common.configure_features is missing. Please add 'ctx' as a named parameter. See https://github.com/bazelbuild/bazel/issues/7793 for details.
            DEBUG: Rule 'org_golang_x_tools' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "2384fa91351a7414b643c5230422ce45f5aa2be8a82727609afd4e64e6973a30"
            DEBUG: Call stack for the definition of repository 'org_golang_x_tools' which is a http_archive (rule definition at /root/.cache/bazel/_bazel_root/763bd7ff73f8885b0a98ed87a918afef/external/bazel_tools/tools/build_defs/repo/http.bzl:237:16):
             - /root/.cache/bazel/_bazel_root/763bd7ff73f8885b0a98ed87a918afef/external/io_bazel_rules_go/go/private/repositories.bzl:199:9
             - /root/.cache/bazel/_bazel_root/763bd7ff73f8885b0a98ed87a918afef/external/io_bazel_rules_go/go/private/repositories.bzl:32:5
             - /go/src/github.com/GoogleContainerTools/skaffold/integration/examples/bazel/WORKSPACE:20:1
            INFO: Call stack for the definition of repository 'six' which is a http_archive (rule definition at /root/.cache/bazel/_bazel_root/763bd7ff73f8885b0a98ed87a918afef/external/bazel_tools/tools/build_defs/repo/http.bzl:237:16):
             - /root/.cache/bazel/_bazel_root/763bd7ff73f8885b0a98ed87a918afef/external/io_bazel_rules_docker/repositories/repositories.bzl:109:9
             - /root/.cache/bazel/_bazel_root/763bd7ff73f8885b0a98ed87a918afef/external/io_bazel_rules_docker/go/image.bzl:43:5
             - /go/src/github.com/GoogleContainerTools/skaffold/integration/examples/bazel/WORKSPACE:30:1
            ERROR: Analysis of target '//:skaffold_example.tar' failed; build aborted: Analysis of target '@io_bazel_rules_go//:go_context_data' failed; build aborted
            INFO: Elapsed time: 34.360s
```