### PR TITLE
Get current namespace as default namespace for port forwards

### DIFF
--- a/docs/content/en/docs/pipeline-stages/port-forwarding.md
+++ b/docs/content/en/docs/pipeline-stages/port-forwarding.md
@@ -52,7 +52,7 @@ Acceptable resource types include: `Service`, `Pod` and Controller resource type
 | ------------- |-------------| -----|
 | resourceType     | `pod`, `service`, `deployment`, `replicaset`, `statefulset`, `replicationcontroller`, `daemonset`, `job`, `cronjob` | Yes | 
 | resourceName     | Name of the resource to forward.     | Yes | 
-| namespace  | The namespace of the resource to port forward.     | No. Defaults to `default` | 
+| namespace  | The namespace of the resource to port forward.     | No. Defaults to current namespace, or `default` if no current namespace is defined | 
 | port | Port is the resource port that will be forwarded. | Yes |
 | localPort | LocalPort is the local port to forward too. | No. Defaults to value set for `port`. |
 

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -285,5 +285,12 @@ func setDefaultLocalPort(pf *latest.PortForwardResource) {
 }
 
 func setDefaultPortForwardNamespace(pf *latest.PortForwardResource) {
-	pf.Namespace = valueOrDefault(pf.Namespace, constants.DefaultPortForwardNamespace)
+	if pf.Namespace == "" {
+		ns, err := currentNamespace()
+		if err != nil {
+			pf.Namespace = constants.DefaultPortForwardNamespace
+			return
+		}
+		pf.Namespace = ns
+	}
 }

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package defaults
 
 import (
+	"errors"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -77,6 +79,7 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 			CurrentContext: "cluster1",
 			Contexts: map[string]*api.Context{
 				"cluster1": {Namespace: "ns"},
+				"cluster2": {Namespace: "toto"},
 			},
 		})
 
@@ -238,23 +241,94 @@ func TestSetDefaultsOnCloudBuild(t *testing.T) {
 }
 
 func TestSetDefaultPortForwardNamespace(t *testing.T) {
-	cfg := &latest.SkaffoldConfig{
-		Pipeline: latest.Pipeline{
-			Build: latest.BuildConfig{},
-			PortForward: []*latest.PortForwardResource{
-				{
-					Type:      constants.Service,
-					Namespace: "mynamespace",
-				}, {
-					Type: constants.Service,
+
+	tests := []struct {
+		description        string
+		currentConfig      api.Config
+		currentConfigErr   error
+		cfg                *latest.SkaffoldConfig
+		expectedNamespaces []string
+	}{
+		{
+			description: "defined namespace",
+			currentConfig: api.Config{
+				CurrentContext: "cluster1",
+				Contexts: map[string]*api.Context{
+					"cluster1": {Namespace: "ns"},
 				},
 			},
+			cfg: &latest.SkaffoldConfig{
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{},
+					PortForward: []*latest.PortForwardResource{
+						{
+							Type:      constants.Service,
+							Namespace: "mynamespace",
+						}, {
+							Type: constants.Service,
+						},
+					},
+				},
+			},
+			expectedNamespaces: []string{"mynamespace", "ns"},
+		},
+		{
+			description: "empty namespace",
+			currentConfig: api.Config{
+				CurrentContext: "cluster1",
+				Contexts: map[string]*api.Context{
+					"cluster1": {Namespace: ""},
+				},
+			},
+			cfg: &latest.SkaffoldConfig{
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{},
+					PortForward: []*latest.PortForwardResource{
+						{
+							Type:      constants.Service,
+							Namespace: "mynamespace",
+						}, {
+							Type: constants.Service,
+						},
+					},
+				},
+			},
+			expectedNamespaces: []string{"mynamespace", "default"},
+		},
+		{
+			description:      "error getting context",
+			currentConfig:    api.Config{},
+			currentConfigErr: errors.New("ome error"),
+			cfg: &latest.SkaffoldConfig{
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{},
+					PortForward: []*latest.PortForwardResource{
+						{
+							Type:      constants.Service,
+							Namespace: "mynamespace",
+						}, {
+							Type: constants.Service,
+						},
+					},
+				},
+			},
+			expectedNamespaces: []string{"mynamespace", "default"},
 		},
 	}
-	err := Set(cfg)
-	testutil.CheckError(t, false, err)
-	testutil.CheckDeepEqual(t, "mynamespace", cfg.PortForward[0].Namespace)
-	testutil.CheckDeepEqual(t, "ns", cfg.PortForward[1].Namespace)
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			kubectx.CurrentConfig = func() (api.Config, error) {
+				return test.currentConfig, test.currentConfigErr
+			}
+			err := Set(test.cfg)
+			t.CheckError(false, err)
+			t.CheckDeepEqual(len(test.expectedNamespaces), len(test.cfg.PortForward))
+			for i, pf := range test.cfg.PortForward {
+				t.CheckDeepEqual(test.expectedNamespaces[i], pf.Namespace)
+			}
+		})
+	}
 }
 
 func TestSetPortForwardLocalPort(t *testing.T) {

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -254,7 +254,7 @@ func TestSetDefaultPortForwardNamespace(t *testing.T) {
 	err := Set(cfg)
 	testutil.CheckError(t, false, err)
 	testutil.CheckDeepEqual(t, "mynamespace", cfg.PortForward[0].Namespace)
-	testutil.CheckDeepEqual(t, constants.DefaultPortForwardNamespace, cfg.PortForward[1].Namespace)
+	testutil.CheckDeepEqual(t, "ns", cfg.PortForward[1].Namespace)
 }
 
 func TestSetPortForwardLocalPort(t *testing.T) {

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -241,7 +241,6 @@ func TestSetDefaultsOnCloudBuild(t *testing.T) {
 }
 
 func TestSetDefaultPortForwardNamespace(t *testing.T) {
-
 	tests := []struct {
 		description        string
 		currentConfig      api.Config

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -79,7 +79,6 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 			CurrentContext: "cluster1",
 			Contexts: map[string]*api.Context{
 				"cluster1": {Namespace: "ns"},
-				"cluster2": {Namespace: "toto"},
 			},
 		})
 


### PR DESCRIPTION
Fixes `#3098`.

**Description**

When declaring a port forward without declaring the namespace, the **current** namespace is used, instead of the namespace named "default".

**Before**

If the namespace is not specified  for a port forward, the "default" namespace is used.

**After**

If the namespace is not specified  for a port forward, the current namespace is used.

**Submitter Checklist**

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

When declaring a port forward without declaring the namespace, the current namespace is used, insted of the namespace named "default"

