### PR TITLE
[refactor] move prompting logic to separate package

### DIFF
--- a/pkg/skaffold/initializer/builders.go
+++ b/pkg/skaffold/initializer/builders.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
@@ -246,7 +247,7 @@ func resolveBuilderImagesInteractively(builderConfigs []InitBuilder, images []st
 		}
 
 		image := images[0]
-		choice, err := promptUserForBuildConfigFunc(image, choices)
+		choice, err := prompt.BuildConfigFunc(image, append(choices, NoBuilder))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/skaffold/initializer/builders_test.go
+++ b/pkg/skaffold/initializer/builders_test.go
@@ -19,6 +19,7 @@ package initializer
 import (
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
@@ -97,7 +98,7 @@ func TestResolveBuilderImages(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			// Overrides promptUserForBuildConfig to choose first option rather than using the interactive menu
-			t.Override(&promptUserForBuildConfigFunc, func(image string, choices []string) (string, error) {
+			t.Override(&prompt.BuildConfigFunc, func(image string, choices []string) (string, error) {
 				if !test.shouldMakeChoice {
 					t.FailNow()
 				}

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -129,7 +130,7 @@ func DoInit(ctx context.Context, out io.Writer, c config.Config) error {
 	}
 
 	if !c.Force {
-		if done, err := promptWritingConfig(out, pipeline, c.Opts.ConfigurationFile); done {
+		if done, err := prompt.WriteSkaffoldConfig(out, pipeline, c.Opts.ConfigurationFile); done {
 			return err
 		}
 	}

--- a/pkg/skaffold/initializer/prompt/prompt.go
+++ b/pkg/skaffold/initializer/prompt/prompt.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package initializer
+package prompt
 
 import (
 	"bufio"
@@ -29,15 +29,14 @@ import (
 
 // For testing
 var (
-	promptUserForBuildConfigFunc = promptUserForBuildConfig
+	BuildConfigFunc = buildConfig
 )
 
-func promptUserForBuildConfig(image string, choices []string) (string, error) {
+func buildConfig(image string, choices []string) (string, error) {
 	var selectedBuildConfig string
-	options := append(choices, NoBuilder)
 	prompt := &survey.Select{
 		Message:  fmt.Sprintf("Choose the builder to build image %s", image),
-		Options:  options,
+		Options:  choices,
 		PageSize: 15,
 	}
 	err := survey.AskOne(prompt, &selectedBuildConfig, nil)
@@ -48,7 +47,7 @@ func promptUserForBuildConfig(image string, choices []string) (string, error) {
 	return selectedBuildConfig, nil
 }
 
-func promptWritingConfig(out io.Writer, pipeline []byte, filePath string) (bool, error) {
+func WriteSkaffoldConfig(out io.Writer, pipeline []byte, filePath string) (bool, error) {
 	fmt.Fprintln(out, string(pipeline))
 
 	reader := bufio.NewReader(os.Stdin)


### PR DESCRIPTION
part of a cleanup and refactor of the init package. this moves the prompting logic to a separate package, so it can be shared between other packages.

this PR has no functional change.