### PR TITLE
Encode artifact image-name and container WORKDIR in container debug info

### DIFF
--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -32,10 +32,20 @@ describing the debug configurations for the pod's containers (linebreaks for rea
 ```
 
 For example the following annotation indicates that the container named `web` is a Go application
-that is being debugged by a headless Delve session on port `56268`:
+that is being debugged by a headless Delve session on port `56268` (linebreaks for readability):
 ```
-debug.cloud.google.com/config={"web":{"dlv":56268,"runtime":"go"}}
+debug.cloud.google.com/config={
+  "web":{
+    "artifactName":"gcr.io/random/image",
+    "runtime":"go",
+    "ports":{"dlv":56268},
+    "workingDir":"/some/path"}}
 ```
+
+`artifactName` is the corresponding artifact's name in the `skaffold.yaml`.
+`runtime` is the language runtime detected.
+`ports` is a list of debug ports keyed by the language runtime debugging protocol.
+`workingDir` is the working directory (if not an empty string).
 
 Some language runtimes require additional support files to enable debugging.
 For these languages, a special set of [runtime-specific images](https://github.com/GoogleContainerTools/container-debug-support)

--- a/pkg/skaffold/debug/debug.go
+++ b/pkg/skaffold/debug/debug.go
@@ -48,6 +48,18 @@ var (
 	}
 )
 
+// ContainerDebugConfiguration captures debugging information for a specific container
+type ContainerDebugConfiguration struct {
+	// ArtifactImage is the image reference used in the skaffold.yaml
+	ArtifactImage string `json:"artifactImage,omitempty"`
+	// Runtime represents the underlying language runtime (`go`, `jvm`, `nodejs`, `python`)
+	Runtime string `json:"runtime,omitempty"`
+	// WorkingDir is the working directory in the image configuration; may be empty
+	WorkingDir string `json:"workingDir,omitempty"`
+	// Ports is the list of debugging ports, keyed by protocol type
+	Ports map[string]uint32 `json:"ports,omitempty"`
+}
+
 // ApplyDebuggingTransforms applies language-platform-specific transforms to a list of manifests.
 func ApplyDebuggingTransforms(l kubectl.ManifestList, builds []build.Artifact, insecureRegistries map[string]bool) (kubectl.ManifestList, error) {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -115,10 +127,12 @@ func retrieveImageConfiguration(ctx context.Context, artifact *build.Artifact, i
 	config := manifest.Config
 	logrus.Debugf("Retrieved local image configuration for %v: %v", artifact.Tag, config)
 	return imageConfiguration{
+		name:       artifact.ImageName,
 		env:        envAsMap(config.Env),
 		entrypoint: config.Entrypoint,
 		arguments:  config.Cmd,
 		labels:     config.Labels,
+		workingDir: config.WorkingDir,
 	}, nil
 }
 

--- a/pkg/skaffold/debug/debug_test.go
+++ b/pkg/skaffold/debug/debug_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package debug
 
 import (
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -114,14 +115,14 @@ func (t testTransformer) RuntimeSupportImage() string {
 	return ""
 }
 
-func (t testTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) map[string]interface{} {
+func (t testTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) *ContainerDebugConfiguration {
 	port := portAlloc(9999)
 	container.Ports = append(container.Ports, v1.ContainerPort{Name: "test", ContainerPort: port})
 
 	testEnv := v1.EnvVar{Name: "KEY", Value: "value"}
 	container.Env = append(container.Env, testEnv)
 
-	return map[string]interface{}{"key": "value"}
+	return &ContainerDebugConfiguration{Runtime: "test"}
 }
 
 func TestApplyDebuggingTransforms(t *testing.T) {
@@ -149,7 +150,7 @@ spec:
 kind: Pod
 metadata:
   annotations:
-    debug.cloud.google.com/config: '{"example":{"key":"value"}}'
+    debug.cloud.google.com/config: '{"example":{"runtime":"test"}}'
   creationTimestamp: null
   name: pod
 spec:
@@ -200,7 +201,7 @@ spec:
   template:
     metadata:
       annotations:
-        debug.cloud.google.com/config: '{"example":{"key":"value"}}'
+        debug.cloud.google.com/config: '{"example":{"runtime":"test"}}'
       creationTimestamp: null
       labels:
         app: debug-app
@@ -252,7 +253,7 @@ spec:
   template:
     metadata:
       annotations:
-        debug.cloud.google.com/config: '{"example":{"key":"value"}}'
+        debug.cloud.google.com/config: '{"example":{"runtime":"test"}}'
       creationTimestamp: null
       labels:
         app: debug-app
@@ -307,7 +308,7 @@ spec:
   template:
     metadata:
       annotations:
-        debug.cloud.google.com/config: '{"example":{"key":"value"}}'
+        debug.cloud.google.com/config: '{"example":{"runtime":"test"}}'
       creationTimestamp: null
       labels:
         app: debug-app
@@ -359,7 +360,7 @@ spec:
   template:
     metadata:
       annotations:
-        debug.cloud.google.com/config: '{"example":{"key":"value"}}'
+        debug.cloud.google.com/config: '{"example":{"runtime":"test"}}'
       creationTimestamp: null
       labels:
         app: debug-app
@@ -414,7 +415,7 @@ spec:
   template:
     metadata:
       annotations:
-        debug.cloud.google.com/config: '{"example":{"key":"value"}}'
+        debug.cloud.google.com/config: '{"example":{"runtime":"test"}}'
       creationTimestamp: null
       labels:
         app: debug-app
@@ -464,7 +465,7 @@ spec:
   template:
     metadata:
       annotations:
-        debug.cloud.google.com/config: '{"example":{"key":"value"}}'
+        debug.cloud.google.com/config: '{"example":{"runtime":"test"}}'
       creationTimestamp: null
       labels:
         app: debug-app
@@ -517,4 +518,42 @@ spec:
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.out, result.String())
 		})
 	}
+}
+
+func TestWorkingDir(t *testing.T) {
+	defer func(c []containerTransformer) { containerTransforms = c }(containerTransforms)
+	containerTransforms = append(containerTransforms, testTransformer{})
+
+	pod := &v1.Pod{
+		TypeMeta:   metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.Version, Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{Name: "podname"},
+		Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "name1", Image: "image1"}}}}
+
+	retriever := func(image string) (imageConfiguration, error) {
+		return imageConfiguration{workingDir: "/a/dir"}, nil
+	}
+
+	result := transformManifest(pod, retriever)
+	testutil.CheckDeepEqual(t, true, result)
+	debugConfig := pod.ObjectMeta.Annotations["debug.cloud.google.com/config"]
+	testutil.CheckDeepEqual(t, true, strings.Contains(debugConfig, `"workingDir":"/a/dir"`))
+}
+
+func TestArtifactImage(t *testing.T) {
+	defer func(c []containerTransformer) { containerTransforms = c }(containerTransforms)
+	containerTransforms = append(containerTransforms, testTransformer{})
+
+	pod := &v1.Pod{
+		TypeMeta:   metav1.TypeMeta{APIVersion: v1.SchemeGroupVersion.Version, Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{Name: "podname"},
+		Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "name1", Image: "image1"}}}}
+
+	retriever := func(image string) (imageConfiguration, error) {
+		return imageConfiguration{name: "gcr.io/random/image"}, nil
+	}
+
+	result := transformManifest(pod, retriever)
+	testutil.CheckDeepEqual(t, true, result)
+	debugConfig := pod.ObjectMeta.Annotations["debug.cloud.google.com/config"]
+	testutil.CheckDeepEqual(t, true, strings.Contains(debugConfig, `"artifactImage":"gcr.io/random/image"`))
 }

--- a/pkg/skaffold/debug/transform_go.go
+++ b/pkg/skaffold/debug/transform_go.go
@@ -79,7 +79,7 @@ func (t dlvTransformer) RuntimeSupportImage() string {
 
 // Apply configures a container definition for Go with Delve.
 // Returns a simple map describing the debug configuration details.
-func (t dlvTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) map[string]interface{} {
+func (t dlvTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) *ContainerDebugConfiguration {
 	logrus.Infof("Configuring %q for Go/Delve debugging", container.Name)
 
 	// try to find existing `dlv` command
@@ -103,9 +103,9 @@ func (t dlvTransformer) Apply(container *v1.Container, config imageConfiguration
 
 	container.Ports = exposePort(container.Ports, "dlv", int32(spec.port))
 
-	return map[string]interface{}{
-		"runtime": "go",
-		"dlv":     spec.port,
+	return &ContainerDebugConfiguration{
+		Runtime: "go",
+		Ports:   map[string]uint32{"dlv": uint32(spec.port)},
 	}
 }
 

--- a/pkg/skaffold/debug/transform_go_test.go
+++ b/pkg/skaffold/debug/transform_go_test.go
@@ -235,7 +235,7 @@ func TestTransformManifestDelve(t *testing.T) {
 			true,
 			&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+					Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"go","ports":{"dlv":56268}}}`},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
@@ -278,7 +278,7 @@ func TestTransformManifestDelve(t *testing.T) {
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"go","ports":{"dlv":56268}}}`},
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
@@ -321,7 +321,7 @@ func TestTransformManifestDelve(t *testing.T) {
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"go","ports":{"dlv":56268}}}`},
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
@@ -364,7 +364,7 @@ func TestTransformManifestDelve(t *testing.T) {
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"go","ports":{"dlv":56268}}}`},
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
@@ -405,7 +405,7 @@ func TestTransformManifestDelve(t *testing.T) {
 				Spec: appsv1.DaemonSetSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"go","ports":{"dlv":56268}}}`},
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
@@ -446,7 +446,7 @@ func TestTransformManifestDelve(t *testing.T) {
 				Spec: batchv1.JobSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"go","ports":{"dlv":56268}}}`},
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
@@ -489,7 +489,7 @@ func TestTransformManifestDelve(t *testing.T) {
 					Replicas: int32p(1),
 					Template: &v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"go","ports":{"dlv":56268}}}`},
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
@@ -542,7 +542,7 @@ func TestTransformManifestDelve(t *testing.T) {
 						}},
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dlv":56268,"runtime":"go"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"go","ports":{"dlv":56268}}}`},
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{

--- a/pkg/skaffold/debug/transform_jvm.go
+++ b/pkg/skaffold/debug/transform_jvm.go
@@ -70,7 +70,7 @@ func (t jdwpTransformer) RuntimeSupportImage() string {
 
 // Apply configures a container definition for JVM debugging.
 // Returns a simple map describing the debug configuration details.
-func (t jdwpTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) map[string]interface{} {
+func (t jdwpTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) *ContainerDebugConfiguration {
 	logrus.Infof("Configuring %q for JVM debugging", container.Name)
 	// try to find existing JAVA_TOOL_OPTIONS or jdwp command argument
 	spec := retrieveJdwpSpec(config)
@@ -89,9 +89,9 @@ func (t jdwpTransformer) Apply(container *v1.Container, config imageConfiguratio
 
 	container.Ports = exposePort(container.Ports, "jdwp", port)
 
-	return map[string]interface{}{
-		"runtime": "jvm",
-		"jdwp":    port,
+	return &ContainerDebugConfiguration{
+		Runtime: "jvm",
+		Ports:   map[string]uint32{"jdwp": uint32(port)},
 	}
 }
 

--- a/pkg/skaffold/debug/transform_jvm_test.go
+++ b/pkg/skaffold/debug/transform_jvm_test.go
@@ -241,7 +241,7 @@ func TestTransformManifestJVM(t *testing.T) {
 			true,
 			&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"jdwp":5005,"runtime":"jvm"}}`},
+					Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"jvm","ports":{"jdwp":5005}}}`},
 				},
 				Spec: v1.PodSpec{Containers: []v1.Container{
 					{
@@ -273,7 +273,7 @@ func TestTransformManifestJVM(t *testing.T) {
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"jdwp":5005,"runtime":"jvm"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"jvm","ports":{"jdwp":5005}}}`},
 						},
 						Spec: v1.PodSpec{Containers: []v1.Container{
 							{
@@ -305,7 +305,7 @@ func TestTransformManifestJVM(t *testing.T) {
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"jdwp":5005,"runtime":"jvm"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"jvm","ports":{"jdwp":5005}}}`},
 						},
 						Spec: v1.PodSpec{Containers: []v1.Container{
 							{
@@ -337,7 +337,7 @@ func TestTransformManifestJVM(t *testing.T) {
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"jdwp":5005,"runtime":"jvm"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"jvm","ports":{"jdwp":5005}}}`},
 						},
 						Spec: v1.PodSpec{Containers: []v1.Container{
 							{
@@ -367,7 +367,7 @@ func TestTransformManifestJVM(t *testing.T) {
 				Spec: appsv1.DaemonSetSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"jdwp":5005,"runtime":"jvm"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"jvm","ports":{"jdwp":5005}}}`},
 						},
 						Spec: v1.PodSpec{Containers: []v1.Container{
 							{
@@ -397,7 +397,7 @@ func TestTransformManifestJVM(t *testing.T) {
 				Spec: batchv1.JobSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"jdwp":5005,"runtime":"jvm"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"jvm","ports":{"jdwp":5005}}}`},
 						},
 						Spec: v1.PodSpec{Containers: []v1.Container{
 							{
@@ -429,7 +429,7 @@ func TestTransformManifestJVM(t *testing.T) {
 					Replicas: int32p(1),
 					Template: &v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"jdwp":5005,"runtime":"jvm"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"jvm","ports":{"jdwp":5005}}}`},
 						},
 						Spec: v1.PodSpec{Containers: []v1.Container{
 							{
@@ -471,7 +471,7 @@ func TestTransformManifestJVM(t *testing.T) {
 						}}},
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"jdwp":5005,"runtime":"jvm"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"jvm","ports":{"jdwp":5005}}}`},
 						},
 						Spec: v1.PodSpec{Containers: []v1.Container{
 							{

--- a/pkg/skaffold/debug/transform_nodejs.go
+++ b/pkg/skaffold/debug/transform_nodejs.go
@@ -74,7 +74,7 @@ func (t nodeTransformer) RuntimeSupportImage() string {
 
 // Apply configures a container definition for NodeJS Chrome V8 Inspector.
 // Returns a simple map describing the debug configuration details.
-func (t nodeTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) map[string]interface{} {
+func (t nodeTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) *ContainerDebugConfiguration {
 	logrus.Infof("Configuring %q for node.js debugging", container.Name)
 
 	// try to find existing `--inspect` command
@@ -103,9 +103,9 @@ func (t nodeTransformer) Apply(container *v1.Container, config imageConfiguratio
 
 	container.Ports = exposePort(container.Ports, "devtools", spec.port)
 
-	return map[string]interface{}{
-		"runtime":  "nodejs",
-		"devtools": spec.port,
+	return &ContainerDebugConfiguration{
+		Runtime: "nodejs",
+		Ports:   map[string]uint32{"devtools": uint32(spec.port)},
 	}
 }
 

--- a/pkg/skaffold/debug/transform_nodejs_test.go
+++ b/pkg/skaffold/debug/transform_nodejs_test.go
@@ -298,7 +298,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 			true,
 			&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"devtools":9229,"runtime":"nodejs"}}`},
+					Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"nodejs","ports":{"devtools":9229}}}`},
 				},
 				Spec: v1.PodSpec{Containers: []v1.Container{
 					{
@@ -329,7 +329,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"devtools":9229,"runtime":"nodejs"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"nodejs","ports":{"devtools":9229}}}`},
 						},
 						Spec: v1.PodSpec{Containers: []v1.Container{
 							{
@@ -360,7 +360,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"devtools":9229,"runtime":"nodejs"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"nodejs","ports":{"devtools":9229}}}`},
 						},
 						Spec: v1.PodSpec{Containers: []v1.Container{
 							{
@@ -391,7 +391,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"devtools":9229,"runtime":"nodejs"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"nodejs","ports":{"devtools":9229}}}`},
 						},
 						Spec: v1.PodSpec{Containers: []v1.Container{
 							{
@@ -420,7 +420,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 				Spec: appsv1.DaemonSetSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"devtools":9229,"runtime":"nodejs"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"nodejs","ports":{"devtools":9229}}}`},
 						},
 						Spec: v1.PodSpec{Containers: []v1.Container{
 							{
@@ -449,7 +449,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 				Spec: batchv1.JobSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"devtools":9229,"runtime":"nodejs"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"nodejs","ports":{"devtools":9229}}}`},
 						},
 						Spec: v1.PodSpec{Containers: []v1.Container{
 							{
@@ -480,7 +480,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 					Replicas: int32p(1),
 					Template: &v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"devtools":9229,"runtime":"nodejs"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"nodejs","ports":{"devtools":9229}}}`},
 						},
 						Spec: v1.PodSpec{Containers: []v1.Container{
 							{
@@ -521,7 +521,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 						}}},
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"devtools":9229,"runtime":"nodejs"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"nodejs","ports":{"devtools":9229}}}`},
 						},
 						Spec: v1.PodSpec{Containers: []v1.Container{
 							{

--- a/pkg/skaffold/debug/transform_python.go
+++ b/pkg/skaffold/debug/transform_python.go
@@ -69,7 +69,7 @@ func (t pythonTransformer) RuntimeSupportImage() string {
 
 // Apply configures a container definition for Python with pydev/ptvsd
 // Returns a simple map describing the debug configuration details.
-func (t pythonTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) map[string]interface{} {
+func (t pythonTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) *ContainerDebugConfiguration {
 	logrus.Infof("Configuring %q for python debugging", container.Name)
 
 	// try to find existing `-mptvsd` command
@@ -98,9 +98,9 @@ func (t pythonTransformer) Apply(container *v1.Container, config imageConfigurat
 	container.Env = setEnvVar(container.Env, "PYTHONUSERBASE", pyUserBase)
 	container.Ports = exposePort(container.Ports, "dap", spec.port)
 
-	return map[string]interface{}{
-		"runtime": "python",
-		"dap":     spec.port,
+	return &ContainerDebugConfiguration{
+		Runtime: "python",
+		Ports:   map[string]uint32{"dap": uint32(spec.port)},
 	}
 }
 

--- a/pkg/skaffold/debug/transform_python_test.go
+++ b/pkg/skaffold/debug/transform_python_test.go
@@ -241,7 +241,7 @@ func TestTransformManifestPython(t *testing.T) {
 			true,
 			&v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dap":5678,"runtime":"python"}}`},
+					Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"python","ports":{"dap":5678}}}`},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
@@ -283,7 +283,7 @@ func TestTransformManifestPython(t *testing.T) {
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dap":5678,"runtime":"python"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"python","ports":{"dap":5678}}}`},
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
@@ -325,7 +325,7 @@ func TestTransformManifestPython(t *testing.T) {
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dap":5678,"runtime":"python"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"python","ports":{"dap":5678}}}`},
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
@@ -367,7 +367,7 @@ func TestTransformManifestPython(t *testing.T) {
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dap":5678,"runtime":"python"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"python","ports":{"dap":5678}}}`},
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
@@ -407,7 +407,7 @@ func TestTransformManifestPython(t *testing.T) {
 				Spec: appsv1.DaemonSetSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dap":5678,"runtime":"python"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"python","ports":{"dap":5678}}}`},
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
@@ -447,7 +447,7 @@ func TestTransformManifestPython(t *testing.T) {
 				Spec: batchv1.JobSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dap":5678,"runtime":"python"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"python","ports":{"dap":5678}}}`},
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
@@ -489,7 +489,7 @@ func TestTransformManifestPython(t *testing.T) {
 					Replicas: int32p(1),
 					Template: &v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dap":5678,"runtime":"python"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"python","ports":{"dap":5678}}}`},
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{
@@ -541,7 +541,7 @@ func TestTransformManifestPython(t *testing.T) {
 						}},
 					{
 						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"dap":5678,"runtime":"python"}}`},
+							Annotations: map[string]string{"debug.cloud.google.com/config": `{"test":{"runtime":"python","ports":{"dap":5678}}}`},
 						},
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{{


### PR DESCRIPTION
Relates to #3122 

Should merge before: xxx

**Description**

`debug` annotates podspecs with debugging configuration information about its debuggable containers.  This debug configuration information was being passed around as map, but it was becoming a bit unwieldy. This PR:
  1. Turns this map into an object (`ContainerDebugConfiguration`).
  2. Turns the debugging ports into a proper map, instead of just being inlined to the config map.
  3. Extracts and encodes the corresponding artifact's image-name and the container working directory into this new `ContainerDebugConfiguration`.

One side-effect is that the serialized JSON doesn't sort the same.

The image-name and working-directory is information requested by the IDEs in #3122. 

**User facing changes**

The pod annotation format for the debug configuration information has changed slightly.  The IDEs do not currently use this information.  Otherwise there should be no visible changes.

**Next PRs.**




**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] ~Adds integration tests if needed.~

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

I don't think this change is worth mentioning since there are no known consumers.
