### PR TITLE
Simplify default repo handling and fix #3088

### DIFF
--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -34,7 +34,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/validation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // For tests
@@ -87,8 +86,6 @@ func createNewRunner(opts config.SkaffoldOptions) (runner.Runner, *latest.Skaffo
 		return nil, nil, errors.Wrap(err, "getting run context")
 	}
 
-	applyDefaultRepoSubstitution(config, runCtx.DefaultRepo)
-
 	runner, err := runner.NewForConfig(runCtx)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating runner")
@@ -101,18 +98,5 @@ func warnIfUpdateIsAvailable() {
 	latest, current, versionErr := update.GetLatestAndCurrentVersion()
 	if versionErr == nil && latest.GT(current) {
 		logrus.Warnf("Your Skaffold version might be too old. Download the latest version (%s) at %s\n", latest, constants.LatestDownloadURL)
-	}
-}
-
-func applyDefaultRepoSubstitution(config *latest.SkaffoldConfig, defaultRepo string) {
-	if defaultRepo == "" {
-		// noop
-		return
-	}
-	for _, artifact := range config.Build.Artifacts {
-		artifact.ImageName = util.SubstituteDefaultRepoIntoImage(defaultRepo, artifact.ImageName)
-	}
-	for _, testCase := range config.Test {
-		testCase.ImageName = util.SubstituteDefaultRepoIntoImage(defaultRepo, testCase.ImageName)
 	}
 }

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -98,15 +98,17 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 		// Image is already built
 		buildComplete(artifact.ImageName)
 		entry := c.artifactCache[result.Hash()]
+		tag := tags[artifact.ImageName]
+
 		var uniqueTag string
 		if c.imagesAreLocal {
 			var err error
-			uniqueTag, err = c.client.TagWithImageID(ctx, artifact.ImageName, entry.ID)
+			uniqueTag, err = c.client.TagWithImageID(ctx, tag, entry.ID)
 			if err != nil {
 				return nil, err
 			}
 		} else {
-			uniqueTag = tags[artifact.ImageName] + "@" + entry.Digest
+			uniqueTag = tag + "@" + entry.Digest
 		}
 
 		alreadyBuilt = append(alreadyBuilt, build.Artifact{

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -72,7 +72,7 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *la
 
 	imageID := digestOrImageID
 	b.builtImages = append(b.builtImages, imageID)
-	return b.localDocker.TagWithImageID(ctx, artifact.ImageName, imageID)
+	return b.localDocker.TagWithImageID(ctx, tag, imageID)
 }
 
 func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -52,7 +52,6 @@ type HelmDeployer struct {
 	kubeContext string
 	kubeConfig  string
 	namespace   string
-	defaultRepo string
 	forceDeploy bool
 }
 
@@ -64,7 +63,6 @@ func NewHelmDeployer(runCtx *runcontext.RunContext) *HelmDeployer {
 		kubeContext: runCtx.KubeContext,
 		kubeConfig:  runCtx.Opts.KubeConfig,
 		namespace:   runCtx.Opts.Namespace,
-		defaultRepo: runCtx.DefaultRepo,
 		forceDeploy: runCtx.Opts.Force,
 	}
 }
@@ -479,9 +477,7 @@ func (h *HelmDeployer) joinTagsToBuildResult(builds []build.Artifact, params map
 	paramToBuildResult := map[string]build.Artifact{}
 
 	for param, imageName := range params {
-		newImageName := util.SubstituteDefaultRepoIntoImage(h.defaultRepo, imageName)
-
-		b, ok := imageToBuildResult[newImageName]
+		b, ok := imageToBuildResult[imageName]
 		if !ok {
 			return nil, fmt.Errorf("no build present for %s", imageName)
 		}

--- a/pkg/skaffold/deploy/kubectl/images_test.go
+++ b/pkg/skaffold/deploy/kubectl/images_test.go
@@ -87,7 +87,7 @@ spec:
 		fakeWarner := &warnings.Collect{}
 		t.Override(&warnings.Printf, fakeWarner.Warnf)
 
-		resultManifest, err := manifests.ReplaceImages(builds, "")
+		resultManifest, err := manifests.ReplaceImages(builds)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(expected.String(), resultManifest.String())
@@ -102,7 +102,7 @@ func TestReplaceEmptyManifest(t *testing.T) {
 	manifests := ManifestList{[]byte(""), []byte("  ")}
 	expected := ManifestList{}
 
-	resultManifest, err := manifests.ReplaceImages(nil, "")
+	resultManifest, err := manifests.ReplaceImages(nil)
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected.String(), resultManifest.String())
 }
@@ -110,7 +110,7 @@ func TestReplaceEmptyManifest(t *testing.T) {
 func TestReplaceInvalidManifest(t *testing.T) {
 	manifests := ManifestList{[]byte("INVALID")}
 
-	_, err := manifests.ReplaceImages(nil, "")
+	_, err := manifests.ReplaceImages(nil)
 
 	testutil.CheckError(t, true, err)
 }
@@ -123,7 +123,7 @@ image:
 - value2
 `)}
 
-	output, err := manifests.ReplaceImages(nil, "")
+	output, err := manifests.ReplaceImages(nil)
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, manifests.String(), output.String())
 }

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -71,7 +71,6 @@ type KustomizeDeployer struct {
 	*latest.KustomizeDeploy
 
 	kubectl            deploy.CLI
-	defaultRepo        string
 	insecureRegistries map[string]bool
 	BuildArgs          []string
 }
@@ -84,7 +83,6 @@ func NewKustomizeDeployer(runCtx *runcontext.RunContext) *KustomizeDeployer {
 			Flags:       runCtx.Cfg.Deploy.KustomizeDeploy.Flags,
 			ForceDeploy: runCtx.Opts.Force,
 		},
-		defaultRepo:        runCtx.DefaultRepo,
 		insecureRegistries: runCtx.InsecureRegistries,
 		BuildArgs:          runCtx.Cfg.Deploy.KustomizeDeploy.BuildArgs,
 	}
@@ -121,7 +119,7 @@ func (k *KustomizeDeployer) Deploy(ctx context.Context, out io.Writer, builds []
 		event.DeployInfoEvent(errors.Wrap(err, "could not fetch deployed resource namespace."+
 			"This might cause port-forward and deploy health-check to fail."))
 	}
-	manifests, err = manifests.ReplaceImages(builds, k.defaultRepo)
+	manifests, err = manifests.ReplaceImages(builds)
 	if err != nil {
 		event.DeployFailed(err)
 		return NewDeployErrorResult(errors.Wrap(err, "replacing images in manifests"))

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -347,8 +347,12 @@ func (l *localDaemon) Tag(ctx context.Context, image, ref string) error {
 // So, the solution we chose is to create a tag, just for Skaffold, from
 // the imageID, and use that in the manifests.
 func (l *localDaemon) TagWithImageID(ctx context.Context, ref string, imageID string) (string, error) {
-	uniqueTag := ref + ":" + strings.TrimPrefix(imageID, "sha256:")
+	parsed, err := ParseReference(ref)
+	if err != nil {
+		return "", err
+	}
 
+	uniqueTag := parsed.BaseName + ":" + strings.TrimPrefix(imageID, "sha256:")
 	if err := l.Tag(ctx, imageID, uniqueTag); err != nil {
 		return "", err
 	}

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -480,9 +480,20 @@ func TestTagWithImageID(t *testing.T) {
 			expected:    "ref:imageID",
 		},
 		{
+			description: "ignore tag",
+			imageName:   "ref:tag",
+			imageID:     "sha256:imageID",
+			expected:    "ref:imageID",
+		},
+		{
 			description: "not found",
 			imageName:   "ref",
 			imageID:     "sha256:unknownImageID",
+			shouldErr:   true,
+		},
+		{
+			description: "invalid",
+			imageName:   "!!invalid!!",
 			shouldErr:   true,
 		},
 	}


### PR DESCRIPTION
Default repo handling currently has to be handled in every deployer.

It's much easier to handle it when tags are generated.
 + We generate the tags using the tag policy
 + Then we apply the default repo

Also fix #3088