### PR TITLE
Don’t need to install go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
         - go test -short -timeout 60s ./...
     - os: linux
       name: "integration"
+      language: minimal
       before_install:
         - curl -Lo ${HOME}/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.6.0/kind-linux-amd64
         - chmod +x ${HOME}/bin/kind


### PR DESCRIPTION
The integration tests don't need go to be installed.
This makes the job little faster.

Signed-off-by: David Gageot <david@gageot.net>

