### PR TITLE
Kaniko docs

### DIFF
--- a/docs/content/en/docs/pipeline-stages/builders/docker.md
+++ b/docs/content/en/docs/pipeline-stages/builders/docker.md
@@ -67,8 +67,7 @@ These credentials are configured in the `cluster` section with the following opt
 
 {{< schema root="ClusterDetails" >}}
 
-To set up the credentials for Kaniko refer to the [kaniko docs](https://github.com/GoogleContainerTools/kaniko#kubernetes-secret).
-The recommended way is to store the pull secret in Kubernetes and configure `pullSecretName`.
+To set up the credentials for Kaniko refer to the [kaniko docs](https://github.com/GoogleContainerTools/kaniko#kubernetes-secret)(**Note**: Rename the downloaded JSON key to *kaniko-secret* without appending *.json*).
 Alternatively, the path to a credentials file can be set with the `pullSecret` option:
 ```yaml
 build:

--- a/docs/content/en/docs/pipeline-stages/builders/docker.md
+++ b/docs/content/en/docs/pipeline-stages/builders/docker.md
@@ -67,7 +67,7 @@ These credentials are configured in the `cluster` section with the following opt
 
 {{< schema root="ClusterDetails" >}}
 
-To set up the credentials for Kaniko refer to the [kaniko docs](https://github.com/GoogleContainerTools/kaniko#kubernetes-secret)(**Note**: Rename the downloaded JSON key to *kaniko-secret* without appending *.json*).
+To set up the credentials for Kaniko refer to the [kaniko docs](https://github.com/GoogleContainerTools/kaniko#kubernetes-secret) (**Note**: Rename the downloaded JSON key to *kaniko-secret* without appending *.json*).
 Alternatively, the path to a credentials file can be set with the `pullSecret` option:
 ```yaml
 build:


### PR DESCRIPTION
Added note to not append *.json* to file name when creating secret for docker images build in kaniko.
Closes #3590 .