### PR TITLE
Add information about top level owner to port forward key

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/gorilla/mux v1.6.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.8.5
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
-	github.com/imdario/mergo v0.3.6 // indirect
+	github.com/imdario/mergo v0.3.6
 	github.com/karrick/godirwalk v1.7.5
 	github.com/knative/pkg v0.0.0-20190730155243-972acd413fb9 // indirect
 	github.com/krishicks/yaml-patch v0.0.10

--- a/go.sum
+++ b/go.sum
@@ -402,6 +402,7 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/api v0.0.0-20190620073856-dcce3486da33 h1:aC/EvF9PT1h8NeMEOVwTel8xxbZwq0SZnxXNThEROnE=
 k8s.io/api v0.0.0-20190620073856-dcce3486da33/go.mod h1:ldk709UQo/iedNLOW7J06V9QSSGY5heETKeWqnPoqF8=
+k8s.io/api v0.0.0-20190814101207-0772a1bdf941 h1:Y8yEkyPyJstRyZRD2qAVXeFfgilYKxdxB8zjO0cb/XY=
 k8s.io/apimachinery v0.0.0-20190620073744-d16981aedf33 h1:Lkd+QNFOB3DqrDyWo796aodJgFJautn/M+t9IGearPc=
 k8s.io/apimachinery v0.0.0-20190620073744-d16981aedf33/go.mod h1:9q5NW/mMno/nwbRZd/Ks2TECgi2PTZ9cwarf4q+ze6Q=
 k8s.io/client-go v0.0.0-20190620074045-585a16d2e773 h1:XyjDnwRO9icfyrN7HRSa8o3NqdPOEQoVW8vWizuqyQQ=

--- a/pkg/skaffold/kubernetes/owner.go
+++ b/pkg/skaffold/kubernetes/owner.go
@@ -57,6 +57,16 @@ func ownerMetaObject(ns string, or metav1.OwnerReference) (metav1.Object, error)
 		return client.AppsV1().Deployments(ns).Get(or.Name, metav1.GetOptions{})
 	case "ReplicaSet":
 		return client.AppsV1().ReplicaSets(ns).Get(or.Name, metav1.GetOptions{})
+	case "Job":
+		return client.BatchV1().Jobs(ns).Get(or.Name, metav1.GetOptions{})
+	case "CronJob":
+		return client.BatchV1beta1().CronJobs(ns).Get(or.Name, metav1.GetOptions{})
+	case "StatefulSet":
+		return client.AppsV1().StatefulSets(ns).Get(or.Name, metav1.GetOptions{})
+	case "ReplicationController":
+		return client.CoreV1().ReplicationControllers(ns).Get(or.Name, metav1.GetOptions{})
+	case "Pod":
+		return client.CoreV1().Pods(ns).Get(or.Name, metav1.GetOptions{})
 	default:
 		return nil, fmt.Errorf("kind %s is not supported", or.Kind)
 	}

--- a/pkg/skaffold/kubernetes/owner.go
+++ b/pkg/skaffold/kubernetes/owner.go
@@ -46,28 +46,28 @@ func TopLevelOwnerKey(obj metav1.Object, kind string) string {
 	}
 }
 
-func ownerMetaObject(ns string, or metav1.OwnerReference) (metav1.Object, error) {
+func ownerMetaObject(ns string, owner metav1.OwnerReference) (metav1.Object, error) {
 	client, err := getClientSet()
 	if err != nil {
 		return nil, err
 	}
 
-	switch or.Kind {
+	switch owner.Kind {
 	case "Deployment":
-		return client.AppsV1().Deployments(ns).Get(or.Name, metav1.GetOptions{})
+		return client.AppsV1().Deployments(ns).Get(owner.Name, metav1.GetOptions{})
 	case "ReplicaSet":
-		return client.AppsV1().ReplicaSets(ns).Get(or.Name, metav1.GetOptions{})
+		return client.AppsV1().ReplicaSets(ns).Get(owner.Name, metav1.GetOptions{})
 	case "Job":
-		return client.BatchV1().Jobs(ns).Get(or.Name, metav1.GetOptions{})
+		return client.BatchV1().Jobs(ns).Get(owner.Name, metav1.GetOptions{})
 	case "CronJob":
-		return client.BatchV1beta1().CronJobs(ns).Get(or.Name, metav1.GetOptions{})
+		return client.BatchV1beta1().CronJobs(ns).Get(owner.Name, metav1.GetOptions{})
 	case "StatefulSet":
-		return client.AppsV1().StatefulSets(ns).Get(or.Name, metav1.GetOptions{})
+		return client.AppsV1().StatefulSets(ns).Get(owner.Name, metav1.GetOptions{})
 	case "ReplicationController":
-		return client.CoreV1().ReplicationControllers(ns).Get(or.Name, metav1.GetOptions{})
+		return client.CoreV1().ReplicationControllers(ns).Get(owner.Name, metav1.GetOptions{})
 	case "Pod":
-		return client.CoreV1().Pods(ns).Get(or.Name, metav1.GetOptions{})
+		return client.CoreV1().Pods(ns).Get(owner.Name, metav1.GetOptions{})
 	default:
-		return nil, fmt.Errorf("kind %s is not supported", or.Kind)
+		return nil, fmt.Errorf("kind %s is not supported", owner.Kind)
 	}
 }

--- a/pkg/skaffold/kubernetes/owner.go
+++ b/pkg/skaffold/kubernetes/owner.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	// For testing
+	getClientSet = GetClientset
+)
+
+// TopLevelOwnerKey returns a key associated with the top level
+// owner of a Kubernetes resource in the form Kind-Name
+func TopLevelOwnerKey(obj metav1.Object, kind string) string {
+	for {
+		or := obj.GetOwnerReferences()
+		if or == nil {
+			return fmt.Sprintf("%s-%s", kind, obj.GetName())
+		}
+		var err error
+		kind = or[0].Kind
+		obj, err = ownerMetaObject(obj.GetNamespace(), or[0])
+		if err != nil {
+			logrus.Warnf("unable to get owner from reference: %v", or[0])
+			return ""
+		}
+	}
+}
+
+func ownerMetaObject(ns string, or metav1.OwnerReference) (metav1.Object, error) {
+	client, err := getClientSet()
+	if err != nil {
+		return nil, err
+	}
+
+	switch or.Kind {
+	case "Deployment":
+		return client.AppsV1().Deployments(ns).Get(or.Name, metav1.GetOptions{})
+	case "ReplicaSet":
+		return client.AppsV1().ReplicaSets(ns).Get(or.Name, metav1.GetOptions{})
+	default:
+		return nil, fmt.Errorf("kind %s is not supported", or.Kind)
+	}
+}

--- a/pkg/skaffold/kubernetes/owner_test.go
+++ b/pkg/skaffold/kubernetes/owner_test.go
@@ -77,21 +77,19 @@ func TestTopLevelOwnerKey(t *testing.T) {
 		objects       []runtime.Object
 		expected      string
 	}{
-		// {
-		// 	description:   "owner is two levels up",
-		// 	initialObject: pod,
-		// 	kind:          "Pod",
-		// 	objects:       []runtime.Object{pod, rs, deployment},
-		// 	expected:      "Deployment-dep",
-		// },
 		{
+			description:   "owner is two levels up",
+			initialObject: pod,
+			kind:          "Pod",
+			objects:       []runtime.Object{pod, rs, deployment},
+			expected:      "Deployment-dep",
+		}, {
 			description:   "object is owner",
 			initialObject: deployment,
 			kind:          "Deployment",
 			objects:       []runtime.Object{pod, rs, deployment},
 			expected:      "Deployment-dep",
-		},
-		{
+		}, {
 			description:   "error, owner doesn't exist",
 			initialObject: pod,
 			kind:          "Pod",

--- a/pkg/skaffold/kubernetes/owner_test.go
+++ b/pkg/skaffold/kubernetes/owner_test.go
@@ -21,6 +21,9 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -165,6 +168,106 @@ func TestOwnerMetaObject(t *testing.T) {
 			expected: &appsv1.ReplicaSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rs",
+					Namespace: "ns",
+				},
+			},
+		}, {
+			description: "getting a job",
+			or: metav1.OwnerReference{
+				Kind: "Job",
+				Name: "job",
+			},
+			objects: []runtime.Object{
+				&batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "job",
+						Namespace: "ns",
+					},
+				},
+			},
+			expected: &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "job",
+					Namespace: "ns",
+				},
+			},
+		}, {
+			description: "getting a cronjob",
+			or: metav1.OwnerReference{
+				Kind: "CronJob",
+				Name: "cj",
+			},
+			objects: []runtime.Object{
+				&batchv1beta1.CronJob{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "cj",
+						Namespace: "ns",
+					},
+				},
+			},
+			expected: &batchv1beta1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cj",
+					Namespace: "ns",
+				},
+			},
+		}, {
+			description: "getting a statefulset",
+			or: metav1.OwnerReference{
+				Kind: "StatefulSet",
+				Name: "ss",
+			},
+			objects: []runtime.Object{
+				&appsv1.StatefulSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ss",
+						Namespace: "ns",
+					},
+				},
+			},
+			expected: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ss",
+					Namespace: "ns",
+				},
+			},
+		}, {
+			description: "getting a replicationcontroller",
+			or: metav1.OwnerReference{
+				Kind: "ReplicationController",
+				Name: "rc",
+			},
+			objects: []runtime.Object{
+				&v1.ReplicationController{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rc",
+						Namespace: "ns",
+					},
+				},
+			},
+			expected: &v1.ReplicationController{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rc",
+					Namespace: "ns",
+				},
+			},
+		}, {
+			description: "getting a pod",
+			or: metav1.OwnerReference{
+				Kind: "Pod",
+				Name: "po",
+			},
+			objects: []runtime.Object{
+				&v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "po",
+						Namespace: "ns",
+					},
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "po",
 					Namespace: "ns",
 				},
 			},

--- a/pkg/skaffold/kubernetes/owner_test.go
+++ b/pkg/skaffold/kubernetes/owner_test.go
@@ -276,11 +276,7 @@ func TestOwnerMetaObject(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			objs := make([]runtime.Object, len(test.objects))
-			for i, s := range test.objects {
-				objs[i] = s
-			}
-			client := fakekubeclientset.NewSimpleClientset(objs...)
+			client := fakekubeclientset.NewSimpleClientset(test.objects...)
 			t.Override(&getClientSet, mockClient(client))
 			actual, err := ownerMetaObject("ns", test.or)
 			t.CheckNoError(err)

--- a/pkg/skaffold/kubernetes/owner_test.go
+++ b/pkg/skaffold/kubernetes/owner_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+	"k8s.io/client-go/kubernetes"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+)
+
+func mockClient(m kubernetes.Interface) func() (kubernetes.Interface, error) {
+	return func() (kubernetes.Interface, error) {
+		return m, nil
+	}
+}
+
+func TestTopLevelOwnerKey(t *testing.T) {
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod",
+			Namespace: "ns",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name: "rs",
+					Kind: "ReplicaSet",
+				},
+			},
+		},
+	}
+
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rs",
+			Namespace: "ns",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Name: "dep",
+					Kind: "Deployment",
+				},
+			},
+		},
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dep",
+			Namespace: "ns",
+		},
+	}
+
+	tests := []struct {
+		description   string
+		initialObject metav1.Object
+		kind          string
+		objects       []runtime.Object
+		expected      string
+	}{
+		// {
+		// 	description:   "owner is two levels up",
+		// 	initialObject: pod,
+		// 	kind:          "Pod",
+		// 	objects:       []runtime.Object{pod, rs, deployment},
+		// 	expected:      "Deployment-dep",
+		// },
+		{
+			description:   "object is owner",
+			initialObject: deployment,
+			kind:          "Deployment",
+			objects:       []runtime.Object{pod, rs, deployment},
+			expected:      "Deployment-dep",
+		},
+		{
+			description:   "error, owner doesn't exist",
+			initialObject: pod,
+			kind:          "Pod",
+			objects:       []runtime.Object{pod, rs},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			client := fakekubeclientset.NewSimpleClientset(test.objects...)
+			t.Override(&getClientSet, mockClient(client))
+			actual := TopLevelOwnerKey(test.initialObject, test.kind)
+			t.CheckDeepEqual(test.expected, actual)
+		})
+	}
+}
+
+func TestOwnerMetaObject(t *testing.T) {
+	tests := []struct {
+		description string
+		or          metav1.OwnerReference
+		objects     []runtime.Object
+		expected    metav1.Object
+	}{
+		{
+			description: "getting a deployment",
+			or: metav1.OwnerReference{
+				Kind: "Deployment",
+				Name: "dep",
+			},
+			objects: []runtime.Object{
+				&v1.Service{},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dep",
+						Namespace: "ns",
+					},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dep",
+						Namespace: "ns2",
+					},
+				},
+			},
+			expected: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dep",
+					Namespace: "ns",
+				},
+			},
+		}, {
+			description: "getting a replica set",
+			or: metav1.OwnerReference{
+				Kind: "ReplicaSet",
+				Name: "rs",
+			},
+			objects: []runtime.Object{
+				&v1.Service{},
+				&appsv1.ReplicaSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "rs",
+						Namespace: "ns",
+					},
+				},
+				&appsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "dep",
+						Namespace: "ns2",
+					},
+				},
+			},
+			expected: &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rs",
+					Namespace: "ns",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			objs := make([]runtime.Object, len(test.objects))
+			for i, s := range test.objects {
+				objs[i] = s
+			}
+			client := fakekubeclientset.NewSimpleClientset(objs...)
+			t.Override(&getClientSet, mockClient(client))
+			actual, err := ownerMetaObject("ns", test.or)
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expected, actual)
+		})
+	}
+}

--- a/pkg/skaffold/kubernetes/portforward/entry_manager_test.go
+++ b/pkg/skaffold/kubernetes/portforward/entry_manager_test.go
@@ -52,13 +52,13 @@ func TestStop(t *testing.T) {
 		Type:      constants.Pod,
 		Name:      "resource",
 		Namespace: "default",
-	}, "", "", "", 9000, false)
+	}, "", "", "", "", 9000, false)
 
 	pfe2 := newPortForwardEntry(0, latest.PortForwardResource{
 		Type:      constants.Pod,
 		Name:      "resource2",
 		Namespace: "default",
-	}, "", "", "", 9001, false)
+	}, "", "", "", "", 9001, false)
 
 	em := NewEntryManager(ioutil.Discard, nil)
 

--- a/pkg/skaffold/kubernetes/portforward/pod_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/pod_forwarder.go
@@ -33,6 +33,7 @@ import (
 var (
 	// For testing
 	aggregatePodWatcher = kubernetes.AggregatePodWatcher
+	topLevelOwnerKey    = kubernetes.TopLevelOwnerKey
 )
 
 // WatchingPodForwarder is responsible for selecting pods satisfying a certain condition and port-forwarding the exposed
@@ -101,6 +102,7 @@ func (p *WatchingPodForwarder) Start(ctx context.Context) error {
 }
 
 func (p *WatchingPodForwarder) portForwardPod(ctx context.Context, pod *v1.Pod) error {
+	ownerReference := topLevelOwnerKey(pod, pod.Kind)
 	for _, c := range pod.Spec.Containers {
 		for _, port := range c.Ports {
 			// get current entry for this container
@@ -112,7 +114,7 @@ func (p *WatchingPodForwarder) portForwardPod(ctx context.Context, pod *v1.Pod) 
 				LocalPort: int(port.ContainerPort),
 			}
 
-			entry, err := p.podForwardingEntry(pod.ResourceVersion, c.Name, port.Name, resource)
+			entry, err := p.podForwardingEntry(pod.ResourceVersion, c.Name, port.Name, ownerReference, resource)
 			if err != nil {
 				return errors.Wrap(err, "getting pod forwarding entry")
 			}
@@ -132,12 +134,12 @@ func (p *WatchingPodForwarder) portForwardPod(ctx context.Context, pod *v1.Pod) 
 	return nil
 }
 
-func (p *WatchingPodForwarder) podForwardingEntry(resourceVersion, containerName, portName string, resource latest.PortForwardResource) (*portForwardEntry, error) {
+func (p *WatchingPodForwarder) podForwardingEntry(resourceVersion, containerName, portName, ownerReference string, resource latest.PortForwardResource) (*portForwardEntry, error) {
 	rv, err := strconv.Atoi(resourceVersion)
 	if err != nil {
 		return nil, errors.Wrap(err, "converting resource version to integer")
 	}
-	entry := newPortForwardEntry(rv, resource, resource.Name, containerName, portName, 0, true)
+	entry := newPortForwardEntry(rv, resource, resource.Name, containerName, portName, ownerReference, 0, true)
 
 	// If we have, return the current entry
 	oldEntry, ok := p.forwardedResources.Load(entry.key())

--- a/pkg/skaffold/kubernetes/portforward/port_forward_entry.go
+++ b/pkg/skaffold/kubernetes/portforward/port_forward_entry.go
@@ -30,6 +30,7 @@ type portForwardEntry struct {
 	podName                string
 	containerName          string
 	portName               string
+	ownerReference         string
 	localPort              int
 	automaticPodForwarding bool
 	terminated             bool
@@ -38,13 +39,14 @@ type portForwardEntry struct {
 }
 
 // newPortForwardEntry returns a port forward entry.
-func newPortForwardEntry(resourceVersion int, resource latest.PortForwardResource, podName, containerName, portName string, localPort int, automaticPodForwarding bool) *portForwardEntry {
+func newPortForwardEntry(resourceVersion int, resource latest.PortForwardResource, podName, containerName, portName, ownerReference string, localPort int, automaticPodForwarding bool) *portForwardEntry {
 	return &portForwardEntry{
 		resourceVersion:        resourceVersion,
 		resource:               resource,
 		podName:                podName,
 		containerName:          containerName,
 		portName:               portName,
+		ownerReference:         ownerReference,
 		localPort:              localPort,
 		automaticPodForwarding: automaticPodForwarding,
 		terminationLock:        &sync.Mutex{},
@@ -56,7 +58,7 @@ func newPortForwardEntry(resourceVersion int, resource latest.PortForwardResourc
 // to be the same whenever pods restart
 func (p *portForwardEntry) key() string {
 	if p.automaticPodForwarding {
-		return fmt.Sprintf("%s-%s-%s-%d", p.containerName, p.resource.Namespace, p.portName, p.resource.Port)
+		return fmt.Sprintf("%s-%s-%s-%s-%d", p.ownerReference, p.containerName, p.resource.Namespace, p.portName, p.resource.Port)
 	}
 	return fmt.Sprintf("%s-%s-%s-%d", p.resource.Type, p.resource.Name, p.resource.Namespace, p.resource.Port)
 }

--- a/pkg/skaffold/kubernetes/portforward/port_forward_entry_test.go
+++ b/pkg/skaffold/kubernetes/portforward/port_forward_entry_test.go
@@ -37,7 +37,7 @@ func TestPortForwardEntryKey(t *testing.T) {
 				Name:      "podName",
 				Namespace: "default",
 				Port:      8080,
-			}, "", "", "", 0, false),
+			}, "", "", "", "", 0, false),
 			expected: "pod-podName-default-8080",
 		}, {
 			description: "entry for deploy",
@@ -46,7 +46,7 @@ func TestPortForwardEntryKey(t *testing.T) {
 				Name:      "depName",
 				Namespace: "namespace",
 				Port:      9000,
-			}, "", "", "", 0, false),
+			}, "", "", "", "", 0, false),
 			expected: "deployment-depName-namespace-9000",
 		},
 	}
@@ -79,8 +79,8 @@ func TestAutomaticPodForwardingKey(t *testing.T) {
 				Name:      "podName",
 				Namespace: "default",
 				Port:      8080,
-			}, "", "containerName", "portName", 0, true),
-			expected: "containerName-default-portName-8080",
+			}, "", "containerName", "portName", "owner", 0, true),
+			expected: "owner-containerName-default-portName-8080",
 		},
 	}
 

--- a/pkg/skaffold/kubernetes/portforward/port_forward_integration.go
+++ b/pkg/skaffold/kubernetes/portforward/port_forward_integration.go
@@ -42,7 +42,7 @@ func WhiteBoxPortForwardCycle(t *testing.T, kubectlCLI *kubectl.CLI, namespace s
 		Name:      "leeroy-web",
 		Namespace: namespace,
 		Port:      8080,
-	}, "", "dummy container", "", localPort, false)
+	}, "", "dummy container", "", "", localPort, false)
 	defer em.Stop()
 	em.forwardPortForwardEntry(ctx, pfe)
 	em.Stop()

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder.go
@@ -83,7 +83,7 @@ func (p *ResourceForwarder) portForwardResource(ctx context.Context, resource la
 
 func (p *ResourceForwarder) getCurrentEntry(resource latest.PortForwardResource) *portForwardEntry {
 	// determine if we have seen this before
-	entry := newPortForwardEntry(0, resource, "", "", "", 0, false)
+	entry := newPortForwardEntry(0, resource, "", "", "", "", 0, false)
 
 	// If we have, return the current entry
 	oldEntry, ok := p.forwardedResources.Load(entry.key())

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -161,7 +161,7 @@ func TestGetCurrentEntryFunc(t *testing.T) {
 				Port: 8080,
 			},
 			availablePorts: []int{8080},
-			expected:       newPortForwardEntry(0, latest.PortForwardResource{}, "", "", "", 8080, false),
+			expected:       newPortForwardEntry(0, latest.PortForwardResource{}, "", "", "", "", 8080, false),
 		}, {
 			description: "port forward existing deployment",
 			resource: latest.PortForwardResource{
@@ -181,7 +181,7 @@ func TestGetCurrentEntryFunc(t *testing.T) {
 					localPort: 9000,
 				},
 			},
-			expected: newPortForwardEntry(0, latest.PortForwardResource{}, "", "", "", 9000, false),
+			expected: newPortForwardEntry(0, latest.PortForwardResource{}, "", "", "", "", 9000, false),
 		},
 	}
 


### PR DESCRIPTION
This should help differentiate identical containers running in different pods for port forwarding.

Fixes #2660 