### PR TITLE
Applied namespace to Cleanup and getArgs

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -204,10 +204,8 @@ func (h *HelmDeployer) Cleanup(ctx context.Context, out io.Writer) error {
 		args := []string{"delete", releaseName}
 		if hv.LT(helm3Version) {
 			args = append(args, "--purge")
-		} else {
-			if r.Namespace != "" {
-				args = append(args, "--namespace", r.Namespace)
-			}
+		} else if r.Namespace != "" {
+			args = append(args, "--namespace", r.Namespace)
 		}
 		if err := h.exec(ctx, out, false, args...); err != nil {
 			return errors.Wrapf(err, "deleting %s", releaseName)


### PR DESCRIPTION
**Description**

Fixes #3762 

This PR changes how the namespace applied in the release in the `skaffold.yaml` file is sent to Helm 3. It currently does not look for helm releases in the defined namespace, this PR applies the `--namespace` parameter to the helm calls, but only for Helm 3.

**User facing changes**

With Helm 3 supporting fully namespace'd releases, it would be expected that setting the namespace in the Skaffold release would make it deploy there. Currently this is only the case for the deployment step. For cleanup and getting the current lists of deployments, it does not apply the namespace. 

**Before**

Skaffold would successfully push the first version of the Helm release successfully. When tearing down, it would fail because the `delete` command did not have the namespace sent to it with the `--namespace` argument. When running Skaffold again, the un-deleted release would still exist, but it would not pick up on it because the function that gets the current releases did not apply the namespace properly either.

**After**

The normal workflow for skaffold is properly executed. Skaffold accesses the current helm releases in the namespace defined in the `skaffold.yaml` file. If it does not exist, it deploys to the namespace, or upgrades if it does. When tearing down, it properly deletes the release from the namespace.

**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes [unit tests](../DEVELOPMENT.md#creating-a-pr)
- [x] Mentions any output changes.
- [x] Adds documentation as needed: user docs, YAML reference, CLI reference.
- [x] Adds integration tests if needed.

**Reviewer Notes**

- [ ] The code flow looks good. 
- [ ] Unit test added.
- [ ] User facing changes look good.


**Release Notes**

This was a bug noticed before support for helm 3 was published, so I'm not sure anything needs to be added here.
