### PR TITLE
Feat(sync): skip sync on non-running pods

### DIFF
--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -169,6 +169,12 @@ func Perform(ctx context.Context, image string, files syncMap, cmdFn func(contex
 		}
 
 		for _, p := range pods.Items {
+
+			if p.Status.Phase != v1.PodRunning {
+				logrus.Infof("Skipping sync with pod %s because it's not running", p.Name)
+				continue
+			}
+
 			for _, c := range p.Spec.Containers {
 				if c.Image != image {
 					continue


### PR DESCRIPTION
Fix issue #2360

The goal of this PR is to avoid trying to sync files in a pod which is
not in a running state. It should avoid errors when working on a single
artifact which is deployed in different pods. For example : one running
a webserver and another running a work or a job. This is typically
something that could happend when a microservice is able to run both web
server and a job which make some sort of batch treatments on the database.