### PR TITLE
Added leeroy-web k8s service for microservice example

### DIFF
--- a/examples/microservices/leeroy-web/kubernetes/deployment.yaml
+++ b/examples/microservices/leeroy-web/kubernetes/deployment.yaml
@@ -1,3 +1,19 @@
+apiVersion: v1	
+kind: Service	
+metadata:	
+  name: leeroy-web	
+  labels:	
+    app: leeroy-web	
+spec:	
+  type: NodePort	
+  ports:	
+    - port: 8080	
+      targetPort: 8080	
+      protocol: TCP	
+      name: leeroy-web	
+  selector:	
+    app: leeroy-web	
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Problem:
--
Following the microserice example. leeroy-web does not expose a service.
So when `curl $(minikube service leeroy-web --url)` nothing happens

Solution:
--
Added service definition for leeroy-web which was removed by this [commit 3f93642deee](https://github.com/GoogleContainerTools/skaffold/commit/3f93642deee42e3ad3dfab741fec88850f14a85b) [here](https://github.com/GoogleContainerTools/skaffold/commit/3f93642deee42e3ad3dfab741fec88850f14a85b#diff-93aba9ab4664919e9d1c519f6798bf06L1)