### PR TITLE
Propagate special error on configuration change

### DIFF
--- a/cmd/skaffold/app/cmd/dev_test.go
+++ b/cmd/skaffold/app/cmd/dev_test.go
@@ -110,3 +110,55 @@ func TestDoDev(t *testing.T) {
 		})
 	}
 }
+
+type mockConfigChangeRunner struct {
+	runner.Runner
+	cycles int
+}
+
+func (m *mockConfigChangeRunner) Dev(context.Context, io.Writer, []*latest.Artifact) error {
+	m.cycles++
+	if m.cycles == 1 {
+		// pass through the first cycle with a config reload
+		return runner.ErrorConfigurationChanged
+	}
+	return context.Canceled
+}
+
+func (m *mockConfigChangeRunner) HasBuilt() bool {
+	return true
+}
+
+func (m *mockConfigChangeRunner) HasDeployed() bool {
+	return true
+}
+
+func (r *mockConfigChangeRunner) Prune(context.Context, io.Writer) error {
+	return nil
+}
+
+func (r *mockConfigChangeRunner) Cleanup(context.Context, io.Writer) error {
+	return nil
+}
+
+func TestDevConfigChange(t *testing.T) {
+	testutil.Run(t, "test config change", func(t *testutil.T) {
+		mockRunner := &mockConfigChangeRunner{}
+
+		t.Override(&createRunner, func(*config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+			return mockRunner, &latest.SkaffoldConfig{}, nil
+		})
+		t.Override(&opts, &config.SkaffoldOptions{
+			Cleanup: true,
+			NoPrune: false,
+		})
+
+		err := doDev(context.Background(), ioutil.Discard)
+
+		// ensure that we received the context.Cancled error (and not ErrorConfigurationChanged)
+		// also ensure that the we run through dev cycles (since we reloaded on the first),
+		// and exit after a real error is received
+		t.CheckDeepEqual(true, err == context.Canceled)
+		t.CheckDeepEqual(mockRunner.cycles, 2)
+	})
+}

--- a/pkg/skaffold/runner/listen.go
+++ b/pkg/skaffold/runner/listen.go
@@ -67,6 +67,11 @@ func (l *SkaffoldListener) WatchForChanges(ctx context.Context, out io.Writer, d
 				logrus.Warnf("skaffold may not run successfully!")
 			}
 			if err := devLoop(ctx, out); err != nil {
+				// propagating this error up causes a new runner to be created
+				// and a new dev loop to start
+				if errors.Cause(err) == ErrorConfigurationChanged {
+					return err
+				}
 				logrus.Errorf("error running dev loop: %s", err.Error())
 			}
 		}


### PR DESCRIPTION
this change makes sure the special case error for a change to the skaffold.yaml makes its way out of the dev loop and up to the caller, which in turn creates a new runner and kicks off a new dev loop.

Fixes #2500