### PR TITLE
[WIP] Autogenerate k8s manifests in skaffold init

### DIFF
--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -27,16 +27,17 @@ import (
 )
 
 var (
-	composeFile            string
-	cliArtifacts           []string
-	cliKubernetesManifests []string
-	skipBuild              bool
-	skipDeploy             bool
-	force                  bool
-	analyze                bool
-	enableJibInit          bool
-	enableBuildpacksInit   bool
-	buildpacksBuilder      string
+	composeFile              string
+	cliArtifacts             []string
+	cliKubernetesManifests   []string
+	skipBuild                bool
+	skipDeploy               bool
+	force                    bool
+	analyze                  bool
+	enableJibInit            bool
+	enableBuildpacksInit     bool
+	enableManifestGeneration bool
+	buildpacksBuilder        string
 )
 
 // for testing
@@ -62,22 +63,25 @@ func NewCmdInit() *cobra.Command {
 			f.MarkHidden("XXenableBuildpacksInit")
 			f.StringVar(&buildpacksBuilder, "XXdefaultBuildpacksBuilder", "heroku/buildpacks", "")
 			f.MarkHidden("XXdefaultBuildpacksBuilder")
+			f.BoolVar(&enableManifestGeneration, "XXenableManifestGeneration", false, "")
+			f.MarkHidden("XXenableManifestGeneration")
 		}).
 		NoArgs(cancelWithCtrlC(context.Background(), doInit))
 }
 
 func doInit(ctx context.Context, out io.Writer) error {
 	return initEntrypoint(ctx, out, initializer.Config{
-		ComposeFile:            composeFile,
-		CliArtifacts:           cliArtifacts,
-		CliKubernetesManifests: cliKubernetesManifests,
-		SkipBuild:              skipBuild,
-		SkipDeploy:             skipDeploy,
-		Force:                  force,
-		Analyze:                analyze,
-		EnableJibInit:          enableJibInit,
-		EnableBuildpacksInit:   enableBuildpacksInit,
-		BuildpacksBuilder:      buildpacksBuilder,
-		Opts:                   opts,
+		ComposeFile:              composeFile,
+		CliArtifacts:             cliArtifacts,
+		CliKubernetesManifests:   cliKubernetesManifests,
+		SkipBuild:                skipBuild,
+		SkipDeploy:               skipDeploy,
+		Force:                    force,
+		Analyze:                  analyze,
+		EnableJibInit:            enableJibInit,
+		EnableBuildpacksInit:     enableBuildpacksInit,
+		EnableManifestGeneration: enableManifestGeneration,
+		BuildpacksBuilder:        buildpacksBuilder,
+		Opts:                     opts,
 	})
 }

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -57,9 +57,12 @@ func (m *MockDeployer) Render(_ context.Context, w io.Writer, _ []build.Artifact
 func NewMockDeployer() *MockDeployer                                     { return &MockDeployer{labels: make(map[string]string)} }
 func (m *MockDeployer) WithLabel(labels map[string]string) *MockDeployer { m.labels = labels; return m }
 func (m *MockDeployer) WithDeployErr(err error) *MockDeployer            { m.deployErr = err; return m }
-func (m *MockDeployer) WithDependenciesErr(err error) *MockDeployer      { m.dependenciesErr = err; return m }
-func (m *MockDeployer) WithCleanupErr(err error) *MockDeployer           { m.cleanupErr = err; return m }
-func (m *MockDeployer) WithRenderErr(err error) *MockDeployer            { m.renderErr = err; return m }
+func (m *MockDeployer) WithDependenciesErr(err error) *MockDeployer {
+	m.dependenciesErr = err
+	return m
+}
+func (m *MockDeployer) WithCleanupErr(err error) *MockDeployer { m.cleanupErr = err; return m }
+func (m *MockDeployer) WithRenderErr(err error) *MockDeployer  { m.renderErr = err; return m }
 func (m *MockDeployer) WithDeployNamespaces(namespaces []string) *MockDeployer {
 	m.deployNamespaces = namespaces
 	return m

--- a/pkg/skaffold/initializer/config_test.go
+++ b/pkg/skaffold/initializer/config_test.go
@@ -39,6 +39,14 @@ func (s stubDeploymentInitializer) GetImages() []string {
 	panic("implement me")
 }
 
+func (s stubDeploymentInitializer) AddManifestForImage(string, string) {
+	panic("nope")
+}
+
+func (s stubDeploymentInitializer) Validate() error {
+	return nil
+}
+
 func TestConfigAnalyzer(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -99,6 +99,19 @@ func TestDoInit(t *testing.T) {
 			},
 		},
 		{
+			name: "CLI artifacts but no manifests",
+			dir:  "testdata/init/allcli",
+			config: Config{
+				CliArtifacts: []string{
+					`{"builder":"Docker","payload":{"path":"Dockerfile"},"image":"passed-in-artifact"}`,
+				},
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml.out",
+				},
+			},
+			shouldErr: true,
+		},
+		{
 			name: "error writing config file",
 			dir:  "testdata/init/microservices",
 

--- a/pkg/skaffold/initializer/kubectl_test.go
+++ b/pkg/skaffold/initializer/kubectl_test.go
@@ -38,10 +38,7 @@ spec:
 `)
 	filename := tmpDir.Path("deployment.yaml")
 
-	k, err := newKubectlInitializer([]string{filename})
-	if err != nil {
-		t.Fatal("failed to create a pipeline")
-	}
+	k := newKubectlInitializer([]string{filename})
 
 	expectedConfig := latest.DeployConfig{
 		DeployType: latest.DeployType{

--- a/pkg/skaffold/initializer/prompt.go
+++ b/pkg/skaffold/initializer/prompt.go
@@ -48,13 +48,22 @@ func promptUserForBuildConfig(image string, choices []string) (string, error) {
 	return selectedBuildConfig, nil
 }
 
-func promptWritingConfig(out io.Writer, pipeline []byte, filePath string) (bool, error) {
+func promptWritingConfig(out io.Writer, pipeline []byte, generatedManifests map[string][]byte, filePath string) (bool, error) {
 	fmt.Fprintln(out, string(pipeline))
+
+	for f, m := range generatedManifests {
+		fmt.Fprintln(out, f, "-", string(m))
+	}
+
+	manifestString := ""
+	if len(generatedManifests) > 0 {
+		manifestString = ", along with the generated k8s manifests,"
+	}
 
 	reader := bufio.NewReader(os.Stdin)
 confirmLoop:
 	for {
-		fmt.Fprintf(out, "Do you want to write this configuration to %s? [y/n]: ", filePath)
+		fmt.Fprintf(out, "Do you want to write this configuration%s to %s? [y/n]: ", manifestString, filePath)
 
 		response, err := reader.ReadString('\n')
 		if err != nil {

--- a/pkg/skaffold/kubernetes/generator/generate.go
+++ b/pkg/skaffold/kubernetes/generator/generate.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generator
+
+import (
+	"bytes"
+	"html/template"
+
+	"github.com/pkg/errors"
+)
+
+type Container struct {
+	Name  string
+	Image string
+}
+
+// Generate generates kubernetes resources for the given image, and returns the generated manifest string
+func Generate(name string) ([]byte, error) {
+	c := Container{name, name}
+
+	t, err := template.New("deployment").Parse(yamlTemplate)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error parsing pod template")
+	}
+	var buf bytes.Buffer
+	err = t.Execute(&buf, c)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error executing template")
+	}
+	return buf.Bytes(), nil
+}

--- a/pkg/skaffold/kubernetes/generator/template.go
+++ b/pkg/skaffold/kubernetes/generator/template.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generator
+
+const yamlTemplate = `apiVersion: v1
+kind: Service
+metadata:
+  name: {{.Name}}
+  labels:
+    app: {{.Name}}
+spec:
+  clusterIP: None
+  selector:
+    app: {{.Name}}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{.Name}}
+  labels:
+    app: {{.Name}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{.Name}}
+  template:
+    metadata:
+      labels:
+        app: {{.Name}}
+    spec:
+      containers:
+      - name: {{.Name}}
+        image: {{.Name}}
+`


### PR DESCRIPTION
*NOTE: this feature is hidden behind a feature flag, `--XXenableManifestGeneration`, to allow for further iteration and improvement before exposing publicly.*

this change adds support for autogenerating k8s manifests in `skaffold init` for projects that do not have any. skaffold will generate a k8s yaml for each found image that is not referenced by an existing k8s yaml in the project directory, and each generated yaml file will contain a deployment for the image, and a service exposing the deployment.

in the event that `skaffold init` finds a builder configuration in a project directory, but no k8s yaml referencing this image, we don't actually have any name for the image, so skaffold will generate a name. this name will either be:
1) the name of the encompassing directory, in the event that the builder is found in a nested directory; or,
2) the name of the builder file itself, in the event that only one builder configuration is found

for each image, a yaml file will be generated containing kubernetes resource definitions for a service and a deployment. this file will either be:
1) `<directory_name>/deployment.yaml`, for each builder that is found in a nested directory; or,
2) `<image_name>-deployment.yaml`, if we only have one builder configuration found

so for the `microservices` example, we would generate
```
.
├── leeroy-app
│   ├── app.go
│   ├── deployment.yaml <-- generated
│   └── Dockerfile
├── leeroy-web
│   ├── deployment.yaml <-- generated
│   ├── Dockerfile
│   └── web.go
├── README.md
└── skaffold.yaml <-- (also generated)
```

whereas for the `getting-started` example, we would generate
```
.
├── deployment.yaml <-- generated
├── Dockerfile
├── main.go
├── README.md
└── skaffold.yaml <-- generated
```

### Future Work
* figure out how to handle ports in the generated yaml - this is currently unsupported, so port forwarding will not work
* figure out the right behavior for resolved **and** unresolved builder configurations - if we have a preexisting `image1` being referenced in `k8s.yaml`, but also another builder configuration, should we always generate?
* remove feature flag