### PR TITLE
Bump golangci-lint to v1.20.0

### DIFF
--- a/hack/golangci.yml
+++ b/hack/golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 6m
+  timeout: 6m
   modules-download-mode: vendor
 
 linters:

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -20,14 +20,11 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if ! [ -x "$(command -v golangci-lint)" ]; then
 	echo "Installing GolangCI-Lint"
-	${DIR}/install_golint.sh -b $GOPATH/bin v1.18.0
+	${DIR}/install_golint.sh -b $GOPATH/bin v1.20.0
 fi
 
 VERBOSE=""
 if [[ "${TRAVIS}" == "true" ]]; then
-    # Use less memory on Travis
-    # See https://github.com/golangci/golangci-lint#memory-usage-of-golangci-lint
-    export GOGC=10
     VERBOSE="-v --print-resources-usage"
 fi
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

Bumps the version of golangci-lint to 1.20.0. One major improvement of this version is its reduced memory footprint (https://github.com/golangci/golangci-lint/pull/758). So I also removed some configuration where the memory footprint is reduced on the travis CI.

**User facing changes**

n/a

**Next PRs.**

n/a

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.
