### PR TITLE
add serviceAccount and runAsUser to kaniko build (resolves #3267)

### DIFF
--- a/docs/content/en/schemas/v2beta3.json
+++ b/docs/content/en/schemas/v2beta3.json
@@ -631,6 +631,16 @@
           "description": "define the resource requirements for the kaniko pod.",
           "x-intellij-html-description": "define the resource requirements for the kaniko pod."
         },
+        "runAsUser": {
+          "type": "integer",
+          "description": "defines the UID to request for running the container. If omitted, no SeurityContext will be specified for the pod and will therefore be inherited from the service account.",
+          "x-intellij-html-description": "defines the UID to request for running the container. If omitted, no SeurityContext will be specified for the pod and will therefore be inherited from the service account."
+        },
+        "serviceAccount": {
+          "type": "string",
+          "description": "describes the Kubernetes service account to use for the pod. Defaults to 'default'.",
+          "x-intellij-html-description": "describes the Kubernetes service account to use for the pod. Defaults to 'default'."
+        },
         "timeout": {
           "type": "string",
           "description": "amount of time (in seconds) that this build is allowed to run. Defaults to 20 minutes (`20m`).",
@@ -653,6 +663,8 @@
         "namespace",
         "timeout",
         "dockerConfig",
+        "serviceAccount",
+        "runAsUser",
         "resources",
         "concurrency",
         "volumes",

--- a/pkg/skaffold/build/cluster/pod.go
+++ b/pkg/skaffold/build/cluster/pod.go
@@ -92,6 +92,19 @@ func (b *Builder) kanikoPodSpec(artifact *latest.KanikoArtifact, tag string) (*v
 		addSecretVolume(pod, constants.DefaultKanikoDockerConfigSecretName, constants.DefaultKanikoDockerConfigPath, b.ClusterDetails.DockerConfig.SecretName)
 	}
 
+	// Add Service Account
+	if b.ClusterDetails.ServiceAccountName != "" {
+		pod.Spec.ServiceAccountName = b.ClusterDetails.ServiceAccountName
+	}
+
+	// Add SecurityContext for runAsUser
+	if b.ClusterDetails.RunAsUser != nil {
+		if pod.Spec.SecurityContext == nil {
+			pod.Spec.SecurityContext = &v1.PodSecurityContext{}
+		}
+		pod.Spec.SecurityContext.RunAsUser = b.ClusterDetails.RunAsUser
+	}
+
 	// Add used-defines Volumes
 	pod.Spec.Volumes = append(pod.Spec.Volumes, b.Volumes...)
 

--- a/pkg/skaffold/build/cluster/pod_test.go
+++ b/pkg/skaffold/build/cluster/pod_test.go
@@ -180,6 +180,7 @@ func TestKanikoPodSpec(t *testing.T) {
 		},
 	}
 
+	var runAsUser int64 = 0
 	builder := &Builder{
 		ClusterDetails: &latest.ClusterDetails{
 			Namespace:           "ns",
@@ -187,6 +188,8 @@ func TestKanikoPodSpec(t *testing.T) {
 			PullSecretMountPath: "/secret",
 			HTTPProxy:           "http://proxy",
 			HTTPSProxy:          "https://proxy",
+			ServiceAccountName:  "aVerySpecialSA",
+			RunAsUser:           &runAsUser,
 			Resources: &latest.ResourceRequirements{
 				Requests: &latest.ResourceRequirement{
 					CPU: "0.1",
@@ -305,6 +308,10 @@ func TestKanikoPodSpec(t *testing.T) {
 					},
 				},
 			}},
+			ServiceAccountName: "aVerySpecialSA",
+			SecurityContext: &v1.PodSecurityContext{
+				RunAsUser: &runAsUser,
+			},
 			RestartPolicy: v1.RestartPolicyNever,
 			Volumes: []v1.Volume{
 				{

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -298,6 +298,15 @@ type ClusterDetails struct {
 	// DockerConfig describes how to mount the local Docker configuration into a pod.
 	DockerConfig *DockerConfig `yaml:"dockerConfig,omitempty"`
 
+	// ServiceAccountName describes the Kubernetes service account to use for the pod.
+	// Defaults to 'default'.
+	ServiceAccountName string `yaml:"serviceAccount,omitempty"`
+
+	// RunAsUser defines the UID to request for running the container.
+	// If omitted, no SeurityContext will be specified for the pod and will therefore be inherited
+	// from the service account.
+	RunAsUser *int64 `yaml:"runAsUser,omitempty"`
+
 	// Resources define the resource requirements for the kaniko pod.
 	Resources *ResourceRequirements `yaml:"resources,omitempty"`
 


### PR DESCRIPTION
**Fixes**: #3267 

**Description**
Add configuration options for serviceAccount and runAsUser.
This allows building in clusters with PodSecurityPolicies (bound to serviceAccount) and OKD/OpenShift 3.11 (requires runAsUser to be set to avoid auto-apply of 'restricted' scc)

