### PR TITLE
Use Go 1.14.2 to prevent SIGILL: illegal instruction on macOS

### DIFF
--- a/deploy/cross/Dockerfile
+++ b/deploy/cross/Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM dockercore/golang-cross:1.13.8 as base
+FROM dockercore/golang-cross:1.13.10 as base
 
 # The base image is not yet available for go 1.14.
 # Let's just replace the Go that's installed with a newer one.
 RUN rm -Rf /usr/local/go && mkdir /usr/local/go
-RUN curl --fail --show-error --silent --location https://dl.google.com/go/go1.14.linux-amd64.tar.gz \
+RUN curl --fail --show-error --silent --location https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz \
     | tar xz --directory=/usr/local/go --strip-components=1
 
 # Cross compile Skaffold for Linux, Windows and MacOS


### PR DESCRIPTION
Fixes #4008

Signed-off-by: David Gageot <david@gageot.net>
