### PR TITLE
add SKAFFOLD_SKIP_LICENSES for skipping license collection when building locally

### DIFF
--- a/hack/generate-statik.sh
+++ b/hack/generate-statik.sh
@@ -16,6 +16,10 @@
 
 set -euo pipefail
 
+if ! [ -z "${SKAFFOLD_SKIP_LICENSES-}" ]; then
+    exit 0
+fi
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 BIN=${DIR}/bin


### PR DESCRIPTION
this gives devs an escape hatch in case we want to skip license collection when building locally. this saves at least 5 seconds on every `make` run, which really adds up. also, allows skipping license collection in the event that something is broken with the `go-licenses` tool.