### PR TITLE
Allow 2020 copyright year

### DIFF
--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -143,7 +143,7 @@ def get_regexs():
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile( 'YEAR' )
     # dates can be 2018, company holder names can be anything
-    regexs["date"] = re.compile( '(2019)' )
+    regexs["date"] = re.compile( '(2019|2020)' )
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
     # strip #!.* from shell scripts


### PR DESCRIPTION
Allows `2019|2020`.

Previously when only 2019 was used, it was a hard requirement that all files use 2019, so any new file added would require a 2019 copyright header.

With this change, there will not be a way to ensure that new files use 2020 except by human :eyes: but we preserve the original copyright year on files that were created earlier than 2020.

