### PR TITLE
Add pkg/diag new package for diagnostics only library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
     - os: linux-diag
       name: "Linux unit for diagnostic"
       script:
-        - make make -f Makefile.diag coverage
+        - make -f Makefile.diag coverage
       cache:
         directories:
           - $HOME/.cache/go-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,3 +59,20 @@ jobs:
         directories:
           - $HOME/.cache/go-build
           - $HOME/.gradle
+    - os: linux-diag
+      name: "Linux unit for diagnostic"
+      script:
+        - make make -f Makefile.diag coverage
+      cache:
+        directories:
+          - $HOME/.cache/go-build
+    - os: osx-diag
+      name: "OSX unit for diagnostic"
+      before_install:
+        - curl -Lo ${HOME}/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5rc2/jq-osx-x86_64
+        - chmod +x ${HOME}/bin/jq
+      script:
+        - make -f Makefile.diag test
+      cache:
+        directories:
+          - $HOME/.cache/go-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,14 +59,14 @@ jobs:
         directories:
           - $HOME/.cache/go-build
           - $HOME/.gradle
-    - os: linux-diag
+    - os: linux
       name: "Linux unit for diagnostic"
       script:
         - make -f Makefile.diag coverage
       cache:
         directories:
           - $HOME/.cache/go-build
-    - os: osx-diag
+    - os: osx
       name: "OSX unit for diagnostic"
       before_install:
         - curl -Lo ${HOME}/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5rc2/jq-osx-x86_64

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,14 +60,14 @@ jobs:
           - $HOME/.cache/go-build
           - $HOME/.gradle
     - os: linux
-      name: "Linux unit for diagnostic"
+      name: "diag/Linux unit"
       script:
         - make -f Makefile.diag coverage
       cache:
         directories:
           - $HOME/.cache/go-build
     - os: osx
-      name: "OSX unit for diagnostic"
+      name: "diag/OSX unit"
       before_install:
         - curl -Lo ${HOME}/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5rc2/jq-osx-x86_64
         - chmod +x ${HOME}/bin/jq

--- a/Makefile.diag
+++ b/Makefile.diag
@@ -1,0 +1,35 @@
+# Copyright 2020 The Skaffold Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+GOOS ?= $(shell go env GOOS)
+GOARCH = amd64
+BUILD_DIR ?= ./out
+ORG := github.com/GoogleContainerTools
+PROJECT := diag
+REPOPATH ?= $(ORG)/skaffold
+VERSION_PACKAGE = $(REPOPATH)/pkg/diag/version
+
+TEST_PACKAGES := $(shell go list ./pkg/diag/...)
+
+# Force using Go Modules and always read the dependencies from
+# the `vendor` folder.
+export GO111MODULE = on
+export GOFLAGS = -mod=vendor
+
+.PHONY: test
+test: $(BUILD_DIR)
+	@ ./hack/gotest.sh -count=1 -race -short -timeout=90s $(TEST_PACKAGES)
+
+.PHONY: coverage
+coverage: $(BUILD_DIR)
+	@ ./hack/gotest.sh -count=1 -race -cover -short -timeout=90s -coverprofile=out/coverage.txt $(TEST_PACKAGES)

--- a/Makefile.diag
+++ b/Makefile.diag
@@ -26,6 +26,9 @@ TEST_PACKAGES := $(shell go list ./pkg/diag/...)
 export GO111MODULE = on
 export GOFLAGS = -mod=vendor
 
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
 .PHONY: test
 test: $(BUILD_DIR)
 	@ ./hack/gotest.sh -count=1 -race -short -timeout=90s $(TEST_PACKAGES)

--- a/hack/gotest.sh
+++ b/hack/gotest.sh
@@ -35,7 +35,12 @@ else
     JQ_FILTER='select(has("Output") and (.Action=="output") and (has("Test")|not) and (.Output!="PASS\n") and (.Output!="FAIL\n") and (.Output|startswith("coverage:")|not) and (.Output|contains("[no test files]")|not)) | .Output'
 fi
 
-echo "go test $@"
+if [ "$#" -le 6 ]; then
+  echo "go test $@"
+else
+  echo "go test ./..."
+fi
+
 go test -json $@ | tee $LOG | jq --unbuffered -j "${JQ_FILTER}" | sed ''/FAIL/s//`printf "${RED}FAIL${RESET}"`/''
 RESULT=${PIPESTATUS[0]}
 

--- a/hack/gotest.sh
+++ b/hack/gotest.sh
@@ -35,10 +35,10 @@ else
     JQ_FILTER='select(has("Output") and (.Action=="output") and (has("Test")|not) and (.Output!="PASS\n") and (.Output!="FAIL\n") and (.Output|startswith("coverage:")|not) and (.Output|contains("[no test files]")|not)) | .Output'
 fi
 
-if [ "$#" -le 6 ]; then
-  echo "go test $@"
+if [[ " ${@}" =~ "pkg/skaffold" ]]; then
+  echo "go test ./pkg/skaffold/..."
 else
-  echo "go test ./..."
+  echo "go test $@"
 fi
 
 go test -json $@ | tee $LOG | jq --unbuffered -j "${JQ_FILTER}" | sed ''/FAIL/s//`printf "${RED}FAIL${RESET}"`/''

--- a/pkg/diag/version/version.go
+++ b/pkg/diag/version/version.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package version
+
+import (
+	"strings"
+
+	"github.com/blang/semver"
+)
+
+// VersionPrefix is the prefix of the git tag for a version
+const VersionPrefix = "v"
+
+// The current version of the minikube
+
+// version is a private field and should be set when compiling with --ldflags="-X github.com/GoogleContainerTools/skaffold/pkg/diag/version.version=vX.Y.Z"
+var version = "v0.0.0-unset"
+
+// gitCommitID is a private field and should be set when compiling with --ldflags="-X github.com/GoogleContainerTool/pkg/diag/version.gitCommitID=<commit-id>"
+var gitCommitID = ""
+
+
+// GetVersion returns the current diag pkg version
+func GetVersion() string {
+	return version
+}
+
+// GetGitCommitID returns the git commit id from which it is being built
+func GetGitCommitID() string {
+	return gitCommitID
+}
+
+
+// GetSemverVersion returns the current semantic version (semver)
+func GetSemverVersion() (semver.Version, error) {
+	return semver.Make(strings.TrimPrefix(GetVersion(), VersionPrefix))
+}

--- a/pkg/diag/version/version.go
+++ b/pkg/diag/version/version.go
@@ -37,11 +37,6 @@ func GetVersion() string {
 	return version
 }
 
-// GetGitCommitID returns the git commit id from which it is being built
-func GetGitCommitID() string {
-	return gitCommitID
-}
-
 // GetSemverVersion returns the current semantic version (semver)
 func GetSemverVersion() (semver.Version, error) {
 	return semver.Make(strings.TrimPrefix(GetVersion(), VersionPrefix))

--- a/pkg/diag/version/version.go
+++ b/pkg/diag/version/version.go
@@ -29,9 +29,6 @@ const VersionPrefix = "v"
 // version is a private field and should be set when compiling with --ldflags="-X github.com/GoogleContainerTools/skaffold/pkg/diag/version.version=vX.Y.Z"
 var version = "v0.0.0-unset"
 
-// gitCommitID is a private field and should be set when compiling with --ldflags="-X github.com/GoogleContainerTool/pkg/diag/version.gitCommitID=<commit-id>"
-var gitCommitID = ""
-
 // GetVersion returns the current diag pkg version
 func GetVersion() string {
 	return version

--- a/pkg/diag/version/version.go
+++ b/pkg/diag/version/version.go
@@ -32,7 +32,6 @@ var version = "v0.0.0-unset"
 // gitCommitID is a private field and should be set when compiling with --ldflags="-X github.com/GoogleContainerTool/pkg/diag/version.gitCommitID=<commit-id>"
 var gitCommitID = ""
 
-
 // GetVersion returns the current diag pkg version
 func GetVersion() string {
 	return version
@@ -42,7 +41,6 @@ func GetVersion() string {
 func GetGitCommitID() string {
 	return gitCommitID
 }
-
 
 // GetSemverVersion returns the current semantic version (semver)
 func GetSemverVersion() (semver.Version, error) {

--- a/pkg/diag/version/version_test.go
+++ b/pkg/diag/version/version_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"github.com/blang/semver"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestGetSemverVersion(t *testing.T) {
+
+	actual, err := GetSemverVersion()
+	expected, _ := semver.Make("0.0.0-unset")
+
+	testutil.CheckErrorAndDeepEqual(t,false, err, expected, actual)
+}

--- a/pkg/diag/version/version_test.go
+++ b/pkg/diag/version/version_test.go
@@ -17,16 +17,16 @@ limitations under the License.
 package version
 
 import (
-	"github.com/blang/semver"
 	"testing"
+
+	"github.com/blang/semver"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestGetSemverVersion(t *testing.T) {
-
 	actual, err := GetSemverVersion()
 	expected, _ := semver.Make("0.0.0-unset")
 
-	testutil.CheckErrorAndDeepEqual(t,false, err, expected, actual)
+	testutil.CheckErrorAndDeepEqual(t, false, err, expected, actual)
 }


### PR DESCRIPTION
This PR, add a new directory `pkg/diag` for new diagnostics library.

Manual Testing notes:

1. `GOFILES` Change in Makefile
Made sure no `*.go` files from `pkg/diag` are included.
```
skaffold (add_diag_pk)find . -type f -name '*.go' -not -path "./vendor/*"  > prev
skaffold (add_diag_pk)find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pkg/diag/*" > no_diag

skaffold (add_diag_pk)diff prev no_diag 
626,629d625
< ./pkg/diag/version/version.go
< ./pkg/diag/version/version_test.go
skaffold (add_diag_pk)
```

2. `SKAFFOLD_TEST_PACKAGES` in Makefile
Made sure no packages from path `pkg/diag` are included.
```
 (add_diag_pk)go list ./... | grep -v diag > new
 (add_diag_pk)go list ./... > prev
(add_diag_pk)diff prev new 
55,56d54
< github.com/GoogleContainerTools/skaffold/pkg/diag/version
skaffold (add_diag_pk)
```

3. Makefile `Makefile.diag`
```
tejaldesai@tejaldesai-macbookpro2 skaffold (add_diag_pk)make -f Makefile.diag test
go test -count=1 -race -short -timeout=90s github.com/GoogleContainerTools/skaffold/pkg/diag/version
ok  	github.com/GoogleContainerTools/skaffold/pkg/diag/version	1.152s

=== Slow Tests ===
tejaldesai@tejaldesai-macbookpro2 skaffold (add_diag_pk)
```

4. Travis file changes 
- Will test it out.