### PR TITLE
faster quicktests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ GO_LDFLAGS_darwin =" $(GO_LDFLAGS)  -extldflags \"$(LDFLAGS_darwin)\""
 GO_LDFLAGS_linux =" $(GO_LDFLAGS)  -extldflags \"$(LDFLAGS_linux)\""
 
 GO_FILES := $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+GOMAXPROCS := $(shell go run hack/numprocs/numprocs.go)
 
 $(BUILD_DIR)/$(PROJECT): $(BUILD_DIR)/$(PROJECT)-$(GOOS)-$(GOARCH)
 	cp $(BUILD_DIR)/$(PROJECT)-$(GOOS)-$(GOARCH) $@
@@ -114,7 +115,7 @@ checks: $(BUILD_DIR)
 
 .PHONY: quicktest
 quicktest:
-	go test -short -timeout=60s ./...
+	GOMAXPROCS=$(GOMAXPROCS) go test -short -timeout=60s ./...
 
 .PHONY: install
 install: $(GO_FILES) $(BUILD_DIR)

--- a/hack/numprocs/numprocs.go
+++ b/hack/numprocs/numprocs.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func main() {
+	fmt.Println(runtime.NumCPU())
+}


### PR DESCRIPTION
passes `$GOMAXPROCS` with the full number of processors to quickest. On my linux workstation this brings down from 140s -> 20 s `make quicktest` - should help with Mac / Win test speeds as well potentially a little bit on Travis. 

Why not test.sh? Maybe that could work too - it didn't seem to matter much (maybe because of `-cover` or `-race` wouldn't allow parallel runs?), so I didn't complicate things - we might need to look into that in more detail. 