### PR TITLE
remove Container Was Terminated message

### DIFF
--- a/pkg/skaffold/kubernetes/log.go
+++ b/pkg/skaffold/kubernetes/log.go
@@ -193,10 +193,6 @@ func (a *LogAggregator) streamRequest(ctx context.Context, headerColor color.Col
 			// Read up to newline
 			line, err := r.ReadString('\n')
 			if err == io.EOF {
-				// Unless the context was interrupted, this means that the container was stopped.
-				if ctx.Err() != context.Canceled {
-					a.printLogLine(headerColor, prefix, "<Container was Terminated>\n")
-				}
 				return nil
 			}
 			if err != nil {


### PR DESCRIPTION
Fixes #2971. 

**Description**

**User facing changes**

Removes `<Container was terminated>` message as it's confusing. 

**Before**

`<Container was terminated>` message gets logged when: 

- container gets terminated
- container / pod from previous dev loop gets terminated
- container / pod from previous skaffold run deployment gets terminated
- container logs stream meets an EOF

**After**

no logging. 


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- ~Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)~
- [x] Mentions any output changes.
- ~Adds documentation as needed: user docs, YAML reference, CLI reference.~
- ~Adds integration tests if needed.~

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.

