### PR TITLE
Fix kind 0.6.0 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ skaffold-builder:
 
 .PHONY: integration-in-kind
 integration-in-kind: kind-cluster skaffold-builder
-	docker exec -it kind-control-plane cat /etc/kubernetes/admin.conf > /tmp/kind-config
+	kind get kubeconfig --internal > /tmp/kind-config
 	echo '{}' > /tmp/docker-config
 	docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \

--- a/docs/content/en/docs/environment/local-cluster.md
+++ b/docs/content/en/docs/environment/local-cluster.md
@@ -5,15 +5,38 @@ weight: 60
 aliases: [/docs/concepts/local_development]
 ---
 
-Skaffold can be easily configured to deploy against a cluster hosted locally, most commonly with
-[`minikube`](https://github.com/kubernetes/minikube/) or `docker-for-desktop`.
-The advantage of this setup is that no images need to be pushed, since the local cluster
-uses images straight from your local docker daemon.
+Skaffold can be easily configured to deploy against a cluster hosted locally, most commonly
+with [`minikube`] or [`Docker Desktop`].
 
-For non-standard local setups, such as a custom `minikube` profile or [kind](https://github.com/kubernetes-sigs/kind),
+The advantage of this setup is that no images need to be pushed, since the local cluster
+uses images straight from your local docker daemon. It leads to much faster development cycles.
+
+### Auto detection
+
+Skaffold's heuristic to detect local clusters is based on the Kubernetes context name.
+The following context names are checked:
+
+| Kubernetes context | Local cluster type | Notes |
+| ------------------ | ------------------ | ----- |
+| docker-desktop     | [`Docker Desktop`] | |
+| docker-for-desktop | [`Docker Desktop`] | This context name is deprecated |
+| minikube           | [`minikube`]       | |
+| kind-(.*)          | [`kind`]           | This pattern is used by kind v0.6.0 |
+| (.*)@kind          | [`kind`]           | This pattern was used by kind < v0.6.0 |
+
+For any other name, Skaffold assumes that the cluster is remote and that images
+have to be pushed.
+
+ [`minikube`]: https://github.com/kubernetes/minikube/
+ [`Docker Desktop`]: https://www.docker.com/products/docker-desktop
+ [`kind`]: https://github.com/kubernetes-sigs/kind
+
+### Manual override
+
+For non-standard local setups, such as a custom `minikube` profile,
 some extra configuration is necessary. The essential steps are:
 
-1. Ensure that Skaffold builds the images with the docker daemon, which also runs the containers.
+1. Ensure that Skaffold builds the images with the same docker daemon that runs the pods' containers.
 1. Tell Skaffold to skip pushing images either by configuring
 
     ```yaml
@@ -35,3 +58,4 @@ For example, when running `minikube` with a custom profile (e.g. `minikube start
     ```bash
     skaffold config set --kube-context my-profile local-cluster true
     ```
+

--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -408,7 +408,7 @@ func createModifiedKubeconfig(namespace string) ([]byte, string, error) {
 
 	contextName := "modified-context"
 	if config.IsKindCluster(kubeConfig.CurrentContext) {
-		contextName += "@kind"
+		contextName = "kind-" + contextName
 	}
 
 	activeContext := kubeConfig.Contexts[kubeConfig.CurrentContext]

--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -407,7 +407,7 @@ func createModifiedKubeconfig(namespace string) ([]byte, string, error) {
 	}
 
 	contextName := "modified-context"
-	if config.IsKindCluster(kubeConfig.CurrentContext) {
+	if isKind, _ := config.IsKindCluster(kubeConfig.CurrentContext); isKind {
 		contextName = "kind-" + contextName
 	}
 

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -197,10 +197,20 @@ func isDefaultLocal(kubeContext string) bool {
 // It also returns the name of the `kind` cluster.
 func IsKindCluster(kubeContext string) (bool, string) {
 	switch {
-	case strings.HasPrefix(kubeContext, "kind-"):
-		return true, strings.TrimPrefix(kubeContext, "kind-")
+	// With kind version < 0.6.0, the k8s context
+	// is `[CLUSTER NAME]@kind`.
+	// For eg: `cluster@kind`
+	// the default name is `kind@kind`
 	case strings.HasSuffix(kubeContext, "@kind"):
 		return true, strings.TrimSuffix(kubeContext, "@kind")
+
+	// With kind version == 0.6.0, the k8s context
+	// is `kind-[CLUSTER NAME]`.
+	// For eg: `kind-cluster`
+	// the default name is `kind-kind`
+	case strings.HasPrefix(kubeContext, "kind-"):
+		return true, strings.TrimPrefix(kubeContext, "kind-")
+
 	default:
 		return false, ""
 	}

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -183,15 +183,27 @@ func GetInsecureRegistries(configFile string) ([]string, error) {
 }
 
 func isDefaultLocal(kubeContext string) bool {
-	return kubeContext == constants.DefaultMinikubeContext ||
+	if kubeContext == constants.DefaultMinikubeContext ||
 		kubeContext == constants.DefaultDockerForDesktopContext ||
-		kubeContext == constants.DefaultDockerDesktopContext ||
-		IsKindCluster(kubeContext)
+		kubeContext == constants.DefaultDockerDesktopContext {
+		return true
+	}
+
+	isKind, _ := IsKindCluster(kubeContext)
+	return isKind
 }
 
-func IsKindCluster(kubeContext string) bool {
-	return strings.HasPrefix(kubeContext, "kind-") ||
-		strings.HasSuffix(kubeContext, "@kind")
+// IsKindCluster checks that the given `kubeContext` is talking to `kind`.
+// It also returns the name of the `kind` cluster.
+func IsKindCluster(kubeContext string) (bool, string) {
+	switch {
+	case strings.HasPrefix(kubeContext, "kind-"):
+		return true, strings.TrimPrefix(kubeContext, "kind-")
+	case strings.HasSuffix(kubeContext, "@kind"):
+		return true, strings.TrimSuffix(kubeContext, "@kind")
+	default:
+		return false, ""
+	}
 }
 
 func IsUpdateCheckEnabled(configfile string) bool {

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -190,7 +190,8 @@ func isDefaultLocal(kubeContext string) bool {
 }
 
 func IsKindCluster(kubeContext string) bool {
-	return strings.HasSuffix(kubeContext, "@kind")
+	return strings.HasPrefix(kubeContext, "kind-") ||
+		strings.HasSuffix(kubeContext, "@kind")
 }
 
 func IsUpdateCheckEnabled(configfile string) bool {

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -262,3 +262,48 @@ func TestIsUpdateCheckEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestIsDefaultLocal(t *testing.T) {
+	tests := []struct {
+		context       string
+		expectedLocal bool
+	}{
+		{context: "kind-other", expectedLocal: true},
+		{context: "kind@kind", expectedLocal: true},
+		{context: "docker-for-desktop", expectedLocal: true},
+		{context: "minikube", expectedLocal: true},
+		{context: "docker-for-desktop", expectedLocal: true},
+		{context: "docker-desktop", expectedLocal: true},
+		{context: "anything-else", expectedLocal: false},
+	}
+	for _, test := range tests {
+		testutil.Run(t, "", func(t *testutil.T) {
+			local := isDefaultLocal(test.context)
+
+			t.CheckDeepEqual(test.expectedLocal, local)
+		})
+	}
+}
+
+func TestIsKindCluster(t *testing.T) {
+	tests := []struct {
+		context        string
+		expecteName    string
+		expectedIsKind bool
+	}{
+		{context: "kind-kind", expecteName: "kind", expectedIsKind: true},
+		{context: "kind-other", expecteName: "other", expectedIsKind: true},
+		{context: "kind@kind", expecteName: "kind", expectedIsKind: true},
+		{context: "other@kind", expecteName: "other", expectedIsKind: true},
+		{context: "docker-for-desktop", expecteName: "", expectedIsKind: false},
+		{context: "not-kind", expecteName: "", expectedIsKind: false},
+	}
+	for _, test := range tests {
+		testutil.Run(t, "", func(t *testutil.T) {
+			isKind, name := IsKindCluster(test.context)
+
+			t.CheckDeepEqual(test.expectedIsKind, isKind)
+			t.CheckDeepEqual(test.expecteName, name)
+		})
+	}
+}

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -275,6 +275,8 @@ func TestIsDefaultLocal(t *testing.T) {
 		{context: "docker-for-desktop", expectedLocal: true},
 		{context: "docker-desktop", expectedLocal: true},
 		{context: "anything-else", expectedLocal: false},
+		{context: "kind@blah", expectedLocal: false},
+		{context: "other-kind", expectedLocal: false},
 	}
 	for _, test := range tests {
 		testutil.Run(t, "", func(t *testutil.T) {
@@ -288,22 +290,22 @@ func TestIsDefaultLocal(t *testing.T) {
 func TestIsKindCluster(t *testing.T) {
 	tests := []struct {
 		context        string
-		expecteName    string
+		expectedName   string
 		expectedIsKind bool
 	}{
-		{context: "kind-kind", expecteName: "kind", expectedIsKind: true},
-		{context: "kind-other", expecteName: "other", expectedIsKind: true},
-		{context: "kind@kind", expecteName: "kind", expectedIsKind: true},
-		{context: "other@kind", expecteName: "other", expectedIsKind: true},
-		{context: "docker-for-desktop", expecteName: "", expectedIsKind: false},
-		{context: "not-kind", expecteName: "", expectedIsKind: false},
+		{context: "kind-kind", expectedName: "kind", expectedIsKind: true},
+		{context: "kind-other", expectedName: "other", expectedIsKind: true},
+		{context: "kind@kind", expectedName: "kind", expectedIsKind: true},
+		{context: "other@kind", expectedName: "other", expectedIsKind: true},
+		{context: "docker-for-desktop", expectedName: "", expectedIsKind: false},
+		{context: "not-kind", expectedName: "", expectedIsKind: false},
 	}
 	for _, test := range tests {
 		testutil.Run(t, "", func(t *testutil.T) {
 			isKind, name := IsKindCluster(test.context)
 
 			t.CheckDeepEqual(test.expectedIsKind, isKind)
-			t.CheckDeepEqual(test.expecteName, name)
+			t.CheckDeepEqual(test.expectedName, name)
 		})
 	}
 }

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -45,9 +45,9 @@ func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []
 		color.Green.Fprintln(out, "   local images can't be referenced by digest. They are tagged and referenced by a unique ID instead")
 	}
 
-	if config.IsKindCluster(r.runCtx.KubeContext) {
+	if isKind, kindCluster := config.IsKindCluster(r.runCtx.KubeContext); isKind {
 		// With `kind`, docker images have to be loaded with the `kind` CLI.
-		if err := r.loadImagesInKindNodes(ctx, out, artifacts); err != nil {
+		if err := r.loadImagesInKindNodes(ctx, out, kindCluster, artifacts); err != nil {
 			return errors.Wrapf(err, "loading images into kind nodes")
 		}
 	}

--- a/pkg/skaffold/runner/kind.go
+++ b/pkg/skaffold/runner/kind.go
@@ -32,7 +32,7 @@ import (
 )
 
 // loadImagesInKindNodes loads a list of artifact images into every node of kind cluster.
-func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Writer, artifacts []build.Artifact) error {
+func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Writer, kindCluster string, artifacts []build.Artifact) error {
 	start := time.Now()
 	color.Default.Fprintln(out, "Loading images into kind cluster nodes...")
 
@@ -59,7 +59,7 @@ func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Write
 			continue
 		}
 
-		cmd := exec.CommandContext(ctx, "kind", "load", "docker-image", artifact.Tag)
+		cmd := exec.CommandContext(ctx, "kind", "load", "docker-image", "--name", kindCluster, artifact.Tag)
 		if err := util.RunCmd(cmd); err != nil {
 			color.Red.Fprintln(out, "Failed")
 			return errors.Wrapf(err, "unable to load image with kind: %s", artifact.Tag)


### PR DESCRIPTION
 + Support new kind naming scheme
 + Properly load docker images into the current kind cluster. This used to fail if the cluster had a non-default name

Fixes #3296