### PR TITLE
Produce a clear error when the Dockerfile is deleted while running `skaffold dev`

### DIFF
--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -66,7 +66,7 @@ var (
 func readCopyCmdsFromDockerfile(onlyLastImage bool, absDockerfilePath, workspace string, buildArgs map[string]*string, insecureRegistries map[string]bool) ([]fromTo, error) {
 	f, err := os.Open(absDockerfilePath)
 	if err != nil {
-		return nil, fmt.Errorf("opening dockerfile %q: %w", absDockerfilePath, err)
+		return nil, err
 	}
 	defer f.Close()
 

--- a/pkg/skaffold/filemon/monitor.go
+++ b/pkg/skaffold/filemon/monitor.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package filemon
 
-import "fmt"
-
 // Monitor monitors files changes for multiples components.
 type Monitor interface {
 	Register(deps func() ([]string, error), onChange func(Events)) error
@@ -48,7 +46,7 @@ type component struct {
 func (w *watchList) Register(deps func() ([]string, error), onChange func(Events)) error {
 	state, err := Stat(deps)
 	if err != nil {
-		return fmt.Errorf("listing files: %w", err)
+		return err
 	}
 
 	w.components = append(w.components, &component{
@@ -69,7 +67,7 @@ func (w *watchList) Run(debounce bool) error {
 	for i, component := range w.components {
 		state, err := Stat(component.deps)
 		if err != nil {
-			return fmt.Errorf("listing files: %w", err)
+			return err
 		}
 		e := events(component.state, state)
 

--- a/pkg/skaffold/runner/listen.go
+++ b/pkg/skaffold/runner/listen.go
@@ -78,9 +78,10 @@ func (l *SkaffoldListener) WatchForChanges(ctx context.Context, out io.Writer, d
 
 func (l *SkaffoldListener) do(ctx context.Context, out io.Writer, devLoop func(context.Context, io.Writer) error) error {
 	if err := l.Monitor.Run(l.Trigger.Debounce()); err != nil {
-		logrus.Warnf("error computing file changes: %s", err.Error())
-		logrus.Warnf("skaffold may not run successfully!")
+		logrus.Warnf("Ignoring changes: %s", err.Error())
+		return nil
 	}
+
 	if err := devLoop(ctx, out); err != nil {
 		// propagating this error up causes a new runner to be created
 		// and a new dev loop to start
@@ -89,5 +90,6 @@ func (l *SkaffoldListener) do(ctx context.Context, out io.Writer, devLoop func(c
 		}
 		logrus.Errorf("error running dev loop: %s", err.Error())
 	}
+
 	return nil
 }

--- a/pkg/skaffold/runner/listen_test.go
+++ b/pkg/skaffold/runner/listen_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/trigger"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+// errMonitor is a filemon.Monitor that always fail to run.
+type errMonitor struct {
+	filemon.Monitor
+}
+
+func (f *errMonitor) Run(debounce bool) error {
+	return errors.New("BUG")
+}
+
+// fakeMonitor is a filemon.Monitor that always succeeds.
+type fakeMonitor struct {
+	filemon.Monitor
+}
+
+func (f *fakeMonitor) Run(debounce bool) error {
+	return nil
+}
+
+type fakeTriggger struct {
+	trigger.Trigger
+}
+
+func (f *fakeTriggger) Debounce() bool {
+	return false
+}
+
+func TestSkipDevLoopOnMonitorError(t *testing.T) {
+	listener := &SkaffoldListener{
+		Monitor: &errMonitor{},
+		Trigger: &fakeTriggger{},
+	}
+
+	var devLoopWasCalled bool
+	err := listener.do(context.Background(), ioutil.Discard, func(context.Context, io.Writer) error {
+		devLoopWasCalled = true
+		return nil
+	})
+
+	testutil.CheckErrorAndDeepEqual(t, false, err, false, devLoopWasCalled)
+}
+
+func TestContinueOnDevLoopError(t *testing.T) {
+	listener := &SkaffoldListener{
+		Monitor: &fakeMonitor{},
+		Trigger: &fakeTriggger{},
+	}
+
+	err := listener.do(context.Background(), ioutil.Discard, func(context.Context, io.Writer) error {
+		return errors.New("devloop error")
+	})
+
+	testutil.CheckError(t, false, err)
+}
+
+func TestReportDevLoopError(t *testing.T) {
+	listener := &SkaffoldListener{
+		Monitor: &fakeMonitor{},
+		Trigger: &fakeTriggger{},
+	}
+
+	err := listener.do(context.Background(), ioutil.Discard, func(context.Context, io.Writer) error {
+		return ErrorConfigurationChanged
+	})
+
+	if err != ErrorConfigurationChanged {
+		t.Fatalf("should have returned a ErrorConfigurationChanged error, returned %v", err)
+	}
+}


### PR DESCRIPTION
Fix dev mode when Dockerfile is deleted. We should just ignore the changes and keep on watching file changes.

Also make error messages shorter:

BEFORE:
```
WARN[0059] error computing file changes: listing files: listing files: opening dockerfile "/Users/dgageot/src/skaffold/examples/getting-started/Dockerfile": open /Users/dgageot/src/skaffold/examples/getting-started/Dockerfile: no such file or directory
WARN[0059] skaffold may not run successfully!
```

AFTER:
```
Watching for changes...
WARN[0018] Ignoring changes: listing files: open /Users/dgageot/src/skaffold/examples/getting-started/Dockerfile: no such file or directory
```

Fixes #3940

Signed-off-by: David Gageot <david@gageot.net>
