### PR TITLE
Allow users to override the run-id

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
@@ -144,5 +145,36 @@ func TestRun(t *testing.T) {
 
 			skaffold.Delete().WithConfig(test.filename).InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunOrFail(t)
 		})
+	}
+}
+
+func TestRunIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
+
+	ns, _, deleteNs := SetupNamespace(t)
+	defer deleteNs()
+
+	// The first `skaffold run` creates resources (deployment.apps/leeroy-web, service/leeroy-app, deployment.apps/leeroy-app)
+	out := skaffold.Run("-l", "skaffold.dev/run-id=notunique").InDir("examples/microservices").InNs(ns.Name).RunOrFailOutput(t)
+	firstOut := string(out)
+	if strings.Count(firstOut, "created") == 0 {
+		t.Errorf("resources should have been created: %s", firstOut)
+	}
+
+	// Because we use the same custom `run-id`, the second `skaffold run` is idempotent:
+	// + It has nothing to rebuild
+	// + It leaves all resources unchanged
+	out = skaffold.Run("-l", "skaffold.dev/run-id=notunique").InDir("examples/microservices").InNs(ns.Name).RunOrFailOutput(t)
+	secondOut := string(out)
+	if strings.Count(secondOut, "created") != 0 {
+		t.Errorf("no resource should have been created: %s", secondOut)
+	}
+	if !strings.Contains(secondOut, "leeroy-web: Found") || !strings.Contains(secondOut, "leeroy-app: Found") {
+		t.Errorf("both artifacts should be in cache: %s", secondOut)
 	}
 }

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -71,7 +71,8 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 	}
 
 	defaultLabeller := deploy.NewLabeller("")
-	labellers := []deploy.Labeller{&runCtx.Opts, builder, deployer, tagger, defaultLabeller}
+	// runCtx.Opts is last to let users override/remove any label
+	labellers := []deploy.Labeller{builder, deployer, tagger, defaultLabeller, &runCtx.Opts}
 
 	builder, tester, deployer = WithTimings(builder, tester, deployer, runCtx.Opts.CacheArtifacts)
 	if runCtx.Opts.Notification {


### PR DESCRIPTION
Skaffold can be made idempotent again by using `skaffold run -l skaffold.dev/run-id=SOMETHING`
Or by setting the `SKAFFOLD_LABELS=skaffold.dev/run-id=dgageot` env variable globally.

Fixes #2745 and #2687

Signed-off-by: David Gageot <david@gageot.net>