### PR TITLE
Fix bugs in insecure registries for kaniko

### DIFF
--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -344,6 +344,13 @@ func TestExpectedBuildFailures(t *testing.T) {
 }
 
 func TestBuildKanikoInsecureRegistry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	if ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is not gcp only")
+	}
+
 	ns, k8sClient, cleanupNs := SetupNamespace(t)
 	defer cleanupNs()
 

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -347,8 +347,10 @@ func TestBuildKanikoInsecureRegistry(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
-	if ShouldRunGCPOnlyTests() {
-		t.Skip("skipping test that is not gcp only")
+
+	// run on GCP as this test requires a load balancer
+	if !ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is gcp only")
 	}
 
 	ns, k8sClient, cleanupNs := SetupNamespace(t)

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -18,6 +18,7 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -34,6 +35,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/pkg/webhook/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	"github.com/docker/docker/api/types"
 	"github.com/sirupsen/logrus"
@@ -339,4 +341,41 @@ func TestExpectedBuildFailures(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildKanikoInsecureRegistry(t *testing.T) {
+	ns, k8sClient, cleanupNs := SetupNamespace(t)
+	defer cleanupNs()
+
+	dir := "testdata/kaniko-insecure-registry"
+
+	cleanup := deployInsecureRegistry(t, ns.Name, dir)
+	defer cleanup()
+
+	ip := getExternalIP(t, k8sClient, ns.Name)
+	registry := fmt.Sprintf("%s:5000", ip)
+
+	skaffold.Build("--insecure-registry", registry, "-d", registry, "-p", "build-artifact").InDir(dir).InNs(ns.Name).RunOrFailOutput(t)
+}
+
+func deployInsecureRegistry(t *testing.T, ns, dir string) func() {
+	skaffold.Run("-p", "deploy-insecure-registry").InDir(dir).InNs(ns).RunOrFailOutput(t)
+
+	cleanup := func() {
+		skaffold.Delete("-p", "deploy-insecure-registry").InDir(dir).InNs(ns).RunOrFailOutput(t)
+	}
+	return cleanup
+}
+
+func getExternalIP(t *testing.T, c *NSKubernetesClient, ns string) string {
+	svc, err := c.client.CoreV1().Services(ns).Get("registry", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("error getting registry service: %v", err)
+	}
+	// Wait for external IP of service
+	ip, err := kubernetes.GetExternalIP(svc)
+	if err != nil {
+		t.Fatalf("error getting external ip: %v", err)
+	}
+	return ip
 }

--- a/integration/testdata/kaniko-insecure-registry/app/Dockerfile
+++ b/integration/testdata/kaniko-insecure-registry/app/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.12.9-alpine3.10 as builder
+COPY main.go .
+RUN go build -o /app main.go
+
+FROM alpine:3.10
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/kaniko-insecure-registry/app/main.go
+++ b/integration/testdata/kaniko-insecure-registry/app/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/testdata/kaniko-insecure-registry/app/skaffold.yaml
+++ b/integration/testdata/kaniko-insecure-registry/app/skaffold.yaml
@@ -1,0 +1,9 @@
+apiVersion: skaffold/v1beta15
+kind: Config
+build:
+  artifacts:
+  - image: gcr.io/k8s-skaffold/skaffold-example
+deploy:
+  kubectl:
+    manifests:
+      - k8s-*

--- a/integration/testdata/kaniko-insecure-registry/insecure-registry/Dockerfile
+++ b/integration/testdata/kaniko-insecure-registry/insecure-registry/Dockerfile
@@ -1,0 +1,3 @@
+FROM registry:2
+
+ADD config.yaml /etc/docker/registry/config.yml

--- a/integration/testdata/kaniko-insecure-registry/insecure-registry/config.yaml
+++ b/integration/testdata/kaniko-insecure-registry/insecure-registry/config.yaml
@@ -1,0 +1,18 @@
+version: 0.1
+log:
+  fields:
+    service: registry
+storage:
+  cache:
+    blobdescriptor: inmemory
+  filesystem:
+    rootdirectory: /var/lib/registry
+http:
+  addr: 0.0.0.0:5000
+  headers:
+    X-Content-Type-Options: [nosniff]
+health:
+  storagedriver:
+    enabled: true
+    interval: 10s
+    threshold: 3

--- a/integration/testdata/kaniko-insecure-registry/insecure-registry/reg.yaml
+++ b/integration/testdata/kaniko-insecure-registry/insecure-registry/reg.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: registry
+  labels:
+    app: registry
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 5000
+      name: registry
+  selector:
+    app: registry
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  labels:
+    app: registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      containers:
+        - name: registry
+          image: gcr.io/k8s-skaffold/devreg
+          ports:
+            - containerPort: 50051

--- a/integration/testdata/kaniko-insecure-registry/skaffold.yaml
+++ b/integration/testdata/kaniko-insecure-registry/skaffold.yaml
@@ -1,0 +1,24 @@
+apiVersion: skaffold/v1beta15
+kind: Config
+profiles:
+  - name: build-artifact
+    build:
+      artifacts:
+        - image: kaniko-insecure
+          context: app
+          kaniko:
+            cache: {}
+            buildContext:
+              localDir: {}
+      cluster:
+        pullSecretName: e2esecret
+  - name: deploy-insecure-registry
+    build:
+      artifacts:
+        - image: gcr.io/k8s-skaffold/devreg
+          context: insecure-registry
+          docker: {}
+    deploy:
+      kubectl:
+        manifests:
+          - insecure-registry/reg.yaml

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -45,7 +45,7 @@ func (b *Builder) runKanikoBuild(ctx context.Context, out io.Writer, artifact *l
 	}
 	defer s.Cleanup(ctx)
 
-	args, err := args(artifact.KanikoArtifact, context, tag)
+	args, err := args(artifact.KanikoArtifact, context, tag, b.insecureRegistries)
 	if err != nil {
 		return "", errors.Wrap(err, "building args list")
 	}
@@ -85,7 +85,7 @@ func (b *Builder) runKanikoBuild(ctx context.Context, out io.Writer, artifact *l
 	return docker.RemoteDigest(tag, b.insecureRegistries)
 }
 
-func args(artifact *latest.KanikoArtifact, context, tag string) ([]string, error) {
+func args(artifact *latest.KanikoArtifact, context, tag string, insecureRegistries map[string]bool) ([]string, error) {
 	// Create pod spec
 	args := []string{
 		"--dockerfile", artifact.DockerfilePath,
@@ -137,6 +137,10 @@ func args(artifact *latest.KanikoArtifact, context, tag string) ([]string, error
 
 	if artifact.Reproducible {
 		args = append(args, "--reproducible")
+	}
+
+	for reg := range insecureRegistries {
+		args = append(args, "--insecure-registry", reg)
 	}
 
 	return args, nil

--- a/pkg/skaffold/build/cluster/kaniko_test.go
+++ b/pkg/skaffold/build/cluster/kaniko_test.go
@@ -26,10 +26,11 @@ import (
 
 func TestArgs(t *testing.T) {
 	tests := []struct {
-		description  string
-		artifact     *latest.KanikoArtifact
-		shouldErr    bool
-		expectedArgs []string
+		description        string
+		artifact           *latest.KanikoArtifact
+		insecureRegistries map[string]bool
+		shouldErr          bool
+		expectedArgs       []string
 	}{
 		{
 			description: "simple build",
@@ -104,12 +105,20 @@ func TestArgs(t *testing.T) {
 			},
 			shouldErr: true,
 		},
+		{
+			description: "insecure registries",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+			},
+			insecureRegistries: map[string]bool{"localhost:4000": true, "localhost:5000": true},
+			expectedArgs:       []string{"--insecure-registry", "localhost:4000", "--insecure-registry", "localhost:5000"},
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			commonArgs := []string{"--dockerfile", "Dockerfile", "--context", "context", "--destination", "tag", "-v", "info"}
 
-			args, err := args(test.artifact, "context", "tag")
+			args, err := args(test.artifact, "context", "tag", test.insecureRegistries)
 
 			t.CheckError(test.shouldErr, err)
 			if !test.shouldErr {

--- a/pkg/skaffold/build/cluster/kaniko_test.go
+++ b/pkg/skaffold/build/cluster/kaniko_test.go
@@ -110,8 +110,8 @@ func TestArgs(t *testing.T) {
 			artifact: &latest.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 			},
-			insecureRegistries: map[string]bool{"localhost:4000": true, "localhost:5000": true},
-			expectedArgs:       []string{"--insecure-registry", "localhost:4000", "--insecure-registry", "localhost:5000"},
+			insecureRegistries: map[string]bool{"localhost:4000": true},
+			expectedArgs:       []string{"--insecure-registry", "localhost:4000"},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -41,7 +41,7 @@ const (
 
 	DefaultKustomizationPath = "."
 
-	DefaultKanikoImage                  = "gcr.io/kaniko-project/executor:v0.10.0@sha256:78d44ec4e9cb5545d7f85c1924695c89503ded86a59f92c7ae658afa3cff5400"
+	DefaultKanikoImage                  = "gcr.io/kaniko-project/executor:4ce8b8db817047f0be7a78c0fdffab71f797e8f8@sha256:fe1b5a428273309088fb6df563f4d88ab806fe602a7b0b3e8fbe1d7ee5f9ead0"
 	DefaultKanikoSecretName             = "kaniko-secret"
 	DefaultKanikoTimeout                = "20m"
 	DefaultKanikoContainerName          = "kaniko"


### PR DESCRIPTION
This PR:

1. Passes in the `--insecure-registry` flag to kaniko, which allows for
insecure image pull and pushes

1. Updates the kaniko image to one that incorporates this bug fix in
kaniko: https://github.com/GoogleContainerTools/kaniko/pull/685. This
bug fix is required for insecure registries to work with caching in
kaniko.

1. Adds an integration test

I found these bugs while trying to push to my own insecure registry.

**Next PRs.**

n/a

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [x] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.
