### PR TITLE
Fix `skaffold debug` panic with nodejs

### DIFF
--- a/pkg/skaffold/debug/transform_nodejs.go
+++ b/pkg/skaffold/debug/transform_nodejs.go
@@ -96,7 +96,7 @@ func (t nodeTransformer) Apply(container *v1.Container, config imageConfiguratio
 			container.Args = rewriteNpmCommandLine(config.arguments, *spec)
 
 		default:
-			container.Env = rewriteNodeOptions(config.env, *spec)
+			container.Env = rewriteWithNodeOptions(config.env, *spec)
 		}
 	}
 
@@ -206,7 +206,7 @@ func rewriteNpmCommandLine(commandLine []string, spec inspectSpec) []string {
 	return commandLine
 }
 
-func rewriteNodeOptions(env map[string]string, spec inspectSpec) []v1.EnvVar {
+func rewriteWithNodeOptions(env map[string]string, spec inspectSpec) []v1.EnvVar {
 	found := false
 	var vars []v1.EnvVar
 	for k, v := range env {

--- a/pkg/skaffold/debug/transform_nodejs.go
+++ b/pkg/skaffold/debug/transform_nodejs.go
@@ -96,8 +96,7 @@ func (t nodeTransformer) Apply(container *v1.Container, config imageConfiguratio
 			container.Args = rewriteNpmCommandLine(config.arguments, *spec)
 
 		default:
-			logrus.Warnf("Skipping %q as does not appear to invoke node", container.Name)
-			return nil
+			container.Env = rewriteNodeOptions(config.env, *spec)
 		}
 	}
 
@@ -205,4 +204,20 @@ func rewriteNpmCommandLine(commandLine []string, spec inspectSpec) []string {
 		commandLine = append(commandLine, newOption)
 	}
 	return commandLine
+}
+
+func rewriteNodeOptions(env map[string]string, spec inspectSpec) []v1.EnvVar {
+	found := false
+	var vars []v1.EnvVar
+	for k, v := range env {
+		if k == "NODE_OPTIONS" {
+			found = true
+			v = v + " " + spec.String()
+		}
+		vars = append(vars, v1.EnvVar{Name: k, Value: v})
+	}
+	if !found {
+		vars = append(vars, v1.EnvVar{Name: "NODE_OPTIONS", Value: spec.String()})
+	}
+	return vars
 }

--- a/pkg/skaffold/debug/transform_nodejs_test.go
+++ b/pkg/skaffold/debug/transform_nodejs_test.go
@@ -205,10 +205,14 @@ func TestNodeTransformer_Apply(t *testing.T) {
 			description:   "empty",
 			containerSpec: v1.Container{},
 			configuration: imageConfiguration{},
-			result:        v1.Container{},
+			// since IsApply() presumably returned true, this is the default case
+			result: v1.Container{
+				Ports: []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
+				Env:   []v1.EnvVar{{Name: "NODE_OPTIONS", Value: "--inspect=9229"}},
+			},
 		},
 		{
-			description:   "basic",
+			description:   "entrypoint",
 			containerSpec: v1.Container{},
 			configuration: imageConfiguration{entrypoint: []string{"node"}},
 			result: v1.Container{
@@ -244,6 +248,18 @@ func TestNodeTransformer_Apply(t *testing.T) {
 			configuration: imageConfiguration{arguments: []string{"node"}},
 			result: v1.Container{
 				Args:  []string{"node", "--inspect=9229"},
+				Ports: []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
+			},
+		},
+		{
+			description:   "docker-entrypoint (#3821)",
+			containerSpec: v1.Container{},
+			configuration: imageConfiguration{
+				env:        map[string]string{"NODE_VERSION": "10.12"},
+				entrypoint: []string{"docker-entrypoint.sh"},
+				arguments:  []string{"npm run script"}},
+			result: v1.Container{
+				Env:   []v1.EnvVar{{Name: "NODE_VERSION", Value: "10.12"}, {Name: "NODE_OPTIONS", Value: "--inspect=9229"}},
 				Ports: []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 			},
 		},


### PR DESCRIPTION
Fixes #3821 

**Description**
The `nodejs` debug transformer's [`IsApplicable()` used the presence of `NODE_VERSION`](https://github.com/GoogleContainerTools/skaffold/blob/201c6154105e02b7720099143a9e3cf849acee43/pkg/skaffold/debug/transform_nodejs.go#L59-L61) to indicate that the container image is NodeJS-based.  But the `Apply()` only handles situations where there is a `npm` or `node` invocation.

**User facing changes (remove if N/A)**

_Look ma, no more panics!_

**Follow-up Work (remove if N/A)**

#2141 must be solved to allow running `examples/nodejs` for example.


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
