### PR TITLE
Don't panic when dockerConfig isn't provided

### DIFF
--- a/pkg/skaffold/build/cluster/cluster.go
+++ b/pkg/skaffold/build/cluster/cluster.go
@@ -72,13 +72,16 @@ func (b *Builder) buildArtifactWithCustomBuilder(ctx context.Context, out io.Wri
 }
 
 func (b *Builder) retrieveExtraEnv() []string {
-	return []string{
+	env := []string{
 		fmt.Sprintf("%s=%s", constants.KubeContext, b.kubeContext),
 		fmt.Sprintf("%s=%s", constants.Namespace, b.ClusterDetails.Namespace),
 		fmt.Sprintf("%s=%s", constants.PullSecretName, b.ClusterDetails.PullSecretName),
-		fmt.Sprintf("%s=%s", constants.DockerConfigSecretName, b.ClusterDetails.DockerConfig.SecretName),
 		fmt.Sprintf("%s=%s", constants.Timeout, b.ClusterDetails.Timeout),
 	}
+	if b.ClusterDetails.DockerConfig != nil {
+		env = append(env, fmt.Sprintf("%s=%s", constants.DockerConfigSecretName, b.ClusterDetails.DockerConfig.SecretName))
+	}
+	return env
 }
 
 func (b *Builder) buildArtifactWithKaniko(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {

--- a/pkg/skaffold/build/cluster/cluster_test.go
+++ b/pkg/skaffold/build/cluster/cluster_test.go
@@ -49,6 +49,25 @@ func TestRetrieveEnv(t *testing.T) {
 	testutil.CheckError(t, false, err)
 
 	actual := builder.retrieveExtraEnv()
-	expected := []string{"KUBE_CONTEXT=kubecontext", "NAMESPACE=namespace", "PULL_SECRET_NAME=pullSecret", "DOCKER_CONFIG_SECRET_NAME=dockerconfig", "TIMEOUT=2m"}
+	expected := []string{"KUBE_CONTEXT=kubecontext", "NAMESPACE=namespace", "PULL_SECRET_NAME=pullSecret", "TIMEOUT=2m", "DOCKER_CONFIG_SECRET_NAME=dockerconfig"}
+	testutil.CheckDeepEqual(t, expected, actual)
+}
+
+func TestRetrieveEnvMinimal(t *testing.T) {
+	builder, err := NewBuilder(&runcontext.RunContext{
+		Cfg: latest.Pipeline{
+			Build: latest.BuildConfig{
+				BuildType: latest.BuildType{
+					Cluster: &latest.ClusterDetails{
+						Timeout: "20m",
+					},
+				},
+			},
+		},
+	})
+	testutil.CheckError(t, false, err)
+
+	actual := builder.retrieveExtraEnv()
+	expected := []string{"KUBE_CONTEXT=", "NAMESPACE=", "PULL_SECRET_NAME=", "TIMEOUT=20m"}
 	testutil.CheckDeepEqual(t, expected, actual)
 }


### PR DESCRIPTION
Prevously, the custom in-cluster builder would break with default
configuration