### PR TITLE
Log durations instead of always printing them

### DIFF
--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -115,7 +115,7 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 		})
 	}
 
-	color.Default.Fprintln(out, "Cache check complete in", time.Since(start))
+	logrus.Infoln("Cache check complete in", time.Since(start))
 
 	bRes, err := buildAndTest(ctx, out, tags, needToBuild)
 	if err != nil {

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
@@ -149,6 +150,6 @@ func (r *SkaffoldRunner) imageTags(ctx context.Context, out io.Writer, artifacts
 		}
 	}
 
-	color.Default.Fprintln(out, "Tags generated in", time.Since(start))
+	logrus.Infoln("Tags generated in", time.Since(start))
 	return imageTags, nil
 }

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -173,7 +173,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 		return errors.Wrapf(err, "watching skaffold configuration %s", r.runCtx.Opts.ConfigurationFile)
 	}
 
-	color.Default.Fprintln(out, "List generated in", time.Since(start))
+	logrus.Infoln("List generated in", time.Since(start))
 
 	// First build
 	if _, err := r.BuildAndTest(ctx, out, artifacts); err != nil {

--- a/pkg/skaffold/runner/timings.go
+++ b/pkg/skaffold/runner/timings.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -65,7 +66,7 @@ func (w withTimings) Build(ctx context.Context, out io.Writer, tags tag.ImageTag
 		return nil, err
 	}
 
-	color.Default.Fprintln(out, "Build complete in", time.Since(start))
+	logrus.Infoln("Build complete in", time.Since(start))
 	return bRes, nil
 }
 
@@ -77,7 +78,7 @@ func (w withTimings) Test(ctx context.Context, out io.Writer, builds []build.Art
 		return err
 	}
 
-	color.Default.Fprintln(out, "Test complete in", time.Since(start))
+	logrus.Infoln("Test complete in", time.Since(start))
 	return nil
 }
 
@@ -90,7 +91,7 @@ func (w withTimings) Deploy(ctx context.Context, out io.Writer, builds []build.A
 		return dr
 	}
 
-	color.Default.Fprintln(out, "Deploy complete in", time.Since(start))
+	logrus.Infoln("Deploy complete in", time.Since(start))
 	return dr
 }
 
@@ -103,7 +104,7 @@ func (w withTimings) Cleanup(ctx context.Context, out io.Writer) error {
 		return err
 	}
 
-	color.Default.Fprintln(out, "Cleanup complete in", time.Since(start))
+	logrus.Infoln("Cleanup complete in", time.Since(start))
 	return nil
 }
 
@@ -116,6 +117,6 @@ func (w withTimings) Prune(ctx context.Context, out io.Writer) error {
 		return err
 	}
 
-	color.Default.Fprintln(out, "Image prune complete in", time.Since(start))
+	logrus.Infoln("Image prune complete in", time.Since(start))
 	return nil
 }

--- a/vendor/github.com/sirupsen/logrus/hooks/test/test.go
+++ b/vendor/github.com/sirupsen/logrus/hooks/test/test.go
@@ -1,0 +1,92 @@
+// The Test package is used for testing logrus. It is here for backwards
+// compatibility from when logrus' organization was upper-case. Please use
+// lower-case logrus and the `null` package instead of this one.
+package test
+
+import (
+	"io/ioutil"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Hook is a hook designed for dealing with logs in test scenarios.
+type Hook struct {
+	// Entries is an array of all entries that have been received by this hook.
+	// For safe access, use the AllEntries() method, rather than reading this
+	// value directly.
+	Entries []logrus.Entry
+	mu      sync.RWMutex
+}
+
+// NewGlobal installs a test hook for the global logger.
+func NewGlobal() *Hook {
+
+	hook := new(Hook)
+	logrus.AddHook(hook)
+
+	return hook
+
+}
+
+// NewLocal installs a test hook for a given local logger.
+func NewLocal(logger *logrus.Logger) *Hook {
+
+	hook := new(Hook)
+	logger.Hooks.Add(hook)
+
+	return hook
+
+}
+
+// NewNullLogger creates a discarding logger and installs the test hook.
+func NewNullLogger() (*logrus.Logger, *Hook) {
+
+	logger := logrus.New()
+	logger.Out = ioutil.Discard
+
+	return logger, NewLocal(logger)
+
+}
+
+func (t *Hook) Fire(e *logrus.Entry) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Entries = append(t.Entries, *e)
+	return nil
+}
+
+func (t *Hook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// LastEntry returns the last entry that was logged or nil.
+func (t *Hook) LastEntry() *logrus.Entry {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	i := len(t.Entries) - 1
+	if i < 0 {
+		return nil
+	}
+	return &t.Entries[i]
+}
+
+// AllEntries returns all entries that were logged.
+func (t *Hook) AllEntries() []*logrus.Entry {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	// Make a copy so the returned value won't race with future log requests
+	entries := make([]*logrus.Entry, len(t.Entries))
+	for i := 0; i < len(t.Entries); i++ {
+		// Make a copy, for safety
+		entries[i] = &t.Entries[i]
+	}
+	return entries
+}
+
+// Reset removes all Entries from this test hook.
+func (t *Hook) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Entries = make([]logrus.Entry, 0)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -279,6 +279,7 @@ github.com/sergi/go-diff/diffmatchpatch
 github.com/shurcooL/sanitized_anchor_name
 # github.com/sirupsen/logrus v1.4.2
 github.com/sirupsen/logrus
+github.com/sirupsen/logrus/hooks/test
 # github.com/spf13/cobra v0.0.5
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5


### PR DESCRIPTION
This is the first PR to simplify Skaffold's output.
This one is simple, it hides the timings that are currently always shown, and log them at Info level.

**Before**:
<img width="1199" alt="before" src="https://user-images.githubusercontent.com/153495/67192608-2b90f200-f3f4-11e9-9c07-fd106da03255.png">

**After**:
<img width="1198" alt="after" src="https://user-images.githubusercontent.com/153495/67192619-2fbd0f80-f3f4-11e9-891a-49ac234e7ec7.png">

Signed-off-by: David Gageot <david@gageot.net>
