### PR TITLE
Add common jib sync code for processing syncmap

### DIFF
--- a/pkg/skaffold/build/jib/sync.go
+++ b/pkg/skaffold/build/jib/sync.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2020 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/skaffold/build/jib/sync.go
+++ b/pkg/skaffold/build/jib/sync.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jib
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"regexp"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+type SyncMap map[string]SyncEntry
+
+type SyncEntry struct {
+	Dest     []string
+	FileTime time.Time
+	IsDirect bool
+}
+
+type JSONSyncMap struct {
+	Direct    []JSONSyncEntry `json:"direct"`
+	Generated []JSONSyncEntry `json:"generated"`
+}
+
+type JSONSyncEntry struct {
+	Src  string `json:"src"`
+	Dest string `json:"dest"`
+}
+
+func getSyncMapFromSystem(cmd *exec.Cmd) (*SyncMap, error) {
+	jsm := JSONSyncMap{}
+	stdout, err := util.RunCmdOut(cmd)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get Jib sync map")
+	}
+
+	// To parse the output, search for "BEGIN JIB JSON", then unmarshal the next line into the pathMap struct.
+	// Syncmap is transitioning to "BEGIN JIB JSON: SYNCMAP/1" starting in jib 2.0.0
+	// perhaps this feature should only be included from 2.0.0 onwards? And we generally avoid this?
+	matches := regexp.MustCompile(`BEGIN JIB JSON(?:: SYNCMAP/1)?\r?\n({.*})`).FindSubmatch(stdout)
+	if len(matches) == 0 {
+		return nil, errors.New("failed to get Jib Sync data")
+	}
+
+	line := bytes.Replace(matches[1], []byte(`\`), []byte(`\\`), -1)
+	if err := json.Unmarshal(line, &jsm); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	sm := make(SyncMap)
+	for _, de := range jsm.Direct {
+		info, err := os.Stat(de.Src)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not obtain file mod time")
+		}
+		sm[de.Src] = SyncEntry{
+			Dest:     []string{de.Dest},
+			FileTime: info.ModTime(),
+			IsDirect: true,
+		}
+	}
+	for _, ge := range jsm.Generated {
+		info, err := os.Stat(ge.Src)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not obtain file mod time")
+		}
+		sm[ge.Src] = SyncEntry{
+			Dest:     []string{ge.Dest},
+			FileTime: info.ModTime(),
+			IsDirect: false,
+		}
+	}
+	return &sm, nil
+}

--- a/pkg/skaffold/build/jib/sync.go
+++ b/pkg/skaffold/build/jib/sync.go
@@ -17,7 +17,6 @@ limitations under the License.
 package jib
 
 import (
-	"bytes"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -62,8 +61,7 @@ func getSyncMapFromSystem(cmd *exec.Cmd) (*SyncMap, error) {
 		return nil, errors.New("failed to get Jib Sync data")
 	}
 
-	line := bytes.Replace(matches[1], []byte(`\`), []byte(`\\`), -1)
-	if err := json.Unmarshal(line, &jsm); err != nil {
+	if err := json.Unmarshal(matches[1], &jsm); err != nil {
 		return nil, errors.WithStack(err)
 	}
 

--- a/pkg/skaffold/build/jib/sync_test.go
+++ b/pkg/skaffold/build/jib/sync_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2020 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/skaffold/build/jib/sync_test.go
+++ b/pkg/skaffold/build/jib/sync_test.go
@@ -68,7 +68,7 @@ func TestGetSyncMapFromSystem(t *testing.T) {
 		{
 			description: "direct only",
 			stdout: "BEGIN JIB JSON: SYNCMAP/1\n" +
-				fmt.Sprintf("{\"direct\":[{\"src\":\"%s\",\"dest\":\"%s\"}]}", dep1, dep1Target),
+				fmt.Sprintf(`{"direct":[{"src":"%s","dest":"%s"}]}`, dep1, dep1Target),
 			shouldErr: false,
 			expected: &SyncMap{
 				dep1: SyncEntry{
@@ -81,7 +81,7 @@ func TestGetSyncMapFromSystem(t *testing.T) {
 		{
 			description: "generated only",
 			stdout: "BEGIN JIB JSON: SYNCMAP/1\n" +
-				fmt.Sprintf("{\"generated\":[{\"src\":\"%s\",\"dest\":\"%s\"}]}", dep1, dep1Target),
+				fmt.Sprintf(`{"generated":[{"src":"%s","dest":"%s"}]}`, dep1, dep1Target),
 			shouldErr: false,
 			expected: &SyncMap{
 				dep1: SyncEntry{
@@ -94,7 +94,7 @@ func TestGetSyncMapFromSystem(t *testing.T) {
 		{
 			description: "generated and direct",
 			stdout: "BEGIN JIB JSON: SYNCMAP/1\n" +
-				fmt.Sprintf("{\"direct\":[{\"src\":\"%s\",\"dest\":\"%s\"}],\"generated\":[{\"src\":\"%s\",\"dest\":\"%s\"}]}", dep1, dep1Target, dep2, dep2Target),
+				fmt.Sprintf(`{"direct":[{"src":"%s","dest":"%s"}],"generated":[{"src":"%s","dest":"%s"}]}"`, dep1, dep1Target, dep2, dep2Target),
 			shouldErr: false,
 			expected: &SyncMap{
 				dep1: SyncEntry{

--- a/pkg/skaffold/build/jib/sync_test.go
+++ b/pkg/skaffold/build/jib/sync_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jib
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestGetSyncMapFromSystem(t *testing.T) {
+	tmpDir, cleanup := testutil.NewTempDir(t)
+	defer cleanup()
+
+	tmpDir.Touch("dep1", "dir/dep2")
+	dep1 := tmpDir.Path("dep1")
+	dep2 := tmpDir.Path("dir/dep2")
+
+	dep1Time := getFileTime(dep1, t)
+	dep2Time := getFileTime(dep2, t)
+
+	dep1Target := "/target/dep1"
+	dep2Target := "/target/anotherDir/dep2"
+
+	tests := []struct {
+		description string
+		stdout      string
+		shouldErr   bool
+		expected    *SyncMap
+	}{
+		{
+			description: "empty",
+			stdout:      "",
+			shouldErr:   true,
+			expected:    nil,
+		},
+		{
+			description: "old style marker",
+			stdout:      "BEGIN JIB JSON\n{}",
+			shouldErr:   false,
+			expected:    &SyncMap{},
+		},
+		{
+			description: "bad marker",
+			stdout:      "BEGIN JIB JSON: BAD/1\n{}",
+			shouldErr:   true,
+			expected:    nil,
+		},
+		{
+			description: "direct only",
+			stdout: "BEGIN JIB JSON: SYNCMAP/1\n" +
+				fmt.Sprintf("{\"direct\":[{\"src\":\"%s\",\"dest\":\"%s\"}]}", dep1, dep1Target),
+			shouldErr: false,
+			expected: &SyncMap{
+				dep1: SyncEntry{
+					[]string{dep1Target},
+					dep1Time,
+					true,
+				},
+			},
+		},
+		{
+			description: "generated only",
+			stdout: "BEGIN JIB JSON: SYNCMAP/1\n" +
+				fmt.Sprintf("{\"generated\":[{\"src\":\"%s\",\"dest\":\"%s\"}]}", dep1, dep1Target),
+			shouldErr: false,
+			expected: &SyncMap{
+				dep1: SyncEntry{
+					[]string{dep1Target},
+					dep1Time,
+					false,
+				},
+			},
+		},
+		{
+			description: "generated and direct",
+			stdout: "BEGIN JIB JSON: SYNCMAP/1\n" +
+				fmt.Sprintf("{\"direct\":[{\"src\":\"%s\",\"dest\":\"%s\"}],\"generated\":[{\"src\":\"%s\",\"dest\":\"%s\"}]}", dep1, dep1Target, dep2, dep2Target),
+			shouldErr: false,
+			expected: &SyncMap{
+				dep1: SyncEntry{
+					[]string{dep1Target},
+					dep1Time,
+					true,
+				},
+				dep2: SyncEntry{
+					Dest:     []string{dep2Target},
+					FileTime: dep2Time,
+					IsDirect: false,
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunOut(
+				"ignored",
+				test.stdout,
+			))
+
+			results, err := getSyncMapFromSystem(&exec.Cmd{Args: []string{"ignored"}})
+
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, results)
+		})
+	}
+}
+
+func getFileTime(file string, t *testing.T) time.Time {
+	info, err := os.Stat(file)
+	if err != nil {
+		t.Fatalf("Failed to stat %s", file)
+		return time.Time{}
+	}
+	return info.ModTime()
+}

--- a/pkg/skaffold/build/jib/sync_test.go
+++ b/pkg/skaffold/build/jib/sync_test.go
@@ -68,7 +68,7 @@ func TestGetSyncMapFromSystem(t *testing.T) {
 		{
 			description: "direct only",
 			stdout: "BEGIN JIB JSON: SYNCMAP/1\n" +
-				fmt.Sprintf(`{"direct":[{"src":"%s","dest":"%s"}]}`, dep1, dep1Target),
+				fmt.Sprintf(`{"direct":[{"src":"%s","dest":"%s"}]}`, escapeBackslashes(dep1), dep1Target),
 			shouldErr: false,
 			expected: &SyncMap{
 				dep1: SyncEntry{
@@ -81,7 +81,7 @@ func TestGetSyncMapFromSystem(t *testing.T) {
 		{
 			description: "generated only",
 			stdout: "BEGIN JIB JSON: SYNCMAP/1\n" +
-				fmt.Sprintf(`{"generated":[{"src":"%s","dest":"%s"}]}`, dep1, dep1Target),
+				fmt.Sprintf(`{"generated":[{"src":"%s","dest":"%s"}]}`, escapeBackslashes(dep1), dep1Target),
 			shouldErr: false,
 			expected: &SyncMap{
 				dep1: SyncEntry{
@@ -94,7 +94,7 @@ func TestGetSyncMapFromSystem(t *testing.T) {
 		{
 			description: "generated and direct",
 			stdout: "BEGIN JIB JSON: SYNCMAP/1\n" +
-				fmt.Sprintf(`{"direct":[{"src":"%s","dest":"%s"}],"generated":[{"src":"%s","dest":"%s"}]}"`, dep1, dep1Target, dep2, dep2Target),
+				fmt.Sprintf(`{"direct":[{"src":"%s","dest":"%s"}],"generated":[{"src":"%s","dest":"%s"}]}"`, escapeBackslashes(dep1), dep1Target, escapeBackslashes(dep2), dep2Target),
 			shouldErr: false,
 			expected: &SyncMap{
 				dep1: SyncEntry{
@@ -131,4 +131,11 @@ func getFileTime(file string, t *testing.T) time.Time {
 		return time.Time{}
 	}
 	return info.ModTime()
+}
+
+// for paths that contain "\", they must be escaped in json strings
+func escapeBackslashes(path string) string {
+	// currently don't do anything so I can verify windows tests fail
+	return path
+	//return strings.Replace(path, `\`, `\\`, -1)
 }

--- a/pkg/skaffold/build/jib/sync_test.go
+++ b/pkg/skaffold/build/jib/sync_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -135,7 +136,5 @@ func getFileTime(file string, t *testing.T) time.Time {
 
 // for paths that contain "\", they must be escaped in json strings
 func escapeBackslashes(path string) string {
-	// currently don't do anything so I can verify windows tests fail
-	return path
-	//return strings.Replace(path, `\`, `\\`, -1)
+	return strings.Replace(path, `\`, `\\`, -1)
 }


### PR DESCRIPTION
~~Introduces code to initialize sync caches, update them and check
for differences when watched files change~~
~~It does not allow actually configuring sync yet. It just sets up the necessary underlying code to make calls out to jib and process the diffs~~

Converted this into two separate PRs

This one now just calls out to jib to get the syncmap and coverts json to a usable object.