### PR TITLE
Move code next to where it’s used

### DIFF
--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
@@ -116,6 +117,11 @@ func (r *SkaffoldRunner) imageTags(ctx context.Context, out io.Writer, artifacts
 	start := time.Now()
 	color.Default.Fprintln(out, "Generating tags...")
 
+	defaultRepo, err := config.GetDefaultRepo(r.runCtx.Opts.GlobalConfig, r.runCtx.Opts.DefaultRepo)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting default repo")
+	}
+
 	tagErrs := make([]chan tagErr, len(artifacts))
 
 	for i := range artifacts {
@@ -143,7 +149,7 @@ func (r *SkaffoldRunner) imageTags(ctx context.Context, out io.Writer, artifacts
 				return nil, errors.Wrapf(t.err, "generating tag for %s", imageName)
 			}
 
-			tag, err := docker.SubstituteDefaultRepoIntoImage(r.runCtx.DefaultRepo, t.tag)
+			tag, err := docker.SubstituteDefaultRepoIntoImage(defaultRepo, t.tag)
 			if err != nil {
 				return nil, errors.Wrapf(t.err, "applying default repo to %s", t.tag)
 			}

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -33,7 +33,6 @@ type RunContext struct {
 	Opts config.SkaffoldOptions
 	Cfg  latest.Pipeline
 
-	DefaultRepo        string
 	KubeContext        string
 	WorkingDir         string
 	Namespaces         []string
@@ -59,11 +58,6 @@ func GetRunContext(opts config.SkaffoldOptions, cfg latest.Pipeline) (*RunContex
 		return nil, errors.Wrap(err, "getting namespace list")
 	}
 
-	defaultRepo, err := config.GetDefaultRepo(opts.GlobalConfig, opts.DefaultRepo)
-	if err != nil {
-		return nil, errors.Wrap(err, "getting default repo")
-	}
-
 	// combine all provided lists of insecure registries into a map
 	cfgRegistries, err := config.GetInsecureRegistries(opts.GlobalConfig)
 	if err != nil {
@@ -80,7 +74,6 @@ func GetRunContext(opts config.SkaffoldOptions, cfg latest.Pipeline) (*RunContex
 		Opts:               opts,
 		Cfg:                cfg,
 		WorkingDir:         cwd,
-		DefaultRepo:        defaultRepo,
 		KubeContext:        kubeContext,
 		Namespaces:         namespaces,
 		InsecureRegistries: insecureRegistries,


### PR DESCRIPTION
The default repo is now used in a single place.
Let’s move it out of the RunContext.

Signed-off-by: David Gageot <david@gageot.net>
