### PR TITLE
Add skip tls verify option to kaniko builder

### DIFF
--- a/docs/content/en/schemas/v1beta16.json
+++ b/docs/content/en/schemas/v1beta16.json
@@ -1289,6 +1289,12 @@
           "x-intellij-html-description": "used to strip timestamps out of the built image.",
           "default": "false"
         },
+        "skipTLS": {
+          "type": "boolean",
+          "description": "skips TLS verification when pulling and pushing the image.",
+          "x-intellij-html-description": "skips TLS verification when pulling and pushing the image.",
+          "default": "false"
+        },
         "target": {
           "type": "string",
           "description": "Dockerfile target name to build.",
@@ -1303,7 +1309,8 @@
         "buildContext",
         "image",
         "cache",
-        "reproducible"
+        "reproducible",
+        "skipTLS"
       ],
       "additionalProperties": false,
       "description": "*alpha* describes an artifact built from a Dockerfile, with kaniko.",

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -139,5 +140,21 @@ func args(artifact *latest.KanikoArtifact, context, tag string) ([]string, error
 		args = append(args, "--reproducible")
 	}
 
+	if artifact.SkipTLS {
+		reg, err := artifactRegistry(tag)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, "--skip-tls-verify-registry", reg)
+	}
+
 	return args, nil
+}
+
+func artifactRegistry(i string) (string, error) {
+	ref, err := name.ParseReference(i)
+	if err != nil {
+		return "", err
+	}
+	return ref.Context().RegistryStr(), nil
 }

--- a/pkg/skaffold/build/cluster/kaniko_test.go
+++ b/pkg/skaffold/build/cluster/kaniko_test.go
@@ -104,12 +104,20 @@ func TestArgs(t *testing.T) {
 			},
 			shouldErr: true,
 		},
+		{
+			description: "skip tls",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				SkipTLS:        true,
+			},
+			expectedArgs: []string{"--skip-tls-verify-registry", "gcr.io"},
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			commonArgs := []string{"--dockerfile", "Dockerfile", "--context", "context", "--destination", "tag", "-v", "info"}
+			commonArgs := []string{"--dockerfile", "Dockerfile", "--context", "context", "--destination", "gcr.io/tag", "-v", "info"}
 
-			args, err := args(test.artifact, "context", "tag")
+			args, err := args(test.artifact, "context", "gcr.io/tag")
 
 			t.CheckError(test.shouldErr, err)
 			if !test.shouldErr {

--- a/pkg/skaffold/build/cluster/kaniko_test.go
+++ b/pkg/skaffold/build/cluster/kaniko_test.go
@@ -28,6 +28,7 @@ func TestArgs(t *testing.T) {
 	tests := []struct {
 		description  string
 		artifact     *latest.KanikoArtifact
+		tag          string
 		shouldErr    bool
 		expectedArgs []string
 	}{
@@ -112,12 +113,25 @@ func TestArgs(t *testing.T) {
 			},
 			expectedArgs: []string{"--skip-tls-verify-registry", "gcr.io"},
 		},
+		{
+			description: "invalid registry",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				SkipTLS:        true,
+			},
+			tag:       "!!!!",
+			shouldErr: true,
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			commonArgs := []string{"--dockerfile", "Dockerfile", "--context", "context", "--destination", "gcr.io/tag", "-v", "info"}
 
-			args, err := args(test.artifact, "context", "gcr.io/tag")
+			tag := "gcr.io/tag"
+			if test.tag != "" {
+				tag = test.tag
+			}
+			args, err := args(test.artifact, "context", tag)
 
 			t.CheckError(test.shouldErr, err)
 			if !test.shouldErr {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -725,6 +725,9 @@ type KanikoArtifact struct {
 
 	// Reproducible is used to strip timestamps out of the built image.
 	Reproducible bool `yaml:"reproducible,omitempty"`
+
+	// SkipTLS skips TLS verification when pulling and pushing the image.
+	SkipTLS bool `yaml:"skipTLS,omitempty"`
 }
 
 // DockerArtifact *beta* describes an artifact built from a Dockerfile,


### PR DESCRIPTION
Relates to _in case of new feature, this should point to issue/(s) which describes the feature_

Should resolve #1961


**Description**

I was able to recreate the error in #1961 by using a kaniko image
without a cert & pushing to an unauthenticated registry in Cloud Run.

Adding this flag resolves that bug.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.
