### PR TITLE
[refactor] move k8s-related utility functions to kubernetes package

### DIFF
--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -32,6 +32,7 @@ import (
 	deploy "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -155,7 +156,7 @@ func (k *KubectlDeployer) manifestFiles(manifests []string) ([]string, error) {
 
 	var filteredManifests []string
 	for _, f := range list {
-		if !util.HasKubernetesFileExtension(f) {
+		if !kubernetes.HasKubernetesFileExtension(f) {
 			if !util.StrSliceContains(manifests, f) {
 				logrus.Infof("refusing to deploy/delete non {json, yaml} file %s", f)
 				logrus.Info("If you still wish to deploy this file, please specify it directly, outside a glob pattern.")

--- a/pkg/skaffold/initializer/kubectl.go
+++ b/pkg/skaffold/initializer/kubectl.go
@@ -17,20 +17,11 @@ limitations under the License.
 package initializer
 
 import (
-	"bufio"
-	"io"
-	"os"
-
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
-	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
-
-var requiredFields = []string{"apiVersion", "kind", "metadata"}
 
 // kubectl implements deploymentInitializer for the kubectl deployer.
 type kubectl struct {
@@ -45,7 +36,7 @@ type kubectlAnalyzer struct {
 }
 
 func (a *kubectlAnalyzer) analyzeFile(filePath string) error {
-	if IsKubernetesManifest(filePath) && !isSkaffoldConfig(filePath) {
+	if kubernetes.IsKubernetesManifest(filePath) && !isSkaffoldConfig(filePath) {
 		a.kubernetesManifests = append(a.kubernetesManifests, filePath)
 	}
 	return nil
@@ -55,7 +46,7 @@ func (a *kubectlAnalyzer) analyzeFile(filePath string) error {
 func newKubectlInitializer(potentialConfigs []string) (*kubectl, error) {
 	var k8sConfigs, images []string
 	for _, file := range potentialConfigs {
-		imgs, err := parseImagesFromKubernetesYaml(file)
+		imgs, err := kubernetes.ParseImagesFromKubernetesYaml(file)
 		if err == nil {
 			k8sConfigs = append(k8sConfigs, file)
 			images = append(images, imgs...)
@@ -68,16 +59,6 @@ func newKubectlInitializer(potentialConfigs []string) (*kubectl, error) {
 		configs: k8sConfigs,
 		images:  images,
 	}, nil
-}
-
-// IsKubernetesManifest is for determining if a file is a valid Kubernetes manifest
-func IsKubernetesManifest(file string) bool {
-	if !util.HasKubernetesFileExtension(file) {
-		return false
-	}
-
-	_, err := parseKubernetesObjects(file)
-	return err == nil
 }
 
 // deployConfig implements the Initializer interface and generates
@@ -96,91 +77,4 @@ func (k *kubectl) deployConfig() latest.DeployConfig {
 // images present in the k8 manifest files.
 func (k *kubectl) GetImages() []string {
 	return k.images
-}
-
-type yamlObject map[interface{}]interface{}
-
-// parseImagesFromKubernetesYaml parses the kubernetes yamls, and if it finds at least one
-// valid Kubernetes object, it will return the images referenced in them.
-func parseImagesFromKubernetesYaml(filepath string) ([]string, error) {
-	k8sObjects, err := parseKubernetesObjects(filepath)
-	if err != nil {
-		return nil, err
-	}
-
-	images := []string{}
-	for _, k8sObject := range k8sObjects {
-		images = append(images, parseImagesFromYaml(k8sObject)...)
-	}
-	return images, nil
-}
-
-// parseKubernetesObjects uses required fields from the k8s spec
-// to determine if a provided yaml file is a valid k8s manifest, as detailed in
-// https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields.
-// If so, it will return the parsed objects.
-func parseKubernetesObjects(filepath string) ([]yamlObject, error) {
-	f, err := os.Open(filepath)
-	if err != nil {
-		return nil, errors.Wrap(err, "opening config file")
-	}
-	r := k8syaml.NewYAMLReader(bufio.NewReader(f))
-
-	var k8sObjects []yamlObject
-
-	for {
-		doc, err := r.Read()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, errors.Wrap(err, "reading config file")
-		}
-
-		obj := make(yamlObject)
-		if err := yaml.Unmarshal(doc, &obj); err != nil {
-			return nil, errors.Wrap(err, "reading Kubernetes YAML")
-		}
-
-		if !hasRequiredK8sManifestFields(obj) {
-			continue
-		}
-
-		k8sObjects = append(k8sObjects, obj)
-	}
-	if len(k8sObjects) == 0 {
-		return nil, errors.New("no valid Kubernetes objects decoded")
-	}
-	return k8sObjects, nil
-}
-
-func hasRequiredK8sManifestFields(doc map[interface{}]interface{}) bool {
-	for _, field := range requiredFields {
-		if _, ok := doc[field]; !ok {
-			logrus.Debugf("%s not present in yaml, continuing", field)
-			return false
-		}
-	}
-	return true
-}
-
-// adapted from pkg/skaffold/deploy/kubectl/recursiveReplaceImage()
-func parseImagesFromYaml(obj interface{}) []string {
-	images := []string{}
-	switch t := obj.(type) {
-	case []interface{}:
-		for _, v := range t {
-			images = append(images, parseImagesFromYaml(v)...)
-		}
-	case yamlObject:
-		for k, v := range t {
-			if k.(string) != "image" {
-				images = append(images, parseImagesFromYaml(v)...)
-				continue
-			}
-
-			images = append(images, v.(string))
-		}
-	}
-	return images
 }

--- a/pkg/skaffold/initializer/kubectl_test.go
+++ b/pkg/skaffold/initializer/kubectl_test.go
@@ -19,6 +19,7 @@ package initializer
 import (
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -117,7 +118,7 @@ spec:
 			tmpDir := t.NewTempDir().
 				Write("deployment.yaml", test.contents)
 
-			images, err := parseImagesFromKubernetesYaml(tmpDir.Path("deployment.yaml"))
+			images, err := kubernetes.ParseImagesFromKubernetesYaml(tmpDir.Path("deployment.yaml"))
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.images, images)
 		})
@@ -178,7 +179,7 @@ func TestIsKubernetesManifest(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.NewTempDir().Write(test.filename, test.content).Chdir()
 
-			supported := IsKubernetesManifest(test.filename)
+			supported := kubernetes.IsKubernetesManifest(test.filename)
 
 			t.CheckDeepEqual(test.expected, supported)
 		})

--- a/pkg/skaffold/kubernetes/util.go
+++ b/pkg/skaffold/kubernetes/util.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+type yamlObject map[interface{}]interface{}
+
+// These are the required fields for a yaml document to be a valid Kubernetes yaml
+var requiredFields = []string{"apiVersion", "kind", "metadata"}
+
+// These are the supported file formats for Kubernetes manifests
+var validSuffixes = []string{".yml", ".yaml", ".json"}
+
+// HasKubernetesFileExtension is for determining if a file under a glob pattern
+// is deployable file format. It makes no attempt to check whether or not the file
+// is actually deployable or has the correct contents.
+func HasKubernetesFileExtension(n string) bool {
+	for _, s := range validSuffixes {
+		if strings.HasSuffix(n, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsKubernetesManifest is for determining if a file is a valid Kubernetes manifest
+func IsKubernetesManifest(file string) bool {
+	if !HasKubernetesFileExtension(file) {
+		return false
+	}
+
+	_, err := parseKubernetesObjects(file)
+	return err == nil
+}
+
+// ParseImagesFromKubernetesYaml parses the kubernetes yamls, and if it finds at least one
+// valid Kubernetes object, it will return the images referenced in them.
+func ParseImagesFromKubernetesYaml(filepath string) ([]string, error) {
+	k8sObjects, err := parseKubernetesObjects(filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	images := []string{}
+	for _, k8sObject := range k8sObjects {
+		images = append(images, parseImagesFromYaml(k8sObject)...)
+	}
+	return images, nil
+}
+
+// parseKubernetesObjects uses required fields from the k8s spec
+// to determine if a provided yaml file is a valid k8s manifest, as detailed in
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields.
+// If so, it will return the parsed objects.
+func parseKubernetesObjects(filepath string) ([]yamlObject, error) {
+	f, err := os.Open(filepath)
+	if err != nil {
+		return nil, errors.Wrap(err, "opening config file")
+	}
+	r := k8syaml.NewYAMLReader(bufio.NewReader(f))
+
+	var k8sObjects []yamlObject
+
+	for {
+		doc, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, errors.Wrap(err, "reading config file")
+		}
+
+		obj := make(yamlObject)
+		if err := yaml.Unmarshal(doc, &obj); err != nil {
+			return nil, errors.Wrap(err, "reading Kubernetes YAML")
+		}
+
+		if !hasRequiredK8sManifestFields(obj) {
+			continue
+		}
+
+		k8sObjects = append(k8sObjects, obj)
+	}
+	if len(k8sObjects) == 0 {
+		return nil, errors.New("no valid Kubernetes objects decoded")
+	}
+	return k8sObjects, nil
+}
+
+func hasRequiredK8sManifestFields(doc map[interface{}]interface{}) bool {
+	for _, field := range requiredFields {
+		if _, ok := doc[field]; !ok {
+			logrus.Debugf("%s not present in yaml, continuing", field)
+			return false
+		}
+	}
+	return true
+}
+
+// adapted from pkg/skaffold/deploy/kubectl/recursiveReplaceImage()
+func parseImagesFromYaml(obj interface{}) []string {
+	images := []string{}
+	switch t := obj.(type) {
+	case []interface{}:
+		for _, v := range t {
+			images = append(images, parseImagesFromYaml(v)...)
+		}
+	case yamlObject:
+		for k, v := range t {
+			if k.(string) != "image" {
+				images = append(images, parseImagesFromYaml(v)...)
+				continue
+			}
+
+			images = append(images, v.(string))
+		}
+	}
+	return images
+}

--- a/pkg/skaffold/kubernetes/util_test.go
+++ b/pkg/skaffold/kubernetes/util_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestSupportedKubernetesFormats(t *testing.T) {
+	tests := []struct {
+		description string
+		in          string
+		out         bool
+	}{
+		{
+			description: "yaml",
+			in:          "filename.yaml",
+			out:         true,
+		},
+		{
+			description: "yml",
+			in:          "filename.yml",
+			out:         true,
+		},
+		{
+			description: "json",
+			in:          "filename.json",
+			out:         true,
+		},
+		{
+			description: "txt",
+			in:          "filename.txt",
+			out:         false,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			actual := HasKubernetesFileExtension(test.in)
+
+			t.CheckDeepEqual(test.out, actual)
+		})
+	}
+}

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -48,21 +48,6 @@ func RandomID() string {
 	return fmt.Sprintf("%x", b)
 }
 
-// These are the supported file formats for Kubernetes manifests
-var validSuffixes = []string{".yml", ".yaml", ".json"}
-
-// HasKubernetesFileExtension is for determining if a file under a glob pattern
-// is deployable file format. It makes no attempt to check whether or not the file
-// is actually deployable or has the correct contents.
-func HasKubernetesFileExtension(n string) bool {
-	for _, s := range validSuffixes {
-		if strings.HasSuffix(n, s) {
-			return true
-		}
-	}
-	return false
-}
-
 func StrSliceContains(sl []string, s string) bool {
 	return StrSliceIndex(sl, s) >= 0
 }

--- a/pkg/skaffold/util/util_test.go
+++ b/pkg/skaffold/util/util_test.go
@@ -24,42 +24,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestSupportedKubernetesFormats(t *testing.T) {
-	tests := []struct {
-		description string
-		in          string
-		out         bool
-	}{
-		{
-			description: "yaml",
-			in:          "filename.yaml",
-			out:         true,
-		},
-		{
-			description: "yml",
-			in:          "filename.yml",
-			out:         true,
-		},
-		{
-			description: "json",
-			in:          "filename.json",
-			out:         true,
-		},
-		{
-			description: "txt",
-			in:          "filename.txt",
-			out:         false,
-		},
-	}
-	for _, test := range tests {
-		testutil.Run(t, test.description, func(t *testutil.T) {
-			actual := HasKubernetesFileExtension(test.in)
-
-			t.CheckDeepEqual(test.out, actual)
-		})
-	}
-}
-
 func TestExpandPathsGlob(t *testing.T) {
 	tests := []struct {
 		description string


### PR DESCRIPTION
part of a cleanup and refactor of the init package. this move kubernetes utility functions to the proper package, since these are not init specific.

this PR introduces no functional change.