### PR TITLE
Bump golangci-lint to 1.23.7

### DIFF
--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -17,7 +17,7 @@
 set -e -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-VERSION=1.23.2
+VERSION=1.23.7
 
 function install_linter() {
   echo "Installing GolangCI-Lint"

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
+func NewMockDeployer() *MockDeployer { return &MockDeployer{labels: make(map[string]string)} }
+
 type MockDeployer struct {
 	labels           map[string]string
 	deployNamespaces []string
@@ -40,34 +42,65 @@ type MockDeployer struct {
 	renderErr        error
 }
 
-func (m *MockDeployer) Labels() map[string]string                { return m.labels }
-func (m *MockDeployer) Dependencies() ([]string, error)          { return m.dependencies, m.dependenciesErr }
-func (m *MockDeployer) Cleanup(context.Context, io.Writer) error { return m.cleanupErr }
+func (m *MockDeployer) Labels() map[string]string {
+	return m.labels
+}
+
+func (m *MockDeployer) Dependencies() ([]string, error) {
+	return m.dependencies, m.dependenciesErr
+}
+
+func (m *MockDeployer) Cleanup(context.Context, io.Writer) error {
+	return m.cleanupErr
+}
+
+func (m *MockDeployer) WithLabel(labels map[string]string) *MockDeployer {
+	m.labels = labels
+	return m
+}
+
+func (m *MockDeployer) WithDeployErr(err error) *MockDeployer {
+	m.deployErr = err
+	return m
+}
+
+func (m *MockDeployer) WithDependenciesErr(err error) *MockDeployer {
+	m.dependenciesErr = err
+	return m
+}
+
+func (m *MockDeployer) WithCleanupErr(err error) *MockDeployer {
+	m.cleanupErr = err
+	return m
+}
+
+func (m *MockDeployer) WithRenderErr(err error) *MockDeployer {
+	m.renderErr = err
+	return m
+}
+
 func (m *MockDeployer) Deploy(context.Context, io.Writer, []build.Artifact, []Labeller) *Result {
 	return &Result{
 		namespaces: m.deployNamespaces,
 		err:        m.deployErr,
 	}
 }
+
 func (m *MockDeployer) Render(_ context.Context, w io.Writer, _ []build.Artifact, _ []Labeller, _ string) error {
 	w.Write([]byte(m.renderResult))
 	return m.renderErr
 }
 
-func NewMockDeployer() *MockDeployer                                     { return &MockDeployer{labels: make(map[string]string)} }
-func (m *MockDeployer) WithLabel(labels map[string]string) *MockDeployer { m.labels = labels; return m }
-func (m *MockDeployer) WithDeployErr(err error) *MockDeployer            { m.deployErr = err; return m }
-func (m *MockDeployer) WithDependenciesErr(err error) *MockDeployer      { m.dependenciesErr = err; return m }
-func (m *MockDeployer) WithCleanupErr(err error) *MockDeployer           { m.cleanupErr = err; return m }
-func (m *MockDeployer) WithRenderErr(err error) *MockDeployer            { m.renderErr = err; return m }
 func (m *MockDeployer) WithDeployNamespaces(namespaces []string) *MockDeployer {
 	m.deployNamespaces = namespaces
 	return m
 }
+
 func (m *MockDeployer) WithDependencies(dependencies []string) *MockDeployer {
 	m.dependencies = dependencies
 	return m
 }
+
 func (m *MockDeployer) WithRenderResult(renderResult string) *MockDeployer {
 	m.renderResult = renderResult
 	return m


### PR DESCRIPTION
For some reason, deploy_mux_test had to be formatted differently.

Signed-off-by: David Gageot <david@gageot.net>
