### PR TITLE
Refactoring on filepath.Walk

### DIFF
--- a/hack/versions/cmd/new/version.go
+++ b/hack/versions/cmd/new/version.go
@@ -29,6 +29,7 @@ import (
 	hackschema "github.com/GoogleContainerTools/skaffold/hack/versions/pkg/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
 )
 
 // Before: prev -> current (latest)
@@ -45,12 +46,12 @@ func main() {
 	}
 
 	makeSchemaDir(current)
+
 	// Create a package for current version
-	walk(path("latest"), func(file string, info os.FileInfo) {
-		if !info.IsDir() {
-			cp(file, path(current, info.Name()))
-			sed(path(current, info.Name()), "package latest", "package "+current)
-		}
+	walk.From(path("latest")).WhenIsFile().MustDo(func(file string, info walk.Dirent) error {
+		cp(file, path(current, info.Name()))
+		sed(path(current, info.Name()), "package latest", "package "+current)
+		return nil
 	})
 
 	next := readNextVersion()
@@ -75,10 +76,9 @@ func main() {
 	hackschema.UpdateVersionComment(path("latest", "config.go"), false)
 
 	// Update skaffold.yaml in integration tests
-	walk("integration", func(path string, info os.FileInfo) {
-		if info.Name() == "skaffold.yaml" {
-			sed(path, current, next)
-		}
+	walk.From("integration").WhenHasName("skaffold.yaml").MustDo(func(path string, _ walk.Dirent) error {
+		sed(path, current, next)
+		return nil
 	})
 
 	// Add the new version to the list of versions
@@ -163,16 +163,4 @@ func lines(path string) []string {
 		lines = append(lines, scanner.Text())
 	}
 	return lines
-}
-
-func walk(root string, fn func(path string, info os.FileInfo)) {
-	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		fn(path, info)
-		return nil
-	}); err != nil {
-		panic("unable to list files")
-	}
 }

--- a/pkg/skaffold/build/jib/jib.go
+++ b/pkg/skaffold/build/jib/jib.go
@@ -31,12 +31,12 @@ import (
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/karrick/godirwalk"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
 )
 
 const (
@@ -250,22 +250,26 @@ func walkFiles(workspace string, watchedFiles []string, ignoredFiles []string, c
 		}
 
 		// Process directory
-		if err = godirwalk.Walk(dep, &godirwalk.Options{
-			Unsorted: true,
-			Callback: func(path string, _ *godirwalk.Dirent) error {
-				if isIgnored(path, ignoredFiles) {
-					return filepath.SkipDir
-				}
-				if info, err := os.Stat(path); err == nil && !info.IsDir() {
-					// try to relativize the path: an error indicates that the file cannot
-					// be made relative to the roots, and so we just use the full path
-					if relative, err := relativize(path, workspaceRoots...); err == nil {
-						path = relative
-					}
-					return callback(path, info)
-				}
+		if err = walk.From(dep).Unsorted().Do(func(path string, info walk.Dirent) error {
+			if isIgnored(path, ignoredFiles) {
+				return filepath.SkipDir
+			}
+
+			if info.IsDir() {
 				return nil
-			},
+			}
+
+			stat, err := os.Stat(path)
+			if err != nil {
+				return nil // Ignore
+			}
+
+			// try to relativize the path: an error indicates that the file cannot
+			// be made relative to the roots, and so we just use the full path
+			if relative, err := relativize(path, workspaceRoots...); err == nil {
+				path = relative
+			}
+			return callback(path, stat)
 		}); err != nil {
 			return fmt.Errorf("filepath walk: %w", err)
 		}

--- a/pkg/skaffold/build/jib/jib.go
+++ b/pkg/skaffold/build/jib/jib.go
@@ -249,16 +249,16 @@ func walkFiles(workspace string, watchedFiles []string, ignoredFiles []string, c
 			continue
 		}
 
-		// Process directory
-		if err = walk.From(dep).Unsorted().Do(func(path string, info walk.Dirent) error {
+		notIgnored := func(path string, info walk.Dirent) (bool, error) {
 			if isIgnored(path, ignoredFiles) {
-				return filepath.SkipDir
+				return false, filepath.SkipDir
 			}
 
-			if info.IsDir() {
-				return nil
-			}
+			return true, nil
+		}
 
+		// Process directory
+		if err = walk.From(dep).Unsorted().When(notIgnored).WhenIsFile().Do(func(path string, info walk.Dirent) error {
 			stat, err := os.Stat(path)
 			if err != nil {
 				return nil // Ignore

--- a/pkg/skaffold/build/list/list.go
+++ b/pkg/skaffold/build/list/list.go
@@ -21,13 +21,14 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
 )
 
 // Files list files in a workspace, given a list of patterns and exclusions.
-// A pattern that doesn't correspond to any file is an error.
 func Files(workspace string, patterns, excludes []string) ([]string, error) {
-	var paths []string
+	notExcluded := notExcluded(workspace, excludes)
+
+	var dependencies []string
 
 	for _, pattern := range patterns {
 		expanded, err := filepath.Glob(filepath.Join(workspace, pattern))
@@ -39,26 +40,47 @@ func Files(workspace string, patterns, excludes []string) ([]string, error) {
 			return nil, fmt.Errorf("pattern %q did not match any file", pattern)
 		}
 
-		for _, e := range expanded {
-			rel, err := filepath.Rel(workspace, e)
-			if err != nil {
-				return nil, err
+		for _, absFrom := range expanded {
+			if err := walk.From(absFrom).Unsorted().When(notExcluded).WhenIsFile().Do(func(path string, info walk.Dirent) error {
+				relPath, err := filepath.Rel(workspace, path)
+				if err != nil {
+					return err
+				}
+
+				dependencies = append(dependencies, relPath)
+				return nil
+			}); err != nil {
+				return nil, fmt.Errorf("walking %q: %w", absFrom, err)
 			}
-
-			paths = append(paths, rel)
 		}
-	}
-
-	files, err := docker.WalkWorkspace(workspace, excludes, paths)
-	if err != nil {
-		return nil, fmt.Errorf("walking workspace %q: %w", workspace, err)
-	}
-
-	var dependencies []string
-	for file := range files {
-		dependencies = append(dependencies, file)
 	}
 
 	sort.Strings(dependencies)
 	return dependencies, nil
+}
+
+// notExcluded creates a walk.Predicate that matches file system entries
+// only if they don't match a list of exclusion patterns.
+func notExcluded(workspace string, excludes []string) walk.Predicate {
+	return func(absPath string, info walk.Dirent) (bool, error) {
+		relPath, err := filepath.Rel(workspace, absPath)
+		if err != nil {
+			return false, err
+		}
+
+		for _, exclude := range excludes {
+			matches, err := filepath.Match(exclude, relPath)
+			if err != nil {
+				return false, err
+			}
+			if matches {
+				if info.IsDir() {
+					return false, filepath.SkipDir
+				}
+				return false, nil
+			}
+		}
+
+		return true, nil
+	}
 }

--- a/pkg/skaffold/build/list/list.go
+++ b/pkg/skaffold/build/list/list.go
@@ -62,8 +62,8 @@ func Files(workspace string, patterns, excludes []string) ([]string, error) {
 // notExcluded creates a walk.Predicate that matches file system entries
 // only if they don't match a list of exclusion patterns.
 func notExcluded(workspace string, excludes []string) walk.Predicate {
-	return func(absPath string, info walk.Dirent) (bool, error) {
-		relPath, err := filepath.Rel(workspace, absPath)
+	return func(path string, info walk.Dirent) (bool, error) {
+		relPath, err := filepath.Rel(workspace, path)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/skaffold/docker/dockerignore.go
+++ b/pkg/skaffold/docker/dockerignore.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
 )
 
-// NewDockerIgnorePredicate creates a walk.Predicate that checks if firectory entries
+// NewDockerIgnorePredicate creates a walk.Predicate that checks if directory entries
 // should be ignored.
 func NewDockerIgnorePredicate(workspace string, excludes []string) (walk.Predicate, error) {
 	matcher, err := fileutils.NewPatternMatcher(excludes)
@@ -34,8 +34,8 @@ func NewDockerIgnorePredicate(workspace string, excludes []string) (walk.Predica
 		return nil, fmt.Errorf("invalid exclude patterns: %w", err)
 	}
 
-	return func(absPath string, info walk.Dirent) (bool, error) {
-		relPath, err := filepath.Rel(workspace, absPath)
+	return func(path string, info walk.Dirent) (bool, error) {
+		relPath, err := filepath.Rel(workspace, path)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/skaffold/docker/dockerignore.go
+++ b/pkg/skaffold/docker/dockerignore.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/docker/pkg/fileutils"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
+)
+
+// NewDockerIgnorePredicate creates a walk.Predicate that checks if firectory entries
+// should be ignored.
+func NewDockerIgnorePredicate(workspace string, excludes []string) (walk.Predicate, error) {
+	matcher, err := fileutils.NewPatternMatcher(excludes)
+	if err != nil {
+		return nil, fmt.Errorf("invalid exclude patterns: %w", err)
+	}
+
+	return func(absPath string, info walk.Dirent) (bool, error) {
+		relPath, err := filepath.Rel(workspace, absPath)
+		if err != nil {
+			return false, err
+		}
+
+		ignored, err := matcher.Matches(relPath)
+		if err != nil {
+			return false, err
+		}
+
+		if ignored && info.IsDir() && skipDir(relPath, matcher) {
+			return false, filepath.SkipDir
+		}
+
+		return ignored, nil
+	}, nil
+}
+
+// exclusion handling closely follows vendor/github.com/docker/docker/pkg/archive/archive.go
+func skipDir(relPath string, matcher *fileutils.PatternMatcher) bool {
+	// No exceptions (!...) in patterns so just skip dir
+	if !matcher.Exclusions() {
+		return true
+	}
+
+	dirSlash := relPath + string(filepath.Separator)
+
+	for _, pat := range matcher.Patterns() {
+		if !pat.Exclusion() {
+			continue
+		}
+		if strings.HasPrefix(pat.String()+string(filepath.Separator), dirSlash) {
+			// found a match - so can't skip this dir
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/skaffold/schema/samples_test.go
+++ b/pkg/skaffold/schema/samples_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/validation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -49,7 +49,7 @@ func TestParseExamples(t *testing.T) {
 // Samples are skaffold.yaml fragments that are used
 // in the documentation.
 func TestParseSamples(t *testing.T) {
-	paths, err := findSamples(samplesRoot)
+	paths, err := walk.From(samplesRoot).WhenIsFile().CollectPaths()
 	if err != nil {
 		t.Fatalf("unable to list samples in %q", samplesRoot)
 	}
@@ -86,7 +86,7 @@ func checkSkaffoldConfig(t *testutil.T, yaml []byte) {
 }
 
 func parseConfigFiles(t *testing.T, root string) {
-	paths, err := findExamples(root)
+	paths, err := walk.From(root).WhenHasName("skaffold.yaml").CollectPaths()
 	if err != nil {
 		t.Fatalf("unable to list skaffold configuration files in %q", root)
 	}
@@ -105,32 +105,6 @@ func parseConfigFiles(t *testing.T, root string) {
 			checkSkaffoldConfig(t, buf)
 		})
 	}
-}
-
-func findSamples(root string) ([]string, error) {
-	var files []string
-
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if !info.IsDir() {
-			files = append(files, path)
-		}
-		return err
-	})
-
-	return files, err
-}
-
-func findExamples(root string) ([]string, error) {
-	var files []string
-
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
-		if !info.IsDir() && info.Name() == "skaffold.yaml" {
-			files = append(files, path)
-		}
-		return err
-	})
-
-	return files, err
 }
 
 func addHeader(buf []byte) []byte {

--- a/pkg/skaffold/walk/walk.go
+++ b/pkg/skaffold/walk/walk.go
@@ -29,14 +29,14 @@ type Dirent interface {
 }
 
 // Predicate represents a predicate on file system entries.
-// Given a file's absolute path and information, it returns `true`
+// Given a file's path and information, it returns `true`
 // when the predicate is matched. It can also return a `filepath.SkipDir`
 // error to skip a directory and its children altogether.
-type Predicate func(absPath string, info Dirent) (bool, error)
+type Predicate func(path string, info Dirent) (bool, error)
 
-// Action is a function that takes a file's absolute path and information,
+// Action is a function that takes a file's path and information,
 // and optionally returns an error.
-type Action func(absPath string, info Dirent) error
+type Action func(path string, info Dirent) error
 
 type Builder interface {
 	// Options

--- a/pkg/skaffold/walk/walk.go
+++ b/pkg/skaffold/walk/walk.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package walk
+
+import (
+	"os"
+
+	"github.com/karrick/godirwalk"
+)
+
+// Dirent stores the name and type of a file system entry.
+type Dirent interface {
+	IsDir() bool
+	Name() string
+}
+
+// Predicate represents a predicate on file system entries.
+// Given a file's absolute path and information, it returns `true`
+// when the predicate is matched. It can also return a `filepath.SkipDir`
+// error to skip a directory and its children altogether.
+type Predicate func(absPath string, info Dirent) (bool, error)
+
+// Action is a function that takes a file's absolute path and information,
+// and optionally returns an error.
+type Action func(absPath string, info Dirent) error
+
+type Builder interface {
+	// Options
+	Unsorted() Builder
+
+	// Predicates
+	When(Predicate) Builder
+	WhenIsDir() Builder
+	WhenIsFile() Builder
+	WhenHasName(string) Builder
+
+	// Actions
+	Do(Action) error
+	MustDo(Action)
+	AppendPaths(*[]string) error
+	CollectPaths() ([]string, error)
+}
+
+type builder struct {
+	dir       string
+	unsorted  bool
+	predicate Predicate
+}
+
+func From(dir string) Builder {
+	return &builder{
+		dir:       dir,
+		unsorted:  false,
+		predicate: func(string, Dirent) (bool, error) { return true, nil },
+	}
+}
+
+func (w *builder) Unsorted() Builder {
+	w.unsorted = true
+	return w
+}
+
+func (w *builder) When(predicate Predicate) Builder {
+	w.predicate = and(w.predicate, predicate)
+	return w
+}
+
+func (w *builder) WhenIsFile() Builder {
+	return w.When(isFile)
+}
+
+func (w *builder) WhenIsDir() Builder {
+	return w.When(isDir)
+}
+
+func (w *builder) WhenHasName(name string) Builder {
+	return w.When(hasName(name))
+}
+
+func (w *builder) AppendPaths(values *[]string) error {
+	return w.Do(appendPaths(values))
+}
+
+func (w *builder) CollectPaths() ([]string, error) {
+	var paths []string
+	err := w.Do(appendPaths(&paths))
+	return paths, err
+}
+
+func (w *builder) Do(action Action) error {
+	info, err := os.Lstat(w.dir)
+	if err != nil {
+		return err
+	}
+
+	if !info.IsDir() {
+		match, err := w.predicate(w.dir, info)
+		if !match || err != nil {
+			return err
+		}
+
+		return action(w.dir, info)
+	}
+
+	return godirwalk.Walk(w.dir, &godirwalk.Options{
+		Unsorted: w.unsorted,
+		Callback: func(path string, info *godirwalk.Dirent) error {
+			match, err := w.predicate(path, info)
+			if !match || err != nil {
+				return err
+			}
+
+			return action(path, info)
+		},
+	})
+}
+
+func (w *builder) MustDo(action Action) {
+	if err := w.Do(action); err != nil {
+		panic("unable to list files: " + err.Error())
+	}
+}
+
+// Predicates
+
+func hasName(name string) Predicate {
+	return func(_ string, info Dirent) (bool, error) {
+		return info.Name() == name, nil
+	}
+}
+
+func isDir(_ string, info Dirent) (bool, error) {
+	return info.IsDir(), nil
+}
+
+func isFile(_ string, info Dirent) (bool, error) {
+	return !info.IsDir(), nil
+}
+
+func and(p1, p2 Predicate) Predicate {
+	return func(path string, info Dirent) (bool, error) {
+		match, err := p1(path, info)
+		if !match || err != nil {
+			return false, err
+		}
+
+		return p2(path, info)
+	}
+}
+
+// Actions
+
+func appendPaths(values *[]string) Action {
+	return func(path string, _ Dirent) error {
+		*values = append(*values, path)
+		return nil
+	}
+}

--- a/testutil/tmp.go
+++ b/testutil/tmp.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/karrick/godirwalk"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
 )
 
 // TempFile creates a temporary file with a given content. Returns the file name
@@ -122,17 +122,7 @@ func (h *TempDir) Rename(oldName, newName string) *TempDir {
 
 // List lists all the files in the temp directory.
 func (h *TempDir) List() ([]string, error) {
-	var files []string
-
-	err := godirwalk.Walk(h.root, &godirwalk.Options{
-		Unsorted: true,
-		Callback: func(path string, _ *godirwalk.Dirent) error {
-			files = append(files, path)
-			return nil
-		},
-	})
-
-	return files, err
+	return walk.From(h.root).Unsorted().CollectPaths()
 }
 
 // Path returns the path to a file in the temp directory.

--- a/vendor/github.com/karrick/godirwalk/go.mod
+++ b/vendor/github.com/karrick/godirwalk/go.mod
@@ -1,1 +1,3 @@
 module github.com/karrick/godirwalk
+
+go 1.14


### PR DESCRIPTION
This is a first step in the refactoring of `filepath.Walk` and `godirwalk.Walk` usage.

The idea is to simplify the code that walks directories by extracting as much common code as possible.
More simplifications are coming but this first step is already bringing many simplifications.

Signed-off-by: David Gageot <david@gageot.net>
