### PR TITLE
Dockerfile detector will only check files containing "Dockerfile" in the name

### DIFF
--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -288,9 +288,12 @@ func detectBuilders(enableJibInit, enableBuildpackInit bool, path string) ([]Ini
 	}
 
 	// Check for Dockerfile
-	if docker.Validate(path) {
-		results := []InitBuilder{docker.ArtifactConfig{File: path}}
-		return results, true
+	base := filepath.Base(path)
+	if strings.Contains(base, "Dockerfile") {
+		if docker.Validate(path) {
+			results := []InitBuilder{docker.ArtifactConfig{File: path}}
+			return results, true
+		}
 	}
 
 	// TODO: Remove backwards compatibility if statement (not entire block)

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -289,7 +289,7 @@ func detectBuilders(enableJibInit, enableBuildpackInit bool, path string) ([]Ini
 
 	// Check for Dockerfile
 	base := filepath.Base(path)
-	if strings.Contains(base, "Dockerfile") {
+	if strings.Contains(strings.ToLower(base), "dockerfile") {
 		if docker.Validate(path) {
 			results := []InitBuilder{docker.ArtifactConfig{File: path}}
 			return results, true

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -142,16 +142,17 @@ func TestWalk(t *testing.T) {
 		{
 			description: "should return correct k8 configs and build files (backwards compatibility)",
 			filesWithContents: map[string]string{
-				"config/test.yaml":      validK8sManifest,
-				"config/invalid.yaml":   emptyFile,
-				"k8pod.yml":             validK8sManifest,
-				"README":                emptyFile,
-				"deploy/Dockerfile":     emptyFile,
-				"deploy/Dockerfile.dev": emptyFile,
-				"deploy/dev.Dockerfile": emptyFile,
-				"gradle/build.gradle":   emptyFile,
-				"maven/pom.xml":         emptyFile,
-				"Dockerfile":            emptyFile,
+				"config/test.yaml":       validK8sManifest,
+				"config/invalid.yaml":    emptyFile,
+				"k8pod.yml":              validK8sManifest,
+				"README":                 emptyFile,
+				"deploy/Dockerfile":      emptyFile,
+				"deploy/Dockerfile.dev":  emptyFile,
+				"deploy/dev.Dockerfile":  emptyFile,
+				"deploy/test.dockerfile": emptyFile,
+				"gradle/build.gradle":    emptyFile,
+				"maven/pom.xml":          emptyFile,
+				"Dockerfile":             emptyFile,
 			},
 			force: false,
 			expectedConfigs: []string{
@@ -163,6 +164,7 @@ func TestWalk(t *testing.T) {
 				"deploy/Dockerfile",
 				"deploy/Dockerfile.dev",
 				"deploy/dev.Dockerfile",
+				"deploy/test.dockerfile",
 			},
 			shouldErr: false,
 		},
@@ -346,7 +348,7 @@ deploy:
 }
 
 func fakeValidateDockerfile(path string) bool {
-	return strings.Contains(path, "Dockerfile")
+	return strings.Contains(strings.ToLower(path), "dockerfile")
 }
 
 func fakeValidateJibConfig(path string) []jib.ArtifactConfig {

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -142,14 +142,16 @@ func TestWalk(t *testing.T) {
 		{
 			description: "should return correct k8 configs and build files (backwards compatibility)",
 			filesWithContents: map[string]string{
-				"config/test.yaml":    validK8sManifest,
-				"config/invalid.yaml": emptyFile,
-				"k8pod.yml":           validK8sManifest,
-				"README":              emptyFile,
-				"deploy/Dockerfile":   emptyFile,
-				"gradle/build.gradle": emptyFile,
-				"maven/pom.xml":       emptyFile,
-				"Dockerfile":          emptyFile,
+				"config/test.yaml":      validK8sManifest,
+				"config/invalid.yaml":   emptyFile,
+				"k8pod.yml":             validK8sManifest,
+				"README":                emptyFile,
+				"deploy/Dockerfile":     emptyFile,
+				"deploy/Dockerfile.dev": emptyFile,
+				"deploy/dev.Dockerfile": emptyFile,
+				"gradle/build.gradle":   emptyFile,
+				"maven/pom.xml":         emptyFile,
+				"Dockerfile":            emptyFile,
 			},
 			force: false,
 			expectedConfigs: []string{
@@ -159,6 +161,8 @@ func TestWalk(t *testing.T) {
 			expectedPaths: []string{
 				"Dockerfile",
 				"deploy/Dockerfile",
+				"deploy/Dockerfile.dev",
+				"deploy/dev.Dockerfile",
 			},
 			shouldErr: false,
 		},
@@ -342,7 +346,7 @@ deploy:
 }
 
 func fakeValidateDockerfile(path string) bool {
-	return strings.HasSuffix(path, "Dockerfile")
+	return strings.Contains(path, "Dockerfile")
 }
 
 func fakeValidateJibConfig(path string) []jib.ArtifactConfig {


### PR DESCRIPTION
Fixes #3484.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

**Description**

Initializer tries to find all available builders by checking each file in the tree for compatible with Dockerfile syntax.
This syntax is not unique and python file can be taken for Dockerfile:
```
from django.test import TestCase
```

This fix adds additional check to the file name which should contain "Dockerfile".

I am not sure if that is appropriate solution, because it can affect existing users.
But as far as I know, developers tend to keep `Dockerfile` in the name even when using multiple files in the same folder.

**User facing changes**

**Before**

When running `skaffold init` with python files like the one mentioned above you can see them in the list of available builders.

**After**

No python files should be listed in the survey.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.

