### PR TITLE
[WIP] experimenting with kaniko & insecure registries 

### DIFF
--- a/integration/testdata/kaniko-insecure/reg-k8s/reg.yaml
+++ b/integration/testdata/kaniko-insecure/reg-k8s/reg.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+  labels:
+    app: registry
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 5000
+      name: registry
+  selector:
+    app: registry
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  labels:
+    app: registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      containers:
+        - name: registry
+          image: gcr.io/k8s-skaffold/devreg
+          ports:
+            - containerPort: 50051

--- a/integration/testdata/kaniko-insecure/reg/Dockerfile
+++ b/integration/testdata/kaniko-insecure/reg/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry:2
+
+ADD config.yaml /etc/docker/registry/config.yml

--- a/integration/testdata/kaniko-insecure/reg/config.yaml
+++ b/integration/testdata/kaniko-insecure/reg/config.yaml
@@ -1,0 +1,18 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: 0.0.0.0:8080
+  headers:
+    X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3

--- a/integration/testdata/kaniko-insecure/skaffold.yaml
+++ b/integration/testdata/kaniko-insecure/skaffold.yaml
@@ -1,0 +1,22 @@
+apiVersion: skaffold/v1beta14
+kind: Config
+profiles:
+  - name: deploy-reg
+    build:
+      artifacts:
+      - image: gcr.io/k8s-skaffold/devreg
+        context: reg
+    deploy:
+      kubectl:
+        manifests:
+        - reg-k8s/reg.yaml
+  - name: kaniko-test
+    build:
+      artifacts:
+        - image: gcr.io/k8s-skaffold/devreg
+          context: reg
+          kaniko:
+            buildContext:
+              localDir: {}
+      cluster:
+        pullSecretName: e2esecret


### PR DESCRIPTION
Hopefully I will be able to close https://github.com/GoogleContainerTools/skaffold/issues/1961 with this. Currently I'm running into all sorts of issues with Kaniko. 
I tried running an insecure registry on a GKE cluster: 

```
DEBU[0000] Build context located at /kaniko/buildcontext 
DEBU[0000] Copying file /kaniko/buildcontext/Dockerfile to /kaniko/Dockerfile 
ERROR: logging before flag.Parse: E0904 20:41:27.018762       1 metadata.go:142] while reading 'google-dockercfg' metadata: http status code: 404 while fetching url http://metadata.google.internal./computeMetadata/v1/instance/attributes/google-dockercfg
ERROR: logging before flag.Parse: E0904 20:41:27.023461       1 metadata.go:159] while reading 'google-dockercfg-url' metadata: http status code: 404 while fetching url http://metadata.google.internal./computeMetadata/v1/instance/attributes/google-dockercfg-url
error checking push permissions -- make sure you entered the correct tag name, and that you are authenticated correctly, and try again: checking push permission for "<ip>:5000/gcr_io_k8s-skaffold_devreg:v0.37.1-117-g9528041a7-dirty": Get https://<ip>:5000/v2/: http: server gave HTTP response to HTTPS client
FATA[0006] build failed: build failed: building [35.232.133.65:5000/gcr_io_k8s-skaffold_devreg]: kaniko build for [<ip>:5000/gcr_io_k8s-skaffold_devreg]: waiting for pod to complete: condition error: pod already in terminal phase: Failed 

```

I tried running against an HTTPS but unauthenticated `registry` on Cloud Run ... 

```
DEBU[0000] Copying file /kaniko/buildcontext/Dockerfile to /kaniko/Dockerfile 
ERROR: logging before flag.Parse: E0904 20:48:58.902684       1 metadata.go:142] while reading 'google-dockercfg' metadata: http status code: 404 while fetching url http://metadata.google.internal./computeMetadata/v1/instance/attributes/google-dockercfg
ERROR: logging before flag.Parse: E0904 20:48:58.905948       1 metadata.go:159] while reading 'google-dockercfg-url' metadata: http status code: 404 while fetching url http://metadata.google.internal./computeMetadata/v1/instance/attributes/google-dockercfg-url
error checking push permissions -- make sure you entered the correct tag name, and that you are authenticated correctly, and try again: checking push permission for "https://devreg-....run.app/v2/gcr_io_k8s-skaffold_devreg:v0.37.1-117-g9528041a7-dirty": Get https://https/v2/: dial tcp: lookup https on 10.55.240.10:53: no such host
```

Probably I'm doing something silly. 
Need to understand better how these things tie together. 
TODO: 
  - clarify all the scenarios (HTTP/HTTPS-with-good-cert/HTTPS-with-bad-cert vs auth/no-auth) with insecure registries and document them 
  - repro HTTPS certificate issue from #1961 - it looks like that one is auth + HTTPS-with-bad-cert 

