### PR TITLE
Turn Jib init plugin names into a proper enum type

### DIFF
--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -281,7 +281,8 @@ func processCliArtifacts(artifacts []string) ([]builderImagePair, error) {
 			pair := builderImagePair{Builder: parsed.Payload, ImageName: a.Image}
 			pairs = append(pairs, pair)
 
-		case jib.JibGradle, jib.JibMaven:
+		// FIXME: shouldn't use a human-readable name?
+		case jib.JibGradle.Name(), jib.JibMaven.Name():
 			parsed := struct {
 				Payload jib.Jib `json:"payload"`
 			}{}

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -38,14 +38,14 @@ func TestPrintAnalyzeJSON(t *testing.T) {
 	}{
 		{
 			description: "builders and images with pairs",
-			pairs:       []builderImagePair{{jib.Jib{BuilderName: jib.JibGradle, Image: "image1", FilePath: "build.gradle", Project: "project"}, "image1"}},
+			pairs:       []builderImagePair{{jib.Jib{BuilderName: jib.JibGradle.Name(), Image: "image1", FilePath: "build.gradle", Project: "project"}, "image1"}},
 			builders:    []InitBuilder{docker.Docker{File: "Dockerfile"}},
 			images:      []string{"image2"},
 			expected:    `{"builders":[{"name":"Jib Gradle Plugin","payload":{"image":"image1","path":"build.gradle","project":"project"}},{"name":"Docker","payload":{"path":"Dockerfile"}}],"images":[{"name":"image1","foundMatch":true},{"name":"image2","foundMatch":false}]}`,
 		},
 		{
 			description: "builders and images with no pairs",
-			builders:    []InitBuilder{jib.Jib{BuilderName: jib.JibGradle, FilePath: "build.gradle", Project: "project"}, docker.Docker{File: "Dockerfile"}},
+			builders:    []InitBuilder{jib.Jib{BuilderName: jib.JibGradle.Name(), FilePath: "build.gradle", Project: "project"}, docker.Docker{File: "Dockerfile"}},
 			images:      []string{"image1", "image2"},
 			expected:    `{"builders":[{"name":"Jib Gradle Plugin","payload":{"path":"build.gradle","project":"project"}},{"name":"Docker","payload":{"path":"Dockerfile"}}],"images":[{"name":"image1","foundMatch":false},{"name":"image2","foundMatch":false}]}`,
 		},
@@ -289,10 +289,10 @@ func fakeValidateDockerfile(path string) bool {
 
 func fakeValidateJibConfig(path string) []jib.Jib {
 	if strings.HasSuffix(path, "build.gradle") {
-		return []jib.Jib{{BuilderName: jib.JibGradle, FilePath: path}}
+		return []jib.Jib{{BuilderName: jib.JibGradle.Name(), FilePath: path}}
 	}
 	if strings.HasSuffix(path, "pom.xml") {
-		return []jib.Jib{{BuilderName: jib.JibMaven, FilePath: path}}
+		return []jib.Jib{{BuilderName: jib.JibMaven.Name(), FilePath: path}}
 	}
 	return nil
 }
@@ -326,7 +326,7 @@ func TestResolveBuilderImages(t *testing.T) {
 		},
 		{
 			description:      "prompt for multiple builders and images",
-			buildConfigs:     []InitBuilder{docker.Docker{File: "Dockerfile1"}, jib.Jib{BuilderName: jib.JibGradle, FilePath: "build.gradle"}, jib.Jib{BuilderName: jib.JibMaven, Project: "project", FilePath: "pom.xml"}},
+			buildConfigs:     []InitBuilder{docker.Docker{File: "Dockerfile1"}, jib.Jib{BuilderName: jib.JibGradle.Name(), FilePath: "build.gradle"}, jib.Jib{BuilderName: jib.JibMaven.Name(), Project: "project", FilePath: "pom.xml"}},
 			images:           []string{"image1", "image2"},
 			shouldMakeChoice: true,
 			expectedPairs: []builderImagePair{
@@ -335,7 +335,7 @@ func TestResolveBuilderImages(t *testing.T) {
 					ImageName: "image1",
 				},
 				{
-					Builder:   jib.Jib{BuilderName: jib.JibGradle, FilePath: "build.gradle"},
+					Builder:   jib.Jib{BuilderName: jib.JibGradle.Name(), FilePath: "build.gradle"},
 					ImageName: "image2",
 				},
 			},
@@ -371,15 +371,15 @@ func TestAutoSelectBuilders(t *testing.T) {
 			description: "no automatic matches",
 			builderConfigs: []InitBuilder{
 				docker.Docker{File: "Dockerfile"},
-				jib.Jib{BuilderName: jib.JibGradle, FilePath: "build.gradle"},
-				jib.Jib{BuilderName: jib.JibMaven, FilePath: "pom.xml", Image: "not a k8s image"},
+				jib.Jib{BuilderName: jib.JibGradle.Name(), FilePath: "build.gradle"},
+				jib.Jib{BuilderName: jib.JibMaven.Name(), FilePath: "pom.xml", Image: "not a k8s image"},
 			},
 			images:        []string{"image1", "image2"},
 			expectedPairs: nil,
 			expectedBuildersLeft: []InitBuilder{
 				docker.Docker{File: "Dockerfile"},
-				jib.Jib{BuilderName: jib.JibGradle, FilePath: "build.gradle"},
-				jib.Jib{BuilderName: jib.JibMaven, FilePath: "pom.xml", Image: "not a k8s image"},
+				jib.Jib{BuilderName: jib.JibGradle.Name(), FilePath: "build.gradle"},
+				jib.Jib{BuilderName: jib.JibMaven.Name(), FilePath: "pom.xml", Image: "not a k8s image"},
 			},
 			expectedFilteredImages: []string{"image1", "image2"},
 		},
@@ -387,17 +387,17 @@ func TestAutoSelectBuilders(t *testing.T) {
 			description: "automatic jib matches",
 			builderConfigs: []InitBuilder{
 				docker.Docker{File: "Dockerfile"},
-				jib.Jib{BuilderName: jib.JibGradle, FilePath: "build.gradle", Image: "image1"},
-				jib.Jib{BuilderName: jib.JibMaven, FilePath: "pom.xml", Image: "image2"},
+				jib.Jib{BuilderName: jib.JibGradle.Name(), FilePath: "build.gradle", Image: "image1"},
+				jib.Jib{BuilderName: jib.JibMaven.Name(), FilePath: "pom.xml", Image: "image2"},
 			},
 			images: []string{"image1", "image2", "image3"},
 			expectedPairs: []builderImagePair{
 				{
-					jib.Jib{BuilderName: jib.JibGradle, FilePath: "build.gradle", Image: "image1"},
+					jib.Jib{BuilderName: jib.JibGradle.Name(), FilePath: "build.gradle", Image: "image1"},
 					"image1",
 				},
 				{
-					jib.Jib{BuilderName: jib.JibMaven, FilePath: "pom.xml", Image: "image2"},
+					jib.Jib{BuilderName: jib.JibMaven.Name(), FilePath: "pom.xml", Image: "image2"},
 					"image2",
 				},
 			},
@@ -407,14 +407,14 @@ func TestAutoSelectBuilders(t *testing.T) {
 		{
 			description: "multiple matches for one image",
 			builderConfigs: []InitBuilder{
-				jib.Jib{BuilderName: jib.JibGradle, FilePath: "build.gradle", Image: "image1"},
-				jib.Jib{BuilderName: jib.JibMaven, FilePath: "pom.xml", Image: "image1"},
+				jib.Jib{BuilderName: jib.JibGradle.Name(), FilePath: "build.gradle", Image: "image1"},
+				jib.Jib{BuilderName: jib.JibMaven.Name(), FilePath: "pom.xml", Image: "image1"},
 			},
 			images:        []string{"image1", "image2"},
 			expectedPairs: nil,
 			expectedBuildersLeft: []InitBuilder{
-				jib.Jib{BuilderName: jib.JibGradle, FilePath: "build.gradle", Image: "image1"},
-				jib.Jib{BuilderName: jib.JibMaven, FilePath: "pom.xml", Image: "image1"},
+				jib.Jib{BuilderName: jib.JibGradle.Name(), FilePath: "build.gradle", Image: "image1"},
+				jib.Jib{BuilderName: jib.JibMaven.Name(), FilePath: "pom.xml", Image: "image1"},
 			},
 			expectedFilteredImages: []string{"image1", "image2"},
 		},

--- a/pkg/skaffold/jib/jib.go
+++ b/pkg/skaffold/jib/jib.go
@@ -39,33 +39,35 @@ const (
 	dotDotSlash = ".." + string(filepath.Separator)
 )
 
-// BuilderType is an enum for the different builders supported by Jib.
-type BuilderType int
+// PluginType is an enum for the different Jib plugins supported.
+type PluginType int
 
+// Define the different plugin types supported by Jib.
 const (
-	JibMaven BuilderType = iota
+	JibMaven PluginType = iota
 	JibGradle
 )
 
-// String returns the identifier for the respective builder type, used in YAML.
-func (t BuilderType) String() string {
+// ID returns the identifier for a plugin type, suited for use in YAML.
+func (t PluginType) ID() string {
 	switch t {
 	case JibMaven:
 		return "maven"
 	case JibGradle:
 		return "gradle"
 	}
-	panic("Unknown Jib Builder Type: " + string(t))
+	panic("Unknown Jib Plugin Type: " + string(t))
 }
 
-func (t BuilderType) Name() string {
+// Name provides a human-oriented label for a plugin type.
+func (t PluginType) Name() string {
 	switch t {
 	case JibMaven:
 		return "Jib Maven Plugin"
 	case JibGradle:
 		return "Jib Gradle Plugin"
 	}
-	panic("Unknown Jib Builder Type: " + string(t))
+	panic("Unknown Jib Plugin Type: " + string(t))
 }
 
 // filesLists contains cached build/input dependencies

--- a/pkg/skaffold/jib/jib.go
+++ b/pkg/skaffold/jib/jib.go
@@ -39,7 +39,7 @@ const (
 	dotDotSlash = ".." + string(filepath.Separator)
 )
 
-// PluginType is an enum for the different Jib plugins supported.
+// PluginType is an enum for the different supported Jib plugins.
 type PluginType int
 
 // Define the different plugin types supported by Jib.
@@ -48,7 +48,7 @@ const (
 	JibGradle
 )
 
-// ID returns the identifier for a plugin type, suited for use in YAML.
+// ID returns the identifier for a Jib plugin type, suitable for external references (YAML, JSON, command-line, etc).
 func (t PluginType) ID() string {
 	switch t {
 	case JibMaven:

--- a/pkg/skaffold/jib/jib.go
+++ b/pkg/skaffold/jib/jib.go
@@ -39,6 +39,35 @@ const (
 	dotDotSlash = ".." + string(filepath.Separator)
 )
 
+// BuilderType is an enum for the different builders supported by Jib.
+type BuilderType int
+
+const (
+	JibMaven BuilderType = iota
+	JibGradle
+)
+
+// String returns the identifier for the respective builder type, used in YAML.
+func (t BuilderType) String() string {
+	switch t {
+	case JibMaven:
+		return "maven"
+	case JibGradle:
+		return "gradle"
+	}
+	panic("Unknown Jib Builder Type: " + string(t))
+}
+
+func (t BuilderType) Name() string {
+	switch t {
+	case JibMaven:
+		return "Jib Maven Plugin"
+	case JibGradle:
+		return "Jib Gradle Plugin"
+	}
+	panic("Unknown Jib Builder Type: " + string(t))
+}
+
 // filesLists contains cached build/input dependencies
 type filesLists struct {
 	// BuildDefinitions lists paths to build definitions that trigger a call out to Jib to refresh the pathMap, as well as a rebuild, upon changing

--- a/pkg/skaffold/jib/jib_init.go
+++ b/pkg/skaffold/jib/jib_init.go
@@ -112,7 +112,7 @@ type jibJSON struct {
 // ValidateJibConfig checks if a file is a valid Jib configuration. Returns the list of Config objects corresponding to each Jib project built by the file, or nil if Jib is not configured.
 func ValidateJibConfig(path string) []Jib {
 	// Determine whether maven or gradle
-	var builderType BuilderType
+	var builderType PluginType
 	var executable, wrapper, taskName string
 	switch {
 	case strings.HasSuffix(path, "pom.xml"):

--- a/pkg/skaffold/jib/jib_init.go
+++ b/pkg/skaffold/jib/jib_init.go
@@ -35,13 +35,6 @@ var (
 	ValidateJibConfigFunc = ValidateJibConfig
 )
 
-const (
-	// JibGradle the name of the Jib Gradle Plugin
-	JibGradle = "Jib Gradle Plugin"
-	// JibMaven the name of the Jib Maven Plugin
-	JibMaven = "Jib Maven Plugin"
-)
-
 // Jib holds information about a Jib project
 type Jib struct {
 	BuilderName string `json:"-"`
@@ -76,7 +69,7 @@ func (j Jib) CreateArtifact(manifestImage string) *latest.Artifact {
 		a.Workspace = workspace
 	}
 
-	if j.BuilderName == JibMaven {
+	if j.BuilderName == JibMaven.Name() {
 		jibMaven := &latest.JibMavenArtifact{}
 		if j.Project != "" {
 			jibMaven.Module = j.Project
@@ -86,7 +79,7 @@ func (j Jib) CreateArtifact(manifestImage string) *latest.Artifact {
 		}
 		a.ArtifactType = latest.ArtifactType{JibMavenArtifact: jibMaven}
 
-	} else if j.BuilderName == JibGradle {
+	} else if j.BuilderName == JibGradle.Name() {
 		jibGradle := &latest.JibGradleArtifact{}
 		if j.Project != "" {
 			jibGradle.Project = j.Project
@@ -119,7 +112,8 @@ type jibJSON struct {
 // ValidateJibConfig checks if a file is a valid Jib configuration. Returns the list of Config objects corresponding to each Jib project built by the file, or nil if Jib is not configured.
 func ValidateJibConfig(path string) []Jib {
 	// Determine whether maven or gradle
-	var builderType, executable, wrapper, taskName string
+	var builderType BuilderType
+	var executable, wrapper, taskName string
 	switch {
 	case strings.HasSuffix(path, "pom.xml"):
 		builderType = JibMaven
@@ -162,7 +156,7 @@ func ValidateJibConfig(path string) []Jib {
 			return nil
 		}
 
-		results[i] = Jib{BuilderName: builderType, Image: parsedJSON.Image, FilePath: path, Project: parsedJSON.Project}
+		results[i] = Jib{BuilderName: builderType.Name(), Image: parsedJSON.Image, FilePath: path, Project: parsedJSON.Project}
 	}
 	return results
 }

--- a/pkg/skaffold/jib/jib_init_test.go
+++ b/pkg/skaffold/jib/jib_init_test.go
@@ -53,7 +53,7 @@ func TestValidateJibConfig(t *testing.T) {
 {"image":"image","project":"project"}
 `,
 			expectedConfig: []Jib{
-				{BuilderName: JibGradle, FilePath: "path/to/build.gradle", Image: "image", Project: "project"},
+				{BuilderName: JibGradle.Name(), FilePath: "path/to/build.gradle", Image: "image", Project: "project"},
 			},
 		},
 		{
@@ -67,8 +67,8 @@ BEGIN JIB JSON
 {"project":"project2"}
 `,
 			expectedConfig: []Jib{
-				{BuilderName: JibGradle, FilePath: "path/to/build.gradle", Image: "image", Project: "project1"},
-				{BuilderName: JibGradle, FilePath: "path/to/build.gradle", Project: "project2"},
+				{BuilderName: JibGradle.Name(), FilePath: "path/to/build.gradle", Image: "image", Project: "project1"},
+				{BuilderName: JibGradle.Name(), FilePath: "path/to/build.gradle", Project: "project2"},
 			},
 		},
 		{
@@ -78,7 +78,7 @@ BEGIN JIB JSON
 			stdout: `BEGIN JIB JSON
 {"image":"image","project":"project"}`,
 			expectedConfig: []Jib{
-				{BuilderName: JibMaven, FilePath: "path/to/pom.xml", Image: "image", Project: "project"},
+				{BuilderName: JibMaven.Name(), FilePath: "path/to/pom.xml", Image: "image", Project: "project"},
 			},
 		},
 		{
@@ -92,8 +92,8 @@ BEGIN JIB JSON
 {"project":"project2"}
 `,
 			expectedConfig: []Jib{
-				{BuilderName: JibMaven, FilePath: "path/to/pom.xml", Image: "image", Project: "project1"},
-				{BuilderName: JibMaven, FilePath: "path/to/pom.xml", Project: "project2"},
+				{BuilderName: JibMaven.Name(), FilePath: "path/to/pom.xml", Image: "image", Project: "project1"},
+				{BuilderName: JibMaven.Name(), FilePath: "path/to/pom.xml", Project: "project2"},
 			},
 		},
 	}
@@ -113,22 +113,22 @@ func TestDescribe(t *testing.T) {
 	}{
 		{
 			description:    "gradle without project",
-			config:         Jib{BuilderName: JibGradle, FilePath: "path/to/build.gradle"},
+			config:         Jib{BuilderName: JibGradle.Name(), FilePath: "path/to/build.gradle"},
 			expectedPrompt: "Jib Gradle Plugin (path/to/build.gradle)",
 		},
 		{
 			description:    "gradle with project",
-			config:         Jib{BuilderName: JibGradle, Project: "project", FilePath: "path/to/build.gradle"},
+			config:         Jib{BuilderName: JibGradle.Name(), Project: "project", FilePath: "path/to/build.gradle"},
 			expectedPrompt: "Jib Gradle Plugin (project, path/to/build.gradle)",
 		},
 		{
 			description:    "maven without project",
-			config:         Jib{BuilderName: JibMaven, FilePath: "path/to/pom.xml"},
+			config:         Jib{BuilderName: JibMaven.Name(), FilePath: "path/to/pom.xml"},
 			expectedPrompt: "Jib Maven Plugin (path/to/pom.xml)",
 		},
 		{
 			description:    "maven with project",
-			config:         Jib{BuilderName: JibMaven, Project: "project", FilePath: "path/to/pom.xml"},
+			config:         Jib{BuilderName: JibMaven.Name(), Project: "project", FilePath: "path/to/pom.xml"},
 			expectedPrompt: "Jib Maven Plugin (project, path/to/pom.xml)",
 		},
 	}
@@ -149,7 +149,7 @@ func TestCreateArtifact(t *testing.T) {
 	}{
 		{
 			description:   "jib gradle with image and project",
-			config:        Jib{BuilderName: JibGradle, FilePath: filepath.Join("path", "to", "build.gradle"), Image: "image", Project: "project"},
+			config:        Jib{BuilderName: JibGradle.Name(), FilePath: filepath.Join("path", "to", "build.gradle"), Image: "image", Project: "project"},
 			manifestImage: "different-image",
 			expectedArtifact: latest.Artifact{
 				ImageName: "image",
@@ -161,7 +161,7 @@ func TestCreateArtifact(t *testing.T) {
 		},
 		{
 			description:   "jib gradle without image and project",
-			config:        Jib{BuilderName: JibGradle, FilePath: filepath.Join("path", "to", "build.gradle")},
+			config:        Jib{BuilderName: JibGradle.Name(), FilePath: filepath.Join("path", "to", "build.gradle")},
 			manifestImage: "different-image",
 			expectedArtifact: latest.Artifact{
 				ImageName: "different-image",
@@ -175,7 +175,7 @@ func TestCreateArtifact(t *testing.T) {
 		},
 		{
 			description:   "jib maven with image and project",
-			config:        Jib{BuilderName: JibMaven, FilePath: filepath.Join("path", "to", "pom.xml"), Image: "image", Project: "project"},
+			config:        Jib{BuilderName: JibMaven.Name(), FilePath: filepath.Join("path", "to", "pom.xml"), Image: "image", Project: "project"},
 			manifestImage: "different-image",
 			expectedArtifact: latest.Artifact{
 				ImageName: "image",
@@ -187,7 +187,7 @@ func TestCreateArtifact(t *testing.T) {
 		},
 		{
 			description:   "jib maven without image and project",
-			config:        Jib{BuilderName: JibMaven, FilePath: filepath.Join("path", "to", "pom.xml")},
+			config:        Jib{BuilderName: JibMaven.Name(), FilePath: filepath.Join("path", "to", "pom.xml")},
 			manifestImage: "different-image",
 			expectedArtifact: latest.Artifact{
 				ImageName: "different-image",
@@ -201,7 +201,7 @@ func TestCreateArtifact(t *testing.T) {
 		},
 		{
 			description:   "ignore workspace",
-			config:        Jib{BuilderName: JibGradle, FilePath: "build.gradle", Image: "image"},
+			config:        Jib{BuilderName: JibGradle.Name(), FilePath: "build.gradle", Image: "image"},
 			manifestImage: "different-image",
 			expectedArtifact: latest.Artifact{
 				ImageName:    "image",

--- a/pkg/skaffold/jib/jib_test.go
+++ b/pkg/skaffold/jib/jib_test.go
@@ -26,10 +26,10 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestBuilderType(t *testing.T) {
-	testutil.CheckDeepEqual(t, "maven", JibMaven.String())
+func TestPluginType(t *testing.T) {
+	testutil.CheckDeepEqual(t, "maven", JibMaven.ID())
 	testutil.CheckDeepEqual(t, "Jib Maven Plugin", JibMaven.Name())
-	testutil.CheckDeepEqual(t, "gradle", JibGradle.String())
+	testutil.CheckDeepEqual(t, "gradle", JibGradle.ID())
 	testutil.CheckDeepEqual(t, "Jib Gradle Plugin", JibGradle.Name())
 }
 

--- a/pkg/skaffold/jib/jib_test.go
+++ b/pkg/skaffold/jib/jib_test.go
@@ -26,6 +26,13 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
+func TestBuilderType(t *testing.T) {
+	testutil.CheckDeepEqual(t, "maven", JibMaven.String())
+	testutil.CheckDeepEqual(t, "Jib Maven Plugin", JibMaven.Name())
+	testutil.CheckDeepEqual(t, "gradle", JibGradle.String())
+	testutil.CheckDeepEqual(t, "Jib Gradle Plugin", JibGradle.Name())
+}
+
 func TestGetDependencies(t *testing.T) {
 	tmpDir, cleanup := testutil.NewTempDir(t)
 	defer cleanup()


### PR DESCRIPTION
Turn the `JibGradle` and `JibMaven` strings, which represent human-meaningful plugin descriptions, into an enum type `JibPluginType` with helper functions to get a `Name()` or `ID()`.

Opened #2747 and left a FIXME in `init.go` as `skaffold init --artifacts '{...json...}`'s JSON object should use an identifier rather than the human-oriented name.