### PR TITLE
[docs] [output] meaningful message for healthcheck context exceeded.

### DIFF
--- a/pkg/skaffold/deploy/status_check.go
+++ b/pkg/skaffold/deploy/status_check.go
@@ -125,7 +125,8 @@ func pollResourceStatus(ctx context.Context, runCtx *runcontext.RunContext, r Re
 	for {
 		select {
 		case <-timeoutContext.Done():
-			r.UpdateStatus(timeoutContext.Err().Error(), timeoutContext.Err())
+			err := errors.Wrap(timeoutContext.Err(), fmt.Sprintf("could not stabilize within %v", r.Deadline()))
+			r.UpdateStatus(err.Error(), err)
 			return
 		case <-time.After(pollDuration):
 			r.CheckStatus(timeoutContext, runCtx)

--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -19,11 +19,11 @@ package deploy
 import (
 	"bytes"
 	"context"
-	"errors"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -208,7 +208,7 @@ type mockResource struct {
 }
 
 func (m *mockResource) UpdateStatus(s string, err error) {
-	err = errors.Unwrap(err)
+	err = errors.Cause(err)
 	if err == context.DeadlineExceeded {
 		m.inErr = true
 	}

--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -208,6 +208,7 @@ type mockResource struct {
 }
 
 func (m *mockResource) UpdateStatus(s string, err error) {
+	err = errors.Unwrap(err)
 	if err == context.DeadlineExceeded {
 		m.inErr = true
 	}
@@ -244,7 +245,7 @@ func TestPollResourceStatus(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&defaultPollPeriodInMilliseconds, 0)
 			pollResourceStatus(context.Background(), nil, test.dummyResource)
-			t.CheckDeepEqual(test.dummyResource.inErr, test.isInErr)
+			t.CheckDeepEqual(test.isInErr, test.dummyResource.inErr)
 		})
 	}
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to CI-CD health check docs.
**Description**
Give users more descriptive messge.

**User facing changes**

yes. Output lines changed. See below

**Before**
When `Deployment` did not stabilize, user will get an error message with 
1. Either `kubectl rollout status command killed` (as timoutContext was cancelled)
```
tejaldesai@@getting-started (add_healthcheck)$ ../../out/skaffold deploy --status-check
Tags used in deployment:
Starting deploy...
kubectl client version: 1.11+
kubectl version 1.12.0 or greater is recommended for use with Skaffold
 - deployment.apps/getting-started created
Waiting for deployments to stabilize
 - default:deployment/getting-started Waiting for rollout to finish: 0 of 1 updated replicas are available...
 - default:deployment/getting-started failed. Error: kubectl rollout status command killed.
FATA[0006] 1/1 deployment(s) failed             
``` 

Or
2. an error message. "context deadline exceeded`. 

```        
tejaldesai@@getting-started (add_healthcheck)$ ../../out/skaffold deploy --status-check
Tags used in deployment:
Starting deploy...
kubectl client version: 1.11+
kubectl version 1.12.0 or greater is recommended for use with Skaffold
 - deployment.apps/getting-started configured
Waiting for deployments to stabilize
 - default:deployment/getting-started Waiting for rollout to finish: 1 old replicas are pending termination...
 - default:deployment/getting-started failed. Error: context deadline exceeded.
FATA[0006] 1/1 deployment(s) failed                     

```

**After**
New message:
```
- default:deployment/getting-started failed. Error: received Ctrl-C or deployments could not stabilize within 5s: kubectl rollout status command interrupted.
```

e.g.

```

tejaldesai@@getting-started (add_healthcheck)$ ../../out/skaffold deploy --status-check
Tags used in deployment:
Starting deploy...
kubectl client version: 1.11+
kubectl version 1.12.0 or greater is recommended for use with Skaffold
 - deployment.apps/getting-started created
Waiting for deployments to stabilize
 - default:deployment/getting-started Waiting for rollout to finish: 0 of 1 updated replicas are available...
 - default:deployment/getting-started failed. Error: received Ctrl-C or deployments could not stabilize within 5s: kubectl rollout status command interrupted.
FATA[0006] 1/1 deployment(s) failed                     
tejaldesai@@getting-started (add_healthcheck)$

```


**Next PRs.**
none

**Submitter Checklist**


<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**
