### PR TITLE
Allow custom go-licenses binary when building

### DIFF
--- a/hack/generate-statik.sh
+++ b/hack/generate-statik.sh
@@ -25,7 +25,10 @@ LICENSES=${BIN}/go-licenses
 TMP_DIR=$(mktemp -d)
 trap "rm -rf $TMP_DIR" EXIT
 
-if ! [ -x "$(command -v ${LICENSES})" ]; then
+if [ -x "$(command -v go-licenses)" ]; then
+    # use go-licenses binary if it's installed on user's path
+    LICENSES=go-licenses
+elif ! [ -x "$(command -v ${LICENSES})" ]; then
     # See https://github.com/golang/go/issues/30515
     # Also can't be easily installed from a vendor folder because it relies on non-go files
     # from a dependency.


### PR DESCRIPTION
the vendored go-licenses binary that we install in this script is broken on my machine due to a bug. this allows me to use a custom binary installed on my path so that I can run `make install`.