### PR TITLE
Try use the Google hosted mirror of Maven Central

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,7 @@ integration-in-kind: skaffold-builder
 		-v $(HOME)/.gradle:/root/.gradle \
 		-v $(HOME)/.cache:/root/.cache \
 		-v /tmp/docker-config:/root/.docker/config.json \
+		-v $(CURDIR)/hack/maven/settings.xml:/root/.m2/settings.xml \
 		-e KUBECONFIG=/tmp/kind-config \
 		gcr.io/$(GCP_PROJECT)/skaffold-builder \
 		sh -c ' \
@@ -198,6 +199,7 @@ integration-in-docker: skaffold-builder
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v $(HOME)/.config/gcloud:/root/.config/gcloud \
 		-v $(GOOGLE_APPLICATION_CREDENTIALS):$(GOOGLE_APPLICATION_CREDENTIALS) \
+		-v $(CURDIR)/hack/maven/settings.xml:/root/.m2/settings.xml \
 		-e GCP_ONLY=$(GCP_ONLY) \
 		-e GCP_PROJECT=$(GCP_PROJECT) \
 		-e GKE_CLUSTER_NAME=$(GKE_CLUSTER_NAME) \

--- a/hack/maven/settings.xml
+++ b/hack/maven/settings.xml
@@ -1,0 +1,10 @@
+<settings>
+  <mirrors>
+    <mirror>
+      <id>google-maven-central</id>
+      <name>GCS Maven Central mirror</name>
+      <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>


### PR DESCRIPTION
We often have issues with Maven Central on our integration tests. It often returns 403 errors.

Signed-off-by: David Gageot <david@gageot.net>
