### PR TITLE
Improve error messages for `deploy.kubeContext` error cases

### DIFF
--- a/integration/examples/profiles/skaffold.yaml
+++ b/integration/examples/profiles/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1beta15
+apiVersion: skaffold/v1beta16
 kind: Config
 build:
   # only build and deploy "world-service" on main profile

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -42,94 +42,113 @@ func TestRun(t *testing.T) {
 			description: "getting-started",
 			dir:         "examples/getting-started",
 			pods:        []string{"getting-started"},
-		}, {
+		},
+		{
 			description: "nodejs",
 			dir:         "examples/nodejs",
 			deployments: []string{"node"},
-		}, {
+		},
+		{
 			description: "structure-tests",
 			dir:         "examples/structure-tests",
 			pods:        []string{"getting-started"},
-		}, {
+		},
+		{
 			description: "microservices",
 			dir:         "examples/microservices",
 			// See https://github.com/GoogleContainerTools/skaffold/issues/2372
 			args:        []string{"--status-check=false"},
 			deployments: []string{"leeroy-app", "leeroy-web"},
-		}, {
+		},
+		{
 			description: "envTagger",
 			dir:         "examples/tagging-with-environment-variables",
 			pods:        []string{"getting-started"},
 			env:         []string{"FOO=foo"},
-		}, {
+		},
+		{
 			description: "bazel",
 			dir:         "examples/bazel",
 			pods:        []string{"bazel"},
-		}, {
+		},
+		{
 			description: "Google Cloud Build",
 			dir:         "examples/google-cloud-build",
 			pods:        []string{"getting-started"},
 			gcpOnly:     true,
-		}, {
+		},
+		{
 			description: "Google Cloud Build with sub folder",
 			dir:         "testdata/gcb-sub-folder",
 			pods:        []string{"getting-started"},
 			gcpOnly:     true,
-		}, {
+		},
+		{
 			description: "Google Cloud Build with Kaniko",
 			dir:         "examples/gcb-kaniko",
 			pods:        []string{"getting-started-kaniko"},
 			gcpOnly:     true,
-		}, {
+		},
+		{
 			description: "kaniko",
 			dir:         "examples/kaniko",
 			pods:        []string{"getting-started-kaniko"},
 			gcpOnly:     true,
-		}, {
+		},
+		{
 			description: "kaniko local",
 			dir:         "examples/kaniko-local",
 			pods:        []string{"getting-started-kaniko"},
 			gcpOnly:     true,
-		}, {
+		},
+		{
 			description: "kaniko local with target",
 			dir:         "testdata/kaniko-target",
 			pods:        []string{"getting-started-kaniko"},
 			gcpOnly:     true,
-		}, {
+		},
+		{
 			description: "kaniko local with sub folder",
 			dir:         "testdata/kaniko-sub-folder",
 			pods:        []string{"getting-started-kaniko"},
 			gcpOnly:     true,
-		}, {
+		},
+		{
 			description: "kaniko microservices",
 			dir:         "testdata/kaniko-microservices",
 			deployments: []string{"leeroy-app", "leeroy-web"},
 			gcpOnly:     true,
-		}, {
+		},
+		{
 			description: "jib",
 			dir:         "testdata/jib",
 			deployments: []string{"web"},
-		}, {
+		},
+		{
 			description: "jib in googlecloudbuild",
 			dir:         "testdata/jib",
 			args:        []string{"-p", "gcb"},
 			deployments: []string{"web"},
 			gcpOnly:     true,
-		}, {
+		},
+		{
 			description: "jib gradle",
 			dir:         "testdata/jib-gradle",
 			deployments: []string{"web"},
-		}, {
+		},
+		{
 			description: "jib gradle in googlecloudbuild",
 			dir:         "testdata/jib-gradle",
 			args:        []string{"-p", "gcb"},
 			deployments: []string{"web"},
 			gcpOnly:     true,
-		}, {
+		},
+		{
 			description: "custom builder",
 			dir:         "testdata/custom",
 			pods:        []string{"bazel"},
-		}, {
+		},
+		{
 			description: "profiles",
 			dir:         "examples/profiles",
 			args:        []string{"-p", "minikube-profile"},

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -75,14 +75,12 @@ func TestRun(t *testing.T) {
 			dir:         "testdata/gcb-sub-folder",
 			pods:        []string{"getting-started"},
 			gcpOnly:     true,
-		},
-		{
+		}, {
 			description: "Google Cloud Build with Kaniko",
 			dir:         "examples/gcb-kaniko",
 			pods:        []string{"getting-started-kaniko"},
 			gcpOnly:     true,
-		},
-		{
+		}, {
 			description: "kaniko",
 			dir:         "examples/kaniko",
 			pods:        []string{"getting-started-kaniko"},
@@ -131,6 +129,11 @@ func TestRun(t *testing.T) {
 			description: "custom builder",
 			dir:         "testdata/custom",
 			pods:        []string{"bazel"},
+		}, {
+			description: "profiles",
+			dir:         "examples/profiles",
+			args:        []string{"-p", "minikube-profile"},
+			pods:        []string{"hello-service"},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/kubernetes/context/context.go
+++ b/pkg/skaffold/kubernetes/context/context.go
@@ -44,15 +44,19 @@ var (
 // Changing the kube-context of a running Skaffold process is not supported, so
 // after the first call, the kube-context will be locked.
 func UseKubeContext(cliValue, yamlValue string) {
+	newKubeContext := yamlValue
+	if cliValue != "" {
+		newKubeContext = cliValue
+	}
 	kubeContextOnce.Do(func() {
-		kubeContext = yamlValue
-		if cliValue != "" {
-			kubeContext = cliValue
-		}
+		kubeContext = newKubeContext
 		if kubeContext != "" {
 			logrus.Infof("Activated kube-context %q", kubeContext)
 		}
 	})
+	if kubeContext != newKubeContext {
+		logrus.Warn("Changing the kube-context is not supported after startup. Please restart Skaffold to take effect.")
+	}
 }
 
 // GetRestClientConfig returns a REST client config for API calls against the Kubernetes API.

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -39,7 +39,7 @@ import (
 func ApplyProfiles(c *latest.SkaffoldConfig, opts cfg.SkaffoldOptions) error {
 	byName := profilesByName(c.Profiles)
 
-	profiles, hasContextActivatedProfile, err := activatedProfiles(c.Profiles, opts)
+	profiles, contextSpecificProfiles, err := activatedProfiles(c.Profiles, opts)
 	if err != nil {
 		return errors.Wrap(err, "finding auto-activated profiles")
 	}
@@ -55,10 +55,10 @@ func ApplyProfiles(c *latest.SkaffoldConfig, opts cfg.SkaffoldOptions) error {
 		}
 	}
 
-	return checkKubeContextConsistency(hasContextActivatedProfile, opts.KubeContext, c.Deploy.KubeContext)
+	return checkKubeContextConsistency(contextSpecificProfiles, opts.KubeContext, c.Deploy.KubeContext)
 }
 
-func checkKubeContextConsistency(isContextImmutable bool, cliContext, effectiveContext string) error {
+func checkKubeContextConsistency(contextSpecificProfiles []string, cliContext, effectiveContext string) error {
 	// cli flag takes precedence
 	if cliContext != "" {
 		return nil
@@ -68,18 +68,19 @@ func checkKubeContextConsistency(isContextImmutable bool, cliContext, effectiveC
 	if err != nil {
 		return errors.Wrap(err, "getting current cluster context")
 	}
+	currentContext := kubeConfig.CurrentContext
 
 	// nothing to do
-	if effectiveContext == "" || effectiveContext == kubeConfig.CurrentContext || !isContextImmutable {
+	if effectiveContext == "" || effectiveContext == currentContext || 0 == len(contextSpecificProfiles) {
 		return nil
 	}
 
-	return fmt.Errorf("some activated profile contains kubecontext specific settings for a different than the effective kubecontext, please revise your profile activations")
+	return fmt.Errorf("profiles %q were activated by kube-context %q, but the effective kube-context is %q -- please revise your profile activations", contextSpecificProfiles, currentContext, effectiveContext)
 }
 
-func activatedProfiles(profiles []latest.Profile, opts cfg.SkaffoldOptions) ([]string, bool, error) {
+func activatedProfiles(profiles []latest.Profile, opts cfg.SkaffoldOptions) ([]string, []string, error) {
 	activated := opts.Profiles
-	hasContextActivatedProfile := false
+	var contextSpecificProfiles []string
 
 	// Auto-activated profiles
 	for _, profile := range profiles {
@@ -88,24 +89,24 @@ func activatedProfiles(profiles []latest.Profile, opts cfg.SkaffoldOptions) ([]s
 
 			env, err := isEnv(cond.Env)
 			if err != nil {
-				return nil, false, err
+				return nil, nil, err
 			}
 
 			kubeContext, err := isKubeContext(cond.KubeContext, opts)
 			if err != nil {
-				return nil, false, err
+				return nil, nil, err
 			}
 
 			if command && env && kubeContext {
 				if cond.KubeContext != "" {
-					hasContextActivatedProfile = true
+					contextSpecificProfiles = append(contextSpecificProfiles, profile.Name)
 				}
 				activated = append(activated, profile.Name)
 			}
 		}
 	}
 
-	return activated, hasContextActivatedProfile, nil
+	return activated, contextSpecificProfiles, nil
 }
 
 func isEnv(env string) (bool, error) {

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -78,6 +78,8 @@ func checkKubeContextConsistency(contextSpecificProfiles []string, cliContext, e
 	return fmt.Errorf("profiles %q were activated by kube-context %q, but the effective kube-context is %q -- please revise your profile activations", contextSpecificProfiles, currentContext, effectiveContext)
 }
 
+// activatedProfiles returns the activated profiles and activated profiles which are kube-context specific.
+// The latter matters for error reporting when the effective kube-context changes.
 func activatedProfiles(profiles []latest.Profile, opts cfg.SkaffoldOptions) ([]string, []string, error) {
 	activated := opts.Profiles
 	var contextSpecificProfiles []string

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -71,7 +71,7 @@ func checkKubeContextConsistency(contextSpecificProfiles []string, cliContext, e
 	currentContext := kubeConfig.CurrentContext
 
 	// nothing to do
-	if effectiveContext == "" || effectiveContext == currentContext || 0 == len(contextSpecificProfiles) {
+	if effectiveContext == "" || effectiveContext == currentContext || len(contextSpecificProfiles) == 0 {
 		return nil
 	}
 

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -75,7 +75,7 @@ func checkKubeContextConsistency(contextSpecificProfiles []string, cliContext, e
 		return nil
 	}
 
-	return fmt.Errorf("profiles %q were activated by kube-context %q, but the effective kube-context is %q -- please revise your profile activations", contextSpecificProfiles, currentContext, effectiveContext)
+	return fmt.Errorf("profiles %q were activated by kube-context %q, but the effective kube-context is %q -- please revise your `profiles.activation` and `deploy.kubeContext` configurations", contextSpecificProfiles, currentContext, effectiveContext)
 }
 
 // activatedProfiles returns the activated profiles and activated profiles which are kube-context specific.


### PR DESCRIPTION
Relates to https://github.com/GoogleContainerTools/skaffold/pull/2510#pullrequestreview-297645363

**Description**

Improve error logging for two error cases which may happen when configuring the kube-context via `skaffold.yaml`

* Improve error message when activating conflicting Skaffold profiles
* Warn when changing the kube-context of a running Skaffold process

In addition, include the newly added `example/profiles` in integration tests (I assumed that all examples are automatically tested, but this is not the case).

**User facing changes**

1. **after** When changing `deploy.kubeContext` of a running Skaffold process, a warn-level log message is printed, saying

   > Changing the kube-context is not supported after startup. Please restart Skaffold to take effect.

2. **before** When trying to activate conflicting Skaffold profiles, there used to be an error with the message

   > some activated profile contains kubecontext specific settings for a different than the effective kubecontext, please revise your profile activations

   **after** This log message was improved to include some more information about the initial and resulting kube-context, and what are the context-specific profiles which got activated by the initial kube-context, e.g.:

   > profiles ["minikube-profile"] were activated by kube-context "minikube", but the effective kube-context is "staging" -- please revise your profile activations

**Next PRs.**
n/a

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.
