### PR TITLE
Only activate `env: "KEY="` for empty environment variable value, clearly document pattern behavior

### DIFF
--- a/docs/content/en/schemas/v1beta14.json
+++ b/docs/content/en/schemas/v1beta14.json
@@ -19,8 +19,8 @@
         },
         "env": {
           "type": "string",
-          "description": "a `key=value` pair. The profile is auto-activated if an Environment Variable `key` has value `value`.",
-          "x-intellij-html-description": "a <code>key=value</code> pair. The profile is auto-activated if an Environment Variable <code>key</code> has value <code>value</code>.",
+          "description": "a `key=pattern` pair. The profile is auto-activated if an Environment Variable `key` matches the pattern. If the pattern starts with `!`, activation happens if the remaining pattern is _not_ matched. The pattern matches if the Environment Variable value is exactly `pattern`, or the regex `pattern` is found in it. An empty `pattern` (e.g. `env: \"key=\"`) always only matches if the Environment Variable is undefined or empty.",
+          "x-intellij-html-description": "a <code>key=pattern</code> pair. The profile is auto-activated if an Environment Variable <code>key</code> matches the pattern. If the pattern starts with <code>!</code>, activation happens if the remaining pattern is <em>not</em> matched. The pattern matches if the Environment Variable value is exactly <code>pattern</code>, or the regex <code>pattern</code> is found in it. An empty <code>pattern</code> (e.g. <code>env: &quot;key=&quot;</code>) always only matches if the Environment Variable is undefined or empty.",
           "examples": [
             "ENV=production"
           ]

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -606,9 +606,13 @@ type JSONPatch struct {
 
 // Activation criteria by which a profile is auto-activated.
 type Activation struct {
-	// Env is a `key=value` pair. The profile is auto-activated if an Environment
-	// Variable `key` has value `value`.
-	// For example: `ENV=production`.
+	// Env is a `key=pattern` pair. The profile is auto-activated if an Environment
+	// Variable `key` matches the pattern. If the pattern starts with `!`, activation
+	// happens if the remaining pattern is _not_ matched. The pattern matches if the
+	// Environment Variable value is exactly `pattern`, or the regex `pattern` is
+	// found in it. An empty `pattern` (e.g. `env: "key="`) always only matches if
+	// the Environment Variable is undefined or empty.
+	// For example: `ENV=production`
 	Env string `yaml:"env,omitempty"`
 
 	// KubeContext is a Kubernetes context for which the profile is auto-activated.

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -98,7 +98,15 @@ func isEnv(env string) (bool, error) {
 	key := keyValue[0]
 	value := keyValue[1]
 
-	return satisfies(value, os.Getenv(key)), nil
+	envValue := os.Getenv(key)
+
+	// Special case, since otherwise the regex substring check (`re.Compile("").MatchString(envValue)`)
+	// would always match which is most probably not what the user wanted.
+	if value == "" {
+		return envValue == "", nil
+	}
+
+	return satisfies(value, envValue), nil
 }
 
 func isCommand(command string, opts cfg.SkaffoldOptions) bool {


### PR DESCRIPTION
This tests and documents expected behavior, and fixes what I believe is a very surprising special case: `env: "KEY="` should only match an empty/undefined environment variable value. Previously, it would match any value since an empty regex search matches anything.

Use case where this is important: monorepo with 50 images where environment variable `ONLY_MODULE=...` specifies which image(s) to build. An empty value should build everything.

Overall, I'd rather change syntax or key to e.g. `env: "KEY~=^my-regex$"` or `envRegex: KEY=REGEX`, and fix the implementation of `env:` to compare the value exactly. But that would it backwards-incompatible and would still require the special `!` handling implemented for both string and regex comparison. Hence I went for a patch that only fixes the expectation for `env: "KEY="`.