### PR TITLE
Use dockercore/golang-cross instead of xgo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,16 +80,17 @@ install: $(BUILD_DIR)/$(PROJECT)
 .PHONY: cross
 cross: $(foreach platform, $(SUPPORTED_PLATFORMS), $(BUILD_DIR)/$(PROJECT)-$(platform).sha256)
 
-$(BUILD_DIR)/$(PROJECT)-%-$(GOARCH): $(STATIK_FILES) $(GO_FILES) $(BUILD_DIR)
+$(BUILD_DIR)/$(PROJECT)-%-$(GOARCH): $(STATIK_FILES) $(GO_FILES) $(BUILD_DIR) deploy/cross/Dockerfile
 	docker build \
-		--build-arg PROJECT=$(REPOPATH) \
-		--build-arg TARGETS=$*/$(GOARCH) \
-		--build-arg FLAG_LDFLAGS=$(GO_LDFLAGS_$(*)) \
-		--build-arg FLAG_TAGS=$(GO_BUILD_TAGS_$(*)) \
+		--build-arg GOOS=$* \
+		--build-arg GOARCH=$(GOARCH) \
+		--build-arg GOFLAGS="$(GOFLAGS)" \
+		--build-arg TAGS=$(GO_BUILD_TAGS_$(*)) \
+		--build-arg LDFLAGS=$(GO_LDFLAGS_$(*)) \
 		-f deploy/cross/Dockerfile \
 		-t skaffold/cross \
 		.
-	docker run --rm --entrypoint sh skaffold/cross -c "cat /build/skaffold*" > $@
+	docker run --rm skaffold/cross cat /build/skaffold > $@
 
 %.sha256: %
 	shasum -a 256 $< > $@

--- a/deploy/cross/Dockerfile
+++ b/deploy/cross/Dockerfile
@@ -12,20 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM karalabe/xgo-1.13.4
+FROM dockercore/golang-cross:1.13.8 as base
 
-ARG PROJECT
-ARG FLAG_LDFLAGS
-ARG FLAG_TAGS
-ARG TARGETS
+# Cross compile Skaffold for Linux, Windows and MacOS
+ARG GOOS
+ARG GOARCH
+ARG GOFLAGS
+ARG TAGS
+ARG LDFLAGS
 
-ENV PACK cmd/skaffold
-ENV EXT_GOPATH /ext-go
-ENV FLAG_LDFLAGS $FLAG_LDFLAGS
-ENV TARGETS $TARGETS
-ENV FLAG_TAGS $FLAG_TAGS
-ENV GO111MODULE off
-
-WORKDIR /ext-go/src/$PROJECT
-COPY . .
-RUN /build.sh $PROJECT
+WORKDIR /skaffold
+COPY . ./
+RUN if [ "$GOOS" = "darwin" ]; then export CC=o64-clang CXX=o64-clang++; fi; \
+    GOOS=$GOOS GOARCH=$GOARCH GOFLAGS=$GOFLAGS CGO_ENABLED=1 \
+    go build -tags "${TAGS}" -ldflags "${LDFLAGS}" -o /build/skaffold ./cmd/skaffold


### PR DESCRIPTION
Will make it easier to switch to another version of Go.

Signed-off-by: David Gageot <david@gageot.net>
