### PR TITLE
Don't set KanikoArtifact if CustomArtifact is set

### DIFF
--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -43,8 +43,11 @@ func Set(c *latest.SkaffoldConfig) error {
 	)
 
 	if c.Build.Cluster != nil {
-		// All artifacts should be built with kaniko
+		// All artifacts should be built with kaniko or a custom command
 		for _, a := range c.Build.Artifacts {
+			if a.CustomArtifact != nil {
+				continue
+			}
 			setDefaultKanikoArtifact(a)
 			setDefaultKanikoArtifactImage(a)
 			setDefaultKanikoArtifactBuildContext(a)

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -115,6 +115,33 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 	})
 }
 
+func TestCustomBuildWithCluster(t *testing.T) {
+	cfg := &latest.SkaffoldConfig{
+		Pipeline: latest.Pipeline{
+			Build: latest.BuildConfig{
+				Artifacts: []*latest.Artifact{
+					{
+						ImageName: "image",
+						ArtifactType: latest.ArtifactType{
+							CustomArtifact: &latest.CustomArtifact{
+								BuildCommand: "./build.sh",
+							},
+						},
+					},
+				},
+				BuildType: latest.BuildType{
+					Cluster: &latest.ClusterDetails{},
+				},
+			},
+		},
+	}
+
+	err := Set(cfg)
+
+	testutil.CheckError(t, false, err)
+	testutil.CheckDeepEqual(t, (*latest.KanikoArtifact)(nil), cfg.Build.Artifacts[0].KanikoArtifact)
+}
+
 func TestSetDefaultsOnCloudBuild(t *testing.T) {
 	cfg := &latest.SkaffoldConfig{
 		Pipeline: latest.Pipeline{


### PR DESCRIPTION
Previously, it wasn't possible to use a custom in-cluster builder

To close #2684 