### PR TITLE
enable finding alternative builders nested under Jib projects

### DIFF
--- a/pkg/skaffold/initializer/analyze_test.go
+++ b/pkg/skaffold/initializer/analyze_test.go
@@ -139,7 +139,9 @@ func TestAnalyze(t *testing.T) {
 				"k8pod.yml":                      validK8sManifest,
 				"gradle/build.gradle":            emptyFile,
 				"gradle/subproject/build.gradle": emptyFile,
+				"gradle/subproject/Dockerfile":   emptyFile,
 				"maven/asubproject/pom.xml":      emptyFile,
+				"maven/asubproject/Dockerfile":   emptyFile,
 				"maven/pom.xml":                  emptyFile,
 			},
 			config: initconfig.Config{
@@ -153,7 +155,9 @@ func TestAnalyze(t *testing.T) {
 			},
 			expectedPaths: []string{
 				"gradle/build.gradle",
+				"gradle/subproject/Dockerfile",
 				"maven/pom.xml",
+				"maven/asubproject/Dockerfile",
 			},
 			shouldErr: false,
 		},

--- a/pkg/skaffold/initializer/builders.go
+++ b/pkg/skaffold/initializer/builders.go
@@ -41,23 +41,24 @@ type builderAnalyzer struct {
 	buildpacksBuilder    string
 	foundBuilders        []InitBuilder
 
-	parentDirToStopFindBuilders string
+	parentDirToStopFindJibSettings string
 }
 
 func (a *builderAnalyzer) analyzeFile(filePath string) error {
-	if a.findBuilders && (a.parentDirToStopFindBuilders == "" || a.parentDirToStopFindBuilders == a.currentDir) {
-		builderConfigs, continueSearchingBuilders := a.detectBuilders(filePath)
+	if a.findBuilders {
+		lookForJib := a.parentDirToStopFindJibSettings == "" || a.parentDirToStopFindJibSettings == a.currentDir
+		builderConfigs, lookForJib := a.detectBuilders(filePath, lookForJib)
 		a.foundBuilders = append(a.foundBuilders, builderConfigs...)
-		if !continueSearchingBuilders {
-			a.parentDirToStopFindBuilders = a.currentDir
+		if !lookForJib {
+			a.parentDirToStopFindJibSettings = a.currentDir
 		}
 	}
 	return nil
 }
 
 func (a *builderAnalyzer) exitDir(dir string) {
-	if a.parentDirToStopFindBuilders == dir {
-		a.parentDirToStopFindBuilders = ""
+	if a.parentDirToStopFindJibSettings == dir {
+		a.parentDirToStopFindJibSettings = ""
 	}
 }
 
@@ -102,9 +103,9 @@ func findExactlyOnceMatchingBuilder(builderConfigs []InitBuilder, image string) 
 // detectBuilders checks if a path is a builder config, and if it is, returns the InitBuilders representing the
 // configs. Also returns a boolean marking search completion for subdirectories (true = subdirectories should
 // continue to be searched, false = subdirectories should not be searched for more builders)
-func (a *builderAnalyzer) detectBuilders(path string) ([]InitBuilder, bool) {
+func (a *builderAnalyzer) detectBuilders(path string, detectJib bool) ([]InitBuilder, bool) {
 	// TODO: Remove backwards compatibility if statement (not entire block)
-	if a.enableJibInit {
+	if a.enableJibInit && detectJib {
 		// Check for jib
 		if builders := jib.Validate(path); builders != nil {
 			results := make([]InitBuilder, len(builders))


### PR DESCRIPTION
Fixes #3654.

Now the output of `skaffold init --analyze --skip-deploy --XXenableJibInit | jq                                                                                                                          ` on the java-guestbook Cloud Code sample is: 

```javascript
{
  "builders": [
    {
      "name": "Jib Maven Plugin",
      "payload": {
        "path": "pom.xml"
      }
    },
    {
      "name": "Jib Maven Plugin",
      "payload": {
        "path": "pom.xml"
      }
    },
    {
      "name": "Docker",
      "payload": {
        "path": "backend/Dockerfile"
      }
    },
    {
      "name": "Docker",
      "payload": {
        "path": "frontend/Dockerfile"
      }
    }
  ]
}
```

note, the repeated pom.xml is still due to https://github.com/GoogleContainerTools/jib/issues/2262