### PR TITLE
Clarify debug docs for deprecated Workload APIs

### DIFF
--- a/docs/content/en/docs/pipeline-stages/builders.md
+++ b/docs/content/en/docs/pipeline-stages/builders.md
@@ -204,11 +204,11 @@ in Maven) that should produce a container image. Then for each such sub-project:
     `:artifactId`, `groupId:artifactId`, or the relative path to the sub-project
     _within the project_.
 
-{{% alert title="Updating from earlier versions" %}}
+{{< alert title="Updating from earlier versions" >}}
 Skaffold had required Maven multi-module projects bind a Jib
-`build` or `dockerBuild` goal to the *package* phase.  These bindings are
+<code>build</code> or <code>dockerBuild</code> goal to the <em>package</em> phase.  These bindings are
 no longer required with Jib 1.4.0 and should be removed.
-{{% /alert %}}
+{{< /alert >}}
 
 #### Gradle
 

--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -46,15 +46,6 @@ For these languages, a special set of [runtime-specific images](https://github.c
 are configured as _init-containers_ to populate a shared-volume that is mounted into
 each of the appropriate containers.  These images are hosted at `gcr.io/gcp-dev-tools/duct-tape`.
 
-{{< alert title="Caution" >}}
-`skaffold debug` does not support deprecated versions of Workload API objects in
-`apps/v1beta1` ([deprecated in Kubernetes 1.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.8.md#other-notable-changes-16))
-and
-`apps/v1beta2` ([deprecated in Kubernetes 1.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md#apps)).
-These deprecated Workload APIs have been [removed in Kubernetes 1.16](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/).
-Applications should transition to the `apps/v1` APIs,
-[introduced in Kubernetes 1.9](https://kubernetes.io/blog/2017/12/kubernetes-19-workloads-expanded-ecosystem/).
-{{< /alert >}}
 
 ### Supported Language Runtimes
 
@@ -114,9 +105,20 @@ DAP is not yet supported by JetBrains IDEs like PyCharm.
 
 ## Limitations
 
-`skaffold debug` has some limitations:
+`skaffold debug` has some limitations.
 
-  - Only the `kubectl` and `kustomize` deployers are supported at the moment: support for
-    the Helm deployer is not yet available.
-  - File sync is disabled for all artifacts.
-    
+### Supported Deployers
+
+`skaffold debug` is only supported with the `kubectl` and `kustomize` deployers at the moment: support for
+the Helm deployer is not yet available ([#2350](https://github.com/GoogleContainerTools/skaffold/issues/2350)).
+
+### Deprecated Workload API Objects
+
+`skaffold debug` does not support deprecated versions of Workload API objects.
+  * `apps/v1beta1` was [deprecated in Kubernetes 1.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.8.md#other-notable-changes-16)
+and
+  * `apps/v1beta2` was [deprecated in Kubernetes 1.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md#apps),
+Both have been [removed in Kubernetes 1.16](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/).
+Applications should transition to the `apps/v1` APIs,
+[introduced in Kubernetes 1.9](https://kubernetes.io/blog/2017/12/kubernetes-19-workloads-expanded-ecosystem/).
+

--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -114,10 +114,11 @@ the Helm deployer is not yet available ([#2350](https://github.com/GoogleContain
 
 ### Deprecated Workload API Objects
 
-`skaffold debug` does not support deprecated versions of Workload API objects.
-  * `apps/v1beta1` was [deprecated in Kubernetes 1.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.8.md#other-notable-changes-16)
-and
-  * `apps/v1beta2` was [deprecated in Kubernetes 1.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md#apps),
+`skaffold debug` does not support deprecated versions of Workload API objects:
+
+  - `apps/v1beta1` was [deprecated in Kubernetes 1.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.8.md#other-notable-changes-16)
+  - `apps/v1beta2` was [deprecated in Kubernetes 1.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md#apps)
+
 Both have been [removed in Kubernetes 1.16](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/).
 Applications should transition to the `apps/v1` APIs,
 [introduced in Kubernetes 1.9](https://kubernetes.io/blog/2017/12/kubernetes-19-workloads-expanded-ecosystem/).

--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -47,7 +47,13 @@ are configured as _init-containers_ to populate a shared-volume that is mounted 
 each of the appropriate containers.  These images are hosted at `gcr.io/gcp-dev-tools/duct-tape`.
 
 {{< alert title="Caution" >}}
-`skaffold debug` does not support deprecated versions of Workload API objects such as `apps/v1beta1`.
+`skaffold debug` does not support deprecated versions of Workload API objects in
+`apps/v1beta1` ([deprecated in Kubernetes 1.8](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.8.md#other-notable-changes-16))
+and
+`apps/v1beta2` ([deprecated in Kubernetes 1.9](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md#apps)).
+These deprecated Workload APIs have been [removed in Kubernetes 1.16](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/).
+Applications should transition to the `apps/v1` APIs,
+[introduced in Kubernetes 1.9](https://kubernetes.io/blog/2017/12/kubernetes-19-workloads-expanded-ecosystem/).
 {{< /alert >}}
 
 ### Supported Language Runtimes


### PR DESCRIPTION
Minor doc modification to expand on `debug` not handling deprecated workload objects.