### PR TITLE
install docs: use "install" and "choco -y"

### DIFF
--- a/docs/content/en/docs/install/_index.md
+++ b/docs/content/en/docs/install/_index.md
@@ -27,8 +27,7 @@ Run these commands to download and place the binary in your /usr/local/bin folde
 
 ```bash
 curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
-chmod +x skaffold
-sudo mv skaffold /usr/local/bin
+sudo install skaffold /usr/local/bin/
 ```
 
 ### Latest bleeding edge binary
@@ -41,8 +40,7 @@ Run these commands to download and place the binary in your /usr/local/bin folde
 
 ```bash
 curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/latest/skaffold-linux-amd64
-chmod +x skaffold
-sudo mv skaffold /usr/local/bin
+sudo install skaffold /usr/local/bin/
 ```
 
 {{% /tab %}}
@@ -64,8 +62,7 @@ Run these commands to download and place the binary in your /usr/local/bin folde
 
 ```bash
 curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-darwin-amd64
-chmod +x skaffold
-sudo mv skaffold /usr/local/bin
+sudo install skaffold /usr/local/bin/
 ```
 
 ### Bleeding edge binary
@@ -78,8 +75,7 @@ Run these commands to download and place the binary in your /usr/local/bin folde
 
 ```bash
 curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/latest/skaffold-darwin-amd64
-chmod +x skaffold
-sudo mv skaffold /usr/local/bin
+sudo install skaffold /usr/local/bin/
 ```
 {{% /tab %}}
 
@@ -88,7 +84,7 @@ sudo mv skaffold /usr/local/bin
 ### Chocolatey
 
 ```bash
-choco install skaffold
+choco install -y skaffold
 ```
 
 ### Stable binary


### PR DESCRIPTION
Use install(1) because it's purpose is more straight-forward. 

Use `-y` for choco to avoid hanging prompt.

Fixes #2948

<!-- Thanks you for your contribution! -->

<!-- Include if applicable: -->
**Fixes**: _Tracking issues that this PR will close_
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
