### PR TITLE
Fix Kubeclt typo in Init.md

### DIFF
--- a/docs/content/en/docs/pipeline-stages/init.md
+++ b/docs/content/en/docs/pipeline-stages/init.md
@@ -51,7 +51,7 @@ skaffold init --XXenableJibInit
 In case you want to configure build artifacts on your own, use `--skip-build` flag.
 
 ## Deploy Config Initialization
-`skaffold init` currently supports only [`Kubeclt` deployer]({{<relref "/docs/pipeline-stages/deployers#deploying-with-kubectl" >}})
+`skaffold init` currently supports only [`kubectl` deployer]({{<relref "/docs/pipeline-stages/deployers#deploying-with-kubectl" >}})
 Skaffold will walk through all the `yaml` files in your project and find valid kubernetes manifest files.
 
 These files will be added to `deploy` config in `skaffold.yaml`.


### PR DESCRIPTION
**Description**
This changes the documentation for the [Init Pipeline Stage](https://skaffold.dev/docs/pipeline-stages/init/), which has a typo.

**User facing changes**
Change `Kubeclt` instead of `kubectl`.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] ~~Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)~~
- [ ] ~~Mentions any output changes.~~
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] ~~Adds integration tests if needed.~~

**Reviewer Notes**

- [ ] ~~The code flow looks good.~~
- [ ] ~~Unit test added.~~
- [ ] User facing changes look good.
