### PR TITLE
Initial implementation of Helm Renderer

### DIFF
--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -178,3 +178,188 @@ spec:
 		})
 	}
 }
+
+func TestHelmRender(t *testing.T) {
+	if testing.Short() || RunOnGCP() {
+		t.Skip("skipping kind integration test")
+	}
+
+	tests := []struct {
+		description  string
+		builds       []build.Artifact
+		labels       []deploy.Labeller
+		helmReleases []latest.HelmRelease
+		expectedOut  string
+	}{
+		{
+			description: "Bare bones render",
+			builds: []build.Artifact{
+				{
+					ImageName: "gke-loadbalancer",
+					Tag:       "gke-loadbalancer:test",
+				},
+			},
+			labels: []deploy.Labeller{},
+			helmReleases: []latest.HelmRelease{{
+				Name:      "gke_loadbalancer",
+				ChartPath: "testdata/gke_loadbalancer/loadbalancer-helm",
+				ArtifactOverrides: map[string]string{
+					"image": "gke-loadbalancer",
+				},
+			}},
+			expectedOut: `---
+# Source: loadbalancer-helm/templates/k8s.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: gke-loadbalancer
+  labels:
+    app: gke-loadbalancer
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      targetPort: 3000
+      protocol: TCP
+      name: http
+  selector:
+    app: "gke-loadbalancer"
+---
+# Source: loadbalancer-helm/templates/k8s.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gke-loadbalancer
+  labels:
+    app: gke-loadbalancer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gke-loadbalancer
+  template:
+    metadata:
+      labels:
+        app: gke-loadbalancer
+    spec:
+      containers:
+        - name: gke-container
+          image: gke-loadbalancer:test
+          ports:
+            - containerPort: 3000
+
+`,
+		},
+		{
+			description: "A more complex template",
+			builds: []build.Artifact{
+				{
+					ImageName: "gcr.io/k8s-skaffold/skaffold-helm",
+					Tag:       "gcr.io/k8s-skaffold/skaffold-helm:sha256-nonsenslettersandnumbers",
+				},
+			},
+			labels: []deploy.Labeller{},
+			helmReleases: []latest.HelmRelease{{
+				Name:      "skaffold-helm",
+				ChartPath: "testdata/helm/skaffold-helm",
+				ArtifactOverrides: map[string]string{
+					"image": "gcr.io/k8s-skaffold/skaffold-helm",
+				},
+			}},
+			expectedOut: `---
+# Source: skaffold-helm/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: skaffold-helm-skaffold-helm
+  labels:
+    app: skaffold-helm
+    chart: skaffold-helm-0.1.0
+    release: skaffold-helm
+    heritage: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: nginx
+  selector:
+    app: skaffold-helm
+    release: skaffold-helm
+---
+# Source: skaffold-helm/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: skaffold-helm
+  labels:
+    app: skaffold-helm
+    chart: skaffold-helm-0.1.0
+    release: skaffold-helm
+    heritage: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: skaffold-helm
+      release: skaffold-helm
+  template:
+    metadata:
+      labels:
+        app: skaffold-helm
+        release: skaffold-helm
+    spec:
+      containers:
+        - name: skaffold-helm
+          image: gcr.io/k8s-skaffold/skaffold-helm:sha256-nonsenslettersandnumbers
+          imagePullPolicy: 
+          ports:
+            - containerPort: 80
+          resources:
+            {}
+---
+# Source: skaffold-helm/templates/ingress.yaml
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: skaffold-helm-skaffold-helm
+  labels:
+    app: skaffold-helm
+    chart: skaffold-helm-0.1.0
+    release: skaffold-helm
+    heritage: Helm
+  annotations:
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /
+            backend:
+              serviceName: skaffold-helm-skaffold-helm
+              servicePort: 80
+
+`,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			deployer := deploy.NewHelmDeployer(&runcontext.RunContext{
+				Cfg: latest.Pipeline{
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							HelmDeploy: &latest.HelmDeploy{
+								Releases: test.helmReleases,
+							},
+						},
+					},
+				},
+			})
+			var b bytes.Buffer
+			err := deployer.Render(context.Background(), &b, test.builds, test.labels, "")
+
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expectedOut, b.String())
+		})
+	}
+}

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -287,11 +287,16 @@ func (h *HelmDeployer) Render(ctx context.Context, out io.Writer, builds []build
 			args = append(args, "--set-string", value)
 		}
 
-		for key, value := range r.ArtifactOverrides {
-			args = append(args, "--set", fmt.Sprintf("%s=%s", key, value))
+		sortedKeys := make([]string, 0, len(r.SetValues))
+		for k := range r.SetValues {
+			sortedKeys = append(sortedKeys, k)
+		}
+		sort.Strings(sortedKeys)
+		for _, k := range sortedKeys {
+			args = append(args, "--set", fmt.Sprintf("%s=%s", k, r.SetValues[k]))
 		}
 
-		sortedKeys := make([]string, 0, len(r.SetValueTemplates))
+		sortedKeys = make([]string, 0, len(r.SetValueTemplates))
 		for k := range r.SetValueTemplates {
 			sortedKeys = append(sortedKeys, k)
 		}

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -1004,7 +1004,7 @@ func TestHelmRender(t *testing.T) {
 			shouldErr:   false,
 			commands: testutil.
 				CmdRunWithOutput("helm version", version21).
-				AndRun("helm --kube-context kubecontext template examples/test --name skaffold-helm --set-string image=skaffold-helm:tag1 --set image=skaffold-helm --kubeconfig kubeconfig"),
+				AndRun("helm --kube-context kubecontext template examples/test --name skaffold-helm --set-string image=skaffold-helm:tag1 --set some.key=somevalue --kubeconfig kubeconfig"),
 			runContext: makeRunContext(testDeployConfig, false),
 			builds: []build.Artifact{
 				{
@@ -1017,7 +1017,7 @@ func TestHelmRender(t *testing.T) {
 			shouldErr:   false,
 			commands: testutil.
 				CmdRunWithOutput("helm version", version31).
-				AndRun("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set image=skaffold-helm --kubeconfig kubeconfig"),
+				AndRun("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set some.key=somevalue --kubeconfig kubeconfig"),
 			runContext: makeRunContext(testDeployConfig, false),
 			builds: []build.Artifact{
 				{
@@ -1030,7 +1030,7 @@ func TestHelmRender(t *testing.T) {
 			shouldErr:   false,
 			commands: testutil.
 				CmdRunWithOutput("helm version", version31).
-				AndRunWithOutput("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set image=skaffold-helm --kubeconfig kubeconfig",
+				AndRunWithOutput("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set some.key=somevalue --kubeconfig kubeconfig",
 					"Dummy Output"),
 			runContext: makeRunContext(testDeployConfig, false),
 			outputFile: "dummy.yaml",
@@ -1046,7 +1046,7 @@ func TestHelmRender(t *testing.T) {
 			shouldErr:   false,
 			commands: testutil.
 				CmdRunWithOutput("helm version", version31).
-				AndRun("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set image=skaffold-helm --set image.name=<no value> --set image.tag=<no value> --set missing.key=<no value> --set other.key=<no value> --set some.key=somevalue --kubeconfig kubeconfig"),
+				AndRun("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set image.name=<no value> --set image.tag=<no value> --set missing.key=<no value> --set other.key=<no value> --set some.key=somevalue --kubeconfig kubeconfig"),
 			runContext: makeRunContext(testDeployConfigTemplated, false),
 			builds: []build.Artifact{
 				{
@@ -1058,7 +1058,7 @@ func TestHelmRender(t *testing.T) {
 			description: "render with namespace",
 			shouldErr:   false,
 			commands: testutil.CmdRunWithOutput("helm version", version31).
-				AndRun("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set image=skaffold-helm --namespace testNamespace --kubeconfig kubeconfig"),
+				AndRun("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set some.key=somevalue --namespace testNamespace --kubeconfig kubeconfig"),
 			runContext: makeRunContext(testDeployNamespacedConfig, false),
 			builds: []build.Artifact{
 				{

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -987,17 +987,103 @@ func TestHelmRender(t *testing.T) {
 	tests := []struct {
 		description string
 		shouldErr   bool
+		commands    util.Command
+		runContext  *runcontext.RunContext
+		outputFile  string
+		expected    string
+		builds      []build.Artifact
 	}{
 		{
-			description: "calling render returns error",
+			description: "error if version can't be retrieved",
 			shouldErr:   true,
+			commands:    testutil.CmdRunErr("helm version", fmt.Errorf("yep not working")),
+			runContext:  makeRunContext(testDeployConfig, false),
+		},
+		{
+			description: "normal render v2",
+			shouldErr:   false,
+			commands: testutil.
+				CmdRunWithOutput("helm version", version21).
+				AndRun("helm --kube-context kubecontext template examples/test --name skaffold-helm --set-string image=skaffold-helm:tag1 --set image=skaffold-helm --kubeconfig kubeconfig"),
+			runContext: makeRunContext(testDeployConfig, false),
+			builds: []build.Artifact{
+				{
+					ImageName: "skaffold-helm",
+					Tag:       "skaffold-helm:tag1",
+				}},
+		},
+		{
+			description: "normal render v3",
+			shouldErr:   false,
+			commands: testutil.
+				CmdRunWithOutput("helm version", version31).
+				AndRun("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set image=skaffold-helm --kubeconfig kubeconfig"),
+			runContext: makeRunContext(testDeployConfig, false),
+			builds: []build.Artifact{
+				{
+					ImageName: "skaffold-helm",
+					Tag:       "skaffold-helm:tag1",
+				}},
+		},
+		{
+			description: "render to a file",
+			shouldErr:   false,
+			commands: testutil.
+				CmdRunWithOutput("helm version", version31).
+				AndRunWithOutput("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set image=skaffold-helm --kubeconfig kubeconfig",
+					"Dummy Output"),
+			runContext: makeRunContext(testDeployConfig, false),
+			outputFile: "dummy.yaml",
+			expected:   "Dummy Output\n",
+			builds: []build.Artifact{
+				{
+					ImageName: "skaffold-helm",
+					Tag:       "skaffold-helm:tag1",
+				}},
+		},
+		{
+			description: "render with templated config",
+			shouldErr:   false,
+			commands: testutil.
+				CmdRunWithOutput("helm version", version31).
+				AndRun("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set image=skaffold-helm --set image.name=<no value> --set image.tag=<no value> --set missing.key=<no value> --set other.key=<no value> --set some.key=somevalue --kubeconfig kubeconfig"),
+			runContext: makeRunContext(testDeployConfigTemplated, false),
+			builds: []build.Artifact{
+				{
+					ImageName: "skaffold-helm",
+					Tag:       "skaffold-helm:tag1",
+				}},
+		},
+		{
+			description: "render with namespace",
+			shouldErr:   false,
+			commands: testutil.CmdRunWithOutput("helm version", version31).
+				AndRun("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set image=skaffold-helm --namespace testNamespace --kubeconfig kubeconfig"),
+			runContext: makeRunContext(testDeployNamespacedConfig, false),
+			builds: []build.Artifact{
+				{
+					ImageName: "skaffold-helm",
+					Tag:       "skaffold-helm:tag1",
+				}},
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			deployer := NewHelmDeployer(&runcontext.RunContext{})
-			actual := deployer.Render(context.Background(), ioutil.Discard, []build.Artifact{}, nil, "tmp/dir")
-			t.CheckError(test.shouldErr, actual)
+			file := ""
+			if test.outputFile != "" {
+				file = t.NewTempDir().Path(test.outputFile)
+			}
+
+			deployer := NewHelmDeployer(test.runContext)
+
+			t.Override(&util.DefaultExecCommand, test.commands)
+			err := deployer.Render(context.Background(), ioutil.Discard, test.builds, nil, file)
+			t.CheckError(test.shouldErr, err)
+
+			if file != "" {
+				dat, _ := ioutil.ReadFile(file)
+				t.CheckDeepEqual(string(dat), test.expected)
+			}
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thanks you for your contribution! -->

<!-- Include if applicable: -->
**Related**:https://github.com/GoogleContainerTools/skaffold/issues/1937

**Description**
This PR should add Render capabilities to the Helm deployer.
I have added support for the following feature: 
 * valuesFiles
 * setValueTemplates
 * values
 * Namespaced charts

I hope this is enough, If I have missed some that are consider a must please let me know. I have also tried having a good support between Helm v3 and v2.

**User facing changes (remove if N/A)**

The only user facing change (except the obvious addition of `skaffold render` for helm, can bee seen [here](https://github.com/GoogleContainerTools/skaffold/compare/master...tete17:Add-Render-Capabilities-to-Helm-Deployer?expand=1#diff-5c13a6850c742c6b4fa07cf1f6aeb088L611).

I have changed this behaviour because it was assuming all members of the `values` map were supposed to be images built by skaffold. This is use to make skaffold replace the images by the combination of the image:tag in the manifest.

I have modified so it only looks for the appropiate images and doesn't fail if you add something like
```yaml
values: 
   image: "skaffold-helm"
   replicas: 3
```
This lead me to modify certain unit tests accordingly. I am not entirely sure about this change I am by no means and expert in helm so feedback is highly welcomed.

It is also my first contribution to a go project so please be gentle :smile:. I hope I followed best practice I have a feeling I am duplicating some code so please let me know if someone else also has that feeling. 

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
