### PR TITLE
Improve the logs when there's no skaffold.yaml

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -20,10 +20,8 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
-	"time"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -55,11 +53,6 @@ func doBuild(ctx context.Context, out io.Writer) error {
 	if quietFlag {
 		buildOut = ioutil.Discard
 	}
-
-	start := time.Now()
-	defer func() {
-		color.Default.Fprintln(buildOut, "Complete in", time.Since(start))
-	}()
 
 	return withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
 		bRes, err := r.BuildAndTest(ctx, buildOut, targetArtifacts(opts, config))

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	configutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
@@ -52,13 +53,14 @@ func withRunner(ctx context.Context, action func(runner.Runner, *latest.Skaffold
 func createNewRunner(opts *config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 	parsed, err := schema.ParseConfig(opts.ConfigurationFile, true)
 	if err != nil {
+		if os.IsNotExist(errors.Cause(err)) {
+			return nil, nil, fmt.Errorf("[%s] not found. You might need to run `skaffold init`", opts.ConfigurationFile)
+		}
+
 		// If the error is NOT that the file doesn't exist, then we warn the user
 		// that maybe they are using an outdated version of Skaffold that's unable to read
 		// the configuration.
-		if !os.IsNotExist(err) {
-			warnIfUpdateIsAvailable()
-		}
-
+		warnIfUpdateIsAvailable()
 		return nil, nil, errors.Wrap(err, "parsing skaffold config")
 	}
 


### PR DESCRIPTION
Before:
```
$ skaffold build
WARN[0000] Your Skaffold version might be too old. Download the latest version (0.33.0) at https://storage.googleapis.com/skaffold/releases/latest/skaffold-darwin-amd64
Complete in 394.890149ms
FATA[0000] creating runner: parsing skaffold config: read skaffold config: open skaffold.yaml: no such file or directory
```

After:
```
$ skaffold build
FATA[0000] creating runner: [skaffold.yaml] not found. You might need to run `skaffold init`
```