### PR TITLE
Simplify error messages

### DIFF
--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -54,7 +54,7 @@ func (c *cache) lookupArtifacts(ctx context.Context, tags tag.ImageTags, artifac
 func (c *cache) lookup(ctx context.Context, a *latest.Artifact, tag string) cacheDetails {
 	hash, err := c.hashForArtifact(ctx, a)
 	if err != nil {
-		return failed{err: fmt.Errorf("getting hash for artifact %s: %v", a.ImageName, err)}
+		return failed{err: fmt.Errorf("getting hash for artifact %q: %s", a.ImageName, err)}
 	}
 
 	entry, cacheHit := c.artifactCache[hash]

--- a/pkg/skaffold/build/cache/lookup_test.go
+++ b/pkg/skaffold/build/cache/lookup_test.go
@@ -43,7 +43,7 @@ func TestLookupLocal(t *testing.T) {
 		{
 			description: "hash failure",
 			hasher:      failingHasher("BUG"),
-			expected:    failed{err: errors.New("getting hash for artifact artifact: BUG")},
+			expected:    failed{err: errors.New("getting hash for artifact \"artifact\": BUG")},
 		},
 		{
 			description: "miss no imageID",
@@ -71,7 +71,7 @@ func TestLookupLocal(t *testing.T) {
 			api: &testutil.FakeAPIClient{
 				ErrImageInspect: true,
 			},
-			expected: failed{err: errors.New("getting imageID for tag: inspecting image: ")},
+			expected: failed{err: errors.New("getting imageID for tag: ")},
 		},
 		{
 			description: "hit",
@@ -139,7 +139,7 @@ func TestLookupRemote(t *testing.T) {
 		{
 			description: "hash failure",
 			hasher:      failingHasher("BUG"),
-			expected:    failed{err: errors.New("getting hash for artifact artifact: BUG")},
+			expected:    failed{err: errors.New("getting hash for artifact \"artifact\": BUG")},
 		},
 		{
 			description: "hit",

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -48,7 +48,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, 
 func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
 	digestOrImageID, err := b.runBuildForArtifact(ctx, out, artifact, tag)
 	if err != nil {
-		return "", fmt.Errorf("build artifact: %w", err)
+		return "", err
 	}
 
 	if b.pushImages {
@@ -98,7 +98,7 @@ func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, artifa
 func (b *Builder) getImageIDForTag(ctx context.Context, tag string) (string, error) {
 	insp, _, err := b.localDocker.ImageInspectWithRaw(ctx, tag)
 	if err != nil {
-		return "", fmt.Errorf("inspecting image: %w", err)
+		return "", err
 	}
 	return insp.ID, nil
 }

--- a/pkg/skaffold/build/parallel.go
+++ b/pkg/skaffold/build/parallel.go
@@ -130,7 +130,7 @@ func collectResults(out io.Writer, artifacts []*latest.Artifact, results *sync.M
 		}
 		switch t := v.(type) {
 		case error:
-			return nil, fmt.Errorf("building [%s]: %w", artifact.ImageName, t)
+			return nil, fmt.Errorf("couldn't build %q: %w", artifact.ImageName, t)
 		case Artifact:
 			built = append(built, t)
 		default:

--- a/pkg/skaffold/build/sequence.go
+++ b/pkg/skaffold/build/sequence.go
@@ -44,7 +44,7 @@ func InSequence(ctx context.Context, out io.Writer, tags tag.ImageTags, artifact
 		finalTag, err := buildArtifact(ctx, out, artifact, tag)
 		if err != nil {
 			event.BuildFailed(artifact.ImageName, err)
-			return nil, fmt.Errorf("building [%s]: %w", artifact.ImageName, err)
+			return nil, fmt.Errorf("couldn't build %q: %w", artifact.ImageName, err)
 		}
 
 		event.BuildComplete(artifact.ImageName)

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -144,7 +144,7 @@ func (l *localDaemon) ConfigFile(ctx context.Context, image string) (*v1.ConfigF
 	} else {
 		cfg, err = RetrieveRemoteConfig(image, l.insecureRegistries)
 		if err != nil {
-			return nil, fmt.Errorf("getting remote config: %w", err)
+			return nil, err
 		}
 	}
 
@@ -373,7 +373,7 @@ func (l *localDaemon) ImageID(ctx context.Context, ref string) (string, error) {
 		if client.IsErrNotFound(err) {
 			return "", nil
 		}
-		return "", fmt.Errorf("inspecting image: %w", err)
+		return "", err
 	}
 
 	return image.ID, nil

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -83,7 +83,7 @@ func readCopyCmdsFromDockerfile(onlyLastImage bool, absDockerfilePath, workspace
 
 	dockerfileLinesWithOnbuild, err := expandOnbuildInstructions(dockerfileLines, insecureRegistries)
 	if err != nil {
-		return nil, fmt.Errorf("expanding ONBUILD instructions: %w", err)
+		return nil, err
 	}
 
 	cpCmds, err := extractCopyCommands(dockerfileLinesWithOnbuild, onlyLastImage, insecureRegistries)
@@ -317,7 +317,7 @@ func parseOnbuild(image string, insecureRegistries map[string]bool) ([]*parser.N
 	// Image names are case SENSITIVE
 	img, err := RetrieveImage(image, insecureRegistries)
 	if err != nil {
-		return nil, fmt.Errorf("processing base image (%s) for ONBUILD triggers: %s", image, err)
+		return nil, fmt.Errorf("retrieving image %q: %w", image, err)
 	}
 
 	if len(img.Config.OnBuild) == 0 {

--- a/pkg/skaffold/docker/remote.go
+++ b/pkg/skaffold/docker/remote.go
@@ -73,7 +73,7 @@ func getRemoteDigest(identifier string, insecureRegistries map[string]bool) (str
 func RetrieveRemoteConfig(identifier string, insecureRegistries map[string]bool) (*v1.ConfigFile, error) {
 	img, err := remoteImage(identifier, insecureRegistries)
 	if err != nil {
-		return nil, fmt.Errorf("getting image: %w", err)
+		return nil, err
 	}
 
 	return img.ConfigFile()

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -48,12 +48,12 @@ func (r *SkaffoldRunner) BuildAndTest(ctx context.Context, out io.Writer, artifa
 
 		bRes, err := r.builder.Build(ctx, out, tags, artifacts)
 		if err != nil {
-			return nil, fmt.Errorf("build failed: %w", err)
+			return nil, err
 		}
 
 		if !r.runCtx.Opts.SkipTests {
 			if err = r.tester.Test(ctx, out, bRes); err != nil {
-				return nil, fmt.Errorf("test failed: %w", err)
+				return nil, err
 			}
 		}
 


### PR DESCRIPTION
Only keep what gives context and actionnable messages.

Signed-off-by: David Gageot <david@gageot.net>
