### PR TITLE
Upgrade Jib to 1.5.0

### DIFF
--- a/examples/jib-gradle/build.gradle
+++ b/examples/jib-gradle/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'groovy'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
     id 'net.ltgt.apt-idea' version '0.18'
-    id 'com.google.cloud.tools.jib' version '1.4.0'
+    id 'com.google.cloud.tools.jib' version '1.5.0'
 }
 
 version '0.1'

--- a/examples/jib-multimodule/pom.xml
+++ b/examples/jib-multimodule/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <jib.maven-plugin-version>1.4.0</jib.maven-plugin-version>
+    <jib.maven-plugin-version>1.5.0</jib.maven-plugin-version>
   </properties>
 
   <dependencies>

--- a/examples/jib/pom.xml
+++ b/examples/jib/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <jib.maven-plugin-version>1.4.0</jib.maven-plugin-version>
+        <jib.maven-plugin-version>1.5.0</jib.maven-plugin-version>
     </properties>
 
     <parent>

--- a/integration/examples/jib-gradle/build.gradle
+++ b/integration/examples/jib-gradle/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'groovy'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
     id 'net.ltgt.apt-idea' version '0.18'
-    id 'com.google.cloud.tools.jib' version '1.4.0'
+    id 'com.google.cloud.tools.jib' version '1.5.0'
 }
 
 version '0.1'

--- a/integration/examples/jib-multimodule/pom.xml
+++ b/integration/examples/jib-multimodule/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <jib.maven-plugin-version>1.4.0</jib.maven-plugin-version>
+    <jib.maven-plugin-version>1.5.0</jib.maven-plugin-version>
   </properties>
 
   <dependencies>

--- a/integration/examples/jib/pom.xml
+++ b/integration/examples/jib/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <jib.maven-plugin-version>1.4.0</jib.maven-plugin-version>
+        <jib.maven-plugin-version>1.5.0</jib.maven-plugin-version>
     </properties>
 
     <parent>

--- a/integration/testdata/debug/jib/pom.xml
+++ b/integration/testdata/debug/jib/pom.xml
@@ -8,7 +8,7 @@
     <description>Simple Java server with Skaffold and Jib</description>
 
     <properties>
-        <jib.maven-plugin-version>1.4.0</jib.maven-plugin-version>
+        <jib.maven-plugin-version>1.5.0</jib.maven-plugin-version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>

--- a/integration/testdata/jib-gradle/build.gradle
+++ b/integration/testdata/jib-gradle/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'com.google.cloud.tools.jib' version '1.4.0'
+  id 'com.google.cloud.tools.jib' version '1.5.0'
 }
 
 sourceCompatibility = 1.8

--- a/integration/testdata/jib/pom.xml
+++ b/integration/testdata/jib/pom.xml
@@ -8,7 +8,7 @@
     <description>Simple Java server with Skaffold and Jib</description>
 
     <properties>
-        <jib.maven-plugin-version>1.4.0</jib.maven-plugin-version>
+        <jib.maven-plugin-version>1.5.0</jib.maven-plugin-version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>


### PR DESCRIPTION
1.5.0 will effectively skip downloading base images on CI/CD when pushing to a registry, so hopefully this will contribute to reducing integration test time. Not sure how much though.