### PR TITLE
Prepare cli-go to accept `--kubeconfig` setting

### DIFF
--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -72,7 +72,7 @@ func createNewRunner(opts config.SkaffoldOptions) (runner.Runner, *latest.Skaffo
 		return nil, nil, errors.Wrap(err, "applying profiles")
 	}
 
-	kubectx.UseKubeContext(opts.KubeContext, config.Deploy.KubeContext)
+	kubectx.ConfigureKubeConfig(opts.KubeConfig, opts.KubeContext, config.Deploy.KubeContext)
 
 	if err := defaults.Set(config); err != nil {
 		return nil, nil, errors.Wrap(err, "setting default values")

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -55,6 +55,7 @@ type SkaffoldOptions struct {
 	CacheFile          string
 	Trigger            string
 	KubeContext        string
+	KubeConfig         string
 	WatchPollInterval  int
 	DefaultRepo        string
 	CustomLabels       []string


### PR DESCRIPTION
Relates to #2699 

Should merge before : #3100 

Should merge after : n/a

**Description**
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
This introduces yet another global state in `context.go`. An alternative could be to
load the kubeconfig eagerly, when ConfigureKubeConfig is called. However,
this would require to call this setup method in all tests which make use
of the k8s rest client, which is a severe disadvantage.

**User facing changes**

n/a

**Next PRs.**

- Prepare `kubectl` and `helm` to accept the `--kubeconfig` setting (#3108 )
- Add a new CLI flag `--kubeconfig` to configure the kubeconfig (#3100)


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.
