### PR TITLE
introduced analysis struct to simplify init walk logic

### DIFF
--- a/pkg/skaffold/initializer/configs.go
+++ b/pkg/skaffold/initializer/configs.go
@@ -17,7 +17,6 @@ limitations under the License.
 package initializer
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -26,29 +25,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
-
-// checkConfigFile checks if filePath is a skaffold config or k8s config, or builder config. Detected k8s configs are added to potentialConfigs.
-// Returns true if filePath is a config file, and false if not.
-func checkConfigFile(filePath string, force bool, potentialConfigs *[]string) (bool, error) {
-	if IsSkaffoldConfig(filePath) {
-		if !force {
-			return true, fmt.Errorf("pre-existing %s found (you may continue with --force)", filePath)
-		}
-		logrus.Debugf("%s is a valid skaffold configuration: continuing since --force=true", filePath)
-		return true, nil
-	}
-
-	if kubectl.IsKubernetesManifest(filePath) {
-		*potentialConfigs = append(*potentialConfigs, filePath)
-		return true, nil
-	}
-
-	return false, nil
-}
 
 func generateSkaffoldConfig(k Initializer, buildConfigPairs []builderImagePair) ([]byte, error) {
 	// if we're here, the user has no skaffold yaml so we need to generate one

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -331,17 +331,22 @@ deploy:
 			t.Override(&docker.Validate, fakeValidateDockerfile)
 			t.Override(&jib.Validate, fakeValidateJibConfig)
 
-			potentialConfigs, builders, err := walk(tmpDir.Root(), test.force, test.enableJibInit, test.enableBuildpackInit)
+			a := analysis{
+				force:               test.force,
+				enableJibInit:       test.enableJibInit,
+				enableBuildpackInit: test.enableBuildpackInit,
+			}
+			err := a.walk(tmpDir.Root())
 
 			t.CheckError(test.shouldErr, err)
 			if test.shouldErr {
 				return
 			}
 
-			t.CheckDeepEqual(tmpDir.Paths(test.expectedConfigs...), potentialConfigs)
-			t.CheckDeepEqual(len(test.expectedPaths), len(builders))
-			for i := range builders {
-				t.CheckDeepEqual(tmpDir.Path(test.expectedPaths[i]), builders[i].Path())
+			t.CheckDeepEqual(tmpDir.Paths(test.expectedConfigs...), a.potentialConfigs)
+			t.CheckDeepEqual(len(test.expectedPaths), len(a.foundBuilders))
+			for i := range a.foundBuilders {
+				t.CheckDeepEqual(tmpDir.Path(test.expectedPaths[i]), a.foundBuilders[i].Path())
 			}
 		})
 	}


### PR DESCRIPTION
Refactoring, no functional change. 
Introduces `analysis` struct to pull together the variables during walk - simplifying the code a little bit. I hope to clear up the DoInit / walk logic eventually to something readable. This is another step in that direction. 

Also inlined the `checkConfigs` function that was very confusing - it had 2 responsibilities - to check whether a file is a skaffold file or a k8s file. This made the walk function a bit longer. I'll tackle that later - I'm hoping that I can separate file walking logic better from detection logic and flow control. 