### PR TITLE
Add Jib-Gradle support for Kotlin buildscripts

### DIFF
--- a/pkg/skaffold/jib/jib.go
+++ b/pkg/skaffold/jib/jib.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -67,7 +68,7 @@ func PluginName(t PluginType) string {
 	case JibGradle:
 		return "Jib Gradle Plugin"
 	}
-	panic("Unknown Jib Plugin Type: " + string(t))
+	panic("Unknown Jib Plugin Type: " + strconv.Itoa(int(t)))
 }
 
 // filesLists contains cached build/input dependencies
@@ -115,7 +116,7 @@ func DeterminePluginType(workspace string, artifact *latest.JibArtifact) (Plugin
 	}
 
 	// check for typical gradle files
-	for _, gradleFile := range []string{"build.gradle", "gradle.properties", "settings.gradle", "gradlew", "gradlew.bat", "gradlew.cmd"} {
+	for _, gradleFile := range []string{"build.gradle", "build.gradle.kts", "gradle.properties", "settings.gradle", "gradlew", "gradlew.bat", "gradlew.cmd"} {
 		if util.IsFile(filepath.Join(workspace, gradleFile)) {
 			return JibGradle, nil
 		}

--- a/pkg/skaffold/jib/jib_init.go
+++ b/pkg/skaffold/jib/jib_init.go
@@ -113,7 +113,7 @@ func ValidateJibConfig(path string) []Jib {
 		executable = "mvn"
 		wrapper = "mvnw"
 		taskName = "jib:_skaffold-init"
-	case strings.HasSuffix(path, "build.gradle"):
+	case strings.HasSuffix(path, "build.gradle"), strings.HasSuffix(path, "build.gradle.kts"):
 		builderType = JibGradle
 		executable = "gradle"
 		wrapper = "gradlew"

--- a/pkg/skaffold/jib/jib_init_test.go
+++ b/pkg/skaffold/jib/jib_init_test.go
@@ -57,6 +57,17 @@ func TestValidateJibConfig(t *testing.T) {
 			},
 		},
 		{
+			description: "jib gradle-kotlin single project",
+			path:        "path/to/build.gradle.kts",
+			command:     "gradle _jibSkaffoldInit -q",
+			stdout: `BEGIN JIB JSON
+{"image":"image","project":"project"}
+`,
+			expectedConfig: []Jib{
+				{BuilderName: PluginName(JibGradle), FilePath: "path/to/build.gradle.kts", Image: "image", Project: "project"},
+			},
+		},
+		{
 			description: "jib gradle multi-project",
 			path:        "path/to/build.gradle",
 			command:     "gradle _jibSkaffoldInit -q",

--- a/pkg/skaffold/jib/jib_test.go
+++ b/pkg/skaffold/jib/jib_test.go
@@ -177,9 +177,10 @@ func TestDeterminePluginType(t *testing.T) {
 		{"gradle-4", []string{"gradlew.bat"}, nil, false, JibGradle},
 		{"gradle-5", []string{"gradlew.cmd"}, nil, false, JibGradle},
 		{"gradle-6", []string{"settings.gradle"}, nil, false, JibGradle},
+		{"gradle-kotlin-1", []string{"build.gradle.kts"}, nil, false, JibGradle},
 		{"maven-1", []string{"pom.xml"}, nil, false, JibMaven},
 		{"maven-2", []string{".mvn/maven.config"}, nil, false, JibMaven},
-		{"maven-2", []string{".mvn/extensions.xml"}, nil, false, JibMaven},
+		{"maven-3", []string{".mvn/extensions.xml"}, nil, false, JibMaven},
 		{"gradle override", []string{"pom.xml"}, &latest.JibArtifact{Type: int(JibGradle)}, false, JibGradle},
 		{"maven override", []string{"build.gradle"}, &latest.JibArtifact{Type: int(JibMaven)}, false, JibMaven},
 	}


### PR DESCRIPTION
Add detection support for `build.gradle.kts` files for Gradle Kotlin buildscripts.

Fixes #2820 