### PR TITLE
[init refactor] introducing init analyzers

### DIFF
--- a/pkg/skaffold/initializer/analyze.go
+++ b/pkg/skaffold/initializer/analyze.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initializer
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+
+	"github.com/karrick/godirwalk"
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+type analysis struct {
+	kubectlAnalyzer  *KubectlAnalyzer
+	skaffoldAnalyzer *SkaffoldConfigAnalyzer
+	builderAnalyzer  *BuilderAnalyzer
+}
+
+// Analyzer is a generic Visitor that is called on every file in the directory
+// It can manage state and react to walking events assuming a bread first search
+type Analyzer interface {
+	EnterDir(dir string)
+	AnalyzeFile(file string) error
+	ExitDir(dir string)
+}
+
+type DirectoryAnalyzer struct {
+	currentDir string
+}
+
+func (a *DirectoryAnalyzer) AnalyzeFile(filePath string) error {
+	return nil
+}
+
+func (a *DirectoryAnalyzer) EnterDir(dir string) {
+	a.currentDir = dir
+}
+func (a *DirectoryAnalyzer) ExitDir(dir string) {
+	//pass
+}
+
+type KubectlAnalyzer struct {
+	DirectoryAnalyzer
+	kubernetesManifests []string
+}
+
+func (a *KubectlAnalyzer) AnalyzeFile(filePath string) error {
+	isSkaffoldConfig := IsSkaffoldConfig(filePath)
+	isKubernetesManifest := kubectl.IsKubernetesManifest(filePath)
+
+	if isKubernetesManifest && !isSkaffoldConfig {
+		a.kubernetesManifests = append(a.kubernetesManifests, filePath)
+	}
+	return nil
+}
+
+type SkaffoldConfigAnalyzer struct {
+	DirectoryAnalyzer
+	force bool
+}
+
+func (a *SkaffoldConfigAnalyzer) AnalyzeFile(filePath string) error {
+	isSkaffoldConfig := IsSkaffoldConfig(filePath)
+	if isSkaffoldConfig {
+		if !a.force {
+			return fmt.Errorf("pre-existing %s found (you may continue with --force)", filePath)
+		}
+		logrus.Debugf("%s is a valid skaffold configuration: continuing since --force=true", filePath)
+	}
+	return nil
+}
+
+type BuilderAnalyzer struct {
+	DirectoryAnalyzer
+	enableJibInit       bool
+	enableBuildpackInit bool
+	findBuilders        bool
+	foundBuilders       []InitBuilder
+
+	parentDirToStopFindBuilders string
+}
+
+func (a *BuilderAnalyzer) AnalyzeFile(filePath string) error {
+	if a.findBuilders && (a.parentDirToStopFindBuilders == "" || a.parentDirToStopFindBuilders == a.currentDir) {
+		builderConfigs, continueSearchingBuilders := detectBuilders(a.enableJibInit, a.enableBuildpackInit, filePath)
+		a.foundBuilders = append(a.foundBuilders, builderConfigs...)
+		if !continueSearchingBuilders {
+			a.parentDirToStopFindBuilders = a.currentDir
+		}
+	}
+	return nil
+}
+
+func (a *BuilderAnalyzer) ExitDir(dir string) {
+	if a.parentDirToStopFindBuilders == dir {
+		a.parentDirToStopFindBuilders = ""
+	}
+}
+
+// walk recursively walks a directory and returns the k8s configs and builder configs that it finds
+func (a *analysis) walk(root string) error {
+	var analyze func(dir string) error
+	analyze = func(dir string) error {
+		for _, analyzer := range a.analyzers() {
+			analyzer.EnterDir(dir)
+		}
+		dirents, err := godirwalk.ReadDirents(dir, nil)
+		if err != nil {
+			return err
+		}
+
+		var subdirectories []*godirwalk.Dirent
+		//this is for deterministic results - given the same directory structure
+		//init should have the same results
+		sort.Sort(dirents)
+
+		// Traverse files
+		for _, file := range dirents {
+			if util.IsHiddenFile(file.Name()) || util.IsHiddenDir(file.Name()) {
+				continue
+			}
+
+			// If we found a directory, keep track of it until we've gone through all the files first
+			if file.IsDir() {
+				subdirectories = append(subdirectories, file)
+				continue
+			}
+
+			filePath := filepath.Join(dir, file.Name())
+			for _, analyzer := range a.analyzers() {
+				if err := analyzer.AnalyzeFile(filePath); err != nil {
+					return err
+				}
+			}
+		}
+
+		// Recurse into subdirectories
+		for _, subdir := range subdirectories {
+			if err = analyze(filepath.Join(dir, subdir.Name())); err != nil {
+				return err
+			}
+		}
+
+		for _, analyzer := range a.analyzers() {
+			analyzer.ExitDir(dir)
+		}
+		return nil
+	}
+
+	return analyze(root)
+}
+
+func (a *analysis) analyzers() []Analyzer {
+	return []Analyzer{
+		a.kubectlAnalyzer,
+		a.skaffoldAnalyzer,
+		a.builderAnalyzer,
+	}
+}

--- a/pkg/skaffold/initializer/analyze.go
+++ b/pkg/skaffold/initializer/analyze.go
@@ -29,67 +29,65 @@ import (
 )
 
 type analysis struct {
-	kubectlAnalyzer  *KubectlAnalyzer
-	skaffoldAnalyzer *SkaffoldConfigAnalyzer
-	builderAnalyzer  *BuilderAnalyzer
+	kubectlAnalyzer  *kubectlAnalyzer
+	skaffoldAnalyzer *skaffoldConfigAnalyzer
+	builderAnalyzer  *builderAnalyzer
 }
 
-// Analyzer is a generic Visitor that is called on every file in the directory
+// analyzer is a generic Visitor that is called on every file in the directory
 // It can manage state and react to walking events assuming a bread first search
-type Analyzer interface {
-	EnterDir(dir string)
-	AnalyzeFile(file string) error
-	ExitDir(dir string)
+type analyzer interface {
+	enterDir(dir string)
+	analyzeFile(file string) error
+	exitDir(dir string)
 }
 
-type DirectoryAnalyzer struct {
+type directoryAnalyzer struct {
 	currentDir string
 }
 
-func (a *DirectoryAnalyzer) AnalyzeFile(filePath string) error {
+func (a *directoryAnalyzer) analyzeFile(filePath string) error {
 	return nil
 }
 
-func (a *DirectoryAnalyzer) EnterDir(dir string) {
+func (a *directoryAnalyzer) enterDir(dir string) {
 	a.currentDir = dir
 }
-func (a *DirectoryAnalyzer) ExitDir(dir string) {
+
+func (a *directoryAnalyzer) exitDir(dir string) {
 	//pass
 }
 
-type KubectlAnalyzer struct {
-	DirectoryAnalyzer
+type kubectlAnalyzer struct {
+	directoryAnalyzer
 	kubernetesManifests []string
 }
 
-func (a *KubectlAnalyzer) AnalyzeFile(filePath string) error {
-	isSkaffoldConfig := IsSkaffoldConfig(filePath)
-	isKubernetesManifest := kubectl.IsKubernetesManifest(filePath)
-
-	if isKubernetesManifest && !isSkaffoldConfig {
+func (a *kubectlAnalyzer) analyzeFile(filePath string) error {
+	if kubectl.IsKubernetesManifest(filePath) && !IsSkaffoldConfig(filePath) {
 		a.kubernetesManifests = append(a.kubernetesManifests, filePath)
 	}
 	return nil
 }
 
-type SkaffoldConfigAnalyzer struct {
-	DirectoryAnalyzer
+type skaffoldConfigAnalyzer struct {
+	directoryAnalyzer
 	force bool
 }
 
-func (a *SkaffoldConfigAnalyzer) AnalyzeFile(filePath string) error {
-	isSkaffoldConfig := IsSkaffoldConfig(filePath)
-	if isSkaffoldConfig {
-		if !a.force {
-			return fmt.Errorf("pre-existing %s found (you may continue with --force)", filePath)
-		}
-		logrus.Debugf("%s is a valid skaffold configuration: continuing since --force=true", filePath)
+func (a *skaffoldConfigAnalyzer) analyzeFile(filePath string) error {
+	if !IsSkaffoldConfig(filePath) {
+		return nil
 	}
+	if !a.force {
+		return fmt.Errorf("pre-existing %s found (you may continue with --force)", filePath)
+	}
+	logrus.Debugf("%s is a valid skaffold configuration: continuing since --force=true", filePath)
 	return nil
 }
 
-type BuilderAnalyzer struct {
-	DirectoryAnalyzer
+type builderAnalyzer struct {
+	directoryAnalyzer
 	enableJibInit       bool
 	enableBuildpackInit bool
 	findBuilders        bool
@@ -98,7 +96,7 @@ type BuilderAnalyzer struct {
 	parentDirToStopFindBuilders string
 }
 
-func (a *BuilderAnalyzer) AnalyzeFile(filePath string) error {
+func (a *builderAnalyzer) analyzeFile(filePath string) error {
 	if a.findBuilders && (a.parentDirToStopFindBuilders == "" || a.parentDirToStopFindBuilders == a.currentDir) {
 		builderConfigs, continueSearchingBuilders := detectBuilders(a.enableJibInit, a.enableBuildpackInit, filePath)
 		a.foundBuilders = append(a.foundBuilders, builderConfigs...)
@@ -109,67 +107,62 @@ func (a *BuilderAnalyzer) AnalyzeFile(filePath string) error {
 	return nil
 }
 
-func (a *BuilderAnalyzer) ExitDir(dir string) {
+func (a *builderAnalyzer) exitDir(dir string) {
 	if a.parentDirToStopFindBuilders == dir {
 		a.parentDirToStopFindBuilders = ""
 	}
 }
 
-// walk recursively walks a directory and returns the k8s configs and builder configs that it finds
-func (a *analysis) walk(root string) error {
-	var analyze func(dir string) error
-	analyze = func(dir string) error {
+// analyze recursively walks a directory and returns the k8s configs and builder configs that it finds
+func (a *analysis) analyze(dir string) error {
+	for _, analyzer := range a.analyzers() {
+		analyzer.enterDir(dir)
+	}
+	dirents, err := godirwalk.ReadDirents(dir, nil)
+	if err != nil {
+		return err
+	}
+
+	var subdirectories []*godirwalk.Dirent
+	//this is for deterministic results - given the same directory structure
+	//init should have the same results
+	sort.Sort(dirents)
+
+	// Traverse files
+	for _, file := range dirents {
+		if util.IsHiddenFile(file.Name()) || util.IsHiddenDir(file.Name()) {
+			continue
+		}
+
+		// If we found a directory, keep track of it until we've gone through all the files first
+		if file.IsDir() {
+			subdirectories = append(subdirectories, file)
+			continue
+		}
+
+		filePath := filepath.Join(dir, file.Name())
 		for _, analyzer := range a.analyzers() {
-			analyzer.EnterDir(dir)
-		}
-		dirents, err := godirwalk.ReadDirents(dir, nil)
-		if err != nil {
-			return err
-		}
-
-		var subdirectories []*godirwalk.Dirent
-		//this is for deterministic results - given the same directory structure
-		//init should have the same results
-		sort.Sort(dirents)
-
-		// Traverse files
-		for _, file := range dirents {
-			if util.IsHiddenFile(file.Name()) || util.IsHiddenDir(file.Name()) {
-				continue
-			}
-
-			// If we found a directory, keep track of it until we've gone through all the files first
-			if file.IsDir() {
-				subdirectories = append(subdirectories, file)
-				continue
-			}
-
-			filePath := filepath.Join(dir, file.Name())
-			for _, analyzer := range a.analyzers() {
-				if err := analyzer.AnalyzeFile(filePath); err != nil {
-					return err
-				}
-			}
-		}
-
-		// Recurse into subdirectories
-		for _, subdir := range subdirectories {
-			if err = analyze(filepath.Join(dir, subdir.Name())); err != nil {
+			if err := analyzer.analyzeFile(filePath); err != nil {
 				return err
 			}
 		}
-
-		for _, analyzer := range a.analyzers() {
-			analyzer.ExitDir(dir)
-		}
-		return nil
 	}
 
-	return analyze(root)
+	// Recurse into subdirectories
+	for _, subdir := range subdirectories {
+		if err = a.analyze(filepath.Join(dir, subdir.Name())); err != nil {
+			return err
+		}
+	}
+
+	for _, analyzer := range a.analyzers() {
+		analyzer.exitDir(dir)
+	}
+	return nil
 }
 
-func (a *analysis) analyzers() []Analyzer {
-	return []Analyzer{
+func (a *analysis) analyzers() []analyzer {
+	return []analyzer{
 		a.kubectlAnalyzer,
 		a.skaffoldAnalyzer,
 		a.builderAnalyzer,

--- a/pkg/skaffold/initializer/builders.go
+++ b/pkg/skaffold/initializer/builders.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"gopkg.in/AlecAivazis/survey.v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
@@ -221,20 +220,4 @@ func resolveBuilderImages(builderConfigs []InitBuilder, images []string, force b
 		logrus.Warnf("unused builder configs found in repository: %v", choices)
 	}
 	return pairs, nil
-}
-
-func promptUserForBuildConfig(image string, choices []string) (string, error) {
-	var selectedBuildConfig string
-	options := append(choices, NoBuilder)
-	prompt := &survey.Select{
-		Message:  fmt.Sprintf("Choose the builder to build image %s", image),
-		Options:  options,
-		PageSize: 15,
-	}
-	err := survey.AskOne(prompt, &selectedBuildConfig, nil)
-	if err != nil {
-		return "", err
-	}
-
-	return selectedBuildConfig, nil
 }

--- a/pkg/skaffold/initializer/config.go
+++ b/pkg/skaffold/initializer/config.go
@@ -23,13 +23,17 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
 
-func generateSkaffoldConfig(k Initializer, buildConfigPairs []builderImagePair) ([]byte, error) {
+var (
+	// for testing
+	getWd = os.Getwd
+)
+
+func generateSkaffoldConfig(k DeploymentInitializer, buildConfigPairs []builderImagePair) *latest.SkaffoldConfig {
 	// if we're here, the user has no skaffold yaml so we need to generate one
 	// if the user doesn't have any k8s yamls, generate one for each dockerfile
 	logrus.Info("generating skaffold config")
@@ -39,7 +43,7 @@ func generateSkaffoldConfig(k Initializer, buildConfigPairs []builderImagePair) 
 		warnings.Printf("Couldn't generate default config name: %s", err.Error())
 	}
 
-	return yaml.Marshal(&latest.SkaffoldConfig{
+	return &latest.SkaffoldConfig{
 		APIVersion: latest.Version,
 		Kind:       "Config",
 		Metadata: latest.Metadata{
@@ -51,11 +55,11 @@ func generateSkaffoldConfig(k Initializer, buildConfigPairs []builderImagePair) 
 			},
 			Deploy: k.GenerateDeployConfig(),
 		},
-	})
+	}
 }
 
 func suggestConfigName() (string, error) {
-	cwd, err := os.Getwd()
+	cwd, err := getWd()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/skaffold/initializer/config_test.go
+++ b/pkg/skaffold/initializer/config_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initializer
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+type stubDeploymentInitializer struct {
+	deployConfig latest.DeployConfig
+}
+
+func (s stubDeploymentInitializer) GenerateDeployConfig() latest.DeployConfig {
+	return s.deployConfig
+}
+
+func (s stubDeploymentInitializer) GetImages() []string {
+	panic("implement me")
+}
+
+func TestGenerateSkaffoldConfig(t *testing.T) {
+	tests := []struct {
+		name                   string
+		expectedSkaffoldConfig *latest.SkaffoldConfig
+		deployConfig           latest.DeployConfig
+		builderConfigPairs     []builderImagePair
+		getWd                  func() (string, error)
+	}{
+		{
+			name:               "empty",
+			builderConfigPairs: []builderImagePair{},
+			deployConfig:       latest.DeployConfig{},
+			getWd: func() (s string, err error) {
+				return filepath.Join("rootDir", "testConfig"), nil
+			},
+			expectedSkaffoldConfig: &latest.SkaffoldConfig{
+				APIVersion: latest.Version,
+				Kind:       "Config",
+				Metadata:   latest.Metadata{Name: "testconfig"},
+				Pipeline: latest.Pipeline{
+					Deploy: latest.DeployConfig{},
+				},
+			},
+		},
+		{
+			name: "root dir + builder image pairs",
+			builderConfigPairs: []builderImagePair{
+				{
+					Builder: docker.ArtifactConfig{
+						File: "testDir/Dockerfile",
+					},
+					ImageName: "image1",
+				},
+			},
+			deployConfig: latest.DeployConfig{},
+			getWd: func() (s string, err error) {
+				return string(filepath.Separator), nil
+			},
+			expectedSkaffoldConfig: &latest.SkaffoldConfig{
+				APIVersion: latest.Version,
+				Kind:       "Config",
+				Metadata:   latest.Metadata{},
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{
+						Artifacts: []*latest.Artifact{
+							{
+								ImageName: "image1",
+								Workspace: "testDir",
+							},
+						},
+					},
+					Deploy: latest.DeployConfig{},
+				},
+			},
+		},
+		{
+			name:               "error working dir",
+			builderConfigPairs: []builderImagePair{},
+			deployConfig:       latest.DeployConfig{},
+			getWd: func() (s string, err error) {
+				return "", errors.New("testError")
+			},
+			expectedSkaffoldConfig: &latest.SkaffoldConfig{
+				APIVersion: latest.Version,
+				Kind:       "Config",
+				Metadata:   latest.Metadata{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			deploymentInitializer := stubDeploymentInitializer{
+				test.deployConfig,
+			}
+			t.Override(&getWd, test.getWd)
+			config := generateSkaffoldConfig(deploymentInitializer, test.builderConfigPairs)
+			t.CheckDeepEqual(config, test.expectedSkaffoldConfig)
+		})
+	}
+}
+
+func TestArtifacts(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		artifacts := artifacts([]builderImagePair{
+			{
+				ImageName: "image1",
+				Builder: docker.ArtifactConfig{
+					File: "Dockerfile",
+				},
+			},
+			{
+				ImageName: "image2",
+				Builder: docker.ArtifactConfig{
+					File: "front/Dockerfile2",
+				},
+			},
+			{
+				ImageName: "image3",
+				Builder: buildpacks.ArtifactConfig{
+					File: "package.json",
+				},
+			},
+		})
+
+		expected := []*latest.Artifact{
+			{
+				ImageName:    "image1",
+				ArtifactType: latest.ArtifactType{},
+			},
+			{
+				ImageName: "image2",
+				Workspace: "front",
+				ArtifactType: latest.ArtifactType{
+					DockerArtifact: &latest.DockerArtifact{
+						DockerfilePath: "Dockerfile2",
+					},
+				},
+			},
+			{
+				ImageName: "image3",
+				ArtifactType: latest.ArtifactType{
+					BuildpackArtifact: &latest.BuildpackArtifact{
+						Builder: "heroku/buildpacks",
+					},
+				},
+			},
+		}
+
+		t.CheckDeepEqual(expected, artifacts)
+	})
+}

--- a/pkg/skaffold/initializer/config_test.go
+++ b/pkg/skaffold/initializer/config_test.go
@@ -22,9 +22,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
-
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -94,18 +94,18 @@ func DoInit(ctx context.Context, out io.Writer, c Config) error {
 	}
 
 	a := &analysis{
-		kubectlAnalyzer: &KubectlAnalyzer{},
-		builderAnalyzer: &BuilderAnalyzer{
+		kubectlAnalyzer: &kubectlAnalyzer{},
+		builderAnalyzer: &builderAnalyzer{
 			findBuilders:        !c.SkipBuild,
 			enableJibInit:       c.EnableJibInit,
 			enableBuildpackInit: c.EnableBuildpackInit,
 		},
-		skaffoldAnalyzer: &SkaffoldConfigAnalyzer{
+		skaffoldAnalyzer: &skaffoldConfigAnalyzer{
 			force: c.Force,
 		},
 	}
 
-	if err := a.walk(rootDir); err != nil {
+	if err := a.analyze(rootDir); err != nil {
 		return err
 	}
 

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -331,17 +331,17 @@ deploy:
 			t.Override(&jib.Validate, fakeValidateJibConfig)
 
 			a := &analysis{
-				kubectlAnalyzer: &KubectlAnalyzer{},
-				builderAnalyzer: &BuilderAnalyzer{
+				kubectlAnalyzer: &kubectlAnalyzer{},
+				builderAnalyzer: &builderAnalyzer{
 					findBuilders:        true,
 					enableJibInit:       test.enableJibInit,
 					enableBuildpackInit: test.enableBuildpackInit,
 				},
-				skaffoldAnalyzer: &SkaffoldConfigAnalyzer{
+				skaffoldAnalyzer: &skaffoldConfigAnalyzer{
 					force: test.force,
 				},
 			}
-			err := a.walk(tmpDir.Root())
+			err := a.analyze(tmpDir.Root())
 
 			t.CheckError(test.shouldErr, err)
 			if test.shouldErr {

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -331,10 +330,16 @@ deploy:
 			t.Override(&docker.Validate, fakeValidateDockerfile)
 			t.Override(&jib.Validate, fakeValidateJibConfig)
 
-			a := analysis{
-				force:               test.force,
-				enableJibInit:       test.enableJibInit,
-				enableBuildpackInit: test.enableBuildpackInit,
+			a := &analysis{
+				kubectlAnalyzer: &KubectlAnalyzer{},
+				builderAnalyzer: &BuilderAnalyzer{
+					findBuilders:        true,
+					enableJibInit:       test.enableJibInit,
+					enableBuildpackInit: test.enableBuildpackInit,
+				},
+				skaffoldAnalyzer: &SkaffoldConfigAnalyzer{
+					force: test.force,
+				},
 			}
 			err := a.walk(tmpDir.Root())
 
@@ -343,10 +348,10 @@ deploy:
 				return
 			}
 
-			t.CheckDeepEqual(tmpDir.Paths(test.expectedConfigs...), a.potentialConfigs)
-			t.CheckDeepEqual(len(test.expectedPaths), len(a.foundBuilders))
-			for i := range a.foundBuilders {
-				t.CheckDeepEqual(tmpDir.Path(test.expectedPaths[i]), a.foundBuilders[i].Path())
+			t.CheckDeepEqual(tmpDir.Paths(test.expectedConfigs...), a.kubectlAnalyzer.kubernetesManifests)
+			t.CheckDeepEqual(len(test.expectedPaths), len(a.builderAnalyzer.foundBuilders))
+			for i := range a.builderAnalyzer.foundBuilders {
+				t.CheckDeepEqual(tmpDir.Path(test.expectedPaths[i]), a.builderAnalyzer.foundBuilders[i].Path())
 			}
 		})
 	}
@@ -680,55 +685,4 @@ func TestRunKompose(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestArtifacts(t *testing.T) {
-	testutil.Run(t, "", func(t *testutil.T) {
-		artifacts := artifacts([]builderImagePair{
-			{
-				ImageName: "image1",
-				Builder: docker.ArtifactConfig{
-					File: "Dockerfile",
-				},
-			},
-			{
-				ImageName: "image2",
-				Builder: docker.ArtifactConfig{
-					File: "front/Dockerfile2",
-				},
-			},
-			{
-				ImageName: "image3",
-				Builder: buildpacks.ArtifactConfig{
-					File: "package.json",
-				},
-			},
-		})
-
-		expected := []*latest.Artifact{
-			{
-				ImageName:    "image1",
-				ArtifactType: latest.ArtifactType{},
-			},
-			{
-				ImageName: "image2",
-				Workspace: "front",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
-						DockerfilePath: "Dockerfile2",
-					},
-				},
-			},
-			{
-				ImageName: "image3",
-				ArtifactType: latest.ArtifactType{
-					BuildpackArtifact: &latest.BuildpackArtifact{
-						Builder: "heroku/buildpacks",
-					},
-				},
-			},
-		}
-
-		t.CheckDeepEqual(expected, artifacts)
-	})
 }

--- a/pkg/skaffold/initializer/prompt.go
+++ b/pkg/skaffold/initializer/prompt.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initializer
+
+import (
+	"fmt"
+
+	"gopkg.in/AlecAivazis/survey.v1"
+)
+
+// For testing
+var (
+	promptUserForBuildConfigFunc = promptUserForBuildConfig
+)
+
+func promptUserForBuildConfig(image string, choices []string) (string, error) {
+	var selectedBuildConfig string
+	options := append(choices, NoBuilder)
+	prompt := &survey.Select{
+		Message:  fmt.Sprintf("Choose the builder to build image %s", image),
+		Options:  options,
+		PageSize: 15,
+	}
+	err := survey.AskOne(prompt, &selectedBuildConfig, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return selectedBuildConfig, nil
+}


### PR DESCRIPTION
Refactoring - shouldn't change anything functionally. 
Introducing analyzers in the `initializer` package. 

An Analyzer is basically implementing a Visitor pattern, can react to EnterDir and ExitDir events and can be called on each file. This creates a more composable design that is open for extension but closed for modification. 

Also added tests to cover config generation logic. 