### PR TITLE
Fix versions used in examples

### DIFF
--- a/examples/buildpacks/skaffold.yaml
+++ b/examples/buildpacks/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1beta14
+apiVersion: skaffold/v1beta15
 kind: Config
 build:
   artifacts:

--- a/hack/versions/cmd/latest/version.go
+++ b/hack/versions/cmd/latest/version.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/hack/versions/pkg/version"
+)
+
+// Print the latest version released.
+func main() {
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	current, _ := version.GetLatestVersion()
+	fmt.Println(current)
+}

--- a/hack/versions/cmd/latest_released/version.go
+++ b/hack/versions/cmd/latest_released/version.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/hack/versions/pkg/version"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
+)
+
+// Print the latest version released.
+func main() {
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	current, latestIsReleased := version.GetLatestVersion()
+
+	if latestIsReleased {
+		fmt.Println(current)
+	} else {
+		prev := strings.TrimPrefix(schema.SchemaVersions[len(schema.SchemaVersions)-2].APIVersion, "skaffold/")
+		fmt.Println(prev)
+	}
+}

--- a/integration/examples/buildpacks/skaffold.yaml
+++ b/integration/examples/buildpacks/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1beta14
+apiVersion: skaffold/v1beta16
 kind: Config
 build:
   artifacts:

--- a/integration/examples/profiles/skaffold.yaml
+++ b/integration/examples/profiles/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1beta15
+apiVersion: skaffold/v1beta16
 kind: Config
 build:
   # only build and deploy "world-service" on main profile


### PR DESCRIPTION
Fix versions used in `/examples/*/skaffold.yaml` and `/integration/examples/*/skaffold.yaml`

Add a check to make sure those versions are always right.

Signed-off-by: David Gageot <david@gageot.net>
