### PR TITLE
Monitor kubectl logs when port forwarding and retry on error

### DIFF
--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -35,6 +36,7 @@ import (
 type EntryForwarder interface {
 	Forward(parentCtx context.Context, pfe *portForwardEntry) error
 	Terminate(p *portForwardEntry)
+	Monitor(*portForwardEntry, func())
 }
 
 type KubectlForwarder struct{}
@@ -42,8 +44,6 @@ type KubectlForwarder struct{}
 // Forward port-forwards a pod using kubectl port-forward
 // It returns an error only if the process fails or was terminated by a signal other than SIGTERM
 func (*KubectlForwarder) Forward(parentCtx context.Context, pfe *portForwardEntry) error {
-	logrus.Debugf("Port forwarding %v", pfe)
-
 	ctx, cancel := context.WithCancel(parentCtx)
 	// when retrying a portforwarding entry, it might already have a context running
 	if pfe.cancel != nil {
@@ -51,23 +51,23 @@ func (*KubectlForwarder) Forward(parentCtx context.Context, pfe *portForwardEntr
 	}
 	pfe.cancel = cancel
 
-	cmd := exec.CommandContext(ctx, "kubectl", "port-forward", fmt.Sprintf("%s/%s", pfe.resource.Type, pfe.resource.Name), fmt.Sprintf("%d:%d", pfe.localPort, pfe.resource.Port), "--namespace", pfe.resource.Namespace)
-	buf := &bytes.Buffer{}
-	cmd.Stdout = buf
-	cmd.Stderr = buf
+	cmd := exec.CommandContext(ctx, "kubectl", "port-forward", "--pod-running-timeout", "5s", fmt.Sprintf("%s/%s", pfe.resource.Type, pfe.resource.Name), fmt.Sprintf("%d:%d", pfe.localPort, pfe.resource.Port), "--namespace", pfe.resource.Namespace)
+	pfe.logBuffer = &bytes.Buffer{}
+	cmd.Stdout = pfe.logBuffer
+	cmd.Stderr = pfe.logBuffer
 
 	if err := cmd.Start(); err != nil {
 		if errors.Cause(err) == context.Canceled {
 			return nil
 		}
-		return errors.Wrapf(err, "port forwarding %s/%s, port: %d to local port: %d, err: %s", pfe.resource.Type, pfe.resource.Name, pfe.resource.Port, pfe.localPort, buf.String())
+		return errors.Wrapf(err, "port forwarding %s/%s, port: %d to local port: %d, err: %s", pfe.resource.Type, pfe.resource.Name, pfe.resource.Port, pfe.localPort, pfe.logBuffer.String())
 	}
 
 	resultChan := make(chan error, 1)
 	go func() {
 		err := cmd.Wait()
 		if err != nil {
-			logrus.Debugf("port forwarding %v terminated: %s, output: %s", pfe, err, buf.String())
+			logrus.Debugf("port forwarding %v terminated: %s, output: %s", pfe, err, pfe.logBuffer.String())
 			resultChan <- err
 		}
 	}()
@@ -94,5 +94,24 @@ func (*KubectlForwarder) Terminate(p *portForwardEntry) {
 
 	if p.cancel != nil {
 		p.cancel()
+	}
+}
+
+// Monitor monitors the logs for a kubectl port forward command
+// If it sees an error, it calls back to the EntryManager to
+// retry the entire port forward operation.
+func (*KubectlForwarder) Monitor(p *portForwardEntry, retryFunc func()) {
+	for {
+		time.Sleep(1 * time.Second)
+		s, _ := p.logBuffer.ReadString(byte('\n'))
+		if s != "" {
+			logrus.Tracef("[port-forward] %s", s)
+			if strings.Contains(s, "error forwarding port") {
+				// kubectl is having an error. retry the command
+				logrus.Infof("retrying kubectl port-forward due to error: %s", s)
+				go retryFunc()
+				return
+			}
+		}
 	}
 }

--- a/pkg/skaffold/kubernetes/portforward/port_forward_entry.go
+++ b/pkg/skaffold/kubernetes/portforward/port_forward_entry.go
@@ -17,6 +17,7 @@ limitations under the License.
 package portforward
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 
@@ -31,6 +32,8 @@ type portForwardEntry struct {
 	portName               string
 	localPort              int
 	automaticPodForwarding bool
+
+	logBuffer *bytes.Buffer
 
 	cancel context.CancelFunc
 }

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -45,6 +45,8 @@ func (f *testForwarder) Forward(ctx context.Context, pfe *portForwardEntry) erro
 	return f.forwardErr
 }
 
+func (f *testForwarder) Monitor(_ *portForwardEntry, _ func()) {}
+
 func (f *testForwarder) Terminate(pfe *portForwardEntry) {
 	f.forwardedResources.Delete(pfe.key())
 	f.forwardedPorts.Delete(pfe.resource.Port)


### PR DESCRIPTION
When `kubectl port-forward` encounters an error (most commonly from the container backing a resource being restarted), an error is logged to stderr, but the process does not actually return with an exit code, or notify the caller in any way than an error occurred. During port forwarding, skaffold verifies that a port is correctly forwarded by attempting to attach to the specified port and ensuring that a listening connection cannot be established, but since kubectl hangs onto the port and continues to run successfully when an error is actually encountered, this check succeeds erroneously.

To handle this, the only indication we have from kubectl that something has gone wrong is from its logs to stderr, so we attach to these logs and search the stream for `"error forwarding port"`. A `Monitor()` call is kicked off in a separate goroutine for each forwarded port, and on seeing this error string in the logs for the associated `kubectl port-forward` process, it will issue a callback to the `EntryManager` to restart the port forwarding operation entirely.

~Additionally, kubectl itself will not actually log this error until the first failed connection to the forwarded port, so in the `Monitor()` call we issue a ping to the port once per second, to tease out any errors that kubectl might encounter. This is very suboptimal, but the implementation (and shortcomings) of `kubectl port-forward` give us very little to work with here.~

update: I removed the ping from the monitor, since this could be really spammy for services where connection logs actually matter (e.g. nginx). after a redeploy, the first attempted connection to a forwarded service will fail, but skaffold will see this and trigger a reconnection. again, not great UX, but this is ultimately a workaround for a bug in kubectl.

Fixes #2523 