### PR TITLE
Fix handling of whitelisted directories in dockerignore

### DIFF
--- a/pkg/skaffold/docker/dependencies_test.go
+++ b/pkg/skaffold/docker/dependencies_test.go
@@ -357,7 +357,7 @@ func TestGetDependencies(t *testing.T) {
 			description: "dockerignore with context in parent directory",
 			dockerfile:  copyDirectory,
 			workspace:   "docker/..",
-			ignore:      "bar\ndocker/*\n*.go",
+			ignore:      "bar\ndocker\n*.go",
 			expected:    []string{".dot", "Dockerfile", "file", "test.conf"},
 		},
 		{
@@ -483,6 +483,20 @@ func TestGetDependencies(t *testing.T) {
 			workspace:   ".",
 			buildArgs:   map[string]*string{"FOO": util.StringPtr("{{")},
 			shouldErr:   true,
+		},
+		{
+			description: "ignore with whitelisting",
+			dockerfile:  copyAll,
+			workspace:   ".",
+			ignore:      "**\n!docker/**",
+			expected:    []string{"Dockerfile", filepath.Join("docker", "bar"), filepath.Join("docker", "nginx.conf")},
+		},
+		{
+			description: "ignore with whitelisting files",
+			dockerfile:  copyAll,
+			workspace:   ".",
+			ignore:      "**\n!server.go",
+			expected:    []string{"Dockerfile", "server.go"},
 		},
 	}
 


### PR DESCRIPTION
This PR fixes handling of whitelisted directories in `.dockerignore`.

The code closely follows the reference implementation from
https://github.com/docker/cli/blame/f019bdcace678c71690a99f6c5f30303c33534bc/vendor/github.com/docker/docker/pkg/archive/archive.go#L832  Does that already mandate a proper attribution?

Fixes #2576