### PR TITLE
display survey prompt which points to survey url

### DIFF
--- a/pkg/skaffold/survey/survey.go
+++ b/pkg/skaffold/survey/survey.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package survey
+
+import (
+	"io"
+	"os"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+)
+
+const (
+	Prompt = `Help improve Skaffold! Take a 10 seconds anonymous survey at
+   $skaffold survey`
+)
+
+// for testing
+var (
+	isStdOut = stdOut
+)
+
+func DisplaySurveyForm(out io.Writer) {
+	if isStdOut(out) {
+		color.Default.Fprintln(out, Prompt)
+	}
+}
+
+func stdOut(out io.Writer) bool {
+	return out == os.Stdout
+}

--- a/pkg/skaffold/survey/survey.go
+++ b/pkg/skaffold/survey/survey.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	Prompt = `Help improve Skaffold! Take a 10 seconds anonymous survey at
+	Prompt = `Help improve Skaffold! Take a 10 seconds anonymous survey by running
    $skaffold survey`
 )
 

--- a/pkg/skaffold/survey/survey_test.go
+++ b/pkg/skaffold/survey/survey_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package survey
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDisplaySurveyForm(t *testing.T) {
+	tests := []struct {
+		description string
+		mockStdOut  bool
+		expected    string
+	}{
+		{
+			description: "std out",
+			mockStdOut:  true,
+			expected:    Prompt + "\n",
+		},
+		{
+			description: "not std out",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			mock := func(io.Writer) bool { return test.mockStdOut }
+			t.Override(&isStdOut, mock)
+			var buf bytes.Buffer
+			DisplaySurveyForm(&buf)
+			t.CheckDeepEqual(test.expected, buf.String())
+		})
+	}
+}
+
+func TestIsStdOut(t *testing.T) {
+	tests := []struct {
+		description string
+		out         io.Writer
+		expected    bool
+	}{
+		{
+			description: "std out passed",
+			out:         os.Stdout,
+			expected:    true,
+		},
+		{
+			description: "out nil",
+			out:         nil,
+		},
+		{
+			description: "out bytes buffer",
+			out:         new(bytes.Buffer),
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expected, isStdOut(test.out))
+		})
+	}
+}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to #3010

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**User facing changes**

yes
**Before**
no prompt displayed.

**After**
When hooked up the following prompt should get displayed
```
Help improve Skaffold! Take a 10 seconds anonymous survey.
    $ skaffold survey
```
**Next PRs.**
- [ ] Add a skaffold config `survey/disable_prompts` to display prompts
- [ ] Add implementation for `skaffold survey` command which opens the "https://forms.gle/BMTbGQXLWSdn7vEs6"
- [ ] Add logic show once in 2 weeks untill user ran `skaffold survey` command.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [X] Mentions any output changes.
- [ n/a] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ n/a] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**
