### PR TITLE
Add unimplemented 'skaffold render' command

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -136,6 +136,7 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 				NewCmdBuild(),
 				NewCmdDeploy(),
 				NewCmdDelete(),
+				NewCmdRender(),
 			},
 		},
 		{

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -230,6 +230,14 @@ var FlagRegistry = []Flag{
 		DefinedOn:     []string{"dev", "debug", "deploy", "run"},
 	},
 	{
+		Name:          "render-only",
+		Usage:         "Print rendered kubernetes manifests instead of deploying them",
+		Value:         &opts.RenderOnly,
+		DefValue:      false,
+		FlagAddMethod: "BoolVar",
+		DefinedOn:     []string{"dev", "run"},
+	},
+	{
 		Name:          "config",
 		Shorthand:     "c",
 		Usage:         "File for global configurations (defaults to $HOME/.skaffold/config)",

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+var (
+	showBuild        bool
+	renderOutputPath string
+)
+
+// NewCmdRender describes the CLI command to build artifacts render kubernetes manifests.
+func NewCmdRender() *cobra.Command {
+	return NewCmd("render").
+		WithDescription("Perform all image builds, and output rendered kubernetes manifests").
+		WithCommonFlags().
+		WithFlags(func(f *pflag.FlagSet) {
+			f.BoolVar(&showBuild, "loud", false, "Show the build logs and output")
+			f.StringVar(&renderOutputPath, "output", "", "file to write rendered manifests to")
+		}).
+		NoArgs(cancelWithCtrlC(context.Background(), doRender))
+}
+
+func doRender(ctx context.Context, out io.Writer) error {
+	buildOut := ioutil.Discard
+	if showBuild {
+		buildOut = out
+	}
+
+	return withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
+		bRes, err := r.BuildAndTest(ctx, buildOut, targetArtifacts(opts, config))
+
+		if err != nil {
+			return errors.Wrap(err, "executing build")
+		}
+
+		if err := r.Render(ctx, out, bRes, renderOutputPath); err != nil {
+			return errors.Wrap(err, "rendering manifests")
+		}
+		return nil
+	})
+}

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -17,6 +17,7 @@ Pipeline building blocks for CI/CD:
 * [skaffold build](#skaffold-build) - to just build and tag your image(s)
 * [skaffold deploy](#skaffold-deploy) - to deploy the given image(s)
 * [skaffold delete](#skaffold-delete) - to cleanup the deployed artifacts
+* [skaffold render](#skaffold-render) - build and tag images, and output templated kubernetes manifests
 
 Getting started with a new project:
 
@@ -71,6 +72,7 @@ Pipeline building blocks for CI/CD:
   build             Build the artifacts
   deploy            Deploy pre-built artifacts
   delete            Delete the deployed application
+  render            Perform all image builds, and output rendered kubernetes manifests
 
 Getting started with a new project:
   init              Generate configuration for deploying an application
@@ -446,6 +448,7 @@ Options:
       --no-prune-children=false: Skip removing layers reused by Skaffold
       --port-forward=false: Port-forward exposed container ports within pods
   -p, --profile=[]: Activate profiles by name
+      --render-only=false: Print rendered kubernetes manifests instead of deploying them
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
@@ -480,6 +483,7 @@ Env vars:
 * `SKAFFOLD_NO_PRUNE_CHILDREN` (same as `--no-prune-children`)
 * `SKAFFOLD_PORT_FORWARD` (same as `--port-forward`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
+* `SKAFFOLD_RENDER_ONLY` (same as `--render-only`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
@@ -580,6 +584,37 @@ The following options can be passed to any command:
 
 ```
 
+### skaffold render
+
+Perform all image builds, and output rendered kubernetes manifests
+
+```
+
+
+Options:
+  -d, --default-repo='': Default repository value (overrides global config)
+  -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
+      --loud=false: Show the build logs and output
+  -n, --namespace='': Run deployments in the specified namespace
+      --output='': file to write rendered manifests to
+  -p, --profile=[]: Activate profiles by name
+
+Usage:
+  skaffold render [options]
+
+Use "skaffold options" for a list of global command-line options (applies to all commands).
+
+
+```
+Env vars:
+
+* `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
+* `SKAFFOLD_FILENAME` (same as `--filename`)
+* `SKAFFOLD_LOUD` (same as `--loud`)
+* `SKAFFOLD_NAMESPACE` (same as `--namespace`)
+* `SKAFFOLD_OUTPUT` (same as `--output`)
+* `SKAFFOLD_PROFILE` (same as `--profile`)
+
 ### skaffold run
 
 Run a pipeline
@@ -610,6 +645,7 @@ Options:
       --no-prune=false: Skip removing images and containers built by Skaffold
       --no-prune-children=false: Skip removing layers reused by Skaffold
   -p, --profile=[]: Activate profiles by name
+      --render-only=false: Print rendered kubernetes manifests instead of deploying them
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
@@ -641,6 +677,7 @@ Env vars:
 * `SKAFFOLD_NO_PRUNE` (same as `--no-prune`)
 * `SKAFFOLD_NO_PRUNE_CHILDREN` (same as `--no-prune-children`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
+* `SKAFFOLD_RENDER_ONLY` (same as `--render-only`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)

--- a/docs/content/en/docs/references/cli/index_header
+++ b/docs/content/en/docs/references/cli/index_header
@@ -17,6 +17,7 @@ Pipeline building blocks for CI/CD:
 * [skaffold build](#skaffold-build) - to just build and tag your image(s)
 * [skaffold deploy](#skaffold-deploy) - to deploy the given image(s)
 * [skaffold delete](#skaffold-delete) - to cleanup the deployed artifacts
+* [skaffold render](#skaffold-render) - build and tag images, and output templated kubernetes manifests
 
 Getting started with a new project:
 

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -49,6 +49,7 @@ type SkaffoldOptions struct {
 	AutoBuild          bool
 	AutoSync           bool
 	AutoDeploy         bool
+	RenderOnly         bool
 	PortForward        PortForwardOptions
 	CustomTag          string
 	Namespace          string

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -29,6 +29,10 @@ import (
 )
 
 func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []build.Artifact) error {
+	if r.runCtx.Opts.RenderOnly {
+		return r.Render(ctx, out, artifacts, "")
+	}
+
 	if config.IsKindCluster(r.runCtx.KubeContext) {
 		// With `kind`, docker images have to be loaded with the `kind` CLI.
 		if err := r.loadImagesInKindNodes(ctx, out, artifacts); err != nil {

--- a/pkg/skaffold/runner/render.go
+++ b/pkg/skaffold/runner/render.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+)
+
+func (r *SkaffoldRunner) Render(ctx context.Context, out io.Writer, builds []build.Artifact, filepath string) error {
+	return r.deployer.Render(ctx, out, builds, filepath)
+}

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -40,6 +40,7 @@ type Runner interface {
 	BuildAndTest(context.Context, io.Writer, []*latest.Artifact) ([]build.Artifact, error)
 	DeployAndLog(context.Context, io.Writer, []build.Artifact) error
 	GeneratePipeline(context.Context, io.Writer, *latest.SkaffoldConfig, []string, string) error
+	Render(context.Context, io.Writer, []build.Artifact, string) error
 	Cleanup(context.Context, io.Writer) error
 	Prune(context.Context, io.Writer) error
 	HasDeployed() bool

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -18,7 +18,6 @@ package runner
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -172,7 +171,7 @@ func (t *TestBench) Deploy(_ context.Context, _ io.Writer, artifacts []build.Art
 }
 
 func (t *TestBench) Render(_ context.Context, _ io.Writer, artifacts []build.Artifact, _ string) error {
-	return errors.New("not yet implemented")
+	return nil
 }
 
 func (t *TestBench) Actions() []Actions {


### PR DESCRIPTION
Relates to #1187 

This adds a new command, `skaffold render`, which will run builds for all artifacts, tag the images, and then output the templated kubernetes manifests to the user rather than actually running the deploy. The manifests are written to stdout by default, but a --output flag can be passed to provide a filename for them to be written to. These manifests can be manually applied by the user if desired, or committed to a repository for use in CI/CD or GitOps workflows.

**This does not add implementations for any deployers. Those will come in follow up PRs.**

This also adds a flag, --render-only to skaffold dev and skaffold run, which will exhibit the same behavior as skaffold render (though in dev mode it will continuously print the templated manifests after each successful build).

By default, the logs and output for the builds are suppressed, but can be displayed using a --loud flag.