### PR TITLE
add container spec args

### DIFF
--- a/pkg/skaffold/debug/transform_go.go
+++ b/pkg/skaffold/debug/transform_go.go
@@ -90,10 +90,10 @@ func (t dlvTransformer) Apply(container *v1.Container, config imageConfiguration
 		spec = &newSpec
 		switch {
 		case len(config.entrypoint) > 0:
-			container.Command = rewriteDlvCommandLine(config.entrypoint, *spec)
+			container.Command = rewriteDlvCommandLine(config.entrypoint, *spec, container.Args)
 
 		case len(config.entrypoint) == 0 && len(config.arguments) > 0:
-			container.Args = rewriteDlvCommandLine(config.arguments, *spec)
+			container.Args = rewriteDlvCommandLine(config.arguments, *spec, container.Args)
 
 		default:
 			logrus.Warnf("Skipping %q as does not appear to be Go-based", container.Name)
@@ -160,10 +160,10 @@ arguments:
 }
 
 // rewriteDlvCommandLine rewrites a go command-line to insert a `dlv`
-func rewriteDlvCommandLine(commandLine []string, spec dlvSpec) []string {
+func rewriteDlvCommandLine(commandLine []string, spec dlvSpec, args []string) []string {
 	// todo: parse off dlv commands if present?
 
-	if len(commandLine) > 1 {
+	if len(commandLine) > 1 || len(args) > 0 {
 		// insert "--" after app binary to indicate end of Delve arguments
 		commandLine = util.StrSliceInsert(commandLine, 1, []string{"--"})
 	}

--- a/pkg/skaffold/debug/transform_go_test.go
+++ b/pkg/skaffold/debug/transform_go_test.go
@@ -171,6 +171,18 @@ func TestDlvTransformerApply(t *testing.T) {
 				Ports: []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
 			},
 		},
+		{
+			description: "entrypoint with args in container spec",
+			containerSpec: v1.Container{
+				Args: []string{"arg1", "arg2"},
+			},
+			configuration: imageConfiguration{entrypoint: []string{"app"}},
+			result: v1.Container{
+				Command: []string{"/dbg/go/bin/dlv", "exec", "--headless", "--continue", "--accept-multiclient", "--listen=localhost:56268", "--api-version=2", "app", "--"},
+				Args:    []string{"arg1", "arg2"},
+				Ports:   []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
+			},
+		},
 	}
 	var identity portAllocator = func(port int32) int32 {
 		return port


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**
When setting up skaffold for [kaniko](https://github.com/GoogleContainerTools/kaniko), `skaffold debug` failed with following error"
```
failed to port forward pod-kaniko-default-56268, port 56268 is taken, retrying...
time="2019-11-20T13:36:31-08:00" level=debug msg="terminated pod-kaniko-default-56268 due to context cancellation"
[kaniko] Error: unknown flag: --no-push
[kaniko] Usage:
[kaniko]   dlv exec <path/to/binary> [flags]
[kaniko] 
[kaniko] Flags:
[kaniko]       --continue   Continue the debugged process on start.
[kaniko] 
[kaniko] Global Flags:
[kaniko]       --accept-multiclient   Allows a headless server to accept multiple client connections.
[kaniko]       --api-version int      Selects API version when headless. (default 1)
[kaniko]       --backend string       Backend selection (see 'dlv help backend'). (default "default")
[kaniko]       --build-flags string   Build flags, to be passed to the compiler.
[kaniko]       --check-go-version     Checks that the version of Go in use is compatible with Delve. (default true)
[kaniko]       --headless             Run debug server only, in headless mode.
[kaniko]       --init string          Init file, executed by the terminal client.
[kaniko]   -l, --listen string        Debugging server listen address. (default "127.0.0.1:0")
[kaniko]       --log                  Enable debugging server logging.
[kaniko]       --log-dest string      Writes logs to the specified file or file descriptor (see 'dlv help log').
[kaniko]       --log-output string    Comma separated list of components that should produce debug output (see 'dlv help log')
[kaniko]       --wd string            Working directory for running the program. (default ".")
[kaniko] 
Port forwarding pod/kaniko in namespace default, remote port 56268 -> local port 56268
```
 
**User facing changes**
No

**Debug Transformation Changes**
**Before**
The container spec generated when debugging was 

```

tejaldesai@@kaniko (add_skaffold)$ kubectl describe po/kaniko
Name:               kaniko
...
  kaniko:
    Container ID:  docker://ee1994b1b80eeb06ba8c506b3cf4b43410ef4ad1372d0559c03098c9ff488303
    Image:         gcr.io/tejal-test/gcr.io/kaniko-project/executor:v0.14.0-7-ge0e59e6-dirty@sha256:7a204497053998c62c69feb1f9b7bbbad92f5e9e9738d1a4147c841b6cb60204
    Image ID:      docker-pullable://gcr.io/tejal-test/gcr.io/kaniko-project/executor@sha256:7a204497053998c62c69feb1f9b7bbbad92f5e9e9738d1a4147c841b6cb60204
    Port:          56268/TCP
    Host Port:     0/TCP
    Command:
      /dbg/go/bin/dlv
      exec
      --headless
      --continue
      --accept-multiclient
      --listen=localhost:56268
      --api-version=2
      /go/src/github.com/GoogleContainerTools/kaniko/out/executor
    Args:
      --no-push
      --context=dir://workspace/
      --dockerfile=integration/dockerfiles/Dockerfile_test_add
....
```

**After**
After this PR, we now have `--` added at the end
```
tejaldesai@@kaniko (add_skaffold)$ kubectl describe po/kaniko
Name:               kaniko
...
Containers:
  kaniko:
    Container ID:  docker://ee1994b1b80eeb06ba8c506b3cf4b43410ef4ad1372d0559c03098c9ff488303
    Image:         gcr.io/tejal-test/gcr.io/kaniko-project/executor:v0.14.0-7-ge0e59e6-dirty@sha256:7a204497053998c62c69feb1f9b7bbbad92f5e9e9738d1a4147c841b6cb60204
    Image ID:      docker-pullable://gcr.io/tejal-test/gcr.io/kaniko-project/executor@sha256:7a204497053998c62c69feb1f9b7bbbad92f5e9e9738d1a4147c841b6cb60204
    Port:          56268/TCP
    Host Port:     0/TCP
    Command:
      /dbg/go/bin/dlv
      exec
      --headless
      --continue
      --accept-multiclient
      --listen=localhost:56268
      --api-version=2
      /go/src/github.com/GoogleContainerTools/kaniko/out/executor
      --
    Args:
      --no-push
      --context=dir://workspace/
      --dockerfile=integration/dockerfiles/Dockerfile_test_add

```

**Next PRs.**
n/a
**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

```
Fix `skaffold debug` when go application have an entrypoint with arguments set.
```
