### PR TITLE
Update documentation on Templated fields

### DIFF
--- a/docs/content/en/docs/how-tos/templating/_index.md
+++ b/docs/content/en/docs/how-tos/templating/_index.md
@@ -16,6 +16,9 @@ List of fields that support templating:
 
 * `build.tagPolicy.envTemplate.template` (see [envTemplate tagger](/docs/how-tos/taggers/##envtemplate-using-values-of-environment-variables-as-tags))
 * `deploy.helm.releases.setValueTemplates` (see [Deploying with helm](/docs/how-tos/deployers/#deploying-with-helm))
+* `deploy.helm.releases.name` (see [Deploying with helm](/docs/how-tos/deployers/#deploying-with-helm))
+
+_Please note, this list is not exhaustive_
 
 List of variables that are available for templating:
 


### PR DESCRIPTION
## Changes

- Add deploy.helm.releases.name to List of fields that support templating

## Motivation

The lack of documentation around helm release templating made my first use of Skaffold unfortunately confusing. Hope to help others :)

I also mentioned the list may not be exhaustive, this was another point of confusion for me.