### PR TITLE
added support for interface type in schema check

### DIFF
--- a/hack/versions/pkg/diff/godiff.go
+++ b/hack/versions/pkg/diff/godiff.go
@@ -111,6 +111,8 @@ func baseTypeName(x ast.Expr) (name string) {
 		return baseTypeName(t.X)
 	case *ast.StarExpr:
 		return "*" + baseTypeName(t.X)
+	case *ast.InterfaceType:
+		return "interface{}"
 	default:
 		panic(fmt.Errorf("not covered %+v %+v ", t, x))
 	}

--- a/hack/versions/pkg/diff/godiff_test.go
+++ b/hack/versions/pkg/diff/godiff_test.go
@@ -64,6 +64,31 @@ func TestCmpGoStructs(t *testing.T) {
 			shouldErr: false,
 		},
 		{
+			name: "all supported types",
+			a: `package a
+type TestStructure struct {
+	a string			// Ident
+	b map[string]int 	// MapType
+	c []interface{} 	// InterfaceType
+	d []byte	 		// ArrayType
+	e (error)    		// ParenExpr
+	f *ast.Ident 		// SelectorExpr and StarExpr
+}
+`,
+			b: `package a
+type TestStructure struct {
+	a string			// Ident
+	b map[string]int 	// MapType
+	c []interface{} 	// InterfaceType
+	d []byte	 		// ArrayType
+	e (error)    		// ParenExpr
+	f *ast.Ident 		// SelectorExpr and StarExpr
+}
+`,
+			same:      true,
+			shouldErr: false,
+		},
+		{
 			name: "renamed struct: not same",
 			a: `package a
 //a comment


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

PR [ 1 / 3] breaking down #2917. 
Related to #2775.

**Description**

Adds support for `interface{}` type signature to schema changes checker. It would panic otherwise on `v1beta5` for example.

**User facing changes**

n/a

**Next PRs.**

- [ ] (6 files) the new comment management logic and hooking it up to `release` and `new_config` 
- [ ] (20 files) update of the comments historically on all config.go files 

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [X] Mentions any output changes.
- [X] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [X] Adds integration tests if needed.

**Reviewer Notes**

- [x] The code flow looks good. 
- [x] Unit test added.
- [x] User facing changes look good.

