### PR TITLE
Improve fake commands handling

### DIFF
--- a/pkg/skaffold/build/bazel/dependencies_test.go
+++ b/pkg/skaffold/build/bazel/dependencies_test.go
@@ -76,7 +76,10 @@ func TestGetDependencies(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&util.DefaultExecCommand, t.FakeRunOut(test.expectedQuery, test.output))
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunOut(
+				test.expectedQuery,
+				test.output,
+			))
 			t.NewTempDir().WriteFiles(test.files).Chdir()
 
 			deps, err := GetDependencies(context.Background(), test.workspace, &latest.BazelArtifact{

--- a/pkg/skaffold/build/custom/dependencies_test.go
+++ b/pkg/skaffold/build/custom/dependencies_test.go
@@ -58,7 +58,7 @@ func TestGetDependenciesDockerfile(t *testing.T) {
 
 func TestGetDependenciesCommand(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
-		t.Override(&util.DefaultExecCommand, t.FakeRunOut(
+		t.Override(&util.DefaultExecCommand, testutil.CmdRunOut(
 			"echo [\"file1\",\"file2\",\"file3\"]",
 			"[\"file1\",\"file2\",\"file3\"]",
 		))

--- a/pkg/skaffold/build/local/bazel_test.go
+++ b/pkg/skaffold/build/local/bazel_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestBazelBin(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
-		t.Override(&util.DefaultExecCommand, t.FakeRunOut(
+		t.Override(&util.DefaultExecCommand, testutil.CmdRunOut(
 			"bazel info bazel-bin --arg1 --arg2",
 			"/absolute/path/bin\n",
 		))

--- a/pkg/skaffold/build/local/docker_test.go
+++ b/pkg/skaffold/build/local/docker_test.go
@@ -71,7 +71,10 @@ func TestDockerCLIBuild(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.NewTempDir().Chdir()
 			dockerfilePath, _ := filepath.Abs("Dockerfile")
-			t.Override(&util.DefaultExecCommand, t.NewFakeCmd().WithRunEnv("docker build . --file "+dockerfilePath+" -t tag --force-rm", test.expectedEnv))
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunEnv(
+				"docker build . --file "+dockerfilePath+" -t tag --force-rm",
+				test.expectedEnv,
+			))
 			t.Override(&util.OSEnviron, func() []string { return []string{"KEY=VALUE"} })
 			t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 				return docker.NewLocalDaemon(&testutil.FakeAPIClient{}, test.extraEnv, false, nil), nil

--- a/pkg/skaffold/build/local/jib_gradle_test.go
+++ b/pkg/skaffold/build/local/jib_gradle_test.go
@@ -34,29 +34,38 @@ func TestBuildJibGradleToDocker(t *testing.T) {
 	tests := []struct {
 		description   string
 		artifact      *latest.JibGradleArtifact
-		cmd           util.Command
+		commands      util.Command
 		shouldErr     bool
 		expectedError string
 	}{
 		{
 			description: "build",
 			artifact:    &latest.JibGradleArtifact{},
-			cmd:         testutil.FakeRun(t, "gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion="+jib.MinimumJibGradleVersion+" :jibDockerBuild --image=img:tag"),
+			commands: testutil.CmdRun(
+				"gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion=" + jib.MinimumJibGradleVersion + " :jibDockerBuild --image=img:tag",
+			),
 		},
 		{
 			description: "build with additional flags",
 			artifact:    &latest.JibGradleArtifact{Flags: []string{"--flag1", "--flag2"}},
-			cmd:         testutil.FakeRun(t, "gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion="+jib.MinimumJibGradleVersion+" :jibDockerBuild --image=img:tag --flag1 --flag2"),
+			commands: testutil.CmdRun(
+				"gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion=" + jib.MinimumJibGradleVersion + " :jibDockerBuild --image=img:tag --flag1 --flag2",
+			),
 		},
 		{
 			description: "build with project",
 			artifact:    &latest.JibGradleArtifact{Project: "project"},
-			cmd:         testutil.FakeRun(t, "gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion="+jib.MinimumJibGradleVersion+" :project:jibDockerBuild --image=img:tag"),
+			commands: testutil.CmdRun(
+				"gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion=" + jib.MinimumJibGradleVersion + " :project:jibDockerBuild --image=img:tag",
+			),
 		},
 		{
-			description:   "fail build",
-			artifact:      &latest.JibGradleArtifact{},
-			cmd:           testutil.FakeRunErr(t, "gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion="+jib.MinimumJibGradleVersion+" :jibDockerBuild --image=img:tag", errors.New("BUG")),
+			description: "fail build",
+			artifact:    &latest.JibGradleArtifact{},
+			commands: testutil.CmdRunErr(
+				"gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion="+jib.MinimumJibGradleVersion+" :jibDockerBuild --image=img:tag",
+				errors.New("BUG"),
+			),
 			shouldErr:     true,
 			expectedError: "gradle build failed",
 		},
@@ -66,7 +75,7 @@ func TestBuildJibGradleToDocker(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			api := (&testutil.FakeAPIClient{}).Add("img:tag", "imageID")
 
-			t.Override(&util.DefaultExecCommand, test.cmd)
+			t.Override(&util.DefaultExecCommand, test.commands)
 			t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 				return docker.NewLocalDaemon(api, nil, false, nil), nil
 			})
@@ -92,29 +101,38 @@ func TestBuildJibGradleToRegistry(t *testing.T) {
 	tests := []struct {
 		description   string
 		artifact      *latest.JibGradleArtifact
-		cmd           util.Command
+		commands      util.Command
 		shouldErr     bool
 		expectedError string
 	}{
 		{
 			description: "remote build",
 			artifact:    &latest.JibGradleArtifact{},
-			cmd:         testutil.FakeRun(t, "gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion="+jib.MinimumJibGradleVersion+" :jib --image=img:tag"),
+			commands: testutil.CmdRun(
+				"gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion=" + jib.MinimumJibGradleVersion + " :jib --image=img:tag",
+			),
 		},
 		{
 			description: "build with additional flags",
 			artifact:    &latest.JibGradleArtifact{Flags: []string{"--flag1", "--flag2"}},
-			cmd:         testutil.FakeRun(t, "gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion="+jib.MinimumJibGradleVersion+" :jib --image=img:tag --flag1 --flag2"),
+			commands: testutil.CmdRun(
+				"gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion=" + jib.MinimumJibGradleVersion + " :jib --image=img:tag --flag1 --flag2",
+			),
 		},
 		{
 			description: "build with project",
 			artifact:    &latest.JibGradleArtifact{Project: "project"},
-			cmd:         testutil.FakeRun(t, "gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion="+jib.MinimumJibGradleVersion+" :project:jib --image=img:tag"),
+			commands: testutil.CmdRun(
+				"gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion=" + jib.MinimumJibGradleVersion + " :project:jib --image=img:tag",
+			),
 		},
 		{
-			description:   "fail build",
-			artifact:      &latest.JibGradleArtifact{},
-			cmd:           testutil.FakeRunErr(t, "gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion="+jib.MinimumJibGradleVersion+" :jib --image=img:tag", errors.New("BUG")),
+			description: "fail build",
+			artifact:    &latest.JibGradleArtifact{},
+			commands: testutil.CmdRunErr(
+				"gradle -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion="+jib.MinimumJibGradleVersion+" :jib --image=img:tag",
+				errors.New("BUG"),
+			),
 			shouldErr:     true,
 			expectedError: "gradle build failed",
 		},
@@ -122,7 +140,7 @@ func TestBuildJibGradleToRegistry(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&util.DefaultExecCommand, test.cmd)
+			t.Override(&util.DefaultExecCommand, test.commands)
 			t.Override(&docker.RemoteDigest, func(identifier string, _ map[string]bool) (string, error) {
 				if identifier == "img:tag" {
 					return "digest", nil

--- a/pkg/skaffold/build/local/jib_maven_test.go
+++ b/pkg/skaffold/build/local/jib_maven_test.go
@@ -34,34 +34,45 @@ func TestBuildJibMavenToDocker(t *testing.T) {
 	tests := []struct {
 		description   string
 		artifact      *latest.JibMavenArtifact
-		cmd           util.Command
+		commands      util.Command
 		shouldErr     bool
 		expectedError string
 	}{
 		{
 			description: "build",
 			artifact:    &latest.JibMavenArtifact{},
-			cmd:         testutil.FakeRun(t, "mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion="+jib.MinimumJibMavenVersion+" --non-recursive prepare-package jib:dockerBuild -Dimage=img:tag"),
+			commands: testutil.CmdRun(
+				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=" + jib.MinimumJibMavenVersion + " --non-recursive prepare-package jib:dockerBuild -Dimage=img:tag",
+			),
 		},
 		{
 			description: "build with additional flags",
 			artifact:    &latest.JibMavenArtifact{Flags: []string{"--flag1", "--flag2"}},
-			cmd:         testutil.FakeRun(t, "mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion="+jib.MinimumJibMavenVersion+" --flag1 --flag2 --non-recursive prepare-package jib:dockerBuild -Dimage=img:tag"),
+			commands: testutil.CmdRun(
+				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=" + jib.MinimumJibMavenVersion + " --flag1 --flag2 --non-recursive prepare-package jib:dockerBuild -Dimage=img:tag",
+			),
 		},
 		{
 			description: "build with module",
 			artifact:    &latest.JibMavenArtifact{Module: "module"},
-			cmd:         testutil.FakeRun(t, "mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion="+jib.MinimumJibMavenVersion+" --projects module --also-make package jib:dockerBuild -Djib.containerize=module -Dimage=img:tag"),
+			commands: testutil.CmdRun(
+				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=" + jib.MinimumJibMavenVersion + " --projects module --also-make package jib:dockerBuild -Djib.containerize=module -Dimage=img:tag",
+			),
 		},
 		{
 			description: "build with module and profile",
 			artifact:    &latest.JibMavenArtifact{Module: "module", Profile: "profile"},
-			cmd:         testutil.FakeRun(t, "mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion="+jib.MinimumJibMavenVersion+" --activate-profiles profile --projects module --also-make package jib:dockerBuild -Djib.containerize=module -Dimage=img:tag"),
+			commands: testutil.CmdRun(
+				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=" + jib.MinimumJibMavenVersion + " --activate-profiles profile --projects module --also-make package jib:dockerBuild -Djib.containerize=module -Dimage=img:tag",
+			),
 		},
 		{
-			description:   "fail build",
-			artifact:      &latest.JibMavenArtifact{},
-			cmd:           testutil.FakeRunErr(t, "mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion="+jib.MinimumJibMavenVersion+" --non-recursive prepare-package jib:dockerBuild -Dimage=img:tag", errors.New("BUG")),
+			description: "fail build",
+			artifact:    &latest.JibMavenArtifact{},
+			commands: testutil.CmdRunErr(
+				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion="+jib.MinimumJibMavenVersion+" --non-recursive prepare-package jib:dockerBuild -Dimage=img:tag",
+				errors.New("BUG"),
+			),
 			shouldErr:     true,
 			expectedError: "maven build failed",
 		},
@@ -73,7 +84,7 @@ func TestBuildJibMavenToDocker(t *testing.T) {
 			t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
 				return docker.NewLocalDaemon(api, nil, false, nil), nil
 			})
-			t.Override(&util.DefaultExecCommand, test.cmd)
+			t.Override(&util.DefaultExecCommand, test.commands)
 
 			builder, err := NewBuilder(stubRunContext(latest.LocalBuild{
 				Push: util.BoolPtr(false),
@@ -96,34 +107,45 @@ func TestBuildJibMavenToRegistry(t *testing.T) {
 	tests := []struct {
 		description   string
 		artifact      *latest.JibMavenArtifact
-		cmd           util.Command
+		commands      util.Command
 		shouldErr     bool
 		expectedError string
 	}{
 		{
 			description: "build",
 			artifact:    &latest.JibMavenArtifact{},
-			cmd:         testutil.FakeRun(t, "mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion="+jib.MinimumJibMavenVersion+" --non-recursive prepare-package jib:build -Dimage=img:tag"),
+			commands: testutil.CmdRun(
+				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=" + jib.MinimumJibMavenVersion + " --non-recursive prepare-package jib:build -Dimage=img:tag",
+			),
 		},
 		{
 			description: "build with additional flags",
 			artifact:    &latest.JibMavenArtifact{Flags: []string{"--flag1", "--flag2"}},
-			cmd:         testutil.FakeRun(t, "mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion="+jib.MinimumJibMavenVersion+" --flag1 --flag2 --non-recursive prepare-package jib:build -Dimage=img:tag"),
+			commands: testutil.CmdRun(
+				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=" + jib.MinimumJibMavenVersion + " --flag1 --flag2 --non-recursive prepare-package jib:build -Dimage=img:tag",
+			),
 		},
 		{
 			description: "build with module",
 			artifact:    &latest.JibMavenArtifact{Module: "module"},
-			cmd:         testutil.FakeRun(t, "mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion="+jib.MinimumJibMavenVersion+" --projects module --also-make package jib:build -Djib.containerize=module -Dimage=img:tag"),
+			commands: testutil.CmdRun(
+				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=" + jib.MinimumJibMavenVersion + " --projects module --also-make package jib:build -Djib.containerize=module -Dimage=img:tag",
+			),
 		},
 		{
 			description: "build with module and profile",
 			artifact:    &latest.JibMavenArtifact{Module: "module", Profile: "profile"},
-			cmd:         testutil.FakeRun(t, "mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion="+jib.MinimumJibMavenVersion+" --activate-profiles profile --projects module --also-make package jib:build -Djib.containerize=module -Dimage=img:tag"),
+			commands: testutil.CmdRun(
+				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=" + jib.MinimumJibMavenVersion + " --activate-profiles profile --projects module --also-make package jib:build -Djib.containerize=module -Dimage=img:tag",
+			),
 		},
 		{
-			description:   "fail build",
-			artifact:      &latest.JibMavenArtifact{},
-			cmd:           testutil.FakeRunErr(t, "mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion="+jib.MinimumJibMavenVersion+" --non-recursive prepare-package jib:build -Dimage=img:tag", errors.New("BUG")),
+			description: "fail build",
+			artifact:    &latest.JibMavenArtifact{},
+			commands: testutil.CmdRunErr(
+				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion="+jib.MinimumJibMavenVersion+" --non-recursive prepare-package jib:build -Dimage=img:tag",
+				errors.New("BUG"),
+			),
 			shouldErr:     true,
 			expectedError: "maven build failed",
 		},
@@ -131,7 +153,7 @@ func TestBuildJibMavenToRegistry(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&util.DefaultExecCommand, test.cmd)
+			t.Override(&util.DefaultExecCommand, test.commands)
 			t.Override(&docker.RemoteDigest, func(identifier string, _ map[string]bool) (string, error) {
 				if identifier == "img:tag" {
 					return "digest", nil

--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -110,7 +110,7 @@ DOCKER_API_VERSION=1.23`,
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&util.DefaultExecCommand, t.FakeRunOut(
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunOut(
 				"minikube docker-env --shell none",
 				test.env,
 			))

--- a/pkg/skaffold/jib/jib_gradle_test.go
+++ b/pkg/skaffold/jib/jib_gradle_test.go
@@ -86,7 +86,7 @@ func TestGetDependenciesGradle(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&util.DefaultExecCommand, t.FakeRunOutErr(
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunOutErr(
 				strings.Join(getCommandGradle(ctx, tmpDir.Root(), &latest.JibGradleArtifact{Project: "gradle-test"}).Args, " "),
 				test.stdout,
 				test.err,

--- a/pkg/skaffold/jib/jib_init_test.go
+++ b/pkg/skaffold/jib/jib_init_test.go
@@ -99,8 +99,14 @@ BEGIN JIB JSON
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&util.DefaultExecCommand, t.FakeRunOut(test.command, test.stdout))
-			t.CheckDeepEqual(test.expectedConfig, ValidateJibConfig(test.path))
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunOut(
+				test.command,
+				test.stdout,
+			))
+
+			validated := ValidateJibConfig(test.path)
+
+			t.CheckDeepEqual(test.expectedConfig, validated)
 		})
 	}
 }

--- a/pkg/skaffold/jib/jib_maven_test.go
+++ b/pkg/skaffold/jib/jib_maven_test.go
@@ -86,7 +86,7 @@ func TestGetDependenciesMaven(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&util.DefaultExecCommand, t.FakeRunOutErr(
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunOutErr(
 				strings.Join(getCommandMaven(ctx, tmpDir.Root(), &latest.JibMavenArtifact{Module: "maven-test"}).Args, " "),
 				test.stdout,
 				test.err,

--- a/pkg/skaffold/jib/jib_test.go
+++ b/pkg/skaffold/jib/jib_test.go
@@ -105,7 +105,10 @@ func TestGetDependencies(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&util.DefaultExecCommand, t.FakeRunOut("ignored", test.stdout))
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunOut(
+				"ignored",
+				test.stdout,
+			))
 
 			results, err := getDependencies(tmpDir.Root(), exec.Cmd{Args: []string{"ignored"}, Dir: tmpDir.Root()}, util.RandomID())
 
@@ -119,10 +122,10 @@ func TestGetUpdatedDependencies(t *testing.T) {
 		tmpDir := t.NewTempDir()
 
 		stdout := fmt.Sprintf("BEGIN JIB JSON\n{\"build\":[\"%s\",\"%s\"],\"inputs\":[],\"ignore\":[]}\n", tmpDir.Path("build.gradle"), tmpDir.Path("settings.gradle"))
-		t.Override(&util.DefaultExecCommand, t.
-			FakeRunOut("ignored", stdout).
-			WithRunOut("ignored", stdout).
-			WithRunOut("ignored", stdout),
+		t.Override(&util.DefaultExecCommand, testutil.
+			CmdRunOut("ignored", stdout).
+			AndRunOut("ignored", stdout).
+			AndRunOut("ignored", stdout),
 		)
 
 		listCmd := exec.Cmd{Args: []string{"ignored"}, Dir: tmpDir.Root()}

--- a/pkg/skaffold/kubectl/cli_test.go
+++ b/pkg/skaffold/kubectl/cli_test.go
@@ -52,27 +52,32 @@ func TestCLI(t *testing.T) {
 	// test cli.Run()
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
-			t.Override(&util.DefaultExecCommand, t.FakeRun(test.expectedCommand))
-			runCtx := &runcontext.RunContext{
+			t.Override(&util.DefaultExecCommand, testutil.CmdRun(
+				test.expectedCommand,
+			))
+
+			cli := NewFromRunContext(&runcontext.RunContext{
 				Opts:        config.SkaffoldOptions{Namespace: test.namespace},
 				KubeContext: test.kubecontext,
-			}
-			cli := NewFromRunContext(runCtx)
+			})
+			err := cli.Run(context.Background(), nil, nil, "exec", "arg1", "arg2")
 
-			t.CheckNoError(cli.Run(context.Background(), nil, nil, "exec", "arg1", "arg2"))
+			t.CheckNoError(err)
 		})
 	}
 
 	// test cli.RunOut()
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
-			t.Override(&util.DefaultExecCommand, t.FakeRunOut(test.expectedCommand, test.output))
-			runCtx := &runcontext.RunContext{
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunOut(
+				test.expectedCommand,
+				test.output,
+			))
+
+			cli := NewFromRunContext(&runcontext.RunContext{
 				Opts:        config.SkaffoldOptions{Namespace: test.namespace},
 				KubeContext: test.kubecontext,
-			}
-			cli := NewFromRunContext(runCtx)
-
+			})
 			out, err := cli.RunOut(context.Background(), "exec", "arg1", "arg2")
 
 			t.CheckNoError(err)

--- a/pkg/skaffold/kubectl/version_test.go
+++ b/pkg/skaffold/kubectl/version_test.go
@@ -29,37 +29,37 @@ import (
 func TestCheckVersion(t *testing.T) {
 	tests := []struct {
 		description     string
-		command         util.Command
+		commands        util.Command
 		shouldErr       bool
 		warnings        []string
 		expectedVersion string
 	}{
 		{
 			description:     "1.12 is valid",
-			command:         testutil.FakeRunOut(t, "kubectl version --client -ojson", `{"clientVersion":{"major":"1","minor":"12"}}`),
+			commands:        testutil.CmdRunOut("kubectl version --client -ojson", `{"clientVersion":{"major":"1","minor":"12"}}`),
 			expectedVersion: "1.12",
 		},
 		{
 			description:     "1.12+ is valid",
-			command:         testutil.FakeRunOut(t, "kubectl version --client -ojson", `{"clientVersion":{"major":"1","minor":"12+"}}`),
+			commands:        testutil.CmdRunOut("kubectl version --client -ojson", `{"clientVersion":{"major":"1","minor":"12+"}}`),
 			expectedVersion: "1.12+",
 		},
 		{
 			description:     "1.11 is too old",
-			command:         testutil.FakeRunOut(t, "kubectl version --client -ojson", `{"clientVersion":{"major":"1","minor":"11"}}`),
+			commands:        testutil.CmdRunOut("kubectl version --client -ojson", `{"clientVersion":{"major":"1","minor":"11"}}`),
 			shouldErr:       true,
 			expectedVersion: "1.11",
 		},
 		{
 			description:     "invalid version",
-			command:         testutil.FakeRunOut(t, "kubectl version --client -ojson", `not json`),
+			commands:        testutil.CmdRunOut("kubectl version --client -ojson", `not json`),
 			shouldErr:       true,
 			warnings:        []string{"unable to parse client version: invalid character 'o' in literal null (expecting 'u')"},
 			expectedVersion: "unknown",
 		},
 		{
 			description:     "cli not found",
-			command:         testutil.FakeRunOutErr(t, "kubectl version --client -ojson", ``, errors.New("not found")),
+			commands:        testutil.CmdRunOutErr("kubectl version --client -ojson", ``, errors.New("not found")),
 			shouldErr:       true,
 			warnings:        []string{"unable to get kubectl client version: not found"},
 			expectedVersion: "unknown",
@@ -69,7 +69,7 @@ func TestCheckVersion(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			fakeWarner := &warnings.Collect{}
 			t.Override(&warnings.Printf, fakeWarner.Warnf)
-			t.Override(&util.DefaultExecCommand, test.command)
+			t.Override(&util.DefaultExecCommand, test.commands)
 
 			cli := CLI{}
 

--- a/pkg/skaffold/runner/kind_test.go
+++ b/pkg/skaffold/runner/kind_test.go
@@ -35,7 +35,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 		description   string
 		built         []build.Artifact
 		deployed      []build.Artifact
-		command       util.Command
+		commands      util.Command
 		shouldErr     bool
 		expectedError string
 	}{
@@ -43,24 +43,24 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			description: "load image",
 			built:       []build.Artifact{{Tag: "tag1"}},
 			deployed:    []build.Artifact{{Tag: "tag1"}},
-			command: testutil.NewFakeCmd(t).
-				WithRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
-				WithRun("kind load docker-image tag1"),
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				AndRun("kind load docker-image tag1"),
 		},
 		{
 			description: "load missing image",
 			built:       []build.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			deployed:    []build.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
-			command: testutil.NewFakeCmd(t).
-				WithRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "tag1").
-				WithRun("kind load docker-image tag2"),
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "tag1").
+				AndRun("kind load docker-image tag2"),
 		},
 		{
 			description: "inspect error",
 			built:       []build.Artifact{{Tag: "tag"}},
 			deployed:    []build.Artifact{{Tag: "tag"}},
-			command: testutil.NewFakeCmd(t).
-				WithRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "", errors.New("BUG")),
+			commands: testutil.
+				CmdRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "", errors.New("BUG")),
 			shouldErr:     true,
 			expectedError: "unable to inspect",
 		},
@@ -68,9 +68,9 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			description: "load error",
 			built:       []build.Artifact{{Tag: "tag"}},
 			deployed:    []build.Artifact{{Tag: "tag"}},
-			command: testutil.NewFakeCmd(t).
-				WithRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
-				WithRunErr("kind load docker-image tag", errors.New("BUG")),
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				AndRunErr("kind load docker-image tag", errors.New("BUG")),
 			shouldErr:     true,
 			expectedError: "unable to load",
 		},
@@ -78,26 +78,24 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			description: "ignore image that's not built",
 			built:       []build.Artifact{{Tag: "built"}},
 			deployed:    []build.Artifact{{Tag: "built"}, {Tag: "busybox"}},
-			command: testutil.NewFakeCmd(t).
-				WithRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
-				WithRun("kind load docker-image built"),
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				AndRun("kind load docker-image built"),
 		},
 		{
 			description: "no artifact",
 			deployed:    []build.Artifact{},
-			command:     testutil.NewFakeCmd(t),
 		},
 		{
 			description: "no built artifact",
 			built:       []build.Artifact{},
 			deployed:    []build.Artifact{{Tag: "busybox"}},
-			command:     testutil.NewFakeCmd(t),
 		},
 	}
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&util.DefaultExecCommand, test.command)
+			t.Override(&util.DefaultExecCommand, test.commands)
 
 			r := &SkaffoldRunner{
 				builds: test.built,

--- a/pkg/skaffold/test/structure/types_test.go
+++ b/pkg/skaffold/test/structure/types_test.go
@@ -33,9 +33,10 @@ func TestNewRunner(t *testing.T) {
 
 	testutil.Run(t, "", func(t *testutil.T) {
 		extraEnv := []string{"SOME=env_var", "OTHER=env_value"}
-		fakeCmd := t.NewFakeCmd().
-			WithRunEnv("container-structure-test test -v warn --image "+imageName+" --config "+structureTestName, extraEnv)
-		t.Override(&util.DefaultExecCommand, fakeCmd)
+		t.Override(&util.DefaultExecCommand, testutil.CmdRunEnv(
+			"container-structure-test test -v warn --image "+imageName+" --config "+structureTestName,
+			extraEnv,
+		))
 
 		testRunner := NewRunner([]string{structureTestName}, extraEnv)
 		err := testRunner.Test(context.Background(), ioutil.Discard, imageName)

--- a/pkg/skaffold/test/test_test.go
+++ b/pkg/skaffold/test/test_test.go
@@ -91,10 +91,9 @@ func TestTestSuccess(t *testing.T) {
 		tmpDir := t.NewTempDir()
 		tmpDir.Touch("tests/test1.yaml", "tests/test2.yaml", "test3.yaml")
 
-		fakeCmd := t.NewFakeCmd().
-			WithRun("container-structure-test test -v warn --image TAG --config " + tmpDir.Path("tests/test1.yaml") + " --config " + tmpDir.Path("tests/test2.yaml")).
-			WithRun("container-structure-test test -v warn --image TAG --config " + tmpDir.Path("test3.yaml"))
-		t.Override(&util.DefaultExecCommand, fakeCmd)
+		t.Override(&util.DefaultExecCommand, testutil.
+			CmdRun("container-structure-test test -v warn --image TAG --config "+tmpDir.Path("tests/test1.yaml")+" --config "+tmpDir.Path("tests/test2.yaml")).
+			AndRun("container-structure-test test -v warn --image TAG --config "+tmpDir.Path("test3.yaml")))
 
 		runCtx := &runcontext.RunContext{
 			WorkingDir: tmpDir.Root(),
@@ -124,12 +123,12 @@ func TestTestSuccess(t *testing.T) {
 
 func TestTestFailure(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
-		tmpDir := t.NewTempDir()
-		tmpDir.Touch("test.yaml")
+		tmpDir := t.NewTempDir().Touch("test.yaml")
 
-		fakeCmd := t.NewFakeCmd().
-			WithRunErr("container-structure-test test -v warn --image broken-image --config "+tmpDir.Path("test.yaml"), errors.New("FAIL"))
-		t.Override(&util.DefaultExecCommand, fakeCmd)
+		t.Override(&util.DefaultExecCommand, testutil.CmdRunErr(
+			"container-structure-test test -v warn --image broken-image --config "+tmpDir.Path("test.yaml"),
+			errors.New("FAIL"),
+		))
 
 		runCtx := &runcontext.RunContext{
 			WorkingDir: tmpDir.Root(),

--- a/testutil/cmd_helper.go
+++ b/testutil/cmd_helper.go
@@ -38,10 +38,8 @@ type run struct {
 	err     error
 }
 
-func NewFakeCmd(t *testing.T) *FakeCmd {
-	return &FakeCmd{
-		t: t,
-	}
+func newFakeCmd() *FakeCmd {
+	return &FakeCmd{}
 }
 
 func (c *FakeCmd) addRun(r run) *FakeCmd {
@@ -59,47 +57,57 @@ func (c *FakeCmd) popRun() (*run, error) {
 	return &run, nil
 }
 
-func FakeRun(t *testing.T, command string) *FakeCmd {
-	return NewFakeCmd(t).WithRun(command)
+func (c *FakeCmd) ForTest(t *testing.T) {
+	if c != nil {
+		c.t = t
+	}
 }
 
-func FakeRunInput(t *testing.T, command, input string) *FakeCmd {
-	return NewFakeCmd(t).WithRunInput(command, input)
+func CmdRun(command string) *FakeCmd {
+	return newFakeCmd().AndRun(command)
 }
 
-func FakeRunErr(t *testing.T, command string, err error) *FakeCmd {
-	return NewFakeCmd(t).WithRunErr(command, err)
+func CmdRunInput(command, input string) *FakeCmd {
+	return newFakeCmd().AndRunInput(command, input)
 }
 
-func FakeRunOut(t *testing.T, command string, output string) *FakeCmd {
-	return NewFakeCmd(t).WithRunOut(command, output)
+func CmdRunErr(command string, err error) *FakeCmd {
+	return newFakeCmd().AndRunErr(command, err)
 }
 
-func FakeRunOutErr(t *testing.T, command string, output string, err error) *FakeCmd {
-	return NewFakeCmd(t).WithRunOutErr(command, output, err)
+func CmdRunOut(command string, output string) *FakeCmd {
+	return newFakeCmd().AndRunOut(command, output)
 }
 
-func (c *FakeCmd) WithRun(command string) *FakeCmd {
+func CmdRunOutErr(command string, output string, err error) *FakeCmd {
+	return newFakeCmd().AndRunOutErr(command, output, err)
+}
+
+func CmdRunEnv(command string, env []string) *FakeCmd {
+	return newFakeCmd().AndRunEnv(command, env)
+}
+
+func (c *FakeCmd) AndRun(command string) *FakeCmd {
 	return c.addRun(run{
 		command: command,
 	})
 }
 
-func (c *FakeCmd) WithRunInput(command, input string) *FakeCmd {
+func (c *FakeCmd) AndRunInput(command, input string) *FakeCmd {
 	return c.addRun(run{
 		command: command,
 		input:   []byte(input),
 	})
 }
 
-func (c *FakeCmd) WithRunErr(command string, err error) *FakeCmd {
+func (c *FakeCmd) AndRunErr(command string, err error) *FakeCmd {
 	return c.addRun(run{
 		command: command,
 		err:     err,
 	})
 }
 
-func (c *FakeCmd) WithRunOut(command string, output string) *FakeCmd {
+func (c *FakeCmd) AndRunOut(command string, output string) *FakeCmd {
 	b := []byte{}
 	if output != "" {
 		b = []byte(output)
@@ -110,7 +118,7 @@ func (c *FakeCmd) WithRunOut(command string, output string) *FakeCmd {
 	})
 }
 
-func (c *FakeCmd) WithRunOutErr(command string, output string, err error) *FakeCmd {
+func (c *FakeCmd) AndRunOutErr(command string, output string, err error) *FakeCmd {
 	return c.addRun(run{
 		command: command,
 		output:  []byte(output),
@@ -118,8 +126,7 @@ func (c *FakeCmd) WithRunOutErr(command string, output string, err error) *FakeC
 	})
 }
 
-// WithRunEnv registers a command that requires the given env variables to be set.
-func (c *FakeCmd) WithRunEnv(command string, env []string) *FakeCmd {
+func (c *FakeCmd) AndRunEnv(command string, env []string) *FakeCmd {
 	return c.addRun(run{
 		command: command,
 		env:     env,

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -38,20 +38,8 @@ type T struct {
 	teardownActions []func()
 }
 
-func (t *T) NewFakeCmd() *FakeCmd {
-	return NewFakeCmd(t.T)
-}
-
-func (t *T) FakeRun(command string) *FakeCmd {
-	return FakeRun(t.T, command)
-}
-
-func (t *T) FakeRunOut(command string, output string) *FakeCmd {
-	return FakeRunOut(t.T, command, output)
-}
-
-func (t *T) FakeRunOutErr(command string, output string, err error) *FakeCmd {
-	return FakeRunOutErr(t.T, command, output, err)
+type ForTester interface {
+	ForTest(t *testing.T)
 }
 
 func (t *T) Override(dest, tmp interface{}) {
@@ -60,6 +48,11 @@ func (t *T) Override(dest, tmp interface{}) {
 		t.Errorf("temporary override value is invalid: %v", err)
 		return
 	}
+
+	if forTester, ok := tmp.(ForTester); ok {
+		forTester.ForTest(t.T)
+	}
+
 	t.teardownActions = append(t.teardownActions, teardown)
 }
 


### PR DESCRIPTION
 + avoid cases where the parent test would be mark
in error instead of the child test. See #2744
 + simplify usage
 + make sure every usage look similar

Signed-off-by: David Gageot <david@gageot.net>