### PR TITLE
Add kubectl config flag to disable validation

### DIFF
--- a/docs/content/en/schemas/v2alpha3.json
+++ b/docs/content/en/schemas/v2alpha3.json
@@ -1517,6 +1517,12 @@
           "x-intellij-html-description": "additional flags passed on deletions (<code>kubectl delete</code>).",
           "default": "[]"
         },
+        "disableValidation": {
+          "type": "boolean",
+          "description": "passes the `--validate=false` flag to supported `kubectl` commands when enabled.",
+          "x-intellij-html-description": "passes the <code>--validate=false</code> flag to supported <code>kubectl</code> commands when enabled.",
+          "default": "false"
+        },
         "global": {
           "items": {
             "type": "string"
@@ -1530,7 +1536,8 @@
       "preferredOrder": [
         "global",
         "apply",
-        "delete"
+        "delete",
+        "disableValidation"
       ],
       "additionalProperties": false,
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",

--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -62,6 +62,10 @@ func (c *CLI) Apply(ctx context.Context, out io.Writer, manifests ManifestList) 
 		args = append(args, "--force", "--grace-period=0")
 	}
 
+	if c.Flags.DisableValidation {
+		args = append(args, "--validate=false")
+	}
+
 	if err := c.Run(ctx, updated.Reader(), out, "apply", c.args(c.Flags.Apply, args...)...); err != nil {
 		return errors.Wrap(err, "kubectl apply")
 	}
@@ -77,6 +81,10 @@ func (c *CLI) ReadManifests(ctx context.Context, manifests []string) (ManifestLi
 	}
 
 	args := c.args([]string{"--dry-run", "-oyaml"}, list...)
+	if c.Flags.DisableValidation {
+		args = append(args, "--validate=false")
+	}
+
 	buf, err := c.RunOut(ctx, "create", args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "kubectl create")

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -73,6 +73,23 @@ func TestKubectlDeploy(t *testing.T) {
 			commands:    testutil.CmdRunOut("kubectl version --client -ojson", kubectlVersion),
 		},
 		{
+			description: "deploy success (disable validation)",
+			cfg: &latest.KubectlDeploy{
+				Manifests: []string{"deployment.yaml"},
+				Flags: latest.KubectlFlags{
+					DisableValidation: true,
+				},
+			},
+			commands: testutil.
+				CmdRunOut("kubectl version --client -ojson", kubectlVersion).
+				AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run -oyaml -f deployment.yaml --validate=false", deploymentWebYAML).
+				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f - --validate=false"),
+			builds: []build.Artifact{{
+				ImageName: "leeroy-web",
+				Tag:       "leeroy-web:123",
+			}},
+		},
+		{
 			description: "deploy success (forced)",
 			cfg: &latest.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -409,6 +409,10 @@ type KubectlFlags struct {
 
 	// Delete are additional flags passed on deletions (`kubectl delete`).
 	Delete []string `yaml:"delete,omitempty"`
+
+	// DisableValidation passes the `--validate=false` flag to supported
+	// `kubectl` commands when enabled.
+	DisableValidation bool `yaml:"disableValidation,omitempty"`
 }
 
 // HelmDeploy *beta* uses the `helm` CLI to apply the charts to the cluster.


### PR DESCRIPTION
Fixes #3222

Relates to n/a

Should merge before : n/a

Should merge after : n/a

**Description**

Add config flag to disable validation when using the kubectl deployer.
When enabled, `--validate=false` is passed to the `kubectl apply` and `kubectl create` commands.

**User facing changes**

n/a

**Before**

n/a

**After**

n/a

**Next PRs.**

n/a


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [x] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

- Add config option to disable validation when using the kubectl deployer.
