### PR TITLE
Align kubectl/kustomize cleanup output with deploy output

### DIFF
--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -138,7 +138,7 @@ func (k *KubectlDeployer) Cleanup(ctx context.Context, out io.Writer) error {
 		}
 	}
 
-	if err := k.kubectl.Delete(ctx, out, manifests); err != nil {
+	if err := k.kubectl.Delete(ctx, textio.NewPrefixWriter(out, " - "), manifests); err != nil {
 		return errors.Wrap(err, "delete")
 	}
 

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -157,7 +157,7 @@ func (k *KustomizeDeployer) Cleanup(ctx context.Context, out io.Writer) error {
 		return errors.Wrap(err, "reading manifests")
 	}
 
-	if err := k.kubectl.Delete(ctx, out, manifests); err != nil {
+	if err := k.kubectl.Delete(ctx, textio.NewPrefixWriter(out, " - "), manifests); err != nil {
 		return errors.Wrap(err, "delete")
 	}
 


### PR DESCRIPTION
Signed-off-by: David Gageot <david@gageot.net>

**Before**:
<img width="1196" alt="before" src="https://user-images.githubusercontent.com/153495/67193496-ad354f80-f3f5-11e9-9a9c-c30a3ecf859c.png">

**After**:
<img width="1198" alt="after" src="https://user-images.githubusercontent.com/153495/67193500-adcde600-f3f5-11e9-98df-f467312f3281.png">
