### PR TITLE
Add missing digest when setting helm image tag

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -189,10 +189,13 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 				}
 				imageRepositoryTag = fmt.Sprintf(
 					"%s.registry=%s,%s.repository=%s,%s.tag=%s",
-					k, dockerRef.Domain, k, dockerRef.Path, k, dockerRef.Tag,
+					k, dockerRef.Domain, k, dockerRef.Path, k, extractTag(v.Tag),
 				)
 			} else {
-				imageRepositoryTag = fmt.Sprintf("%s.repository=%s,%s.tag=%s", k, dockerRef.BaseName, k, dockerRef.Tag)
+				imageRepositoryTag = fmt.Sprintf(
+					"%s.repository=%s,%s.tag=%s",
+					k, dockerRef.BaseName, k, extractTag(v.Tag),
+				)
 			}
 			setOpts = append(setOpts, imageRepositoryTag)
 		} else {


### PR DESCRIPTION
Description
--

The helm deployer did not append the digest during deployment,
which caused file sync and log output (and maybe other features)
to stop working.

Explanation
--

![goland-debug](https://i.imgur.com/vgs9t55.png)

 * _I removed our repository's name from the screenshot_

As you can see in the screenshot, `dockerRef.Tag` (which does not contain the digest) is used for setting the image tag (line [192](https://github.com/GoogleContainerTools/skaffold/blob/47262b9710e628e8c72fd1080c2b28a501d0d65d/pkg/skaffold/deploy/helm.go#L192) and [195](https://github.com/GoogleContainerTools/skaffold/blob/47262b9710e628e8c72fd1080c2b28a501d0d65d/pkg/skaffold/deploy/helm.go#L195)) if the `imageStrategy` is set to `helm`. If the `imageStrategy` is not set to `helm` the deployer uses `v.Tag` which contains the registry location, the repository name and the tag (including the digest).

Issues
--

Fixes #1379 

Related
--

 * #2111