### PR TITLE
Add page about kube-context handling in docs concepts section

### DIFF
--- a/docs/content/en/docs/concepts/_index.md
+++ b/docs/content/en/docs/concepts/_index.md
@@ -16,3 +16,4 @@ understanding of Skaffold.
 | [Skaffold config]({{< relref "/docs/concepts/config" >}}) | Global configuration options |
 | [Local development]({{< relref "/docs/concepts/local_development" >}}) | Understand how to develop locally with Skaffold |
 | [Image repository handling]({{< relref "/docs/concepts/image_repositories" >}}) | Understand the image repository handling |
+| [Kube-context handling]({{< relref "/docs/concepts/kube_context" >}}) | Understand how the kube-context is selected |

--- a/docs/content/en/docs/concepts/kube_context/_index.md
+++ b/docs/content/en/docs/concepts/kube_context/_index.md
@@ -61,10 +61,7 @@ This happens for
 - `skaffold run -p profile-1` if the current kube-context is `minikube`
 
 {{< alert title="Note" >}}
-It is possible to activate conflicting profiles in conjunction with the CLI flag. So the following example is valid:
-
-    skaffold run --kube-context minikube -p profile-1,profile-2
-
+It is possible to activate conflicting profiles in conjunction with the CLI flag. So the following example is valid `skaffold run --kube-context minikube -p profile-1,profile-2`
 {{< /alert >}}
 
 ### Limitations

--- a/docs/content/en/docs/concepts/kube_context/_index.md
+++ b/docs/content/en/docs/concepts/kube_context/_index.md
@@ -1,0 +1,71 @@
+---
+title: "Kube-context activation"
+linkTitle: "Kube-context activation"
+weight: 80
+---
+
+This page discusses how Skaffold selects the kube-context.
+
+
+When interacting with a kubernetes cluster, Skaffold does so via a kube-context.
+Thus, the selected kube-context determines the kubernetes cluster, the kubernetes user, and the default namespace.
+By default, Skaffold uses the _current_ kube-context from your kube-config file.
+
+To override this default, Skaffold offers two options:
+
+1. Via the `kube-context` flag
+
+    ```bash
+    skaffold dev --kube-context <myrepo>
+    ```
+
+1. Via the `deploy.kubeContext` option in `skaffold.yaml`
+
+    ```yaml
+    deploy:
+      kubeContext: minikube
+    ```
+
+When both are given, the CLI flag always takes precedence.
+
+### Kube-context activation and Skaffold profiles
+
+The kube-context has a double role for Skaffold profiles:
+
+1. Profiles may be auto-activated by a given kube-context.
+
+1. It is possible to change the kube-context through a `deploy.kubeContext` option in a Skaffold profile.
+
+For clarity, Skaffold does the whole profile activation with the original kube-context.
+In addition, when a profile is auto-activated by a matching kube-context, the resulting kube-context must remain unchanged.
+This rule prevents profile-specific settings for one context to be deployed into a different context.
+
+
+For example, given the following profiles:
+```yaml
+profiles:
+  - name: profile-1
+    deploy:
+      kubeContext: docker-for-desktop
+
+  - name: profile-2
+    activation:
+      - kubeContext: minikube
+```
+
+It is illegal to activate both profiles which happens when
+
+- `skaffold run -p profile-1,profile-2`
+- `skaffold run -p profile-1` if the current kube-context is `minikube`
+
+{{< alert title="Note" >}}
+It is possible to activate conflicting profiles in conjunction with the CLI flag:
+
+    skaffold run --kube-context minikube -p profile-1,profile-2
+
+{{< /alert >}}
+
+### Limitations
+
+It is not possible to change the kube-context of a running `skaffold dev` session.
+In order to pick up the new kube-context from `skaffold.yaml`, Skaffold has to be restarted.

--- a/docs/content/en/docs/concepts/kube_context/_index.md
+++ b/docs/content/en/docs/concepts/kube_context/_index.md
@@ -4,22 +4,22 @@ linkTitle: "Kube-context activation"
 weight: 80
 ---
 
-This page discusses how Skaffold selects the kube-context.
+This page discusses how Skaffold selects the `kube-context`.
 
 
 When interacting with a kubernetes cluster, Skaffold does so via a kube-context.
 Thus, the selected kube-context determines the kubernetes cluster, the kubernetes user, and the default namespace.
 By default, Skaffold uses the _current_ kube-context from your kube-config file.
 
-To override this default, Skaffold offers two options:
+You can override this default via
 
-1. Via the `kube-context` flag
+1. `--kube-context` flag
 
     ```bash
     skaffold dev --kube-context <myrepo>
     ```
 
-1. Via the `deploy.kubeContext` option in `skaffold.yaml`
+1. Specify `deploy.kubeContext` configuration in `skaffold.yaml`
 
     ```yaml
     deploy:
@@ -32,16 +32,17 @@ When both are given, the CLI flag always takes precedence.
 
 The kube-context has a double role for Skaffold profiles:
 
-1. Profiles may be auto-activated by a given kube-context.
+1. A Skaffold profile may be auto-activated by the current kube-context (via `profiles.activation.kubeContext`).
 
-1. It is possible to change the kube-context through a `deploy.kubeContext` option in a Skaffold profile.
+1. A Skaffold profile may change the kube-context (via `profiles.deploy.kubeContext`).
 
-For clarity, Skaffold does the whole profile activation with the original kube-context.
-In addition, when a profile is auto-activated by a matching kube-context, the resulting kube-context must remain unchanged.
+Skaffold ensures that these two roles are not conflicting.
+To that end, profile activation is done with the original kube-context.
+If any profile is auto-activated by a matching kube-context, the resulting kube-context must remain unchanged.
 This rule prevents profile-specific settings for one context to be deployed into a different context.
 
-
 For example, given the following profiles:
+
 ```yaml
 profiles:
   - name: profile-1
@@ -53,13 +54,14 @@ profiles:
       - kubeContext: minikube
 ```
 
-It is illegal to activate both profiles which happens when
+It is illegal to activate both profiles here, because `profile-2` has an activation by `kube-context` and `profile-1` changes the effective `kube-context`.
+This happens for
 
 - `skaffold run -p profile-1,profile-2`
 - `skaffold run -p profile-1` if the current kube-context is `minikube`
 
 {{< alert title="Note" >}}
-It is possible to activate conflicting profiles in conjunction with the CLI flag:
+It is possible to activate conflicting profiles in conjunction with the CLI flag. So the following example is valid:
 
     skaffold run --kube-context minikube -p profile-1,profile-2
 
@@ -68,4 +70,4 @@ It is possible to activate conflicting profiles in conjunction with the CLI flag
 ### Limitations
 
 It is not possible to change the kube-context of a running `skaffold dev` session.
-In order to pick up the new kube-context from `skaffold.yaml`, Skaffold has to be restarted.
+To pick up the changes to `kubeContext`, you will need to quit and re-run `skaffold dev`.


### PR DESCRIPTION
Relates to #2510 and #2447 
Also see https://github.com/GoogleContainerTools/skaffold/blob/master/docs/design_proposals/configurable-kubecontext.md

**Description**

This PR adds a page to the concepts section in the docs about the kube-context activation. The PR also addresses a comment from https://github.com/GoogleContainerTools/skaffold/pull/2510#pullrequestreview-297645363.

**User facing changes**
n/a
**Before**
n/a
**After**
n/a
**Next PRs.**
n/a
**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.

