### PR TITLE
upgrade hugo + small fixes

### DIFF
--- a/deploy/webhook/Dockerfile
+++ b/deploy/webhook/Dockerfile
@@ -25,7 +25,7 @@ RUN git clone "${DOCSY_URL}" . && \
 
 # Download Hugo
 FROM alpine:3.10 as download-hugo
-ENV HUGO_VERSION 0.59.1
+ENV HUGO_VERSION 0.67.1
 ENV HUGO_URL https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz
 RUN wget -O- "${HUGO_URL}" | tar xz
 

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -38,6 +38,9 @@ pygmentsStyle = "tango"
 # Enable Emojis
 enableEmoji = true
 
+[markup.goldmark.renderer]
+unsafe= true
+
 # Configure how URLs look like per section.
 [permalinks]
 blog = "/:section/:year/:month/:day/:slug/"

--- a/docs/content/en/docs/references/_index.md
+++ b/docs/content/en/docs/references/_index.md
@@ -10,6 +10,6 @@ weight: 100
 | [skaffold.yaml]({{< relref "/docs/references/yaml" >}}) |
 | [gRPC API]({{< relref "/docs/references/api/grpc" >}}) |
 | [HTTP API]({{< relref "/docs/references/api/swagger" >}}) |
-| [Privacy Settings] ({{< relref "/docs/references/privacy" >}}) |
+| [Privacy Settings]({{< relref "/docs/references/privacy" >}}) |
 | [Deprecation Policy]({{< relref "/docs/references/deprecation" >}}) |
 


### PR DESCRIPTION
This upgrades hugo to the latest version - not the default behavior of including HTML changed, hence the `unsafe=true` for the goldmark renderer (when I manually pushed yesterday the site, this resulted in a bunch of pages to not work including the install page - you can still see that here: https://skaffold-latest.firebaseapp.com/docs/install/). Also Privacy settings link was not working. 