### PR TITLE
add flag --survey to set to set/unset disable survey prompt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,4 +245,4 @@ generate-schemas:
 
 .PHONY: generate-statik
 generate-statik:
-	echo hack/generate-statik.sh
+	hack/generate-statik.sh

--- a/Makefile
+++ b/Makefile
@@ -245,4 +245,4 @@ generate-schemas:
 
 .PHONY: generate-statik
 generate-statik:
-	hack/generate-statik.sh
+	echo hack/generate-statik.sh

--- a/cmd/skaffold/app/cmd/config/flags.go
+++ b/cmd/skaffold/app/cmd/config/flags.go
@@ -37,5 +37,5 @@ func AddListFlags(f *pflag.FlagSet) {
 func AddSetUnsetFlags(f *pflag.FlagSet) {
 	f.BoolVarP(&global, "global", "g", false, "Set value for global config")
 	f.BoolVarP(&survey, "survey", "s", false, "Set value for skaffold survey config")
-  f.MarkHidden("survey")
+	f.MarkHidden("survey")
 }

--- a/cmd/skaffold/app/cmd/config/flags.go
+++ b/cmd/skaffold/app/cmd/config/flags.go
@@ -16,11 +16,13 @@ limitations under the License.
 
 package config
 
-import "github.com/spf13/pflag"
+import (
+	"github.com/spf13/pflag"
+)
 
 var (
 	configFile, kubecontext string
-	showAll, global         bool
+	showAll, global, survey bool
 )
 
 func AddCommonFlags(f *pflag.FlagSet) {
@@ -34,4 +36,6 @@ func AddListFlags(f *pflag.FlagSet) {
 
 func AddSetUnsetFlags(f *pflag.FlagSet) {
 	f.BoolVarP(&global, "global", "g", false, "Set value for global config")
+	f.BoolVarP(&survey, "survey", "s", false, "Set value for skaffold survey config")
+  f.MarkHidden("survey")
 }

--- a/cmd/skaffold/app/cmd/config/set.go
+++ b/cmd/skaffold/app/cmd/config/set.go
@@ -30,6 +30,16 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 )
 
+const (
+	surveyFieldName = "Survey"
+)
+
+type cfgStruct struct {
+	value reflect.Value
+	rType reflect.Type
+	idx   []int
+}
+
 func Set(out io.Writer, args []string) error {
 	if err := setConfigValue(args[0], args[1]); err != nil {
 		return err
@@ -44,34 +54,66 @@ func setConfigValue(name string, value string) error {
 		return err
 	}
 
-	fieldName := getFieldName(cfg, name)
-	if fieldName == "" {
-		return fmt.Errorf("%s is not a valid config field", name)
+	fieldIdx, err := getFieldIndex(cfg, name)
+	if err != nil {
+		return err
 	}
 
-	field := reflect.Indirect(reflect.ValueOf(cfg)).FieldByName(fieldName)
+	field := reflect.Indirect(reflect.ValueOf(cfg)).FieldByIndex(fieldIdx)
 	val, err := parseAsType(value, field)
 	if err != nil {
 		return fmt.Errorf("%s is not a valid value for field %s", value, name)
 	}
 
-	reflect.ValueOf(cfg).Elem().FieldByName(fieldName).Set(val)
+	reflect.ValueOf(cfg).Elem().FieldByIndex(fieldIdx).Set(val)
 
 	return writeConfig(cfg)
 }
 
-func getFieldName(cfg *config.ContextConfig, name string) string {
-	cfgValue := reflect.Indirect(reflect.ValueOf(cfg))
-	var fieldName string
-	for i := 0; i < cfgValue.NumField(); i++ {
-		fieldType := reflect.TypeOf(*cfg).Field(i)
+func getFieldIndex(cfg *config.ContextConfig, name string) ([]int, error) {
+	cs, err := getConfigStructWithIndex(cfg)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < cs.value.NumField(); i++ {
+		fieldType := cs.rType.Field(i)
 		for _, tag := range strings.Split(fieldType.Tag.Get("yaml"), ",") {
 			if tag == name {
-				fieldName = fieldType.Name
+				if f, ok := cs.rType.FieldByName(fieldType.Name); ok {
+					return append(cs.idx, f.Index...), nil
+				}
+				return nil, fmt.Errorf("could not find config field %s", name)
 			}
 		}
 	}
-	return fieldName
+	return nil, fmt.Errorf("%s is not a valid config field", name)
+}
+
+func getConfigStructWithIndex(cfg *config.ContextConfig) (*cfgStruct, error) {
+	t := reflect.TypeOf(*cfg)
+	if survey {
+		if cfg.Survey == nil {
+			cfg.Survey = &config.SurveyConfig{}
+		}
+		return surveyStruct(cfg.Survey, t)
+	}
+	return &cfgStruct{
+		value: reflect.Indirect(reflect.ValueOf(cfg)),
+		rType: t,
+		idx:   []int{},
+	}, nil
+}
+
+func surveyStruct(s *config.SurveyConfig, t reflect.Type) (*cfgStruct, error) {
+	surveyType := reflect.TypeOf(*s)
+	if surveyField, ok := t.FieldByName(surveyFieldName); ok {
+		return &cfgStruct{
+			value: reflect.Indirect(reflect.ValueOf(s)),
+			rType: surveyType,
+			idx:   surveyField.Index,
+		}, nil
+	}
+	return nil, fmt.Errorf("survey config field 'Survey' not found in config struct %s", t.Name())
 }
 
 func parseAsType(value string, field reflect.Value) (reflect.Value, error) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->


Relates to #3011 
Shd merge before #3733

In this PR, add a hidden flag `--survey` to set `disable-prompt` field in upcoming PRs

Changes:
1. Use `FieldByIndex` instead of `FieldByName` to set, unset values

Testing Done:

```
mv ~/.skaffold/config ~/.skaffold/config_old

make && ./out/skaffold config set  --survey --global disable-prompt true
set global value disable-prompt to true
tejaldesai@@skaffold (add_survey_set)$ cat ~/.skaffold/config 
global:
  survey:
    disable-prompt: true
kubeContexts: []
tejaldesai@@skaffold (add_survey_set)$ 
```

```
 ./out/skaffold config set  --survey  disable-prompt true
set value disable-prompt to true for context gke_tejal-test_us-central1-a_dump
tejaldesai@@skaffold (add_survey_set)$ cat ~/.skaffold/config 
global:
  survey:
    disable-prompt: true
kubeContexts:
- kube-context: gke_tejal-test_us-central1-a_dump
  survey:
    disable-prompt: true
tejaldesai@@skaffold (add_survey_set)$ 
```

```
./out/skaffold config unset  --survey  disable-prompt
unset value disable-prompt for context gke_tejal-test_us-central1-a_dump
tejaldesai@@skaffold (add_survey_set)$ cat ~/.skaffold/config 
global:
  survey:
    disable-prompt: true
kubeContexts:
- kube-context: gke_tejal-test_us-central1-a_dump
  survey: {}
```

```
./out/skaffold config unset  --survey  --global disable-prompt
unset global value disable-prompt
tejaldesai@@skaffold (add_survey_set)$ cat ~/.skaffold/config 
global:
  survey: {}
kubeContexts:
- kube-context: gke_tejal-test_us-central1-a_dump
  survey: {}
tejaldesai@@skaffold (add_survey_set)$ 


```