### PR TITLE
[Diagnostics] Add validator interface. Add resource interface and PodValidator

### DIFF
--- a/pkg/diag/validator/pod.go
+++ b/pkg/diag/validator/pod.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validator
 
 import (
+	"context"
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
@@ -36,36 +37,59 @@ var (
 	waitingContainerStatus = getWaitingContainerStatus
 )
 
-type PodStatus struct {
-	phase string
-	err   *PodErr
+// PodValidator implements the Validator interface for Pods
+type PodValidator struct {
+	k kubernetes.Interface
 }
 
-type PodErr struct {
+// NewPodValidator initializes a PodValidator
+func NewPodValidator(k kubernetes.Interface) *PodValidator {
+	return &PodValidator{k: k}
+}
+
+// Run implements the Run method for Validator interface
+func (p *PodValidator) Run(ctx context.Context, ns string, opts meta_v1.ListOptions) ([]Resource, error) {
+	pods, err := p.k.CoreV1().Pods(ns).List(opts)
+	if err != nil {
+		return nil, err
+	}
+	rs := []Resource{}
+	for _, po := range pods.Items {
+		ps := p.getPodStatus(&po)
+		rs = append(rs, NewResourceFromObject(&po, Status(ps.phase), ps.reason.String()))
+	}
+	return rs, nil
+}
+
+type podStatus struct {
+	phase  string
+	reason *podReason
+}
+
+type podReason struct {
 	reason  string
 	message string
 }
 
-func (e *PodErr) Error() string {
-	return fmt.Sprintf("pod in error due to reason: %s, message: %s", e.reason, e.message)
+func (r *podReason) String() string {
+	if r == nil {
+		return ""
+	}
+	return fmt.Sprintf("pod unstable due to reason: %s, message: %s", r.reason, r.message)
 }
 
-func GetPodDetails(client kubernetes.Interface, ns string, podName string) PodStatus {
-	pod, err := client.CoreV1().Pods(ns).Get(podName, meta_v1.GetOptions{})
-	if err != nil {
-		return PodStatus{err: &PodErr{message: err.Error()}}
-	}
+func (p *PodValidator) getPodStatus(pod *v1.Pod) podStatus {
 	switch pod.Status.Phase {
 	case v1.PodSucceeded:
-		return PodStatus{phase: success}
+		return podStatus{phase: success}
 	case v1.PodRunning:
-		return PodStatus{phase: running}
+		return podStatus{phase: running}
 	default:
 		return getPendingDetails(pod)
 	}
 }
 
-func getPendingDetails(pod *v1.Pod) PodStatus {
+func getPendingDetails(pod *v1.Pod) podStatus {
 	// See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions
 	for _, c := range pod.Status.Conditions {
 		switch c.Status {
@@ -91,20 +115,20 @@ func getWaitingContainerStatus(cs []v1.ContainerStatus) (string, string) {
 	return success, success
 }
 
-func newPendingStatus(r string, d string) PodStatus {
-	return PodStatus{
+func newPendingStatus(r string, d string) podStatus {
+	return podStatus{
 		phase: pending,
-		err: &PodErr{
+		reason: &podReason{
 			reason:  r,
 			message: d,
 		},
 	}
 }
 
-func newUnknownStatus() PodStatus {
-	return PodStatus{
+func newUnknownStatus() podStatus {
+	return podStatus{
 		phase: unknown,
-		err: &PodErr{
+		reason: &podReason{
 			reason:  unknown,
 			message: unknown,
 		},

--- a/pkg/diag/validator/pod.go
+++ b/pkg/diag/validator/pod.go
@@ -47,8 +47,8 @@ func NewPodValidator(k kubernetes.Interface) *PodValidator {
 	return &PodValidator{k: k}
 }
 
-// Run implements the Run method for Validator interface
-func (p *PodValidator) Run(ctx context.Context, ns string, opts meta_v1.ListOptions) ([]Resource, error) {
+// Validate implements the Validate method for Validator interface
+func (p *PodValidator) Validate(ctx context.Context, ns string, opts meta_v1.ListOptions) ([]Resource, error) {
 	pods, err := p.k.CoreV1().Pods(ns).List(opts)
 	if err != nil {
 		return nil, err

--- a/pkg/diag/validator/pod_test.go
+++ b/pkg/diag/validator/pod_test.go
@@ -155,9 +155,9 @@ func TestRun(t *testing.T) {
 				rs[i] = p
 			}
 			f := fakekubeclientset.NewSimpleClientset(rs...)
-			actual, err := NewPodValidator(f).Run(context.Background(), "test", meta_v1.ListOptions{})
+			actual, err := NewPodValidator(f).Validate(context.Background(), "test", meta_v1.ListOptions{})
 			t.CheckNoError(err)
-			t.CheckDeepEqual(test.expected, actual, cmp.AllowUnexported(resource{}))
+			t.CheckDeepEqual(test.expected, actual, cmp.AllowUnexported(Resource{}))
 		})
 	}
 }

--- a/pkg/diag/validator/resource.go
+++ b/pkg/diag/validator/resource.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validator
+
+import (
+	"fmt"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type Resource interface {
+	// Namespace of the resource.
+	Namespace() string
+
+	// Kind of resource, e.g., service, pod, deployment
+	Kind() string
+	// Name of the resource, e.g., cluster name, node name, persistent volume name, etc.
+	Name() string
+
+	// Status if resource is healthy or not
+	Status() Status
+
+	// Reason if resource is not stable.
+	Reason() string
+}
+
+type resource struct {
+	namespace string
+	kind      string
+	name      string
+	reason    string
+	status    Status
+}
+
+func (r *resource) Kind() string      { return r.kind }
+func (r *resource) Name() string      { return r.name }
+func (r *resource) Reason() string    { return r.reason }
+func (r *resource) Namespace() string { return r.namespace }
+func (r *resource) Status() Status    { return r.status }
+func (r *resource) String() string {
+	return fmt.Sprintf("{%s:%s/%s}", r.kind, r.namespace, r.name)
+}
+
+// NewResource creates new resource of kind
+func NewResource(namespace, kind, name string, status Status, reason string) Resource {
+	return &resource{namespace: namespace, kind: kind, name: name, status: status, reason: reason}
+}
+
+// objectWithMetadata is any k8s object that has kind and object metadata.
+type objectWithMetadata interface {
+	runtime.Object
+	meta_v1.Object
+}
+
+// NewResourceFromObject creates new resource with fields populated from object metadata.
+func NewResourceFromObject(object objectWithMetadata, status Status, reason string) Resource {
+	return NewResource(object.GetNamespace(), object.GetObjectKind().GroupVersionKind().Kind, object.GetName(), status, reason)
+}

--- a/pkg/diag/validator/resource.go
+++ b/pkg/diag/validator/resource.go
@@ -23,23 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-type Resource interface {
-	// Namespace of the resource.
-	Namespace() string
-
-	// Kind of resource, e.g., service, pod, deployment
-	Kind() string
-	// Name of the resource, e.g., cluster name, node name, persistent volume name, etc.
-	Name() string
-
-	// Status if resource is healthy or not
-	Status() Status
-
-	// Reason if resource is not stable.
-	Reason() string
-}
-
-type resource struct {
+type Resource struct {
 	namespace string
 	kind      string
 	name      string
@@ -47,18 +31,18 @@ type resource struct {
 	status    Status
 }
 
-func (r *resource) Kind() string      { return r.kind }
-func (r *resource) Name() string      { return r.name }
-func (r *resource) Reason() string    { return r.reason }
-func (r *resource) Namespace() string { return r.namespace }
-func (r *resource) Status() Status    { return r.status }
-func (r *resource) String() string {
+func (r Resource) Kind() string      { return r.kind }
+func (r Resource) Name() string      { return r.name }
+func (r Resource) Reason() string    { return r.reason }
+func (r Resource) Namespace() string { return r.namespace }
+func (r Resource) Status() Status    { return r.status }
+func (r Resource) String() string {
 	return fmt.Sprintf("{%s:%s/%s}", r.kind, r.namespace, r.name)
 }
 
-// NewResource creates new resource of kind
+// NewResource creates new Resource of kind
 func NewResource(namespace, kind, name string, status Status, reason string) Resource {
-	return &resource{namespace: namespace, kind: kind, name: name, status: status, reason: reason}
+	return Resource{namespace: namespace, kind: kind, name: name, status: status, reason: reason}
 }
 
 // objectWithMetadata is any k8s object that has kind and object metadata.
@@ -67,7 +51,7 @@ type objectWithMetadata interface {
 	meta_v1.Object
 }
 
-// NewResourceFromObject creates new resource with fields populated from object metadata.
+// NewResourceFromObject creates new Resource with fields populated from object metadata.
 func NewResourceFromObject(object objectWithMetadata, status Status, reason string) Resource {
 	return NewResource(object.GetNamespace(), object.GetObjectKind().GroupVersionKind().Kind, object.GetName(), status, reason)
 }

--- a/pkg/diag/validator/validator.go
+++ b/pkg/diag/validator/validator.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validator
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Status string
+
+type Validator interface {
+	// Run runs the validator and returns the list of resources with status.
+	Run(ctx context.Context, client kubernetes.Interface, ns string, opts metav1.ListOptions) ([]Resource, error)
+}

--- a/pkg/diag/validator/validator.go
+++ b/pkg/diag/validator/validator.go
@@ -26,6 +26,6 @@ import (
 type Status string
 
 type Validator interface {
-	// Run runs the validator and returns the list of resources with status.
-	Run(ctx context.Context, client kubernetes.Interface, ns string, opts metav1.ListOptions) ([]Resource, error)
+	// Validate runs the validator and returns the list of resources with status.
+	Validate(ctx context.Context, client kubernetes.Interface, ns string, opts metav1.ListOptions) ([]Resource, error)
 }


### PR DESCRIPTION
Fixes #3740 

Relates to #3739 

In this PR,
- Added a new Validator interface which implements an interface to validate a kubernetes resource.
- Added a new Resource interface which describes any kubernetes resource
- Added a new `PodValidator` and modified the existing functions in `pod.go` to validate pods.