### PR TITLE
Small refactors

### DIFF
--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -82,9 +82,3 @@ func NewDeployment(name string, ns string, deadline time.Duration) *Deployment {
 		status:    newStatus("", nil),
 	}
 }
-
-// For testing
-func (d *Deployment) WithStatus(details string, err error) *Deployment {
-	d.UpdateStatus(details, err)
-	return d
-}

--- a/pkg/skaffold/deploy/status_check.go
+++ b/pkg/skaffold/deploy/status_check.go
@@ -81,7 +81,7 @@ func StatusCheck(ctx context.Context, defaultLabeller *DefaultLabeller, runCtx *
 			defer wg.Done()
 			pollDeploymentRolloutStatus(ctx, kubectl.NewFromRunContext(runCtx), d)
 			pending := c.markProcessed()
-			printStatusCheckSummary(d, pending, c.total, out)
+			printStatusCheckSummary(out, d, pending, c.total)
 		}(d)
 	}
 
@@ -166,7 +166,7 @@ func getDeadline(d int) time.Duration {
 	return defaultStatusCheckDeadline
 }
 
-func printStatusCheckSummary(d *resource.Deployment, pending int, total int, out io.Writer) {
+func printStatusCheckSummary(out io.Writer, d *resource.Deployment, pending int, total int) {
 	status := fmt.Sprintf("%s %s", tabHeader, d)
 	if err := d.Status().Error(); err != nil {
 		status = fmt.Sprintf("%s failed.%s Error: %s.",


### PR DESCRIPTION
1. Refactor signature for `printStatusCheckSummary`
2. Move `Deployment.WithStatus` to `withStatus` since it was used for
testing.