### PR TITLE
Reduce default status check deadline to 2 mins

### DIFF
--- a/pkg/skaffold/deploy/status_check.go
+++ b/pkg/skaffold/deploy/status_check.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	defaultStatusCheckDeadline = time.Duration(2) * time.Minute
+	defaultStatusCheckDeadline = 2 * time.Minute
 
 	// Poll period for checking set to 100 milliseconds
 	defaultPollPeriodInMilliseconds = 100
@@ -72,7 +72,7 @@ func StatusCheck(ctx context.Context, defaultLabeller *DefaultLabeller, runCtx *
 	deployments, err := getDeployments(client, runCtx.Opts.Namespace, defaultLabeller,
 		getDeadline(runCtx.Cfg.Deploy.StatusCheckDeadlineSeconds))
 
-	deadline := statusCheckDeadline(runCtx.Cfg.Deploy.StatusCheckDeadlineSeconds, deployments)
+	deadline := statusCheckMaxDeadline(runCtx.Cfg.Deploy.StatusCheckDeadlineSeconds, deployments)
 
 	if err != nil {
 		return errors.Wrap(err, "could not fetch deployments")
@@ -261,7 +261,7 @@ func (c *resourceCounter) markProcessed(err error) resourceCounter {
 	}
 }
 
-func statusCheckDeadline(value int, deployments []Resource) time.Duration {
+func statusCheckMaxDeadline(value int, deployments []Resource) time.Duration {
 	if value > 0 {
 		return time.Duration(value) * time.Second
 	}

--- a/pkg/skaffold/deploy/status_check.go
+++ b/pkg/skaffold/deploy/status_check.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	defaultStatusCheckDeadline = time.Duration(10) * time.Minute
+	defaultStatusCheckDeadline = time.Duration(2) * time.Minute
 
 	// Poll period for checking set to 100 milliseconds
 	defaultPollPeriodInMilliseconds = 100
@@ -69,8 +69,11 @@ func StatusCheck(ctx context.Context, defaultLabeller *DefaultLabeller, runCtx *
 		return errors.Wrap(err, "getting Kubernetes client")
 	}
 
-	deadline := getDeadline(runCtx.Cfg.Deploy.StatusCheckDeadlineSeconds)
-	deployments, err := getDeployments(client, runCtx.Opts.Namespace, defaultLabeller, deadline)
+	deployments, err := getDeployments(client, runCtx.Opts.Namespace, defaultLabeller,
+		getDeadline(runCtx.Cfg.Deploy.StatusCheckDeadlineSeconds))
+
+	deadline := statusCheckDeadline(runCtx.Cfg.Deploy.StatusCheckDeadlineSeconds, deployments)
+
 	if err != nil {
 		return errors.Wrap(err, "could not fetch deployments")
 	}
@@ -110,7 +113,7 @@ func getDeployments(client kubernetes.Interface, ns string, l *DefaultLabeller, 
 	deployments := make([]Resource, 0, len(deps.Items))
 	for _, d := range deps.Items {
 		var deadline time.Duration
-		if d.Spec.ProgressDeadlineSeconds == nil || *d.Spec.ProgressDeadlineSeconds > int32(deadlineDuration.Seconds()) {
+		if d.Spec.ProgressDeadlineSeconds == nil {
 			deadline = deadlineDuration
 		} else {
 			deadline = time.Duration(*d.Spec.ProgressDeadlineSeconds) * time.Second
@@ -256,4 +259,18 @@ func (c *resourceCounter) markProcessed(err error) resourceCounter {
 		deployments: &depCp,
 		pods:        &podCp,
 	}
+}
+
+
+func statusCheckDeadline(value int, deployments []Resource) time.Duration {
+	if value > 0 {
+		return time.Duration(value) * time.Second
+	}
+	d := time.Duration(0)
+	for _, r := range deployments {
+		if r.Deadline() > d {
+			d = r.Deadline()
+		}
+	}
+	return d
 }

--- a/pkg/skaffold/deploy/status_check.go
+++ b/pkg/skaffold/deploy/status_check.go
@@ -261,7 +261,6 @@ func (c *resourceCounter) markProcessed(err error) resourceCounter {
 	}
 }
 
-
 func statusCheckDeadline(value int, deployments []Resource) time.Duration {
 	if value > 0 {
 		return time.Duration(value) * time.Second

--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -500,22 +500,13 @@ func TestGetStatusCheckDeadline(t *testing.T) {
 			expected: time.Duration(20) * time.Second,
 		},
 		{
-			description: "no value specified less than all other resources",
+			description: "value specified less than all other resources",
 			value: 5,
 			deps: []Resource{
 				resource.NewDeployment("dep1", "test", time.Duration(10)*time.Second),
 				resource.NewDeployment("dep2", "test", time.Duration(20)*time.Second),
 			},
 			expected: time.Duration(5) * time.Second,
-		},
-		{
-			description: "no value specified greater than all other resources",
-			value: 50,
-			deps: []Resource{
-				resource.NewDeployment("dep1", "test", time.Duration(10)*time.Second),
-				resource.NewDeployment("dep2", "test", time.Duration(20)*time.Second),
-			},
-			expected: time.Duration(50) * time.Second,
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -511,7 +511,7 @@ func TestGetStatusCheckDeadline(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.CheckDeepEqual(test.expected, statusCheckDeadline(test.value, test.deps))
+			t.CheckDeepEqual(test.expected, statusCheckMaxDeadline(test.value, test.deps))
 		})
 	}
 }

--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -89,7 +89,7 @@ func TestGetDeployments(t *testing.T) {
 				},
 			},
 			expected: []Resource{
-				resource.NewDeployment("dep1", "test", time.Duration(200)*time.Second),
+				resource.NewDeployment("dep1", "test", time.Duration(300)*time.Second),
 			},
 		},
 		{
@@ -480,6 +480,47 @@ func TestResourceMarkProcessed(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.CheckDeepEqual(test.expected, test.c.markProcessed(test.err), cmp.AllowUnexported(resourceCounter{}, counter{}))
+		})
+	}
+}
+
+func TestGetStatusCheckDeadline(t *testing.T) {
+	tests := []struct {
+		description string
+		value  int
+		deps []Resource
+		expected time.Duration
+	}{
+		{
+			description: "no value specified",
+			deps: []Resource{
+				resource.NewDeployment("dep1", "test", time.Duration(10)*time.Second),
+				resource.NewDeployment("dep2", "test", time.Duration(20)*time.Second),
+			},
+			expected: time.Duration(20) * time.Second,
+		},
+		{
+			description: "no value specified less than all other resources",
+			value: 5,
+			deps: []Resource{
+				resource.NewDeployment("dep1", "test", time.Duration(10)*time.Second),
+				resource.NewDeployment("dep2", "test", time.Duration(20)*time.Second),
+			},
+			expected: time.Duration(5) * time.Second,
+		},
+		{
+			description: "no value specified greater than all other resources",
+			value: 50,
+			deps: []Resource{
+				resource.NewDeployment("dep1", "test", time.Duration(10)*time.Second),
+				resource.NewDeployment("dep2", "test", time.Duration(20)*time.Second),
+			},
+			expected: time.Duration(50) * time.Second,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expected, statusCheckDeadline(test.value, test.deps))
 		})
 	}
 }

--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -487,9 +487,9 @@ func TestResourceMarkProcessed(t *testing.T) {
 func TestGetStatusCheckDeadline(t *testing.T) {
 	tests := []struct {
 		description string
-		value  int
-		deps []Resource
-		expected time.Duration
+		value       int
+		deps        []Resource
+		expected    time.Duration
 	}{
 		{
 			description: "no value specified",
@@ -501,7 +501,7 @@ func TestGetStatusCheckDeadline(t *testing.T) {
 		},
 		{
 			description: "value specified less than all other resources",
-			value: 5,
+			value:       5,
 			deps: []Resource{
 				resource.NewDeployment("dep1", "test", time.Duration(10)*time.Second),
 				resource.NewDeployment("dep2", "test", time.Duration(20)*time.Second),


### PR DESCRIPTION
Related to #3638

In this PR, we decrease the default Status check deadline to 3 seconds. 

In this changes
- if `statusCheckDeadlineSeconds` is present in the skaffold deploy config, respect that.
- if not, then set deadline as maximum deadline seen in the `progressDeadlineSeconds` in `Deployment.Spec`
- If none of them specified, use `defaultStatusCheckDeadline` 