### PR TITLE
Fix schema doc

### DIFF
--- a/docs/content/en/docs/references/yaml/_index.html
+++ b/docs/content/en/docs/references/yaml/_index.html
@@ -6,5 +6,5 @@ weight: 120
 
 <link href="https://fonts.googleapis.com/css?family=Roboto+Mono:400,700" rel="stylesheet">
 <link rel="stylesheet" type="text/css" href="main.css">
-<script type="module" src="main.js?version={{% skaffold-version %}}"></script>
-<table id="table"></table>
+<script type="module" src="main.js"></script>
+<table id="table" data-version="{{% skaffold-version %}}"></table>

--- a/docs/content/en/docs/references/yaml/main.js
+++ b/docs/content/en/docs/references/yaml/main.js
@@ -3,8 +3,8 @@ import { unsafeHTML } from "https://unpkg.com/lit-html@1.0.0/directives/unsafe-h
 
 var version;
 (async function() {
-  const url = new URL(import.meta.url);
-  version = url.searchParams.get('version').replace('skaffold/', '');
+  version = document.getElementById('table').attributes['data-version'].value;
+  version = version.replace('skaffold/', '');
 
   const response = await fetch(`/schemas/${version}.json`);
   const json = await response.json();

--- a/docs/content/en/docs/references/yaml/main.js
+++ b/docs/content/en/docs/references/yaml/main.js
@@ -1,5 +1,5 @@
-import { html, render } from "https://unpkg.com/lit-html@1.0.0/lit-html.js";
-import { unsafeHTML } from "https://unpkg.com/lit-html@1.0.0/directives/unsafe-html.js";
+import { html, render } from 'https://unpkg.com/lit-html@1.0.0/lit-html.js';
+import { unsafeHTML } from 'https://unpkg.com/lit-html@1.0.0/directives/unsafe-html.js';
 
 var version;
 (async function() {
@@ -8,7 +8,7 @@ var version;
 
   const response = await fetch(`/schemas/${version}.json`);
   const json = await response.json();
-  const table = document.getElementById("table");
+  const table = document.getElementById('table');
 
   render(html`
     ${template(json.definitions, undefined, json.anyOf[0].$ref, 0)}
@@ -16,7 +16,7 @@ var version;
 })();
 
 function* template(definitions, parentDefinition, ref, ident) {
-  const name = ref.replace("#/definitions/", "");
+  const name = ref.replace('#/definitions/', '');
   const allProperties = [];
   const seen = {};
 
@@ -37,28 +37,28 @@ function* template(definitions, parentDefinition, ref, ident) {
   }
 
   let index = -1;
-  for (var [key, definition] of allProperties) {
+  for (let [key, definition] of allProperties) {
     index++;
 
     // Key
     let required = definitions[name].required && definitions[name].required.includes(key);
-    let keyClass = required ? "key required" : "key";
+    let keyClass = required ? 'key required' : 'key';
 
     // Value
     let value = definition.default;
-    if (key === "apiVersion") {
+    if (key === 'apiVersion') {
       value = `skaffold/${version}`;
     } else if (definition.examples && definition.examples.length > 0) {
       value = definition.examples[0];
     }
-    let valueClass = definition.examples ? "example" : "value";
+    let valueClass = definition.examples ? 'example' : 'value';
 
     // Description
-    const desc = definition["x-intellij-html-description"];
+    const desc = definition['x-intellij-html-description'];
     
     // Special case for profiles
-    if ((name === "Profile") && (key === "build" || key === "test" || key === "deploy")) {
-      value = "{}";
+    if ((name === 'Profile') && (key === 'build' || key === 'test' || key === 'deploy')) {
+      value = '{}';
       yield html`
         <tr>
           <td>
@@ -74,9 +74,9 @@ function* template(definitions, parentDefinition, ref, ident) {
 
     if (definition.$ref) {
       // Check if the referenced description is a final one
-      const refName = definition.$ref.replace("#/definitions/", "");
+      const refName = definition.$ref.replace('#/definitions/', '');
       if (!definitions[refName].properties && !definitions[refName].anyOf) {
-        value = "{}";
+        value = '{}';
       }
 
       yield html`
@@ -100,7 +100,7 @@ function* template(definitions, parentDefinition, ref, ident) {
           <td class="comment">${unsafeHTML(desc)}</td>
         </tr>
       `;
-    } else if (parentDefinition && (parentDefinition.type === "array") && (index == 0)) {
+    } else if (parentDefinition && (parentDefinition.type === 'array') && (index === 0)) {
       yield html`
         <tr>
           <td>
@@ -111,7 +111,7 @@ function* template(definitions, parentDefinition, ref, ident) {
           <td class="comment">${unsafeHTML(desc)}</td>
         </tr>
       `;
-    } else if ((definition.type === "array") && value && (value != "[]")) {
+    } else if ((definition.type === 'array') && value && (value !== '[]')) {
       // Parse value to json array
       const values = JSON.parse(value);
 
@@ -137,7 +137,7 @@ function* template(definitions, parentDefinition, ref, ident) {
           </tr>
         `;
       }
-    } else if (definition.type === "object" && value && value != "{}") {
+    } else if (definition.type === 'object' && value && value !== '{}') {
       // Parse value to json object
       const values = JSON.parse(value);
 
@@ -154,6 +154,7 @@ function* template(definitions, parentDefinition, ref, ident) {
       `;
 
       for (const k in values) {
+        if (!values.hasOwnProperty(k)) continue;
         const v = values[k];
 
         yield html`

--- a/docs/content/en/schemas/v1alpha2.json
+++ b/docs/content/en/schemas/v1alpha2.json
@@ -277,7 +277,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number"
+          "type": "integer"
         },
         "dockerImage": {
           "type": "string"

--- a/docs/content/en/schemas/v1alpha3.json
+++ b/docs/content/en/schemas/v1alpha3.json
@@ -277,7 +277,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number"
+          "type": "integer"
         },
         "dockerImage": {
           "type": "string"

--- a/docs/content/en/schemas/v1alpha4.json
+++ b/docs/content/en/schemas/v1alpha4.json
@@ -359,7 +359,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number"
+          "type": "integer"
         },
         "dockerImage": {
           "type": "string"

--- a/docs/content/en/schemas/v1alpha5.json
+++ b/docs/content/en/schemas/v1alpha5.json
@@ -406,7 +406,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number"
+          "type": "integer"
         },
         "dockerImage": {
           "type": "string"

--- a/docs/content/en/schemas/v1beta1.json
+++ b/docs/content/en/schemas/v1beta1.json
@@ -367,7 +367,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number"
+          "type": "integer"
         },
         "dockerImage": {
           "type": "string"

--- a/docs/content/en/schemas/v1beta10.json
+++ b/docs/content/en/schemas/v1beta10.json
@@ -804,7 +804,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number",
+          "type": "integer",
           "description": "disk size of the VM that runs the build. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions).",
           "x-intellij-html-description": "disk size of the VM that runs the build. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions\">Cloud Build Reference</a>."
         },

--- a/docs/content/en/schemas/v1beta11.json
+++ b/docs/content/en/schemas/v1beta11.json
@@ -804,7 +804,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number",
+          "type": "integer",
           "description": "disk size of the VM that runs the build. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions).",
           "x-intellij-html-description": "disk size of the VM that runs the build. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions\">Cloud Build Reference</a>."
         },

--- a/docs/content/en/schemas/v1beta12.json
+++ b/docs/content/en/schemas/v1beta12.json
@@ -804,7 +804,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number",
+          "type": "integer",
           "description": "disk size of the VM that runs the build. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions).",
           "x-intellij-html-description": "disk size of the VM that runs the build. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions\">Cloud Build Reference</a>."
         },
@@ -1475,7 +1475,7 @@
     "PortForwardResource": {
       "properties": {
         "localPort": {
-          "$ref": "#/definitions/int32",
+          "type": "integer",
           "description": "local port to forward to. If the port is unavailable, Skaffold will choose a random open port to forward to. *Optional*.",
           "x-intellij-html-description": "local port to forward to. If the port is unavailable, Skaffold will choose a random open port to forward to. <em>Optional</em>."
         },
@@ -1485,7 +1485,7 @@
           "x-intellij-html-description": "namespace of the resource to port forward."
         },
         "port": {
-          "$ref": "#/definitions/int32",
+          "type": "integer",
           "description": "resource port that will be forwarded.",
           "x-intellij-html-description": "resource port that will be forwarded."
         },

--- a/docs/content/en/schemas/v1beta2.json
+++ b/docs/content/en/schemas/v1beta2.json
@@ -367,7 +367,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number"
+          "type": "integer"
         },
         "dockerImage": {
           "type": "string"

--- a/docs/content/en/schemas/v1beta3.json
+++ b/docs/content/en/schemas/v1beta3.json
@@ -384,7 +384,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number"
+          "type": "integer"
         },
         "dockerImage": {
           "type": "string"

--- a/docs/content/en/schemas/v1beta4.json
+++ b/docs/content/en/schemas/v1beta4.json
@@ -405,7 +405,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number"
+          "type": "integer"
         },
         "dockerImage": {
           "type": "string"

--- a/docs/content/en/schemas/v1beta5.json
+++ b/docs/content/en/schemas/v1beta5.json
@@ -672,7 +672,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number",
+          "type": "integer",
           "description": "disk size of the VM that runs the build. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions).",
           "x-intellij-html-description": "disk size of the VM that runs the build. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions\">Cloud Build Reference</a>."
         },

--- a/docs/content/en/schemas/v1beta6.json
+++ b/docs/content/en/schemas/v1beta6.json
@@ -674,7 +674,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number",
+          "type": "integer",
           "description": "disk size of the VM that runs the build. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions).",
           "x-intellij-html-description": "disk size of the VM that runs the build. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions\">Cloud Build Reference</a>."
         },

--- a/docs/content/en/schemas/v1beta7.json
+++ b/docs/content/en/schemas/v1beta7.json
@@ -762,7 +762,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number",
+          "type": "integer",
           "description": "disk size of the VM that runs the build. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions).",
           "x-intellij-html-description": "disk size of the VM that runs the build. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions\">Cloud Build Reference</a>."
         },

--- a/docs/content/en/schemas/v1beta8.json
+++ b/docs/content/en/schemas/v1beta8.json
@@ -808,7 +808,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number",
+          "type": "integer",
           "description": "disk size of the VM that runs the build. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions).",
           "x-intellij-html-description": "disk size of the VM that runs the build. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions\">Cloud Build Reference</a>."
         },

--- a/docs/content/en/schemas/v1beta9.json
+++ b/docs/content/en/schemas/v1beta9.json
@@ -708,7 +708,7 @@
     "GoogleCloudBuild": {
       "properties": {
         "diskSizeGb": {
-          "type": "number",
+          "type": "integer",
           "description": "disk size of the VM that runs the build. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions).",
           "x-intellij-html-description": "disk size of the VM that runs the build. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions\">Cloud Build Reference</a>."
         },

--- a/hack/schemas/main.go
+++ b/hack/schemas/main.go
@@ -123,7 +123,9 @@ func generateSchemas(root string, dryRun bool) (bool, error) {
 		}
 
 		if !dryRun {
-			ioutil.WriteFile(output, buf, os.ModePerm)
+			if err := ioutil.WriteFile(output, buf, os.ModePerm); err != nil {
+				return false, errors.Wrapf(err, "unable to write schema %s", output)
+			}
 		}
 	}
 

--- a/hack/schemas/main.go
+++ b/hack/schemas/main.go
@@ -144,8 +144,8 @@ func setTypeOrRef(def *Definition, typeName string) {
 		def.Type = typeName
 	case "bool":
 		def.Type = "boolean"
-	case "int", "int64":
-		def.Type = "number"
+	case "int", "int64", "int32":
+		def.Type = "integer"
 	default:
 		def.Ref = defPrefix + typeName
 	}

--- a/hack/schemas/main_test.go
+++ b/hack/schemas/main_test.go
@@ -45,6 +45,7 @@ func TestGenerators(t *testing.T) {
 		{name: "inline"},
 		{name: "inline-anyof"},
 		{name: "inline-hybrid"},
+		{name: "integer"},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {

--- a/hack/schemas/testdata/integer/input.go
+++ b/hack/schemas/testdata/integer/input.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package latest
+
+// TestStruct for testing the schema generator.
+type TestStruct struct {
+	// Int32Field is an integer
+	Int32Field int32 `yaml:"int32Field"`
+
+	// Int64Field is an integer
+	Int64Field int32 `yaml:"int64Field"`
+
+	// IntField is an integer
+	IntField int `yaml:"intField"`
+}

--- a/hack/schemas/testdata/integer/output.json
+++ b/hack/schemas/testdata/integer/output.json
@@ -1,0 +1,38 @@
+{
+  "type": "object",
+  "anyOf": [
+    {
+      "$ref": "#/definitions/TestStruct"
+    }
+  ],
+  "$schema": "http://json-schema-org/draft-07/schema#",
+  "definitions": {
+    "TestStruct": {
+      "properties": {
+        "int32Field": {
+          "type": "integer",
+          "description": "an integer",
+          "x-intellij-html-description": "an integer"
+        },
+        "int64Field": {
+          "type": "integer",
+          "description": "an integer",
+          "x-intellij-html-description": "an integer"
+        },
+        "intField": {
+          "type": "integer",
+          "description": "an integer",
+          "x-intellij-html-description": "an integer"
+        }
+      },
+      "preferredOrder": [
+        "int32Field",
+        "int64Field",
+        "intField"
+      ],
+      "additionalProperties": false,
+      "description": "for testing the schema generator.",
+      "x-intellij-html-description": "for testing the schema generator."
+    }
+  }
+}


### PR DESCRIPTION
This fixes multiple issues with the schema documentation generation:
 + In the *unreleased* `v1beta12` version, some fields are `int32`, which wasn't supported
 + `int`, `int32` and `int64` should be of type `integer` and not `number`
 + Older versions of Firefox couldn't load the documentation because they don't support `import.meta`
 + Fixed a few warnings in the javascript code