### PR TITLE
Less ugly warning when there’s no git repo

### DIFF
--- a/pkg/skaffold/build/tag/git_commit.go
+++ b/pkg/skaffold/build/tag/git_commit.go
@@ -75,7 +75,8 @@ func (c *GitCommit) Labels() map[string]string {
 func (c *GitCommit) GenerateFullyQualifiedImageName(workingDir string, imageName string) (string, error) {
 	ref, err := c.makeGitTag(workingDir)
 	if err != nil {
-		logrus.Warnln("Unable to find git commit:", err)
+		logrus.Warnln("Unable to find git commit")
+		logrus.Debugln("Unable to find git commit:", err)
 		return fmt.Sprintf("%s:dirty", imageName), nil
 	}
 


### PR DESCRIPTION
Signed-off-by: David Gageot <david@gageot.net>

Still far from perfect but a bit better.

Before:
```
$ skaffold build
Generating tags...
 - gcr.io/dga-demo/hello -> WARN[0000] Unable to find git commit: Running [git describe --tags --always]: stdout , stderr: fatal: not a git repository (or any of the parent directories): .git
, err: exit status 128: exit status 128
gcr.io/dga-demo/hello:dirty
Tags generated in 7.661572ms
Checking cache...
 - gcr.io/dga-demo/hello: Found
Cache check complete in 7.370399ms
Starting test...
Test complete in 14.331µs
Complete in 38.329275ms
```

After:
```
$ skaffold build
Generating tags...
 - gcr.io/dga-demo/hello -> WARN[0000] Unable to find git commit
gcr.io/dga-demo/hello:dirty
Tags generated in 8.347994ms
Checking cache...
 - gcr.io/dga-demo/hello: Found
Cache check complete in 8.126029ms
Starting test...
Test complete in 17.72µs
Complete in 43.552802ms
```