### PR TITLE
Add missing mock

### DIFF
--- a/pkg/skaffold/docker/context_test.go
+++ b/pkg/skaffold/docker/context_test.go
@@ -31,6 +31,7 @@ func TestDockerContext(t *testing.T) {
 		testutil.Run(t, dir, func(t *testutil.T) {
 			imageFetcher := fakeImageFetcher{}
 			t.Override(&RetrieveImage, imageFetcher.fetch)
+			t.Override(&WorkingDir, func(string, map[string]bool) (string, error) { return "/", nil })
 			t.NewTempDir().
 				Write(dir+"/.dockerignore", "**/ignored.txt\nalsoignored.txt").
 				Write(dir+"/Dockerfile", "FROM alpine\nCOPY ./files /files").


### PR DESCRIPTION
Test fails without it (but interestingly, not when it runs with `-race`...)

Signed-off-by: David Gageot <david@gageot.net>