### PR TITLE
kustomize dependencies include environment files (#3720)

### DIFF
--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -69,10 +69,14 @@ type patchJSON6902 struct {
 
 type configMapGenerator struct {
 	Files []string `yaml:"files"`
+	Env   string   `yaml:"env"`
+	Envs  []string `yaml:"envs"`
 }
 
 type secretGenerator struct {
 	Files []string `yaml:"files"`
+	Env   string   `yaml:"env"`
+	Envs  []string `yaml:"envs"`
 }
 
 // KustomizeDeployer deploys workflows using kustomize CLI.
@@ -285,9 +289,19 @@ func dependenciesForKustomization(dir string) ([]string, error) {
 	}
 	for _, generator := range content.ConfigMapGenerator {
 		deps = append(deps, util.AbsolutePaths(dir, generator.Files)...)
+		envs := generator.Envs
+		if generator.Env != "" {
+			envs = append(envs, generator.Env)
+		}
+		deps = append(deps, util.AbsolutePaths(dir, envs)...)
 	}
 	for _, generator := range content.SecretGenerator {
 		deps = append(deps, util.AbsolutePaths(dir, generator.Files)...)
+		envs := generator.Envs
+		if generator.Env != "" {
+			envs = append(envs, generator.Env)
+		}
+		deps = append(deps, util.AbsolutePaths(dir, envs)...)
 	}
 
 	return deps, nil

--- a/pkg/skaffold/deploy/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize_test.go
@@ -254,15 +254,19 @@ func TestDependenciesForKustomization(t *testing.T) {
 			description: "configMapGenerator",
 			kustomizations: map[string]string{"kustomization.yaml": `configMapGenerator:
 - files: [app1.properties]
-- files: [app2.properties, app3.properties]`},
-			expected: []string{"app1.properties", "app2.properties", "app3.properties", "kustomization.yaml"},
+- files: [app2.properties, app3.properties]
+- env: app1.env
+- envs: [app2.env, app3.env]`},
+			expected: []string{"app1.env", "app1.properties", "app2.env", "app2.properties", "app3.env", "app3.properties", "kustomization.yaml"},
 		},
 		{
 			description: "secretGenerator",
 			kustomizations: map[string]string{"kustomization.yaml": `secretGenerator:
 - files: [secret1.file]
-- files: [secret2.file, secret3.file]`},
-			expected: []string{"kustomization.yaml", "secret1.file", "secret2.file", "secret3.file"},
+- files: [secret2.file, secret3.file]
+- env: secret1.env
+- envs: [secret2.env, secret3.env]`},
+			expected: []string{"kustomization.yaml", "secret1.env", "secret1.file", "secret2.env", "secret2.file", "secret3.env", "secret3.file"},
 		},
 		{
 			description:    "base exists locally",


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #3720.

**Description**

ConfigMapGenerators and SecretGenerators can have `env` or `envs` fields, with paths to "environment files", with a format like this:

```
foo=bar
baz=qux
```

Each line in the file creates a new key-value pair in the generated ConfigMap or Secret.  Thus, changes to the contents of those files should trigger redeploys.

**User facing changes**

**Before**

While running skaffold dev or debug, changes to the environment files would not trigger a redeploy.

**After**

They do.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [x] Adds integration tests if needed.

<!--
_See [the contribution guide](../CONTRIBUTING.md) for more details._
Double check this list of stuff that's easy to miss:
- If you are adding [a example to the `examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/examples), please copy them to [`integration/examples`](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples)
- Every new example added in [`integration/examples` dir](https://github.com/GoogleContainerTools/skaffold/tree/master/integration/examples), should be tested in [integration test](https://github.com/GoogleContainerTools/skaffold/tree/master/integration)
-->

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

<!-- 
Describe any user facing changes here so maintainer can include it in the release notes, or delete this block.
-->

```
- kustomize deployer correctly watches for changes to files listed in the `env` or `envs` keys of `configMapGenerators` and `SecretGenerators`
```