### PR TITLE
Prepare kubectl and helm deployers for `--kubeconfig` flag

### DIFF
--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -55,6 +55,7 @@ type SkaffoldOptions struct {
 	CacheFile          string
 	Trigger            string
 	KubeContext        string
+	KubeConfig         string
 	WatchPollInterval  int
 	DefaultRepo        string
 	CustomLabels       []string

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -50,6 +50,7 @@ type HelmDeployer struct {
 	*latest.HelmDeploy
 
 	kubeContext string
+	kubeConfig  string
 	namespace   string
 	defaultRepo string
 	forceDeploy bool
@@ -61,6 +62,7 @@ func NewHelmDeployer(runCtx *runcontext.RunContext) *HelmDeployer {
 	return &HelmDeployer{
 		HelmDeploy:  runCtx.Cfg.Deploy.HelmDeploy,
 		kubeContext: runCtx.KubeContext,
+		kubeConfig:  runCtx.Opts.KubeConfig,
 		namespace:   runCtx.Opts.Namespace,
 		defaultRepo: runCtx.DefaultRepo,
 		forceDeploy: runCtx.Opts.Force,
@@ -161,6 +163,9 @@ func (h *HelmDeployer) Cleanup(ctx context.Context, out io.Writer) error {
 func (h *HelmDeployer) helm(ctx context.Context, out io.Writer, useSecrets bool, arg ...string) error {
 	args := append([]string{"--kube-context", h.kubeContext}, arg...)
 	args = append(args, h.Flags.Global...)
+	if h.kubeConfig != "" {
+		args = append(args, "--kubeconfig", h.kubeConfig)
+	}
 
 	if useSecrets {
 		args = append([]string{"secrets"}, args...)

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -529,8 +529,12 @@ func (m *MockHelm) RunCmd(c *exec.Cmd) error {
 		m.t.Errorf("Not enough args in command %v", c)
 	}
 
-	if c.Args[1] != "--kube-context" || c.Args[2] != testKubeContext {
+	argString := strings.Join(c.Args, " ")
+	if !strings.Contains(argString, "--kube-context "+testKubeContext) {
 		m.t.Errorf("Invalid Kubernetes context %v", c)
+	}
+	if !strings.Contains(argString, "--kubeconfig "+testKubeConfig) {
+		m.t.Errorf("Invalid Kubernetes config %v", c)
 	}
 
 	if c.Args[3] == "get" || c.Args[3] == "upgrade" {
@@ -863,8 +867,9 @@ func makeRunContext(deploy latest.HelmDeploy, force bool) *runcontext.RunContext
 		Cfg:         pipeline,
 		KubeContext: testKubeContext,
 		Opts: config.SkaffoldOptions{
-			Namespace: testNamespace,
-			Force:     force,
+			Namespace:  testNamespace,
+			KubeConfig: testKubeConfig,
+			Force:      force,
 		},
 	}
 }

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -36,6 +36,7 @@ import (
 
 const (
 	testKubeContext = "kubecontext"
+	testKubeConfig  = "kubeconfig"
 	kubectlVersion  = `{"clientVersion":{"major":"1","minor":"12"}}`
 )
 

--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -29,6 +29,7 @@ import (
 // CLI holds parameters to run kubectl.
 type CLI struct {
 	KubeContext string
+	KubeConfig  string
 	Namespace   string
 
 	version     ClientVersion
@@ -38,6 +39,7 @@ type CLI struct {
 func NewFromRunContext(runCtx *runcontext.RunContext) *CLI {
 	return &CLI{
 		KubeContext: runCtx.KubeContext,
+		KubeConfig:  runCtx.Opts.KubeConfig,
 		Namespace:   runCtx.Opts.Namespace,
 	}
 }
@@ -85,6 +87,9 @@ func (c *CLI) args(command string, namespace string, arg ...string) []string {
 	namespace = c.resolveNamespace(namespace)
 	if namespace != "" {
 		args = append(args, "--namespace", namespace)
+	}
+	if c.KubeConfig != "" {
+		args = append(args, "--kubeconfig", c.KubeConfig)
 	}
 	args = append(args, command)
 	args = append(args, arg...)


### PR DESCRIPTION
Relates to #2699 

Should merge before : #3100 

Should merge after : n/a

**Description**
<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
Adds the infrastructure to pass the `--kubeconfig` CLI setting to `kubectl` and `helm`.

**User facing changes**

n/a

**Next PRs.**

- Prepare cli-go to accept the `--kubeconfig` setting (#3107)
- Add a new CLI flag `--kubeconfig` to configure the kubeconfig (#3100)


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.
