### PR TITLE
Fix Control API endpoint table rendering

### DIFF
--- a/docs/content/en/docs/design/api.md
+++ b/docs/content/en/docs/design/api.md
@@ -104,7 +104,7 @@ kick off a suite of Selenium tests against the newly deployed service.
 
 | protocol | endpoint | encoding |
 | ---- | --- | --- |
-| HTTP | `http://localhost:{HTTP_RPC_PORT}/v1/events` | newline separated JSON using chunk transfer encoding over HTTP|  
+| HTTP | `http://localhost:{HTTP_RPC_PORT}/v1/events` | newline separated JSON using chunk transfer encoding over HTTP|
 | gRPC | `client.Events(ctx)` method on the [`SkaffoldService`]({{< relref "/docs/references/api#skaffoldservice">}}) | protobuf 3 over HTTP |
 
 


### PR DESCRIPTION
Simple doc fix for the [Control API Contract](https://skaffold.dev/docs/design/api/#control-api) table.

Before:

![Screen Shot 2019-12-10 at 9 58 07 AM](https://user-images.githubusercontent.com/202851/70540614-92e53b80-1b33-11ea-992d-a22d3dbe7e85.png)

After:

![Screen Shot 2019-12-10 at 9 58 24 AM](https://user-images.githubusercontent.com/202851/70540647-9d073a00-1b33-11ea-9be8-83a160da9ca6.png)
