### PR TITLE
link validation in docs

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -17,6 +17,10 @@ defaultContentLanguageInSubdir = false
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
 
+# validate links and fail if not found
+refLinksErrorLevel="ERROR"
+relativeURLs=true
+canonifyURLs=false
 disableKinds = ["taxonomy", "taxonomyTerm"]
 
 # Highlighting config
@@ -38,7 +42,9 @@ blog = "/:section/:year/:month/:day/:slug/"
 ## Configuration for BlackFriday markdown parser: https://github.com/russross/blackfriday
 [blackfriday]
 plainIDAnchors = true
-hrefTargetBlank = true
+
+# due to https://github.com/gohugoio/hugo/issues/2424 this should not be turned on until it is fixed
+hrefTargetBlank = false
 angledQuotes = false
 latexDashes = true
 

--- a/docs/content/en/docs/concepts/_index.md
+++ b/docs/content/en/docs/concepts/_index.md
@@ -9,10 +9,10 @@ understanding of Skaffold.
 
 | Skaffold Concepts | |
 |----------|---|
-| [Workflow](/docs/concepts/workflow) | Understand the Skaffold workflow |
-| [Architecture](/docs/concepts/architecture) | Overview over the architecture of Skaffold |
-| [Operating modes](/docs/concepts/modes) | Understand the operating modes of Skaffold |
-| [Skaffold pipeline](/docs/concepts/pipeline) | General structure of a Skaffold pipeline |
-| [Skaffold config](/docs/concepts/config) | Global configuration options |
-| [Local development](/docs/concepts/local_development) | Understand how to develop locally with Skaffold |
-| [Image repository handling](/docs/concepts/image_repositories) | Understand the image repository handling |
+| [Workflow]({{< relref "/docs/concepts/workflow" >}}) | Understand the Skaffold workflow |
+| [Architecture]({{< relref "/docs/concepts/architecture" >}}) | Overview over the architecture of Skaffold |
+| [Operating modes]({{< relref "/docs/concepts/modes" >}}) | Understand the operating modes of Skaffold |
+| [Skaffold pipeline]({{< relref "/docs/concepts/pipeline" >}}) | General structure of a Skaffold pipeline |
+| [Skaffold config]({{< relref "/docs/concepts/config" >}}) | Global configuration options |
+| [Local development]({{< relref "/docs/concepts/local_development" >}}) | Understand how to develop locally with Skaffold |
+| [Image repository handling]({{< relref "/docs/concepts/image_repositories" >}}) | Understand the image repository handling |

--- a/docs/content/en/docs/concepts/architecture/_index.md
+++ b/docs/content/en/docs/concepts/architecture/_index.md
@@ -44,5 +44,5 @@ Cloud Build and deploy using Helm:
 Skaffold also supports development profiles. You can specify multiple different
 profiles in the configuration and use whichever best serves your need in the
 moment without having to modify the configuration file. You can learn more about
-profiles from [Profiles](/docs/how-tos/profiles).
+profiles from [Profiles]({{< relref "/docs/how-tos/profiles" >}}).
 

--- a/docs/content/en/docs/concepts/modes/_index.md
+++ b/docs/content/en/docs/concepts/modes/_index.md
@@ -18,5 +18,5 @@ Skaffold provides two separate operating modes:
     application.
 
 Skaffold command-line interface also provides other functionalities that may
-be helpful to your project. For more information, see [CLI References](/docs/references/cli).
+be helpful to your project. For more information, see [CLI References]({{< relref "/docs/references/cli" >}}).
 

--- a/docs/content/en/docs/concepts/pipeline/_index.md
+++ b/docs/content/en/docs/concepts/pipeline/_index.md
@@ -18,9 +18,9 @@ read the configuration file from the current directory.
 | ---------- | ------------|
 | `apiVersion` | The Skaffold API version you would like to use. The current API version is {{< skaffold-version >}}. |
 | `kind`  |  The Skaffold configuration file has the kind `Config`.  |
-| `build`  |  Specifies how Skaffold builds artifacts. You have control over what tool Skaffold can use, how Skaffold tags artifacts and how Skaffold pushes artifacts. Skaffold supports using local Docker daemon, Google Cloud Build, Kaniko, or Bazel to build artifacts. See [Builders](/docs/how-tos/builders) and [Taggers](/docs/how-tos/taggers) for more information. |
-| `test` |  Specifies how Skaffold tests artifacts. Skaffold supports [container-structure-tests](https://github.com/GoogleContainerTools/container-structure-test) to test built artifacts. See [Testers](/docs/how-tos/testers) for more information. |
-| `deploy` |  Specifies how Skaffold deploys artifacts. Skaffold supports using `kubectl`, `helm`, or `kustomize` to deploy artifacts. See [Deployers](/docs/how-tos/deployers) for more information. |
+| `build`  |  Specifies how Skaffold builds artifacts. You have control over what tool Skaffold can use, how Skaffold tags artifacts and how Skaffold pushes artifacts. Skaffold supports using local Docker daemon, Google Cloud Build, Kaniko, or Bazel to build artifacts. See [Builders](/docs/how-tos/builders) and [Taggers]({{< relref "/docs/how-tos/taggers" >}}) for more information. |
+| `test` |  Specifies how Skaffold tests artifacts. Skaffold supports [container-structure-tests](https://github.com/GoogleContainerTools/container-structure-test) to test built artifacts. See [Testers]({{< relref "/docs/how-tos/testers" >}}) for more information. |
+| `deploy` |  Specifies how Skaffold deploys artifacts. Skaffold supports using `kubectl`, `helm`, or `kustomize` to deploy artifacts. See [Deployers]({{< relref "/docs/how-tos/deployers" >}}) for more information. |
 | `profiles`|  Profile is a set of settings that, when activated, overrides the current configuration. You can use Profile to override the `build`, `test` and `deploy` sections. |
 
-You can [learn more](/docs/references/yaml) about the syntax of `skaffold.yaml`.
+You can [learn more]({{< relref "/docs/references/yaml" >}}) about the syntax of `skaffold.yaml`.

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -7,7 +7,7 @@ weight: 10
 This document showcases how to get started with Skaffold using [Docker](https://www.docker.com/)
 and Kubernetes command-line tool, [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/).
 Aside from `Docker` and `kubectl`, Skaffold also supports a variety of other tools
-and workflows; see [How-to Guides](/docs/how-tos) and [Tutorials](/docs/tutorials) for
+and workflows; see [How-to Guides](/docs/how-tos) and [Tutorials]({{< relref "/docs/tutorials" >}}) for
 more information.
 
 In this quickstart, you will:
@@ -149,7 +149,7 @@ For the latest **bleeding edge** build:
 To keep Skaffold up to date, update checks are made to Google servers to see if a new version of
 Skaffold is available.
 
-You can turn this update check off by following <a href=/docs/references/privacy/#update-check>these instructions</a>.
+You can turn this update check off by following <a href=/docs/references/privacy#update-check>these instructions</a>.
 
 
 Your use of this software is subject to the <a href=https://policies.google.com/privacy>Google Privacy Policy</a>
@@ -255,10 +255,10 @@ Skaffold will perform the workflow described in `skaffold.yaml` exactly once.
 
 ## What's next
 
-For more in-depth topics of Skaffold, explore [Skaffold Concepts: Configuration](/docs/concepts/#configuration),
-[Skaffold Concepts: Workflow](/docs/concepts/#workflow), and [Skaffold Concepts: Architecture](/docs/concepts/#architecture).
+For more in-depth topics of Skaffold, explore [Skaffold Concepts: Configuration]({{< relref "/docs/concepts#configuration" >}}),
+[Skaffold Concepts: Workflow](/docs/concepts#workflow), and [Skaffold Concepts: Architecture]({{< relref "/docs/concepts#architecture" >}}).
 
 To learn more about how Skaffold builds, tags, and deploys your app, see the How-to Guides on
-using [Builders](/docs/how-tos/builders), [Taggers](/docs/how-tos/taggers), and [Deployers](/docs/how-tos/deployers).
+using [Builders](/docs/how-tos/builders), [Taggers](/docs/how-tos/taggers), and [Deployers]({{< relref "/docs/how-tos/deployers" >}}).
 
-[Skaffold Tutorials](/docs/tutorials) details some of the common use cases of Skaffold.
+[Skaffold Tutorials]({{< relref "/docs/tutorials" >}}) details some of the common use cases of Skaffold.

--- a/docs/content/en/docs/how-tos/_index.md
+++ b/docs/content/en/docs/how-tos/_index.md
@@ -6,12 +6,12 @@ weight: 30
 
 | Skaffold Workflow | |
 |----------|---|
-| [Builders](/docs/how-tos/builders) | How Docker images are built |
-| [Testers](/docs/how-tos/testers) | How images are tested |
-| [Taggers](/docs/how-tos/taggers) | How images are tagged |
-| [Deployers](/docs/how-tos/deployers) | How your app is deployed to a Kubernetes cluster |
-| [File sync](/docs/how-tos/filesync) | File sync for files that don’t require full rebuild |
-| [Port forwarding](/docs/how-tos/portforward) | Port forwarding from pods |
-| [Profiles](/docs/how-tos/profiles) | Define configurations for different contexts |
-| [Templated fields](/docs/how-tos/templating) | Adjust configuration with environment variables |
-| [Debugging (alpha)](/docs/how-tos/debug) | Enabling debugging of apps as deployed to a Kubernetes cluster |
+| [Builders]({{< relref "/docs/how-tos/builders" >}}) | How Docker images are built |
+| [Testers]({{< relref "/docs/how-tos/testers" >}}) | How images are tested |
+| [Taggers]({{< relref "/docs/how-tos/taggers" >}}) | How images are tagged |
+| [Deployers]({{< relref "/docs/how-tos/deployers" >}}) | How your app is deployed to a Kubernetes cluster |
+| [File sync]({{< relref "/docs/how-tos/filesync" >}}) | File sync for files that don’t require full rebuild |
+| [Port forwarding]({{< relref "/docs/how-tos/portforward" >}}) | Port forwarding from pods |
+| [Profiles]({{< relref "/docs/how-tos/profiles" >}}) | Define configurations for different contexts |
+| [Templated fields]({{< relref "/docs/how-tos/templating" >}}) | Adjust configuration with environment variables |
+| [Debugging (alpha)]({{< relref "/docs/how-tos/debug" >}}) | Enabling debugging of apps as deployed to a Kubernetes cluster |

--- a/docs/content/en/docs/how-tos/builders/_index.md
+++ b/docs/content/en/docs/how-tos/builders/_index.md
@@ -24,8 +24,8 @@ artifacts, add the value representing the tool and options for using that tool
 to the `build` section.
 
 For a detailed discussion on Skaffold configuration, see
-[Skaffold Concepts](/docs/concepts/#configuration) and
-[skaffold.yaml References](/docs/references/yaml).
+[Skaffold Concepts]({{< relref "/docs/concepts#configuration" >}}) and
+[skaffold.yaml References]({{< relref "/docs/references/yaml" >}}).
 
 ## Dockerfile locally with Docker
 
@@ -262,7 +262,7 @@ Skaffold will pass in the following environment variables to the custom build sc
 | $IMAGES     | An array of fully qualified image names, separated by spaces. For example, "gcr.io/image1 gcr.io/image2" | The custom build script is expected to build an image and tag it with each image name in $IMAGES. Each image should also be pushed if `$PUSH_IMAGE=true`. | 
 | $PUSH_IMAGE      | Set to true if each image in `$IMAGES` is expected to exist in a remote registry. Set to false if each image in `$IMAGES` is expected to exist locally.      |   The custom build script will push each image in `$IMAGES` if `$PUSH_IMAGE=true` | 
 | $BUILD_CONTEXT  | An absolute path to the directory this artifact is meant to be built from. Specified by artifact `context` in the skaffold.yaml.      | None. | 
-| Local environment variables | The current state of the local environment (e.g. `$HOST`, `$PATH)`. Determined by the golang [os.Environ](https://golang.org/pkg/os/#Environ) function.| None. |
+| Local environment variables | The current state of the local environment (e.g. `$HOST`, `$PATH)`. Determined by the golang [os.Environ](https://golang.org/pkg/os#Environ) function.| None. |
 
 As described above, the custom build script is expected to:
 

--- a/docs/content/en/docs/how-tos/deployers/_index.md
+++ b/docs/content/en/docs/how-tos/deployers/_index.md
@@ -27,8 +27,8 @@ artifacts, add the value representing the tool and options for using the tool
 to the `deploy` section.
 
 For a detailed discussion on Skaffold configuration, see
-[Skaffold Concepts](/docs/concepts/#configuration) and
-[skaffold.yaml References](/docs/references/yaml).
+[Skaffold Concepts]({{< relref "/docs/concepts#configuration" >}}) and
+[skaffold.yaml References]({{< relref "/docs/references/yaml" >}}).
 
 ## Deploying with kubectl
 

--- a/docs/content/en/docs/how-tos/profiles/_index.md
+++ b/docs/content/en/docs/how-tos/profiles/_index.md
@@ -11,8 +11,8 @@ environments in your app's lifecycle, like Production or Development.
 You can create profiles in the `profiles` section of `skaffold.yaml`.
 
 For a detailed discussion on Skaffold configuration, see
-[Skaffold Concepts](/docs/concepts/#configuration) and
-[skaffold.yaml References](/docs/references/yaml).
+[Skaffold Concepts]({{< relref "/docs/concepts#configuration" >}}) and
+[skaffold.yaml References]({{< relref "/docs/references/yaml" >}}).
 
 ## Profiles (`profiles`)
 
@@ -29,9 +29,9 @@ Once a profile is activated, the specified `build`, `test` and `deploy` configur
 in it will replace the `build`, `test` and `deploy` sections declared
 in the main section of `skaffold.yaml`. The `build`, `test` and `deploy` configuration in the `profiles`
 section use the same syntax as the `build`, `test` and `deploy` sections of
-`skaffold.yaml`; for more information, see [Builders](/docs/how-tos/builders),
-[Testers](/docs/how-tos/testers), [Deployers](/docs/how-tos/deployers) and you can always refer to
- [skaffold.yaml reference](/docs/references/yaml/) for an overview of the syntax.
+`skaffold.yaml`; for more information, see [Builders]({{< relref "/docs/how-tos/builders" >}}),
+[Testers](/docs/how-tos/testers), [Deployers]({{< relref "/docs/how-tos/deployers" >}}) and you can always refer to
+ [skaffold.yaml reference]({{< relref "/docs/references/yaml" >}}) for an overview of the syntax.
  Alternatively, you can override the main configuration with finer grained control using `patches`.
 
 

--- a/docs/content/en/docs/how-tos/taggers/_index.md
+++ b/docs/content/en/docs/how-tos/taggers/_index.md
@@ -17,8 +17,8 @@ Tag policy is specified in the `tagPolicy` field of the `build` section of the
 Skaffold configuration file, `skaffold.yaml`.
 
 For a detailed discussion on Skaffold configuration, see
-[Skaffold Concepts](/docs/concepts/#configuration) and
-[skaffold.yaml References](/docs/references/yaml).
+[Skaffold Concepts]({{< relref "/docs/concepts#configuration" >}}) and
+[skaffold.yaml References]({{< relref "/docs/references/yaml" >}}).
 
 ## `gitCommit`: uses Git commit IDs as tags
 
@@ -93,7 +93,7 @@ will be `gcr.io/k8s-skaffold/example:v1`.
 
 The tag template uses the [Go Programming Language Syntax](https://golang.org/pkg/text/template/).
 As showcased in the example, `envTemplate` tag policy features one
-**required** parameter, `template`, which is the tag template to use. To learn more about templating support in Skaffold.yaml see [Templated fields](/docs/how-tos/templating)
+**required** parameter, `template`, which is the tag template to use. To learn more about templating support in Skaffold.yaml see [Templated fields]({{< relref "/docs/how-tos/templating" >}})
 
 ## `dateTime`: uses data and time values as tags
 
@@ -117,7 +117,7 @@ be `gcr.io/k8s-skaffold/example:2006-01-02_15-04-05.999_MST`.
 ### Configuration
 
 You can learn more about what time format and time zone you can use in
-[Go Programming Language Documentation: Time package/Format Function](https://golang.org/pkg/time/#Time.Format) and
-[Go Programming Language Documentation: Time package/LoadLocation Function](https://golang.org/pkg/time/#LoadLocation) respectively. As showcased in the
+[Go Programming Language Documentation: Time package/Format Function](https://golang.org/pkg/time#Time.Format) and
+[Go Programming Language Documentation: Time package/LoadLocation Function](https://golang.org/pkg/time#LoadLocation) respectively. As showcased in the
 example, `dateTime`
 tag policy features two optional parameters: `format` and `timezone`.

--- a/docs/content/en/docs/how-tos/templating/_index.md
+++ b/docs/content/en/docs/how-tos/templating/_index.md
@@ -14,14 +14,14 @@ will be `gcr.io/k8s-skaffold/example:v1`.
 
 List of fields that support templating:
 
-* `build.artifacts.[].docker.buildArgs` (see [builders](/docs/how-tos/builders/))
-* `build.tagPolicy.envTemplate.template` (see [envTemplate tagger](/docs/how-tos/taggers/##envtemplate-using-values-of-environment-variables-as-tags))
-* `deploy.helm.releases.setValueTemplates` (see [Deploying with helm](/docs/how-tos/deployers/#deploying-with-helm))
-* `deploy.helm.releases.name` (see [Deploying with helm](/docs/how-tos/deployers/#deploying-with-helm))
+* `build.artifacts.[].docker.buildArgs` (see [builders]({{< relref "/docs/how-tos/builders" >}})
+* `build.tagPolicy.envTemplate.template` (see [envTemplate tagger]({{< relref "/docs/how-tos/taggers#envtemplate-using-values-of-environment-variables-as-tags)" >}})
+* `deploy.helm.releases.setValueTemplates` (see [Deploying with helm]({{< relref "/docs/how-tos/deployers#deploying-with-helm)" >}})
+* `deploy.helm.releases.name` (see [Deploying with helm]({{< relref "/docs/how-tos/deployers#deploying-with-helm)" >}})
 
 _Please note, this list is not exhaustive_
 
 List of variables that are available for templating:
 
 * all environment variables passed to the Skaffold process at startup
-* `IMAGE_NAME` - the artifacts' image name - the [image name rewriting](/docs/concepts/#image-repository-handling) acts after the template is calculated
+* `IMAGE_NAME` - the artifacts' image name - the [image name rewriting]({{< relref "/docs/concepts#image-repository-handling" >}}) acts after the template is calculated

--- a/docs/content/en/docs/references/_index.md
+++ b/docs/content/en/docs/references/_index.md
@@ -6,7 +6,7 @@ weight: 100
 
 | Skaffold References  |
 |----------|
-| [CLI](/docs/references/cli) |
-| [skaffold.yaml](/docs/references/yaml) |
+| [CLI]({{< relref "/docs/references/cli" >}}) |
+| [skaffold.yaml]({{< relref "/docs/references/yaml" >}}) |
 | [Privacy Settings] (/docs/references/privacy) |
 

--- a/docs/content/en/docs/resources/_index.md
+++ b/docs/content/en/docs/resources/_index.md
@@ -36,7 +36,7 @@ See [Release Notes](https://github.com/GoogleContainerTools/skaffold/blob/master
 
 You can join the Skaffold community and discuss the product at:
 
-* [Skaffold Mailing List](https://groups.google.com/forum/#!forum/skaffold-users)
+* [Skaffold Mailing List](https://groups.google.com/forum#!forum/skaffold-users)
 * [Skaffold Topic on Kubernetes Slack](https://kubernetes.slack.com/messages/CABQMSZA6/)
 
 The Skaffold Project also holds a bi-weekly meeting at 9:30am PST on Google


### PR DESCRIPTION
Relates to _in case of new feature, this should point to issue/(s) which describes the feature_

**Description**

Enables link validation for relative links within our docs. This is useful as guards against mistakes. 
However, due to https://github.com/gohugoio/hugo/issues/2424 this means that links are now all opened in the same tab, even external ones. I believe that the validation is useful enough to take the hit on the external link openings. Opinions welcome :) 

**User facing changes**

External links are now opened in the same tab. (sideeffect of https://github.com/gohugoio/hugo/issues/2424) 

**Before**

External links are currently opened in a new tab (`target="_blank"`)

**After**


External links are now opened in the same tab. 

**Reviewer Notes**

- [ ] User facing changes look good.
