### PR TITLE
When a tagger fails, use a fallback tagger

### DIFF
--- a/pkg/skaffold/build/tag/git_commit.go
+++ b/pkg/skaffold/build/tag/git_commit.go
@@ -77,8 +77,7 @@ func (c *GitCommit) Labels() map[string]string {
 func (c *GitCommit) GenerateFullyQualifiedImageName(workingDir string, imageName string) (string, error) {
 	ref, err := c.makeGitTag(workingDir)
 	if err != nil {
-		logrus.Warnln("Unable to find git commit:", err)
-		return fmt.Sprintf("%s:dirty", imageName), nil
+		return "", fmt.Errorf("unable to find git commit: %w", err)
 	}
 
 	changes, err := runGit(workingDir, "status", ".", "--porcelain")

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -146,6 +146,7 @@ func (r *SkaffoldRunner) imageTags(ctx context.Context, out io.Writer, artifacts
 	}
 
 	imageTags := make(tag.ImageTags, len(artifacts))
+	showWarning := false
 
 	for i, artifact := range artifacts {
 		imageName := artifact.ImageName
@@ -157,7 +158,6 @@ func (r *SkaffoldRunner) imageTags(ctx context.Context, out io.Writer, artifacts
 
 		case t := <-tagErrs[i]:
 			err := t.err
-			showWarning := false
 
 			if err != nil {
 				logrus.Debugln(err)
@@ -177,15 +177,13 @@ func (r *SkaffoldRunner) imageTags(ctx context.Context, out io.Writer, artifacts
 				return nil, fmt.Errorf("applying default repo to %q: %w", t.tag, t.err)
 			}
 
-			if showWarning {
-				fmt.Fprint(out, tag)
-				color.Yellow.Fprintln(out, " (check the logs for errors)")
-			} else {
-				fmt.Fprintln(out, tag)
-			}
-
+			fmt.Fprintln(out, tag)
 			imageTags[imageName] = tag
 		}
+	}
+
+	if showWarning {
+		color.Yellow.Fprintln(out, "Some taggers failed. Rerun with -vdebug for errors.")
 	}
 
 	logrus.Infoln("Tags generated in", time.Since(start))

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -161,12 +161,12 @@ func (r *SkaffoldRunner) imageTags(ctx context.Context, out io.Writer, artifacts
 
 			if err != nil {
 				logrus.Debugln(err)
-				logrus.Debugln("Using a fallback tagger")
+				logrus.Debugln("Using a fall-back tagger")
 
 				fallbackTagger := &tag.ChecksumTagger{}
 				t.tag, err = fallbackTagger.GenerateFullyQualifiedImageName(artifact.Workspace, imageName)
 				if err != nil {
-					return nil, fmt.Errorf("generating tag for %q: %w", imageName, err)
+					return nil, fmt.Errorf("generating checksum as fall-back tag for %q: %w", imageName, err)
 				}
 
 				showWarning = true


### PR DESCRIPTION
This is contributing to reduce the amount of strange error messages the user get.

 + Let the git tagger fail when no git information is found.
 + Use a fallback tagger (usually will tag with :latest)
 + Move the errors to the debug log and show a discrete warning to the user

BEFORE:

```
Generating tags...
 - leeroy-web -> WARN[0000] Unable to find git commit: running [git describe --tags --always]
 - stdout:
 - stderr: "fatal: not a git repository (or any of the parent directories): .git\n": exit status 128
leeroy-web:dirty
 - leeroy-app -> WARN[0000] Unable to find git commit: running [git describe --tags --always]
 - stdout:
 - stderr: "fatal: not a git repository (or any of the parent directories): .git\n": exit status 128
leeroy-app:dirty
Checking cache...
 - leeroy-web: Found Locally
 - leeroy-app: Found Locally
```

AFTER:

```
Generating tags...
 - leeroy-web -> leeroy-web:latest (check the logs for errors)
 - leeroy-app -> leeroy-app:latest (check the logs for errors)
Checking cache...
 - leeroy-web: Found Locally
 - leeroy-app: Found Locally
```

Signed-off-by: David Gageot <david@gageot.net>
