### PR TITLE
Improve skaffold init file traversal

### DIFF
--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -553,6 +553,8 @@ func walk(dir string, force, enableJibInit bool, validateBuildFile func(bool, st
 		var directories []*godirwalk.Dirent
 		findBuildersInDirectories := true
 		sort.Sort(dirents)
+
+		// Traverse files
 		for _, file := range dirents {
 			// If we found a directory, keep track of it until we've gone through all the files first
 			if file.IsDir() {
@@ -575,6 +577,7 @@ func walk(dir string, force, enableJibInit bool, validateBuildFile func(bool, st
 				potentialConfigs = append(potentialConfigs, filePath)
 				continue
 			}
+
 			// try and parse build file
 			if findBuilders {
 				if builderConfigs, err := validateBuildFile(enableJibInit, filePath); builderConfigs != nil {
@@ -589,7 +592,7 @@ func walk(dir string, force, enableJibInit bool, validateBuildFile func(bool, st
 			}
 		}
 
-		// Otherwise traverse deeper
+		// Traverse into subdirectories
 		for _, dir := range directories {
 			if util.IsHiddenDir(dir.Name()) {
 				logrus.Debugf("skip walking hidden dir %s", dir.Name())

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -244,7 +244,7 @@ func autoSelectBuilders(builderConfigs []InitBuilder, images []string) ([]builde
 }
 
 // detectBuilders checks if a path is a builder config, and if it is, returns the InitBuilders representing the
-// configs. Also returns a boolean marking whether search completion for subdirectories (true = subdirectories should
+// configs. Also returns a boolean marking search completion for subdirectories (true = subdirectories should
 // continue to be searched, false = subdirectories should not be searched for more builders)
 func detectBuilders(enableJibInit bool, path string) ([]InitBuilder, bool) {
 	// TODO: Remove backwards compatibility if statement (not entire block)
@@ -546,8 +546,8 @@ func walk(dir string, force, enableJibInit bool) ([]string, []InitBuilder, error
 	var potentialConfigs []string
 	var foundBuilders []InitBuilder
 
-	var dirCallback func(path string, findBuilders bool) error
-	dirCallback = func(path string, findBuilders bool) error {
+	var enterDirectory func(path string, findBuilders bool) error
+	enterDirectory = func(path string, findBuilders bool) error {
 		dirents, err := godirwalk.ReadDirents(path, nil)
 		if err != nil {
 			return err
@@ -577,7 +577,7 @@ func walk(dir string, force, enableJibInit bool) ([]string, []InitBuilder, error
 
 		// Traverse into subdirectories
 		for _, dir := range directories {
-			err = dirCallback(filepath.Join(path, dir.Name()), findBuildersInDirectories)
+			err = enterDirectory(filepath.Join(path, dir.Name()), findBuildersInDirectories)
 			if err != nil {
 				return err
 			}
@@ -586,7 +586,7 @@ func walk(dir string, force, enableJibInit bool) ([]string, []InitBuilder, error
 		return nil
 	}
 
-	err := dirCallback(dir, true)
+	err := enterDirectory(dir, true)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -552,6 +552,7 @@ func walk(dir string, force, enableJibInit bool, validateBuildFile func(bool, st
 
 		var directories []*godirwalk.Dirent
 		findBuildersInDirectories := true
+		sort.Sort(dirents)
 		for _, file := range dirents {
 			// If we found a directory, keep track of it until we've gone through all the files first
 			if file.IsDir() {

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -171,9 +171,9 @@ func TestWalk(t *testing.T) {
 			},
 			expectedPaths: []string{
 				"Dockerfile",
-				"maven/pom.xml",
 				"deploy/Dockerfile",
 				"gradle/build.gradle",
+				"maven/pom.xml",
 			},
 			shouldErr: false,
 		},
@@ -194,8 +194,8 @@ func TestWalk(t *testing.T) {
 				"config/test.yaml",
 			},
 			expectedPaths: []string{
-				"maven/pom.xml",
 				"gradle/build.gradle",
+				"maven/pom.xml",
 			},
 			shouldErr: false,
 		},
@@ -217,8 +217,8 @@ func TestWalk(t *testing.T) {
 			},
 			expectedPaths: []string{
 				"Dockerfile",
-				"pom.xml",
 				"build.gradle",
+				"pom.xml",
 			},
 			shouldErr: false,
 		},

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -311,7 +311,7 @@ deploy:
 			t.Override(&docker.ValidateDockerfileFunc, fakeValidateDockerfile)
 			t.Override(&jib.ValidateJibConfigFunc, fakeValidateJibConfig)
 
-			potentialConfigs, builders, err := walk(tmpDir.Root(), test.force, test.enableJibInit, detectBuilders)
+			potentialConfigs, builders, err := walk(tmpDir.Root(), test.force, test.enableJibInit)
 
 			t.CheckError(test.shouldErr, err)
 			if test.shouldErr {

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -143,8 +143,8 @@ func TestWalk(t *testing.T) {
 			},
 			force: false,
 			expectedConfigs: []string{
-				"config/test.yaml",
 				"k8pod.yml",
+				"config/test.yaml",
 			},
 			expectedPaths: []string{
 				"Dockerfile",
@@ -166,14 +166,14 @@ func TestWalk(t *testing.T) {
 			force:         false,
 			enableJibInit: true,
 			expectedConfigs: []string{
-				"config/test.yaml",
 				"k8pod.yml",
+				"config/test.yaml",
 			},
 			expectedPaths: []string{
 				"Dockerfile",
+				"maven/pom.xml",
 				"deploy/Dockerfile",
 				"gradle/build.gradle",
-				"maven/pom.xml",
 			},
 			shouldErr: false,
 		},
@@ -184,18 +184,41 @@ func TestWalk(t *testing.T) {
 				"k8pod.yml":                      emptyFile,
 				"gradle/build.gradle":            emptyFile,
 				"gradle/subproject/build.gradle": emptyFile,
+				"maven/asubproject/pom.xml":      emptyFile,
 				"maven/pom.xml":                  emptyFile,
-				"maven/subproject/pom.xml":       emptyFile,
 			},
 			force:         false,
 			enableJibInit: true,
 			expectedConfigs: []string{
-				"config/test.yaml",
 				"k8pod.yml",
+				"config/test.yaml",
 			},
 			expectedPaths: []string{
-				"gradle/build.gradle",
 				"maven/pom.xml",
+				"gradle/build.gradle",
+			},
+			shouldErr: false,
+		},
+		{
+			description: "multiple builders in same directory",
+			filesWithContents: map[string]string{
+				"build.gradle":                 emptyFile,
+				"ignored-builder/build.gradle": emptyFile,
+				"not-ignored-config/test.yaml": emptyFile,
+				"Dockerfile":                   emptyFile,
+				"k8pod.yml":                    emptyFile,
+				"pom.xml":                      emptyFile,
+			},
+			force:         false,
+			enableJibInit: true,
+			expectedConfigs: []string{
+				"k8pod.yml",
+				"not-ignored-config/test.yaml",
+			},
+			expectedPaths: []string{
+				"Dockerfile",
+				"pom.xml",
+				"build.gradle",
 			},
 			shouldErr: false,
 		},
@@ -234,8 +257,8 @@ deploy:
 			force:         true,
 			enableJibInit: true,
 			expectedConfigs: []string{
-				"config/test.yaml",
 				"k8pod.yml",
+				"config/test.yaml",
 			},
 			expectedPaths: []string{
 				"Dockerfile",
@@ -244,7 +267,7 @@ deploy:
 			shouldErr: false,
 		},
 		{
-			description: "should  error when skaffold.config present and force = false",
+			description: "should error when skaffold.config present and force = false",
 			filesWithContents: map[string]string{
 				"config/test.yaml":  emptyFile,
 				"k8pod.yml":         emptyFile,
@@ -262,11 +285,28 @@ deploy:
 			expectedPaths:   nil,
 			shouldErr:       true,
 		},
+		{
+			description: "should error when skaffold.config present with jib config",
+			filesWithContents: map[string]string{
+				"config/test.yaml": emptyFile,
+				"k8pod.yml":        emptyFile,
+				"README":           emptyFile,
+				"pom.xml":          emptyFile,
+				"skaffold.yaml": `apiVersion: skaffold/v1beta6
+kind: Config
+deploy:
+  kustomize: {}`,
+			},
+			force:           false,
+			enableJibInit:   true,
+			expectedConfigs: nil,
+			expectedPaths:   nil,
+			shouldErr:       true,
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			tmpDir := t.NewTempDir().
-				WriteFiles(test.filesWithContents)
+			tmpDir := t.NewTempDir().WriteFiles(test.filesWithContents)
 
 			t.Override(&docker.ValidateDockerfileFunc, fakeValidateDockerfile)
 			t.Override(&jib.ValidateJibConfigFunc, fakeValidateJibConfig)
@@ -274,6 +314,10 @@ deploy:
 			potentialConfigs, builders, err := walk(tmpDir.Root(), test.force, test.enableJibInit, detectBuilders)
 
 			t.CheckError(test.shouldErr, err)
+			if test.shouldErr {
+				return
+			}
+
 			t.CheckDeepEqual(tmpDir.Paths(test.expectedConfigs...), potentialConfigs)
 			t.CheckDeepEqual(len(test.expectedPaths), len(builders))
 			for i := range builders {


### PR DESCRIPTION
Fixes #3060. 

**Description**

Currently, `skaffold init` ends directory traversal early when a Jib config is detected, so as to not accidentally traverse sub-modules, detect more Jib configurations, and end up with a list of redundant builders. However, the directory traversal had issues that could cause other important files to be missed, such as k8s configs, existing skaffold.yamls, or other build files in the Jib config directory (see before/after descriptions below). This PR changes `skaffold init` to fully walk the project directory, using a flag to ignore builders in nested directories instead of ignoring the directories altogether. This lets us find k8s manifests/skaffold.yamls regardless of where they are relative to Jib build files, while letting us ignore redundant builder configs.

**User facing changes**

`skaffold init` will now detect important files more consistently.

**Before**

Given the example project directory below:

```
Dockerfile
build.gradle  <-- Jib configured here
kubernetes-manifests/
pom.xml
skaffold.yaml
src/
target/
```

`skaffold init` would traverse the directory in alphabetical order, finding the dockerfile first, then finding Jib configured in the `build.gradle` first, causing it to stop and return to the parent directory. This causes it to miss another potential Jib config in the same directory (`pom.xml`), the kubernetes manifests, and the existing `skaffold.yaml`.

**After**

Now, `skaffold init` traverses all the files in a directory first before traversing sub-directories (solving the problem of missed builders/`skaffold.yaml`). If a Jib config is found, then it will not continue to search for builders in the sub-directories; however it will continue to traverse deeper to find k8s manifests (e.g. in `kubernetes-manifests/`).

**Submitter Checklist**

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [x] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.

**Release Notes**

Fix `skaffold init` ending file traversal early when Jib config is detected.
