### PR TITLE
File output flag for writing built images to a specified file

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
@@ -35,6 +36,7 @@ import (
 var (
 	quietFlag       bool
 	buildFormatFlag = flags.NewTemplateFlag("{{json .}}", flags.BuildOutput{})
+	buildOutputFlag string
 )
 
 // NewCmdBuild describes the CLI command to build artifacts.
@@ -46,6 +48,7 @@ func NewCmdBuild() *cobra.Command {
 			f.StringSliceVarP(&opts.TargetImages, "build-image", "b", nil, "Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts")
 			f.BoolVarP(&quietFlag, "quiet", "q", false, "Suppress the build output and print image built on success. See --output to format output.")
 			f.VarP(buildFormatFlag, "output", "o", "Used in conjunction with --quiet flag. "+buildFormatFlag.Usage())
+			f.StringVar(&buildOutputFlag, "file-output", "", "Filename to write build images to")
 		}).
 		NoArgs(cancelWithCtrlC(context.Background(), doBuild))
 }
@@ -64,8 +67,19 @@ func doBuild(ctx context.Context, out io.Writer) error {
 	return withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
 		bRes, err := r.BuildAndTest(ctx, buildOut, targetArtifacts(opts, config))
 
-		if quietFlag {
+		if quietFlag || buildOutputFlag != "" {
 			cmdOut := flags.BuildOutput{Builds: bRes}
+
+			if buildOutputFlag != "" {
+				f, err := os.OpenFile(buildOutputFlag, os.O_RDWR|os.O_CREATE, 0755)
+				if err != nil {
+					return errors.Wrap(err, "opening file")
+				}
+				defer func() {
+					f.Close()
+				}()
+				out = f
+			}
 			if err := buildFormatFlag.Template().Execute(out, cmdOut); err != nil {
 				return errors.Wrap(err, "executing template")
 			}

--- a/cmd/skaffold/app/cmd/build_test.go
+++ b/cmd/skaffold/app/cmd/build_test.go
@@ -93,6 +93,68 @@ func TestQuietFlag(t *testing.T) {
 	}
 }
 
+func TestFileOutputFlag(t *testing.T) {
+	mockCreateRunner := func(opts *config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+		return &mockRunner{}, &latest.SkaffoldConfig{}, nil
+	}
+
+	var tests = []struct {
+		description         string
+		filename            string
+		quietFlag           bool
+		template            string
+		expectedOutput      []byte
+		expectedFileContent []byte
+	}{
+		{
+			description:         "file output flag creates a file",
+			filename:            "testfile.out",
+			quietFlag:           false,
+			expectedOutput:      []byte(`Complete in `),
+			expectedFileContent: []byte(`{"builds":[{"imageName":"gcr.io/skaffold/example","tag":"test"}]}`),
+		},
+		{
+			description:         "file output flag with quiet flag creates a file and suppresses build output",
+			filename:            "testfile.out",
+			quietFlag:           true,
+			expectedOutput:      []byte(`{"builds":[{"imageName":"gcr.io/skaffold/example","tag":"test"}]}`),
+			expectedFileContent: []byte(`{"builds":[{"imageName":"gcr.io/skaffold/example","tag":"test"}]}`),
+		},
+		{
+			description:         "file output flag with template properly formats output and writes to a file",
+			filename:            "testfile.out",
+			quietFlag:           true,
+			template:            "{{range .Builds}}{{.ImageName}} -> {{.Tag}}\n{{end}}",
+			expectedOutput:      []byte("gcr.io/skaffold/example -> test\n"),
+			expectedFileContent: []byte("gcr.io/skaffold/example -> test\n"),
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&quietFlag, test.quietFlag)
+			t.Override(&buildOutputFlag, test.filename)
+			t.Override(&createRunner, mockCreateRunner)
+			if test.template != "" {
+				t.Override(&buildFormatFlag, flags.NewTemplateFlag(test.template, flags.BuildOutput{}))
+			}
+
+			// tempDir for writing file to
+			tempDir := t.NewTempDir()
+			tempDir.Chdir()
+
+			// Check that stdout is correct
+			var output bytes.Buffer
+			err := doBuild(context.Background(), &output)
+			t.CheckError(false, err)
+			t.CheckContains(string(test.expectedOutput), output.String())
+
+			// Check that file contents are correct
+			fileContent, err := ioutil.ReadFile(test.filename)
+			t.CheckErrorAndDeepEqual(false, err, string(test.expectedFileContent), string(fileContent))
+		})
+	}
+}
+
 func TestRunBuild(t *testing.T) {
 	errRunner := func(opts *config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 		return nil, nil, errors.New("some error")

--- a/cmd/skaffold/app/cmd/build_test.go
+++ b/cmd/skaffold/app/cmd/build_test.go
@@ -37,6 +37,7 @@ type mockRunner struct {
 }
 
 func (r *mockRunner) BuildAndTest(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+	out.Write([]byte("Build Completed"))
 	return []build.Artifact{{
 		ImageName: "gcr.io/skaffold/example",
 		Tag:       "test",
@@ -107,10 +108,10 @@ func TestFileOutputFlag(t *testing.T) {
 		expectedFileContent []byte
 	}{
 		{
-			description:         "file output flag creates a file",
+			description:         "build runs successfully with flag and creates a file",
 			filename:            "testfile.out",
 			quietFlag:           false,
-			expectedOutput:      []byte(`Complete in `),
+			expectedOutput:      []byte("Build Completed"),
 			expectedFileContent: []byte(`{"builds":[{"imageName":"gcr.io/skaffold/example","tag":"test"}]}`),
 		},
 		{
@@ -145,8 +146,7 @@ func TestFileOutputFlag(t *testing.T) {
 			// Check that stdout is correct
 			var output bytes.Buffer
 			err := doBuild(context.Background(), &output)
-			t.CheckError(false, err)
-			t.CheckContains(string(test.expectedOutput), output.String())
+			t.CheckErrorAndDeepEqual(false, err, string(test.expectedOutput), output.String())
 
 			// Check that file contents are correct
 			fileContent, err := ioutil.ReadFile(test.filename)

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -103,6 +103,7 @@ Options:
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
   -d, --default-repo='': Default repository value (overrides global config)
       --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
+      --file-output='': Filename to write build images to
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
       --insecure-registry=[]: Target registries for built images which are not secure
   -n, --namespace='': Run deployments in the specified namespace
@@ -128,6 +129,7 @@ Env vars:
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
+* `SKAFFOLD_FILE_OUTPUT` (same as `--file-output`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_INSECURE_REGISTRY` (same as `--insecure-registry`)
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)


### PR DESCRIPTION
This is essentially the same as running skaffold build --quiet > file.out, but doesn't silence the standard output from skaffold.