### PR TITLE
refactor: Add upgrade utility to handle all pipelines in a SkaffoldConfig

### DIFF
--- a/pkg/skaffold/schema/util/upgrade_pipelines.go
+++ b/pkg/skaffold/schema/util/upgrade_pipelines.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	fieldMainPipeline    = "Pipeline"
+	fieldProfilePipeline = "Pipeline"
+	fieldProfile         = "Profiles"
+)
+
+type pipelineUpgrader struct {
+	oldConfig, newConfig reflect.Value
+	upgrade              func(o, n interface{}) error
+}
+
+func UpgradePipelines(oldConfig, newConfig interface{}, upgrade func(o, n interface{}) error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			switch x := r.(type) {
+			case string:
+				err = fmt.Errorf("upgrading pipelines failed: %s", x)
+			case error:
+				err = x
+			default:
+				err = errors.New("unknown panic")
+			}
+		}
+	}()
+
+	upgrader := pipelineUpgrader{
+		oldConfig: reflect.Indirect(reflect.ValueOf(oldConfig)),
+		newConfig: reflect.Indirect(reflect.ValueOf(newConfig)),
+		upgrade:   upgrade,
+	}
+
+	if err := upgrader.mainPipeline(); err != nil {
+		return err
+	}
+
+	return upgrader.profiles()
+}
+
+func (u *pipelineUpgrader) mainPipeline() error {
+	oldPipeline := u.oldConfig.FieldByName(fieldMainPipeline).Addr().Interface()
+	newPipeline := u.newConfig.FieldByName(fieldMainPipeline).Addr().Interface()
+
+	err := u.upgrade(oldPipeline, newPipeline)
+	return errors.Wrapf(err, "upgrading main pipeline")
+}
+
+func (u *pipelineUpgrader) profiles() error {
+	profilesOld := u.oldConfig.FieldByName(fieldProfile)
+	profilesNew := u.newConfig.FieldByName(fieldProfile)
+
+	if profilesOld.Len() != profilesNew.Len() {
+		return fmt.Errorf("lengths of old and new profiles differ")
+	}
+
+	for i := 0; i < profilesOld.Len(); i++ {
+		oldPipeline := profilesOld.Index(i).FieldByName(fieldProfilePipeline).Addr().Interface()
+		newPipeline := profilesNew.Index(i).FieldByName(fieldProfilePipeline).Addr().Interface()
+
+		if err := u.upgrade(oldPipeline, newPipeline); err != nil {
+			return errors.Wrapf(err, "upgrading pipeline of profile %d", i+1)
+		}
+	}
+
+	return nil
+}

--- a/pkg/skaffold/schema/util/upgrade_pipelines.go
+++ b/pkg/skaffold/schema/util/upgrade_pipelines.go
@@ -23,15 +23,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	fieldMainPipeline    = "Pipeline"
-	fieldProfilePipeline = "Pipeline"
-	fieldProfile         = "Profiles"
-)
-
 type pipelineUpgrader struct {
-	oldConfig, newConfig reflect.Value
-	upgrade              func(o, n interface{}) error
+	oldConfig reflect.Value
+	newConfig reflect.Value
+	upgrade   func(o, n interface{}) error
 }
 
 func UpgradePipelines(oldConfig, newConfig interface{}, upgrade func(o, n interface{}) error) (err error) {
@@ -62,6 +57,8 @@ func UpgradePipelines(oldConfig, newConfig interface{}, upgrade func(o, n interf
 }
 
 func (u *pipelineUpgrader) mainPipeline() error {
+	const fieldMainPipeline = "Pipeline"
+
 	oldPipeline := u.oldConfig.FieldByName(fieldMainPipeline).Addr().Interface()
 	newPipeline := u.newConfig.FieldByName(fieldMainPipeline).Addr().Interface()
 
@@ -70,8 +67,13 @@ func (u *pipelineUpgrader) mainPipeline() error {
 }
 
 func (u *pipelineUpgrader) profiles() error {
-	profilesOld := u.oldConfig.FieldByName(fieldProfile)
-	profilesNew := u.newConfig.FieldByName(fieldProfile)
+	const (
+		fieldProfilePipeline = "Pipeline"
+		fieldProfiles        = "Profiles"
+	)
+
+	profilesOld := u.oldConfig.FieldByName(fieldProfiles)
+	profilesNew := u.newConfig.FieldByName(fieldProfiles)
 
 	if profilesOld.Len() != profilesNew.Len() {
 		return fmt.Errorf("lengths of old and new profiles differ")

--- a/pkg/skaffold/schema/util/upgrade_pipelines_test.go
+++ b/pkg/skaffold/schema/util/upgrade_pipelines_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+type testConfig struct {
+	Pipeline testPipeline
+	Profiles []testConfig
+}
+
+type testPipeline struct {
+	name string
+}
+
+func TestUpgradePipelines(t *testing.T) {
+	from := testConfig{
+		Pipeline: testPipeline{name: "main"},
+		Profiles: []testConfig{
+			{Pipeline: testPipeline{name: "profile-0"}},
+			{Pipeline: testPipeline{name: "profile-1"}},
+		},
+	}
+	to := testConfig{
+		Profiles: []testConfig{{}, {}},
+	}
+
+	testUpgrade := func(o, n interface{}) error {
+		src := o.(*testPipeline)
+		dest := n.(*testPipeline)
+
+		dest.name = src.name + "-upgraded"
+		return nil
+	}
+
+	err := UpgradePipelines(&from, &to, testUpgrade)
+	testutil.CheckError(t, false, err)
+
+	if to.Pipeline.name != "main-upgraded" {
+		t.Error("expected main pipeline to be upgraded")
+	}
+	if to.Profiles[0].Pipeline.name != "profile-0-upgraded" {
+		t.Error("expected profile-0 to be upgraded")
+	}
+	if to.Profiles[1].Pipeline.name != "profile-1-upgraded" {
+		t.Error("expected profile-1 to be upgraded")
+	}
+}

--- a/pkg/skaffold/schema/v1beta9/upgrade.go
+++ b/pkg/skaffold/schema/v1beta9/upgrade.go
@@ -20,11 +20,11 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta10"
 	pkgutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -44,58 +44,26 @@ var (
 // 3. Updates:
 //    - sync map becomes a list of sync rules
 func (config *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
-	// convert Deploy (should be the same)
-	var newDeploy next.DeployConfig
-	if err := pkgutil.CloneThroughJSON(config.Deploy, &newDeploy); err != nil {
-		return nil, errors.Wrap(err, "converting deploy config")
+	var newConfig next.SkaffoldConfig
+
+	if err := pkgutil.CloneThroughJSON(config, &newConfig); err != nil {
+		return nil, err
+	}
+	newConfig.APIVersion = next.Version
+
+	if err := util.UpgradePipelines(config, &newConfig, upgradeOnePipeline); err != nil {
+		return nil, err
 	}
 
-	// convert Profiles (should be the same)
-	var newProfiles []next.Profile
-	for _, p := range config.Profiles {
-		var newProfile next.Profile
-		if err := pkgutil.CloneThroughJSON(p, &newProfile); err != nil {
-			return nil, errors.Wrap(err, "converting new profile")
-		}
-		newProfileBuild, err := convertBuildConfig(p.Build)
-		if err != nil {
-			return nil, errors.Wrap(err, "converting new profile build")
-		}
-		newProfile.Build = newProfileBuild
-		newProfiles = append(newProfiles, newProfile)
-	}
-
-	newBuild, err := convertBuildConfig(config.Build)
-	if err != nil {
-		return nil, errors.Wrap(err, "converting new build")
-	}
-
-	// convert Test (should be the same)
-	var newTest []*next.TestCase
-	if err := pkgutil.CloneThroughJSON(config.Test, &newTest); err != nil {
-		return nil, errors.Wrap(err, "converting new test")
-	}
-
-	return &next.SkaffoldConfig{
-		APIVersion: next.Version,
-		Kind:       config.Kind,
-		Pipeline: next.Pipeline{
-			Build:  newBuild,
-			Test:   newTest,
-			Deploy: newDeploy,
-		},
-		Profiles: newProfiles,
-	}, nil
+	return &newConfig, nil
 }
 
-func convertBuildConfig(build BuildConfig) (next.BuildConfig, error) {
-	// convert Build (should be same)
-	var newBuild next.BuildConfig
-	if err := pkgutil.CloneThroughJSON(build, &newBuild); err != nil {
-		return next.BuildConfig{}, err
-	}
+func upgradeOnePipeline(oldPipeline, newPipeline interface{}) error {
+	oldBuild := &oldPipeline.(*Pipeline).Build
+	newBuild := &newPipeline.(*next.Pipeline).Build
+
 	// set Sync in newBuild
-	newSyncRules := convertSyncRules(build.Artifacts)
+	newSyncRules := convertSyncRules(oldBuild.Artifacts)
 	for i, a := range newBuild.Artifacts {
 		if len(newSyncRules[i]) > 0 {
 			a.Sync = &next.Sync{
@@ -103,7 +71,7 @@ func convertBuildConfig(build BuildConfig) (next.BuildConfig, error) {
 			}
 		}
 	}
-	return newBuild, nil
+	return nil
 }
 
 // convertSyncRules converts the old sync map into sync rules.


### PR DESCRIPTION
Before, the main pipeline and the profile pipelines had to be upgraded
manually, which was easy to forget.

In contrast to what is outlined in #2469, I didn't introduce a new interface. This is mainly because I want to avoid double json-cloning of the same objects. Instead, I opted for reflection which has the main drawback that it requires the exact same go-naming for `Pipeline` and `Profiles[*].Pipeline`. Given that this naming scheme is rather stable now, I think this is affordable.

Fixes #2469