### PR TITLE
Fix redundant Jib image flags generated by init

### DIFF
--- a/pkg/skaffold/jib/jib_init.go
+++ b/pkg/skaffold/jib/jib_init.go
@@ -68,18 +68,17 @@ func (j Jib) CreateArtifact(manifestImage string) *latest.Artifact {
 		a.Workspace = workspace
 	}
 
+	jib := &latest.JibArtifact{}
 	if j.BuilderName == PluginName(JibMaven) {
-		jibMaven := &latest.JibArtifact{Type: string(JibMaven)}
 		if j.Project != "" {
-			jibMaven.Project = j.Project
+			jib.Project = j.Project
 		}
-		a.ArtifactType = latest.ArtifactType{JibArtifact: jibMaven}
+		a.ArtifactType = latest.ArtifactType{JibArtifact: jib}
 	} else if j.BuilderName == PluginName(JibGradle) {
-		jibGradle := &latest.JibArtifact{Type: string(JibGradle)}
 		if j.Project != "" {
-			jibGradle.Project = j.Project
+			jib.Project = j.Project
 		}
-		a.ArtifactType = latest.ArtifactType{JibArtifact: jibGradle}
+		a.ArtifactType = latest.ArtifactType{JibArtifact: jib}
 	}
 
 	return a

--- a/pkg/skaffold/jib/jib_init.go
+++ b/pkg/skaffold/jib/jib_init.go
@@ -69,17 +69,10 @@ func (j Jib) CreateArtifact(manifestImage string) *latest.Artifact {
 	}
 
 	jib := &latest.JibArtifact{}
-	if j.BuilderName == PluginName(JibMaven) {
-		if j.Project != "" {
-			jib.Project = j.Project
-		}
-		a.ArtifactType = latest.ArtifactType{JibArtifact: jib}
-	} else if j.BuilderName == PluginName(JibGradle) {
-		if j.Project != "" {
-			jib.Project = j.Project
-		}
-		a.ArtifactType = latest.ArtifactType{JibArtifact: jib}
+	if j.Project != "" {
+		jib.Project = j.Project
 	}
+	a.ArtifactType = latest.ArtifactType{JibArtifact: jib}
 
 	return a
 }

--- a/pkg/skaffold/jib/jib_init.go
+++ b/pkg/skaffold/jib/jib_init.go
@@ -73,14 +73,12 @@ func (j Jib) CreateArtifact(manifestImage string) *latest.Artifact {
 		if j.Project != "" {
 			jibMaven.Project = j.Project
 		}
-		jibMaven.Flags = []string{"-Dimage=" + manifestImage}
 		a.ArtifactType = latest.ArtifactType{JibArtifact: jibMaven}
 	} else if j.BuilderName == PluginName(JibGradle) {
 		jibGradle := &latest.JibArtifact{Type: string(JibGradle)}
 		if j.Project != "" {
 			jibGradle.Project = j.Project
 		}
-		jibGradle.Flags = []string{"-Dimage=" + manifestImage}
 		a.ArtifactType = latest.ArtifactType{JibArtifact: jibGradle}
 	}
 

--- a/pkg/skaffold/jib/jib_init_test.go
+++ b/pkg/skaffold/jib/jib_init_test.go
@@ -189,7 +189,7 @@ func TestCreateArtifact(t *testing.T) {
 			expectedArtifact: latest.Artifact{
 				ImageName:    "different-image",
 				Workspace:    filepath.Join("path", "to"),
-				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Project: "project", Type: string(JibGradle)}},
+				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Project: "project"}},
 			},
 		},
 		{
@@ -199,7 +199,7 @@ func TestCreateArtifact(t *testing.T) {
 			expectedArtifact: latest.Artifact{
 				ImageName:    "different-image",
 				Workspace:    filepath.Join("path", "to"),
-				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Type: string(JibGradle)}},
+				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{}},
 			},
 		},
 		{
@@ -209,7 +209,7 @@ func TestCreateArtifact(t *testing.T) {
 			expectedArtifact: latest.Artifact{
 				ImageName:    "different-image",
 				Workspace:    filepath.Join("path", "to"),
-				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Project: "project", Type: string(JibMaven)}},
+				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Project: "project"}},
 			},
 		},
 		{
@@ -219,7 +219,7 @@ func TestCreateArtifact(t *testing.T) {
 			expectedArtifact: latest.Artifact{
 				ImageName:    "different-image",
 				Workspace:    filepath.Join("path", "to"),
-				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Type: string(JibMaven)}},
+				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{}},
 			},
 		},
 		{
@@ -228,7 +228,7 @@ func TestCreateArtifact(t *testing.T) {
 			manifestImage: "different-image",
 			expectedArtifact: latest.Artifact{
 				ImageName:    "different-image",
-				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Type: string(JibGradle)}},
+				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{}},
 			},
 		},
 	}

--- a/pkg/skaffold/jib/jib_init_test.go
+++ b/pkg/skaffold/jib/jib_init_test.go
@@ -187,11 +187,9 @@ func TestCreateArtifact(t *testing.T) {
 			config:        Jib{BuilderName: "Jib Gradle Plugin", FilePath: filepath.Join("path", "to", "build.gradle"), Image: "image", Project: "project"},
 			manifestImage: "different-image",
 			expectedArtifact: latest.Artifact{
-				ImageName: "different-image",
-				Workspace: filepath.Join("path", "to"),
-				ArtifactType: latest.ArtifactType{
-					JibArtifact: &latest.JibArtifact{Project: "project", Flags: []string{"-Dimage=different-image"}, Type: string(JibGradle)},
-				},
+				ImageName:    "different-image",
+				Workspace:    filepath.Join("path", "to"),
+				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Project: "project", Type: string(JibGradle)}},
 			},
 		},
 		{
@@ -199,11 +197,9 @@ func TestCreateArtifact(t *testing.T) {
 			config:        Jib{BuilderName: "Jib Gradle Plugin", FilePath: filepath.Join("path", "to", "build.gradle")},
 			manifestImage: "different-image",
 			expectedArtifact: latest.Artifact{
-				ImageName: "different-image",
-				Workspace: filepath.Join("path", "to"),
-				ArtifactType: latest.ArtifactType{
-					JibArtifact: &latest.JibArtifact{Flags: []string{"-Dimage=different-image"}, Type: string(JibGradle)},
-				},
+				ImageName:    "different-image",
+				Workspace:    filepath.Join("path", "to"),
+				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Type: string(JibGradle)}},
 			},
 		},
 		{
@@ -213,7 +209,7 @@ func TestCreateArtifact(t *testing.T) {
 			expectedArtifact: latest.Artifact{
 				ImageName:    "different-image",
 				Workspace:    filepath.Join("path", "to"),
-				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Project: "project", Flags: []string{"-Dimage=different-image"}, Type: string(JibMaven)}},
+				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Project: "project", Type: string(JibMaven)}},
 			},
 		},
 		{
@@ -221,11 +217,9 @@ func TestCreateArtifact(t *testing.T) {
 			config:        Jib{BuilderName: "Jib Maven Plugin", FilePath: filepath.Join("path", "to", "pom.xml")},
 			manifestImage: "different-image",
 			expectedArtifact: latest.Artifact{
-				ImageName: "different-image",
-				Workspace: filepath.Join("path", "to"),
-				ArtifactType: latest.ArtifactType{
-					JibArtifact: &latest.JibArtifact{Flags: []string{"-Dimage=different-image"}, Type: string(JibMaven)},
-				},
+				ImageName:    "different-image",
+				Workspace:    filepath.Join("path", "to"),
+				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Type: string(JibMaven)}},
 			},
 		},
 		{
@@ -234,7 +228,7 @@ func TestCreateArtifact(t *testing.T) {
 			manifestImage: "different-image",
 			expectedArtifact: latest.Artifact{
 				ImageName:    "different-image",
-				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Flags: []string{"-Dimage=different-image"}, Type: string(JibGradle)}},
+				ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Type: string(JibGradle)}},
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #3190.

**Description**

Since the correct `-Dimage` flag is automatically generated during Jib builds, it's unnecessary (or even error prone) to generate the flags during `skaffold init`. 

**Release Notes**

Fix unnecessary Jib image flags generated during `skaffold init`.