### PR TITLE
cleanup common flags + better -f description

### DIFF
--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
@@ -36,10 +35,7 @@ import (
 func NewCmdDiagnose() *cobra.Command {
 	return NewCmd("diagnose").
 		WithDescription("Run a diagnostic on Skaffold").
-		WithFlags(func(f *pflag.FlagSet) {
-			f.StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
-			f.StringSliceVarP(&opts.Profiles, "profile", "p", nil, "Activate profiles by name")
-		}).
+		WithCommonFlags().
 		NoArgs(cancelWithCtrlC(context.Background(), doDiagnose))
 }
 

--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -34,8 +34,8 @@ import (
 func NewCmdFix() *cobra.Command {
 	return NewCmd("fix").
 		WithDescription("Update old configuration to newest schema version").
+		WithCommonFlags().
 		WithFlags(func(f *pflag.FlagSet) {
-			f.StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
 			f.BoolVar(&overwrite, "overwrite", false, "Overwrite original config with fixed config")
 		}).
 		NoArgs(doFix)

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -47,7 +47,7 @@ var FlagRegistry = []Flag{
 	{
 		Name:          "filename",
 		Shorthand:     "f",
-		Usage:         "Filename or URL to the pipeline file",
+		Usage:         "Path or URL to the Skaffold config file",
 		Value:         &opts.ConfigurationFile,
 		DefValue:      "skaffold.yaml",
 		FlagAddMethod: "StringVar",
@@ -60,7 +60,7 @@ var FlagRegistry = []Flag{
 		Value:         &opts.Profiles,
 		DefValue:      []string{},
 		FlagAddMethod: "StringSliceVar",
-		DefinedOn:     []string{"all"},
+		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "build", "delete", "diagnose"},
 	},
 	{
 		Name:          "namespace",
@@ -69,7 +69,7 @@ var FlagRegistry = []Flag{
 		Value:         &opts.Namespace,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",
-		DefinedOn:     []string{"all"},
+		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "build", "delete"},
 	},
 	{
 		Name:          "default-repo",
@@ -78,7 +78,7 @@ var FlagRegistry = []Flag{
 		Value:         &opts.DefaultRepo,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",
-		DefinedOn:     []string{"all"},
+		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "build", "delete"},
 	},
 	{
 		Name:          "cache-artifacts",

--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -51,8 +51,8 @@ var initEntrypoint = initializer.DoInit
 func NewCmdInit() *cobra.Command {
 	return NewCmd("init").
 		WithDescription("[alpha] Generate configuration for deploying an application").
+		WithCommonFlags().
 		WithFlags(func(f *pflag.FlagSet) {
-			f.StringVarP(&opts.ConfigurationFile, "filename", "f", "skaffold.yaml", "Filename or URL to the pipeline file")
 			f.BoolVar(&skipBuild, "skip-build", false, "Skip generating build artifacts in Skaffold config")
 			f.BoolVar(&skipDeploy, "skip-deploy", false, "Skip generating deploy stanza in Skaffold config")
 			f.MarkHidden("skip-deploy")

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -130,7 +130,7 @@ Options:
   -d, --default-repo='': Default repository value (overrides global config)
       --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
       --file-output='': Filename to write build images to
-  -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
+  -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --insecure-registry=[]: Target registries for built images which are not secure
       --kube-context='': Deploy to this Kubernetes context
       --kubeconfig='': Path to the kubeconfig file to use for CLI requests.
@@ -330,7 +330,7 @@ Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
-  -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
+  -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime! (true by default for `skaffold dev`)
       --insecure-registry=[]: Target registries for built images which are not secure
       --kube-context='': Deploy to this Kubernetes context
@@ -391,7 +391,7 @@ Delete the deployed application
 Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
-  -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
+  -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --kube-context='': Deploy to this Kubernetes context
       --kubeconfig='': Path to the kubeconfig file to use for CLI requests.
   -n, --namespace='': Run deployments in the specified namespace
@@ -437,7 +437,7 @@ E.g. build.out created by running skaffold build --quiet -o "{{json .}}" > build
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
-  -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
+  -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime! (true by default for `skaffold dev`)
   -i, --images=: A list of pre-built images to deploy
       --kube-context='': Deploy to this Kubernetes context
@@ -492,7 +492,7 @@ Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
-  -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
+  -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime! (true by default for `skaffold dev`)
       --insecure-registry=[]: Target registries for built images which are not secure
       --kube-context='': Deploy to this Kubernetes context
@@ -559,7 +559,8 @@ Run a diagnostic on Skaffold
 
 
 Options:
-  -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
+  -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
+  -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
   -p, --profile=[]: Activate profiles by name
 
 Usage:
@@ -571,6 +572,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 ```
 Env vars:
 
+* `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 
@@ -582,7 +584,7 @@ Update old configuration to newest schema version
 
 
 Options:
-  -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
+  -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --overwrite=false: Overwrite original config with fixed config
 
 Usage:
@@ -609,7 +611,7 @@ Options:
   -a, --artifact=[]: '='-delimited Dockerfile/image pair, or JSON string, to generate build artifact
 (example: --artifact='{"builder":"Docker","payload":{"path":"/web/Dockerfile.web"},"image":"gcr.io/web-project/image"}')
       --compose-file='': Initialize from a docker-compose file
-  -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
+  -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Force the generation of the Skaffold config
   -k, --kubernetes-manifest=[]: a path or a glob pattern to kubernetes manifests (can be non-existent) to be added to the kubectl deployer (overrides detection of kubernetes manifests). Repeat the flag for multiple entries. E.g.: skaffold init -k pod.yaml -k k8s/*.yml
       --skip-build=false: Skip generating build artifacts in Skaffold config
@@ -653,7 +655,7 @@ The following options can be passed to any command:
 
 Options:
   -d, --default-repo='': Default repository value (overrides global config)
-  -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
+  -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
   -l, --label=[]: Add custom labels to deployed objects. Set multiple times for multiple labels
       --loud=false: Show the build logs and output
   -n, --namespace='': Run deployments in the specified namespace
@@ -698,7 +700,7 @@ Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
-  -f, --filename='skaffold.yaml': Filename or URL to the pipeline file
+  -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime! (true by default for `skaffold dev`)
       --insecure-registry=[]: Target registries for built images which are not secure
       --kube-context='': Deploy to this Kubernetes context


### PR DESCRIPTION
I wanted to rename `-f` flag's description to `Path or URL to the Skaffold config file`. 
However I found that we had a bunch of duplication - so I cleaned up that duplication. 
In the process, I had to add `CommonFlags` to `diagnose`, `fix` and `init`.  It turns out we wanted `diagnose` to take `-c` as well, so I left it there. 