### PR TITLE
build master only on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ go_import_path: /skaffold
 git:
   submodules: false
 
+branches:
+  only:
+    - master
+
 jobs:
   include:
     - os: linux


### PR DESCRIPTION
**Problem**

As we introduced the use of release branches temporarily, when I want to raise the PR to merge changes back to the master branch from the release branch, we see two status checks, one for the release branch, one for the PR merge (similar to https://github.com/travis-ci/travis-ci/issues/3241). 

**Solution**

We do want travis to build on pushes to master. Running builds on pushes to branches requires a global switch - that enables running on _all_ branches. So I'll leave that alone. This PR filters the built branches to `master` only.
