### PR TITLE
Include build args in cache hash generation

### DIFF
--- a/pkg/skaffold/build/cache/hash.go
+++ b/pkg/skaffold/build/cache/hash.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"sort"
@@ -61,6 +62,12 @@ func getHashForArtifact(ctx context.Context, depLister DependencyLister, a *late
 		inputs = append(inputs, h)
 	}
 
+	// add build args for the artifact if specified
+	if buildArgs := retrieveBuildArgs(a); buildArgs != nil {
+		args := convertBuildArgsToStringArray(buildArgs)
+		inputs = append(inputs, args...)
+	}
+
 	// get a key for the hashes
 	hasher := sha256.New()
 	enc := json.NewEncoder(hasher)
@@ -78,6 +85,33 @@ func artifactConfig(a *latest.Artifact) (string, error) {
 	}
 
 	return string(buf), nil
+}
+
+func retrieveBuildArgs(a *latest.Artifact) map[string]*string {
+	if a.ArtifactType.DockerArtifact != nil {
+		return a.ArtifactType.DockerArtifact.BuildArgs
+	}
+	if a.ArtifactType.KanikoArtifact != nil {
+		return a.KanikoArtifact.BuildArgs
+	}
+	customArtifact := a.ArtifactType.CustomArtifact
+	if customArtifact != nil && customArtifact.Dependencies.Dockerfile != nil {
+		return customArtifact.Dependencies.Dockerfile.BuildArgs
+	}
+	return nil
+}
+
+func convertBuildArgsToStringArray(buildArgs map[string]*string) []string {
+	var args []string
+	for k, v := range buildArgs {
+		if v == nil {
+			args = append(args, k)
+			continue
+		}
+		args = append(args, fmt.Sprintf("%s=%s", k, *v))
+	}
+	sort.Strings(args)
+	return args
 }
 
 // cacheHasher takes hashes the contents and name of a file

--- a/pkg/skaffold/build/cache/hash.go
+++ b/pkg/skaffold/build/cache/hash.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/pkg/errors"
 )
@@ -64,6 +65,10 @@ func getHashForArtifact(ctx context.Context, depLister DependencyLister, a *late
 
 	// add build args for the artifact if specified
 	if buildArgs := retrieveBuildArgs(a); buildArgs != nil {
+		buildArgs, err := docker.EvaluateBuildArgs(buildArgs)
+		if err != nil {
+			return "", errors.Wrap(err, "evaluating build args")
+		}
 		args := convertBuildArgsToStringArray(buildArgs)
 		inputs = append(inputs, args...)
 	}

--- a/pkg/skaffold/build/cache/hash_test.go
+++ b/pkg/skaffold/build/cache/hash_test.go
@@ -189,10 +189,9 @@ func TestBuildArgsEnvSubstitution(t *testing.T) {
 		t.Override(&artifactConfigFunction, fakeArtifactConfig)
 
 		depLister := &stubDependencyLister{dependencies: []string{"dep"}}
-		actual, err := getHashForArtifact(context.Background(), depLister, artifact)
+		hash1, err := getHashForArtifact(context.Background(), depLister, artifact)
 
 		t.CheckNoError(err)
-		t.CheckDeepEqual("afc018228939a12195994275d6a24ef8f0eb7fa5019ae0582b2daf9e4c353656", actual)
 
 		// Make sure hash is different with a new env
 
@@ -200,10 +199,12 @@ func TestBuildArgsEnvSubstitution(t *testing.T) {
 			return []string{"FOO=baz"}
 		}
 
-		actual, err = getHashForArtifact(context.Background(), depLister, artifact)
+		hash2, err := getHashForArtifact(context.Background(), depLister, artifact)
 
 		t.CheckNoError(err)
-		t.CheckDeepEqual("f698ab606ce86ad1c6b7842890a6573060dfaa770e6df0913076f83f14ac32ae", actual)
+		if hash1 == hash2 {
+			t.Fatal("hashes are the same even though build arg changed")
+		}
 	})
 }
 


### PR DESCRIPTION
Fixes #2922


**Description**

Include build args in cache hash generation. This should fix the bug
described in #2922, where changing buildArgs resulted in the same
cache key, causing incorrect deployments.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes. 
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference. 
- [x] Adds integration tests if needed.

**Reviewer Notes**

- [x] The code flow looks good. 
- [x] Unit test added.
- [x] User facing changes look good.


**Release Notes**

Describe any user facing changes here so maintainer can include it in the release notes, or delete this block.

Include build args in cache hash generation. This should fix the bug
described in #2922, where changing buildArgs resulted in the same
cache key, causing incorrect deployments.
