### PR TITLE
Wait for the logs to be printed

### DIFF
--- a/hack/tests/main.go
+++ b/hack/tests/main.go
@@ -123,6 +123,7 @@ func goTest(testArgs []string) error {
 	} else {
 		pr.Close()
 	}
+	wc.Wait()
 	return err
 }
 


### PR DESCRIPTION
Previous fix removed the `wc.Wait()` by error

Signed-off-by: David Gageot <david@gageot.net>
