### PR TITLE
Auto sync with Buildpacks

### DIFF
--- a/pkg/skaffold/build/buildpacks/build_test.go
+++ b/pkg/skaffold/build/buildpacks/build_test.go
@@ -41,23 +41,19 @@ func (f *fakePack) runPack(_ context.Context, _ io.Writer, opts pack.BuildOption
 func TestBuild(t *testing.T) {
 	tests := []struct {
 		description     string
-		artifact        *latest.BuildpackArtifact
+		artifact        *latest.Artifact
 		tag             string
 		api             *testutil.FakeAPIClient
 		pushImages      bool
-		noPull          bool
+		devMode         bool
 		shouldErr       bool
 		expectedOptions *pack.BuildOptions
 	}{
 		{
 			description: "success",
-			artifact: &latest.BuildpackArtifact{
-				Builder:      "my/builder",
-				RunImage:     "my/run",
-				Dependencies: defaultBuildpackDependencies(),
-			},
-			tag: "img:tag",
-			api: &testutil.FakeAPIClient{},
+			artifact:    buildpacksArtifact("my/builder", "my/run"),
+			tag:         "img:tag",
+			api:         &testutil.FakeAPIClient{},
 			expectedOptions: &pack.BuildOptions{
 				AppPath:  ".",
 				Builder:  "my/builder",
@@ -67,25 +63,47 @@ func TestBuild(t *testing.T) {
 			},
 		},
 		{
-			description: "invalid ref",
-			artifact: &latest.BuildpackArtifact{
-				Builder:      "my/builder",
-				RunImage:     "my/run",
-				Dependencies: defaultBuildpackDependencies(),
+			description: "dev mode",
+			artifact:    withSync(&latest.Sync{Infer: []string{"**/*"}}, buildpacksArtifact("another/builder", "another/run")),
+			tag:         "img:tag",
+			api:         &testutil.FakeAPIClient{},
+			devMode:     true,
+			expectedOptions: &pack.BuildOptions{
+				AppPath:  ".",
+				Builder:  "another/builder",
+				RunImage: "another/run",
+				Env: map[string]string{
+					"GOOGLE_DEVMODE": "1",
+				},
+				Image: "img:latest",
 			},
-			tag:       "in valid ref",
-			api:       &testutil.FakeAPIClient{},
-			shouldErr: true,
+		},
+		{
+			description: "dev mode but no sync",
+			artifact:    buildpacksArtifact("my/other-builder", "my/run"),
+			tag:         "img:tag",
+			api:         &testutil.FakeAPIClient{},
+			devMode:     true,
+			expectedOptions: &pack.BuildOptions{
+				AppPath:  ".",
+				Builder:  "my/other-builder",
+				RunImage: "my/run",
+				Env:      map[string]string{},
+				Image:    "img:latest",
+			},
+		},
+		{
+			description: "invalid ref",
+			artifact:    buildpacksArtifact("my/builder", "my/run"),
+			tag:         "in valid ref",
+			api:         &testutil.FakeAPIClient{},
+			shouldErr:   true,
 		},
 		{
 			description: "push error",
-			artifact: &latest.BuildpackArtifact{
-				Builder:      "my/builder",
-				RunImage:     "my/run",
-				Dependencies: defaultBuildpackDependencies(),
-			},
-			tag:        "img:tag",
-			pushImages: true,
+			artifact:    buildpacksArtifact("my/builder", "my/run"),
+			tag:         "img:tag",
+			pushImages:  true,
 			api: &testutil.FakeAPIClient{
 				ErrImagePush: true,
 			},
@@ -93,15 +111,10 @@ func TestBuild(t *testing.T) {
 		},
 		{
 			description: "invalid env",
-			artifact: &latest.BuildpackArtifact{
-				Builder:      "my/builder",
-				RunImage:     "my/run",
-				Env:          []string{"INVALID"},
-				Dependencies: defaultBuildpackDependencies(),
-			},
-			tag:       "img:tag",
-			api:       &testutil.FakeAPIClient{},
-			shouldErr: true,
+			artifact:    withEnv([]string{"INVALID"}, buildpacksArtifact("my/builder", "my/run")),
+			tag:         "img:tag",
+			api:         &testutil.FakeAPIClient{},
+			shouldErr:   true,
 		},
 	}
 	for _, test := range tests {
@@ -111,18 +124,13 @@ func TestBuild(t *testing.T) {
 			t.Override(&runPackBuildFunc, pack.runPack)
 
 			test.api.
-				Add(test.artifact.Builder, "builderImageID").
-				Add(test.artifact.RunImage, "runImageID").
+				Add(test.artifact.BuildpackArtifact.Builder, "builderImageID").
+				Add(test.artifact.BuildpackArtifact.RunImage, "runImageID").
 				Add("img:latest", "builtImageID")
 			localDocker := docker.NewLocalDaemon(test.api, nil, false, nil)
 
-			builder := NewArtifactBuilder(localDocker, test.pushImages)
-			_, err := builder.Build(context.Background(), ioutil.Discard, &latest.Artifact{
-				Workspace: ".",
-				ArtifactType: latest.ArtifactType{
-					BuildpackArtifact: test.artifact,
-				},
-			}, test.tag)
+			builder := NewArtifactBuilder(localDocker, test.pushImages, test.devMode)
+			_, err := builder.Build(context.Background(), ioutil.Discard, test.artifact, test.tag)
 
 			t.CheckError(test.shouldErr, err)
 			if test.expectedOptions != nil {
@@ -132,8 +140,27 @@ func TestBuild(t *testing.T) {
 	}
 }
 
-func defaultBuildpackDependencies() *latest.BuildpackDependencies {
-	return &latest.BuildpackDependencies{
-		Paths: []string{"."},
+func buildpacksArtifact(builder, runImage string) *latest.Artifact {
+	return &latest.Artifact{
+		Workspace: ".",
+		ArtifactType: latest.ArtifactType{
+			BuildpackArtifact: &latest.BuildpackArtifact{
+				Builder:  builder,
+				RunImage: runImage,
+				Dependencies: &latest.BuildpackDependencies{
+					Paths: []string{"."},
+				},
+			},
+		},
 	}
+}
+
+func withEnv(env []string, artifact *latest.Artifact) *latest.Artifact {
+	artifact.BuildpackArtifact.Env = env
+	return artifact
+}
+
+func withSync(sync *latest.Sync, artifact *latest.Artifact) *latest.Artifact {
+	artifact.Sync = sync
+	return artifact
 }

--- a/pkg/skaffold/build/buildpacks/lifecycle.go
+++ b/pkg/skaffold/build/buildpacks/lifecycle.go
@@ -59,6 +59,10 @@ func (b *Builder) build(ctx context.Context, out io.Writer, a *latest.Artifact, 
 		return "", errors.Wrap(err, "unable to evaluate env variables")
 	}
 
+	if b.devMode && a.Sync != nil && len(a.Sync.Infer) > 0 {
+		env = append(env, "GOOGLE_DEVMODE=1")
+	}
+
 	alreadyPulled := images.AreAlreadyPulled(artifact.Builder, artifact.RunImage)
 
 	if err := runPackBuildFunc(ctx, out, pack.BuildOptions{

--- a/pkg/skaffold/build/buildpacks/metadata.go
+++ b/pkg/skaffold/build/buildpacks/metadata.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildpacks
+
+import (
+	"encoding/json"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+)
+
+type buildMetadata struct {
+	Bom []bom `json:"bom"`
+}
+
+type bom struct {
+	Metadata bomMetadata `json:"metadata"`
+}
+
+type bomMetadata struct {
+	Sync []syncRule `json:"devmode.sync"`
+}
+
+type syncRule struct {
+	Src  string `json:"src"`
+	Dest string `json:"dest"`
+}
+
+// $ docker inspect demo/buildpacks | jq -r '.[].Config.Labels["io.buildpacks.build.metadata"] | fromjson.bom[].metadata["devmode.sync"]'
+func SyncRules(labels map[string]string) ([]*latest.SyncRule, error) {
+	metadataJSON, present := labels["io.buildpacks.build.metadata"]
+	if !present {
+		return nil, nil
+	}
+
+	m := buildMetadata{}
+	if err := json.Unmarshal([]byte(metadataJSON), &m); err != nil {
+		return nil, err
+	}
+
+	var rules []*latest.SyncRule
+
+	for _, b := range m.Bom {
+		for _, sync := range b.Metadata.Sync {
+			rules = append(rules, &latest.SyncRule{
+				Src:  sync.Src,
+				Dest: sync.Dest,
+			})
+		}
+	}
+
+	return rules, nil
+}

--- a/pkg/skaffold/build/buildpacks/metadata_test.go
+++ b/pkg/skaffold/build/buildpacks/metadata_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildpacks
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestSyncRules(t *testing.T) {
+	tests := []struct {
+		description   string
+		labels        map[string]string
+		expectedRules []*latest.SyncRule
+		shouldErr     bool
+	}{
+		{
+			description: "missing labels",
+			labels:      map[string]string{},
+		},
+		{
+			description: "invalid labels",
+			labels: map[string]string{
+				"io.buildpacks.build.metadata": "invalid",
+			},
+			shouldErr: true,
+		},
+		{
+			description: "valid labels",
+			labels: map[string]string{
+				"io.buildpacks.build.metadata": `{
+					"bom":[{
+						"metadata":{
+							"devmode.sync": [
+								{"src":"src-value1","dest":"dest-value1"},
+								{"src":"src-value2","dest":"dest-value2"}
+							]
+						}
+					}]
+				}`,
+			},
+			expectedRules: []*latest.SyncRule{
+				{Src: "src-value1", Dest: "dest-value1"},
+				{Src: "src-value2", Dest: "dest-value2"},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			rules, err := SyncRules(test.labels)
+
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedRules, rules)
+		})
+	}
+}

--- a/pkg/skaffold/build/buildpacks/types.go
+++ b/pkg/skaffold/build/buildpacks/types.go
@@ -22,12 +22,14 @@ import "github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 type Builder struct {
 	localDocker docker.LocalDaemon
 	pushImages  bool
+	devMode     bool
 }
 
 // NewArtifactBuilder returns a new buildpack artifact builder
-func NewArtifactBuilder(localDocker docker.LocalDaemon, pushImages bool) *Builder {
+func NewArtifactBuilder(localDocker docker.LocalDaemon, pushImages, devMode bool) *Builder {
 	return &Builder{
 		localDocker: localDocker,
 		pushImages:  pushImages,
+		devMode:     devMode,
 	}
 }

--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -50,6 +50,7 @@ type cache struct {
 	insecureRegistries map[string]bool
 	cacheFile          string
 	imagesAreLocal     bool
+	devMode            bool
 }
 
 // DependencyLister fetches a list of dependencies for an artifact
@@ -85,6 +86,7 @@ func NewCache(runCtx *runcontext.RunContext, imagesAreLocal bool, dependencies D
 		insecureRegistries: runCtx.InsecureRegistries,
 		cacheFile:          cacheFile,
 		imagesAreLocal:     imagesAreLocal,
+		devMode:            runCtx.DevMode,
 	}, nil
 }
 

--- a/pkg/skaffold/build/cache/hash_test.go
+++ b/pkg/skaffold/build/cache/hash_test.go
@@ -39,9 +39,12 @@ var mockCacheHasher = func(s string) (string, error) {
 	return s, nil
 }
 
-var fakeArtifactConfig = func(a *latest.Artifact) (string, error) {
+var fakeArtifactConfig = func(a *latest.Artifact, devMode bool) (string, error) {
 	if a.ArtifactType.DockerArtifact != nil {
 		return "docker/target=" + a.ArtifactType.DockerArtifact.Target, nil
+	}
+	if devMode {
+		return "devmode", nil
 	}
 	return "other", nil
 }
@@ -51,6 +54,7 @@ func TestGetHashForArtifact(t *testing.T) {
 		description  string
 		dependencies []string
 		artifact     *latest.Artifact
+		devMode      bool
 		expected     string
 	}{
 		{
@@ -124,6 +128,13 @@ func TestGetHashForArtifact(t *testing.T) {
 			},
 			expected: "a2e225e66c5932e41b0026164bf204533d59974b42fbb645da2855dc9d432cb9",
 		},
+		{
+			description:  "devmode",
+			dependencies: []string{"a", "b"},
+			artifact:     &latest.Artifact{},
+			devMode:      true,
+			expected:     "f019dda9d0c38fea4aab1685c7da54f7009aba1cb47e3cb4c6c1ce5b10fa5c32",
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
@@ -131,7 +142,7 @@ func TestGetHashForArtifact(t *testing.T) {
 			t.Override(&artifactConfigFunction, fakeArtifactConfig)
 
 			depLister := stubDependencyLister(test.dependencies)
-			actual, err := getHashForArtifact(context.Background(), depLister, test.artifact)
+			actual, err := getHashForArtifact(context.Background(), depLister, test.artifact, test.devMode)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)
@@ -147,7 +158,7 @@ func TestArtifactConfig(t *testing.T) {
 					Target: "target",
 				},
 			},
-		})
+		}, false)
 		t.CheckNoError(err)
 
 		config2, err := artifactConfig(&latest.Artifact{
@@ -156,11 +167,40 @@ func TestArtifactConfig(t *testing.T) {
 					Target: "other",
 				},
 			},
-		})
+		}, false)
 		t.CheckNoError(err)
 
 		if config1 == config2 {
 			t.Errorf("configs should be different: [%s] [%s]", config1, config2)
+		}
+	})
+}
+
+func TestArtifactConfigDevMode(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		artifact := latest.ArtifactType{
+			BuildpackArtifact: &latest.BuildpackArtifact{
+				Builder: "any/builder",
+			},
+		}
+		sync := &latest.Sync{
+			Infer: []string{"**/*"},
+		}
+
+		config, err := artifactConfig(&latest.Artifact{
+			ArtifactType: artifact,
+			Sync:         sync,
+		}, false)
+		t.CheckNoError(err)
+
+		configDevMode, err := artifactConfig(&latest.Artifact{
+			ArtifactType: artifact,
+			Sync:         sync,
+		}, true)
+		t.CheckNoError(err)
+
+		if config == configDevMode {
+			t.Errorf("configs should be different: [%s] [%s]", config, configDevMode)
 		}
 	})
 }
@@ -180,21 +220,21 @@ func TestBuildArgs(t *testing.T) {
 		t.Override(&hashFunction, mockCacheHasher)
 		t.Override(&artifactConfigFunction, fakeArtifactConfig)
 
-		actual, err := getHashForArtifact(context.Background(), stubDependencyLister(nil), artifact)
+		actual, err := getHashForArtifact(context.Background(), stubDependencyLister(nil), artifact, false)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(expected, actual)
 
 		// Change order of buildargs
 		artifact.ArtifactType.DockerArtifact.BuildArgs = map[string]*string{"two": stringPointer("2"), "one": stringPointer("1")}
-		actual, err = getHashForArtifact(context.Background(), stubDependencyLister(nil), artifact)
+		actual, err = getHashForArtifact(context.Background(), stubDependencyLister(nil), artifact, false)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(expected, actual)
 
 		// Change build args, get different hash
 		artifact.ArtifactType.DockerArtifact.BuildArgs = map[string]*string{"one": stringPointer("1")}
-		actual, err = getHashForArtifact(context.Background(), stubDependencyLister(nil), artifact)
+		actual, err = getHashForArtifact(context.Background(), stubDependencyLister(nil), artifact, false)
 
 		t.CheckNoError(err)
 		if actual == expected {
@@ -223,7 +263,7 @@ func TestBuildArgsEnvSubstitution(t *testing.T) {
 		t.Override(&artifactConfigFunction, fakeArtifactConfig)
 
 		depLister := stubDependencyLister([]string{"dep"})
-		hash1, err := getHashForArtifact(context.Background(), depLister, artifact)
+		hash1, err := getHashForArtifact(context.Background(), depLister, artifact, false)
 
 		t.CheckNoError(err)
 
@@ -233,7 +273,7 @@ func TestBuildArgsEnvSubstitution(t *testing.T) {
 			return []string{"FOO=baz"}
 		}
 
-		hash2, err := getHashForArtifact(context.Background(), depLister, artifact)
+		hash2, err := getHashForArtifact(context.Background(), depLister, artifact, false)
 
 		t.CheckNoError(err)
 		if hash1 == hash2 {
@@ -290,7 +330,7 @@ func TestCacheHasher(t *testing.T) {
 			path := originalFile
 			depLister := stubDependencyLister([]string{tmpDir.Path(originalFile)})
 
-			oldHash, err := getHashForArtifact(context.Background(), depLister, &latest.Artifact{})
+			oldHash, err := getHashForArtifact(context.Background(), depLister, &latest.Artifact{}, false)
 			t.CheckNoError(err)
 
 			test.update(originalFile, tmpDir)
@@ -299,7 +339,7 @@ func TestCacheHasher(t *testing.T) {
 			}
 
 			depLister = stubDependencyLister([]string{tmpDir.Path(path)})
-			newHash, err := getHashForArtifact(context.Background(), depLister, &latest.Artifact{})
+			newHash, err := getHashForArtifact(context.Background(), depLister, &latest.Artifact{}, false)
 
 			t.CheckNoError(err)
 			t.CheckFalse(test.differentHash && oldHash == newHash)

--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -53,7 +53,7 @@ func (c *cache) lookupArtifacts(ctx context.Context, tags tag.ImageTags, artifac
 }
 
 func (c *cache) lookup(ctx context.Context, a *latest.Artifact, tag string) cacheDetails {
-	hash, err := hashForArtifact(ctx, c.dependencies, a)
+	hash, err := hashForArtifact(ctx, c.dependencies, a, c.devMode)
 	if err != nil {
 		return failed{err: fmt.Errorf("getting hash for artifact %s: %v", a.ImageName, err)}
 	}

--- a/pkg/skaffold/build/cache/lookup_test.go
+++ b/pkg/skaffold/build/cache/lookup_test.go
@@ -30,7 +30,7 @@ import (
 func TestLookupLocal(t *testing.T) {
 	tests := []struct {
 		description string
-		hasher      func(context.Context, DependencyLister, *latest.Artifact) (string, error)
+		hasher      func(context.Context, DependencyLister, *latest.Artifact, bool) (string, error)
 		cache       map[string]ImageDetails
 		api         *testutil.FakeAPIClient
 		expected    cacheDetails
@@ -126,7 +126,7 @@ func TestLookupLocal(t *testing.T) {
 func TestLookupRemote(t *testing.T) {
 	tests := []struct {
 		description string
-		hasher      func(context.Context, DependencyLister, *latest.Artifact) (string, error)
+		hasher      func(context.Context, DependencyLister, *latest.Artifact, bool) (string, error)
 		cache       map[string]ImageDetails
 		api         *testutil.FakeAPIClient
 		expected    cacheDetails
@@ -208,14 +208,14 @@ func TestLookupRemote(t *testing.T) {
 	}
 }
 
-func mockHasher(value string) func(context.Context, DependencyLister, *latest.Artifact) (string, error) {
-	return func(context.Context, DependencyLister, *latest.Artifact) (string, error) {
+func mockHasher(value string) func(context.Context, DependencyLister, *latest.Artifact, bool) (string, error) {
+	return func(context.Context, DependencyLister, *latest.Artifact, bool) (string, error) {
 		return value, nil
 	}
 }
 
-func failingHasher(errMessage string) func(context.Context, DependencyLister, *latest.Artifact) (string, error) {
-	return func(context.Context, DependencyLister, *latest.Artifact) (string, error) {
+func failingHasher(errMessage string) func(context.Context, DependencyLister, *latest.Artifact, bool) (string, error) {
+	return func(context.Context, DependencyLister, *latest.Artifact, bool) (string, error) {
 		return "", errors.New(errMessage)
 	}
 }

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -89,7 +89,7 @@ func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, artifa
 		return custom.NewArtifactBuilder(b.localDocker, b.insecureRegistries, b.pushImages, b.retrieveExtraEnv()).Build(ctx, out, artifact, tag)
 
 	case artifact.BuildpackArtifact != nil:
-		return buildpacks.NewArtifactBuilder(b.localDocker, b.pushImages).Build(ctx, out, artifact, tag)
+		return buildpacks.NewArtifactBuilder(b.localDocker, b.pushImages, b.devMode).Build(ctx, out, artifact, tag)
 
 	default:
 		return "", fmt.Errorf("undefined artifact type: %+v", artifact.ArtifactType)

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -41,6 +41,7 @@ type Builder struct {
 	prune              bool
 	pruneChildren      bool
 	skipTests          bool
+	devMode            bool
 	kubeContext        string
 	builtImages        []string
 	insecureRegistries map[string]bool
@@ -78,6 +79,7 @@ func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
 		localCluster:       localCluster,
 		pushImages:         pushImages,
 		skipTests:          runCtx.Opts.SkipTests,
+		devMode:            runCtx.DevMode,
 		prune:              runCtx.Opts.Prune(),
 		pruneChildren:      !runCtx.Opts.NoPruneChildren,
 		insecureRegistries: runCtx.InsecureRegistries,

--- a/pkg/skaffold/docker/image_util.go
+++ b/pkg/skaffold/docker/image_util.go
@@ -65,3 +65,15 @@ func RetrieveWorkingDir(tagged string, insecureRegistries map[string]bool) (stri
 		return cf.Config.WorkingDir, nil
 	}
 }
+
+func RetrieveLabels(tagged string, insecureRegistries map[string]bool) (map[string]string, error) {
+	cf, err := RetrieveConfigFile(tagged, insecureRegistries)
+	switch {
+	case err != nil:
+		return nil, err
+	case cf == nil:
+		return nil, nil
+	default:
+		return cf.Config.Labels, nil
+	}
+}

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -37,6 +37,7 @@ type RunContext struct {
 	WorkingDir         string
 	Namespaces         []string
 	InsecureRegistries map[string]bool
+	DevMode            bool
 }
 
 func GetRunContext(opts config.SkaffoldOptions, cfg latest.Pipeline) (*RunContext, error) {
@@ -70,6 +71,9 @@ func GetRunContext(opts config.SkaffoldOptions, cfg latest.Pipeline) (*RunContex
 		insecureRegistries[r] = true
 	}
 
+	// TODO(dgageot): what about debug?
+	devMode := opts.Command == "dev"
+
 	return &RunContext{
 		Opts:               opts,
 		Cfg:                cfg,
@@ -77,6 +81,7 @@ func GetRunContext(opts config.SkaffoldOptions, cfg latest.Pipeline) (*RunContex
 		KubeContext:        kubeContext,
 		Namespaces:         namespaces,
 		InsecureRegistries: insecureRegistries,
+		DevMode:            devMode,
 	}, nil
 }
 

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -32,6 +32,7 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
@@ -42,42 +43,63 @@ import (
 // For testing
 var (
 	WorkingDir = docker.RetrieveWorkingDir
+	Labels     = docker.RetrieveLabels
 	SyncMap    = syncMapForArtifact
 )
 
 func NewItem(a *latest.Artifact, e filemon.Events, builds []build.Artifact, insecureRegistries map[string]bool) (*Item, error) {
-	switch {
-	case !e.HasChanged():
+	if !e.HasChanged() || a.Sync == nil {
 		return nil, nil
+	}
 
-	case a.Sync != nil && len(a.Sync.Manual) > 0:
-		return manualSyncItem(a, e, builds, insecureRegistries)
+	tag := latestTag(a.ImageName, builds)
+	if tag == "" {
+		return nil, fmt.Errorf("could not find latest tag for image %s in builds: %v", a.ImageName, builds)
+	}
 
-	case a.Sync != nil && len(a.Sync.Infer) > 0:
-		return inferredSyncItem(a, e, builds, insecureRegistries)
+	switch {
+	case len(a.Sync.Manual) > 0:
+		return syncItem(a, tag, e, a.Sync.Manual, insecureRegistries)
+
+	case a.BuildpackArtifact != nil && len(a.Sync.Infer) > 0:
+		labels, err := Labels(tag, insecureRegistries)
+		if err != nil {
+			return nil, errors.Wrapf(err, "retrieving labels for %s", tag)
+		}
+
+		rules, err := buildpacks.SyncRules(labels)
+		if err != nil {
+			return nil, errors.Wrapf(err, "extracting sync rules from labels for %s", tag)
+		}
+
+		// filter out modifications based on Sync.Infer patterns
+		e, err = filterEvents(a.Workspace, e, a.Sync.Infer)
+		if err != nil {
+			return nil, err
+		}
+
+		return syncItem(a, tag, e, rules, insecureRegistries)
+
+	case len(a.Sync.Infer) > 0:
+		return inferredSyncItem(a, tag, e, insecureRegistries)
 
 	default:
 		return nil, nil
 	}
 }
 
-func manualSyncItem(a *latest.Artifact, e filemon.Events, builds []build.Artifact, insecureRegistries map[string]bool) (*Item, error) {
-	tag := latestTag(a.ImageName, builds)
-	if tag == "" {
-		return nil, fmt.Errorf("could not find latest tag for image %s in builds: %v", a.ImageName, builds)
-	}
-
+func syncItem(a *latest.Artifact, tag string, e filemon.Events, syncRules []*latest.SyncRule, insecureRegistries map[string]bool) (*Item, error) {
 	containerWd, err := WorkingDir(tag, insecureRegistries)
 	if err != nil {
 		return nil, errors.Wrapf(err, "retrieving working dir for %s", tag)
 	}
 
-	toCopy, err := intersect(a.Workspace, containerWd, a.Sync.Manual, append(e.Added, e.Modified...))
+	toCopy, err := intersect(a.Workspace, containerWd, syncRules, append(e.Added, e.Modified...))
 	if err != nil {
 		return nil, errors.Wrap(err, "intersecting sync map and added, modified files")
 	}
 
-	toDelete, err := intersect(a.Workspace, containerWd, a.Sync.Manual, e.Deleted)
+	toDelete, err := intersect(a.Workspace, containerWd, syncRules, e.Deleted)
 	if err != nil {
 		return nil, errors.Wrap(err, "intersecting sync map and deleted files")
 	}
@@ -90,15 +112,10 @@ func manualSyncItem(a *latest.Artifact, e filemon.Events, builds []build.Artifac
 	return &Item{Image: tag, Copy: toCopy, Delete: toDelete}, nil
 }
 
-func inferredSyncItem(a *latest.Artifact, e filemon.Events, builds []build.Artifact, insecureRegistries map[string]bool) (*Item, error) {
+func inferredSyncItem(a *latest.Artifact, tag string, e filemon.Events, insecureRegistries map[string]bool) (*Item, error) {
 	// deleted files are no longer contained in the syncMap, so we need to rebuild
 	if len(e.Deleted) > 0 {
 		return nil, nil
-	}
-
-	tag := latestTag(a.ImageName, builds)
-	if tag == "" {
-		return nil, fmt.Errorf("could not find latest tag for image %s in builds: %v", a.ImageName, builds)
 	}
 
 	syncMap, err := SyncMap(a, insecureRegistries)
@@ -182,6 +199,53 @@ func intersect(contextWd, containerWd string, syncRules []*latest.SyncRule, file
 		ret[f] = dsts
 	}
 	return ret, nil
+}
+
+// filterEvents only considers changes that match the given patterns
+func filterEvents(contextWd string, e filemon.Events, patterns []string) (filemon.Events, error) {
+	added, err := filter(contextWd, e.Added, patterns)
+	if err != nil {
+		return filemon.Events{}, err
+	}
+	modified, err := filter(contextWd, e.Modified, patterns)
+	if err != nil {
+		return filemon.Events{}, err
+	}
+	deleted, err := filter(contextWd, e.Deleted, patterns)
+	if err != nil {
+		return filemon.Events{}, err
+	}
+
+	return filemon.Events{
+		Added:    added,
+		Modified: modified,
+		Deleted:  deleted,
+	}, nil
+}
+
+func filter(contextWd string, paths []string, patterns []string) ([]string, error) {
+	var filtered []string
+
+	for _, path := range paths {
+		for _, pattern := range patterns {
+			relPath, err := filepath.Rel(contextWd, path)
+			if err != nil {
+				return nil, errors.Wrapf(err, "changed file %s can't be found relative to context %s", path, contextWd)
+			}
+
+			matches, err := doublestar.PathMatch(filepath.FromSlash(pattern), relPath)
+			if err != nil {
+				return nil, err
+			}
+
+			if matches {
+				filtered = append(filtered, path)
+				break
+			}
+		}
+	}
+
+	return filtered, nil
 }
 
 func matchSyncRules(syncRules []*latest.SyncRule, relPath, containerWd string) ([]string, error) {


### PR DESCRIPTION
This adds automatic sync configuration for buildpacks.

Buildpacks can set special metadata on the image to indicate which files need to be synced.

More work is needed on this feature but I'd like this first step to be reviewed and merged.

Signed-off-by: David Gageot <david@gageot.net>
