### PR TITLE
Binaries for linux-arm #2068

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 GOOS ?= $(shell go env GOOS)
-GOARCH = amd64
+GOARCH ?= amd64
 BUILD_DIR ?= ./out
 ORG = github.com/GoogleContainerTools
 PROJECT = skaffold

--- a/Makefile.diag
+++ b/Makefile.diag
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 GOOS ?= $(shell go env GOOS)
-GOARCH = amd64
+GOARCH ?= amd64
 BUILD_DIR ?= ./out
 ORG := github.com/GoogleContainerTools
 PROJECT := diag


### PR DESCRIPTION
Make GOARCH configurable in order to build skaffold on other platforms
such as arm and arm64.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

Fixes #2068

Tested using:

```GOARCH=arm make```

which successfully built an arm based binary on Raspbian (RPi4). I don't know the current release build cycle but it should be trivial to create a skaffold release for arm now provided you have the right cross build env or access to a native one.