### PR TITLE
Simplify Debug Transformer interface and allow Apply to fail on images

### DIFF
--- a/pkg/skaffold/debug/debug_test.go
+++ b/pkg/skaffold/debug/debug_test.go
@@ -111,18 +111,14 @@ func (t testTransformer) IsApplicable(config imageConfiguration) bool {
 	return true
 }
 
-func (t testTransformer) RuntimeSupportImage() string {
-	return ""
-}
-
-func (t testTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) *ContainerDebugConfiguration {
+func (t testTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) (ContainerDebugConfiguration, string, error) {
 	port := portAlloc(9999)
 	container.Ports = append(container.Ports, v1.ContainerPort{Name: "test", ContainerPort: port})
 
 	testEnv := v1.EnvVar{Name: "KEY", Value: "value"}
 	container.Env = append(container.Env, testEnv)
 
-	return &ContainerDebugConfiguration{Runtime: "test"}
+	return ContainerDebugConfiguration{Runtime: "test"}, "", nil
 }
 
 func TestApplyDebuggingTransforms(t *testing.T) {

--- a/pkg/skaffold/debug/transform_jvm.go
+++ b/pkg/skaffold/debug/transform_jvm.go
@@ -63,14 +63,9 @@ type jdwpSpec struct {
 	server  bool
 }
 
-func (t jdwpTransformer) RuntimeSupportImage() string {
-	// no additional support required
-	return ""
-}
-
 // Apply configures a container definition for JVM debugging.
 // Returns a simple map describing the debug configuration details.
-func (t jdwpTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) *ContainerDebugConfiguration {
+func (t jdwpTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) (ContainerDebugConfiguration, string, error) {
 	logrus.Infof("Configuring %q for JVM debugging", container.Name)
 	// try to find existing JAVA_TOOL_OPTIONS or jdwp command argument
 	spec := retrieveJdwpSpec(config)
@@ -89,10 +84,10 @@ func (t jdwpTransformer) Apply(container *v1.Container, config imageConfiguratio
 
 	container.Ports = exposePort(container.Ports, "jdwp", port)
 
-	return &ContainerDebugConfiguration{
+	return ContainerDebugConfiguration{
 		Runtime: "jvm",
 		Ports:   map[string]uint32{"jdwp": uint32(port)},
-	}
+	}, "", nil
 }
 
 func retrieveJdwpSpec(config imageConfiguration) *jdwpSpec {

--- a/pkg/skaffold/debug/transform_nodejs.go
+++ b/pkg/skaffold/debug/transform_nodejs.go
@@ -67,14 +67,9 @@ func (t nodeTransformer) IsApplicable(config imageConfiguration) bool {
 	return false
 }
 
-func (t nodeTransformer) RuntimeSupportImage() string {
-	// no additional support required
-	return ""
-}
-
 // Apply configures a container definition for NodeJS Chrome V8 Inspector.
 // Returns a simple map describing the debug configuration details.
-func (t nodeTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) *ContainerDebugConfiguration {
+func (t nodeTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) (ContainerDebugConfiguration, string, error) {
 	logrus.Infof("Configuring %q for node.js debugging", container.Name)
 
 	// try to find existing `--inspect` command
@@ -102,10 +97,10 @@ func (t nodeTransformer) Apply(container *v1.Container, config imageConfiguratio
 
 	container.Ports = exposePort(container.Ports, "devtools", spec.port)
 
-	return &ContainerDebugConfiguration{
+	return ContainerDebugConfiguration{
 		Runtime: "nodejs",
 		Ports:   map[string]uint32{"devtools": uint32(spec.port)},
-	}
+	}, "", nil
 }
 
 func retrieveNodeInspectSpec(config imageConfiguration) *inspectSpec {

--- a/pkg/skaffold/debug/transform_nodejs_test.go
+++ b/pkg/skaffold/debug/transform_nodejs_test.go
@@ -60,10 +60,6 @@ func TestExtractInspectArg(t *testing.T) {
 	}
 }
 
-func TestNodeTransformer_RuntimeSupportImage(t *testing.T) {
-	testutil.CheckDeepEqual(t, "", nodeTransformer{}.RuntimeSupportImage())
-}
-
 func TestNodeTransformer_IsApplicable(t *testing.T) {
 	tests := []struct {
 		description string
@@ -195,21 +191,24 @@ func TestRewriteNpmCommandLine(t *testing.T) {
 }
 
 func TestNodeTransformer_Apply(t *testing.T) {
+	// no shouldErr as Apply always succeeds
 	tests := []struct {
 		description   string
 		containerSpec v1.Container
 		configuration imageConfiguration
 		result        v1.Container
+		debugConfig   ContainerDebugConfiguration
+		image         string
 	}{
 		{
 			description:   "empty",
 			containerSpec: v1.Container{},
 			configuration: imageConfiguration{},
-			// since IsApply() presumably returned true, this is the default case
 			result: v1.Container{
-				Ports: []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 				Env:   []v1.EnvVar{{Name: "NODE_OPTIONS", Value: "--inspect=9229"}},
+				Ports: []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 			},
+			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},
 		{
 			description:   "entrypoint",
@@ -219,6 +218,7 @@ func TestNodeTransformer_Apply(t *testing.T) {
 				Command: []string{"node", "--inspect=9229"},
 				Ports:   []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 			},
+			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},
 		{
 			description: "existing port",
@@ -230,6 +230,7 @@ func TestNodeTransformer_Apply(t *testing.T) {
 				Command: []string{"node", "--inspect=9229"},
 				Ports:   []v1.ContainerPort{{Name: "http-server", ContainerPort: 8080}, {Name: "devtools", ContainerPort: 9229}},
 			},
+			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},
 		{
 			description: "existing devtools port",
@@ -241,6 +242,7 @@ func TestNodeTransformer_Apply(t *testing.T) {
 				Command: []string{"node", "--inspect=9229"},
 				Ports:   []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 			},
+			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},
 		{
 			description:   "command not entrypoint",
@@ -250,6 +252,7 @@ func TestNodeTransformer_Apply(t *testing.T) {
 				Args:  []string{"node", "--inspect=9229"},
 				Ports: []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 			},
+			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},
 		{
 			description:   "docker-entrypoint (#3821)",
@@ -262,6 +265,7 @@ func TestNodeTransformer_Apply(t *testing.T) {
 				Env:   []v1.EnvVar{{Name: "NODE_VERSION", Value: "10.12"}, {Name: "NODE_OPTIONS", Value: "--inspect=9229"}},
 				Ports: []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 			},
+			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},
 	}
 	var identity portAllocator = func(port int32) int32 {
@@ -269,9 +273,13 @@ func TestNodeTransformer_Apply(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			nodeTransformer{}.Apply(&test.containerSpec, test.configuration, identity)
+			config, image, err := nodeTransformer{}.Apply(&test.containerSpec, test.configuration, identity)
 
+			// Apply never fails since there's always the option to set NODE_OPTIONS
+			t.CheckNil(err)
 			t.CheckDeepEqual(test.result, test.containerSpec)
+			t.CheckDeepEqual(test.debugConfig, config)
+			t.CheckDeepEqual(test.image, image) // always empty as we don't have a nodejs image
 		})
 	}
 }

--- a/pkg/skaffold/debug/transform_python.go
+++ b/pkg/skaffold/debug/transform_python.go
@@ -17,6 +17,7 @@ limitations under the License.
 package debug
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -62,13 +63,9 @@ func (t pythonTransformer) IsApplicable(config imageConfiguration) bool {
 	return false
 }
 
-func (t pythonTransformer) RuntimeSupportImage() string {
-	return "python"
-}
-
 // Apply configures a container definition for Python with pydev/ptvsd
 // Returns a simple map describing the debug configuration details.
-func (t pythonTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) *ContainerDebugConfiguration {
+func (t pythonTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator) (ContainerDebugConfiguration, string, error) {
 	logrus.Infof("Configuring %q for python debugging", container.Name)
 
 	// try to find existing `-mptvsd` command
@@ -84,8 +81,7 @@ func (t pythonTransformer) Apply(container *v1.Container, config imageConfigurat
 			container.Args = rewritePythonCommandLine(config.arguments, *spec)
 
 		default:
-			logrus.Warnf("Skipping %q as does not appear to invoke python", container.Name)
-			return nil
+			return ContainerDebugConfiguration{}, "", fmt.Errorf("%q does not appear to invoke python", container.Name)
 		}
 	}
 
@@ -97,10 +93,10 @@ func (t pythonTransformer) Apply(container *v1.Container, config imageConfigurat
 	container.Env = setEnvVar(container.Env, "PYTHONUSERBASE", pyUserBase)
 	container.Ports = exposePort(container.Ports, "dap", spec.port)
 
-	return &ContainerDebugConfiguration{
+	return ContainerDebugConfiguration{
 		Runtime: "python",
 		Ports:   map[string]uint32{"dap": uint32(spec.port)},
-	}
+	}, "python", nil
 }
 
 func retrievePtvsdSpec(config imageConfiguration) *ptvsdSpec {

--- a/pkg/skaffold/debug/transform_python_test.go
+++ b/pkg/skaffold/debug/transform_python_test.go
@@ -129,22 +129,22 @@ func TestPythonTransformer_IsApplicable(t *testing.T) {
 	}
 }
 
-func TestPythonTransformer_RuntimeSupportImage(t *testing.T) {
-	testutil.CheckDeepEqual(t, "python", pythonTransformer{}.RuntimeSupportImage())
-}
-
 func TestPythonTransformer_Apply(t *testing.T) {
 	tests := []struct {
 		description   string
 		containerSpec v1.Container
 		configuration imageConfiguration
+		shouldErr     bool
 		result        v1.Container
+		debugConfig   ContainerDebugConfiguration
+		image         string
 	}{
 		{
 			description:   "empty",
 			containerSpec: v1.Container{},
 			configuration: imageConfiguration{},
 			result:        v1.Container{},
+			shouldErr:     true,
 		},
 		{
 			description:   "basic",
@@ -155,6 +155,8 @@ func TestPythonTransformer_Apply(t *testing.T) {
 				Ports:   []v1.ContainerPort{{Name: "dap", ContainerPort: 5678}},
 				Env:     []v1.EnvVar{{Name: "PYTHONUSERBASE", Value: "/dbg/python"}},
 			},
+			debugConfig: ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
+			image:       "python",
 		},
 		{
 			description: "existing port",
@@ -167,6 +169,8 @@ func TestPythonTransformer_Apply(t *testing.T) {
 				Ports:   []v1.ContainerPort{{Name: "http-server", ContainerPort: 8080}, {Name: "dap", ContainerPort: 5678}},
 				Env:     []v1.EnvVar{{Name: "PYTHONUSERBASE", Value: "/dbg/python"}},
 			},
+			debugConfig: ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
+			image:       "python",
 		},
 		{
 			description: "existing port and env",
@@ -179,6 +183,8 @@ func TestPythonTransformer_Apply(t *testing.T) {
 				Ports:   []v1.ContainerPort{{Name: "dap", ContainerPort: 5678}},
 				Env:     []v1.EnvVar{{Name: "PYTHONUSERBASE", Value: "/dbg/python:/foo"}},
 			},
+			debugConfig: ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
+			image:       "python",
 		},
 		{
 			description:   "command not entrypoint",
@@ -189,6 +195,8 @@ func TestPythonTransformer_Apply(t *testing.T) {
 				Ports: []v1.ContainerPort{{Name: "dap", ContainerPort: 5678}},
 				Env:   []v1.EnvVar{{Name: "PYTHONUSERBASE", Value: "/dbg/python"}},
 			},
+			debugConfig: ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
+			image:       "python",
 		},
 	}
 	var identity portAllocator = func(port int32) int32 {
@@ -196,9 +204,12 @@ func TestPythonTransformer_Apply(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			pythonTransformer{}.Apply(&test.containerSpec, test.configuration, identity)
+			config, image, err := pythonTransformer{}.Apply(&test.containerSpec, test.configuration, identity)
 
+			t.CheckError(test.shouldErr, err)
 			t.CheckDeepEqual(test.result, test.containerSpec)
+			t.CheckDeepEqual(test.debugConfig, config)
+			t.CheckDeepEqual(test.image, image)
 		})
 	}
 }


### PR DESCRIPTION
- avoid panics by returning a `ContainerDebugConfiguration` instead of a pointer
- allow returning a different debug-helper image: this will be helpful with support musl vs glibc situations
- return a more helpful error message when `Apply()` is unable to be applied
