### PR TITLE
[docs] fix alerts

### DIFF
--- a/docs/content/en/docs/design/api.md
+++ b/docs/content/en/docs/design/api.md
@@ -51,7 +51,7 @@ WARN[0000] port 50051 for gRPC server already in use: using 50053 instead
 To connect to the `gRPC` server at default port `50051` use the following code snippet.
 
 {{< alert title="Note" >}}
-The skaffold gRPC server is not an HTTPS service, hence we need to specify <code>grpc.WithInSecure()</code>
+The skaffold gRPC server is not an HTTPS service, hence we need to specify `grpc.WithInSecure()`
 {{</alert>}}
 
 ```golang

--- a/docs/content/en/docs/install/_index.md
+++ b/docs/content/en/docs/install/_index.md
@@ -8,10 +8,10 @@ weight: 1
 To keep Skaffold up to date, update checks are made to Google servers to see if a new version of
 Skaffold is available.
 
-You can turn this update check off by following <a href=/docs/references/privacy#update-check>these instructions</a>.
+You can turn this update check off by following [these instructions]({{<relref "/docs/references/privacy#update-check">}}).
 
+Your use of this software is subject to the [Google Privacy Policy](https://policies.google.com/privacy)
 
-Your use of this software is subject to the <a href=https://policies.google.com/privacy>Google Privacy Policy</a>
 {{< /alert >}}
 
 

--- a/docs/content/en/docs/pipeline-stages/builders.md
+++ b/docs/content/en/docs/pipeline-stages/builders.md
@@ -206,7 +206,7 @@ in Maven) that should produce a container image. Then for each such sub-project:
 
 {{< alert title="Updating from earlier versions" >}}
 Skaffold had required Maven multi-module projects bind a Jib
-<code>build</code> or <code>dockerBuild</code> goal to the <em>package</em> phase.  These bindings are
+`build` or `dockerBuild` goal to the **package** phase.  These bindings are
 no longer required with Jib 1.4.0 and should be removed.
 {{< /alert >}}
 

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -76,8 +76,8 @@ image.
 {{< alert >}}
 <b>Note</b><br>
 
-<code>IMAGE_NAME</code> is a built-in variable whose value is the <code>imageName</code> field in
-the <code>artifacts</code> part of the <code>build</code> section.
+`IMAGE_NAME` is a built-in variable whose value is the `imageName` field in
+the `artifacts` part of the `build` section.
 {{< /alert >}}
 
 ### Example

--- a/docs/content/en/docs/quickstart/_index.md
+++ b/docs/content/en/docs/quickstart/_index.md
@@ -8,8 +8,8 @@ Follow this tutorial to learn about Skaffold on a small Kubernetes app built wit
 and deployed with [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)! 
 
 {{< alert title="Note">}}
-Aside from <code>Docker</code> and <code>kubectl</code>, Skaffold also supports a variety of other tools
-and workflows; see <a href="/docs/tutorials">Tutorials</a> for
+Aside from `Docker` and `kubectl`, Skaffold also supports a variety of other tools
+and workflows; see [Tutorials]({{<relref "/docs/tutorials">}}) for
 more information.
 {{</alert>}}
 

--- a/docs/layouts/shortcodes/alert.html
+++ b/docs/layouts/shortcodes/alert.html
@@ -1,0 +1,6 @@
+{{ $_hugo_config := `{ "version": 1 }` }}
+{{ $color := .Get "color" | default "primary" }}
+<div class="alert alert-{{ $color }}" role="alert">
+    {{ with .Get "title" }}<h4 class="alert-heading">{{ . | safeHTML }}</h4>{{ end }}
+    {{ .Inner | markdownify }}
+</div>


### PR DESCRIPTION
This fixes the docsy issue that alerts were not being able to parse Markdown. 
Note - at one point we should upgrade our docsy base - however currently that totally breaks the new splash page so I'd rather not go through that. 
