### PR TITLE
`skaffold build-image` command

### DIFF
--- a/cmd/skaffold/app/cmd/buildimage.go
+++ b/cmd/skaffold/app/cmd/buildimage.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"io"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/buildimage"
+)
+
+var options buildimage.Options
+
+// NewCmdBuildImage describes the CLI command to build one image.
+func NewCmdBuildImage() *cobra.Command {
+	return NewCmd("build-image").
+		WithDescription("Build an image from sources").
+		WithLongDescription("Build, test and tag an image from a source workspace").
+		WithExample("Build and push an image", "skaffold build-image --name my-image --push=true").
+		WithCommonFlags().
+		WithFlags(func(f *pflag.FlagSet) {
+			f.BoolVar(&options.Push, "push", false, "Push the image to a registry")
+			f.StringVar(&options.Name, "name", "", "Name of the image. Defaults to the name of the current folder")
+			f.StringVar(&options.Tagger, "tagger", "", "Type of the tagger. Defaults to gitCommit")
+			f.StringVar(&options.Type, "type", "", "Type of the artifact. Default to docker (docker build with a Dockerfile)")
+
+			// Docker specific flags
+			f.StringVar(&options.Target, "target", "", "Dockerfile target to build")
+		}).
+		AtMostArgs(1, func(ctx context.Context, out io.Writer, args []string) error {
+			setWorkspace(args)
+			return doBuildImage(ctx, out)
+		})
+}
+
+func setWorkspace(args []string) {
+	options.Workspace = "."
+	if len(args) == 1 {
+		options.Workspace = args[0]
+	}
+}
+
+func doBuildImage(ctx context.Context, out io.Writer) error {
+	return buildimage.BuildImage(ctx, out, opts, options)
+}

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -133,6 +133,7 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 			Message: "Pipeline building blocks for CI/CD:",
 			Commands: []*cobra.Command{
 				NewCmdBuild(),
+				NewCmdBuildImage(),
 				NewCmdDeploy(),
 				NewCmdDelete(),
 				NewCmdRender(),

--- a/cmd/skaffold/app/cmd/commands.go
+++ b/cmd/skaffold/app/cmd/commands.go
@@ -34,6 +34,7 @@ type Builder interface {
 	WithCommonFlags() Builder
 	Hidden() Builder
 	ExactArgs(argCount int, action func(context.Context, io.Writer, []string) error) *cobra.Command
+	AtMostArgs(argCount int, action func(context.Context, io.Writer, []string) error) *cobra.Command
 	NoArgs(action func(context.Context, io.Writer) error) *cobra.Command
 }
 
@@ -85,6 +86,14 @@ func (b *builder) Hidden() Builder {
 
 func (b *builder) ExactArgs(argCount int, action func(context.Context, io.Writer, []string) error) *cobra.Command {
 	b.cmd.Args = cobra.ExactArgs(argCount)
+	b.cmd.RunE = func(_ *cobra.Command, args []string) error {
+		return action(b.cmd.Context(), b.cmd.OutOrStdout(), args)
+	}
+	return &b.cmd
+}
+
+func (b *builder) AtMostArgs(argCount int, action func(context.Context, io.Writer, []string) error) *cobra.Command {
+	b.cmd.Args = cobra.RangeArgs(0, argCount)
 	b.cmd.RunE = func(_ *cobra.Command, args []string) error {
 		return action(b.cmd.Context(), b.cmd.OutOrStdout(), args)
 	}

--- a/cmd/skaffold/app/cmd/commands_test.go
+++ b/cmd/skaffold/app/cmd/commands_test.go
@@ -70,6 +70,14 @@ func TestNewCmdExactArgs(t *testing.T) {
 	testutil.CheckError(t, true, cmd.Args(cmd, []string{"valid", "extra"}))
 }
 
+func TestNewCmdAtMostArgs(t *testing.T) {
+	cmd := NewCmd("").AtMostArgs(1, nil)
+
+	testutil.CheckError(t, false, cmd.Args(cmd, []string{}))
+	testutil.CheckError(t, false, cmd.Args(cmd, []string{"valid"}))
+	testutil.CheckError(t, true, cmd.Args(cmd, []string{"valid", "extra"}))
+}
+
 func TestNewCmdError(t *testing.T) {
 	cmd := NewCmd("").NoArgs(func(ctx context.Context, out io.Writer) error {
 		return errors.New("expected error")
@@ -84,6 +92,20 @@ func TestNewCmdOutput(t *testing.T) {
 	var buf bytes.Buffer
 
 	cmd := NewCmd("").ExactArgs(1, func(ctx context.Context, out io.Writer, args []string) error {
+		fmt.Fprintf(out, "test output: %v\n", args)
+		return nil
+	})
+	cmd.SetOutput(&buf)
+
+	err := cmd.RunE(nil, []string{"arg1"})
+
+	testutil.CheckErrorAndDeepEqual(t, false, err, "test output: [arg1]\n", buf.String())
+}
+
+func TestNewCmdOutputAtMostArgs(t *testing.T) {
+	var buf bytes.Buffer
+
+	cmd := NewCmd("").AtMostArgs(2, func(ctx context.Context, out io.Writer, args []string) error {
 		fmt.Fprintf(out, "test output: %v\n", args)
 		return nil
 	})

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -86,7 +86,7 @@ var FlagRegistry = []Flag{
 		Value:         &opts.CacheArtifacts,
 		DefValue:      true,
 		FlagAddMethod: "BoolVar",
-		DefinedOn:     []string{"dev", "build", "run", "debug"},
+		DefinedOn:     []string{"dev", "build", "build-image", "run", "debug"},
 	},
 	{
 		Name:          "cache-file",
@@ -94,7 +94,7 @@ var FlagRegistry = []Flag{
 		Value:         &opts.CacheFile,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",
-		DefinedOn:     []string{"dev", "build", "run", "debug"},
+		DefinedOn:     []string{"dev", "build", "build-image", "run", "debug"},
 	},
 	{
 		Name:          "insecure-registry",
@@ -102,7 +102,7 @@ var FlagRegistry = []Flag{
 		Value:         &opts.InsecureRegistries,
 		DefValue:      []string{},
 		FlagAddMethod: "StringSliceVar",
-		DefinedOn:     []string{"dev", "build", "run", "debug"},
+		DefinedOn:     []string{"dev", "build", "build-image", "run", "debug"},
 	},
 	{
 		Name:          "enable-rpc",
@@ -177,7 +177,7 @@ var FlagRegistry = []Flag{
 		Value:         &opts.SkipTests,
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",
-		DefinedOn:     []string{"dev", "run", "debug", "build"},
+		DefinedOn:     []string{"dev", "run", "debug", "build", "build-image"},
 	},
 	{
 		Name:          "cleanup",
@@ -259,7 +259,7 @@ var FlagRegistry = []Flag{
 		Value:         &opts.CustomTag,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",
-		DefinedOn:     []string{"build", "debug", "dev", "run"},
+		DefinedOn:     []string{"build", "build-image", "debug", "dev", "run"},
 	},
 	{
 		Name:          "minikube-profile",

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -73,6 +73,7 @@ End-to-end pipelines:
 
 Pipeline building blocks for CI/CD:
   build             Build the artifacts
+  build-image       Build an image from sources
   deploy            Deploy pre-built artifacts
   delete            Delete the deployed application
   render            [alpha] Perform all image builds, and output rendered Kubernetes manifests
@@ -173,6 +174,51 @@ Env vars:
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
+
+### skaffold build-image
+
+Build an image from sources
+
+```
+
+
+Examples:
+  # Build and push an image
+  skaffold skaffold build-image --name my-image --push=true
+
+Options:
+      --cache-artifacts=true: Set to false to disable default caching of artifacts
+      --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
+  -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
+      --insecure-registry=[]: Target registries for built images which are not secure
+      --name='': Name of the image. Defaults to the name of the current folder
+      --push=false: Push the image to a registry
+      --skip-tests=false: Whether to skip the tests after building
+  -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
+      --tagger='': Type of the tagger. Defaults to gitCommit
+      --target='': Dockerfile target to build
+      --type='': Type of the artifact. Default to docker (docker build with a Dockerfile)
+
+Usage:
+  skaffold build-image [options]
+
+Use "skaffold options" for a list of global command-line options (applies to all commands).
+
+
+```
+Env vars:
+
+* `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
+* `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
+* `SKAFFOLD_FILENAME` (same as `--filename`)
+* `SKAFFOLD_INSECURE_REGISTRY` (same as `--insecure-registry`)
+* `SKAFFOLD_NAME` (same as `--name`)
+* `SKAFFOLD_PUSH` (same as `--push`)
+* `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
+* `SKAFFOLD_TAG` (same as `--tag`)
+* `SKAFFOLD_TAGGER` (same as `--tagger`)
+* `SKAFFOLD_TARGET` (same as `--target`)
+* `SKAFFOLD_TYPE` (same as `--type`)
 
 ### skaffold completion
 

--- a/integration/build_image_test.go
+++ b/integration/build_image_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
+)
+
+func TestBuildImage(t *testing.T) {
+	if testing.Short() || RunOnGCP() {
+		t.Skip("skipping kind integration test")
+	}
+
+	tests := []struct {
+		description string
+		dir         string
+	}{
+		{
+			description: "docker build",
+			dir:         "examples/getting-started",
+		},
+		{
+			description: "buildpacks build",
+			dir:         "examples/buildpacks",
+		},
+		{
+			description: "jib build",
+			dir:         "examples/jib",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			// Build without artifact caching
+			skaffold.BuildImage("--cache-artifacts=false").InDir(test.dir).RunOrFail(t)
+
+			// Build with artifact caching
+			skaffold.BuildImage("--cache-artifacts=true").InDir(test.dir).RunOrFail(t)
+
+			// Build a second time with artifact caching
+			out := skaffold.BuildImage("--cache-artifacts=true").InDir(test.dir).RunOrFailOutput(t)
+			if strings.Contains(string(out), "Not found. Building") {
+				t.Errorf("images were expected to be found in cache: %s", out)
+			}
+		})
+	}
+}

--- a/integration/skaffold/helper.go
+++ b/integration/skaffold/helper.go
@@ -62,6 +62,11 @@ func Build(args ...string) *RunBuilder {
 	return withDefaults("build", args)
 }
 
+// BuildImage runs `skaffold build-image` with the given arguments.
+func BuildImage(args ...string) *RunBuilder {
+	return withDefaults("build-image", args)
+}
+
 // Deploy runs `skaffold deploy` with the given arguments.
 func Deploy(args ...string) *RunBuilder {
 	return withDefaults("deploy", args)

--- a/pkg/skaffold/buildimage/buildimage.go
+++ b/pkg/skaffold/buildimage/buildimage.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildimage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+
+	cfg "github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	analyz "github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/analyze"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+)
+
+const defaultBuildpacksBuilder = "heroku/buildpacks"
+
+type Options struct {
+	Push      bool
+	Tagger    string
+	Type      string
+	Name      string
+	Workspace string
+	Target    string
+}
+
+// Use-cases:
+// $ skaffold build-image [--type docker|buildpacks|jib] [--build-arg KEY=VALUE] [--name my-image] [.|context]
+
+// docker specific flags:
+// --target TARGET
+// --build-arg KEY=VALUE
+
+// jib specific flags:
+// --project
+// --args
+
+// buildpacks specific flags:
+// --builder
+// --run-image
+// -e
+
+// TODO: what if image name contains a tag?
+// TODO: what about k8s context?
+func BuildImage(ctx context.Context, out io.Writer, globalOpts cfg.SkaffoldOptions, buildOpts Options) error {
+	cfg, err := buildConfig(buildOpts)
+	if err != nil {
+		return err
+	}
+
+	runner, err := buildRunner(globalOpts, cfg)
+	if err != nil {
+		return err
+	}
+
+	_, err = runner.BuildAndTest(ctx, out, cfg.Pipeline.Build.Artifacts)
+	return err
+}
+
+func buildRunner(globalOpts cfg.SkaffoldOptions, cfg *latest.SkaffoldConfig) (*runner.SkaffoldRunner, error) {
+	runCtx, err := runcontext.GetRunContext(globalOpts, cfg.Pipeline)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting run context")
+	}
+
+	return runner.NewForConfig(runCtx)
+}
+
+func buildConfig(buildOpts Options) (*latest.SkaffoldConfig, error) {
+	artifact, err := artifact(buildOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	tagPolicy, err := tagPolicy(buildOpts.Tagger)
+	if err != nil {
+		return nil, err
+	}
+
+	// Hardcode the skaffold.yaml to
+	//  + Build only. No deployment.
+	//  + Build only one artifact (image).
+	cfg := &latest.SkaffoldConfig{
+		Pipeline: latest.Pipeline{
+			Build: latest.BuildConfig{
+				TagPolicy: tagPolicy,
+				Artifacts: []*latest.Artifact{artifact},
+				BuildType: latest.BuildType{
+					LocalBuild: &latest.LocalBuild{
+						Push: &buildOpts.Push,
+					},
+				},
+			},
+		},
+	}
+
+	if err := defaults.Set(cfg); err != nil {
+		return nil, errors.Wrap(err, "setting default values")
+	}
+
+	return cfg, nil
+}
+
+func artifact(opts Options) (*latest.Artifact, error) {
+	imageName, err := imageName(opts.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	artifactType, err := artifactType(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	artifact := &latest.Artifact{
+		ImageName:    imageName,
+		Workspace:    opts.Workspace,
+		ArtifactType: artifactType,
+	}
+
+	// Set options from the command line flags
+	if docker := artifact.ArtifactType.DockerArtifact; docker != nil {
+		docker.Target = opts.Target
+	}
+
+	return artifact, nil
+}
+
+func artifactType(opts Options) (latest.ArtifactType, error) {
+	switch {
+	// Guess the type of the artifact.
+	case opts.Type == "":
+		return guessArtifactType(opts)
+
+	// User-specified artifact type.
+	case opts.Type == "docker":
+		return latest.ArtifactType{
+			DockerArtifact: &latest.DockerArtifact{},
+		}, nil
+	case opts.Type == "jib":
+		return latest.ArtifactType{
+			JibArtifact: &latest.JibArtifact{},
+		}, nil
+	case opts.Type == "buildpacks":
+		return latest.ArtifactType{
+			BuildpackArtifact: &latest.BuildpackArtifact{
+				Builder: defaultBuildpacksBuilder,
+			},
+		}, nil
+
+	default:
+		return latest.ArtifactType{}, fmt.Errorf("unsupported artifact type %s", opts.Type)
+	}
+}
+
+func guessArtifactType(opts Options) (latest.ArtifactType, error) {
+	a := analyz.NewAnalyzer(config.Config{
+		EnableJibInit:        true,
+		EnableBuildpacksInit: true,
+		BuildpacksBuilder:    defaultBuildpacksBuilder,
+	})
+	if err := a.Analyze(opts.Workspace); err != nil {
+		return latest.ArtifactType{}, errors.Wrap(err, "unable to guess artifact's type")
+	}
+
+	builders := a.Builders()
+	if len(builders) != 1 {
+		return latest.ArtifactType{}, fmt.Errorf("unable to guess a unique artifact type. Found %d", len(builders))
+	}
+
+	at := builders[0].ArtifactType()
+
+	// TODO(dgageot): this is a hack to make sure DockerArtifact is
+	// never nil for a docker artifact
+	if builders[0].Name() == "Docker" && at.DockerArtifact == nil {
+		at.DockerArtifact = &latest.DockerArtifact{}
+	}
+
+	return at, nil
+}
+
+func imageName(imageName string) (string, error) {
+	if imageName != "" {
+		return imageName, nil
+	}
+
+	// Default to the base name of current working directory.
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Base(wd), nil
+}
+
+func tagPolicy(tagger string) (latest.TagPolicy, error) {
+	p := latest.TagPolicy{}
+
+	switch tagger {
+	case "gitCommit":
+		p.GitTagger = &latest.GitTagger{}
+	case "sha256":
+		p.ShaTagger = &latest.ShaTagger{}
+	case "envTemplate":
+		p.EnvTemplateTagger = &latest.EnvTemplateTagger{}
+	case "dateTime":
+		p.DateTimeTagger = &latest.DateTimeTagger{}
+	case "":
+		// Let the default tagger be applied.
+	default:
+		return p, fmt.Errorf("unknown tagger %q", tagger)
+	}
+
+	return p, nil
+}

--- a/pkg/skaffold/buildimage/buildimage_test.go
+++ b/pkg/skaffold/buildimage/buildimage_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildimage
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestArtifact(t *testing.T) {
+	tests := []struct {
+		description      string
+		options          Options
+		expectedArtifact *latest.Artifact
+	}{
+		{
+			description: "docker artifact",
+			options:     Options{Name: "my-image", Workspace: ".", Type: "docker"},
+			expectedArtifact: &latest.Artifact{
+				ImageName: "my-image",
+				Workspace: ".",
+				ArtifactType: latest.ArtifactType{
+					DockerArtifact: &latest.DockerArtifact{},
+				},
+			},
+		},
+		{
+			description: "docker artifact with target",
+			options:     Options{Name: "my-image", Workspace: ".", Type: "docker", Target: "my-target"},
+			expectedArtifact: &latest.Artifact{
+				ImageName: "my-image",
+				Workspace: ".",
+				ArtifactType: latest.ArtifactType{
+					DockerArtifact: &latest.DockerArtifact{
+						Target: "my-target",
+					},
+				},
+			},
+		},
+		{
+			description: "buildpacks artifact",
+			options:     Options{Name: "other-image", Workspace: ".", Type: "buildpacks"},
+			expectedArtifact: &latest.Artifact{
+				ImageName: "other-image",
+				Workspace: ".",
+				ArtifactType: latest.ArtifactType{
+					BuildpackArtifact: &latest.BuildpackArtifact{
+						Builder: defaultBuildpacksBuilder,
+					},
+				},
+			},
+		},
+		{
+			description: "jib artifact",
+			options:     Options{Name: "other-image", Workspace: ".", Type: "jib"},
+			expectedArtifact: &latest.Artifact{
+				ImageName: "other-image",
+				Workspace: ".",
+				ArtifactType: latest.ArtifactType{
+					JibArtifact: &latest.JibArtifact{},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			a, err := artifact(test.options)
+
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expectedArtifact, a)
+		})
+	}
+}
+
+func TestArtifactAutoDetect(t *testing.T) {
+	tests := []struct {
+		description      string
+		options          Options
+		files            map[string]string
+		expectedArtifact *latest.Artifact
+	}{
+		{
+			description: "docker artifact",
+			options:     Options{Name: "my-image", Workspace: "."},
+			files: map[string]string{
+				"Dockerfile": "FROM scratch",
+			},
+			expectedArtifact: &latest.Artifact{
+				ImageName: "my-image",
+				Workspace: ".",
+				ArtifactType: latest.ArtifactType{
+					DockerArtifact: &latest.DockerArtifact{},
+				},
+			},
+		},
+		{
+			description: "docker artifact with target",
+			options:     Options{Name: "my-image", Workspace: ".", Target: "my-target"},
+			files: map[string]string{
+				"Dockerfile": "FROM scratch",
+			},
+			expectedArtifact: &latest.Artifact{
+				ImageName: "my-image",
+				Workspace: ".",
+				ArtifactType: latest.ArtifactType{
+					DockerArtifact: &latest.DockerArtifact{
+						Target: "my-target",
+					},
+				},
+			},
+		},
+		{
+			description: "buildpacks artifact",
+			options:     Options{Name: "my-image", Workspace: "."},
+			files: map[string]string{
+				"go.mod": "something",
+			},
+			expectedArtifact: &latest.Artifact{
+				ImageName: "my-image",
+				Workspace: ".",
+				ArtifactType: latest.ArtifactType{
+					BuildpackArtifact: &latest.BuildpackArtifact{
+						Builder: defaultBuildpacksBuilder,
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.NewTempDir().Chdir().WriteFiles(test.files)
+
+			a, err := artifact(test.options)
+
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expectedArtifact, a)
+		})
+	}
+}


### PR DESCRIPTION
Preliminary implementation of `skaffold build-image`.

The idea of this new command is to be able to build a Docker image out of any folder. Skaffolf will auto detect which builder to use among Docker, Jib and Buildpacks.

For example in `examples/getting-started` folder:

```
skaffold build-image --name my-image
```

Should build an image with `docker build` .