### PR TITLE
Track changes of transitive BUILD files

### DIFF
--- a/pkg/skaffold/build/bazel/dependencies.go
+++ b/pkg/skaffold/build/bazel/dependencies.go
@@ -33,7 +33,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
-const sourceQuery = "kind('source file', deps('%[1]s')) union buildfiles('%[1]s')"
+const sourceQuery = "kind('source file', deps('%[1]s')) union buildfiles(deps('%[1]s'))"
 
 func query(target string) string {
 	return fmt.Sprintf(sourceQuery, target)

--- a/pkg/skaffold/build/bazel/dependencies_test.go
+++ b/pkg/skaffold/build/bazel/dependencies_test.go
@@ -47,7 +47,7 @@ func TestGetDependencies(t *testing.T) {
 				"dep1":      "",
 				"dep2":      "",
 			},
-			expectedQuery: "bazel query kind('source file', deps('target')) union buildfiles('target') --noimplicit_deps --order_output=no --output=label",
+			expectedQuery: "bazel query kind('source file', deps('target')) union buildfiles(deps('target')) --noimplicit_deps --order_output=no --output=label",
 			output:        "@ignored\n//:BUILD\n//external/ignored\n\n//:dep1\n//:dep2\n",
 			expected:      []string{"BUILD", "dep1", "dep2", "WORKSPACE"},
 		},
@@ -63,7 +63,7 @@ func TestGetDependencies(t *testing.T) {
 				"sub/folder/dep2":     "",
 				"sub/folder/baz/dep3": "",
 			},
-			expectedQuery: "bazel query kind('source file', deps('target2')) union buildfiles('target2') --noimplicit_deps --order_output=no --output=label",
+			expectedQuery: "bazel query kind('source file', deps('target2')) union buildfiles(deps('target2')) --noimplicit_deps --order_output=no --output=label",
 			output:        "@ignored\n//:BUILD\n//sub/folder:BUILD\n//external/ignored\n\n//sub/folder:dep1\n//sub/folder:dep2\n//sub/folder/baz:dep3\n",
 			expected:      []string{filepath.Join("..", "..", "BUILD"), "BUILD", "dep1", "dep2", filepath.Join("baz", "dep3"), filepath.Join("..", "..", "WORKSPACE")},
 		},
@@ -94,7 +94,7 @@ func TestGetDependencies(t *testing.T) {
 func TestQuery(t *testing.T) {
 	query := query("//:skaffold_example.tar")
 
-	expectedQuery := `kind('source file', deps('//:skaffold_example.tar')) union buildfiles('//:skaffold_example.tar')`
+	expectedQuery := `kind('source file', deps('//:skaffold_example.tar')) union buildfiles(deps('//:skaffold_example.tar'))`
 	if query != expectedQuery {
 		t.Errorf("Expected [%s]. Got [%s]", expectedQuery, query)
 	}


### PR DESCRIPTION
Fixes #3459

Wanted to add a test but it looks like there are no tests that run the bazel query command.