### PR TITLE
Make all docs have TOC on the right hand side.

### DIFF
--- a/docs/content/en/docs/concepts/modes/_index.md
+++ b/docs/content/en/docs/concepts/modes/_index.md
@@ -6,16 +6,16 @@ weight: 30
 
 This page discusses various operating modes of Skaffold.
 
-
 Skaffold provides two separate operating modes:
 
-* `skaffold dev`, the continuous development mode, enables monitoring of the
-    source repository, so that every time you make changes to the source code,
-    Skaffold will build and deploy your application.
-* `skaffold run`, the standard mode, instructs Skaffold to build and deploy
-    your application exactly once. When you make changes to the source code,
-    you will have to call `skaffold run` again to build and deploy your
-    application.
+## `skaffold dev`
+A continuous development mode, enables monitoring of the source repository,
+so that every time you make changes to the source code, Skaffold will build and deploy your application.
+
+## `skaffold run`
+A standard mode, instructs Skaffold to build and deploy your application exactly once.
+When you make changes to the source code, you will have to call `skaffold run`
+again to build and deploy your application.
 
 Skaffold command-line interface also provides other functionalities that may
 be helpful to your project. For more information, see [CLI References]({{< relref "/docs/references/cli" >}}).

--- a/docs/content/en/docs/how-tos/buildpacks/_index.md
+++ b/docs/content/en/docs/how-tos/buildpacks/_index.md
@@ -9,7 +9,7 @@ Buildpacks enable building language-based containers from source code, without t
 
 ## Before you begin
 First, you will need to have Skaffold and a Kubernetes cluster set up.
-To learn more about how to set up Skaffold and a Kubernetes cluster, see the [getting started docs](/docs/getting-started/).
+To learn more about how to set up Skaffold and a Kubernetes cluster, see the [quickstart docs]({{< relref "/docs/quickstart" >}}).
 
 To use buildpacks with Skaffold, please install the following additional tools:
 

--- a/docs/content/en/docs/how-tos/buildpacks/_index.md
+++ b/docs/content/en/docs/how-tos/buildpacks/_index.md
@@ -9,7 +9,7 @@ Buildpacks enable building language-based containers from source code, without t
 
 ## Before you begin
 First, you will need to have Skaffold and a Kubernetes cluster set up.
-To learn more about how to set up Skaffold and a Kubernetes cluster, see the [getting started docs](https://skaffold.dev/docs/getting-started/).
+To learn more about how to set up Skaffold and a Kubernetes cluster, see the [getting started docs](/docs/getting-started/).
 
 To use buildpacks with Skaffold, please install the following additional tools:
 

--- a/docs/content/en/docs/references/deprecation/_index.md
+++ b/docs/content/en/docs/references/deprecation/_index.md
@@ -67,8 +67,8 @@ Control API |alpha|Applications can control sync, build and deployment during in
 [Debug]({{< relref "/docs/how-tos/debug" >}})|alpha|Language-aware reconfiguration of containers on the fly to become debuggable
 [Default-repo]({{< relref "/docs/concepts/image_repositories" >}})|alpha|specify a default image repository & rewrite image names to default repo
 Delete|beta |delete everything deployed by skaffold run from the cluster
-[Deploy] ({{< relref "docs/how-tos/deployers" >}})|beta |Deploy a set of deployables as your applications and replace the image name with the built images
-Dev|beta |Continuous development
+[Deploy]({{< relref "docs/how-tos/deployers" >}})|beta |Deploy a set of deployables as your applications and replace the image name with the built images
+[Dev](../../concepts/modes#skaffold-dev)|beta |Continuous development
 Diagnose|beta |Diagnose the current project and its configuration
 Event API v1|alpha|Publish events and state of the application on gRPC and HTTP
 [Filesync]({{< relref "/docs/how-tos/filesync" >}})|alpha|Instead of rebuilding, copy the changed files in the running container
@@ -79,7 +79,7 @@ Insecure registry handling|alpha |Target registries for built images which are n
 [Profiles]({{< relref "/docs/how-tos/profiles" >}})|beta |Create different pipeline configurations based on overrides and patches defined in one or more profiles
 skaffold build |beta |run skaffold build separately
 skaffold fix|beta |Upgrade an older skaffold config to the current version
-skaffold run|beta |One-off build & deployment of the skaffold application
+[skaffold run](../../concepts/modes#skaffold-run)|beta |One-off build & deployment of the skaffold application
 [Tagpolicy]({{< relref "/docs/how-tos/taggers" >}})|beta |Automated tagging
 [Test]({{< relref "/docs/how-tos/testers" >}})|alpha |Run tests as part of your pipeline
 Trigger|alpha |Feature area: Trigger configured actions when source files change

--- a/docs/content/en/docs/references/deprecation/_index.md
+++ b/docs/content/en/docs/references/deprecation/_index.md
@@ -68,7 +68,7 @@ Control API |alpha|Applications can control sync, build and deployment during in
 [Default-repo]({{< relref "/docs/concepts/image_repositories" >}})|alpha|specify a default image repository & rewrite image names to default repo
 Delete|beta |delete everything deployed by skaffold run from the cluster
 [Deploy]({{< relref "docs/how-tos/deployers" >}})|beta |Deploy a set of deployables as your applications and replace the image name with the built images
-[Dev](../../concepts/modes#skaffold-dev)|beta |Continuous development
+[Dev]({{< relref "/docs/concepts/modes#skaffold-dev" >}})|beta |Continuous development
 Diagnose|beta |Diagnose the current project and its configuration
 Event API v1|alpha|Publish events and state of the application on gRPC and HTTP
 [Filesync]({{< relref "/docs/how-tos/filesync" >}})|alpha|Instead of rebuilding, copy the changed files in the running container
@@ -79,7 +79,7 @@ Insecure registry handling|alpha |Target registries for built images which are n
 [Profiles]({{< relref "/docs/how-tos/profiles" >}})|beta |Create different pipeline configurations based on overrides and patches defined in one or more profiles
 skaffold build |beta |run skaffold build separately
 skaffold fix|beta |Upgrade an older skaffold config to the current version
-[skaffold run](../../concepts/modes#skaffold-run)|beta |One-off build & deployment of the skaffold application
+[skaffold run]({{< relref "/docs/concepts/modes#skaffold-run" >}})|beta |One-off build & deployment of the skaffold application
 [Tagpolicy]({{< relref "/docs/how-tos/taggers" >}})|beta |Automated tagging
 [Test]({{< relref "/docs/how-tos/testers" >}})|alpha |Run tests as part of your pipeline
 Trigger|alpha |Feature area: Trigger configured actions when source files change

--- a/docs/layouts/partials/toc.html
+++ b/docs/layouts/partials/toc.html
@@ -1,0 +1,6 @@
+{{ partial "page-meta-links.html" . }}
+{{ if not .Params.notoc }}
+{{ with .TableOfContents }}
+{{ . }}
+{{ end }}
+{{ end }}


### PR DESCRIPTION

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to #3023, #3024.


**Description**

- make all docs have a toc on the right. 
- Add links to operating modes in deprecation Table. 
- Fix link in Build packs doc


**User facing changes**

See docs preview url.


**Next PRs.**

n/a


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [X] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [x] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

Double check this list of stuff that's easy to miss:

- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)

**Reviewer Notes**

- [X] The code flow looks good. 
- [X] Unit test added.
- [X] User facing changes look good.


**Release Notes**
n/a