### PR TITLE
Add CLI flag `--config` for configuring the global config location

### DIFF
--- a/cmd/skaffold/app/cmd/config/config_test.go
+++ b/cmd/skaffold/app/cmd/config/config_test.go
@@ -19,16 +19,17 @@ package config
 import (
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	yaml "gopkg.in/yaml.v2"
 )
 
-var baseConfig = &Config{
-	Global: &ContextConfig{
+var baseConfig = &config.GlobalConfig{
+	Global: &config.ContextConfig{
 		DefaultRepo: "test-repository",
 	},
-	ContextConfigs: []*ContextConfig{
+	ContextConfigs: []*config.ContextConfig{
 		{
 			Kubecontext: "test-context",
 			DefaultRepo: "context-local-repository",
@@ -36,13 +37,13 @@ var baseConfig = &Config{
 	},
 }
 
-var emptyConfig = &Config{}
+var emptyConfig = &config.GlobalConfig{}
 
 func TestReadConfig(t *testing.T) {
 	tests := []struct {
 		description string
 		filename    string
-		expectedCfg *Config
+		expectedCfg *config.GlobalConfig
 		shouldErr   bool
 	}{
 		{
@@ -78,8 +79,8 @@ func TestSetAndUnsetConfig(t *testing.T) {
 	dummyContext := "dummy_context"
 
 	tests := []struct {
-		expectedSetCfg   *Config
-		expectedUnsetCfg *Config
+		expectedSetCfg   *config.GlobalConfig
+		expectedUnsetCfg *config.GlobalConfig
 		description      string
 		key              string
 		value            string
@@ -92,16 +93,16 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			key:         "default-repo",
 			value:       "value",
 			kubecontext: "this_is_a_context",
-			expectedSetCfg: &Config{
-				ContextConfigs: []*ContextConfig{
+			expectedSetCfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
 					{
 						Kubecontext: "this_is_a_context",
 						DefaultRepo: "value",
 					},
 				},
 			},
-			expectedUnsetCfg: &Config{
-				ContextConfigs: []*ContextConfig{
+			expectedUnsetCfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
 					{
 						Kubecontext: "this_is_a_context",
 					},
@@ -113,16 +114,16 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			key:         "local-cluster",
 			value:       "false",
 			kubecontext: "this_is_a_context",
-			expectedSetCfg: &Config{
-				ContextConfigs: []*ContextConfig{
+			expectedSetCfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
 					{
 						Kubecontext:  "this_is_a_context",
 						LocalCluster: util.BoolPtr(false),
 					},
 				},
 			},
-			expectedUnsetCfg: &Config{
-				ContextConfigs: []*ContextConfig{
+			expectedUnsetCfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
 					{
 						Kubecontext: "this_is_a_context",
 					},
@@ -134,8 +135,8 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			key:         "local-cluster",
 			shouldErr:   true,
 			value:       "not-a-bool",
-			expectedSetCfg: &Config{
-				ContextConfigs: []*ContextConfig{
+			expectedSetCfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
 					{
 						Kubecontext: dummyContext,
 					},
@@ -146,8 +147,8 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			description: "set fake value",
 			key:         "not_a_real_value",
 			shouldErr:   true,
-			expectedSetCfg: &Config{
-				ContextConfigs: []*ContextConfig{
+			expectedSetCfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
 					{
 						Kubecontext: dummyContext,
 					},
@@ -159,15 +160,15 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			key:         "default-repo",
 			value:       "global",
 			global:      true,
-			expectedSetCfg: &Config{
-				Global: &ContextConfig{
+			expectedSetCfg: &config.GlobalConfig{
+				Global: &config.ContextConfig{
 					DefaultRepo: "global",
 				},
-				ContextConfigs: []*ContextConfig{},
+				ContextConfigs: []*config.ContextConfig{},
 			},
-			expectedUnsetCfg: &Config{
-				Global:         &ContextConfig{},
-				ContextConfigs: []*ContextConfig{},
+			expectedUnsetCfg: &config.GlobalConfig{
+				Global:         &config.ContextConfig{},
+				ContextConfigs: []*config.ContextConfig{},
 			},
 		},
 		{
@@ -175,15 +176,15 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			key:         "local-cluster",
 			value:       "true",
 			global:      true,
-			expectedSetCfg: &Config{
-				Global: &ContextConfig{
+			expectedSetCfg: &config.GlobalConfig{
+				Global: &config.ContextConfig{
 					LocalCluster: util.BoolPtr(true),
 				},
-				ContextConfigs: []*ContextConfig{},
+				ContextConfigs: []*config.ContextConfig{},
 			},
-			expectedUnsetCfg: &Config{
-				Global:         &ContextConfig{},
-				ContextConfigs: []*ContextConfig{},
+			expectedUnsetCfg: &config.GlobalConfig{
+				Global:         &config.ContextConfig{},
+				ContextConfigs: []*config.ContextConfig{},
 			},
 		},
 		{
@@ -191,16 +192,16 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			key:         "insecure-registries",
 			value:       "my.insecure.registry",
 			kubecontext: "this_is_a_context",
-			expectedSetCfg: &Config{
-				ContextConfigs: []*ContextConfig{
+			expectedSetCfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
 					{
 						Kubecontext:        "this_is_a_context",
 						InsecureRegistries: []string{"my.insecure.registry"},
 					},
 				},
 			},
-			expectedUnsetCfg: &Config{
-				ContextConfigs: []*ContextConfig{
+			expectedUnsetCfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
 					{
 						Kubecontext: "this_is_a_context",
 					},

--- a/cmd/skaffold/app/cmd/config/config_test.go
+++ b/cmd/skaffold/app/cmd/config/config_test.go
@@ -39,42 +39,6 @@ var baseConfig = &config.GlobalConfig{
 
 var emptyConfig = &config.GlobalConfig{}
 
-func TestReadConfig(t *testing.T) {
-	tests := []struct {
-		description string
-		filename    string
-		expectedCfg *config.GlobalConfig
-		shouldErr   bool
-	}{
-		{
-			description: "valid config",
-			filename:    "config",
-			expectedCfg: baseConfig,
-			shouldErr:   false,
-		},
-		{
-			description: "missing config",
-			filename:    "",
-			shouldErr:   true,
-		},
-	}
-	for _, test := range tests {
-		testutil.Run(t, test.description, func(t *testutil.T) {
-			tmpDir := t.NewTempDir().
-				Chdir()
-
-			if test.filename != "" {
-				c, _ := yaml.Marshal(*baseConfig)
-				tmpDir.Write(test.filename, string(c))
-			}
-
-			cfg, err := ReadConfigForFile(test.filename)
-
-			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedCfg, cfg)
-		})
-	}
-}
-
 func TestSetAndUnsetConfig(t *testing.T) {
 	dummyContext := "dummy_context"
 
@@ -226,7 +190,7 @@ func TestSetAndUnsetConfig(t *testing.T) {
 
 			// set specified value
 			err := setConfigValue(test.key, test.value)
-			actualConfig, cfgErr := readConfig()
+			actualConfig, cfgErr := config.ReadConfigForFile(cfg)
 			t.CheckNoError(cfgErr)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedSetCfg, actualConfig)
 
@@ -237,7 +201,7 @@ func TestSetAndUnsetConfig(t *testing.T) {
 
 			// unset the value
 			err = unsetConfigValue(test.key)
-			newConfig, cfgErr := readConfig()
+			newConfig, cfgErr := config.ReadConfigForFile(cfg)
 			t.CheckNoError(cfgErr)
 
 			t.CheckNoError(err)

--- a/cmd/skaffold/app/cmd/config/list.go
+++ b/cmd/skaffold/app/cmd/config/list.go
@@ -22,12 +22,14 @@ import (
 
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 )
 
 func List(out io.Writer) error {
 	var configYaml []byte
 	if showAll {
-		cfg, err := readConfig()
+		cfg, err := config.ReadConfigFile(configFile)
 		if err != nil {
 			return err
 		}
@@ -39,14 +41,14 @@ func List(out io.Writer) error {
 			return errors.Wrap(err, "marshaling config")
 		}
 	} else {
-		config, err := GetConfigForKubectx()
+		contextConfig, err := getConfigForKubectx()
 		if err != nil {
 			return err
 		}
-		if config == nil { // empty config
+		if contextConfig == nil { // empty config
 			return nil
 		}
-		configYaml, err = yaml.Marshal(&config)
+		configYaml, err = yaml.Marshal(&contextConfig)
 		if err != nil {
 			return errors.Wrap(err, "marshaling config")
 		}

--- a/cmd/skaffold/app/cmd/config/list_test.go
+++ b/cmd/skaffold/app/cmd/config/list_test.go
@@ -1,13 +1,31 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import (
 	"bytes"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
-	"gopkg.in/yaml.v2"
-	"strings"
-	"testing"
 )
 
 func TestList(t *testing.T) {

--- a/cmd/skaffold/app/cmd/config/list_test.go
+++ b/cmd/skaffold/app/cmd/config/list_test.go
@@ -1,0 +1,159 @@
+package config
+
+import (
+	"bytes"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+	"gopkg.in/yaml.v2"
+	"strings"
+	"testing"
+)
+
+func TestList(t *testing.T) {
+	const dummyContext = "dummy-context"
+
+	tests := []struct {
+		cfg            *config.GlobalConfig
+		name           string
+		kubecontext    string
+		global         bool
+		showAll        bool
+		expectedOutput string
+	}{
+		{
+			name:        "print configs of a single kube-context",
+			kubecontext: "this_is_a_context",
+			cfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
+					{
+						Kubecontext:        "another_context",
+						DefaultRepo:        "other-value",
+						LocalCluster:       util.BoolPtr(false),
+						InsecureRegistries: []string{"good.io", "better.io"},
+					},
+					{
+						Kubecontext:        "this_is_a_context",
+						DefaultRepo:        "value",
+						LocalCluster:       util.BoolPtr(true),
+						InsecureRegistries: []string{"bad.io", "worse.io"},
+					},
+				},
+			},
+			expectedOutput: `kube-context: this_is_a_context
+default-repo: value
+local-cluster: true
+insecure-registries:
+- bad.io
+- worse.io
+`,
+		},
+		{
+			name:   "print global configs",
+			global: true,
+			cfg: &config.GlobalConfig{
+				Global: &config.ContextConfig{
+					DefaultRepo:        "default-repo-value",
+					LocalCluster:       util.BoolPtr(true),
+					InsecureRegistries: []string{"mediocre.io"},
+				},
+				ContextConfigs: []*config.ContextConfig{
+					{
+						Kubecontext: "this_is_a_context",
+						DefaultRepo: "value",
+					},
+				},
+			},
+			expectedOutput: `default-repo: default-repo-value
+local-cluster: true
+insecure-registries:
+- mediocre.io
+`,
+		},
+		{
+			name:    "show all",
+			showAll: true,
+			cfg: &config.GlobalConfig{
+				Global: &config.ContextConfig{
+					DefaultRepo:        "default-repo-value",
+					LocalCluster:       util.BoolPtr(true),
+					InsecureRegistries: []string{"mediocre.io"},
+				},
+				ContextConfigs: []*config.ContextConfig{
+					{
+						Kubecontext: "this_is_a_context",
+						DefaultRepo: "value",
+					},
+				},
+			},
+			expectedOutput: `
+global:
+  default-repo: default-repo-value
+  local-cluster: true
+  insecure-registries:
+  - mediocre.io
+kubeContexts:
+- kube-context: this_is_a_context
+  default-repo: value
+`,
+		},
+		{
+			name:        "config has no values for kubecontext",
+			kubecontext: "context-without-config",
+			cfg: &config.GlobalConfig{
+				Global: &config.ContextConfig{
+					DefaultRepo:        "default-repo-value",
+					LocalCluster:       util.BoolPtr(true),
+					InsecureRegistries: []string{"mediocre.io"},
+				},
+			},
+		},
+		{
+			name:        "config has no values for global",
+			kubecontext: "context-without-config",
+			cfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
+					{
+						Kubecontext: "this_is_a_context",
+						DefaultRepo: "value",
+					},
+				},
+			},
+		},
+		{
+			name:        "show all with empty config",
+			showAll:     true,
+			kubecontext: "context-without-config",
+			cfg:         &config.GlobalConfig{},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			// create new config file
+			content, _ := yaml.Marshal(*test.cfg)
+			cfg := t.TempFile("config", content)
+
+			t.Override(&config.ReadConfigFile, config.ReadConfigFileNoCache)
+			t.Override(&configFile, cfg)
+			t.Override(&global, test.global)
+			t.Override(&showAll, test.showAll)
+			if test.kubecontext != "" {
+				t.Override(&kubecontext, test.kubecontext)
+			} else {
+				t.Override(&kubecontext, dummyContext)
+			}
+
+			buf := &bytes.Buffer{}
+			// list values
+			err := List(buf)
+			t.CheckNoError(err)
+
+			if test.expectedOutput != "" && !strings.HasSuffix(buf.String(), test.expectedOutput) {
+				t.Errorf("expecting output to contain\n\n%s\nbut found\n\n%s\ninstead", test.expectedOutput, buf.String())
+			}
+			if test.expectedOutput == "" && buf.String() != "" {
+				t.Errorf("expecting no output but found\n\n%s", buf.String())
+			}
+		})
+	}
+}

--- a/cmd/skaffold/app/cmd/config/set.go
+++ b/cmd/skaffold/app/cmd/config/set.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 )
 
 func Set(out io.Writer, args []string) error {
@@ -58,7 +60,7 @@ func setConfigValue(name string, value string) error {
 	return writeConfig(cfg)
 }
 
-func getFieldName(cfg *ContextConfig, name string) string {
+func getFieldName(cfg *config.ContextConfig, name string) string {
 	cfgValue := reflect.Indirect(reflect.ValueOf(cfg))
 	var fieldName string
 	for i := 0; i < cfgValue.NumField(); i++ {
@@ -96,7 +98,7 @@ func parseAsType(value string, field reflect.Value) (reflect.Value, error) {
 	}
 }
 
-func writeConfig(cfg *ContextConfig) error {
+func writeConfig(cfg *config.ContextConfig) error {
 	fullConfig, err := readConfig()
 	if err != nil {
 		return err
@@ -113,7 +115,7 @@ func writeConfig(cfg *ContextConfig) error {
 	return writeFullConfig(fullConfig)
 }
 
-func writeFullConfig(cfg *Config) error {
+func writeFullConfig(cfg *config.GlobalConfig) error {
 	contents, err := yaml.Marshal(cfg)
 	if err != nil {
 		return errors.Wrap(err, "marshaling config")

--- a/cmd/skaffold/app/cmd/config/unset.go
+++ b/cmd/skaffold/app/cmd/config/unset.go
@@ -22,7 +22,6 @@ import (
 )
 
 func Unset(out io.Writer, args []string) error {
-	resolveKubectlContext()
 	if err := unsetConfigValue(args[0]); err != nil {
 		return err
 	}

--- a/cmd/skaffold/app/cmd/config/util.go
+++ b/cmd/skaffold/app/cmd/config/util.go
@@ -18,9 +18,11 @@ package config
 
 import (
 	"fmt"
+
+	"github.com/sirupsen/logrus"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
-	"github.com/sirupsen/logrus"
 )
 
 func resolveKubectlContext() {
@@ -60,7 +62,7 @@ func getConfigForKubectxOrDefault() (*config.ContextConfig, error) {
 func getConfigForKubectx() (*config.ContextConfig, error) {
 	resolveKubectlContext()
 
-	if kubecontext == "" && global == false {
+	if kubecontext == "" && !global {
 		return nil, fmt.Errorf("missing `--kube-context` or `--global`")
 	}
 

--- a/cmd/skaffold/app/cmd/config/util.go
+++ b/cmd/skaffold/app/cmd/config/util.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -64,20 +65,20 @@ func resolveConfigFile() error {
 }
 
 // ReadConfigForFile reads the specified file and returns the contents
-// parsed into a Config struct.
-func ReadConfigForFile(filename string) (*Config, error) {
+// parsed into a GlobalConfig struct.
+func ReadConfigForFile(filename string) (*config.GlobalConfig, error) {
 	contents, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading global config")
 	}
-	config := Config{}
+	config := config.GlobalConfig{}
 	if err := yaml.Unmarshal(contents, &config); err != nil {
 		return nil, errors.Wrap(err, "unmarshalling global skaffold config")
 	}
 	return &config, nil
 }
 
-func readConfig() (*Config, error) {
+func readConfig() (*config.GlobalConfig, error) {
 	if err := resolveConfigFile(); err != nil {
 		return nil, errors.Wrap(err, "resolving config file location")
 	}
@@ -88,7 +89,7 @@ func readConfig() (*Config, error) {
 // provided kube context.
 // Either returns the config corresponding to the provided or current context,
 // or the global config if that is specified (or if no current context is set).
-func GetConfigForKubectx() (*ContextConfig, error) {
+func GetConfigForKubectx() (*config.ContextConfig, error) {
 	resolveKubectlContext()
 	cfg, err := readConfig()
 	if err != nil {
@@ -107,7 +108,7 @@ func GetConfigForKubectx() (*ContextConfig, error) {
 }
 
 // GetGlobalConfig returns the global config values
-func GetGlobalConfig() (*ContextConfig, error) {
+func GetGlobalConfig() (*config.ContextConfig, error) {
 	cfg, err := readConfig()
 	if err != nil {
 		return nil, err
@@ -115,7 +116,7 @@ func GetGlobalConfig() (*ContextConfig, error) {
 	return cfg.Global, nil
 }
 
-func getOrCreateConfigForKubectx() (*ContextConfig, error) {
+func getOrCreateConfigForKubectx() (*config.ContextConfig, error) {
 	resolveKubectlContext()
 	cfg, err := readConfig()
 	if err != nil {
@@ -123,7 +124,7 @@ func getOrCreateConfigForKubectx() (*ContextConfig, error) {
 	}
 	if global {
 		if cfg.Global == nil {
-			newCfg := &ContextConfig{}
+			newCfg := &config.ContextConfig{}
 			cfg.Global = newCfg
 			if err := writeFullConfig(cfg); err != nil {
 				return nil, err
@@ -136,7 +137,7 @@ func getOrCreateConfigForKubectx() (*ContextConfig, error) {
 			return contextCfg, nil
 		}
 	}
-	newCfg := &ContextConfig{
+	newCfg := &config.ContextConfig{
 		Kubecontext: kubecontext,
 	}
 	cfg.ContextConfigs = append(cfg.ContextConfigs, newCfg)

--- a/cmd/skaffold/app/cmd/config/util.go
+++ b/cmd/skaffold/app/cmd/config/util.go
@@ -17,23 +17,10 @@ limitations under the License.
 package config
 
 import (
-	"io/ioutil"
-	"path/filepath"
-	"strings"
-
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 
-	homedir "github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v2"
 )
-
-const defaultConfigDir = ".skaffold"
-const defaultConfigFile = "config"
 
 func resolveKubectlContext() {
 	if kubecontext != "" {
@@ -53,70 +40,7 @@ func resolveKubectlContext() {
 	}
 }
 
-func resolveConfigFile() error {
-	if configFile == "" {
-		home, err := homedir.Dir()
-		if err != nil {
-			return errors.Wrap(err, "retrieving home directory")
-		}
-		configFile = filepath.Join(home, defaultConfigDir, defaultConfigFile)
-	}
-	return util.VerifyOrCreateFile(configFile)
-}
-
-// ReadConfigForFile reads the specified file and returns the contents
-// parsed into a GlobalConfig struct.
-func ReadConfigForFile(filename string) (*config.GlobalConfig, error) {
-	contents, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return nil, errors.Wrap(err, "reading global config")
-	}
-	config := config.GlobalConfig{}
-	if err := yaml.Unmarshal(contents, &config); err != nil {
-		return nil, errors.Wrap(err, "unmarshalling global skaffold config")
-	}
-	return &config, nil
-}
-
-func readConfig() (*config.GlobalConfig, error) {
-	if err := resolveConfigFile(); err != nil {
-		return nil, errors.Wrap(err, "resolving config file location")
-	}
-	return ReadConfigForFile(configFile)
-}
-
-// GetConfigForKubectx returns the specific config to be modified based on the
-// provided kube context.
-// Either returns the config corresponding to the provided or current context,
-// or the global config if that is specified (or if no current context is set).
-func GetConfigForKubectx() (*config.ContextConfig, error) {
-	resolveKubectlContext()
-	cfg, err := readConfig()
-	if err != nil {
-		return nil, err
-	}
-	if global {
-		return cfg.Global, nil
-	}
-	for _, contextCfg := range cfg.ContextConfigs {
-		if contextCfg.Kubecontext == kubecontext {
-			return contextCfg, nil
-		}
-	}
-	logrus.Infof("no config entry found for kube-context %s", kubecontext)
-	return nil, nil
-}
-
-// GetGlobalConfig returns the global config values
-func GetGlobalConfig() (*config.ContextConfig, error) {
-	cfg, err := readConfig()
-	if err != nil {
-		return nil, err
-	}
-	return cfg.Global, nil
-}
-
-func getOrCreateConfigForKubectx() (*config.ContextConfig, error) {
+func getOrCreateConfigForKubectx() (*ContextConfig, error) {
 	resolveKubectlContext()
 	cfg, err := readConfig()
 	if err != nil {
@@ -124,7 +48,7 @@ func getOrCreateConfigForKubectx() (*config.ContextConfig, error) {
 	}
 	if global {
 		if cfg.Global == nil {
-			newCfg := &config.ContextConfig{}
+			newCfg := &ContextConfig{}
 			cfg.Global = newCfg
 			if err := writeFullConfig(cfg); err != nil {
 				return nil, err
@@ -137,7 +61,7 @@ func getOrCreateConfigForKubectx() (*config.ContextConfig, error) {
 			return contextCfg, nil
 		}
 	}
-	newCfg := &config.ContextConfig{
+	newCfg := &ContextConfig{
 		Kubecontext: kubecontext,
 	}
 	cfg.ContextConfigs = append(cfg.ContextConfigs, newCfg)
@@ -147,93 +71,4 @@ func getOrCreateConfigForKubectx() (*config.ContextConfig, error) {
 	}
 
 	return newCfg, nil
-}
-
-func GetDefaultRepo(cliValue string) (string, error) {
-	// CLI flag takes precedence. If no default-repo specified from a flag,
-	// retrieve the value from the global config.
-	if cliValue != "" {
-		return cliValue, nil
-	}
-	cfg, err := GetConfigForKubectx()
-	if err != nil {
-		return "", errors.Wrap(err, "retrieving global config")
-	}
-	var defaultRepo string
-	if cfg != nil {
-		defaultRepo = cfg.DefaultRepo
-	}
-	if defaultRepo == "" {
-		// if we don't have a defaultRepo value set for the current context,
-		// retrieve the global config and use this value as a fallback
-		cfg, err := GetGlobalConfig()
-		if err != nil {
-			return "", errors.Wrap(err, "retrieving global config")
-		}
-		if cfg != nil {
-			defaultRepo = cfg.DefaultRepo
-		}
-	}
-	return defaultRepo, nil
-}
-
-func GetLocalCluster() (bool, error) {
-	cfg, err := GetConfigForKubectx()
-	localCluster := isDefaultLocal(kubecontext)
-	if err != nil {
-		return localCluster, errors.Wrap(err, "retrieving global config")
-	}
-
-	if cfg != nil {
-		if cfg.LocalCluster != nil {
-			localCluster = *cfg.LocalCluster
-		}
-	} else {
-		// if no value is set for this cluster, fall back to the global setting
-		globalCfg, err := GetGlobalConfig()
-		if err != nil {
-			return localCluster, errors.Wrap(err, "retrieving global config")
-		}
-		if globalCfg != nil && globalCfg.LocalCluster != nil {
-			localCluster = *globalCfg.LocalCluster
-		}
-	}
-
-	return localCluster, nil
-}
-
-func GetInsecureRegistries() ([]string, error) {
-	cfg, err := GetConfigForKubectx()
-	registries := []string{}
-	if err != nil {
-		return registries, errors.Wrap(err, "retrieving global config")
-	}
-
-	if cfg != nil {
-		if cfg.InsecureRegistries != nil {
-			registries = cfg.InsecureRegistries
-		}
-	} else {
-		// if no value is set for this cluster, fall back to the global setting
-		globalCfg, err := GetGlobalConfig()
-		if err != nil {
-			return registries, errors.Wrap(err, "retrieving global config")
-		}
-		if globalCfg != nil && globalCfg.InsecureRegistries != nil {
-			registries = globalCfg.InsecureRegistries
-		}
-	}
-
-	return registries, nil
-}
-
-func isDefaultLocal(kubeContext string) bool {
-	return kubeContext == constants.DefaultMinikubeContext ||
-		kubeContext == constants.DefaultDockerForDesktopContext ||
-		kubeContext == constants.DefaultDockerDesktopContext ||
-		IsKindCluster(kubeContext)
-}
-
-func IsKindCluster(kubeContext string) bool {
-	return strings.HasSuffix(kubeContext, "@kind")
 }

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -229,6 +229,15 @@ var FlagRegistry = []Flag{
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "debug", "deploy", "run"},
 	},
+	{
+		Name:          "config",
+		Shorthand:     "c",
+		Usage:         "File for global configurations (defaults to $HOME/.skaffold/config)",
+		Value:         &opts.GlobalConfig,
+		DefValue:      "",
+		FlagAddMethod: "StringVar",
+		DefinedOn:     []string{"run", "dev", "debug", "build", "deploy", "delete", "diagnose"},
+	},
 }
 
 var commandFlags []*pflag.Flag

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
@@ -31,8 +34,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/validation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // For tests

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -118,6 +118,7 @@ Options:
   -b, --build-image=[]: Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts
       --cache-artifacts=true: Set to true to enable caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
+  -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
       --file-output='': Filename to write build images to
@@ -144,6 +145,7 @@ Env vars:
 * `SKAFFOLD_BUILD_IMAGE` (same as `--build-image`)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
+* `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILE_OUTPUT` (same as `--file-output`)
@@ -286,6 +288,7 @@ Options:
       --cache-artifacts=true: Set to true to enable caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
       --cleanup=true: Delete deployments after dev or debug mode is interrupted
+  -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
@@ -315,6 +318,7 @@ Env vars:
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
 * `SKAFFOLD_CLEANUP` (same as `--cleanup`)
+* `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
@@ -340,6 +344,7 @@ Delete the deployed application
 
 
 Options:
+  -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
   -n, --namespace='': Run deployments in the specified namespace
@@ -354,6 +359,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 ```
 Env vars:
 
+* `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)
@@ -369,6 +375,7 @@ Deploy pre-built artifacts
 Options:
   -a, --build-artifacts=: Filepath containing build output.
 E.g. build.out created by running skaffold build --quiet {{json .}} > build.out
+  -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
@@ -392,6 +399,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 Env vars:
 
 * `SKAFFOLD_BUILD_ARTIFACTS` (same as `--build-artifacts`)
+* `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
@@ -416,6 +424,7 @@ Options:
       --cache-artifacts=true: Set to true to enable caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
       --cleanup=true: Delete deployments after dev or debug mode is interrupted
+  -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
@@ -448,6 +457,7 @@ Env vars:
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
 * `SKAFFOLD_CLEANUP` (same as `--cleanup`)
+* `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
@@ -577,6 +587,7 @@ Options:
       --cache-artifacts=true: Set to true to enable caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
       --cleanup=true: Delete deployments after dev or debug mode is interrupted
+  -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
   -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
@@ -606,6 +617,7 @@ Env vars:
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
 * `SKAFFOLD_CLEANUP` (same as `--cleanup`)
+* `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -248,7 +248,7 @@ func TestNewBuilder(t *testing.T) {
 		shouldErr       bool
 		localBuild      latest.LocalBuild
 		expectedBuilder *Builder
-		localClusterFn  func() (bool, error)
+		localClusterFn  func(string) (bool, error)
 		localDockerFn   func(*runcontext.RunContext) (docker.LocalDaemon, error)
 	}{
 		{
@@ -263,7 +263,7 @@ func TestNewBuilder(t *testing.T) {
 			localDockerFn: func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 				return dummyDaemon, nil
 			},
-			localClusterFn: func() (b bool, e error) {
+			localClusterFn: func(string) (b bool, e error) {
 				b = false //because this is false and localBuild.push is nil
 				return
 			},
@@ -285,7 +285,7 @@ func TestNewBuilder(t *testing.T) {
 			localDockerFn: func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 				return dummyDaemon, nil
 			},
-			localClusterFn: func() (b bool, e error) {
+			localClusterFn: func(string) (b bool, e error) {
 				b = false
 				return
 			},

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 	"io"
 
-	configutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // Builder uses the host docker daemon to build and tag the image.
@@ -48,7 +49,7 @@ type Builder struct {
 // external dependencies are wrapped
 // into private functions for testability
 
-var getLocalCluster = configutil.GetLocalCluster
+var getLocalCluster = config.GetLocalCluster
 
 // NewBuilder returns an new instance of a local Builder.
 func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
@@ -57,7 +58,7 @@ func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
 		return nil, errors.Wrap(err, "getting docker client")
 	}
 
-	localCluster, err := getLocalCluster()
+	localCluster, err := getLocalCluster(runCtx.Opts.GlobalConfig)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting localCluster")
 	}

--- a/pkg/skaffold/config/global_config.go
+++ b/pkg/skaffold/config/global_config.go
@@ -16,9 +16,9 @@ limitations under the License.
 
 package config
 
-// Config is the top level struct for the global Skaffold config
+// GlobalConfig is the top level struct for the global Skaffold config
 // It is unrelated to the SkaffoldConfig object (parsed from the skaffold.yaml)
-type Config struct {
+type GlobalConfig struct {
 	Global         *ContextConfig   `yaml:"global,omitempty"`
 	ContextConfigs []*ContextConfig `yaml:"kubeContexts"`
 }

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -33,6 +33,7 @@ type PortForwardOptions struct {
 // in the config file itself
 type SkaffoldOptions struct {
 	ConfigurationFile  string
+	GlobalConfig       string
 	Cleanup            bool
 	Notification       bool
 	Tail               bool

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -96,7 +96,6 @@ func ReadConfigFileNoCache(configFile string) (*GlobalConfig, error) {
 // GetConfigForCurrentKubectx returns the specific config to be modified based on the kubeContext.
 // Either returns the config corresponding to the provided or current context,
 // or the global config.
-// Note: the returned ContextConfig can be nil, even if there was no error.
 func GetConfigForCurrentKubectx(configFile string) (*ContextConfig, error) {
 	configOnce.Do(func() {
 		cfg, err := ReadConfigFile(configFile)
@@ -117,6 +116,9 @@ func GetConfigForCurrentKubectx(configFile string) (*ContextConfig, error) {
 
 func getConfigForKubeContextWithGlobalDefaults(cfg *GlobalConfig, kubeContext string) (*ContextConfig, error) {
 	if kubeContext == "" {
+		if cfg.Global == nil {
+			return &ContextConfig{}, nil
+		}
 		return cfg.Global, nil
 	}
 
@@ -146,7 +148,7 @@ func GetDefaultRepo(configFile, cliValue string) (string, error) {
 		return cliValue, nil
 	}
 	cfg, err := GetConfigForCurrentKubectx(configFile)
-	if err != nil || cfg == nil {
+	if err != nil {
 		return "", err
 	}
 
@@ -159,7 +161,7 @@ func GetLocalCluster(configFile string) (bool, error) {
 		return false, err
 	}
 	// when set, the local-cluster config takes precedence
-	if cfg != nil && cfg.LocalCluster != nil {
+	if cfg.LocalCluster != nil {
 		return *cfg.LocalCluster, nil
 	}
 
@@ -172,7 +174,7 @@ func GetLocalCluster(configFile string) (bool, error) {
 
 func GetInsecureRegistries(configFile string) ([]string, error) {
 	cfg, err := GetConfigForCurrentKubectx(configFile)
-	if err != nil || cfg == nil {
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/imdario/mergo"
+	"github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+const (
+	defaultConfigDir  = ".skaffold"
+	defaultConfigFile = "config"
+)
+
+var (
+	// config-file content
+	configFile     *GlobalConfig
+	configFileErr  error
+	configFileOnce sync.Once
+
+	// config for a kubeContext
+	config     *ContextConfig
+	configErr  error
+	configOnce sync.Once
+
+	ReadConfigFile = readConfigFileCached
+)
+
+// readConfigFileCached reads the specified file and returns the contents
+// parsed into a GlobalConfig struct.
+// This function will always return the identical data from the first read.
+func readConfigFileCached(filename string) (*GlobalConfig, error) {
+	configFileOnce.Do(func() {
+		filenameOrDefault, err := ResolveConfigFile(filename)
+		if err != nil {
+			configFileErr = err
+			return
+		}
+		configFile, configFileErr = ReadConfigFileNoCache(filenameOrDefault)
+	})
+	return configFile, configFileErr
+}
+
+// ResolveConfigFile determines the default config location, if the configFile argument is empty.
+func ResolveConfigFile(configFile string) (string, error) {
+	if configFile == "" {
+		home, err := homedir.Dir()
+		if err != nil {
+			return "", errors.Wrap(err, "retrieving home directory")
+		}
+		configFile = filepath.Join(home, defaultConfigDir, defaultConfigFile)
+	}
+	return configFile, util.VerifyOrCreateFile(configFile)
+}
+
+// ReadConfigFileNoCache reads the given config yaml file and unmarshals the contents.
+// Only visible for testing, use ReadConfigFile instead.
+func ReadConfigFileNoCache(configFile string) (*GlobalConfig, error) {
+	contents, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading global config")
+	}
+	config := GlobalConfig{}
+	if err := yaml.Unmarshal(contents, &config); err != nil {
+		return nil, errors.Wrap(err, "unmarshalling global skaffold config")
+	}
+	return &config, nil
+}
+
+// GetConfigForCurrentKubectx returns the specific config to be modified based on the kubeContext.
+// Either returns the config corresponding to the provided or current context,
+// or the global config.
+// Note: the returned ContextConfig can be nil, even if there was no error.
+func GetConfigForCurrentKubectx(configFile string) (*ContextConfig, error) {
+	configOnce.Do(func() {
+		cfg, err := ReadConfigFile(configFile)
+		if err != nil {
+			configErr = err
+			return
+		}
+		kubeconfig, err := kubectx.CurrentConfig()
+		if err != nil {
+			configErr = err
+			return
+		}
+		config, configErr = getConfigForKubeContextWithGlobalDefaults(cfg, kubeconfig.CurrentContext)
+	})
+
+	return config, configErr
+}
+
+func getConfigForKubeContextWithGlobalDefaults(cfg *GlobalConfig, kubeContext string) (*ContextConfig, error) {
+	if kubeContext == "" {
+		return cfg.Global, nil
+	}
+
+	var mergedConfig ContextConfig
+	for _, contextCfg := range cfg.ContextConfigs {
+		if contextCfg.Kubecontext == kubeContext {
+			logrus.Debugf("found config for context %q", kubeContext)
+			mergedConfig = *contextCfg
+		}
+	}
+	// in case there was no config for this kubeContext in cfg.ContextConfigs
+	mergedConfig.Kubecontext = kubeContext
+
+	if cfg.Global != nil {
+		// if values are unset for the current context, retrieve
+		// the global config and use its values as a fallback.
+		if err := mergo.Merge(&mergedConfig, cfg.Global); err != nil {
+			return nil, errors.Wrapf(err, "merging context-specific and global config")
+		}
+	}
+	return &mergedConfig, nil
+}
+
+func GetDefaultRepo(configFile, cliValue string) (string, error) {
+	// CLI flag takes precedence.
+	if cliValue != "" {
+		return cliValue, nil
+	}
+	cfg, err := GetConfigForCurrentKubectx(configFile)
+	if err != nil || cfg == nil {
+		return "", err
+	}
+
+	return cfg.DefaultRepo, nil
+}
+
+func GetLocalCluster(configFile string) (bool, error) {
+	cfg, err := GetConfigForCurrentKubectx(configFile)
+	if err != nil {
+		return false, err
+	}
+	// when set, the local-cluster config takes precedence
+	if cfg != nil && cfg.LocalCluster != nil {
+		return *cfg.LocalCluster, nil
+	}
+
+	config, err := kubectx.CurrentConfig()
+	if err != nil {
+		return true, err
+	}
+	return isDefaultLocal(config.CurrentContext), nil
+}
+
+func GetInsecureRegistries(configFile string) ([]string, error) {
+	cfg, err := GetConfigForCurrentKubectx(configFile)
+	if err != nil || cfg == nil {
+		return nil, err
+	}
+
+	return cfg.InsecureRegistries, nil
+}
+
+func isDefaultLocal(kubeContext string) bool {
+	return kubeContext == constants.DefaultMinikubeContext ||
+		kubeContext == constants.DefaultDockerForDesktopContext ||
+		kubeContext == constants.DefaultDockerDesktopContext ||
+		IsKindCluster(kubeContext)
+}
+
+func IsKindCluster(kubeContext string) bool {
+	return strings.HasSuffix(kubeContext, "@kind")
+}

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -1,0 +1,200 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestReadConfig(t *testing.T) {
+	baseConfig := &GlobalConfig{
+		Global: &ContextConfig{
+			DefaultRepo: "test-repository",
+		},
+		ContextConfigs: []*ContextConfig{
+			{
+				Kubecontext:        "test-context",
+				InsecureRegistries: []string{"bad.io", "worse.io"},
+				LocalCluster:       util.BoolPtr(true),
+				DefaultRepo:        "context-local-repository",
+			},
+		},
+	}
+
+	tests := []struct {
+		description string
+		filename    string
+		expectedCfg *GlobalConfig
+		content     *GlobalConfig
+	}{
+		{
+			description: "first read",
+			filename:    "config",
+			content:     baseConfig,
+			expectedCfg: baseConfig,
+		},
+		{
+			description: "second run uses cached result",
+			expectedCfg: baseConfig,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			tmpDir := t.NewTempDir().
+				Chdir()
+
+			if test.content != nil {
+				c, _ := yaml.Marshal(*test.content)
+				tmpDir.Write(test.filename, string(c))
+			}
+
+			cfg, err := ReadConfigFile(test.filename)
+
+			t.CheckErrorAndDeepEqual(false, err, test.expectedCfg, cfg)
+		})
+	}
+}
+
+func TestResolveConfigFile(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		actual, err := ResolveConfigFile("")
+		t.CheckNoError(err)
+		const suffix = ".skaffold/config"
+		if !strings.HasSuffix(actual, suffix) {
+			t.Errorf("expecting %q to have suffix %q", actual, suffix)
+		}
+	})
+
+	testutil.Run(t, "", func(t *testutil.T) {
+		cfg := t.TempFile("givenConfigurationFile", nil)
+		actual, err := ResolveConfigFile(cfg)
+		t.CheckErrorAndDeepEqual(false, err, cfg, actual)
+	})
+}
+
+func Test_getConfigForKubeContextWithGlobalDefaults(t *testing.T) {
+	const someKubeContext = "this_is_a_context"
+	sampleConfig1 := &ContextConfig{
+		Kubecontext:        someKubeContext,
+		InsecureRegistries: []string{"bad.io", "worse.io"},
+		LocalCluster:       util.BoolPtr(true),
+		DefaultRepo:        "my-private-registry",
+	}
+	sampleConfig2 := &ContextConfig{
+		Kubecontext:        "another_context",
+		InsecureRegistries: []string{"good.io", "better.io"},
+		LocalCluster:       util.BoolPtr(false),
+		DefaultRepo:        "my-public-registry",
+	}
+
+	tests := []struct {
+		name           string
+		kubecontext    string
+		cfg            *GlobalConfig
+		expectedConfig *ContextConfig
+	}{
+		{
+			name: "global config when kubecontext is empty",
+			cfg: &GlobalConfig{
+				Global: &ContextConfig{
+					InsecureRegistries: []string{"mediocre.io"},
+					LocalCluster:       util.BoolPtr(true),
+					DefaultRepo:        "my-private-registry",
+				},
+				ContextConfigs: []*ContextConfig{
+					{
+						Kubecontext: someKubeContext,
+						DefaultRepo: "value",
+					},
+				},
+			},
+			expectedConfig: &ContextConfig{
+				InsecureRegistries: []string{"mediocre.io"},
+				LocalCluster:       util.BoolPtr(true),
+				DefaultRepo:        "my-private-registry",
+			},
+		},
+		{
+			name:        "config for unknown kubecontext",
+			kubecontext: someKubeContext,
+			cfg:         &GlobalConfig{},
+			expectedConfig: &ContextConfig{
+				Kubecontext: someKubeContext,
+			},
+		},
+		{
+			name:        "config for kubecontext when globals are empty",
+			kubecontext: someKubeContext,
+			cfg: &GlobalConfig{
+				ContextConfigs: []*ContextConfig{sampleConfig2, sampleConfig1},
+			},
+			expectedConfig: sampleConfig1,
+		},
+		{
+			name:        "config for kubecontext without merged values",
+			kubecontext: someKubeContext,
+			cfg: &GlobalConfig{
+				Global:         sampleConfig2,
+				ContextConfigs: []*ContextConfig{sampleConfig1},
+			},
+			expectedConfig: sampleConfig1,
+		},
+		{
+			name:        "config for kubecontext with merged values",
+			kubecontext: someKubeContext,
+			cfg: &GlobalConfig{
+				Global: sampleConfig2,
+				ContextConfigs: []*ContextConfig{
+					{
+						Kubecontext: someKubeContext,
+					},
+				},
+			},
+			expectedConfig: &ContextConfig{
+				Kubecontext:        someKubeContext,
+				InsecureRegistries: []string{"good.io", "better.io"},
+				LocalCluster:       util.BoolPtr(false),
+				DefaultRepo:        "my-public-registry",
+			},
+		},
+		{
+			name:        "config for unknown kubecontext with merged values",
+			kubecontext: someKubeContext,
+			cfg:         &GlobalConfig{Global: sampleConfig2},
+			expectedConfig: &ContextConfig{
+				Kubecontext:        someKubeContext,
+				InsecureRegistries: []string{"good.io", "better.io"},
+				LocalCluster:       util.BoolPtr(false),
+				DefaultRepo:        "my-public-registry",
+			},
+		},
+		/* todo(corneliusweig): this behavior can be enabled with `mergo.WithAppendSlice` -> clarify requirements
+		{
+			name:        "merge global and context-specific insecure-registries",
+			kubecontext: someKubeContext,
+			cfg: &GlobalConfig{
+				Global:         &ContextConfig{
+					InsecureRegistries: []string{"good.io", "better.io"},
+				},
+				ContextConfigs: []*ContextConfig{{
+					Kubecontext: someKubeContext,
+					InsecureRegistries: []string{"bad.io", "worse.io"},
+				}},
+			},
+			expectedConfig: &ContextConfig{
+				Kubecontext:        someKubeContext,
+				InsecureRegistries: []string{"bad.io", "worse.io", "good.io", "better.io"},
+			},
+		},*/
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			actual, err := getConfigForKubeContextWithGlobalDefaults(test.cfg, test.kubecontext)
+			t.CheckErrorAndDeepEqual(false, err, test.expectedConfig, actual)
+		})
+	}
+}

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -79,7 +80,7 @@ func TestResolveConfigFile(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		actual, err := ResolveConfigFile("")
 		t.CheckNoError(err)
-		const suffix = ".skaffold/config"
+		suffix := filepath.FromSlash(".skaffold/config")
 		if !strings.HasSuffix(actual, suffix) {
 			t.Errorf("expecting %q to have suffix %q", actual, suffix)
 		}

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -194,24 +194,6 @@ func Test_getConfigForKubeContextWithGlobalDefaults(t *testing.T) {
 				DefaultRepo:        "my-public-registry",
 			},
 		},
-		/* todo(corneliusweig): this behavior can be enabled with `mergo.WithAppendSlice` -> clarify requirements
-		{
-			name:        "merge global and context-specific insecure-registries",
-			kubecontext: someKubeContext,
-			cfg: &GlobalConfig{
-				Global:         &ContextConfig{
-					InsecureRegistries: []string{"good.io", "better.io"},
-				},
-				ContextConfigs: []*ContextConfig{{
-					Kubecontext: someKubeContext,
-					InsecureRegistries: []string{"bad.io", "worse.io"},
-				}},
-			},
-			expectedConfig: &ContextConfig{
-				Kubecontext:        someKubeContext,
-				InsecureRegistries: []string{"bad.io", "worse.io", "good.io", "better.io"},
-			},
-		},*/
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -119,6 +119,11 @@ func Test_getConfigForKubeContextWithGlobalDefaults(t *testing.T) {
 			},
 		},
 		{
+			name:           "no global config and no kubecontext",
+			cfg:            &GlobalConfig{},
+			expectedConfig: &ContextConfig{},
+		},
+		{
 			name:        "config for unknown kubecontext",
 			kubecontext: someKubeContext,
 			cfg:         &GlobalConfig{},

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import (

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -20,14 +20,15 @@ import (
 	"context"
 	"io"
 
-	cfg "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
+	"github.com/pkg/errors"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
-	"github.com/pkg/errors"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 )
 
 func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []build.Artifact) error {
-	if cfg.IsKindCluster(r.runCtx.KubeContext) {
+	if config.IsKindCluster(r.runCtx.KubeContext) {
 		// With `kind`, docker images have to be loaded with the `kind` CLI.
 		if err := r.loadImagesInKindNodes(ctx, out, artifacts); err != nil {
 			return errors.Wrapf(err, "loading images into kind nodes")

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -19,13 +19,13 @@ package runcontext
 import (
 	"os"
 
-	configutil "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	runnerutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 type RunContext struct {
@@ -58,13 +58,13 @@ func GetRunContext(opts config.SkaffoldOptions, cfg latest.Pipeline) (*RunContex
 		return nil, errors.Wrap(err, "getting namespace list")
 	}
 
-	defaultRepo, err := configutil.GetDefaultRepo(opts.DefaultRepo)
+	defaultRepo, err := config.GetDefaultRepo(opts.GlobalConfig, opts.DefaultRepo)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting default repo")
 	}
 
 	// combine all provided lists of insecure registries into a map
-	cfgRegistries, err := configutil.GetInsecureRegistries()
+	cfgRegistries, err := config.GetInsecureRegistries(opts.GlobalConfig)
 	if err != nil {
 		logrus.Warnf("error retrieving insecure registries from global config: push/pull issues may exist...")
 	}


### PR DESCRIPTION
So far, `skaffold config` has a `--config` flag, to modify skaffold configs with non-standard locations (default is `$HOME/.skaffold/config`). Other Skaffold commands do not have a flag to set the config location (see #2468).

This PR adds a config flag to configure the location of the global config for the `run`, `dev`, `debug`, `build`, `deploy`, `delete`, and `diagnose` subcommands. The reason for not making this flag global (such as `--color`) is that `skaffold config` has no access to the Skaffold options, so it would require an awkward workaround. Let me know if this makes sense.

To achieve its goal, this PR required a substantial refactoring of the global config handling. I hope it got simpler.

Fixes #2468 
Related #2554