### PR TITLE
Simplify test debug

### DIFF
--- a/integration/testdata/debug/nodejs/Dockerfile
+++ b/integration/testdata/debug/nodejs/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.12.0-alpine
+FROM node:10.15.3-alpine
 
 WORKDIR /opt/backend
 EXPOSE 3000

--- a/integration/testdata/debug/npm/Dockerfile
+++ b/integration/testdata/debug/npm/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.12.0-alpine
+FROM node:10.15.3-alpine
 
 WORKDIR /opt/backend
 EXPOSE 3000

--- a/integration/testdata/debug/python3/Dockerfile
+++ b/integration/testdata/debug/python3/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.7.3-alpine3.9
 
 EXPOSE 5000
 CMD ["python3", "app.py"]


### PR DESCRIPTION
+ Remove code that's not required
+ Use base images that are already used elsewhere. It might help reduce the number of images we pull

See #2398 