### PR TITLE
Mounting of secrets and config maps to Kaniko Pod #3226

### DIFF
--- a/docs/content/en/schemas/v2alpha1.json
+++ b/docs/content/en/schemas/v2alpha1.json
@@ -608,6 +608,14 @@
           "type": "string",
           "description": "amount of time (in seconds) that this build is allowed to run. Defaults to 20 minutes (`20m`).",
           "x-intellij-html-description": "amount of time (in seconds) that this build is allowed to run. Defaults to 20 minutes (<code>20m</code>)."
+        },
+        "volumes": {
+          "items": {
+            "$ref": "#/definitions/VolumeMount"
+          },
+          "type": "array",
+          "description": "define container mounts for ConfigMap and Secret resources.",
+          "x-intellij-html-description": "define container mounts for ConfigMap and Secret resources."
         }
       },
       "preferredOrder": [
@@ -620,11 +628,53 @@
         "timeout",
         "dockerConfig",
         "resources",
-        "concurrency"
+        "concurrency",
+        "volumes"
       ],
       "additionalProperties": false,
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
+    },
+    "ConfigMapMount": {
+      "required": [
+        "name",
+        "mountPath",
+        "volumeName"
+      ],
+      "properties": {
+        "items": {
+          "items": {
+            "$ref": "#/definitions/KeyToPath"
+          },
+          "type": "array",
+          "description": "if specified then only defined keys of the ConfigMap will be projected to the pod filesystem using relative paths as described in [volumes configMap](https://kubernetes.io/docs/concepts/storage/volumes/#configmap).",
+          "x-intellij-html-description": "if specified then only defined keys of the ConfigMap will be projected to the pod filesystem using relative paths as described in <a href=\"https://kubernetes.io/docs/concepts/storage/volumes/#configmap\">volumes configMap</a>."
+        },
+        "mountPath": {
+          "type": "string",
+          "description": "defines the path to mount the ConfigMap.",
+          "x-intellij-html-description": "defines the path to mount the ConfigMap."
+        },
+        "name": {
+          "type": "string",
+          "description": "Kubernetes ConfigMap name.",
+          "x-intellij-html-description": "Kubernetes ConfigMap name."
+        },
+        "volumeName": {
+          "type": "string",
+          "description": "defines Kubernetes pod.spec.volumes[].name for the Pod.",
+          "x-intellij-html-description": "defines Kubernetes pod.spec.volumes[].name for the Pod."
+        }
+      },
+      "preferredOrder": [
+        "name",
+        "items",
+        "mountPath",
+        "volumeName"
+      ],
+      "additionalProperties": false,
+      "description": "describes one ConfigMap mount to the kaniko container filesystem.",
+      "x-intellij-html-description": "describes one ConfigMap mount to the kaniko container filesystem."
     },
     "CustomArtifact": {
       "properties": {
@@ -1536,6 +1586,31 @@
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
+    "KeyToPath": {
+      "required": [
+        "key",
+        "path"
+      ],
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "key to get from the Resource.",
+          "x-intellij-html-description": "key to get from the Resource."
+        },
+        "path": {
+          "type": "string",
+          "description": "relative path to mount Key to.",
+          "x-intellij-html-description": "relative path to mount Key to."
+        }
+      },
+      "preferredOrder": [
+        "key",
+        "path"
+      ],
+      "additionalProperties": false,
+      "description": "describes mapping from ConfigMap or Secret resource key to a path within a volume.",
+      "x-intellij-html-description": "describes mapping from ConfigMap or Secret resource key to a path within a volume."
+    },
     "KubectlDeploy": {
       "properties": {
         "flags": {
@@ -1886,6 +1961,47 @@
       "description": "describes the Kubernetes resource types used for port forwarding.",
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
+    "SecretMount": {
+      "required": [
+        "name",
+        "mountPath",
+        "volumeName"
+      ],
+      "properties": {
+        "items": {
+          "items": {
+            "$ref": "#/definitions/KeyToPath"
+          },
+          "type": "array",
+          "description": "if specified then only defined keys of the Secret will be projected to the pod filesystem using relative paths as described in [volumes secret](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets).",
+          "x-intellij-html-description": "if specified then only defined keys of the Secret will be projected to the pod filesystem using relative paths as described in <a href=\"https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets\">volumes secret</a>."
+        },
+        "mountPath": {
+          "type": "string",
+          "description": "defines the path to mount the Secret.",
+          "x-intellij-html-description": "defines the path to mount the Secret."
+        },
+        "name": {
+          "type": "string",
+          "description": "Kubernetes Secret name.",
+          "x-intellij-html-description": "Kubernetes Secret name."
+        },
+        "volumeName": {
+          "type": "string",
+          "description": "defines Kubernetes pod.spec.volumes[].name for the Pod.",
+          "x-intellij-html-description": "defines Kubernetes pod.spec.volumes[].name for the Pod."
+        }
+      },
+      "preferredOrder": [
+        "name",
+        "items",
+        "mountPath",
+        "volumeName"
+      ],
+      "additionalProperties": false,
+      "description": "describes one Secret mount to a kaniko container filesystem.",
+      "x-intellij-html-description": "describes one Secret mount to a kaniko container filesystem."
+    },
     "ShaTagger": {
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
@@ -2095,6 +2211,27 @@
       "additionalProperties": false,
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
+    },
+    "VolumeMount": {
+      "properties": {
+        "configMap": {
+          "$ref": "#/definitions/ConfigMapMount",
+          "description": "specifies a ConfigMap mount into the kaniko pod container.",
+          "x-intellij-html-description": "specifies a ConfigMap mount into the kaniko pod container."
+        },
+        "secret": {
+          "$ref": "#/definitions/SecretMount",
+          "description": "specifies a Secret mount into the kaniko pod container.",
+          "x-intellij-html-description": "specifies a Secret mount into the kaniko pod container."
+        }
+      },
+      "preferredOrder": [
+        "configMap",
+        "secret"
+      ],
+      "additionalProperties": false,
+      "description": "represents a volume to mount to the kaniko container. Only one of its members may be specified.",
+      "x-intellij-html-description": "represents a volume to mount to the kaniko container. Only one of its members may be specified."
     }
   }
 }

--- a/docs/content/en/schemas/v2alpha1.json
+++ b/docs/content/en/schemas/v2alpha1.json
@@ -642,6 +642,11 @@
         "volumeName"
       ],
       "properties": {
+        "defaultMode": {
+          "type": "integer",
+          "description": "UNIX mode bits to set on mounted files. Must be a value between 0 and 0777. Defaults to 0644.",
+          "x-intellij-html-description": "UNIX mode bits to set on mounted files. Must be a value between 0 and 0777. Defaults to 0644."
+        },
         "items": {
           "items": {
             "$ref": "#/definitions/KeyToPath"
@@ -670,7 +675,8 @@
         "name",
         "items",
         "mountPath",
-        "volumeName"
+        "volumeName",
+        "defaultMode"
       ],
       "additionalProperties": false,
       "description": "describes one ConfigMap mount to the kaniko container filesystem.",
@@ -1597,6 +1603,11 @@
           "description": "key to get from the Resource.",
           "x-intellij-html-description": "key to get from the Resource."
         },
+        "mode": {
+          "type": "integer",
+          "description": "UNIX mode bits to set on mounted files. Must be a value between 0 and 0777. Defaults to 0644.",
+          "x-intellij-html-description": "UNIX mode bits to set on mounted files. Must be a value between 0 and 0777. Defaults to 0644."
+        },
         "path": {
           "type": "string",
           "description": "relative path to mount Key to.",
@@ -1605,7 +1616,8 @@
       },
       "preferredOrder": [
         "key",
-        "path"
+        "path",
+        "mode"
       ],
       "additionalProperties": false,
       "description": "describes mapping from ConfigMap or Secret resource key to a path within a volume.",
@@ -1968,6 +1980,11 @@
         "volumeName"
       ],
       "properties": {
+        "defaultMode": {
+          "type": "integer",
+          "description": "UNIX mode bits to set on mounted files. Must be a value between 0 and 0777. Defaults to 0644.",
+          "x-intellij-html-description": "UNIX mode bits to set on mounted files. Must be a value between 0 and 0777. Defaults to 0644."
+        },
         "items": {
           "items": {
             "$ref": "#/definitions/KeyToPath"
@@ -1996,7 +2013,8 @@
         "name",
         "items",
         "mountPath",
-        "volumeName"
+        "volumeName",
+        "defaultMode"
       ],
       "additionalProperties": false,
       "description": "describes one Secret mount to a kaniko container filesystem.",

--- a/pkg/skaffold/build/cluster/sources/sources.go
+++ b/pkg/skaffold/build/cluster/sources/sources.go
@@ -99,23 +99,23 @@ func podTemplate(clusterDetails *latest.ClusterDetails, artifact *latest.KanikoA
 		addHostPathVolume(pod, constants.DefaultKanikoCacheDirName, constants.DefaultKanikoCacheDirMountPath, artifact.Cache.HostPath)
 	}
 
+	// Add user-configured ConfigMaps and Secrets
+	for _, vol := range clusterDetails.Volumes {
+		if vol.ConfigMap != nil {
+			addConfigMapVolume(pod, vol.ConfigMap.VolumeName, vol.ConfigMap.MountPath, vol.ConfigMap.Name, vol.ConfigMap.Items)
+		}
+
+		if vol.Secret != nil {
+			addSecretVolume(pod, vol.Secret.VolumeName, vol.Secret.MountPath, vol.Secret.Name, vol.Secret.Items)
+		}
+	}
+
 	if clusterDetails.DockerConfig == nil {
 		return pod
 	}
 
 	// Add secret for docker config if specified
 	addSecretVolume(pod, constants.DefaultKanikoDockerConfigSecretName, constants.DefaultKanikoDockerConfigPath, clusterDetails.DockerConfig.SecretName, nil)
-
-	// Add user-configured ConfigMaps and Secrets
-	for _, vol := range clusterDetails.Volumes {
-		if vol.ConfigMap != nil {
-			addConfigMapVolume(pod, vol.ConfigMap.Name, vol.ConfigMap.MountPath, vol.ConfigMap.VolumeName, vol.ConfigMap.Items)
-		}
-
-		if vol.Secret != nil {
-			addSecretVolume(pod, vol.Secret.Name, vol.Secret.MountPath, vol.Secret.VolumeName, vol.Secret.Items)
-		}
-	}
 
 	return pod
 }

--- a/pkg/skaffold/build/cluster/sources/sources_test.go
+++ b/pkg/skaffold/build/cluster/sources/sources_test.go
@@ -409,7 +409,7 @@ func TestSecretVolume(t *testing.T) {
 							MountPath:  "/mount-dir",
 							VolumeName: "kubernetes-secret-volume",
 							Items: []latest.KeyToPath{
-								latest.KeyToPath{
+								{
 									Key:  "secret-file",
 									Path: "secret/subpath",
 								},
@@ -455,7 +455,7 @@ func TestSecretVolume(t *testing.T) {
 								Secret: &v1.SecretVolumeSource{
 									SecretName: "kubernetes-secret",
 									Items: []v1.KeyToPath{
-										v1.KeyToPath{
+										{
 											Key:  "secret-file",
 											Path: "secret/subpath",
 										},
@@ -557,7 +557,7 @@ func TestConfigMapVolume(t *testing.T) {
 							MountPath:  "/mount-dir",
 							VolumeName: "kubernetes-config-map-volume",
 							Items: []latest.KeyToPath{
-								latest.KeyToPath{
+								{
 									Key:  "config-map-file",
 									Path: "config-map/subpath",
 								},
@@ -605,7 +605,7 @@ func TestConfigMapVolume(t *testing.T) {
 										Name: "kubernetes-config-map",
 									},
 									Items: []v1.KeyToPath{
-										v1.KeyToPath{
+										{
 											Key:  "config-map-file",
 											Path: "config-map/subpath",
 										},

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -310,6 +310,60 @@ type ClusterDetails struct {
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit"
 	// Defaults to 0.
 	Concurrency int `yaml:"concurrency,omitempty"`
+
+	// Volumes define container mounts for ConfigMap and Secret resources
+	Volumes []VolumeMount `yaml:"volumes,omitempty"`
+}
+
+// VolumeMount represents a volume to mount to the kaniko container.
+// Only one of its members may be specified.
+type VolumeMount struct {
+	// ConfigMap specifies a ConfigMap mount into the kaniko pod container
+	ConfigMap *ConfigMapMount `yaml:"configMap,omitempty" yamltags:"oneOf=volumeType"`
+
+	// Secret specifies a Secret mount into the kaniko pod container
+	Secret *SecretMount `yaml:"secret,omitempty" yamltags:"oneOf=volumeType"`
+}
+
+// ConfigMapMount describes one ConfigMap mount to the kaniko container filesystem.
+type ConfigMapMount struct {
+	// Name is the Kubernetes ConfigMap name
+	Name string `yaml:"name" yamltags:"required"`
+
+	// Items if specified then only defined keys of the ConfigMap will be projected to the pod filesystem using relative paths as
+	// described in [volumes configMap](https://kubernetes.io/docs/concepts/storage/volumes/#configmap)
+	Items []KeyToPath `yaml:"items,omitempty"`
+
+	// Defines the path to mount the ConfigMap
+	MountPath string `yaml:"mountPath" yamltags:"required"`
+
+	// VolumeName defines Kubernetes pod.spec.volumes[].name for the Pod
+	VolumeName string `yaml:"volumeName" yamltags:"required"`
+}
+
+// SecretMount describes one Secret mount to a kaniko container filesystem.
+type SecretMount struct {
+	// Name is the Kubernetes Secret name
+	Name string `yaml:"name" yamltags:"required"`
+
+	// Items if specified then only defined keys of the Secret will be projected to the pod filesystem using relative paths as
+	// described in [volumes secret](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets)
+	Items []KeyToPath `yaml:"items,omitempty"`
+
+	// Defines the path to mount the Secret
+	MountPath string `yaml:"mountPath" yamltags:"required"`
+
+	// VolumeName defines Kubernetes pod.spec.volumes[].name for the Pod
+	VolumeName string `yaml:"volumeName" yamltags:"required"`
+}
+
+// KeyToPath describes mapping from ConfigMap or Secret resource key to a path within a volume.
+type KeyToPath struct {
+	// Key is the key to get from the Resource.
+	Key string `yaml:"key" yamltags:"required"`
+
+	// Path is the relative path to mount Key to.
+	Path string `yaml:"path" yamltags:"required"`
 }
 
 // DockerConfig contains information about the docker `config.json` to mount.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -339,6 +339,10 @@ type ConfigMapMount struct {
 
 	// VolumeName defines Kubernetes pod.spec.volumes[].name for the Pod.
 	VolumeName string `yaml:"volumeName" yamltags:"required"`
+
+	// DefaultMode UNIX mode bits to set on mounted files. Must be a
+	// value between 0 and 0777. Defaults to 0644.
+	DefaultMode *int32 `yaml:"defaultMode,omitempty"`
 }
 
 // SecretMount describes one Secret mount to a kaniko container filesystem.
@@ -355,6 +359,10 @@ type SecretMount struct {
 
 	// VolumeName defines Kubernetes pod.spec.volumes[].name for the Pod.
 	VolumeName string `yaml:"volumeName" yamltags:"required"`
+
+	// DefaultMode UNIX mode bits to set on mounted files. Must be a
+	// value between 0 and 0777. Defaults to 0644.
+	DefaultMode *int32 `yaml:"defaultMode,omitempty"`
 }
 
 // KeyToPath describes mapping from ConfigMap or Secret resource key to a path within a volume.
@@ -364,6 +372,10 @@ type KeyToPath struct {
 
 	// Path is the relative path to mount Key to.
 	Path string `yaml:"path" yamltags:"required"`
+
+	// Mode UNIX mode bits to set on mounted files. Must be a
+	// value between 0 and 0777. Defaults to 0644.
+	Mode *int32 `yaml:"mode,omitempty"`
 }
 
 // DockerConfig contains information about the docker `config.json` to mount.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -318,42 +318,42 @@ type ClusterDetails struct {
 // VolumeMount represents a volume to mount to the kaniko container.
 // Only one of its members may be specified.
 type VolumeMount struct {
-	// ConfigMap specifies a ConfigMap mount into the kaniko pod container
+	// ConfigMap specifies a ConfigMap mount into the kaniko pod container.
 	ConfigMap *ConfigMapMount `yaml:"configMap,omitempty" yamltags:"oneOf=volumeType"`
 
-	// Secret specifies a Secret mount into the kaniko pod container
+	// Secret specifies a Secret mount into the kaniko pod container.
 	Secret *SecretMount `yaml:"secret,omitempty" yamltags:"oneOf=volumeType"`
 }
 
 // ConfigMapMount describes one ConfigMap mount to the kaniko container filesystem.
 type ConfigMapMount struct {
-	// Name is the Kubernetes ConfigMap name
+	// Name is the Kubernetes ConfigMap name.
 	Name string `yaml:"name" yamltags:"required"`
 
 	// Items if specified then only defined keys of the ConfigMap will be projected to the pod filesystem using relative paths as
-	// described in [volumes configMap](https://kubernetes.io/docs/concepts/storage/volumes/#configmap)
+	// described in [volumes configMap](https://kubernetes.io/docs/concepts/storage/volumes/#configmap).
 	Items []KeyToPath `yaml:"items,omitempty"`
 
-	// Defines the path to mount the ConfigMap
+	// MountPath defines the path to mount the ConfigMap.
 	MountPath string `yaml:"mountPath" yamltags:"required"`
 
-	// VolumeName defines Kubernetes pod.spec.volumes[].name for the Pod
+	// VolumeName defines Kubernetes pod.spec.volumes[].name for the Pod.
 	VolumeName string `yaml:"volumeName" yamltags:"required"`
 }
 
 // SecretMount describes one Secret mount to a kaniko container filesystem.
 type SecretMount struct {
-	// Name is the Kubernetes Secret name
+	// Name is the Kubernetes Secret name.
 	Name string `yaml:"name" yamltags:"required"`
 
 	// Items if specified then only defined keys of the Secret will be projected to the pod filesystem using relative paths as
-	// described in [volumes secret](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets)
+	// described in [volumes secret](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets).
 	Items []KeyToPath `yaml:"items,omitempty"`
 
-	// Defines the path to mount the Secret
+	// MountPath defines the path to mount the Secret.
 	MountPath string `yaml:"mountPath" yamltags:"required"`
 
-	// VolumeName defines Kubernetes pod.spec.volumes[].name for the Pod
+	// VolumeName defines Kubernetes pod.spec.volumes[].name for the Pod.
 	VolumeName string `yaml:"volumeName" yamltags:"required"`
 }
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -311,7 +311,7 @@ type ClusterDetails struct {
 	// Defaults to 0.
 	Concurrency int `yaml:"concurrency,omitempty"`
 
-	// Volumes define container mounts for ConfigMap and Secret resources
+	// Volumes define container mounts for ConfigMap and Secret resources.
 	Volumes []VolumeMount `yaml:"volumes,omitempty"`
 }
 

--- a/pkg/skaffold/schema/v1/upgrade.go
+++ b/pkg/skaffold/schema/v1/upgrade.go
@@ -25,6 +25,7 @@ import (
 // Upgrade upgrades a configuration to the next version.
 // Config changes from v1 to v2alpha1
 // 1. Additions:
+// 	  Add Volumes, VolumeMount, ConfigMapMount and SecretMount to ClusterDetails.
 // 2. Removals:
 // 3. No updates
 func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {


### PR DESCRIPTION
Signed-off-by: Dmitriy Ermakov <demonihin@gmail.com>

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to #3226

**Description**

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->
PR adds an ability to mount Kubernetes Secret and ConfigMap as a Volume to Kaniko Pod

**User facing changes**

User can add mounts as described below:
```yaml
build:
  cluster:
    volumes:
      - secret:
          name: secret-name
          volumeName: secret-name-in-pod-specs
          mountPath: /dir-to-mount-secret-to
          defaultMode: 0400
          items:
            - key: secret-data-name
              path: subdir/subpath
              mode: 0500
      - configMap:
          name: config-map-name
          volumeName: config-map-in-pod-specs
          mountPath: /dir-to-mount-config-map-to
          defaultMode: 0400
          items:
            - key: config-map-data-name
              path: subdir/subpath
              mode: 0500
```

**Before**

A possiblity to mount ConfigMap or Secret does not exist.

**After**
If configured in `cluster.volumes` section creates and mounts volumes in Kaniko Pod


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

<!-- 
Describe any user facing changes here so maintainer can include it in the release notes, or delete this block.
-->

Adds `volumes` list section to build cluster config with `secret` or `configMap` subsections to mount them as Kubernetes Volumes.

