### PR TITLE
Fix helm deployer with imageStrategy helm and fix test runner

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -288,9 +288,9 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 					return nil, errors.Wrapf(err, "image reference %s has no domain", v.Tag)
 				}
 
-				value = fmt.Sprintf("%[1]s.registry=%[2]s,%[1]s.repository=%[3]s,%[1]s.tag=%[4]s", k, dockerRef.Domain, dockerRef.Path, v.Tag)
+				value = fmt.Sprintf("%[1]s.registry=%[2]s,%[1]s.repository=%[3]s,%[1]s.tag=%[4]s", k, dockerRef.Domain, dockerRef.Path, dockerRef.Tag)
 			} else {
-				value = fmt.Sprintf("%[1]s.repository=%[2]s,%[1]s.tag=%[3]s", k, dockerRef.BaseName, v.Tag)
+				value = fmt.Sprintf("%[1]s.repository=%[2]s,%[1]s.tag=%[3]s", k, dockerRef.BaseName, dockerRef.Tag)
 			}
 		} else {
 			value = fmt.Sprintf("%s=%s", k, v.Tag)

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -277,23 +277,10 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 	for k, v := range params {
 		var value string
 
-		if cfg := r.ImageStrategy.HelmImageConfig.HelmConventionConfig; cfg != nil {
-			dockerRef, err := docker.ParseReference(v.Tag)
-			if err != nil {
-				return nil, errors.Wrapf(err, "cannot parse the image reference %s", v.Tag)
-			}
-
-			if cfg.ExplicitRegistry {
-				if dockerRef.Domain == "" {
-					return nil, errors.Wrapf(err, "image reference %s has no domain", v.Tag)
-				}
-
-				value = fmt.Sprintf("%[1]s.registry=%[2]s,%[1]s.repository=%[3]s,%[1]s.tag=%[4]s", k, dockerRef.Domain, dockerRef.Path, dockerRef.Tag)
-			} else {
-				value = fmt.Sprintf("%[1]s.repository=%[2]s,%[1]s.tag=%[3]s", k, dockerRef.BaseName, dockerRef.Tag)
-			}
-		} else {
-			value = fmt.Sprintf("%s=%s", k, v.Tag)
+		cfg := r.ImageStrategy.HelmImageConfig.HelmConventionConfig
+		value, err = getImageSetValueFromHelmStrategy(cfg, k, v.Tag)
+		if err != nil {
+			return nil, err
 		}
 
 		valuesSet[v.Tag] = true
@@ -412,6 +399,34 @@ func (h *HelmDeployer) getReleaseInfo(ctx context.Context, release string) (*buf
 		return nil, fmt.Errorf("error retrieving helm deployment info: %s", releaseInfo.String())
 	}
 	return bufio.NewReader(&releaseInfo), nil
+}
+
+func getImageSetValueFromHelmStrategy(cfg *latest.HelmConventionConfig, valueName string, tag string) (string, error) {
+	if cfg != nil {
+		dockerRef, err := docker.ParseReference(tag)
+		if err != nil {
+			return "", errors.Wrapf(err, "cannot parse the image reference %s", tag)
+		}
+
+		if cfg.ExplicitRegistry {
+			if dockerRef.Domain == "" {
+				return "", errors.New(fmt.Sprintf("image reference %s has no domain", tag))
+			}
+			return fmt.Sprintf(
+				"%[1]s.registry=%[2]s,%[1]s.repository=%[3]s,%[1]s.tag=%[4]s",
+				valueName,
+				dockerRef.Domain,
+				dockerRef.Path,
+				dockerRef.Tag,
+			), nil
+		}
+		return fmt.Sprintf(
+			"%[1]s.repository=%[2]s,%[1]s.tag=%[3]s",
+			valueName, dockerRef.BaseName,
+			dockerRef.Tag,
+		), nil
+	}
+	return fmt.Sprintf("%s=%s", valueName, tag), nil
 }
 
 // Retrieve info about all releases using helm get

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -288,9 +288,9 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 					return nil, errors.Wrapf(err, "image reference %s has no domain", v.Tag)
 				}
 
-				value = fmt.Sprintf("%[1]s.registry=%s,%[1]s.repository=%s,%[1]s.tag=%s", k, dockerRef.Domain, dockerRef.Path, v.Tag)
+				value = fmt.Sprintf("%[1]s.registry=%[2]s,%[1]s.repository=%[3]s,%[1]s.tag=%[4]s", k, dockerRef.Domain, dockerRef.Path, v.Tag)
 			} else {
-				value = fmt.Sprintf("%[1]s.repository=%s,%[1]s.tag=%s", k, dockerRef.BaseName, v.Tag)
+				value = fmt.Sprintf("%[1]s.repository=%[2]s,%[1]s.tag=%[3]s", k, dockerRef.BaseName, v.Tag)
 			}
 		} else {
 			value = fmt.Sprintf("%s=%s", k, v.Tag)

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -541,7 +541,7 @@ func (m *MockHelm) RunCmd(c *exec.Cmd) error {
 	case "get":
 		return m.getResult
 	case "install":
-		if m.upgradeMatcher != nil && !m.installMatcher(c) {
+		if m.installMatcher != nil && !m.installMatcher(c) {
 			m.t.Errorf("install matcher failed to match commands: %+v", c.Args)
 		}
 		return m.installResult


### PR DESCRIPTION
This PR fixes https://github.com/GoogleContainerTools/skaffold/issues/2902 and another bug revealed after fixing the first.

The first is deploying with helm with the following config

`skaffold.yaml`
```
...
deploy:
  helm:
    releases:
      - name: skaffold-helm
        chartPath: k8s/skaffold-helm
        values:
          image: skaffold-helm
        imageStrategy:
          helm: {}
      ...
```
when we deploy with helm we get
```
helm install --set image=skaffold-helm,tag=skaffold:helm
```

because of a bug introduced changing the format string from https://github.com/GoogleContainerTools/skaffold/commit/4899ae571b5a74ff903ceefa1688df6254a79a0d#diff-5c13a6850c742c6b4fa07cf1f6aeb088L210 into https://github.com/GoogleContainerTools/skaffold/commit/4899ae571b5a74ff903ceefa1688df6254a79a0d#diff-5c13a6850c742c6b4fa07cf1f6aeb088R291

> After processing a bracketed expression [n], subsequent verbs will use arguments n+1, n+2, etc. unless otherwise directed.
https://golang.org/pkg/fmt/

After fixing this bug, we get the following incorrect `helm` command
```
helm install --set image=skaffold-helm,tag=skaffold-helm:latest
```

because of the exact same change where `extractTag` was removed.

These were both missed because of https://github.com/GoogleContainerTools/skaffold/commit/4899ae571b5a74ff903ceefa1688df6254a79a0d#diff-a1535a4f321ed1903fdc7f27ac166432L534
where some tests were no longer executed.

ORIGINAL:

To be honest, I'm not totally sure whether the behavior is correct in all possible cases here, given https://github.com/GoogleContainerTools/skaffold/issues/2697 and https://github.com/GoogleContainerTools/skaffold/issues/1379 and given the PR https://github.com/GoogleContainerTools/skaffold/pull/2624 but the tests are all passing (and running) now and `skaffold` is working for us again.