### PR TITLE
Fix `make quicktest`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ GKE_ZONE ?= us-central1-a
 SUPPORTED_PLATFORMS = linux-$(GOARCH) darwin-$(GOARCH) windows-$(GOARCH).exe
 BUILD_PACKAGE = $(REPOPATH)/cmd/skaffold
 
-SKAFFOLD_TEST_PACKAGES = $(shell go list ./... | grep -v diag)
+SKAFFOLD_TEST_PACKAGES = ./pkg/skaffold/... ./cmd/... ./hack/... ./pkg/webhook/...
 GO_FILES = $(shell find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./pkg/diag/*")
 
 VERSION_PACKAGE = $(REPOPATH)/pkg/skaffold/version

--- a/hack/gotest.sh
+++ b/hack/gotest.sh
@@ -29,19 +29,15 @@ RESET='\033[0m'
 LOG=$(mktemp -t tests.json.XXXXXX)
 trap "rm -f $LOG" EXIT
 
-if [[ " ${@}" =~ "pkg/skaffold" ]]; then
-  echo "go test ./pkg/skaffold/..."
-else
-  echo "go test $@"
-fi
+echo "go test $@"
 
 # Keep execution simple for users who do not have jq installed
-if [[ ! $(command -v jq >/dev/null) ]]; then
+if ! $(command -v jq > /dev/null); then
   go test $* | sed ''/FAIL/s//`printf "${RED}FAIL${RESET}"`/''
   exit ${PIPESTATUS[0]}
 fi
 
-if [[ " ${@} " =~ "-v" ]]; then
+if [[ $@ == *"-v"* ]]; then
     JQ_FILTER='select(has("Output") and (.Action=="output")) | .Output'
 else
     JQ_FILTER='select(has("Output") and (.Action=="output") and (has("Test")|not) and (.Output!="PASS\n") and (.Output!="FAIL\n") and (.Output|startswith("coverage:")|not) and (.Output|contains("[no test files]")|not)) | .Output'


### PR DESCRIPTION
 + Print which packages are actually tested
 + Restore “smart” output when jq is installed
 + Fix handling of -v

Signed-off-by: David Gageot <david@gageot.net>
