### PR TITLE
Schemas: Make sure preferredOrder is in sync with field order in Go structs

### DIFF
--- a/docs/content/en/schemas/v1beta10.json
+++ b/docs/content/en/schemas/v1beta10.json
@@ -1509,11 +1509,11 @@
       },
       "preferredOrder": [
         "name",
-        "patches",
-        "activation",
         "build",
         "test",
-        "deploy"
+        "deploy",
+        "patches",
+        "activation"
       ],
       "additionalProperties": false,
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
@@ -1618,10 +1618,10 @@
       "preferredOrder": [
         "apiVersion",
         "kind",
-        "profiles",
         "build",
         "test",
-        "deploy"
+        "deploy",
+        "profiles"
       ],
       "additionalProperties": false,
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",

--- a/docs/content/en/schemas/v1beta11.json
+++ b/docs/content/en/schemas/v1beta11.json
@@ -1522,11 +1522,11 @@
       },
       "preferredOrder": [
         "name",
-        "patches",
-        "activation",
         "build",
         "test",
-        "deploy"
+        "deploy",
+        "patches",
+        "activation"
       ],
       "additionalProperties": false,
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
@@ -1631,10 +1631,10 @@
       "preferredOrder": [
         "apiVersion",
         "kind",
-        "profiles",
         "build",
         "test",
-        "deploy"
+        "deploy",
+        "profiles"
       ],
       "additionalProperties": false,
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",

--- a/docs/content/en/schemas/v1beta12.json
+++ b/docs/content/en/schemas/v1beta12.json
@@ -1569,12 +1569,12 @@
       },
       "preferredOrder": [
         "name",
-        "patches",
-        "activation",
         "build",
         "test",
         "deploy",
-        "portForward"
+        "portForward",
+        "patches",
+        "activation"
       ],
       "additionalProperties": false,
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
@@ -1692,11 +1692,11 @@
       "preferredOrder": [
         "apiVersion",
         "kind",
-        "profiles",
         "build",
         "test",
         "deploy",
-        "portForward"
+        "portForward",
+        "profiles"
       ],
       "additionalProperties": false,
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",

--- a/docs/content/en/schemas/v1beta8.json
+++ b/docs/content/en/schemas/v1beta8.json
@@ -1513,11 +1513,11 @@
       },
       "preferredOrder": [
         "name",
-        "patches",
-        "activation",
         "build",
         "test",
-        "deploy"
+        "deploy",
+        "patches",
+        "activation"
       ],
       "additionalProperties": false,
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
@@ -1622,10 +1622,10 @@
       "preferredOrder": [
         "apiVersion",
         "kind",
-        "profiles",
         "build",
         "test",
-        "deploy"
+        "deploy",
+        "profiles"
       ],
       "additionalProperties": false,
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",

--- a/docs/content/en/schemas/v1beta9.json
+++ b/docs/content/en/schemas/v1beta9.json
@@ -1413,11 +1413,11 @@
       },
       "preferredOrder": [
         "name",
-        "patches",
-        "activation",
         "build",
         "test",
-        "deploy"
+        "deploy",
+        "patches",
+        "activation"
       ],
       "additionalProperties": false,
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
@@ -1522,10 +1522,10 @@
       "preferredOrder": [
         "apiVersion",
         "kind",
-        "profiles",
         "build",
         "test",
-        "deploy"
+        "deploy",
+        "profiles"
       ],
       "additionalProperties": false,
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",

--- a/hack/schemas/testdata/inline/input.go
+++ b/hack/schemas/testdata/inline/input.go
@@ -20,18 +20,21 @@ package latest
 type TestStruct struct {
 	// RequiredField should be required
 	RequiredField string `yaml:"reqField" yamltags:"required"`
-	InlineStruct  `yaml:"inline"`
+
+	InlineStruct `yaml:"inline"`
+
+	// Field4 should be listed last in `preferredOrder`
+	Field4 string `yaml:"field4"`
 }
 
-//InlineOneOfStruct is embedded inline into TestStruct
+// InlineStruct is embedded inline into TestStruct.
 type InlineStruct struct {
-
-	//Field1 should be the first field
+	// Field1 should be the first field
 	Field1 string `yaml:"field1"`
 
-	//Field2 should be the second field
+	// Field2 should be the second field
 	Field2 string `yaml:"field2"`
 
-	//Field3 should be the third field and listed in required
+	// Field3 should be the third field and listed in required
 	RequiredField3 string `yaml:"reqField3" yamltags:"required"`
 }

--- a/hack/schemas/testdata/inline/output.json
+++ b/hack/schemas/testdata/inline/output.json
@@ -23,6 +23,11 @@
           "description": "should be the second field",
           "x-intellij-html-description": "should be the second field"
         },
+        "field4": {
+          "type": "string",
+          "description": "should be listed last in `preferredOrder`",
+          "x-intellij-html-description": "should be listed last in <code>preferredOrder</code>"
+        },
         "reqField": {
           "type": "string",
           "description": "should be required",
@@ -38,7 +43,8 @@
         "reqField",
         "field1",
         "field2",
-        "reqField3"
+        "reqField3",
+        "field4"
       ],
       "additionalProperties": false,
       "description": "for testing the schema generator.",


### PR DESCRIPTION
Fields from inlined definitions were always at the end.

Fixes #2003

Signed-off-by: David Gageot <david@gageot.net>