### PR TITLE
fix a nilpointer when running status_check_Test

### DIFF
--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -20,6 +20,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"testing"
 	"time"
 
@@ -298,6 +300,7 @@ func TestGetDeployStatus(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			event.InitializeState(latest.BuildConfig{})
 			err := getSkaffoldDeployStatus(test.counter)
 			t.CheckError(test.shouldErr, err)
 			if test.shouldErr {


### PR DESCRIPTION
**Description**

Fixes the error below by initializing the event handler. 

Running ` go test -v github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy -run "TestGetDeployStatus" ` currently fails with 

```
=== RUN   TestGetDeployStatus
=== RUN   TestGetDeployStatus/one_error
=== RUN   TestGetDeployStatus/no_error
=== RUN   TestGetDeployStatus/multiple_errors
=== RUN   TestGetDeployStatus/0_deployments
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1934520]

goroutine 12 [running]:
github.com/GoogleContainerTools/skaffold/pkg/skaffold/event.(*eventHandler).handle(0x2f6f740, 0xc0003ef110)
        /Users/balintp/skaffold/pkg/skaffold/event/event.go:419 +0xd10
created by github.com/GoogleContainerTools/skaffold/pkg/skaffold/event.(*eventHandler).handleStatusCheckEvent
        /Users/balintp/skaffold/pkg/skaffold/event/event.go:329 +0xa8
FAIL    github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy    1.049s
```

**User facing changes (remove if N/A)**
none 

**Follow-up Work (remove if N/A)**
none 


