### PR TITLE
Spelling

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ If behavior changes: describe succinctly the current behavior
 **After**
 
 If log/output changes: Paste skaffold output after your change
-If behavior changes: describe succintly the behavior after your change
+If behavior changes: describe succinctly the behavior after your change
 
 **Next PRs.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -325,7 +325,7 @@ Docs:
 * Fix sample’s version [#3015](https://github.com/GoogleContainerTools/skaffold/pull/3015)
 * Fix versions used in examples [#2999](https://github.com/GoogleContainerTools/skaffold/pull/2999)
 * Docs Splash Page Update [#3031](https://github.com/GoogleContainerTools/skaffold/pull/3031)
-* [docs] readd exceptions in deprecation policy [#3029](https://github.com/GoogleContainerTools/skaffold/pull/3029)
+* [docs] re-add exceptions in deprecation policy [#3029](https://github.com/GoogleContainerTools/skaffold/pull/3029)
 * add links to docs which are present [#3026](https://github.com/GoogleContainerTools/skaffold/pull/3026)
 * moving deprecation policy to skaffold.dev [#3017](https://github.com/GoogleContainerTools/skaffold/pull/3017)
 * add survey link and reword community office hours [#3019](https://github.com/GoogleContainerTools/skaffold/pull/3019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -451,7 +451,7 @@ Bug Fixes:
 * Small random fixes to tests and code [#2801](https://github.com/GoogleContainerTools/skaffold/pull/2801)
 * skaffold init can be interrupted when kompose is running [#2803](https://github.com/GoogleContainerTools/skaffold/pull/2803)
 * Fix portforward flake [#2824](https://github.com/GoogleContainerTools/skaffold/pull/2824)
-* Improve `skaffold init` behaviour when tags are used in manifests [#2773](https://github.com/GoogleContainerTools/skaffold/pull/2773)
+* Improve `skaffold init` behavior when tags are used in manifests [#2773](https://github.com/GoogleContainerTools/skaffold/pull/2773)
 * Skip secret creation/check [#2783](https://github.com/GoogleContainerTools/skaffold/pull/2783)
 
 Updates & Refactors:
@@ -1941,7 +1941,7 @@ Bug fixes:
 
 * Improve Kaniko builder [#1168](https://github.com/GoogleContainerTools/skaffold/pull/1168)
 * Use os.SameFile() to check for mvnw working-dir echo bug [#1167](https://github.com/GoogleContainerTools/skaffold/pull/1167)
-* Fix kaniko default behaviour [#1139](https://github.com/GoogleContainerTools/skaffold/pull/1139)
+* Fix kaniko default behavior [#1139](https://github.com/GoogleContainerTools/skaffold/pull/1139)
 
 Updates:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2453,7 +2453,7 @@ New Features
 * Added options for GCR auth
 * Set default log level to warn
 * Change git commit to use short ID instead
-* Helm deployer now acceptes namespace and values file
+* Helm deployer now accepts namespace and values file
 * Local builder now accepts docker build-args
 * Added --tag flag for skaffold run
 * Cache image configs by name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1554,7 +1554,7 @@ Fixes:
 * `[kubectl]` apply labels by patching yaml [#1489](https://github.com/GoogleContainerTools/skaffold/pull/1489)
 
 Updates & refactorings:
-* Optimise sync [#1641](https://github.com/GoogleContainerTools/skaffold/pull/1641)
+* Optimize sync [#1641](https://github.com/GoogleContainerTools/skaffold/pull/1641)
 * kubectl deployer: warn when pattern matches no file [#1647](https://github.com/GoogleContainerTools/skaffold/pull/1647)
 * Add integration tests for taggers [#1635](https://github.com/GoogleContainerTools/skaffold/pull/1635)
 * Adding a few tests for `skaffold build` [#1628](https://github.com/GoogleContainerTools/skaffold/pull/1628)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -934,7 +934,7 @@ Bug Fixes:
 * Docker is case sensitive about networks [#2288](https://github.com/GoogleContainerTools/skaffold/pull/2288)
 * cluster builder fails to detect insecure registries [#2266](https://github.com/GoogleContainerTools/skaffold/pull/2266)
 * fix static linking of linux binary [#2252](https://github.com/GoogleContainerTools/skaffold/pull/2252)
-* fix racey test [#2251](https://github.com/GoogleContainerTools/skaffold/pull/2251)
+* fix racy test [#2251](https://github.com/GoogleContainerTools/skaffold/pull/2251)
 
 Updates & Refactors:
 * Remove the `config out of date` warning [#2298](https://github.com/GoogleContainerTools/skaffold/pull/2298)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -547,7 +547,7 @@ Updates & Refactors:
 * more debugging for kubectl portforward [#2707](https://github.com/GoogleContainerTools/skaffold/pull/2707)
 * Remove time sensitive tests [#2655](https://github.com/GoogleContainerTools/skaffold/pull/2655)
 * Log a warning and rebuild if needed when caching fails [#2685](https://github.com/GoogleContainerTools/skaffold/pull/2685)
-* Improve logging warning when enountering profile field of unhandled type [#2691](https://github.com/GoogleContainerTools/skaffold/pull/2691)
+* Improve logging warning when encountering profile field of unhandled type [#2691](https://github.com/GoogleContainerTools/skaffold/pull/2691)
 * refactor: Add upgrade utility to handle all pipelines in a SkaffoldConfig [#2582](https://github.com/GoogleContainerTools/skaffold/pull/2582)
 * Add struct for generate_pipeline to keep track of related data [#2686](https://github.com/GoogleContainerTools/skaffold/pull/2686)
 * Add unit tests to kubectl forwarder [#2661](https://github.com/GoogleContainerTools/skaffold/pull/2661)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2400,7 +2400,7 @@ New Features
 Bug Fixes
 * Logs use relative time instead of host time, which fixes issues with clock sync on local clusters
 * Removed duplicate error
-* Docker build args passsed to Google Container Builder
+* Docker build args passed to Google Container Builder
 * Fixed unreliable file detection when using IntelliJ or other IDEs
 * Better handling of default values
 * Fixed issue with some logs being displayed twice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Highlights:
 New Features: 
 * Add `—port-forward` to `skaffold deploy` [#3418](https://github.com/GoogleContainerTools/skaffold/pull/3418)
 * Add --port-forward to skaffold run [#3263](https://github.com/GoogleContainerTools/skaffold/pull/3263)
-* Skaffold init recognises nodeJS projects built with Buildpacks [#3394](https://github.com/GoogleContainerTools/skaffold/pull/3394)
+* Skaffold init recognizes nodeJS projects built with Buildpacks [#3394](https://github.com/GoogleContainerTools/skaffold/pull/3394)
 * Add env vars to kaniko specs [#3389](https://github.com/GoogleContainerTools/skaffold/pull/3389)
 * Default to gcloud auth [#3282](https://github.com/GoogleContainerTools/skaffold/pull/3282)
 * Apply resource labels in the deployer [#3390](https://github.com/GoogleContainerTools/skaffold/pull/3390)

--- a/cmd/skaffold/app/cmd/dev_test.go
+++ b/cmd/skaffold/app/cmd/dev_test.go
@@ -155,7 +155,7 @@ func TestDevConfigChange(t *testing.T) {
 
 		err := doDev(context.Background(), ioutil.Discard)
 
-		// ensure that we received the context.Cancled error (and not ErrorConfigurationChanged)
+		// ensure that we received the context.Canceled error (and not ErrorConfigurationChanged)
 		// also ensure that the we run through dev cycles (since we reloaded on the first),
 		// and exit after a real error is received
 		t.CheckTrue(err == context.Canceled)

--- a/cmd/skaffold/app/cmd/flags_test.go
+++ b/cmd/skaffold/app/cmd/flags_test.go
@@ -61,7 +61,7 @@ func TestHasCmdAnnotation(t *testing.T) {
 func TestAddFlagsSmoke(t *testing.T) {
 	testCmd := &cobra.Command{
 		Use:   "test",
-		Short: "Test commanf for smoke testing",
+		Short: "Test command for smoke testing",
 	}
 	SetupFlags()
 	AddFlags(testCmd.Flags(), "test")

--- a/cmd/skaffold/app/flags/image_test.go
+++ b/cmd/skaffold/app/flags/image_test.go
@@ -55,7 +55,7 @@ func TestImagesFlagSet(t *testing.T) {
 			},
 		},
 		{
-			description: "set on correct value return right artifact without dogest",
+			description: "set on correct value return right artifact without digest",
 			setValue:    "gcr.io/test/test-image@sha256:81daf011d63b68cfa514ddab7741a1adddd59d3264118dfb0fd9266328bb8883",
 			expectedArtifact: build.Artifact{
 				ImageName: "gcr.io/test/test-image",

--- a/docs/content/en/docs/design/api.md
+++ b/docs/content/en/docs/design/api.md
@@ -18,7 +18,7 @@ To retrieve information about the Skaffold pipeline, the Skaffold API provides t
   
   * A snapshot of the [overall state]({{< relref "#state-api" >}}) of the pipeline at any given time during the run.
 
-To control the individual phases of the Skaffold, the Skaffold API provides [fine grained control]({{< relref "#controlling-build-sync-deploy" >}})
+To control the individual phases of the Skaffold, the Skaffold API provides [fine-grained control]({{< relref "#controlling-build-sync-deploy" >}})
 over the individual phases of the pipeline (build, deploy, and sync).
 
 

--- a/docs/content/en/docs/design/api.md
+++ b/docs/content/en/docs/design/api.md
@@ -31,7 +31,7 @@ For reference, we generate the server's [gRPC service definitions and message pr
 
 
 ### HTTP server
-The HTTP API is exposed on port `50052` by default. The default HTTP port can be overriden with the `--rpc-http-port` flag. 
+The HTTP API is exposed on port `50052` by default. The default HTTP port can be overridden with the `--rpc-http-port` flag. 
 If the HTTP API port is taken, Skaffold will find the next available port.
 The final port can be found from Skaffold's startup logs.
 
@@ -42,7 +42,7 @@ WARN[0000] port 50052 for gRPC HTTP server already in use: using 50055 instead
 
 ### gRPC Server
 
-The gRPC API is exposed on port `50051` by default and can be overriden with the `--rpc-port` flag.
+The gRPC API is exposed on port `50051` by default and can be overridden with the `--rpc-port` flag.
 As with the HTTP API, if this port is taken, Skaffold will find the next available port.
 You can find this port from Skaffold's logs on startup.
 

--- a/docs/content/en/docs/pipeline-stages/deployers.md
+++ b/docs/content/en/docs/pipeline-stages/deployers.md
@@ -87,7 +87,7 @@ Each `release` includes the following fields:
 
 ### Helm Build Dependencies
 
-The `skipBuildDependencies` flag toggles whether depenedencies of the Helm chart are built with the `helm dep build` command. This command manipulates files inside the `charts` subfolder of the specified Helm chart.
+The `skipBuildDependencies` flag toggles whether dependencies of the Helm chart are built with the `helm dep build` command. This command manipulates files inside the `charts` subfolder of the specified Helm chart.
 
 If `skipBuildDependencies` is `false` then `skaffold dev` does **not** watch the `charts` subfolder of the Helm chart, in order to prevent a build loop - the actions of `helm dep build` always trigger another build.
 

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -31,7 +31,7 @@ the artifact's `context` directory and tag according to those rules:
 
  + If the workspace is on a Git tag, that tag is used to tag images
  + If the workspace is on a Git commit, the short commit is used
- + It the workspace has uncommited changes, a `-dirty` suffix is appended to the image tag
+ + It the workspace has uncommitted changes, a `-dirty` suffix is appended to the image tag
 
 ### Example
 

--- a/docs/content/en/docs/references/api/_index.md
+++ b/docs/content/en/docs/references/api/_index.md
@@ -4,7 +4,7 @@ linkTitle: "API"
 weight: 30
 ---
 
-Skaffold exposes an API for retrieving information about the state of the process and to provide fine grained control over the execution. 
+Skaffold exposes an API for retrieving information about the state of the process and to provide fine-grained control over the execution. 
 For a detailed description of the [Skaffold API]({{<relref "/docs/design/api" >}}). 
 
 The same API is exposed two ways, through gRPC and HTTP, for which the generated reference can be found below:      

--- a/docs/content/en/docs/references/deprecation.md
+++ b/docs/content/en/docs/references/deprecation.md
@@ -47,8 +47,8 @@ In order to be transparent about the maturity of feature areas and things that m
 
 You can safely depend on the skaffold config with the assumption that skaffold will auto-upgrade to the latest version:
 
-- Removal and other non-upgradable changes are subject to the deprecation policy for all (even new) features under the config.
-- Auto-upgradable changes are not considered breaking changes.
+- Removal and other non-upgradeable changes are subject to the deprecation policy for all (even new) features under the config.
+- Auto-upgradeable changes are not considered breaking changes.
 
 ## Skaffold features
 

--- a/docs/content/en/docs/resources/_index.md
+++ b/docs/content/en/docs/resources/_index.md
@@ -15,7 +15,7 @@ Coming soon!
 * IDE integration VSCode and IntelliJ Skaffold dev/build/run/deploy support, Skaffold Config code completion
    * DONE, see [Cloud Code](http://cloud.google.com/code)
 * Debugging JVM applications 
-    * DONE, we have Java, go, python and node for [debbuging]({{<relref "/docs/workflows/debug">}})
+    * DONE, we have Java, go, python and node for [debugging]({{<relref "/docs/workflows/debug">}})
 * Skaffold keeps track of what it built, for faster restarts
     * DONE, artifact caching is enabled by default, can be controlled with the `--cache-artifacts` flag
 * Pipeline CRD integration

--- a/docs/content/en/docs/workflows/dev.md
+++ b/docs/content/en/docs/workflows/dev.md
@@ -21,7 +21,7 @@ The dev loop will run until the user cancels the Skaffold process with `Ctrl+C`.
 
 ## Precedence of Actions
 
-The actions performed by Skaffold during the dev loop have precendence over one another, so that behavior is always predictable. The order of actions is:
+The actions performed by Skaffold during the dev loop have precedence over one another, so that behavior is always predictable. The order of actions is:
 
 1. File Sync
 1. Build

--- a/docs/design_proposals/digest-tagger.md
+++ b/docs/design_proposals/digest-tagger.md
@@ -40,7 +40,7 @@ Here are some rules about how tagging currently works:
    **So the `git` tagger seems like a wrong choice for a default tagger**.
  + `sha256` is a misleading name. It is named like that because, in the end, when Skaffold
    deploys to a remote cluster, the image's sha256 digest is used as the immutable tag.
-   **Users are confused with this name and behaviour**.
+   **Users are confused with this name and behavior**.
  + the `sha256` used to be able to use the image tags provided in the artifact definition,
    instead of `latest`. This was not documented and is not possible anymore because artifact
    definitions are now considered invalid if images names have a tag.

--- a/docs/design_proposals/digest-tagger.md
+++ b/docs/design_proposals/digest-tagger.md
@@ -61,7 +61,7 @@ Here are some rules about how tagging currently works:
  + An `inputDigest` is added. It uses the digest of the artifact's inputs as the tag.
    [#2301](https://github.com/GoogleContainerTools/skaffold/pull/2301) tried to implement
    such tagger by computing the digest of the whole workspace. We should instead compute
-   the digest of the artifact's dependencies, inluding the artifact's configuration. This
+   the digest of the artifact's dependencies, including the artifact's configuration. This
    is exactly what the caching mechanism currently does.
  + `envTemplate` learns how to replace `{{.DIGEST}}` with a digest of the artifact's
     inputs as computed by the `inputDigest` tagger.

--- a/docs/design_proposals/digest-tagger.md
+++ b/docs/design_proposals/digest-tagger.md
@@ -20,7 +20,7 @@ Here are some rules about how tagging currently works:
    to compute tags after the build. It made the process super complex with a lot of retagging.
    It also produced images that were tagged with their own digest or imageID which is superfluous
    since those can be used to reference the images directly.
- + **No matter the tagger, Skaffold always uses immutable references in Kubenetes manifests**.
+ + **No matter the tagger, Skaffold always uses immutable references in Kubernetes manifests**.
    Which reference is used depends on whether the images are pushed or not:
      + **When images are pushed**, their immutable digest is available. Skaffold then references
        images both by tag and digest. Something like `image:tag@sha256:abacabac...`.

--- a/docs/design_proposals/event-api-v2.md
+++ b/docs/design_proposals/event-api-v2.md
@@ -16,7 +16,7 @@ Thank you @nkubala  and @tejal29  for all the hard work in exploring this avenue
 Currently there are two major pain points with the event API:
 
 * calling code is clunky, ugly, and not very portable
-* event handler is racey and generally not concurrency-friendly
+* event handler is racy and generally not concurrency-friendly
 
 The second issue here comes more from bad execution rather than bad design. Some fixes for this have already been proposed and/or merged ([#1786](https://github.com/GoogleContainerTools/skaffold/pull/1786) and [#1801](https://github.com/GoogleContainerTools/skaffold/pull/1801)), so progress has already been made, but we can probably improve on this more.
 

--- a/docs/design_proposals/kaniko-proxy-setting.md
+++ b/docs/design_proposals/kaniko-proxy-setting.md
@@ -50,10 +50,10 @@ For a new config change, please mention:
 // ClusterDetails *beta* describes how to do an on-cluster build.
 type ClusterDetails struct {
     
-    // HTTP_PROXY sets the "http_proxy" environment varaible to the pod running cluster build.      
+    // HTTP_PROXY sets the "http_proxy" environment variable to the pod running cluster build.      
     HTTP_PROXY string `yaml:"httpProxy,omitempty"`
 
-    // HTTPS_PROXY sets the "https_proxy" environment varaible to the pod running cluster build. 
+    // HTTPS_PROXY sets the "https_proxy" environment variable to the pod running cluster build. 
     HTTPS_PROXY string `yaml:"httpsProxy,omitempty"`
     
     // PullSecret is the path to the secret key file.

--- a/integration/examples/jib-multimodule/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/integration/examples/jib-multimodule/.mvn/wrapper/MavenWrapperDownloader.java
@@ -82,7 +82,7 @@ public class MavenWrapperDownloader {
         if(!outputFile.getParentFile().exists()) {
             if(!outputFile.getParentFile().mkdirs()) {
                 System.out.println(
-                        "- ERROR creating output direcrory '" + outputFile.getParentFile().getAbsolutePath() + "'");
+                        "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() + "'");
             }
         }
         System.out.println("- Downloading to: " + outputFile.getAbsolutePath());

--- a/integration/examples/jib/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/integration/examples/jib/.mvn/wrapper/MavenWrapperDownloader.java
@@ -82,7 +82,7 @@ public class MavenWrapperDownloader {
         if(!outputFile.getParentFile().exists()) {
             if(!outputFile.getParentFile().mkdirs()) {
                 System.out.println(
-                        "- ERROR creating output direcrory '" + outputFile.getParentFile().getAbsolutePath() + "'");
+                        "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() + "'");
             }
         }
         System.out.println("- Downloading to: " + outputFile.getAbsolutePath());

--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -36,7 +36,7 @@ func TestHelmDeploy(t *testing.T) {
 	env := []string{fmt.Sprintf("TEST_NS=%s", ns.Name)}
 	skaffold.Deploy("--images", "gcr.io/k8s-skaffold/skaffold-helm").InDir("testdata/helm").InNs(ns.Name).WithEnv(env).RunOrFail(t)
 
-	// check if labels are set correctly for deploment
+	// check if labels are set correctly for deployment
 	dep := client.GetDeployment("skaffold-helm-" + ns.Name)
 	testutil.CheckDeepEqual(t, dep.Name, dep.ObjectMeta.Labels["release"])
 	testutil.CheckDeepEqual(t, "helm", dep.ObjectMeta.Labels["skaffold.dev/deployer"])

--- a/integration/skaffold/helper.go
+++ b/integration/skaffold/helper.go
@@ -263,7 +263,7 @@ func (b *RunBuilder) cmd(ctx context.Context) *exec.Cmd {
 }
 
 // removeSkaffoldEnvVariables makes sure Skaffold runs without
-// any env variable that might change its behaviour, such as
+// any env variable that might change its behavior, such as
 // enabling caching.
 func removeSkaffoldEnvVariables(env []string) []string {
 	var clean []string

--- a/integration/testdata/debug/jib/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/integration/testdata/debug/jib/.mvn/wrapper/MavenWrapperDownloader.java
@@ -82,7 +82,7 @@ public class MavenWrapperDownloader {
         if(!outputFile.getParentFile().exists()) {
             if(!outputFile.getParentFile().mkdirs()) {
                 System.out.println(
-                        "- ERROR creating output direcrory '" + outputFile.getParentFile().getAbsolutePath() + "'");
+                        "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() + "'");
             }
         }
         System.out.println("- Downloading to: " + outputFile.getAbsolutePath());

--- a/integration/testdata/jib/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/integration/testdata/jib/.mvn/wrapper/MavenWrapperDownloader.java
@@ -82,7 +82,7 @@ public class MavenWrapperDownloader {
         if(!outputFile.getParentFile().exists()) {
             if(!outputFile.getParentFile().mkdirs()) {
                 System.out.println(
-                        "- ERROR creating output direcrory '" + outputFile.getParentFile().getAbsolutePath() + "'");
+                        "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() + "'");
             }
         }
         System.out.println("- Downloading to: " + outputFile.getAbsolutePath());

--- a/pkg/skaffold/build/cache/hash_test.go
+++ b/pkg/skaffold/build/cache/hash_test.go
@@ -394,7 +394,7 @@ func TestConvertBuildArgsToStringArray(t *testing.T) {
 			},
 			expected: []string{"one=", "two="},
 		}, {
-			description: "build args with nil vlaue",
+			description: "build args with nil value",
 			buildArgs: map[string]*string{
 				"one": nil,
 				"two": nil,

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -119,7 +119,7 @@ func TestLocalRun(t *testing.T) {
 			shouldErr: true,
 		},
 		{
-			description: "dont push on build error",
+			description: "Don't push on build error",
 			artifacts: []*latest.Artifact{{
 				ImageName: "gcr.io/test/image",
 				ArtifactType: latest.ArtifactType{

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -96,7 +96,7 @@ var (
 	// KubeContext is the expected kubecontext to build an artifact with a custom build script on cluster
 	KubeContext = "KUBE_CONTEXT"
 
-	// Namespace is the expected namsepace to build an artifact with a custom build script on cluster.
+	// Namespace is the expected namespace to build an artifact with a custom build script on cluster.
 	Namespace = "NAMESPACE"
 
 	// PullSecretName is the secret with authentication required to pull a base image/push the final image built on cluster.

--- a/pkg/skaffold/deploy/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize_test.go
@@ -180,7 +180,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 			},
 		},
 		{
-			description: "paches",
+			description: "patches",
 			yaml:        `patches: [patch1.yaml, path/patch2.yaml]`,
 			expected:    []string{"kustomization.yaml", "patch1.yaml", "path/patch2.yaml"},
 		},

--- a/pkg/skaffold/deploy/resource.go
+++ b/pkg/skaffold/deploy/resource.go
@@ -39,7 +39,7 @@ type Resource interface {
 	// UpdateStatus updates the resource status
 	UpdateStatus(string, error)
 
-	// IsStatusCheckComplete returns if the resource status check is complele
+	// IsStatusCheckComplete returns if the resource status check is complete
 	IsStatusCheckComplete() bool
 
 	// Deadline returns the deadline for the resource

--- a/pkg/skaffold/deploy/resource/deployment_test.go
+++ b/pkg/skaffold/deploy/resource/deployment_test.go
@@ -165,7 +165,7 @@ func TestIsErrAndNotRetriable(t *testing.T) {
 			expected:    true,
 		},
 		{
-			description: "rollout status parent conetct timed out",
+			description: "rollout status parent context timed out",
 			err:         context.DeadlineExceeded,
 			expected:    true,
 		},

--- a/pkg/skaffold/docker/authenticators.go
+++ b/pkg/skaffold/docker/authenticators.go
@@ -34,7 +34,7 @@ type Authenticators struct {
 	lock       sync.Mutex
 }
 
-// For retrieves the authentiator for a given image reference.
+// For retrieves the authenticator for a given image reference.
 func (a *Authenticators) For(ref name.Reference) authn.Authenticator {
 	registry := ref.Context().Registry.Name()
 

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -77,7 +77,7 @@ func TestPush(t *testing.T) {
 	}
 }
 
-func TestDontPushAlreadyPushed(t *testing.T) {
+func TestDoNotPushAlreadyPushed(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		t.Override(&DefaultAuthHelper, testAuthHelper{})
 

--- a/pkg/skaffold/docker/reference_test.go
+++ b/pkg/skaffold/docker/reference_test.go
@@ -30,7 +30,7 @@ func TestParseReference(t *testing.T) {
 		expectedTag            string
 		expectedDigest         string
 		expectedFullyQualified bool
-		shoudErr               bool
+		shouldErr              bool
 	}{
 		{
 			description:            "port and tag",
@@ -85,15 +85,15 @@ func TestParseReference(t *testing.T) {
 		{
 			description: "invalid reference",
 			image:       "!!invalid!!",
-			shoudErr:    true,
+			shouldErr:   true,
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			parsed, err := ParseReference(test.image)
 
-			t.CheckError(test.shoudErr, err)
-			if !test.shoudErr {
+			t.CheckError(test.shouldErr, err)
+			if !test.shouldErr {
 				t.CheckDeepEqual(test.expectedName, parsed.BaseName)
 				t.CheckDeepEqual(test.expectedTag, parsed.Tag)
 				t.CheckDeepEqual(test.expectedDigest, parsed.Digest)

--- a/pkg/skaffold/filemon/changes_test.go
+++ b/pkg/skaffold/filemon/changes_test.go
@@ -120,7 +120,7 @@ func TestStatNotExist(t *testing.T) {
 		shouldErr   bool
 	}{
 		{
-			description: "no error when deps returns nonexisting file",
+			description: "no error when deps returns nonexistent file",
 			deps:        []string{"file/that/does/not/exist/anymore"},
 		},
 		{

--- a/pkg/skaffold/filemon/changes_test.go
+++ b/pkg/skaffold/filemon/changes_test.go
@@ -121,11 +121,11 @@ func TestStatNotExist(t *testing.T) {
 	}{
 		{
 			description: "no error when deps returns nonexisting file",
-			deps:        []string{"file/that/doesnt/exist/anymore"},
+			deps:        []string{"file/that/does/not/exist/anymore"},
 		},
 		{
 			description: "deps function error",
-			deps:        []string{"file/that/doesnt/exist/anymore"},
+			deps:        []string{"file/that/does/not/exist/anymore"},
 			depsErr:     fmt.Errorf(""),
 			shouldErr:   true,
 		},

--- a/pkg/skaffold/kubernetes/portforward/port_forward_entry_test.go
+++ b/pkg/skaffold/kubernetes/portforward/port_forward_entry_test.go
@@ -53,14 +53,14 @@ func TestPortForwardEntryKey(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			acutalKey := test.pfe.key()
+			actualKey := test.pfe.key()
 
-			if acutalKey != test.expected {
-				t.Fatalf("port forward entry key is incorrect: \n actual: %s \n expected: %s", acutalKey, test.expected)
+			if actualKey != test.expected {
+				t.Fatalf("port forward entry key is incorrect: \n actual: %s \n expected: %s", actualKey, test.expected)
 			}
 
 			if test.pfe.String() != test.expected {
-				t.Fatalf("port forward entry string is incorrect: \n actual: %s \n expected: %s", acutalKey, test.expected)
+				t.Fatalf("port forward entry string is incorrect: \n actual: %s \n expected: %s", actualKey, test.expected)
 			}
 		})
 	}
@@ -86,13 +86,13 @@ func TestAutomaticPodForwardingKey(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			acutalKey := test.pfe.key()
+			actualKey := test.pfe.key()
 
-			if acutalKey != test.expected {
-				t.Fatalf("port forward entry key is incorrect: \n actual: %s \n expected: %s", acutalKey, test.expected)
+			if actualKey != test.expected {
+				t.Fatalf("port forward entry key is incorrect: \n actual: %s \n expected: %s", actualKey, test.expected)
 			}
 
-			if strings.Contains(acutalKey, "pod") {
+			if strings.Contains(actualKey, "pod") {
 				t.Fatal("key should not contain podname, otherwise containers will be mapped to a new port every time a pod is regenerated. See Issues #1815 and #1594.")
 			}
 		})

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -612,7 +612,7 @@ func TestActivatedProfiles(t *testing.T) {
 			expected: []string{"one", "one-as-well", "not-two"},
 		},
 		{
-			description: "Profiles on the command line are activated after auto-activatd profiles",
+			description: "Profiles on the command line are activated after auto-activated profiles",
 			opts: cfg.SkaffoldOptions{
 				Command:  "run",
 				Profiles: []string{"activated", "also-activated"},

--- a/pkg/skaffold/schema/v1alpha5/upgrade_test.go
+++ b/pkg/skaffold/schema/v1alpha5/upgrade_test.go
@@ -37,7 +37,7 @@ deploy:
     manifests:
       - k8s-*
 `
-	upgradeShouldFailt(t, yaml)
+	upgradeShouldFail(t, yaml)
 }
 
 func TestUpgrade_removeACRInProfiles(t *testing.T) {
@@ -55,7 +55,7 @@ profiles:
    build: 
     acr: {}
 `
-	upgradeShouldFailt(t, yaml)
+	upgradeShouldFail(t, yaml)
 }
 
 func TestUpgrade(t *testing.T) {
@@ -116,7 +116,7 @@ profiles:
 	verifyUpgrade(t, yaml, expected)
 }
 
-func upgradeShouldFailt(t *testing.T, input string) {
+func upgradeShouldFail(t *testing.T, input string) {
 	config := NewSkaffoldConfig()
 	err := yaml.UnmarshalStrict([]byte(input), config)
 	testutil.CheckErrorAndDeepEqual(t, false, err, Version, config.GetVersion())


### PR DESCRIPTION
**Description**

Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`

* I've selected en-US over en-GB as the majority of the words appear to favor that (especially for the handful of en-GB words I encountered) -- I can include a marker in the commit message for such words if necessary, but I haven't here.
* I try to avoid changes files that appear to be from third-party code, but I'm a (sleepy) human, if I missed some code, please let me know, I'll try to apply the same algorithm to the upstream (and drop the commits locally).

**User facing changes**

I don't think anything user-visible has changed, but I'm not absolutely certain.

**After**

> If behavior changes: describe _succintly_ the behavior after your change

Ok, this specific line in future PRs will be changed.

**Next PRs.**

I might offer a PR to remove misspellings from CHANGELOG.md. I know it's nice to record all changes in the changelog, but it's really frustrating when running a spelling-checker to have to actively say "oh, yes, they intentionally misspelled that word to say that they used to misspell that word". It's better for commits to only mention the correct spelling, if someone is curious, they can use history to learn all of the misspellings.

**Submitter Checklist**

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.