### PR TITLE
fix codeowners for debug

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,8 +8,8 @@
 **/jib_** @briandealwis @loosebazooka @TadCordle @chanseokoh @balopat @dgageot @nkubala @priyawadhwa @tejal29
 
 # Debug owners
-pkg/skaffold/debug/** @briandealwis @loosebazooka @quoctruong
-docs/content/en/docs/how-tos/debug/** @briandealwis @loosebazooka @quoctruong
-integration/test-data/debug/** @briandealwis @loosebazooka @quoctruong
-integration/debug_test.go  @briandealwis @loosebazooka @quoctruong
 
+pkg/skaffold/debug/** @briandealwis @loosebazooka @quoctruong @balopat @dgageot @nkubala @priyawadhwa @tejal29
+docs/content/en/docs/how-tos/debug/** @briandealwis @loosebazooka @quoctruong @balopat @dgageot @nkubala @priyawadhwa @tejal29
+integration/test-data/debug/** @briandealwis @loosebazooka @quoctruong @balopat @dgageot @nkubala @priyawadhwa @tejal29
+integration/debug_test.go  @briandealwis @loosebazooka @quoctruong @balopat @dgageot @nkubala @priyawadhwa @tejal29


### PR DESCRIPTION
GitHub's requiring an approval from @loosebazooka for #2306, despite the fact that  @dgageot had approved:

![Screen Shot 2019-09-12 at 10 28 34 AM](https://user-images.githubusercontent.com/202851/64792953-38ded500-d548-11e9-8c26-df00834b0316.png)

This fix adds the skaffold team to the debug entries.