### PR TITLE
Skaffold init recognises nodeJS projects built with Buildpacks

### DIFF
--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -27,12 +27,13 @@ import (
 )
 
 var (
-	composeFile   string
-	cliArtifacts  []string
-	skipBuild     bool
-	force         bool
-	analyze       bool
-	enableJibInit bool
+	composeFile         string
+	cliArtifacts        []string
+	skipBuild           bool
+	force               bool
+	analyze             bool
+	enableJibInit       bool
+	enableBuildpackInit bool
 )
 
 // NewCmdInit describes the CLI command to generate a Skaffold configuration.
@@ -48,18 +49,21 @@ func NewCmdInit() *cobra.Command {
 			f.BoolVar(&analyze, "analyze", false, "Print all discoverable Dockerfiles and images in JSON format to stdout")
 			f.BoolVar(&enableJibInit, "XXenableJibInit", false, "")
 			f.MarkHidden("XXenableJibInit")
+			f.BoolVar(&enableBuildpackInit, "XXenableBuildpackInit", false, "")
+			f.MarkHidden("XXenableBuildpackInit")
 		}).
 		NoArgs(cancelWithCtrlC(context.Background(), doInit))
 }
 
 func doInit(ctx context.Context, out io.Writer) error {
 	return initializer.DoInit(ctx, out, initializer.Config{
-		ComposeFile:   composeFile,
-		CliArtifacts:  cliArtifacts,
-		SkipBuild:     skipBuild,
-		Force:         force,
-		Analyze:       analyze,
-		EnableJibInit: enableJibInit,
-		Opts:          opts,
+		ComposeFile:         composeFile,
+		CliArtifacts:        cliArtifacts,
+		SkipBuild:           skipBuild,
+		Force:               force,
+		Analyze:             analyze,
+		EnableJibInit:       enableJibInit,
+		EnableBuildpackInit: enableBuildpackInit,
+		Opts:                opts,
 	})
 }

--- a/pkg/skaffold/build/buildpacks/init.go
+++ b/pkg/skaffold/build/buildpacks/init.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildpacks
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+)
+
+// For testing
+var (
+	ValidateConfig = validateConfig
+)
+
+// Name is the name of the Buildpack builder
+var Name = "Buildpacks"
+
+// Buildpack holds information about a Buildpack project
+type Buildpacks struct {
+	File string `json:"path,omitempty"`
+}
+
+// Name returns the name of the builder
+func (b Buildpacks) Name() string {
+	return Name
+}
+
+// Describe returns the initBuilder's string representation, used when prompting the user to choose a builder.
+func (b Buildpacks) Describe() string {
+	return fmt.Sprintf("%s (%s)", b.Name(), b.File)
+}
+
+// CreateArtifact creates an Artifact to be included in the generated Build Config
+func (b Buildpacks) CreateArtifact(manifestImage string) *latest.Artifact {
+	a := &latest.Artifact{
+		ImageName: manifestImage,
+		ArtifactType: latest.ArtifactType{
+			BuildpackArtifact: &latest.BuildpackArtifact{
+				Builder: "heroku/buildpacks",
+			},
+		},
+	}
+
+	workspace := filepath.Dir(b.File)
+	if workspace != "." {
+		a.Workspace = workspace
+	}
+
+	return a
+}
+
+// ConfiguredImage returns the target image configured by the builder, or empty string if no image is configured
+func (b Buildpacks) ConfiguredImage() string {
+	// Target image is not configured in dockerfiles
+	return ""
+}
+
+// Path returns the path to the build definition
+func (b Buildpacks) Path() string {
+	return b.File
+}
+
+// validateConfig checks if a file is a valid Buildpack configuration.
+func validateConfig(path string) bool {
+	return filepath.Base(path) == "package.json"
+}

--- a/pkg/skaffold/build/buildpacks/init_test.go
+++ b/pkg/skaffold/build/buildpacks/init_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildpacks
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestValidateConfig(t *testing.T) {
+	var tests = []struct {
+		description   string
+		path          string
+		expectedValid bool
+	}{
+		{
+			description:   "NodeJS",
+			path:          "path/to/package.json",
+			expectedValid: true,
+		},
+		{
+			description:   "Unknown language",
+			path:          "path/to/something.txt",
+			expectedValid: false,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			tmpDir := t.NewTempDir().Touch(test.path)
+
+			isValid := ValidateConfig(tmpDir.Path(test.path))
+
+			t.CheckDeepEqual(test.expectedValid, isValid)
+		})
+	}
+}
+
+func TestDescribe(t *testing.T) {
+	var tests = []struct {
+		description    string
+		config         Buildpacks
+		expectedPrompt string
+	}{
+		{
+			description:    "buildpacks",
+			config:         Buildpacks{File: "/path/to/package.json"},
+			expectedPrompt: "Buildpacks (/path/to/package.json)",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expectedPrompt, test.config.Describe())
+		})
+	}
+}
+
+func TestCreateArtifact(t *testing.T) {
+	var tests = []struct {
+		description      string
+		config           Buildpacks
+		manifestImage    string
+		expectedArtifact latest.Artifact
+		expectedImage    string
+	}{
+		{
+			description:   "buildpacks",
+			config:        Buildpacks{File: filepath.Join("path", "to", "package.json")},
+			manifestImage: "image",
+			expectedArtifact: latest.Artifact{
+				ImageName: "image",
+				Workspace: filepath.Join("path", "to"),
+				ArtifactType: latest.ArtifactType{BuildpackArtifact: &latest.BuildpackArtifact{
+					Builder: "heroku/buildpacks",
+				}},
+			},
+		},
+		{
+			description:   "ignore workspace",
+			config:        Buildpacks{File: "build.gradle"},
+			manifestImage: "other-image",
+			expectedArtifact: latest.Artifact{
+				ImageName: "other-image",
+				ArtifactType: latest.ArtifactType{BuildpackArtifact: &latest.BuildpackArtifact{
+					Builder: "heroku/buildpacks",
+				}},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			artifact := test.config.CreateArtifact(test.manifestImage)
+
+			t.CheckDeepEqual(test.expectedArtifact, *artifact)
+		})
+	}
+}


### PR DESCRIPTION
This is the beginning of `skaffold init`'s support for Cloud Native Buildpacks.

It's still a work in progress and currently only recognizes nodejs projects that have a package.json.
Since it's activated by a hidden flag, I'd like to get this merged before adding support for more languages.

Signed-off-by: David Gageot <david@gageot.net>
