### PR TITLE
Improve `skaffold init` behaviour when tags are used in manifests

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -40,6 +40,10 @@ func TestInit(t *testing.T) {
 			dir:  "testdata/init/hello",
 		},
 		{
+			name: "ignore existing tags",
+			dir:  "testdata/init/ignore-tags",
+		},
+		{
 			name: "microservices (backwards compatibility)",
 			dir:  "testdata/init/microservices",
 			args: []string{

--- a/integration/testdata/init/ignore-tags/Dockerfile
+++ b/integration/testdata/init/ignore-tags/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.12.9-alpine3.10 as builder
+COPY main.go .
+RUN go build -o /app main.go
+
+FROM alpine:3.10
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/init/ignore-tags/k8s-pod.yaml
+++ b/integration/testdata/init/ignore-tags/k8s-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+    - name: getting-started
+      image: gcr.io/k8s-skaffold/skaffold-example:tag

--- a/integration/testdata/init/ignore-tags/main.go
+++ b/integration/testdata/init/ignore-tags/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/pkg/skaffold/deploy/kubectl/images_test.go
+++ b/pkg/skaffold/deploy/kubectl/images_test.go
@@ -37,14 +37,14 @@ spec:
   - image: gcr.io/k8s-skaffold/example:latest
     name: latest
   - image: gcr.io/k8s-skaffold/example:v1
-    name: fully-qualified
+    name: ignored-tag
   - image: skaffold/other
     name: other
   - image: gcr.io/k8s-skaffold/example@sha256:81daf011d63b68cfa514ddab7741a1adddd59d3264118dfb0fd9266328bb8883
     name: digest
   - image: skaffold/usedbyfqn:TAG
-  - image: skaffold/usedwrongfqn:OTHER
-  - image: in valid
+  - image: not valid
+  - image: unknown
 `)}
 
 	builds := []build.Artifact{{
@@ -59,9 +59,6 @@ spec:
 	}, {
 		ImageName: "skaffold/usedbyfqn",
 		Tag:       "skaffold/usedbyfqn:TAG",
-	}, {
-		ImageName: "skaffold/usedwrongfqn",
-		Tag:       "skaffold/usedwrongfqn:TAG",
 	}}
 
 	expected := ManifestList{[]byte(`
@@ -75,15 +72,15 @@ spec:
     name: not-tagged
   - image: gcr.io/k8s-skaffold/example:TAG
     name: latest
-  - image: gcr.io/k8s-skaffold/example:v1
-    name: fully-qualified
+  - image: gcr.io/k8s-skaffold/example:TAG
+    name: ignored-tag
   - image: skaffold/other:OTHER_TAG
     name: other
   - image: gcr.io/k8s-skaffold/example@sha256:81daf011d63b68cfa514ddab7741a1adddd59d3264118dfb0fd9266328bb8883
     name: digest
   - image: skaffold/usedbyfqn:TAG
-  - image: skaffold/usedwrongfqn:OTHER
-  - image: in valid
+  - image: not valid
+  - image: unknown
 `)}
 
 	testutil.Run(t, "", func(t *testutil.T) {
@@ -95,9 +92,8 @@ spec:
 		t.CheckNoError(err)
 		t.CheckDeepEqual(expected.String(), resultManifest.String())
 		t.CheckDeepEqual([]string{
-			"Couldn't parse image: in valid",
+			"Couldn't parse image [not valid]: invalid reference format",
 			"image [skaffold/unused] is not used by the deployment",
-			"image [skaffold/usedwrongfqn] is not used by the deployment",
 		}, fakeWarner.Warnings)
 	})
 }


### PR DESCRIPTION
+ Skaffold init now ignores images that can't be parsed
+ It also ignores images references by digest in the manifests
+ Skaffold run/dev ignore tags (not digests) in manifests

Fixes #834 and #2463
