### PR TITLE
Document Docker buildArgs as templated field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bin/
 out/
 examples/bazel/bazel-*
 integration/examples/bazel/bazel-*

--- a/docs/content/en/docs/how-tos/templating/_index.md
+++ b/docs/content/en/docs/how-tos/templating/_index.md
@@ -14,6 +14,7 @@ will be `gcr.io/k8s-skaffold/example:v1`.
 
 List of fields that support templating:
 
+* `build.artifacts.[].docker.buildArgs` (see [builders](/docs/how-tos/builders/))
 * `build.tagPolicy.envTemplate.template` (see [envTemplate tagger](/docs/how-tos/taggers/##envtemplate-using-values-of-environment-variables-as-tags))
 * `deploy.helm.releases.setValueTemplates` (see [Deploying with helm](/docs/how-tos/deployers/#deploying-with-helm))
 


### PR DESCRIPTION
...and git-ignore the `bin` directory which gets created by `hack/install_golint.sh`