### PR TITLE
Add kind Matcher which accepts a blacklist of values for `Kind` key

### DIFF
--- a/pkg/skaffold/deploy/kubectl/matcher/kind.go
+++ b/pkg/skaffold/deploy/kubectl/matcher/kind.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matcher
+
+import (
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	kindKey = "kind"
+)
+
+// Kind matches an object with "Kind" which is not listed in the forbiddenValues.
+type Kind struct {
+	forbiddenValues map[string]struct{}
+}
+
+func (k *Kind) Matches(v interface{}) bool {
+	if str, ok := k.getValue(v); ok {
+		return k.notInBlacklist(str)
+	}
+	logrus.Debugf("%v is type %T but type string expected for key `%s`. skipping value match.", v, v, kindKey)
+	return true
+}
+
+func (k *Kind) getValue(v interface{}) (string, bool) {
+	value, ok := v.(string)
+	return value, ok
+}
+
+func (k *Kind) notInBlacklist(s string) bool {
+	_, ok := k.forbiddenValues[s]
+	return !ok
+}
+
+func (k *Kind) IsMatchKey(key string) bool {
+	return strings.ToLower(key) == kindKey
+}
+
+func New(values []string) *Kind {
+	m := map[string]struct{}{}
+	for _, v := range values {
+		m[v] = struct{}{}
+	}
+	return &Kind{
+		forbiddenValues: m,
+	}
+}

--- a/pkg/skaffold/deploy/kubectl/matcher/kind.go
+++ b/pkg/skaffold/deploy/kubectl/matcher/kind.go
@@ -26,7 +26,7 @@ const (
 	kindKey = "kind"
 )
 
-// Kind matches an object with "Kind" which is not listed in the forbiddenValues.
+// Kind matches the value of "Kind" key with values not listed in the forbiddenValues.
 type Kind struct {
 	forbiddenValues map[string]struct{}
 }

--- a/pkg/skaffold/deploy/kubectl/matcher/kind_test.go
+++ b/pkg/skaffold/deploy/kubectl/matcher/kind_test.go
@@ -31,7 +31,7 @@ func TestKindIsMatchKey(t *testing.T) {
 		expected    bool
 	}{
 		{
-			description: "returns false for kind key",
+			description: "returns true for kind key",
 			key:         "kind",
 			expected:    true,
 		},

--- a/pkg/skaffold/deploy/kubectl/matcher/kind_test.go
+++ b/pkg/skaffold/deploy/kubectl/matcher/kind_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matcher
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+	"github.com/sirupsen/logrus"
+)
+
+func TestKindIsMatchKey(t *testing.T) {
+	tests := []struct {
+		description string
+		key         string
+		expected    bool
+	}{
+		{
+			description: "returns false for kind key",
+			key:         "kind",
+			expected:    true,
+		},
+		{
+			description: "returns false for other key",
+			key:         "not-kind",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			actual := New([]string{}).IsMatchKey(test.key)
+			t.CheckDeepEqual(test.expected, actual)
+		})
+	}
+}
+
+func TestKindMatches(t *testing.T) {
+	tests := []struct {
+		description string
+		blacklist   []string
+		value       interface{}
+		expectedLog string
+		expected    bool
+	}{
+		{
+			description: "returns true for value not in the list",
+			blacklist:   []string{"taboo", "taboo-1"},
+			value:       "test",
+			expected:    true,
+		},
+		{
+			description: "returns false for value in the list",
+			blacklist:   []string{"taboo", "taboo-1"},
+			value:       "taboo",
+		},
+		{
+			description: "returns true for value not in the list and not string",
+			blacklist:   []string{"taboo", "taboo-1"},
+			value:       1,
+			expectedLog: "1 is type int but type string expected for key `kind`",
+			expected:    true,
+		},
+		{
+			description: "returns true for value not in the list and not string",
+			blacklist:   []string{"taboo", "taboo-1"},
+			value:       struct{}{},
+			expectedLog: "{} is type struct {} but type string expected for key `kind`",
+			expected:    true,
+		},
+	}
+	for _, test := range tests {
+		var buf bytes.Buffer
+		logrus.SetOutput(&buf)
+		logrus.SetLevel(logrus.DebugLevel)
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			actual := New(test.blacklist).Matches(test.value)
+			t.CheckDeepEqual(test.expected, actual)
+			t.CheckContains(test.expectedLog, buf.String())
+		})
+	}
+}


### PR DESCRIPTION
Relates to #1737 

Should go after #2862
Addressed subsequent work from #2060 

In this PR, 

**Output Changed**:
Add a debug line when "Kind" key has a non string value. 
For an invalid  manifest with "kind" value of not string type
```
apiVersion: v1
kind: {}
metadata:

```
Output line will look this in debug mode.
```
DEBU[0000] {} is type struct {} but type string expected for key `kind`. skipping value match.
```


**Next Changes:**
 - [ ]  Use the KindMatcher for labelSetter 
Something like this:
```
type labelsSetter struct {
        matcher matcher.Kind
	labels map[string]string
}

func newLabelsSetter(labels map[string]string) *labelsSetter {
	return &labelsSetter{
		labels: labels,
+                matcher: matcher.New([]string{'CustomResourceDefinition'})
	}
}

func (r *labelsSetter) ObjMatcher() Matcher {
	return r.matcher
}
```