### PR TITLE
Fix build script for doc generation.

### DIFF
--- a/deploy/docs/build.sh
+++ b/deploy/docs/build.sh
@@ -19,7 +19,7 @@ set -exu
 readonly BASE_URL=${1}
 
 cd docs
-mkdir themes
+mkdir -p themes
 ln -s /app/docs/themes/docsy ./themes/docsy
 ln -s /app/docs/node_modules ./node_modules
 hugo --baseURL=${BASE_URL}


### PR DESCRIPTION
The latest doc-modification job failed due 
https://storage.googleapis.com/webhook-logs/logs-2879-1568411607494563296

```
Init container logs: 
 Cloning into 'skaffold-1'...
 
Container Logs: 
 + readonly BASE_URL=http://34.94.233.95:1313
+ BASE_URL=http://34.94.233.95:1313
+ cd docs
+ mkdir themes
mkdir: cannot create directory 'themes': File exists
```