### PR TITLE
fix kaniko cache-dir

### DIFF
--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cluster/sources"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -133,7 +134,7 @@ func args(artifact *latest.KanikoArtifact, context, tag string, insecureRegistri
 			args = append(args, "--cache-repo", artifact.Cache.Repo)
 		}
 		if artifact.Cache.HostPath != "" {
-			args = append(args, "--cache-dir", artifact.Cache.HostPath)
+			args = append(args, "--cache-dir", constants.DefaultKanikoCacheDirMountPath)
 		}
 	}
 

--- a/pkg/skaffold/build/cluster/kaniko_test.go
+++ b/pkg/skaffold/build/cluster/kaniko_test.go
@@ -63,7 +63,7 @@ func TestArgs(t *testing.T) {
 			artifact: &latest.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Cache: &latest.KanikoCache{
-					HostPath: "/cache",
+					HostPath: "/host/cache",
 				},
 			},
 			expectedArgs: []string{"--cache=true", "--cache-dir", "/cache"},


### PR DESCRIPTION
Fixes #3156.

**Description**

Fix kaniko caching by using the right cache-dir

**User facing changes**

n/a

**Before**

INFO[0000] Downloading base image alpine:latest         
INFO[0002] Error while retrieving image from cache: getting file info: stat /data/docker/kaniko/cache/sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a: no such file or directory

**After**

INFO[0000] Downloading base image alpine:latest         
INFO[0002] Found sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a in local cache 
INFO[0002] Found manifest at /cache/sha256:e4355b66995c96b4b468159fc5c7e3540fcef961189ca13fee877798649f531a.json

**Next PRs.**

n/a

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.
