### PR TITLE
[doc] `debug` does not work with buildpack builder and maybe custom builder images too

### DIFF
--- a/docs/content/en/docs/pipeline-stages/builders/buildpacks.md
+++ b/docs/content/en/docs/pipeline-stages/builders/buildpacks.md
@@ -9,7 +9,7 @@ featureId: build.buildpacks
 a container image from source code without the need for a Dockerfile.
 
 Skaffold supports building with Cloud Native Buildpacks, requiring only
-a local Docker daemon.  Skaffold performs the build inside a container
+a local Docker daemon. Skaffold performs the build inside a container
 using the `builder` specified in the `buildpack` config.
 
 On successful build completion, the built image will be pushed to the remote registry.
@@ -63,8 +63,8 @@ buildpack:
 
 ### Limitations
 
-`skaffold debug` is unable to configure the container images produced
-by Cloud Native Buildpacks for debugging.  Images produced by the
-produced by Cloud Native Buildpacks use a `launcher` binary that
-runs commands specified in a set of configuration files, which cannot
+The container images produced by Cloud Native Buildpacks [cannot
+be configured by `skaffold debug` for debugging]({{< relref "/docs/workflows/debug#unsupported-container-entrypoints" >}}).
+These images use a `launcher` binary as an entrypoint to run commands
+that are specified in a set of configuration files, which cannot
 be altered by `debug`.

--- a/docs/content/en/docs/pipeline-stages/builders/buildpacks.md
+++ b/docs/content/en/docs/pipeline-stages/builders/buildpacks.md
@@ -5,25 +5,21 @@ weight: 50
 featureId: build.buildpacks
 ---
 
-[Cloud Native Buildpacks](https://buildpacks.io/) enable building language-based
-containers from source code, without the need for a Dockerfile.
+[Cloud Native Buildpacks](https://buildpacks.io/) enable building
+a container image from source code without the need for a Dockerfile.
 
-Skaffold supports building with Buildpacks natively, without installing
-additional software. However, Buildpacks require a local Docker daemon
-to be used.
+Skaffold supports building with Cloud Native Buildpacks, requiring only
+a local Docker daemon.  Skaffold performs the build inside a container
+using the `builder` specified in the `buildpack` config.
 
-Once all the necessary data is present, Skaffold will build inside a container,
-with the local Docker daemon, with ther builder image specified in `builder`,
-in the `buildpack` config.
-
-On successful build completion, built images will be pushed to the remote registry.
+On successful build completion, the built image will be pushed to the remote registry.
 You can choose to skip this step.
 
 ### Configuration
 
 To use Buildpacks, add a `buildpack` field to each artifact you specify in the
 `artifacts` part of the `build` section. `context` should be a path to
-your sources.
+your source.
 
 The following options can optionally be configured:
 
@@ -64,3 +60,11 @@ buildpack:
     ignore:
     - vendor/**
 ```
+
+### Limitations
+
+`skaffold debug` is unable to configure the container images produced
+by Cloud Native Buildpacks for debugging.  Images produced by the
+produced by Cloud Native Buildpacks use a `launcher` binary that
+runs commands specified in a set of configuration files, which cannot
+be altered by `debug`.

--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -102,6 +102,15 @@ DAP is not yet supported by JetBrains IDEs like PyCharm.
 
 `skaffold debug` has some limitations.
 
+### Entrypoints using Launchers or Scripts
+
+`skaffold debug` requires being able to examine and alter the
+command-line used to launch a program, and as such will not work
+with images that use intermediate an launch scripts or binaries.
+For example, `debug` cannot work with an image produced by the Cloud
+Native Buildpacks builder as it uses a `launcher` binary to run
+commands that are specified in a set of configuration files.
+
 ### Supported Deployers
 
 `skaffold debug` is only supported with the `kubectl` and `kustomize` deployers at the moment: support for

--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -11,7 +11,7 @@ The associated debugging ports are exposed and labelled so that they can be port
 local machine. Helper metadata is also added to allow IDEs to detect the debugging
 configuration parameters.
  
-## How it works
+## How It Works
 
 `skaffold debug` examines the built artifacts to determine the underlying runtime technology.
 Any Kubernetes manifest that references these artifacts are transformed to enable the runtime technology's
@@ -72,7 +72,7 @@ to treat the source location for headless launches as being relative to `/go`.  
 }
 ```
 
-#### Java and other JVM languages
+#### Java and Other JVM Languages
 
 Java/JVM applications are configured to expose the JDWP agent using the `JAVA_TOOL_OPTIONS`
 environment variable.  
@@ -102,14 +102,15 @@ DAP is not yet supported by JetBrains IDEs like PyCharm.
 
 `skaffold debug` has some limitations.
 
-### Entrypoints using Launchers or Scripts
+### Unsupported Container Entrypoints
 
 `skaffold debug` requires being able to examine and alter the
-command-line used to launch a program, and as such will not work
-with images that use intermediate an launch scripts or binaries.
-For example, `debug` cannot work with an image produced by the Cloud
-Native Buildpacks builder as it uses a `launcher` binary to run
-commands that are specified in a set of configuration files.
+command-line used in the container entrypoint.  This transformation
+will not work with images that use intermediate launch scripts or
+binaries.  For example, `debug` cannot work with an image produced
+by the Cloud Native Buildpacks builder as it uses a `launcher`
+binary to run commands that are specified in a set of configuration
+files.
 
 ### Supported Deployers
 


### PR DESCRIPTION
`skaffold debug` requires being able to examine and alter an image's entrypoint, and won't work with images using a launcher or some startup script.  Add note to `debug` doc  and explicitly call this out on the _Buildpacks_ builder too.  Also incorporates minor tweaks to #3199 too.