### PR TITLE
Support kustomize "extended" patches. #2909

### DIFF
--- a/pkg/skaffold/deploy/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize_test.go
@@ -212,7 +212,24 @@ func TestDependenciesForKustomization(t *testing.T) {
 			},
 		},
 		{
-			description:    "patches",
+			description: "extended patches with paths",
+			kustomizations: map[string]string{"kustomization.yaml": `patches:
+- path: patch1.yaml
+  target:
+    kind: Deployment`},
+			expected: []string{"kustomization.yaml", "patch1.yaml"},
+		},
+		{
+			description: "extended patches with inline",
+			kustomizations: map[string]string{"kustomization.yaml": `patches:
+- patch: |-
+    inline: patch
+  target:
+    kind: Deployment`},
+			expected: []string{"kustomization.yaml"},
+		},
+		{
+			description:    "patches legacy",
 			kustomizations: map[string]string{"kustomization.yaml": `patches: [patch1.yaml, path/patch2.yaml]`},
 			expected:       []string{"kustomization.yaml", "patch1.yaml", "path/patch2.yaml"},
 		},


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to _in case of new feature, this should point to issue/(s) which describes the feature_

Fixes #2909

Should merge before :n/a

Should merge after : n/a

**Description**
 
implement #2909: support extended kustomize patches


**User facing changes**

n/a

**Before**

n/a
**After**
n/a
**Next PRs.**
n/a
-->


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [n/a ] Mentions any output changes.
- [n/a ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ n/a] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

<!-- 
Describe any user facing changes here so maintainer can include it in the release notes, or delete this block.
-->

```
Examples of user facing changes:
- Skaffold config changes like
  e.g. "Add buildArgs to `Kustomize` deployer skaffold config."
- Bug fixes
  e.g. "Improve skaffold init behavior when tags are used in manifests"
- Any changes in skaffold behavior
  e.g. "Artifact caching is turned on by default."

```
