### PR TITLE
Script to list the top 20 Slowest tests

### DIFF
--- a/hack/slowtests.sh
+++ b/hack/slowtests.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2019 The Skaffold Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+LOG=$(mktemp)
+trap "rm -f $LOG" EXIT
+
+go test -count=1 -short -timeout=60s -json ./... | tee $LOG | jq -j 'select(has("Output") and (.Action=="output") and (has("Test")|not) and (.Output!="PASS\n")) | .Output'
+echo "=== Slot Tests ==="
+cat $LOG | jq -rs 'map(select(has("Test"))) | sort_by(.Elapsed) | reverse | map("\(.Elapsed)\t\(.Test)")[]' | head -n20


### PR DESCRIPTION
Today's output:

```
=== Slot Tests ===
5	TestUnavailablePort
4.02	TestMonitorErrorLogs
3	TestGracefulBuildCancel/terminate_gracefully_and_kill_process
3	TestGracefulBuildCancel/terminate_gracefully_and_exit_0
2.01	TestGetAvailablePort
2.01	TestGetAvailablePortOnForwardedPorts
1.22	TestInParallelConcurrency
1.1	TestInParallelConcurrency/100_artifacts,_max_concurrency=1
1.01	TestMonitorErrorLogs/match_on_'error_upgrading_connection'
1.01	TestMonitorErrorLogs/match_on_'error_forwarding_port'
1.01	TestMonitorErrorLogs/no_error_logs_appear
1	TestMonitorErrorLogs/match_on_'unable_to_forward'
0.46	TestBuild
0.41	TestGetDependencies
0.33	TestSchemas
0.31	TestStartPodForwarder
0.28	TestSyncMap
0.28	TestNewMinikubeImageAPIClient
0.27	TestNewMinikubeImageAPIClient/correct_client
0.26	TestBuild/force_pull
```