### PR TITLE
restoring microservices/skaffold.yaml

### DIFF
--- a/examples/microservices/skaffold.yaml
+++ b/examples/microservices/skaffold.yaml
@@ -1,0 +1,18 @@
+apiVersion: skaffold/v2alpha2
+kind: Config
+build:
+  artifacts:
+    - image: leeroy-web
+      context: ./leeroy-web/
+    - image: leeroy-app
+      context: ./leeroy-app/
+deploy:
+  kubectl:
+    manifests:
+      - ./leeroy-web/kubernetes/*
+      - ./leeroy-app/kubernetes/*
+portForward:
+  - resourceType: deployment
+    resourceName: leeroy-web
+    port: 8080
+    localPort: 9000

--- a/hack/check-samples.sh
+++ b/hack/check-samples.sh
@@ -31,6 +31,20 @@ if [ ! -z "$EXAMPLES_MINUS_INTEGRATION_EXAMPLES" ]; then
   exit 1
 fi
 
+MISSING_SKAFFOLD_YAMLs="false"
+# to whitelist an example from having a skaffold.yaml, add a `grep -v "example_name"` here
+cat $EXAMPLES | grep -v "compose" | while read e; do
+  NUM_SKAFFOLD_YAML=$(find "examples/$e" -type f -name skaffold.yaml | wc -l)
+  if [[ NUM_SKAFFOLD_YAML -eq 0 ]]; then
+    echo "examples/$e doesn't have a skaffold.yaml!"
+    MISSING_SKAFFOLD_YAMLs="true"
+  fi
+done
+
+if [[ "$MISSING_SKAFFOLD_YAMLs" == "true" ]]; then
+  exit 1
+fi
+
 # /examples should use the latest released version
 LATEST_RELEASED="skaffold/$(go run ./hack/versions/cmd/latest_released/version.go)"
 


### PR DESCRIPTION
I accidentally deleted the examples/microservices/skaffold.yaml in one of the previous PRs.
This PR restores it and adds a test in check-samples.sh to test for existence of skaffold.yaml in all our examples, except the whitelisted ones (e.g. compose). 