### PR TITLE
init: Add default config name

### DIFF
--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -430,7 +431,18 @@ func suggestConfigName() (string, error) {
 		return "", nil
 	}
 
-	return base, nil
+	return canonicalizeName(base), nil
+}
+
+// canonicalizeName converts a given string to a valid k8s name string.
+// See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names for details
+func canonicalizeName(name string) string {
+	forbidden := regexp.MustCompile(`[^-.a-z]+`)
+	canonicalized := forbidden.ReplaceAllString(strings.ToLower(name), "-")
+	if len(canonicalized) <= 253 {
+		return canonicalized
+	}
+	return canonicalized[:253]
 }
 
 func printAnalyzeJSONNoJib(out io.Writer, skipBuild bool, pairs []builderImagePair, unresolvedBuilders []InitBuilder, unresolvedImages []string) error {

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -498,3 +498,44 @@ func TestProcessCliArtifacts(t *testing.T) {
 		})
 	}
 }
+
+func Test_canonicalizeName(t *testing.T) {
+	const length253 = "aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa-aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa-aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaa"
+	tests := []struct {
+		in, out string
+	}{
+		{
+			in:  "abc def",
+			out: "abc-def",
+		},
+		{
+			in:  "abc    def",
+			out: "abc-def",
+		},
+		{
+			in:  "abc...def",
+			out: "abc...def",
+		},
+		{
+			in:  "abc---def",
+			out: "abc---def",
+		},
+		{
+			in:  "aBc DeF",
+			out: "abc-def",
+		},
+		{
+			in:  length253 + "XXXXXXX",
+			out: length253,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.in, func(t *testing.T) {
+			actual := canonicalizeName(test.in)
+			if actual != test.out {
+				t.Errorf("%s: expected %s, found %s", test.in, test.out, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As discussed in #2556 `skaffold init` could populate the `metadata.name` field in `skaffold.yaml`. This PR adds the logic to populate the field with the basename of the currect working dir. I thought about adding tests, but I decided against adding some, because the test-cases could only test the trivial happy path of the added function.

Also, I have added the config name to all examples. This may be a controversial change..
Even though this field is optional in Skaffold, I think it makes the yaml files easier to navigate, because every example `skaffold.yaml` states what example it is.

Close #2556 