### PR TITLE
Link task resources in pipeline

### DIFF
--- a/integration/testdata/generate_pipeline/existing_oncluster/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/existing_oncluster/expectedPipeline.yaml
@@ -33,10 +33,20 @@ spec:
     - build.out
     command:
     - skaffold
+    env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /secret/kaniko-secret
     image: gcr.io/k8s-skaffold/skaffold:test-version
     name: run-build
     resources: {}
+    volumeMounts:
+    - mountPath: /secret
+      name: kaniko-secret
     workingDir: /workspace/source
+  volumes:
+  - name: kaniko-secret
+    secret:
+      secretName: kaniko-secret
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Task
@@ -55,8 +65,6 @@ spec:
     - deploy
     - --filename
     - skaffold.yaml
-    - --profile
-    - oncluster
     - --build-artifacts
     - build.out
     command:

--- a/integration/testdata/generate_pipeline/existing_other/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/existing_other/expectedPipeline.yaml
@@ -33,10 +33,20 @@ spec:
     - build.out
     command:
     - skaffold
+    env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /secret/kaniko-secret
     image: gcr.io/k8s-skaffold/skaffold:test-version
     name: run-build
     resources: {}
+    volumeMounts:
+    - mountPath: /secret
+      name: kaniko-secret
     workingDir: /workspace/source
+  volumes:
+  - name: kaniko-secret
+    secret:
+      secretName: kaniko-secret
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Task
@@ -55,8 +65,6 @@ spec:
     - deploy
     - --filename
     - skaffold.yaml
-    - --profile
-    - oncluster
     - --build-artifacts
     - build.out
     command:

--- a/integration/testdata/generate_pipeline/no_profiles/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/no_profiles/expectedPipeline.yaml
@@ -33,10 +33,20 @@ spec:
     - build.out
     command:
     - skaffold
+    env:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /secret/kaniko-secret
     image: gcr.io/k8s-skaffold/skaffold:test-version
     name: run-build
     resources: {}
+    volumeMounts:
+    - mountPath: /secret
+      name: kaniko-secret
     workingDir: /workspace/source
+  volumes:
+  - name: kaniko-secret
+    secret:
+      secretName: kaniko-secret
 ---
 apiVersion: tekton.dev/v1alpha1
 kind: Task
@@ -55,8 +65,6 @@ spec:
     - deploy
     - --filename
     - skaffold.yaml
-    - --profile
-    - oncluster
     - --build-artifacts
     - build.out
     command:

--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -17,8 +17,10 @@ limitations under the License.
 package deploy
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -38,6 +40,7 @@ import (
 type KubectlDeployer struct {
 	*latest.KubectlDeploy
 
+	originalImages     []build.Artifact
 	workingDir         string
 	kubectl            deploy.CLI
 	defaultRepo        string
@@ -79,6 +82,24 @@ func (k *KubectlDeployer) Deploy(ctx context.Context, out io.Writer, builds []bu
 		event.DeployFailed(err)
 		return errors.Wrap(err, "reading manifests")
 	}
+
+	for _, m := range k.RemoteManifests {
+		manifest, err := k.readRemoteManifest(ctx, m)
+		if err != nil {
+			return errors.Wrap(err, "get remote manifests")
+		}
+
+		manifests = append(manifests, manifest)
+	}
+
+	if len(k.originalImages) == 0 {
+		k.originalImages, err = manifests.GetImages()
+		if err != nil {
+			return errors.Wrap(err, "get images from manifests")
+		}
+	}
+
+	logrus.Debugln("manifests", manifests.String())
 
 	if len(manifests) == 0 {
 		return nil
@@ -122,6 +143,22 @@ func (k *KubectlDeployer) Cleanup(ctx context.Context, out io.Writer) error {
 		return errors.Wrap(err, "reading manifests")
 	}
 
+	// pull remote manifests
+	var rm deploy.ManifestList
+	for _, m := range k.RemoteManifests {
+		manifest, err := k.readRemoteManifest(ctx, m)
+		if err != nil {
+			return errors.Wrap(err, "get remote manifests")
+		}
+		rm = append(rm, manifest)
+	}
+	upd, err := rm.ReplaceImages(k.originalImages, k.defaultRepo)
+	if err != nil {
+		return errors.Wrap(err, "replacing with originals")
+	}
+	if err := k.kubectl.Apply(ctx, out, upd); err != nil {
+		return errors.Wrap(err, "apply original")
+	}
 	if err := k.kubectl.Delete(ctx, out, manifests); err != nil {
 		return errors.Wrap(err, "delete")
 	}
@@ -181,4 +218,24 @@ func (k *KubectlDeployer) readManifests(ctx context.Context) (deploy.ManifestLis
 	}
 
 	return k.kubectl.ReadManifests(ctx, manifests)
+}
+
+// readRemoteManifests will try to read manifests from the given kubernetes
+// context in the specified namespace and for the specified type
+func (k *KubectlDeployer) readRemoteManifest(ctx context.Context, name string) ([]byte, error) {
+	var args []string
+	ns := ""
+	if parts := strings.Split(name, ":"); len(parts) > 1 {
+		ns = parts[0]
+		name = parts[1]
+	}
+	args = append(args, name, "-o", "yaml")
+
+	var manifest bytes.Buffer
+	err := k.kubectl.RunInNamespace(ctx, nil, &manifest, "get", ns, args...)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting manifest")
+	}
+
+	return manifest.Bytes(), nil
 }

--- a/pkg/skaffold/deploy/kubectl/visitor.go
+++ b/pkg/skaffold/deploy/kubectl/visitor.go
@@ -18,7 +18,7 @@ package kubectl
 
 import (
 	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // Replacer is used to replace portions of yaml manifests that match a given key.

--- a/pkg/skaffold/generate_pipeline/constants.go
+++ b/pkg/skaffold/generate_pipeline/constants.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generatepipeline
+
+const (
+	kanikoSecretName = "kaniko-secret"
+)

--- a/pkg/skaffold/generate_pipeline/generate_pipeline.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline.go
@@ -35,7 +35,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func Yaml(out io.Writer, config *latest.SkaffoldConfig) (*bytes.Buffer, error) {
+func Yaml(out io.Writer, config *latest.SkaffoldConfig, profile *latest.Profile) (*bytes.Buffer, error) {
 	// Generate git resource for pipeline
 	gitResource, err := generateGitResource()
 	if err != nil {
@@ -44,7 +44,7 @@ func Yaml(out io.Writer, config *latest.SkaffoldConfig) (*bytes.Buffer, error) {
 
 	// Generate build task for pipeline
 	var tasks []*tekton.Task
-	taskBuild, err := generateBuildTask(config.Pipeline.Build)
+	taskBuild, err := generateBuildTask(profile.Pipeline.Build)
 	if err != nil {
 		return nil, errors.Wrap(err, "generating build task")
 	}
@@ -139,7 +139,33 @@ func generateBuildTask(buildConfig latest.BuildConfig) (*tekton.Task, error) {
 		},
 	}
 
-	return pipeline.NewTask("skaffold-build", resources, steps), nil
+	var volumes []corev1.Volume
+	if buildConfig.Artifacts[0].KanikoArtifact != nil {
+		volumes = []corev1.Volume{
+			{
+				Name: kanikoSecretName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: kanikoSecretName,
+					},
+				},
+			},
+		}
+		steps[0].VolumeMounts = []corev1.VolumeMount{
+			{
+				Name:      kanikoSecretName,
+				MountPath: "/secret",
+			},
+		}
+		steps[0].Env = []corev1.EnvVar{
+			{
+				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+				Value: "/secret/" + kanikoSecretName,
+			},
+		}
+	}
+
+	return pipeline.NewTask("skaffold-build", resources, steps, volumes), nil
 }
 
 func generateDeployTask(deployConfig latest.DeployConfig) (*tekton.Task, error) {
@@ -167,13 +193,12 @@ func generateDeployTask(deployConfig latest.DeployConfig) (*tekton.Task, error) 
 			Args: []string{
 				"deploy",
 				"--filename", "skaffold.yaml",
-				"--profile", "oncluster",
 				"--build-artifacts", "build.out",
 			},
 		},
 	}
 
-	return pipeline.NewTask("skaffold-deploy", resources, steps), nil
+	return pipeline.NewTask("skaffold-deploy", resources, steps, nil), nil
 }
 
 func generatePipeline(tasks []*tekton.Task) (*tekton.Pipeline, error) {

--- a/pkg/skaffold/generate_pipeline/generate_pipeline_test.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline_test.go
@@ -38,7 +38,7 @@ func TestGeneratePipeline(t *testing.T) {
 			tasks: []*tekton.Task{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "test",
+						Name: "test-build",
 					},
 				},
 			},
@@ -59,13 +59,18 @@ func TestGeneratePipeline(t *testing.T) {
 					},
 					Tasks: []tekton.PipelineTask{
 						{
-							Name: "test-task",
+							Name: "test-build-task",
 							TaskRef: tekton.TaskRef{
-								Name: "test",
+								Name: "test-build",
 							},
-							RunAfter: []string{},
 							Resources: &tekton.PipelineTaskResources{
 								Inputs: []tekton.PipelineTaskInputResource{
+									{
+										Name:     "source",
+										Resource: "source-repo",
+									},
+								},
+								Outputs: []tekton.PipelineTaskOutputResource{
 									{
 										Name:     "source",
 										Resource: "source-repo",
@@ -83,12 +88,12 @@ func TestGeneratePipeline(t *testing.T) {
 			tasks: []*tekton.Task{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "test1",
+						Name: "test-build",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "test2",
+						Name: "test-deploy",
 					},
 				},
 			},
@@ -109,13 +114,18 @@ func TestGeneratePipeline(t *testing.T) {
 					},
 					Tasks: []tekton.PipelineTask{
 						{
-							Name: "test1-task",
+							Name: "test-build-task",
 							TaskRef: tekton.TaskRef{
-								Name: "test1",
+								Name: "test-build",
 							},
-							RunAfter: []string{},
 							Resources: &tekton.PipelineTaskResources{
 								Inputs: []tekton.PipelineTaskInputResource{
+									{
+										Name:     "source",
+										Resource: "source-repo",
+									},
+								},
+								Outputs: []tekton.PipelineTaskOutputResource{
 									{
 										Name:     "source",
 										Resource: "source-repo",
@@ -124,16 +134,16 @@ func TestGeneratePipeline(t *testing.T) {
 							},
 						},
 						{
-							Name: "test2-task",
+							Name: "test-deploy-task",
 							TaskRef: tekton.TaskRef{
-								Name: "test2",
+								Name: "test-deploy",
 							},
-							RunAfter: []string{"test1-task"},
 							Resources: &tekton.PipelineTaskResources{
 								Inputs: []tekton.PipelineTaskInputResource{
 									{
 										Name:     "source",
 										Resource: "source-repo",
+										From:     []string{"test-build-task"},
 									},
 								},
 							},

--- a/pkg/skaffold/generate_pipeline/profile.go
+++ b/pkg/skaffold/generate_pipeline/profile.go
@@ -32,22 +32,16 @@ import (
 	yamlv2 "gopkg.in/yaml.v2"
 )
 
-func CreateSkaffoldProfile(out io.Writer, config *latest.SkaffoldConfig, configFile string) error {
+func CreateSkaffoldProfile(out io.Writer, config *latest.SkaffoldConfig, configFile string) (*latest.Profile, error) {
 	reader := bufio.NewReader(os.Stdin)
 
+	// Check for existing oncluster profile, if none exists then prompt to create one
 	color.Default.Fprintln(out, "Checking for oncluster skaffold profile...")
-	profileExists := false
 	for _, profile := range config.Profiles {
 		if profile.Name == "oncluster" {
-			profileExists = true
-			break
+			color.Default.Fprintln(out, "profile \"oncluster\" found")
+			return &profile, nil
 		}
-	}
-
-	// Check for existing oncluster profile, if none exists then prompt to create one
-	if profileExists {
-		color.Default.Fprintln(out, "profile \"oncluster\" found!")
-		return nil
 	}
 
 confirmLoop:
@@ -55,7 +49,7 @@ confirmLoop:
 		color.Default.Fprintf(out, "No profile \"oncluster\" found. Create one? [y/n]: ")
 		response, err := reader.ReadString('\n')
 		if err != nil {
-			return errors.Wrap(err, "reading user confirmation")
+			return nil, errors.Wrap(err, "reading user confirmation")
 		}
 
 		response = strings.ToLower(strings.TrimSpace(response))
@@ -63,24 +57,24 @@ confirmLoop:
 		case "y", "yes":
 			break confirmLoop
 		case "n", "no":
-			return nil
+			return nil, nil
 		}
 	}
 
 	color.Default.Fprintln(out, "Creating skaffold profile \"oncluster\"...")
 	profile, err := generateProfile(out, config)
 	if err != nil {
-		return errors.Wrap(err, "generating profile \"oncluster\"")
+		return nil, errors.Wrap(err, "generating profile \"oncluster\"")
 	}
 
 	bProfile, err := yamlv2.Marshal([]*latest.Profile{profile})
 	if err != nil {
-		return errors.Wrap(err, "marshaling new profile")
+		return nil, errors.Wrap(err, "marshaling new profile")
 	}
 
 	fileContents, err := ioutil.ReadFile(configFile)
 	if err != nil {
-		return errors.Wrap(err, "reading file contents")
+		return nil, errors.Wrap(err, "reading file contents")
 	}
 	fileStrings := strings.Split(strings.TrimSpace(string(fileContents)), "\n")
 
@@ -104,10 +98,10 @@ confirmLoop:
 	fileContents = []byte((strings.Join(fileStrings, "\n")))
 
 	if err := ioutil.WriteFile(configFile, fileContents, 0644); err != nil {
-		return errors.Wrap(err, "writing profile to skaffold config")
+		return nil, errors.Wrap(err, "writing profile to skaffold config")
 	}
 
-	return nil
+	return profile, nil
 }
 
 func generateProfile(out io.Writer, config *latest.SkaffoldConfig) (*latest.Profile, error) {
@@ -122,11 +116,9 @@ func generateProfile(out io.Writer, config *latest.SkaffoldConfig) (*latest.Prof
 			Deploy: latest.DeployConfig{},
 		},
 	}
-	profile.Build.Cluster = &latest.ClusterDetails{
-		PullSecretName: "kaniko-secret",
-	}
-	profile.Build.LocalBuild = nil
+
 	// Add kaniko build config for artifacts
+	addKaniko := false
 	for _, artifact := range profile.Build.Artifacts {
 		artifact.ImageName = fmt.Sprintf("%s-pipeline", artifact.ImageName)
 		if artifact.DockerArtifact != nil {
@@ -137,7 +129,15 @@ func generateProfile(out io.Writer, config *latest.SkaffoldConfig) (*latest.Prof
 					GCSBucket: "skaffold-kaniko",
 				},
 			}
+			addKaniko = true
 		}
+	}
+	// Add kaniko config to build config if needed
+	if addKaniko {
+		profile.Build.Cluster = &latest.ClusterDetails{
+			PullSecretName: "kaniko-secret",
+		}
+		profile.Build.LocalBuild = nil
 	}
 
 	return profile, nil

--- a/pkg/skaffold/generate_pipeline/profile_test.go
+++ b/pkg/skaffold/generate_pipeline/profile_test.go
@@ -33,13 +33,16 @@ func TestGenerateProfile(t *testing.T) {
 		shouldErr       bool
 	}{
 		{
-			description: "successful profile generation",
+			description: "successful profile generation docker",
 			skaffoldConfig: &latest.SkaffoldConfig{
 				Pipeline: latest.Pipeline{
 					Build: latest.BuildConfig{
 						Artifacts: []*latest.Artifact{
 							{
 								ImageName: "test",
+								ArtifactType: latest.ArtifactType{
+									DockerArtifact: &latest.DockerArtifact{},
+								},
 							},
 						},
 					},
@@ -52,11 +55,58 @@ func TestGenerateProfile(t *testing.T) {
 						Artifacts: []*latest.Artifact{
 							{
 								ImageName: "test-pipeline",
+								ArtifactType: latest.ArtifactType{
+									KanikoArtifact: &latest.KanikoArtifact{
+										BuildContext: &latest.KanikoBuildContext{
+											GCSBucket: "skaffold-kaniko",
+										},
+									},
+								},
 							},
 						},
 						BuildType: latest.BuildType{
 							Cluster: &latest.ClusterDetails{
 								PullSecretName: "kaniko-secret",
+							},
+						},
+					},
+				},
+			},
+			shouldErr: false,
+		},
+		{
+			description: "successful profile generation jib",
+			skaffoldConfig: &latest.SkaffoldConfig{
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{
+						Artifacts: []*latest.Artifact{
+							{
+								ImageName: "test",
+								ArtifactType: latest.ArtifactType{
+									JibMavenArtifact: &latest.JibMavenArtifact{
+										Module:  "test-module",
+										Profile: "test-profile",
+									},
+									DockerArtifact: nil,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedProfile: &latest.Profile{
+				Name: "oncluster",
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{
+						Artifacts: []*latest.Artifact{
+							{
+								ImageName: "test-pipeline",
+								ArtifactType: latest.ArtifactType{
+									JibMavenArtifact: &latest.JibMavenArtifact{
+										Module:  "test-module",
+										Profile: "test-profile",
+									},
+								},
 							},
 						},
 					},

--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -44,13 +44,28 @@ func NewFromRunContext(runCtx *runcontext.RunContext) *CLI {
 
 // Command creates the underlying exec.CommandContext. This allows low-level control of the executed command.
 func (c *CLI) Command(ctx context.Context, command string, arg ...string) *exec.Cmd {
-	args := c.args(command, arg...)
+	args := c.args(command, "", arg...)
+	return exec.CommandContext(ctx, "kubectl", args...)
+}
+
+// Command creates the underlying exec.CommandContext with namespace. This allows low-level control of the executed command.
+func (c *CLI) CommandWithNamespaceArg(ctx context.Context, command string, namespace string, arg ...string) *exec.Cmd {
+	args := c.args(command, namespace, arg...)
 	return exec.CommandContext(ctx, "kubectl", args...)
 }
 
 // Run shells out kubectl CLI.
 func (c *CLI) Run(ctx context.Context, in io.Reader, out io.Writer, command string, arg ...string) error {
 	cmd := c.Command(ctx, command, arg...)
+	cmd.Stdin = in
+	cmd.Stdout = out
+	cmd.Stderr = out
+	return util.RunCmd(cmd)
+}
+
+// Run shells out kubectl CLI with given namespace
+func (c *CLI) RunInNamespace(ctx context.Context, in io.Reader, out io.Writer, command string, namespace string, arg ...string) error {
+	cmd := c.CommandWithNamespaceArg(ctx, command, namespace, arg...)
 	cmd.Stdin = in
 	cmd.Stdout = out
 	cmd.Stderr = out
@@ -65,12 +80,20 @@ func (c *CLI) RunOut(ctx context.Context, command string, arg ...string) ([]byte
 
 // args builds an argument list for calling kubectl and consistently
 // adds the `--context` and `--namespace` flags.
-func (c *CLI) args(command string, arg ...string) []string {
+func (c *CLI) args(command string, namespace string, arg ...string) []string {
 	args := []string{"--context", c.KubeContext}
-	if c.Namespace != "" {
-		args = append(args, "--namespace", c.Namespace)
+	namespace = c.resolveNamespace(namespace)
+	if namespace != "" {
+		args = append(args, "--namespace", namespace)
 	}
 	args = append(args, command)
 	args = append(args, arg...)
 	return args
+}
+
+func (c *CLI) resolveNamespace(ns string) string {
+	if ns != "" {
+		return ns
+	}
+	return c.Namespace
 }

--- a/pkg/skaffold/pipeline/task.go
+++ b/pkg/skaffold/pipeline/task.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewTask(taskName string, inResources []tekton.TaskResource, steps []corev1.Container, volumes []corev1.Volume) *tekton.Task {
+func NewTask(taskName string, inputs *tekton.Inputs, outputs *tekton.Outputs, steps []corev1.Container, volumes []corev1.Volume) *tekton.Task {
 	return &tekton.Task{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Task",
@@ -32,9 +32,8 @@ func NewTask(taskName string, inResources []tekton.TaskResource, steps []corev1.
 			Name: taskName,
 		},
 		Spec: tekton.TaskSpec{
-			Inputs: &tekton.Inputs{
-				Resources: inResources,
-			},
+			Inputs:  inputs,
+			Outputs: outputs,
 			Steps:   steps,
 			Volumes: volumes,
 		},

--- a/pkg/skaffold/pipeline/task.go
+++ b/pkg/skaffold/pipeline/task.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewTask(taskName string, inResources []tekton.TaskResource, steps []corev1.Container) *tekton.Task {
+func NewTask(taskName string, inResources []tekton.TaskResource, steps []corev1.Container, volumes []corev1.Volume) *tekton.Task {
 	return &tekton.Task{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Task",
@@ -35,7 +35,8 @@ func NewTask(taskName string, inResources []tekton.TaskResource, steps []corev1.
 			Inputs: &tekton.Inputs{
 				Resources: inResources,
 			},
-			Steps: steps,
+			Steps:   steps,
+			Volumes: volumes,
 		},
 	}
 }

--- a/pkg/skaffold/pipeline/task_test.go
+++ b/pkg/skaffold/pipeline/task_test.go
@@ -30,7 +30,7 @@ func TestNewTask(t *testing.T) {
 	tests := []struct {
 		description string
 		taskName    string
-		resources   []tekton.TaskResource
+		inputs      *tekton.Inputs
 		steps       []corev1.Container
 		expected    *tekton.Task
 	}{
@@ -41,18 +41,18 @@ func TestNewTask(t *testing.T) {
 					Kind:       "Task",
 					APIVersion: "tekton.dev/v1alpha1",
 				},
-				Spec: tekton.TaskSpec{
-					Inputs: &tekton.Inputs{},
-				},
+				Spec: tekton.TaskSpec{},
 			},
 		},
 		{
 			description: "normal params",
 			taskName:    "task-test",
-			resources: []tekton.TaskResource{
-				{
-					Name: "source",
-					Type: tekton.PipelineResourceTypeGit,
+			inputs: &tekton.Inputs{
+				Resources: []tekton.TaskResource{
+					{
+						Name: "source",
+						Type: tekton.PipelineResourceTypeGit,
+					},
 				},
 			},
 			steps: []corev1.Container{
@@ -94,22 +94,20 @@ func TestNewTask(t *testing.T) {
 		{
 			description: "empty params",
 			taskName:    "",
-			resources:   []tekton.TaskResource{},
+			inputs:      &tekton.Inputs{},
 			steps:       []corev1.Container{},
 			expected: &tekton.Task{
 				TypeMeta: metav1.TypeMeta{Kind: "Task", APIVersion: "tekton.dev/v1alpha1"},
 				Spec: tekton.TaskSpec{
-					Inputs: &tekton.Inputs{
-						Resources: []tekton.TaskResource{},
-					},
-					Steps: []corev1.Container{},
+					Inputs: &tekton.Inputs{},
+					Steps:  []corev1.Container{},
 				},
 			},
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			pipeline := NewTask(test.taskName, test.resources, test.steps, nil)
+			pipeline := NewTask(test.taskName, test.inputs, nil, test.steps, nil)
 			t.CheckDeepEqual(test.expected, pipeline)
 		})
 	}

--- a/pkg/skaffold/pipeline/task_test.go
+++ b/pkg/skaffold/pipeline/task_test.go
@@ -109,7 +109,7 @@ func TestNewTask(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			pipeline := NewTask(test.taskName, test.resources, test.steps)
+			pipeline := NewTask(test.taskName, test.resources, test.steps, nil)
 			t.CheckDeepEqual(test.expected, pipeline)
 		})
 	}

--- a/pkg/skaffold/runner/generate_pipeline.go
+++ b/pkg/skaffold/runner/generate_pipeline.go
@@ -31,12 +31,13 @@ import (
 
 func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, config *latest.SkaffoldConfig, fileOut string) error {
 	color.Default.Fprintln(out, "Running profile setup...")
-	if err := pipeline.CreateSkaffoldProfile(out, config, r.runCtx.Opts.ConfigurationFile); err != nil {
+	profile, err := pipeline.CreateSkaffoldProfile(out, config, r.runCtx.Opts.ConfigurationFile)
+	if err != nil {
 		return errors.Wrap(err, "setting up profile")
 	}
 
 	color.Default.Fprintln(out, "Generating Pipeline...")
-	pipelineYaml, err := pipeline.Yaml(out, config)
+	pipelineYaml, err := pipeline.Yaml(out, config, profile)
 	if err != nil {
 		return errors.Wrap(err, "generating pipeline yaml contents")
 	}


### PR DESCRIPTION
Build on top of https://github.com/GoogleContainerTools/skaffold/pull/2622

Adds connection of resources from build to deploy task. Removes the need for runAfter. Instead, the task order is determined resource dependency. This allows the deploy task to use the build.out file that is generated by the build task.

TODO: Update integration tests for new pipeline output