### PR TITLE
Fix examples for debug

### DIFF
--- a/examples/compose/Dockerfile
+++ b/examples/compose/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/examples/gcb-kaniko/Dockerfile
+++ b/examples/gcb-kaniko/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/examples/generate-pipeline/Dockerfile
+++ b/examples/generate-pipeline/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/examples/getting-started/Dockerfile
+++ b/examples/getting-started/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/examples/google-cloud-build/Dockerfile
+++ b/examples/google-cloud-build/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/examples/kaniko/Dockerfile
+++ b/examples/kaniko/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/examples/microservices/leeroy-app/Dockerfile
+++ b/examples/microservices/leeroy-app/Dockerfile
@@ -3,5 +3,8 @@ COPY app.go .
 RUN go build -o /app .
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/examples/microservices/leeroy-web/Dockerfile
+++ b/examples/microservices/leeroy-web/Dockerfile
@@ -3,5 +3,8 @@ COPY web.go .
 RUN go build -o /web .
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./web"]
 COPY --from=builder /web .

--- a/examples/profile-patches/base-service/Dockerfile
+++ b/examples/profile-patches/base-service/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/examples/profile-patches/hello-service/Dockerfile
+++ b/examples/profile-patches/hello-service/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/examples/profile-patches/world-service/Dockerfile
+++ b/examples/profile-patches/world-service/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/examples/profiles/hello-service/Dockerfile
+++ b/examples/profiles/hello-service/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/examples/profiles/world-service/Dockerfile
+++ b/examples/profiles/world-service/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/examples/structure-tests/Dockerfile
+++ b/examples/structure-tests/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/examples/tagging-with-environment-variables/Dockerfile
+++ b/examples/tagging-with-environment-variables/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/integration/examples/compose/Dockerfile
+++ b/integration/examples/compose/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/integration/examples/gcb-kaniko/Dockerfile
+++ b/integration/examples/gcb-kaniko/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/integration/examples/generate-pipeline/Dockerfile
+++ b/integration/examples/generate-pipeline/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/integration/examples/getting-started/Dockerfile
+++ b/integration/examples/getting-started/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/integration/examples/google-cloud-build/Dockerfile
+++ b/integration/examples/google-cloud-build/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/integration/examples/kaniko/Dockerfile
+++ b/integration/examples/kaniko/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/integration/examples/microservices/leeroy-app/Dockerfile
+++ b/integration/examples/microservices/leeroy-app/Dockerfile
@@ -3,5 +3,8 @@ COPY app.go .
 RUN go build -o /app .
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/integration/examples/microservices/leeroy-web/Dockerfile
+++ b/integration/examples/microservices/leeroy-web/Dockerfile
@@ -3,5 +3,8 @@ COPY web.go .
 RUN go build -o /web .
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./web"]
 COPY --from=builder /web .

--- a/integration/examples/profile-patches/base-service/Dockerfile
+++ b/integration/examples/profile-patches/base-service/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/integration/examples/profile-patches/hello-service/Dockerfile
+++ b/integration/examples/profile-patches/hello-service/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/integration/examples/profile-patches/world-service/Dockerfile
+++ b/integration/examples/profile-patches/world-service/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/integration/examples/profiles/hello-service/Dockerfile
+++ b/integration/examples/profiles/hello-service/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/integration/examples/profiles/world-service/Dockerfile
+++ b/integration/examples/profiles/world-service/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/integration/examples/structure-tests/Dockerfile
+++ b/integration/examples/structure-tests/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .

--- a/integration/examples/tagging-with-environment-variables/Dockerfile
+++ b/integration/examples/tagging-with-environment-variables/Dockerfile
@@ -3,5 +3,8 @@ COPY main.go .
 RUN go build -o /app main.go
 
 FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
 CMD ["./app"]
 COPY --from=builder /app .


### PR DESCRIPTION
Fixes #3897

**Description**

Adds `GOTRACEBACK=single` to all Go-based examples to mark the image as using the Go language runtime so as to enable `skaffold debug`. `GOTRACEBACK`'s default setting is  `single` so there are no functional changes.
