### PR TITLE
Log a warning and rebuild if needed when caching fails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/gorilla/mux v1.6.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.8.5
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
-	github.com/imdario/mergo v0.3.6 // indirect
+	github.com/imdario/mergo v0.3.6
 	github.com/karrick/godirwalk v1.7.5
 	github.com/knative/pkg v0.0.0-20190730155243-972acd413fb9 // indirect
 	github.com/krishicks/yaml-patch v0.0.10

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -64,12 +64,12 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 		switch result := result.(type) {
 		case failed:
 			logrus.Warnf("error checking cache, caching may not work as expected: %v", result.err)
-			color.Red.Fprintln(out, "Error checking cache. Rebuilding.")
+			color.Yellow.Fprintln(out, "Error checking cache. Rebuilding.")
 			needToBuild = append(needToBuild, artifact)
 			continue
 
 		case needsBuilding:
-			color.Red.Fprintln(out, "Not found. Building")
+			color.Yellow.Fprintln(out, "Not found. Building")
 			hashByName[artifact.ImageName] = result.hash
 			needToBuild = append(needToBuild, artifact)
 			continue

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -62,7 +63,10 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 		result := results[i]
 		switch result := result.(type) {
 		case failed:
-			return nil, errors.Wrap(result.err, "checking cache")
+			logrus.Warnf("error checking cache, caching may not work as expected: %v", result.err)
+			color.Red.Fprintln(out, "Error checking cache. Rebuilding.")
+			needToBuild = append(needToBuild, artifact)
+			continue
 
 		case needsBuilding:
 			color.Red.Fprintln(out, "Not found. Building")
@@ -114,11 +118,13 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 	}
 
 	if err := c.addArtifacts(ctx, bRes, hashByName); err != nil {
-		return nil, errors.Wrap(err, "adding artifacts to cache")
+		logrus.Warnf("error adding artifacts to cache; caching may not work as expected: %v", err)
+		return append(bRes, alreadyBuilt...), nil
 	}
 
 	if err := saveArtifactCache(c.cacheFile, c.artifactCache); err != nil {
-		return nil, errors.Wrap(err, "saving cache")
+		logrus.Warnf("error saving cache file; caching may not work as expected: %v", err)
+		return append(bRes, alreadyBuilt...), nil
 	}
 
 	return append(bRes, alreadyBuilt...), err


### PR DESCRIPTION
We should never error out if caching fails. Instead, log a warning and rebuild the artifact if it still needs to be rebuilt.

Should fix #2677 

cc @balopat @briandealwis @prary 

