### PR TITLE
[refactor] move build and analyze related code into separate packages

### DIFF
--- a/pkg/skaffold/initializer/analyze/analyze.go
+++ b/pkg/skaffold/initializer/analyze/analyze.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package initializer
+package analyze
 
 import (
 	"os"
@@ -24,47 +24,53 @@ import (
 
 	"github.com/karrick/godirwalk"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
-// TODO(nkubala): move this along with all analyzer code into a separate analysis package
-// kubectlAnalyzer is a Visitor during the directory analysis that collects kubernetes manifests
-type kubectlAnalyzer struct {
-	directoryAnalyzer
-	kubernetesManifests []string
+// analyzer is following the visitor pattern. It is called on every file
+// as the analysis.analyze function walks the directory structure recursively.
+// It can manage state and react to walking events assuming a breadth first search.
+type analyzer interface {
+	enterDir(dir string)
+	analyzeFile(file string) error
+	exitDir(dir string)
 }
 
-func (k *kubectlAnalyzer) analyzeFile(filePath string) error {
-	if kubernetes.IsKubernetesManifest(filePath) && !schema.IsSkaffoldConfig(filePath) {
-		k.kubernetesManifests = append(k.kubernetesManifests, filePath)
+type ProjectAnalysis struct {
+	configAnalyzer  *skaffoldConfigAnalyzer
+	kubeAnalyzer    *kubeAnalyzer
+	builderAnalyzer *builderAnalyzer
+}
+
+func (a *ProjectAnalysis) Builders() []build.InitBuilder {
+	return a.builderAnalyzer.foundBuilders
+}
+
+func (a *ProjectAnalysis) Manifests() []string {
+	return a.kubeAnalyzer.kubernetesManifests
+}
+
+func (a *ProjectAnalysis) analyzers() []analyzer {
+	return []analyzer{
+		a.kubeAnalyzer,
+		a.configAnalyzer,
+		a.builderAnalyzer,
 	}
-	return nil
-}
-
-func (k *kubectlAnalyzer) Manifests() []string {
-	return k.kubernetesManifests
-}
-
-type analysis struct {
-	KubectlAnalyzer  *kubectlAnalyzer
-	skaffoldAnalyzer *skaffoldConfigAnalyzer
-	builderAnalyzer  *builderAnalyzer
 }
 
 // newAnalysis sets up the analysis of the directory based on the initializer configuration
-func newAnalysis(c config.Config) *analysis {
-	return &analysis{
-		KubectlAnalyzer: &kubectlAnalyzer{},
+func NewAnalyzer(c config.Config) *ProjectAnalysis {
+	return &ProjectAnalysis{
+		kubeAnalyzer: &kubeAnalyzer{},
 		builderAnalyzer: &builderAnalyzer{
 			findBuilders:         !c.SkipBuild,
 			enableJibInit:        c.EnableJibInit,
 			enableBuildpacksInit: c.EnableBuildpacksInit,
 			buildpacksBuilder:    c.BuildpacksBuilder,
 		},
-		skaffoldAnalyzer: &skaffoldConfigAnalyzer{
+		configAnalyzer: &skaffoldConfigAnalyzer{
 			force:        c.Force,
 			analyzeMode:  c.Analyze,
 			targetConfig: c.Opts.ConfigurationFile,
@@ -75,7 +81,7 @@ func newAnalysis(c config.Config) *analysis {
 // analyze recursively walks a directory and notifies the analyzers of files and enterDir and exitDir events
 // at the end of the analyze function the analysis struct's analyzers should contain the state that we can
 // use to do further computation.
-func (a *analysis) analyze(dir string) error {
+func (a *ProjectAnalysis) Analyze(dir string) error {
 	for _, analyzer := range a.analyzers() {
 		analyzer.enterDir(dir)
 	}
@@ -113,7 +119,7 @@ func (a *analysis) analyze(dir string) error {
 
 	// Recurse into subdirectories
 	for _, subdir := range subdirectories {
-		if err = a.analyze(filepath.Join(dir, subdir.Name())); err != nil {
+		if err = a.Analyze(filepath.Join(dir, subdir.Name())); err != nil {
 			return err
 		}
 	}
@@ -122,40 +128,4 @@ func (a *analysis) analyze(dir string) error {
 		analyzer.exitDir(dir)
 	}
 	return nil
-}
-
-func (a *analysis) analyzers() []analyzer {
-	return []analyzer{
-		a.KubectlAnalyzer,
-		a.skaffoldAnalyzer,
-		a.builderAnalyzer,
-	}
-}
-
-// analyzer is following the visitor pattern. It is called on every file
-// as the analysis.analyze function walks the directory structure recursively.
-// It can manage state and react to walking events assuming a breadth first search.
-type analyzer interface {
-	enterDir(dir string)
-	analyzeFile(file string) error
-	exitDir(dir string)
-}
-
-// directoryAnalyzer is a base analyzer that can be included in every analyzer as a convenience
-// it saves the current directory on enterDir events. Benefits to include this into other analyzers is that
-// they can rely on the current directory var, but also they don't have to implement enterDir and exitDir.
-type directoryAnalyzer struct {
-	currentDir string
-}
-
-func (a *directoryAnalyzer) analyzeFile(_ string) error {
-	return nil
-}
-
-func (a *directoryAnalyzer) enterDir(dir string) {
-	a.currentDir = dir
-}
-
-func (a *directoryAnalyzer) exitDir(_ string) {
-	//pass
 }

--- a/pkg/skaffold/initializer/analyze/analyze_test.go
+++ b/pkg/skaffold/initializer/analyze/analyze_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package initializer
+package analyze
 
 import (
 	"strings"
@@ -294,19 +294,20 @@ deploy:
 			t.Override(&docker.Validate, fakeValidateDockerfile)
 			t.Override(&jib.Validate, fakeValidateJibConfig)
 
-			a := newAnalysis(test.config)
+			a := NewAnalyzer(test.config)
 
-			err := a.analyze(".")
+			err := a.Analyze(".")
 
 			t.CheckError(test.shouldErr, err)
 			if test.shouldErr {
 				return
 			}
 
-			t.CheckDeepEqual(test.expectedConfigs, a.KubectlAnalyzer.kubernetesManifests)
-			t.CheckDeepEqual(len(test.expectedPaths), len(a.builderAnalyzer.foundBuilders))
-			for i := range a.builderAnalyzer.foundBuilders {
-				t.CheckDeepEqual(test.expectedPaths[i], a.builderAnalyzer.foundBuilders[i].Path())
+			t.CheckDeepEqual(test.expectedConfigs, a.Manifests())
+			builders := a.Builders()
+			t.CheckDeepEqual(len(test.expectedPaths), len(builders))
+			for i := range builders {
+				t.CheckDeepEqual(test.expectedPaths[i], builders[i].Path())
 			}
 		})
 	}

--- a/pkg/skaffold/initializer/analyze/builder.go
+++ b/pkg/skaffold/initializer/analyze/builder.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analyze
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/build"
+)
+
+type builderAnalyzer struct {
+	directoryAnalyzer
+	enableJibInit        bool
+	enableBuildpacksInit bool
+	findBuilders         bool
+	buildpacksBuilder    string
+	foundBuilders        []build.InitBuilder
+
+	parentDirToStopFindJibSettings string
+}
+
+func (a *builderAnalyzer) analyzeFile(filePath string) error {
+	if a.findBuilders {
+		lookForJib := a.parentDirToStopFindJibSettings == "" || a.parentDirToStopFindJibSettings == a.currentDir
+		builderConfigs, lookForJib := a.detectBuilders(filePath, lookForJib)
+		a.foundBuilders = append(a.foundBuilders, builderConfigs...)
+		if !lookForJib {
+			a.parentDirToStopFindJibSettings = a.currentDir
+		}
+	}
+	return nil
+}
+
+func (a *builderAnalyzer) exitDir(dir string) {
+	if a.parentDirToStopFindJibSettings == dir {
+		a.parentDirToStopFindJibSettings = ""
+	}
+}
+
+// detectBuilders checks if a path is a builder config, and if it is, returns the InitBuilders representing the
+// configs. Also returns a boolean marking search completion for subdirectories (true = subdirectories should
+// continue to be searched, false = subdirectories should not be searched for more builders)
+func (a *builderAnalyzer) detectBuilders(path string, detectJib bool) ([]build.InitBuilder, bool) {
+	// TODO: Remove backwards compatibility if statement (not entire block)
+	if a.enableJibInit && detectJib {
+		// Check for jib
+		if builders := jib.Validate(path); builders != nil {
+			results := make([]build.InitBuilder, len(builders))
+			for i := range builders {
+				results[i] = builders[i]
+			}
+			return results, false
+		}
+	}
+
+	// Check for Dockerfile
+	base := filepath.Base(path)
+	if strings.Contains(strings.ToLower(base), "dockerfile") {
+		if docker.Validate(path) {
+			results := []build.InitBuilder{docker.ArtifactConfig{File: path}}
+			return results, true
+		}
+	}
+
+	// TODO: Remove backwards compatibility if statement (not entire block)
+	if a.enableBuildpacksInit {
+		// Check for buildpacks
+		if buildpacks.Validate(path) {
+			results := []build.InitBuilder{buildpacks.ArtifactConfig{
+				File:    path,
+				Builder: a.buildpacksBuilder,
+			}}
+			return results, true
+		}
+	}
+
+	// TODO: Check for more builders
+
+	return nil, true
+}

--- a/pkg/skaffold/initializer/analyze/config.go
+++ b/pkg/skaffold/initializer/analyze/config.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analyze
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
+)
+
+type skaffoldConfigAnalyzer struct {
+	directoryAnalyzer
+	force        bool
+	analyzeMode  bool
+	targetConfig string
+}
+
+func (a *skaffoldConfigAnalyzer) analyzeFile(filePath string) error {
+	if !schema.IsSkaffoldConfig(filePath) || a.force || a.analyzeMode {
+		return nil
+	}
+	sameFiles, err := sameFiles(filePath, a.targetConfig)
+	if err != nil {
+		return fmt.Errorf("failed to analyze file %s: %s", filePath, err)
+	}
+	if !sameFiles {
+		return nil
+	}
+	return fmt.Errorf("pre-existing %s found (you may continue with --force)", filePath)
+}
+
+func sameFiles(a, b string) (bool, error) {
+	absA, err := filepath.Abs(a)
+	if err != nil {
+		return false, err
+	}
+	absB, err := filepath.Abs(b)
+	if err != nil {
+		return false, err
+	}
+	return absA == absB, nil
+}

--- a/pkg/skaffold/initializer/analyze/config_test.go
+++ b/pkg/skaffold/initializer/analyze/config_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analyze
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestConfigAnalyzer(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputFile string
+		analyzer  skaffoldConfigAnalyzer
+		shouldErr bool
+	}{
+		{
+			name:      "not skaffold config",
+			inputFile: "../testdata/init/hello/main.go",
+			analyzer:  skaffoldConfigAnalyzer{},
+			shouldErr: false,
+		},
+		{
+			name:      "skaffold config equals target config",
+			inputFile: "../testdata/init/hello/skaffold.yaml",
+			analyzer: skaffoldConfigAnalyzer{
+				targetConfig: "../testdata/init/hello/skaffold.yaml",
+			},
+			shouldErr: true,
+		},
+		{
+			name:      "skaffold config does not equal target config",
+			inputFile: "../testdata/init/hello/skaffold.yaml",
+			analyzer: skaffoldConfigAnalyzer{
+				targetConfig: "../testdata/init/hello/skaffold.yaml.out",
+			},
+			shouldErr: false,
+		},
+		{
+			name:      "force overrides",
+			inputFile: "../testdata/init/hello/skaffold.yaml",
+			analyzer: skaffoldConfigAnalyzer{
+				force:        true,
+				targetConfig: "../testdata/init/hello/skaffold.yaml",
+			},
+			shouldErr: false,
+		},
+		{
+			name:      "analyze mode can skip writing, no error",
+			inputFile: "../testdata/init/hello/skaffold.yaml",
+			analyzer: skaffoldConfigAnalyzer{
+				force:        false,
+				analyzeMode:  true,
+				targetConfig: testutil.Abs(t, "../testdata/init/hello/skaffold.yaml"),
+			},
+			shouldErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			err := test.analyzer.analyzeFile(test.inputFile)
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}

--- a/pkg/skaffold/initializer/analyze/directory.go
+++ b/pkg/skaffold/initializer/analyze/directory.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analyze
+
+// directoryAnalyzer is a base analyzer that can be included in every analyzer as a convenience
+// it saves the current directory on enterDir events. Benefits to include this into other analyzers is that
+// they can rely on the current directory var, but also they don't have to implement enterDir and exitDir.
+type directoryAnalyzer struct {
+	currentDir string
+}
+
+func (a *directoryAnalyzer) analyzeFile(_ string) error {
+	return nil
+}
+
+func (a *directoryAnalyzer) enterDir(dir string) {
+	a.currentDir = dir
+}
+
+func (a *directoryAnalyzer) exitDir(_ string) {
+	//pass
+}

--- a/pkg/skaffold/initializer/analyze/kubernetes.go
+++ b/pkg/skaffold/initializer/analyze/kubernetes.go
@@ -14,20 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package initializer
+package analyze
 
-import "sort"
+import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
+)
 
-type sortedSet map[string]interface{}
-
-func (s sortedSet) add(value string) {
-	s[value] = value
+// kubectlAnalyzer is a Visitor during the directory analysis that collects kubernetes manifests
+type kubeAnalyzer struct {
+	directoryAnalyzer
+	kubernetesManifests []string
 }
 
-func (s sortedSet) values() (values []string) {
-	for val := range s {
-		values = append(values, val)
+func (k *kubeAnalyzer) analyzeFile(filePath string) error {
+	if kubernetes.IsKubernetesManifest(filePath) && !schema.IsSkaffoldConfig(filePath) {
+		k.kubernetesManifests = append(k.kubernetesManifests, filePath)
 	}
-	sort.Strings(values)
-	return values
+	return nil
 }

--- a/pkg/skaffold/initializer/build/json.go
+++ b/pkg/skaffold/initializer/build/json.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package initializer
+package build
 
 import (
 	"encoding/json"
@@ -25,7 +25,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 )
 
-func printAnalyzeOldFormat(out io.Writer, skipBuild bool, pairs []builderImagePair, unresolvedBuilders []InitBuilder, unresolvedImages []string) error {
+// TODO(nkubala): make these private again once DoInit() relinquishes control of the builder/image processing
+func PrintAnalyzeOldFormat(out io.Writer, skipBuild bool, pairs []BuilderImagePair, unresolvedBuilders []InitBuilder, unresolvedImages []string) error {
 	if !skipBuild && len(unresolvedBuilders) == 0 {
 		return errors.New("one or more valid Dockerfiles must be present to build images with skaffold; please provide at least one Dockerfile and try again, or run `skaffold init --skip-build`")
 	}
@@ -52,7 +53,7 @@ func printAnalyzeOldFormat(out io.Writer, skipBuild bool, pairs []builderImagePa
 
 // printAnalyzeJSON takes the automatically resolved builder/image pairs, the unresolved images, and the unresolved builders, and generates
 // a JSON string containing builder config information,
-func printAnalyzeJSON(out io.Writer, skipBuild bool, pairs []builderImagePair, unresolvedBuilders []InitBuilder, unresolvedImages []string) error {
+func PrintAnalyzeJSON(out io.Writer, skipBuild bool, pairs []BuilderImagePair, unresolvedBuilders []InitBuilder, unresolvedImages []string) error {
 	if !skipBuild && len(unresolvedBuilders) == 0 {
 		return errors.New("one or more valid Dockerfiles must be present to build images with skaffold; please provide at least one Dockerfile and try again, or run `skaffold init --skip-build`")
 	}

--- a/pkg/skaffold/initializer/build/json_test.go
+++ b/pkg/skaffold/initializer/build/json_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package initializer
+package build
 
 import (
 	"bytes"
@@ -28,7 +28,7 @@ import (
 func TestPrintAnalyzeJSON(t *testing.T) {
 	tests := []struct {
 		description string
-		pairs       []builderImagePair
+		pairs       []BuilderImagePair
 		builders    []InitBuilder
 		images      []string
 		skipBuild   bool
@@ -37,7 +37,7 @@ func TestPrintAnalyzeJSON(t *testing.T) {
 	}{
 		{
 			description: "builders and images with pairs",
-			pairs:       []builderImagePair{{jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), Image: "image1", File: "build.gradle", Project: "project"}, "image1"}},
+			pairs:       []BuilderImagePair{{jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), Image: "image1", File: "build.gradle", Project: "project"}, "image1"}},
 			builders:    []InitBuilder{docker.ArtifactConfig{File: "Dockerfile"}},
 			images:      []string{"image2"},
 			expected:    `{"builders":[{"name":"Jib Gradle Plugin","payload":{"image":"image1","path":"build.gradle","project":"project"}},{"name":"Docker","payload":{"path":"Dockerfile"}}],"images":[{"name":"image1","foundMatch":true},{"name":"image2","foundMatch":false}]}` + "\n",
@@ -68,7 +68,7 @@ func TestPrintAnalyzeJSON(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			var out bytes.Buffer
 
-			err := printAnalyzeJSON(&out, test.skipBuild, test.pairs, test.builders, test.images)
+			err := PrintAnalyzeJSON(&out, test.skipBuild, test.pairs, test.builders, test.images)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, out.String())
 		})
@@ -78,7 +78,7 @@ func TestPrintAnalyzeJSON(t *testing.T) {
 func TestPrintAnalyzeJSONNoJib(t *testing.T) {
 	tests := []struct {
 		description string
-		pairs       []builderImagePair
+		pairs       []BuilderImagePair
 		builders    []InitBuilder
 		images      []string
 		skipBuild   bool
@@ -111,7 +111,7 @@ func TestPrintAnalyzeJSONNoJib(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			var out bytes.Buffer
 
-			err := printAnalyzeOldFormat(&out, test.skipBuild, test.pairs, test.builders, test.images)
+			err := PrintAnalyzeOldFormat(&out, test.skipBuild, test.pairs, test.builders, test.images)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, out.String())
 		})

--- a/pkg/skaffold/initializer/build/set.go
+++ b/pkg/skaffold/initializer/build/set.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import "sort"
+
+type sortedSet map[string]interface{}
+
+func (s sortedSet) add(value string) {
+	s[value] = value
+}
+
+func (s sortedSet) values() (values []string) {
+	for val := range s {
+		values = append(values, val)
+	}
+	sort.Strings(values)
+	return values
+}

--- a/pkg/skaffold/initializer/config.go
+++ b/pkg/skaffold/initializer/config.go
@@ -17,7 +17,6 @@ limitations under the License.
 package initializer
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -25,8 +24,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/deploy"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
@@ -36,40 +35,7 @@ var (
 	getWd = os.Getwd
 )
 
-type skaffoldConfigAnalyzer struct {
-	directoryAnalyzer
-	force        bool
-	analyzeMode  bool
-	targetConfig string
-}
-
-func (a *skaffoldConfigAnalyzer) analyzeFile(filePath string) error {
-	if !schema.IsSkaffoldConfig(filePath) || a.force || a.analyzeMode {
-		return nil
-	}
-	sameFiles, err := sameFiles(filePath, a.targetConfig)
-	if err != nil {
-		return fmt.Errorf("failed to analyze file %s: %s", filePath, err)
-	}
-	if !sameFiles {
-		return nil
-	}
-	return fmt.Errorf("pre-existing %s found (you may continue with --force)", filePath)
-}
-
-func sameFiles(a, b string) (bool, error) {
-	absA, err := filepath.Abs(a)
-	if err != nil {
-		return false, err
-	}
-	absB, err := filepath.Abs(b)
-	if err != nil {
-		return false, err
-	}
-	return absA == absB, nil
-}
-
-func generateSkaffoldConfig(k deploy.DeploymentInitializer, buildConfigPairs []builderImagePair) *latest.SkaffoldConfig {
+func generateSkaffoldConfig(k deploy.DeploymentInitializer, buildConfigPairs []build.BuilderImagePair) *latest.SkaffoldConfig {
 	// if we're here, the user has no skaffold yaml so we need to generate one
 	// if the user doesn't have any k8s yamls, generate one for each dockerfile
 	logrus.Info("generating skaffold config")
@@ -121,7 +87,7 @@ func canonicalizeName(name string) string {
 	return canonicalized[:253]
 }
 
-func artifacts(pairs []builderImagePair) []*latest.Artifact {
+func artifacts(pairs []build.BuilderImagePair) []*latest.Artifact {
 	var artifacts []*latest.Artifact
 
 	for _, pair := range pairs {

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -26,37 +26,12 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/analyze"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
-
-// NoBuilder allows users to specify they don't want to build
-// an image we parse out from a Kubernetes manifest
-const NoBuilder = "None (image not built from these sources)"
-
-// InitBuilder represents a builder that can be chosen by skaffold init.
-type InitBuilder interface {
-	// Name returns the name of the builder
-	Name() string
-	// Describe returns the initBuilder's string representation, used when prompting the user to choose a builder.
-	// Must be unique between artifacts.
-	Describe() string
-	// UpdateArtifact updates the Artifact to be included in the generated Build Config
-	UpdateArtifact(*latest.Artifact)
-	// ConfiguredImage returns the target image configured by the builder, or an empty string if no image is configured.
-	// This should be a cheap operation.
-	ConfiguredImage() string
-	// Path returns the path to the build file
-	Path() string
-}
-
-// builderImagePair defines a builder and the image it builds
-type builderImagePair struct {
-	Builder   InitBuilder
-	ImageName string
-}
 
 // DoInit executes the `skaffold init` flow.
 func DoInit(ctx context.Context, out io.Writer, c config.Config) error {
@@ -68,43 +43,43 @@ func DoInit(ctx context.Context, out io.Writer, c config.Config) error {
 		}
 	}
 
-	a := newAnalysis(c)
+	a := analyze.NewAnalyzer(c)
 
-	if err := a.analyze(rootDir); err != nil {
+	if err := a.Analyze(rootDir); err != nil {
 		return err
 	}
 
-	deployInitializer, err := deploy.NewDeployInitializer(a.KubectlAnalyzer.Manifests(), c)
+	deployInitializer, err := deploy.NewDeployInitializer(a.Manifests(), c)
 	if err != nil {
 		return err
 	}
 
 	// Determine which builders/images require prompting
 	pairs, unresolvedBuilderConfigs, unresolvedImages :=
-		matchBuildersToImages(
-			a.builderAnalyzer.foundBuilders,
-			stripTags(deployInitializer.GetImages()))
+		build.MatchBuildersToImages(
+			a.Builders(),
+			build.StripTags(deployInitializer.GetImages()))
 
 	if c.Analyze {
 		// TODO: Remove backwards compatibility block
 		if !c.EnableNewInitFormat {
-			return printAnalyzeOldFormat(out, c.SkipBuild, pairs, unresolvedBuilderConfigs, unresolvedImages)
+			return build.PrintAnalyzeOldFormat(out, c.SkipBuild, pairs, unresolvedBuilderConfigs, unresolvedImages)
 		}
 
-		return printAnalyzeJSON(out, c.SkipBuild, pairs, unresolvedBuilderConfigs, unresolvedImages)
+		return build.PrintAnalyzeJSON(out, c.SkipBuild, pairs, unresolvedBuilderConfigs, unresolvedImages)
 	}
 	if !c.SkipBuild {
-		if len(a.builderAnalyzer.foundBuilders) == 0 && c.CliArtifacts == nil {
+		if len(a.Builders()) == 0 && c.CliArtifacts == nil {
 			return errors.New("one or more valid builder configuration (Dockerfile or Jib configuration) must be present to build images with skaffold; please provide at least one build config and try again or run `skaffold init --skip-build`")
 		}
 		if c.CliArtifacts != nil {
-			newPairs, err := processCliArtifacts(c.CliArtifacts)
+			newPairs, err := build.ProcessCliArtifacts(c.CliArtifacts)
 			if err != nil {
 				return errors.Wrap(err, "processing cli artifacts")
 			}
 			pairs = append(pairs, newPairs...)
 		} else {
-			resolved, err := resolveBuilderImages(unresolvedBuilderConfigs, unresolvedImages, c.Force)
+			resolved, err := build.ResolveBuilderImages(unresolvedBuilderConfigs, unresolvedImages, c.Force)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
part of a cleanup and refactor of the init package. this moves builder and analyzer code into their respective separate packages.

a few test files were separate, but not rewritten. a few structs were renamed for clarity, and some were also made public, since they are being used outside their package.

some functions were also made public so they can be used outside their package. these will be made private again once `DoInit()` hands control of the processing to the separate components - this was omitted from this PR for ease of review. notes were made where appropriate.

this PR has no functional change.