### PR TITLE
move set->sortedset in its own file

### DIFF
--- a/pkg/skaffold/initializer/builders.go
+++ b/pkg/skaffold/initializer/builders.go
@@ -38,7 +38,7 @@ import (
 // separately returns the builder configs and images that didn't have any matches.
 func autoSelectBuilders(builderConfigs []InitBuilder, images []string) ([]builderImagePair, []InitBuilder, []string) {
 	var pairs []builderImagePair
-	var unresolvedImages = make(set)
+	var unresolvedImages = make(sortedSet)
 	for _, image := range images {
 		matchingConfigIndex := -1
 		for i, config := range builderConfigs {

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -91,20 +91,6 @@ type builderImagePair struct {
 	ImageName string
 }
 
-type set map[string]interface{}
-
-func (s set) add(value string) {
-	s[value] = value
-}
-
-func (s set) values() (values []string) {
-	for val := range s {
-		values = append(values, val)
-	}
-	sort.Strings(values)
-	return values
-}
-
 // DoInit executes the `skaffold init` flow.
 func DoInit(ctx context.Context, out io.Writer, c Config) error {
 	rootDir := "."

--- a/pkg/skaffold/initializer/set.go
+++ b/pkg/skaffold/initializer/set.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initializer
+
+import "sort"
+
+type sortedSet map[string]interface{}
+
+func (s sortedSet) add(value string) {
+	s[value] = value
+}
+
+func (s sortedSet) values() (values []string) {
+	for val := range s {
+		values = append(values, val)
+	}
+	sort.Strings(values)
+	return values
+}


### PR DESCRIPTION
Just refactoring. 
Moved `set` to its own file. Also renamed it to `sortedSet` as the `values` function sorts the values on query. 