### PR TITLE
Refactor deployment healthcheck

### DIFF
--- a/examples/microservices/leeroy-app/kubernetes/deployment.yaml
+++ b/examples/microservices/leeroy-app/kubernetes/deployment.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     app: leeroy-app
 spec:
-  replicas: 1
+  replicas: 6
   selector:
     matchLabels:
       app: leeroy-app

--- a/examples/microservices/leeroy-app/kubernetes/deployment.yaml
+++ b/examples/microservices/leeroy-app/kubernetes/deployment.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     app: leeroy-app
 spec:
-  replicas: 6
+  replicas: 1
   selector:
     matchLabels:
       app: leeroy-app

--- a/pkg/skaffold/deploy/resource.go
+++ b/pkg/skaffold/deploy/resource.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deploy
+
+import (
+	"context"
+	"io"
+	"time"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/resources"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+)
+
+type Resource interface {
+	// String returns the string representation of a resource.
+	String() string
+	// Type returns the type of the resource
+	Type() string
+	// Status returns the resource status
+	Status() *resources.Status
+	// Namespace returns the resource namespace
+	Namespace() string
+	// Name returns the resource name
+	Name() string
+	// CheckStatus performs the resource status check.
+	CheckStatus(ctx context.Context, runCtx *runcontext.RunContext)
+	// Deadline returns the status check deadline for the resource
+	Deadline() time.Duration
+	// UpdateStatus updates the status of a resource with the given error message
+	UpdateStatus(msg string, reason string, err error)
+	// IsStatusCheckComplete returns if a status check is complete for a resource
+	IsStatusCheckComplete() bool
+	// ReportSinceLastUpdated writes the last known status to out if it hasn't been reported earlier.
+	ReportSinceLastUpdated(out io.Writer)
+}

--- a/pkg/skaffold/deploy/resources/deployment.go
+++ b/pkg/skaffold/deploy/resources/deployment.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+)
+
+const (
+	DeploymentType = "deployment"
+)
+
+type Deployment struct {
+	*ResourceObj
+	deadline time.Duration
+}
+
+func NewDeployment(name string, ns string, deadline time.Duration) *Deployment {
+	return &Deployment{
+		ResourceObj: &ResourceObj{name: name, namespace: ns, rType: DeploymentType},
+		deadline:    deadline,
+	}
+}
+
+func (d *Deployment) CheckStatus(ctx context.Context, runCtx *runcontext.RunContext) {
+	kubeCtl := kubectl.NewFromRunContext(runCtx)
+	b, err := kubeCtl.RunOut(ctx, "rollout", "status", "deployment", d.name, "--namespace", d.namespace, "--watch=false")
+	if err != nil {
+		d.UpdateStatus("", err.Error(), err)
+		if !strings.Contains(err.Error(), "Unable to connect to the server") {
+			d.checkComplete()
+		}
+		return
+	}
+	if s := string(b); strings.Contains(s, "successfully rolled out") {
+		d.UpdateStatus(s, s, nil)
+		d.checkComplete()
+		return
+	}
+	d.UpdateStatus(string(b), string(b), nil)
+}
+
+func (d *Deployment) Deadline() time.Duration {
+	return d.deadline
+}
+
+func (d *Deployment) WithError(err error) *Deployment {
+	d.UpdateStatus("", "", err)
+	return d
+}

--- a/pkg/skaffold/deploy/resources/deployment.go
+++ b/pkg/skaffold/deploy/resources/deployment.go
@@ -66,11 +66,6 @@ func (d *Deployment) Deadline() time.Duration {
 	return d.deadline
 }
 
-func (d *Deployment) WithError(err error) *Deployment {
-	d.UpdateStatus("", err.Error(), err)
-	return d
-}
-
 func parseKubectlError(errMsg string) (string, string) {
 	errMsg = strings.TrimSuffix(errMsg, "\n")
 	if strings.Contains(errMsg, "Unable to connect to the server") {
@@ -80,4 +75,14 @@ func parseKubectlError(errMsg string) (string, string) {
 		return KubectlKilled, "kubectl killed due to timeout"
 	}
 	return errMsg, errMsg
+}
+
+func (d *Deployment) WithError(err error) *Deployment {
+	d.UpdateStatus("", err.Error(), err)
+	return d
+}
+
+func (d *Deployment) WithStatus(status Status) *Deployment {
+	d.status = status
+	return d
 }

--- a/pkg/skaffold/deploy/resources/deployment_test.go
+++ b/pkg/skaffold/deploy/resources/deployment_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDeploymentCheckStatus(t *testing.T) {
+	rolloutCmd := "kubectl --context kubecontext rollout status deployment dep --namespace test --watch=false"
+	tests := []struct {
+		description    string
+		command        util.Command
+		expectedErr    string
+		expectedReason string
+		complete       bool
+	}{
+		{
+			description: "rollout status success",
+			command: testutil.NewFakeCmd(t).
+				WithRunOut(rolloutCmd, "deployment dep successfully rolled out"),
+			expectedReason: "deployment dep successfully rolled out",
+			complete:       true,
+		}, {
+			description: "resource not complete",
+			command: testutil.NewFakeCmd(t).
+				WithRunOut(rolloutCmd, "Waiting for replicas to be available"),
+			expectedReason: "Waiting for replicas to be available",
+		}, {
+			description: "no output",
+			command: testutil.NewFakeCmd(t).
+				WithRunOut(rolloutCmd, ""),
+		}, {
+			description: "rollout status error",
+			command: testutil.NewFakeCmd(t).
+				WithRunOutErr(rolloutCmd, "", fmt.Errorf("error")),
+			expectedErr: "error",
+			complete:    true,
+		},
+		{
+			description: "rollout kubectl client connection error",
+			command: testutil.NewFakeCmd(t).
+				WithRunOutErr(rolloutCmd, "", fmt.Errorf("Unable to connect to the server")),
+			expectedReason: "Unable to connect to the server",
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&util.DefaultExecCommand, test.command)
+			r := Deployment{ResourceObj: &ResourceObj{namespace: "test", name: "dep"}}
+			runCtx := &runcontext.RunContext{
+				KubeContext: "kubecontext",
+			}
+
+			r.CheckStatus(context.Background(), runCtx)
+			t.CheckDeepEqual(test.complete, r.IsStatusCheckComplete())
+			if test.expectedErr != "" {
+				t.CheckErrorContains(test.expectedErr, r.Status().Error())
+			} else {
+				t.CheckDeepEqual(r.status.reason, test.expectedReason)
+			}
+		})
+	}
+}

--- a/pkg/skaffold/deploy/resources/deployment_test.go
+++ b/pkg/skaffold/deploy/resources/deployment_test.go
@@ -61,7 +61,7 @@ func TestDeploymentCheckStatus(t *testing.T) {
 			description: "rollout kubectl client connection error",
 			command: testutil.NewFakeCmd(t).
 				WithRunOutErr(rolloutCmd, "", fmt.Errorf("Unable to connect to the server")),
-			expectedReason: "Unable to connect to the server",
+			expectedReason: "KubectlConnection",
 		},
 	}
 

--- a/pkg/skaffold/deploy/resources/resource.go
+++ b/pkg/skaffold/deploy/resources/resource.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+)
+
+type ResourceObj struct {
+	name      string
+	namespace string
+	rType     string
+	status    Status
+}
+
+func (r *ResourceObj) String() string {
+	return fmt.Sprintf("%s/%s", r.rType, r.name)
+}
+
+func (r *ResourceObj) Type() string {
+	return r.rType
+}
+
+func (r *ResourceObj) UpdateStatus(msg string, reason string, err error) {
+	newStatus := Status{details: msg, reason: reason, err: err}
+	if !r.status.Equal(&newStatus) {
+		r.status.err = err
+		r.status.details = msg
+		r.status.reason = reason
+		r.status.lastUpdated = time.Now().UnixNano()
+	}
+}
+
+func (r *ResourceObj) Status() *Status {
+	return &r.status
+}
+
+func (r *ResourceObj) Namespace() string {
+	return r.namespace
+}
+
+func (r *ResourceObj) Name() string {
+	return r.name
+}
+
+func (r *ResourceObj) checkComplete() {
+	r.status.completed = true
+}
+
+func (r *ResourceObj) IsStatusCheckComplete() bool {
+	return r.status.completed
+}
+
+func (r *ResourceObj) ReportSinceLastUpdated(out io.Writer) {
+	if r.status.lastUpdated <= r.status.lastReported {
+		return
+	}
+	r.status.lastReported = time.Now().UnixNano()
+	color.Default.Fprintln(out, fmt.Sprintf("%s %s", r.String(), r.status.String()))
+}
+
+type Status struct {
+	err          error
+	reason       string
+	details      string
+	lastUpdated  int64
+	lastReported int64
+	completed    bool
+}
+
+func (rs *Status) Error() error {
+	return rs.err
+}
+
+func (rs *Status) Equal(other *Status) bool {
+	return rs.reason == other.reason && rs.err == other.err
+
+}
+
+func (rs *Status) String() string {
+	if rs.err != nil {
+		return fmt.Sprintf("is pending due to %s", rs.err.Error())
+	}
+	return fmt.Sprintf("is pending due to %s", rs.details)
+}

--- a/pkg/skaffold/deploy/resources/resource_test.go
+++ b/pkg/skaffold/deploy/resources/resource_test.go
@@ -53,12 +53,13 @@ func TestReportSinceLastUpdated(t *testing.T) {
 	}{
 		{
 			description: "updating an error status",
+			message:     "cannot pull image",
 			err:         fmt.Errorf("cannot pull image"),
-			expected:    "deployment/test is pending due to cannot pull image\n",
+			expected:    " - deployment/test is pending due to cannot pull image\n",
 		}, {
 			description: "updating a non error status",
 			message:     "is waiting for container",
-			expected:    "deployment/test is pending due to is waiting for container\n",
+			expected:    " - deployment/test is pending due to is waiting for container\n",
 		},
 	}
 	for _, test := range tests {
@@ -81,7 +82,7 @@ func TestReportSinceLastUpdatedMultipleTimes(t *testing.T) {
 		{
 			description: "report first time should write to out",
 			times:       1,
-			expected:    "deployment/test is pending due to cannot pull image\n",
+			expected:    " - deployment/test is pending due to cannot pull image\n",
 		}, {
 			description: "report 2nd time should not write to out",
 			times:       2,
@@ -118,23 +119,23 @@ func TestUpdateStatus(t *testing.T) {
 			old:         Status{details: "same", reason: "same", err: nil},
 			new:         Status{details: "same", reason: "same", err: nil},
 		}, {
-			description: "updateTimestamp should not change for same statuses if details change",
-			old:         Status{details: "same", reason: "same", err: nil},
-			new:         Status{details: "another", reason: "same", err: nil},
-		}, {
 			description:  "updateTimestamp should change if reason change",
 			old:          Status{details: "same", reason: "same", err: nil},
 			new:          Status{details: "same", reason: "another", err: nil},
 			expectChange: true,
 		}, {
-			description:  "updateTimestamp should change if error change",
+			description: "updateTimestamp should not change if reason son",
+			old:         Status{details: "same", reason: "same", err: nil},
+			new:         Status{details: "same", reason: "same", err: fmt.Errorf("see this error")},
+		}, {
+			description:  "updateTimestamp should change if reason and err change",
 			old:          Status{details: "same", reason: "same", err: nil},
-			new:          Status{details: "same", reason: "same", err: fmt.Errorf("see this error")},
+			new:          Status{details: "same", reason: "another", err: fmt.Errorf("see this error")},
 			expectChange: true,
 		}, {
-			description:  "updateTimestamp should change if both reason and error change",
+			description:  "updateTimestamp should change if both reason and details change",
 			old:          Status{details: "same", reason: "same", err: nil},
-			new:          Status{reason: "error", err: fmt.Errorf("cannot pull image")},
+			new:          Status{details: "error", reason: "error", err: nil},
 			expectChange: true,
 		},
 	}

--- a/pkg/skaffold/deploy/resources/resource_test.go
+++ b/pkg/skaffold/deploy/resources/resource_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+const (
+	ZeroTimestamp int64 = 0
+)
+
+func TestUpdateTimestamp(t *testing.T) {
+	dep := NewDeployment("test", "test-ns", time.Millisecond)
+
+	// Check both updated and reported timestamp are 0
+	testutil.CheckDeepEqual(t, dep.status.lastUpdated, ZeroTimestamp)
+	testutil.CheckDeepEqual(t, dep.status.lastReported, ZeroTimestamp)
+
+	// Update the status
+	dep.UpdateStatus("success", "success", nil)
+	// Check the updated timestamp is present
+	if dep.status.lastUpdated == ZeroTimestamp {
+		t.Errorf("expeceted lastUpdated timestamp to be non zero. Got %d", dep.status.lastUpdated)
+	}
+}
+
+func TestReportSinceLastUpdated(t *testing.T) {
+	var tests = []struct {
+		description string
+		message     string
+		err         error
+		expected    string
+	}{
+		{
+			description: "updating an error status",
+			err:         fmt.Errorf("cannot pull image"),
+			expected:    "deployment/test is pending due to cannot pull image\n",
+		}, {
+			description: "updating a non error status",
+			message:     "is waiting for container",
+			expected:    "deployment/test is pending due to is waiting for container\n",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			dep := NewDeployment("test", "test-ns", time.Millisecond)
+			out := new(bytes.Buffer)
+			dep.UpdateStatus(test.message, test.message, test.err)
+			dep.ReportSinceLastUpdated(out)
+			t.CheckDeepEqual(test.expected, out.String())
+		})
+	}
+}
+
+func TestReportSinceLastUpdatedMultipleTimes(t *testing.T) {
+	var tests = []struct {
+		description string
+		times       int
+		expected    string
+	}{
+		{
+			description: "report first time should write to out",
+			times:       1,
+			expected:    "deployment/test is pending due to cannot pull image\n",
+		}, {
+			description: "report 2nd time should not write to out",
+			times:       2,
+			expected:    "",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			dep := NewDeployment("test", "test-ns", time.Millisecond)
+			dep.UpdateStatus("cannot pull image", "err", nil)
+			var out *bytes.Buffer
+			for i := 0; i < test.times; i++ {
+				out = new(bytes.Buffer)
+				dep.ReportSinceLastUpdated(out)
+				// Check reported timestamp is present
+				if dep.status.lastReported == ZeroTimestamp {
+					t.Errorf("expeceted lastReported timestamp to be non zero. Got %d", dep.status.lastReported)
+				}
+			}
+			t.CheckDeepEqual(test.expected, out.String())
+		})
+	}
+}
+
+func TestUpdateStatus(t *testing.T) {
+	var tests = []struct {
+		description  string
+		old          Status
+		new          Status
+		expectChange bool
+	}{
+		{
+			description: "updateTimestamp should not change for same statuses",
+			old:         Status{details: "same", reason: "same", err: nil},
+			new:         Status{details: "same", reason: "same", err: nil},
+		}, {
+			description: "updateTimestamp should not change for same statuses if details change",
+			old:         Status{details: "same", reason: "same", err: nil},
+			new:         Status{details: "another", reason: "same", err: nil},
+		}, {
+			description:  "updateTimestamp should change if reason change",
+			old:          Status{details: "same", reason: "same", err: nil},
+			new:          Status{details: "same", reason: "another", err: nil},
+			expectChange: true,
+		}, {
+			description:  "updateTimestamp should change if error change",
+			old:          Status{details: "same", reason: "same", err: nil},
+			new:          Status{details: "same", reason: "same", err: fmt.Errorf("see this error")},
+			expectChange: true,
+		}, {
+			description:  "updateTimestamp should change if both reason and error change",
+			old:          Status{details: "same", reason: "same", err: nil},
+			new:          Status{reason: "error", err: fmt.Errorf("cannot pull image")},
+			expectChange: true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			dep := NewDeployment("test", "test-ns", time.Millisecond)
+			dep.UpdateStatus(test.old.details, test.old.reason, test.old.err)
+			oldUpdateTimestamp := dep.Status().lastUpdated
+			dep.UpdateStatus(test.new.details, test.new.reason, test.new.err)
+			t.CheckDeepEqual(test.expectChange, oldUpdateTimestamp != dep.status.lastUpdated)
+		})
+	}
+}

--- a/pkg/skaffold/deploy/resources/resource_test.go
+++ b/pkg/skaffold/deploy/resources/resource_test.go
@@ -28,12 +28,12 @@ import (
 func TestUpdateTimestamp(t *testing.T) {
 	dep := NewDeployment("test", "test-ns", time.Millisecond)
 
-	// Check both updated is false
+	// Check updated bool is false
 	testutil.CheckDeepEqual(t, false, dep.status.updated)
 
 	// Update the status
 	dep.UpdateStatus("success", "success", nil)
-	// Check the updated timestamp is present
+	// Check the updated bool is true
 	testutil.CheckDeepEqual(t, true, dep.status.updated)
 }
 

--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -29,7 +29,6 @@ import (
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 	utilpointer "k8s.io/utils/pointer"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -42,7 +41,7 @@ func TestFetchDeployments(t *testing.T) {
 		shouldErr   bool
 	}{
 		{
-			description: "multiple deployments in same namespace",
+			description: "multiple resources.Deployments in same namespace",
 			deps: []*appsv1.Deployment{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -71,7 +70,7 @@ func TestFetchDeployments(t *testing.T) {
 				resources.NewDeployment("dep2", "test", 20*time.Second),
 			},
 		}, {
-			description: "command flag deadline is less than deployment spec.",
+			description: "command flag deadline is less than resources.Deployment spec.",
 			deps: []*appsv1.Deployment{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -88,7 +87,7 @@ func TestFetchDeployments(t *testing.T) {
 			expected: []*resources.Deployment{resources.NewDeployment("dep1", "test", 200*time.Second)},
 		},
 		{
-			description: "multiple deployments with 1 no progress deadline set",
+			description: "multiple resources.Deployments with 1 no progress deadline set",
 			deps: []*appsv1.Deployment{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -116,11 +115,11 @@ func TestFetchDeployments(t *testing.T) {
 			},
 		},
 		{
-			description: "no deployments",
+			description: "no resources.Deployments",
 			expected:    []*resources.Deployment{},
 		},
 		{
-			description: "multiple deployments in different namespaces",
+			description: "multiple resources.Deployments in different namespaces",
 			deps: []*appsv1.Deployment{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -148,7 +147,7 @@ func TestFetchDeployments(t *testing.T) {
 			},
 		},
 		{
-			description: "deployment in correct namespace but not deployed by skaffold",
+			description: "resources.Deployment in correct namespace but not deployed by skaffold",
 			deps: []*appsv1.Deployment{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -164,7 +163,7 @@ func TestFetchDeployments(t *testing.T) {
 			expected: []*resources.Deployment{},
 		},
 		{
-			description: "deployment in correct namespace deployed by skaffold but different run",
+			description: "resources.Deployment in correct namespace deployed by skaffold but different run",
 			deps: []*appsv1.Deployment{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -231,40 +230,6 @@ func TestIsSkaffoldDeployInError(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			checker := Checker{}
 			t.CheckDeepEqual(test.shouldErr, checker.isSkaffoldDeployInError(test.resources))
-		})
-	}
-}
-
-func TestCheckResourceStatus(t *testing.T) {
-	rolloutCmd := "kubectl --context kubecontext --namespace test rollout status deployment dep --watch=false"
-	var tests = []struct {
-		description string
-		command     util.Command
-		expected    string
-		shouldErr   bool
-	}{
-		{
-			description: "some output",
-			command: testutil.NewFakeCmd(t).
-				WithRunOut(rolloutCmd, "Waiting for replicas to be available"),
-			expected: "Waiting for replicas to be available",
-		},
-		{
-			description: "no output",
-			command: testutil.NewFakeCmd(t).
-				WithRunOut(rolloutCmd, ""),
-		},
-		{
-			description: "rollout status error",
-			command: testutil.NewFakeCmd(t).
-				WithRunOutErr(rolloutCmd, "", fmt.Errorf("error")),
-			shouldErr: true,
-		},
-	}
-
-	for _, test := range tests {
-		testutil.Run(t, test.description, func(t *testutil.T) {
-
 		})
 	}
 }

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -19,6 +19,7 @@ package runner
 import (
 	"context"
 	"io"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -47,12 +48,13 @@ func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []
 func (r *SkaffoldRunner) performStatusCheck(ctx context.Context, out io.Writer) error {
 	// Check if we need to perform deploy status
 	if r.runCtx.Opts.StatusCheck {
+		start := time.Now()
 		color.Default.Fprintln(out, "Waiting for deployments to stabilize")
 		err := statusCheck(ctx, r.defaultLabeller, r.runCtx, out)
 		if err != nil {
-			color.Default.Fprintln(out, err.Error())
+			return err
 		}
-		return err
+		color.Default.Fprintln(out, "Deployments stabilized in", time.Since(start))
 	}
 	return nil
 }

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -48,7 +48,7 @@ func (r *SkaffoldRunner) performStatusCheck(ctx context.Context, out io.Writer) 
 	// Check if we need to perform deploy status
 	if r.runCtx.Opts.StatusCheck {
 		color.Default.Fprintln(out, "Waiting for deployments to stabilize")
-		err := statusCheck(ctx, r.defaultLabeller, r.runCtx)
+		err := statusCheck(ctx, r.defaultLabeller, r.runCtx, out)
 		if err != nil {
 			color.Default.Fprintln(out, err.Error())
 		}

--- a/pkg/skaffold/runner/deploy_test.go
+++ b/pkg/skaffold/runner/deploy_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"io/ioutil"
 	"strings"
 	"testing"
@@ -59,7 +60,7 @@ func TestDeploy(t *testing.T) {
 		},
 	}
 
-	dummyStatusCheck := func(ctx context.Context, l *deploy.DefaultLabeller, runCtx *runcontext.RunContext) error {
+	dummyStatusCheck := func(context.Context, *deploy.DefaultLabeller, *runcontext.RunContext, io.Writer) error {
 		return nil
 	}
 	for _, test := range tests {
@@ -109,7 +110,7 @@ func TestDeployNamespace(t *testing.T) {
 		},
 	}
 
-	dummyStatusCheck := func(ctx context.Context, l *deploy.DefaultLabeller, runCtx *runcontext.RunContext) error {
+	dummyStatusCheck := func(context.Context, *deploy.DefaultLabeller, *runcontext.RunContext, io.Writer) error {
 		return nil
 	}
 	for _, test := range tests {


### PR DESCRIPTION
In this Pr

- Refactor health check to add a Resource interface which will implement the details if a resource is healthy or not.

- Print health check summary after every resource check is returned indicating, if the current resource is ready or in error. How many more are remaining.
```
deployment/leeroy-app is ready. [1/2 deployment(s) still pending]
```
In case the deployment is in error, the message looks like:
```
deployment/leeroy-app failed [1/2 deployment(s) still pending]. Error: resource deployment/leeroy-app could not be fetched within 10s: context deadline exceeded.
deployment/leeroy-app is pending due to resource deployment/leeroy-app could not be fetched within 10s: context deadline exceeded

```

- After every 150 milliseconds, print the state of the resource, to give users more insights on what the current status of a deployment is. e.g in case of deployments with a large number of `replicas`, 
the user will see the current stautus of the deployment
```
deployment.apps/leeroy-web configured
Waiting for deployments to stabilize
deployment/leeroy-app is pending due to Waiting for rollout to finish: 5 out of 10 new replicas have been updated...
deployment/leeroy-app is pending due to Waiting for rollout to finish: 6 out of 10 new replicas have been updated...
```

- And then finally special error handling for errors when we can't fetch deployment due to connectivity issues. In such case, we should wait until the `statusCheckDeadlineSeconds` is not reached.
```
tejaldesai@@microservices (health_check_refactor)$ skaffold dev --default-repo=gcr.io/tejal-test --status-check
Generating tags...
 - gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-web -> gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-web:v0.36.0-104-gdeba6031
 - gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-app -> gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-app:v0.36.0-104-gdeba6031-dirty
Tags generated in 23.115371ms
Checking cache...
 - gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-web: Found
 - gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-app: Found
Cache check complete in 889.162173ms
Starting deploy...
kubectl client version: 1.11+
kubectl version 1.12.0 or greater is recommended for use with Skaffold
deployment.apps/leeroy-web created
service/leeroy-app configured
deployment.apps/leeroy-app created
Deploy complete in 1.265634429s
Waiting for deployments to stabilize
deployment/leeroy-web is ready. [1/2 deployment(s) still pending]
deployment/leeroy-app is pending due to Waiting for rollout to finish: 0 of 3 updated replicas are available...
deployment/leeroy-app is pending due to Waiting for rollout to finish: 0 of 3 updated replicas are available...
deployment/leeroy-app is pending due to Running [kubectl --context gke_tejal-test_us-central1-a_dump rollout status deployment leeroy-app --namespace default --watch=false]: stdout , stderr: Unable to connect to the server: dial tcp 35.238.80.213:443: connect: network is unreachable
, err: exit status 1: exit status 1
deployment/leeroy-app is ready. 
Watching for changes...

```

Sample full output
```
tejaldesai@@microservices (health_check_refactor)$ skaffold dev --default-repo=gcr.io/tejal-test --status-check
Generating tags...
 - gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-web -> gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-web:v0.36.0-104-gdeba6031
 - gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-app -> gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-app:v0.36.0-104-gdeba6031-dirty
Tags generated in 29.447689ms
Checking cache...
 - gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-web: Found
 - gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-app: Found
Cache check complete in 739.122386ms
Starting deploy...
kubectl client version: 1.11+
kubectl version 1.12.0 or greater is recommended for use with Skaffold
deployment.apps/leeroy-web created
service/leeroy-app configured
deployment.apps/leeroy-app created
Deploy complete in 1.039965467s
Waiting for deployments to stabilize
deployment/leeroy-app is pending due to Waiting for rollout to finish: 0 of 3 updated replicas are available...
deployment/leeroy-web is pending due to Waiting for rollout to finish: 0 of 1 updated replicas are available...
deployment/leeroy-app is ready. [1/2 deployment(s) still pending]
deployment/leeroy-web is ready. 
Watching for changes...
[leeroy-app-54788f4dc4-dsdlx leeroy-app] 2019/08/28 23:43:16 leeroy app server ready
[leeroy-app-54788f4dc4-tvhqt leeroy-app] 2019/08/28 23:43:16 leeroy app server ready
[leeroy-app-54788f4dc4-g87km leeroy-app] 2019/08/28 23:43:16 leeroy app server ready
[leeroy-web-5b986bffc4-xj77k leeroy-web] 2019/08/28 23:43:16 leeroy web server ready
^C
```