### PR TITLE
Fix Flake TestPollResourceStatus/resource_stabilizes by removing sleep from test.

### DIFF
--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -226,7 +226,6 @@ func (m *mockResource) IsStatusCheckComplete() bool {
 func TestPollResourceStatus(t *testing.T) {
 	tests := []struct {
 		description   string
-		pollTime      int
 		dummyResource *mockResource
 		isInErr       bool
 	}{

--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -226,6 +226,7 @@ func (m *mockResource) IsStatusCheckComplete() bool {
 func TestPollResourceStatus(t *testing.T) {
 	tests := []struct {
 		description   string
+		pollTime      int
 		dummyResource *mockResource
 		isInErr       bool
 	}{
@@ -241,7 +242,7 @@ func TestPollResourceStatus(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&defaultPollPeriodInMilliseconds, 10)
+			t.Override(&defaultPollPeriodInMilliseconds, 0)
 			pollResourceStatus(context.Background(), nil, test.dummyResource)
 			t.CheckDeepEqual(test.dummyResource.inErr, test.isInErr)
 		})


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes: #2906

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Fixes test flake by setting `defaultPollingPeriod` to 0
**User facing changes**

Write n/a if not output or log lines changed and no behavior is changed

**Before**

n/a
**After**
n/a

**Next PRs.**

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

Describe any user facing changes here so maintainer can include it in the release notes, or delete this block.