### PR TITLE
Wait for parallel builds to be cancelled on error

### DIFF
--- a/pkg/skaffold/build/custom/custom.go
+++ b/pkg/skaffold/build/custom/custom.go
@@ -54,17 +54,17 @@ func NewArtifactBuilder(pushImages bool, additionalEnv []string) *ArtifactBuilde
 // Build builds a custom artifact
 // It returns true if the image is expected to exist remotely, or false if it is expected to exist locally
 func (b *ArtifactBuilder) Build(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) error {
-	cmd, err := b.retrieveCmd(a, tag)
+	cmd, err := b.retrieveCmd(ctx, a, tag)
 	if err != nil {
 		return errors.Wrap(err, "retrieving cmd")
 	}
 	return cmd.Run()
 }
 
-func (b *ArtifactBuilder) retrieveCmd(a *latest.Artifact, tag string) (*exec.Cmd, error) {
+func (b *ArtifactBuilder) retrieveCmd(ctx context.Context, a *latest.Artifact, tag string) (*exec.Cmd, error) {
 	artifact := a.CustomArtifact
 	split := strings.Split(artifact.BuildCommand, " ")
-	cmd := exec.Command(split[0], split[1:]...)
+	cmd := exec.CommandContext(ctx, split[0], split[1:]...)
 	env, err := b.retrieveEnv(a, tag)
 	if err != nil {
 		return nil, errors.Wrapf(err, "retrieving env variables for %s", a.ImageName)

--- a/pkg/skaffold/build/custom/custom_test.go
+++ b/pkg/skaffold/build/custom/custom_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package custom
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"reflect"
@@ -115,7 +116,7 @@ func TestRetrieveCmd(t *testing.T) {
 			t.Override(&buildContext, func(string) (string, error) { return test.artifact.Workspace, nil })
 
 			builder := NewArtifactBuilder(false, nil)
-			cmd, err := builder.retrieveCmd(test.artifact, test.tag)
+			cmd, err := builder.retrieveCmd(context.Background(), test.artifact, test.tag)
 
 			t.CheckNoError(err)
 			// cmp.Diff cannot access unexported fields in *exec.Cmd, so use reflect.DeepEqual here directly
@@ -127,7 +128,7 @@ func TestRetrieveCmd(t *testing.T) {
 }
 
 func expectedCmd(buildCommand, dir string, args, env []string) *exec.Cmd {
-	cmd := exec.Command(buildCommand, args...)
+	cmd := exec.CommandContext(context.Background(), buildCommand, args...)
 	cmd.Dir = dir
 	cmd.Env = env
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
to fix #2268 

Previously, if building the first cluster artifact failed, skaffold
would exit immediately after. Build goroutines for other artifacts may
have still been running and not get a chance to clean up

The Kaniko build has logic to handle cancellation, but allow custom
commands to be cancelled as well

I'm still new to Go so be liberal with requesting changes