### PR TITLE
Enable multiple kustomizations in the kustomize deployer

### DIFF
--- a/docs/content/en/docs/pipeline-stages/deployers.md
+++ b/docs/content/en/docs/pipeline-stages/deployers.md
@@ -122,6 +122,8 @@ The `kustomize` type offers the following options:
 
 {{< schema root="KustomizeDeploy" >}}
 
+Each entry in `paths` should point to a folder with a kustomization file.
+
 `flags` section offers the following options:
 
 {{< schema root="KubectlFlags" >}}

--- a/docs/content/en/samples/deployers/kustomize.yaml
+++ b/docs/content/en/samples/deployers/kustomize.yaml
@@ -3,4 +3,4 @@ deploy:
 # The deploy section above is equal to
 # deploy:
 #   kustomize:
-#     path: "."
+#     paths: ["."]

--- a/docs/content/en/schemas/v2alpha3.json
+++ b/docs/content/en/schemas/v2alpha3.json
@@ -1559,15 +1559,18 @@
           "description": "additional flags passed to `kubectl`.",
           "x-intellij-html-description": "additional flags passed to <code>kubectl</code>."
         },
-        "path": {
-          "type": "string",
+        "paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
           "description": "path to Kustomization files.",
           "x-intellij-html-description": "path to Kustomization files.",
           "default": "."
         }
       },
       "preferredOrder": [
-        "path",
+        "paths",
         "flags",
         "buildArgs"
       ],

--- a/integration/testdata/deploy-multiple/skaffold.yaml
+++ b/integration/testdata/deploy-multiple/skaffold.yaml
@@ -6,7 +6,8 @@ build:
       context: ./kubectl
 deploy:
   kustomize:
-    path: ./kustomize
+    paths:
+    - ./kustomize
 
   kubectl:
     manifests:

--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -49,7 +49,7 @@ func (s stringSet) insert(strings ...string) {
 
 // toList returns the sorted list of inserted strings.
 func (s stringSet) toList() []string {
-	res := make([]string, 0, len(s))
+	var res []string
 	for item := range s {
 		res = append(res, item)
 	}

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -174,16 +173,15 @@ func (k *KustomizeDeployer) Cleanup(ctx context.Context, out io.Writer) error {
 
 // Dependencies lists all the files that can change what needs to be deployed.
 func (k *KustomizeDeployer) Dependencies() ([]string, error) {
-	var deps []string
+	deps := newStringSet()
 	for _, kustomizePath := range k.KustomizePaths {
 		depsForKustomization, err := dependenciesForKustomization(kustomizePath)
 		if err != nil {
 			return nil, err
 		}
-		deps = append(deps, depsForKustomization...)
+		deps.insert(depsForKustomization...)
 	}
-	sort.Strings(deps)
-	return deps, nil
+	return deps.toList(), nil
 }
 
 func (k *KustomizeDeployer) Render(ctx context.Context, out io.Writer, builds []build.Artifact, filepath string) error {

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -173,7 +174,16 @@ func (k *KustomizeDeployer) Cleanup(ctx context.Context, out io.Writer) error {
 
 // Dependencies lists all the files that can change what needs to be deployed.
 func (k *KustomizeDeployer) Dependencies() ([]string, error) {
-	return dependenciesForKustomization(k.KustomizePath)
+	var deps []string
+	for _, kustomizePath := range k.KustomizePaths {
+		depsForKustomization, err := dependenciesForKustomization(kustomizePath)
+		if err != nil {
+			return nil, err
+		}
+		deps = append(deps, depsForKustomization...)
+	}
+	sort.Strings(deps)
+	return deps, nil
 }
 
 func (k *KustomizeDeployer) Render(ctx context.Context, out io.Writer, builds []build.Artifact, filepath string) error {
@@ -280,18 +290,19 @@ func pathExistsLocally(filename string, workingDir string) (bool, os.FileMode) {
 }
 
 func (k *KustomizeDeployer) readManifests(ctx context.Context) (deploy.ManifestList, error) {
-	cmd := exec.CommandContext(ctx, "kustomize", buildCommandArgs(k.BuildArgs, k.KustomizePath)...)
-	out, err := util.RunCmdOut(cmd)
-	if err != nil {
-		return nil, errors.Wrap(err, "kustomize build")
-	}
-
-	if len(out) == 0 {
-		return nil, nil
-	}
-
 	var manifests deploy.ManifestList
-	manifests.Append(out)
+	for _, kustomizePath := range k.KustomizePaths {
+		cmd := exec.CommandContext(ctx, "kustomize", buildCommandArgs(k.BuildArgs, kustomizePath)...)
+		out, err := util.RunCmdOut(cmd)
+		if err != nil {
+			return nil, errors.Wrap(err, "kustomize build")
+		}
+
+		if len(out) == 0 {
+			continue
+		}
+		manifests.Append(out)
+	}
 	return manifests, nil
 }
 

--- a/pkg/skaffold/deploy/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize_test.go
@@ -44,7 +44,7 @@ func TestKustomizeDeploy(t *testing.T) {
 		{
 			description: "no manifest",
 			cfg: &latest.KustomizeDeploy{
-				KustomizePath: ".",
+				KustomizePaths: []string{"."},
 			},
 			commands: testutil.
 				CmdRunOut("kubectl version --client -ojson", kubectlVersion).
@@ -53,7 +53,7 @@ func TestKustomizeDeploy(t *testing.T) {
 		{
 			description: "deploy success",
 			cfg: &latest.KustomizeDeploy{
-				KustomizePath: ".",
+				KustomizePaths: []string{"."},
 			},
 			commands: testutil.
 				CmdRunOut("kubectl version --client -ojson", kubectlVersion).
@@ -107,7 +107,7 @@ func TestKustomizeCleanup(t *testing.T) {
 		{
 			description: "cleanup success",
 			cfg: &latest.KustomizeDeploy{
-				KustomizePath: tmpDir.Root(),
+				KustomizePaths: []string{tmpDir.Root()},
 			},
 			commands: testutil.
 				CmdRunOut("kustomize build "+tmpDir.Root(), deploymentWebYAML).
@@ -116,7 +116,7 @@ func TestKustomizeCleanup(t *testing.T) {
 		{
 			description: "cleanup error",
 			cfg: &latest.KustomizeDeploy{
-				KustomizePath: tmpDir.Root(),
+				KustomizePaths: []string{tmpDir.Root()},
 			},
 			commands: testutil.
 				CmdRunOut("kustomize build "+tmpDir.Root(), deploymentWebYAML).
@@ -126,7 +126,7 @@ func TestKustomizeCleanup(t *testing.T) {
 		{
 			description: "fail to read manifests",
 			cfg: &latest.KustomizeDeploy{
-				KustomizePath: tmpDir.Root(),
+				KustomizePaths: []string{tmpDir.Root()},
 			},
 			commands: testutil.CmdRunOutErr(
 				"kustomize build "+tmpDir.Root(),
@@ -317,7 +317,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 					Deploy: latest.DeployConfig{
 						DeployType: latest.DeployType{
 							KustomizeDeploy: &latest.KustomizeDeploy{
-								KustomizePath: tmpDir.Root(),
+								KustomizePaths: []string{tmpDir.Root()},
 							},
 						},
 					},
@@ -339,49 +339,49 @@ func TestKustomizeBuildCommandArgs(t *testing.T) {
 		expectedArgs  []string
 	}{
 		{
-			description:   "no BuildArgs, empty KustomizePath ",
+			description:   "no BuildArgs, empty KustomizePaths ",
 			buildArgs:     []string{},
 			kustomizePath: "",
 			expectedArgs:  []string{"build"},
 		},
 		{
-			description:   "One BuildArg, empty KustomizePath",
+			description:   "One BuildArg, empty KustomizePaths",
 			buildArgs:     []string{"--foo"},
 			kustomizePath: "",
 			expectedArgs:  []string{"build", "--foo"},
 		},
 		{
-			description:   "no BuildArgs, non-empty KustomizePath",
+			description:   "no BuildArgs, non-empty KustomizePaths",
 			buildArgs:     []string{},
 			kustomizePath: "foo",
 			expectedArgs:  []string{"build", "foo"},
 		},
 		{
-			description:   "One BuildArg, non-empty KustomizePath",
+			description:   "One BuildArg, non-empty KustomizePaths",
 			buildArgs:     []string{"--foo"},
 			kustomizePath: "bar",
 			expectedArgs:  []string{"build", "--foo", "bar"},
 		},
 		{
-			description:   "Multiple BuildArg, empty KustomizePath",
+			description:   "Multiple BuildArg, empty KustomizePaths",
 			buildArgs:     []string{"--foo", "--bar"},
 			kustomizePath: "",
 			expectedArgs:  []string{"build", "--foo", "--bar"},
 		},
 		{
-			description:   "Multiple BuildArg with spaces, empty KustomizePath",
+			description:   "Multiple BuildArg with spaces, empty KustomizePaths",
 			buildArgs:     []string{"--foo bar", "--baz"},
 			kustomizePath: "",
 			expectedArgs:  []string{"build", "--foo", "bar", "--baz"},
 		},
 		{
-			description:   "Multiple BuildArg with spaces, non-empty KustomizePath",
+			description:   "Multiple BuildArg with spaces, non-empty KustomizePaths",
 			buildArgs:     []string{"--foo bar", "--baz"},
 			kustomizePath: "barfoo",
 			expectedArgs:  []string{"build", "--foo", "bar", "--baz", "barfoo"},
 		},
 		{
-			description:   "Multiple BuildArg no spaces, non-empty KustomizePath",
+			description:   "Multiple BuildArg no spaces, non-empty KustomizePaths",
 			buildArgs:     []string{"--foo", "bar", "--baz"},
 			kustomizePath: "barfoo",
 			expectedArgs:  []string{"build", "--foo", "bar", "--baz", "barfoo"},
@@ -450,7 +450,7 @@ spec:
 					Deploy: latest.DeployConfig{
 						DeployType: latest.DeployType{
 							KustomizeDeploy: &latest.KustomizeDeploy{
-								KustomizePath: ".",
+								KustomizePaths: []string{"."},
 							},
 						},
 					},

--- a/pkg/skaffold/deploy/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize_test.go
@@ -174,7 +174,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 		{
 			description: "resources",
 			yaml:        `resources: [pod1.yaml, path/pod2.yaml]`,
-			expected:    []string{"kustomization.yaml", "pod1.yaml", "path/pod2.yaml"},
+			expected:    []string{"kustomization.yaml", "path/pod2.yaml", "pod1.yaml"},
 			createFiles: map[string]string{
 				"pod1.yaml":      "",
 				"path/pod2.yaml": "",
@@ -193,7 +193,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 		{
 			description: "crds",
 			yaml:        `patches: [crd1.yaml, path/crd2.yaml]`,
-			expected:    []string{"kustomization.yaml", "crd1.yaml", "path/crd2.yaml"},
+			expected:    []string{"crd1.yaml", "kustomization.yaml", "path/crd2.yaml"},
 		},
 		{
 			description: "patches json 6902",
@@ -207,7 +207,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 			yaml: `configMapGenerator:
 - files: [app1.properties]
 - files: [app2.properties, app3.properties]`,
-			expected: []string{"kustomization.yaml", "app1.properties", "app2.properties", "app3.properties"},
+			expected: []string{"app1.properties", "app2.properties", "app3.properties", "kustomization.yaml"},
 		},
 		{
 			description: "secretGenerator",
@@ -219,7 +219,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 		{
 			description: "base exists locally",
 			yaml:        `bases: [base]`,
-			expected:    []string{"kustomization.yaml", "base/kustomization.yaml", "base/app.yaml"},
+			expected:    []string{"base/app.yaml", "base/kustomization.yaml", "kustomization.yaml"},
 			createFiles: map[string]string{
 				"base/kustomization.yaml": `resources: [app.yaml]`,
 				"base/app.yaml":           "",
@@ -233,7 +233,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 		{
 			description: "local kustomization resource",
 			yaml:        `resources: [app.yaml, base]`,
-			expected:    []string{"kustomization.yaml", "app.yaml", "base/kustomization.yaml", "base/app.yaml"},
+			expected:    []string{"app.yaml", "base/app.yaml", "base/kustomization.yaml", "kustomization.yaml"},
 			createFiles: map[string]string{
 				"app.yaml":                "",
 				"base/kustomization.yaml": `resources: [app.yaml]`,
@@ -243,7 +243,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 		{
 			description: "missing local kustomization resource",
 			yaml:        `resources: [app.yaml, missing-or-remote-base]`,
-			expected:    []string{"kustomization.yaml", "app.yaml"},
+			expected:    []string{"app.yaml", "kustomization.yaml"},
 			createFiles: map[string]string{
 				"app.yaml": "",
 			},
@@ -251,7 +251,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 		{
 			description: "mixed resource types",
 			yaml:        `resources: [app.yaml, missing-or-remote-base, base]`,
-			expected:    []string{"kustomization.yaml", "app.yaml", "base/kustomization.yaml", "base/app.yaml"},
+			expected:    []string{"app.yaml", "base/app.yaml", "base/kustomization.yaml", "kustomization.yaml"},
 			createFiles: map[string]string{
 				"app.yaml":                "",
 				"base/kustomization.yaml": `resources: [app.yaml]`,
@@ -261,7 +261,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 		{
 			description: "alt config name: kustomization.yml",
 			yaml:        `resources: [app.yaml]`,
-			expected:    []string{"kustomization.yml", "app.yaml"},
+			expected:    []string{"app.yaml", "kustomization.yml"},
 			createFiles: map[string]string{
 				"app.yaml": "",
 			},
@@ -279,7 +279,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 		{
 			description: "mixture of config names",
 			yaml:        `resources: [app.yaml, base1, base2]`,
-			expected:    []string{"Kustomization", "app.yaml", "base1/kustomization.yml", "base1/app.yaml", "base2/kustomization.yaml", "base2/app.yaml"},
+			expected:    []string{"Kustomization", "app.yaml", "base1/app.yaml", "base1/kustomization.yml", "base2/app.yaml", "base2/kustomization.yaml"},
 			createFiles: map[string]string{
 				"app.yaml":                 "",
 				"base1/kustomization.yml":  `resources: [app.yaml]`,

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -170,7 +170,7 @@ func TestDoInitAnalyze(t *testing.T) {
 				},
 			},
 
-			expectedOut: strip(`{"dockerfiles":["Dockerfile"]}`),
+			expectedOut: strip(`{"dockerfiles":["Dockerfile"]}`) + "\n",
 		},
 	}
 

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -172,8 +172,9 @@ func setDefaultKustomizePath(c *latest.SkaffoldConfig) {
 	if kustomize == nil {
 		return
 	}
-
-	kustomize.KustomizePath = valueOrDefault(kustomize.KustomizePath, constants.DefaultKustomizationPath)
+	if len(kustomize.KustomizePaths) == 0 {
+		kustomize.KustomizePaths = []string{constants.DefaultKustomizationPath}
+	}
 }
 
 func setDefaultKubectlManifests(c *latest.SkaffoldConfig) {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -440,9 +440,9 @@ type HelmDeployFlags struct {
 
 // KustomizeDeploy *beta* uses the `kustomize` CLI to "patch" a deployment for a target environment.
 type KustomizeDeploy struct {
-	// KustomizePath is the path to Kustomization files.
+	// KustomizePaths is the path to Kustomization files.
 	// Defaults to `.`.
-	KustomizePath string `yaml:"path,omitempty"`
+	KustomizePaths []string `yaml:"paths,omitempty"`
 
 	// Flags are additional flags passed to `kubectl`.
 	Flags KubectlFlags `yaml:"flags,omitempty"`

--- a/pkg/skaffold/schema/v2alpha2/upgrade.go
+++ b/pkg/skaffold/schema/v2alpha2/upgrade.go
@@ -26,8 +26,8 @@ import (
 // Config changes from v2alpha2 to v2alpha3
 // 1. Additions:
 // 2. Removals:
-//    kaniko.buildContext
-// 3. No updates
+// 3. Updates:
+//    - kustomize deployer supports multiple paths
 func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
 	var newConfig next.SkaffoldConfig
 
@@ -40,7 +40,15 @@ func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
 	return &newConfig, nil
 }
 
-// Placeholder for upgrade logic
-func upgradeOnePipeline(_, _ interface{}) error {
+func upgradeOnePipeline(oldPipeline, newPipeline interface{}) error {
+	oldDeploy := &oldPipeline.(*Pipeline).Deploy
+	newDeploy := &newPipeline.(*next.Pipeline).Deploy
+
+	if oldKustomize := oldDeploy.KustomizeDeploy; oldKustomize != nil {
+		if path := oldKustomize.KustomizePath; path != "" {
+			newDeploy.KustomizeDeploy.KustomizePaths = []string{path}
+		}
+	}
+
 	return nil
 }

--- a/pkg/skaffold/schema/v2alpha2/upgrade_test.go
+++ b/pkg/skaffold/schema/v2alpha2/upgrade_test.go
@@ -53,6 +53,8 @@ deploy:
   kubectl:
     manifests:
     - k8s-*
+  kustomize:
+    path: kustomization-main
 profiles:
   - name: test profile
     build:
@@ -71,6 +73,8 @@ profiles:
       kubectl:
         manifests:
         - k8s-*
+      kustomize:
+        path: kustomization-test
   - name: test local
     build:
       artifacts:
@@ -83,6 +87,7 @@ profiles:
       kubectl:
         manifests:
         - k8s-*
+      kustomize: {}
 `
 	expected := `apiVersion: skaffold/v2alpha3
 kind: Config
@@ -111,6 +116,9 @@ deploy:
   kubectl:
     manifests:
     - k8s-*
+  kustomize:
+    paths:
+    - kustomization-main
 profiles:
   - name: test profile
     build:
@@ -129,6 +137,9 @@ profiles:
       kubectl:
         manifests:
         - k8s-*
+      kustomize:
+        paths:
+        - kustomization-test
   - name: test local
     build:
       artifacts:
@@ -141,6 +152,7 @@ profiles:
       kubectl:
         manifests:
         - k8s-*
+      kustomize: {}
 `
 	verifyUpgrade(t, yaml, expected)
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #1872.

**Description**

So far, the kustomize deployer only accepted a single path to a kustomization folder. This required an umbrella kustomization when working with multiple kustomization folders. On the other hand, for helm it has always been possible to deploy multiple charts, so that the UX between the differnent deployers was kind of inconsistent as pointed out in #1872.
Therefore, this PR enables multiple kustomization folders/paths in a single deployer stanza.

**User facing changes**

The  (`string`) key changed to `deploy.kustomize.paths` (`[]string`). When not specified, it defaults to `[]string{"."}` and behaves equivalently to the previous config version.

**Before**

The pipeline had a key `deploy.kustomize.path` of type `string` to specify a _single_ kustomization folder. When empty it defaults to `"."`.

**After**

The pipeline has a key `deploy.kustomize.paths` of type `[]string` to specify a _multiple_ kustomization folders. When empty (`nil` or length zero) it defaults to `[]string{"."}`.


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

```
Examples of user facing changes:
- The Kustomize deployer now handles multiple kustomization root paths.
```
