### PR TITLE
Cause debug to skip unmarshallable yamls

### DIFF
--- a/pkg/skaffold/debug/debug.go
+++ b/pkg/skaffold/debug/debug.go
@@ -67,7 +67,7 @@ func applyDebuggingTransforms(l kubectl.ManifestList, retriever configurationRet
 	for _, manifest := range l {
 		obj, _, err := decodeFromYaml(manifest, nil, nil)
 		if err != nil {
-			logrus.Debugf("Unable to load Kubernetes YAML: %v\n", err)
+			logrus.Debugf("Unable to interpret manifest for debugging: %v\n", err)
 		} else if transformManifest(obj, retriever) {
 			manifest, err = encodeAsYaml(obj)
 			if err != nil {

--- a/pkg/skaffold/debug/debug.go
+++ b/pkg/skaffold/debug/debug.go
@@ -67,10 +67,8 @@ func applyDebuggingTransforms(l kubectl.ManifestList, retriever configurationRet
 	for _, manifest := range l {
 		obj, _, err := decodeFromYaml(manifest, nil, nil)
 		if err != nil {
-			return nil, errors.Wrap(err, "reading Kubernetes YAML")
-		}
-
-		if transformManifest(obj, retriever) {
+			logrus.Debugf("Unable to load Kubernetes YAML: %v\n", err)
+		} else if transformManifest(obj, retriever) {
 			manifest, err = encodeAsYaml(obj)
 			if err != nil {
 				return nil, errors.Wrap(err, "marshalling yaml")

--- a/pkg/skaffold/debug/debug_test.go
+++ b/pkg/skaffold/debug/debug_test.go
@@ -485,7 +485,7 @@ status:
 		},
 		{
 			description: "skip unhandled yamls like crds",
-			shouldErr: false,
+			shouldErr:   false,
 			in: `---
 apiVersion: openfaas.com/v1alpha2
 kind: Function

--- a/pkg/skaffold/debug/debug_test.go
+++ b/pkg/skaffold/debug/debug_test.go
@@ -483,6 +483,28 @@ spec:
 status:
   replicas: 0`,
 		},
+		{
+			description: "skip unhandled yamls like crds",
+			shouldErr: false,
+			in: `---
+apiVersion: openfaas.com/v1alpha2
+kind: Function
+metadata:
+  name: myfunction
+  namespace: openfaas-fn
+spec:
+  name: myfunction
+  image: myfunction`,
+			out: `---
+apiVersion: openfaas.com/v1alpha2
+kind: Function
+metadata:
+  name: myfunction
+  namespace: openfaas-fn
+spec:
+  name: myfunction
+  image: myfunction`,
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {


### PR DESCRIPTION
Fixes #3281

**Description**

Change `debug` to skip processing any manifests that cannot be unmarshalled.

**User facing changes**

A debug-level message is now output (if level = debug):
```
time="2019-11-29T14:48:53-05:00" level=debug msg="Unable to load Kubernetes YAML: no kind \"Function\" is registered for version \"openfaas.com/v1alpha2\" in scheme \"pkg/runtime/scheme.go:101\"\n"
```

**Before**

`skaffold debug` would exit on an unhandled manifest

**After**

`skaffold debug` skips unhandled manifests.

**Next PRs.**

n/a

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [ ] ~Adds documentation as needed: user docs, YAML reference, CLI reference.~
- [ ] ~Adds integration tests if needed.~

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

n/a