### PR TITLE
remove unused values helm example

### DIFF
--- a/examples/helm-deployment/skaffold-helm/values.yaml
+++ b/examples/helm-deployment/skaffold-helm/values.yaml
@@ -1,8 +1,7 @@
 replicaCount: 1
-image: nginx:stable
 service:
   name: nginx
-  type: ClusterIP
+  type: NodePort
   externalPort: 80
   internalPort: 80
 ingress:

--- a/integration/examples/helm-deployment/skaffold-helm/values.yaml
+++ b/integration/examples/helm-deployment/skaffold-helm/values.yaml
@@ -2,7 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 replicaCount: 1
-image: nginx:stable
 # This is the helm convention on declaring images
 # image:
 #   repository: nginx
@@ -10,7 +9,7 @@ image: nginx:stable
 #   pullPolicy: IfNotPresent
 service:
   name: nginx
-  type: ClusterIP
+  type: NodePort
   externalPort: 80
   internalPort: 80
 ingress:


### PR DESCRIPTION
value image is not used.
the image comes from the dockerfile.

also the nodeport is better so we can access it by `minikube service svc_name`