### PR TITLE
Skaffold run support new parameter '--render-output' with '--render-only

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -234,6 +234,15 @@ var FlagRegistry = []Flag{
 		DefinedOn:     []string{"dev", "run"},
 	},
 	{
+		Name:          "output",
+		Shorthand:     "o",
+		Usage:         "Writes '--render-only' output to the specified file",
+		Value:         &opts.Output,
+		DefValue:      '',
+		FlagAddMethod: "StringVar",
+		DefinedOn:     []string{"dev", "run"},
+	},
+	{
 		Name:          "config",
 		Shorthand:     "c",
 		Usage:         "File for global configurations (defaults to $HOME/.skaffold/config)",

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -234,10 +234,9 @@ var FlagRegistry = []Flag{
 		DefinedOn:     []string{"dev", "run"},
 	},
 	{
-		Name:          "output",
-		Shorthand:     "o",
+		Name:          "render-output",
 		Usage:         "Writes '--render-only' output to the specified file",
-		Value:         &opts.Output,
+		Value:         &opts.RenderOutput,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",
 		DefinedOn:     []string{"dev", "run"},

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -239,7 +239,7 @@ var FlagRegistry = []Flag{
 		Value:         &opts.RenderOutput,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",
-		DefinedOn:     []string{"dev", "run"},
+		DefinedOn:     []string{"run"},
 	},
 	{
 		Name:          "config",

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -238,7 +238,7 @@ var FlagRegistry = []Flag{
 		Shorthand:     "o",
 		Usage:         "Writes '--render-only' output to the specified file",
 		Value:         &opts.Output,
-		DefValue:      '',
+		DefValue:      "",
 		FlagAddMethod: "StringVar",
 		DefinedOn:     []string{"dev", "run"},
 	},

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -524,6 +524,7 @@ Options:
   -n, --namespace='': Run deployments in the specified namespace
       --no-prune=false: Skip removing images and containers built by Skaffold
       --no-prune-children=false: Skip removing layers reused by Skaffold
+  -o, --output='': Writes '--render-only' output to the specified file
       --port-forward=false: Port-forward exposed container ports within pods
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
@@ -563,6 +564,7 @@ Env vars:
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)
 * `SKAFFOLD_NO_PRUNE` (same as `--no-prune`)
 * `SKAFFOLD_NO_PRUNE_CHILDREN` (same as `--no-prune-children`)
+* `SKAFFOLD_OUTPUT` (same as `--output`)
 * `SKAFFOLD_PORT_FORWARD` (same as `--port-forward`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
@@ -770,6 +772,7 @@ Options:
   -n, --namespace='': Run deployments in the specified namespace
       --no-prune=false: Skip removing images and containers built by Skaffold
       --no-prune-children=false: Skip removing layers reused by Skaffold
+  -o, --output='': Writes '--render-only' output to the specified file
       --port-forward=false: Port-forward exposed container ports within pods
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
@@ -806,6 +809,7 @@ Env vars:
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)
 * `SKAFFOLD_NO_PRUNE` (same as `--no-prune`)
 * `SKAFFOLD_NO_PRUNE_CHILDREN` (same as `--no-prune-children`)
+* `SKAFFOLD_OUTPUT` (same as `--output`)
 * `SKAFFOLD_PORT_FORWARD` (same as `--port-forward`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -524,7 +524,6 @@ Options:
   -n, --namespace='': Run deployments in the specified namespace
       --no-prune=false: Skip removing images and containers built by Skaffold
       --no-prune-children=false: Skip removing layers reused by Skaffold
-  -o, --output='': Writes '--render-only' output to the specified file
       --port-forward=false: Port-forward exposed container ports within pods
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
@@ -564,7 +563,6 @@ Env vars:
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)
 * `SKAFFOLD_NO_PRUNE` (same as `--no-prune`)
 * `SKAFFOLD_NO_PRUNE_CHILDREN` (same as `--no-prune-children`)
-* `SKAFFOLD_OUTPUT` (same as `--output`)
 * `SKAFFOLD_PORT_FORWARD` (same as `--port-forward`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
@@ -772,11 +770,11 @@ Options:
   -n, --namespace='': Run deployments in the specified namespace
       --no-prune=false: Skip removing images and containers built by Skaffold
       --no-prune-children=false: Skip removing layers reused by Skaffold
-  -o, --output='': Writes '--render-only' output to the specified file
       --port-forward=false: Port-forward exposed container ports within pods
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --render-only=false: Print rendered Kubernetes manifests instead of deploying them
+      --render-output='': Writes '--render-only' output to the specified file
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
@@ -809,11 +807,11 @@ Env vars:
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)
 * `SKAFFOLD_NO_PRUNE` (same as `--no-prune`)
 * `SKAFFOLD_NO_PRUNE_CHILDREN` (same as `--no-prune-children`)
-* `SKAFFOLD_OUTPUT` (same as `--output`)
 * `SKAFFOLD_PORT_FORWARD` (same as `--port-forward`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
 * `SKAFFOLD_RENDER_ONLY` (same as `--render-only`)
+* `SKAFFOLD_RENDER_OUTPUT` (same as `--render-output`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -37,6 +37,72 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
+func TestKubectlRenderOutput(t *testing.T) {
+	if testing.Short() || RunOnGCP() {
+		t.Skip("skipping kind integration test")
+	}
+
+	test := struct {
+		description string
+		builds      []build.Artifact
+		labels      []deploy.Labeller
+		renderPath  string
+		input       string
+		expectedOut string
+	}{
+		description: "it persist rendered manifest to provided filepath",
+		builds: []build.Artifact{
+			{
+				ImageName: "gcr.io/k8s-skaffold/skaffold",
+				Tag:       "gcr.io/k8s-skaffold/skaffold:test",
+			},
+		},
+		labels:     []deploy.Labeller{},
+		renderPath: "./test-output",
+		input: `apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/skaffold
+    name: skaffold
+`,
+		expectedOut: `apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/skaffold:test
+    name: skaffold
+`}
+
+	testutil.Run(t, test.description, func(t *testutil.T) {
+		t.NewTempDir().
+			Write("deployment.yaml", test.input).
+			Chdir()
+		deployer := deploy.NewKubectlDeployer(&runcontext.RunContext{
+			WorkingDir: ".",
+			Cfg: latest.Pipeline{
+				Deploy: latest.DeployConfig{
+					DeployType: latest.DeployType{
+						KubectlDeploy: &latest.KubectlDeploy{
+							Manifests: []string{"deployment.yaml"},
+						},
+					},
+				},
+			},
+		})
+		var b bytes.Buffer
+		err := deployer.Render(context.Background(), &b, test.builds, test.labels, false, test.renderPath)
+
+		t.CheckNoError(err)
+		dat, err := ioutil.ReadFile(test.renderPath)
+		t.CheckNoError(err)
+
+		t.CheckDeepEqual(test.expectedOut, string(dat))
+	})
+}
+
 func TestKubectlRender(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -50,7 +50,7 @@ func TestKubectlRenderOutput(t *testing.T) {
 		input       string
 		expectedOut string
 	}{
-		description: "it persist rendered manifest to provided filepath",
+		description: "write rendered manifest to provided filepath",
 		builds: []build.Artifact{
 			{
 				ImageName: "gcr.io/k8s-skaffold/skaffold",

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -162,10 +162,7 @@ func TestRunRenderOnly(t *testing.T) {
 		dat, err := ioutil.ReadFile(renderPath)
 		tu.CheckNoError(err)
 
-		exp, err := ioutil.ReadFile(test.dir + "/k8s-pod.yaml")
-		tu.CheckNoError(err)
-
-		tu.CheckDeepEqual(string(exp), string(dat))
+		tu.CheckMatches("name: getting-started", string(dat))
 	})
 }
 

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -141,7 +141,7 @@ func TestRunRenderOnly(t *testing.T) {
 		t.Skip("skipping kind integration test")
 	}
 
-	testutil.Run(t, "it persist rendered manifest to provided filepath", func(tu *testutil.T) {
+	testutil.Run(t, "write rendered manifest to provided filepath", func(tu *testutil.T) {
 		tmpDir := tu.NewTempDir()
 		renderPath := tmpDir.Path("output.yaml")
 

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -48,6 +48,7 @@ type SkaffoldOptions struct {
 	AutoSync              bool
 	AutoDeploy            bool
 	RenderOnly            bool
+	Output                string
 	ProfileAutoActivation bool
 	DryRun                bool
 

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -48,7 +48,7 @@ type SkaffoldOptions struct {
 	AutoSync              bool
 	AutoDeploy            bool
 	RenderOnly            bool
-	Output                string
+	RenderOutput          string
 	ProfileAutoActivation bool
 	DryRun                bool
 

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -34,7 +34,7 @@ import (
 
 func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []build.Artifact) error {
 	if r.runCtx.Opts.RenderOnly {
-		return r.Render(ctx, out, artifacts, false, r.runCtx.Opts.Output)
+		return r.Render(ctx, out, artifacts, false, r.runCtx.Opts.RenderOutput)
 	}
 
 	color.Default.Fprintln(out, "Tags used in deployment:")

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -34,7 +34,7 @@ import (
 
 func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []build.Artifact) error {
 	if r.runCtx.Opts.RenderOnly {
-		return r.Render(ctx, out, artifacts, false, "")
+		return r.Render(ctx, out, artifacts, false, r.runCtx.Opts.Output)
 	}
 
 	color.Default.Fprintln(out, "Tags used in deployment:")

--- a/pkg/skaffold/runner/deploy_test.go
+++ b/pkg/skaffold/runner/deploy_test.go
@@ -28,7 +28,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -132,4 +134,27 @@ func TestDeployNamespace(t *testing.T) {
 			t.CheckDeepEqual(test.expected, runner.runCtx.Namespaces)
 		})
 	}
+}
+
+func TestSkaffoldDeployRenderOnly(t *testing.T) {
+	testutil.Run(t, "does not make kubectl calls", func(t *testutil.T) {
+		runCtx := &runcontext.RunContext{
+			Opts: config.SkaffoldOptions{
+				Namespace:  "testNamespace",
+				RenderOnly: true,
+			},
+			KubeContext: "does-not-exist",
+		}
+
+		r := SkaffoldRunner{
+			runCtx:     runCtx,
+			kubectlCLI: kubectl.NewFromRunContext(runCtx),
+			deployer:   getDeployer(runCtx),
+		}
+		var builds []build.Artifact
+
+		err := r.Deploy(context.Background(), ioutil.Discard, builds)
+
+		t.CheckNoError(err)
+	})
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to https://github.com/GoogleContainerTools/skaffold/issues/3582


Should merge before : n/a

Should merge after : n/a

**Description**
Added new parameter for skaffold dev and run. --output, currently it works only with --render-only. If --render-only and --output specified the output of --render-only will be written into the filepath given to --output
**User facing changes**
skaffold run got a new parameter
**Before**

n/a

**After**

n/a

**Next PRs.**

n/a

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

<!-- 
Describe any user facing changes here so maintainer can include it in the release notes, or delete this block.
-->

```
Adds a new flag `--render-output` to write rendered output to a file.
```
