### PR TITLE
Support YAML anchors in skaffold.yaml (key must start with a dot)

### DIFF
--- a/docs/content/en/docs/references/yaml/_index.html
+++ b/docs/content/en/docs/references/yaml/_index.html
@@ -8,3 +8,9 @@ weight: 120
 <link rel="stylesheet" type="text/css" href="main.css">
 <script type="module" src="main.js"></script>
 <table id="table" data-version="{{% skaffold-version %}}"></table>
+
+<h3>YAML anchors</h3>
+<p>
+    Anchors can be defined by having top-level keys starting with a dot, e.g. <code>.common_stuff: &alias_name</code>.
+    You can then reuse the value using <code>*alias_name</code>.
+</p>

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -18,6 +18,7 @@ package schema
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -106,6 +107,21 @@ func ParseConfig(filename string, upgrade bool) (util.VersionedConfig, error) {
 	factory, present := SchemaVersions.Find(apiVersion.Version)
 	if !present {
 		return nil, errors.Errorf("unknown api version: '%s'", apiVersion.Version)
+	}
+
+	// Remove all top-level keys starting with `.` so they can be used as YAML anchors
+	parsed := make(map[string]interface{})
+	if err := yaml.UnmarshalStrict(buf, parsed); err != nil {
+		return nil, errors.Wrap(err, "unable to parse YAML")
+	}
+	for field := range parsed {
+		if strings.HasPrefix(field, ".") {
+			delete(parsed, field)
+		}
+	}
+	buf, err = yaml.Marshal(parsed)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to re-marshal YAML without dotted keys")
 	}
 
 	cfg := factory()

--- a/testutil/checks.go
+++ b/testutil/checks.go
@@ -43,3 +43,12 @@ func (t *T) CheckNoError(err error) {
 		t.Errorf("unexpected error: %s", err)
 	}
 }
+
+func (t *T) RequireNoError(err error) {
+	t.Helper()
+
+	if err != nil {
+		t.Errorf("unexpected error (failing test now): %s", err)
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
Example which doesn't work with current Skaffold version:

```
apiVersion: skaffold/v1beta12
kind: Config

.build_common: &build_common
  local:
    useDockerCLI: yes

  tagPolicy:
    gitCommit:
      variant: AbbrevCommitSha

.build_common_activation: &build_common_activation
  # Empty `ONLY_MODULE` builds all modules (activate all profiles)
  env: ONLY_MODULE=

profiles:
  - name: client
    activation:
      - *build_common_activation
      - env: ONLY_MODULE=client
    build:
      <<: *build_common
      artifacts:
        - image: client
          docker:
            buildArgs:
              ONLY_MODULE: client

  - name: server
    activation:
      - *build_common_activation
      - env: ONLY_MODULE=server
    build:
      <<: *build_common
      artifacts:
        - image: server
          docker:
            buildArgs:
              ONLY_MODULE: server
```

The environment variable approach is a real-world use case I have (a script uses that variable to create the manifest for only one module of the monorepo, or all modules).

This change discards all top-level keys of the YAML dictionary before the strict parsing step. The yaml.v2 package already takes care to resolve aliases correctly, so only the keys need to be removed, since they cannot be mapped to config struct fields.

The concept is the same as [supported by .gitlab-ci.yml](https://docs.gitlab.com/ee/ci/yaml/#anchors), for instance: using `.` as prefix.