### PR TITLE
[skaffold deploy] A tag must be provided for every image

### DIFF
--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -22,6 +22,7 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
+	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -49,7 +50,7 @@ E.g. build.out created by running skaffold build --quiet {{json .}} > build.out`
 
 func doDeploy(ctx context.Context, out io.Writer) error {
 	return withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
-		deployed, err := getDeployedArtifacts(buildOutputFile.BuildArtifacts(), preBuiltImages.Artifacts(), config.Build.Artifacts)
+		deployed, err := getDeployedArtifacts(out, buildOutputFile.BuildArtifacts(), preBuiltImages.Artifacts(), config.Build.Artifacts)
 		if err != nil {
 			return err
 		}
@@ -58,7 +59,7 @@ func doDeploy(ctx context.Context, out io.Writer) error {
 	})
 }
 
-func getDeployedArtifacts(fromFile, fromCLI []build.Artifact, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+func getDeployedArtifacts(out io.Writer, fromFile, fromCLI []build.Artifact, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 	var deployed []build.Artifact
 	for _, artifact := range artifacts {
 		deployed = append(deployed, build.Artifact{
@@ -73,6 +74,7 @@ func getDeployedArtifacts(fromFile, fromCLI []build.Artifact, artifacts []*lates
 	// Check that every image has a non empty tag
 	for _, d := range deployed {
 		if d.Tag == "" {
+			tips.PrintUseRunVsDeploy(out)
 			return nil, fmt.Errorf("no tag provided for image [%s]", d.ImageName)
 		}
 	}

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -50,7 +50,7 @@ E.g. build.out created by running skaffold build --quiet {{json .}} > build.out`
 
 func doDeploy(ctx context.Context, out io.Writer) error {
 	return withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
-		deployed, err := getDeployedArtifacts(out, buildOutputFile.BuildArtifacts(), preBuiltImages.Artifacts(), config.Build.Artifacts)
+		deployed, err := getArtifactsToDeploy(out, buildOutputFile.BuildArtifacts(), preBuiltImages.Artifacts(), config.Build.Artifacts)
 		if err != nil {
 			return err
 		}
@@ -59,7 +59,7 @@ func doDeploy(ctx context.Context, out io.Writer) error {
 	})
 }
 
-func getDeployedArtifacts(out io.Writer, fromFile, fromCLI []build.Artifact, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+func getArtifactsToDeploy(out io.Writer, fromFile, fromCLI []build.Artifact, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 	var deployed []build.Artifact
 	for _, artifact := range artifacts {
 		deployed = append(deployed, build.Artifact{

--- a/cmd/skaffold/app/cmd/deploy_test.go
+++ b/cmd/skaffold/app/cmd/deploy_test.go
@@ -85,7 +85,7 @@ func TestGetDeployedArtifacts(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			deployed, err := getDeployedArtifacts(ioutil.Discard, test.fromFile, test.fromCLI, test.artifacts)
+			deployed, err := getArtifactsToDeploy(ioutil.Discard, test.fromFile, test.fromCLI, test.artifacts)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, deployed)
 		})

--- a/cmd/skaffold/app/cmd/deploy_test.go
+++ b/cmd/skaffold/app/cmd/deploy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"io/ioutil"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -84,7 +85,7 @@ func TestGetDeployedArtifacts(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			deployed, err := getDeployedArtifacts(test.fromFile, test.fromCLI, test.artifacts)
+			deployed, err := getDeployedArtifacts(ioutil.Discard, test.fromFile, test.fromCLI, test.artifacts)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, deployed)
 		})

--- a/cmd/skaffold/app/cmd/deploy_test.go
+++ b/cmd/skaffold/app/cmd/deploy_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestGetDeployedArtifacts(t *testing.T) {
+	tests := []struct {
+		description string
+		artifacts   []*latest.Artifact
+		fromFile    []build.Artifact
+		fromCLI     []build.Artifact
+		expected    []build.Artifact
+		shouldErr   bool
+	}{
+		{
+			description: "no artifact",
+			artifacts:   nil,
+			fromFile:    nil,
+			fromCLI:     nil,
+			expected:    []build.Artifact(nil),
+		},
+		{
+			description: "from file",
+			artifacts:   []*latest.Artifact{{ImageName: "image"}},
+			fromFile:    []build.Artifact{{ImageName: "image", Tag: "image:tag"}},
+			fromCLI:     nil,
+			expected:    []build.Artifact{{ImageName: "image", Tag: "image:tag"}},
+		},
+		{
+			description: "from CLI",
+			artifacts:   []*latest.Artifact{{ImageName: "image"}},
+			fromFile:    nil,
+			fromCLI:     []build.Artifact{{ImageName: "image", Tag: "image:tag"}},
+			expected:    []build.Artifact{{ImageName: "image", Tag: "image:tag"}},
+		},
+		{
+			description: "one from file, one from CLI",
+			artifacts:   []*latest.Artifact{{ImageName: "image1"}, {ImageName: "image2"}},
+			fromFile:    []build.Artifact{{ImageName: "image1", Tag: "image1:tag"}},
+			fromCLI:     []build.Artifact{{ImageName: "image2", Tag: "image2:tag"}},
+			expected:    []build.Artifact{{ImageName: "image1", Tag: "image1:tag"}, {ImageName: "image2", Tag: "image2:tag"}},
+		},
+		{
+			description: "file takes precedence on CLI",
+			artifacts:   []*latest.Artifact{{ImageName: "image1"}, {ImageName: "image2"}},
+			fromFile:    []build.Artifact{{ImageName: "image1", Tag: "image1:tag"}, {ImageName: "image2", Tag: "image2:tag"}},
+			fromCLI:     []build.Artifact{{ImageName: "image1", Tag: "image1:ignored"}},
+			expected:    []build.Artifact{{ImageName: "image1", Tag: "image1:tag"}, {ImageName: "image2", Tag: "image2:tag"}},
+		},
+		{
+			description: "provide tag for non-artifact",
+			artifacts:   []*latest.Artifact{},
+			fromCLI:     []build.Artifact{{ImageName: "busybox", Tag: "busybox:v1"}},
+			expected:    []build.Artifact{{ImageName: "busybox", Tag: "busybox:v1"}},
+		},
+		{
+			description: "missing tag",
+			artifacts:   []*latest.Artifact{{ImageName: "image1"}, {ImageName: "image2"}},
+			fromFile:    nil,
+			fromCLI:     nil,
+			shouldErr:   true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			deployed, err := getDeployedArtifacts(test.fromFile, test.fromCLI, test.artifacts)
+
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, deployed)
+		})
+	}
+}

--- a/cmd/skaffold/app/tips/tips.go
+++ b/cmd/skaffold/app/tips/tips.go
@@ -37,6 +37,13 @@ func PrintForInit(out io.Writer, opts config.SkaffoldOptions) {
 	printTip(out, "or [skaffold dev] to enter development mode, with auto-redeploy")
 }
 
+// PrintUseRunVsDeploy prints tips on when to use skaffold run vs deploy.
+func PrintUseRunVsDeploy(out io.Writer) {
+	printTip(out, "You either need to:")
+	printTip(out, "run [skaffold deploy] with [--images TAG] for each pre-built artifact")
+	printTip(out, "or [skaffold run] instead, to let Skaffold build, tag and deploy artifacts.")
+}
+
 func printTip(out io.Writer, message string) {
 	color.Green.Fprintln(out, message)
 }

--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
@@ -109,24 +110,11 @@ func TestDeployWithInCorrectConfig(t *testing.T) {
 	ns, _, deleteNs := SetupNamespace(t)
 	defer deleteNs()
 
-	err := skaffold.Deploy("--status-check=true").InDir("testdata/unstable-deployment").InNs(ns.Name).Run(t)
+	// We're not providing a tag for the getting-started image
+	output, err := skaffold.Deploy().InDir("examples/getting-started").InNs(ns.Name).RunWithCombinedOutput(t)
 	if err == nil {
-		t.Error("expected an error to see since the deployment is not stable. However deploy returned success")
+		t.Errorf("expected to see an error since not every image tag is provided: %s", output)
+	} else if !strings.Contains(string(output), "no tag provided for image [gcr.io/k8s-skaffold/skaffold-example]") {
+		t.Errorf("failed without saying the reason: %s", output)
 	}
-
-	skaffold.Delete().InDir("testdata/unstable-deployment").InNs(ns.Name).RunOrFail(t)
-}
-
-func TestDeployWithInCorrectConfigWithNoStatusCheck(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-	if ShouldRunGCPOnlyTests() {
-		t.Skip("skipping test that is not gcp only")
-	}
-
-	ns, _, deleteNs := SetupNamespace(t)
-	defer deleteNs()
-
-	skaffold.Deploy().InDir("testdata/unstable-deployment").InNs(ns.Name).RunOrFail(t)
 }

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -178,3 +178,36 @@ func TestRunIdempotent(t *testing.T) {
 		t.Errorf("both artifacts should be in cache: %s", secondOut)
 	}
 }
+
+func TestRunUnstableChecked(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
+
+	ns, _, deleteNs := SetupNamespace(t)
+	defer deleteNs()
+
+	output, err := skaffold.Run("--status-check=true").InDir("testdata/unstable-deployment").InNs(ns.Name).RunWithCombinedOutput(t)
+	if err == nil {
+		t.Errorf("expected to see an error since the deployment is not stable: %s", output)
+	} else if !strings.Contains(string(output), "deployment unstable-deployment failed") {
+		t.Errorf("failed without saying the reason: %s", output)
+	}
+}
+
+func TestRunUnstableNotChecked(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
+
+	ns, _, deleteNs := SetupNamespace(t)
+	defer deleteNs()
+
+	skaffold.Run().InDir("testdata/unstable-deployment").InNs(ns.Name).RunOrFail(t)
+}

--- a/integration/testdata/unstable-deployment/Dockerfile
+++ b/integration/testdata/unstable-deployment/Dockerfile
@@ -1,3 +1,3 @@
-FROM SCRATCH
+FROM scratch
 COPY hello /
 CMD ["/hello"]

--- a/integration/testdata/unstable-deployment/README.adoc
+++ b/integration/testdata/unstable-deployment/README.adoc
@@ -1,3 +1,0 @@
-=== Example: This example is used in integration tests.
-
-This is an invalid deployment. Please do not use it.

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -437,12 +437,7 @@ func (h *HelmDeployer) joinTagsToBuildResult(builds []build.Artifact, params map
 
 		b, ok := imageToBuildResult[newImageName]
 		if !ok {
-			if len(builds) == 0 {
-				logrus.Debugf("no build artifacts present. Assuming skaffold deploy. Continuing with %s", imageName)
-				b = build.Artifact{ImageName: imageName, Tag: imageName}
-			} else {
-				return nil, fmt.Errorf("no build present for %s", imageName)
-			}
+			return nil, fmt.Errorf("no build present for %s", imageName)
 		}
 
 		paramToBuildResult[param] = b

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -320,13 +320,7 @@ func TestHelmDeploy(t *testing.T) {
 			builds:      testBuilds,
 		},
 		{
-			description: "deploy should not error for unmatched parameter when no builds present",
-			commands:    &MockHelm{},
-			runContext:  makeRunContext(testDeployConfigParameterUnmatched, false),
-			builds:      nil,
-		},
-		{
-			description: "deploy should error for unmatched parameter when builds present",
+			description: "deploy should error for unmatched parameter",
 			commands:    &MockHelm{},
 			runContext:  makeRunContext(testDeployConfigParameterUnmatched, false),
 			builds:      testBuilds,


### PR DESCRIPTION
This should help catch cases were users are using
`skaffold deploy` instead of `skaffold run`

Signed-off-by: David Gageot <david@gageot.net>