### PR TITLE
Show test output for failed tests, remove -v flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
         - GO111MODULE=on
         - GOFLAGS="-mod=vendor"
       script:
-        - go test -v -short -timeout 60s ./...
+        - go test -short -timeout 60s ./...
       cache:
         directories:
           - C:\\Users\\travis\\AppData\\Local\\go-build

--- a/Makefile
+++ b/Makefile
@@ -104,12 +104,12 @@ cross: $(foreach platform, $(SUPPORTED_PLATFORMS), $(BUILD_DIR)/$(PROJECT)-$(pla
 
 .PHONY: test
 test: $(BUILD_DIR)
-	@ ./hack/gotest.sh -v -count=1 -race -short -timeout=90s ./...
+	@ ./hack/gotest.sh -count=1 -race -short -timeout=90s ./...
 	@ ./hack/checks.sh
 
 .PHONY: coverage
 coverage: $(BUILD_DIR)
-	@ ./hack/gotest.sh -v -count=1 -race -cover -short -timeout=90s -coverprofile=out/coverage.txt -coverpkg="./pkg/...,./cmd/..." ./...
+	@ ./hack/gotest.sh -count=1 -race -cover -short -timeout=90s -coverprofile=out/coverage.txt -coverpkg="./pkg/...,./cmd/..." ./...
 	@- curl -s https://codecov.io/bash > $(BUILD_DIR)/upload_coverage && bash $(BUILD_DIR)/upload_coverage
 
 .PHONY: checks
@@ -118,7 +118,7 @@ checks: $(BUILD_DIR)
 
 .PHONY: quicktest
 quicktest:
-	@ ./hack/gotest.sh -v -short -timeout=60s ./...
+	@ ./hack/gotest.sh -short -timeout=60s ./...
 
 .PHONY: install
 install: $(GO_FILES) $(BUILD_DIR)

--- a/hack/gotest.sh
+++ b/hack/gotest.sh
@@ -21,6 +21,7 @@ set -e
 # - It recaps the failures at the end
 # - It lists the 20 slowest tests
 
+BOLD='\033[1m'
 RED='\033[0;31m'
 YELLOW='\033[0;33m'
 RESET='\033[0m'
@@ -49,7 +50,7 @@ if [ $RESULT != 0 ]; then
     PACKAGE_NAME=${ID[0]}
     TRIMMED_PACKAGE_NAME=${PACKAGE_NAME#"$MODULE"}
     TEST_NAME=${ID[1]}
-    echo -e "$TRIMMED_PACKAGE_NAME/$TEST_NAME"
+    echo -e "${BOLD}$TRIMMED_PACKAGE_NAME/$TEST_NAME${RESET}"
     JQ_FILTER="select(.Action==\"output\" and has(\"Test\") and .Package==\"$PACKAGE_NAME\" and .Test==\"$TEST_NAME\" and has(\"Output\") and (.Output|startswith(\"=== RUN\")|not)) | \"\(.Output|rtrimstr(\"\\n\"))\""
     cat $LOG | jq -r "${JQ_FILTER}"
   done <<< "$FAILED_TESTS"

--- a/hack/gotest.sh
+++ b/hack/gotest.sh
@@ -45,7 +45,7 @@ if [ $RESULT != 0 ]; then
 
   FAILED_TESTS=$(cat $LOG | jq -r 'select(.Action=="fail" and has("Test")) | "\(.Package) \(.Test)"')
   while IFS= read -r line; do
-    ID=( $FAILED_TESTS )
+    ID=( $line )
     PACKAGE_NAME=${ID[0]}
     TRIMMED_PACKAGE_NAME=${PACKAGE_NAME#"$MODULE"}
     TEST_NAME=${ID[1]}

--- a/hack/gotest.sh
+++ b/hack/gotest.sh
@@ -32,7 +32,6 @@ trap "rm -f $LOG" EXIT
 if [[ " ${@} " =~ "-v" ]]; then
     JQ_FILTER='select(has("Output") and (.Action=="output")) | .Output'
 else
-    #POTATO=1
     JQ_FILTER='select(has("Output") and (.Action=="output") and (has("Test")|not) and (.Output!="PASS\n") and (.Output!="FAIL\n") and (.Output|startswith("coverage:")|not) and (.Output|contains("[no test files]")|not)) | .Output'
 fi
 


### PR DESCRIPTION
Looks like I did the wrong thing in #3548 

Remove the `-v` flags and include detailed failed test output instead.

This only applies to macOS/linux builds, windows runs its tests without using the gotest.sh script: https://github.com/GoogleContainerTools/skaffold/blob/master/.travis.yml#L49 (which probably doesn't need the `-v` flag either, I think I misunderstood what the default was as I didn't realize this script did what it did)

The difference in output is:
OLD:
```
=== Failed Tests ===                                                                                                      
pkg/skaffold/build/jib/TestGetSyncMapFromSystem/direct_only
pkg/skaffold/build/jib/TestGetSyncMapFromSystem
```

NEW:
```
=== Failed Tests ===
/pkg/skaffold/build/jib/TestGetSyncMapFromSystem/direct_only
    --- FAIL: TestGetSyncMapFromSystem/direct_only (0.00s)
        sync_test.go:126: *jib.SyncMap differ (-got, +want):   &jib.SyncMap{                     
                "/tmp/skaffold684430519/dep1": {                                                                          
                        Dest:     []string{"/target/dep1"},                                                               
                        FileTime: s"2020-01-23 15:05:53.741546968 -0500 EST",       
            -           IsDirect: true,                                                                                   
            +           IsDirect: false,                                                                                  
                },                                                                                                        
              }    
/pkg/skaffold/build/jib/TestGetSyncMapFromSystem
    --- FAIL: TestGetSyncMapFromSystem (0.00s)
```

example failure in travis:
- MacOS: https://travis-ci.com/GoogleContainerTools/skaffold/jobs/279436130#L337
- Linux: https://travis-ci.com/GoogleContainerTools/skaffold/jobs/279436129#L324