### PR TITLE
Add PullSecretMountPath to ClusterDetails

### DIFF
--- a/docs/content/en/schemas/v1beta15.json
+++ b/docs/content/en/schemas/v1beta15.json
@@ -474,6 +474,11 @@
           "description": "path to the Google Cloud service account secret key file.",
           "x-intellij-html-description": "path to the Google Cloud service account secret key file."
         },
+        "pullSecretMountPath": {
+          "type": "string",
+          "description": "path the pull secret will be mounted at within the running container.",
+          "x-intellij-html-description": "path the pull secret will be mounted at within the running container."
+        },
         "pullSecretName": {
           "type": "string",
           "description": "name of the Kubernetes secret for pulling the files from the build context and pushing the final image. If given, the secret needs to contain the Google Cloud service account secret key under the key `kaniko-secret`.",
@@ -496,6 +501,7 @@
         "HTTPS_PROXY",
         "pullSecret",
         "pullSecretName",
+        "pullSecretMountPath",
         "namespace",
         "timeout",
         "dockerConfig",

--- a/docs/content/en/schemas/v1beta15.json
+++ b/docs/content/en/schemas/v1beta15.json
@@ -474,11 +474,6 @@
           "description": "path to the Google Cloud service account secret key file.",
           "x-intellij-html-description": "path to the Google Cloud service account secret key file."
         },
-        "pullSecretMountPath": {
-          "type": "string",
-          "description": "path the pull secret will be mounted at within the running container.",
-          "x-intellij-html-description": "path the pull secret will be mounted at within the running container."
-        },
         "pullSecretName": {
           "type": "string",
           "description": "name of the Kubernetes secret for pulling the files from the build context and pushing the final image. If given, the secret needs to contain the Google Cloud service account secret key under the key `kaniko-secret`.",
@@ -501,7 +496,6 @@
         "HTTPS_PROXY",
         "pullSecret",
         "pullSecretName",
-        "pullSecretMountPath",
         "namespace",
         "timeout",
         "dockerConfig",

--- a/docs/content/en/schemas/v1beta16.json
+++ b/docs/content/en/schemas/v1beta16.json
@@ -474,6 +474,11 @@
           "description": "path to the Google Cloud service account secret key file.",
           "x-intellij-html-description": "path to the Google Cloud service account secret key file."
         },
+        "pullSecretMountPath": {
+          "type": "string",
+          "description": "path the pull secret will be mounted at within the running container.",
+          "x-intellij-html-description": "path the pull secret will be mounted at within the running container."
+        },
         "pullSecretName": {
           "type": "string",
           "description": "name of the Kubernetes secret for pulling the files from the build context and pushing the final image. If given, the secret needs to contain the Google Cloud service account secret key under the key `kaniko-secret`.",
@@ -496,6 +501,7 @@
         "HTTPS_PROXY",
         "pullSecret",
         "pullSecretName",
+        "pullSecretMountPath",
         "namespace",
         "timeout",
         "dockerConfig",

--- a/pkg/skaffold/build/cluster/sources/localdir_test.go
+++ b/pkg/skaffold/build/cluster/sources/localdir_test.go
@@ -55,9 +55,10 @@ func TestPod(t *testing.T) {
 			},
 		},
 		clusterDetails: &latest.ClusterDetails{
-			Namespace:      "ns",
-			PullSecretName: "secret",
-			Resources:      reqs,
+			Namespace:           "ns",
+			PullSecretName:      "secret",
+			PullSecretMountPath: "/secret",
+			Resources:           reqs,
 		},
 	}
 

--- a/pkg/skaffold/build/cluster/sources/sources.go
+++ b/pkg/skaffold/build/cluster/sources/sources.go
@@ -91,7 +91,7 @@ func podTemplate(clusterDetails *latest.ClusterDetails, artifact *latest.KanikoA
 
 	// Add secret for pull secret
 	if clusterDetails.PullSecretName != "" {
-		addSecretVolume(pod, constants.DefaultKanikoSecretName, "/secret", clusterDetails.PullSecretName)
+		addSecretVolume(pod, constants.DefaultKanikoSecretName, clusterDetails.PullSecretMountPath, clusterDetails.PullSecretName)
 	}
 
 	// Add host path volume for cache

--- a/pkg/skaffold/build/cluster/sources/sources_test.go
+++ b/pkg/skaffold/build/cluster/sources/sources_test.go
@@ -68,7 +68,8 @@ func TestPodTemplate(t *testing.T) {
 		{
 			description: "with docker config",
 			initial: &latest.ClusterDetails{
-				PullSecretName: "pull-secret",
+				PullSecretName:      "pull-secret",
+				PullSecretMountPath: "/secret",
 				DockerConfig: &latest.DockerConfig{
 					SecretName: "docker-cfg",
 					Path:       "/kaniko/.docker",

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -51,6 +51,7 @@ const (
 	DefaultKanikoCacheDirMountPath      = "/cache"
 	DefaultKanikoDockerConfigSecretName = "docker-cfg"
 	DefaultKanikoDockerConfigPath       = "/kaniko/.docker"
+	DefaultKanikoSecretMountPath        = "/secret"
 
 	DefaultBusyboxImage = "busybox"
 

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -217,6 +217,7 @@ func setDefaultClusterPullSecret(cluster *latest.ClusterDetails) error {
 		}
 		cluster.PullSecret = absPath
 		cluster.PullSecretName = valueOrDefault(cluster.PullSecretName, constants.DefaultKanikoSecretName)
+		cluster.PullSecretMountPath = valueOrDefault(cluster.PullSecretMountPath, constants.DefaultKanikoSecretMountPath)
 		return nil
 	}
 	return nil

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -210,6 +210,7 @@ func setDefaultClusterTimeout(cluster *latest.ClusterDetails) error {
 }
 
 func setDefaultClusterPullSecret(cluster *latest.ClusterDetails) error {
+	cluster.PullSecretMountPath = valueOrDefault(cluster.PullSecretMountPath, constants.DefaultKanikoSecretMountPath)
 	if cluster.PullSecret != "" {
 		absPath, err := homedir.Expand(cluster.PullSecret)
 		if err != nil {
@@ -217,7 +218,6 @@ func setDefaultClusterPullSecret(cluster *latest.ClusterDetails) error {
 		}
 		cluster.PullSecret = absPath
 		cluster.PullSecretName = valueOrDefault(cluster.PullSecretName, constants.DefaultKanikoSecretName)
-		cluster.PullSecretMountPath = valueOrDefault(cluster.PullSecretMountPath, constants.DefaultKanikoSecretMountPath)
 		return nil
 	}
 	return nil

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -111,6 +111,27 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(constants.DefaultKanikoSecretName, cfg.Build.Cluster.PullSecretName)
+		t.CheckDeepEqual(constants.DefaultKanikoSecretMountPath, cfg.Build.Cluster.PullSecretMountPath)
+
+		// pull secret mount path set
+		path := "/path"
+		cfg = &latest.SkaffoldConfig{
+			Pipeline: latest.Pipeline{
+				Build: latest.BuildConfig{
+					BuildType: latest.BuildType{
+						Cluster: &latest.ClusterDetails{
+							PullSecret:          "path/to/pull/secret",
+							PullSecretMountPath: path,
+						},
+					},
+				},
+			},
+		}
+
+		err = Set(cfg)
+		t.CheckNoError(err)
+		t.CheckDeepEqual(constants.DefaultKanikoSecretName, cfg.Build.Cluster.PullSecretName)
+		t.CheckDeepEqual(path, cfg.Build.Cluster.PullSecretMountPath)
 
 		// default docker config
 		cfg.Pipeline.Build.BuildType.Cluster.DockerConfig = &latest.DockerConfig{}

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -287,6 +287,9 @@ type ClusterDetails struct {
 	// Defaults to `kaniko-secret`.
 	PullSecretName string `yaml:"pullSecretName,omitempty"`
 
+	// PullSecretMountPath is the path the pull secret will be mounted at within the running container.
+	PullSecretMountPath string `yaml:"pullSecretMountPath,omitempty"`
+
 	// Namespace is the Kubernetes namespace.
 	// Defaults to current namespace in Kubernetes configuration.
 	Namespace string `yaml:"namespace,omitempty"`

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -172,7 +172,7 @@ func TestParseConfig(t *testing.T) {
 			description: "Minimal Kaniko config",
 			config:      minimalKanikoConfig,
 			expected: config(
-				withClusterBuild("", "", "default", "", "20m",
+				withClusterBuild("", "/secret", "default", "", "20m",
 					withGitTagger(),
 					withKanikoArtifact("image1", "./examples/app1", "Dockerfile", "demo"),
 				),

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -172,7 +172,7 @@ func TestParseConfig(t *testing.T) {
 			description: "Minimal Kaniko config",
 			config:      minimalKanikoConfig,
 			expected: config(
-				withClusterBuild("", "default", "", "20m",
+				withClusterBuild("", "", "default", "", "20m",
 					withGitTagger(),
 					withKanikoArtifact("image1", "./examples/app1", "Dockerfile", "demo"),
 				),
@@ -184,7 +184,7 @@ func TestParseConfig(t *testing.T) {
 			description: "Complete Kaniko config",
 			config:      completeKanikoConfig,
 			expected: config(
-				withClusterBuild("secret-name", "nskaniko", "/secret.json", "120m",
+				withClusterBuild("secret-name", "/secret", "nskaniko", "/secret.json", "120m",
 					withGitTagger(),
 					withDockerConfig("config-name", "/kaniko/.docker"),
 					withKanikoArtifact("image1", "./examples/app1", "Dockerfile", ""),
@@ -283,13 +283,14 @@ func withGoogleCloudBuild(id string, ops ...func(*latest.BuildConfig)) func(*lat
 	}
 }
 
-func withClusterBuild(secretName, namespace, secret string, timeout string, ops ...func(*latest.BuildConfig)) func(*latest.SkaffoldConfig) {
+func withClusterBuild(secretName, mountPath, namespace, secret string, timeout string, ops ...func(*latest.BuildConfig)) func(*latest.SkaffoldConfig) {
 	return func(cfg *latest.SkaffoldConfig) {
 		b := latest.BuildConfig{BuildType: latest.BuildType{Cluster: &latest.ClusterDetails{
-			PullSecretName: secretName,
-			Namespace:      namespace,
-			PullSecret:     secret,
-			Timeout:        timeout,
+			PullSecretName:      secretName,
+			Namespace:           namespace,
+			PullSecret:          secret,
+			PullSecretMountPath: mountPath,
+			Timeout:             timeout,
 		}}}
 		for _, op := range ops {
 			op(&b)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to _in case of new feature, this should point to issue/(s) which describes the feature_

Fixes #731 



**Description**

This will give users the option to specify where the pull secret should
be mounted within the container. This should fix #731 and enable ECR
support.

**User facing changes**

n/a


**Next PRs.**

n/a

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


