### PR TITLE
Upgrade kompose to 1.21.0

### DIFF
--- a/deploy/skaffold/Dockerfile
+++ b/deploy/skaffold/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This base image has to be updated manually after running `make build_deps`
-FROM gcr.io/k8s-skaffold/build_deps:0c78248757f1753c4c64a791160d5e2fdd35f157 as builder
+FROM gcr.io/k8s-skaffold/build_deps:d414a205df8d8307c92eff8e577cbf2691e46a34 as builder
 WORKDIR /skaffold
 COPY . .
 

--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -35,7 +35,7 @@ RUN tar -xvf kustomize.tar.gz
 
 # Download kompose
 FROM alpine:3.10 as download-kompose
-ENV KOMPOSE_VERSION v1.20.0
+ENV KOMPOSE_VERSION v1.21.0
 ENV KOMPOSE_URL https://github.com/kubernetes/kompose/releases/download/${KOMPOSE_VERSION}/kompose-linux-amd64
 RUN wget -O kompose "${KOMPOSE_URL}"
 RUN chmod +x kompose


### PR DESCRIPTION
Properly generates deployments of type `apps/v1` instead of deprecated type `extensions/v1beta2`

Signed-off-by: David Gageot <david@gageot.net>
