### PR TITLE
Clean up grammar in log tailing documentation page

### DIFF
--- a/docs/content/en/docs/pipeline-stages/log-tailing.md
+++ b/docs/content/en/docs/pipeline-stages/log-tailing.md
@@ -26,7 +26,7 @@ will produce an output like this
 ![logging-output](/images/logging-output.png)
 
 
-For, every log line, skaffold will prefix the pod name and container name if they're not the same.
+For every log line, skaffold will prefix the pod name and container name if they're not the same.
 
 ![logging-output](/images/log-line-single.png)
 

--- a/docs/content/en/docs/pipeline-stages/log-tailing.md
+++ b/docs/content/en/docs/pipeline-stages/log-tailing.md
@@ -26,7 +26,7 @@ will produce an output like this
 ![logging-output](/images/logging-output.png)
 
 
-For, every log line, skaffold will prefix the pod name and container name if there not the same.
+For, every log line, skaffold will prefix the pod name and container name if they're not the same.
 
 ![logging-output](/images/log-line-single.png)
 


### PR DESCRIPTION
**Description**

Two _very minor_ (low priority) grammar fixes to the log tailing documentation

**User facing changes**

n/a

**Before**

n/a

**After**

n/a

**Next PRs.**

n/a


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.
