### PR TITLE
Remove -mod='', as go v1.14 drops this flag

### DIFF
--- a/hack/generate-statik.sh
+++ b/hack/generate-statik.sh
@@ -31,7 +31,7 @@ if ! [ -x "$(command -v ${LICENSES})" ]; then
     # from a dependency.
     echo "Installing go-licenses"
     pushd $(mktemp -d)
-    go mod init tmp; GOBIN=${BIN} go get -mod='' github.com/google/go-licenses
+    go mod init tmp; GOBIN=${BIN} go get github.com/google/go-licenses
     popd
 fi
 


### PR DESCRIPTION
Fixes #3699