### PR TITLE
Fail fast with clear message if Docker is not started

### DIFF
--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -74,6 +74,16 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *la
 }
 
 func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+	if !b.pushImages {
+		// All of the builders will rely on a local Docker:
+		// + Either to build the image,
+		// + Or to docker load it.
+		// Let's fail fast if Docker is not available
+		if _, err := b.localDocker.ServerVersion(ctx); err != nil {
+			return "", err
+		}
+	}
+
 	switch {
 	case artifact.DockerArtifact != nil:
 		return b.buildDocker(ctx, out, artifact, tag)

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -210,6 +210,21 @@ func TestLocalRun(t *testing.T) {
 			tags:      tag.ImageTags(map[string]string{"gcr.io/test/image": "gcr.io/test/image:tag"}),
 			shouldErr: true,
 		},
+		{
+			description: "fail fast docker not found",
+			artifacts: []*latest.Artifact{{
+				ImageName: "gcr.io/test/image",
+				ArtifactType: latest.ArtifactType{
+					DockerArtifact: &latest.DockerArtifact{},
+				}},
+			},
+			tags: tag.ImageTags(map[string]string{"gcr.io/test/image": "gcr.io/test/image:tag"}),
+			api: &testutil.FakeAPIClient{
+				ErrVersion: true,
+			},
+			pushImages: false,
+			shouldErr:  true,
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {

--- a/testutil/fake_image_api.go
+++ b/testutil/fake_image_api.go
@@ -19,6 +19,7 @@ package testutil
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -49,10 +50,18 @@ type FakeAPIClient struct {
 	ErrImagePush    bool
 	ErrImagePull    bool
 	ErrStream       bool
+	ErrVersion      bool
 
 	nextImageID int
 	Pushed      map[string]string
 	Built       []types.ImageBuildOptions
+}
+
+func (f *FakeAPIClient) ServerVersion(ctx context.Context) (types.Version, error) {
+	if f.ErrVersion {
+		return types.Version{}, errors.New("docker not found")
+	}
+	return types.Version{}, nil
 }
 
 func (f *FakeAPIClient) Add(tag, imageID string) *FakeAPIClient {


### PR DESCRIPTION
All of the local builders will rely on a local Docker:
 + Either to build the image,
+ Or to docker load it.

Let's fail fast if Docker is not available

Signed-off-by: David Gageot <david@gageot.net>
