### PR TITLE
Watch all artifact workspaces, including those outside of the working directory

### DIFF
--- a/pkg/skaffold/trigger/triggers.go
+++ b/pkg/skaffold/trigger/triggers.go
@@ -48,7 +48,7 @@ func NewTrigger(runctx *runcontext.RunContext) (Trigger, error) {
 			Interval: time.Duration(runctx.Opts.WatchPollInterval) * time.Millisecond,
 		}, nil
 	case "notify":
-		return newFSNotifyTrigger(runctx)
+		return newFSNotifyTrigger(runctx), nil
 	case "manual":
 		return &manualTrigger{}, nil
 	default:
@@ -56,7 +56,7 @@ func NewTrigger(runctx *runcontext.RunContext) (Trigger, error) {
 	}
 }
 
-func newFSNotifyTrigger(runctx *runcontext.RunContext) (*fsNotifyTrigger, error) {
+func newFSNotifyTrigger(runctx *runcontext.RunContext) *fsNotifyTrigger {
 	workspaces := map[string]struct{}{}
 	for _, a := range runctx.Cfg.Build.Artifacts {
 		workspaces[a.Workspace] = struct{}{}
@@ -64,7 +64,7 @@ func newFSNotifyTrigger(runctx *runcontext.RunContext) (*fsNotifyTrigger, error)
 	return &fsNotifyTrigger{
 		Interval:   time.Duration(runctx.Opts.WatchPollInterval) * time.Millisecond,
 		workspaces: workspaces,
-	}, nil
+	}
 }
 
 // pollTrigger watches for changes on a given interval of time.

--- a/pkg/skaffold/trigger/triggers.go
+++ b/pkg/skaffold/trigger/triggers.go
@@ -48,19 +48,23 @@ func NewTrigger(runctx *runcontext.RunContext) (Trigger, error) {
 			Interval: time.Duration(runctx.Opts.WatchPollInterval) * time.Millisecond,
 		}, nil
 	case "notify":
-		workspaces := map[string]struct{}{}
-		for _, a := range runctx.Cfg.Build.Artifacts {
-			workspaces[a.Workspace] = struct{}{}
-		}
-		return &fsNotifyTrigger{
-			Interval:   time.Duration(runctx.Opts.WatchPollInterval) * time.Millisecond,
-			workspaces: workspaces,
-		}, nil
+		return newFSNotifyTrigger(runctx)
 	case "manual":
 		return &manualTrigger{}, nil
 	default:
 		return nil, fmt.Errorf("unsupported trigger: %s", runctx.Opts.Trigger)
 	}
+}
+
+func newFSNotifyTrigger(runctx *runcontext.RunContext) (*fsNotifyTrigger, error) {
+	workspaces := map[string]struct{}{}
+	for _, a := range runctx.Cfg.Build.Artifacts {
+		workspaces[a.Workspace] = struct{}{}
+	}
+	return &fsNotifyTrigger{
+		Interval:   time.Duration(runctx.Opts.WatchPollInterval) * time.Millisecond,
+		workspaces: workspaces,
+	}, nil
 }
 
 // pollTrigger watches for changes on a given interval of time.

--- a/pkg/skaffold/trigger/triggers.go
+++ b/pkg/skaffold/trigger/triggers.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -47,8 +48,13 @@ func NewTrigger(runctx *runcontext.RunContext) (Trigger, error) {
 			Interval: time.Duration(runctx.Opts.WatchPollInterval) * time.Millisecond,
 		}, nil
 	case "notify":
+		workspaces := map[string]struct{}{}
+		for _, a := range runctx.Cfg.Build.Artifacts {
+			workspaces[a.Workspace] = struct{}{}
+		}
 		return &fsNotifyTrigger{
-			Interval: time.Duration(runctx.Opts.WatchPollInterval) * time.Millisecond,
+			Interval:   time.Duration(runctx.Opts.WatchPollInterval) * time.Millisecond,
+			workspaces: workspaces,
 		}, nil
 	case "manual":
 		return &manualTrigger{}, nil
@@ -134,7 +140,8 @@ func (t *manualTrigger) Start(ctx context.Context) (<-chan bool, error) {
 
 // notifyTrigger watches for changes with fsnotify
 type fsNotifyTrigger struct {
-	Interval time.Duration
+	Interval   time.Duration
+	workspaces map[string]struct{}
 }
 
 // Debounce tells the watcher to not debounce rapid sequence of changes.
@@ -154,6 +161,13 @@ func (t *fsNotifyTrigger) Start(ctx context.Context) (<-chan bool, error) {
 	// Watch current directory recursively
 	if err := notify.Watch("./...", c, notify.All); err != nil {
 		return nil, err
+	}
+
+	// Watch all workspaces recursively
+	for w := range t.workspaces {
+		if err := notify.Watch(filepath.Join(w, "..."), c, notify.All); err != nil {
+			return nil, err
+		}
 	}
 
 	// Since the file watcher runs in a separate go routine


### PR DESCRIPTION
This should fix #2613: Watcher doesn't detect changes when artifacts are outside the directory from where skaffold is run