### PR TITLE
Remove logs before building and testing

### DIFF
--- a/pkg/skaffold/runner/timings.go
+++ b/pkg/skaffold/runner/timings.go
@@ -59,7 +59,6 @@ func (w withTimings) Build(ctx context.Context, out io.Writer, tags tag.ImageTag
 		return nil, nil
 	}
 	start := time.Now()
-	color.Default.Fprintln(out, "Starting build...")
 
 	bRes, err := w.Builder.Build(ctx, out, tags, artifacts)
 	if err != nil {
@@ -72,7 +71,6 @@ func (w withTimings) Build(ctx context.Context, out io.Writer, tags tag.ImageTag
 
 func (w withTimings) Test(ctx context.Context, out io.Writer, builds []build.Artifact) error {
 	start := time.Now()
-	color.Default.Fprintln(out, "Starting test...")
 
 	err := w.Tester.Test(ctx, out, builds)
 	if err != nil {

--- a/pkg/skaffold/runner/timings_test.go
+++ b/pkg/skaffold/runner/timings_test.go
@@ -90,12 +90,12 @@ func TestTimingsBuild(t *testing.T) {
 	}{
 		{
 			description:  "build success",
-			shouldOutput: "(?m)^Starting build...\nBuild complete in .+$",
+			shouldOutput: "(?m)^Build complete in .+$",
 			shouldErr:    false,
 		},
 		{
 			description:  "build failure",
-			shouldOutput: "^Starting build...\n$",
+			shouldOutput: "",
 			shouldErr:    true,
 		},
 	}
@@ -152,12 +152,12 @@ func TestTimingsTest(t *testing.T) {
 	}{
 		{
 			description:  "test success",
-			shouldOutput: "(?m)^Starting test...\nTest complete in .+$",
+			shouldOutput: "(?m)^Test complete in .+$",
 			shouldErr:    false,
 		},
 		{
 			description:  "test failure",
-			shouldOutput: "^Starting test...\n$",
+			shouldOutput: "",
 			shouldErr:    true,
 		},
 	}


### PR DESCRIPTION
There are enough logs before each individual build or test.

Signed-off-by: David Gageot <david@gageot.net>

**Before**
<img width="807" alt="before" src="https://user-images.githubusercontent.com/153495/67194741-f8506200-f3f7-11e9-9518-aa410a11d67a.png">

**After**
<img width="810" alt="after" src="https://user-images.githubusercontent.com/153495/67194743-f9818f00-f3f7-11e9-8bef-6452b6271447.png">

