### PR TITLE
Add alias for old /docs/getting-started/

### DIFF
--- a/docs/content/en/docs/install/_index.md
+++ b/docs/content/en/docs/install/_index.md
@@ -2,6 +2,7 @@
 title: "Installing Skaffold"
 linkTitle: "Installing Skaffold"
 weight: 10
+aliases: [/docs/getting-started/]
 ---
 
 {{< alert title="Note" >}}


### PR DESCRIPTION
Fix #2710 external documents that link to the old getting-started page.

As noted by @sageprice, there are external documents that link to https://skaffold.dev/docs/getting-started/#installing-skaffold and are breaking.  This PR uses a [Hugo alias](https://gohugo.io/content-management/urls/#aliases) to redirect to the new install page.

(Verified with `make preview-docs` on `localhost:1313/docs/getting-started/#installing-skaffold`