### PR TITLE
Support --default-repo=‘’ to erase the value from global config

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -77,7 +77,7 @@ var FlagRegistry = []Flag{
 		Usage:         "Default repository value (overrides global config)",
 		Value:         &opts.DefaultRepo,
 		DefValue:      "",
-		FlagAddMethod: "StringVar",
+		FlagAddMethod: "Var",
 		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "build", "delete"},
 	},
 	{
@@ -278,12 +278,13 @@ func SetupFlags() {
 	commandFlags = make([]*pflag.Flag, len(FlagRegistry))
 	for i, fl := range FlagRegistry {
 		fs := pflag.NewFlagSet(fl.Name, pflag.ContinueOnError)
-		inputs := []reflect.Value{
-			reflect.ValueOf(fl.Value),
-			reflect.ValueOf(fl.Name),
-			reflect.ValueOf(fl.DefValue),
-			reflect.ValueOf(fl.Usage),
+
+		inputs := []reflect.Value{reflect.ValueOf(fl.Value), reflect.ValueOf(fl.Name)}
+		if fl.FlagAddMethod != "Var" {
+			inputs = append(inputs, reflect.ValueOf(fl.DefValue))
 		}
+		inputs = append(inputs, reflect.ValueOf(fl.Usage))
+
 		reflect.ValueOf(fs).MethodByName(fl.FlagAddMethod).Call(inputs)
 		f := fs.Lookup(fl.Name)
 		if fl.Shorthand != "" {

--- a/cmd/skaffold/app/cmd/init_test.go
+++ b/cmd/skaffold/app/cmd/init_test.go
@@ -22,6 +22,9 @@ import (
 	"io"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
+	cfg "github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -154,7 +157,7 @@ func TestFlagsToConfigVersion(t *testing.T) {
 
 			// we ignore Skaffold options
 			test.expectedConfig.Opts = capturedConfig.Opts
-			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedConfig, capturedConfig)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedConfig, capturedConfig, cmp.AllowUnexported(cfg.StringOrUndefined{}))
 		})
 	}
 }

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -57,7 +57,7 @@ type SkaffoldOptions struct {
 	KubeContext        string
 	KubeConfig         string
 	WatchPollInterval  int
-	DefaultRepo        string
+	DefaultRepo        StringOrUndefined
 	CustomLabels       []string
 	TargetImages       []string
 	Profiles           []string

--- a/pkg/skaffold/config/types.go
+++ b/pkg/skaffold/config/types.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+// StringOrUndefined holds the value of a flag of type `string`,
+// that's by default `undefined`.
+// We use this instead of just `string` to differentiate `undefined`
+// and `empty string` values.
+type StringOrUndefined struct {
+	value *string
+}
+
+func (s *StringOrUndefined) Type() string {
+	return "string"
+}
+
+func (s *StringOrUndefined) Value() *string {
+	return s.value
+}
+
+func (s *StringOrUndefined) Set(v string) error {
+	s.value = &v
+	return nil
+}
+
+func (s *StringOrUndefined) String() string {
+	if s.value == nil {
+		return ""
+	}
+	return *s.value
+}

--- a/pkg/skaffold/config/types_test.go
+++ b/pkg/skaffold/config/types_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestStringOrUndefinedUsage(t *testing.T) {
+	var output bytes.Buffer
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Var(&StringOrUndefined{}, "flag", "use it like this")
+	cmd.SetOutput(&output)
+	cmd.Usage()
+
+	testutil.CheckDeepEqual(t, "Usage:\n\nFlags:\n      --flag string   use it like this\n", output.String())
+}
+
+func TestStringOrUndefined(t *testing.T) {
+	tests := []struct {
+		description string
+		args        []string
+		expected    *string
+	}{
+		{
+			description: "undefined",
+			args:        []string{},
+			expected:    nil,
+		},
+		{
+			description: "set",
+			args:        []string{"--flag=value"},
+			expected:    util.StringPtr("value"),
+		},
+		{
+			description: "empty",
+			args:        []string{"--flag="},
+			expected:    util.StringPtr(""),
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			var flag StringOrUndefined
+
+			cmd := &cobra.Command{}
+			cmd.Flags().Var(&flag, "flag", "")
+			cmd.SetArgs(test.args)
+			cmd.Execute()
+
+			t.CheckDeepEqual(test.expected, flag.value)
+		})
+	}
+}

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -147,10 +147,10 @@ func getConfigForKubeContextWithGlobalDefaults(cfg *GlobalConfig, kubeContext st
 	return &mergedConfig, nil
 }
 
-func GetDefaultRepo(configFile, cliValue string) (string, error) {
+func GetDefaultRepo(configFile string, cliValue *string) (string, error) {
 	// CLI flag takes precedence.
-	if cliValue != "" {
-		return cliValue, nil
+	if cliValue != nil {
+		return *cliValue, nil
 	}
 	cfg, err := GetConfigForCurrentKubectx(configFile)
 	if err != nil {

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -128,7 +128,7 @@ func (r *SkaffoldRunner) imageTags(ctx context.Context, out io.Writer, artifacts
 	start := time.Now()
 	color.Default.Fprintln(out, "Generating tags...")
 
-	defaultRepo, err := config.GetDefaultRepo(r.runCtx.Opts.GlobalConfig, r.runCtx.Opts.DefaultRepo)
+	defaultRepo, err := config.GetDefaultRepo(r.runCtx.Opts.GlobalConfig, r.runCtx.Opts.DefaultRepo.Value())
 	if err != nil {
 		return nil, fmt.Errorf("getting default repo: %w", err)
 	}


### PR DESCRIPTION
Fixes #3923

Signed-off-by: David Gageot <david@gageot.net>
