### PR TITLE
[docs] [release] fix firebase-tools version

### DIFF
--- a/deploy/webhook/Dockerfile
+++ b/deploy/webhook/Dockerfile
@@ -37,7 +37,8 @@ RUN wget -O kubectl "${KUBECTL_URL}"
 RUN chmod +x kubectl
 
 FROM node:10.15.3-stretch as runtime_deps
-RUN npm install -g firebase-tools postcss-cli
+ENV FIREBASE_TOOLS_VERSION 7.13.1
+RUN npm install -g firebase-tools@${FIREBASE_TOOLS_VERSION} postcss-cli
 WORKDIR /app/docs
 RUN npm install autoprefixer
 COPY --from=download-docsy /docsy ./themes/docsy


### PR DESCRIPTION
Fixes the issues with the Firebase deploys and as such it: Fixes #3847. 
The firebase-tools package was always installed from latest - hence Docker build cached it, and never upgraded it, this change makes the version explicit - so we have to keep it up to date. This fixes the `Error: An unexpected error has occurred.` errors in our Cloud Build firebase deploys. 