### PR TITLE
Add a `metadata.name` field to skaffold.yaml

### DIFF
--- a/docs/content/en/schemas/v1beta12.json
+++ b/docs/content/en/schemas/v1beta12.json
@@ -1472,6 +1472,21 @@
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
+    "Metadata": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "an identifier for the project.",
+          "x-intellij-html-description": "an identifier for the project."
+        }
+      },
+      "preferredOrder": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "description": "holds an optional name of the project.",
+      "x-intellij-html-description": "holds an optional name of the project."
+    },
     "PortForwardResource": {
       "properties": {
         "localPort": {
@@ -1664,6 +1679,11 @@
           "x-intellij-html-description": "always <code>Config</code>.",
           "default": "Config"
         },
+        "metadata": {
+          "$ref": "#/definitions/Metadata",
+          "description": "holds additional information about the config.",
+          "x-intellij-html-description": "holds additional information about the config."
+        },
         "portForward": {
           "items": {
             "$ref": "#/definitions/PortForwardResource"
@@ -1692,6 +1712,7 @@
       "preferredOrder": [
         "apiVersion",
         "kind",
+        "metadata",
         "build",
         "test",
         "deploy",

--- a/docs/content/en/schemas/v1beta12.json
+++ b/docs/content/en/schemas/v1beta12.json
@@ -1472,21 +1472,6 @@
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
-    "Metadata": {
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "an identifier for the project.",
-          "x-intellij-html-description": "an identifier for the project."
-        }
-      },
-      "preferredOrder": [
-        "name"
-      ],
-      "additionalProperties": false,
-      "description": "holds an optional name of the project.",
-      "x-intellij-html-description": "holds an optional name of the project."
-    },
     "PortForwardResource": {
       "properties": {
         "localPort": {
@@ -1679,11 +1664,6 @@
           "x-intellij-html-description": "always <code>Config</code>.",
           "default": "Config"
         },
-        "metadata": {
-          "$ref": "#/definitions/Metadata",
-          "description": "holds additional information about the config.",
-          "x-intellij-html-description": "holds additional information about the config."
-        },
         "portForward": {
           "items": {
             "$ref": "#/definitions/PortForwardResource"
@@ -1712,7 +1692,6 @@
       "preferredOrder": [
         "apiVersion",
         "kind",
-        "metadata",
         "build",
         "test",
         "deploy",

--- a/docs/content/en/schemas/v1beta13.json
+++ b/docs/content/en/schemas/v1beta13.json
@@ -1484,6 +1484,21 @@
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
+    "Metadata": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "an identifier for the project.",
+          "x-intellij-html-description": "an identifier for the project."
+        }
+      },
+      "preferredOrder": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "description": "holds an optional name of the project.",
+      "x-intellij-html-description": "holds an optional name of the project."
+    },
     "PortForwardResource": {
       "properties": {
         "localPort": {
@@ -1676,6 +1691,11 @@
           "x-intellij-html-description": "always <code>Config</code>.",
           "default": "Config"
         },
+        "metadata": {
+          "$ref": "#/definitions/Metadata",
+          "description": "holds additional information about the config.",
+          "x-intellij-html-description": "holds additional information about the config."
+        },
         "portForward": {
           "items": {
             "$ref": "#/definitions/PortForwardResource"
@@ -1704,6 +1724,7 @@
       "preferredOrder": [
         "apiVersion",
         "kind",
+        "metadata",
         "build",
         "test",
         "deploy",

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -35,11 +35,20 @@ type SkaffoldConfig struct {
 	// Kind is always `Config`. Defaults to `Config`.
 	Kind string `yaml:"kind" yamltags:"required"`
 
+	// Metadata holds additional information about the config.
+	Metadata Metadata `yaml:"metadata,omitempty"`
+
 	// Pipeline defines the Build/Test/Deploy phases.
 	Pipeline `yaml:",inline"`
 
 	// Profiles *beta* can override be used to `build`, `test` or `deploy` configuration.
 	Profiles []Profile `yaml:"profiles,omitempty"`
+}
+
+// Metadata holds an optional name of the project.
+type Metadata struct {
+	// Name is an identifier for the project.
+	Name string `yaml:"name,omitempty"`
 }
 
 // Pipeline describes a Skaffold pipeline.


### PR DESCRIPTION
This allows to name pipelines such that multiple skaffold.yaml can be merged with kustomize (#2200).

Close #2200 