### PR TITLE
Cache expensive Go compilation and linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,28 @@ jobs:
   include:
     - os: linux
       name: "checks"
+      env:
+        - STATICCHECK_CACHE=$HOME/linting
       script:
         - make checks
+      cache:
+        directories:
+          - $STATICCHECK_CACHE
+          - $HOME/.cache/go-build
     - os: linux
       name: "Linux unit"
       script:
         - make coverage
+      cache:
+        directories:
+          - $HOME/.cache/go-build
     - os: osx
       name: "OSX unit"
       script:
         - make quicktest
+      cache:
+        directories:
+          - $HOME/.cache/go-build
     - os: windows
       name: "Windows unit"
       env:
@@ -32,6 +44,9 @@ jobs:
         - GOFLAGS="-mod=vendor"
       script:
         - go test -short -timeout 60s ./...
+      cache:
+        directories:
+          - C:\\Users\\travis\\AppData\\Local\\go-build
     - os: linux
       name: "integration"
       language: minimal


### PR DESCRIPTION
This will significantly reduce "unit tests" and "checks" jobs on TravisCI.

Signed-off-by: David Gageot <david@gageot.net>
