### PR TITLE
Add a quicktest Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,10 @@ cross: $(foreach platform, $(SUPPORTED_PLATFORMS), $(BUILD_DIR)/$(PROJECT)-$(pla
 test: $(BUILD_DIR)
 	@ ./hack/test.sh
 
+.PHONY: quicktest
+quicktest:
+	go test -short -timeout=60s ./...
+
 .PHONY: install
 install: $(GO_FILES) $(BUILD_DIR)
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go install -tags $(GO_BUILD_TAGS_$(GOOS)) -ldflags $(GO_LDFLAGS_$(GOOS)) -gcflags $(GO_GCFLAGS) -asmflags $(GO_ASMFLAGS) $(BUILD_PACKAGE)


### PR DESCRIPTION
Useful to quickly run the unit tests without coverage,
without the race detector and with the test cache.

Signed-off-by: David Gageot <david@gageot.net>