### PR TITLE
Directs "Download" button to Quickstart

### DIFF
--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -9,8 +9,8 @@ linkTitle = "Skaffold"
 	<a class="btn btn-lg btn-primary mr-3 mb-4" href="{{< relref "/docs" >}}">
 		Learn More <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
-	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://github.com/GoogleContainerTools/skaffold">
-		Download <i class="fab fa-github ml-2 "></i>
+	<a class="btn btn-lg btn-secondary mr-3 mb-4" href="https://skaffold.dev/docs/getting-started/#installing-skaffold">
+		Download <i class="fas fa-download ml-2 "></i>
 	</a>
 	<div class="mx-auto mt-5">
 		{{< blocks/link-down color="info" >}}


### PR DESCRIPTION
-Directs the "Download" button on the homepage of skaffold.dev to the quickstart in the documentation instead of having the user navigate to GitHub where they eventually discover a link that takes them to the quickstart
-Updates the icon of the "Download" button from the GitHub logo to a more clear "Download" icon already used elsewhere on the page