### PR TITLE
Fix issue with remote Kustomizations in dev mode. (#2581)

### DIFF
--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -164,7 +164,8 @@ func dependenciesForKustomization(dir string) ([]string, error) {
 
 	path, err := findKustomizationConfig(dir)
 	if err != nil {
-		return nil, err
+		// No kustomiization config found so assume it's remote and stop traversing
+		return deps, nil
 	}
 
 	buf, err := ioutil.ReadFile(path)
@@ -217,7 +218,7 @@ func dependenciesForKustomization(dir string) ([]string, error) {
 	return deps, nil
 }
 
-// A kustomization config must be at the root of the direectory. Kustomize will
+// A Kustomization config must be at the root of the directory. Kustomize will
 // error if more than one of these files exists so order doesn't matter.
 func findKustomizationConfig(dir string) (string, error) {
 	candidates := []string{"kustomization.yaml", "kustomization.yml", "Kustomization"}


### PR DESCRIPTION
Closes #2581 

Remote Kustomization support was added previously, but it only supported
remote resources referenced inside of a Kustomization config file rather
than remote Kustomization config files themselves. This commit causes
the file watcher code to assume the absence of a Kustomization config
means that it is a remote reference and skips it since it can't watch
remote files for changes. It pushes error handling onto Kustomize
itself for invalid remote locations.