### PR TITLE
[refactor] move deploy related init code to deploy package

### DIFF
--- a/pkg/skaffold/initializer/analyze.go
+++ b/pkg/skaffold/initializer/analyze.go
@@ -37,9 +37,9 @@ type kubectlAnalyzer struct {
 	kubernetesManifests []string
 }
 
-func (a *kubectlAnalyzer) analyzeFile(filePath string) error {
+func (k *kubectlAnalyzer) analyzeFile(filePath string) error {
 	if kubernetes.IsKubernetesManifest(filePath) && !schema.IsSkaffoldConfig(filePath) {
-		a.kubernetesManifests = append(a.kubernetesManifests, filePath)
+		k.kubernetesManifests = append(k.kubernetesManifests, filePath)
 	}
 	return nil
 }

--- a/pkg/skaffold/initializer/analyze_test.go
+++ b/pkg/skaffold/initializer/analyze_test.go
@@ -303,7 +303,7 @@ deploy:
 				return
 			}
 
-			t.CheckDeepEqual(test.expectedConfigs, a.kubectlAnalyzer.kubernetesManifests)
+			t.CheckDeepEqual(test.expectedConfigs, a.KubectlAnalyzer.kubernetesManifests)
 			t.CheckDeepEqual(len(test.expectedPaths), len(a.builderAnalyzer.foundBuilders))
 			for i := range a.builderAnalyzer.foundBuilders {
 				t.CheckDeepEqual(test.expectedPaths[i], a.builderAnalyzer.foundBuilders[i].Path())

--- a/pkg/skaffold/initializer/config.go
+++ b/pkg/skaffold/initializer/config.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
@@ -68,7 +69,7 @@ func sameFiles(a, b string) (bool, error) {
 	return absA == absB, nil
 }
 
-func generateSkaffoldConfig(k deploymentInitializer, buildConfigPairs []builderImagePair) *latest.SkaffoldConfig {
+func generateSkaffoldConfig(k deploy.DeploymentInitializer, buildConfigPairs []builderImagePair) *latest.SkaffoldConfig {
 	// if we're here, the user has no skaffold yaml so we need to generate one
 	// if the user doesn't have any k8s yamls, generate one for each dockerfile
 	logrus.Info("generating skaffold config")
@@ -88,7 +89,7 @@ func generateSkaffoldConfig(k deploymentInitializer, buildConfigPairs []builderI
 			Build: latest.BuildConfig{
 				Artifacts: artifacts(buildConfigPairs),
 			},
-			Deploy: k.deployConfig(),
+			Deploy: k.DeployConfig(),
 		},
 	}
 }

--- a/pkg/skaffold/initializer/config_test.go
+++ b/pkg/skaffold/initializer/config_test.go
@@ -31,7 +31,7 @@ type stubDeploymentInitializer struct {
 	config latest.DeployConfig
 }
 
-func (s stubDeploymentInitializer) deployConfig() latest.DeployConfig {
+func (s stubDeploymentInitializer) DeployConfig() latest.DeployConfig {
 	return s.config
 }
 

--- a/pkg/skaffold/initializer/deploy/init.go
+++ b/pkg/skaffold/initializer/deploy/init.go
@@ -14,14 +14,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package initializer
+package deploy
 
-import "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+)
 
 // deploymentInitializer detects a deployment type and is able to extract image names from it
-type deploymentInitializer interface {
+type DeploymentInitializer interface {
 	// deployConfig generates Deploy Config for skaffold configuration.
-	deployConfig() latest.DeployConfig
+	DeployConfig() latest.DeployConfig
 	// GetImages fetches all the images defined in the manifest files.
 	GetImages() []string
 }
@@ -30,7 +33,7 @@ type cliDeployInit struct {
 	cliKubernetesManifests []string
 }
 
-func (c *cliDeployInit) deployConfig() latest.DeployConfig {
+func (c *cliDeployInit) DeployConfig() latest.DeployConfig {
 	return latest.DeployConfig{
 		DeployType: latest.DeployType{
 			KubectlDeploy: &latest.KubectlDeploy{
@@ -46,10 +49,21 @@ func (c *cliDeployInit) GetImages() []string {
 type emptyDeployInit struct {
 }
 
-func (c *emptyDeployInit) deployConfig() latest.DeployConfig {
+func (c *emptyDeployInit) DeployConfig() latest.DeployConfig {
 	return latest.DeployConfig{}
 }
 
 func (c *emptyDeployInit) GetImages() []string {
 	return nil
+}
+
+func NewDeployInitializer(manifests []string, c config.Config) (DeploymentInitializer, error) {
+	switch {
+	case c.SkipDeploy:
+		return &emptyDeployInit{}, nil
+	case len(c.CliKubernetesManifests) > 0:
+		return &cliDeployInit{c.CliKubernetesManifests}, nil
+	default:
+		return newKubectlInitializer(manifests)
+	}
 }

--- a/pkg/skaffold/initializer/deploy/kubectl.go
+++ b/pkg/skaffold/initializer/deploy/kubectl.go
@@ -14,13 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package initializer
+package deploy
 
 import (
 	"github.com/pkg/errors"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -28,19 +27,6 @@ import (
 type kubectl struct {
 	configs []string
 	images  []string
-}
-
-// kubectlAnalyzer is a Visitor during the directory analysis that collects kubernetes manifests
-type kubectlAnalyzer struct {
-	directoryAnalyzer
-	kubernetesManifests []string
-}
-
-func (a *kubectlAnalyzer) analyzeFile(filePath string) error {
-	if kubernetes.IsKubernetesManifest(filePath) && !schema.IsSkaffoldConfig(filePath) {
-		a.kubernetesManifests = append(a.kubernetesManifests, filePath)
-	}
-	return nil
 }
 
 // newKubectlInitializer returns a kubectl skaffold generator.
@@ -64,7 +50,7 @@ func newKubectlInitializer(potentialConfigs []string) (*kubectl, error) {
 
 // deployConfig implements the Initializer interface and generates
 // skaffold kubectl deployment config.
-func (k *kubectl) deployConfig() latest.DeployConfig {
+func (k *kubectl) DeployConfig() latest.DeployConfig {
 	return latest.DeployConfig{
 		DeployType: latest.DeployType{
 			KubectlDeploy: &latest.KubectlDeploy{

--- a/pkg/skaffold/initializer/deploy/kubectl_test.go
+++ b/pkg/skaffold/initializer/deploy/kubectl_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package initializer
+package deploy
 
 import (
 	"testing"
@@ -51,7 +51,7 @@ spec:
 			},
 		},
 	}
-	testutil.CheckDeepEqual(t, expectedConfig, k.deployConfig())
+	testutil.CheckDeepEqual(t, expectedConfig, k.DeployConfig())
 }
 
 func TestParseImagesFromKubernetesYaml(t *testing.T) {

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
@@ -73,18 +74,9 @@ func DoInit(ctx context.Context, out io.Writer, c config.Config) error {
 		return err
 	}
 
-	var deployInitializer deploymentInitializer
-	switch {
-	case c.SkipDeploy:
-		deployInitializer = &emptyDeployInit{}
-	case len(c.CliKubernetesManifests) > 0:
-		deployInitializer = &cliDeployInit{c.CliKubernetesManifests}
-	default:
-		k, err := newKubectlInitializer(a.kubectlAnalyzer.kubernetesManifests)
-		if err != nil {
-			return err
-		}
-		deployInitializer = k
+	deployInitializer, err := deploy.NewDeployInitializer(a.KubectlAnalyzer.Manifests(), c)
+	if err != nil {
+		return err
 	}
 
 	// Determine which builders/images require prompting


### PR DESCRIPTION
part of a cleanup and refactor of the init package. this moves deploy related init code into a separate `deploy` package.

this PR has no functional change.