### PR TITLE
Fix ordering in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,9 @@
-# Global owners
-
-* @balopat @dgageot @nkubala @priyawadhwa @tejal29
+# Order is important; the last matching pattern takes the most precedence
 
 # JIB owners
 
-**/**jib** @briandealwis @loosebazooka @TadCordle @chanseokoh @balopat @dgageot @nkubala @priyawadhwa @tejal29
-**/jib_** @briandealwis @loosebazooka @TadCordle @chanseokoh @balopat @dgageot @nkubala @priyawadhwa @tejal29
+**/**jib** @briandealwis @loosebazooka @TadCordle @chanseokoh
+**/jib_** @briandealwis @loosebazooka @TadCordle @chanseokoh
 
 # Debug owners
 pkg/skaffold/debug/** @briandealwis @loosebazooka @quoctruong
@@ -13,3 +11,5 @@ docs/content/en/docs/how-tos/debug/** @briandealwis @loosebazooka @quoctruong
 integration/test-data/debug/** @briandealwis @loosebazooka @quoctruong
 integration/debug_test.go  @briandealwis @loosebazooka @quoctruong
 
+# Global owners
+* @balopat @dgageot @nkubala @priyawadhwa @tejal29


### PR DESCRIPTION
GitHub's requiring an approval from @loosebazooka for #2306, despite the fact that  @dgageot had approved:

![Screen Shot 2019-09-12 at 10 28 34 AM](https://user-images.githubusercontent.com/202851/64792953-38ded500-d548-11e9-8c26-df00834b0316.png)

According to https://help.github.com/en/articles/about-code-owners the order matters:
```
# These owners will be the default owners for everything in
# the repo. Unless a later match takes precedence,
# @global-owner1 and @global-owner2 will be requested for
# review when someone opens a pull request.
*       @global-owner1 @global-owner2

# Order is important; the last matching pattern takes the most
# precedence. When someone opens a pull request that only
# modifies JS files, only @js-owner and not the global
# owner(s) will be requested for a review.
*.js    @js-owner
```

This change pushes the global owners to the bottom of the file.