### PR TITLE
Faster unit tests

### DIFF
--- a/pkg/skaffold/build/parallel_test.go
+++ b/pkg/skaffold/build/parallel_test.go
@@ -256,12 +256,12 @@ func TestInParallelConcurrency(t *testing.T) {
 			maxConcurrency: 10,
 		},
 		{
-			artifacts:      100,
+			artifacts:      50,
 			limit:          1,
 			maxConcurrency: 1,
 		},
 		{
-			artifacts:      100,
+			artifacts:      50,
 			limit:          10,
 			maxConcurrency: 10,
 		},
@@ -285,7 +285,7 @@ func TestInParallelConcurrency(t *testing.T) {
 				if atomic.AddInt32(&actualConcurrency, 1) > int32(test.maxConcurrency) {
 					return "", fmt.Errorf("only %d build can run at a time", test.maxConcurrency)
 				}
-				time.Sleep(10 * time.Millisecond)
+				time.Sleep(5 * time.Millisecond)
 				atomic.AddInt32(&actualConcurrency, -1)
 
 				return tag, nil

--- a/pkg/skaffold/kubernetes/portforward/entry_manager_test.go
+++ b/pkg/skaffold/kubernetes/portforward/entry_manager_test.go
@@ -17,19 +17,13 @@ limitations under the License.
 package portforward
 
 import (
-	"fmt"
 	"io/ioutil"
-	"net"
 	"reflect"
-	"sync"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 func TestNewEntryManager(t *testing.T) {
@@ -136,39 +130,4 @@ func TestForwardedResources(t *testing.T) {
 		}
 	}()
 	pf.Store("resource2", "not port forward entry")
-}
-
-//This is the same behavior
-func TestGetAvailablePortOnForwardedPorts(t *testing.T) {
-	AssertCompetingProcessesCanSucceed(newForwardedPorts(), t)
-}
-
-//TODO this is copy pasted to portforward.forwardedPorts testing as well - it should go away when we introduce port brokering
-// https://github.com/GoogleContainerTools/skaffold/issues/2503
-func AssertCompetingProcessesCanSucceed(ports util.ForwardedPorts, t *testing.T) {
-	t.Helper()
-	N := 100
-	var (
-		errors int32
-		wg     sync.WaitGroup
-	)
-	wg.Add(N)
-	for i := 0; i < N; i++ {
-		go func() {
-			port := util.GetAvailablePort("127.0.0.1", 4503, ports)
-
-			l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", util.Loopback, port))
-			if err != nil {
-				atomic.AddInt32(&errors, 1)
-			} else {
-				l.Close()
-			}
-			time.Sleep(2 * time.Second)
-			wg.Done()
-		}()
-	}
-	wg.Wait()
-	if atomic.LoadInt32(&errors) > 0 {
-		t.Fatalf("A port that was available couldn't be used %d times", errors)
-	}
 }

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -25,13 +25,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
-
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-
 	"github.com/sirupsen/logrus"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 type EntryForwarder interface {
@@ -52,11 +50,13 @@ func NewKubectlForwarder(out io.Writer, cli *kubectl.CLI) *KubectlForwarder {
 	}
 }
 
+// For testing
 var (
-	// For testing
-	isPortFree     = util.IsPortFree
-	portForwardCmd = portForwardCommand
-	deferFunc      = func() {}
+	isPortFree      = util.IsPortFree
+	portForwardCmd  = portForwardCommand
+	deferFunc       = func() {}
+	waitPortNotFree = 5 * time.Second
+	waitErrorLogs   = 1 * time.Second
 )
 
 // Forward port-forwards a pod using kubectl port-forward in the background
@@ -85,7 +85,7 @@ func (k *KubectlForwarder) forward(parentCtx context.Context, pfe *portForwardEn
 			//since the dev loop kicked off. We are notifying the user in the hope that they can fix it
 			color.Red.Fprintf(k.out, "failed to port forward %v, port %d is taken, retrying...\n", pfe, pfe.localPort)
 			notifiedUser = true
-			time.Sleep(5 * time.Second)
+			time.Sleep(waitPortNotFree)
 			continue
 		}
 
@@ -165,21 +165,24 @@ func (*KubectlForwarder) monitorErrorLogs(ctx context.Context, buf *bytes.Buffer
 		case <-ctx.Done():
 			return
 		default:
-			time.Sleep(1 * time.Second)
-			s, _ := buf.ReadString(byte('\n'))
-			if s != "" {
-				logrus.Tracef("[port-forward] %s", s)
+			time.Sleep(waitErrorLogs)
 
-				if strings.Contains(s, "error forwarding port") ||
-					strings.Contains(s, "unable to forward") ||
-					strings.Contains(s, "error upgrading connection") {
-					// kubectl is having an error. retry the command
-					logrus.Tracef("killing port forwarding %v", p)
-					if err := cmd.Process.Kill(); err != nil {
-						logrus.Tracef("failed to kill port forwarding %v, err: %s", p, err)
-					}
-					return
+			s, _ := buf.ReadString(byte('\n'))
+			if s == "" {
+				continue
+			}
+
+			logrus.Tracef("[port-forward] %s", s)
+
+			if strings.Contains(s, "error forwarding port") ||
+				strings.Contains(s, "unable to forward") ||
+				strings.Contains(s, "error upgrading connection") {
+				// kubectl is having an error. retry the command
+				logrus.Tracef("killing port forwarding %v", p)
+				if err := cmd.Process.Kill(); err != nil {
+					logrus.Tracef("failed to kill port forwarding %v, err: %s", p, err)
 				}
+				return
 			}
 		}
 	}

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
@@ -32,6 +32,8 @@ import (
 
 func TestUnavailablePort(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
+		t.Override(&waitPortNotFree, 100*time.Millisecond)
+
 		// Return that the port is false, while also
 		// adding a sync group so we know when isPortFree
 		// has been called
@@ -112,6 +114,8 @@ func TestMonitorErrorLogs(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&waitErrorLogs, 50*time.Millisecond)
+
 			ctx, cancel := context.WithCancel(context.Background())
 
 			cmd := exec.Command("sleep", "5")
@@ -132,7 +136,7 @@ func TestMonitorErrorLogs(t *testing.T) {
 			// need to sleep for one second before cancelling the context
 			// because there is a one second sleep in the switch statement
 			// of monitorLogs
-			time.Sleep(1 * time.Second)
+			time.Sleep(50 * time.Millisecond)
 
 			// cancel the context and then wait for monitorErrorLogs to return
 			cancel()

--- a/pkg/skaffold/util/port_test.go
+++ b/pkg/skaffold/util/port_test.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 )
 
 func TestGetAvailablePort(t *testing.T) {
@@ -49,7 +48,6 @@ func AssertCompetingProcessesCanSucceed(ports ForwardedPorts, t *testing.T) {
 			} else {
 				l.Close()
 			}
-			time.Sleep(2 * time.Second)
 			wg.Done()
 		}()
 	}


### PR DESCRIPTION
Top 20 slow tests BEFORE:
```
=== Slow Tests ===
5	TestUnavailablePort
5	TestUnavailablePort/TestUnavailablePort
4.94	TestSchemas
4.03	TestMonitorErrorLogs
3.01	TestGracefulBuildCancel/terminate_gracefully_and_exit_0
3.01	TestGracefulBuildCancel/terminate_gracefully_and_kill_process
2.02	TestGetAvailablePort
2.02	TestGetAvailablePortOnForwardedPorts
1.25	TestInParallelConcurrency
1.14	TestGetLogEvents
1.12	TestCmd_RunCmdOut
1.11	TestInParallelConcurrency/100_artifacts,_max_concurrency=1
1.07	TestCmd_RunCmdOut/skaffold_test
1.01	TestMonitorErrorLogs/match_on_'unable_to_forward'
1.01	TestMonitorErrorLogs/match_on_'error_forwarding_port'
1.01	TestMonitorErrorLogs/no_error_logs_appear
1	TestMonitorErrorLogs/match_on_'error_upgrading_connection'
0.46	TestGitCommit_GenerateFullyQualifiedImageName/git_repo_with_no_commit
0.44	TestGitCommit_GenerateFullyQualifiedImageName/non_git_repo
0.44	TestGitCommit_GenerateFullyQualifiedImageName/sub_directory
```

Top 20 slow tests AFTER:
```
1.12	TestGetLogEvents
1.1	TestCmd_RunCmdOut
1.05	TestCmd_RunCmdOut/skaffold_test
0.95	TestSchemas
0.4	TestSyncMap
0.39	TestGitCommit_GenerateFullyQualifiedImageName/clean_artifact_in_dirty_repo
0.37	TestNewMinikubeImageAPIClient
0.36	TestGitCommit_GenerateFullyQualifiedImageName/rename
0.36	TestGitCommit_GenerateFullyQualifiedImageName/git_repo_with_no_commit
0.35	TestNewMinikubeImageAPIClient/correct_client
0.35	TestGitCommit_GenerateFullyQualifiedImageName/treeSha_only_considers_current_tree_content
0.35	TestGitCommit_GenerateFullyQualifiedImageName/tag_plus_one_commit
0.35	TestGitCommit_GenerateFullyQualifiedImageName/dirty_worktree_without_tag
0.35	TestGitCommit_GenerateFullyQualifiedImageName/deleted_file
0.34	TestInParallelConcurrency
0.33	TestGitCommit_GenerateFullyQualifiedImageName/sub_directory
0.33	TestGracefulBuildCancel
0.32	TestStartPodForwarder
0.31	TestApplyDebuggingTransforms
0.3	TestGitCommit_GenerateFullyQualifiedImageName/clean_worktree_with_tags
```


Signed-off-by: David Gageot <david@gageot.net>
