### PR TITLE
skaffold trace -> kaniko debug

### DIFF
--- a/pkg/skaffold/build/cluster/logs.go
+++ b/pkg/skaffold/build/cluster/logs.go
@@ -28,11 +28,14 @@ import (
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-// logLevel makes sure kaniko logs at least at Info level.
+// logLevel makes sure kaniko logs at least at Info level and at most Debug level (trace doesn't work with Kaniko)
 func logLevel() logrus.Level {
 	level := logrus.GetLevel()
 	if level < logrus.InfoLevel {
 		return logrus.InfoLevel
+	}
+	if level > logrus.DebugLevel {
+		return logrus.DebugLevel
 	}
 	return level
 }

--- a/pkg/skaffold/build/cluster/logs_test.go
+++ b/pkg/skaffold/build/cluster/logs_test.go
@@ -28,6 +28,7 @@ func TestLogLevel(t *testing.T) {
 		logrusLevel logrus.Level
 		expected    logrus.Level
 	}{
+		{logrusLevel: logrus.TraceLevel, expected: logrus.DebugLevel},
 		{logrusLevel: logrus.DebugLevel, expected: logrus.DebugLevel},
 		{logrusLevel: logrus.InfoLevel, expected: logrus.InfoLevel},
 		{logrusLevel: logrus.WarnLevel, expected: logrus.InfoLevel},


### PR DESCRIPTION
Kaniko fails with `trace` level debugging. This protects against that. 