### PR TITLE
Always add image flag to jib builders in skaffold init

### DIFF
--- a/pkg/skaffold/jib/jib_init.go
+++ b/pkg/skaffold/jib/jib_init.go
@@ -60,10 +60,7 @@ func (j Jib) Describe() string {
 func (j Jib) CreateArtifact(manifestImage string) *latest.Artifact {
 	workspace := filepath.Dir(j.FilePath)
 
-	a := &latest.Artifact{ImageName: j.Image}
-	if j.Image == "" {
-		a.ImageName = manifestImage
-	}
+	a := &latest.Artifact{ImageName: manifestImage}
 
 	if workspace != "." {
 		a.Workspace = workspace
@@ -74,9 +71,7 @@ func (j Jib) CreateArtifact(manifestImage string) *latest.Artifact {
 		if j.Project != "" {
 			jibMaven.Module = j.Project
 		}
-		if j.Image == "" {
-			jibMaven.Flags = []string{"-Dimage=" + manifestImage}
-		}
+		jibMaven.Flags = []string{"-Dimage=" + manifestImage}
 		a.ArtifactType = latest.ArtifactType{JibMavenArtifact: jibMaven}
 
 	} else if j.BuilderName == JibGradle.Name() {
@@ -84,9 +79,7 @@ func (j Jib) CreateArtifact(manifestImage string) *latest.Artifact {
 		if j.Project != "" {
 			jibGradle.Project = j.Project
 		}
-		if j.Image == "" {
-			jibGradle.Flags = []string{"-Dimage=" + manifestImage}
-		}
+		jibGradle.Flags = []string{"-Dimage=" + manifestImage}
 		a.ArtifactType = latest.ArtifactType{JibGradleArtifact: jibGradle}
 	}
 

--- a/pkg/skaffold/jib/jib_init_test.go
+++ b/pkg/skaffold/jib/jib_init_test.go
@@ -158,10 +158,10 @@ func TestCreateArtifact(t *testing.T) {
 			config:        Jib{BuilderName: JibGradle.Name(), FilePath: filepath.Join("path", "to", "build.gradle"), Image: "image", Project: "project"},
 			manifestImage: "different-image",
 			expectedArtifact: latest.Artifact{
-				ImageName: "image",
+				ImageName: "different-image",
 				Workspace: filepath.Join("path", "to"),
 				ArtifactType: latest.ArtifactType{
-					JibGradleArtifact: &latest.JibGradleArtifact{Project: "project"},
+					JibGradleArtifact: &latest.JibGradleArtifact{Project: "project", Flags: []string{"-Dimage=different-image"}},
 				},
 			},
 		},
@@ -173,9 +173,7 @@ func TestCreateArtifact(t *testing.T) {
 				ImageName: "different-image",
 				Workspace: filepath.Join("path", "to"),
 				ArtifactType: latest.ArtifactType{
-					JibGradleArtifact: &latest.JibGradleArtifact{
-						Flags: []string{"-Dimage=different-image"},
-					},
+					JibGradleArtifact: &latest.JibGradleArtifact{Flags: []string{"-Dimage=different-image"}},
 				},
 			},
 		},
@@ -184,10 +182,10 @@ func TestCreateArtifact(t *testing.T) {
 			config:        Jib{BuilderName: JibMaven.Name(), FilePath: filepath.Join("path", "to", "pom.xml"), Image: "image", Project: "project"},
 			manifestImage: "different-image",
 			expectedArtifact: latest.Artifact{
-				ImageName: "image",
+				ImageName: "different-image",
 				Workspace: filepath.Join("path", "to"),
 				ArtifactType: latest.ArtifactType{
-					JibMavenArtifact: &latest.JibMavenArtifact{Module: "project"},
+					JibMavenArtifact: &latest.JibMavenArtifact{Module: "project", Flags: []string{"-Dimage=different-image"}},
 				},
 			},
 		},
@@ -199,9 +197,7 @@ func TestCreateArtifact(t *testing.T) {
 				ImageName: "different-image",
 				Workspace: filepath.Join("path", "to"),
 				ArtifactType: latest.ArtifactType{
-					JibMavenArtifact: &latest.JibMavenArtifact{
-						Flags: []string{"-Dimage=different-image"},
-					},
+					JibMavenArtifact: &latest.JibMavenArtifact{Flags: []string{"-Dimage=different-image"}},
 				},
 			},
 		},
@@ -210,8 +206,10 @@ func TestCreateArtifact(t *testing.T) {
 			config:        Jib{BuilderName: JibGradle.Name(), FilePath: "build.gradle", Image: "image"},
 			manifestImage: "different-image",
 			expectedArtifact: latest.Artifact{
-				ImageName:    "image",
-				ArtifactType: latest.ArtifactType{JibGradleArtifact: &latest.JibGradleArtifact{}},
+				ImageName: "different-image",
+				ArtifactType: latest.ArtifactType{
+					JibGradleArtifact: &latest.JibGradleArtifact{Flags: []string{"-Dimage=different-image"}},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #2852 

`skaffold init` used to use Jib's configured `to.image` to auto-pair Jib projects with k8s images. However, the skaffold.yaml that was generated prioritized the `to.image` configuration over the k8s images, possibly resulting in a skaffold.yaml that points a Jib builder to an image that isn't defined in a k8s manifest. This PR fixes that by only using k8s images in the generated artifacts, and also always explicitly passing a `-Dimage=` flag to Jib to make sure it builds the correct image, despite its configuration.

@GoogleContainerTools/java-tools-build 