### PR TITLE
Add heuristics to speed up Jib check in skaffold init

### DIFF
--- a/pkg/skaffold/jib/jib_init_test.go
+++ b/pkg/skaffold/jib/jib_init_test.go
@@ -29,6 +29,7 @@ func TestValidateJibConfig(t *testing.T) {
 	var tests = []struct {
 		description    string
 		path           string
+		fileContents   string
 		command        string
 		stdout         string
 		expectedConfig []Jib
@@ -39,16 +40,24 @@ func TestValidateJibConfig(t *testing.T) {
 			expectedConfig: nil,
 		},
 		{
-			description:    "jib not configured",
+			description:    "jib string not found",
 			path:           "path/to/build.gradle",
+			fileContents:   "not a useful string",
+			expectedConfig: nil,
+		},
+		{
+			description:    "jib string found but not configured",
+			path:           "path/to/build.gradle",
+			fileContents:   "com.google.cloud.tools.jib",
 			command:        "gradle _jibSkaffoldInit -q",
 			stdout:         "error",
 			expectedConfig: nil,
 		},
 		{
-			description: "jib gradle single project",
-			path:        "path/to/build.gradle",
-			command:     "gradle _jibSkaffoldInit -q",
+			description:  "jib gradle single project",
+			path:         "path/to/build.gradle",
+			fileContents: "com.google.cloud.tools.jib",
+			command:      "gradle _jibSkaffoldInit -q",
 			stdout: `BEGIN JIB JSON
 {"image":"image","project":"project"}
 `,
@@ -57,9 +66,10 @@ func TestValidateJibConfig(t *testing.T) {
 			},
 		},
 		{
-			description: "jib gradle-kotlin single project",
-			path:        "path/to/build.gradle.kts",
-			command:     "gradle _jibSkaffoldInit -q",
+			description:  "jib gradle-kotlin single project",
+			path:         "path/to/build.gradle.kts",
+			fileContents: "com.google.cloud.tools.jib",
+			command:      "gradle _jibSkaffoldInit -q",
 			stdout: `BEGIN JIB JSON
 {"image":"image","project":"project"}
 `,
@@ -68,9 +78,10 @@ func TestValidateJibConfig(t *testing.T) {
 			},
 		},
 		{
-			description: "jib gradle multi-project",
-			path:        "path/to/build.gradle",
-			command:     "gradle _jibSkaffoldInit -q",
+			description:  "jib gradle multi-project",
+			path:         "path/to/build.gradle",
+			fileContents: "com.google.cloud.tools.jib",
+			command:      "gradle _jibSkaffoldInit -q",
 			stdout: `BEGIN JIB JSON
 {"image":"image","project":"project1"}
 
@@ -83,9 +94,10 @@ BEGIN JIB JSON
 			},
 		},
 		{
-			description: "jib maven single module",
-			path:        "path/to/pom.xml",
-			command:     "mvn jib:_skaffold-init -q",
+			description:  "jib maven single module",
+			path:         "path/to/pom.xml",
+			fileContents: "<artifactId>jib-maven-plugin</artifactId>",
+			command:      "mvn jib:_skaffold-init -q",
 			stdout: `BEGIN JIB JSON
 {"image":"image","project":"project"}`,
 			expectedConfig: []Jib{
@@ -93,9 +105,10 @@ BEGIN JIB JSON
 			},
 		},
 		{
-			description: "jib maven multi-module",
-			path:        "path/to/pom.xml",
-			command:     "mvn jib:_skaffold-init -q",
+			description:  "jib maven multi-module",
+			path:         "path/to/pom.xml",
+			fileContents: "<artifactId>jib-maven-plugin</artifactId>",
+			command:      "mvn jib:_skaffold-init -q",
 			stdout: `BEGIN JIB JSON
 {"image":"image","project":"project1"}
 
@@ -110,12 +123,17 @@ BEGIN JIB JSON
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			tmpDir := t.NewTempDir().Write(test.path, test.fileContents)
+			for i := range test.expectedConfig {
+				test.expectedConfig[i].FilePath = tmpDir.Path(test.expectedConfig[i].FilePath)
+			}
+
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunOut(
 				test.command,
 				test.stdout,
 			))
 
-			validated := ValidateJibConfig(test.path)
+			validated := ValidateJibConfig(tmpDir.Path(test.path))
 
 			t.CheckDeepEqual(test.expectedConfig, validated)
 		})


### PR DESCRIPTION
With this PR, skaffold first checks for Jib-related strings in the build file before attempting to run the task/goal, rather than attempting to call into Jib any time a build.gradle or pom.xml is found. This eliminates a lot of false positives and speeds up `skaffold init` considerably on projects that don't have Jib configured.

Here are the timings for running `skaffold init --XXenableJibInit --analyze` on a 2-module maven project with no Jib configurations, before and after this PR:
* Before: **5.593s**
* After: **0.246s**

Timings before and after are about the same if Jib is configured on all modules. This PR seems to save around 2-3 seconds for every module Jib is not configured.

It still may be a good idea to consider automatically applying Jib on Java projects where it isn't already configured, but in the meantime this seems like a good improvement to have.

**Release Notes**

Speed up Jib checks in `skaffold init` on Java projects.
