### PR TITLE
Use pointers for connection listeners so they can be closed properly

### DIFF
--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -44,7 +44,7 @@ type eventHandler struct {
 	state     proto.State
 	stateLock sync.Mutex
 
-	listeners []listener
+	listeners []*listener
 }
 
 type listener struct {
@@ -100,7 +100,7 @@ func (ev *eventHandler) logEvent(entry proto.LogEntry) {
 }
 
 func (ev *eventHandler) forEachEvent(callback func(*proto.LogEntry) error) error {
-	listener := listener{
+	listener := &listener{
 		callback: callback,
 		errors:   make(chan error),
 	}


### PR DESCRIPTION
When a listener's connection is dropped, skaffold marks it as "closed" so it can be skipped when we're sending out new events to all connections. The issue is that dropped connections were not actually being marked as closed (since they were being passed by value), causing all other connections to hang when waiting for that listener's callback to process.

Fixes #2647 