### PR TITLE
Do not fail on unregistered kinds when debugging.

### DIFF
--- a/pkg/skaffold/debug/debug_test.go
+++ b/pkg/skaffold/debug/debug_test.go
@@ -483,6 +483,36 @@ spec:
 status:
   replicas: 0`,
 		},
+		{
+			`Function`, false,
+			`apiVersion: openfaas.com/v1alpha2
+kind: Function
+metadata:
+  name: my-function
+  namespace: openfaas-fn
+spec:
+  name: my-function
+  handler: ./handler
+  image: gcr.io/k8s-debug/debug-example:latest
+  environment:
+    KEY: value
+  secrets:
+    - my-secret
+`,
+			`apiVersion: openfaas.com/v1alpha2
+kind: Function
+metadata:
+  name: my-function
+  namespace: openfaas-fn
+spec:
+  name: my-function
+  handler: ./handler
+  image: gcr.io/k8s-debug/debug-example:latest
+  environment:
+    KEY: value
+  secrets:
+    - my-secret`,
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #3281.

**Description**

This PR allows `skaffold debug` to "bypass" manifests on unknown (unregistered) kinds as suggested in #3281 while still allowing them to be deployed (albeit unmodified).

**User facing changes**

None at the API level, but there's a behavioural change to `skaffold debug` as described above and exemplified below.

**Before**

```
$ skaffold debug
(...)
Starting deploy...
Cleaning up...
FATA[0001] exiting dev mode because first deploy failed: unable to transform manifests: reading Kubernetes YAML: no kind "Function" is registered for version "openfaas.com/v1alpha2" in scheme "k8s.io/client-go/kubernetes/scheme/register.go:65"
```

**After**
```
$ skaffold debug
(...)
Starting deploy...
time="2019-12-02T20:00:43Z" level=warning msg="Skipping manifest transformation due to parsing error: no kind \"Function\" is registered for version \"openfaas.com/v1alpha2\" in scheme \"vendor/k8s.io/client-go/kubernetes/scheme/register.go:65\""
time="2019-12-02T20:00:43Z" level=warning msg="Skipping manifest transformation due to parsing error: no kind \"Function\" is registered for version \"openfaas.com/v1alpha2\" in scheme \"vendor/k8s.io/client-go/kubernetes/scheme/register.go:65\""
 - function.openfaas.com/foo created
 - function.openfaas.com/bar created
(...)
Watching for changes...
(...)
```

**Next PRs.**

N/A


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [x] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

<!-- 
Describe any user facing changes here so maintainer can include it in the release notes, or delete this block.
-->

```
`skaffold debug` no longer fails to deploy manifests on unregistered kinds.
```
