### PR TITLE
Print the tags actually used in deployments

### DIFF
--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -67,6 +67,19 @@ func (r *SkaffoldRunner) BuildAndTest(ctx context.Context, out io.Writer, artifa
 
 	// Make sure all artifacts are redeployed. Not only those that were just built.
 	r.builds = build.MergeWithPreviousBuilds(bRes, r.builds)
+
+	color.Default.Fprintln(out, "Tags used in deployment:")
+
+	if r.imagesAreLocal {
+		color.Yellow.Fprintln(out, " - Since images are not pushed, they can't be referenced by digest")
+		color.Yellow.Fprintln(out, "   They are tagged and referenced by a unique ID instead")
+	}
+
+	for _, build := range r.builds {
+		color.Default.Fprintf(out, " - %s -> ", build.ImageName)
+		fmt.Fprintln(out, build.Tag)
+	}
+
 	return bRes, nil
 }
 

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -113,6 +113,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		cache:                artifactCache,
 		runCtx:               runCtx,
 		intents:              newIntents(runCtx.Opts.AutoBuild, runCtx.Opts.AutoSync, runCtx.Opts.AutoDeploy),
+		imagesAreLocal:       imagesAreLocal,
 	}
 
 	if err := r.setupTriggerCallbacks(intentChan); err != nil {

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -66,11 +66,10 @@ type SkaffoldRunner struct {
 	portForwardResources []*latest.PortForwardResource
 	builds               []build.Artifact
 	imageList            *kubernetes.ImageList
-
-	hasBuilt    bool
-	hasDeployed bool
-
-	intents *intents
+	imagesAreLocal       bool
+	hasBuilt             bool
+	hasDeployed          bool
+	intents              *intents
 }
 
 // for testing


### PR DESCRIPTION
This should help debug tagging issues.
We’ll be able to see if it’s the tagger that’s
not well configured or if it’s the deployer.

Signed-off-by: David Gageot <david@gageot.net>