### PR TITLE
[init refactor] cleanup on analyzers and moving things into a single package

### DIFF
--- a/pkg/skaffold/initializer/config_test.go
+++ b/pkg/skaffold/initializer/config_test.go
@@ -28,11 +28,11 @@ import (
 )
 
 type stubDeploymentInitializer struct {
-	deployConfig latest.DeployConfig
+	config latest.DeployConfig
 }
 
-func (s stubDeploymentInitializer) GenerateDeployConfig() latest.DeployConfig {
-	return s.deployConfig
+func (s stubDeploymentInitializer) deployConfig() latest.DeployConfig {
+	return s.config
 }
 
 func (s stubDeploymentInitializer) GetImages() []string {

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -32,7 +32,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
@@ -41,10 +40,10 @@ import (
 // an image we parse out from a Kubernetes manifest
 const NoBuilder = "None (image not built from these sources)"
 
-// DeploymentInitializer detects a deployment type and is able to extract image names from it
-type DeploymentInitializer interface {
-	// GenerateDeployConfig generates Deploy Config for skaffold configuration.
-	GenerateDeployConfig() latest.DeployConfig
+// deploymentInitializer detects a deployment type and is able to extract image names from it
+type deploymentInitializer interface {
+	// deployConfig generates Deploy Config for skaffold configuration.
+	deployConfig() latest.DeployConfig
 	// GetImages fetches all the images defined in the manifest files.
 	GetImages() []string
 }
@@ -109,7 +108,7 @@ func DoInit(ctx context.Context, out io.Writer, c Config) error {
 		return err
 	}
 
-	k, err := kubectl.New(a.kubectlAnalyzer.kubernetesManifests)
+	k, err := newKubectlInitializer(a.kubectlAnalyzer.kubernetesManifests)
 	if err != nil {
 		return err
 	}

--- a/pkg/skaffold/initializer/kubectl_test.go
+++ b/pkg/skaffold/initializer/kubectl_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubectl
+package initializer
 
 import (
 	"testing"
@@ -38,7 +38,7 @@ spec:
 `)
 	filename := tmpDir.Path("deployment.yaml")
 
-	k, err := New([]string{filename})
+	k, err := newKubectlInitializer([]string{filename})
 	if err != nil {
 		t.Fatal("failed to create a pipeline")
 	}
@@ -50,7 +50,7 @@ spec:
 			},
 		},
 	}
-	testutil.CheckDeepEqual(t, expectedConfig, k.GenerateDeployConfig())
+	testutil.CheckDeepEqual(t, expectedConfig, k.deployConfig())
 }
 
 func TestParseImagesFromKubernetesYaml(t *testing.T) {

--- a/pkg/skaffold/initializer/util.go
+++ b/pkg/skaffold/initializer/util.go
@@ -18,8 +18,8 @@ package initializer
 
 import "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 
-// IsSkaffoldConfig is for determining if a file is skaffold config file.
-func IsSkaffoldConfig(file string) bool {
+// isSkaffoldConfig is for determining if a file is skaffold config file.
+func isSkaffoldConfig(file string) bool {
 	if config, err := schema.ParseConfig(file, false); err == nil && config != nil {
 		return true
 	}

--- a/pkg/skaffold/initializer/util_test.go
+++ b/pkg/skaffold/initializer/util_test.go
@@ -55,7 +55,7 @@ deploy:
 			tmpDir := t.NewTempDir().
 				Write("skaffold.yaml", test.contents)
 
-			isValid := IsSkaffoldConfig(tmpDir.Path("skaffold.yaml"))
+			isValid := isSkaffoldConfig(tmpDir.Path("skaffold.yaml"))
 
 			t.CheckDeepEqual(test.isValid, isValid)
 		})


### PR DESCRIPTION
No functional change, pure refactor.

- moved kubectl package back into initializer - everything is unexported - we really don't need exporting there
- moved analyzers to their corresponding files - this way logic stay closer to each other - we can already see much easier how the kubectlnitializer gets the manifests - there are more simplifications to come there! 