### PR TITLE
More explicit command checking in helm unit tests

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -298,9 +298,14 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 	}
 
 	// SetValues
-	for k, v := range r.SetValues {
-		valuesSet[v] = true
-		args = append(args, "--set", fmt.Sprintf("%s=%s", k, v))
+	sortedKeys := make([]string, 0, len(r.SetValues))
+	for k := range r.SetValues {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+	for _, k := range sortedKeys {
+		valuesSet[r.SetValues[k]] = true
+		args = append(args, "--set", fmt.Sprintf("%s=%s", k, r.SetValues[k]))
 	}
 
 	// SetFiles
@@ -317,10 +322,15 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 			envMap[k+suffix] = v
 		}
 	}
-	logrus.Debugf("EnvVarMap: %#v\n", envMap)
+	logrus.Debugf("EnvVarMap: %+v\n", envMap)
 
-	for k, v := range r.SetValueTemplates {
-		v, err := templatedField(v, envMap)
+	sortedKeys = make([]string, 0, len(r.SetValueTemplates))
+	for k := range r.SetValueTemplates {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+	for _, k := range sortedKeys {
+		v, err := templatedField(r.SetValueTemplates[k], envMap)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -17,23 +17,17 @@ limitations under the License.
 package deploy
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"io/ioutil"
-	"os"
-	"os/exec"
 	"runtime"
 	"sort"
-	"strings"
 	"testing"
 
 	homedir "github.com/mitchellh/go-homedir"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -332,7 +326,7 @@ MANIFEST:
 func TestHelmDeploy(t *testing.T) {
 	tests := []struct {
 		description      string
-		commands         *MockHelm
+		commands         util.Command
 		runContext       *runcontext.RunContext
 		builds           []build.Artifact
 		shouldErr        bool
@@ -340,197 +334,195 @@ func TestHelmDeploy(t *testing.T) {
 	}{
 		{
 			description: "deploy success",
-			commands:    &MockHelm{},
-			runContext:  makeRunContext(testDeployConfig, false),
-			builds:      testBuilds,
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --namespace testNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
+			runContext: makeRunContext(testDeployConfig, false),
+			builds:     testBuilds,
 		},
 		{
 			description: "deploy success with recreatePods",
-			commands:    &MockHelm{},
-			runContext:  makeRunContext(testDeployRecreatePodsConfig, false),
-			builds:      testBuilds,
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade skaffold-helm --recreate-pods examples/test --namespace testNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
+			runContext: makeRunContext(testDeployRecreatePodsConfig, false),
+			builds:     testBuilds,
 		},
 		{
 			description: "deploy success with skipBuildDependencies",
-			commands:    &MockHelm{},
-			runContext:  makeRunContext(testDeploySkipBuildDependenciesConfig, false),
-			builds:      testBuilds,
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --namespace testNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
+			runContext: makeRunContext(testDeploySkipBuildDependenciesConfig, false),
+			builds:     testBuilds,
 		},
 		{
 			description: "deploy should error for unmatched parameter",
-			commands:    &MockHelm{},
-			runContext:  makeRunContext(testDeployConfigParameterUnmatched, false),
-			builds:      testBuilds,
-			shouldErr:   true,
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --namespace testNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
+			runContext: makeRunContext(testDeployConfigParameterUnmatched, false),
+			builds:     testBuilds,
+			shouldErr:  true,
 		},
 		{
 			description: "deploy success remote chart with skipBuildDependencies",
-			commands:    &MockHelm{},
-			runContext:  makeRunContext(testDeploySkipBuildDependencies, false),
-			builds:      testBuilds,
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade skaffold-helm stable/chartmuseum --namespace testNamespace --set-string image.tag=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
+			runContext: makeRunContext(testDeploySkipBuildDependencies, false),
+			builds:     testBuilds,
 		},
 		{
 			description: "deploy error remote chart without skipBuildDependencies",
-			commands: &MockHelm{
-				depResult: fmt.Errorf("unexpected error"),
-			},
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get skaffold-helm-remote --kubeconfig kubeconfig").
+				AndRunErr("helm --kube-context kubecontext dep build stable/chartmuseum --kubeconfig kubeconfig", fmt.Errorf("building helm dependencies")),
 			runContext: makeRunContext(testDeployRemoteChart, false),
 			builds:     testBuilds,
 			shouldErr:  true,
 		},
 		{
 			description: "get failure should install not upgrade",
-			commands: &MockHelm{
-				getResult: fmt.Errorf("not found"),
-				installMatcher: func(cmd *exec.Cmd) bool {
-					expected := fmt.Sprintf("image=%s", testBuilds[0].Tag)
-					return util.StrSliceContains(cmd.Args, expected)
-				},
-				upgradeResult: fmt.Errorf("should not have called upgrade"),
-			},
+			commands: testutil.
+				CmdRunErr("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig", fmt.Errorf("not found")).
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext install --name skaffold-helm examples/test --namespace testNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
 			runContext: makeRunContext(testDeployConfig, false),
 			builds:     testBuilds,
 		},
 		{
 			description: "get failure should install not upgrade with helm image strategy",
-			commands: &MockHelm{
-				getResult: fmt.Errorf("not found"),
-				installMatcher: func(cmd *exec.Cmd) bool {
-					dockerRef, err := docker.ParseReference(testBuilds[0].Tag)
-					if err != nil {
-						return false
-					}
-
-					expected := fmt.Sprintf("image.repository=%s,image.tag=%s", dockerRef.BaseName, dockerRef.Tag)
-					return util.StrSliceContains(cmd.Args, expected)
-				},
-				upgradeResult: fmt.Errorf("should not have called upgrade"),
-			},
-			runContext: makeRunContext(testDeployHelmStyleConfig, false),
-			builds:     testBuilds,
-		},
-		{
-			description: "image values should be set using --set-string",
-			commands: &MockHelm{
-				getResult: fmt.Errorf("not found"),
-				installMatcher: func(cmd *exec.Cmd) bool {
-					setStringIndex := util.StrSliceIndex(cmd.Args, "--set-string")
-					if setStringIndex == -1 {
-						return false
-					}
-					expected := fmt.Sprintf("image.repository=%s,image.tag=%s", "docker.io:5000/skaffold-helm", "3605e7bc17cf46e53f4d81c4cbc24e5b4c495184")
-					return setStringIndex+1 < len(cmd.Args) && cmd.Args[setStringIndex+1] == expected
-				},
-				upgradeResult: fmt.Errorf("should not have called upgrade"),
-			},
+			commands: testutil.
+				CmdRunErr("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig", fmt.Errorf("not found")).
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext install --name skaffold-helm examples/test --namespace testNamespace -f skaffold-overrides.yaml --set-string image.repository=docker.io:5000/skaffold-helm,image.tag=3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
 			runContext: makeRunContext(testDeployHelmStyleConfig, false),
 			builds:     testBuilds,
 		},
 		{
 			description: "helm image strategy with explicit registry should set the Helm registry value",
-			commands: &MockHelm{
-				getResult: fmt.Errorf("not found"),
-				installMatcher: func(cmd *exec.Cmd) bool {
-					expected := fmt.Sprintf("image.registry=%s,image.repository=%s,image.tag=%s", "docker.io:5000", "skaffold-helm", "3605e7bc17cf46e53f4d81c4cbc24e5b4c495184")
-					return util.StrSliceContains(cmd.Args, expected)
-				},
-				upgradeResult: fmt.Errorf("should not have called upgrade"),
-			},
+			commands: testutil.
+				CmdRunErr("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig", fmt.Errorf("not found")).
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext install --name skaffold-helm examples/test --namespace testNamespace -f skaffold-overrides.yaml --set-string image.registry=docker.io:5000,image.repository=skaffold-helm,image.tag=3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
 			runContext: makeRunContext(testDeployHelmExplicitRegistryStyleConfig, false),
 			builds:     testBuilds,
 		},
 		{
 			description: "get success should upgrade by force, not install",
-			commands: &MockHelm{
-				upgradeMatcher: func(cmd *exec.Cmd) bool {
-					return util.StrSliceContains(cmd.Args, "--force")
-				},
-				installResult: fmt.Errorf("should not have called install"),
-			},
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade skaffold-helm --force examples/test --namespace testNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
 			runContext: makeRunContext(testDeployConfig, true),
 			builds:     testBuilds,
 		},
 		{
 			description: "get success should upgrade without force, not install",
-			commands: &MockHelm{
-				upgradeMatcher: func(cmd *exec.Cmd) bool {
-					return !util.StrSliceContains(cmd.Args, "--force")
-				},
-				installResult: fmt.Errorf("should not have called install"),
-			},
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --namespace testNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
 			runContext: makeRunContext(testDeployConfig, false),
 			builds:     testBuilds,
 		},
 		{
 			description: "deploy error",
-			commands: &MockHelm{
-				upgradeResult: fmt.Errorf("unexpected error"),
-			},
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
+				AndRunErr("helm --kube-context kubecontext upgrade skaffold-helm examples/test --namespace testNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig", fmt.Errorf("unexpected error")).
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
 			shouldErr:  true,
 			runContext: makeRunContext(testDeployConfig, false),
 			builds:     testBuilds,
 		},
 		{
 			description: "dep build error",
-			commands: &MockHelm{
-				depResult: fmt.Errorf("unexpected error"),
-			},
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig").
+				AndRunErr("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig", fmt.Errorf("unexpected error")).
+				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --namespace testNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
 			shouldErr:  true,
 			runContext: makeRunContext(testDeployConfig, false),
 			builds:     testBuilds,
 		},
 		{
 			description: "should package chart and deploy",
-			commands: &MockHelm{
-				packageOut: bytes.NewBufferString("Packaged to " + os.TempDir() + "foo-0.1.2.tgz"),
-			},
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get foo --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext dep build testdata/foo --kubeconfig kubeconfig").
+				AndRunWithOutput("helm --kube-context kubecontext package testdata/foo --destination /tmp --version 0.1.2 --app-version 1.2.3 --kubeconfig kubeconfig", "Packaged to /tmp/foo-0.1.2.tgz").
+				AndRun("helm --kube-context kubecontext upgrade foo /tmp/foo-0.1.2.tgz --namespace testNamespace --set-string image=foo:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get foo --kubeconfig kubeconfig"),
 			shouldErr:  false,
 			runContext: makeRunContext(testDeployFooWithPackaged, false),
 			builds:     testBuildsFoo,
 		},
 		{
 			description: "should fail to deploy when packaging fails",
-			commands: &MockHelm{
-				packageResult: fmt.Errorf("packaging failed"),
-			},
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get foo --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext dep build testdata/foo --kubeconfig kubeconfig").
+				AndRunErr("helm --kube-context kubecontext package testdata/foo --destination /tmp --version 0.1.2 --app-version 1.2.3 --kubeconfig kubeconfig", fmt.Errorf("packaging failed")),
 			shouldErr:  true,
 			runContext: makeRunContext(testDeployFooWithPackaged, false),
 			builds:     testBuildsFoo,
 		},
 		{
 			description: "deploy and get templated release name",
-			commands:    &MockHelm{},
-			runContext:  makeRunContext(testDeployWithTemplatedName, false),
-			builds:      testBuilds,
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get <no value>-skaffold-helm --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade <no value>-skaffold-helm examples/test --namespace testNamespace -f skaffold-overrides.yaml --set-string image.tag=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get <no value>-skaffold-helm --kubeconfig kubeconfig"),
+			runContext: makeRunContext(testDeployWithTemplatedName, false),
+			builds:     testBuilds,
 		},
 		{
 			description: "deploy with templated values",
-			commands: &MockHelm{
-				upgradeMatcher: func(cmd *exec.Cmd) bool {
-					return util.StrSliceContains(cmd.Args, "other.key=FOOBAR") &&
-						util.StrSliceContains(cmd.Args, "missing.key=<no value>") &&
-						util.StrSliceContains(cmd.Args, "image.name=skaffold-helm") &&
-						util.StrSliceContains(cmd.Args, "image.tag=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184")
-				},
-			},
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --namespace testNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set image.name=skaffold-helm --set image.tag=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set missing.key=<no value> --set other.key=FOOBAR --set some.key=somevalue --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
 			runContext: makeRunContext(testDeployConfigTemplated, false),
 			builds:     testBuilds,
 		},
 		{
 			description: "deploy with valuesFiles templated",
-			commands: &MockHelm{
-				upgradeMatcher: func(cmd *exec.Cmd) bool {
-					return util.StrSliceContains(cmd.Args, "/some/file-FOOBAR.yaml")
-				},
-			},
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --namespace testNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 -f /some/file-FOOBAR.yaml --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
 			runContext: makeRunContext(testDeployConfigValuesFilesTemplated, false),
 			builds:     testBuilds,
 		},
 		{
 			description: "deploy without actual tags",
-			commands:    &MockHelm{},
-			runContext:  makeRunContext(testDeployWithoutTags, false),
-			builds:      testBuilds,
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --namespace testNamespace --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
+			runContext: makeRunContext(testDeployWithoutTags, false),
+			builds:     testBuilds,
 			expectedWarnings: []string{
 				"See helm sample for how to replace image names with their actual tags: https://github.com/GoogleContainerTools/skaffold/blob/master/examples/helm-deployment/skaffold.yaml",
 				"image [docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184] is not used.",
@@ -539,9 +531,17 @@ func TestHelmDeploy(t *testing.T) {
 		},
 		{
 			description: "first release without tag, second with tag",
-			commands:    &MockHelm{},
-			runContext:  makeRunContext(testTwoReleases, false),
-			builds:      testBuilds,
+			commands: testutil.
+				CmdRun("helm --kube-context kubecontext get other --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade other examples/test --namespace testNamespace --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get other --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext dep build  --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade skaffold-helm  --namespace testNamespace --set-string image.tag=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
+			runContext: makeRunContext(testTwoReleases, false),
+			builds:     testBuilds,
 		},
 	}
 	for _, test := range tests {
@@ -562,76 +562,8 @@ func TestHelmDeploy(t *testing.T) {
 	}
 }
 
-type CommandMatcher func(*exec.Cmd) bool
+func TestPackageHelmChart(t *testing.T) {
 
-type MockHelm struct {
-	t *testing.T
-
-	getResult      error
-	installResult  error
-	installMatcher CommandMatcher
-	upgradeResult  error
-	upgradeMatcher CommandMatcher
-	depResult      error
-
-	packageOut    io.Reader
-	packageResult error
-}
-
-func (m *MockHelm) ForTest(t *testing.T) {
-	m.t = t
-}
-
-func (m *MockHelm) RunCmdOut(c *exec.Cmd) ([]byte, error) {
-	m.t.Error("Shouldn't be used")
-	return nil, nil
-}
-
-func (m *MockHelm) RunCmd(c *exec.Cmd) error {
-	if len(c.Args) < 3 {
-		m.t.Errorf("Not enough args in command %v", c)
-	}
-
-	argString := strings.Join(c.Args, " ")
-	if !strings.Contains(argString, "--kube-context "+testKubeContext) {
-		m.t.Errorf("Invalid Kubernetes context %v", c)
-	}
-	if !strings.Contains(argString, "--kubeconfig "+testKubeConfig) {
-		m.t.Errorf("Invalid Kubernetes config %v", c)
-	}
-
-	if c.Args[3] == "get" || c.Args[3] == "upgrade" {
-		if releaseName := c.Args[4]; strings.Contains(releaseName, "{{") {
-			m.t.Errorf("Invalid release name: %v", releaseName)
-		}
-	}
-
-	switch c.Args[3] {
-	case "get":
-		return m.getResult
-	case "install":
-		if m.installMatcher != nil && !m.installMatcher(c) {
-			m.t.Errorf("install matcher failed to match commands: %+v", c.Args)
-		}
-		return m.installResult
-	case "upgrade":
-		if m.upgradeMatcher != nil && !m.upgradeMatcher(c) {
-			m.t.Errorf("upgrade matcher failed to match commands: %+v", c.Args)
-		}
-		return m.upgradeResult
-	case "dep":
-		return m.depResult
-	case "package":
-		if m.packageOut != nil {
-			if _, err := io.Copy(c.Stdout, m.packageOut); err != nil {
-				m.t.Errorf("Failed to copy stdout")
-			}
-		}
-		return m.packageResult
-	default:
-		m.t.Errorf("Unknown helm command: %+v", c)
-		return nil
-	}
 }
 
 func TestParseHelmRelease(t *testing.T) {

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"testing"
@@ -324,6 +326,7 @@ MANIFEST:
 `
 
 func TestHelmDeploy(t *testing.T) {
+	tmpDir := os.TempDir()
 	tests := []struct {
 		description      string
 		commands         util.Command
@@ -467,8 +470,8 @@ func TestHelmDeploy(t *testing.T) {
 			commands: testutil.
 				CmdRun("helm --kube-context kubecontext get foo --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext dep build testdata/foo --kubeconfig kubeconfig").
-				AndRunWithOutput("helm --kube-context kubecontext package testdata/foo --destination /tmp --version 0.1.2 --app-version 1.2.3 --kubeconfig kubeconfig", "Packaged to /tmp/foo-0.1.2.tgz").
-				AndRun("helm --kube-context kubecontext upgrade foo /tmp/foo-0.1.2.tgz --namespace testNamespace --set-string image=foo:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --kubeconfig kubeconfig").
+				AndRunWithOutput("helm --kube-context kubecontext package testdata/foo --destination "+tmpDir+" --version 0.1.2 --app-version 1.2.3 --kubeconfig kubeconfig", "Packaged to "+filepath.Join(tmpDir, "foo-0.1.2.tgz")).
+				AndRun("helm --kube-context kubecontext upgrade foo " + filepath.Join(tmpDir, "foo-0.1.2.tgz") + " --namespace testNamespace --set-string image=foo:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext get foo --kubeconfig kubeconfig"),
 			shouldErr:  false,
 			runContext: makeRunContext(testDeployFooWithPackaged, false),
@@ -479,7 +482,7 @@ func TestHelmDeploy(t *testing.T) {
 			commands: testutil.
 				CmdRun("helm --kube-context kubecontext get foo --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext dep build testdata/foo --kubeconfig kubeconfig").
-				AndRunErr("helm --kube-context kubecontext package testdata/foo --destination /tmp --version 0.1.2 --app-version 1.2.3 --kubeconfig kubeconfig", fmt.Errorf("packaging failed")),
+				AndRunErr("helm --kube-context kubecontext package testdata/foo --destination "+tmpDir+" --version 0.1.2 --app-version 1.2.3 --kubeconfig kubeconfig", fmt.Errorf("packaging failed")),
 			shouldErr:  true,
 			runContext: makeRunContext(testDeployFooWithPackaged, false),
 			builds:     testBuildsFoo,


### PR DESCRIPTION
this PR rewrites the helm unit tests to explicitly check each command issued by the helm deployer, rather than doing pattern matching.

this is necessary for testing new helm 3 functionality, since there are very subtle differences in the flags that are provided to each command.

**one small functional change:** the `Values` and `ValuesTemplates` that are passed to helm via the `--set` flags are now sorted before adding to the argument string. this shouldn't manifest itself to the user though.

this also adds a small new test helper, `AddRunWithOutput`, which allows a test to specify a command with output, which calls `RunCmd` and pipes the output to the `FakeCmd`'s embedded `exec.Cmd`'s `stdout`, rather than simply expecting a `RunCmdOut` to be called.