### PR TITLE
init --analyze should return unique image names

### DIFF
--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -143,9 +143,9 @@ func DoInit(ctx context.Context, out io.Writer, c Config) error {
 
 	if c.Analyze {
 		// TODO: Remove backwards compatibility block
-		// if !c.EnableJibInit {
-		// 	return printAnalyzeJSONNoJib(out, c.SkipBuild, pairs, unresolvedBuilderConfigs, unresolvedImages)
-		// }
+		if !c.EnableJibInit {
+			return printAnalyzeJSONNoJib(out, c.SkipBuild, pairs, unresolvedBuilderConfigs, unresolvedImages)
+		}
 
 		return printAnalyzeJSON(out, c.SkipBuild, pairs, unresolvedBuilderConfigs, unresolvedImages)
 	}

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -56,6 +56,12 @@ func TestPrintAnalyzeJSON(t *testing.T) {
 			expected:    `{"images":[{"name":"image1","foundMatch":false},{"name":"image2","foundMatch":false}]}`,
 		},
 		{
+			description: "image names should be unique",
+			images:      []string{"image1", "image2", "image1"},
+			skipBuild:   true,
+			expected:    `{"images":[{"name":"image1","foundMatch":false},{"name":"image2","foundMatch":false}]}`,
+		},
+		{
 			description: "no dockerfile",
 			images:      []string{"image1", "image2"},
 			shouldErr:   true,
@@ -95,6 +101,12 @@ func TestPrintAnalyzeJSONNoJib(t *testing.T) {
 		{
 			description: "no dockerfile, skip build (backwards compatibility)",
 			images:      []string{"image1", "image2"},
+			skipBuild:   true,
+			expected:    `{"images":["image1","image2"]}`,
+		},
+		{
+			description: "image names should be unique",
+			images:      []string{"image1", "image2", "image1"},
 			skipBuild:   true,
 			expected:    `{"images":["image1","image2"]}`,
 		},

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -464,11 +464,11 @@ func TestAutoSelectBuilders(t *testing.T) {
 			expectedFilteredImages: []string{"image1", "image2"},
 		},
 		{
-			description: "show unique image names",
-			builderConfigs: nil,
-			images:        []string{"image1", "image1"},
-			expectedPairs: nil,
-			expectedBuildersLeft: nil,
+			description:            "show unique image names",
+			builderConfigs:         nil,
+			images:                 []string{"image1", "image1"},
+			expectedPairs:          nil,
+			expectedBuildersLeft:   nil,
 			expectedFilteredImages: []string{"image1"},
 		},
 	}

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -56,12 +56,6 @@ func TestPrintAnalyzeJSON(t *testing.T) {
 			expected:    `{"images":[{"name":"image1","foundMatch":false},{"name":"image2","foundMatch":false}]}`,
 		},
 		{
-			description: "image names should be unique",
-			images:      []string{"image1", "image2", "image1"},
-			skipBuild:   true,
-			expected:    `{"images":[{"name":"image1","foundMatch":false},{"name":"image2","foundMatch":false}]}`,
-		},
-		{
 			description: "no dockerfile",
 			images:      []string{"image1", "image2"},
 			shouldErr:   true,
@@ -101,12 +95,6 @@ func TestPrintAnalyzeJSONNoJib(t *testing.T) {
 		{
 			description: "no dockerfile, skip build (backwards compatibility)",
 			images:      []string{"image1", "image2"},
-			skipBuild:   true,
-			expected:    `{"images":["image1","image2"]}`,
-		},
-		{
-			description: "image names should be unique",
-			images:      []string{"image1", "image2", "image1"},
 			skipBuild:   true,
 			expected:    `{"images":["image1","image2"]}`,
 		},
@@ -474,6 +462,14 @@ func TestAutoSelectBuilders(t *testing.T) {
 				jib.Jib{BuilderName: jib.PluginName(jib.JibMaven), FilePath: "pom.xml", Image: "image1"},
 			},
 			expectedFilteredImages: []string{"image1", "image2"},
+		},
+		{
+			description: "show unique image names",
+			builderConfigs: nil,
+			images:        []string{"image1", "image1"},
+			expectedPairs: nil,
+			expectedBuildersLeft: nil,
+			expectedFilteredImages: []string{"image1"},
 		},
 	}
 


### PR DESCRIPTION
Fixes #3128

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

<!-- 
Describe any user facing changes here so maintainer can include it in the release notes, or delete this block.
-->

```
Bug fixes
    * "Skaffold init --analyze returns a unique list of image names"
```
