### PR TITLE
Disable Python detector's use of PYTHON_VERSION

### DIFF
--- a/pkg/skaffold/debug/transform_python.go
+++ b/pkg/skaffold/debug/transform_python.go
@@ -52,9 +52,8 @@ func isLaunchingPython(args []string) bool {
 }
 
 func (t pythonTransformer) IsApplicable(config imageConfiguration) bool {
-	if _, found := config.env["PYTHON_VERSION"]; found {
-		return true
-	}
+	// We can only put Python in debug mode by modifying the python command line,
+	// so looking for Python-related environment variables is insufficient.
 	if len(config.entrypoint) > 0 {
 		return isLaunchingPython(config.entrypoint)
 	} else if len(config.arguments) > 0 {

--- a/pkg/skaffold/debug/transform_python_test.go
+++ b/pkg/skaffold/debug/transform_python_test.go
@@ -66,7 +66,7 @@ func TestPythonTransformer_IsApplicable(t *testing.T) {
 		{
 			description: "PYTHON_VERSION",
 			source:      imageConfiguration{env: map[string]string{"PYTHON_VERSION": "2.7"}},
-			result:      true,
+			result:      false, 
 		},
 		{
 			description: "entrypoint python",

--- a/pkg/skaffold/debug/transform_python_test.go
+++ b/pkg/skaffold/debug/transform_python_test.go
@@ -66,7 +66,7 @@ func TestPythonTransformer_IsApplicable(t *testing.T) {
 		{
 			description: "PYTHON_VERSION",
 			source:      imageConfiguration{env: map[string]string{"PYTHON_VERSION": "2.7"}},
-			result:      false, 
+			result:      false,
 		},
 		{
 			description: "entrypoint python",


### PR DESCRIPTION
**Fixes**: #3918

**Description**

The Python language runtime detection for `skaffold debug` was blindly accepting any image with the `PYTHON_VERSION` environment variable set.  Although this does identify an Python-based image, successfully transforming the container requires that the image's entrypoint or command actually invoke the `python` interpreter.  So the presence of `PYTHON_VERSION` does not necessarily mean that the image can be transformed 

**User facing changes (remove if N/A)**

Should avoid a possible panic.

**Follow-up Work (remove if N/A)**

I need to rework the `Apply` interface to remove the possibility of this nil panic.


@code128: if you are willing to try this on your insta-puller, you can build a private copy of `skaffold` by running `go build -o skaffold ./cmd/skaffold/`.  Skaffold does require Go 1.14 for building.