### PR TITLE
Add gradle/maven sync parts + restructure tests

### DIFF
--- a/pkg/skaffold/build/gcb/jib_test.go
+++ b/pkg/skaffold/build/gcb/jib_test.go
@@ -80,7 +80,7 @@ func TestJibGradleBuildSpec(t *testing.T) {
 		{
 			description:  "skip tests",
 			skipTests:    true,
-			expectedArgs: []string{"-c", "gradle -Duser.home=$$HOME -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion=" + jib.MinimumJibGradleVersion + " :jib --image=img -x test"},
+			expectedArgs: []string{"-c", "gradle -Duser.home=$$HOME -Djib.console=plain _skaffoldFailIfJibOutOfDate -Djib.requiredVersion=" + jib.MinimumJibGradleVersion + " :jib -x test --image=img"},
 		},
 		{
 			description:  "do not skip tests",

--- a/pkg/skaffold/build/jib/gradle.go
+++ b/pkg/skaffold/build/jib/gradle.go
@@ -120,7 +120,6 @@ func gradleBuildArgs(task string, a *latest.JibArtifact, skipTests bool) []strin
 	}
 	args = append(args, a.Flags...)
 	return args
-
 }
 
 // Do not use directly, use gradleArgsFunc

--- a/pkg/skaffold/build/jib/gradle.go
+++ b/pkg/skaffold/build/jib/gradle.go
@@ -30,6 +30,12 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
+// For testing
+var (
+	gradleArgsFunc      = gradleArgs
+	gradleBuildArgsFunc = gradleBuildArgs
+)
+
 // Skaffold-Jib depends on functionality introduced with Jib-Gradle 1.4.0
 const MinimumJibGradleVersion = "1.4.0"
 
@@ -81,31 +87,44 @@ func getDependenciesGradle(ctx context.Context, workspace string, a *latest.JibA
 }
 
 func getCommandGradle(ctx context.Context, workspace string, a *latest.JibArtifact) exec.Cmd {
-	args := append(gradleCommand(a, "_jibSkaffoldFilesV2"), "-q")
+	args := append(gradleArgsFunc(a, "_jibSkaffoldFilesV2"), "-q")
 	return GradleCommand.CreateCommand(ctx, workspace, args)
+}
+
+func getSyncMapCommandGradle(ctx context.Context, workspace string, a *latest.JibArtifact) *exec.Cmd {
+	cmd := GradleCommand.CreateCommand(ctx, workspace, gradleBuildArgsFunc("_jibSkaffoldSyncMap", a, true))
+	return &cmd
 }
 
 // GenerateGradleArgs generates the arguments to Gradle for building the project as an image.
 func GenerateGradleArgs(task string, imageName string, a *latest.JibArtifact, skipTests bool, insecureRegistries map[string]bool) []string {
-	// disable jib's rich progress footer; we could use `--console=plain`
-	// but it also disables colour which can be helpful
-	args := []string{"-Djib.console=plain"}
-	args = append(args, gradleCommand(a, task)...)
-
+	args := gradleBuildArgsFunc(task, a, skipTests)
 	if insecure, err := isOnInsecureRegistry(imageName, insecureRegistries); err == nil && insecure {
 		// jib doesn't support marking specific registries as insecure
 		args = append(args, "-Djib.allowInsecureRegistries=true")
 	}
 
 	args = append(args, "--image="+imageName)
+	return args
+}
+
+// Do not use directly, use gradleBuildArgsFunc
+func gradleBuildArgs(task string, a *latest.JibArtifact, skipTests bool) []string {
+	// disable jib's rich progress footer; we could use `--console=plain`
+	// but it also disables colour which can be helpful
+	args := []string{"-Djib.console=plain"}
+	args = append(args, gradleArgsFunc(a, task)...)
+
 	if skipTests {
 		args = append(args, "-x", "test")
 	}
 	args = append(args, a.Flags...)
 	return args
+
 }
 
-func gradleCommand(a *latest.JibArtifact, task string) []string {
+// Do not use directly, use gradleArgsFunc
+func gradleArgs(a *latest.JibArtifact, task string) []string {
 	args := []string{"_skaffoldFailIfJibOutOfDate", "-Djib.requiredVersion=" + MinimumJibGradleVersion}
 	if a.Project == "" {
 		return append(args, ":"+task)

--- a/pkg/skaffold/build/jib/gradle_test.go
+++ b/pkg/skaffold/build/jib/gradle_test.go
@@ -291,10 +291,10 @@ func TestGetCommandGradle(t *testing.T) {
 func TestGetSyncMapCommandGradle(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
-		description      string
-		workspace        string
-		jibArtifact      latest.JibArtifact
-		expectedCmd      func(workspace string) exec.Cmd
+		description string
+		workspace   string
+		jibArtifact latest.JibArtifact
+		expectedCmd func(workspace string) exec.Cmd
 	}{
 		{
 			description: "single module",
@@ -325,7 +325,7 @@ func TestGetSyncMapCommandGradle(t *testing.T) {
 
 func TestGenerateGradleArgs(t *testing.T) {
 	tests := []struct {
-		description string
+		description        string
 		in                 latest.JibArtifact
 		image              string
 		skipTests          bool
@@ -343,25 +343,25 @@ func TestGenerateGradleArgs(t *testing.T) {
 			t.Override(&gradleBuildArgsFunc, gradleBuildArgsFuncFake)
 			command := GenerateGradleArgs("testTask", test.image, &test.in, test.skipTests, test.insecureRegistries)
 			t.CheckDeepEqual(test.out, command)
-		});
+		})
 	}
 }
 
 func TestGradleArgs(t *testing.T) {
 	tests := []struct {
-		description	string
+		description string
 		jibArtifact latest.JibArtifact
-		expected []string
-	} {
+		expected    []string
+	}{
 		{
 			description: "single module",
 			jibArtifact: latest.JibArtifact{},
-			expected: []string{"_skaffoldFailIfJibOutOfDate", "-Djib.requiredVersion=" + MinimumJibGradleVersion, ":testTask"},
+			expected:    []string{"_skaffoldFailIfJibOutOfDate", "-Djib.requiredVersion=" + MinimumJibGradleVersion, ":testTask"},
 		},
 		{
 			description: "multi module",
 			jibArtifact: latest.JibArtifact{Project: "module"},
-			expected: []string{"_skaffoldFailIfJibOutOfDate", "-Djib.requiredVersion=" + MinimumJibGradleVersion, ":module:testTask"},
+			expected:    []string{"_skaffoldFailIfJibOutOfDate", "-Djib.requiredVersion=" + MinimumJibGradleVersion, ":module:testTask"},
 		},
 	}
 	for _, test := range tests {
@@ -374,44 +374,44 @@ func TestGradleBuildArgs(t *testing.T) {
 	tests := []struct {
 		description string
 		jibArtifact latest.JibArtifact
-		skipTests bool
-		expected []string
-	} {
+		skipTests   bool
+		expected    []string
+	}{
 		{
 			description: "single module",
 			jibArtifact: latest.JibArtifact{},
-			skipTests: false,
-			expected: []string{"-Djib.console=plain", "fake-gradleArgs-for-testTask"},
+			skipTests:   false,
+			expected:    []string{"-Djib.console=plain", "fake-gradleArgs-for-testTask"},
 		},
 		{
 			description: "single module skip tests",
 			jibArtifact: latest.JibArtifact{},
-			skipTests: true,
-			expected: []string{"-Djib.console=plain", "fake-gradleArgs-for-testTask", "-x", "test"},
+			skipTests:   true,
+			expected:    []string{"-Djib.console=plain", "fake-gradleArgs-for-testTask", "-x", "test"},
 		},
 		{
 			description: "single module with extra flags",
-			jibArtifact: latest.JibArtifact{Flags: []string{"--flag1", "--flag2"},},
-			skipTests: false,
-			expected: []string{"-Djib.console=plain", "fake-gradleArgs-for-testTask", "--flag1", "--flag2"},
+			jibArtifact: latest.JibArtifact{Flags: []string{"--flag1", "--flag2"}},
+			skipTests:   false,
+			expected:    []string{"-Djib.console=plain", "fake-gradleArgs-for-testTask", "--flag1", "--flag2"},
 		},
 		{
 			description: "multi module",
 			jibArtifact: latest.JibArtifact{Project: "module"},
-			skipTests: false,
-			expected: []string{"-Djib.console=plain", "fake-gradleArgs-for-module-for-testTask"},
+			skipTests:   false,
+			expected:    []string{"-Djib.console=plain", "fake-gradleArgs-for-module-for-testTask"},
 		},
 		{
 			description: "single module skip tests",
 			jibArtifact: latest.JibArtifact{Project: "module"},
-			skipTests: true,
-			expected: []string{"-Djib.console=plain", "fake-gradleArgs-for-module-for-testTask", "-x", "test"},
+			skipTests:   true,
+			expected:    []string{"-Djib.console=plain", "fake-gradleArgs-for-module-for-testTask", "-x", "test"},
 		},
 		{
 			description: "multi module with extra flags",
 			jibArtifact: latest.JibArtifact{Project: "module", Flags: []string{"--flag1", "--flag2"}},
-			skipTests: false,
-			expected: []string{"-Djib.console=plain", "fake-gradleArgs-for-module-for-testTask", "--flag1", "--flag2"},
+			skipTests:   false,
+			expected:    []string{"-Djib.console=plain", "fake-gradleArgs-for-module-for-testTask", "--flag1", "--flag2"},
 		},
 	}
 	for _, test := range tests {
@@ -427,7 +427,7 @@ func gradleArgsFuncFake(a *latest.JibArtifact, task string) []string {
 	if a.Project == "" {
 		return []string{"fake-gradleArgs-for-" + task}
 	} else {
-		return []string{"fake-gradleArgs-for-" + a.Project + "-for-" + task }
+		return []string{"fake-gradleArgs-for-" + a.Project + "-for-" + task}
 	}
 }
 
@@ -438,8 +438,8 @@ func gradleBuildArgsFuncFake(task string, a *latest.JibArtifact, skipTests bool)
 		testString = "-skipTests"
 	}
 	if a.Project == "" {
-		return []string{"fake-gradleBuildArgs-for-" + task + testString};
+		return []string{"fake-gradleBuildArgs-for-" + task + testString}
 	} else {
-		return []string{"fake-gradleBuildArgs-for-" + a.Project + "-for-" + task + testString};
+		return []string{"fake-gradleBuildArgs-for-" + a.Project + "-for-" + task + testString}
 	}
 }

--- a/pkg/skaffold/build/jib/gradle_test.go
+++ b/pkg/skaffold/build/jib/gradle_test.go
@@ -426,9 +426,8 @@ func TestGradleBuildArgs(t *testing.T) {
 func gradleArgsFuncFake(a *latest.JibArtifact, task string) []string {
 	if a.Project == "" {
 		return []string{"fake-gradleArgs-for-" + task}
-	} else {
-		return []string{"fake-gradleArgs-for-" + a.Project + "-for-" + task}
 	}
+	return []string{"fake-gradleArgs-for-" + a.Project + "-for-" + task}
 }
 
 // check that parameters are actually passed though
@@ -437,9 +436,9 @@ func gradleBuildArgsFuncFake(task string, a *latest.JibArtifact, skipTests bool)
 	if skipTests {
 		testString = "-skipTests"
 	}
+
 	if a.Project == "" {
 		return []string{"fake-gradleBuildArgs-for-" + task + testString}
-	} else {
-		return []string{"fake-gradleBuildArgs-for-" + a.Project + "-for-" + task + testString}
 	}
+	return []string{"fake-gradleBuildArgs-for-" + a.Project + "-for-" + task + testString}
 }

--- a/pkg/skaffold/build/jib/jib.go
+++ b/pkg/skaffold/build/jib/jib.go
@@ -89,7 +89,7 @@ type filesLists struct {
 var watchedFiles = map[string]filesLists{}
 
 func GetBuildDefinitions(a *latest.JibArtifact) []string {
-		return watchedFiles[a.Project].BuildDefinitions
+	return watchedFiles[a.Project].BuildDefinitions
 }
 
 // GetDependencies returns a list of files to watch for changes to rebuild

--- a/pkg/skaffold/build/jib/jib.go
+++ b/pkg/skaffold/build/jib/jib.go
@@ -88,6 +88,10 @@ type filesLists struct {
 // watchedFiles maps from project name to watched files
 var watchedFiles = map[string]filesLists{}
 
+func GetBuildDefinitions(a *latest.JibArtifact) []string {
+		return watchedFiles[a.Project].BuildDefinitions
+}
+
 // GetDependencies returns a list of files to watch for changes to rebuild
 func GetDependencies(ctx context.Context, workspace string, artifact *latest.JibArtifact) ([]string, error) {
 	t, err := DeterminePluginType(workspace, artifact)

--- a/pkg/skaffold/build/jib/maven_test.go
+++ b/pkg/skaffold/build/jib/maven_test.go
@@ -421,9 +421,8 @@ func TestMavenArgs(t *testing.T) {
 func mavenArgsFuncFake(a *latest.JibArtifact) []string {
 	if a.Project == "" {
 		return []string{"fake-mavenArgs"}
-	} else {
-		return []string{"fake-mavenArgs-for-" + a.Project}
 	}
+	return []string{"fake-mavenArgs-for-" + a.Project}
 }
 
 // check that parameters are actually passed though
@@ -432,9 +431,9 @@ func mavenBuildArgsFuncFake(goal string, a *latest.JibArtifact, skipTests bool) 
 	if skipTests {
 		testString = "-skipTests"
 	}
+
 	if a.Project == "" {
 		return []string{"fake-mavenBuildArgs-for-" + goal + testString}
-	} else {
-		return []string{"fake-mavenBuildArgs-for-" + a.Project + "-for-" + goal + testString}
 	}
+	return []string{"fake-mavenBuildArgs-for-" + a.Project + "-for-" + goal + testString}
 }

--- a/pkg/skaffold/build/jib/maven_test.go
+++ b/pkg/skaffold/build/jib/maven_test.go
@@ -46,28 +46,21 @@ func TestBuildJibMavenToDocker(t *testing.T) {
 			description: "build",
 			artifact:    &latest.JibArtifact{},
 			commands: testutil.CmdRun(
-				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=" + MinimumJibMavenVersion + " --non-recursive prepare-package jib:dockerBuild -Dimage=img:tag",
-			),
-		},
-		{
-			description: "build with additional flags",
-			artifact:    &latest.JibArtifact{Flags: []string{"--flag1", "--flag2"}},
-			commands: testutil.CmdRun(
-				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=" + MinimumJibMavenVersion + " --flag1 --flag2 --non-recursive prepare-package jib:dockerBuild -Dimage=img:tag",
+				"mvn fake-mavenBuildArgs-for-dockerBuild -Dimage=img:tag",
 			),
 		},
 		{
 			description: "build with module",
 			artifact:    &latest.JibArtifact{Project: "module"},
 			commands: testutil.CmdRun(
-				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=" + MinimumJibMavenVersion + " --projects module --also-make package jib:dockerBuild -Djib.containerize=module -Dimage=img:tag",
+				"mvn fake-mavenBuildArgs-for-module-for-dockerBuild -Dimage=img:tag",
 			),
 		},
 		{
 			description: "fail build",
 			artifact:    &latest.JibArtifact{},
 			commands: testutil.CmdRunErr(
-				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion="+MinimumJibMavenVersion+" --non-recursive prepare-package jib:dockerBuild -Dimage=img:tag",
+				"mvn fake-mavenBuildArgs-for-dockerBuild -Dimage=img:tag",
 				errors.New("BUG"),
 			),
 			shouldErr:     true,
@@ -77,6 +70,7 @@ func TestBuildJibMavenToDocker(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&mavenBuildArgsFunc, mavenBuildArgsFuncFake)
 			t.NewTempDir().Touch("pom.xml").Chdir()
 			t.Override(&util.DefaultExecCommand, test.commands)
 			api := (&testutil.FakeAPIClient{}).Add("img:tag", "imageID")
@@ -111,28 +105,21 @@ func TestBuildJibMavenToRegistry(t *testing.T) {
 			description: "build",
 			artifact:    &latest.JibArtifact{},
 			commands: testutil.CmdRun(
-				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=" + MinimumJibMavenVersion + " --non-recursive prepare-package jib:build -Dimage=img:tag",
-			),
-		},
-		{
-			description: "build with additional flags",
-			artifact:    &latest.JibArtifact{Flags: []string{"--flag1", "--flag2"}},
-			commands: testutil.CmdRun(
-				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=" + MinimumJibMavenVersion + " --flag1 --flag2 --non-recursive prepare-package jib:build -Dimage=img:tag",
+				"mvn fake-mavenBuildArgs-for-build -Dimage=img:tag",
 			),
 		},
 		{
 			description: "build with module",
 			artifact:    &latest.JibArtifact{Project: "module"},
 			commands: testutil.CmdRun(
-				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion=" + MinimumJibMavenVersion + " --projects module --also-make package jib:build -Djib.containerize=module -Dimage=img:tag",
+				"mvn fake-mavenBuildArgs-for-module-for-build -Dimage=img:tag",
 			),
 		},
 		{
 			description: "fail build",
 			artifact:    &latest.JibArtifact{},
 			commands: testutil.CmdRunErr(
-				"mvn -Djib.console=plain jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion="+MinimumJibMavenVersion+" --non-recursive prepare-package jib:build -Dimage=img:tag",
+				"mvn fake-mavenBuildArgs-for-build -Dimage=img:tag",
 				errors.New("BUG"),
 			),
 			shouldErr:     true,
@@ -142,6 +129,7 @@ func TestBuildJibMavenToRegistry(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&mavenBuildArgsFunc, mavenBuildArgsFuncFake)
 			t.NewTempDir().Touch("pom.xml").Chdir()
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.Override(&docker.RemoteDigest, func(identifier string, _ map[string]bool) (string, error) {
@@ -256,17 +244,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibArtifact:      latest.JibArtifact{},
 			filesInWorkspace: []string{},
 			expectedCmd: func(workspace string) exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--non-recursive", "jib:_skaffold-files-v2", "--quiet"})
-			},
-		},
-		{
-			description: "maven with extra flags",
-			jibArtifact: latest.JibArtifact{
-				Flags: []string{"-DskipTests", "-x"},
-			},
-			filesInWorkspace: []string{},
-			expectedCmd: func(workspace string) exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "-DskipTests", "-x", "--non-recursive", "jib:_skaffold-files-v2", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"fake-mavenArgs", "jib:_skaffold-files-v2", "--quiet"})
 			},
 		},
 		{
@@ -274,15 +252,7 @@ func TestGetCommandMaven(t *testing.T) {
 			jibArtifact:      latest.JibArtifact{},
 			filesInWorkspace: []string{"mvnw", "mvnw.bat"},
 			expectedCmd: func(workspace string) exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--non-recursive", "jib:_skaffold-files-v2", "--quiet"})
-			},
-		},
-		{
-			description:      "maven with wrapper",
-			jibArtifact:      latest.JibArtifact{},
-			filesInWorkspace: []string{"mvnw", "mvnw.cmd"},
-			expectedCmd: func(workspace string) exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--non-recursive", "jib:_skaffold-files-v2", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"fake-mavenArgs", "jib:_skaffold-files-v2", "--quiet"})
 			},
 		},
 		{
@@ -290,12 +260,13 @@ func TestGetCommandMaven(t *testing.T) {
 			jibArtifact:      latest.JibArtifact{Project: "module"},
 			filesInWorkspace: []string{"mvnw", "mvnw.bat"},
 			expectedCmd: func(workspace string) exec.Cmd {
-				return MavenCommand.CreateCommand(ctx, workspace, []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--projects", "module", "--also-make", "jib:_skaffold-files-v2", "--quiet"})
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"fake-mavenArgs-for-module", "jib:_skaffold-files-v2", "--quiet"})
 			},
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&mavenArgsFunc, mavenArgsFuncFake)
 			tmpDir := t.NewTempDir().
 				Touch(test.filesInWorkspace...)
 
@@ -309,23 +280,161 @@ func TestGetCommandMaven(t *testing.T) {
 	}
 }
 
+func TestGetSyncMapCommandMaven(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		description      string
+		workspace        string
+		jibArtifact      latest.JibArtifact
+		expectedCmd      func(workspace string) exec.Cmd
+	}{
+		{
+			description: "single module",
+			jibArtifact: latest.JibArtifact{},
+			expectedCmd: func(workspace string) exec.Cmd {
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"fake-mavenBuildArgs-for-_skaffold-sync-map-skipTests"})
+			},
+		},
+		{
+			description: "multi module",
+			jibArtifact: latest.JibArtifact{Project: "module"},
+			expectedCmd: func(workspace string) exec.Cmd {
+				return MavenCommand.CreateCommand(ctx, workspace, []string{"fake-mavenBuildArgs-for-module-for-_skaffold-sync-map-skipTests"})
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&mavenBuildArgsFunc, mavenBuildArgsFuncFake)
+			cmd := getSyncMapCommandMaven(ctx, test.workspace, &test.jibArtifact)
+			expectedCmd := test.expectedCmd(test.workspace)
+			t.CheckDeepEqual(expectedCmd.Path, cmd.Path)
+			t.CheckDeepEqual(expectedCmd.Args, cmd.Args)
+			t.CheckDeepEqual(expectedCmd.Dir, cmd.Dir)
+		})
+	}
+}
+
 func TestGenerateMavenArgs(t *testing.T) {
 	tests := []struct {
-		in                 latest.JibArtifact
+		description        string
+		a                  latest.JibArtifact
 		image              string
 		skipTests          bool
 		insecureRegistries map[string]bool
 		out                []string
 	}{
-		{latest.JibArtifact{}, "image", false, nil, []string{"-Djib.console=plain", "jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--non-recursive", "prepare-package", "jib:goal", "-Dimage=image"}},
-		{latest.JibArtifact{}, "image", true, nil, []string{"-Djib.console=plain", "jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--non-recursive", "-DskipTests=true", "prepare-package", "jib:goal", "-Dimage=image"}},
-		{latest.JibArtifact{Project: "module"}, "image", false, nil, []string{"-Djib.console=plain", "jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--projects", "module", "--also-make", "package", "jib:goal", "-Djib.containerize=module", "-Dimage=image"}},
-		{latest.JibArtifact{Project: "module"}, "image", true, nil, []string{"-Djib.console=plain", "jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--projects", "module", "--also-make", "-DskipTests=true", "package", "jib:goal", "-Djib.containerize=module", "-Dimage=image"}},
-		{latest.JibArtifact{Project: "module"}, "registry.tld/image", true, map[string]bool{"registry.tld": true}, []string{"-Djib.console=plain", "jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--projects", "module", "--also-make", "-DskipTests=true", "package", "jib:goal", "-Djib.containerize=module", "-Djib.allowInsecureRegistries=true", "-Dimage=registry.tld/image"}},
+		{"single module", latest.JibArtifact{}, "image", false, nil, []string{"fake-mavenBuildArgs-for-test-goal", "-Dimage=image"}},
+		{"single module without tests", latest.JibArtifact{}, "image", true, nil, []string{"fake-mavenBuildArgs-for-test-goal-skipTests", "-Dimage=image"}},
+		{"multi module", latest.JibArtifact{Project: "module"}, "image", false, nil, []string{"fake-mavenBuildArgs-for-module-for-test-goal", "-Dimage=image"}},
+		{"multi module without tests", latest.JibArtifact{Project: "module"}, "image", true, nil, []string{"fake-mavenBuildArgs-for-module-for-test-goal-skipTests", "-Dimage=image"}},
+		{"multi module without tests with insecure-registry", latest.JibArtifact{Project: "module"}, "registry.tld/image", true, map[string]bool{"registry.tld": true}, []string{"fake-mavenBuildArgs-for-module-for-test-goal-skipTests", "-Djib.allowInsecureRegistries=true", "-Dimage=registry.tld/image"}},
 	}
 	for _, test := range tests {
-		args := GenerateMavenArgs("goal", test.image, &test.in, test.skipTests, test.insecureRegistries)
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&mavenBuildArgsFunc, mavenBuildArgsFuncFake)
+			args := GenerateMavenArgs("test-goal", test.image, &test.a, test.skipTests, test.insecureRegistries)
+			t.CheckDeepEqual(test.out, args)
+		})
+	}
+}
 
-		testutil.CheckDeepEqual(t, test.out, args)
+func TestMavenBuildArgs(t *testing.T) {
+	tests := []struct {
+		description string
+		jibArtifact latest.JibArtifact
+		skipTests bool
+		expected []string
+	} {
+		{
+			description: "single module",
+			jibArtifact: latest.JibArtifact{},
+			skipTests: false,
+			expected: []string{"-Djib.console=plain", "fake-mavenArgs", "prepare-package", "jib:test-goal"},
+		},
+		{
+			description: "single module skip tests",
+			jibArtifact: latest.JibArtifact{},
+			skipTests: true,
+			expected: []string{"-Djib.console=plain", "fake-mavenArgs", "-DskipTests=true", "prepare-package", "jib:test-goal"},
+		},
+		{
+			description: "multi module",
+			jibArtifact: latest.JibArtifact{Project: "module"},
+			skipTests: false,
+			expected: []string{"-Djib.console=plain", "fake-mavenArgs-for-module", "package", "jib:test-goal", "-Djib.containerize=module"},
+		},
+		{
+			description: "single module skip tests",
+			jibArtifact: latest.JibArtifact{Project: "module"},
+			skipTests: true,
+			expected: []string{"-Djib.console=plain", "fake-mavenArgs-for-module", "-DskipTests=true", "package", "jib:test-goal", "-Djib.containerize=module"},
+		},
+  }
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&mavenArgsFunc, mavenArgsFuncFake)
+			args := mavenBuildArgs("test-goal", &test.jibArtifact, test.skipTests)
+			t.CheckDeepEqual(test.expected, args)
+		})
+	}
+}
+
+func TestMavenArgs(t *testing.T) {
+	tests := []struct {
+		description	string
+		jibArtifact latest.JibArtifact
+		expected []string
+	} {
+		{
+			description: "single module",
+			jibArtifact: latest.JibArtifact{},
+			expected: []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--non-recursive"},
+		},
+		{
+			description: "single module with extra flags",
+			jibArtifact: latest.JibArtifact{
+				Flags: []string{"--flag1", "--flag2"},
+			},
+			expected: []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--flag1", "--flag2", "--non-recursive"},
+		},
+		{
+			description: "multi module",
+			jibArtifact: latest.JibArtifact{Project: "module"},
+			expected: []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--projects", "module", "--also-make"},
+		},
+		{
+			description: "multi module with extra falgs",
+			jibArtifact: latest.JibArtifact{
+				Project: "module",
+				Flags: []string{"--flag1", "--flag2"},
+			},
+			expected: []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--flag1", "--flag2", "--projects", "module", "--also-make"},
+		},
+	}
+	for _, test := range tests {
+		args := mavenArgs(&test.jibArtifact)
+		testutil.CheckDeepEqual(t, test.expected, args)
+	}
+}
+
+func mavenArgsFuncFake(a *latest.JibArtifact) []string {
+	if a.Project == "" {
+		return []string{"fake-mavenArgs"}
+	} else {
+		return []string{"fake-mavenArgs-for-" + a.Project}
+	}
+}
+
+// check that parameters are actually passed though
+func mavenBuildArgsFuncFake(goal string, a *latest.JibArtifact, skipTests bool) []string {
+	testString := ""
+	if skipTests {
+		testString = "-skipTests"
+	}
+	if a.Project == "" {
+		return []string{"fake-mavenBuildArgs-for-" + goal + testString};
+	} else {
+		return []string{"fake-mavenBuildArgs-for-" + a.Project + "-for-" + goal + testString};
 	}
 }

--- a/pkg/skaffold/build/jib/maven_test.go
+++ b/pkg/skaffold/build/jib/maven_test.go
@@ -283,10 +283,10 @@ func TestGetCommandMaven(t *testing.T) {
 func TestGetSyncMapCommandMaven(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
-		description      string
-		workspace        string
-		jibArtifact      latest.JibArtifact
-		expectedCmd      func(workspace string) exec.Cmd
+		description string
+		workspace   string
+		jibArtifact latest.JibArtifact
+		expectedCmd func(workspace string) exec.Cmd
 	}{
 		{
 			description: "single module",
@@ -343,34 +343,34 @@ func TestMavenBuildArgs(t *testing.T) {
 	tests := []struct {
 		description string
 		jibArtifact latest.JibArtifact
-		skipTests bool
-		expected []string
-	} {
+		skipTests   bool
+		expected    []string
+	}{
 		{
 			description: "single module",
 			jibArtifact: latest.JibArtifact{},
-			skipTests: false,
-			expected: []string{"-Djib.console=plain", "fake-mavenArgs", "prepare-package", "jib:test-goal"},
+			skipTests:   false,
+			expected:    []string{"-Djib.console=plain", "fake-mavenArgs", "prepare-package", "jib:test-goal"},
 		},
 		{
 			description: "single module skip tests",
 			jibArtifact: latest.JibArtifact{},
-			skipTests: true,
-			expected: []string{"-Djib.console=plain", "fake-mavenArgs", "-DskipTests=true", "prepare-package", "jib:test-goal"},
+			skipTests:   true,
+			expected:    []string{"-Djib.console=plain", "fake-mavenArgs", "-DskipTests=true", "prepare-package", "jib:test-goal"},
 		},
 		{
 			description: "multi module",
 			jibArtifact: latest.JibArtifact{Project: "module"},
-			skipTests: false,
-			expected: []string{"-Djib.console=plain", "fake-mavenArgs-for-module", "package", "jib:test-goal", "-Djib.containerize=module"},
+			skipTests:   false,
+			expected:    []string{"-Djib.console=plain", "fake-mavenArgs-for-module", "package", "jib:test-goal", "-Djib.containerize=module"},
 		},
 		{
 			description: "single module skip tests",
 			jibArtifact: latest.JibArtifact{Project: "module"},
-			skipTests: true,
-			expected: []string{"-Djib.console=plain", "fake-mavenArgs-for-module", "-DskipTests=true", "package", "jib:test-goal", "-Djib.containerize=module"},
+			skipTests:   true,
+			expected:    []string{"-Djib.console=plain", "fake-mavenArgs-for-module", "-DskipTests=true", "package", "jib:test-goal", "-Djib.containerize=module"},
 		},
-  }
+	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&mavenArgsFunc, mavenArgsFuncFake)
@@ -382,14 +382,14 @@ func TestMavenBuildArgs(t *testing.T) {
 
 func TestMavenArgs(t *testing.T) {
 	tests := []struct {
-		description	string
+		description string
 		jibArtifact latest.JibArtifact
-		expected []string
-	} {
+		expected    []string
+	}{
 		{
 			description: "single module",
 			jibArtifact: latest.JibArtifact{},
-			expected: []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--non-recursive"},
+			expected:    []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--non-recursive"},
 		},
 		{
 			description: "single module with extra flags",
@@ -401,13 +401,13 @@ func TestMavenArgs(t *testing.T) {
 		{
 			description: "multi module",
 			jibArtifact: latest.JibArtifact{Project: "module"},
-			expected: []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--projects", "module", "--also-make"},
+			expected:    []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--projects", "module", "--also-make"},
 		},
 		{
 			description: "multi module with extra falgs",
 			jibArtifact: latest.JibArtifact{
 				Project: "module",
-				Flags: []string{"--flag1", "--flag2"},
+				Flags:   []string{"--flag1", "--flag2"},
 			},
 			expected: []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + MinimumJibMavenVersion, "--flag1", "--flag2", "--projects", "module", "--also-make"},
 		},
@@ -433,8 +433,8 @@ func mavenBuildArgsFuncFake(goal string, a *latest.JibArtifact, skipTests bool) 
 		testString = "-skipTests"
 	}
 	if a.Project == "" {
-		return []string{"fake-mavenBuildArgs-for-" + goal + testString};
+		return []string{"fake-mavenBuildArgs-for-" + goal + testString}
 	} else {
-		return []string{"fake-mavenBuildArgs-for-" + a.Project + "-for-" + goal + testString};
+		return []string{"fake-mavenBuildArgs-for-" + a.Project + "-for-" + goal + testString}
 	}
 }


### PR DESCRIPTION
Towards #2901

Adds in functions to get the correct sync command. Refactor out some code to share the generation of build args in maven/gradle.

This PR also heavily restructures the jib maven/gradle tests to isolate testing to the methods under test while offering some rudimentary "mockito style" verify to ensure parameters are passed though.

