### PR TITLE
Related to #2849: Allows ValuesFiles to be templatable

### DIFF
--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -85,6 +85,20 @@ var testDeployConfigTemplated = latest.HelmDeploy{
 	}},
 }
 
+var testDeployConfigValuesFilesTemplated = latest.HelmDeploy{
+	Releases: []latest.HelmRelease{{
+		Name:      "skaffold-helm",
+		ChartPath: "examples/test",
+		Values: map[string]string{
+			"image": "skaffold-helm",
+		},
+		Overrides: schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
+		ValuesFiles: []string{
+			"/some/file-{{.FOO}}.yaml",
+		},
+	}},
+}
+
 var testDeployRecreatePodsConfig = latest.HelmDeploy{
 	Releases: []latest.HelmRelease{{
 		Name:      "skaffold-helm",
@@ -467,6 +481,16 @@ func TestHelmDeploy(t *testing.T) {
 				},
 			},
 			runContext: makeRunContext(testDeployConfigTemplated, false),
+			builds:     testBuilds,
+		},
+		{
+			description: "deploy with valuesFiles templated",
+			commands: &MockHelm{
+				upgradeMatcher: func(cmd *exec.Cmd) bool {
+					return util.StrSliceContains(cmd.Args, "/some/file-FOOBAR.yaml")
+				},
+			},
+			runContext: makeRunContext(testDeployConfigValuesFilesTemplated, false),
 			builds:     testBuilds,
 		},
 		{


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to #2849.

Should merge before :  none

Should merge after :  none

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

**User facing changes**

Behaviour change on helm, allows ValuesFiles to be used as templates

**Before**

n/a

**After**

n/a

**Next PRs.**

More fields to be templatable, up to design decision from the skaffold team

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

<!-- 
Describe any user facing changes here so maintainer can include it in the release notes, or delete this block.
-->

```
Update on helm:
* ValuesFiles can be rendered with environment and build variables
```
