### PR TITLE
[doc] Add missing configuration to the git tagger

### DIFF
--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -43,7 +43,7 @@ specified explicitly:
 
 ### Configuration
 
-`gitCommit` tag policy features no options.
+{{< schema root="GitTagger" >}}
 
 ## `sha256`: uses Sha256 hashes of contents as tags
 


### PR DESCRIPTION
Signed-off-by: David Gageot <david@gageot.net>
