### PR TITLE
Fix broken link

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -136,7 +136,7 @@ To build with your local changes you have two options:
 If you are iterating on skaffold and want to see your changes in action, you can:
 
 1. [Build skaffold](#building-skaffold)
-2. [Use the quickstart example](examples/getting-started/README.adoc)
+2. [Use the quickstart example](examples/getting-started)
 
 ## Testing skaffold
 


### PR DESCRIPTION
**Description**

Fixing broken link on `DEVELOPMENT.md`

Previously pointed to `examples/getting-started/README.adoc` which no longer exists.
Changed to `examples/getting-started`

