### PR TITLE
Refactor: Use new `kubectl.CLI` util to shell out to `kubectl`

### DIFF
--- a/integration/white_box_test.go
+++ b/integration/white_box_test.go
@@ -19,10 +19,14 @@ package integration
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
 	"github.com/sirupsen/logrus"
 
+	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 )
 
 func TestPortForward(t *testing.T) {
@@ -32,10 +36,25 @@ func TestPortForward(t *testing.T) {
 	if ShouldRunGCPOnlyTests() {
 		t.Skip("skipping test that is not gcp only")
 	}
+
 	ns, _, deleteNs := SetupNamespace(t)
 	defer deleteNs()
+
 	dir := "examples/microservices"
 	skaffold.Run().InDir(dir).InNs(ns.Name).RunOrFailOutput(t)
+
+	cfg, err := kubectx.CurrentConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kubectlCLI := kubectlcli.NewFromRunContext(&runcontext.RunContext{
+		KubeContext: cfg.CurrentContext,
+		Opts: config.SkaffoldOptions{
+			Namespace: ns.Name,
+		},
+	})
+
 	logrus.SetLevel(logrus.DebugLevel)
-	portforward.WhiteBoxPortForwardCycle(ns.Name, t)
+	portforward.WhiteBoxPortForwardCycle(t, kubectlCLI, ns.Name)
 }

--- a/integration/white_box_test.go
+++ b/integration/white_box_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
@@ -48,7 +48,7 @@ func TestPortForward(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	kubectlCLI := kubectlcli.NewFromRunContext(&runcontext.RunContext{
+	kubectlCLI := kubectl.NewFromRunContext(&runcontext.RunContext{
 		KubeContext: cfg.CurrentContext,
 		Opts: config.SkaffoldOptions{
 			Namespace: ns.Name,

--- a/pkg/skaffold/build/cluster/cluster_test.go
+++ b/pkg/skaffold/build/cluster/cluster_test.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -27,6 +28,9 @@ import (
 func TestRetrieveEnv(t *testing.T) {
 	builder, err := NewBuilder(&runcontext.RunContext{
 		KubeContext: "kubecontext",
+		Opts: config.SkaffoldOptions{
+			Namespace: "test-namespace",
+		},
 		Cfg: latest.Pipeline{
 			Build: latest.BuildConfig{
 				BuildType: latest.BuildType{

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -34,7 +34,7 @@ import (
 
 func (b *Builder) runKanikoBuild(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
 	// Prepare context
-	s := sources.Retrieve(b.ClusterDetails, artifact.KanikoArtifact)
+	s := sources.Retrieve(b.kubectlcli, b.ClusterDetails, artifact.KanikoArtifact)
 	dependencies, err := b.DependenciesForArtifact(ctx, artifact)
 	if err != nil {
 		return "", errors.Wrapf(err, "getting dependencies for %s", artifact.ImageName)

--- a/pkg/skaffold/build/cluster/sources/localdir.go
+++ b/pkg/skaffold/build/cluster/sources/localdir.go
@@ -21,17 +21,17 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
+
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sources"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-	"github.com/pkg/errors"
-	v1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -43,6 +43,7 @@ const (
 type LocalDir struct {
 	artifact       *latest.KanikoArtifact
 	clusterDetails *latest.ClusterDetails
+	kubectl        *kubectl.CLI
 	tarPath        string
 }
 
@@ -111,14 +112,12 @@ func (g *LocalDir) ModifyPod(ctx context.Context, p *v1.Pod) error {
 	defer f.Close()
 
 	// Copy the context to the empty dir and extract it
-	copyAndExtract := exec.CommandContext(ctx, "kubectl", "exec", "-i", p.Name, "-c", initContainer, "-n", p.Namespace, "--", "tar", "-xzf", "-", "-C", constants.DefaultKanikoEmptyDirMountPath)
-	copyAndExtract.Stdin = f
-	if err := util.RunCmd(copyAndExtract); err != nil {
+	err = g.kubectl.Run(ctx, f, nil, "exec", "-i", p.Name, "-c", initContainer, "-n", p.Namespace, "--", "tar", "-xzf", "-", "-C", constants.DefaultKanikoEmptyDirMountPath)
+	if err != nil {
 		return errors.Wrap(err, "copying and extracting buildcontext to empty dir")
 	}
 	// Generate a file to successfully terminate the init container
-	file := exec.CommandContext(ctx, "kubectl", "exec", p.Name, "-c", initContainer, "-n", p.Namespace, "--", "touch", "/tmp/complete")
-	return util.RunCmd(file)
+	return g.kubectl.Run(ctx, nil, nil, "exec", p.Name, "-c", initContainer, "-n", p.Namespace, "--", "touch", "/tmp/complete")
 }
 
 // Cleanup deletes the buildcontext tarball stored on the local filesystem

--- a/pkg/skaffold/build/cluster/sources/sources.go
+++ b/pkg/skaffold/build/cluster/sources/sources.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"io"
 
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // BuildContextSource is the generic type for the different build context sources the kaniko builder can use
@@ -37,11 +38,12 @@ type BuildContextSource interface {
 }
 
 // Retrieve returns the correct build context based on the config
-func Retrieve(clusterDetails *latest.ClusterDetails, artifact *latest.KanikoArtifact) BuildContextSource {
+func Retrieve(cli *kubectl.CLI, clusterDetails *latest.ClusterDetails, artifact *latest.KanikoArtifact) BuildContextSource {
 	if artifact.BuildContext.LocalDir != nil {
 		return &LocalDir{
 			clusterDetails: clusterDetails,
 			artifact:       artifact,
+			kubectl:        cli,
 		}
 	}
 

--- a/pkg/skaffold/build/cluster/types.go
+++ b/pkg/skaffold/build/cluster/types.go
@@ -22,19 +22,22 @@ import (
 	"io"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-	"github.com/pkg/errors"
 )
 
 // Builder builds docker artifacts on Kubernetes.
 type Builder struct {
 	*latest.ClusterDetails
 
+	kubectlcli         *kubectl.CLI
 	kubeContext        string
 	timeout            time.Duration
 	insecureRegistries map[string]bool
@@ -49,6 +52,7 @@ func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
 
 	return &Builder{
 		ClusterDetails:     runCtx.Cfg.Build.Cluster,
+		kubectlcli:         kubectl.NewFromRunContext(runCtx),
 		timeout:            timeout,
 		kubeContext:        runCtx.KubeContext,
 		insecureRegistries: runCtx.InsecureRegistries,

--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -20,16 +20,18 @@ import (
 	"context"
 	"io"
 
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // KubectlDeployer deploys workflows using kubectl CLI.
@@ -37,7 +39,7 @@ type KubectlDeployer struct {
 	*latest.KubectlDeploy
 
 	workingDir         string
-	kubectl            kubectl.CLI
+	kubectl            kubectl.DeployerCLI
 	defaultRepo        string
 	insecureRegistries map[string]bool
 }
@@ -48,9 +50,11 @@ func NewKubectlDeployer(runCtx *runcontext.RunContext) *KubectlDeployer {
 	return &KubectlDeployer{
 		KubectlDeploy: runCtx.Cfg.Deploy.KubectlDeploy,
 		workingDir:    runCtx.WorkingDir,
-		kubectl: kubectl.CLI{
-			Namespace:   runCtx.Opts.Namespace,
-			KubeContext: runCtx.KubeContext,
+		kubectl: kubectl.DeployerCLI{
+			CLI: &kubectlcli.CLI{
+				KubeContext: runCtx.KubeContext,
+				Namespace:   runCtx.Opts.Namespace,
+			},
 			Flags:       runCtx.Cfg.Deploy.KubectlDeploy.Flags,
 			ForceDeploy: runCtx.Opts.ForceDeploy(),
 		},

--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -23,13 +23,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	pkgkubectl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
-// DeployerCLI holds parameters to run kubectl.
-type DeployerCLI struct {
-	*kubectlcli.CLI
+// CLI holds parameters to run kubectl.
+type CLI struct {
+	*pkgkubectl.CLI
 	Flags latest.KubectlFlags
 
 	ForceDeploy   bool
@@ -37,7 +37,7 @@ type DeployerCLI struct {
 }
 
 // Delete runs `kubectl delete` on a list of manifests.
-func (c *DeployerCLI) Delete(ctx context.Context, out io.Writer, manifests ManifestList) error {
+func (c *CLI) Delete(ctx context.Context, out io.Writer, manifests ManifestList) error {
 	args := c.args(c.Flags.Delete, "--ignore-not-found=true", "-f", "-")
 	if err := c.Run(ctx, manifests.Reader(), out, "delete", args...); err != nil {
 		return errors.Wrap(err, "kubectl delete")
@@ -47,7 +47,7 @@ func (c *DeployerCLI) Delete(ctx context.Context, out io.Writer, manifests Manif
 }
 
 // Apply runs `kubectl apply` on a list of manifests.
-func (c *DeployerCLI) Apply(ctx context.Context, out io.Writer, manifests ManifestList) error {
+func (c *CLI) Apply(ctx context.Context, out io.Writer, manifests ManifestList) error {
 	// Only redeploy modified or new manifests
 	// TODO(dgageot): should we delete a manifest that was deployed and is not anymore?
 	updated := c.previousApply.Diff(manifests)
@@ -70,7 +70,7 @@ func (c *DeployerCLI) Apply(ctx context.Context, out io.Writer, manifests Manife
 }
 
 // ReadManifests reads a list of manifests in yaml format.
-func (c *DeployerCLI) ReadManifests(ctx context.Context, manifests []string) (ManifestList, error) {
+func (c *CLI) ReadManifests(ctx context.Context, manifests []string) (ManifestList, error) {
 	var list []string
 	for _, manifest := range manifests {
 		list = append(list, "-f", manifest)
@@ -89,7 +89,7 @@ func (c *DeployerCLI) ReadManifests(ctx context.Context, manifests []string) (Ma
 	return manifestList, nil
 }
 
-func (c *DeployerCLI) args(commandFlags []string, additionalArgs ...string) []string {
+func (c *CLI) args(commandFlags []string, additionalArgs ...string) []string {
 	args := make([]string, 0, len(c.Flags.Global)+len(commandFlags)+len(additionalArgs))
 
 	args = append(args, c.Flags.Global...)

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -157,8 +157,8 @@ func TestKubectlDeploy(t *testing.T) {
 			},
 			command: testutil.NewFakeCmd(t).
 				WithRunOut("kubectl version --client -ojson", kubectlVersion).
-				WithRunOut("kubectl --context kubecontext --namespace testNamespace -v=0 create --dry-run -oyaml -f deployment.yaml", deploymentWebYAML).
-				WithRunErr("kubectl --context kubecontext --namespace testNamespace -v=0 apply --overwrite=true -f -", fmt.Errorf("")),
+				WithRunOut("kubectl --context kubecontext --namespace testNamespace create -v=0 --dry-run -oyaml -f deployment.yaml", deploymentWebYAML).
+				WithRunErr("kubectl --context kubecontext --namespace testNamespace apply -v=0 --overwrite=true -f -", fmt.Errorf("")),
 			builds: []build.Artifact{{
 				ImageName: "leeroy-web",
 				Tag:       "leeroy-web:123",
@@ -238,8 +238,8 @@ func TestKubectlCleanup(t *testing.T) {
 				},
 			},
 			command: testutil.NewFakeCmd(t).
-				WithRunOut("kubectl --context kubecontext --namespace testNamespace -v=0 create --dry-run -oyaml -f deployment.yaml", deploymentWebYAML).
-				WithRun("kubectl --context kubecontext --namespace testNamespace -v=0 delete --grace-period=1 --ignore-not-found=true -f -"),
+				WithRunOut("kubectl --context kubecontext --namespace testNamespace create -v=0 --dry-run -oyaml -f deployment.yaml", deploymentWebYAML).
+				WithRun("kubectl --context kubecontext --namespace testNamespace delete -v=0 --grace-period=1 --ignore-not-found=true -f -"),
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -32,10 +33,10 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-	"github.com/pkg/errors"
 )
 
 // kustomization is the content of a kustomization.yaml file.
@@ -66,7 +67,7 @@ type secretGenerator struct {
 type KustomizeDeployer struct {
 	*latest.KustomizeDeploy
 
-	kubectl            kubectl.CLI
+	kubectl            kubectl.DeployerCLI
 	defaultRepo        string
 	insecureRegistries map[string]bool
 }
@@ -74,9 +75,11 @@ type KustomizeDeployer struct {
 func NewKustomizeDeployer(runCtx *runcontext.RunContext) *KustomizeDeployer {
 	return &KustomizeDeployer{
 		KustomizeDeploy: runCtx.Cfg.Deploy.KustomizeDeploy,
-		kubectl: kubectl.CLI{
-			Namespace:   runCtx.Opts.Namespace,
-			KubeContext: runCtx.KubeContext,
+		kubectl: kubectl.DeployerCLI{
+			CLI: &kubectlcli.CLI{
+				KubeContext: runCtx.KubeContext,
+				Namespace:   runCtx.Opts.Namespace,
+			},
 			Flags:       runCtx.Cfg.Deploy.KustomizeDeploy.Flags,
 			ForceDeploy: runCtx.Opts.ForceDeploy(),
 		},

--- a/pkg/skaffold/deploy/labels.go
+++ b/pkg/skaffold/deploy/labels.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
-	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -34,6 +32,9 @@ import (
 	patch "k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 )
 
 // Artifact contains all information about a completed deployment

--- a/pkg/skaffold/deploy/status_check.go
+++ b/pkg/skaffold/deploy/status_check.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	kubernetesutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 )
@@ -58,10 +58,7 @@ func StatusCheck(ctx context.Context, defaultLabeller *DefaultLabeller, runCtx *
 	wg := sync.WaitGroup{}
 	// Its safe to use sync.Map without locks here as each subroutine adds a different key to the map.
 	syncMap := &sync.Map{}
-	kubeCtl := &kubectlcli.CLI{
-		KubeContext: runCtx.KubeContext,
-		Namespace:   runCtx.Opts.Namespace,
-	}
+	kubeCtl := kubectl.NewFromRunContext(runCtx)
 
 	for dName, deadline := range dMap {
 		deadlineDuration := time.Duration(deadline) * time.Second
@@ -101,7 +98,7 @@ func getDeployments(client kubernetes.Interface, ns string, l *DefaultLabeller) 
 	return depMap, nil
 }
 
-func pollDeploymentRolloutStatus(ctx context.Context, k *kubectlcli.CLI, dName string, deadline time.Duration, syncMap *sync.Map) {
+func pollDeploymentRolloutStatus(ctx context.Context, k *kubectl.CLI, dName string, deadline time.Duration, syncMap *sync.Map) {
 	pollDuration := time.Duration(defaultPollPeriodInMilliseconds) * time.Millisecond
 	// Add poll duration to account for one last attempt after progressDeadlineSeconds.
 	timeoutContext, cancel := context.WithTimeout(ctx, deadline+pollDuration)
@@ -141,7 +138,7 @@ func getSkaffoldDeployStatus(m *sync.Map) error {
 	return fmt.Errorf("following deployments are not stable:\n%s", strings.Join(errorStrings, "\n"))
 }
 
-func getRollOutStatus(ctx context.Context, k *kubectlcli.CLI, dName string) (string, error) {
+func getRollOutStatus(ctx context.Context, k *kubectl.CLI, dName string) (string, error) {
 	b, err := k.RunOut(ctx, "rollout", "status", "deployment", dName, "--watch=false")
 	return string(b), err
 }

--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -24,13 +24,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-	"github.com/GoogleContainerTools/skaffold/testutil"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+
+	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestGetDeployments(t *testing.T) {
@@ -180,7 +181,7 @@ type MockRolloutStatus struct {
 	err       error
 }
 
-func (m *MockRolloutStatus) Executefunc(context.Context, *kubectl.CLI, string) (string, error) {
+func (m *MockRolloutStatus) Executefunc(context.Context, *kubectlcli.CLI, string) (string, error) {
 	var resp string
 	if m.err != nil {
 		m.called++
@@ -258,7 +259,7 @@ func TestPollDeploymentRolloutStatus(t *testing.T) {
 			defer func() { defaultPollPeriodInMilliseconds = originalPollingPeriod }()
 
 			actual := &sync.Map{}
-			pollDeploymentRolloutStatus(context.Background(), &kubectl.CLI{}, "dep", time.Duration(test.duration)*time.Millisecond, actual)
+			pollDeploymentRolloutStatus(context.Background(), &kubectlcli.CLI{}, "dep", time.Duration(test.duration)*time.Millisecond, actual)
 
 			if _, ok := actual.Load("dep"); !ok {
 				t.Error("expected result for deployment dep. But found none")
@@ -354,10 +355,7 @@ func TestGetRollOutStatus(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, test.command)
-			cli := &kubectl.CLI{
-				Namespace:   "test",
-				KubeContext: testKubeContext,
-			}
+			cli := &kubectlcli.CLI{KubeContext: testKubeContext, Namespace: "test"}
 			actual, err := getRollOutStatus(context.Background(), cli, "dep")
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, actual)
 		})

--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 
-	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -181,7 +181,7 @@ type MockRolloutStatus struct {
 	err       error
 }
 
-func (m *MockRolloutStatus) Executefunc(context.Context, *kubectlcli.CLI, string) (string, error) {
+func (m *MockRolloutStatus) Executefunc(context.Context, *kubectl.CLI, string) (string, error) {
 	var resp string
 	if m.err != nil {
 		m.called++
@@ -259,7 +259,7 @@ func TestPollDeploymentRolloutStatus(t *testing.T) {
 			defer func() { defaultPollPeriodInMilliseconds = originalPollingPeriod }()
 
 			actual := &sync.Map{}
-			pollDeploymentRolloutStatus(context.Background(), &kubectlcli.CLI{}, "dep", time.Duration(test.duration)*time.Millisecond, actual)
+			pollDeploymentRolloutStatus(context.Background(), &kubectl.CLI{}, "dep", time.Duration(test.duration)*time.Millisecond, actual)
 
 			if _, ok := actual.Load("dep"); !ok {
 				t.Error("expected result for deployment dep. But found none")
@@ -355,7 +355,7 @@ func TestGetRollOutStatus(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, test.command)
-			cli := &kubectlcli.CLI{KubeContext: testKubeContext, Namespace: "test"}
+			cli := &kubectl.CLI{KubeContext: testKubeContext, Namespace: "test"}
 			actual, err := getRollOutStatus(context.Background(), cli, "dep")
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, actual)
 		})

--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -35,6 +35,13 @@ type CLI struct {
 	versionOnce sync.Once
 }
 
+func NewFromRunContext(runCtx *runcontext.RunContext) *CLI {
+	return &CLI{
+		KubeContext: runCtx.KubeContext,
+		Namespace:   runCtx.Opts.Namespace,
+	}
+}
+
 // Command creates the underlying exec.CommandContext. This allows low-level control of the executed command.
 func (c *CLI) Command(ctx context.Context, command string, arg ...string) *exec.Cmd {
 	args := c.args(command, arg...)

--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"context"
+	"io"
+	"os/exec"
+	"sync"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+// CLI holds parameters to run kubectl.
+type CLI struct {
+	KubeContext string
+	Namespace   string
+
+	version     ClientVersion
+	versionOnce sync.Once
+}
+
+// Command creates the underlying exec.CommandContext. This allows low-level control of the executed command.
+func (c *CLI) Command(ctx context.Context, command string, arg ...string) *exec.Cmd {
+	args := c.args(command, arg...)
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	return cmd
+}
+
+// Run shells out kubectl CLI.
+func (c *CLI) Run(ctx context.Context, in io.Reader, out io.Writer, command string, arg ...string) error {
+	cmd := c.Command(ctx, command, arg...)
+	cmd.Stdin = in
+	cmd.Stdout = out
+	cmd.Stderr = out
+	return util.RunCmd(cmd)
+}
+
+// Run shells out kubectl CLI.
+func (c *CLI) RunOut(ctx context.Context, command string, arg ...string) ([]byte, error) {
+	args := c.args(command, arg...)
+	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	return util.RunCmdOut(cmd)
+}
+
+func (c *CLI) args(command string, arg ...string) []string {
+	args := []string{"--context", c.KubeContext}
+	if c.Namespace != "" {
+		args = append(args, "--namespace", c.Namespace)
+	}
+	args = append(args, command)
+	args = append(args, arg...)
+	return args
+}

--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -45,8 +45,7 @@ func NewFromRunContext(runCtx *runcontext.RunContext) *CLI {
 // Command creates the underlying exec.CommandContext. This allows low-level control of the executed command.
 func (c *CLI) Command(ctx context.Context, command string, arg ...string) *exec.Cmd {
 	args := c.args(command, arg...)
-	cmd := exec.CommandContext(ctx, "kubectl", args...)
-	return cmd
+	return exec.CommandContext(ctx, "kubectl", args...)
 }
 
 // Run shells out kubectl CLI.
@@ -60,11 +59,12 @@ func (c *CLI) Run(ctx context.Context, in io.Reader, out io.Writer, command stri
 
 // Run shells out kubectl CLI.
 func (c *CLI) RunOut(ctx context.Context, command string, arg ...string) ([]byte, error) {
-	args := c.args(command, arg...)
-	cmd := exec.CommandContext(ctx, "kubectl", args...)
+	cmd := c.Command(ctx, command, arg...)
 	return util.RunCmdOut(cmd)
 }
 
+// args builds an argument list for calling kubectl and consistently
+// adds the `--context` and `--namespace` flags.
 func (c *CLI) args(command string, arg ...string) []string {
 	args := []string{"--context", c.KubeContext}
 	if c.Namespace != "" {

--- a/pkg/skaffold/kubectl/cli_test.go
+++ b/pkg/skaffold/kubectl/cli_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestCLI(t *testing.T) {
+	tests := []struct {
+		name            string
+		kubecontext     string
+		namespace       string
+		output          string
+		expectedCommand string
+	}{
+		{
+			name:            "with context and namespace",
+			kubecontext:     "some-kubecontext",
+			namespace:       "some-namespace",
+			output:          "this is the expected output",
+			expectedCommand: "kubectl --context some-kubecontext --namespace some-namespace exec arg1 arg2",
+		},
+		{
+			name:            "only context, no namespace",
+			kubecontext:     "some-kubecontext",
+			output:          "this is the expected output",
+			expectedCommand: "kubectl --context some-kubecontext exec arg1 arg2",
+		},
+	}
+
+	// test cli.Run()
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			t.Override(&util.DefaultExecCommand, t.FakeRun(test.expectedCommand))
+			runCtx := &runcontext.RunContext{
+				Opts:        config.SkaffoldOptions{Namespace: test.namespace},
+				KubeContext: test.kubecontext,
+			}
+			cli := NewFromRunContext(runCtx)
+
+			t.CheckNoError(cli.Run(context.Background(), nil, nil, "exec", "arg1", "arg2"))
+		})
+	}
+
+	// test cli.RunOut()
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			t.Override(&util.DefaultExecCommand, t.FakeRunOut(test.expectedCommand, test.output))
+			runCtx := &runcontext.RunContext{
+				Opts:        config.SkaffoldOptions{Namespace: test.namespace},
+				KubeContext: test.kubecontext,
+			}
+			cli := NewFromRunContext(runCtx)
+
+			out, err := cli.RunOut(context.Background(), "exec", "arg1", "arg2")
+
+			t.CheckNoError(err)
+			t.CheckDeepEqual(string(out), test.output)
+		})
+	}
+}

--- a/pkg/skaffold/kubectl/version.go
+++ b/pkg/skaffold/kubectl/version.go
@@ -23,9 +23,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
-	"github.com/pkg/errors"
 )
 
 const unknown = "unknown"

--- a/pkg/skaffold/kubectl/version_test.go
+++ b/pkg/skaffold/kubectl/version_test.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pkg/errors"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 	"github.com/GoogleContainerTools/skaffold/testutil"
-	"github.com/pkg/errors"
 )
 
 func TestCheckVersion(t *testing.T) {

--- a/pkg/skaffold/kubernetes/portforward/entry_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/entry_manager.go
@@ -23,9 +23,11 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 )
 
 var (
@@ -150,12 +152,12 @@ type EntryManager struct {
 
 // NewEntryManager returns a new port forward entry manager to keep track
 // of forwarded ports and resources
-func NewEntryManager(out io.Writer) EntryManager {
+func NewEntryManager(out io.Writer, cli *kubectl.CLI) EntryManager {
 	return EntryManager{
 		output:             out,
 		forwardedPorts:     newForwardedPorts(),
 		forwardedResources: newForwardedResources(),
-		EntryForwarder:     &KubectlForwarder{},
+		EntryForwarder:     &KubectlForwarder{kubectl: cli},
 	}
 }
 

--- a/pkg/skaffold/kubernetes/portforward/entry_manager_test.go
+++ b/pkg/skaffold/kubernetes/portforward/entry_manager_test.go
@@ -22,18 +22,20 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
 func TestNewEntryManager(t *testing.T) {
 	out := ioutil.Discard
+	cli := &kubectl.CLI{}
 	expected := EntryManager{
 		output:             out,
 		forwardedPorts:     newForwardedPorts(),
 		forwardedResources: newForwardedResources(),
-		EntryForwarder:     &KubectlForwarder{},
+		EntryForwarder:     &KubectlForwarder{kubectl: cli},
 	}
-	actual := NewEntryManager(out)
+	actual := NewEntryManager(out, cli)
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("Expected result different from actual result. Expected: %v, Actual: %v", expected, actual)
 	}
@@ -57,7 +59,7 @@ func TestStop(t *testing.T) {
 		localPort: 9001,
 	}
 
-	em := NewEntryManager(ioutil.Discard)
+	em := NewEntryManager(ioutil.Discard, nil)
 
 	em.forwardedResources = newForwardedResources()
 	em.forwardedResources.Store("pod-resource-default-0", pfe1)

--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
@@ -44,12 +45,12 @@ var (
 )
 
 // NewForwarderManager returns a new port manager which handles starting and stopping port forwarding
-func NewForwarderManager(out io.Writer, podSelector kubernetes.PodSelector, namespaces []string, label string, opts config.PortForwardOptions, userDefined []*latest.PortForwardResource) *ForwarderManager {
+func NewForwarderManager(out io.Writer, cli *kubectl.CLI, podSelector kubernetes.PodSelector, namespaces []string, label string, opts config.PortForwardOptions, userDefined []*latest.PortForwardResource) *ForwarderManager {
 	if !opts.Enabled {
 		return emptyForwarderManager
 	}
 
-	em := NewEntryManager(out)
+	em := NewEntryManager(out, cli)
 
 	ForwarderManager := &ForwarderManager{
 		output:     out,

--- a/pkg/skaffold/kubernetes/portforward/pod_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/pod_forwarder_test.go
@@ -24,16 +24,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/testutil"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestAutomaticPortForwardPod(t *testing.T) {
@@ -515,7 +516,7 @@ func TestStartPodForwarder(t *testing.T) {
 			imageList := kubernetes.NewImageList()
 			imageList.Add("image")
 
-			p := NewWatchingPodForwarder(NewEntryManager(ioutil.Discard), imageList, nil)
+			p := NewWatchingPodForwarder(NewEntryManager(ioutil.Discard, nil), imageList, nil)
 			fakeForwarder := newTestForwarder(nil)
 			p.EntryForwarder = fakeForwarder
 			p.Start(context.Background())

--- a/pkg/skaffold/kubernetes/portforward/port_forward_integration.go
+++ b/pkg/skaffold/kubernetes/portforward/port_forward_integration.go
@@ -22,18 +22,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/sirupsen/logrus"
-
+	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
 // For WhiteBox testing only
 // This is testing a port forward + stop + restart in a simulated dev cycle
-func WhiteBoxPortForwardCycle(namespace string, t *testing.T) {
-	// todo
-	em := NewEntryManager(os.Stdout, nil)
+func WhiteBoxPortForwardCycle(t *testing.T, kubectlCLI *kubectlcli.CLI, namespace string) {
+	em := NewEntryManager(os.Stdout, kubectlCLI)
 	portForwardEventHandler := portForwardEvent
 	defer func() { portForwardEvent = portForwardEventHandler }()
 	portForwardEvent = func(entry *portForwardEntry) {}

--- a/pkg/skaffold/kubernetes/portforward/port_forward_integration.go
+++ b/pkg/skaffold/kubernetes/portforward/port_forward_integration.go
@@ -25,13 +25,13 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
 // For WhiteBox testing only
 // This is testing a port forward + stop + restart in a simulated dev cycle
-func WhiteBoxPortForwardCycle(t *testing.T, kubectlCLI *kubectlcli.CLI, namespace string) {
+func WhiteBoxPortForwardCycle(t *testing.T, kubectlCLI *kubectl.CLI, namespace string) {
 	em := NewEntryManager(os.Stdout, kubectlCLI)
 	portForwardEventHandler := portForwardEvent
 	defer func() { portForwardEvent = portForwardEventHandler }()

--- a/pkg/skaffold/kubernetes/portforward/port_forward_integration.go
+++ b/pkg/skaffold/kubernetes/portforward/port_forward_integration.go
@@ -32,7 +32,8 @@ import (
 // For WhiteBox testing only
 // This is testing a port forward + stop + restart in a simulated dev cycle
 func WhiteBoxPortForwardCycle(namespace string, t *testing.T) {
-	em := NewEntryManager(os.Stdout)
+	// todo
+	em := NewEntryManager(os.Stdout, nil)
 	portForwardEventHandler := portForwardEvent
 	defer func() { portForwardEvent = portForwardEventHandler }()
 	portForwardEvent = func(entry *portForwardEntry) {}

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -23,13 +23,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
-	"github.com/google/go-cmp/cmp"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type testForwarder struct {
@@ -119,7 +120,7 @@ func TestStart(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			event.InitializeState(latest.BuildConfig{})
 			fakeForwarder := newTestForwarder(nil)
-			rf := NewResourceForwarder(NewEntryManager(ioutil.Discard), "", nil)
+			rf := NewResourceForwarder(NewEntryManager(ioutil.Discard, nil), "", nil)
 			rf.EntryForwarder = fakeForwarder
 
 			t.Override(&retrieveAvailablePort, mockRetrieveAvailablePort(map[int]struct{}{}, test.availablePorts))
@@ -190,7 +191,7 @@ func TestGetCurrentEntryFunc(t *testing.T) {
 			expectedEntry := test.expected
 			expectedEntry.resource = test.resource
 
-			rf := NewResourceForwarder(NewEntryManager(ioutil.Discard), "", nil)
+			rf := NewResourceForwarder(NewEntryManager(ioutil.Discard, nil), "", nil)
 			rf.forwardedResources = forwardedResources{
 				resources: test.forwardedResources,
 				lock:      &sync.Mutex{},
@@ -233,7 +234,7 @@ func TestUserDefinedResources(t *testing.T) {
 	testutil.Run(t, "one service and one user defined pod", func(t *testutil.T) {
 		event.InitializeState(latest.BuildConfig{})
 		fakeForwarder := newTestForwarder(nil)
-		rf := NewResourceForwarder(NewEntryManager(ioutil.Discard), "", []*latest.PortForwardResource{pod})
+		rf := NewResourceForwarder(NewEntryManager(ioutil.Discard, nil), "", []*latest.PortForwardResource{pod})
 		rf.EntryForwarder = fakeForwarder
 
 		t.Override(&retrieveAvailablePort, mockRetrieveAvailablePort(map[int]struct{}{}, []int{8080, 9000}))

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
-	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/pkg/errors"
@@ -107,7 +107,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	r.createLogger(out, artifacts)
 	defer r.logger.Stop()
 
-	kubectlCLI := kubectlcli.NewFromRunContext(r.runCtx)
+	kubectlCLI := kubectl.NewFromRunContext(r.runCtx)
 	r.createForwarder(out, kubectlCLI)
 	defer r.forwarderManager.Stop()
 

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
+	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/pkg/errors"
@@ -106,7 +107,8 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	r.createLogger(out, artifacts)
 	defer r.logger.Stop()
 
-	r.createForwarder(out, r.kubectlCLI())
+	kubectlCLI := kubectlcli.NewFromRunContext(r.runCtx)
+	r.createForwarder(out, kubectlCLI)
 	defer r.forwarderManager.Stop()
 
 	// Watch artifacts

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -106,7 +106,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	r.createLogger(out, artifacts)
 	defer r.logger.Stop()
 
-	r.createForwarder(out)
+	r.createForwarder(out, r.kubectlCLI())
 	defer r.forwarderManager.Stop()
 
 	// Watch artifacts

--- a/pkg/skaffold/runner/kind.go
+++ b/pkg/skaffold/runner/kind.go
@@ -23,10 +23,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-	"github.com/pkg/errors"
 )
 
 // loadImagesInKindNodes loads a list of artifact images into every node of kind cluster.
@@ -47,7 +49,7 @@ func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Write
 		// Only `kind load` the images that are unknown to the node
 		if knownImages == nil {
 			var err error
-			if knownImages, err = findKnownImages(ctx); err != nil {
+			if knownImages, err = findKnownImages(ctx, r.kubectlCLI()); err != nil {
 				return errors.Wrapf(err, "unable to retrieve node's images")
 			}
 		}
@@ -69,9 +71,8 @@ func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Write
 	return nil
 }
 
-func findKnownImages(ctx context.Context) ([]string, error) {
-	cmdNodeGet := exec.CommandContext(ctx, "kubectl", "get", "nodes", `-ojsonpath='{@.items[*].status.images[*].names[*]}'`)
-	nodeGetOut, err := util.RunCmdOut(cmdNodeGet)
+func findKnownImages(ctx context.Context, cli *kubectl.CLI) ([]string, error) {
+	nodeGetOut, err := cli.RunOut(ctx, "get", "nodes", `-ojsonpath='{@.items[*].status.images[*].names[*]}'`)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to inspect the nodes")
 	}

--- a/pkg/skaffold/runner/kind.go
+++ b/pkg/skaffold/runner/kind.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -49,7 +49,8 @@ func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Write
 		// Only `kind load` the images that are unknown to the node
 		if knownImages == nil {
 			var err error
-			if knownImages, err = findKnownImages(ctx, r.kubectlCLI()); err != nil {
+			kubectlCLI := kubectlcli.NewFromRunContext(r.runCtx)
+			if knownImages, err = findKnownImages(ctx, kubectlCLI); err != nil {
 				return errors.Wrapf(err, "unable to retrieve node's images")
 			}
 		}
@@ -71,7 +72,7 @@ func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Write
 	return nil
 }
 
-func findKnownImages(ctx context.Context, cli *kubectl.CLI) ([]string, error) {
+func findKnownImages(ctx context.Context, cli *kubectlcli.CLI) ([]string, error) {
 	nodeGetOut, err := cli.RunOut(ctx, "get", "nodes", `-ojsonpath='{@.items[*].status.images[*].names[*]}'`)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to inspect the nodes")

--- a/pkg/skaffold/runner/kind.go
+++ b/pkg/skaffold/runner/kind.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
-	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -49,7 +49,7 @@ func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Write
 		// Only `kind load` the images that are unknown to the node
 		if knownImages == nil {
 			var err error
-			kubectlCLI := kubectlcli.NewFromRunContext(r.runCtx)
+			kubectlCLI := kubectl.NewFromRunContext(r.runCtx)
 			if knownImages, err = findKnownImages(ctx, kubectlCLI); err != nil {
 				return errors.Wrapf(err, "unable to retrieve node's images")
 			}
@@ -72,7 +72,7 @@ func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Write
 	return nil
 }
 
-func findKnownImages(ctx context.Context, cli *kubectlcli.CLI) ([]string, error) {
+func findKnownImages(ctx context.Context, cli *kubectl.CLI) ([]string, error) {
 	nodeGetOut, err := cli.RunOut(ctx, "get", "nodes", `-ojsonpath='{@.items[*].status.images[*].names[*]}'`)
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to inspect the nodes")

--- a/pkg/skaffold/runner/kind_test.go
+++ b/pkg/skaffold/runner/kind_test.go
@@ -21,10 +21,13 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/pkg/errors"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
-	"github.com/pkg/errors"
 )
 
 func TestLoadImagesInKindNodes(t *testing.T) {
@@ -41,7 +44,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			built:       []build.Artifact{{Tag: "tag1"}},
 			deployed:    []build.Artifact{{Tag: "tag1"}},
 			command: testutil.NewFakeCmd(t).
-				WithRunOut("kubectl get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				WithRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
 				WithRun("kind load docker-image tag1"),
 		},
 		{
@@ -49,7 +52,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			built:       []build.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			deployed:    []build.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			command: testutil.NewFakeCmd(t).
-				WithRunOut("kubectl get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "tag1").
+				WithRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "tag1").
 				WithRun("kind load docker-image tag2"),
 		},
 		{
@@ -57,7 +60,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			built:       []build.Artifact{{Tag: "tag"}},
 			deployed:    []build.Artifact{{Tag: "tag"}},
 			command: testutil.NewFakeCmd(t).
-				WithRunOutErr("kubectl get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "", errors.New("BUG")),
+				WithRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "", errors.New("BUG")),
 			shouldErr:     true,
 			expectedError: "unable to inspect",
 		},
@@ -66,7 +69,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			built:       []build.Artifact{{Tag: "tag"}},
 			deployed:    []build.Artifact{{Tag: "tag"}},
 			command: testutil.NewFakeCmd(t).
-				WithRunOut("kubectl get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				WithRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
 				WithRunErr("kind load docker-image tag", errors.New("BUG")),
 			shouldErr:     true,
 			expectedError: "unable to load",
@@ -76,7 +79,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			built:       []build.Artifact{{Tag: "built"}},
 			deployed:    []build.Artifact{{Tag: "built"}, {Tag: "busybox"}},
 			command: testutil.NewFakeCmd(t).
-				WithRunOut("kubectl get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				WithRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
 				WithRun("kind load docker-image built"),
 		},
 		{
@@ -98,6 +101,12 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 
 			r := &SkaffoldRunner{
 				builds: test.built,
+				runCtx: &runcontext.RunContext{
+					Opts: &config.SkaffoldOptions{
+						Namespace: "namespace",
+					},
+					KubeContext: "kubecontext",
+				},
 			}
 			err := r.loadImagesInKindNodes(context.Background(), ioutil.Discard, test.deployed)
 

--- a/pkg/skaffold/runner/kind_test.go
+++ b/pkg/skaffold/runner/kind_test.go
@@ -102,7 +102,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			r := &SkaffoldRunner{
 				builds: test.built,
 				runCtx: &runcontext.RunContext{
-					Opts: &config.SkaffoldOptions{
+					Opts: config.SkaffoldOptions{
 						Namespace: "namespace",
 					},
 					KubeContext: "kubecontext",

--- a/pkg/skaffold/runner/logger.go
+++ b/pkg/skaffold/runner/logger.go
@@ -32,5 +32,5 @@ func (r *SkaffoldRunner) createLogger(out io.Writer, artifacts []*latest.Artifac
 }
 
 func (r *SkaffoldRunner) newLoggerForImages(out io.Writer, images []string) *kubernetes.LogAggregator {
-	return kubernetes.NewLogAggregator(out, images, r.imageList, r.runCtx.Namespaces)
+	return kubernetes.NewLogAggregator(out, r.kubectlCLI(), images, r.imageList, r.runCtx.Namespaces)
 }

--- a/pkg/skaffold/runner/logger.go
+++ b/pkg/skaffold/runner/logger.go
@@ -19,6 +19,7 @@ package runner
 import (
 	"io"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
@@ -32,5 +33,6 @@ func (r *SkaffoldRunner) createLogger(out io.Writer, artifacts []*latest.Artifac
 }
 
 func (r *SkaffoldRunner) newLoggerForImages(out io.Writer, images []string) *kubernetes.LogAggregator {
-	return kubernetes.NewLogAggregator(out, r.kubectlCLI(), images, r.imageList, r.runCtx.Namespaces)
+	kubectlCLI := kubectl.NewFromRunContext(r.runCtx)
+	return kubernetes.NewLogAggregator(out, kubectlCLI, images, r.imageList, r.runCtx.Namespaces)
 }

--- a/pkg/skaffold/runner/portforwarder.go
+++ b/pkg/skaffold/runner/portforwarder.go
@@ -19,9 +19,10 @@ package runner
 import (
 	"io"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
 )
 
-func (r *SkaffoldRunner) createForwarder(out io.Writer) {
-	r.forwarderManager = portforward.NewForwarderManager(out, r.imageList, r.runCtx.Namespaces, r.defaultLabeller.K8sManagedByLabelKeyValueString(), r.runCtx.Opts.PortForward, r.portForwardResources)
+func (r *SkaffoldRunner) createForwarder(out io.Writer, kubectlCLI *kubectl.CLI) {
+	r.forwarderManager = portforward.NewForwarderManager(out, kubectlCLI, r.imageList, r.runCtx.Namespaces, r.defaultLabeller.K8sManagedByLabelKeyValueString(), r.runCtx.Opts.PortForward, r.portForwardResources)
 }

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -198,7 +198,7 @@ func (k *podSyncer) Sync(ctx context.Context, s *Item) error {
 	if len(s.Copy) > 0 {
 		logrus.Infoln("Copying files:", s.Copy, "to", s.Image)
 
-		if err := Perform(ctx, s.Image, s.Copy, copyFileFn, k.namespaces); err != nil {
+		if err := Perform(ctx, s.Image, s.Copy, k.copyFileFn, k.namespaces); err != nil {
 			return errors.Wrap(err, "copying files")
 		}
 	}
@@ -206,7 +206,7 @@ func (k *podSyncer) Sync(ctx context.Context, s *Item) error {
 	if len(s.Delete) > 0 {
 		logrus.Infoln("Deleting files:", s.Delete, "from", s.Image)
 
-		if err := Perform(ctx, s.Image, s.Delete, deleteFileFn, k.namespaces); err != nil {
+		if err := Perform(ctx, s.Image, s.Delete, k.deleteFileFn, k.namespaces); err != nil {
 			return errors.Wrap(err, "deleting files")
 		}
 	}

--- a/pkg/skaffold/sync/types.go
+++ b/pkg/skaffold/sync/types.go
@@ -19,6 +19,7 @@ package sync
 import (
 	"context"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 )
 
@@ -37,11 +38,13 @@ type Syncer interface {
 }
 
 type podSyncer struct {
+	kubectl    *kubectl.CLI
 	namespaces []string
 }
 
-func NewSyncer(runCtx *runcontext.RunContext) Syncer {
+func NewSyncer(cli *kubectl.CLI, runCtx *runcontext.RunContext) Syncer {
 	return &podSyncer{
+		kubectl:    cli,
 		namespaces: runCtx.Namespaces,
 	}
 }

--- a/pkg/skaffold/sync/types.go
+++ b/pkg/skaffold/sync/types.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	kubectlcli "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 )
 
@@ -42,9 +43,9 @@ type podSyncer struct {
 	namespaces []string
 }
 
-func NewSyncer(cli *kubectl.CLI, runCtx *runcontext.RunContext) Syncer {
+func NewSyncer(runCtx *runcontext.RunContext) Syncer {
 	return &podSyncer{
-		kubectl:    cli,
+		kubectl:    kubectlcli.NewFromRunContext(runCtx),
 		namespaces: runCtx.Namespaces,
 	}
 }


### PR DESCRIPTION
There are a few places where Skaffold shells out to `kubectl`, for example port forwarding, log streaming, file sync, or kaniko cluster builds. All of these places were directly shelling out to `kubectl`, making it difficult to consistently use a different kube-context.

This PR adds a `kubectl.CLI` util for consistent `kubectl` usage in Skaffold. This ensures that kubecontext and namespace are consistently set to the expected values when shelling out to `kubectl`.

This is a pre-requisite for #2447 .