### PR TITLE
Add resync/rebuild directly in monitor callback

### DIFF
--- a/pkg/skaffold/runner/changeset.go
+++ b/pkg/skaffold/runner/changeset.go
@@ -17,22 +17,15 @@ limitations under the License.
 package runner
 
 import (
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 )
 
 type changeSet struct {
-	dirtyArtifacts []*artifactChange
-	needsRebuild   []*latest.Artifact
-	needsResync    []*sync.Item
-	needsRedeploy  bool
-	needsReload    bool
-}
-
-type artifactChange struct {
-	artifact *latest.Artifact
-	events   filemon.Events
+	needsRebuild  []*latest.Artifact
+	needsResync   []*sync.Item
+	needsRedeploy bool
+	needsReload   bool
 }
 
 func (c *changeSet) AddRebuild(a *latest.Artifact) {
@@ -44,7 +37,6 @@ func (c *changeSet) AddResync(s *sync.Item) {
 }
 
 func (c *changeSet) reset() {
-	c.dirtyArtifacts = nil
 	c.needsRebuild = nil
 	c.needsResync = nil
 

--- a/pkg/skaffold/runner/changeset.go
+++ b/pkg/skaffold/runner/changeset.go
@@ -35,10 +35,6 @@ type artifactChange struct {
 	events   filemon.Events
 }
 
-func (c *changeSet) AddDirtyArtifact(a *latest.Artifact, e filemon.Events) {
-	c.dirtyArtifacts = append(c.dirtyArtifacts, &artifactChange{artifact: a, events: e})
-}
-
 func (c *changeSet) AddRebuild(a *latest.Artifact) {
 	c.needsRebuild = append(c.needsRebuild, a)
 }

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -93,11 +93,12 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 			func() ([]string, error) { return r.Builder.DependenciesForArtifact(ctx, artifact) },
 			func(e filemon.Events) {
 				s, err := sync.NewItem(artifact, e, r.builds, r.runCtx.InsecureRegistries)
-				if err != nil {
+				switch {
+				case err != nil:
 					logrus.Warnf("error adding dirty artifact to changeset: %s", err.Error())
-				} else if s != nil {
+				case s != nil:
 					r.changeSet.AddResync(s)
-				} else {
+				default:
 					r.changeSet.AddRebuild(artifact)
 				}
 			},

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -33,30 +33,10 @@ import (
 // ErrorConfigurationChanged is a special error that's returned when the skaffold configuration was changed.
 var ErrorConfigurationChanged = errors.New("configuration changed")
 
-func (r *SkaffoldRunner) separateBuildAndSync() error {
-	// TODO(nkubala): can this be moved into callback registered in monitor?
-	for _, a := range r.changeSet.dirtyArtifacts {
-		s, err := sync.NewItem(a.artifact, a.events, r.builds, r.runCtx.InsecureRegistries)
-		if err != nil {
-			return errors.Wrap(err, "sync")
-		}
-		if s != nil {
-			r.changeSet.AddResync(s)
-		} else {
-			r.changeSet.AddRebuild(a.artifact)
-		}
-	}
-	return nil
-}
-
 func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer) error {
 	defer r.changeSet.reset()
 
 	r.logger.Mute()
-
-	if err := r.separateBuildAndSync(); err != nil {
-		return err
-	}
 
 	if r.changeSet.needsAction() {
 		// if any action is going to be performed, reset the monitor's changed component tracker for debouncing
@@ -111,7 +91,16 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 
 		if err := r.monitor.Register(
 			func() ([]string, error) { return r.Builder.DependenciesForArtifact(ctx, artifact) },
-			func(e filemon.Events) { r.changeSet.AddDirtyArtifact(artifact, e) },
+			func(e filemon.Events) {
+				s, err := sync.NewItem(artifact, e, r.builds, r.runCtx.InsecureRegistries)
+				if err != nil {
+					logrus.Warnf("error adding dirty artifact to changeset: %s", err.Error())
+				} else if s != nil {
+					r.changeSet.AddResync(s)
+				} else {
+					r.changeSet.AddRebuild(artifact)
+				}
+			},
 		); err != nil {
 			return errors.Wrapf(err, "watching files for artifact %s", artifact.ImageName)
 		}


### PR DESCRIPTION
small refactor to clean the code up a bit, this code doesn't make much sense in the dev loop IMO.

the small functional effect of this change is that instead of erroring out the dev loop if we encounter an error when creating the sync item (*note: this is **not** the same as if an actual sync error occurred*), this will now log a warn to the user when skaffold tries to add the artifact to the `changeSet`, but the dev loop will continue. we could also log this as an error if that seems more appropriate.