### PR TITLE
Restrict build to watched images for `skaffold dev`

### DIFF
--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -42,7 +42,7 @@ func NewCmdDev() *cobra.Command {
 			f.MarkHidden("auto-sync")
 			f.BoolVar(&opts.AutoDeploy, "auto-deploy", true, "When set to false, deploys wait for API request instead of running automatically (default true)")
 			f.MarkHidden("auto-deploy")
-			f.StringSliceVarP(&opts.TargetImages, "watch-image", "w", nil, "Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts")
+			f.StringSliceVarP(&opts.TargetImages, "watch-image", "w", nil, "Choose which artifacts to watch. Only artifacts with image names that contain the expression will be built and watched. Default is to watch sources for all artifacts")
 			f.IntVarP(&opts.WatchPollInterval, "watch-poll-interval", "i", 1000, "Interval (in ms) between two checks for file changes")
 		}).
 		NoArgs(cancelWithCtrlC(context.Background(), doDev))

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -129,11 +129,13 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	start := time.Now()
 	color.Default.Fprintln(out, "Listing files to watch...")
 
+	var targetArtifacts []*latest.Artifact
 	for i := range artifacts {
 		artifact := artifacts[i]
 		if !r.runCtx.Opts.IsTargetImage(artifact) {
 			continue
 		}
+		targetArtifacts = append(targetArtifacts, artifact)
 
 		color.Default.Fprintf(out, " - %s\n", artifact.ImageName)
 
@@ -188,7 +190,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	logrus.Infoln("List generated in", time.Since(start))
 
 	// First build
-	if _, err := r.BuildAndTest(ctx, out, artifacts); err != nil {
+	if _, err := r.BuildAndTest(ctx, out, targetArtifacts); err != nil {
 		return errors.Wrap(err, "exiting dev mode because first build failed")
 	}
 


### PR DESCRIPTION
Relates to #3118

**Description**

Demo PR to show that my suggestion is easy to implement. Not a full solution yet because 1) you may want to introduce a CLI parameter for this behavior and 2) no tests.

**User facing changes**

`skaffold dev -w PATTERN` restricts first and further builds to only images matching the pattern.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

n/a (demo PR, don't merge as-is)