### PR TITLE
Include unrecognized builder in error

### DIFF
--- a/pkg/skaffold/initializer/builders.go
+++ b/pkg/skaffold/initializer/builders.go
@@ -195,7 +195,7 @@ func processCliArtifacts(artifacts []string) ([]builderImagePair, error) {
 			pairs = append(pairs, pair)
 
 		default:
-			return nil, errors.New("unknown builder type in CLI artifacts")
+			return nil, fmt.Errorf("unknown builder type in CLI artifacts: %q", a.Name)
 		}
 	}
 	return pairs, nil


### PR DESCRIPTION
**Description**

Improve the `skaffold init --artifact` error mesage for unrecognized builders.

**User facing changes**

Different error message.

**Before**

```
$ skaffold init --artifact '{"builder": "404"}'
FATA[0001] processing cli artifacts: unknown builder type in CLI artifacts 
```

**After**

```
$ skaffold init --artifact '{"builder": "404"}'
FATA[0001] processing cli artifacts: unknown builder type in CLI artifacts: "404" 
```


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.
