### PR TITLE
Apply resource labels in the deployer

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -99,7 +99,7 @@ func (h *HelmDeployer) Deploy(ctx context.Context, out io.Writer, builds []build
 
 	event.DeployComplete()
 
-	labels := merge(labellers...)
+	labels := merge(h, labellers...)
 	labelDeployResults(labels, dRes)
 
 	// Collect namespaces in a string

--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -86,7 +86,7 @@ func (k *KubectlDeployer) Deploy(ctx context.Context, out io.Writer, builds []bu
 		return NewDeploySuccessResult(nil)
 	}
 
-	manifests, err = manifests.SetLabels(merge(labellers...))
+	manifests, err = manifests.SetLabels(merge(k, labellers...))
 	if err != nil {
 		event.DeployFailed(err)
 		return NewDeployErrorResult(errors.Wrap(err, "setting labels in manifests"))

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -367,27 +367,26 @@ spec:
 				Namespace: testNamespace,
 			},
 		})
-		labellers := []Labeller{deployer}
 
 		// Deploy one manifest
 		err := deployer.Deploy(context.Background(), ioutil.Discard, []build.Artifact{
 			{ImageName: "leeroy-web", Tag: "leeroy-web:v1"},
 			{ImageName: "leeroy-app", Tag: "leeroy-app:v1"},
-		}, labellers).GetError()
+		}, nil).GetError()
 		t.CheckNoError(err)
 
 		// Deploy one manifest since only one image is updated
 		err = deployer.Deploy(context.Background(), ioutil.Discard, []build.Artifact{
 			{ImageName: "leeroy-web", Tag: "leeroy-web:v1"},
 			{ImageName: "leeroy-app", Tag: "leeroy-app:v2"},
-		}, labellers).GetError()
+		}, nil).GetError()
 		t.CheckNoError(err)
 
 		// Deploy zero manifest since no image is updated
 		err = deployer.Deploy(context.Background(), ioutil.Discard, []build.Artifact{
 			{ImageName: "leeroy-web", Tag: "leeroy-web:v1"},
 			{ImageName: "leeroy-app", Tag: "leeroy-app:v2"},
-		}, labellers).GetError()
+		}, nil).GetError()
 		t.CheckNoError(err)
 	})
 }

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -125,7 +125,7 @@ func (k *KustomizeDeployer) Deploy(ctx context.Context, out io.Writer, builds []
 		return NewDeployErrorResult(errors.Wrap(err, "replacing images in manifests"))
 	}
 
-	manifests, err = manifests.SetLabels(merge(labellers...))
+	manifests, err = manifests.SetLabels(merge(k, labellers...))
 	if err != nil {
 		event.DeployFailed(err)
 		return NewDeployErrorResult(errors.Wrap(err, "setting labels in manifests"))

--- a/pkg/skaffold/deploy/labels.go
+++ b/pkg/skaffold/deploy/labels.go
@@ -49,8 +49,8 @@ type Labeller interface {
 }
 
 // merge merges the labels from multiple sources.
-func merge(sources ...Labeller) map[string]string {
-	merged := make(map[string]string)
+func merge(deployer Labeller, sources ...Labeller) map[string]string {
+	merged := deployer.Labels()
 
 	for _, src := range sources {
 		copyMap(merged, src.Labels())

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -77,7 +77,8 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 
 	defaultLabeller := deploy.NewLabeller("")
 	// runCtx.Opts is last to let users override/remove any label
-	labellers := []deploy.Labeller{builder, deployer, tagger, defaultLabeller, &runCtx.Opts}
+	// deployer labels are added during deployment
+	labellers := []deploy.Labeller{builder, tagger, defaultLabeller, &runCtx.Opts}
 
 	builder, tester, deployer = WithTimings(builder, tester, deployer, runCtx.Opts.CacheArtifacts)
 	if runCtx.Opts.Notification {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to #2875, #3292 

Should merge before : #3392

**Description**

This prepares for having multiple deployers per skaffold.yaml, and
ensures that every resource has the label of the proper deployer it was
deployed with.


**User facing changes**

n/a

**Next PRs.**

- add a deployer implementation that handles multiple deployers (i.e. `kubectl`, `kustomize`, `helm`)
- adapt `skaffold.yaml` to accept multiple deployer configurations in the `deploy` field.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.


**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.

