### PR TITLE
Remove a few more references to gcr.io/k8s-skaffold

### DIFF
--- a/docs/content/en/docs/quickstart/_index.md
+++ b/docs/content/en/docs/quickstart/_index.md
@@ -52,42 +52,37 @@ You should see some outputs similar to the following entries:
 
 ```
 Listing files to watch...
- - gcr.io/k8s-skaffold/skaffold-example
-List generated in 2.46354ms
+ - skaffold-example
 Generating tags...
- - gcr.io/k8s-skaffold/skaffold-example -> gcr.io/k8s-skaffold/skaffold-example:v0.39.0-131-g1759410a7-dirty
-Tags generated in 65.661438ms
-Starting build...
-Found [minikube] context, using local docker daemon.
-Building [gcr.io/k8s-skaffold/skaffold-example]...
+ - skaffold-example -> skaffold-example:v1.1.0-113-g4649f2c16
+Checking cache...
+ - skaffold-example: Not found. Building
+Found [docker-desktop] context, using local docker daemon.
+Building [skaffold-example]...
 Sending build context to Docker daemon  3.072kB
 Step 1/6 : FROM golang:1.12.9-alpine3.10 as builder
  ---> e0d646523991
 Step 2/6 : COPY main.go .
  ---> Using cache
- ---> 2d4b0b8a9dda
+ ---> e4788ffa88e7
 Step 3/6 : RUN go build -o /app main.go
  ---> Using cache
- ---> 3eae8e329453
+ ---> 686396d9e9cc
 Step 4/6 : FROM alpine:3.10
- ---> 961769676411
+ ---> 965ea09ff2eb
 Step 5/6 : CMD ["./app"]
  ---> Using cache
- ---> ce76e22da3bd
+ ---> be0603b9d79e
 Step 6/6 : COPY --from=builder /app .
- ---> dec4a50e0fd1
-Successfully built dec4a50e0fd1
-Successfully tagged gcr.io/k8s-skaffold/skaffold-example:v0.39.0-131-g1759410a7-dirty
-Build complete in 232.935849ms
-Starting test...
-Test complete in 4.189µs
+ ---> Using cache
+ ---> c827aa5a4b12
+Successfully built c827aa5a4b12
+Successfully tagged skaffold-example:v1.1.0-113-g4649f2c16
 Tags used in deployment:
- - Since images are not pushed, they can't be referenced by digest
-   They are tagged and referenced by a unique ID instead
- - gcr.io/k8s-skaffold/skaffold-example -> gcr.io/k8s-skaffold/skaffold-example:dec4a50e0fd1ca2f56c6aad2a6c6e1d3806e5f6bd8aa2751e0a10db0d46faaba
+ - skaffold-example -> skaffold-example:c827aa5a4b12e707163842b803d666eda11b8ec20c7a480198960cfdcb251042
+   local images can't be referenced by digest. They are tagged and referenced by a unique ID instead
 Starting deploy...
  - pod/getting-started created
-Deploy complete in 374.060415ms
 Watching for changes...
 [getting-started] Hello world!
 [getting-started] Hello world!

--- a/docs/content/en/docs/tutorials/_index.md
+++ b/docs/content/en/docs/tutorials/_index.md
@@ -6,22 +6,23 @@ weight: 90
 
 See the [Github Examples page](https://github.com/GoogleContainerTools/skaffold/tree/master/examples) for examples.
 
-As we have gcr.io/k8s-skaffold in our image names, to run the examples, you have two options:
+### Deploying examples to a remote cluster
 
-1. manually replace the image repositories in skaffold.yaml from gcr.io/k8s-skaffold to yours
-1. you can point skaffold to your default image repository in one of the four ways:
-    1. flag: `skaffold dev --default-repo <myrepo>`
-    1. env var: `SKAFFOLD_DEFAULT_REPO=<myrepo> skaffold dev`
-    1. global skaffold config (one time): `skaffold config set --global default-repo <myrepo>`
-    1. skaffold config for current kubectl context: `skaffold config set default-repo <myrepo>`
+When deploying to a remote cluster you have to point Skaffold to your default image repository in one of the four ways:
 
+ 1. flag: `skaffold dev --default-repo <myrepo>`
+ 1. env var: `SKAFFOLD_DEFAULT_REPO=<myrepo> skaffold dev`
+ 1. global skaffold config (one time): `skaffold config set --global default-repo <myrepo>`
+ 1. skaffold config for current kubectl context: `skaffold config set default-repo <myrepo>`
+
+### Survey
 
 :mega: **Please fill out our [quick 5-question survey](https://forms.gle/BMTbGQXLWSdn7vEs6)** to tell us how satisfied you are with Skaffold, and what improvements we should make. Thank you! :dancers:
 
+### What's next
 
-## What's next
-Take a look at our other guides
+Take a look at our other guides:
 
-| Tutorials References  |
-|----------|
+| Detailed Tutorials |
+|--------------------|
 | [Custom Build Script]({{< relref "/docs/tutorials/custom-builder" >}}) |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,12 +1,13 @@
 # Examples
 
-To run the examples, you either have to manually replace the image repositories in the examples from `gcr.io/k8s-skaffold`
-to yours or you can point Skaffold to your default image repository in one of the four ways:
+Each of those examples can be tried with `skaffold dev`. For example:
 
-* flag: `skaffold dev --default-repo <myrepo>`
-* env var: `SKAFFOLD_DEFAULT_REPO=<myrepo> skaffold dev`
-* global skaffold config (one time): `skaffold config set --global default-repo <myrepo>`
-* skaffold config for current kubectl context: `skaffold config set default-repo <myrepo>`
+```
+cd getting-started
+skaffold dev
+```
+
+Read the [Quickstart](https://skaffold.dev/docs/quickstart/) for more detailed instructions.
 
 These examples are made to work with the latest release of Skaffold.
 
@@ -14,3 +15,17 @@ If you are running Skaffold at HEAD or have built it from source, please use the
 
 *Note for contributors*: If you wish to make changes to these examples, please edit the ones at `integration/examples`,
 as those will be synced on release.
+
+## Deploying to a local cluster
+
+When deploying to a [local cluster](https://skaffold.dev/docs/environment/local-cluster/) such as minikube or Docker Desktop, no additional configuration step is required.
+
+## Deploying to a remote cluster
+
+When deploying to a remote cluster you have to point Skaffold to your default image repository in one of the four ways:
+
+* flag: `skaffold dev --default-repo <myrepo>`
+* env var: `SKAFFOLD_DEFAULT_REPO=<myrepo> skaffold dev`
+* global skaffold config (one time): `skaffold config set --global default-repo <myrepo>`
+* skaffold config for current kubectl context: `skaffold config set default-repo <myrepo>`
+

--- a/integration/examples/README.md
+++ b/integration/examples/README.md
@@ -1,12 +1,13 @@
 # Examples
 
-To run the examples, you either have to manually replace the image repositories in the examples from `gcr.io/k8s-skaffold`
-to yours or you can point Skaffold to your default image repository in one of the four ways:
+Each of those examples can be tried with `skaffold dev`. For example:
 
-* flag: `skaffold dev --default-repo <myrepo>`
-* env var: `SKAFFOLD_DEFAULT_REPO=<myrepo> skaffold dev`
-* global skaffold config (one time): `skaffold config set --global default-repo <myrepo>`
-* skaffold config for current kubectl context: `skaffold config set default-repo <myrepo>`
+```
+cd getting-started
+skaffold dev
+```
+
+Read the [Quickstart](https://skaffold.dev/docs/quickstart/) for more detailed instructions.
 
 These examples are made to work with the latest release of Skaffold.
 
@@ -14,3 +15,17 @@ If you are running Skaffold at HEAD or have built it from source, please use the
 
 *Note for contributors*: If you wish to make changes to these examples, please edit the ones at `integration/examples`,
 as those will be synced on release.
+
+## Deploying to a local cluster
+
+When deploying to a [local cluster](https://skaffold.dev/docs/environment/local-cluster/) such as minikube or Docker Desktop, no additional configuration step is required.
+
+## Deploying to a remote cluster
+
+When deploying to a remote cluster you have to point Skaffold to your default image repository in one of the four ways:
+
+* flag: `skaffold dev --default-repo <myrepo>`
+* env var: `SKAFFOLD_DEFAULT_REPO=<myrepo> skaffold dev`
+* global skaffold config (one time): `skaffold config set --global default-repo <myrepo>`
+* skaffold config for current kubectl context: `skaffold config set default-repo <myrepo>`
+


### PR DESCRIPTION
Now that the samples don't use the `gcr.io/k8s-skaffold/` prefix, the docs needed a little update.

Signed-off-by: David Gageot <david@gageot.net>
