### PR TITLE
Use --set-string for helm image values

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -288,7 +288,7 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 		}
 
 		valuesSet[v.Tag] = true
-		args = append(args, "--set", value)
+		args = append(args, "--set-string", value)
 	}
 
 	// SetValues

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -380,6 +380,23 @@ func TestHelmDeploy(t *testing.T) {
 			builds:     testBuilds,
 		},
 		{
+			description: "image values should be set using --set-string",
+			commands: &MockHelm{
+				getResult: fmt.Errorf("not found"),
+				installMatcher: func(cmd *exec.Cmd) bool {
+					setStringIndex := util.StrSliceIndex(cmd.Args, "--set-string")
+					if setStringIndex == -1 {
+						return false
+					}
+					expected := fmt.Sprintf("image.repository=%s,image.tag=%s", "docker.io:5000/skaffold-helm", "3605e7bc17cf46e53f4d81c4cbc24e5b4c495184")
+					return setStringIndex+1 < len(cmd.Args) && cmd.Args[setStringIndex+1] == expected
+				},
+				upgradeResult: fmt.Errorf("should not have called upgrade"),
+			},
+			runContext: makeRunContext(testDeployHelmStyleConfig, false),
+			builds:     testBuilds,
+		},
+		{
 			description: "helm image strategy with explicit registry should set the Helm registry value",
 			commands: &MockHelm{
 				getResult: fmt.Errorf("not found"),


### PR DESCRIPTION
Fixes #1992, related to https://github.com/helm/helm/issues/1707

**Description**

This prevents helm from interpreting tags as numbers, for example, short git commits made up of numeric characters.

**User facing changes**

n/a

**Before**

`helm` is called with the image and tag information using something like `--set image.repository=container,image.tag=5678444` causing the tag to be interpreted as a number. This leads to `Pod`s failing with `InvalidImageName`:

```
  Warning  InspectFailed  9s (x3 over 10s)  kubelet, minikube  Failed to apply default image tag "container:5.555559e+06": couldn't parse image reference "container:5.678444e+06": invalid reference format
  Warning  Failed         9s (x3 over 10s)  kubelet, minikube  Error: InvalidImageName
```

**After**

`helm` is called with the image and tag information using something like `--set-string image.repository=container,image.tag=5678444`, preventing `5678444` from being interpreted as a float.

**Next PRs.**

<!-- In this section describe a list of follow up PRs if the current PR is a part of big feature change.
See example https://github.com/GoogleContainerTools/skaffold/pull/2811
Write n/a if not applicable.
-->


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [x] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

<!-- 
Describe any user facing changes here so maintainer can include it in the release notes, or delete this block.
-->

```
Examples of user facing changes:
- Skaffold config changes like
  e.g. "Add buildArgs to `Kustomize` deployer skaffold config."
- Bug fixes
  e.g. "Improve skaffold init behaviour when tags are used in manifests"
- Any changes in skaffold behavior
  e.g. "Artiface cachine is turned on by default."

```
