### PR TITLE
remove unused value in helm example

### DIFF
--- a/examples/helm-deployment/skaffold-helm/values.yaml
+++ b/examples/helm-deployment/skaffold-helm/values.yaml
@@ -1,5 +1,4 @@
 replicaCount: 1
-image: nginx:stable
 service:
   name: nginx
   type: ClusterIP

--- a/examples/helm-deployment/skaffold-helm/values.yaml
+++ b/examples/helm-deployment/skaffold-helm/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 service:
   name: nginx
-  type: ClusterIP
+  type: NodePort
   externalPort: 80
   internalPort: 80
 ingress:


### PR DESCRIPTION
image value is not used, as the image is built from Dockerfile.
also changed the service type to NodePort so we can access it by `minikube service svc-name` command.