### PR TITLE
Link task resources in generate-pipeline output

### DIFF
--- a/integration/testdata/generate_pipeline/existing_oncluster/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/existing_oncluster/expectedPipeline.yaml
@@ -22,17 +22,21 @@ spec:
       outputImageDir: ""
       targetPath: ""
       type: git
+  outputs:
+    resources:
+    - name: source
+      outputImageDir: ""
+      targetPath: ""
+      type: git
   steps:
   - args:
-    - build
-    - --filename
-    - skaffold.yaml
     - --profile
     - oncluster
     - --file-output
     - build.out
     command:
     - skaffold
+    - build
     env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /secret/kaniko-secret
@@ -62,13 +66,11 @@ spec:
       type: git
   steps:
   - args:
-    - deploy
-    - --filename
-    - skaffold.yaml
     - --build-artifacts
     - build.out
     command:
     - skaffold
+    - deploy
     image: gcr.io/k8s-skaffold/skaffold:test-version
     name: run-deploy
     resources: {}
@@ -89,15 +91,18 @@ spec:
       inputs:
       - name: source
         resource: source-repo
+      outputs:
+      - name: source
+        resource: source-repo
     taskRef:
       name: skaffold-build
   - name: skaffold-deploy-task
     resources:
       inputs:
-      - name: source
+      - from:
+        - skaffold-build-task
+        name: source
         resource: source-repo
-    runAfter:
-    - skaffold-build-task
     taskRef:
       name: skaffold-deploy
 status: {}

--- a/integration/testdata/generate_pipeline/existing_other/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/existing_other/expectedPipeline.yaml
@@ -22,17 +22,21 @@ spec:
       outputImageDir: ""
       targetPath: ""
       type: git
+  outputs:
+    resources:
+    - name: source
+      outputImageDir: ""
+      targetPath: ""
+      type: git
   steps:
   - args:
-    - build
-    - --filename
-    - skaffold.yaml
     - --profile
     - oncluster
     - --file-output
     - build.out
     command:
     - skaffold
+    - build
     env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /secret/kaniko-secret
@@ -62,13 +66,11 @@ spec:
       type: git
   steps:
   - args:
-    - deploy
-    - --filename
-    - skaffold.yaml
     - --build-artifacts
     - build.out
     command:
     - skaffold
+    - deploy
     image: gcr.io/k8s-skaffold/skaffold:test-version
     name: run-deploy
     resources: {}
@@ -89,15 +91,18 @@ spec:
       inputs:
       - name: source
         resource: source-repo
+      outputs:
+      - name: source
+        resource: source-repo
     taskRef:
       name: skaffold-build
   - name: skaffold-deploy-task
     resources:
       inputs:
-      - name: source
+      - from:
+        - skaffold-build-task
+        name: source
         resource: source-repo
-    runAfter:
-    - skaffold-build-task
     taskRef:
       name: skaffold-deploy
 status: {}

--- a/integration/testdata/generate_pipeline/no_profiles/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/no_profiles/expectedPipeline.yaml
@@ -22,17 +22,21 @@ spec:
       outputImageDir: ""
       targetPath: ""
       type: git
+  outputs:
+    resources:
+    - name: source
+      outputImageDir: ""
+      targetPath: ""
+      type: git
   steps:
   - args:
-    - build
-    - --filename
-    - skaffold.yaml
     - --profile
     - oncluster
     - --file-output
     - build.out
     command:
     - skaffold
+    - build
     env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /secret/kaniko-secret
@@ -62,13 +66,11 @@ spec:
       type: git
   steps:
   - args:
-    - deploy
-    - --filename
-    - skaffold.yaml
     - --build-artifacts
     - build.out
     command:
     - skaffold
+    - deploy
     image: gcr.io/k8s-skaffold/skaffold:test-version
     name: run-deploy
     resources: {}
@@ -89,15 +91,18 @@ spec:
       inputs:
       - name: source
         resource: source-repo
+      outputs:
+      - name: source
+        resource: source-repo
     taskRef:
       name: skaffold-build
   - name: skaffold-deploy-task
     resources:
       inputs:
-      - name: source
+      - from:
+        - skaffold-build-task
+        name: source
         resource: source-repo
-    runAfter:
-    - skaffold-build-task
     taskRef:
       name: skaffold-deploy
 status: {}

--- a/pkg/skaffold/generate_pipeline/generate_pipeline_test.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline_test.go
@@ -38,7 +38,7 @@ func TestGeneratePipeline(t *testing.T) {
 			tasks: []*tekton.Task{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "test",
+						Name: "test-build",
 					},
 				},
 			},
@@ -59,13 +59,18 @@ func TestGeneratePipeline(t *testing.T) {
 					},
 					Tasks: []tekton.PipelineTask{
 						{
-							Name: "test-task",
+							Name: "test-build-task",
 							TaskRef: tekton.TaskRef{
-								Name: "test",
+								Name: "test-build",
 							},
-							RunAfter: []string{},
 							Resources: &tekton.PipelineTaskResources{
 								Inputs: []tekton.PipelineTaskInputResource{
+									{
+										Name:     "source",
+										Resource: "source-repo",
+									},
+								},
+								Outputs: []tekton.PipelineTaskOutputResource{
 									{
 										Name:     "source",
 										Resource: "source-repo",
@@ -83,12 +88,12 @@ func TestGeneratePipeline(t *testing.T) {
 			tasks: []*tekton.Task{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "test1",
+						Name: "test-build",
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "test2",
+						Name: "test-deploy",
 					},
 				},
 			},
@@ -109,13 +114,18 @@ func TestGeneratePipeline(t *testing.T) {
 					},
 					Tasks: []tekton.PipelineTask{
 						{
-							Name: "test1-task",
+							Name: "test-build-task",
 							TaskRef: tekton.TaskRef{
-								Name: "test1",
+								Name: "test-build",
 							},
-							RunAfter: []string{},
 							Resources: &tekton.PipelineTaskResources{
 								Inputs: []tekton.PipelineTaskInputResource{
+									{
+										Name:     "source",
+										Resource: "source-repo",
+									},
+								},
+								Outputs: []tekton.PipelineTaskOutputResource{
 									{
 										Name:     "source",
 										Resource: "source-repo",
@@ -124,16 +134,16 @@ func TestGeneratePipeline(t *testing.T) {
 							},
 						},
 						{
-							Name: "test2-task",
+							Name: "test-deploy-task",
 							TaskRef: tekton.TaskRef{
-								Name: "test2",
+								Name: "test-deploy",
 							},
-							RunAfter: []string{"test1-task"},
 							Resources: &tekton.PipelineTaskResources{
 								Inputs: []tekton.PipelineTaskInputResource{
 									{
 										Name:     "source",
 										Resource: "source-repo",
+										From:     []string{"test-build-task"},
 									},
 								},
 							},

--- a/pkg/skaffold/pipeline/task.go
+++ b/pkg/skaffold/pipeline/task.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NewTask(taskName string, inResources []tekton.TaskResource, steps []corev1.Container, volumes []corev1.Volume) *tekton.Task {
+func NewTask(taskName string, inputs *tekton.Inputs, outputs *tekton.Outputs, steps []corev1.Container, volumes []corev1.Volume) *tekton.Task {
 	return &tekton.Task{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Task",
@@ -32,9 +32,8 @@ func NewTask(taskName string, inResources []tekton.TaskResource, steps []corev1.
 			Name: taskName,
 		},
 		Spec: tekton.TaskSpec{
-			Inputs: &tekton.Inputs{
-				Resources: inResources,
-			},
+			Inputs:  inputs,
+			Outputs: outputs,
 			Steps:   steps,
 			Volumes: volumes,
 		},

--- a/pkg/skaffold/pipeline/task_test.go
+++ b/pkg/skaffold/pipeline/task_test.go
@@ -30,7 +30,7 @@ func TestNewTask(t *testing.T) {
 	tests := []struct {
 		description string
 		taskName    string
-		resources   []tekton.TaskResource
+		inputs      *tekton.Inputs
 		steps       []corev1.Container
 		expected    *tekton.Task
 	}{
@@ -41,18 +41,18 @@ func TestNewTask(t *testing.T) {
 					Kind:       "Task",
 					APIVersion: "tekton.dev/v1alpha1",
 				},
-				Spec: tekton.TaskSpec{
-					Inputs: &tekton.Inputs{},
-				},
+				Spec: tekton.TaskSpec{},
 			},
 		},
 		{
 			description: "normal params",
 			taskName:    "task-test",
-			resources: []tekton.TaskResource{
-				{
-					Name: "source",
-					Type: tekton.PipelineResourceTypeGit,
+			inputs: &tekton.Inputs{
+				Resources: []tekton.TaskResource{
+					{
+						Name: "source",
+						Type: tekton.PipelineResourceTypeGit,
+					},
 				},
 			},
 			steps: []corev1.Container{
@@ -94,22 +94,20 @@ func TestNewTask(t *testing.T) {
 		{
 			description: "empty params",
 			taskName:    "",
-			resources:   []tekton.TaskResource{},
+			inputs:      &tekton.Inputs{},
 			steps:       []corev1.Container{},
 			expected: &tekton.Task{
 				TypeMeta: metav1.TypeMeta{Kind: "Task", APIVersion: "tekton.dev/v1alpha1"},
 				Spec: tekton.TaskSpec{
-					Inputs: &tekton.Inputs{
-						Resources: []tekton.TaskResource{},
-					},
-					Steps: []corev1.Container{},
+					Inputs: &tekton.Inputs{},
+					Steps:  []corev1.Container{},
 				},
 			},
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			pipeline := NewTask(test.taskName, test.resources, test.steps, nil)
+			pipeline := NewTask(test.taskName, test.inputs, nil, test.steps, nil)
 			t.CheckDeepEqual(test.expected, pipeline)
 		})
 	}


### PR DESCRIPTION
Adds connection of resources from build to deploy task. Removes the need for runAfter. Instead, the task order is determined resource dependency. This allows the deploy task to use the build.out file that is generated by the build task.