### PR TITLE
Use ko instead of buildpacks for the custom builder

### DIFF
--- a/deploy/skaffold/Dockerfile
+++ b/deploy/skaffold/Dockerfile
@@ -68,13 +68,6 @@ ENV BAZEL_URL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERS
 RUN wget -O bazel "${BAZEL_URL}"
 RUN chmod +x bazel
 
-# Download pack
-FROM alpine:3.10 as download-pack
-ENV PACK_VERSION 0.6.0
-ENV PACK_URL https://github.com/buildpack/pack/releases/download/v${PACK_VERSION}/pack-v${PACK_VERSION}-linux.tgz
-RUN wget -O pack.tgz "${PACK_URL}"
-RUN tar -zxf pack.tgz
-
 FROM gcr.io/gcp-runtimes/ubuntu_16_0_4 as runtime_deps
 
 RUN apt-get update && \
@@ -90,7 +83,6 @@ COPY --from=download-kompose kompose /usr/local/bin/
 COPY --from=download-container-structure-test container-structure-test /usr/local/bin/
 COPY --from=download-bazel bazel /usr/local/bin/
 COPY --from=download-gcloud google-cloud-sdk/ /google-cloud-sdk/
-COPY --from=download-pack pack /usr/local/bin/
 COPY --from=download-kind kind /usr/local/bin/
 
 # Finish installation of bazel

--- a/docs/content/en/docs/tutorials/custom-builder.md
+++ b/docs/content/en/docs/tutorials/custom-builder.md
@@ -4,47 +4,28 @@ linkTitle: "Custom Build Script"
 weight: 100
 ---
 
-This page describes building Skaffold artifacts using a custom build script, which builds images using [buildpacks](https://buildpacks.io/).
-Buildpacks enable building language-based containers from source code, without the need for a Dockerfile.
+This page describes building Skaffold artifacts using a custom build script, which builds images using [ko](https://github.com/google/ko).
+ko builds containers from Go source code, without the need for a Dockerfile or
+even installing Docker.
 
 ## Before you begin
+
 First, you will need to have Skaffold and a Kubernetes cluster set up.
 To learn more about how to set up Skaffold and a Kubernetes cluster, see the [quickstart docs]({{< relref "/docs/quickstart" >}}).
 
-For this tutorial, to use buildpacks as a custom builder with Skaffold, please install the following additional tools:
-
-* [pack](https://buildpacks.io/docs/install-pack/)
-* [docker](https://docs.docker.com/install/)
-
-
-To use buildpacks with your own project, you must choose a buildpack image to build your artifacts.
-To see a list of available buildpacks, run:
-
-```shell
-$ pack suggest-builders
-```
-
-Choose a buildpack from the list, making sure your chosen image can detect the runtime your project is written in.
-Set your default buildpack:
-
-```shell
-$ pack set-default-builder <insert buildpack image here>
-```
-
 ## Tutorial - Hello World in Go
 
-This tutorial will be based on the [buildpacks example](https://github.com/GoogleContainerTools/skaffold/tree/master/examples/buildpacks) in our repository.
+This tutorial will be based on the [custom example](https://github.com/GoogleContainerTools/skaffold/tree/master/examples/custom) in our repository.
 
 
 ## Adding a Custom Builder to Your Skaffold Project
 
-We'll need to configure your Skaffold config to build artifacts with this custom builder.
+We'll need to configure your Skaffold config to build artifacts with [ko](https://github.com/google/ko).
 To do this, we will take advantage of the [custom builder]({{<relref "/docs/pipeline-stages/builders/custom" >}}) in Skaffold.
 
 First, add a `build.sh` file which Skaffold will call to build artifacts:
 
 {{% readfile file="samples/builders/custom-buildpacks/build.sh" %}}
-
 
 Then, configure artifacts in your `skaffold.yaml` to build with `build.sh`: 
 
@@ -55,5 +36,3 @@ For more information about listing dependencies for custom artifacts, see the do
 
 You can check custom builder is properly configured by running `skaffold build`.
 This command should build the artifacts and exit successfully.
-
-

--- a/docs/content/en/samples/builders/custom-buildpacks/build.sh
+++ b/docs/content/en/samples/builders/custom-buildpacks/build.sh
@@ -1,12 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
-images=$(echo $IMAGES | tr " " "\n")
 
-for image in $images
-do
-    pack build $image
-    if $PUSH_IMAGE
-    then
-        docker push $image
-    fi
-done
+if ! [ -x "$(command -v ko)" ]; then
+    GO111MODULE=on go get -mod=readonly github.com/google/ko/cmd/ko
+fi
+
+output=$(ko publish --local --preserve-import-paths --tags= . | tee)
+ref=$(echo $output | tail -n1)
+
+docker tag $ref $IMAGE
+if $PUSH_IMAGE; then
+    docker push $IMAGE
+fi

--- a/docs/content/en/samples/builders/custom-buildpacks/skaffold.yaml
+++ b/docs/content/en/samples/builders/custom-buildpacks/skaffold.yaml
@@ -1,14 +1,10 @@
-apiVersion: skaffold/v1
+apiVersion: skaffold/v2alpha1
 kind: Config
 build:
   artifacts:
-    - image: gcr.io/k8s-skaffold/image
-      custom:
-        buildCommand: build.sh
-        dependencies:
-          paths:
-            - .
-deploy:
-  kubectl:
-    manifests:
-      - ./k8s/**
+  - image: gcr.io/k8s-skaffold/skaffold-custom
+    custom:
+      buildCommand: ./build.sh
+      dependencies:
+        paths:
+        - .

--- a/examples/custom/build.sh
+++ b/examples/custom/build.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
-pack build --builder=heroku/buildpacks $IMAGE
+if ! [ -x "$(command -v ko)" ]; then
+    GO111MODULE=on go get -mod=readonly github.com/google/ko/cmd/ko
+fi
 
+output=$(ko publish --local --preserve-import-paths --tags= . | tee)
+ref=$(echo $output | tail -n1)
+
+docker tag $ref $IMAGE
 if $PUSH_IMAGE; then
     docker push $IMAGE
 fi

--- a/examples/custom/go.mod
+++ b/examples/custom/go.mod
@@ -1,3 +1,3 @@
-module github.com/GoogleContainerTools/skaffold/examples/buildpacks
+module github.com/GoogleContainerTools/skaffold/examples/custom
 
-go 1.12
+go 1.13

--- a/examples/custom/k8s/pod.yaml
+++ b/examples/custom/k8s/pod.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
   - name: getting-started
-    image: gcr.io/k8s-skaffold/skaffold-example
+    image: gcr.io/k8s-skaffold/skaffold-custom

--- a/examples/custom/skaffold.yaml
+++ b/examples/custom/skaffold.yaml
@@ -2,6 +2,9 @@ apiVersion: skaffold/v2alpha1
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/k8s-skaffold/skaffold-example
+  - image: gcr.io/k8s-skaffold/skaffold-custom
     custom:
       buildCommand: ./build.sh
+      dependencies:
+        paths:
+        - .

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -80,13 +80,6 @@ func TestBuild(t *testing.T) {
 		{
 			description: "custom",
 			dir:         "examples/custom",
-			setup: func(t *testing.T, _ string) func() {
-				cmd := exec.Command("pack", "set-default-builder", "heroku/buildpacks")
-				if err := cmd.Run(); err != nil {
-					t.Fatalf("error setting default buildpacks builder: %v", err)
-				}
-				return func() {}
-			},
 		},
 		{
 			description: "--tag arg",

--- a/integration/examples/custom/build.sh
+++ b/integration/examples/custom/build.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
-pack build --builder=heroku/buildpacks $IMAGE
+if ! [ -x "$(command -v ko)" ]; then
+    GO111MODULE=on go get -mod=readonly github.com/google/ko/cmd/ko
+fi
 
+output=$(ko publish --local --preserve-import-paths --tags= . | tee)
+ref=$(echo $output | tail -n1)
+
+docker tag $ref $IMAGE
 if $PUSH_IMAGE; then
     docker push $IMAGE
 fi

--- a/integration/examples/custom/go.mod
+++ b/integration/examples/custom/go.mod
@@ -1,3 +1,3 @@
-module github.com/GoogleContainerTools/skaffold/examples/buildpacks
+module github.com/GoogleContainerTools/skaffold/examples/custom
 
-go 1.12
+go 1.13

--- a/integration/examples/custom/k8s/pod.yaml
+++ b/integration/examples/custom/k8s/pod.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   containers:
   - name: getting-started
-    image: gcr.io/k8s-skaffold/skaffold-example
+    image: gcr.io/k8s-skaffold/skaffold-custom

--- a/integration/examples/custom/skaffold.yaml
+++ b/integration/examples/custom/skaffold.yaml
@@ -2,6 +2,9 @@ apiVersion: skaffold/v2alpha1
 kind: Config
 build:
   artifacts:
-  - image: gcr.io/k8s-skaffold/skaffold-example
+  - image: gcr.io/k8s-skaffold/skaffold-custom
     custom:
       buildCommand: ./build.sh
+      dependencies:
+        paths:
+        - .


### PR DESCRIPTION
Since buildpacks are natively supported, it’s better
to use another example for the custom build script.

Signed-off-by: David Gageot <david@gageot.net>
