### PR TITLE
skip-build shouldn't detect builders

### DIFF
--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -107,6 +107,7 @@ func DoInit(ctx context.Context, out io.Writer, c Config) error {
 		force:               c.Force,
 		enableJibInit:       c.EnableJibInit,
 		enableBuildpackInit: c.EnableBuildpackInit,
+		skipBuild:           c.SkipBuild,
 	}
 
 	if err := a.walk(rootDir); err != nil {
@@ -215,6 +216,7 @@ type analysis struct {
 	force               bool
 	enableJibInit       bool
 	enableBuildpackInit bool
+	skipBuild           bool
 
 	potentialConfigs []string
 	foundBuilders    []InitBuilder
@@ -277,5 +279,5 @@ func (a *analysis) walk(dir string) error {
 		return nil
 	}
 
-	return searchConfigsAndBuilders(dir, true)
+	return searchConfigsAndBuilders(dir, !a.skipBuild)
 }

--- a/pkg/skaffold/initializer/kubectl/kubectl_test.go
+++ b/pkg/skaffold/initializer/kubectl/kubectl_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestGenerateKubeCtlPipeline(t *testing.T) {
+func TestGenerateKubectlPipeline(t *testing.T) {
 	tmpDir, delete := testutil.NewTempDir(t)
 	defer delete()
 


### PR DESCRIPTION
When `--skip-build` is passed in, `skaffold init` should just skip artifacts section in the skaffold.yaml. This works, however currently we still traverse into the subdirectories and detect all the builders! This PR removes that issue. 

Note: There is no significant time diff on my laptop weirdly on the skaffold repo between master and this version. Maybe I'm missing something, or artifact detection is fast...

This also helps moving the design toward a visitor pattern, where I could turn on and off certain visitors that aggregate the state independently in the `analysis` struct. 