### PR TITLE
Strip the debugging information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ GO_LDFLAGS = -X $(VERSION_PACKAGE).version=$(VERSION)
 GO_LDFLAGS += -X $(VERSION_PACKAGE).buildDate=$(shell date +'%Y-%m-%dT%H:%M:%SZ')
 GO_LDFLAGS += -X $(VERSION_PACKAGE).gitCommit=$(COMMIT)
 GO_LDFLAGS += -X $(VERSION_PACKAGE).gitTreeState=$(if $(shell git status --porcelain),dirty,clean)
+GO_LDFLAGS += -s -w
 
 GO_LDFLAGS_windows =" $(GO_LDFLAGS)  -extldflags \"$(LDFLAGS_windows)\""
 GO_LDFLAGS_darwin =" $(GO_LDFLAGS)  -extldflags \"$(LDFLAGS_darwin)\""


### PR DESCRIPTION
Binary size goes from 61Mb to 44Mb

Signed-off-by: David Gageot <david@gageot.net>
