### PR TITLE
Starting a refactoring around RunContext and Docker local/remote Api

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -90,7 +90,7 @@ func doBuild(ctx context.Context, out io.Writer) error {
 	})
 }
 
-func targetArtifacts(opts *config.SkaffoldOptions, cfg *latest.SkaffoldConfig) []*latest.Artifact {
+func targetArtifacts(opts config.SkaffoldOptions, cfg *latest.SkaffoldConfig) []*latest.Artifact {
 	var targetArtifacts []*latest.Artifact
 
 	for _, artifact := range cfg.Build.Artifacts {

--- a/cmd/skaffold/app/cmd/build_test.go
+++ b/cmd/skaffold/app/cmd/build_test.go
@@ -49,7 +49,7 @@ func (r *mockRunner) Stop() error {
 }
 
 func TestQuietFlag(t *testing.T) {
-	mockCreateRunner := func(opts *config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+	mockCreateRunner := func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 		return &mockRunner{}, &latest.SkaffoldConfig{}, nil
 	}
 
@@ -95,7 +95,7 @@ func TestQuietFlag(t *testing.T) {
 }
 
 func TestFileOutputFlag(t *testing.T) {
-	mockCreateRunner := func(opts *config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+	mockCreateRunner := func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 		return &mockRunner{}, &latest.SkaffoldConfig{}, nil
 	}
 
@@ -156,16 +156,16 @@ func TestFileOutputFlag(t *testing.T) {
 }
 
 func TestRunBuild(t *testing.T) {
-	errRunner := func(opts *config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+	errRunner := func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 		return nil, nil, errors.New("some error")
 	}
-	mockCreateRunner := func(opts *config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+	mockCreateRunner := func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 		return &mockRunner{}, &latest.SkaffoldConfig{}, nil
 	}
 
 	tests := []struct {
 		description string
-		mock        func(opts *config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error)
+		mock        func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error)
 		shouldErr   bool
 	}{
 		{

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -39,7 +39,7 @@ import (
 )
 
 var (
-	opts         = &config.SkaffoldOptions{}
+	opts         config.SkaffoldOptions
 	v            string
 	forceColors  bool
 	defaultColor int

--- a/cmd/skaffold/app/cmd/dev_test.go
+++ b/cmd/skaffold/app/cmd/dev_test.go
@@ -95,10 +95,10 @@ func TestDoDev(t *testing.T) {
 				hasDeployed: test.hasDeployed,
 				errDev:      context.Canceled,
 			}
-			t.Override(&createRunner, func(*config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+			t.Override(&createRunner, func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 				return mockRunner, &latest.SkaffoldConfig{}, nil
 			})
-			t.Override(&opts, &config.SkaffoldOptions{
+			t.Override(&opts, config.SkaffoldOptions{
 				Cleanup: true,
 				NoPrune: false,
 			})
@@ -145,10 +145,10 @@ func TestDevConfigChange(t *testing.T) {
 	testutil.Run(t, "test config change", func(t *testutil.T) {
 		mockRunner := &mockConfigChangeRunner{}
 
-		t.Override(&createRunner, func(*config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+		t.Override(&createRunner, func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 			return mockRunner, &latest.SkaffoldConfig{}, nil
 		})
-		t.Override(&opts, &config.SkaffoldOptions{
+		t.Override(&opts, config.SkaffoldOptions{
 			Cleanup: true,
 			NoPrune: false,
 		})

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -50,7 +50,7 @@ func withRunner(ctx context.Context, action func(runner.Runner, *latest.Skaffold
 }
 
 // createNewRunner creates a Runner and returns the SkaffoldConfig associated with it.
-func createNewRunner(opts *config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+func createNewRunner(opts config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 	parsed, err := schema.ParseConfig(opts.ConfigurationFile, true)
 	if err != nil {
 		if os.IsNotExist(errors.Cause(err)) {

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -78,7 +78,7 @@ func createNewRunner(opts config.SkaffoldOptions) (runner.Runner, *latest.Skaffo
 		return nil, nil, errors.Wrap(err, "invalid skaffold config")
 	}
 
-	runCtx, err := runcontext.GetRunContext(opts, &config.Pipeline)
+	runCtx, err := runcontext.GetRunContext(opts, config.Pipeline)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "getting run context")
 	}

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -85,7 +86,12 @@ func createNewRunner(opts *config.SkaffoldOptions) (runner.Runner, *latest.Skaff
 
 	applyDefaultRepoSubstitution(config, defaultRepo)
 
-	runner, err := runner.NewForConfig(opts, config)
+	runCtx, err := runcontext.GetRunContext(opts, &config.Pipeline)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "getting run context")
+	}
+
+	runner, err := runner.NewForConfig(runCtx)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating runner")
 	}

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 
-	configutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
@@ -79,17 +78,12 @@ func createNewRunner(opts *config.SkaffoldOptions) (runner.Runner, *latest.Skaff
 		return nil, nil, errors.Wrap(err, "invalid skaffold config")
 	}
 
-	defaultRepo, err := configutil.GetDefaultRepo(opts.DefaultRepo)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "getting default repo")
-	}
-
-	applyDefaultRepoSubstitution(config, defaultRepo)
-
 	runCtx, err := runcontext.GetRunContext(opts, &config.Pipeline)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "getting run context")
 	}
+
+	applyDefaultRepoSubstitution(config, runCtx.DefaultRepo)
 
 	runner, err := runner.NewForConfig(runCtx)
 	if err != nil {

--- a/cmd/skaffold/app/cmd/runner_test.go
+++ b/cmd/skaffold/app/cmd/runner_test.go
@@ -29,14 +29,14 @@ func TestCreateNewRunner(t *testing.T) {
 	tests := []struct {
 		description   string
 		config        string
-		options       *config.SkaffoldOptions
+		options       config.SkaffoldOptions
 		shouldErr     bool
 		expectedError string
 	}{
 		{
 			description: "valid config",
 			config:      "",
-			options: &config.SkaffoldOptions{
+			options: config.SkaffoldOptions{
 				ConfigurationFile: "skaffold.yaml",
 				Trigger:           "polling",
 			},
@@ -45,7 +45,7 @@ func TestCreateNewRunner(t *testing.T) {
 		{
 			description: "invalid config",
 			config:      "invalid",
-			options: &config.SkaffoldOptions{
+			options: config.SkaffoldOptions{
 				ConfigurationFile: "skaffold.yaml",
 			},
 			shouldErr: true,
@@ -53,7 +53,7 @@ func TestCreateNewRunner(t *testing.T) {
 		{
 			description: "missing config",
 			config:      "",
-			options: &config.SkaffoldOptions{
+			options: config.SkaffoldOptions{
 				ConfigurationFile: "missing-skaffold.yaml",
 			},
 			shouldErr: true,
@@ -61,7 +61,7 @@ func TestCreateNewRunner(t *testing.T) {
 		{
 			description: "unknown profile",
 			config:      "",
-			options: &config.SkaffoldOptions{
+			options: config.SkaffoldOptions{
 				ConfigurationFile: "skaffold.yaml",
 				Profiles:          []string{"unknown-profile"},
 			},
@@ -71,7 +71,7 @@ func TestCreateNewRunner(t *testing.T) {
 		{
 			description: "unsupported trigger",
 			config:      "",
-			options: &config.SkaffoldOptions{
+			options: config.SkaffoldOptions{
 				ConfigurationFile: "skaffold.yaml",
 				Trigger:           "unknown trigger",
 			},

--- a/cmd/skaffold/app/tips/tips.go
+++ b/cmd/skaffold/app/tips/tips.go
@@ -24,14 +24,14 @@ import (
 )
 
 // PrintForRun prints tips to the user who has run `skaffold run`.
-func PrintForRun(out io.Writer, opts *config.SkaffoldOptions) {
+func PrintForRun(out io.Writer, opts config.SkaffoldOptions) {
 	if !opts.Tail {
 		printTip(out, "You can also run [skaffold run --tail] to get the logs")
 	}
 }
 
 // PrintForInit prints tips to the user who has run `skaffold init`.
-func PrintForInit(out io.Writer, opts *config.SkaffoldOptions) {
+func PrintForInit(out io.Writer, opts config.SkaffoldOptions) {
 	printTip(out, "You can now run [skaffold build] to build the artifacts")
 	printTip(out, "or [skaffold run] to build and deploy")
 	printTip(out, "or [skaffold dev] to enter development mode, with auto-redeploy")

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -27,6 +27,7 @@ import (
 	"4d63.com/tz"
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/docker/docker/api/types"
 	"github.com/sirupsen/logrus"
@@ -115,7 +116,7 @@ func removeImage(t *testing.T, image string) {
 		return
 	}
 
-	client, err := docker.NewAPIClient(false, nil)
+	client, err := docker.NewAPIClient(&runcontext.RunContext{})
 	failNowIfError(t, err)
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
@@ -134,7 +135,7 @@ func checkImageExists(t *testing.T, image string) {
 		return
 	}
 
-	client, err := docker.NewAPIClient(false, nil)
+	client, err := docker.NewAPIClient(&runcontext.RunContext{})
 	failNowIfError(t, err)
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))

--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -74,7 +74,7 @@ func NewCache(runCtx *runcontext.RunContext, imagesAreLocal bool, dependencies D
 		return &noCache{}, nil
 	}
 
-	client, err := docker.NewAPIClient(runCtx.Opts.Prune(), runCtx.InsecureRegistries)
+	client, err := docker.NewAPIClient(runCtx)
 	if imagesAreLocal && err != nil {
 		return nil, errors.Wrap(err, "getting local Docker client")
 	}

--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -32,11 +32,6 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-// For testing
-var (
-	newDockerClient = createDockerClient
-)
-
 // ImageDetails holds the Digest and ID of an image
 type ImageDetails struct {
 	Digest string `yaml:"digest,omitempty"`
@@ -79,7 +74,7 @@ func NewCache(runCtx *runcontext.RunContext, imagesAreLocal bool, dependencies D
 		return &noCache{}, nil
 	}
 
-	client, err := newDockerClient(runCtx)
+	client, err := docker.NewAPIClient(runCtx.Opts.Prune(), runCtx.InsecureRegistries)
 	if imagesAreLocal && err != nil {
 		return nil, errors.Wrap(err, "getting local Docker client")
 	}
@@ -92,10 +87,6 @@ func NewCache(runCtx *runcontext.RunContext, imagesAreLocal bool, dependencies D
 		cacheFile:          cacheFile,
 		imagesAreLocal:     imagesAreLocal,
 	}, nil
-}
-
-func createDockerClient(runCtx *runcontext.RunContext) (docker.LocalDaemon, error) {
-	return docker.NewAPIClient(runCtx.Opts.Prune(), runCtx.InsecureRegistries)
 }
 
 // resolveCacheFile makes sure that either a passed in cache file or the default cache file exists

--- a/pkg/skaffold/build/cache/lookup_test.go
+++ b/pkg/skaffold/build/cache/lookup_test.go
@@ -187,7 +187,7 @@ func TestLookupRemote(t *testing.T) {
 			cache := &cache{
 				imagesAreLocal: false,
 				artifactCache:  test.cache,
-				client:         docker.NewLocalDaemon(test.api, nil, false, map[string]bool{}),
+				client:         docker.NewLocalDaemon(test.api, nil, false, nil),
 			}
 			details := cache.lookupArtifacts(context.Background(), map[string]string{"artifact": "tag"}, []*latest.Artifact{{
 				ImageName: "artifact",

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -92,7 +92,7 @@ func TestCacheBuildLocal(t *testing.T) {
 			Chdir()
 
 		runCtx := &runcontext.RunContext{
-			Opts: &config.SkaffoldOptions{
+			Opts: config.SkaffoldOptions{
 				CacheArtifacts: true,
 				CacheFile:      tmpDir.Path("cache"),
 			},
@@ -158,7 +158,7 @@ func TestCacheBuildRemote(t *testing.T) {
 			Chdir()
 
 		runCtx := &runcontext.RunContext{
-			Opts: &config.SkaffoldOptions{
+			Opts: config.SkaffoldOptions{
 				CacheArtifacts: true,
 				CacheFile:      tmpDir.Path("cache"),
 			},

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -114,7 +114,7 @@ func TestCacheBuildLocal(t *testing.T) {
 
 		// Mock Docker
 		dockerDaemon := docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, nil)
-		t.Override(&docker.NewAPIClient, func(bool, map[string]bool) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 			return dockerDaemon, nil
 		})
 
@@ -180,7 +180,7 @@ func TestCacheBuildRemote(t *testing.T) {
 
 		// Mock Docker
 		dockerDaemon := docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, nil)
-		t.Override(&docker.NewAPIClient, func(bool, map[string]bool) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 			return dockerDaemon, nil
 		})
 

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -114,7 +114,7 @@ func TestCacheBuildLocal(t *testing.T) {
 
 		// Mock Docker
 		dockerDaemon := docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, nil)
-		t.Override(&newDockerClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(bool, map[string]bool) (docker.LocalDaemon, error) {
 			return dockerDaemon, nil
 		})
 
@@ -180,7 +180,7 @@ func TestCacheBuildRemote(t *testing.T) {
 
 		// Mock Docker
 		dockerDaemon := docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, nil)
-		t.Override(&newDockerClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(bool, map[string]bool) (docker.LocalDaemon, error) {
 			return dockerDaemon, nil
 		})
 

--- a/pkg/skaffold/build/cluster/cluster_test.go
+++ b/pkg/skaffold/build/cluster/cluster_test.go
@@ -27,7 +27,7 @@ import (
 func TestRetrieveEnv(t *testing.T) {
 	builder, err := NewBuilder(&runcontext.RunContext{
 		KubeContext: "kubecontext",
-		Cfg: &latest.Pipeline{
+		Cfg: latest.Pipeline{
 			Build: latest.BuildConfig{
 				BuildType: latest.BuildType{
 					Cluster: &latest.ClusterDetails{
@@ -42,11 +42,9 @@ func TestRetrieveEnv(t *testing.T) {
 			},
 		},
 	})
-	if err != nil {
-		t.Fatalf("err retrieving builder: %v", err)
-	}
+	testutil.CheckError(t, false, err)
 
 	actual := builder.retrieveExtraEnv()
 	expected := []string{"KUBE_CONTEXT=kubecontext", "NAMESPACE=namespace", "PULL_SECRET_NAME=pullSecret", "DOCKER_CONFIG_SECRET_NAME=dockerconfig", "TIMEOUT=2m"}
-	testutil.CheckErrorAndDeepEqual(t, false, nil, expected, actual)
+	testutil.CheckDeepEqual(t, expected, actual)
 }

--- a/pkg/skaffold/build/cluster/types_test.go
+++ b/pkg/skaffold/build/cluster/types_test.go
@@ -103,14 +103,11 @@ func TestSyncMapNotSupported(t *testing.T) {
 }
 
 func stubRunContext(clusterDetails *latest.ClusterDetails, insecureRegistries map[string]bool) *runcontext.RunContext {
+	pipeline := latest.Pipeline{}
+	pipeline.Build.BuildType.Cluster = clusterDetails
+
 	return &runcontext.RunContext{
+		Cfg:                pipeline,
 		InsecureRegistries: insecureRegistries,
-		Cfg: &latest.Pipeline{
-			Build: latest.BuildConfig{
-				BuildType: latest.BuildType{
-					Cluster: clusterDetails,
-				},
-			},
-		},
 	}
 }

--- a/pkg/skaffold/build/local/custom_test.go
+++ b/pkg/skaffold/build/local/custom_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -27,7 +28,7 @@ import (
 func TestRetrieveEnv(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		extraEnv := []string{"EXTRA_ENV=additional"}
-		t.Override(&docker.NewAPIClient, func(bool, map[string]bool) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 			return docker.NewLocalDaemon(&testutil.FakeAPIClient{}, extraEnv, false, nil), nil
 		})
 

--- a/pkg/skaffold/build/local/custom_test.go
+++ b/pkg/skaffold/build/local/custom_test.go
@@ -20,18 +20,22 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestRetrieveEnv(t *testing.T) {
-	extraEnv := []string{"EXTRA_ENV=additional"}
-	fakeClient := docker.NewLocalDaemon(&testutil.FakeAPIClient{}, extraEnv, false, nil)
+	testutil.Run(t, "", func(t *testutil.T) {
+		extraEnv := []string{"EXTRA_ENV=additional"}
+		t.Override(&docker.NewAPIClient, func(bool, map[string]bool) (docker.LocalDaemon, error) {
+			return docker.NewLocalDaemon(&testutil.FakeAPIClient{}, extraEnv, false, nil), nil
+		})
 
-	builder := &Builder{
-		localDocker: fakeClient,
-	}
+		builder, err := NewBuilder(stubRunContext(latest.LocalBuild{}))
+		t.CheckNoError(err)
 
-	actual := builder.retrieveExtraEnv()
-	expected := extraEnv
-	testutil.CheckErrorAndDeepEqual(t, false, nil, expected, actual)
+		actual := builder.retrieveExtraEnv()
+
+		t.CheckDeepEqual(extraEnv, actual)
+	})
 }

--- a/pkg/skaffold/build/local/jib_gradle_test.go
+++ b/pkg/skaffold/build/local/jib_gradle_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/jib"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -68,7 +69,7 @@ func TestBuildJibGradleToDocker(t *testing.T) {
 			}
 
 			t.Override(&util.DefaultExecCommand, test.cmd)
-			t.Override(&docker.NewAPIClient, func(bool, map[string]bool) (docker.LocalDaemon, error) {
+			t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 				return docker.NewLocalDaemon(api, nil, false, nil), nil
 			})
 
@@ -130,7 +131,7 @@ func TestBuildJibGradleToRegistry(t *testing.T) {
 				}
 				return "", errors.New("unknown remote tag")
 			})
-			t.Override(&docker.NewAPIClient, func(bool, map[string]bool) (docker.LocalDaemon, error) {
+			t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 				return docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, nil), nil
 			})
 

--- a/pkg/skaffold/build/local/jib_gradle_test.go
+++ b/pkg/skaffold/build/local/jib_gradle_test.go
@@ -71,7 +71,7 @@ func TestBuildJibGradleToDocker(t *testing.T) {
 
 			builder := &Builder{
 				pushImages:  false,
-				localDocker: docker.NewLocalDaemon(api, nil, false, map[string]bool{}),
+				localDocker: docker.NewLocalDaemon(api, nil, false, nil),
 			}
 			result, err := builder.buildJibGradle(context.Background(), ioutil.Discard, ".", test.artifact, "img:tag")
 
@@ -129,7 +129,7 @@ func TestBuildJibGradleToRegistry(t *testing.T) {
 
 			builder := &Builder{
 				pushImages:  true,
-				localDocker: docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, map[string]bool{}),
+				localDocker: docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, nil),
 			}
 			result, err := builder.buildJibGradle(context.Background(), ioutil.Discard, ".", test.artifact, "img:tag")
 

--- a/pkg/skaffold/build/local/jib_maven_test.go
+++ b/pkg/skaffold/build/local/jib_maven_test.go
@@ -76,7 +76,7 @@ func TestBuildJibMavenToDocker(t *testing.T) {
 
 			builder := &Builder{
 				pushImages:  false,
-				localDocker: docker.NewLocalDaemon(api, nil, false, map[string]bool{}),
+				localDocker: docker.NewLocalDaemon(api, nil, false, nil),
 			}
 			result, err := builder.buildJibMaven(context.Background(), ioutil.Discard, ".", test.artifact, "img:tag")
 
@@ -139,7 +139,7 @@ func TestBuildJibMavenToRegistry(t *testing.T) {
 
 			builder := &Builder{
 				pushImages:  true,
-				localDocker: docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, map[string]bool{}),
+				localDocker: docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, nil),
 			}
 			result, err := builder.buildJibMaven(context.Background(), ioutil.Discard, ".", test.artifact, "img:tag")
 

--- a/pkg/skaffold/build/local/jib_maven_test.go
+++ b/pkg/skaffold/build/local/jib_maven_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/jib"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -73,7 +74,7 @@ func TestBuildJibMavenToDocker(t *testing.T) {
 			api := &testutil.FakeAPIClient{
 				TagToImageID: map[string]string{"img:tag": "imageID"},
 			}
-			t.Override(&docker.NewAPIClient, func(bool, map[string]bool) (docker.LocalDaemon, error) {
+			t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 				return docker.NewLocalDaemon(api, nil, false, nil), nil
 			})
 
@@ -140,7 +141,7 @@ func TestBuildJibMavenToRegistry(t *testing.T) {
 				}
 				return "", errors.New("unknown remote tag")
 			})
-			t.Override(&docker.NewAPIClient, func(bool, map[string]bool) (docker.LocalDaemon, error) {
+			t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 				return docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, nil), nil
 			})
 

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -21,13 +21,8 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/pkg/errors"
-
-	"github.com/google/go-cmp/cmp"
-
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/context"
@@ -35,6 +30,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	"github.com/docker/docker/api/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 )
 
 type testAuthHelper struct{}
@@ -351,11 +348,5 @@ func stubRunContext(localBuild *latest.LocalBuild) *runcontext.RunContext {
 				},
 			},
 		},
-		Opts: &config.SkaffoldOptions{
-			NoPrune:        false,
-			CacheArtifacts: false,
-			SkipTests:      false,
-		},
 	}
-
 }

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -219,7 +219,7 @@ func TestLocalRun(t *testing.T) {
 			t.Override(&docker.DefaultAuthHelper, testAuthHelper{})
 			fakeWarner := &warnings.Collect{}
 			t.Override(&warnings.Printf, fakeWarner.Warnf)
-			t.Override(&docker.NewAPIClient, func(bool, map[string]bool) (docker.LocalDaemon, error) {
+			t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 				return docker.NewLocalDaemon(&test.api, nil, false, nil), nil
 			})
 
@@ -256,18 +256,18 @@ func TestNewBuilder(t *testing.T) {
 		localBuild      latest.LocalBuild
 		expectedBuilder *Builder
 		localClusterFn  func() (bool, error)
-		localDockerFn   func(bool, map[string]bool) (docker.LocalDaemon, error)
+		localDockerFn   func(*runcontext.RunContext) (docker.LocalDaemon, error)
 	}{
 		{
 			description: "failed to get docker client",
-			localDockerFn: func(bool, map[string]bool) (docker.LocalDaemon, error) {
+			localDockerFn: func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 				return nil, errors.New("dummy docker error")
 			},
 			shouldErr: true,
 		},
 		{
 			description: "pushImages becomes !localCluster when local:push is not defined",
-			localDockerFn: func(bool, map[string]bool) (docker.LocalDaemon, error) {
+			localDockerFn: func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 				return dummyDaemon, nil
 			},
 			localClusterFn: func() (b bool, e error) {
@@ -289,7 +289,7 @@ func TestNewBuilder(t *testing.T) {
 		},
 		{
 			description: "pushImages defined in config (local:push)",
-			localDockerFn: func(bool, map[string]bool) (docker.LocalDaemon, error) {
+			localDockerFn: func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 				return dummyDaemon, nil
 			},
 			localClusterFn: func() (b bool, e error) {

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -230,7 +230,7 @@ func TestLocalRun(t *testing.T) {
 
 			l := Builder{
 				cfg:         &latest.LocalBuild{},
-				localDocker: docker.NewLocalDaemon(&test.api, nil, false, map[string]bool{}),
+				localDocker: docker.NewLocalDaemon(&test.api, nil, false, nil),
 				pushImages:  test.pushImages,
 			}
 

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -50,13 +50,9 @@ type Builder struct {
 
 var getLocalCluster = configutil.GetLocalCluster
 
-var getLocalDocker = func(runCtx *runcontext.RunContext) (docker.LocalDaemon, error) {
-	return docker.NewAPIClient(runCtx.Opts.Prune(), runCtx.InsecureRegistries)
-}
-
 // NewBuilder returns an new instance of a local Builder.
 func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
-	localDocker, err := getLocalDocker(runCtx)
+	localDocker, err := docker.NewAPIClient(runCtx.Opts.Prune(), runCtx.InsecureRegistries)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting docker client")
 	}

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -52,7 +52,7 @@ var getLocalCluster = configutil.GetLocalCluster
 
 // NewBuilder returns an new instance of a local Builder.
 func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
-	localDocker, err := docker.NewAPIClient(runCtx.Opts.Prune(), runCtx.InsecureRegistries)
+	localDocker, err := docker.NewAPIClient(runCtx)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting docker client")
 	}

--- a/pkg/skaffold/config/options_test.go
+++ b/pkg/skaffold/config/options_test.go
@@ -152,7 +152,7 @@ func TestIsTargetImage(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			opts := &SkaffoldOptions{
+			opts := SkaffoldOptions{
 				TargetImages: test.targetImages,
 			}
 

--- a/pkg/skaffold/config/options_test.go
+++ b/pkg/skaffold/config/options_test.go
@@ -164,3 +164,31 @@ func TestIsTargetImage(t *testing.T) {
 		})
 	}
 }
+
+func TestForceDeploy(t *testing.T) {
+	opts := SkaffoldOptions{}
+	testutil.CheckDeepEqual(t, false, opts.ForceDeploy())
+
+	opts = SkaffoldOptions{ForceDev: true}
+	testutil.CheckDeepEqual(t, true, opts.ForceDeploy())
+
+	opts = SkaffoldOptions{Force: true}
+	testutil.CheckDeepEqual(t, true, opts.ForceDeploy())
+
+	opts = SkaffoldOptions{ForceDev: true, Force: true}
+	testutil.CheckDeepEqual(t, true, opts.ForceDeploy())
+}
+
+func TestPrune(t *testing.T) {
+	opts := SkaffoldOptions{}
+	testutil.CheckDeepEqual(t, true, opts.Prune())
+
+	opts = SkaffoldOptions{NoPrune: true}
+	testutil.CheckDeepEqual(t, false, opts.Prune())
+
+	opts = SkaffoldOptions{CacheArtifacts: true}
+	testutil.CheckDeepEqual(t, false, opts.Prune())
+
+	opts = SkaffoldOptions{NoPrune: true, CacheArtifacts: true}
+	testutil.CheckDeepEqual(t, false, opts.Prune())
+}

--- a/pkg/skaffold/debug/debug.go
+++ b/pkg/skaffold/debug/debug.go
@@ -22,16 +22,15 @@ import (
 	"context"
 	"strings"
 
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	serializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"k8s.io/client-go/kubernetes/scheme"
-
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/context"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime"
+	serializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 var (
@@ -99,7 +98,10 @@ func findArtifact(image string, builds []build.Artifact) *build.Artifact {
 // retrieveImageConfiguration retrieves the image container configuration for
 // the given build artifact
 func retrieveImageConfiguration(ctx context.Context, artifact *build.Artifact, insecureRegistries map[string]bool) (imageConfiguration, error) {
-	apiClient, err := docker.NewAPIClient(false, insecureRegistries)
+	// TODO: use the proper RunContext
+	apiClient, err := docker.NewAPIClient(&runcontext.RunContext{
+		InsecureRegistries: insecureRegistries,
+	})
 	if err != nil {
 		return imageConfiguration{}, errors.Wrap(err, "could not connect to local docker daemon")
 	}

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -695,7 +695,7 @@ func makeRunContext(helmDeploy *latest.HelmDeploy, force bool) *runcontext.RunCo
 			},
 		},
 		KubeContext: testKubeContext,
-		Opts: &config.SkaffoldOptions{
+		Opts: config.SkaffoldOptions{
 			Namespace: testNamespace,
 			Force:     force,
 		},

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -41,153 +41,131 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var testBuilds = []build.Artifact{
-	{
-		ImageName: "skaffold-helm",
-		Tag:       "docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184",
-	},
+var testBuilds = []build.Artifact{{
+	ImageName: "skaffold-helm",
+	Tag:       "docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184",
+}}
+
+var testBuildsFoo = []build.Artifact{{
+	ImageName: "foo",
+	Tag:       "foo:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184",
+}}
+
+var testDeployConfig = latest.HelmDeploy{
+	Releases: []latest.HelmRelease{{
+		Name:      "skaffold-helm",
+		ChartPath: "examples/test",
+		Values: map[string]string{
+			"image": "skaffold-helm",
+		},
+		Overrides: schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
+		SetValues: map[string]string{
+			"some.key": "somevalue",
+		},
+	}},
 }
 
-var testBuildsFoo = []build.Artifact{
-	{
-		ImageName: "foo",
-		Tag:       "foo:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184",
-	},
+var testDeployRecreatePodsConfig = latest.HelmDeploy{
+	Releases: []latest.HelmRelease{{
+		Name:      "skaffold-helm",
+		ChartPath: "examples/test",
+		Values: map[string]string{
+			"image": "skaffold-helm",
+		},
+		Overrides: schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
+		SetValues: map[string]string{
+			"some.key": "somevalue",
+		},
+		RecreatePods: true,
+	}},
 }
 
-var testDeployConfig = &latest.HelmDeploy{
-	Releases: []latest.HelmRelease{
-		{
-			Name:      "skaffold-helm",
-			ChartPath: "examples/test",
-			Values: map[string]string{
-				"image": "skaffold-helm",
-			},
-			Overrides: schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
-			SetValues: map[string]string{
-				"some.key": "somevalue",
+var testDeploySkipBuildDependenciesConfig = latest.HelmDeploy{
+	Releases: []latest.HelmRelease{{
+		Name:      "skaffold-helm",
+		ChartPath: "examples/test",
+		Values: map[string]string{
+			"image": "skaffold-helm",
+		},
+		Overrides: schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
+		SetValues: map[string]string{
+			"some.key": "somevalue",
+		},
+		SkipBuildDependencies: true,
+	}},
+}
+
+var testDeployHelmStyleConfig = latest.HelmDeploy{
+	Releases: []latest.HelmRelease{{
+		Name:      "skaffold-helm",
+		ChartPath: "examples/test",
+		Values: map[string]string{
+			"image": "skaffold-helm",
+		},
+		Overrides: schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
+		SetValues: map[string]string{
+			"some.key": "somevalue",
+		},
+		ImageStrategy: latest.HelmImageStrategy{
+			HelmImageConfig: latest.HelmImageConfig{
+				HelmConventionConfig: &latest.HelmConventionConfig{},
 			},
 		},
+	}},
+}
+
+var testDeployConfigParameterUnmatched = latest.HelmDeploy{
+	Releases: []latest.HelmRelease{{
+		Name:      "skaffold-helm",
+		ChartPath: "examples/test",
+		Values: map[string]string{
+			"image": "skaffold-helm-unmatched",
+		}},
 	},
 }
 
-var testDeployRecreatePodsConfig = &latest.HelmDeploy{
-	Releases: []latest.HelmRelease{
-		{
-			Name:      "skaffold-helm",
-			ChartPath: "examples/test",
-			Values: map[string]string{
-				"image": "skaffold-helm",
-			},
-			Overrides: schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
-			SetValues: map[string]string{
-				"some.key": "somevalue",
-			},
-			RecreatePods: true,
+var testDeployFooWithPackaged = latest.HelmDeploy{
+	Releases: []latest.HelmRelease{{
+		Name:      "foo",
+		ChartPath: "testdata/foo",
+		Values: map[string]string{
+			"image": "foo",
 		},
+		Packaged: &latest.HelmPackaged{
+			Version:    "0.1.2",
+			AppVersion: "1.2.3",
+		},
+	}},
+}
+
+var testDeployWithTemplatedName = latest.HelmDeploy{
+	Releases: []latest.HelmRelease{{
+		Name:      "{{.USER}}-skaffold-helm",
+		ChartPath: "examples/test",
+		Values: map[string]string{
+			"image.tag": "skaffold-helm",
+		},
+		Overrides: schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
+		SetValues: map[string]string{
+			"some.key": "somevalue",
+		}},
 	},
 }
 
-var testDeploySkipBuildDependenciesConfig = &latest.HelmDeploy{
-	Releases: []latest.HelmRelease{
-		{
-			Name:      "skaffold-helm",
-			ChartPath: "examples/test",
-			Values: map[string]string{
-				"image": "skaffold-helm",
-			},
-			Overrides: schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
-			SetValues: map[string]string{
-				"some.key": "somevalue",
-			},
-			SkipBuildDependencies: true,
-		},
-	},
+var testDeploySkipBuildDependencies = latest.HelmDeploy{
+	Releases: []latest.HelmRelease{{
+		Name:                  "skaffold-helm",
+		ChartPath:             "stable/chartmuseum",
+		SkipBuildDependencies: true,
+	}},
 }
 
-var testDeployHelmStyleConfig = &latest.HelmDeploy{
-	Releases: []latest.HelmRelease{
-		{
-			Name:      "skaffold-helm",
-			ChartPath: "examples/test",
-			Values: map[string]string{
-				"image": "skaffold-helm",
-			},
-			Overrides: schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
-			SetValues: map[string]string{
-				"some.key": "somevalue",
-			},
-			ImageStrategy: latest.HelmImageStrategy{
-				HelmImageConfig: latest.HelmImageConfig{
-					HelmConventionConfig: &latest.HelmConventionConfig{},
-				},
-			},
-		},
-	},
-}
-
-var testDeployConfigParameterUnmatched = &latest.HelmDeploy{
-	Releases: []latest.HelmRelease{
-		{
-			Name:      "skaffold-helm",
-			ChartPath: "examples/test",
-			Values: map[string]string{
-				"image": "skaffold-helm-unmatched",
-			},
-		},
-	},
-}
-
-var testDeployFooWithPackaged = &latest.HelmDeploy{
-	Releases: []latest.HelmRelease{
-		{
-			Name:      "foo",
-			ChartPath: "testdata/foo",
-			Values: map[string]string{
-				"image": "foo",
-			},
-			Packaged: &latest.HelmPackaged{
-				Version:    "0.1.2",
-				AppVersion: "1.2.3",
-			},
-		},
-	},
-}
-
-var testDeployWithTemplatedName = &latest.HelmDeploy{
-	Releases: []latest.HelmRelease{
-		{
-			Name:      "{{.USER}}-skaffold-helm",
-			ChartPath: "examples/test",
-			Values: map[string]string{
-				"image.tag": "skaffold-helm",
-			},
-			Overrides: schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
-			SetValues: map[string]string{
-				"some.key": "somevalue",
-			},
-		},
-	},
-}
-
-var testDeploySkipBuildDependencies = &latest.HelmDeploy{
-	Releases: []latest.HelmRelease{
-		{
-			Name:                  "skaffold-helm",
-			ChartPath:             "stable/chartmuseum",
-			SkipBuildDependencies: true,
-		},
-	},
-}
-
-var testDeployRemoteChart = &latest.HelmDeploy{
-	Releases: []latest.HelmRelease{
-		{
-			Name:                  "skaffold-helm-remote",
-			ChartPath:             "stable/chartmuseum",
-			SkipBuildDependencies: false,
-		},
-	},
+var testDeployRemoteChart = latest.HelmDeploy{
+	Releases: []latest.HelmRelease{{
+		Name:                  "skaffold-helm-remote",
+		ChartPath:             "stable/chartmuseum",
+		SkipBuildDependencies: false,
+	}},
 }
 
 var testNamespace = "testNamespace"
@@ -622,18 +600,17 @@ func TestHelmDependencies(t *testing.T) {
 			tmpDir := t.NewTempDir().
 				Touch(test.files...)
 
-			deployer := NewHelmDeployer(makeRunContext(&latest.HelmDeploy{
-				Releases: []latest.HelmRelease{
-					{
-						Name:                  "skaffold-helm",
-						ChartPath:             tmpDir.Root(),
-						ValuesFiles:           test.valuesFiles,
-						Values:                map[string]string{"image": "skaffold-helm"},
-						Overrides:             schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
-						SetValues:             map[string]string{"some.key": "somevalue"},
-						SkipBuildDependencies: test.skipBuildDependencies,
-						Remote:                test.remote,
-					},
+			deployer := NewHelmDeployer(makeRunContext(latest.HelmDeploy{
+				Releases: []latest.HelmRelease{{
+					Name:                  "skaffold-helm",
+					ChartPath:             tmpDir.Root(),
+					ValuesFiles:           test.valuesFiles,
+					Values:                map[string]string{"image": "skaffold-helm"},
+					Overrides:             schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
+					SetValues:             map[string]string{"some.key": "somevalue"},
+					SkipBuildDependencies: test.skipBuildDependencies,
+					Remote:                test.remote,
+				},
 				},
 			}, false))
 
@@ -685,15 +662,12 @@ func TestExpandPaths(t *testing.T) {
 	}
 }
 
-func makeRunContext(helmDeploy *latest.HelmDeploy, force bool) *runcontext.RunContext {
+func makeRunContext(deploy latest.HelmDeploy, force bool) *runcontext.RunContext {
+	pipeline := latest.Pipeline{}
+	pipeline.Deploy.DeployType.HelmDeploy = &deploy
+
 	return &runcontext.RunContext{
-		Cfg: &latest.Pipeline{
-			Deploy: latest.DeployConfig{
-				DeployType: latest.DeployType{
-					HelmDeploy: helmDeploy,
-				},
-			},
-		},
+		Cfg:         pipeline,
 		KubeContext: testKubeContext,
 		Opts: config.SkaffoldOptions{
 			Namespace: testNamespace,

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -177,7 +177,7 @@ func TestKubectlDeploy(t *testing.T) {
 
 			k := NewKubectlDeployer(&runcontext.RunContext{
 				WorkingDir: ".",
-				Cfg: &latest.Pipeline{
+				Cfg: latest.Pipeline{
 					Deploy: latest.DeployConfig{
 						DeployType: latest.DeployType{
 							KubectlDeploy: test.cfg,
@@ -251,7 +251,7 @@ func TestKubectlCleanup(t *testing.T) {
 
 			k := NewKubectlDeployer(&runcontext.RunContext{
 				WorkingDir: ".",
-				Cfg: &latest.Pipeline{
+				Cfg: latest.Pipeline{
 					Deploy: latest.DeployConfig{
 						DeployType: latest.DeployType{
 							KubectlDeploy: test.cfg,
@@ -319,7 +319,7 @@ spec:
 		}
 		deployer := NewKubectlDeployer(&runcontext.RunContext{
 			WorkingDir: tmpDir.Root(),
-			Cfg: &latest.Pipeline{
+			Cfg: latest.Pipeline{
 				Deploy: latest.DeployConfig{
 					DeployType: latest.DeployType{
 						KubectlDeploy: cfg,

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -185,7 +185,7 @@ func TestKubectlDeploy(t *testing.T) {
 					},
 				},
 				KubeContext: testKubeContext,
-				Opts: &config.SkaffoldOptions{
+				Opts: config.SkaffoldOptions{
 					Namespace: testNamespace,
 					Force:     test.forceDeploy,
 				},
@@ -259,7 +259,7 @@ func TestKubectlCleanup(t *testing.T) {
 					},
 				},
 				KubeContext: testKubeContext,
-				Opts: &config.SkaffoldOptions{
+				Opts: config.SkaffoldOptions{
 					Namespace: testNamespace,
 				},
 			})
@@ -327,7 +327,7 @@ spec:
 				},
 			},
 			KubeContext: testKubeContext,
-			Opts: &config.SkaffoldOptions{
+			Opts: config.SkaffoldOptions{
 				Namespace: testNamespace,
 			},
 		})

--- a/pkg/skaffold/deploy/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize_test.go
@@ -72,7 +72,7 @@ func TestKustomizeDeploy(t *testing.T) {
 
 			k := NewKustomizeDeployer(&runcontext.RunContext{
 				WorkingDir: ".",
-				Cfg: &latest.Pipeline{
+				Cfg: latest.Pipeline{
 					Deploy: latest.DeployConfig{
 						DeployType: latest.DeployType{
 							KustomizeDeploy: test.cfg,
@@ -136,7 +136,7 @@ func TestKustomizeCleanup(t *testing.T) {
 
 			k := NewKustomizeDeployer(&runcontext.RunContext{
 				WorkingDir: tmpDir.Root(),
-				Cfg: &latest.Pipeline{
+				Cfg: latest.Pipeline{
 					Deploy: latest.DeployConfig{
 						DeployType: latest.DeployType{
 							KustomizeDeploy: test.cfg,
@@ -305,7 +305,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 			}
 
 			k := NewKustomizeDeployer(&runcontext.RunContext{
-				Cfg: &latest.Pipeline{
+				Cfg: latest.Pipeline{
 					Deploy: latest.DeployConfig{
 						DeployType: latest.DeployType{
 							KustomizeDeploy: &latest.KustomizeDeploy{

--- a/pkg/skaffold/deploy/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize_test.go
@@ -80,7 +80,7 @@ func TestKustomizeDeploy(t *testing.T) {
 					},
 				},
 				KubeContext: testKubeContext,
-				Opts: &config.SkaffoldOptions{
+				Opts: config.SkaffoldOptions{
 					Namespace: testNamespace,
 					Force:     test.forceDeploy,
 				},
@@ -144,7 +144,7 @@ func TestKustomizeCleanup(t *testing.T) {
 					},
 				},
 				KubeContext: testKubeContext,
-				Opts: &config.SkaffoldOptions{
+				Opts: config.SkaffoldOptions{
 					Namespace: testNamespace,
 				},
 			})
@@ -315,7 +315,6 @@ func TestDependenciesForKustomization(t *testing.T) {
 					},
 				},
 				KubeContext: testKubeContext,
-				Opts:        &config.SkaffoldOptions{},
 			})
 			deps, err := k.Dependencies()
 

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -40,14 +40,19 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// For testing
+var (
+	NewAPIClient = NewAPIClientImpl
+)
+
 var (
 	dockerAPIClientOnce sync.Once
 	dockerAPIClient     LocalDaemon
 	dockerAPIClientErr  error
 )
 
-// NewAPIClient guesses the docker client to use based on current kubernetes context.
-func NewAPIClient(forceRemove bool, insecureRegistries map[string]bool) (LocalDaemon, error) {
+// NewAPIClientImpl guesses the docker client to use based on current kubernetes context.
+func NewAPIClientImpl(forceRemove bool, insecureRegistries map[string]bool) (LocalDaemon, error) {
 	dockerAPIClientOnce.Do(func() {
 		kubeConfig, err := kubectx.CurrentConfig()
 		if err != nil {

--- a/pkg/skaffold/docker/context_test.go
+++ b/pkg/skaffold/docker/context_test.go
@@ -46,7 +46,7 @@ func TestDockerContext(t *testing.T) {
 
 			reader, writer := io.Pipe()
 			go func() {
-				err := CreateDockerTarContext(context.Background(), writer, dir, artifact, map[string]bool{})
+				err := CreateDockerTarContext(context.Background(), writer, dir, artifact, nil)
 				if err != nil {
 					writer.CloseWithError(err)
 				} else {

--- a/pkg/skaffold/docker/dependencies_test.go
+++ b/pkg/skaffold/docker/dependencies_test.go
@@ -504,7 +504,7 @@ func TestGetDependencies(t *testing.T) {
 			}
 
 			workspace := tmpDir.Path(test.workspace)
-			deps, err := GetDependencies(context.Background(), workspace, "Dockerfile", test.buildArgs, map[string]bool{})
+			deps, err := GetDependencies(context.Background(), workspace, "Dockerfile", test.buildArgs, nil)
 
 			t.CheckError(test.shouldErr, err)
 			t.CheckDeepEqual(test.expected, deps)

--- a/pkg/skaffold/docker/image_util.go
+++ b/pkg/skaffold/docker/image_util.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"strings"
 
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/context"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -33,7 +34,8 @@ func RetrieveWorkingDir(tagged string, insecureRegistries map[string]bool) (stri
 		return "/", nil
 	}
 
-	localDocker, err := NewAPIClient(false, nil)
+	// TODO: use the proper RunContext
+	localDocker, err := NewAPIClient(&runcontext.RunContext{})
 	if err == nil {
 		cf, err = localDocker.ConfigFile(context.Background(), tagged)
 	}

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/moby/buildkit/frontend/dockerfile/command"
@@ -347,7 +348,10 @@ func fromInstruction(node *parser.Node) from {
 }
 
 func retrieveImage(image string, insecureRegistries map[string]bool) (*v1.ConfigFile, error) {
-	localDaemon, err := NewAPIClient(false, insecureRegistries) // Cached after first call
+	// TODO: use the proper RunContext
+	localDaemon, err := NewAPIClient(&runcontext.RunContext{
+		InsecureRegistries: insecureRegistries,
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "getting docker client")
 	}

--- a/pkg/skaffold/docker/remote_test.go
+++ b/pkg/skaffold/docker/remote_test.go
@@ -28,7 +28,7 @@ func TestRemoteDigest(t *testing.T) {
 	}
 
 	for _, ref := range validReferences {
-		_, err := RemoteDigest(ref, map[string]bool{})
+		_, err := RemoteDigest(ref, nil)
 
 		// Ignore networking errors
 		if err != nil && strings.Contains(err.Error(), "could not parse") {

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -83,7 +83,7 @@ type Config struct {
 	Force         bool
 	Analyze       bool
 	EnableJibInit bool // TODO: Remove this parameter
-	Opts          *config.SkaffoldOptions
+	Opts          config.SkaffoldOptions
 }
 
 // builderImagePair defines a builder and the image it builds

--- a/pkg/skaffold/runner/context/context.go
+++ b/pkg/skaffold/runner/context/context.go
@@ -30,7 +30,7 @@ import (
 
 type RunContext struct {
 	Opts config.SkaffoldOptions
-	Cfg  *latest.Pipeline
+	Cfg  latest.Pipeline
 
 	DefaultRepo        string
 	KubeContext        string
@@ -39,7 +39,7 @@ type RunContext struct {
 	InsecureRegistries map[string]bool
 }
 
-func GetRunContext(opts config.SkaffoldOptions, cfg *latest.Pipeline) (*RunContext, error) {
+func GetRunContext(opts config.SkaffoldOptions, cfg latest.Pipeline) (*RunContext, error) {
 	kubeConfig, err := kubectx.CurrentConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting current cluster context")

--- a/pkg/skaffold/runner/context/context.go
+++ b/pkg/skaffold/runner/context/context.go
@@ -29,7 +29,7 @@ import (
 )
 
 type RunContext struct {
-	Opts *config.SkaffoldOptions
+	Opts config.SkaffoldOptions
 	Cfg  *latest.Pipeline
 
 	DefaultRepo        string
@@ -39,7 +39,7 @@ type RunContext struct {
 	InsecureRegistries map[string]bool
 }
 
-func GetRunContext(opts *config.SkaffoldOptions, cfg *latest.Pipeline) (*RunContext, error) {
+func GetRunContext(opts config.SkaffoldOptions, cfg *latest.Pipeline) (*RunContext, error) {
 	kubeConfig, err := kubectx.CurrentConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting current cluster context")

--- a/pkg/skaffold/runner/diagnose_test.go
+++ b/pkg/skaffold/runner/diagnose_test.go
@@ -69,7 +69,7 @@ func TestSizeOfDockerContext(t *testing.T) {
 				},
 			}
 
-			actual, err := sizeOfDockerContext(context.TODO(), dummyArtifact, map[string]bool{})
+			actual, err := sizeOfDockerContext(context.TODO(), dummyArtifact, nil)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, actual)
 		})
 	}

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -121,7 +121,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 	}
 
 	defaultLabeller := deploy.NewLabeller("")
-	labellers := []deploy.Labeller{runCtx.Opts, builder, deployer, tagger, defaultLabeller}
+	labellers := []deploy.Labeller{&runCtx.Opts, builder, deployer, tagger, defaultLabeller}
 
 	builder, tester, deployer = WithTimings(builder, tester, deployer, runCtx.Opts.CacheArtifacts)
 	if runCtx.Opts.Notification {

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -203,7 +203,7 @@ func createRunner(t *testutil.T, testBench *TestBench, monitor filemon.Monitor) 
 	defaults.Set(cfg)
 
 	runCtx := &runcontext.RunContext{
-		Cfg: &cfg.Pipeline,
+		Cfg: cfg.Pipeline,
 		Opts: config.SkaffoldOptions{
 			Trigger:           "polling",
 			WatchPollInterval: 100,
@@ -240,7 +240,7 @@ func createRunner(t *testutil.T, testBench *TestBench, monitor filemon.Monitor) 
 func TestNewForConfig(t *testing.T) {
 	tests := []struct {
 		description      string
-		pipeline         *latest.Pipeline
+		pipeline         latest.Pipeline
 		shouldErr        bool
 		cacheArtifacts   bool
 		expectedBuilder  build.Builder
@@ -249,7 +249,7 @@ func TestNewForConfig(t *testing.T) {
 	}{
 		{
 			description: "local builder config",
-			pipeline: &latest.Pipeline{
+			pipeline: latest.Pipeline{
 				Build: latest.BuildConfig{
 					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
 					BuildType: latest.BuildType{
@@ -268,7 +268,7 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "bad tagger config",
-			pipeline: &latest.Pipeline{
+			pipeline: latest.Pipeline{
 				Build: latest.BuildConfig{
 					TagPolicy: latest.TagPolicy{},
 					BuildType: latest.BuildType{
@@ -284,24 +284,8 @@ func TestNewForConfig(t *testing.T) {
 			shouldErr: true,
 		},
 		{
-			description: "unknown builder",
-			pipeline: &latest.Pipeline{
-				Build: latest.BuildConfig{},
-			},
-			shouldErr:        true,
-			expectedBuilder:  &local.Builder{},
-			expectedTester:   &test.FullTester{},
-			expectedDeployer: &deploy.KubectlDeployer{},
-		},
-		{
-			description: "unknown tagger",
-			pipeline: &latest.Pipeline{
-				Build: latest.BuildConfig{
-					TagPolicy: latest.TagPolicy{},
-					BuildType: latest.BuildType{
-						LocalBuild: &latest.LocalBuild{},
-					},
-				}},
+			description:      "unknown builder and tagger",
+			pipeline:         latest.Pipeline{},
 			shouldErr:        true,
 			expectedBuilder:  &local.Builder{},
 			expectedTester:   &test.FullTester{},
@@ -309,7 +293,7 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "unknown deployer",
-			pipeline: &latest.Pipeline{
+			pipeline: latest.Pipeline{
 				Build: latest.BuildConfig{
 					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
 					BuildType: latest.BuildType{
@@ -321,7 +305,7 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "no artifacts, cache",
-			pipeline: &latest.Pipeline{
+			pipeline: latest.Pipeline{
 				Build: latest.BuildConfig{
 					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
 					BuildType: latest.BuildType{
@@ -422,7 +406,7 @@ func TestTriggerCallbackAndIntents(t *testing.T) {
 				AutoSync:          test.autoSync,
 				AutoDeploy:        test.autoDeploy,
 			}
-			pipeline := &latest.Pipeline{
+			pipeline := latest.Pipeline{
 				Build: latest.BuildConfig{
 					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
 					BuildType: latest.BuildType{

--- a/pkg/skaffold/runner/util/util.go
+++ b/pkg/skaffold/runner/util/util.go
@@ -28,7 +28,7 @@ import (
 // + The namespace passed on the command line
 // + Current kube context's namespace
 // + Namespaces referenced in Helm releases
-func GetAllPodNamespaces(configNamespace string, cfg *latest.Pipeline) ([]string, error) {
+func GetAllPodNamespaces(configNamespace string, cfg latest.Pipeline) ([]string, error) {
 	nsMap := make(map[string]bool)
 
 	if configNamespace == "" {
@@ -63,10 +63,10 @@ func GetAllPodNamespaces(configNamespace string, cfg *latest.Pipeline) ([]string
 	return namespaces, nil
 }
 
-func collectHelmReleasesNamespaces(cfg *latest.Pipeline) []string {
+func collectHelmReleasesNamespaces(cfg latest.Pipeline) []string {
 	var namespaces []string
 
-	if cfg != nil && cfg.Deploy.HelmDeploy != nil {
+	if cfg.Deploy.HelmDeploy != nil {
 		for _, release := range cfg.Deploy.HelmDeploy.Releases {
 			namespaces = append(namespaces, release.Namespace)
 		}

--- a/pkg/skaffold/runner/util/util_test.go
+++ b/pkg/skaffold/runner/util/util_test.go
@@ -31,7 +31,7 @@ func TestGetAllPodNamespaces(t *testing.T) {
 		description    string
 		argNamespace   string
 		currentContext string
-		cfg            *latest.Pipeline
+		cfg            latest.Pipeline
 		expected       []string
 	}{
 		{
@@ -52,7 +52,7 @@ func TestGetAllPodNamespaces(t *testing.T) {
 		{
 			description:  "add namespaces for helm",
 			argNamespace: "ns",
-			cfg: &latest.Pipeline{
+			cfg: latest.Pipeline{
 				Deploy: latest.DeployConfig{
 					DeployType: latest.DeployType{
 						HelmDeploy: &latest.HelmDeploy{

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -35,7 +35,7 @@ import (
 
 // ApplyProfiles returns configuration modified by the application
 // of a list of profiles.
-func ApplyProfiles(c *latest.SkaffoldConfig, opts *cfg.SkaffoldOptions) error {
+func ApplyProfiles(c *latest.SkaffoldConfig, opts cfg.SkaffoldOptions) error {
 	byName := profilesByName(c.Profiles)
 
 	profiles, err := activatedProfiles(c.Profiles, opts)
@@ -57,7 +57,7 @@ func ApplyProfiles(c *latest.SkaffoldConfig, opts *cfg.SkaffoldOptions) error {
 	return nil
 }
 
-func activatedProfiles(profiles []latest.Profile, opts *cfg.SkaffoldOptions) ([]string, error) {
+func activatedProfiles(profiles []latest.Profile, opts cfg.SkaffoldOptions) ([]string, error) {
 	activated := opts.Profiles
 
 	// Auto-activated profiles
@@ -100,7 +100,7 @@ func isEnv(env string) (bool, error) {
 	return satisfies(value, os.Getenv(key)), nil
 }
 
-func isCommand(command string, opts *cfg.SkaffoldOptions) bool {
+func isCommand(command string, opts cfg.SkaffoldOptions) bool {
 	if command == "" {
 		return true
 	}

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -57,7 +57,7 @@ profiles:
 		t.CheckNoError(err)
 
 		skaffoldConfig := parsed.(*latest.SkaffoldConfig)
-		err = ApplyProfiles(skaffoldConfig, &cfg.SkaffoldOptions{
+		err = ApplyProfiles(skaffoldConfig, cfg.SkaffoldOptions{
 			Profiles: []string{"patches"},
 		})
 
@@ -87,7 +87,7 @@ profiles:
 		t.CheckNoError(err)
 
 		skaffoldConfig := parsed.(*latest.SkaffoldConfig)
-		err = ApplyProfiles(skaffoldConfig, &cfg.SkaffoldOptions{
+		err = ApplyProfiles(skaffoldConfig, cfg.SkaffoldOptions{
 			Profiles: []string{"patches"},
 		})
 
@@ -306,7 +306,7 @@ func TestApplyProfiles(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			err := ApplyProfiles(test.config, &cfg.SkaffoldOptions{
+			err := ApplyProfiles(test.config, cfg.SkaffoldOptions{
 				Profiles: []string{test.profile},
 			})
 
@@ -323,13 +323,13 @@ func TestActivatedProfiles(t *testing.T) {
 	tests := []struct {
 		description string
 		profiles    []latest.Profile
-		opts        *cfg.SkaffoldOptions
+		opts        cfg.SkaffoldOptions
 		expected    []string
 		shouldErr   bool
 	}{
 		{
 			description: "Selected on the command line",
-			opts: &cfg.SkaffoldOptions{
+			opts: cfg.SkaffoldOptions{
 				Command:  "dev",
 				Profiles: []string{"activated", "also-activated"},
 			},
@@ -341,7 +341,7 @@ func TestActivatedProfiles(t *testing.T) {
 			expected: []string{"activated", "also-activated"},
 		}, {
 			description: "Auto-activated by command",
-			opts: &cfg.SkaffoldOptions{
+			opts: cfg.SkaffoldOptions{
 				Command: "dev",
 			},
 			profiles: []latest.Profile{
@@ -354,7 +354,6 @@ func TestActivatedProfiles(t *testing.T) {
 			expected: []string{"dev-profile", "non-run-profile", "run-or-dev-profile"},
 		}, {
 			description: "Auto-activated by env variable",
-			opts:        &cfg.SkaffoldOptions{},
 			profiles: []latest.Profile{
 				{Name: "activated", Activation: []latest.Activation{{Env: "KEY=VALUE"}}},
 				{Name: "not-activated", Activation: []latest.Activation{{Env: "KEY=OTHER"}}},
@@ -364,14 +363,13 @@ func TestActivatedProfiles(t *testing.T) {
 			expected: []string{"activated", "also-activated", "regex-activated"},
 		}, {
 			description: "Invalid env variable",
-			opts:        &cfg.SkaffoldOptions{},
+			opts:        cfg.SkaffoldOptions{},
 			profiles: []latest.Profile{
 				{Name: "activated", Activation: []latest.Activation{{Env: "KEY:VALUE"}}},
 			},
 			shouldErr: true,
 		}, {
 			description: "Auto-activated by kube context",
-			opts:        &cfg.SkaffoldOptions{},
 			profiles: []latest.Profile{
 				{Name: "activated", Activation: []latest.Activation{{KubeContext: "prod-context"}}},
 				{Name: "not-activated", Activation: []latest.Activation{{KubeContext: "dev-context"}}},
@@ -383,7 +381,7 @@ func TestActivatedProfiles(t *testing.T) {
 			expected: []string{"activated", "also-activated", "activated-regexp"},
 		}, {
 			description: "AND between activation criteria",
-			opts: &cfg.SkaffoldOptions{
+			opts: cfg.SkaffoldOptions{
 				Command: "dev",
 			},
 			profiles: []latest.Profile{
@@ -405,7 +403,7 @@ func TestActivatedProfiles(t *testing.T) {
 			expected: []string{"activated"},
 		}, {
 			description: "OR between activations",
-			opts: &cfg.SkaffoldOptions{
+			opts: cfg.SkaffoldOptions{
 				Command: "dev",
 			},
 			profiles: []latest.Profile{

--- a/pkg/skaffold/server/server.go
+++ b/pkg/skaffold/server/server.go
@@ -62,7 +62,7 @@ func SetSyncCallback(callback func()) {
 // Initialize creates the gRPC and HTTP servers for serving the state and event log.
 // It returns a shutdown callback for tearing down the grpc server,
 // which the runner is responsible for calling.
-func Initialize(opts *config.SkaffoldOptions) (func() error, error) {
+func Initialize(opts config.SkaffoldOptions) (func() error, error) {
 	if !opts.EnableRPC {
 		return func() error { return nil }, nil
 	}

--- a/pkg/skaffold/server/server_test.go
+++ b/pkg/skaffold/server/server_test.go
@@ -34,7 +34,7 @@ var (
 
 func TestServerStartup(t *testing.T) {
 	// start up servers
-	shutdown, err := Initialize(&config.SkaffoldOptions{
+	shutdown, err := Initialize(config.SkaffoldOptions{
 		EnableRPC:   true,
 		RPCPort:     rpcAddr,
 		RPCHTTPPort: httpAddr,

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -641,7 +641,7 @@ func TestNewSyncItem(t *testing.T) {
 			})
 
 			provider := func() (map[string][]string, error) { return test.dependencies, nil }
-			actual, err := NewItem(test.artifact, test.evt, test.builds, map[string]bool{}, provider)
+			actual, err := NewItem(test.artifact, test.evt, test.builds, nil, provider)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, actual)
 		})

--- a/pkg/skaffold/test/test_test.go
+++ b/pkg/skaffold/test/test_test.go
@@ -30,9 +30,7 @@ import (
 )
 
 func TestNoTestDependencies(t *testing.T) {
-	runCtx := &runcontext.RunContext{
-		Cfg: &latest.Pipeline{},
-	}
+	runCtx := &runcontext.RunContext{}
 
 	deps, err := NewTester(runCtx).TestDependencies()
 
@@ -47,7 +45,7 @@ func TestTestDependencies(t *testing.T) {
 
 	runCtx := &runcontext.RunContext{
 		WorkingDir: tmpDir.Root(),
-		Cfg: &latest.Pipeline{
+		Cfg: latest.Pipeline{
 			Test: []*latest.TestCase{
 				{StructureTests: []string{"./tests/*"}},
 				{},
@@ -64,7 +62,7 @@ func TestTestDependencies(t *testing.T) {
 
 func TestWrongPattern(t *testing.T) {
 	runCtx := &runcontext.RunContext{
-		Cfg: &latest.Pipeline{
+		Cfg: latest.Pipeline{
 			Test: []*latest.TestCase{
 				{StructureTests: []string{"[]"}},
 			},
@@ -81,9 +79,7 @@ func TestWrongPattern(t *testing.T) {
 }
 
 func TestNoTest(t *testing.T) {
-	runCtx := &runcontext.RunContext{
-		Cfg: &latest.Pipeline{},
-	}
+	runCtx := &runcontext.RunContext{}
 
 	err := NewTester(runCtx).Test(context.Background(), ioutil.Discard, nil)
 
@@ -104,7 +100,7 @@ func TestTestSuccess(t *testing.T) {
 
 	runCtx := &runcontext.RunContext{
 		WorkingDir: tmpDir.Root(),
-		Cfg: &latest.Pipeline{
+		Cfg: latest.Pipeline{
 			Test: []*latest.TestCase{
 				{
 					ImageName:      "image",
@@ -140,7 +136,7 @@ func TestTestFailure(t *testing.T) {
 
 	runCtx := &runcontext.RunContext{
 		WorkingDir: tmpDir.Root(),
-		Cfg: &latest.Pipeline{
+		Cfg: latest.Pipeline{
 			Test: []*latest.TestCase{
 				{
 					ImageName:      "broken-image",

--- a/pkg/skaffold/trigger/triggers_test.go
+++ b/pkg/skaffold/trigger/triggers_test.go
@@ -29,32 +29,32 @@ import (
 func TestNewTrigger(t *testing.T) {
 	tests := []struct {
 		description string
-		opts        *config.SkaffoldOptions
+		opts        config.SkaffoldOptions
 		expected    Trigger
 		shouldErr   bool
 	}{
 		{
 			description: "polling trigger",
-			opts:        &config.SkaffoldOptions{Trigger: "polling", WatchPollInterval: 1},
+			opts:        config.SkaffoldOptions{Trigger: "polling", WatchPollInterval: 1},
 			expected: &pollTrigger{
 				Interval: time.Duration(1) * time.Millisecond,
 			},
 		},
 		{
 			description: "notify trigger",
-			opts:        &config.SkaffoldOptions{Trigger: "notify", WatchPollInterval: 1},
+			opts:        config.SkaffoldOptions{Trigger: "notify", WatchPollInterval: 1},
 			expected: &fsNotifyTrigger{
 				Interval: time.Duration(1) * time.Millisecond,
 			},
 		},
 		{
 			description: "manual trigger",
-			opts:        &config.SkaffoldOptions{Trigger: "manual"},
+			opts:        config.SkaffoldOptions{Trigger: "manual"},
 			expected:    &manualTrigger{},
 		},
 		{
 			description: "unknown trigger",
-			opts:        &config.SkaffoldOptions{Trigger: "unknown"},
+			opts:        config.SkaffoldOptions{Trigger: "unknown"},
 			shouldErr:   true,
 		},
 	}


### PR DESCRIPTION
My goals are:
+ Make the code safer
+ Make is easier to mock
+ Reduce the number of parameters that are to be passed along such as insecureregistries

This is just the beginning of the refactoring but already improves a bit the codebase
