### PR TITLE
Hide message about context

### DIFF
--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -28,7 +28,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/bazel"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/custom"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/jib"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -39,7 +38,7 @@ import (
 // its checksum. It streams build progress to the writer argument.
 func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 	if b.localCluster {
-		color.Default.Fprintf(out, "Found [%s] context, using local docker daemon.\n", b.kubeContext)
+		logrus.Infof("Found [%s] context, using local docker daemon.\n", b.kubeContext)
 	}
 	defer b.localDocker.Close()
 


### PR DESCRIPTION
Make it an info log instead of a message that’s always printed.

Signed-off-by: David Gageot <david@gageot.net>

**Before**
<img width="916" alt="before" src="https://user-images.githubusercontent.com/153495/67195358-18ccec00-f3f9-11e9-815c-f63c84cc7903.png">

**After**
<img width="929" alt="Screenshot 2019-10-21 at 11 48 47" src="https://user-images.githubusercontent.com/153495/67195361-19658280-f3f9-11e9-8a72-3a37e1dd7956.png">


