### PR TITLE
Use helm release name to query port forward resources for helm deployments.

### DIFF
--- a/pkg/skaffold/runner/portforwarder_test.go
+++ b/pkg/skaffold/runner/portforwarder_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestCreateLabelQuery(t *testing.T) {
+	tests := []struct {
+		description string
+		deploy      *latest.HelmDeploy
+		expected    string
+	}{
+		{
+			description: "one helm release",
+			deploy: &latest.HelmDeploy{
+				Releases: []latest.HelmRelease{{Name: "foo"}},
+			},
+			expected: "release in (foo)",
+		}, {
+			description: "multiple helm release",
+			deploy: &latest.HelmDeploy{
+				Releases: []latest.HelmRelease{{Name: "foo"}, {Name: "bar"}},
+			},
+			expected: "release in (foo,bar)",
+		}, {
+			description: "no helm release",
+			expected:    "K8ManagedBy=test",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			actual := createLabelQuery(test.deploy, "K8ManagedBy=test")
+			t.CheckDeepEqual(actual, test.expected)
+		})
+	}
+}


### PR DESCRIPTION
fixes #2379 

Instead of using skaffold applied label "app.kubernetes.io/managed-by=skaffold-<version>" this PR use shelm label "release=<release_name>" which is applied by helm for resources.


On my branch
```
@helm-deployment (fix_2379)$ skaffold dev --port-forward=true
Generating tags...
 - gcr.io/k8s-skaffold/skaffold-helm -> gcr.io/k8s-skaffold/skaffold-helm:latest
Tags generated in 110.294µs
Starting build...
Found [gke_tejal-test_us-central1-a_dump] context, using local docker daemon.
Building [gcr.io/k8s-skaffold/skaffold-helm]...
Sending build context to Docker daemon  4.096kB
Step 1/2 : FROM nginx:stable
 ---> 3014a6ac1176
Step 2/2 : COPY static /usr/share/nginx/html/
 ---> Using cache
 ---> e3c1f7501fa3
Successfully built e3c1f7501fa3
Successfully tagged gcr.io/k8s-skaffold/skaffold-helm:latest
Build complete in 159.043255ms
Starting test...
Test complete in 12.294µs
Starting deploy...
Error: release: "skaffold-helm" not found
Helm release skaffold-helm not installed. Installing...
No requirements found in skaffold-helm/charts.
NAME:   skaffold-helm
LAST DEPLOYED: Fri Jul 26 10:24:04 2019
NAMESPACE: default
STATUS: DEPLOYED

RESOURCES:
==> v1beta1/Ingress
NAME                         HOSTS  ADDRESS  PORTS  AGE
skaffold-helm-skaffold-helm  *      80       0s

==> v1/Pod(related)
NAME                           READY  STATUS             RESTARTS  AGE
skaffold-helm-7564fd45f-h6dbx  0/1    ContainerCreating  0         0s

==> v1/Service
NAME                         TYPE       CLUSTER-IP     EXTERNAL-IP  PORT(S)  AGE
skaffold-helm-skaffold-helm  ClusterIP  10.23.250.144  <none>       80/TCP   1s

==> v1beta1/Deployment
NAME           DESIRED  CURRENT  UP-TO-DATE  AVAILABLE  AGE
skaffold-helm  1        1        1           0          0s


Deploy complete in 2.932925744s
Watching for changes...

Port forwarded service/skaffold-helm-skaffold-helm from remote port 80 to local port 4503
```

