### PR TITLE
add deploy stabilize timer

### DIFF
--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -19,6 +19,7 @@ package runner
 import (
 	"context"
 	"io"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -47,12 +48,13 @@ func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []
 func (r *SkaffoldRunner) performStatusCheck(ctx context.Context, out io.Writer) error {
 	// Check if we need to perform deploy status
 	if r.runCtx.Opts.StatusCheck {
+		start := time.Now()
 		color.Default.Fprintln(out, "Waiting for deployments to stabilize")
 		err := statusCheck(ctx, r.defaultLabeller, r.runCtx)
 		if err != nil {
-			color.Default.Fprintln(out, err.Error())
+			return err
 		}
-		return err
+		color.Default.Fprintln(out, "Deployments stabilized in", time.Since(start))
 	}
 	return nil
 }


### PR DESCRIPTION
Related to #176

This PR is part of breaking up a larger PR (#2811) that improves logging for health check based deployment status checking: 

- Removes duplicated error log when deployment health check failed.
- Adds timings output line for deploy health check phase in case it is successful: 

Before
```
tejaldesai@@microservices (add_deploy_stable_timer)$ skaffold run --default-repo=gcr.io/tejal-test --status-check
Generating tags...
...
Starting deploy...
kubectl client version: 1.11+
kubectl version 1.12.0 or greater is recommended for use with Skaffold
 - deployment.apps/leeroy-web configured
 - service/leeroy-app configured
 - deployment.apps/leeroy-app configured
Deploy complete in 3.791356548s
Waiting for deployments to stabilize
You can also run [skaffold run --tail] to get the logs
```

After:
```
tejaldesai@@microservices (add_deploy_stable_timer)$ skaffold run --default-repo=gcr.io/tejal-test --status-check
Generating tags...
...
Starting deploy...
kubectl client version: 1.11+
kubectl version 1.12.0 or greater is recommended for use with Skaffold
 - deployment.apps/leeroy-web configured
 - service/leeroy-app configured
 - deployment.apps/leeroy-app configured
Deploy complete in 3.791356548s
Waiting for deployments to stabilize
Deployments stabilized in 6.059712568s
You can also run [skaffold run --tail] to get the logs
```