### PR TITLE
Fix console output for internal Jib tasks/goals

### DIFF
--- a/pkg/skaffold/build/jib/init.go
+++ b/pkg/skaffold/build/jib/init.go
@@ -87,7 +87,7 @@ type jibJSON struct {
 func validate(path string) []ArtifactConfig {
 	// Determine whether maven or gradle
 	var builderType PluginType
-	var executable, wrapper, taskName, searchString string
+	var executable, wrapper, taskName, searchString, consoleFlag string
 	switch {
 	case strings.HasSuffix(path, "pom.xml"):
 		builderType = JibMaven
@@ -95,12 +95,14 @@ func validate(path string) []ArtifactConfig {
 		wrapper = "mvnw"
 		searchString = "<artifactId>jib-maven-plugin</artifactId>"
 		taskName = "jib:_skaffold-init"
+		consoleFlag = "--batch-mode"
 	case strings.HasSuffix(path, "build.gradle"), strings.HasSuffix(path, "build.gradle.kts"):
 		builderType = JibGradle
 		executable = "gradle"
 		wrapper = "gradlew"
 		searchString = "com.google.cloud.tools.jib"
 		taskName = "_jibSkaffoldInit"
+		consoleFlag = "--console=plain"
 	default:
 		return nil
 	}
@@ -114,7 +116,7 @@ func validate(path string) []ArtifactConfig {
 	if wrapperExecutable, err := util.AbsFile(filepath.Dir(path), wrapper); err == nil {
 		executable = wrapperExecutable
 	}
-	cmd := exec.Command(executable, taskName, "-q")
+	cmd := exec.Command(executable, taskName, "-q", consoleFlag)
 	cmd.Dir = filepath.Dir(path)
 	stdout, err := util.RunCmdOut(cmd)
 	if err != nil {

--- a/pkg/skaffold/build/jib/init_test.go
+++ b/pkg/skaffold/build/jib/init_test.go
@@ -49,7 +49,7 @@ func TestValidate(t *testing.T) {
 			description:    "jib string found but not configured",
 			path:           "path/to/build.gradle",
 			fileContents:   "com.google.cloud.tools.jib",
-			command:        "gradle _jibSkaffoldInit -q",
+			command:        "gradle _jibSkaffoldInit -q --console=plain",
 			stdout:         "error",
 			expectedConfig: nil,
 		},
@@ -57,7 +57,7 @@ func TestValidate(t *testing.T) {
 			description:  "jib gradle single project",
 			path:         "path/to/build.gradle",
 			fileContents: "com.google.cloud.tools.jib",
-			command:      "gradle _jibSkaffoldInit -q",
+			command:      "gradle _jibSkaffoldInit -q --console=plain",
 			stdout: `BEGIN JIB JSON
 {"image":"image","project":"project"}
 `,
@@ -69,7 +69,7 @@ func TestValidate(t *testing.T) {
 			description:  "jib gradle-kotlin single project",
 			path:         "path/to/build.gradle.kts",
 			fileContents: "com.google.cloud.tools.jib",
-			command:      "gradle _jibSkaffoldInit -q",
+			command:      "gradle _jibSkaffoldInit -q --console=plain",
 			stdout: `BEGIN JIB JSON
 {"image":"image","project":"project"}
 `,
@@ -81,7 +81,7 @@ func TestValidate(t *testing.T) {
 			description:  "jib gradle multi-project",
 			path:         "path/to/build.gradle",
 			fileContents: "com.google.cloud.tools.jib",
-			command:      "gradle _jibSkaffoldInit -q",
+			command:      "gradle _jibSkaffoldInit -q --console=plain",
 			stdout: `BEGIN JIB JSON
 {"image":"image","project":"project1"}
 
@@ -97,7 +97,7 @@ BEGIN JIB JSON
 			description:  "jib maven single module",
 			path:         "path/to/pom.xml",
 			fileContents: "<artifactId>jib-maven-plugin</artifactId>",
-			command:      "mvn jib:_skaffold-init -q",
+			command:      "mvn jib:_skaffold-init -q --batch-mode",
 			stdout: `BEGIN JIB JSON
 {"image":"image","project":"project"}`,
 			expectedConfig: []ArtifactConfig{
@@ -108,7 +108,7 @@ BEGIN JIB JSON
 			description:  "jib maven multi-module",
 			path:         "path/to/pom.xml",
 			fileContents: "<artifactId>jib-maven-plugin</artifactId>",
-			command:      "mvn jib:_skaffold-init -q",
+			command:      "mvn jib:_skaffold-init -q --batch-mode",
 			stdout: `BEGIN JIB JSON
 {"image":"image","project":"project1"}
 


### PR DESCRIPTION
Fixes #3795.

Jib's internal tasks/goals (`_skaffoldFailIfJibOutOfDate`, `_jibSkaffoldInit`, `_jibFilesTaskV2`, `_jibSkaffoldSyncMap`, and the maven equivalents)  will now run with `--console=plain` (gradle) or `--batch-mode` (maven) to avoid unexpected output interfering with what we're trying to parse. For normal builds (`jibDockerBuild` and `jib` for gradle, `jib:dockerBuild` and `jib:build` for maven), we continue passing the `-Djib.console=plain` flag as usual.

@GoogleContainerTools/java-tools-build 