### PR TITLE
docker auth: use GetAllCredentials() to use credHelpers

### DIFF
--- a/pkg/skaffold/docker/auth.go
+++ b/pkg/skaffold/docker/auth.go
@@ -77,9 +77,7 @@ func (credsHelper) GetAllAuthConfigs() (map[string]types.AuthConfig, error) {
 		return nil, errors.Wrap(err, "docker config")
 	}
 
-	// TODO(dgageot): this is really slow because it has to run all the credential helpers.
-	// return cf.GetAllCredentials()
-	return cf.GetCredentialsStore("").GetAll()
+	return cf.GetAllCredentials()
 }
 
 func (l *localDaemon) encodedRegistryAuth(ctx context.Context, a AuthConfigHelper, image string) (string, error) {


### PR DESCRIPTION
The current mechanism for building the map of `AuthConfig` to pass to
the docker daemon when building the image bypasses any credsHelpers in
the user's docker config json file.

`cf.GetCredentialsStore("").GetAll()` ends up returning the `auths`
section from the config file, and does not use or execute any configured
`credHelpers`.

There is a comment in the source code here for a commented-out call to
GetAllCredentials() that it is too slow, but I think it is worth noting
that this is the same function used by a regular `docker build`:
https://github.com/docker/cli/blob/e06530297ddd4d0a4baf4361fc094f4afb36de92/cli/command/image/build.go#L403

While it might be slow to execute each of the configured credHelpers to
be able to build a full map of `AuthConfigs`, this seems like the only
way to pass all of the user's auth configs from their config file to the
build command - otherwise any image pulls needed to build the image will
fail if they require authentication.

Fixes #239.