### PR TITLE
Refactor generate_pipeline code to support multiple configs

### DIFF
--- a/pkg/skaffold/generate_pipeline/generate_pipeline.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline.go
@@ -28,12 +28,10 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
 
+	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/pipeline"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
-
-	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // Struct keeps track of config files and their corresponding SkaffoldConfigs and generated Profiles
@@ -115,103 +113,6 @@ func generateGitResource() (*tekton.PipelineResource, error) {
 	}
 
 	return pipeline.NewGitResource("source-git", gitURL), nil
-}
-
-func generateBuildTask(configFile *ConfigFile) (*tekton.Task, error) {
-	buildConfig := configFile.Profile.Build
-	if len(buildConfig.Artifacts) == 0 {
-		return nil, errors.New("no artifacts to build")
-	}
-
-	skaffoldVersion := os.Getenv("PIPELINE_SKAFFOLD_VERSION")
-	if skaffoldVersion == "" {
-		skaffoldVersion = version.Get().Version
-	}
-
-	resources := []tekton.TaskResource{
-		{
-			Name: "source",
-			Type: tekton.PipelineResourceTypeGit,
-		},
-	}
-	inputs := &tekton.Inputs{Resources: resources}
-	outputs := &tekton.Outputs{Resources: resources}
-	steps := []corev1.Container{
-		{
-			Name:       "run-build",
-			Image:      fmt.Sprintf("gcr.io/k8s-skaffold/skaffold:%s", skaffoldVersion),
-			WorkingDir: "/workspace/source",
-			Command:    []string{"skaffold", "build"},
-			Args: []string{
-				"--filename", configFile.Name,
-				"--profile", "oncluster",
-				"--file-output", "build.out",
-			},
-		},
-	}
-
-	// Add secret volume mounting for artifacts that need to be built with kaniko
-	var volumes []corev1.Volume
-	if buildConfig.Artifacts[0].KanikoArtifact != nil {
-		volumes = []corev1.Volume{
-			{
-				Name: kanikoSecretName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: kanikoSecretName,
-					},
-				},
-			},
-		}
-		steps[0].VolumeMounts = []corev1.VolumeMount{
-			{
-				Name:      kanikoSecretName,
-				MountPath: "/secret",
-			},
-		}
-		steps[0].Env = []corev1.EnvVar{
-			{
-				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
-				Value: "/secret/" + kanikoSecretName,
-			},
-		}
-	}
-
-	return pipeline.NewTask("skaffold-build", inputs, outputs, steps, volumes), nil
-}
-
-func generateDeployTask(configFile *ConfigFile) (*tekton.Task, error) {
-	deployConfig := configFile.Config.Deploy
-	if deployConfig.HelmDeploy == nil && deployConfig.KubectlDeploy == nil && deployConfig.KustomizeDeploy == nil {
-		return nil, errors.New("no Helm/Kubectl/Kustomize deploy config")
-	}
-
-	skaffoldVersion := os.Getenv("PIPELINE_SKAFFOLD_VERSION")
-	if skaffoldVersion == "" {
-		skaffoldVersion = version.Get().Version
-	}
-
-	resources := []tekton.TaskResource{
-		{
-			Name: "source",
-			Type: tekton.PipelineResourceTypeGit,
-		},
-	}
-	inputs := &tekton.Inputs{Resources: resources}
-	steps := []corev1.Container{
-		{
-			Name:       "run-deploy",
-			Image:      fmt.Sprintf("gcr.io/k8s-skaffold/skaffold:%s", skaffoldVersion),
-			WorkingDir: "/workspace/source",
-			Command:    []string{"skaffold", "deploy"},
-			Args: []string{
-				"--filename", configFile.Name,
-				"--build-artifacts", "build.out",
-			},
-		},
-	}
-
-	return pipeline.NewTask("skaffold-deploy", inputs, nil, steps, nil), nil
 }
 
 func generatePipeline(tasks []*tekton.Task) (*tekton.Pipeline, error) {

--- a/pkg/skaffold/generate_pipeline/generate_pipeline.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline.go
@@ -41,7 +41,7 @@ type ConfigFile struct {
 	Profile *latest.Profile
 }
 
-func Yaml(out io.Writer, configFile *ConfigFile) (*bytes.Buffer, error) {
+func Yaml(out io.Writer, configFiles []*ConfigFile) (*bytes.Buffer, error) {
 	// Generate git resource for pipeline
 	gitResource, err := generateGitResource()
 	if err != nil {
@@ -50,18 +50,18 @@ func Yaml(out io.Writer, configFile *ConfigFile) (*bytes.Buffer, error) {
 
 	// Generate build task for pipeline
 	var tasks []*tekton.Task
-	taskBuild, err := generateBuildTask(configFile)
+	buildTasks, err := generateBuildTasks(configFiles)
 	if err != nil {
 		return nil, errors.Wrap(err, "generating build task")
 	}
-	tasks = append(tasks, taskBuild)
+	tasks = append(tasks, buildTasks...)
 
 	// Generate deploy task for pipeline
-	taskDeploy, err := generateDeployTask(configFile)
+	deployTasks, err := generateDeployTasks(configFiles)
 	if err != nil {
 		return nil, errors.Wrap(err, "generating deploy task")
 	}
-	tasks = append(tasks, taskDeploy)
+	tasks = append(tasks, deployTasks...)
 
 	// Generate pipeline from git resource and tasks
 	pipeline, err := generatePipeline(tasks)

--- a/pkg/skaffold/generate_pipeline/generate_pipeline_test.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline_test.go
@@ -19,7 +19,6 @@ package generatepipeline
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -163,93 +162,6 @@ func TestGeneratePipeline(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			pipeline, err := generatePipeline(test.tasks)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedPipeline, pipeline)
-		})
-	}
-}
-
-func TestGenerateBuildTask(t *testing.T) {
-	var tests = []struct {
-		description string
-		buildConfig latest.BuildConfig
-		shouldErr   bool
-	}{
-		{
-			description: "successfully generate build task",
-			buildConfig: latest.BuildConfig{
-				Artifacts: []*latest.Artifact{
-					{
-						ImageName: "testArtifact",
-					},
-				},
-			},
-			shouldErr: false,
-		},
-		{
-			description: "fail generating build task",
-			buildConfig: latest.BuildConfig{
-				Artifacts: []*latest.Artifact{},
-			},
-			shouldErr: true,
-		},
-	}
-
-	for _, test := range tests {
-		testutil.Run(t, test.description, func(t *testutil.T) {
-			configFile := &ConfigFile{
-				Name: "test",
-				Profile: &latest.Profile{
-					Pipeline: latest.Pipeline{
-						Build: test.buildConfig,
-					},
-				},
-			}
-			_, err := generateBuildTask(configFile)
-			t.CheckError(test.shouldErr, err)
-		})
-	}
-}
-
-func TestGenerateDeployTask(t *testing.T) {
-	var tests = []struct {
-		description  string
-		deployConfig latest.DeployConfig
-		shouldErr    bool
-	}{
-		{
-			description: "successfully generate deploy task",
-			deployConfig: latest.DeployConfig{
-				DeployType: latest.DeployType{
-					HelmDeploy: &latest.HelmDeploy{},
-				},
-			},
-			shouldErr: false,
-		},
-		{
-			description: "fail generating deploy task",
-			deployConfig: latest.DeployConfig{
-				DeployType: latest.DeployType{
-					HelmDeploy:      nil,
-					KubectlDeploy:   nil,
-					KustomizeDeploy: nil,
-				},
-			},
-			shouldErr: true,
-		},
-	}
-
-	for _, test := range tests {
-		testutil.Run(t, test.description, func(t *testutil.T) {
-			configFile := &ConfigFile{
-				Name: "test",
-				Config: &latest.SkaffoldConfig{
-					Pipeline: latest.Pipeline{
-						Deploy: test.deployConfig,
-					},
-				},
-			}
-
-			_, err := generateDeployTask(configFile)
-			t.CheckError(test.shouldErr, err)
 		})
 	}
 }

--- a/pkg/skaffold/generate_pipeline/tasks.go
+++ b/pkg/skaffold/generate_pipeline/tasks.go
@@ -76,30 +76,32 @@ func generateBuildTask(configFile *ConfigFile) (*tekton.Task, error) {
 		},
 	}
 
-	// Add secret volume mounting for artifacts that need to be built with kaniko
+	// Add secret volume mounting if any artifacts in config need to be built with kaniko
 	var volumes []corev1.Volume
-	if buildConfig.Artifacts[0].KanikoArtifact != nil {
-		volumes = []corev1.Volume{
-			{
-				Name: kanikoSecretName,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: kanikoSecretName,
+	for _, artifact := range buildConfig.Artifacts {
+		if artifact.KanikoArtifact != nil {
+			volumes = []corev1.Volume{
+				{
+					Name: kanikoSecretName,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: kanikoSecretName,
+						},
 					},
 				},
-			},
-		}
-		steps[0].VolumeMounts = []corev1.VolumeMount{
-			{
-				Name:      kanikoSecretName,
-				MountPath: "/secret",
-			},
-		}
-		steps[0].Env = []corev1.EnvVar{
-			{
-				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
-				Value: "/secret/" + kanikoSecretName,
-			},
+			}
+			steps[0].VolumeMounts = []corev1.VolumeMount{
+				{
+					Name:      kanikoSecretName,
+					MountPath: "/secret",
+				},
+			}
+			steps[0].Env = []corev1.EnvVar{
+				{
+					Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+					Value: "/secret/" + kanikoSecretName,
+				},
+			}
 		}
 	}
 

--- a/pkg/skaffold/generate_pipeline/tasks.go
+++ b/pkg/skaffold/generate_pipeline/tasks.go
@@ -109,7 +109,7 @@ func generateBuildTask(configFile *ConfigFile) (*tekton.Task, error) {
 func generateDeployTasks(configFiles []*ConfigFile) ([]*tekton.Task, error) {
 	var tasks []*tekton.Task
 	for _, configFile := range configFiles {
-		task, err := generateBuildTask(configFile)
+		task, err := generateDeployTask(configFile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/skaffold/generate_pipeline/tasks.go
+++ b/pkg/skaffold/generate_pipeline/tasks.go
@@ -29,6 +29,20 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func generateBuildTasks(configFiles []*ConfigFile) ([]*tekton.Task, error) {
+	var tasks []*tekton.Task
+	for _, configFile := range configFiles {
+		task, err := generateBuildTask(configFile)
+		if err != nil {
+			return nil, err
+		}
+
+		tasks = append(tasks, task)
+	}
+
+	return tasks, nil
+}
+
 func generateBuildTask(configFile *ConfigFile) (*tekton.Task, error) {
 	buildConfig := configFile.Profile.Build
 	if len(buildConfig.Artifacts) == 0 {
@@ -90,6 +104,20 @@ func generateBuildTask(configFile *ConfigFile) (*tekton.Task, error) {
 	}
 
 	return pipeline.NewTask("skaffold-build", inputs, outputs, steps, volumes), nil
+}
+
+func generateDeployTasks(configFiles []*ConfigFile) ([]*tekton.Task, error) {
+	var tasks []*tekton.Task
+	for _, configFile := range configFiles {
+		task, err := generateBuildTask(configFile)
+		if err != nil {
+			return nil, err
+		}
+
+		tasks = append(tasks, task)
+	}
+
+	return tasks, nil
 }
 
 func generateDeployTask(configFile *ConfigFile) (*tekton.Task, error) {

--- a/pkg/skaffold/generate_pipeline/tasks.go
+++ b/pkg/skaffold/generate_pipeline/tasks.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generatepipeline
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/pipeline"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
+
+	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func generateBuildTask(configFile *ConfigFile) (*tekton.Task, error) {
+	buildConfig := configFile.Profile.Build
+	if len(buildConfig.Artifacts) == 0 {
+		return nil, errors.New("no artifacts to build")
+	}
+
+	skaffoldVersion := os.Getenv("PIPELINE_SKAFFOLD_VERSION")
+	if skaffoldVersion == "" {
+		skaffoldVersion = version.Get().Version
+	}
+
+	resources := []tekton.TaskResource{
+		{
+			Name: "source",
+			Type: tekton.PipelineResourceTypeGit,
+		},
+	}
+	inputs := &tekton.Inputs{Resources: resources}
+	outputs := &tekton.Outputs{Resources: resources}
+	steps := []corev1.Container{
+		{
+			Name:       "run-build",
+			Image:      fmt.Sprintf("gcr.io/k8s-skaffold/skaffold:%s", skaffoldVersion),
+			WorkingDir: "/workspace/source",
+			Command:    []string{"skaffold", "build"},
+			Args: []string{
+				"--filename", configFile.Name,
+				"--profile", "oncluster",
+				"--file-output", "build.out",
+			},
+		},
+	}
+
+	// Add secret volume mounting for artifacts that need to be built with kaniko
+	var volumes []corev1.Volume
+	if buildConfig.Artifacts[0].KanikoArtifact != nil {
+		volumes = []corev1.Volume{
+			{
+				Name: kanikoSecretName,
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: kanikoSecretName,
+					},
+				},
+			},
+		}
+		steps[0].VolumeMounts = []corev1.VolumeMount{
+			{
+				Name:      kanikoSecretName,
+				MountPath: "/secret",
+			},
+		}
+		steps[0].Env = []corev1.EnvVar{
+			{
+				Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+				Value: "/secret/" + kanikoSecretName,
+			},
+		}
+	}
+
+	return pipeline.NewTask("skaffold-build", inputs, outputs, steps, volumes), nil
+}
+
+func generateDeployTask(configFile *ConfigFile) (*tekton.Task, error) {
+	deployConfig := configFile.Config.Deploy
+	if deployConfig.HelmDeploy == nil && deployConfig.KubectlDeploy == nil && deployConfig.KustomizeDeploy == nil {
+		return nil, errors.New("no Helm/Kubectl/Kustomize deploy config")
+	}
+
+	skaffoldVersion := os.Getenv("PIPELINE_SKAFFOLD_VERSION")
+	if skaffoldVersion == "" {
+		skaffoldVersion = version.Get().Version
+	}
+
+	resources := []tekton.TaskResource{
+		{
+			Name: "source",
+			Type: tekton.PipelineResourceTypeGit,
+		},
+	}
+	inputs := &tekton.Inputs{Resources: resources}
+	steps := []corev1.Container{
+		{
+			Name:       "run-deploy",
+			Image:      fmt.Sprintf("gcr.io/k8s-skaffold/skaffold:%s", skaffoldVersion),
+			WorkingDir: "/workspace/source",
+			Command:    []string{"skaffold", "deploy"},
+			Args: []string{
+				"--filename", configFile.Name,
+				"--build-artifacts", "build.out",
+			},
+		},
+	}
+
+	return pipeline.NewTask("skaffold-deploy", inputs, nil, steps, nil), nil
+}

--- a/pkg/skaffold/generate_pipeline/tasks.go
+++ b/pkg/skaffold/generate_pipeline/tasks.go
@@ -69,7 +69,7 @@ func generateBuildTask(configFile *ConfigFile) (*tekton.Task, error) {
 			WorkingDir: "/workspace/source",
 			Command:    []string{"skaffold", "build"},
 			Args: []string{
-				"--filename", configFile.Name,
+				"--filename", configFile.Path,
 				"--profile", "oncluster",
 				"--file-output", "build.out",
 			},
@@ -145,7 +145,7 @@ func generateDeployTask(configFile *ConfigFile) (*tekton.Task, error) {
 			WorkingDir: "/workspace/source",
 			Command:    []string{"skaffold", "deploy"},
 			Args: []string{
-				"--filename", configFile.Name,
+				"--filename", configFile.Path,
 				"--build-artifacts", "build.out",
 			},
 		},

--- a/pkg/skaffold/generate_pipeline/tasks_test.go
+++ b/pkg/skaffold/generate_pipeline/tasks_test.go
@@ -23,6 +23,56 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
+func TestGenerateBuildTasks(t *testing.T) {
+	var tests = []struct {
+		description string
+		configFiles []*ConfigFile
+		shouldErr   bool
+	}{
+		{
+			description: "successfully generate build tasks",
+			configFiles: []*ConfigFile{
+				{
+					Path: "test1",
+					Profile: &latest.Profile{
+						Pipeline: latest.Pipeline{
+							Build: latest.BuildConfig{
+								Artifacts: []*latest.Artifact{
+									{
+										ImageName: "testArtifact1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					Path: "test2",
+					Profile: &latest.Profile{
+						Pipeline: latest.Pipeline{
+							Build: latest.BuildConfig{
+								Artifacts: []*latest.Artifact{
+									{
+										ImageName: "testArtifact2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			_, err := generateBuildTasks(test.configFiles)
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}
+
 func TestGenerateBuildTask(t *testing.T) {
 	var tests = []struct {
 		description string
@@ -60,6 +110,52 @@ func TestGenerateBuildTask(t *testing.T) {
 				},
 			}
 			_, err := generateBuildTask(configFile)
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}
+
+func TestGenerateDeployTasks(t *testing.T) {
+	var tests = []struct {
+		description string
+		configFiles []*ConfigFile
+		shouldErr   bool
+	}{
+		{
+			description: "successfully generate deploy tasks",
+			configFiles: []*ConfigFile{
+				{
+					Path: "test1",
+					Config: &latest.SkaffoldConfig{
+						Pipeline: latest.Pipeline{
+							Deploy: latest.DeployConfig{
+								DeployType: latest.DeployType{
+									HelmDeploy: &latest.HelmDeploy{},
+								},
+							},
+						},
+					},
+				},
+				{
+					Path: "test2",
+					Config: &latest.SkaffoldConfig{
+						Pipeline: latest.Pipeline{
+							Deploy: latest.DeployConfig{
+								DeployType: latest.DeployType{
+									HelmDeploy: &latest.HelmDeploy{},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			_, err := generateDeployTasks(test.configFiles)
 			t.CheckError(test.shouldErr, err)
 		})
 	}

--- a/pkg/skaffold/generate_pipeline/tasks_test.go
+++ b/pkg/skaffold/generate_pipeline/tasks_test.go
@@ -52,7 +52,7 @@ func TestGenerateBuildTask(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			configFile := &ConfigFile{
-				Name: "test",
+				Path: "test",
 				Profile: &latest.Profile{
 					Pipeline: latest.Pipeline{
 						Build: test.buildConfig,
@@ -96,7 +96,7 @@ func TestGenerateDeployTask(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			configFile := &ConfigFile{
-				Name: "test",
+				Path: "test",
 				Config: &latest.SkaffoldConfig{
 					Pipeline: latest.Pipeline{
 						Deploy: test.deployConfig,

--- a/pkg/skaffold/generate_pipeline/tasks_test.go
+++ b/pkg/skaffold/generate_pipeline/tasks_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generatepipeline
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestGenerateBuildTask(t *testing.T) {
+	var tests = []struct {
+		description string
+		buildConfig latest.BuildConfig
+		shouldErr   bool
+	}{
+		{
+			description: "successfully generate build task",
+			buildConfig: latest.BuildConfig{
+				Artifacts: []*latest.Artifact{
+					{
+						ImageName: "testArtifact",
+					},
+				},
+			},
+			shouldErr: false,
+		},
+		{
+			description: "fail generating build task",
+			buildConfig: latest.BuildConfig{
+				Artifacts: []*latest.Artifact{},
+			},
+			shouldErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			configFile := &ConfigFile{
+				Name: "test",
+				Profile: &latest.Profile{
+					Pipeline: latest.Pipeline{
+						Build: test.buildConfig,
+					},
+				},
+			}
+			_, err := generateBuildTask(configFile)
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}
+
+func TestGenerateDeployTask(t *testing.T) {
+	var tests = []struct {
+		description  string
+		deployConfig latest.DeployConfig
+		shouldErr    bool
+	}{
+		{
+			description: "successfully generate deploy task",
+			deployConfig: latest.DeployConfig{
+				DeployType: latest.DeployType{
+					HelmDeploy: &latest.HelmDeploy{},
+				},
+			},
+			shouldErr: false,
+		},
+		{
+			description: "fail generating deploy task",
+			deployConfig: latest.DeployConfig{
+				DeployType: latest.DeployType{
+					HelmDeploy:      nil,
+					KubectlDeploy:   nil,
+					KustomizeDeploy: nil,
+				},
+			},
+			shouldErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			configFile := &ConfigFile{
+				Name: "test",
+				Config: &latest.SkaffoldConfig{
+					Pipeline: latest.Pipeline{
+						Deploy: test.deployConfig,
+					},
+				},
+			}
+
+			_, err := generateDeployTask(configFile)
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}

--- a/pkg/skaffold/runner/generate_pipeline.go
+++ b/pkg/skaffold/runner/generate_pipeline.go
@@ -32,19 +32,23 @@ import (
 func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, config *latest.SkaffoldConfig, fileOut string) error {
 	// Keep track of files, configs, and profiles. This will be used to know which files to write
 	// profiles to and what flags to add to task commands
-	configFile := &pipeline.ConfigFile{
-		Name:    r.runCtx.Opts.ConfigurationFile,
-		Config:  config,
-		Profile: nil,
+	configFiles := []*pipeline.ConfigFile{
+		{
+			Name:    r.runCtx.Opts.ConfigurationFile,
+			Config:  config,
+			Profile: nil,
+		},
 	}
 
 	color.Default.Fprintln(out, "Running profile setup...")
-	if err := pipeline.CreateSkaffoldProfile(out, configFile); err != nil {
-		return errors.Wrap(err, "seeting up profile")
+	for _, configFile := range configFiles {
+		if err := pipeline.CreateSkaffoldProfile(out, configFile); err != nil {
+			return errors.Wrap(err, "seeting up profile")
+		}
 	}
 
 	color.Default.Fprintln(out, "Generating Pipeline...")
-	pipelineYaml, err := pipeline.Yaml(out, configFile)
+	pipelineYaml, err := pipeline.Yaml(out, configFiles)
 	if err != nil {
 		return errors.Wrap(err, "generating pipeline yaml contents")
 	}

--- a/pkg/skaffold/runner/generate_pipeline.go
+++ b/pkg/skaffold/runner/generate_pipeline.go
@@ -40,6 +40,7 @@ func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, co
 		},
 	}
 
+	// Will run the profile setup multiple times and require user input for each specified config
 	color.Default.Fprintln(out, "Running profile setup...")
 	for _, configFile := range configFiles {
 		if err := pipeline.CreateSkaffoldProfile(out, configFile); err != nil {


### PR DESCRIPTION
More refactors to prep the generate-pipeline command to support multiple config files.

No functionality changes in this PR.