### PR TITLE
Don't assume string keys in helm charts

### DIFF
--- a/pkg/skaffold/deploy/kubectl/images.go
+++ b/pkg/skaffold/deploy/kubectl/images.go
@@ -38,7 +38,7 @@ type imageSaver struct {
 	Images []build.Artifact
 }
 
-func (is *imageSaver) Matches(key string) bool {
+func (is *imageSaver) Matches(key interface{}) bool {
 	return key == "image"
 }
 
@@ -94,7 +94,7 @@ func newImageReplacer(builds []build.Artifact, defaultRepo string) *imageReplace
 	}
 }
 
-func (r *imageReplacer) Matches(key string) bool {
+func (r *imageReplacer) Matches(key interface{}) bool {
 	return key == "image"
 }
 

--- a/pkg/skaffold/deploy/kubectl/labels.go
+++ b/pkg/skaffold/deploy/kubectl/labels.go
@@ -46,7 +46,7 @@ func newLabelsSetter(labels map[string]string) *labelsSetter {
 	}
 }
 
-func (r *labelsSetter) Matches(key string) bool {
+func (r *labelsSetter) Matches(key interface{}) bool {
 	return key == "metadata"
 }
 

--- a/pkg/skaffold/deploy/kubectl/matcher.go
+++ b/pkg/skaffold/deploy/kubectl/matcher.go
@@ -20,7 +20,7 @@ package kubectl
 // on a manifest key in the Manifest
 // Note: If the manifest key is not present, the replacer will replace.
 type Matcher interface {
-	IsMatchKey(key string) bool
+	IsMatchKey(key interface{}) bool
 	Matches(v interface{}) bool
 }
 
@@ -31,7 +31,7 @@ func (f anyMatcher) Matches(interface{}) bool {
 	return true
 }
 
-func (f anyMatcher) IsMatchKey(key string) bool {
+func (f anyMatcher) IsMatchKey(key interface{}) bool {
 	return false
 }
 

--- a/pkg/skaffold/deploy/kubectl/namespaces.go
+++ b/pkg/skaffold/deploy/kubectl/namespaces.go
@@ -50,7 +50,7 @@ func newNamespaceCollector() *namespaceCollector {
 	}
 }
 
-func (r *namespaceCollector) Matches(key string) bool {
+func (r *namespaceCollector) Matches(key interface{}) bool {
 	return key == "metadata"
 }
 

--- a/pkg/skaffold/deploy/kubectl/visitor.go
+++ b/pkg/skaffold/deploy/kubectl/visitor.go
@@ -23,7 +23,7 @@ import (
 
 // Replacer is used to replace portions of yaml manifests that match a given key.
 type Replacer interface {
-	Matches(key string) bool
+	Matches(key interface{}) bool
 
 	NewValue(old interface{}) (bool, interface{})
 
@@ -70,17 +70,15 @@ func recursiveVisit(i interface{}, replacer Replacer) {
 		//    skip replacing the entire Object.
 		if replacer.ObjMatcher() != nil {
 			for k, v := range t {
-				key := k.(string)
-				if replacer.ObjMatcher().IsMatchKey(key) && !replacer.ObjMatcher().Matches(v) {
+				if replacer.ObjMatcher().IsMatchKey(k) && !replacer.ObjMatcher().Matches(v) {
 					return
 				}
 			}
 		}
 		// Now do the actual replacement.
 		for k, v := range t {
-			key := k.(string)
 			switch {
-			case replacer.Matches(key):
+			case replacer.Matches(k):
 				ok, newValue := replacer.NewValue(v)
 				if ok {
 					t[k] = newValue

--- a/pkg/skaffold/deploy/kubectl/visitor_test.go
+++ b/pkg/skaffold/deploy/kubectl/visitor_test.go
@@ -28,8 +28,8 @@ type dummyReplacer struct {
 	m Matcher
 }
 
-func (r *dummyReplacer) Matches(key string) bool {
-	return key == "replace-key"
+func (r *dummyReplacer) Matches(key interface{}) bool {
+	return key == "replace-key" || key == 1234
 }
 
 func (r *dummyReplacer) NewValue(old interface{}) (bool, interface{}) {
@@ -54,7 +54,7 @@ func (m mockMatcher) Matches(value interface{}) bool {
 	return false
 }
 
-func (m mockMatcher) IsMatchKey(key string) bool {
+func (m mockMatcher) IsMatchKey(key interface{}) bool {
 	return key == "match-key"
 }
 
@@ -124,6 +124,16 @@ replace-key: not-replaced`),
 				[]byte(`
 match-key: match-value
 replace-key: replaced`)},
+		},
+		{
+			description: "single manifest in the list with matched key and string value",
+			manifests: ManifestList{[]byte(`
+123: match-value
+1234: not-replaced`)},
+			matchValues: []string{"match-value"},
+			expected: ManifestList{[]byte(`
+123: match-value
+1234: replaced`)},
 		},
 	}
 


### PR DESCRIPTION
Fixes:  #2918
**Description**

Correctly handle integer keys when replacing values while
deploying Helm charts.

**User facing changes**

n/a

**Before**

Panic when helm chart contained integer keys.

**After**

Integer keys are processed without a panic.

**Next PRs.**

n/a

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)

**Reviewer Notes**

- [x] The code flow looks good.
- [x] Unit test added.
- [x] User facing changes look good.


**Release Notes**

- Bug fix
  Correctly handle integer keys when replacing values in helm charts.