### PR TITLE
Update error message to use `are` since `manifests` is plural

### DIFF
--- a/pkg/skaffold/initializer/deploy/init.go
+++ b/pkg/skaffold/initializer/deploy/init.go
@@ -25,7 +25,7 @@ type Error string
 
 func (e Error) Error() string { return string(e) }
 
-const NoManifest = Error("one or more Kubernetes manifests is required to run skaffold")
+const NoManifest = Error("one or more Kubernetes manifests are required to run skaffold")
 
 // Initializer detects a deployment type and is able to extract image names from it
 type Initializer interface {


### PR DESCRIPTION
**Description**
A small fix to update the grammar of the error message returned when no kubernetes manifest files can be found.

Before:
``` FATA[0000] one or more Kubernetes manifests is required to run skaffold ```

After:
```FATA[0000] one or more Kubernetes manifests are required to run skaffold```

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
