### PR TITLE
Remove obsolete `remoteManifests` field

### DIFF
--- a/docs/content/en/schemas/v1beta13.json
+++ b/docs/content/en/schemas/v1beta13.json
@@ -1378,20 +1378,10 @@
           "description": "the Kubernetes yaml or json manifests.",
           "x-intellij-html-description": "the Kubernetes yaml or json manifests.",
           "default": "[\"k8s/*.yaml\"]"
-        },
-        "remoteManifests": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "Kubernetes manifests in remote clusters.",
-          "x-intellij-html-description": "Kubernetes manifests in remote clusters.",
-          "default": "[]"
         }
       },
       "preferredOrder": [
         "manifests",
-        "remoteManifests",
         "flags"
       ],
       "additionalProperties": false,

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -360,9 +360,6 @@ type KubectlDeploy struct {
 	// Defaults to `["k8s/*.yaml"]`.
 	Manifests []string `yaml:"manifests,omitempty"`
 
-	// RemoteManifests lists Kubernetes manifests in remote clusters.
-	RemoteManifests []string `yaml:"remoteManifests,omitempty"`
-
 	// Flags are additional flags passed to `kubectl`.
 	Flags KubectlFlags `yaml:"flags,omitempty"`
 }


### PR DESCRIPTION
I looks like `remoteManifests` has been combined with `manifests` in #1451 (commit 160cfa11fce8cc70537f5beb294932079b8f7bee).
The field is not used anywhere, so we can break nobody by finally removing it.