### PR TITLE
Fix auto-project selection for GCB and Kaniko

### DIFF
--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -390,8 +390,6 @@ func getExternalIP(t *testing.T, c *NSKubernetesClient, ns string) string {
 	return ip
 }
 
-// Make sure GCB project is deduced from artifact's image name,
-// AFTER the default repo is applied.
 func TestBuildGCBWithDefaultRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -400,11 +398,12 @@ func TestBuildGCBWithDefaultRepo(t *testing.T) {
 		t.Skip("skipping test that is gcp only")
 	}
 
+	// The GCB project (k8s-skaffold) has to be deduced from artifact's image name
+	// after the default repo is applied.
+	// If it's not properly resolved, the build will fail.
 	skaffold.Build("-d", "gcr.io/k8s-skaffold").InDir("testdata/gcb-default-repo").RunOrFail(t)
 }
 
-// Make sure GCB project is deduced from artifact's image name,
-// AFTER the default repo is applied.
 func TestBuildKanikoWithDefaultRepo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
@@ -413,5 +412,8 @@ func TestBuildKanikoWithDefaultRepo(t *testing.T) {
 		t.Skip("skipping test that is gcp only")
 	}
 
+	// The GCS project (k8s-skaffold) has to be deduced from artifact's image name
+	// after the default repo is applied.
+	// If it's not properly resolved, the build will fail.
 	skaffold.Build("-d", "gcr.io/k8s-skaffold").InDir("testdata/kaniko-default-repo").RunOrFail(t)
 }

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -28,12 +28,11 @@ import (
 	"testing"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"4d63.com/tz"
 	"github.com/docker/docker/api/types"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
@@ -389,4 +388,30 @@ func getExternalIP(t *testing.T, c *NSKubernetesClient, ns string) string {
 		t.Fatalf("error getting external ip: %v", err)
 	}
 	return ip
+}
+
+// Make sure GCB project is deduced from artifact's image name,
+// AFTER the default repo is applied.
+func TestBuildGCBWithDefaultRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	if !ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is gcp only")
+	}
+
+	skaffold.Build("-d", "gcr.io/k8s-skaffold").InDir("testdata/gcb-default-repo").RunOrFail(t)
+}
+
+// Make sure GCB project is deduced from artifact's image name,
+// AFTER the default repo is applied.
+func TestBuildKanikoWithDefaultRepo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	if !ShouldRunGCPOnlyTests() {
+		t.Skip("skipping test that is gcp only")
+	}
+
+	skaffold.Build("-d", "gcr.io/k8s-skaffold").InDir("testdata/kaniko-default-repo").RunOrFail(t)
 }

--- a/integration/testdata/gcb-default-repo/Dockerfile
+++ b/integration/testdata/gcb-default-repo/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.12.9-alpine3.10 as builder
+COPY main.go .
+RUN go build -o /app main.go
+
+FROM alpine:3.10  
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/gcb-default-repo/main.go
+++ b/integration/testdata/gcb-default-repo/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/testdata/gcb-default-repo/skaffold.yaml
+++ b/integration/testdata/gcb-default-repo/skaffold.yaml
@@ -1,0 +1,6 @@
+apiVersion: skaffold/v1beta4
+kind: Config
+build:
+  artifacts:
+  - image: skaffold-default-repo
+  googleCloudBuild: {}

--- a/integration/testdata/kaniko-default-repo/Dockerfile
+++ b/integration/testdata/kaniko-default-repo/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.12.9-alpine3.10 as builder
+COPY main.go .
+RUN go build -o /app main.go
+
+FROM alpine:3.10  
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/kaniko-default-repo/main.go
+++ b/integration/testdata/kaniko-default-repo/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/testdata/kaniko-default-repo/skaffold.yaml
+++ b/integration/testdata/kaniko-default-repo/skaffold.yaml
@@ -1,0 +1,10 @@
+apiVersion: skaffold/v2alpha1
+kind: Config
+build:
+  artifacts:
+    - image: skaffold-default-repo
+      kaniko:
+        buildContext:
+          localDir: {}
+  cluster:
+    pullSecretName: e2esecret

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -32,7 +32,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 func (b *Builder) runKanikoBuild(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
@@ -44,7 +43,7 @@ func (b *Builder) runKanikoBuild(ctx context.Context, out io.Writer, artifact *l
 		return "", errors.Wrapf(err, "getting dependencies for %s", artifact.ImageName)
 	}
 
-	context, err := s.Setup(ctx, out, artifact, util.RandomID(), dependencies)
+	context, err := s.Setup(ctx, out, artifact, tag, dependencies)
 	if err != nil {
 		return "", errors.Wrap(err, "setting up build context")
 	}

--- a/pkg/skaffold/build/cluster/sources/gcs.go
+++ b/pkg/skaffold/build/cluster/sources/gcs.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/gcp"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sources"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
 
@@ -39,10 +40,10 @@ type GCSBucket struct {
 }
 
 // Setup uploads the context to the provided GCS bucket
-func (g *GCSBucket) Setup(ctx context.Context, out io.Writer, artifact *latest.Artifact, initialTag string, dependencies []string) (string, error) {
+func (g *GCSBucket) Setup(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string, dependencies []string) (string, error) {
 	bucket := g.artifact.BuildContext.GCSBucket
 	if bucket == "" {
-		guessedProjectID, err := gcp.ExtractProjectID(artifact.ImageName)
+		guessedProjectID, err := gcp.ExtractProjectID(tag)
 		if err != nil {
 			return "", errors.Wrap(err, "extracting projectID from image name")
 		}
@@ -52,7 +53,7 @@ func (g *GCSBucket) Setup(ctx context.Context, out io.Writer, artifact *latest.A
 
 	color.Default.Fprintln(out, "Uploading sources to", bucket, "GCS bucket")
 
-	g.tarName = fmt.Sprintf("context-%s.tar.gz", initialTag)
+	g.tarName = fmt.Sprintf("context-%s.tar.gz", util.RandomID())
 	c, err := cstorage.NewClient(ctx, gcp.ClientOptions()...)
 	if err != nil {
 		return "", errors.Wrap(err, "getting cloud storage client")

--- a/pkg/skaffold/build/cluster/sources/localdir.go
+++ b/pkg/skaffold/build/cluster/sources/localdir.go
@@ -49,8 +49,8 @@ type LocalDir struct {
 }
 
 // Setup for LocalDir creates a tarball of the buildcontext and stores it in /tmp
-func (g *LocalDir) Setup(ctx context.Context, out io.Writer, artifact *latest.Artifact, initialTag string, dependencies []string) (string, error) {
-	g.tarPath = filepath.Join(os.TempDir(), fmt.Sprintf("context-%s.tar.gz", initialTag))
+func (g *LocalDir) Setup(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string, dependencies []string) (string, error) {
+	g.tarPath = filepath.Join(os.TempDir(), fmt.Sprintf("context-%s.tar.gz", util.RandomID()))
 	color.Default.Fprintln(out, "Storing build context at", g.tarPath)
 
 	f, err := os.Create(g.tarPath)

--- a/pkg/skaffold/build/cluster/sources/sources.go
+++ b/pkg/skaffold/build/cluster/sources/sources.go
@@ -32,7 +32,7 @@ import (
 
 // BuildContextSource is the generic type for the different build context sources the kaniko builder can use
 type BuildContextSource interface {
-	Setup(ctx context.Context, out io.Writer, artifact *latest.Artifact, initialTag string, dependencies []string) (string, error)
+	Setup(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string, dependencies []string) (string, error)
 	Pod(args []string) *v1.Pod
 	ModifyPod(ctx context.Context, p *v1.Pod) error
 	Cleanup(ctx context.Context) error

--- a/pkg/skaffold/build/gcb/cloud_build.go
+++ b/pkg/skaffold/build/gcb/cloud_build.go
@@ -63,7 +63,7 @@ func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer
 
 	projectID := b.ProjectID
 	if projectID == "" {
-		guessedProjectID, err := gcp.ExtractProjectID(artifact.ImageName)
+		guessedProjectID, err := gcp.ExtractProjectID(tag)
 		if err != nil {
 			return "", errors.Wrap(err, "extracting projectID from image name")
 		}


### PR DESCRIPTION
The GCP project should be deduced from the image name being pushed, after the default repo is applied.