### PR TITLE
Disable all colors in Buildpacks’s output when not in a terminal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,6 @@ require (
 	github.com/gophercloud/gophercloud v0.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.12.1
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
-	github.com/heroku/color v0.0.6
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c // indirect
 	github.com/imdario/mergo v0.3.8
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
@@ -71,6 +70,7 @@ require (
 	github.com/krishicks/yaml-patch v0.0.10
 	github.com/markbates/inflect v1.0.4 // indirect
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a // indirect
+	github.com/mattn/go-colorable v0.1.4
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/buildkit v0.6.3
 	github.com/onsi/ginkgo v1.10.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,6 @@ github.com/buildpacks/imgutil v0.0.0-20200127205531-eec2000815b1 h1:1+v3XHezNuXC
 github.com/buildpacks/imgutil v0.0.0-20200127205531-eec2000815b1/go.mod h1:E3lXJcNXcRefJQAHW5rqboonet+jtOml4qImbJhYGAo=
 github.com/buildpacks/lifecycle v0.5.1-0.20191217221752-3b74c943b7b3 h1:15zYyFmNbrtx5MmyVEKVgY2/eearqEqGJXLCjmvUo58=
 github.com/buildpacks/lifecycle v0.5.1-0.20191217221752-3b74c943b7b3/go.mod h1:ZIuIs9B6tjAW4dthhltKVyEUlhRfFWWix9eqoInMGX4=
-github.com/buildpacks/pack v0.8.1-0.20200128153201-c4636375b6a7 h1:fVBzTLxaLqrERBNPQuATKEr+nZskEain+OHtzQ4kb3c=
-github.com/buildpacks/pack v0.8.1-0.20200128153201-c4636375b6a7/go.mod h1:7obZCatYJVAQOmYCinSsKw/lfJhf3lrx4n0Z88uxVj0=
 github.com/buildpacks/pack v0.8.2-0.20200131162247-1a6e03a48c94 h1:QwGqY47lEgvCDSFNSD3EnAa7zny0AFvvCNgEX/qipCc=
 github.com/buildpacks/pack v0.8.2-0.20200131162247-1a6e03a48c94/go.mod h1:hcHY0ZiDxwa6oxMPDE+gng+aJHJjUnnYfAwuonvu/Wc=
 github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=

--- a/pkg/skaffold/build/buildpacks/lifecycle.go
+++ b/pkg/skaffold/build/buildpacks/lifecycle.go
@@ -22,14 +22,12 @@ import (
 	"strings"
 
 	"github.com/buildpacks/pack"
-	"github.com/heroku/color"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // For testing
@@ -85,12 +83,6 @@ func (b *Builder) build(ctx context.Context, out io.Writer, a *latest.Artifact, 
 }
 
 func runPackBuild(ctx context.Context, out io.Writer, localDocker docker.LocalDaemon, opts pack.BuildOptions) error {
-	// If out is not a terminal, let's make sure pack doesn't output with colors.
-	if _, isTerm := util.IsTerminal(out); !isTerm {
-		// pack uses heroku/color under the hood.
-		color.Disable(true)
-	}
-
 	packClient, err := pack.NewClient(
 		pack.WithDockerClient(localDocker.RawClient()),
 		pack.WithLogger(NewLogger(out)),

--- a/pkg/skaffold/build/buildpacks/logger.go
+++ b/pkg/skaffold/build/buildpacks/logger.go
@@ -40,6 +40,8 @@ func NewLogger(out io.Writer) logging.Logger {
 
 	l := logrus.New()
 	l.SetOutput(out)
+
+	// By default, logrus prefixes lines with 'INFO[XXX]'.
 	l.SetFormatter(new(plainFormatter))
 
 	return &logger{

--- a/pkg/skaffold/build/buildpacks/logger.go
+++ b/pkg/skaffold/build/buildpacks/logger.go
@@ -20,7 +20,10 @@ import (
 	"io"
 
 	"github.com/buildpacks/pack/logging"
+	"github.com/mattn/go-colorable"
 	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // logger exists to meet the requirements of the pack logger.
@@ -30,10 +33,25 @@ type logger struct {
 }
 
 func NewLogger(out io.Writer) logging.Logger {
+	// If out is not a terminal, let's make sure no colors are printed.
+	if _, isTerm := util.IsTerminal(out); !isTerm {
+		out = colorable.NewNonColorable(out)
+	}
+
+	l := logrus.New()
+	l.SetOutput(out)
+	l.SetFormatter(new(plainFormatter))
+
 	return &logger{
-		Logger: logrus.StandardLogger(),
+		Logger: l,
 		out:    out,
 	}
+}
+
+type plainFormatter struct{}
+
+func (f *plainFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	return []byte(entry.Message + "\n"), nil
 }
 
 func (l *logger) Debug(msg string) {


### PR DESCRIPTION
 + Make sure the output from pack and from buildpacks goes to stdout
 + Make sure all colors are disabled when not printing to a terminal