### PR TITLE
Don't look up services in all namespaces.

### DIFF
--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
@@ -54,7 +54,7 @@ func NewForwarderManager(out io.Writer, cli *kubectl.CLI, podSelector kubernetes
 
 	ForwarderManager := &ForwarderManager{
 		output:     out,
-		Forwarders: []Forwarder{NewResourceForwarder(em, label, userDefined)},
+		Forwarders: []Forwarder{NewResourceForwarder(em, namespaces, label, userDefined)},
 	}
 
 	if opts.ForwardPods {

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder.go
@@ -41,7 +41,7 @@ var (
 	// For testing
 	retrieveAvailablePort = util.GetAvailablePort
 	retrieveServices      = retrieveServiceResources
-	kClientSet            = kubernetes.GetClientset
+	getClientSet          = kubernetes.GetClientset
 )
 
 // NewResourceForwarder returns a struct that tracks and port-forwards pods as they are created and modified
@@ -104,7 +104,7 @@ func (p *ResourceForwarder) getCurrentEntry(resource latest.PortForwardResource)
 // retrieveServiceResources retrieves all services in the cluster matching the given label
 // as a list of PortForwardResources
 func retrieveServiceResources(label string, namespaces []string) ([]*latest.PortForwardResource, error) {
-	clientset, err := kClientSet()
+	clientset, err := getClientSet()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting clientset")
 	}

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder.go
@@ -41,6 +41,7 @@ var (
 	// For testing
 	retrieveAvailablePort = util.GetAvailablePort
 	retrieveServices      = retrieveServiceResources
+	kClientSet            = kubernetes.GetClientset
 )
 
 // NewResourceForwarder returns a struct that tracks and port-forwards pods as they are created and modified
@@ -103,7 +104,7 @@ func (p *ResourceForwarder) getCurrentEntry(resource latest.PortForwardResource)
 // retrieveServiceResources retrieves all services in the cluster matching the given label
 // as a list of PortForwardResources
 func retrieveServiceResources(label string, namespaces []string) ([]*latest.PortForwardResource, error) {
-	clientset, err := kubernetes.GetClientset()
+	clientset, err := kClientSet()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting clientset")
 	}

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -326,6 +326,20 @@ func TestRetrieveServices(t *testing.T) {
 					Spec: v1.ServiceSpec{Ports: []v1.ServicePort{{Port: 8080}}},
 				},
 			},
+		}, {
+			description: "services present but does not expose any port",
+			namespaces:  []string{"test"},
+			services: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "svc1",
+						Namespace: "test",
+						Labels: map[string]string{
+							deploy.RunIDLabel: "9876-6789",
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -350,7 +350,7 @@ func TestRetrieveServices(t *testing.T) {
 				objs[i] = s
 			}
 			client := fakekubeclientset.NewSimpleClientset(objs...)
-			t.Override(&kClientSet, mockClient(client))
+			t.Override(&getClientSet, mockClient(client))
 			actual, err := retrieveServiceResources(fmt.Sprintf("%s=9876-6789", deploy.RunIDLabel), test.namespaces)
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -116,11 +116,11 @@ func TestStart(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			event.InitializeState(latest.BuildConfig{})
 			fakeForwarder := newTestForwarder()
-			rf := NewResourceForwarder(NewEntryManager(ioutil.Discard, nil), "", nil)
+			rf := NewResourceForwarder(NewEntryManager(ioutil.Discard, nil), []string{"test"}, "", nil)
 			rf.EntryForwarder = fakeForwarder
 
 			t.Override(&retrieveAvailablePort, mockRetrieveAvailablePort(map[int]struct{}{}, test.availablePorts))
-			t.Override(&retrieveServices, func(string) ([]*latest.PortForwardResource, error) {
+			t.Override(&retrieveServices, func(string, []string) ([]*latest.PortForwardResource, error) {
 				return test.resources, nil
 			})
 
@@ -189,7 +189,7 @@ func TestGetCurrentEntryFunc(t *testing.T) {
 			expectedEntry := test.expected
 			expectedEntry.resource = test.resource
 
-			rf := NewResourceForwarder(NewEntryManager(ioutil.Discard, nil), "", nil)
+			rf := NewResourceForwarder(NewEntryManager(ioutil.Discard, nil), []string{"test"}, "", nil)
 			rf.forwardedResources = forwardedResources{
 				resources: test.forwardedResources,
 				lock:      &sync.Mutex{},
@@ -232,11 +232,11 @@ func TestUserDefinedResources(t *testing.T) {
 	testutil.Run(t, "one service and one user defined pod", func(t *testutil.T) {
 		event.InitializeState(latest.BuildConfig{})
 		fakeForwarder := newTestForwarder()
-		rf := NewResourceForwarder(NewEntryManager(ioutil.Discard, nil), "", []*latest.PortForwardResource{pod})
+		rf := NewResourceForwarder(NewEntryManager(ioutil.Discard, nil), []string{"test"}, "", []*latest.PortForwardResource{pod})
 		rf.EntryForwarder = fakeForwarder
 
 		t.Override(&retrieveAvailablePort, mockRetrieveAvailablePort(map[int]struct{}{}, []int{8080, 9000}))
-		t.Override(&retrieveServices, func(string) ([]*latest.PortForwardResource, error) {
+		t.Override(&retrieveServices, func(string, []string) ([]*latest.PortForwardResource, error) {
 			return []*latest.PortForwardResource{svc}, nil
 		})
 


### PR DESCRIPTION
fixes #2495, 

In #2640, i made changes to collect all namespaces for deployed resources.
In PR, we go through all namespaces in the context and then look for services in each namespace.