### PR TITLE
Add support for kustomization resources (#2416)

### DIFF
--- a/pkg/skaffold/deploy/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize_test.go
@@ -167,6 +167,10 @@ func TestDependenciesForKustomization(t *testing.T) {
 			description: "resources",
 			yaml:        `resources: [pod1.yaml, path/pod2.yaml]`,
 			expected:    []string{"kustomization.yaml", "pod1.yaml", "path/pod2.yaml"},
+			createFiles: map[string]string{
+				"pod1.yaml":      "",
+				"path/pod2.yaml": "",
+			},
 		},
 		{
 			description: "paches",
@@ -207,15 +211,44 @@ func TestDependenciesForKustomization(t *testing.T) {
 		{
 			description: "base exists locally",
 			yaml:        `bases: [base]`,
-			expected:    []string{"base/kustomization.yaml", "base/app.yaml", "kustomization.yaml"},
+			expected:    []string{"kustomization.yaml", "base/kustomization.yaml", "base/app.yaml"},
 			createFiles: map[string]string{
 				"base/kustomization.yaml": `resources: [app.yaml]`,
+				"base/app.yaml":           "",
 			},
 		},
 		{
 			description: "missing base locally",
 			yaml:        `bases: [missing-or-remote-base]`,
 			expected:    []string{"kustomization.yaml"},
+		},
+		{
+			description: "local kustomization resource",
+			yaml:        `resources: [app.yaml, base]`,
+			expected:    []string{"kustomization.yaml", "app.yaml", "base/kustomization.yaml", "base/app.yaml"},
+			createFiles: map[string]string{
+				"app.yaml":                "",
+				"base/kustomization.yaml": `resources: [app.yaml]`,
+				"base/app.yaml":           "",
+			},
+		},
+		{
+			description: "missing local kustomization resource",
+			yaml:        `resources: [app.yaml, missing-or-remote-base]`,
+			expected:    []string{"kustomization.yaml", "app.yaml"},
+			createFiles: map[string]string{
+				"app.yaml": "",
+			},
+		},
+		{
+			description: "mixed resource types",
+			yaml:        `resources: [app.yaml, missing-or-remote-base, base]`,
+			expected:    []string{"kustomization.yaml", "app.yaml", "base/kustomization.yaml", "base/app.yaml"},
+			createFiles: map[string]string{
+				"app.yaml":                "",
+				"base/kustomization.yaml": `resources: [app.yaml]`,
+				"base/app.yaml":           "",
+			},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
As of version 2.1, Kustomize has deprecated bases in favor of combining
the functionality with resources by enforcing merge order based on
resource array order. This means resources now may act as bases do today
instead of being simply files - they may point to kustomiziations
(directories with a kustomization config in the root) or even to remote
locations. The code to generate the list of dependencies for file
watching has been updated accordingly.

----

This will close  Issue #2416. Please review it carefully as it's a non-trivial change to the behavior of dependency gathering. I've added the basic test cases, but if you can think of any edge cases to add let me know.

Note: tests now must create all files referenced within both the "resources" and "bases" section of any kustomization configs encountered during the walk, otherwise those files will not be added to the dependency array and the test will fail. This is to allow support for remote files, as first introduced in PR #2269.