### PR TITLE
Better status check

### DIFF
--- a/pkg/skaffold/deploy/resource/base.go
+++ b/pkg/skaffold/deploy/resource/base.go
@@ -53,5 +53,5 @@ func (b *Base) ReportSinceLastUpdated() string {
 		return ""
 	}
 	b.status.reported = true
-	return fmt.Sprintf("%s %s", b, b.status)
+	return fmt.Sprintf("%s: %s", b, b.status)
 }

--- a/pkg/skaffold/deploy/resource/base.go
+++ b/pkg/skaffold/deploy/resource/base.go
@@ -29,6 +29,10 @@ type Base struct {
 }
 
 func (b *Base) String() string {
+	if b.namespace == "default" {
+		return fmt.Sprintf("%s/%s", b.rType, b.name)
+	}
+
 	return fmt.Sprintf("%s:%s/%s", b.namespace, b.rType, b.name)
 }
 

--- a/pkg/skaffold/deploy/resource/base_test.go
+++ b/pkg/skaffold/deploy/resource/base_test.go
@@ -34,12 +34,12 @@ func TestReportSinceLastUpdated(t *testing.T) {
 			description: "updating an error status",
 			message:     "cannot pull image",
 			err:         errors.New("cannot pull image"),
-			expected:    "test-ns:deployment/test cannot pull image",
+			expected:    "test-ns:deployment/test: cannot pull image",
 		},
 		{
 			description: "updating a non error status",
-			message:     "is waiting for container",
-			expected:    "test-ns:deployment/test is waiting for container",
+			message:     "waiting for container",
+			expected:    "test-ns:deployment/test: waiting for container",
 		},
 	}
 	for _, test := range tests {
@@ -62,7 +62,7 @@ func TestReportSinceLastUpdatedMultipleTimes(t *testing.T) {
 		{
 			description: "report first time should return status",
 			times:       1,
-			expected:    "test-ns:deployment/test cannot pull image",
+			expected:    "test-ns:deployment/test: cannot pull image",
 		},
 		{
 			description: "report 2nd time should not return",

--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -72,13 +72,24 @@ func NewDeployment(name string, ns string, deadline time.Duration) *Deployment {
 
 func (d *Deployment) CheckStatus(ctx context.Context, runCtx *runcontext.RunContext) {
 	kubeCtl := kubectl.NewFromRunContext(runCtx)
+
 	b, err := kubeCtl.RunOut(ctx, "rollout", "status", "deployment", d.name, "--namespace", d.namespace, "--watch=false")
-	details := string(b)
+	details := d.cleanupStatus(string(b))
+
 	err = parseKubectlRolloutError(err)
 	if err == errKubectlKilled {
 		err = fmt.Errorf("received Ctrl-C or deployments could not stabilize within %v: %w", d.deadline, err)
 	}
+
 	d.UpdateStatus(details, err)
+}
+
+func (d *Deployment) cleanupStatus(msg string) string {
+	clean := strings.ReplaceAll(msg, `deployment "`+d.Name()+`" `, "")
+	if len(clean) > 0 {
+		clean = strings.ToLower(clean[0:1]) + clean[1:]
+	}
+	return clean
 }
 
 func parseKubectlRolloutError(err error) error {

--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -74,6 +74,10 @@ func (d *Deployment) CheckStatus(ctx context.Context, runCtx *runcontext.RunCont
 	kubeCtl := kubectl.NewFromRunContext(runCtx)
 
 	b, err := kubeCtl.RunOut(ctx, "rollout", "status", "deployment", d.name, "--namespace", d.namespace, "--watch=false")
+	if ctx.Err() != nil {
+		return
+	}
+
 	details := d.cleanupStatus(string(b))
 
 	err = parseKubectlRolloutError(err)

--- a/pkg/skaffold/deploy/resource/deployment_test.go
+++ b/pkg/skaffold/deploy/resource/deployment_test.go
@@ -39,9 +39,9 @@ func TestDeploymentCheckStatus(t *testing.T) {
 			description: "rollout status success",
 			commands: testutil.CmdRunOut(
 				rolloutCmd,
-				"deployment dep successfully rolled out",
+				"deployment \"dep\" successfully rolled out",
 			),
-			expectedDetails: "deployment dep successfully rolled out",
+			expectedDetails: "successfully rolled out",
 			complete:        true,
 		},
 		{
@@ -50,7 +50,7 @@ func TestDeploymentCheckStatus(t *testing.T) {
 				rolloutCmd,
 				"Waiting for replicas to be available",
 			),
-			expectedDetails: "Waiting for replicas to be available",
+			expectedDetails: "waiting for replicas to be available",
 		},
 		{
 			description: "no output",

--- a/pkg/skaffold/deploy/status_check.go
+++ b/pkg/skaffold/deploy/status_check.go
@@ -30,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/resource"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	pkgkubernetes "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
@@ -182,7 +181,7 @@ func printStatusCheckSummary(out io.Writer, r Resource, rc resourceCounter) {
 		status = fmt.Sprintf("%s is ready.%s", status, getPendingMessage(rc.deployments.pending, rc.deployments.total))
 	}
 
-	color.Default.Fprintln(out, status)
+	fmt.Fprintln(out, status)
 }
 
 // Print resource statuses until all status check are completed or context is cancelled.
@@ -212,7 +211,7 @@ func printStatus(resources []Resource, out io.Writer) bool {
 		allResourcesCheckComplete = false
 		if str := r.ReportSinceLastUpdated(); str != "" {
 			event.ResourceStatusCheckEventUpdated(r.String(), str)
-			color.Default.Fprintln(out, tabHeader, trimNewLine(str))
+			fmt.Fprintln(out, tabHeader, trimNewLine(str))
 		}
 	}
 	return allResourcesCheckComplete

--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -292,30 +292,48 @@ func TestGetDeployStatus(t *testing.T) {
 func TestPrintSummaryStatus(t *testing.T) {
 	tests := []struct {
 		description string
+		namespace   string
+		deployment  string
 		pending     int32
 		err         error
 		expected    string
 	}{
 		{
 			description: "no deployment left and current is in success",
+			namespace:   "test",
+			deployment:  "dep",
 			pending:     0,
 			err:         nil,
 			expected:    " - test:deployment/dep is ready.\n",
 		},
 		{
+			description: "default namespace",
+			namespace:   "default",
+			deployment:  "dep",
+			pending:     0,
+			err:         nil,
+			expected:    " - deployment/dep is ready.\n",
+		},
+		{
 			description: "no deployment left and current is in error",
+			namespace:   "test",
+			deployment:  "dep",
 			pending:     0,
 			err:         errors.New("context deadline expired"),
 			expected:    " - test:deployment/dep failed. Error: context deadline expired.\n",
 		},
 		{
 			description: "more than 1 deployment left and current is in success",
+			namespace:   "test",
+			deployment:  "dep",
 			pending:     4,
 			err:         nil,
 			expected:    " - test:deployment/dep is ready. [4/10 deployment(s) still pending]\n",
 		},
 		{
 			description: "more than 1 deployment left and current is in error",
+			namespace:   "test",
+			deployment:  "dep",
 			pending:     8,
 			err:         errors.New("context deadline expired"),
 			expected:    " - test:deployment/dep failed. [8/10 deployment(s) still pending] Error: context deadline expired.\n",
@@ -329,7 +347,7 @@ func TestPrintSummaryStatus(t *testing.T) {
 			rc.deployments.pending = test.pending
 			printStatusCheckSummary(
 				out,
-				withStatus(resource.NewDeployment("dep", "test", 0), "", test.err),
+				withStatus(resource.NewDeployment(test.deployment, test.namespace, 0), "", test.err),
 				*rc,
 			)
 			t.CheckDeepEqual(test.expected, out.String())

--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -398,14 +398,14 @@ func TestPrintStatus(t *testing.T) {
 					nil,
 				),
 			},
-			expectedOut: " - test:deployment/r2 pending\n",
+			expectedOut: " - test:deployment/r2: pending\n",
 		},
 		{
 			description: "multiple resources 1 not complete and retry-able error",
 			rs: []Resource{
 				withStatus(
 					resource.NewDeployment("r1", "test", 1),
-					"deployment successfully rolled out",
+					"eployment successfully rolled out",
 					nil,
 				),
 				withStatus(
@@ -414,7 +414,7 @@ func TestPrintStatus(t *testing.T) {
 					resource.ErrKubectlConnection,
 				),
 			},
-			expectedOut: " - test:deployment/r2 kubectl connection error\n",
+			expectedOut: " - test:deployment/r2: kubectl connection error\n",
 		},
 	}
 

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -61,14 +61,18 @@ func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []
 
 func (r *SkaffoldRunner) performStatusCheck(ctx context.Context, out io.Writer) error {
 	// Check if we need to perform deploy status
-	if r.runCtx.Opts.StatusCheck {
-		start := time.Now()
-		color.Default.Fprintln(out, "Waiting for deployments to stabilize")
-		err := statusCheck(ctx, r.defaultLabeller, r.runCtx, out)
-		if err != nil {
-			return err
-		}
-		color.Default.Fprintln(out, "Deployments stabilized in", time.Since(start))
+	if !r.runCtx.Opts.StatusCheck {
+		return nil
 	}
+
+	start := time.Now()
+	color.Default.Fprintln(out, "Waiting for deployments to stabilize...")
+
+	err := statusCheck(ctx, r.defaultLabeller, r.runCtx, out)
+	if err != nil {
+		return err
+	}
+
+	color.Default.Fprintln(out, "Deployments stabilized in", time.Since(start))
 	return nil
 }

--- a/pkg/skaffold/runner/deploy_test.go
+++ b/pkg/skaffold/runner/deploy_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestDeploy(t *testing.T) {
-	expectedOutput := "Waiting for deployments to stabilize"
+	expectedOutput := "Waiting for deployments to stabilize..."
 	tests := []struct {
 		description string
 		testBench   *TestBench


### PR DESCRIPTION
+ Don't print the status summary if the user ctrl-Cd …
+ Print deployment statuses with default colour …
+ Omit “default:” namespace prefix …
+ Remove duplicate name from the status …
