### PR TITLE
Fix kaniko permissions with generate-pipeline command

### DIFF
--- a/integration/testdata/generate_pipeline/existing_oncluster/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/existing_oncluster/expectedPipeline.yaml
@@ -33,10 +33,20 @@ spec:
     - build.out
     command:
     - skaffold
+    env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /secret/kaniko-secret
     image: gcr.io/k8s-skaffold/skaffold:test-version
     name: run-build
     resources: {}
+    volumeMounts:
+    - mountPath: /secret
+      name: kaniko-secret
     workingDir: /workspace/source
+  volumes:
+  - name: kaniko-secret
+    secret:
+      secretName: kaniko-secret
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Task
@@ -55,8 +65,6 @@ spec:
     - deploy
     - --filename
     - skaffold.yaml
-    - --profile
-    - oncluster
     - --build-artifacts
     - build.out
     command:

--- a/integration/testdata/generate_pipeline/existing_other/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/existing_other/expectedPipeline.yaml
@@ -33,10 +33,20 @@ spec:
     - build.out
     command:
     - skaffold
+    env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /secret/kaniko-secret
     image: gcr.io/k8s-skaffold/skaffold:test-version
     name: run-build
     resources: {}
+    volumeMounts:
+    - mountPath: /secret
+      name: kaniko-secret
     workingDir: /workspace/source
+  volumes:
+  - name: kaniko-secret
+    secret:
+      secretName: kaniko-secret
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Task
@@ -55,8 +65,6 @@ spec:
     - deploy
     - --filename
     - skaffold.yaml
-    - --profile
-    - oncluster
     - --build-artifacts
     - build.out
     command:

--- a/integration/testdata/generate_pipeline/no_profiles/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/no_profiles/expectedPipeline.yaml
@@ -33,10 +33,20 @@ spec:
     - build.out
     command:
     - skaffold
+    env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /secret/kaniko-secret
     image: gcr.io/k8s-skaffold/skaffold:test-version
     name: run-build
     resources: {}
+    volumeMounts:
+    - mountPath: /secret
+      name: kaniko-secret
     workingDir: /workspace/source
+  volumes:
+  - name: kaniko-secret
+    secret:
+      secretName: kaniko-secret
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Task
@@ -55,8 +65,6 @@ spec:
     - deploy
     - --filename
     - skaffold.yaml
-    - --profile
-    - oncluster
     - --build-artifacts
     - build.out
     command:

--- a/pkg/skaffold/generate_pipeline/constants.go
+++ b/pkg/skaffold/generate_pipeline/constants.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package generatepipeline
 
 const (

--- a/pkg/skaffold/generate_pipeline/constants.go
+++ b/pkg/skaffold/generate_pipeline/constants.go
@@ -1,0 +1,5 @@
+package generatepipeline
+
+const (
+	defaultKanikoSecretName = "kaniko-secret"
+)

--- a/pkg/skaffold/generate_pipeline/constants.go
+++ b/pkg/skaffold/generate_pipeline/constants.go
@@ -17,5 +17,5 @@ limitations under the License.
 package generatepipeline
 
 const (
-	defaultKanikoSecretName = "kaniko-secret"
+	kanikoSecretName = "kaniko-secret"
 )

--- a/pkg/skaffold/generate_pipeline/generate_pipeline.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline.go
@@ -143,24 +143,24 @@ func generateBuildTask(buildConfig latest.BuildConfig) (*tekton.Task, error) {
 	if buildConfig.Artifacts[0].KanikoArtifact != nil {
 		volumes = []corev1.Volume{
 			{
-				Name: "kaniko-secret",
+				Name: defaultKanikoSecretName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "kaniko-secret",
+						SecretName: defaultKanikoSecretName,
 					},
 				},
 			},
 		}
 		steps[0].VolumeMounts = []corev1.VolumeMount{
 			{
-				Name:      "kaniko-secret",
+				Name:      defaultKanikoSecretName,
 				MountPath: "/secret",
 			},
 		}
 		steps[0].Env = []corev1.EnvVar{
 			{
 				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
-				Value: "/secret/kaniko-secret",
+				Value: "/secret/" + defaultKanikoSecretName,
 			},
 		}
 	}

--- a/pkg/skaffold/generate_pipeline/generate_pipeline.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline.go
@@ -143,24 +143,24 @@ func generateBuildTask(buildConfig latest.BuildConfig) (*tekton.Task, error) {
 	if buildConfig.Artifacts[0].KanikoArtifact != nil {
 		volumes = []corev1.Volume{
 			{
-				Name: defaultKanikoSecretName,
+				Name: kanikoSecretName,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: defaultKanikoSecretName,
+						SecretName: kanikoSecretName,
 					},
 				},
 			},
 		}
 		steps[0].VolumeMounts = []corev1.VolumeMount{
 			{
-				Name:      defaultKanikoSecretName,
+				Name:      kanikoSecretName,
 				MountPath: "/secret",
 			},
 		}
 		steps[0].Env = []corev1.EnvVar{
 			{
 				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
-				Value: "/secret/" + defaultKanikoSecretName,
+				Value: "/secret/" + kanikoSecretName,
 			},
 		}
 	}

--- a/pkg/skaffold/generate_pipeline/profile.go
+++ b/pkg/skaffold/generate_pipeline/profile.go
@@ -32,22 +32,16 @@ import (
 	yamlv2 "gopkg.in/yaml.v2"
 )
 
-func CreateSkaffoldProfile(out io.Writer, config *latest.SkaffoldConfig, configFile string) error {
+func CreateSkaffoldProfile(out io.Writer, config *latest.SkaffoldConfig, configFile string) (*latest.Profile, error) {
 	reader := bufio.NewReader(os.Stdin)
 
+	// Check for existing oncluster profile, if none exists then prompt to create one
 	color.Default.Fprintln(out, "Checking for oncluster skaffold profile...")
-	profileExists := false
 	for _, profile := range config.Profiles {
 		if profile.Name == "oncluster" {
-			profileExists = true
-			break
+			color.Default.Fprintln(out, "profile \"oncluster\" found")
+			return &profile, nil
 		}
-	}
-
-	// Check for existing oncluster profile, if none exists then prompt to create one
-	if profileExists {
-		color.Default.Fprintln(out, "profile \"oncluster\" found!")
-		return nil
 	}
 
 confirmLoop:
@@ -55,7 +49,7 @@ confirmLoop:
 		color.Default.Fprintf(out, "No profile \"oncluster\" found. Create one? [y/n]: ")
 		response, err := reader.ReadString('\n')
 		if err != nil {
-			return errors.Wrap(err, "reading user confirmation")
+			return nil, errors.Wrap(err, "reading user confirmation")
 		}
 
 		response = strings.ToLower(strings.TrimSpace(response))
@@ -63,24 +57,24 @@ confirmLoop:
 		case "y", "yes":
 			break confirmLoop
 		case "n", "no":
-			return nil
+			return nil, nil
 		}
 	}
 
 	color.Default.Fprintln(out, "Creating skaffold profile \"oncluster\"...")
 	profile, err := generateProfile(out, config)
 	if err != nil {
-		return errors.Wrap(err, "generating profile \"oncluster\"")
+		return nil, errors.Wrap(err, "generating profile \"oncluster\"")
 	}
 
 	bProfile, err := yamlv2.Marshal([]*latest.Profile{profile})
 	if err != nil {
-		return errors.Wrap(err, "marshaling new profile")
+		return nil, errors.Wrap(err, "marshaling new profile")
 	}
 
 	fileContents, err := ioutil.ReadFile(configFile)
 	if err != nil {
-		return errors.Wrap(err, "reading file contents")
+		return nil, errors.Wrap(err, "reading file contents")
 	}
 	fileStrings := strings.Split(strings.TrimSpace(string(fileContents)), "\n")
 
@@ -104,10 +98,10 @@ confirmLoop:
 	fileContents = []byte((strings.Join(fileStrings, "\n")))
 
 	if err := ioutil.WriteFile(configFile, fileContents, 0644); err != nil {
-		return errors.Wrap(err, "writing profile to skaffold config")
+		return nil, errors.Wrap(err, "writing profile to skaffold config")
 	}
 
-	return nil
+	return profile, nil
 }
 
 func generateProfile(out io.Writer, config *latest.SkaffoldConfig) (*latest.Profile, error) {
@@ -122,11 +116,9 @@ func generateProfile(out io.Writer, config *latest.SkaffoldConfig) (*latest.Prof
 			Deploy: latest.DeployConfig{},
 		},
 	}
-	profile.Build.Cluster = &latest.ClusterDetails{
-		PullSecretName: "kaniko-secret",
-	}
-	profile.Build.LocalBuild = nil
+
 	// Add kaniko build config for artifacts
+	addKaniko := false
 	for _, artifact := range profile.Build.Artifacts {
 		artifact.ImageName = fmt.Sprintf("%s-pipeline", artifact.ImageName)
 		if artifact.DockerArtifact != nil {
@@ -137,7 +129,15 @@ func generateProfile(out io.Writer, config *latest.SkaffoldConfig) (*latest.Prof
 					GCSBucket: "skaffold-kaniko",
 				},
 			}
+			addKaniko = true
 		}
+	}
+	// Add kaniko config to build config if needed
+	if addKaniko {
+		profile.Build.Cluster = &latest.ClusterDetails{
+			PullSecretName: "kaniko-secret",
+		}
+		profile.Build.LocalBuild = nil
 	}
 
 	return profile, nil

--- a/pkg/skaffold/generate_pipeline/profile_test.go
+++ b/pkg/skaffold/generate_pipeline/profile_test.go
@@ -33,13 +33,16 @@ func TestGenerateProfile(t *testing.T) {
 		shouldErr       bool
 	}{
 		{
-			description: "successful profile generation",
+			description: "successful profile generation docker",
 			skaffoldConfig: &latest.SkaffoldConfig{
 				Pipeline: latest.Pipeline{
 					Build: latest.BuildConfig{
 						Artifacts: []*latest.Artifact{
 							{
 								ImageName: "test",
+								ArtifactType: latest.ArtifactType{
+									DockerArtifact: &latest.DockerArtifact{},
+								},
 							},
 						},
 					},
@@ -52,11 +55,58 @@ func TestGenerateProfile(t *testing.T) {
 						Artifacts: []*latest.Artifact{
 							{
 								ImageName: "test-pipeline",
+								ArtifactType: latest.ArtifactType{
+									KanikoArtifact: &latest.KanikoArtifact{
+										BuildContext: &latest.KanikoBuildContext{
+											GCSBucket: "skaffold-kaniko",
+										},
+									},
+								},
 							},
 						},
 						BuildType: latest.BuildType{
 							Cluster: &latest.ClusterDetails{
 								PullSecretName: "kaniko-secret",
+							},
+						},
+					},
+				},
+			},
+			shouldErr: false,
+		},
+		{
+			description: "successful profile generation jib",
+			skaffoldConfig: &latest.SkaffoldConfig{
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{
+						Artifacts: []*latest.Artifact{
+							{
+								ImageName: "test",
+								ArtifactType: latest.ArtifactType{
+									JibMavenArtifact: &latest.JibMavenArtifact{
+										Module:  "test-module",
+										Profile: "test-profile",
+									},
+									DockerArtifact: nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedProfile: &latest.Profile{
+				Name: "oncluster",
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{
+						Artifacts: []*latest.Artifact{
+							{
+								ImageName: "test-pipeline",
+								ArtifactType: latest.ArtifactType{
+									JibMavenArtifact: &latest.JibMavenArtifact{
+										Module:  "test-module",
+										Profile: "test-profile",
+									},
+								},
 							},
 						},
 					},

--- a/pkg/skaffold/pipeline/task.go
+++ b/pkg/skaffold/pipeline/task.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewTask(taskName string, inResources []tekton.TaskResource, steps []corev1.Container) *tekton.Task {
+func NewTask(taskName string, inResources []tekton.TaskResource, steps []corev1.Container, volumes []corev1.Volume) *tekton.Task {
 	return &tekton.Task{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Task",
@@ -35,7 +35,8 @@ func NewTask(taskName string, inResources []tekton.TaskResource, steps []corev1.
 			Inputs: &tekton.Inputs{
 				Resources: inResources,
 			},
-			Steps: steps,
+			Steps:   steps,
+			Volumes: volumes,
 		},
 	}
 }

--- a/pkg/skaffold/pipeline/task_test.go
+++ b/pkg/skaffold/pipeline/task_test.go
@@ -109,7 +109,7 @@ func TestNewTask(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			pipeline := NewTask(test.taskName, test.resources, test.steps)
+			pipeline := NewTask(test.taskName, test.resources, test.steps, nil)
 			t.CheckDeepEqual(test.expected, pipeline)
 		})
 	}

--- a/pkg/skaffold/runner/generate_pipeline.go
+++ b/pkg/skaffold/runner/generate_pipeline.go
@@ -31,12 +31,13 @@ import (
 
 func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, config *latest.SkaffoldConfig, fileOut string) error {
 	color.Default.Fprintln(out, "Running profile setup...")
-	if err := pipeline.CreateSkaffoldProfile(out, config, r.runCtx.Opts.ConfigurationFile); err != nil {
+	profile, err := pipeline.CreateSkaffoldProfile(out, config, r.runCtx.Opts.ConfigurationFile)
+	if err != nil {
 		return errors.Wrap(err, "setting up profile")
 	}
 
 	color.Default.Fprintln(out, "Generating Pipeline...")
-	pipelineYaml, err := pipeline.Yaml(out, config)
+	pipelineYaml, err := pipeline.Yaml(out, config, profile)
 	if err != nil {
 		return errors.Wrap(err, "generating pipeline yaml contents")
 	}


### PR DESCRIPTION
Changes functions used by generate-pipeline command to only add kaniko information to profile artifacts when necessary. Also adds GOOGLE_APPLICATION_CREDENTIALS env variable to tekton tasks when an artifact is built with kaniko.

Updated integration tests to match the new pipeline output.