### PR TITLE
refactored new_config in preparation for schema change checks

### DIFF
--- a/hack/new_version.sh
+++ b/hack/new_version.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-go run ./hack/new_config_version/version.go $@
+go run ./hack/versions/cmd/new/version.go $@
 
 goimports -w ./pkg/skaffold/schema
 make generate-schemas
@@ -26,7 +26,7 @@ make test
 echo
 echo "---------------------------------------"
 echo
-echo "Files generated for $NEW_VERSION."
+echo "Files generated for the new version."
 echo "All tests should have passed. For the docs change, commit the results and rerun 'make test'."
 echo "Please double check manually the generated files as well: the upgrade functionality, and all the examples:"
 echo

--- a/hack/versions/cmd/new/new.go
+++ b/hack/versions/cmd/new/new.go
@@ -18,21 +18,15 @@ package main
 
 import (
 	"bufio"
-	"context"
-	"fmt"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-
+	"github.com/GoogleContainerTools/skaffold/hack/versions/pkg/version"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
-
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
-	"github.com/google/go-github/github"
 	"github.com/sirupsen/logrus"
 )
 
@@ -42,14 +36,10 @@ func main() {
 	logrus.SetLevel(logrus.DebugLevel)
 	prev := strings.TrimPrefix(schema.SchemaVersions[len(schema.SchemaVersions)-2].APIVersion, "skaffold/")
 	logrus.Infof("Previous Skaffold version: %s", prev)
-	current := strings.TrimPrefix(latest.Version, "skaffold/")
-	logrus.Infof("Current Skaffold version: %s", current)
-	next := readNextVersion()
 
-	logrus.Infof("checking for released status of %s...", prev)
-	lastReleased := getLastReleasedConfigVersion()
-	logrus.Infof("last released version: %s", lastReleased)
-	if lastReleased != current {
+	current, latestIsReleased := version.GetLatestVersion()
+
+	if !latestIsReleased {
 		logrus.Fatalf("There is no need to create a new version, %s is still not released", current)
 	}
 
@@ -61,6 +51,8 @@ func main() {
 			sed(path(current, info.Name()), "package latest", "package "+current)
 		}
 	})
+
+	next := readNextVersion()
 
 	// Create code to upgrade from current to new
 	cp(path(prev, "upgrade.go"), path(current, "upgrade.go"))
@@ -99,26 +91,6 @@ func main() {
 
 	// Update the docs with the new version
 	sed("docs/config.toml", current, next)
-}
-
-func getLastReleasedConfigVersion() string {
-	client := github.NewClient(nil)
-	releases, _, _ := client.Repositories.ListReleases(context.Background(), "GoogleContainerTools", "skaffold", &github.ListOptions{})
-	lastTag := *releases[0].TagName
-	logrus.Infof("last release tag: %s", lastTag)
-	configURL := fmt.Sprintf("https://raw.githubusercontent.com/GoogleContainerTools/skaffold/%s/pkg/skaffold/schema/latest/config.go", lastTag)
-	resp, err := http.Get(configURL)
-	if err != nil {
-		logrus.Fatalf("can't determine latest released config version, failed to download %s: %s", configURL, err)
-	}
-	defer resp.Body.Close()
-	config, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		logrus.Fatalf("failed to read during download %s, err: %s", configURL, err)
-	}
-	versionPattern := regexp.MustCompile("const Version string = \"skaffold/(.*)\"")
-	lastReleased := versionPattern.FindStringSubmatch(string(config))[1]
-	return lastReleased
 }
 
 func makeSchemaDir(new string) {

--- a/hack/versions/pkg/version/version.go
+++ b/hack/versions/pkg/version/version.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+
+	"github.com/google/go-github/github"
+	"github.com/sirupsen/logrus"
+)
+
+func GetLatestVersion() (string, bool) {
+	current := strings.TrimPrefix(latest.Version, "skaffold/")
+	logrus.Infof("Current Skaffold version: %s", current)
+	logrus.Infof("checking for released status of %s...", current)
+	lastReleased := getLastReleasedConfigVersion()
+	logrus.Infof("last released version: %s", lastReleased)
+	latestIsReleased := lastReleased == current
+	return current, latestIsReleased
+}
+
+func getLastReleasedConfigVersion() string {
+	client := github.NewClient(nil)
+	releases, _, err := client.Repositories.ListReleases(context.Background(), "GoogleContainerTools", "skaffold", &github.ListOptions{})
+	if err != nil {
+		logrus.Fatalf("error listing Github releases: %s", err)
+	}
+	lastTag := *releases[0].TagName
+	logrus.Infof("last release tag: %s", lastTag)
+	configURL := fmt.Sprintf("https://raw.githubusercontent.com/GoogleContainerTools/skaffold/%s/pkg/skaffold/schema/latest/config.go", lastTag)
+	resp, err := http.Get(configURL)
+	if err != nil {
+		logrus.Fatalf("can't determine latest released config version, failed to download %s: %s", configURL, err)
+	}
+	defer resp.Body.Close()
+	config, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		logrus.Fatalf("failed to read during download %s, err: %s", configURL, err)
+	}
+	versionPattern := regexp.MustCompile("const Version string = \"skaffold/(.*)\"")
+	lastReleased := versionPattern.FindStringSubmatch(string(config))[1]
+	return lastReleased
+}


### PR DESCRIPTION
This is part 1/2 of https://github.com/GoogleContainerTools/skaffold/pull/2864 to solve the schema structure change checking described in #2775. 

- fixes a bug of undefined $NEW_VERSION variable in the output of the new_config.sh script
- creates a package structure in preparation for #2864