### PR TITLE
[Custom] [Deprecation] Use $IMAGE instead of $IMAGES 

### DIFF
--- a/docs/content/en/docs/pipeline-stages/builders.md
+++ b/docs/content/en/docs/pipeline-stages/builders.md
@@ -265,15 +265,15 @@ Skaffold will pass in the following environment variables to the custom build sc
 
 | Environment Variable         | Description           | Expectation  |
 | ------------- |-------------| -----|
-| $IMAGES     | An array of fully qualified image names, separated by spaces. For example, "gcr.io/image1 gcr.io/image2" | The custom build script is expected to build an image and tag it with each image name in $IMAGES. Each image should also be pushed if `$PUSH_IMAGE=true`. | 
-| $PUSH_IMAGE      | Set to true if each image in `$IMAGES` is expected to exist in a remote registry. Set to false if each image in `$IMAGES` is expected to exist locally.      |   The custom build script will push each image in `$IMAGES` if `$PUSH_IMAGE=true` | 
+| $IMAGE     | The fully qualified image name. For example, "gcr.io/image1:tag" | The custom build script is expected to build this image and tag it with the name provided in $IMAGE. The image should also be pushed if `$PUSH_IMAGE=true`. | 
+| $PUSH_IMAGE      | Set to true if the image in `$IMAGE` is expected to exist in a remote registry. Set to false if the image is expected to exist locally.      |   The custom build script will push the image `$IMAGE` if `$PUSH_IMAGE=true` | 
 | $BUILD_CONTEXT  | An absolute path to the directory this artifact is meant to be built from. Specified by artifact `context` in the skaffold.yaml.      | None. | 
 | Local environment variables | The current state of the local environment (e.g. `$HOST`, `$PATH)`. Determined by the golang [os.Environ](https://golang.org/pkg/os#Environ) function.| None. |
 
 As described above, the custom build script is expected to:
 
-1. Build and tag each image in `$IMAGES`
-2. Push each image in `$IMAGES` if `$PUSH_IMAGE=true`
+1. Build and tag the `$IMAGE` image
+2. Push the image if `$PUSH_IMAGE=true`
 
 Once the build script has finished executing, skaffold will try to obtain the digest of the newly built image from a remote registry (if `$PUSH_IMAGE=true`) or the local daemon (if `$PUSH_IMAGE=false`).
 If skaffold fails to obtain the digest, it will error out.

--- a/docs/content/en/docs/references/deprecation/_index.md
+++ b/docs/content/en/docs/references/deprecation/_index.md
@@ -113,7 +113,8 @@ Exceptions will always be announced in all relevant release notes.
 
 ## Current deprecation notices
 
-No active deprecation notices.
+10/21/2019: With release v0.41.0 we mark for deprecation the `$IMAGES` environment variable passed to custom builders. Variable `$IMAGE` should be used instead.
+This environment variable flag will be removed no earlier than 01/21/2020.
 
 ## Past deprecation notices
 

--- a/pkg/skaffold/build/custom/custom.go
+++ b/pkg/skaffold/build/custom/custom.go
@@ -90,14 +90,14 @@ func (b *ArtifactBuilder) retrieveCmd(out io.Writer, a *latest.Artifact, tag str
 }
 
 func (b *ArtifactBuilder) retrieveEnv(a *latest.Artifact, tag string) ([]string, error) {
-	images := strings.Join([]string{tag}, " ")
 	buildContext, err := buildContext(a.Workspace)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting absolute path for artifact build context")
 	}
 
 	envs := []string{
-		fmt.Sprintf("%s=%s", constants.Images, images),
+		fmt.Sprintf("%s=%s", constants.Image, tag),
+		fmt.Sprintf("%s=%s", constants.DeprecatedImages, tag),
 		fmt.Sprintf("%s=%t", constants.PushImage, b.pushImages),
 		fmt.Sprintf("%s=%s", constants.BuildContext, buildContext),
 	}

--- a/pkg/skaffold/build/custom/custom_test.go
+++ b/pkg/skaffold/build/custom/custom_test.go
@@ -42,24 +42,24 @@ func TestRetrieveEnv(t *testing.T) {
 			tag:          "gcr.io/image/tag:mytag",
 			environ:      nil,
 			buildContext: "/some/path",
-			expected:     []string{"IMAGES=gcr.io/image/tag:mytag", "PUSH_IMAGE=false", "BUILD_CONTEXT=/some/path"},
+			expected:     []string{"IMAGE=gcr.io/image/tag:mytag", "IMAGES=gcr.io/image/tag:mytag", "PUSH_IMAGE=false", "BUILD_CONTEXT=/some/path"},
 		}, {
 			description:  "make sure environ is correctly applied",
 			tag:          "gcr.io/image/tag:anothertag",
 			environ:      []string{"PATH=/path", "HOME=/root"},
 			buildContext: "/some/path",
-			expected:     []string{"IMAGES=gcr.io/image/tag:anothertag", "PUSH_IMAGE=false", "BUILD_CONTEXT=/some/path", "PATH=/path", "HOME=/root"},
+			expected:     []string{"IMAGE=gcr.io/image/tag:anothertag", "IMAGES=gcr.io/image/tag:anothertag", "PUSH_IMAGE=false", "BUILD_CONTEXT=/some/path", "PATH=/path", "HOME=/root"},
 		}, {
 			description: "push image is true",
 			tag:         "gcr.io/image/push:tag",
 			pushImages:  true,
-			expected:    []string{"IMAGES=gcr.io/image/push:tag", "PUSH_IMAGE=true", "BUILD_CONTEXT="},
+			expected:    []string{"IMAGE=gcr.io/image/push:tag", "IMAGES=gcr.io/image/push:tag", "PUSH_IMAGE=true", "BUILD_CONTEXT="},
 		}, {
 			description:   "add additional env",
 			tag:           "gcr.io/image/push:tag",
 			pushImages:    true,
 			additionalEnv: []string{"KUBECONTEXT=mycluster"},
-			expected:      []string{"IMAGES=gcr.io/image/push:tag", "PUSH_IMAGE=true", "BUILD_CONTEXT=", "KUBECONTEXT=mycluster"},
+			expected:      []string{"IMAGE=gcr.io/image/push:tag", "IMAGES=gcr.io/image/push:tag", "PUSH_IMAGE=true", "BUILD_CONTEXT=", "KUBECONTEXT=mycluster"},
 		},
 	}
 	for _, test := range tests {
@@ -94,7 +94,7 @@ func TestRetrieveCmd(t *testing.T) {
 				},
 			},
 			tag:      "image:tag",
-			expected: expectedCmd("./build.sh", "workspace", nil, []string{"IMAGES=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT=workspace"}),
+			expected: expectedCmd("./build.sh", "workspace", nil, []string{"IMAGE=image:tag", "IMAGES=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT=workspace"}),
 		}, {
 			description: "buildcommand with multiple args",
 			artifact: &latest.Artifact{
@@ -105,7 +105,7 @@ func TestRetrieveCmd(t *testing.T) {
 				},
 			},
 			tag:      "image:tag",
-			expected: expectedCmd("./build.sh", "", []string{"--flag", "--anotherflag"}, []string{"IMAGES=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT="}),
+			expected: expectedCmd("./build.sh", "", []string{"--flag", "--anotherflag"}, []string{"IMAGE=image:tag", "IMAGES=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT="}),
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -80,8 +80,11 @@ var (
 )
 
 var (
-	// Images is an environment variable key, whose value is an array of fully qualified image names passed in to a custom build script.
-	Images = "IMAGES"
+	// DeprecatedImages is an environment variable key, whose value is an array of fully qualified image names passed in to a custom build script.
+	DeprecatedImages = "IMAGES"
+
+	// Image is an environment variable key, whose value is the fully qualified image name passed in to a custom build script.
+	Image = "IMAGE"
 
 	// PushImage lets the custom build script know if the image is expected to be pushed to a remote registry
 	PushImage = "PUSH_IMAGE"


### PR DESCRIPTION
Fixes #3081

`$IMAGES` is still passed, for compatibility reasons, but it no documented anymore

Signed-off-by: David Gageot <david@gageot.net>
