### PR TITLE
Validate port-forwards by attempting to bind to port

### DIFF
--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -63,7 +63,7 @@ func portForwardSuccessful(port int32) error {
 	// creating a listening port should not succeed
 	if ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", util.Loopback, port)); err == nil {
 		ln.Close()
-		return errors.New("port-forward failed") 
+		return errors.New("port-forward failed")
 	}
 	return nil
 }

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"net/http"
+	"net"
 	"os/exec"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -60,8 +60,12 @@ func (*KubectlForwarder) Forward(parentCtx context.Context, pfe *portForwardEntr
 }
 
 func portForwardSuccessful(port int32) error {
-	_, err := http.Get(fmt.Sprintf("http://%s:%d", util.Loopback, port))
-	return err
+	// creating a listening port should not succeed
+	if ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", util.Loopback, port)); err == nil {
+		ln.Close()
+		return errors.New("port-forward failed") 
+	}
+	return nil
 }
 
 // Terminate terminates an existing kubectl port-forward command using SIGTERM


### PR DESCRIPTION
Skaffold's port-forwarding now [attempts a GET on forwarded-ports](https://github.com/GoogleContainerTools/skaffold/pull/2215/files#diff-eaf874fd53206ef9938074f0539dd53fR62) to verify that the port-forward was successful, but this breaks JVM debugging (non-HTTP based) and causes spurious log messages.  (It also introduces latency when dealing with remote clusters.) 

This patch changes the port-forwarding validation check to attempt to bind to the port instead, which is expected to fail.

```
$ cd examples/jib; ../../cmd/skaffold/skaffold debug --port-forward
...
Forwarding container web-586567d484-j6st9/web to local port 5006.
Port Forwarding pod/web-586567d484-j6st9 5005 -> 5006
[web-586567d484-j6st9 web] Debugger failed to attach: handshake failed - received >GET / HTTP/1.1< - expected >JDWP-Handshake<
[web-586567d484-j6st9 web] Debugger failed to attach: handshake failed - received >GET / HTTP/1.1< - expected >JDWP-Handshake<
[...repeated...]
```