### PR TITLE
Faster Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,6 @@ endif
 export GO111MODULE = on
 export GOFLAGS = -mod=vendor
 
-GO_GCFLAGS = "all=-trimpath=$(CURDIR)"
-GO_ASMFLAGS = "all=-trimpath=$(CURDIR)"
-
 LDFLAGS_linux = -static
 LDFLAGS_darwin =
 LDFLAGS_windows =
@@ -69,7 +66,7 @@ GO_LDFLAGS_linux =" $(GO_LDFLAGS)  -extldflags \"$(LDFLAGS_linux)\""
 
 # Build for local development.
 $(BUILD_DIR)/$(PROJECT): generate-statik $(GO_FILES) $(BUILD_DIR)
-	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -tags $(GO_BUILD_TAGS_$(GOOS)) -ldflags $(GO_LDFLAGS_$(GOOS)) -gcflags $(GO_GCFLAGS) -asmflags $(GO_ASMFLAGS) -o $@ $(BUILD_PACKAGE)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 go build -tags $(GO_BUILD_TAGS_$(GOOS)) -ldflags $(GO_LDFLAGS_$(GOOS)) -o $@ $(BUILD_PACKAGE)
 
 .PHONY: install
 install: $(BUILD_DIR)/$(PROJECT)

--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ GKE_ZONE ?= us-central1-a
 SUPPORTED_PLATFORMS = linux-$(GOARCH) darwin-$(GOARCH) windows-$(GOARCH).exe
 BUILD_PACKAGE = $(REPOPATH)/cmd/skaffold
 
-SKAFFOLD_TEST_PACKAGES := $(shell go list ./... | grep -v diag)
-GO_FILES := $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pkg/diag/*")
+SKAFFOLD_TEST_PACKAGES = $(shell go list ./... | grep -v diag)
+GO_FILES = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pkg/diag/*")
 
 VERSION_PACKAGE = $(REPOPATH)/pkg/skaffold/version
 COMMIT = $(shell git rev-parse HEAD)

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,6 @@ BUILD_PACKAGE = $(REPOPATH)/cmd/skaffold
 
 SKAFFOLD_TEST_PACKAGES := $(shell go list ./... | grep -v diag)
 GO_FILES := $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pkg/diag/*")
-DEPS_DIGEST := $(shell ./hack/skaffold-deps-sha1.sh)
 
 VERSION_PACKAGE = $(REPOPATH)/pkg/skaffold/version
 COMMIT = $(shell git rev-parse HEAD)
@@ -165,6 +164,7 @@ clean:
 
 .PHONY: build_deps
 build_deps:
+	$(eval DEPS_DIGEST := $(shell ./hack/skaffold-deps-sha1.sh))
 	docker build \
 		-f deploy/skaffold/Dockerfile.deps \
 		-t gcr.io/$(GCP_PROJECT)/build_deps:$(DEPS_DIGEST) \

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ endif
 export GO111MODULE = on
 export GOFLAGS = -mod=vendor
 
-GO_GCFLAGS = "all=-trimpath=${PWD}"
-GO_ASMFLAGS = "all=-trimpath=${PWD}"
+GO_GCFLAGS = "all=-trimpath=$(CURDIR)"
+GO_ASMFLAGS = "all=-trimpath=$(CURDIR)"
 
 LDFLAGS_linux = -static
 LDFLAGS_darwin =

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@
 GOOS ?= $(shell go env GOOS)
 GOARCH = amd64
 BUILD_DIR ?= ./out
-ORG := github.com/GoogleContainerTools
-PROJECT := skaffold
+ORG = github.com/GoogleContainerTools
+PROJECT = skaffold
 REPOPATH ?= $(ORG)/$(PROJECT)
 RELEASE_BUCKET ?= $(PROJECT)
 GSC_BUILD_PATH ?= gs://$(RELEASE_BUCKET)/builds/$(COMMIT)
@@ -28,10 +28,12 @@ GCP_PROJECT ?= k8s-skaffold
 GKE_CLUSTER_NAME ?= integration-tests
 GKE_ZONE ?= us-central1-a
 
-SUPPORTED_PLATFORMS := linux-$(GOARCH) darwin-$(GOARCH) windows-$(GOARCH).exe
+SUPPORTED_PLATFORMS = linux-$(GOARCH) darwin-$(GOARCH) windows-$(GOARCH).exe
 BUILD_PACKAGE = $(REPOPATH)/cmd/skaffold
 
 SKAFFOLD_TEST_PACKAGES := $(shell go list ./... | grep -v diag)
+GO_FILES := $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pkg/diag/*")
+DEPS_DIGEST := $(shell ./hack/skaffold-deps-sha1.sh)
 
 VERSION_PACKAGE = $(REPOPATH)/pkg/skaffold/version
 COMMIT = $(shell git rev-parse HEAD)
@@ -45,16 +47,16 @@ endif
 export GO111MODULE = on
 export GOFLAGS = -mod=vendor
 
-GO_GCFLAGS := "all=-trimpath=${PWD}"
-GO_ASMFLAGS := "all=-trimpath=${PWD}"
+GO_GCFLAGS = "all=-trimpath=${PWD}"
+GO_ASMFLAGS = "all=-trimpath=${PWD}"
 
 LDFLAGS_linux = -static
 LDFLAGS_darwin =
 LDFLAGS_windows =
 
-GO_BUILD_TAGS_linux := "osusergo netgo static_build release"
-GO_BUILD_TAGS_darwin := "release"
-GO_BUILD_TAGS_windows := "release"
+GO_BUILD_TAGS_linux = "osusergo netgo static_build release"
+GO_BUILD_TAGS_darwin = "release"
+GO_BUILD_TAGS_windows = "release"
 
 GO_LDFLAGS = -X $(VERSION_PACKAGE).version=$(VERSION)
 GO_LDFLAGS += -X $(VERSION_PACKAGE).buildDate=$(shell date +'%Y-%m-%dT%H:%M:%SZ')
@@ -65,9 +67,6 @@ GO_LDFLAGS += -s -w
 GO_LDFLAGS_windows =" $(GO_LDFLAGS)  -extldflags \"$(LDFLAGS_windows)\""
 GO_LDFLAGS_darwin =" $(GO_LDFLAGS)  -extldflags \"$(LDFLAGS_darwin)\""
 GO_LDFLAGS_linux =" $(GO_LDFLAGS)  -extldflags \"$(LDFLAGS_linux)\""
-
-GO_FILES := $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pkg/diag/*")
-DEPS_DIGEST := $(shell ./hack/skaffold-deps-sha1.sh)
 
 $(BUILD_DIR)/$(PROJECT): $(BUILD_DIR)/$(PROJECT)-$(GOOS)-$(GOARCH)
 	cp $(BUILD_DIR)/$(PROJECT)-$(GOOS)-$(GOARCH) $@


### PR DESCRIPTION
This solves multiple slowness issues with the current Makefile:
 + Some variables are eagerly evaluated even if they are not used by the current target.
 + `make generate-statik` should make its inputs and outputs  explicit so that we can avoid the cost of regenerating

The net result is that `make` and `make install` will be faster to find out that nothing needs to be rebuilt and will be faster to rebuild changes to the Go code.

cc @nkubala @tstromberg This should fix the issue you had with `make`