### PR TITLE
Use json.Encoder for skaffold init

### DIFF
--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -128,7 +128,7 @@ func TestDoInitAnalyze(t *testing.T) {
 			expectedOut: strip(`{
 							"dockerfiles":["leeroy-app/Dockerfile","leeroy-web/Dockerfile"],
 							"images":["gcr.io/k8s-skaffold/leeroy-app","gcr.io/k8s-skaffold/leeroy-web"]
-							}`),
+							}`) + "\n",
 		},
 		{
 			name: "analyze microservices new format",
@@ -144,7 +144,7 @@ func TestDoInitAnalyze(t *testing.T) {
 									],
 									"images":[
 										{"name":"gcr.io/k8s-skaffold/leeroy-app","foundMatch":false},
-										{"name":"gcr.io/k8s-skaffold/leeroy-web","foundMatch":false}]}`),
+										{"name":"gcr.io/k8s-skaffold/leeroy-web","foundMatch":false}]}`) + "\n",
 		},
 	}
 

--- a/pkg/skaffold/initializer/json.go
+++ b/pkg/skaffold/initializer/json.go
@@ -47,7 +47,7 @@ func printAnalyzeJSONNoJib(out io.Writer, skipBuild bool, pairs []builderImagePa
 		}
 	}
 
-	return printJSON(out, a)
+	return json.NewEncoder(out).Encode(a)
 }
 
 // printAnalyzeJSON takes the automatically resolved builder/image pairs, the unresolved images, and the unresolved builders, and generates
@@ -105,15 +105,5 @@ func printAnalyzeJSON(out io.Writer, skipBuild bool, pairs []builderImagePair, u
 		a.Images = append(a.Images, Image{Name: image, FoundMatch: false})
 	}
 
-	return printJSON(out, a)
-}
-
-func printJSON(out io.Writer, v interface{}) error {
-	contents, err := json.Marshal(v)
-	if err != nil {
-		return errors.Wrap(err, "marshalling contents")
-	}
-
-	_, err = out.Write(contents)
-	return err
+	return json.NewEncoder(out).Encode(a)
 }

--- a/pkg/skaffold/initializer/json_test.go
+++ b/pkg/skaffold/initializer/json_test.go
@@ -40,19 +40,19 @@ func TestPrintAnalyzeJSON(t *testing.T) {
 			pairs:       []builderImagePair{{jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), Image: "image1", File: "build.gradle", Project: "project"}, "image1"}},
 			builders:    []InitBuilder{docker.ArtifactConfig{File: "Dockerfile"}},
 			images:      []string{"image2"},
-			expected:    `{"builders":[{"name":"Jib Gradle Plugin","payload":{"image":"image1","path":"build.gradle","project":"project"}},{"name":"Docker","payload":{"path":"Dockerfile"}}],"images":[{"name":"image1","foundMatch":true},{"name":"image2","foundMatch":false}]}`,
+			expected:    `{"builders":[{"name":"Jib Gradle Plugin","payload":{"image":"image1","path":"build.gradle","project":"project"}},{"name":"Docker","payload":{"path":"Dockerfile"}}],"images":[{"name":"image1","foundMatch":true},{"name":"image2","foundMatch":false}]}` + "\n",
 		},
 		{
 			description: "builders and images with no pairs",
 			builders:    []InitBuilder{jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), File: "build.gradle", Project: "project"}, docker.ArtifactConfig{File: "Dockerfile"}},
 			images:      []string{"image1", "image2"},
-			expected:    `{"builders":[{"name":"Jib Gradle Plugin","payload":{"path":"build.gradle","project":"project"}},{"name":"Docker","payload":{"path":"Dockerfile"}}],"images":[{"name":"image1","foundMatch":false},{"name":"image2","foundMatch":false}]}`,
+			expected:    `{"builders":[{"name":"Jib Gradle Plugin","payload":{"path":"build.gradle","project":"project"}},{"name":"Docker","payload":{"path":"Dockerfile"}}],"images":[{"name":"image1","foundMatch":false},{"name":"image2","foundMatch":false}]}` + "\n",
 		},
 		{
 			description: "no dockerfile, skip build",
 			images:      []string{"image1", "image2"},
 			skipBuild:   true,
-			expected:    `{"images":[{"name":"image1","foundMatch":false},{"name":"image2","foundMatch":false}]}`,
+			expected:    `{"images":[{"name":"image1","foundMatch":false},{"name":"image2","foundMatch":false}]}` + "\n",
 		},
 		{
 			description: "no dockerfile",
@@ -89,13 +89,13 @@ func TestPrintAnalyzeJSONNoJib(t *testing.T) {
 			description: "builders and images (backwards compatibility)",
 			builders:    []InitBuilder{docker.ArtifactConfig{File: "Dockerfile1"}, docker.ArtifactConfig{File: "Dockerfile2"}},
 			images:      []string{"image1", "image2"},
-			expected:    `{"dockerfiles":["Dockerfile1","Dockerfile2"],"images":["image1","image2"]}`,
+			expected:    `{"dockerfiles":["Dockerfile1","Dockerfile2"],"images":["image1","image2"]}` + "\n",
 		},
 		{
 			description: "no dockerfile, skip build (backwards compatibility)",
 			images:      []string{"image1", "image2"},
 			skipBuild:   true,
-			expected:    `{"images":["image1","image2"]}`,
+			expected:    `{"images":["image1","image2"]}` + "\n",
 		},
 		{
 			description: "no dockerfile",


### PR DESCRIPTION
**Description**

This adds a newline to the end of the output (and is less code). Lack
of newline is somewhat frustrating when using this on the CLI, since it
messes up the prompt.


**User facing changes**



**Before**

jonjohnson $ skaffold init --analyze
{...}jonjohnson $

**After**

jonjohnson $ skaffold init --analyze
{...}
jonjohnson $

**Next PRs.**

n/a


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.
