### PR TITLE
Use origin/master as baseline for schema version check

### DIFF
--- a/hack/check-schema-changes.sh
+++ b/hack/check-schema-changes.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-# This check checks whether the PR compared to master contains any changes
+# This check checks whether the PR compared to origin/master contains any changes
 # in the config.go files under pkg/skaffold/schema. If yes, it checks if those changes
 # are structural changes or not.
 # If they are structural changes and the package is not "latest",

--- a/hack/versions/pkg/schema/check.go
+++ b/hack/versions/pkg/schema/check.go
@@ -31,8 +31,10 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 )
 
+const baseRef = "origin/master"
+
 func RunSchemaCheckOnChangedFiles() error {
-	git, err := newGit()
+	git, err := newGit(baseRef)
 	if err != nil {
 		return err
 	}
@@ -52,7 +54,6 @@ func RunSchemaCheckOnChangedFiles() error {
 		return err
 	}
 	var filesInError []string
-	baseRef := "master"
 	for _, configFile := range changedConfigFiles {
 		content, err := ioutil.ReadFile(configFile)
 		if err != nil {
@@ -63,7 +64,7 @@ func RunSchemaCheckOnChangedFiles() error {
 			return errors.Wrapf(err, "writing changed version of %s", configFile)
 		}
 
-		content, err = git.getFileFromRef(configFile, baseRef)
+		content, err = git.getFileFromBaseline(configFile)
 		if err != nil {
 			if strings.Contains(err.Error(), fmt.Sprintf("config.go' exists on disk, but not in '%s'", baseRef)) {
 				logrus.Warnf("Can't find %s in %s. Assuming this PR is for a new version creation, skipping...", configFile, baseRef)
@@ -102,7 +103,7 @@ func RunSchemaCheckOnChangedFiles() error {
 
 	for _, file := range filesInError {
 		logrus.Errorf(changeDetected(file))
-		changes, err := git.diffWithRef(file, baseRef)
+		changes, err := git.diffWithBaseline(file)
 		if err != nil {
 			logrus.Errorf("failed to get diff: %s", err)
 		}

--- a/hack/versions/pkg/schema/check.go
+++ b/hack/versions/pkg/schema/check.go
@@ -74,7 +74,7 @@ func RunSchemaCheckOnChangedFiles() error {
 		}
 		baseFile := path.Join(root, "base.go")
 		if err = ioutil.WriteFile(baseFile, content, 0666); err != nil {
-			return errors.Wrapf(err, "writing master version of %s", configFile)
+			return errors.Wrapf(err, "writing %s version of %s", baseRef, configFile)
 		}
 
 		diff, err := diff.CompareGoStructs(baseFile, changedFile)
@@ -122,8 +122,8 @@ func changeDetected(configFile string) string {
 Structural change detected in a released config: %s
 Please create a new PR first with a new version.
 You can use 'hack/new_version.sh' to generate the new config version.
-If you are running this locally, make sure you have the master branch up to date!
+If you are running this locally, make sure you have the %s branch up to date!
 Admin rights are required to merge this PR!
 --------
-`, configFile)
+`, configFile, baseRef)
 }


### PR DESCRIPTION
**Description**

This is just a small teak to improve the usability of the schema version test.

Before it used the `master` branch as the reference version. However, this branch is not automatically updated by git when fetching changes from remote. On the other hand, the `origin/master` branch is reset to the newest version on every pull/fetch from origin. Hence, the reference version automatically updates even if the user never updates his `master` branch.

This assumes that users have a standard setup for remote repository names. But I think this is as widespread as the name `master`.

**User facing changes**

n/a

**Next PRs.**

n/a

**Submitter Checklist**

n/a

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.
