### PR TITLE
init refactor/clearer k8s manifest parsing

### DIFF
--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -161,7 +161,7 @@ func (k *KubectlDeployer) manifestFiles(manifests []string) ([]string, error) {
 
 	var filteredManifests []string
 	for _, f := range list {
-		if !util.IsSupportedKubernetesFormat(f) {
+		if !util.HasKubernetesFileExtension(f) {
 			if !util.StrSliceContains(manifests, f) {
 				logrus.Infof("refusing to deploy/delete non {json, yaml} file %s", f)
 				logrus.Info("If you still wish to deploy this file, please specify it directly, outside a glob pattern.")

--- a/pkg/skaffold/initializer/kubectl/kubectl.go
+++ b/pkg/skaffold/initializer/kubectl/kubectl.go
@@ -137,7 +137,6 @@ func parseKubernetesObjects(filepath string) ([]yamlObject, error) {
 		}
 
 		k8sObjects = append(k8sObjects, obj)
-
 	}
 	if len(k8sObjects) == 0 {
 		return nil, errors.New("no valid Kubernetes objects decoded")

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -51,10 +51,10 @@ func RandomID() string {
 // These are the supported file formats for Kubernetes manifests
 var validSuffixes = []string{".yml", ".yaml", ".json"}
 
-// IsSupportedKubernetesFormat is for determining if a file under a glob pattern
+// HasKubernetesFileExtension is for determining if a file under a glob pattern
 // is deployable file format. It makes no attempt to check whether or not the file
 // is actually deployable or has the correct contents.
-func IsSupportedKubernetesFormat(n string) bool {
+func HasKubernetesFileExtension(n string) bool {
 	for _, s := range validSuffixes {
 		if strings.HasSuffix(n, s) {
 			return true

--- a/pkg/skaffold/util/util_test.go
+++ b/pkg/skaffold/util/util_test.go
@@ -53,7 +53,7 @@ func TestSupportedKubernetesFormats(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			actual := IsSupportedKubernetesFormat(test.in)
+			actual := HasKubernetesFileExtension(test.in)
 
 			t.CheckDeepEqual(test.out, actual)
 		})


### PR DESCRIPTION
small refactoring, cleanup in parsing k8s yamls in `skaffold init`. 
The main changes: 
- introduce `yamlObject` type alias for readability 
- split out image parsing from yaml parsing into a single responsibility function `parseKubernetesObjects` and then using that in Kubernetes manifest file detection instead of image parsing