### PR TITLE
Add Resource.Status object and remove sync.Map

### DIFF
--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -30,6 +30,7 @@ type Deployment struct {
 	namespace string
 	rType     string
 	deadline  time.Duration
+	status    *Status
 }
 
 func (d *Deployment) String() string {
@@ -44,11 +45,27 @@ func (d *Deployment) Deadline() time.Duration {
 	return d.deadline
 }
 
+func (d *Deployment) Status() *Status {
+	return d.status
+}
+
+func (d *Deployment) UpdateStatus(details string, err error) {
+	d.status.err = err
+	d.status.details = details
+}
+
 func NewDeployment(name string, ns string, deadline time.Duration) *Deployment {
 	return &Deployment{
 		name:      name,
 		namespace: ns,
 		rType:     deploymentType,
 		deadline:  deadline,
+		status:    NewStatus("", nil),
 	}
+}
+
+// For testing
+func (d *Deployment) WithStatus(details string, err error) *Deployment {
+	d.UpdateStatus(details, err)
+	return d
 }

--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -30,7 +30,7 @@ type Deployment struct {
 	namespace string
 	rType     string
 	deadline  time.Duration
-	status    *Status
+	status    Status
 }
 
 func (d *Deployment) String() string {
@@ -45,13 +45,12 @@ func (d *Deployment) Deadline() time.Duration {
 	return d.deadline
 }
 
-func (d *Deployment) Status() *Status {
+func (d *Deployment) Status() Status {
 	return d.status
 }
 
 func (d *Deployment) UpdateStatus(details string, err error) {
-	d.status.err = err
-	d.status.details = details
+	d.status = newStatus(details, err)
 }
 
 func NewDeployment(name string, ns string, deadline time.Duration) *Deployment {
@@ -60,7 +59,7 @@ func NewDeployment(name string, ns string, deadline time.Duration) *Deployment {
 		namespace: ns,
 		rType:     deploymentType,
 		deadline:  deadline,
-		status:    NewStatus("", nil),
+		status:    newStatus("", nil),
 	}
 }
 

--- a/pkg/skaffold/deploy/resource/status.go
+++ b/pkg/skaffold/deploy/resource/status.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resource
+
+type Status struct {
+	err     error
+	details string
+}
+
+func (rs *Status) Error() error {
+	return rs.err
+}
+
+func (rs *Status) String() string {
+	if rs.err != nil {
+		return rs.err.Error()
+	}
+	return rs.details
+}
+
+func NewStatus(msg string, err error) *Status {
+	return &Status{
+		details: msg,
+		err:     err,
+	}
+}

--- a/pkg/skaffold/deploy/resource/status.go
+++ b/pkg/skaffold/deploy/resource/status.go
@@ -21,19 +21,19 @@ type Status struct {
 	details string
 }
 
-func (rs *Status) Error() error {
+func (rs Status) Error() error {
 	return rs.err
 }
 
-func (rs *Status) String() string {
+func (rs Status) String() string {
 	if rs.err != nil {
 		return rs.err.Error()
 	}
 	return rs.details
 }
 
-func NewStatus(msg string, err error) *Status {
-	return &Status{
+func newStatus(msg string, err error) Status {
+	return Status{
 		details: msg,
 		err:     err,
 	}


### PR DESCRIPTION
Relates to #176 

Add a `resource.Status` struct which stores the status of the deployment in `Deployment.status` field.

Remove `sync.Map` which was used to deployments status.

Output changes:
* No output changes.

Next PRs:
- [ ] Add `updated` and `reported` booleans to `resource.Status`.
- [ ] Update Status only if its changed instead of updating every single time.
- [ ] Finally merge in #2813