### PR TITLE
reset deploy state

### DIFF
--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -399,3 +399,12 @@ func ResetStateOnBuild() {
 	newState := emptyStateWithArtifacts(builds)
 	handler.setState(newState)
 }
+
+// ResetStateOnDeploy resets the deploy, sync and status check state
+func ResetStateOnDeploy() {
+	newState := handler.getState()
+	newState.DeployState.Status = NotStarted
+	newState.StatusCheckState.Status = NotStarted
+	newState.ForwardedPorts = map[int32]*proto.PortEvent{}
+	handler.setState(newState)
+}

--- a/pkg/skaffold/event/event_test.go
+++ b/pkg/skaffold/event/event_test.go
@@ -276,7 +276,14 @@ func TestResetStateOnBuild(t *testing.T) {
 					"image1": Complete,
 				},
 			},
-			DeployState:      &proto.DeployState{Status: Complete},
+			DeployState: &proto.DeployState{Status: Complete},
+			ForwardedPorts: map[int32]*proto.PortEvent{
+				2001: {
+					LocalPort:  2000,
+					RemotePort: 2001,
+					PodName:    "test/pod",
+				},
+			},
 			StatusCheckState: &proto.StatusCheckState{Status: Complete},
 		},
 	}
@@ -302,8 +309,14 @@ func TestResetStateOnDeploy(t *testing.T) {
 					"image1": Complete,
 				},
 			},
-
-			DeployState:      &proto.DeployState{Status: Complete},
+			DeployState: &proto.DeployState{Status: Complete},
+			ForwardedPorts: map[int32]*proto.PortEvent{
+				2001: {
+					LocalPort:  2000,
+					RemotePort: 2001,
+					PodName:    "test/pod",
+				},
+			},
 			StatusCheckState: &proto.StatusCheckState{Status: Complete},
 		},
 	}
@@ -311,7 +324,7 @@ func TestResetStateOnDeploy(t *testing.T) {
 	expected := proto.State{
 		BuildState: &proto.BuildState{
 			Artifacts: map[string]string{
-				"image1": NotStarted,
+				"image1": Complete,
 			},
 		},
 		DeployState:      &proto.DeployState{Status: NotStarted},

--- a/pkg/skaffold/event/event_test.go
+++ b/pkg/skaffold/event/event_test.go
@@ -292,3 +292,30 @@ func TestResetStateOnBuild(t *testing.T) {
 	}
 	testutil.CheckDeepEqual(t, expected, handler.getState())
 }
+
+func TestResetStateOnDeploy(t *testing.T) {
+	defer func() { handler = &eventHandler{} }()
+	handler = &eventHandler{
+		state: proto.State{
+			BuildState: &proto.BuildState{
+				Artifacts: map[string]string{
+					"image1": Complete,
+				},
+			},
+
+			DeployState:      &proto.DeployState{Status: Complete},
+			StatusCheckState: &proto.StatusCheckState{Status: Complete},
+		},
+	}
+	ResetStateOnDeploy()
+	expected := proto.State{
+		BuildState: &proto.BuildState{
+			Artifacts: map[string]string{
+				"image1": NotStarted,
+			},
+		},
+		DeployState:      &proto.DeployState{Status: NotStarted},
+		StatusCheckState: &proto.StatusCheckState{Status: NotStarted},
+	}
+	testutil.CheckDeepEqual(t, expected, handler.getState())
+}

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -82,6 +82,7 @@ func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer) error {
 	}
 
 	if needsDeploy {
+		event.ResetStateOnDeploy()
 		defer func() {
 			r.changeSet.resetDeploy()
 			r.intents.resetDeploy()

--- a/pkg/skaffold/server/endpoints.go
+++ b/pkg/skaffold/server/endpoints.go
@@ -50,6 +50,7 @@ func (s *server) Execute(ctx context.Context, intent *proto.UserIntentRequest) (
 	}
 
 	if intent.GetIntent().GetDeploy() {
+		event.ResetStateOnDeploy()
 		go func() {
 			s.deployIntentCallback()
 		}()


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to #2940

**Description**
Reset Deploy state when a Deploy Trigger is received or via Control API, a deploy request is sent.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**Before**
skaffold Build from master, run with RPC.
1. cd examples/microservices
```
skaffold dev --default-repo=gcr.io/tejal-test --auto-deploy=false --enable-rpc -v=debug --port-forward
```
2. Change a file (only build shd happen)
3.  Sent a deploy intent and get the state

```
$ curl localhost:50052/v1/execute -d '{"deploy": true}' &&  localhost:50052/v1/state | jq
{}  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   453  100   453    0     0   221k      0 --:--:-- --:--:-- --:--:--  221k
{
  "buildState": {
    "artifacts": {
      "gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-app": "Complete",
      "gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-web": "Complete"
    }
  },
  "deployState": {
    "status": "Complete"
  },
  "forwardedPorts": {
    "9000": {
      "localPort": 9000,
      "remotePort": 8080,
      "namespace": "default",
      "resourceType": "deployment",
      "resourceName": "leeroy-web"
    },
    "50053": {
      "localPort": 50053,
      "remotePort": 50051,
      "namespace": "default",
      "resourceType": "service",
      "resourceName": "leeroy-app"
    }
  }
}
```
Note:  Deploy state is complete.
**After**

1. skaffold Build from master, run with RPC.
```
cd examples/microservices
../../out/skaffold dev --default-repo=gcr.io/tejal-test  --auto-deploy=false --enable-rpc -v=debug --port-forward
```
2. Change a file ( Only Build shd happen)

3. Send a deploy intent and curl the state
```
tejaldesai@@skaffold (reset-on-deploy)$ curl localhost:50052/v1/execute -d '{"deploy": true}' && curl localhost:50052/v1/state | jq
{}  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   237  100   237    0     0   231k      0 --:--:-- --:--:-- --:--:--  231k
{
  "buildState": {
    "artifacts": {
      "gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-app": "Complete",
      "gcr.io/tejal-test/gcr.io/k8s-skaffold/leeroy-web": "Complete"
    }
  },
  "deployState": {
    "status": "Not Started"
  },
  "statusCheckState": {
    "status": "Not Started"
  }
}

```
**Next PRs.**
None

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [X] Mentions any output changes.
- [X] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [X] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

Describe any user facing changes here so maintainer can include it in the release notes, or delete this block.