### PR TITLE
Simplify caching

### DIFF
--- a/testutil/fake_image_api.go
+++ b/testutil/fake_image_api.go
@@ -43,6 +43,7 @@ type FakeAPIClient struct {
 	ErrStream       bool
 
 	nextImageID  int
+	Tagged       []string
 	Pushed       []string
 	Built        []types.ImageBuildOptions
 	PushedImages []string
@@ -119,7 +120,7 @@ func (f *FakeAPIClient) ImageTag(_ context.Context, image, ref string) error {
 		f.TagToImageID = make(map[string]string)
 	}
 	f.TagToImageID[ref] = imageID
-
+	f.Tagged = append(f.Tagged, ref)
 	return nil
 }
 


### PR DESCRIPTION
This PR simplifies caching to the following rules, described in my
second design doc for artifact caching:

If remote cluster or push:true :
 1. Check if image exists remotely. If it does, return.
 1. Check if image exists locally. If it does, push.
 2. If not, check if same digest exists locally. If it does, retag and push.
 3. If not, rebuild (via standard build step).

If local cluster, and push:false:
 1. Check if image exists locally. If it does, return.
 2. If not, check if same digest exists locally. If it does, retag.
 3. If not, rebuild (via standard build step).