### PR TITLE
Remove time sensitive tests

### DIFF
--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -208,13 +208,6 @@ func TestPollDeploymentRolloutStatus(t *testing.T) {
 			shouldErr: true,
 			duration:  50,
 		}, {
-			description: "rollout returns success before time out",
-			command: testutil.NewFakeCmd(t).
-				WithRunOut(rolloutCmd, "Waiting for rollout to finish: 0 of 1 updated replicas are available...").
-				WithRunOut(rolloutCmd, "Waiting for rollout to finish: 0 of 1 updated replicas are available...").
-				WithRunOut(rolloutCmd, "deployment.apps/dep successfully rolled out"),
-			duration: 80,
-		}, {
 			description: "rollout returns did not stabilize within the given timeout",
 			command: testutil.NewFakeCmd(t).
 				WithRunOut(rolloutCmd, "Waiting for rollout to finish: 1 of 3 updated replicas are available...").


### PR DESCRIPTION
fixes #2606
In #2591, i removed the test to check expected number of call and switched to `testutil.NewFakeCmd`.
However, some PRs would still see another test flake, where the below test would not return success within 80ms
```
-               }, {
-                       description: "rollout returns success before time out",
-                       command: testutil.NewFakeCmd(t).
-                               WithRunOut(rolloutCmd, "Waiting for rollout to finish: 0 of 1 updated replicas are available...").
-                               WithRunOut(rolloutCmd, "Waiting for rollout to finish: 0 of 1 updated replicas are available...").
-                               WithRunOut(rolloutCmd, "deployment.apps/dep successfully rolled out"),
-                       duration: 80
```

Removing this time dependent test case for now.