### PR TITLE
Use unique key for jib caches

### DIFF
--- a/pkg/skaffold/build/jib/gradle.go
+++ b/pkg/skaffold/build/jib/gradle.go
@@ -78,7 +78,7 @@ func (b *Builder) runGradleCommand(ctx context.Context, out io.Writer, workspace
 // All paths are absolute.
 func getDependenciesGradle(ctx context.Context, workspace string, a *latest.JibArtifact) ([]string, error) {
 	cmd := getCommandGradle(ctx, workspace, a)
-	deps, err := getDependencies(workspace, cmd, a.Project)
+	deps, err := getDependencies(workspace, cmd, a)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting jib-gradle dependencies")
 	}

--- a/pkg/skaffold/build/jib/maven.go
+++ b/pkg/skaffold/build/jib/maven.go
@@ -76,7 +76,7 @@ func (b *Builder) runMavenCommand(ctx context.Context, out io.Writer, workspace 
 // getDependenciesMaven finds the source dependencies for the given jib-maven artifact.
 // All paths are absolute.
 func getDependenciesMaven(ctx context.Context, workspace string, a *latest.JibArtifact) ([]string, error) {
-	deps, err := getDependencies(workspace, getCommandMaven(ctx, workspace, a), a.Project)
+	deps, err := getDependencies(workspace, getCommandMaven(ctx, workspace, a), a)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting jib-maven dependencies")
 	}


### PR DESCRIPTION
If two jib projects had clashing Project fields (even empty), they would trigger refreshing dependencies on every cycle of the skaffold dev loop. This creates a projectKey from the workspace and the project and uses it as the key. 

While nothing was broken before, this provides the functionality we actually expected.