### PR TITLE
Restart the dev loop when the skaffold config changes

### DIFF
--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -85,7 +86,11 @@ func doDev(ctx context.Context, out io.Writer) error {
 				return err
 			})
 			if err != nil {
-				return err
+				if errors.Cause(err) != runner.ErrorConfigurationChanged {
+					return err
+				}
+				// Otherwise, the skaffold config has changed.
+				// just recreate a new runner and restart a dev loop
 			}
 		}
 	}


### PR DESCRIPTION
I thought I fixed that recently but it turns out I
haven’t!

Move default labeller to deploy since it used in deployer.