### PR TITLE
[refactor] move config util function to schema package

### DIFF
--- a/pkg/skaffold/initializer/config.go
+++ b/pkg/skaffold/initializer/config.go
@@ -43,7 +43,7 @@ type skaffoldConfigAnalyzer struct {
 }
 
 func (a *skaffoldConfigAnalyzer) analyzeFile(filePath string) error {
-	if !isSkaffoldConfig(filePath) || a.force || a.analyzeMode {
+	if !schema.IsSkaffoldConfig(filePath) || a.force || a.analyzeMode {
 		return nil
 	}
 	sameFiles, err := sameFiles(filePath, a.targetConfig)
@@ -139,12 +139,4 @@ func artifacts(pairs []builderImagePair) []*latest.Artifact {
 	}
 
 	return artifacts
-}
-
-// isSkaffoldConfig is for determining if a file is skaffold config file.
-func isSkaffoldConfig(file string) bool {
-	if config, err := schema.ParseConfig(file, false); err == nil && config != nil {
-		return true
-	}
-	return false
 }

--- a/pkg/skaffold/initializer/config_test.go
+++ b/pkg/skaffold/initializer/config_test.go
@@ -231,46 +231,6 @@ func TestArtifacts(t *testing.T) {
 	})
 }
 
-func TestIsSkaffoldConfig(t *testing.T) {
-	tests := []struct {
-		description string
-		contents    string
-		isValid     bool
-	}{
-		{
-			description: "valid skaffold config",
-			contents: `apiVersion: skaffold/v1beta6
-kind: Config
-deploy:
-  kustomize: {}`,
-			isValid: true,
-		},
-		{
-			description: "not a valid format",
-			contents:    "test",
-			isValid:     false,
-		},
-		{
-			description: "invalid skaffold config version",
-			contents: `apiVersion: skaffold/v2beta1
-kind: Config
-deploy:
-  kustomize: {}`,
-			isValid: false,
-		},
-	}
-	for _, test := range tests {
-		testutil.Run(t, test.description, func(t *testutil.T) {
-			tmpDir := t.NewTempDir().
-				Write("skaffold.yaml", test.contents)
-
-			isValid := isSkaffoldConfig(tmpDir.Path("skaffold.yaml"))
-
-			t.CheckDeepEqual(test.isValid, isValid)
-		})
-	}
-}
-
 func Test_canonicalizeName(t *testing.T) {
 	const length253 = "aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa-aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa-aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaaaaaaaa.aaa"
 	tests := []struct {

--- a/pkg/skaffold/initializer/kubectl.go
+++ b/pkg/skaffold/initializer/kubectl.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -36,7 +37,7 @@ type kubectlAnalyzer struct {
 }
 
 func (a *kubectlAnalyzer) analyzeFile(filePath string) error {
-	if kubernetes.IsKubernetesManifest(filePath) && !isSkaffoldConfig(filePath) {
+	if kubernetes.IsKubernetesManifest(filePath) && !schema.IsSkaffoldConfig(filePath) {
 		a.kubernetesManifests = append(a.kubernetesManifests, filePath)
 	}
 	return nil

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -106,6 +106,14 @@ func (v *Versions) Find(apiVersion string) (func() util.VersionedConfig, bool) {
 	return nil, false
 }
 
+// IsSkaffoldConfig is for determining if a file is skaffold config file.
+func IsSkaffoldConfig(file string) bool {
+	if config, err := ParseConfig(file, false); err == nil && config != nil {
+		return true
+	}
+	return false
+}
+
 // ParseConfig reads a configuration file.
 func ParseConfig(filename string, upgrade bool) (util.VersionedConfig, error) {
 	buf, err := misc.ReadConfiguration(filename)

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -109,6 +109,46 @@ deploy:
 `
 )
 
+func TestIsSkaffoldConfig(t *testing.T) {
+	tests := []struct {
+		description string
+		contents    string
+		isValid     bool
+	}{
+		{
+			description: "valid skaffold config",
+			contents: `apiVersion: skaffold/v1beta6
+kind: Config
+deploy:
+  kustomize: {}`,
+			isValid: true,
+		},
+		{
+			description: "not a valid format",
+			contents:    "test",
+			isValid:     false,
+		},
+		{
+			description: "invalid skaffold config version",
+			contents: `apiVersion: skaffold/v2beta1
+kind: Config
+deploy:
+  kustomize: {}`,
+			isValid: false,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			tmpDir := t.NewTempDir().
+				Write("skaffold.yaml", test.contents)
+
+			isValid := IsSkaffoldConfig(tmpDir.Path("skaffold.yaml"))
+
+			t.CheckDeepEqual(test.isValid, isValid)
+		})
+	}
+}
+
 func TestParseConfig(t *testing.T) {
 	tests := []struct {
 		apiVersion  string


### PR DESCRIPTION
part of a cleanup and refactor of the init package. this config related utility function has no place in the init package, this code moves it into the `schema` package where it belongs.

this PR has no functional change.
