### PR TITLE
[json schema] When we don’t know a field’s type, let’s leave it empty

### DIFF
--- a/docs/content/en/schemas/v1.json
+++ b/docs/content/en/schemas/v1.json
@@ -1351,7 +1351,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v1beta10.json
+++ b/docs/content/en/schemas/v1beta10.json
@@ -1153,7 +1153,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v1beta11.json
+++ b/docs/content/en/schemas/v1beta11.json
@@ -1162,7 +1162,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v1beta12.json
+++ b/docs/content/en/schemas/v1beta12.json
@@ -1162,7 +1162,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v1beta13.json
+++ b/docs/content/en/schemas/v1beta13.json
@@ -1214,7 +1214,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v1beta14.json
+++ b/docs/content/en/schemas/v1beta14.json
@@ -1198,7 +1198,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v1beta15.json
+++ b/docs/content/en/schemas/v1beta15.json
@@ -1208,7 +1208,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v1beta16.json
+++ b/docs/content/en/schemas/v1beta16.json
@@ -1250,7 +1250,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v1beta17.json
+++ b/docs/content/en/schemas/v1beta17.json
@@ -1250,7 +1250,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v1beta5.json
+++ b/docs/content/en/schemas/v1beta5.json
@@ -957,7 +957,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v1beta6.json
+++ b/docs/content/en/schemas/v1beta6.json
@@ -1006,7 +1006,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v1beta7.json
+++ b/docs/content/en/schemas/v1beta7.json
@@ -1101,7 +1101,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v1beta8.json
+++ b/docs/content/en/schemas/v1beta8.json
@@ -1147,7 +1147,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v1beta9.json
+++ b/docs/content/en/schemas/v1beta9.json
@@ -1052,7 +1052,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v2alpha1.json
+++ b/docs/content/en/schemas/v2alpha1.json
@@ -1364,7 +1364,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v2alpha2.json
+++ b/docs/content/en/schemas/v2alpha2.json
@@ -1303,7 +1303,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v2alpha3.json
+++ b/docs/content/en/schemas/v2alpha3.json
@@ -1335,7 +1335,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v2alpha4.json
+++ b/docs/content/en/schemas/v2alpha4.json
@@ -1335,7 +1335,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v2beta1.json
+++ b/docs/content/en/schemas/v2beta1.json
@@ -1339,7 +1339,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/docs/content/en/schemas/v2beta2.json
+++ b/docs/content/en/schemas/v2beta2.json
@@ -1339,7 +1339,6 @@
           ]
         },
         "value": {
-          "type": "object",
           "description": "value to apply. Can be any portion of yaml.",
           "x-intellij-html-description": "value to apply. Can be any portion of yaml."
         }

--- a/hack/schemas/main.go
+++ b/hack/schemas/main.go
@@ -214,8 +214,6 @@ func (g *schemaGenerator) newDefinition(name string, t ast.Expr, comment string,
 		if ident, ok := tt.X.(*ast.Ident); ok {
 			typeName := ident.Name
 			setTypeOrRef(def, typeName)
-		} else if _, ok := tt.X.(*ast.SelectorExpr); ok {
-			def.Type = "object"
 		}
 
 	case *ast.ArrayType:


### PR DESCRIPTION
Fixes #3932

Signed-off-by: David Gageot <david@gageot.net>
