### PR TITLE
Custom artifact depends by default on the whole workspace

### DIFF
--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -156,7 +156,9 @@ func defaultToDockerArtifact(a *latest.Artifact) {
 
 func setCustomArtifactDefaults(a *latest.CustomArtifact) {
 	if a.Dependencies == nil {
-		a.Dependencies = &latest.CustomDependencies{}
+		a.Dependencies = &latest.CustomDependencies{
+			Paths: []string{"."},
+		}
 	}
 }
 

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -66,7 +66,7 @@ func TestSetDefaults(t *testing.T) {
 	testutil.CheckDeepEqual(t, "Dockerfile.second", cfg.Build.Artifacts[1].DockerArtifact.DockerfilePath)
 
 	testutil.CheckDeepEqual(t, "third", cfg.Build.Artifacts[2].ImageName)
-	testutil.CheckDeepEqual(t, []string(nil), cfg.Build.Artifacts[2].CustomArtifact.Dependencies.Paths)
+	testutil.CheckDeepEqual(t, []string{"."}, cfg.Build.Artifacts[2].CustomArtifact.Dependencies.Paths)
 	testutil.CheckDeepEqual(t, []string(nil), cfg.Build.Artifacts[2].CustomArtifact.Dependencies.Ignore)
 }
 


### PR DESCRIPTION
Otherwise, with caching activated, no rebuild is ever triggered on a file change.

Signed-off-by: David Gageot <david@gageot.net>