### PR TITLE
Negotiate docker API version when creating minikube docker client

### DIFF
--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -33,7 +33,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/pkg/errors"
@@ -117,16 +116,15 @@ func newMinikubeAPIClient() ([]string, client.CommonAPIClient, error) {
 	if host == "" {
 		host = client.DefaultDockerHost
 	}
-	version := env["DOCKER_API_VERSION"]
-	if version == "" {
-		version = api.DefaultVersion
-	}
 
 	api, err := client.NewClientWithOpts(
 		client.WithHost(host),
-		client.WithVersion(version),
 		client.WithHTTPClient(httpclient),
 		client.WithHTTPHeaders(getUserAgentHeader()))
+
+	if api != nil {
+		api.NegotiateAPIVersion(context.Background())
+	}
 
 	// Keep the minikube environment variables
 	var environment []string


### PR DESCRIPTION
we've been using the minikube docker-env to get the API version for our docker client in skaffold, and if this isn't set (which it isn't by default), we use the default API version in the client library. the issue is that recently, we updated our docker client dependency, which defaults to API version 1.40, but the default server version in minikube is somewhere around 1.39 so they're incompatible. let's just use the docker client API to do the negotiation for us.