### PR TITLE
Add missing T.Helper() in testutil.Check* as required

### DIFF
--- a/testutil/util.go
+++ b/testutil/util.go
@@ -55,25 +55,29 @@ func (t *T) Override(dest, tmp interface{}) {
 }
 
 func (t *T) CheckMatches(pattern, actual string) {
-	t.T.Helper()
+	t.Helper()
 	if matches, _ := regexp.MatchString(pattern, actual); !matches {
 		t.Errorf("expected output %s to match: %s", actual, pattern)
 	}
 }
 
 func (t *T) CheckContains(expected, actual string) {
+	t.Helper()
 	CheckContains(t.T, expected, actual)
 }
 
 func (t *T) CheckDeepEqual(expected, actual interface{}, opts ...cmp.Option) {
+	t.Helper()
 	CheckDeepEqual(t.T, expected, actual, opts...)
 }
 
 func (t *T) CheckErrorAndDeepEqual(shouldErr bool, err error, expected, actual interface{}, opts ...cmp.Option) {
+	t.Helper()
 	CheckErrorAndDeepEqual(t.T, shouldErr, err, expected, actual, opts...)
 }
 
 func (t *T) CheckError(shouldErr bool, err error) {
+	t.Helper()
 	CheckError(t.T, shouldErr, err)
 }
 


### PR DESCRIPTION
Turns

```
--- FAIL: TestWalk (0.02s)
    --- FAIL: TestWalk/should_return_correct_k8_configs_and_build_files (0.00s)
        util.go:69: int differ (-got, +want):   int(
            - 	4,
            + 	5,
              )
        util.go:69: string differ (-got, +want):   strings.Join({
              	"/var/folders/mx/_6wvyq4n3psb4nj95d8ycpv80000gn/T/skaffold7141983",
              	"63/",
            - 	"maven/pom.xml",
            + 	"gradle-kotlin/build.gradle.kts",
              }, "")
```

into

```
--- FAIL: TestWalk (0.02s)
    --- FAIL: TestWalk/should_return_correct_k8_configs_and_build_files (0.00s)
        init_test.go:281: int differ (-got, +want):   int(
            - 	4,
            + 	5,
              )
        init_test.go:283: string differ (-got, +want):   strings.Join({
              	"/var/folders/mx/_6wvyq4n3psb4nj95d8ycpv80000gn/T/skaffold9003403",
              	"91/",
            - 	"maven/pom.xml",
            + 	"gradle-kotlin/build.gradle.kts",
              }, "")
```