### PR TITLE
[linters] Use vendored dependencies. Don’t download them.

### DIFF
--- a/hack/golangci.yml
+++ b/hack/golangci.yml
@@ -1,0 +1,27 @@
+run:
+  deadline: 6m
+  modules-download-mode: vendor
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - goconst
+    - gocritic
+    - goimports
+    - golint
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - maligned
+    - misspell
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -31,28 +31,5 @@ if [[ "${TRAVIS}" == "true" ]]; then
     VERBOSE="-v --print-resources-usage"
 fi
 
-golangci-lint run ${VERBOSE} \
-	--deadline=6m \
-	--no-config \
-    --disable-all \
-    -E bodyclose \
-    -E deadcode \
-    -E goconst \
-    -E gocritic \
-    -E goimports \
-    -E golint \
-    -E gosimple \
-    -E govet \
-    -E ineffassign \
-    -E interfacer \
-    -E maligned \
-    -E misspell \
-    -E staticcheck \
-    -E structcheck \
-    -E stylecheck \
-    -E typecheck \
-    -E unconvert \
-    -E unparam \
-    -E unused \
-    -E varcheck \
-	--skip-dirs vendor | awk '/out of memory/ || /Deadline exceeded/ {failed = 1}; {print}; END {exit failed}'
+golangci-lint run ${VERBOSE} -c ${DIR}/golangci.yml \
+    | awk '/out of memory/ || /Deadline exceeded/ {failed = 1}; {print}; END {exit failed}'


### PR DESCRIPTION
This behaviour can’t be set on the command line. We have to use a config file.
Also, removed the `--skip-dirs vendor` because it’s done by default by golangci-lint.

Signed-off-by: David Gageot <david@gageot.net>