### PR TITLE
Add forwarding deployer muxer to enable multiple deployers

### DIFF
--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+)
+
+// DeployerMux forwards all method calls to the deployers it contains.
+// When encountering an error, it aborts and returns the error. Otherwise,
+// it collects the results and returns it in bulk.
+type DeployerMux []Deployer
+
+var _ Deployer = DeployerMux{}
+
+func (m DeployerMux) Labels() map[string]string {
+	labels := make(map[string]string)
+	for _, deployer := range m {
+		copyMap(labels, deployer.Labels())
+	}
+	return labels
+}
+
+func (m DeployerMux) Deploy(ctx context.Context, w io.Writer, as []build.Artifact, ls []Labeller) *Result {
+	seenNamespaces := sets.String{}
+	for _, deployer := range m {
+		result := deployer.Deploy(ctx, w, as, ls)
+		if result.err != nil {
+			return result
+		}
+		seenNamespaces.Insert(result.Namespaces()...)
+	}
+	return NewDeploySuccessResult(seenNamespaces.List())
+}
+
+func (m DeployerMux) Dependencies() ([]string, error) {
+	deps := sets.String{}
+	for _, deployer := range m {
+		result, err := deployer.Dependencies()
+		if err != nil {
+			return nil, err
+		}
+		deps.Insert(result...)
+	}
+	return deps.List(), nil
+}
+
+func (m DeployerMux) Cleanup(ctx context.Context, w io.Writer) error {
+	for _, deployer := range m {
+		if err := deployer.Cleanup(ctx, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m DeployerMux) Render(ctx context.Context, w io.Writer, as []build.Artifact, filepath string) error {
+	resources, buf := []string{}, &bytes.Buffer{}
+	for _, deployer := range m {
+		buf.Reset()
+		if err := deployer.Render(ctx, buf, as, "" /* never write to files */); err != nil {
+			return err
+		}
+		resources = append(resources, buf.String())
+	}
+
+	allResources := strings.Join(resources, "\n---\n")
+	return dumpToFileOrWriter(allResources, filepath, w)
+}

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -1,0 +1,280 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+type MockDeployer struct {
+	labels           map[string]string
+	deployNamespaces []string
+	deployErr        error
+	dependencies     []string
+	dependenciesErr  error
+	cleanupErr       error
+	renderResult     string
+	renderErr        error
+}
+
+var _ Deployer = &MockDeployer{}
+
+func (m *MockDeployer) Labels() map[string]string                { return m.labels }
+func (m *MockDeployer) Dependencies() ([]string, error)          { return m.dependencies, m.dependenciesErr }
+func (m *MockDeployer) Cleanup(context.Context, io.Writer) error { return m.cleanupErr }
+func (m *MockDeployer) Deploy(context.Context, io.Writer, []build.Artifact, []Labeller) *Result {
+	return &Result{
+		namespaces: m.deployNamespaces,
+		err:        m.deployErr,
+	}
+}
+func (m *MockDeployer) Render(_ context.Context, w io.Writer, _ []build.Artifact, _ string) error {
+	w.Write([]byte(m.renderResult))
+	return m.renderErr
+}
+
+func NewMockDeployer() *MockDeployer                                     { return &MockDeployer{labels: make(map[string]string)} }
+func (m *MockDeployer) WithLabel(labels map[string]string) *MockDeployer { m.labels = labels; return m }
+func (m *MockDeployer) WithDeployErr(err error) *MockDeployer            { m.deployErr = err; return m }
+func (m *MockDeployer) WithDependenciesErr(err error) *MockDeployer      { m.dependenciesErr = err; return m }
+func (m *MockDeployer) WithCleanupErr(err error) *MockDeployer           { m.cleanupErr = err; return m }
+func (m *MockDeployer) WithRenderErr(err error) *MockDeployer            { m.renderErr = err; return m }
+func (m *MockDeployer) WithDeployNamespaces(namespaces []string) *MockDeployer {
+	m.deployNamespaces = namespaces
+	return m
+}
+func (m *MockDeployer) WithDependencies(dependencies []string) *MockDeployer {
+	m.dependencies = dependencies
+	return m
+}
+func (m *MockDeployer) WithRenderResult(renderResult string) *MockDeployer {
+	m.renderResult = renderResult
+	return m
+}
+
+func TestDeployerMux_Labels(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels1  map[string]string
+		labels2  map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "disjoint labels",
+			labels1:  map[string]string{"key-a": "val-a"},
+			labels2:  map[string]string{"key-b": "val-b"},
+			expected: map[string]string{"key-a": "val-a", "key-b": "val-b"},
+		},
+		{
+			name:     "last wins for overlapping labels",
+			labels1:  map[string]string{"key": "first"},
+			labels2:  map[string]string{"key": "second"},
+			expected: map[string]string{"key": "second"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			deployerMux := DeployerMux([]Deployer{
+				NewMockDeployer().WithLabel(test.labels1),
+				NewMockDeployer().WithLabel(test.labels2),
+			})
+
+			actual := deployerMux.Labels()
+			testutil.CheckDeepEqual(t, test.expected, actual)
+		})
+	}
+}
+
+func TestDeployerMux_Deploy(t *testing.T) {
+	tests := []struct {
+		name        string
+		namespaces1 []string
+		namespaces2 []string
+		err1        error
+		err2        error
+		expectedNs  []string
+		shouldErr   bool
+	}{
+		{
+			name:        "disjoint namespaces are combined",
+			namespaces1: []string{"ns-a"},
+			namespaces2: []string{"ns-b"},
+			expectedNs:  []string{"ns-a", "ns-b"},
+		},
+		{
+			name:        "repeated namespaces are not duplicated",
+			namespaces1: []string{"ns-a", "ns-c"},
+			namespaces2: []string{"ns-b", "ns-c"},
+			expectedNs:  []string{"ns-a", "ns-b", "ns-c"},
+		},
+		{
+			name:        "short-circuits when first call fails",
+			namespaces1: []string{"ns-a"},
+			err1:        fmt.Errorf("failed in first"),
+			namespaces2: []string{"ns-b"},
+			expectedNs:  []string{"ns-a"},
+			shouldErr:   true,
+		},
+		{
+			name:        "when second call fails",
+			namespaces1: []string{"ns-a"},
+			namespaces2: []string{"ns-b"},
+			err2:        fmt.Errorf("failed in second"),
+			expectedNs:  []string{"ns-b"},
+			shouldErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			deployerMux := DeployerMux([]Deployer{
+				NewMockDeployer().WithDeployNamespaces(test.namespaces1).WithDeployErr(test.err1),
+				NewMockDeployer().WithDeployNamespaces(test.namespaces2).WithDeployErr(test.err2),
+			})
+
+			result := deployerMux.Deploy(context.Background(), nil, nil, nil)
+			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, result.err, test.expectedNs, result.namespaces)
+		})
+	}
+}
+
+func TestDeployerMux_Dependencies(t *testing.T) {
+	tests := []struct {
+		name         string
+		deps1        []string
+		deps2        []string
+		err1         error
+		err2         error
+		expectedDeps []string
+		shouldErr    bool
+	}{
+		{
+			name:         "disjoint dependencies are combined",
+			deps1:        []string{"dep-a"},
+			deps2:        []string{"dep-b"},
+			expectedDeps: []string{"dep-a", "dep-b"},
+		},
+		{
+			name:         "repeated dependencies are not duplicated",
+			deps1:        []string{"dep-a", "dep-c"},
+			deps2:        []string{"dep-b", "dep-c"},
+			expectedDeps: []string{"dep-a", "dep-b", "dep-c"},
+		},
+		{
+			name:      "when first call fails",
+			deps1:     []string{"dep-a"},
+			err1:      fmt.Errorf("failed in first"),
+			deps2:     []string{"dep-b"},
+			shouldErr: true,
+		},
+		{
+			name:      "when second call fails",
+			deps1:     []string{"dep-a"},
+			deps2:     []string{"dep-b"},
+			err2:      fmt.Errorf("failed in second"),
+			shouldErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			deployerMux := DeployerMux([]Deployer{
+				NewMockDeployer().WithDependencies(test.deps1).WithDependenciesErr(test.err1),
+				NewMockDeployer().WithDependencies(test.deps2).WithDependenciesErr(test.err2),
+			})
+
+			dependencies, err := deployerMux.Dependencies()
+			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expectedDeps, dependencies)
+		})
+	}
+}
+
+func TestDeployerMux_Render(t *testing.T) {
+	tests := []struct {
+		name           string
+		render1        string
+		render2        string
+		err1           error
+		err2           error
+		expectedRender string
+		shouldErr      bool
+	}{
+		{
+			name:           "concatenates render results with separator",
+			render1:        "manifest-1",
+			render2:        "manifest-2",
+			expectedRender: "manifest-1\n---\nmanifest-2\n",
+		},
+		{
+			name:      "short-circuits when first call fails",
+			render1:   "manifest-1",
+			err1:      fmt.Errorf("failed in first"),
+			render2:   "manifest-2",
+			shouldErr: true,
+		},
+		{
+			name:      "short-circuits when second call fails",
+			render1:   "manifest-1",
+			render2:   "manifest-2",
+			err2:      fmt.Errorf("failed in first"),
+			shouldErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("output to writer "+test.name, func(t *testing.T) {
+			deployerMux := DeployerMux([]Deployer{
+				NewMockDeployer().WithRenderResult(test.render1).WithRenderErr(test.err1),
+				NewMockDeployer().WithRenderResult(test.render2).WithRenderErr(test.err2),
+			})
+
+			buf := &bytes.Buffer{}
+			err := deployerMux.Render(context.Background(), buf, nil, "")
+			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expectedRender, buf.String())
+		})
+	}
+
+	t.Run("output to file", func(t *testing.T) {
+		// only check the good case here
+		test := tests[0]
+
+		tempDir, tearDown := testutil.NewTempDir(t)
+		defer tearDown()
+
+		deployerMux := DeployerMux([]Deployer{
+			NewMockDeployer().WithRenderResult(test.render1).WithRenderErr(test.err1),
+			NewMockDeployer().WithRenderResult(test.render2).WithRenderErr(test.err2),
+		})
+
+		err := deployerMux.Render(context.Background(), nil, nil, tempDir.Path("render"))
+		testutil.CheckError(t, false, err)
+
+		file, _ := os.Open(tempDir.Path("render"))
+		content, _ := ioutil.ReadAll(file)
+		testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expectedRender, string(content))
+	})
+}

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -40,8 +40,6 @@ type MockDeployer struct {
 	renderErr        error
 }
 
-var _ Deployer = &MockDeployer{}
-
 func (m *MockDeployer) Labels() map[string]string                { return m.labels }
 func (m *MockDeployer) Dependencies() ([]string, error)          { return m.dependencies, m.dependenciesErr }
 func (m *MockDeployer) Cleanup(context.Context, io.Writer) error { return m.cleanupErr }

--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -19,9 +19,7 @@ package deploy
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -220,24 +218,11 @@ func (k *KubectlDeployer) readRemoteManifest(ctx context.Context, name string) (
 
 func (k *KubectlDeployer) Render(ctx context.Context, out io.Writer, builds []build.Artifact, filepath string) error {
 	manifests, err := k.renderManifests(ctx, out, builds)
-
 	if err != nil {
 		return err
 	}
 
-	manifestOut := out
-	if filepath != "" {
-		f, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0666)
-		if err != nil {
-			return errors.Wrap(err, "opening file for writing manifests")
-		}
-		defer f.Close()
-		f.WriteString(manifests.String() + "\n")
-	} else {
-		fmt.Fprintln(manifestOut, manifests.String())
-	}
-
-	return nil
+	return dumpToFileOrWriter(manifests.String(), filepath, out)
 }
 
 func (k *KubectlDeployer) renderManifests(ctx context.Context, out io.Writer, builds []build.Artifact) (deploy.ManifestList, error) {

--- a/pkg/skaffold/deploy/util.go
+++ b/pkg/skaffold/deploy/util.go
@@ -21,9 +21,10 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"os"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -81,4 +82,19 @@ func getObjectNamespaceIfDefined(doc []byte, ns string) (string, error) {
 		}
 	}
 	return ns, nil
+}
+
+func dumpToFileOrWriter(renderedManifests string, filepath string, manifestOut io.Writer) error {
+	if filepath == "" {
+		_, err := fmt.Fprintln(manifestOut, renderedManifests)
+		return err
+	}
+
+	f, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return errors.Wrap(err, "opening file for writing manifests")
+	}
+	defer f.Close()
+	_, err = f.WriteString(renderedManifests + "\n")
+	return err
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to #2875, #3292

Should merge before : #3392 


**Description**

Add a deployer implementation (`DeployerMux`) that multiplexes the deployer actions with multiple deployer instances. This new deployer is simply a `[]deploy.Deployer` which forwards the commands of the `Deployer` interface to the instances in the list. When encountering an error, `DeployerMux` aborts and returns this error. Otherwise it collects the outputs and returns all results in bulk.

This is a pre-requisite for enabling multiple deployers in `skaffold.yaml`.

**User facing changes**

n/a

This PR only adds the functionality but does not enable anything.

**Next PRs.**

- adapt `skaffold.yaml` to accept multiple deployer configurations in the `deploy` field.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.

