### PR TITLE
add event api integration for deploy health check

### DIFF
--- a/pkg/skaffold/deploy/status_check.go
+++ b/pkg/skaffold/deploy/status_check.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/resource"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	pkgkubernetes "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 )
@@ -58,6 +59,7 @@ type counter struct {
 
 func StatusCheck(ctx context.Context, defaultLabeller *DefaultLabeller, runCtx *runcontext.RunContext, out io.Writer) error {
 	client, err := pkgkubernetes.Client()
+	event.StatusCheckEventStarted()
 	if err != nil {
 		return errors.Wrap(err, "getting kubernetes client")
 	}
@@ -136,9 +138,12 @@ func pollResourceStatus(ctx context.Context, runCtx *runcontext.RunContext, r Re
 
 func getSkaffoldDeployStatus(c *counter) error {
 	if c.failed == 0 {
+		event.StatusCheckEventSucceeded()
 		return nil
 	}
-	return fmt.Errorf("%d/%d deployment(s) failed", c.failed, c.total)
+	err := fmt.Errorf("%d/%d deployment(s) failed", c.failed, c.total)
+	event.StatusCheckEventFailed(err)
+	return err
 }
 
 func getDeadline(d int) time.Duration {
@@ -151,12 +156,14 @@ func getDeadline(d int) time.Duration {
 func printStatusCheckSummary(out io.Writer, r Resource, pending int, total int) {
 	status := fmt.Sprintf("%s %s", tabHeader, r)
 	if err := r.Status().Error(); err != nil {
+		event.ResourceStatusCheckEventFailed(r.String(), err)
 		status = fmt.Sprintf("%s failed.%s Error: %s.",
 			status,
 			trimNewLine(getPendingMessage(pending, total)),
 			trimNewLine(err.Error()),
 		)
 	} else {
+		event.ResourceStatusCheckEventSucceeded(r.String())
 		status = fmt.Sprintf("%s is ready.%s", status, getPendingMessage(pending, total))
 	}
 	color.Default.Fprintln(out, status)
@@ -188,6 +195,7 @@ func printStatus(resources []Resource, out io.Writer) bool {
 		}
 		allResourcesCheckComplete = false
 		if str := r.ReportSinceLastUpdated(); str != "" {
+			event.ResourceStatusCheckEventUpdated(r.String(), str)
 			color.Default.Fprintln(out, tabHeader, trimNewLine(str))
 		}
 	}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to #176

Fixes #3020 
/cc @sujit-kamireddy
**Description**

In this PR, we add events for deployment status check phase which will help IDEs to get signal if a deployment is stabilized before they can start debugging an application.

**User facing changes**

Event Changes

**Before**
1. On [example](https://github.com/GoogleCloudPlatform/cloud-code-samples/tree/master/nodejs/nodejs-guestbook)  run `skaffold dev --port-forward --status-check`
No deployment status check related events are seen.
```
tejaldesai@@nodejs-guestbook (master)$ curl localhost:50052/v1/event_log

{"result":{"timestamp":"2019-10-16T21:58:38.402979793Z","event":{"buildEvent":{"artifact":"gcr.io/tejal-test/node-guestbook-frontend","status":"Complete"}},"entry":"Build completed for artifact gcr.io/tejal-test/node-guestbook-frontend"}}
{"result":{"timestamp":"2019-10-16T21:58:38.796363557Z","event":{"deployEvent":{"status":"In Progress"}},"entry":"Deploy started"}}
{"result":{"timestamp":"2019-10-16T21:58:40.002287949Z","event":{"deployEvent":{"status":"Complete"}},"entry":"Deploy complete"}}
{"result":{"timestamp":"2019-10-16T21:58:40.203815130Z","event":{"portEvent":{"localPort":8080,"remotePort":8080,"namespace":"default","resourceType":"service","resourceName":"node-guestbook-backend"}},"entry":"Forwarding container  to local port 8080"}}

```
**After**
Deployment status check events are seen.
```
{"result":{"timestamp":"2019-10-16T22:04:27.036932835Z","event":{"buildEvent":{"artifact":"gcr.io/tejal-test/node-guestbook-frontend","status":"Complete"}},"entry":"Build completed for artifact gcr.io/tejal-test/node-guestbook-frontend"}}
{"result":{"timestamp":"2019-10-16T22:04:27.041619570Z","event":{"deployEvent":{"status":"In Progress"}},"entry":"Deploy started"}}
{"result":{"timestamp":"2019-10-16T22:04:28.839756885Z","event":{"deployEvent":{"status":"Complete"}},"entry":"Deploy complete"}}

{"result":{"timestamp":"2019-10-16T22:04:28.841071895Z","event":{"statusCheckEvent":{"status":"Started"}},"entry":"Status check started"}}

{"result":{"timestamp":"2019-10-16T22:04:29.554067745Z","event":{"resourceStatusCheckEvent":
{"resource":"default:deployment/node-guestbook-backend","status":"In Progress",
"message":"default:deployment/node-guestbook-backend Waiting for rollout to finish: 0 of 1 updated replicas are available...\n"}},
"entry":"Resource default:deployment/node-guestbook-backend status updated to In Progress"}}

{"result":{"timestamp":"2019-10-16T22:04:29.554119649Z","event":{"resourceStatusCheckEvent":
{"resource":"default:deployment/node-guestbook-frontend","status":"In Progress",
"message":"default:deployment/node-guestbook-frontend Waiting for rollout to finish: 0 of 1 updated replicas are available...\n"}},
"entry":"Resource default:deployment/node-guestbook-frontend status updated to In Progress"}}

{"result":{"timestamp":"2019-10-16T22:04:29.554152477Z","event":{"resourceStatusCheckEvent":
{"resource":"default:deployment/node-guestbook-mongodb","status":"In Progress",
"message":"default:deployment/node-guestbook-mongodb Waiting for rollout to finish: 0 of 1 updated replicas are available...\n"}},
"entry":"Resource default:deployment/node-guestbook-mongodb status updated to In Progress"}}

{"result":{"timestamp":"2019-10-16T22:04:30.652952944Z","event":{"resourceStatusCheckEvent":
{"resource":"default:deployment/node-guestbook-backend","status":"Succeeded",
"message":"Succeeded"}},
"entry":"Resource default:deployment/node-guestbook-backend status completed successfully"}}

{"result":{"timestamp":"2019-10-16T22:04:30.654777428Z","event":{"resourceStatusCheckEvent":
{"resource":"default:deployment/node-guestbook-frontend","status":"Succeeded",
"message":"Succeeded"}},
"entry":"Resource default:deployment/node-guestbook-frontend status completed successfully"}}

{"result":{"timestamp":"2019-10-16T22:04:31.860354818Z","event":{"resourceStatusCheckEvent":
{"resource":"default:deployment/node-guestbook-mongodb","status":"Succeeded",
"message":"Succeeded"}},
"entry":"Resource default:deployment/node-guestbook-mongodb status completed successfully"}}

{"result":{"timestamp":"2019-10-16T22:04:31.860376342Z","event":{"statusCheckEvent":
{"status":"Succeeded"}},"entry":"Status check succeeded"}}

{"result":{"timestamp":"2019-10-16T22:04:31.934776579Z",
"event":{"portEvent{"localPort":8080,"remotePort":8080,"namespace":"default",
"resourceType":"service","resourceName":"node-guestbook-backend"}},
"entry":"Forwarding container  to local port 8080"}}


```


**Next PRs.**

None

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

_See [the contribution guide](../CONTRIBUTING.md) for more details._

<!--
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

Describe any user facing changes here so maintainer can include it in the release notes, or delete this block.

```
Add skaffold deploy health check events for deployments, when 
- A deployment has a new status 
- A deployment failed
- A deployed is rolled out successfully.

```
