### PR TITLE
Improve error output when kompose fails

### DIFF
--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -18,11 +18,15 @@ package initializer
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/jib"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -609,6 +613,45 @@ func Test_canonicalizeName(t *testing.T) {
 			actual := canonicalizeName(test.in)
 			if actual != test.out {
 				t.Errorf("%s: expected %s, found %s", test.in, test.out, actual)
+			}
+		})
+	}
+}
+
+func TestRunKompose(t *testing.T) {
+	tests := []struct {
+		description   string
+		composeFile   string
+		commands      util.Command
+		expectedError string
+	}{
+		{
+			description: "success",
+			composeFile: "docker-compose.yaml",
+			commands:    testutil.CmdRunOut("kompose convert -f docker-compose.yaml", ""),
+		},
+		{
+			description:   "not found",
+			composeFile:   "not-found.yaml",
+			expectedError: "(no such file or directory|cannot find the file specified)",
+		},
+		{
+			description:   "failure",
+			composeFile:   "docker-compose.yaml",
+			commands:      testutil.CmdRunOutErr("kompose convert -f docker-compose.yaml", "", errors.New("BUG")),
+			expectedError: "BUG",
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.NewTempDir().Touch("docker-compose.yaml").Chdir()
+			t.Override(&util.DefaultExecCommand, test.commands)
+
+			err := runKompose(context.Background(), test.composeFile)
+
+			if test.expectedError != "" {
+				t.CheckMatches(test.expectedError, err.Error())
 			}
 		})
 	}

--- a/pkg/skaffold/util/cmd.go
+++ b/pkg/skaffold/util/cmd.go
@@ -74,7 +74,7 @@ func (*Commander) RunCmdOut(cmd *exec.Cmd) ([]byte, error) {
 
 	err = cmd.Wait()
 	if err != nil {
-		return stdout, errors.Wrapf(err, "Running %s: stdout %s, stderr: %s, err: %v", cmd.Args, stdout, stderr, err)
+		return stdout, errors.Wrapf(err, "Running %s\n - stdout: %s\n - stderr: %s", cmd.Args, stdout, stderr)
 	}
 
 	if len(stderr) > 0 {


### PR DESCRIPTION
 + Improve the output of `util.RunCmdOut()` in case of error.
 + Use that improved output when kompose fails

Before:
```
$ skaffold init --compose-file docker-compose.yaml
FATA[0000] running kompose: exit status 1
```

After:
```
$ skaffold init --compose-file docker-compose.yaml
FATA[0000] Running [kompose convert -f docker-compose.yaml]
 - stdout:
 - stderr: FATA ima_ge Additional property ima_ge is not allowed
: exit status 1
```

Signed-off-by: David Gageot <david@gageot.net>
