### PR TITLE
Logger’s start time should be set before deploy

### DIFF
--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -28,7 +28,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 )
@@ -122,8 +121,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	r.createLogger(out, artifacts)
 	defer r.logger.Stop()
 
-	kubectlCLI := kubectl.NewFromRunContext(r.runCtx)
-	r.createForwarder(out, kubectlCLI)
+	r.createForwarder(out)
 	defer r.forwarderManager.Stop()
 
 	// Watch artifacts

--- a/pkg/skaffold/runner/logger.go
+++ b/pkg/skaffold/runner/logger.go
@@ -29,10 +29,10 @@ func (r *SkaffoldRunner) createLogger(out io.Writer, artifacts []*latest.Artifac
 	for _, artifact := range artifacts {
 		imageNames = append(imageNames, artifact.ImageName)
 	}
-	r.logger = r.newLoggerForImages(out, imageNames)
+	r.createLoggerForImages(out, imageNames)
 }
 
-func (r *SkaffoldRunner) newLoggerForImages(out io.Writer, images []string) *kubernetes.LogAggregator {
+func (r *SkaffoldRunner) createLoggerForImages(out io.Writer, images []string) {
 	kubectlCLI := kubectl.NewFromRunContext(r.runCtx)
-	return kubernetes.NewLogAggregator(out, kubectlCLI, images, r.podSelector, r.runCtx.Namespaces)
+	r.logger = kubernetes.NewLogAggregator(out, kubectlCLI, images, r.podSelector, r.runCtx.Namespaces)
 }

--- a/pkg/skaffold/runner/portforwarder.go
+++ b/pkg/skaffold/runner/portforwarder.go
@@ -23,7 +23,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
 )
 
-func (r *SkaffoldRunner) createForwarder(out io.Writer, kubectlCLI *kubectl.CLI) {
+func (r *SkaffoldRunner) createForwarder(out io.Writer) {
+	kubectlCLI := kubectl.NewFromRunContext(r.runCtx)
 	r.forwarderManager = portforward.NewForwarderManager(out,
 		kubectlCLI,
 		r.podSelector,


### PR DESCRIPTION
This prevents losing the initial logs when a deploy
takes a long time.

Also take this opportunity to make the code look
more similar to its counterpart in dev.go. Maybe
we can extract that in some shared code in the
future.

Signed-off-by: David Gageot <david@gageot.net>
