### PR TITLE
Support Dockerfile.dockerignore

### DIFF
--- a/pkg/skaffold/docker/dependencies.go
+++ b/pkg/skaffold/docker/dependencies.go
@@ -89,10 +89,10 @@ func GetDependencies(ctx context.Context, workspace string, dockerfilePath strin
 }
 
 // readDockerignore reads patterns to ignore
-func readDockerignore(workspace string, dockerfilePath string) ([]string, error) {
+func readDockerignore(workspace string, absDockerfilePath string) ([]string, error) {
 	var excludes []string
 	dockerignorePaths := []string{
-		dockerfilePath + ".dockerignore",
+		absDockerfilePath + ".dockerignore",
 		filepath.Join(workspace, ".dockerignore"),
 	}
 	for _, dockerignorePath := range dockerignorePaths {
@@ -110,7 +110,7 @@ func readDockerignore(workspace string, dockerfilePath string) ([]string, error)
 			return excludes, nil
 		}
 	}
-	return excludes, nil
+	return nil, nil
 }
 
 // WalkWorkspace walks the given host directories and records all files found.

--- a/pkg/skaffold/docker/dependencies_test.go
+++ b/pkg/skaffold/docker/dependencies_test.go
@@ -236,12 +236,13 @@ func (f *fakeImageFetcher) fetch(image string, _ map[string]bool) (*v1.ConfigFil
 
 func TestGetDependencies(t *testing.T) {
 	tests := []struct {
-		description string
-		dockerfile  string
-		workspace   string
-		ignore      string
-		buildArgs   map[string]*string
-		env         []string
+		description    string
+		dockerfile     string
+		workspace      string
+		ignore         string
+		ignoreFilename string
+		buildArgs      map[string]*string
+		env            []string
 
 		expected  []string
 		badReader bool
@@ -522,6 +523,14 @@ func TestGetDependencies(t *testing.T) {
 			workspace:   ".",
 			expected:    []string{"Dockerfile", "file"},
 		},
+		{
+			description:    "find specific dockerignore",
+			dockerfile:     copyDirectory,
+			workspace:      ".",
+			ignore:         "bar\ndocker/*",
+			ignoreFilename: "Dockerfile.dockerignore",
+			expected:       []string{".dot", "Dockerfile", "Dockerfile.dockerignore", "file", "server.go", "test.conf", "worker.go"},
+		},
 	}
 
 	for _, test := range tests {
@@ -538,7 +547,11 @@ func TestGetDependencies(t *testing.T) {
 			}
 
 			if test.ignore != "" {
-				tmpDir.Write(test.workspace+"/.dockerignore", test.ignore)
+				ignoreFilename := ".dockerignore"
+				if test.ignoreFilename != "" {
+					ignoreFilename = test.ignoreFilename
+				}
+				tmpDir.Write(filepath.Join(test.workspace, ignoreFilename), test.ignore)
 			}
 
 			workspace := tmpDir.Path(test.workspace)

--- a/pkg/skaffold/docker/syncmap.go
+++ b/pkg/skaffold/docker/syncmap.go
@@ -41,7 +41,7 @@ func SyncMap(workspace string, dockerfilePath string, buildArgs map[string]*stri
 		return nil, err
 	}
 
-	excludes, err := readDockerignore(workspace)
+	excludes, err := readDockerignore(workspace, absDockerfilePath)
 	if err != nil {
 		return nil, errors.Wrap(err, "reading .dockerignore")
 	}


### PR DESCRIPTION
<!-- Thanks you for your contribution! -->

<!-- Include if applicable: -->
**Fixes**: Did not create an issue for this, please let me know if I should.

**Description**
Add support for getting dependencies from Dockerfile.dockerignore files. See e.g. https://github.com/moby/buildkit/pull/901 . Since the same code produces dependencies for Kaniko I expect this will also make Skaffold align better with Kaniko (https://github.com/GoogleContainerTools/kaniko/pull/801).

**User facing changes**
Users with multiple Dockerfiles will now be able to have different `.dockerignore` files. For example, this is the behavior with the following context:
```
.
├── .dockerignore
├── Dockerfile
├── Dockerfile.dev
└── Dockerfile.dev.dockerignore
```
**_before_:** `docker` would respect `Dockerfile.dev.dockerignore` but `skaffold` would not take it into account when producing dependencies, and syncing could break e.g. if `.dockerignore` hid files used by `Dockerfile.dev.dockerignore`, leading to unexpected behavior.

**_after_:** `skaffold` will make `Dockerfile.dev.dockerignore` take precedence over `.dockerignore` (will fall back to `.dockerignore` if it doesn't exist).