### PR TITLE
Convert image string to fix sync

### DIFF
--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -165,6 +166,10 @@ func Perform(ctx context.Context, image string, files syncMap, cmdFn func(contex
 		if err != nil {
 			return errors.Wrap(err, "getting pods for namespace "+ns)
 		}
+
+		r := regexp.MustCompile("(.*)@(.*)")
+		g := r.FindSubmatch([]byte(image))
+		image = string(g[1])
 
 		for _, p := range pods.Items {
 			for _, c := range p.Spec.Containers {

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -169,7 +169,9 @@ func Perform(ctx context.Context, image string, files syncMap, cmdFn func(contex
 
 		r := regexp.MustCompile("(.*)@(.*)")
 		g := r.FindSubmatch([]byte(image))
-		image = string(g[1])
+		if g != nil {
+			image = string(g[1])
+		}
 
 		for _, p := range pods.Items {
 			for _, c := range p.Spec.Containers {


### PR DESCRIPTION
The image string Skaffold has is like below.
```
docker.io/yoshwata/yoshwata_test-file-sync:v0.32.0-86-g6bcaa54e-dirty@sha256:8ac12f6ff6f5e4a06f475e0005bd7b3713c2f8588030abfa9e20dc0514761db9
```
However, image string that pod has is like below.
```
docker.io/yoshwata/yoshwata_test-file-sync:v0.32.0-86-g6bcaa54e-dirty
```

These are never match, so syncing is skipped. Trimming strings back of `@` is my workaround.
