### PR TITLE
hack/new_version.sh must process `skaffold init` tests too

### DIFF
--- a/hack/versions/cmd/new/version.go
+++ b/hack/versions/cmd/new/version.go
@@ -81,6 +81,12 @@ func main() {
 		return nil
 	})
 
+	// Update skaffold.yaml in init tests
+	walk.From("pkg/skaffold/initializer/testdata").WhenHasName("skaffold.yaml").MustDo(func(path string, _ walk.Dirent) error {
+		sed(path, current, next)
+		return nil
+	})
+
 	// Add the new version to the list of versions
 	lines := lines(path("versions.go"))
 	var content string


### PR DESCRIPTION
**Description**

Generating a new schema version currently results in failing tests in `pkg/skaffold/initializer`.

These tests have separate test projects found in `pkg/skaffold/initializer/testdata` withg `skaffold.yaml` files that must also be updated on a new schema version.