### PR TITLE
Add CLI option `--kube-context` to override the kubecontext in Skaffold

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -23,19 +23,20 @@ import (
 	"os"
 	"strings"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/server"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
-	"k8s.io/kubectl/pkg/util/templates"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/server"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
 
 var (
@@ -70,6 +71,8 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 			}
 			color.OverwriteDefault(color.Color(defaultColor))
 			cmd.Root().SetOutput(out)
+
+			kubectx.UseKubeContext(opts.KubeContext)
 
 			// Setup logs
 			if err := setUpLogs(err, v); err != nil {

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -240,7 +240,7 @@ var FlagRegistry = []Flag{
 	},
 	{
 		Name:          "kube-context",
-		Usage:         "Use this kubernetes context",
+		Usage:         "Deploy to this kubernetes context",
 		Value:         &opts.KubeContext,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -238,6 +238,14 @@ var FlagRegistry = []Flag{
 		FlagAddMethod: "StringVar",
 		DefinedOn:     []string{"run", "dev", "debug", "build", "deploy", "delete", "diagnose"},
 	},
+	{
+		Name:          "kube-context",
+		Usage:         "Use this kubernetes context",
+		Value:         &opts.KubeContext,
+		DefValue:      "",
+		FlagAddMethod: "StringVar",
+		DefinedOn:     []string{"build", "debug", "delete", "deploy", "dev", "run"},
+	},
 }
 
 var commandFlags []*pflag.Flag

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -124,6 +124,7 @@ Options:
       --file-output='': Filename to write build images to
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
       --insecure-registry=[]: Target registries for built images which are not secure
+      --kube-context='': Use this kubernetes context
   -n, --namespace='': Run deployments in the specified namespace
   -o, --output={{json .}}: Used in conjunction with --quiet flag. Format output with go-template. For full struct documentation, see https://godoc.org/github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags#BuildOutput
   -p, --profile=[]: Activate profiles by name
@@ -151,6 +152,7 @@ Env vars:
 * `SKAFFOLD_FILE_OUTPUT` (same as `--file-output`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_INSECURE_REGISTRY` (same as `--insecure-registry`)
+* `SKAFFOLD_KUBE_CONTEXT` (same as `--kube-context`)
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)
 * `SKAFFOLD_OUTPUT` (same as `--output`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
@@ -294,6 +296,7 @@ Options:
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
       --force=true: Recreate kubernetes resources if necessary for deployment (warning: might cause downtime!)
       --insecure-registry=[]: Target registries for built images which are not secure
+      --kube-context='': Use this kubernetes context
   -l, --label=[]: Add custom labels to deployed objects. Set multiple times for multiple labels
   -n, --namespace='': Run deployments in the specified namespace
       --no-prune=false: Skip removing images and containers built by Skaffold
@@ -324,6 +327,7 @@ Env vars:
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)
 * `SKAFFOLD_INSECURE_REGISTRY` (same as `--insecure-registry`)
+* `SKAFFOLD_KUBE_CONTEXT` (same as `--kube-context`)
 * `SKAFFOLD_LABEL` (same as `--label`)
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)
 * `SKAFFOLD_NO_PRUNE` (same as `--no-prune`)
@@ -347,6 +351,7 @@ Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
+      --kube-context='': Use this kubernetes context
   -n, --namespace='': Run deployments in the specified namespace
   -p, --profile=[]: Activate profiles by name
 
@@ -362,6 +367,7 @@ Env vars:
 * `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
+* `SKAFFOLD_KUBE_CONTEXT` (same as `--kube-context`)
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 
@@ -381,6 +387,7 @@ E.g. build.out created by running skaffold build --quiet {{json .}} > build.out
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
       --force=false: Recreate kubernetes resources if necessary for deployment (default false, warning: might cause downtime!)
   -i, --images=: A list of pre-built images to deploy
+      --kube-context='': Use this kubernetes context
   -l, --label=[]: Add custom labels to deployed objects. Set multiple times for multiple labels
   -n, --namespace='': Run deployments in the specified namespace
   -p, --profile=[]: Activate profiles by name
@@ -405,6 +412,7 @@ Env vars:
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)
 * `SKAFFOLD_IMAGES` (same as `--images`)
+* `SKAFFOLD_KUBE_CONTEXT` (same as `--kube-context`)
 * `SKAFFOLD_LABEL` (same as `--label`)
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
@@ -430,6 +438,7 @@ Options:
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
       --force=true: Recreate kubernetes resources if necessary for deployment (warning: might cause downtime!)
       --insecure-registry=[]: Target registries for built images which are not secure
+      --kube-context='': Use this kubernetes context
   -l, --label=[]: Add custom labels to deployed objects. Set multiple times for multiple labels
   -n, --namespace='': Run deployments in the specified namespace
       --no-prune=false: Skip removing images and containers built by Skaffold
@@ -463,6 +472,7 @@ Env vars:
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)
 * `SKAFFOLD_INSECURE_REGISTRY` (same as `--insecure-registry`)
+* `SKAFFOLD_KUBE_CONTEXT` (same as `--kube-context`)
 * `SKAFFOLD_LABEL` (same as `--label`)
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)
 * `SKAFFOLD_NO_PRUNE` (same as `--no-prune`)
@@ -593,6 +603,7 @@ Options:
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
       --force=true: Recreate kubernetes resources if necessary for deployment (warning: might cause downtime!)
       --insecure-registry=[]: Target registries for built images which are not secure
+      --kube-context='': Use this kubernetes context
   -l, --label=[]: Add custom labels to deployed objects. Set multiple times for multiple labels
   -n, --namespace='': Run deployments in the specified namespace
       --no-prune=false: Skip removing images and containers built by Skaffold
@@ -623,6 +634,7 @@ Env vars:
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)
 * `SKAFFOLD_INSECURE_REGISTRY` (same as `--insecure-registry`)
+* `SKAFFOLD_KUBE_CONTEXT` (same as `--kube-context`)
 * `SKAFFOLD_LABEL` (same as `--label`)
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)
 * `SKAFFOLD_NO_PRUNE` (same as `--no-prune`)

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -124,7 +124,7 @@ Options:
       --file-output='': Filename to write build images to
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
       --insecure-registry=[]: Target registries for built images which are not secure
-      --kube-context='': Use this kubernetes context
+      --kube-context='': Deploy to this kubernetes context
   -n, --namespace='': Run deployments in the specified namespace
   -o, --output={{json .}}: Used in conjunction with --quiet flag. Format output with go-template. For full struct documentation, see https://godoc.org/github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags#BuildOutput
   -p, --profile=[]: Activate profiles by name
@@ -296,7 +296,7 @@ Options:
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
       --force=true: Recreate kubernetes resources if necessary for deployment (warning: might cause downtime!)
       --insecure-registry=[]: Target registries for built images which are not secure
-      --kube-context='': Use this kubernetes context
+      --kube-context='': Deploy to this kubernetes context
   -l, --label=[]: Add custom labels to deployed objects. Set multiple times for multiple labels
   -n, --namespace='': Run deployments in the specified namespace
       --no-prune=false: Skip removing images and containers built by Skaffold
@@ -351,7 +351,7 @@ Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
-      --kube-context='': Use this kubernetes context
+      --kube-context='': Deploy to this kubernetes context
   -n, --namespace='': Run deployments in the specified namespace
   -p, --profile=[]: Activate profiles by name
 
@@ -387,7 +387,7 @@ E.g. build.out created by running skaffold build --quiet {{json .}} > build.out
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
       --force=false: Recreate kubernetes resources if necessary for deployment (default false, warning: might cause downtime!)
   -i, --images=: A list of pre-built images to deploy
-      --kube-context='': Use this kubernetes context
+      --kube-context='': Deploy to this kubernetes context
   -l, --label=[]: Add custom labels to deployed objects. Set multiple times for multiple labels
   -n, --namespace='': Run deployments in the specified namespace
   -p, --profile=[]: Activate profiles by name
@@ -438,7 +438,7 @@ Options:
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
       --force=true: Recreate kubernetes resources if necessary for deployment (warning: might cause downtime!)
       --insecure-registry=[]: Target registries for built images which are not secure
-      --kube-context='': Use this kubernetes context
+      --kube-context='': Deploy to this kubernetes context
   -l, --label=[]: Add custom labels to deployed objects. Set multiple times for multiple labels
   -n, --namespace='': Run deployments in the specified namespace
       --no-prune=false: Skip removing images and containers built by Skaffold
@@ -603,7 +603,7 @@ Options:
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
       --force=true: Recreate kubernetes resources if necessary for deployment (warning: might cause downtime!)
       --insecure-registry=[]: Target registries for built images which are not secure
-      --kube-context='': Use this kubernetes context
+      --kube-context='': Deploy to this kubernetes context
   -l, --label=[]: Add custom labels to deployed objects. Set multiple times for multiple labels
   -n, --namespace='': Run deployments in the specified namespace
       --no-prune=false: Skip removing images and containers built by Skaffold

--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -26,12 +26,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/clientcmd"
+
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/proto"
 	"github.com/GoogleContainerTools/skaffold/testutil"
-	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestDev(t *testing.T) {
@@ -362,4 +364,56 @@ func readEventAPIStream(client proto.SkaffoldServiceClient, t *testing.T, retrie
 		}
 	}
 	return stream, err
+}
+
+func TestDev_WithKubecontextOverride(t *testing.T) {
+	const (
+		kubecontext = "modified-context"
+		kubeconfig  = "kubeconfig"
+	)
+
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	testutil.Run(t, "skaffold run with kubecontext override", func(t *testutil.T) {
+		dir := "examples/getting-started"
+		pods := []string{"getting-started"}
+
+		ns, client, deleteNs := SetupNamespace(t.T)
+		defer deleteNs()
+
+		modifiedKubeconfig, err := createModifiedKubeconfig(kubecontext, ns.Name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		kubeconfig := t.NewTempDir().
+			Write(kubeconfig, string(modifiedKubeconfig)).
+			Path(kubeconfig)
+		env := []string{fmt.Sprintf("KUBECONFIG=%s", kubeconfig)}
+
+		// n.b. for the sake of this test the namespace must not be given explicitly
+		skaffold.Run("--kube-context", kubecontext).InDir(dir).WithEnv(env).RunOrFailOutput(t.T)
+
+		client.WaitForPodsReady(pods...)
+
+		// n.b. for the sake of this test the namespace must not be given explicitly
+		skaffold.Delete("--kube-context", kubecontext).InDir(dir).WithEnv(env).RunOrFail(t.T)
+	})
+}
+
+func createModifiedKubeconfig(contextName, namespace string) ([]byte, error) {
+	config, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+	if err != nil {
+		return nil, err
+	}
+	activeContext := config.Contexts[config.CurrentContext]
+	// clear the namespace in the active context
+	activeContext.Namespace = ""
+
+	newContext := activeContext.DeepCopy()
+	newContext.Namespace = namespace
+	config.Contexts[contextName] = newContext
+
+	return clientcmd.Write(*config)
 }

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -54,6 +54,7 @@ type SkaffoldOptions struct {
 	Namespace          string
 	CacheFile          string
 	Trigger            string
+	KubeContext        string
 	WatchPollInterval  int
 	DefaultRepo        string
 	CustomLabels       []string

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -325,7 +325,7 @@ func parseOnbuild(image string, insecureRegistries map[string]bool) ([]*parser.N
 		return []*parser.Node{}, nil
 	}
 
-	logrus.Debugf("Found ONBUILD triggers %v in image %s", img.Config.OnBuild, image)
+	logrus.Tracef("Found ONBUILD triggers %v in image %s", img.Config.OnBuild, image)
 
 	obRes, err := parser.Parse(strings.NewReader(strings.Join(img.Config.OnBuild, "\n")))
 	if err != nil {

--- a/pkg/skaffold/kubernetes/client.go
+++ b/pkg/skaffold/kubernetes/client.go
@@ -17,38 +17,26 @@ limitations under the License.
 package kubernetes
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 
 	// Initialize all known client auth plugins
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 func GetClientset() (kubernetes.Interface, error) {
-	config, err := getClientConfig()
+	config, err := context.GetRestClientConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting client config for kubernetes client")
 	}
 	return kubernetes.NewForConfig(config)
 }
 
-func getClientConfig() (*restclient.Config, error) {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, &clientcmd.ConfigOverrides{})
-	clientConfig, err := kubeConfig.ClientConfig()
-	if err != nil {
-		return nil, fmt.Errorf("error creating kubeConfig: %s", err)
-	}
-	return clientConfig, nil
-}
-
 func GetDynamicClient() (dynamic.Interface, error) {
-	config, err := getClientConfig()
+	config, err := context.GetRestClientConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting client config for dynamic client")
 	}

--- a/pkg/skaffold/kubernetes/context/context.go
+++ b/pkg/skaffold/kubernetes/context/context.go
@@ -36,8 +36,8 @@ var (
 	kubeContext    string
 )
 
-// ResetConfig is used by tests
-func ResetConfig() {
+// resetConfig is used by tests
+func resetConfig() {
 	kubeConfigOnce = sync.Once{}
 }
 
@@ -47,12 +47,16 @@ func UseKubeContext(overrideKubeContext string) {
 	kubeContext = overrideKubeContext
 }
 
+// GetRestClientConfig returns a REST client config for API calls against the Kubernetes API.
+// If UseKubeContext was called before, the CurrentContext will be overridden.
+// The result will be cached after the first call.
 func GetRestClientConfig() (*restclient.Config, error) {
 	clientConfig, err := getKubeConfig().ClientConfig()
 	return clientConfig, errors.Wrap(err, "error creating kubeConfig")
 }
 
 // getCurrentConfig retrieves the kubeconfig file. If UseKubeContext was called before, the CurrentContext will be overridden.
+// The result will be cached after the first call.
 func getCurrentConfig() (clientcmdapi.Config, error) {
 	cfg, err := getKubeConfig().RawConfig()
 	if kubeContext != "" {
@@ -62,7 +66,7 @@ func getCurrentConfig() (clientcmdapi.Config, error) {
 	return cfg, errors.Wrap(err, "loading kubeconfig")
 }
 
-// getKubeConfig creates a cached kubeConfig. If UseKubeContext was called before, the CurrentContext will be overridden.
+// getKubeConfig retrieves and caches the kubeConfig. If UseKubeContext was called before, the CurrentContext will be overridden.
 func getKubeConfig() clientcmd.ClientConfig {
 	kubeConfigOnce.Do(func() {
 		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()

--- a/pkg/skaffold/kubernetes/context/context.go
+++ b/pkg/skaffold/kubernetes/context/context.go
@@ -33,6 +33,7 @@ var (
 	currentConfigOnce sync.Once
 	currentConfig     clientcmdapi.Config
 	currentConfigErr  error
+	kubeContext       string
 )
 
 // ResetCurrentConfig is used by tests
@@ -40,6 +41,7 @@ func ResetCurrentConfig() {
 	currentConfigOnce = sync.Once{}
 }
 
+// getCurrentConfig retrieves the kubeconfig file. If UseKubeContext was called before, the CurrentContext will be overridden.
 func getCurrentConfig() (clientcmdapi.Config, error) {
 	currentConfigOnce.Do(func() {
 		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -50,6 +52,16 @@ func getCurrentConfig() (clientcmdapi.Config, error) {
 			return
 		}
 		currentConfig = cfg
+
+		if kubeContext != "" {
+			currentConfig.CurrentContext = kubeContext
+		}
 	})
 	return currentConfig, currentConfigErr
+}
+
+// UseKubeContext sets an override for the current context in the k8s config.
+// This override must be set before calling CurrentConfig.
+func UseKubeContext(overrideKubeContext string) {
+	kubeContext = overrideKubeContext
 }

--- a/pkg/skaffold/kubernetes/context/context_test.go
+++ b/pkg/skaffold/kubernetes/context/context_test.go
@@ -22,24 +22,51 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
+const validKubeConfig = `
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://foo.com
+  name: cluster-foo
+- cluster:
+    server: https://bar.com
+  name: cluster-bar
+contexts:
+- context:
+    cluster: cluster-foo
+    user: user1
+  name: cluster-foo
+- context:
+    cluster: cluster-bar
+    user: user1
+  name: cluster-bar
+current-context: cluster-foo
+users:
+- name: user1
+  user:
+    password: secret
+    username: user
+`
+
 func TestCurrentContext(t *testing.T) {
 	testutil.Run(t, "valid context", func(t *testutil.T) {
-		resetKubeConfig(t, "apiVersion: v1\nkind: Config\ncurrent-context: cluster1\n")
+		resetKubeConfig(t, validKubeConfig)
 
 		config, err := CurrentConfig()
 
 		t.CheckNoError(err)
-		t.CheckDeepEqual("cluster1", config.CurrentContext)
+		t.CheckDeepEqual("cluster-foo", config.CurrentContext)
 	})
 
-	testutil.Run(t, "override context", func(t *testutil.T) {
-		resetKubeConfig(t, "apiVersion: v1\nkind: Config\ncurrent-context: cluster1\n")
+	testutil.Run(t, "valid with override context", func(t *testutil.T) {
+		resetKubeConfig(t, validKubeConfig)
 
-		UseKubeContext("cluster2")
+		kubeContext = "cluster-bar"
 		config, err := CurrentConfig()
 
 		t.CheckNoError(err)
-		t.CheckDeepEqual("cluster2", config.CurrentContext)
+		t.CheckDeepEqual("cluster-bar", config.CurrentContext)
 	})
 
 	testutil.Run(t, "invalid context", func(t *testutil.T) {
@@ -51,9 +78,38 @@ func TestCurrentContext(t *testing.T) {
 	})
 }
 
+func TestGetRestClientConfig(t *testing.T) {
+	testutil.Run(t, "valid context", func(t *testutil.T) {
+		resetKubeConfig(t, validKubeConfig)
+
+		cfg, err := GetRestClientConfig()
+
+		t.CheckNoError(err)
+		t.CheckDeepEqual("https://foo.com", cfg.Host)
+	})
+
+	testutil.Run(t, "valid context with override", func(t *testutil.T) {
+		resetKubeConfig(t, validKubeConfig)
+
+		kubeContext = "cluster-bar"
+		cfg, err := GetRestClientConfig()
+
+		t.CheckNoError(err)
+		t.CheckDeepEqual("https://bar.com", cfg.Host)
+	})
+
+	testutil.Run(t, "invalid context", func(t *testutil.T) {
+		resetKubeConfig(t, "invalid")
+
+		_, err := GetRestClientConfig()
+
+		t.CheckError(true, err)
+	})
+}
+
 func resetKubeConfig(t *testutil.T, content string) {
 	kubeConfig := t.TempFile("config", []byte(content))
-	t.SetEnvs(map[string]string{"KUBECONFIG": kubeConfig})
 	kubeContext = ""
-	ResetCurrentConfig()
+	t.SetEnvs(map[string]string{"KUBECONFIG": kubeConfig})
+	ResetConfig()
 }

--- a/pkg/skaffold/kubernetes/context/context_test.go
+++ b/pkg/skaffold/kubernetes/context/context_test.go
@@ -111,5 +111,5 @@ func resetKubeConfig(t *testutil.T, content string) {
 	kubeConfig := t.TempFile("config", []byte(content))
 	kubeContext = ""
 	t.SetEnvs(map[string]string{"KUBECONFIG": kubeConfig})
-	ResetConfig()
+	resetConfig()
 }

--- a/pkg/skaffold/kubernetes/context/context_test.go
+++ b/pkg/skaffold/kubernetes/context/context_test.go
@@ -32,6 +32,16 @@ func TestCurrentContext(t *testing.T) {
 		t.CheckDeepEqual("cluster1", config.CurrentContext)
 	})
 
+	testutil.Run(t, "override context", func(t *testutil.T) {
+		resetKubeConfig(t, "apiVersion: v1\nkind: Config\ncurrent-context: cluster1\n")
+
+		UseKubeContext("cluster2")
+		config, err := CurrentConfig()
+
+		t.CheckNoError(err)
+		t.CheckDeepEqual("cluster2", config.CurrentContext)
+	})
+
 	testutil.Run(t, "invalid context", func(t *testutil.T) {
 		resetKubeConfig(t, "invalid")
 
@@ -44,5 +54,6 @@ func TestCurrentContext(t *testing.T) {
 func resetKubeConfig(t *testutil.T, content string) {
 	kubeConfig := t.TempFile("config", []byte(content))
 	t.SetEnvs(map[string]string{"KUBECONFIG": kubeConfig})
+	kubeContext = ""
 	ResetCurrentConfig()
 }


### PR DESCRIPTION
This PR adds a new CLI option `--kube-context` to Skaffold `run`, `dev`, `debug`, `delete`, `deploy`, and `build`. It's the frist step in providing several options to override the kubecontext to use in Skaffold.

See #2384
~~Depends on #2509~~