### PR TITLE
Setup kind and build the docker image in //

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,4 +57,4 @@ jobs:
         - curl -Lo ${HOME}/bin/kind https://github.com/kubernetes-sigs/kind/releases/download/v0.6.1/kind-linux-amd64
         - chmod +x ${HOME}/bin/kind
       script:
-        - make integration-in-kind
+        - make -j integration-in-kind


### PR DESCRIPTION
By creating the kind cluster in parallel of building the docker image, 
this could make the integration tests 2 minutes faster.