### PR TITLE
Keep built artifacts always in their original order.

### DIFF
--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -146,6 +146,9 @@ func TestCacheBuildLocal(t *testing.T) {
 		t.CheckNoError(err)
 		t.CheckDeepEqual(0, len(builder.built))
 		t.CheckDeepEqual(2, len(bRes))
+		// Artifacts should always be returned in their original order
+		t.CheckDeepEqual("artifact1", bRes[0].ImageName)
+		t.CheckDeepEqual("artifact2", bRes[1].ImageName)
 
 		// Third build: change one artifact's dependencies
 		tmpDir.Write("dep1", "new content")
@@ -155,6 +158,8 @@ func TestCacheBuildLocal(t *testing.T) {
 		t.CheckNoError(err)
 		t.CheckDeepEqual(1, len(builder.built))
 		t.CheckDeepEqual(2, len(bRes))
+		t.CheckDeepEqual("artifact1", bRes[0].ImageName)
+		t.CheckDeepEqual("artifact2", bRes[1].ImageName)
 	})
 }
 
@@ -218,6 +223,9 @@ func TestCacheBuildRemote(t *testing.T) {
 		t.CheckNoError(err)
 		t.CheckDeepEqual(2, len(builder.built))
 		t.CheckDeepEqual(2, len(bRes))
+		// Artifacts should always be returned in their original order
+		t.CheckDeepEqual("artifact1", bRes[0].ImageName)
+		t.CheckDeepEqual("artifact2", bRes[1].ImageName)
 
 		// Second build: both artifacts are read from cache
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: true}
@@ -226,6 +234,8 @@ func TestCacheBuildRemote(t *testing.T) {
 		t.CheckNoError(err)
 		t.CheckDeepEqual(0, len(builder.built))
 		t.CheckDeepEqual(2, len(bRes))
+		t.CheckDeepEqual("artifact1", bRes[0].ImageName)
+		t.CheckDeepEqual("artifact2", bRes[1].ImageName)
 
 		// Third build: change one artifact's dependencies
 		tmpDir.Write("dep1", "new content")
@@ -235,5 +245,7 @@ func TestCacheBuildRemote(t *testing.T) {
 		t.CheckNoError(err)
 		t.CheckDeepEqual(1, len(builder.built))
 		t.CheckDeepEqual(2, len(bRes))
+		t.CheckDeepEqual("artifact1", bRes[0].ImageName)
+		t.CheckDeepEqual("artifact2", bRes[1].ImageName)
 	})
 }

--- a/pkg/skaffold/build/util.go
+++ b/pkg/skaffold/build/util.go
@@ -18,19 +18,28 @@ package build
 
 // MergeWithPreviousBuilds merges previous or prebuilt build artifacts with
 // builds. If an artifact is already present in builds, the same artifact from
-// previous will be ignored.
+// previous will be replaced at the same position.
 func MergeWithPreviousBuilds(builds, previous []Artifact) []Artifact {
-	updatedBuilds := map[string]bool{}
+	updatedBuilds := map[string]Artifact{}
 	for _, build := range builds {
-		updatedBuilds[build.ImageName] = true
+		updatedBuilds[build.ImageName] = build
 	}
 
+	added := map[string]bool{}
 	var merged []Artifact
-	merged = append(merged, builds...)
 
-	for _, b := range previous {
-		if !updatedBuilds[b.ImageName] {
-			merged = append(merged, b)
+	for _, artifact := range previous {
+		if updated, found := updatedBuilds[artifact.ImageName]; found {
+			merged = append(merged, updated)
+		} else {
+			merged = append(merged, artifact)
+		}
+		added[artifact.ImageName] = true
+	}
+
+	for _, artifact := range builds {
+		if !added[artifact.ImageName] {
+			merged = append(merged, artifact)
 		}
 	}
 

--- a/pkg/skaffold/build/util_test.go
+++ b/pkg/skaffold/build/util_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+// TestMergeWithPreviousBuilds tests that artifacts are always kept in the same order
+func TestMergeWithPreviousBuilds(t *testing.T) {
+	builds := MergeWithPreviousBuilds([]Artifact{artifact("img1", "tag1_1"), artifact("img2", "tag2_1")}, nil)
+	testutil.CheckDeepEqual(t, "img1:tag1_1,img2:tag2_1", tags(builds))
+
+	builds = MergeWithPreviousBuilds([]Artifact{artifact("img1", "tag1_2")}, builds)
+	testutil.CheckDeepEqual(t, "img1:tag1_2,img2:tag2_1", tags(builds))
+
+	builds = MergeWithPreviousBuilds([]Artifact{artifact("img2", "tag2_2")}, builds)
+	testutil.CheckDeepEqual(t, "img1:tag1_2,img2:tag2_2", tags(builds))
+
+	builds = MergeWithPreviousBuilds([]Artifact{artifact("img1", "tag1_3"), artifact("img2", "tag2_3")}, builds)
+	testutil.CheckDeepEqual(t, "img1:tag1_3,img2:tag2_3", tags(builds))
+}
+
+func artifact(image, tag string) Artifact {
+	return Artifact{
+		ImageName: image,
+		Tag:       tag,
+	}
+}
+
+func tags(artifacts []Artifact) string {
+	var tags string
+
+	for i, a := range artifacts {
+		if i > 0 {
+			tags += ","
+		}
+		tags += fmt.Sprintf("%s:%s", a.ImageName, a.Tag)
+	}
+
+	return tags
+}

--- a/pkg/skaffold/runner/dev_test.go
+++ b/pkg/skaffold/runner/dev_test.go
@@ -232,7 +232,7 @@ func TestDev(t *testing.T) {
 				{
 					Built:    []string{"img2:2"},
 					Tested:   []string{"img2:2"},
-					Deployed: []string{"img2:2", "img1:1"},
+					Deployed: []string{"img1:1", "img2:2"},
 				},
 			},
 		},


### PR DESCRIPTION
We should use the order used in the skaffold.yaml
Fix #2680

I'll take a look at adding an integration test but it looks complicated

Signed-off-by: David Gageot <david@gageot.net>