### PR TITLE
Error instead of opening interactive prompt with --force init

### DIFF
--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -177,7 +177,7 @@ func DoInit(ctx context.Context, out io.Writer, c Config) error {
 			}
 			pairs = append(pairs, newPairs...)
 		} else {
-			resolved, err := resolveBuilderImages(unresolvedBuilderConfigs, unresolvedImages)
+			resolved, err := resolveBuilderImages(unresolvedBuilderConfigs, unresolvedImages, c.Force)
 			if err != nil {
 				return err
 			}
@@ -343,7 +343,7 @@ func processCliArtifacts(artifacts []string) ([]builderImagePair, error) {
 }
 
 // For each image parsed from all k8s manifests, prompt the user for the builder that builds the referenced image
-func resolveBuilderImages(builderConfigs []InitBuilder, images []string) ([]builderImagePair, error) {
+func resolveBuilderImages(builderConfigs []InitBuilder, images []string, force bool) ([]builderImagePair, error) {
 	// If nothing to choose, don't bother prompting
 	if len(images) == 0 || len(builderConfigs) == 0 {
 		return []builderImagePair{}, nil
@@ -355,6 +355,10 @@ func resolveBuilderImages(builderConfigs []InitBuilder, images []string) ([]buil
 			Builder:   builderConfigs[0],
 			ImageName: images[0],
 		}}, nil
+	}
+
+	if force {
+		return nil, errors.New("unable to automatically resolve builder/image pairs; run `skaffold init` without `--force` to manually resolve ambiguities")
 	}
 
 	// Build map from choice string to builder config struct

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -420,11 +420,7 @@ func TestResolveBuilderImages(t *testing.T) {
 
 			pairs, err := resolveBuilderImages(test.buildConfigs, test.images, test.force)
 
-			t.CheckError(test.shouldErr, err)
-			if test.shouldErr {
-				return
-			}
-			t.CheckDeepEqual(test.expectedPairs, pairs)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedPairs, pairs)
 		})
 	}
 }

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -346,7 +346,9 @@ func TestResolveBuilderImages(t *testing.T) {
 		description      string
 		buildConfigs     []InitBuilder
 		images           []string
+		force            bool
 		shouldMakeChoice bool
+		shouldErr        bool
 		expectedPairs    []builderImagePair
 	}{
 		{
@@ -384,6 +386,27 @@ func TestResolveBuilderImages(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:      "successful force",
+			buildConfigs:     []InitBuilder{jib.Jib{BuilderName: jib.PluginName(jib.JibGradle), FilePath: "build.gradle"}},
+			images:           []string{"image1"},
+			shouldMakeChoice: false,
+			force:            true,
+			expectedPairs: []builderImagePair{
+				{
+					Builder:   jib.Jib{BuilderName: jib.PluginName(jib.JibGradle), FilePath: "build.gradle"},
+					ImageName: "image1",
+				},
+			},
+		},
+		{
+			description:      "error with ambiguous force",
+			buildConfigs:     []InitBuilder{docker.Docker{File: "Dockerfile1"}, jib.Jib{BuilderName: jib.PluginName(jib.JibGradle), FilePath: "build.gradle"}},
+			images:           []string{"image1", "image2"},
+			shouldMakeChoice: false,
+			force:            true,
+			shouldErr:        true,
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
@@ -395,9 +418,12 @@ func TestResolveBuilderImages(t *testing.T) {
 				return choices[0], nil
 			})
 
-			pairs, err := resolveBuilderImages(test.buildConfigs, test.images)
+			pairs, err := resolveBuilderImages(test.buildConfigs, test.images, test.force)
 
-			t.CheckNoError(err)
+			t.CheckError(test.shouldErr, err)
+			if test.shouldErr {
+				return
+			}
 			t.CheckDeepEqual(test.expectedPairs, pairs)
 		})
 	}


### PR DESCRIPTION
Fixes #3221.

`skaffold init --force` now shows an error if all builder/image pairs can't be automatically resolved.