### PR TITLE
Use pack CLI to build on GCB

### DIFF
--- a/deploy/buildpacks/Dockerfile
+++ b/deploy/buildpacks/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2019 The Skaffold Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.10
+
+ARG PACK_VERSION
+ENV PACK_URL https://github.com/buildpack/pack/releases/download/${PACK_VERSION}/pack-${PACK_VERSION}-linux.tgz
+RUN wget -O- "${PACK_URL}" | tar -C /usr/local/bin -xz pack

--- a/deploy/buildpacks/publish.sh
+++ b/deploy/buildpacks/publish.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Skaffold Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+PACK_VERSION=v0.6.0
+
+docker build . --build-arg PACK_VERSION=${PACK_VERSION} -t gcr.io/k8s-skaffold/pack:${PACK_VERSION} -t gcr.io/k8s-skaffold/pack:latest
+docker push gcr.io/k8s-skaffold/pack:${PACK_VERSION}
+docker push gcr.io/k8s-skaffold/pack:latest

--- a/docs/content/en/schemas/v2alpha2.json
+++ b/docs/content/en/schemas/v2alpha2.json
@@ -1021,6 +1021,12 @@
           "x-intellij-html-description": "image that runs a Maven build. See <a href=\"https://cloud.google.com/cloud-build/docs/cloud-builders\">Cloud Builders</a>.",
           "default": "gcr.io/cloud-builders/mvn"
         },
+        "packImage": {
+          "type": "string",
+          "description": "image that runs a Cloud Native Buildpacks build. See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).",
+          "x-intellij-html-description": "image that runs a Cloud Native Buildpacks build. See <a href=\"https://cloud.google.com/cloud-build/docs/cloud-builders\">Cloud Builders</a>.",
+          "default": "gcr.io/k8s-skaffold/pack"
+        },
         "projectId": {
           "type": "string",
           "description": "ID of your Cloud Platform Project. If it is not provided, Skaffold will guess it from the image name. For example, given the artifact image name `gcr.io/myproject/image`, Skaffold will use the `myproject` GCP project.",
@@ -1041,6 +1047,7 @@
         "kanikoImage",
         "mavenImage",
         "gradleImage",
+        "packImage",
         "concurrency"
       ],
       "additionalProperties": false,

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -62,6 +62,7 @@ const (
 	DefaultCloudBuildMavenImage  = "gcr.io/cloud-builders/mvn"
 	DefaultCloudBuildGradleImage = "gcr.io/cloud-builders/gradle"
 	DefaultCloudBuildKanikoImage = "gcr.io/kaniko-project/executor"
+	DefaultCloudBuildPackImage   = "gcr.io/k8s-skaffold/pack"
 
 	DefaultSkaffoldDir = ".skaffold"
 	DefaultCacheFile   = "cache"

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -69,6 +69,7 @@ func Set(c *latest.SkaffoldConfig) error {
 		setDefaultCloudBuildMavenImage,
 		setDefaultCloudBuildGradleImage,
 		setDefaultCloudBuildKanikoImage,
+		setDefaultCloudBuildPackImage,
 	)
 
 	if err := withClusterConfig(c,
@@ -143,6 +144,10 @@ func setDefaultCloudBuildGradleImage(gcb *latest.GoogleCloudBuild) {
 
 func setDefaultCloudBuildKanikoImage(gcb *latest.GoogleCloudBuild) {
 	gcb.KanikoImage = valueOrDefault(gcb.KanikoImage, constants.DefaultCloudBuildKanikoImage)
+}
+
+func setDefaultCloudBuildPackImage(gcb *latest.GoogleCloudBuild) {
+	gcb.PackImage = valueOrDefault(gcb.PackImage, constants.DefaultCloudBuildPackImage)
 }
 
 func setDefaultTagger(c *latest.SkaffoldConfig) {

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -254,6 +254,7 @@ func TestSetDefaultsOnCloudBuild(t *testing.T) {
 	testutil.CheckDeepEqual(t, constants.DefaultCloudBuildDockerImage, cfg.Build.GoogleCloudBuild.DockerImage)
 	testutil.CheckDeepEqual(t, constants.DefaultCloudBuildMavenImage, cfg.Build.GoogleCloudBuild.MavenImage)
 	testutil.CheckDeepEqual(t, constants.DefaultCloudBuildGradleImage, cfg.Build.GoogleCloudBuild.GradleImage)
+	testutil.CheckDeepEqual(t, constants.DefaultCloudBuildPackImage, cfg.Build.GoogleCloudBuild.PackImage)
 }
 
 func TestSetDefaultsOnLocalBuild(t *testing.T) {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -246,6 +246,11 @@ type GoogleCloudBuild struct {
 	// Defaults to `gcr.io/cloud-builders/gradle`.
 	GradleImage string `yaml:"gradleImage,omitempty"`
 
+	// PackImage is the image that runs a Cloud Native Buildpacks build.
+	// See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).
+	// Defaults to `gcr.io/k8s-skaffold/pack`.
+	PackImage string `yaml:"packImage,omitempty"`
+
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit"
 	// Defaults to 0.
 	Concurrency int `yaml:"concurrency,omitempty"`

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -140,6 +140,7 @@ func TestApplyProfiles(t *testing.T) {
 									MavenImage:  "gcr.io/cloud-builders/mvn",
 									GradleImage: "gcr.io/cloud-builders/gradle",
 									KanikoImage: "gcr.io/kaniko-project/executor",
+									PackImage:   "gcr.io/k8s-skaffold/pack",
 								},
 							},
 						},

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -272,6 +272,7 @@ func withGoogleCloudBuild(id string, ops ...func(*latest.BuildConfig)) func(*lat
 			MavenImage:  "gcr.io/cloud-builders/mvn",
 			GradleImage: "gcr.io/cloud-builders/gradle",
 			KanikoImage: "gcr.io/kaniko-project/executor",
+			PackImage:   "gcr.io/k8s-skaffold/pack",
 		}}}
 		for _, op := range ops {
 			op(&b)


### PR DESCRIPTION
Instead of using our own implementation of the Buildpacks lifecycle, it's more robust to use `pack` CLI.