### PR TITLE
add render interface to deployers which is not implemented

### DIFF
--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -38,6 +38,10 @@ type Deployer interface {
 
 	// Cleanup deletes what was deployed by calling Deploy.
 	Cleanup(context.Context, io.Writer) error
+
+	// Render generates the Kubernetes manifests replacing the build results and
+	// writes them to the given file path
+	Render(context.Context, io.Writer, []build.Artifact, string) error
 }
 
 type Result struct {

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -462,7 +462,7 @@ func (h *HelmDeployer) joinTagsToBuildResult(builds []build.Artifact, params map
 }
 
 func (h *HelmDeployer) Render(context.Context, io.Writer, []build.Artifact, string) error {
-	return fmt.Errorf("not yet implemented")
+	return errors.New("not yet implemented")
 }
 
 func evaluateReleaseName(nameTemplate string) (string, error) {

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -461,6 +461,10 @@ func (h *HelmDeployer) joinTagsToBuildResult(builds []build.Artifact, params map
 	return paramToBuildResult, nil
 }
 
+func (k *HelmDeployer) Render(context.Context, io.Writer, []build.Artifact, string) error {
+	return fmt.Errorf("not yet implemented")
+}
+
 func evaluateReleaseName(nameTemplate string) (string, error) {
 	tmpl, err := util.ParseEnvTemplate(nameTemplate)
 	if err != nil {

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -461,7 +461,7 @@ func (h *HelmDeployer) joinTagsToBuildResult(builds []build.Artifact, params map
 	return paramToBuildResult, nil
 }
 
-func (k *HelmDeployer) Render(context.Context, io.Writer, []build.Artifact, string) error {
+func (h *HelmDeployer) Render(context.Context, io.Writer, []build.Artifact, string) error {
 	return fmt.Errorf("not yet implemented")
 }
 

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -714,6 +714,25 @@ func TestExpandPaths(t *testing.T) {
 	}
 }
 
+func TestHelmRender(t *testing.T) {
+	tests := []struct {
+		description string
+		shouldErr   bool
+	}{
+		{
+			description: "calling render returns error",
+			shouldErr:   true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			deployer := NewHelmDeployer(&runcontext.RunContext{})
+			actual := deployer.Render(context.Background(), ioutil.Discard, []build.Artifact{}, "tmp/dir")
+			t.CheckError(test.shouldErr, actual)
+		})
+	}
+}
+
 func makeRunContext(deploy latest.HelmDeploy, force bool) *runcontext.RunContext {
 	pipeline := latest.Pipeline{}
 	pipeline.Deploy.DeployType.HelmDeploy = &deploy

--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -19,6 +19,7 @@ package deploy
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"strings"
 
@@ -250,4 +251,8 @@ func (k *KubectlDeployer) readRemoteManifest(ctx context.Context, name string) (
 	}
 
 	return manifest.Bytes(), nil
+}
+
+func (k *KubectlDeployer) Render(context.Context, io.Writer, []build.Artifact, string) error {
+	return fmt.Errorf("not yet implemented")
 }

--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -19,7 +19,6 @@ package deploy
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"strings"
 
@@ -254,5 +253,5 @@ func (k *KubectlDeployer) readRemoteManifest(ctx context.Context, name string) (
 }
 
 func (k *KubectlDeployer) Render(context.Context, io.Writer, []build.Artifact, string) error {
-	return fmt.Errorf("not yet implemented")
+	return errors.New("not yet implemented")
 }

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -457,3 +457,32 @@ func TestDependencies(t *testing.T) {
 		})
 	}
 }
+
+func TestKubectlRender(t *testing.T) {
+	tests := []struct {
+		description string
+		shouldErr   bool
+	}{
+		{
+			description: "calling render returns error",
+			shouldErr:   true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			deployer := NewKubectlDeployer(&runcontext.RunContext{
+				Cfg: latest.Pipeline{
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							KubectlDeploy: &latest.KubectlDeploy{
+								Manifests: []string{},
+							},
+						},
+					},
+				},
+			})
+			actual := deployer.Render(context.Background(), ioutil.Discard, []build.Artifact{}, "tmp/dir")
+			t.CheckError(test.shouldErr, actual)
+		})
+	}
+}

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -168,7 +168,7 @@ func (k *KustomizeDeployer) Dependencies() ([]string, error) {
 }
 
 func (k *KustomizeDeployer) Render(context.Context, io.Writer, []build.Artifact, string) error {
-	return fmt.Errorf("not yet implemented")
+	return errors.New("not yet implemented")
 }
 
 func dependenciesForKustomization(dir string) ([]string, error) {

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -167,6 +167,10 @@ func (k *KustomizeDeployer) Dependencies() ([]string, error) {
 	return dependenciesForKustomization(k.KustomizePath)
 }
 
+func (k *KustomizeDeployer) Render(context.Context, io.Writer, []build.Artifact, string) error {
+	return fmt.Errorf("not yet implemented")
+}
+
 func dependenciesForKustomization(dir string) ([]string, error) {
 	var deps []string
 

--- a/pkg/skaffold/deploy/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize_test.go
@@ -393,3 +393,30 @@ func TestKustomizeBuildCommandArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestKustomizeRender(t *testing.T) {
+	tests := []struct {
+		description string
+		shouldErr   bool
+	}{
+		{
+			description: "calling render returns error",
+			shouldErr:   true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			deployer := NewKustomizeDeployer(&runcontext.RunContext{
+				Cfg: latest.Pipeline{
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							KustomizeDeploy: &latest.KustomizeDeploy{},
+						},
+					},
+				},
+			})
+			actual := deployer.Render(context.Background(), ioutil.Discard, []build.Artifact{}, "tmp/dir")
+			t.CheckError(test.shouldErr, actual)
+		})
+	}
+}

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -170,6 +170,10 @@ func (t *TestBench) Deploy(_ context.Context, _ io.Writer, artifacts []build.Art
 	return deploy.NewDeploySuccessResult(t.namespaces)
 }
 
+func (t *TestBench) Render(_ context.Context, _ io.Writer, artifacts []build.Artifact, _ string) error {
+	return fmt.Errorf("not yet implemented")
+}
+
 func (t *TestBench) Actions() []Actions {
 	return append(t.actions, t.currentActions)
 }

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -18,6 +18,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -171,7 +172,7 @@ func (t *TestBench) Deploy(_ context.Context, _ io.Writer, artifacts []build.Art
 }
 
 func (t *TestBench) Render(_ context.Context, _ io.Writer, artifacts []build.Artifact, _ string) error {
-	return fmt.Errorf("not yet implemented")
+	return errors.New("not yet implemented")
 }
 
 func (t *TestBench) Actions() []Actions {


### PR DESCRIPTION
This is for #1187 and #1937

In this PR, we define an interface `Render` to Deployer and all the deployers have no implementation.

Next 
- [ ] Add implementation to kubectl deployer
- [ ] Add a render command to skaffold.