### PR TITLE
Fix writing rendered manifests to files

### DIFF
--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -17,7 +17,6 @@ limitations under the License.
 package deploy
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"fmt"
@@ -228,14 +227,16 @@ func (k *KubectlDeployer) Render(ctx context.Context, out io.Writer, builds []bu
 
 	manifestOut := out
 	if filepath != "" {
-		f, err := os.Open(filepath)
+		f, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0666)
 		if err != nil {
 			return errors.Wrap(err, "opening file for writing manifests")
 		}
-		manifestOut = bufio.NewWriter(f)
+		defer f.Close()
+		f.WriteString(manifests.String() + "\n")
+	} else {
+		fmt.Fprintln(manifestOut, manifests.String())
 	}
 
-	fmt.Fprintln(manifestOut, manifests.String())
 	return nil
 }
 


### PR DESCRIPTION
before this change, trying to run `skaffold render --output file.txt` would fail with 

```➜  getting-started git:(master) skaffold render --output render.txt
FATA[0001] rendering manifests: opening file for writing manifests: open file.txt: no such file or directory
```

this was happening because we were trying to do an `os.Open()` on a file that didn't exist. now, we'll just do an `os.OpenFile()` with the right opening mode, and just call `file.WriteString()` rather than creating a new `Writer`.