### PR TITLE
[refactor] move shared initializer config to separate package

### DIFF
--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
 )
 
 var (
@@ -70,7 +71,7 @@ func NewCmdInit() *cobra.Command {
 }
 
 func doInit(ctx context.Context, out io.Writer) error {
-	return initEntrypoint(ctx, out, initializer.Config{
+	return initEntrypoint(ctx, out, config.Config{
 		ComposeFile:            composeFile,
 		CliArtifacts:           cliArtifacts,
 		CliKubernetesManifests: cliKubernetesManifests,

--- a/cmd/skaffold/app/cmd/init_test.go
+++ b/cmd/skaffold/app/cmd/init_test.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -30,7 +30,7 @@ func TestFlagsToConfigVersion(t *testing.T) {
 	tests := []struct {
 		name           string
 		args           []string
-		expectedConfig initializer.Config
+		expectedConfig config.Config
 		initResult     error
 		shouldErr      bool
 	}{
@@ -41,7 +41,7 @@ func TestFlagsToConfigVersion(t *testing.T) {
 			},
 			initResult: errors.New("test error"),
 			shouldErr:  true,
-			expectedConfig: initializer.Config{
+			expectedConfig: config.Config{
 				ComposeFile:            "",
 				CliArtifacts:           nil,
 				CliKubernetesManifests: nil,
@@ -75,7 +75,7 @@ func TestFlagsToConfigVersion(t *testing.T) {
 				"--XXenableNewInitFormat",
 				"--XXdefaultBuildpacksBuilder", "buildpacks/builder",
 			},
-			expectedConfig: initializer.Config{
+			expectedConfig: config.Config{
 				ComposeFile:            "a-compose-file",
 				CliArtifacts:           []string{"a1=b1", "a2=b2"},
 				CliKubernetesManifests: []string{"m1", "m2"},
@@ -97,7 +97,7 @@ func TestFlagsToConfigVersion(t *testing.T) {
 				"init",
 				"--XXenableJibInit",
 			},
-			expectedConfig: initializer.Config{
+			expectedConfig: config.Config{
 				ComposeFile:            "",
 				CliArtifacts:           nil,
 				CliKubernetesManifests: nil,
@@ -118,7 +118,7 @@ func TestFlagsToConfigVersion(t *testing.T) {
 				"init",
 				"--XXenableBuildpacksInit",
 			},
-			expectedConfig: initializer.Config{
+			expectedConfig: config.Config{
 				ComposeFile:            "",
 				CliArtifacts:           nil,
 				CliKubernetesManifests: nil,
@@ -136,8 +136,8 @@ func TestFlagsToConfigVersion(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
-			var capturedConfig initializer.Config
-			t.Override(&initEntrypoint, func(_ context.Context, _ io.Writer, c initializer.Config) error {
+			var capturedConfig config.Config
+			t.Override(&initEntrypoint, func(_ context.Context, _ io.Writer, c config.Config) error {
 				capturedConfig = c
 				return test.initResult
 			})

--- a/pkg/skaffold/initializer/analyze.go
+++ b/pkg/skaffold/initializer/analyze.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/karrick/godirwalk"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -34,7 +35,7 @@ type analysis struct {
 }
 
 // newAnalysis sets up the analysis of the directory based on the initializer configuration
-func newAnalysis(c Config) *analysis {
+func newAnalysis(c config.Config) *analysis {
 	return &analysis{
 		kubectlAnalyzer: &kubectlAnalyzer{},
 		builderAnalyzer: &builderAnalyzer{

--- a/pkg/skaffold/initializer/analyze_test.go
+++ b/pkg/skaffold/initializer/analyze_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	initconfig "github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
@@ -36,7 +37,7 @@ func TestAnalyze(t *testing.T) {
 		filesWithContents map[string]string
 		expectedConfigs   []string
 		expectedPaths     []string
-		config            Config
+		config            initconfig.Config
 		shouldErr         bool
 	}{
 		{
@@ -54,7 +55,7 @@ func TestAnalyze(t *testing.T) {
 				"maven/pom.xml":          emptyFile,
 				"Dockerfile":             emptyFile,
 			},
-			config: Config{
+			config: initconfig.Config{
 				Force:                false,
 				EnableBuildpacksInit: false,
 				EnableJibInit:        false,
@@ -87,7 +88,7 @@ func TestAnalyze(t *testing.T) {
 				"maven/pom.xml":          emptyFile,
 				"Dockerfile":             emptyFile,
 			},
-			config: Config{
+			config: initconfig.Config{
 				Force:                false,
 				EnableBuildpacksInit: false,
 				EnableJibInit:        false,
@@ -113,7 +114,7 @@ func TestAnalyze(t *testing.T) {
 				"Dockerfile":          emptyFile,
 				"node/package.json":   emptyFile,
 			},
-			config: Config{
+			config: initconfig.Config{
 				Force:                false,
 				EnableBuildpacksInit: true,
 				EnableJibInit:        true,
@@ -141,7 +142,7 @@ func TestAnalyze(t *testing.T) {
 				"maven/asubproject/pom.xml":      emptyFile,
 				"maven/pom.xml":                  emptyFile,
 			},
-			config: Config{
+			config: initconfig.Config{
 				Force:                false,
 				EnableBuildpacksInit: false,
 				EnableJibInit:        true,
@@ -166,7 +167,7 @@ func TestAnalyze(t *testing.T) {
 				"k8pod.yml":                    validK8sManifest,
 				"pom.xml":                      emptyFile,
 			},
-			config: Config{
+			config: initconfig.Config{
 				Force:                false,
 				EnableBuildpacksInit: false,
 				EnableJibInit:        true,
@@ -191,7 +192,7 @@ func TestAnalyze(t *testing.T) {
 				".hidden/Dockerfile": emptyFile,
 				"Dockerfile":         emptyFile,
 			},
-			config: Config{
+			config: initconfig.Config{
 				Force:                false,
 				EnableBuildpacksInit: false,
 				EnableJibInit:        true,
@@ -217,7 +218,7 @@ deploy:
 				"deploy/Dockerfile": emptyFile,
 				"Dockerfile":        emptyFile,
 			},
-			config: Config{
+			config: initconfig.Config{
 				Force:                true,
 				EnableBuildpacksInit: false,
 				EnableJibInit:        true,
@@ -245,7 +246,7 @@ kind: Config
 deploy:
   kustomize: {}`,
 			},
-			config: Config{
+			config: initconfig.Config{
 				Force:                false,
 				EnableBuildpacksInit: false,
 				EnableJibInit:        true,
@@ -269,7 +270,7 @@ kind: Config
 deploy:
   kustomize: {}`,
 			},
-			config: Config{
+			config: initconfig.Config{
 				Force:                false,
 				EnableBuildpacksInit: false,
 				EnableJibInit:        true,

--- a/pkg/skaffold/initializer/config/config.go
+++ b/pkg/skaffold/initializer/config/config.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import "github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+
+// Config contains all the parameters for the initializer package
+type Config struct {
+	ComposeFile            string
+	CliArtifacts           []string
+	CliKubernetesManifests []string
+	SkipBuild              bool
+	SkipDeploy             bool
+	Force                  bool
+	Analyze                bool
+	EnableJibInit          bool // TODO: Remove this parameter
+	EnableBuildpacksInit   bool
+	EnableNewInitFormat    bool
+	BuildpacksBuilder      string
+	Opts                   config.SkaffoldOptions
+}

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -26,7 +26,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -50,22 +50,6 @@ type InitBuilder interface {
 	Path() string
 }
 
-// Config contains all the parameters for the initializer package
-type Config struct {
-	ComposeFile            string
-	CliArtifacts           []string
-	CliKubernetesManifests []string
-	SkipBuild              bool
-	SkipDeploy             bool
-	Force                  bool
-	Analyze                bool
-	EnableJibInit          bool // TODO: Remove this parameter
-	EnableBuildpacksInit   bool
-	EnableNewInitFormat    bool
-	BuildpacksBuilder      string
-	Opts                   config.SkaffoldOptions
-}
-
 // builderImagePair defines a builder and the image it builds
 type builderImagePair struct {
 	Builder   InitBuilder
@@ -73,7 +57,7 @@ type builderImagePair struct {
 }
 
 // DoInit executes the `skaffold init` flow.
-func DoInit(ctx context.Context, out io.Writer, c Config) error {
+func DoInit(ctx context.Context, out io.Writer, c config.Config) error {
 	rootDir := "."
 
 	if c.ComposeFile != "" {

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	initconfig "github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -34,14 +35,14 @@ func TestDoInit(t *testing.T) {
 	tests := []struct {
 		name      string
 		dir       string
-		config    Config
+		config    initconfig.Config
 		shouldErr bool
 	}{
 		//TODO: mocked kompose test
 		{
 			name: "getting-started",
 			dir:  "testdata/init/hello",
-			config: Config{
+			config: initconfig.Config{
 				Opts: config.SkaffoldOptions{
 					ConfigurationFile: "skaffold.yaml.out",
 				},
@@ -50,7 +51,7 @@ func TestDoInit(t *testing.T) {
 		{
 			name: "ignore existing tags",
 			dir:  "testdata/init/ignore-tags",
-			config: Config{
+			config: initconfig.Config{
 				Opts: config.SkaffoldOptions{
 					ConfigurationFile: "skaffold.yaml.out",
 				},
@@ -59,7 +60,7 @@ func TestDoInit(t *testing.T) {
 		{
 			name: "microservices (backwards compatibility)",
 			dir:  "testdata/init/microservices",
-			config: Config{
+			config: initconfig.Config{
 				CliArtifacts: []string{
 					"leeroy-app/Dockerfile=gcr.io/k8s-skaffold/leeroy-app",
 					"leeroy-web/Dockerfile=gcr.io/k8s-skaffold/leeroy-web",
@@ -72,7 +73,7 @@ func TestDoInit(t *testing.T) {
 		{
 			name: "microservices",
 			dir:  "testdata/init/microservices",
-			config: Config{
+			config: initconfig.Config{
 				CliArtifacts: []string{
 					`{"builder":"Docker","payload":{"path":"leeroy-app/Dockerfile"},"image":"gcr.io/k8s-skaffold/leeroy-app"}`,
 					`{"builder":"Docker","payload":{"path":"leeroy-web/Dockerfile"},"image":"gcr.io/k8s-skaffold/leeroy-web"}`,
@@ -85,7 +86,7 @@ func TestDoInit(t *testing.T) {
 		{
 			name: "CLI artifacts + manifest placeholders",
 			dir:  "testdata/init/allcli",
-			config: Config{
+			config: initconfig.Config{
 				CliArtifacts: []string{
 					`{"builder":"Docker","payload":{"path":"Dockerfile"},"image":"passed-in-artifact"}`,
 				},
@@ -102,7 +103,7 @@ func TestDoInit(t *testing.T) {
 			name: "error writing config file",
 			dir:  "testdata/init/microservices",
 
-			config: Config{
+			config: initconfig.Config{
 				CliArtifacts: []string{
 					`{"builder":"Docker","payload":{"path":"leeroy-app/Dockerfile"},"image":"gcr.io/k8s-skaffold/leeroy-app"}`,
 					`{"builder":"Docker","payload":{"path":"leeroy-web/Dockerfile"},"image":"gcr.io/k8s-skaffold/leeroy-web"}`,
@@ -118,7 +119,7 @@ func TestDoInit(t *testing.T) {
 			name: "error no manifests",
 			dir:  "testdata/init/hello-no-manifest",
 
-			config: Config{
+			config: initconfig.Config{
 				Opts: config.SkaffoldOptions{
 					ConfigurationFile: "skaffold.yaml.out",
 				},
@@ -144,13 +145,13 @@ func TestDoInitAnalyze(t *testing.T) {
 	tests := []struct {
 		name        string
 		dir         string
-		config      Config
+		config      initconfig.Config
 		expectedOut string
 	}{
 		{
 			name: "analyze microservices",
 			dir:  "testdata/init/microservices",
-			config: Config{
+			config: initconfig.Config{
 				Analyze: true,
 			},
 			expectedOut: strip(`{
@@ -161,7 +162,7 @@ func TestDoInitAnalyze(t *testing.T) {
 		{
 			name: "analyze microservices new format",
 			dir:  "testdata/init/microservices",
-			config: Config{
+			config: initconfig.Config{
 				Analyze:             true,
 				EnableNewInitFormat: true,
 			},
@@ -178,7 +179,7 @@ func TestDoInitAnalyze(t *testing.T) {
 			name: "no error with no manifests in analyze mode with skip-deploy",
 			dir:  "testdata/init/hello-no-manifest",
 
-			config: Config{
+			config: initconfig.Config{
 				Analyze:    true,
 				SkipDeploy: true,
 				Opts: config.SkaffoldOptions{


### PR DESCRIPTION
part of a cleanup and refactor of the init functionality. this config will be shared between separate packages, so it should live in its own package.

this PR has no functional change.