### PR TITLE
Fail when cache check should have succeeded

### DIFF
--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -64,10 +64,8 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 		result := results[i]
 		switch result := result.(type) {
 		case failed:
-			logrus.Warnf("error checking cache, caching may not work as expected: %v", result.err)
-			color.Yellow.Fprintln(out, "Error checking cache. Rebuilding.")
-			needToBuild = append(needToBuild, artifact)
-			continue
+			color.Red.Fprintln(out, "Error checking cache.")
+			return nil, result.err
 
 		case needsBuilding:
 			color.Yellow.Fprintln(out, "Not found. Building")


### PR DESCRIPTION
For every case of failure here, there’s going to be the same issue down the line.
We should not ignore those errors.

The only case where we should ignore them is when images are not local and this is already done.

(This piece of code wasn't tested before and I couldn't find a way to test it properly)

Signed-off-by: David Gageot <david@gageot.net>
