### PR TITLE
adding secret to kaniko pod

### DIFF
--- a/docs/content/en/schemas/v2alpha1.json
+++ b/docs/content/en/schemas/v2alpha1.json
@@ -604,6 +604,14 @@
           "description": "define the resource requirements for the kaniko pod.",
           "x-intellij-html-description": "define the resource requirements for the kaniko pod."
         },
+        "secrets": {
+          "items": {
+            "$ref": "#/definitions/MountSecrets"
+          },
+          "type": "array",
+          "description": "list of secrets which would be mounted to kaniko pod.",
+          "x-intellij-html-description": "list of secrets which would be mounted to kaniko pod."
+        },
         "timeout": {
           "type": "string",
           "description": "amount of time (in seconds) that this build is allowed to run. Defaults to 20 minutes (`20m`).",
@@ -620,7 +628,8 @@
         "timeout",
         "dockerConfig",
         "resources",
-        "concurrency"
+        "concurrency",
+        "secrets"
       ],
       "additionalProperties": false,
       "description": "*beta* describes how to do an on-cluster build.",
@@ -1700,6 +1709,27 @@
       "additionalProperties": false,
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
+    },
+    "MountSecrets": {
+      "properties": {
+        "mountPath": {
+          "type": "string",
+          "description": "of the secrets.",
+          "x-intellij-html-description": "of the secrets."
+        },
+        "string": {
+          "type": "string",
+          "description": "of the secrets.",
+          "x-intellij-html-description": "of the secrets."
+        }
+      },
+      "preferredOrder": [
+        "string",
+        "mountPath"
+      ],
+      "additionalProperties": false,
+      "description": "contains the secret name and its mount path.",
+      "x-intellij-html-description": "contains the secret name and its mount path."
     },
     "PortForwardResource": {
       "properties": {

--- a/pkg/skaffold/build/cluster/sources/sources.go
+++ b/pkg/skaffold/build/cluster/sources/sources.go
@@ -105,6 +105,10 @@ func podTemplate(clusterDetails *latest.ClusterDetails, artifact *latest.KanikoA
 
 	// Add secret for docker config if specified
 	addSecretVolume(pod, constants.DefaultKanikoDockerConfigSecretName, constants.DefaultKanikoDockerConfigPath, clusterDetails.DockerConfig.SecretName)
+
+	for _, secret := range clusterDetails.Secrets {
+		addSecretVolume(pod, secret.Name, secret.MountPath, secret.Name)
+	}
 	return pod
 }
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -310,6 +310,14 @@ type ClusterDetails struct {
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit"
 	// Defaults to 0.
 	Concurrency int `yaml:"concurrency,omitempty"`
+
+	// Secrets is list of secrets which would be mounted to kaniko pod
+	Secrets []MountSecrets `yaml: secrets, omitempty`
+}
+
+type MountSecrets struct {
+	Name      string `yaml: "string,omitempty"`
+	MountPath string `yaml: "mountPath,omitempty"`
 }
 
 // DockerConfig contains information about the docker `config.json` to mount.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -311,13 +311,16 @@ type ClusterDetails struct {
 	// Defaults to 0.
 	Concurrency int `yaml:"concurrency,omitempty"`
 
-	// Secrets is list of secrets which would be mounted to kaniko pod
-	Secrets []MountSecrets `yaml: secrets, omitempty`
+	// Secrets is list of secrets which would be mounted to kaniko pod.
+	Secrets []MountSecrets `yaml:"secrets, omitempty"`
 }
 
+// MountSecrets contains the secret name and its mount path.
 type MountSecrets struct {
-	Name      string `yaml: "string,omitempty"`
-	MountPath string `yaml: "mountPath,omitempty"`
+	// Name of the secrets.
+	Name string `yaml:"string,omitempty"`
+	// MountPath of the secrets.
+	MountPath string `yaml:"mountPath,omitempty"`
 }
 
 // DockerConfig contains information about the docker `config.json` to mount.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -312,7 +312,7 @@ type ClusterDetails struct {
 	Concurrency int `yaml:"concurrency,omitempty"`
 
 	// Secrets is list of secrets which would be mounted to kaniko pod.
-	Secrets []MountSecrets `yaml:"secrets, omitempty"`
+	Secrets []MountSecrets `yaml:"secrets,omitempty"`
 }
 
 // MountSecrets contains the secret name and its mount path.


### PR DESCRIPTION
Fixes #3226 .

**Description**

Mounting secret to kaniko pod

**User facing changes**

With this user can mount secret to kaniko pods

**Next PRs.**

Mounting of config map to kaniko pod 
-->


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.


**Reviewer Notes**

- [ * ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.
