### PR TITLE
Use NODEJS_VERSION and NODE_ENV in detection

### DIFF
--- a/pkg/skaffold/debug/transform_nodejs.go
+++ b/pkg/skaffold/debug/transform_nodejs.go
@@ -56,8 +56,13 @@ func isLaunchingNpm(args []string) bool {
 }
 
 func (t nodeTransformer) IsApplicable(config imageConfiguration) bool {
-	if _, found := config.env["NODE_VERSION"]; found {
-		return true
+	// NODE_VERSION defined in Official Docker `node` image
+	// NODEJS_VERSION defined in RedHat's node base image
+	// NODE_ENV is a common var found to toggle debug and production
+	for _, v := range []string{"NODE_VERSION", "NODEJS_VERSION", "NODE_ENV"} {
+		if _, found := config.env[v]; found {
+			return true
+		}
 	}
 	if len(config.entrypoint) > 0 {
 		return isLaunchingNode(config.entrypoint) || isLaunchingNpm(config.entrypoint)

--- a/pkg/skaffold/debug/transform_nodejs_test.go
+++ b/pkg/skaffold/debug/transform_nodejs_test.go
@@ -72,6 +72,16 @@ func TestNodeTransformer_IsApplicable(t *testing.T) {
 			result:      true,
 		},
 		{
+			description: "NODEJS_VERSION",
+			source:      imageConfiguration{env: map[string]string{"NODEJS_VERSION": "12"}},
+			result:      true,
+		},
+		{
+			description: "NODE_ENV",
+			source:      imageConfiguration{env: map[string]string{"NODE_ENV": "production"}},
+			result:      true,
+		},
+		{
 			description: "entrypoint node",
 			source:      imageConfiguration{entrypoint: []string{"node", "init.js"}},
 			result:      true,


### PR DESCRIPTION
Fix #4003

**Description**

Use `NODE_ENV` and `NODEJS_VERSION` (used in RedHat's _universal base images_) to detect NodeJS images for `skaffold debug`.

**User facing changes (remove if N/A)**

`skaffold debug` uses `NODE_ENV` and `NODEJS_VERSION` to detect NodeJS applications.
