### PR TITLE
Ignore Jib project name when skaffold init only finds one module

### DIFF
--- a/pkg/skaffold/jib/jib_init.go
+++ b/pkg/skaffold/jib/jib_init.go
@@ -156,7 +156,11 @@ func ValidateJibConfig(path string) []Jib {
 			return nil
 		}
 
-		results[i] = Jib{BuilderName: builderType.Name(), Image: parsedJSON.Image, FilePath: path, Project: parsedJSON.Project}
+		results[i] = Jib{BuilderName: builderType.Name(), Image: parsedJSON.Image, FilePath: path}
+		if len(matches) > 1 {
+			// Only apply project if there are multiple modules
+			results[i].Project = parsedJSON.Project
+		}
 	}
 	return results
 }

--- a/pkg/skaffold/jib/jib_init_test.go
+++ b/pkg/skaffold/jib/jib_init_test.go
@@ -53,7 +53,7 @@ func TestValidateJibConfig(t *testing.T) {
 {"image":"image","project":"project"}
 `,
 			expectedConfig: []Jib{
-				{BuilderName: JibGradle.Name(), FilePath: "path/to/build.gradle", Image: "image", Project: "project"},
+				{BuilderName: JibGradle.Name(), FilePath: "path/to/build.gradle", Image: "image"},
 			},
 		},
 		{
@@ -78,7 +78,7 @@ BEGIN JIB JSON
 			stdout: `BEGIN JIB JSON
 {"image":"image","project":"project"}`,
 			expectedConfig: []Jib{
-				{BuilderName: JibMaven.Name(), FilePath: "path/to/pom.xml", Image: "image", Project: "project"},
+				{BuilderName: JibMaven.Name(), FilePath: "path/to/pom.xml", Image: "image"},
 			},
 		},
 		{


### PR DESCRIPTION
Fixes #2844 

@GoogleContainerTools/java-tools-build 