### PR TITLE
Fix test flake TestPollResourceStatus

### DIFF
--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -213,7 +213,7 @@ func (m *mockResource) UpdateStatus(s string, err error) {
 }
 
 func (m *mockResource) Deadline() time.Duration {
-	return 5
+	return 5 * time.Millisecond
 }
 
 func (m *mockResource) CheckStatus(context.Context, *runcontext.RunContext) {


### PR DESCRIPTION
Fixes #2906

# Description
In this PR, add millisecond duration. By default the duration is `Nanosecond` which would get exceeded even before `CheckStatus` had a chance to execute.

# Output changes 
n/a


# Next PRs.
n/a

# Test flake run

## Before 
1. Ran 100 times
```
tejaldesai@@skaffold1 (fix_resource_stable)$ go test ./pkg/skaffold/deploy/...  -run ^TestPollResourceStatus$ -count 100
--- FAIL: TestPollResourceStatus (0.02s)
    --- FAIL: TestPollResourceStatus/resource_stabilizes (0.01s)
        util.go:69: bool differ (-got, +want):   bool(
            - 	false,
            + 	true,
              )
--- FAIL: TestPollResourceStatus (0.02s)
    --- FAIL: TestPollResourceStatus/resource_stabilizes (0.01s)
        util.go:69: bool differ (-got, +want):   bool(
            - 	false,
            + 	true,
              )
--- FAIL: TestPollResourceStatus (0.02s)
    --- FAIL: TestPollResourceStatus/resource_stabilizes (0.01s)
        util.go:69: bool differ (-got, +want):   bool(
            - 	false,
            + 	true,
              )
--- FAIL: TestPollResourceStatus (0.02s)
    --- FAIL: TestPollResourceStatus/resource_stabilizes (0.01s)
        util.go:69: bool differ (-got, +want):   bool(
            - 	false,
            + 	true,
              )
--- FAIL: TestPollResourceStatus (0.02s)
    --- FAIL: TestPollResourceStatus/resource_stabilizes (0.01s)
        util.go:69: bool differ (-got, +want):   bool(
            - 	false,
            + 	true,
              )
--- FAIL: TestPollResourceStatus (0.02s)
    --- FAIL: TestPollResourceStatus/resource_stabilizes (0.01s)
        util.go:69: bool differ (-got, +want):   bool(
            - 	false,
            + 	true,
              )
--- FAIL: TestPollResourceStatus (0.02s)
    --- FAIL: TestPollResourceStatus/resource_stabilizes (0.01s)
        util.go:69: bool differ (-got, +want):   bool(
            - 	false,
            + 	true,
              )
--- FAIL: TestPollResourceStatus (0.02s)
    --- FAIL: TestPollResourceStatus/resource_stabilizes (0.01s)
        util.go:69: bool differ (-got, +want):   bool(
            - 	false,
            + 	true,
              )
--- FAIL: TestPollResourceStatus (0.02s)
    --- FAIL: TestPollResourceStatus/resource_stabilizes (0.01s)
        util.go:69: bool differ (-got, +want):   bool(
            - 	false,
            + 	true,
              )
--- FAIL: TestPollResourceStatus (0.02s)
    --- FAIL: TestPollResourceStatus/resource_stabilizes (0.01s)
        util.go:69: bool differ (-got, +want):   bool(
            - 	false,
            + 	true,
              )
FAIL
FAIL	github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy	2.259s
```

## After
Ran 1000 times.
```
tejaldesai@@skaffold1 (fix_resource_stable)$ go test ./pkg/skaffold/deploy/...  -run ^TestPollResourceStatus$ -count 1000
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy	30.830s
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl	0.142s [no tests to run]
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/resource	0.109s [no tests to run]
tejaldesai@@skaffold1 (fix_resource_stable)$
```