### PR TITLE
[Custom] Clearer message when image was not built

### DIFF
--- a/pkg/skaffold/build/local/custom.go
+++ b/pkg/skaffold/build/local/custom.go
@@ -18,6 +18,7 @@ package local
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/pkg/errors"
@@ -39,7 +40,15 @@ func (b *Builder) buildCustom(ctx context.Context, out io.Writer, artifact *late
 		return docker.RemoteDigest(tag, b.insecureRegistries)
 	}
 
-	return b.localDocker.ImageID(ctx, tag)
+	imageID, err := b.localDocker.ImageID(ctx, tag)
+	if err != nil {
+		return "", err
+	}
+	if imageID == "" {
+		return "", fmt.Errorf("the custom script didn't produce an image with tag [%s]", tag)
+	}
+
+	return imageID, nil
 }
 
 func (b *Builder) retrieveExtraEnv() []string {


### PR DESCRIPTION
When the custom script failed to build the image with the provided tag, it used to give an error like:

```
building [img]: Error parsing reference: "" is not a valid repository/tag: invalid reference format 
```

It's now:

```
building [img]: build artifact: The custom script didn't produce an image with tag [img:tag]
```

Will help debugs issue like #3077

Signed-off-by: David Gageot <david@gageot.net>
