### PR TITLE
Add `options` command to show global flags

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -54,6 +54,9 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 		Use:           "skaffold",
 		Short:         "A tool that facilitates continuous development for Kubernetes applications.",
 		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			cmd.Root().SilenceUsage = true
 
@@ -148,8 +151,9 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 	rootCmd.AddCommand(NewCmdConfig())
 	rootCmd.AddCommand(NewCmdFindConfigs())
 	rootCmd.AddCommand(NewCmdDiagnose())
+	rootCmd.AddCommand(NewCmdOptions())
 
-	templates.ActsAsRootCommand(rootCmd, []string{"options"}, groups...)
+	templates.ActsAsRootCommand(rootCmd, nil, groups...)
 	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", constants.DefaultLogLevel.String(), "Log level (debug, info, warn, error, fatal, panic)")
 	rootCmd.PersistentFlags().IntVar(&defaultColor, "color", int(color.Default), "Specify the default output color in ANSI escape codes")
 	rootCmd.PersistentFlags().BoolVar(&forceColors, "force-colors", false, "Always print color codes (hidden)")
@@ -158,6 +162,18 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 	setFlagsFromEnvVariables(rootCmd)
 
 	return rootCmd
+}
+
+func NewCmdOptions() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "options",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Usage()
+		},
+	}
+	templates.UseOptionsTemplates(cmd)
+
+	return cmd
 }
 
 func updateCheck(ch chan string) error {

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -82,6 +82,7 @@ Other Commands:
   version      Print the version information
 
 Use "skaffold <command> --help" for more information about a given command.
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```
@@ -117,7 +118,7 @@ Options:
 Usage:
   skaffold build [options]
 
-Use "skaffold build options" for a list of global command-line options (applies to all commands).
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```
@@ -149,7 +150,7 @@ Output shell completion for the given shell (bash or zsh)
 Usage:
   skaffold completion SHELL [options]
 
-Use "skaffold completion options" for a list of global command-line options (applies to all commands).
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```
@@ -186,7 +187,7 @@ Options:
 Usage:
   skaffold config list [options]
 
-Use "skaffold config options" for a list of global command-line options (applies to all commands).
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```
@@ -211,7 +212,7 @@ Options:
 Usage:
   skaffold config set [options]
 
-Use "skaffold config options" for a list of global command-line options (applies to all commands).
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```
@@ -236,7 +237,7 @@ Options:
 Usage:
   skaffold config unset [options]
 
-Use "skaffold config options" for a list of global command-line options (applies to all commands).
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```
@@ -277,7 +278,7 @@ Options:
 Usage:
   skaffold debug [options]
 
-Use "skaffold debug options" for a list of global command-line options (applies to all commands).
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```
@@ -319,7 +320,7 @@ Options:
 Usage:
   skaffold delete [options]
 
-Use "skaffold delete options" for a list of global command-line options (applies to all commands).
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```
@@ -356,7 +357,7 @@ E.g. build.out created by running skaffold build --quiet {{json .}} > build.out
 Usage:
   skaffold deploy [options]
 
-Use "skaffold deploy options" for a list of global command-line options (applies to all commands).
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```
@@ -410,7 +411,7 @@ Options:
 Usage:
   skaffold dev [options]
 
-Use "skaffold dev options" for a list of global command-line options (applies to all commands).
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```
@@ -453,7 +454,7 @@ Options:
 Usage:
   skaffold diagnose [options]
 
-Use "skaffold diagnose options" for a list of global command-line options (applies to all commands).
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```
@@ -476,7 +477,7 @@ Options:
 Usage:
   skaffold fix [options]
 
-Use "skaffold fix options" for a list of global command-line options (applies to all commands).
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```
@@ -504,7 +505,7 @@ Options:
 Usage:
   skaffold init [options]
 
-Use "skaffold init options" for a list of global command-line options (applies to all commands).
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```
@@ -516,6 +517,19 @@ Env vars:
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)
 * `SKAFFOLD_SKIP_BUILD` (same as `--skip-build`)
+
+### skaffold options
+
+
+
+```
+The following options can be passed to any command:
+
+      --color=34: Specify the default output color in ANSI escape codes
+  -v, --verbosity='warning': Log level (debug, info, warn, error, fatal, panic)
+
+
+```
 
 ### skaffold run
 
@@ -548,7 +562,7 @@ Options:
 Usage:
   skaffold run [options]
 
-Use "skaffold run options" for a list of global command-line options (applies to all commands).
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```
@@ -588,7 +602,7 @@ Options:
 Usage:
   skaffold version [options]
 
-Use "skaffold version options" for a list of global command-line options (applies to all commands).
+Use "skaffold options" for a list of global command-line options (applies to all commands).
 
 
 ```


### PR DESCRIPTION
Fix #2444

Signed-off-by: David Gageot <david@gageot.net>