### PR TITLE
Better integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,6 @@ jobs:
       before_install:
         - curl -Lo ${HOME}/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.4.0/kind-linux-amd64
         - chmod +x ${HOME}/bin/kind
-      script: make integration-in-kind
+      script:
+      - df -h
+      - make integration-in-kind

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+
 language: go
 
 git:

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ ifeq ($(GCP_ONLY),true)
 		--zone $(GKE_ZONE) \
 		--project $(GCP_PROJECT)
 endif
+	kubectl get nodes -oyaml
 	GCP_ONLY=$(GCP_ONLY) go test -v $(REPOPATH)/integration -timeout 15m $(INTEGRATION_TEST_ARGS)
 
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ ifeq ($(GCP_ONLY),true)
 		--project $(GCP_PROJECT)
 endif
 	kubectl get nodes -oyaml
-	GCP_ONLY=$(GCP_ONLY) go test -v $(REPOPATH)/integration -timeout 15m $(INTEGRATION_TEST_ARGS)
+	GCP_ONLY=$(GCP_ONLY) go test -v $(REPOPATH)/integration -timeout 20m $(INTEGRATION_TEST_ARGS)
 
 .PHONY: release
 release: cross $(BUILD_DIR)/VERSION

--- a/Makefile
+++ b/Makefile
@@ -114,11 +114,11 @@ endif
 .PHONY: release
 release: cross $(BUILD_DIR)/VERSION
 	docker build \
-        		-f deploy/skaffold/Dockerfile \
-        		--cache-from gcr.io/$(GCP_PROJECT)/skaffold-builder \
-        		--build-arg VERSION=$(VERSION) \
-        		-t gcr.io/$(GCP_PROJECT)/skaffold:latest \
-        		-t gcr.io/$(GCP_PROJECT)/skaffold:$(VERSION) .
+		-f deploy/skaffold/Dockerfile \
+		--cache-from gcr.io/$(GCP_PROJECT)/skaffold-builder \
+		--build-arg VERSION=$(VERSION) \
+		-t gcr.io/$(GCP_PROJECT)/skaffold:latest \
+		-t gcr.io/$(GCP_PROJECT)/skaffold:$(VERSION) .
 	gsutil -m cp $(BUILD_DIR)/$(PROJECT)-* $(GSC_RELEASE_PATH)/
 	gsutil -m cp $(BUILD_DIR)/VERSION $(GSC_RELEASE_PATH)/VERSION
 	gsutil -m cp -r $(GSC_RELEASE_PATH)/* $(GSC_RELEASE_LATEST)
@@ -126,10 +126,10 @@ release: cross $(BUILD_DIR)/VERSION
 .PHONY: release-in-docker
 release-in-docker:
 	docker build \
-    		-f deploy/skaffold/Dockerfile \
-    		-t gcr.io/$(GCP_PROJECT)/skaffold-builder \
-    		--target builder \
-    		.
+		-f deploy/skaffold/Dockerfile \
+		-t gcr.io/$(GCP_PROJECT)/skaffold-builder \
+		--target builder \
+		.
 	docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(HOME)/.config/gcloud:/root/.config/gcloud \
@@ -138,20 +138,20 @@ release-in-docker:
 .PHONY: release-build
 release-build: cross
 	docker build \
-    		-f deploy/skaffold/Dockerfile \
-    		--cache-from gcr.io/$(GCP_PROJECT)/skaffold-builder \
-    		-t gcr.io/$(GCP_PROJECT)/skaffold:edge \
-    		-t gcr.io/$(GCP_PROJECT)/skaffold:$(COMMIT) .
+		-f deploy/skaffold/Dockerfile \
+		--cache-from gcr.io/$(GCP_PROJECT)/skaffold-builder \
+		-t gcr.io/$(GCP_PROJECT)/skaffold:edge \
+		-t gcr.io/$(GCP_PROJECT)/skaffold:$(COMMIT) .
 	gsutil -m cp $(BUILD_DIR)/$(PROJECT)-* $(GSC_BUILD_PATH)/
 	gsutil -m cp -r $(GSC_BUILD_PATH)/* $(GSC_BUILD_LATEST)
 
 .PHONY: release-build-in-docker
 release-build-in-docker:
 	docker build \
-    		-f deploy/skaffold/Dockerfile \
-    		-t gcr.io/$(GCP_PROJECT)/skaffold-builder \
-    		--target builder \
-    		.
+		-f deploy/skaffold/Dockerfile \
+		-t gcr.io/$(GCP_PROJECT)/skaffold-builder \
+		--target builder \
+		.
 	docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(HOME)/.config/gcloud:/root/.config/gcloud \

--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -43,10 +43,6 @@ func TestDev(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			// TODO(nkubala): fix this test and remove the skip
-			if test.skipFlakyTest {
-				t.Skip("Skip flaky test")
-			}
 			if testing.Short() {
 				t.Skip("skipping integration test")
 			}

--- a/integration/util.go
+++ b/integration/util.go
@@ -103,6 +103,8 @@ func (k *NSKubernetesClient) WaitForPodsReady(podNames ...string) {
 	waitLoop:
 		select {
 		case <-ctx.Done():
+			k.printDiskFreeSpace()
+			k.debug("nodes")
 			k.debug("pods")
 			k.t.Fatalf("Timed out waiting for pods %v ready in namespace %s", podNames, k.ns)
 
@@ -158,6 +160,8 @@ func (k *NSKubernetesClient) WaitForDeploymentsToStabilize(depNames ...string) {
 	waitLoop:
 		select {
 		case <-ctx.Done():
+			k.printDiskFreeSpace()
+			k.debug("nodes")
 			k.debug("deployments.apps")
 			k.debug("pods")
 			k.t.Fatalf("Timed out waiting for deployments %v to stabilize in namespace %s", depNames, k.ns)
@@ -187,6 +191,12 @@ func (k *NSKubernetesClient) debug(entities string) {
 
 	logrus.Warnln(cmd.Args)
 	// Use fmt.Println, not logrus, for prettier output
+	fmt.Println(string(out))
+}
+
+func (k *NSKubernetesClient) printDiskFreeSpace() {
+	cmd := exec.Command("df", "-h")
+	out, _ := cmd.CombinedOutput()
 	fmt.Println(string(out))
 }
 


### PR DESCRIPTION
+ Switch to latest TravisCI env (xenial) because it seems faster and has more disk space for integration tests
+ Print more information when an integration test goes wrong
+ Re-enable TestDev that wasn't flaky
+ Increase the duration of the test suite to increase the chance of running all the tests when one goes wrong.