### PR TITLE
[refactor] make DoInit() a proper controller

### DIFF
--- a/pkg/skaffold/initializer/build/builders.go
+++ b/pkg/skaffold/initializer/build/builders.go
@@ -17,26 +17,21 @@ limitations under the License.
 package build
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"sort"
-	"strings"
+	"io"
 
-	"github.com/sirupsen/logrus"
-
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
 
 // NoBuilder allows users to specify they don't want to build
 // an image we parse out from a Kubernetes manifest
 const NoBuilder = "None (image not built from these sources)"
+
+type Error string
+
+func (e Error) Error() string { return string(e) }
+
+const ErrorNoBuilder = Error("one or more valid builder configuration (Dockerfile or Jib configuration) must be present to build images with skaffold; please provide at least one build config and try again or run `skaffold init --skip-build`")
 
 // InitBuilder represents a builder that can be chosen by skaffold init.
 type InitBuilder interface {
@@ -60,183 +55,50 @@ type BuilderImagePair struct {
 	ImageName string
 }
 
-// MatchBuildersToImages takes a list of builders and images, checks if any of the builders' configured target
-// images match an image in the image list, and returns a list of the matching builder/image pairs. Also
-// separately returns the builder configs and images that didn't have any matches.
-func MatchBuildersToImages(builderConfigs []InitBuilder, images []string) ([]BuilderImagePair, []InitBuilder, []string) {
-	var pairs []BuilderImagePair
-	var unresolvedImages = make(sortedSet)
-	for _, image := range images {
-		builderIdx := findExactlyOnceMatchingBuilder(builderConfigs, image)
-
-		// exactly one builder found for the image
-		if builderIdx != -1 {
-			// save the pair
-			pairs = append(pairs, BuilderImagePair{ImageName: image, Builder: builderConfigs[builderIdx]})
-			// remove matched builder from builderConfigs
-			builderConfigs = append(builderConfigs[:builderIdx], builderConfigs[builderIdx+1:]...)
-		} else {
-			// No definite pair found, add to images list
-			unresolvedImages.add(image)
-		}
-	}
-	return pairs, builderConfigs, unresolvedImages.values()
+type Initializer interface {
+	ProcessImages([]string) error
+	BuildConfig() latest.BuildConfig
+	BuilderImagePairs() []BuilderImagePair
+	PrintAnalysis(io.Writer) error
 }
 
-func findExactlyOnceMatchingBuilder(builderConfigs []InitBuilder, image string) int {
-	matchingConfigIndex := -1
-	for i, config := range builderConfigs {
-		if image != config.ConfiguredImage() {
-			continue
-		}
-		// Found more than one match;
-		if matchingConfigIndex != -1 {
-			return -1
-		}
-		matchingConfigIndex = i
-	}
-	return matchingConfigIndex
+type emptyBuildInitializer struct {
 }
 
-// TODO(nkubala): make these private again once DoInit() relinquishes control of the builder/image processing
-func ProcessCliArtifacts(artifacts []string) ([]BuilderImagePair, error) {
-	var pairs []BuilderImagePair
-	for _, artifact := range artifacts {
-		// Parses JSON in the form of: {"builder":"Name of Builder","payload":{...},"image":"image.name"}.
-		// The builder field is parsed first to determine the builder type, and the payload is parsed
-		// afterwards once the type is determined.
-		a := struct {
-			Name  string `json:"builder"`
-			Image string `json:"image"`
-		}{}
-		if err := json.Unmarshal([]byte(artifact), &a); err != nil {
-			// Not JSON, use backwards compatible method
-			parts := strings.Split(artifact, "=")
-			if len(parts) != 2 {
-				return nil, fmt.Errorf("malformed artifact provided: %s", artifact)
-			}
-			pairs = append(pairs, BuilderImagePair{
-				Builder:   docker.ArtifactConfig{File: parts[0]},
-				ImageName: parts[1],
-			})
-			continue
-		}
-
-		// Use builder type to parse payload
-		switch a.Name {
-		case docker.Name:
-			parsed := struct {
-				Payload docker.ArtifactConfig `json:"payload"`
-			}{}
-			if err := json.Unmarshal([]byte(artifact), &parsed); err != nil {
-				return nil, err
-			}
-			pair := BuilderImagePair{Builder: parsed.Payload, ImageName: a.Image}
-			pairs = append(pairs, pair)
-
-		// FIXME: shouldn't use a human-readable name?
-		case jib.PluginName(jib.JibGradle), jib.PluginName(jib.JibMaven):
-			parsed := struct {
-				Payload jib.ArtifactConfig `json:"payload"`
-			}{}
-			if err := json.Unmarshal([]byte(artifact), &parsed); err != nil {
-				return nil, err
-			}
-			parsed.Payload.BuilderName = a.Name
-			pair := BuilderImagePair{Builder: parsed.Payload, ImageName: a.Image}
-			pairs = append(pairs, pair)
-
-		case buildpacks.Name:
-			parsed := struct {
-				Payload buildpacks.ArtifactConfig `json:"payload"`
-			}{}
-			if err := json.Unmarshal([]byte(artifact), &parsed); err != nil {
-				return nil, err
-			}
-			pair := BuilderImagePair{Builder: parsed.Payload, ImageName: a.Image}
-			pairs = append(pairs, pair)
-
-		default:
-			return nil, fmt.Errorf("unknown builder type in CLI artifacts: %q", a.Name)
-		}
-	}
-	return pairs, nil
+func (e *emptyBuildInitializer) ProcessImages([]string) error {
+	return nil
 }
 
-// For each image parsed from all k8s manifests, prompt the user for the builder that builds the referenced image
-func ResolveBuilderImages(builderConfigs []InitBuilder, images []string, force bool) ([]BuilderImagePair, error) {
-	// If nothing to choose, don't bother prompting
-	if len(images) == 0 || len(builderConfigs) == 0 {
-		return []BuilderImagePair{}, nil
-	}
-
-	// if we only have 1 image and 1 build config, don't bother prompting
-	if len(images) == 1 && len(builderConfigs) == 1 {
-		return []BuilderImagePair{{
-			Builder:   builderConfigs[0],
-			ImageName: images[0],
-		}}, nil
-	}
-
-	if force {
-		return nil, errors.New("unable to automatically resolve builder/image pairs; run `skaffold init` without `--force` to manually resolve ambiguities")
-	}
-
-	return resolveBuilderImagesInteractively(builderConfigs, images)
+func (e *emptyBuildInitializer) BuildConfig() latest.BuildConfig {
+	return latest.BuildConfig{}
 }
 
-func resolveBuilderImagesInteractively(builderConfigs []InitBuilder, images []string) ([]BuilderImagePair, error) {
-	// Build map from choice string to builder config struct
-	choices := make([]string, len(builderConfigs))
-	choiceMap := make(map[string]InitBuilder, len(builderConfigs))
-	for i, buildConfig := range builderConfigs {
-		choice := buildConfig.Describe()
-		choices[i] = choice
-		choiceMap[choice] = buildConfig
-	}
-	sort.Strings(choices)
-
-	// For each choice, use prompt string to pair builder config with k8s image
-	pairs := []BuilderImagePair{}
-	for {
-		if len(images) == 0 {
-			break
-		}
-
-		image := images[0]
-		choice, err := prompt.BuildConfigFunc(image, append(choices, NoBuilder))
-		if err != nil {
-			return nil, err
-		}
-
-		if choice != NoBuilder {
-			pairs = append(pairs, BuilderImagePair{Builder: choiceMap[choice], ImageName: image})
-			choices = util.RemoveFromSlice(choices, choice)
-		}
-		images = util.RemoveFromSlice(images, image)
-	}
-	if len(choices) > 0 {
-		logrus.Warnf("unused builder configs found in repository: %v", choices)
-	}
-	return pairs, nil
+func (e *emptyBuildInitializer) BuilderImagePairs() []BuilderImagePair {
+	return nil
 }
 
-func StripTags(taggedImages []string) []string {
-	// Remove tags from image names
-	var images []string
-	for _, image := range taggedImages {
-		parsed, err := docker.ParseReference(image)
-		if err != nil {
-			// It's possible that it's a templatized name that can't be parsed as is.
-			warnings.Printf("Couldn't parse image [%s]: %s", image, err.Error())
-			continue
-		}
-		if parsed.Digest != "" {
-			warnings.Printf("Ignoring image referenced by digest: [%s]", image)
-			continue
-		}
+func (e *emptyBuildInitializer) PrintAnalysis(io.Writer) error {
+	return nil
+}
 
-		images = append(images, parsed.BaseName)
+func NewInitializer(builders []InitBuilder, c config.Config) Initializer {
+	switch {
+	case c.SkipBuild:
+		return &emptyBuildInitializer{}
+	case c.CliArtifacts != nil:
+		return &cliBuildInitializer{
+			cliArtifacts:    c.CliArtifacts,
+			builders:        builders,
+			skipBuild:       c.SkipBuild,
+			enableNewFormat: c.EnableNewInitFormat,
+		}
+	default:
+		return &defaultBuildInitializer{
+			builders:        builders,
+			skipBuild:       c.SkipBuild,
+			force:           c.Force,
+			enableNewFormat: c.EnableNewInitFormat,
+			resolveImages:   !c.Analyze,
+		}
 	}
-	return images
 }

--- a/pkg/skaffold/initializer/build/cli.go
+++ b/pkg/skaffold/initializer/build/cli.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+)
+
+type cliBuildInitializer struct {
+	cliArtifacts      []string
+	builderImagePairs []BuilderImagePair
+	builders          []InitBuilder
+	skipBuild         bool
+	enableNewFormat   bool
+}
+
+func (c *cliBuildInitializer) ProcessImages(images []string) error {
+	if len(c.builders) == 0 && len(c.cliArtifacts) == 0 {
+		return ErrorNoBuilder
+	}
+	if err := c.processCliArtifacts(); err != nil {
+		return errors.Wrap(err, "processing cli artifacts")
+	}
+	return nil
+}
+
+func (c *cliBuildInitializer) BuildConfig() latest.BuildConfig {
+	return latest.BuildConfig{
+		Artifacts: artifacts(c.builderImagePairs),
+	}
+}
+
+func (c *cliBuildInitializer) BuilderImagePairs() []BuilderImagePair {
+	return c.builderImagePairs
+}
+
+func (c *cliBuildInitializer) PrintAnalysis(out io.Writer) error {
+	return printAnalysis(out, c.enableNewFormat, c.skipBuild, c.builderImagePairs, c.builders, nil)
+}
+
+func (c *cliBuildInitializer) processCliArtifacts() error {
+	pairs, err := processCliArtifacts(c.cliArtifacts)
+	if err != nil {
+		return err
+	}
+	c.builderImagePairs = pairs
+	return nil
+}
+
+func processCliArtifacts(cliArtifacts []string) ([]BuilderImagePair, error) {
+	var pairs []BuilderImagePair
+	for _, artifact := range cliArtifacts {
+		// Parses JSON in the form of: {"builder":"Name of Builder","payload":{...},"image":"image.name"}.
+		// The builder field is parsed first to determine the builder type, and the payload is parsed
+		// afterwards once the type is determined.
+		a := struct {
+			Name  string `json:"builder"`
+			Image string `json:"image"`
+		}{}
+		if err := json.Unmarshal([]byte(artifact), &a); err != nil {
+			// Not JSON, use backwards compatible method
+			parts := strings.Split(artifact, "=")
+			if len(parts) != 2 {
+				return nil, fmt.Errorf("malformed artifact provided: %s", artifact)
+			}
+			pairs = append(pairs, BuilderImagePair{
+				Builder:   docker.ArtifactConfig{File: parts[0]},
+				ImageName: parts[1],
+			})
+			continue
+		}
+
+		// Use builder type to parse payload
+		switch a.Name {
+		case docker.Name:
+			parsed := struct {
+				Payload docker.ArtifactConfig `json:"payload"`
+			}{}
+			if err := json.Unmarshal([]byte(artifact), &parsed); err != nil {
+				return nil, err
+			}
+			pair := BuilderImagePair{Builder: parsed.Payload, ImageName: a.Image}
+			pairs = append(pairs, pair)
+
+		// FIXME: shouldn't use a human-readable name?
+		case jib.PluginName(jib.JibGradle), jib.PluginName(jib.JibMaven):
+			parsed := struct {
+				Payload jib.ArtifactConfig `json:"payload"`
+			}{}
+			if err := json.Unmarshal([]byte(artifact), &parsed); err != nil {
+				return nil, err
+			}
+			parsed.Payload.BuilderName = a.Name
+			pair := BuilderImagePair{Builder: parsed.Payload, ImageName: a.Image}
+			pairs = append(pairs, pair)
+
+		case buildpacks.Name:
+			parsed := struct {
+				Payload buildpacks.ArtifactConfig `json:"payload"`
+			}{}
+			if err := json.Unmarshal([]byte(artifact), &parsed); err != nil {
+				return nil, err
+			}
+			pair := BuilderImagePair{Builder: parsed.Payload, ImageName: a.Image}
+			pairs = append(pairs, pair)
+
+		default:
+			return nil, fmt.Errorf("unknown builder type in CLI artifacts: %q", a.Name)
+		}
+	}
+	return pairs, nil
+}

--- a/pkg/skaffold/initializer/build/init.go
+++ b/pkg/skaffold/initializer/build/init.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+)
+
+type defaultBuildInitializer struct {
+	builders          []InitBuilder
+	builderImagePairs []BuilderImagePair
+	unresolvedImages  []string
+	skipBuild         bool
+	force             bool
+	enableNewFormat   bool
+	resolveImages     bool
+}
+
+func (d *defaultBuildInitializer) ProcessImages(images []string) error {
+	if len(d.builders) == 0 {
+		return ErrorNoBuilder
+	}
+	if d.skipBuild {
+		return nil
+	}
+
+	// if we're in `analyze` mode, we want to match if we can, but not resolve
+	d.matchBuildersToImages(images)
+	if d.resolveImages {
+		return d.resolveBuilderImages()
+	}
+	return nil
+}
+
+func (d *defaultBuildInitializer) BuildConfig() latest.BuildConfig {
+	return latest.BuildConfig{
+		Artifacts: artifacts(d.builderImagePairs),
+	}
+}
+
+func (d *defaultBuildInitializer) BuilderImagePairs() []BuilderImagePair {
+	return d.builderImagePairs
+}
+
+func (d *defaultBuildInitializer) PrintAnalysis(out io.Writer) error {
+	return printAnalysis(out, d.enableNewFormat, d.skipBuild, d.builderImagePairs, d.builders, d.unresolvedImages)
+}
+
+// matchBuildersToImages takes a list of builders and images, checks if any of the builders' configured target
+// images match an image in the image list, and returns a list of the matching builder/image pairs. Also
+// separately returns the builder configs and images that didn't have any matches.
+func (d *defaultBuildInitializer) matchBuildersToImages(images []string) {
+	pairs, unresolvedBuilders, unresolvedImages := matchBuildersToImages(d.builders, images)
+	d.builderImagePairs = pairs
+	d.unresolvedImages = unresolvedImages
+	d.builders = unresolvedBuilders
+}

--- a/pkg/skaffold/initializer/build/json.go
+++ b/pkg/skaffold/initializer/build/json.go
@@ -25,6 +25,14 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 )
 
+func printAnalysis(out io.Writer, enableNewFormat bool, skipBuild bool, pairs []BuilderImagePair, unresolvedBuilderConfigs []InitBuilder, unresolvedImages []string) error {
+	if !enableNewFormat {
+		return PrintAnalyzeOldFormat(out, skipBuild, pairs, unresolvedBuilderConfigs, unresolvedImages)
+	}
+
+	return PrintAnalyzeJSON(out, skipBuild, pairs, unresolvedBuilderConfigs, unresolvedImages)
+}
+
 // TODO(nkubala): make these private again once DoInit() relinquishes control of the builder/image processing
 func PrintAnalyzeOldFormat(out io.Writer, skipBuild bool, pairs []BuilderImagePair, unresolvedBuilders []InitBuilder, unresolvedImages []string) error {
 	if !skipBuild && len(unresolvedBuilders) == 0 {

--- a/pkg/skaffold/initializer/build/resolve.go
+++ b/pkg/skaffold/initializer/build/resolve.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"sort"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+// For each image parsed from all k8s manifests, prompt the user for the builder that builds the referenced image
+func (d *defaultBuildInitializer) resolveBuilderImages() error {
+	// If nothing to choose, don't bother prompting
+	if len(d.unresolvedImages) == 0 || len(d.builders) == 0 {
+		return nil
+	}
+
+	// if we only have 1 image and 1 build config, don't bother prompting
+	if len(d.unresolvedImages) == 1 && len(d.builders) == 1 {
+		d.builderImagePairs = append(d.builderImagePairs, BuilderImagePair{
+			Builder:   d.builders[0],
+			ImageName: d.unresolvedImages[0],
+		})
+		return nil
+	}
+
+	if d.force {
+		return errors.New("unable to automatically resolve builder/image pairs; run `skaffold init` without `--force` to manually resolve ambiguities")
+	}
+
+	return d.resolveBuilderImagesInteractively()
+}
+
+func (d *defaultBuildInitializer) resolveBuilderImagesInteractively() error {
+	// Build map from choice string to builder config struct
+	choices := make([]string, len(d.builders))
+	choiceMap := make(map[string]InitBuilder, len(d.builders))
+	for i, buildConfig := range d.builders {
+		choice := buildConfig.Describe()
+		choices[i] = choice
+		choiceMap[choice] = buildConfig
+	}
+	sort.Strings(choices)
+
+	// For each choice, use prompt string to pair builder config with k8s image
+	pairs := []BuilderImagePair{}
+	for {
+		if len(d.unresolvedImages) == 0 {
+			break
+		}
+
+		image := d.unresolvedImages[0]
+		choice, err := prompt.BuildConfigFunc(image, append(choices, NoBuilder))
+		if err != nil {
+			return err
+		}
+
+		if choice != NoBuilder {
+			pairs = append(pairs, BuilderImagePair{Builder: choiceMap[choice], ImageName: image})
+			choices = util.RemoveFromSlice(choices, choice)
+		}
+		d.unresolvedImages = util.RemoveFromSlice(d.unresolvedImages, image)
+	}
+	if len(choices) > 0 {
+		logrus.Warnf("unused builder configs found in repository: %v", choices)
+	}
+	d.builderImagePairs = append(d.builderImagePairs, pairs...)
+	return nil
+}

--- a/pkg/skaffold/initializer/build/util.go
+++ b/pkg/skaffold/initializer/build/util.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"path/filepath"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
+)
+
+func matchBuildersToImages(builders []InitBuilder, images []string) ([]BuilderImagePair, []InitBuilder, []string) {
+	images = stripTags(images)
+
+	var pairs []BuilderImagePair
+	var unresolvedImages = make(sortedSet)
+	for _, image := range images {
+		builderIdx := findExactlyOneMatchingBuilder(builders, image)
+
+		// exactly one builder found for the image
+		if builderIdx != -1 {
+			// save the pair
+			pairs = append(pairs, BuilderImagePair{ImageName: image, Builder: builders[builderIdx]})
+			// remove matched builder from builderConfigs
+			builders = append(builders[:builderIdx], builders[builderIdx+1:]...)
+		} else {
+			// No definite pair found, add to images list
+			unresolvedImages.add(image)
+		}
+	}
+	return pairs, builders, unresolvedImages.values()
+}
+
+func findExactlyOneMatchingBuilder(builderConfigs []InitBuilder, image string) int {
+	matchingConfigIndex := -1
+	for i, config := range builderConfigs {
+		if image != config.ConfiguredImage() {
+			continue
+		}
+		// Found more than one match;
+		if matchingConfigIndex != -1 {
+			return -1
+		}
+		matchingConfigIndex = i
+	}
+	return matchingConfigIndex
+}
+
+func stripTags(taggedImages []string) []string {
+	// Remove tags from image names
+	var images []string
+	for _, image := range taggedImages {
+		parsed, err := docker.ParseReference(image)
+		if err != nil {
+			// It's possible that it's a templatized name that can't be parsed as is.
+			warnings.Printf("Couldn't parse image [%s]: %s", image, err.Error())
+			continue
+		}
+		if parsed.Digest != "" {
+			warnings.Printf("Ignoring image referenced by digest: [%s]", image)
+			continue
+		}
+
+		images = append(images, parsed.BaseName)
+	}
+	return images
+}
+
+func artifacts(pairs []BuilderImagePair) []*latest.Artifact {
+	var artifacts []*latest.Artifact
+
+	for _, pair := range pairs {
+		artifact := &latest.Artifact{
+			ImageName: pair.ImageName,
+		}
+
+		workspace := filepath.Dir(pair.Builder.Path())
+		if workspace != "." {
+			artifact.Workspace = workspace
+		}
+
+		pair.Builder.UpdateArtifact(artifact)
+
+		artifacts = append(artifacts, artifact)
+	}
+
+	return artifacts
+}

--- a/pkg/skaffold/initializer/config.go
+++ b/pkg/skaffold/initializer/config.go
@@ -35,7 +35,7 @@ var (
 	getWd = os.Getwd
 )
 
-func generateSkaffoldConfig(k deploy.DeploymentInitializer, buildConfigPairs []build.BuilderImagePair) *latest.SkaffoldConfig {
+func generateSkaffoldConfig(b build.Initializer, d deploy.Initializer) *latest.SkaffoldConfig {
 	// if we're here, the user has no skaffold yaml so we need to generate one
 	// if the user doesn't have any k8s yamls, generate one for each dockerfile
 	logrus.Info("generating skaffold config")
@@ -52,10 +52,8 @@ func generateSkaffoldConfig(k deploy.DeploymentInitializer, buildConfigPairs []b
 			Name: name,
 		},
 		Pipeline: latest.Pipeline{
-			Build: latest.BuildConfig{
-				Artifacts: artifacts(buildConfigPairs),
-			},
-			Deploy: k.DeployConfig(),
+			Build:  b.BuildConfig(),
+			Deploy: d.DeployConfig(),
 		},
 	}
 }

--- a/pkg/skaffold/initializer/config_test.go
+++ b/pkg/skaffold/initializer/config_test.go
@@ -18,6 +18,7 @@ package initializer
 
 import (
 	"errors"
+	"io"
 	"path/filepath"
 	"testing"
 
@@ -38,6 +39,28 @@ func (s stubDeploymentInitializer) DeployConfig() latest.DeployConfig {
 
 func (s stubDeploymentInitializer) GetImages() []string {
 	panic("implement me")
+}
+
+type stubBuildInitializer struct {
+	pairs []build.BuilderImagePair
+}
+
+func (s stubBuildInitializer) ProcessImages([]string) error {
+	panic("no")
+}
+
+func (s stubBuildInitializer) BuilderImagePairs() []build.BuilderImagePair {
+	panic("nope")
+}
+
+func (s stubBuildInitializer) PrintAnalysis(io.Writer) error {
+	panic("no sir")
+}
+
+func (s stubBuildInitializer) BuildConfig() latest.BuildConfig {
+	return latest.BuildConfig{
+		Artifacts: artifacts(s.pairs),
+	}
 }
 
 func TestGenerateSkaffoldConfig(t *testing.T) {
@@ -115,8 +138,11 @@ func TestGenerateSkaffoldConfig(t *testing.T) {
 			deploymentInitializer := stubDeploymentInitializer{
 				test.deployConfig,
 			}
+			buildInitializer := stubBuildInitializer{
+				test.builderConfigPairs,
+			}
 			t.Override(&getWd, test.getWd)
-			config := generateSkaffoldConfig(deploymentInitializer, test.builderConfigPairs)
+			config := generateSkaffoldConfig(buildInitializer, deploymentInitializer)
 			t.CheckDeepEqual(config, test.expectedSkaffoldConfig)
 		})
 	}

--- a/pkg/skaffold/initializer/deploy/init.go
+++ b/pkg/skaffold/initializer/deploy/init.go
@@ -21,8 +21,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
-// deploymentInitializer detects a deployment type and is able to extract image names from it
-type DeploymentInitializer interface {
+// Initializer detects a deployment type and is able to extract image names from it
+type Initializer interface {
 	// deployConfig generates Deploy Config for skaffold configuration.
 	DeployConfig() latest.DeployConfig
 	// GetImages fetches all the images defined in the manifest files.
@@ -57,7 +57,7 @@ func (c *emptyDeployInit) GetImages() []string {
 	return nil
 }
 
-func NewDeployInitializer(manifests []string, c config.Config) (DeploymentInitializer, error) {
+func NewInitializer(manifests []string, c config.Config) (Initializer, error) {
 	switch {
 	case c.SkipDeploy:
 		return &emptyDeployInit{}, nil


### PR DESCRIPTION
last piece of the init refactor. this transfer control of the individual pieces of the init flow to their respective components, and refactors the `DoInit()` entrypoint to simply control these components without worrying about their implementations.

this PR has no functional change.