### PR TITLE
Kaniko: Cancel log streaming when pod fails to complete

### DIFF
--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -82,6 +82,7 @@ func (b *Builder) runKanikoBuild(ctx context.Context, out io.Writer, artifact *l
 	waitForLogs := streamLogs(ctx, out, pod.Name, pods)
 
 	if err := kubernetes.WaitForPodSucceeded(ctx, pods, pod.Name, b.timeout); err != nil {
+		waitForLogs()
 		return "", errors.Wrap(err, "waiting for pod to complete")
 	}
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


#3238 basically reverted the changes I did in #2352. @dgageot 

**Description**

Right now if a Kaniko build fails immediately after starting the pod, the user sees no output.

**Before**

No log output when Kaniko pod fails immediately.

**After**

Log output when Kaniko pod fails immediately.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [x] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.