### PR TITLE
Better detection of terminals.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 	github.com/gophercloud/gophercloud v0.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.12.1
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
+	github.com/heroku/color v0.0.6
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
 	github.com/imdario/mergo v0.3.8
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect

--- a/pkg/skaffold/build/buildpacks/lifecycle.go
+++ b/pkg/skaffold/build/buildpacks/lifecycle.go
@@ -89,9 +89,13 @@ func runPackBuild(ctx context.Context, out io.Writer, localDocker docker.LocalDa
 		io.Writer
 	}
 
-	// If out is not a terminal, let's make sure pack doesn't output with colors
+	// If out is not a terminal, let's make sure pack doesn't output with colors.
 	if _, isTerm := util.IsTerminal(out); !isTerm {
+		// pack uses heroku/color under the hood.
 		color.Disable(true)
+
+		// pack is not good at detecting when something is not a terminal.
+		// https://github.com/buildpacks/pack/issues/477
 		out = &notATerminal{Writer: out}
 	}
 

--- a/pkg/skaffold/color/formatter.go
+++ b/pkg/skaffold/color/formatter.go
@@ -19,10 +19,9 @@ package color
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // IsTerminal will check if the specified output stream is a terminal. This can be changed
@@ -103,12 +102,8 @@ func isTerminal(w io.Writer) bool {
 		return true
 	}
 
-	switch v := w.(type) {
-	case *os.File:
-		return terminal.IsTerminal(int(v.Fd()))
-	default:
-		return false
-	}
+	_, isTerm := util.IsTerminal(w)
+	return isTerm
 }
 
 func ForceColors() func() {

--- a/pkg/skaffold/color/formatter.go
+++ b/pkg/skaffold/color/formatter.go
@@ -95,8 +95,6 @@ func OverwriteDefault(color Color) {
 	Default = color
 }
 
-// This implementation comes from logrus (https://github.com/sirupsen/logrus/blob/master/terminal_check_notappengine.go),
-// unfortunately logrus doesn't expose a public interface we can use to call it.
 func isTerminal(w io.Writer) bool {
 	if _, ok := w.(ColoredWriteCloser); ok {
 		return true

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -219,18 +219,9 @@ func (l *localDaemon) Build(ctx context.Context, out io.Writer, workspace string
 	return imageID, nil
 }
 
-type descriptor interface {
-	Fd() uintptr
-}
-
 // streamDockerMessages streams formatted json output from the docker daemon
 func streamDockerMessages(dst io.Writer, src io.Reader, auxCallback func(jsonmessage.JSONMessage)) error {
-	var termFd uintptr
-	f, isTerm := dst.(descriptor)
-	if isTerm {
-		termFd = f.Fd()
-	}
-
+	termFd, isTerm := util.IsTerminal(dst)
 	return jsonmessage.DisplayJSONMessagesStream(src, dst, termFd, isTerm, auxCallback)
 }
 

--- a/pkg/skaffold/util/term.go
+++ b/pkg/skaffold/util/term.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"io"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func IsTerminal(w io.Writer) (uintptr, bool) {
+	type descriptor interface {
+		Fd() uintptr
+	}
+
+	if f, ok := w.(descriptor); ok {
+		termFd := f.Fd()
+		isTerm := terminal.IsTerminal(int(termFd))
+		return termFd, isTerm
+	}
+
+	return 0, false
+}

--- a/pkg/skaffold/util/term_test.go
+++ b/pkg/skaffold/util/term_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestIsNotTerminal(t *testing.T) {
+	var w bytes.Buffer
+
+	termFd, isTerm := IsTerminal(&w)
+
+	testutil.CheckDeepEqual(t, uintptr(0x00), termFd)
+	testutil.CheckDeepEqual(t, false, isTerm)
+}


### PR DESCRIPTION
Will disable docker progress bars and buildpack’s coloured output in VSCode.

cc @jonjohnsonjr 

Signed-off-by: David Gageot <david@gageot.net>
