### PR TITLE
Improve versioning

### DIFF
--- a/hack/new_config_version/version.go
+++ b/hack/new_config_version/version.go
@@ -57,7 +57,7 @@ func main() {
 	configURL := fmt.Sprintf("https://raw.githubusercontent.com/GoogleContainerTools/skaffold/%s/pkg/skaffold/schema/latest/config.go", lastTag)
 	resp, err := http.Get(configURL)
 	if err != nil {
-		logrus.Fatalf("can't determine latest released config lastReleasedVersion, failed to download %s: %s", configURL, err)
+		logrus.Fatalf("can't determine latest released config version, failed to download %s: %s", configURL, err)
 	}
 
 	config, err := ioutil.ReadAll(resp.Body)
@@ -65,11 +65,11 @@ func main() {
 		logrus.Fatalf("failed to read during download %s, err: %s", configURL, err)
 	}
 	versionPattern := regexp.MustCompile("const Version string = \"(skaffold/.*)\"")
-	lastReleasedVersion := versionPattern.FindStringSubmatch(string(config))[1]
+	lastReleased := versionPattern.FindStringSubmatch(string(config))[1]
 
-	logrus.Infof("last released version: %s", lastReleasedVersion)
+	logrus.Infof("last released version: %s", lastReleased)
 
-	if lastReleasedVersion != current {
+	if lastReleased != current {
 		logrus.Fatalf("There is no need to create a new version, %s is still not released", current)
 	}
 

--- a/hack/new_config_version/version.go
+++ b/hack/new_config_version/version.go
@@ -59,11 +59,13 @@ func main() {
 	if err != nil {
 		logrus.Fatalf("can't determine latest released config version, failed to download %s: %s", configURL, err)
 	}
+	defer resp.Body.Close()
 
 	config, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		logrus.Fatalf("failed to read during download %s, err: %s", configURL, err)
 	}
+
 	versionPattern := regexp.MustCompile("const Version string = \"(skaffold/.*)\"")
 	lastReleased := versionPattern.FindStringSubmatch(string(config))[1]
 

--- a/hack/new_config_version/version.go
+++ b/hack/new_config_version/version.go
@@ -27,54 +27,33 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/google/go-github/github"
-
-	"github.com/sirupsen/logrus"
-
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
+	"github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
 )
 
 // Before: prev -> current (latest)
 // After:  prev -> current -> new (latest)
 func main() {
 	logrus.SetLevel(logrus.DebugLevel)
-	new := os.Args[1]
-	current := latest.Version
-	fmt.Printf("current version: %s", current)
 	prev := strings.TrimPrefix(schema.SchemaVersions[len(schema.SchemaVersions)-2].APIVersion, "skaffold/")
-	logrus.Infof("previous version: %s", prev)
+	logrus.Infof("Previous Skaffold version: %s", prev)
+	current := strings.TrimPrefix(latest.Version, "skaffold/")
+	logrus.Infof("Current Skaffold version: %s", current)
+	next := readNextVersion()
 
 	logrus.Infof("checking for released status of %s...", prev)
-	client := github.NewClient(nil)
-
-	releases, _, _ := client.Repositories.ListReleases(context.Background(), "GoogleContainerTools", "skaffold", &github.ListOptions{})
-	lastTag := *releases[0].TagName
-
-	logrus.Infof("last release tag: %s", lastTag)
-
-	configURL := fmt.Sprintf("https://raw.githubusercontent.com/GoogleContainerTools/skaffold/%s/pkg/skaffold/schema/latest/config.go", lastTag)
-	resp, err := http.Get(configURL)
-	if err != nil {
-		logrus.Fatalf("can't determine latest released config version, failed to download %s: %s", configURL, err)
-	}
-	defer resp.Body.Close()
-
-	config, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		logrus.Fatalf("failed to read during download %s, err: %s", configURL, err)
-	}
-
-	versionPattern := regexp.MustCompile("const Version string = \"(skaffold/.*)\"")
-	lastReleased := versionPattern.FindStringSubmatch(string(config))[1]
-
+	lastReleased := getLastReleasedConfigVersion()
 	logrus.Infof("last released version: %s", lastReleased)
-
 	if lastReleased != current {
 		logrus.Fatalf("There is no need to create a new version, %s is still not released", current)
 	}
 
+	makeSchemaDir(current)
 	// Create a package for current version
 	walk(path("latest"), func(file string, info os.FileInfo) {
 		if !info.IsDir() {
@@ -85,12 +64,12 @@ func main() {
 
 	// Create code to upgrade from current to new
 	cp(path(prev, "upgrade.go"), path(current, "upgrade.go"))
-	sed(path(current, "upgrade.go"), current, new)
+	sed(path(current, "upgrade.go"), current, next)
 	sed(path(current, "upgrade.go"), prev, current)
 
 	// Create a test for the upgrade from current to new
 	cp(path(prev, "upgrade_test.go"), path(current, "upgrade_test.go"))
-	sed(path(current, "upgrade_test.go"), current, new)
+	sed(path(current, "upgrade_test.go"), current, next)
 	sed(path(current, "upgrade_test.go"), prev, current)
 
 	// Previous version now upgrades to current instead of latest
@@ -98,12 +77,12 @@ func main() {
 	sed(path(prev, "upgrade_test.go"), "latest", current)
 
 	// Latest uses the new version
-	sed(path("latest", "config.go"), current, new)
+	sed(path("latest", "config.go"), current, next)
 
 	// Update skaffold.yaml in integration tests
 	walk("integration", func(path string, info os.FileInfo) {
 		if info.Name() == "skaffold.yaml" {
-			sed(path, current, new)
+			sed(path, current, next)
 		}
 	})
 
@@ -119,7 +98,51 @@ func main() {
 	write(path("versions.go"), []byte(content))
 
 	// Update the docs with the new version
-	sed("docs/config.toml", current, new)
+	sed("docs/config.toml", current, next)
+}
+
+func getLastReleasedConfigVersion() string {
+	client := github.NewClient(nil)
+	releases, _, _ := client.Repositories.ListReleases(context.Background(), "GoogleContainerTools", "skaffold", &github.ListOptions{})
+	lastTag := *releases[0].TagName
+	logrus.Infof("last release tag: %s", lastTag)
+	configURL := fmt.Sprintf("https://raw.githubusercontent.com/GoogleContainerTools/skaffold/%s/pkg/skaffold/schema/latest/config.go", lastTag)
+	resp, err := http.Get(configURL)
+	if err != nil {
+		logrus.Fatalf("can't determine latest released config version, failed to download %s: %s", configURL, err)
+	}
+	defer resp.Body.Close()
+	config, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		logrus.Fatalf("failed to read during download %s, err: %s", configURL, err)
+	}
+	versionPattern := regexp.MustCompile("const Version string = \"skaffold/(.*)\"")
+	lastReleased := versionPattern.FindStringSubmatch(string(config))[1]
+	return lastReleased
+}
+
+func makeSchemaDir(new string) {
+	latestDir, _ := os.Stat(path("latest"))
+	newDirPath := path(new)
+	if err := os.Mkdir(newDirPath, latestDir.Mode()); err != nil {
+		logrus.Fatalf("creating dir %s: %s", newDirPath, err)
+	}
+}
+
+func readNextVersion() string {
+	var new string
+	if len(os.Args) <= 1 {
+		color.Red.Fprintln(os.Stdout, "Please enter new version (e.g. v1beta15): ")
+		reader := bufio.NewReader(os.Stdin)
+		if line, err := reader.ReadString('\n'); err == nil {
+			new = line
+		} else {
+			logrus.Fatalf("error reading input: %s", err)
+		}
+	} else {
+		new = os.Args[1]
+	}
+	return new
 }
 
 func path(elem ...string) string {

--- a/hack/new_version.sh
+++ b/hack/new_version.sh
@@ -14,11 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-echo "Current skaffold config version: " $(sed -n 's;.*Version.*"skaffold/\(.*\)";\1;p' pkg/skaffold/schema/latest/config.go)
+set -e
 
-echo
+NEW_VERSION=$1
+
+if [[ "" == "$NEW_VERSION" ]]; then
 echo "Please enter new config version:"
 read NEW_VERSION
+fi
 
 go run ./hack/new_config_version/version.go ${NEW_VERSION}
 

--- a/hack/new_version.sh
+++ b/hack/new_version.sh
@@ -16,14 +16,7 @@
 
 set -e
 
-NEW_VERSION=$1
-
-if [[ "" == "$NEW_VERSION" ]]; then
-echo "Please enter new config version:"
-read NEW_VERSION
-fi
-
-go run ./hack/new_config_version/version.go ${NEW_VERSION}
+go run ./hack/new_config_version/version.go $@
 
 goimports -w ./pkg/skaffold/schema
 make generate-schemas


### PR DESCRIPTION
This is regarding #2775.

- hack/new_version now checks via the Github API whether the current version is released or not - if not then fails 
- hack/new_version.sh now takes the new version as an argument for easier testing, e.g, try it out with `hack/new_version.sh v1beta15`!

next PRs will cater for :
- add a PR check that uses this release logic to ensure that no released version is mutated

 