### PR TITLE
Normalize capitalization for types while port forwarding

### DIFF
--- a/pkg/skaffold/kubernetes/portforward/port_forward_entry.go
+++ b/pkg/skaffold/kubernetes/portforward/port_forward_entry.go
@@ -19,6 +19,7 @@ package portforward
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -59,10 +60,10 @@ func (p *portForwardEntry) key() string {
 	if p.automaticPodForwarding {
 		return fmt.Sprintf("%s-%s-%s-%s-%d", p.ownerReference, p.containerName, p.resource.Namespace, p.portName, p.resource.Port)
 	}
-	return fmt.Sprintf("%s-%s-%s-%d", p.resource.Type, p.resource.Name, p.resource.Namespace, p.resource.Port)
+	return fmt.Sprintf("%s-%s-%s-%d", strings.ToLower(string(p.resource.Type)), p.resource.Name, p.resource.Namespace, p.resource.Port)
 }
 
 // String is a utility function that returns the port forward entry as a user-readable string
 func (p *portForwardEntry) String() string {
-	return fmt.Sprintf("%s-%s-%s-%d", p.resource.Type, p.resource.Name, p.resource.Namespace, p.resource.Port)
+	return fmt.Sprintf("%s-%s-%s-%d", strings.ToLower(string(p.resource.Type)), p.resource.Name, p.resource.Namespace, p.resource.Port)
 }

--- a/pkg/skaffold/kubernetes/portforward/port_forward_entry_test.go
+++ b/pkg/skaffold/kubernetes/portforward/port_forward_entry_test.go
@@ -48,6 +48,15 @@ func TestPortForwardEntryKey(t *testing.T) {
 				Port:      9000,
 			}, "", "", "", "", 0, false),
 			expected: "deployment-depName-namespace-9000",
+		}, {
+			description: "entry for deployment with capital normalization",
+			pfe: newPortForwardEntry(0, latest.PortForwardResource{
+				Type:      "Deployment",
+				Name:      "depName",
+				Namespace: "namespace",
+				Port:      9000,
+			}, "", "", "", "", 0, false),
+			expected: "deployment-depName-namespace-9000",
 		},
 	}
 


### PR DESCRIPTION
**Description**
Currently, if `--port-forward` is used, skaffold will create automated port forwards for resources that are not defined in the `portForward` field. This works great, but sometimes there are issues with capitalization. For example, I was recently working on a project where the type of the service resource was understood to be `service` by skaffold, but in the `portForward` section of the `skaffold.yaml`, I had set the Type to `Service`. These were interpreted as two different port forwarding configurations and leads to unintentional duplication on the same resource.

My solution to this was to normalize the capitalization when calculating the `key` for the `portForwardEntry`. This makes it such that resources of the same type, but different capitalization, will be treated the same. Ex. `service/my-api-service` and `Service/my-api-service` will be treated the same.

A unit test has been added to support this.
