### PR TITLE
Add struct for generate_pipeline to keep track of related data

### DIFF
--- a/integration/testdata/generate_pipeline/existing_oncluster/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/existing_oncluster/expectedPipeline.yaml
@@ -30,6 +30,8 @@ spec:
       type: git
   steps:
   - args:
+    - --filename
+    - skaffold.yaml
     - --profile
     - oncluster
     - --file-output
@@ -66,6 +68,8 @@ spec:
       type: git
   steps:
   - args:
+    - --filename
+    - skaffold.yaml
     - --build-artifacts
     - build.out
     command:

--- a/integration/testdata/generate_pipeline/existing_other/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/existing_other/expectedPipeline.yaml
@@ -30,6 +30,8 @@ spec:
       type: git
   steps:
   - args:
+    - --filename
+    - skaffold.yaml
     - --profile
     - oncluster
     - --file-output
@@ -66,6 +68,8 @@ spec:
       type: git
   steps:
   - args:
+    - --filename
+    - skaffold.yaml
     - --build-artifacts
     - build.out
     command:

--- a/integration/testdata/generate_pipeline/no_profiles/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/no_profiles/expectedPipeline.yaml
@@ -30,6 +30,8 @@ spec:
       type: git
   steps:
   - args:
+    - --filename
+    - skaffold.yaml
     - --profile
     - oncluster
     - --file-output
@@ -66,6 +68,8 @@ spec:
       type: git
   steps:
   - args:
+    - --filename
+    - skaffold.yaml
     - --build-artifacts
     - build.out
     command:

--- a/pkg/skaffold/generate_pipeline/generate_pipeline.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline.go
@@ -143,7 +143,7 @@ func generateBuildTask(configFile *ConfigFile) (*tekton.Task, error) {
 			WorkingDir: "/workspace/source",
 			Command:    []string{"skaffold", "build"},
 			Args: []string{
-				"--filename", "/workspace/" + configFile.Name,
+				"--filename", configFile.Name,
 				"--profile", "oncluster",
 				"--file-output", "build.out",
 			},
@@ -205,7 +205,7 @@ func generateDeployTask(configFile *ConfigFile) (*tekton.Task, error) {
 			WorkingDir: "/workspace/source",
 			Command:    []string{"skaffold", "deploy"},
 			Args: []string{
-				"--filename", "/workspace/" + configFile.Name,
+				"--filename", configFile.Name,
 				"--build-artifacts", "build.out",
 			},
 		},

--- a/pkg/skaffold/generate_pipeline/generate_pipeline.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline.go
@@ -36,9 +36,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// Struct keeps track of config files and their corresponding SkaffoldConfigs and generated Profiles
+// ConfigFile keeps track of config files and their corresponding SkaffoldConfigs and generated Profiles
 type ConfigFile struct {
-	Name    string
+	Path    string
 	Config  *latest.SkaffoldConfig
 	Profile *latest.Profile
 }
@@ -143,7 +143,7 @@ func generateBuildTask(configFile *ConfigFile) (*tekton.Task, error) {
 			WorkingDir: "/workspace/source",
 			Command:    []string{"skaffold", "build"},
 			Args: []string{
-				"--filename", configFile.Name,
+				"--filename", configFile.Path,
 				"--profile", "oncluster",
 				"--file-output", "build.out",
 			},
@@ -205,7 +205,7 @@ func generateDeployTask(configFile *ConfigFile) (*tekton.Task, error) {
 			WorkingDir: "/workspace/source",
 			Command:    []string{"skaffold", "deploy"},
 			Args: []string{
-				"--filename", configFile.Name,
+				"--filename", configFile.Path,
 				"--build-artifacts", "build.out",
 			},
 		},

--- a/pkg/skaffold/generate_pipeline/generate_pipeline_test.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline_test.go
@@ -196,7 +196,7 @@ func TestGenerateBuildTask(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			configFile := &ConfigFile{
-				Name: "test",
+				Path: "test",
 				Profile: &latest.Profile{
 					Pipeline: latest.Pipeline{
 						Build: test.buildConfig,
@@ -240,7 +240,7 @@ func TestGenerateDeployTask(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			configFile := &ConfigFile{
-				Name: "test",
+				Path: "test",
 				Config: &latest.SkaffoldConfig{
 					Pipeline: latest.Pipeline{
 						Deploy: test.deployConfig,

--- a/pkg/skaffold/generate_pipeline/generate_pipeline_test.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline_test.go
@@ -195,7 +195,15 @@ func TestGenerateBuildTask(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			_, err := generateBuildTask(test.buildConfig)
+			configFile := &ConfigFile{
+				Name: "test",
+				Profile: &latest.Profile{
+					Pipeline: latest.Pipeline{
+						Build: test.buildConfig,
+					},
+				},
+			}
+			_, err := generateBuildTask(configFile)
 			t.CheckError(test.shouldErr, err)
 		})
 	}
@@ -231,7 +239,16 @@ func TestGenerateDeployTask(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			_, err := generateDeployTask(test.deployConfig)
+			configFile := &ConfigFile{
+				Name: "test",
+				Config: &latest.SkaffoldConfig{
+					Pipeline: latest.Pipeline{
+						Deploy: test.deployConfig,
+					},
+				},
+			}
+
+			_, err := generateDeployTask(configFile)
 			t.CheckError(test.shouldErr, err)
 		})
 	}

--- a/pkg/skaffold/generate_pipeline/profile.go
+++ b/pkg/skaffold/generate_pipeline/profile.go
@@ -36,7 +36,7 @@ func CreateSkaffoldProfile(out io.Writer, configFile *ConfigFile) error {
 	reader := bufio.NewReader(os.Stdin)
 
 	// Check for existing oncluster profile, if none exists then prompt to create one
-	color.Default.Fprintf(out, "Checking for oncluster skaffold profile in %s...\n", configFile.Name)
+	color.Default.Fprintf(out, "Checking for oncluster skaffold profile in %s...\n", configFile.Path)
 	for _, profile := range configFile.Config.Profiles {
 		if profile.Name == "oncluster" {
 			color.Default.Fprintln(out, "profile \"oncluster\" found")
@@ -73,7 +73,7 @@ confirmLoop:
 		return errors.Wrap(err, "marshaling new profile")
 	}
 
-	fileContents, err := ioutil.ReadFile(configFile.Name)
+	fileContents, err := ioutil.ReadFile(configFile.Path)
 	if err != nil {
 		return errors.Wrap(err, "reading file contents")
 	}
@@ -98,7 +98,7 @@ confirmLoop:
 
 	fileContents = []byte((strings.Join(fileStrings, "\n")))
 
-	if err := ioutil.WriteFile(configFile.Name, fileContents, 0644); err != nil {
+	if err := ioutil.WriteFile(configFile.Path, fileContents, 0644); err != nil {
 		return errors.Wrap(err, "writing profile to skaffold config")
 	}
 

--- a/pkg/skaffold/runner/generate_pipeline.go
+++ b/pkg/skaffold/runner/generate_pipeline.go
@@ -30,14 +30,21 @@ import (
 )
 
 func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, config *latest.SkaffoldConfig, fileOut string) error {
+	// Keep track of files, configs, and profiles. This will be used to know which files to write
+	// profiles to and what flags to add to task commands
+	configFile := &pipeline.ConfigFile{
+		Name:    r.runCtx.Opts.ConfigurationFile,
+		Config:  config,
+		Profile: nil,
+	}
+
 	color.Default.Fprintln(out, "Running profile setup...")
-	profile, err := pipeline.CreateSkaffoldProfile(out, config, r.runCtx.Opts.ConfigurationFile)
-	if err != nil {
-		return errors.Wrap(err, "setting up profile")
+	if err := pipeline.CreateSkaffoldProfile(out, configFile); err != nil {
+		return errors.Wrap(err, "seeting up profile")
 	}
 
 	color.Default.Fprintln(out, "Generating Pipeline...")
-	pipelineYaml, err := pipeline.Yaml(out, config, profile)
+	pipelineYaml, err := pipeline.Yaml(out, configFile)
 	if err != nil {
 		return errors.Wrap(err, "generating pipeline yaml contents")
 	}

--- a/pkg/skaffold/runner/generate_pipeline.go
+++ b/pkg/skaffold/runner/generate_pipeline.go
@@ -33,7 +33,7 @@ func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, co
 	// Keep track of files, configs, and profiles. This will be used to know which files to write
 	// profiles to and what flags to add to task commands
 	configFile := &pipeline.ConfigFile{
-		Name:    r.runCtx.Opts.ConfigurationFile,
+		Path:    r.runCtx.Opts.ConfigurationFile,
 		Config:  config,
 		Profile: nil,
 	}


### PR DESCRIPTION
This ConfigFile struct ties a file to its corresponding SkaffoldConfig and the Profile that gets generated from that config. This PR adds the struct and refactors generate_pipeline code to utilize it. 

This prepares for the generate-pipeline command to support multiple skaffold config files.