### PR TITLE
`skaffold build` shouldn’t print the tags used in deployments

### DIFF
--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -69,18 +69,6 @@ func (r *SkaffoldRunner) BuildAndTest(ctx context.Context, out io.Writer, artifa
 	// Make sure all artifacts are redeployed. Not only those that were just built.
 	r.builds = build.MergeWithPreviousBuilds(bRes, r.builds)
 
-	color.Default.Fprintln(out, "Tags used in deployment:")
-
-	if r.imagesAreLocal {
-		color.Yellow.Fprintln(out, " - Since images are not pushed, they can't be referenced by digest")
-		color.Yellow.Fprintln(out, "   They are tagged and referenced by a unique ID instead")
-	}
-
-	for _, build := range r.builds {
-		color.Default.Fprintf(out, " - %s -> ", build.ImageName)
-		fmt.Fprintln(out, build.Tag)
-	}
-
 	return bRes, nil
 }
 

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -18,6 +18,7 @@ package runner
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"time"
 
@@ -31,6 +32,17 @@ import (
 func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []build.Artifact) error {
 	if r.runCtx.Opts.RenderOnly {
 		return r.Render(ctx, out, artifacts, "")
+	}
+
+	color.Default.Fprintln(out, "Tags used in deployment:")
+
+	for _, artifact := range artifacts {
+		color.Default.Fprintf(out, " - %s -> ", artifact.ImageName)
+		fmt.Fprintln(out, artifact.Tag)
+	}
+
+	if r.imagesAreLocal && len(artifacts) > 0 {
+		color.Green.Fprintln(out, "   local images can't be referenced by digest. They are tagged and referenced by a unique ID instead")
 	}
 
 	if config.IsKindCluster(r.runCtx.KubeContext) {


### PR DESCRIPTION
Fixes #3090

Also took the opportunity make the message about digests not being used for local deployments less intrusive. It's now shorter and shown in green instead of orange.

Signed-off-by: David Gageot <david@gageot.net>
