### PR TITLE
report actual copy error when syncing files to containers

### DIFF
--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -332,9 +332,12 @@ func Perform(ctx context.Context, image string, files syncMap, cmdFn func(contex
 		}
 	}
 
+	if err := errs.Wait(); err != nil {
+		return err
+	}
+
 	if numSynced == 0 {
 		return errors.New("didn't sync any files")
 	}
-
-	return errs.Wait()
+	return nil
 }


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to #3685 

When investigating #3685, looks like there is an error when copying the sycn file into the container on minikube. 
The error message skaffold ends up returning is 
`didn't sync any files`

This PR, surfaces the actual error by waiting for the actual error and return that first.