### PR TITLE
Retry port forwarding when we see forwarding-related errors from kubectl

### DIFF
--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -106,7 +106,7 @@ func (*KubectlForwarder) Monitor(p *portForwardEntry, retryFunc func()) {
 		s, _ := p.logBuffer.ReadString(byte('\n'))
 		if s != "" {
 			logrus.Tracef("[port-forward] %s", s)
-			if strings.Contains(s, "error forwarding port") {
+			if strings.Contains(s, "error forwarding port") || strings.Contains(s, "unable to forward") {
 				// kubectl is having an error. retry the command
 				logrus.Infof("retrying kubectl port-forward due to error: %s", s)
 				go retryFunc()


### PR DESCRIPTION
sometimes kubectl port-forward will throw errors that look like 
`error: unable to forward port because pod is not running. Current status=Pending`
and sometimes it will throw errors that look like 
`error forwarding port....`

now, we'll just retry anytime we see an `error` in the logs from kubectl port-forward.