### PR TITLE
Allow Sync for non-root containers-hotreload example

### DIFF
--- a/examples/hot-reload/k8s/node.yaml
+++ b/examples/hot-reload/k8s/node.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         app: node
     spec:
+      securityContext:
+        runAsUser: 1000
       containers:
       - name: node
         image: node-example

--- a/examples/hot-reload/k8s/python.yaml
+++ b/examples/hot-reload/k8s/python.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         app: python
     spec:
+      securityContext:
+        runAsUser: 1000
       containers:
       - name: python
         image: python-reload

--- a/examples/hot-reload/node/Dockerfile
+++ b/examples/hot-reload/node/Dockerfile
@@ -5,5 +5,5 @@ EXPOSE 3000
 CMD ["npm", "run", "dev"]
 
 COPY package* ./
-RUN npm ci
+RUN chown -R 400:400 /app && npm ci
 COPY src .

--- a/examples/hot-reload/node/Dockerfile
+++ b/examples/hot-reload/node/Dockerfile
@@ -1,9 +1,14 @@
-FROM node:10.15.3-alpine
+FROM node:12.16.0-alpine3.10
 
-WORKDIR /app
+USER node
+RUN mkdir /home/node/app
+WORKDIR /home/node/app
+
 EXPOSE 3000
-CMD ["npm", "run", "dev"]
+ARG ENV=production
+ENV NODE_ENV $ENV
+CMD npm run $NODE_ENV
 
-COPY package* ./
-RUN chown -R 400:400 /app && npm ci
-COPY src .
+COPY --chown=node:node package* ./
+RUN npm ci
+COPY --chown=node:node . .

--- a/examples/hot-reload/node/package.json
+++ b/examples/hot-reload/node/package.json
@@ -2,9 +2,10 @@
   "name": "backend",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
-    "dev": "nodemon index.js"
+    "production": "node src/index.js",
+    "development": "nodemon src/index.js"
   },
   "dependencies": {
     "express": "^4.16.4"

--- a/examples/hot-reload/python/Dockerfile
+++ b/examples/hot-reload/python/Dockerfile
@@ -1,9 +1,18 @@
 FROM python:3.7.4-alpine3.10
-CMD ["python", "-m", "flask", "run", "--host=0.0.0.0"]
-ENV FLASK_DEBUG=1
-ENV FLASK_APP=app.py
-WORKDIR /usr/src/app
-COPY requirements.txt .
-RUN chown -R 400:400 /usr/src/app && pip install -r requirements.txt
-COPY src ./
 
+RUN pip install --upgrade pip
+
+RUN adduser -D python
+USER python
+WORKDIR /home/python
+
+ARG DEBUG=0
+ENV FLASK_DEBUG $DEBUG
+ENV FLASK_APP=src/app.py
+CMD ["python", "-m", "flask", "run", "--host=0.0.0.0"]
+
+COPY --chown=python:python requirements.txt .
+ENV PATH="/home/python/.local/bin:${PATH}"
+RUN pip install --user -r requirements.txt
+
+COPY --chown=python:python src src

--- a/examples/hot-reload/python/Dockerfile
+++ b/examples/hot-reload/python/Dockerfile
@@ -2,8 +2,8 @@ FROM python:3.7.4-alpine3.10
 CMD ["python", "-m", "flask", "run", "--host=0.0.0.0"]
 ENV FLASK_DEBUG=1
 ENV FLASK_APP=app.py
-
+WORKDIR /usr/src/app
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN chown -R 400:400 /usr/src/app && pip install -r requirements.txt
 COPY src ./
 

--- a/examples/hot-reload/skaffold.yaml
+++ b/examples/hot-reload/skaffold.yaml
@@ -4,11 +4,35 @@ build:
   artifacts:
   - image: node-example
     context: node
-    sync:
-      infer:
-      - 'src/**/*.js'
+
   - image: python-reload
     context: python
-    sync:
-      infer:
-      - 'src/**/*.py'
+
+profiles:
+  - name: dev
+    activation:
+      - command: dev
+    build:
+      artifacts:
+      - image: node-example
+        context: node
+        docker:
+          buildArgs:
+            ENV: development
+        sync:
+          manual:
+          # Sync all the javascript files that are in the src folder
+          # with the container src folder
+          - src: 'src/**/*.js'
+            dest: .
+      - image: python-reload
+        context: python
+        docker:
+          buildArgs:
+            DEBUG: 1
+        sync:
+          manual:
+          # Sync all the javascript files that are in the src folder
+          # with the container src folder
+          - src: 'src/**/*.py'
+            dest: .

--- a/examples/hot-reload/skaffold.yaml
+++ b/examples/hot-reload/skaffold.yaml
@@ -36,3 +36,4 @@ profiles:
           # with the container src folder
           - src: 'src/**/*.py'
             dest: .
+            

--- a/examples/hot-reload/skaffold.yaml
+++ b/examples/hot-reload/skaffold.yaml
@@ -36,4 +36,3 @@ profiles:
           # with the container src folder
           - src: 'src/**/*.py'
             dest: .
-            

--- a/integration/examples/hot-reload/k8s/node.yaml
+++ b/integration/examples/hot-reload/k8s/node.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         app: node
     spec:
+      securityContext:
+        runAsUser: 1000
       containers:
       - name: node
         image: node-example

--- a/integration/examples/hot-reload/k8s/python.yaml
+++ b/integration/examples/hot-reload/k8s/python.yaml
@@ -22,6 +22,8 @@ spec:
       labels:
         app: python
     spec:
+      securityContext:
+        runAsUser: 1000
       containers:
       - name: python
         image: python-reload

--- a/integration/examples/hot-reload/node/Dockerfile
+++ b/integration/examples/hot-reload/node/Dockerfile
@@ -5,5 +5,5 @@ EXPOSE 3000
 CMD ["npm", "run", "dev"]
 
 COPY package* ./
-RUN npm ci
+RUN chown -R 400:400 /app && npm ci
 COPY src .

--- a/integration/examples/hot-reload/node/Dockerfile
+++ b/integration/examples/hot-reload/node/Dockerfile
@@ -1,9 +1,14 @@
-FROM node:10.15.3-alpine
+FROM node:12.16.0-alpine3.10
 
-WORKDIR /app
+USER node
+RUN mkdir /home/node/app
+WORKDIR /home/node/app
+
 EXPOSE 3000
-CMD ["npm", "run", "dev"]
+ARG ENV=production
+ENV NODE_ENV $ENV
+CMD npm run $NODE_ENV
 
-COPY package* ./
-RUN chown -R 400:400 /app && npm ci
-COPY src .
+COPY --chown=node:node package* ./
+RUN npm ci
+COPY --chown=node:node . .

--- a/integration/examples/hot-reload/node/package.json
+++ b/integration/examples/hot-reload/node/package.json
@@ -2,9 +2,10 @@
   "name": "backend",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
-    "dev": "nodemon index.js"
+    "production": "node src/index.js",
+    "development": "nodemon src/index.js"
   },
   "dependencies": {
     "express": "^4.16.4"

--- a/integration/examples/hot-reload/python/Dockerfile
+++ b/integration/examples/hot-reload/python/Dockerfile
@@ -2,8 +2,7 @@ FROM python:3.7.4-alpine3.10
 CMD ["python", "-m", "flask", "run", "--host=0.0.0.0"]
 ENV FLASK_DEBUG=1
 ENV FLASK_APP=app.py
-
+WORKDIR /usr/src/app
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN chown -R 400:400 /usr/src/app && pip install -r requirements.txt
 COPY src ./
-

--- a/integration/examples/hot-reload/python/Dockerfile
+++ b/integration/examples/hot-reload/python/Dockerfile
@@ -1,8 +1,18 @@
 FROM python:3.7.4-alpine3.10
+
+RUN pip install --upgrade pip
+
+RUN adduser -D python
+USER python
+WORKDIR /home/python
+
+ARG DEBUG=0
+ENV FLASK_DEBUG $DEBUG
+ENV FLASK_APP=src/app.py
 CMD ["python", "-m", "flask", "run", "--host=0.0.0.0"]
-ENV FLASK_DEBUG=1
-ENV FLASK_APP=app.py
-WORKDIR /usr/src/app
-COPY requirements.txt .
-RUN chown -R 400:400 /usr/src/app && pip install -r requirements.txt
-COPY src ./
+
+COPY --chown=python:python requirements.txt .
+ENV PATH="/home/python/.local/bin:${PATH}"
+RUN pip install --user -r requirements.txt
+
+COPY --chown=python:python src src

--- a/integration/examples/hot-reload/skaffold.yaml
+++ b/integration/examples/hot-reload/skaffold.yaml
@@ -4,11 +4,35 @@ build:
   artifacts:
   - image: node-example
     context: node
-    sync:
-      infer:
-      - 'src/**/*.js'
+
   - image: python-reload
     context: python
-    sync:
-      infer:
-      - 'src/**/*.py'
+
+profiles:
+  - name: dev
+    activation:
+      - command: dev
+    build:
+      artifacts:
+      - image: node-example
+        context: node
+        docker:
+          buildArgs:
+            ENV: development
+        sync:
+          manual:
+          # Sync all the javascript files that are in the src folder
+          # with the container src folder
+          - src: 'src/**/*.js'
+            dest: .
+      - image: python-reload
+        context: python
+        docker:
+          buildArgs:
+            DEBUG: 1
+        sync:
+          manual:
+          # Sync all the javascript files that are in the src folder
+          # with the container src folder
+          - src: 'src/**/*.py'
+            dest: .

--- a/integration/examples/hot-reload/skaffold.yaml
+++ b/integration/examples/hot-reload/skaffold.yaml
@@ -36,3 +36,4 @@ profiles:
           # with the container src folder
           - src: 'src/**/*.py'
             dest: .
+            

--- a/integration/examples/hot-reload/skaffold.yaml
+++ b/integration/examples/hot-reload/skaffold.yaml
@@ -36,4 +36,3 @@ profiles:
           # with the container src folder
           - src: 'src/**/*.py'
             dest: .
-            


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
When deploying the hot-reload example to non-root containers, skaffold dev sync functionality fails with "permissions denied"
There has been multiple open issues referring to this error: #2041 #1950 
This change will ensure examples will be compatible with more clusters with higher security requirements.

**Description**
chowning the target folder with the proper runtime UID so that tar xmf (Sync) command will not fail

**User facing changes**

Write n/a if not output or log lines changed and no behavior is changed

**Before**
The following error cases the Sync on save to break
```
WARN[0024] Skipping deploy due to sync error: copying files: Running [kubectl --context <context> exec node-56846577b4-c878r --namespace <namespace> -c node -i -- tar xmf - -C / --no-same-owner]
 - stdout: 
 - stderr: tar: removing leading '/' from member names
tar: can't remove old file app/index.js: Permission denied
command terminated with exit code 1
: exit status 1 
```
**After**
skaffold dev sync is working as expected on both node and python examples

**Next PRs.**

<!-- In this section describe a list of follow up PRs if the current PR is a part of big feature change.
See example https://github.com/GoogleContainerTools/skaffold/pull/2811
Write n/a if not applicable.
-->

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [ ] Mentions any output changes.
- [ ] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [ ] Adds integration tests if needed.


**Reviewer Notes**


**Release Notes**
- hot-reload example skaffold dev sync working on non-root containers

