### PR TITLE
Don’t store log lines as mutable slices of bytes

### DIFF
--- a/pkg/skaffold/build/parallel_test.go
+++ b/pkg/skaffold/build/parallel_test.go
@@ -325,10 +325,10 @@ func TestColoredOutput(t *testing.T) {
 	}
 }
 
-func setUpChannels(n int) []chan []byte {
-	outputs := make([]chan []byte, n)
+func setUpChannels(n int) []chan string {
+	outputs := make([]chan string, n)
 	for i := 0; i < n; i++ {
-		outputs[i] = make(chan []byte, 10)
+		outputs[i] = make(chan string, 10)
 		close(outputs[i])
 	}
 	return outputs


### PR DESCRIPTION
Use immutable strings instead.

Fixes #2669

Signed-off-by: David Gageot <david@gageot.net>