### PR TITLE
Faster integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,12 +162,10 @@ kind-cluster:
 
 .PHONY: skaffold-builder
 skaffold-builder:
-	-time docker pull gcr.io/$(GCP_PROJECT)/skaffold-builder
 	time docker build \
-		--cache-from gcr.io/$(GCP_PROJECT)/skaffold-builder \
 		-f deploy/skaffold/Dockerfile \
-		--target integration \
-		-t gcr.io/$(GCP_PROJECT)/skaffold-integration .
+		--target builder \
+		-t gcr.io/$(GCP_PROJECT)/skaffold-builder .
 
 .PHONY: integration-in-kind
 integration-in-kind: kind-cluster skaffold-builder
@@ -178,7 +176,8 @@ integration-in-kind: kind-cluster skaffold-builder
 		-v /tmp/kind-config:/kind-config \
 		-v /tmp/docker-config:/root/.docker/config.json \
 		-e KUBECONFIG=/kind-config \
-		gcr.io/$(GCP_PROJECT)/skaffold-integration
+		gcr.io/$(GCP_PROJECT)/skaffold-builder \
+		make integration
 
 .PHONY: integration-in-docker
 integration-in-docker: skaffold-builder
@@ -193,7 +192,8 @@ integration-in-docker: skaffold-builder
 		-e DOCKER_CONFIG=/root/.docker \
 		-e GOOGLE_APPLICATION_CREDENTIALS=$(GOOGLE_APPLICATION_CREDENTIALS) \
 		-e INTEGRATION_TEST_ARGS=$(INTEGRATION_TEST_ARGS) \
-		gcr.io/$(GCP_PROJECT)/skaffold-integration
+		gcr.io/$(GCP_PROJECT)/skaffold-builder \
+		make integration
 
 .PHONY: submit-build-trigger
 submit-build-trigger:

--- a/deploy/skaffold/Dockerfile
+++ b/deploy/skaffold/Dockerfile
@@ -91,6 +91,7 @@ COPY --from=download-container-structure-test container-structure-test /usr/loca
 COPY --from=download-bazel bazel /usr/local/bin/
 COPY --from=download-gcloud google-cloud-sdk/ /google-cloud-sdk/
 COPY --from=download-pack pack /usr/local/bin/
+COPY --from=download-kind kind /usr/local/bin/
 
 # Finish installation of bazel
 RUN bazel version
@@ -116,16 +117,14 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=golang:1.12 /usr/local/go /usr/local/go
-ENV PATH /usr/local/go/bin:/go/bin:$PATH
+ENV PATH /usr/local/go/bin:/root/go/bin:$PATH
 WORKDIR /skaffold
 COPY . .
 
-FROM builder as integration
+FROM builder as build-skaffold
 ARG VERSION
-COPY --from=download-kind kind /usr/local/bin/
 RUN make clean && make out/skaffold-linux-amd64 VERSION=$VERSION && mv out/skaffold-linux-amd64 /usr/bin/skaffold
-CMD ["make", "integration"]
 
 FROM runtime_deps as distribution
-COPY --from=integration /usr/bin/skaffold /usr/bin/skaffold
+COPY --from=build-skaffold /usr/bin/skaffold /usr/bin/skaffold
 RUN skaffold credits -d /THIRD_PARTY_NOTICES


### PR DESCRIPTION
The duration of integration test is not very stable so it's hard to compare this run with previous runs. Here's what this PR changes:
+ Skaffold binary used to be built twice for the integration tests. It's now built only once (roughly one minute faster)
+ The docker image that's built for the integration tests can't use any previously built image as a cache, because it's using multi-stage builds. This PR removes the `docker pull` before the `docker build` (roughly one minute faster)

Signed-off-by: David Gageot <david@gageot.net>
