### PR TITLE
[Bazel] Target must end with .tar

### DIFF
--- a/docs/content/en/docs/how-tos/builders/_index.md
+++ b/docs/content/en/docs/how-tos/builders/_index.md
@@ -243,6 +243,13 @@ To use Bazel, `bazel` field to each artifact you specify in the
 
 {{< schema root="BazelArtifact" >}}
 
+{{% alert title="Not any Bazel target can be used" %}}
+The target specified must produce a bundle compatible
+with docker load. See
+<a href="https://github.com/bazelbuild/rules_docker#using-with-docker-locally">https://github.com/bazelbuild/rules_docker#using-with-docker-locally</a>
+{{% /alert %}}
+
+
 ### Example
 
 The following `build` section instructs Skaffold to build a

--- a/pkg/skaffold/build/local/bazel.go
+++ b/pkg/skaffold/build/local/bazel.go
@@ -32,22 +32,22 @@ import (
 )
 
 func (b *Builder) buildBazel(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
-	args := []string{"build"}
 	a := artifact.ArtifactType.BazelArtifact
-	workspace := artifact.Workspace
+
+	args := []string{"build"}
 	args = append(args, a.BuildArgs...)
 	args = append(args, a.BuildTarget)
 
 	// FIXME: is it possible to apply b.skipTests?
 	cmd := exec.CommandContext(ctx, "bazel", args...)
-	cmd.Dir = workspace
+	cmd.Dir = artifact.Workspace
 	cmd.Stdout = out
 	cmd.Stderr = out
 	if err := util.RunCmd(cmd); err != nil {
 		return "", errors.Wrap(err, "running command")
 	}
 
-	bazelBin, err := bazelBin(ctx, workspace, a)
+	bazelBin, err := bazelBin(ctx, artifact.Workspace, a)
 	if err != nil {
 		return "", errors.Wrap(err, "getting path of bazel-bin")
 	}

--- a/pkg/skaffold/build/local/bazel.go
+++ b/pkg/skaffold/build/local/bazel.go
@@ -34,6 +34,10 @@ import (
 func (b *Builder) buildBazel(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
 	a := artifact.ArtifactType.BazelArtifact
 
+	if !strings.HasSuffix(a.BuildTarget, ".tar") {
+		return "", errors.New("the bazel build target should end with .tar, see https://github.com/bazelbuild/rules_docker#using-with-docker-locally")
+	}
+
 	args := []string{"build"}
 	args = append(args, a.BuildArgs...)
 	args = append(args, a.BuildTarget)

--- a/pkg/skaffold/build/local/bazel_test.go
+++ b/pkg/skaffold/build/local/bazel_test.go
@@ -18,12 +18,43 @@ package local
 
 import (
 	"context"
+	"io/ioutil"
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
+
+func TestBuildBazel(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		t.NewTempDir().Mkdir("bin").Chdir()
+		t.Override(&util.DefaultExecCommand, testutil.CmdRun("bazel build //:app.tar").AndRunOut("bazel info bazel-bin", "bin"))
+		t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
+			return docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, nil), nil
+		})
+		testutil.CreateFakeImageTar("bazel:app", "bin/app.tar")
+
+		builder, err := NewBuilder(stubRunContext(latest.LocalBuild{
+			Push: util.BoolPtr(false),
+		}))
+		t.CheckNoError(err)
+
+		artifact := &latest.Artifact{
+			Workspace: ".",
+			ArtifactType: latest.ArtifactType{
+				BazelArtifact: &latest.BazelArtifact{
+					BuildTarget: "//:app.tar",
+				},
+			},
+		}
+
+		_, err = builder.buildBazel(context.Background(), ioutil.Discard, artifact, "img:tag")
+		t.CheckNoError(err)
+	})
+}
 
 func TestBazelBin(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {

--- a/testutil/fake_image_api.go
+++ b/testutil/fake_image_api.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -178,4 +179,33 @@ func (f *FakeAPIClient) Info(context.Context) (types.Info, error) {
 	}, nil
 }
 
+func (f *FakeAPIClient) ImageLoad(ctx context.Context, input io.Reader, quiet bool) (types.ImageLoadResponse, error) {
+	ref, err := ReadRefFromFakeTar(input)
+	if err != nil {
+		return types.ImageLoadResponse{}, fmt.Errorf("reading tar")
+	}
+
+	f.nextImageID++
+	imageID := fmt.Sprintf("sha256:%d", f.nextImageID)
+	f.Add(ref, imageID)
+
+	return types.ImageLoadResponse{
+		Body: f.body(imageID),
+	}, nil
+}
+
 func (f *FakeAPIClient) Close() error { return nil }
+
+// TODO(dgageot): create something that looks more like an actual tar file.
+func CreateFakeImageTar(ref string, path string) error {
+	return ioutil.WriteFile(path, []byte(ref), os.ModePerm)
+}
+
+func ReadRefFromFakeTar(input io.Reader) (string, error) {
+	buf, err := ioutil.ReadAll(input)
+	if err != nil {
+		return "", fmt.Errorf("reading tar")
+	}
+
+	return string(buf), nil
+}


### PR DESCRIPTION
The Bazel target must end with `.tar` so that it produces a bundle compatible with `docker load`

**User facing changes**

Bazel build will fail with an error and a pointer to the documentation

**Before**

It used to fail later when the image was docker loaded.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [X] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [X] Adds documentation as needed: user docs, YAML reference, CLI reference.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.

**Release Notes**

Bazel artifact are now required to use a target that ends with .tar

