### PR TITLE
Whitelist recursively transformable kinds.

### DIFF
--- a/pkg/skaffold/deploy/kubectl/namespace_test.go
+++ b/pkg/skaffold/deploy/kubectl/namespace_test.go
@@ -29,7 +29,7 @@ func TestCollectNamespaces(t *testing.T) {
 		expected    []string
 	}{
 		{
-			description: "single manifest in the list",
+			description: "single Pod manifest in the list",
 			manifests: ManifestList{[]byte(`
 apiVersion: v1
 kind: Pod
@@ -40,6 +40,24 @@ spec:
   containers:
   - image: gcr.io/k8s-skaffold/example
     name: example
+`)},
+			expected: []string{"test"},
+		}, {
+			description: "single Service manifest in the list",
+			manifests: ManifestList{[]byte(`
+apiVersion: v1
+kind: Service
+metadata:
+  name: getting-started
+  namespace: test
+spec:
+  type: ClusterIP
+  ports:
+  - port: 443
+    targetPort: 8443
+    protocol: TCP
+  selector:
+    app: getting-started
 `)},
 			expected: []string{"test"},
 		}, {


### PR DESCRIPTION
**Description**
Refers to/fixes #1737, particularly to [this comment](https://github.com/GoogleContainerTools/skaffold/issues/1737#issuecomment-595440282).

Previously ([PR](https://github.com/GoogleContainerTools/skaffold/pull/3456)) FieldVisitors (image/namespace collector/transformer, labelsSetter) are applied to all fields of all resources recursively except for CRDs which were known to break otherwise since their schema contains a "metadata" property as well.
However other unknown kinds / CRs may contain such properties as well and break.

This PR whitelists the known kinds that can be transformed recursively instead of attempting to blacklist kinds that cannot be.

**User facing changes**
Applying a CR that contains a "metadata" or "image" field within the spec will work. (Previously skaffold destroyed the CR.)
Resource label and image modifications are only applied recursively on the fields of a known workload kind: Pod, ReplicaSet, StatefulSet, Deployment, DaemonSet, Job, CronJob.