### PR TITLE
Enable debugging of Buildpacks

### DIFF
--- a/integration/rpc_test.go
+++ b/integration/rpc_test.go
@@ -124,6 +124,7 @@ func TestEventsRPC(t *testing.T) {
 			deployEntries++
 			t.Logf("deploy event %d: %v", deployEntries, entry.Event)
 		default:
+			t.Logf("unknown event: %v", entry.Event)
 		}
 	}
 	// make sure we have exactly 1 meta entry, 2 deploy entries and 2 build entries

--- a/integration/rpc_test.go
+++ b/integration/rpc_test.go
@@ -116,10 +116,13 @@ func TestEventsRPC(t *testing.T) {
 		switch entry.Event.GetEventType().(type) {
 		case *proto.Event_MetaEvent:
 			metaEntries++
+			t.Logf("meta event %d: %v", metaEntries, entry.Event)
 		case *proto.Event_BuildEvent:
 			buildEntries++
+			t.Logf("build event %d: %v", buildEntries, entry.Event)
 		case *proto.Event_DeployEvent:
 			deployEntries++
+			t.Logf("deploy event %d: %v", deployEntries, entry.Event)
 		default:
 		}
 	}

--- a/pkg/skaffold/debug/cnb.go
+++ b/pkg/skaffold/debug/cnb.go
@@ -63,7 +63,7 @@ func updateForCNBImage(container *v1.Container, ic imageConfiguration, transform
 	}
 	m := cnb.BuildMetadata{}
 	if err := json.Unmarshal([]byte(metadataJSON), &m); err != nil {
-		return ContainerDebugConfiguration{}, "", fmt.Errorf("unable to parse image buildpacks metadata")		
+		return ContainerDebugConfiguration{}, "", fmt.Errorf("unable to parse image buildpacks metadata")
 	}
 	if len(m.Processes) == 0 {
 		return ContainerDebugConfiguration{}, "", fmt.Errorf("buildpacks metadata has no processes")

--- a/pkg/skaffold/debug/cnb.go
+++ b/pkg/skaffold/debug/cnb.go
@@ -108,17 +108,16 @@ func adjustCommandLine(m cnb.BuildMetadata, ic imageConfiguration) (imageConfigu
 				return ic, func(transformed []string) []string {
 					return append([]string{"--"}, transformed...)
 				}
+			}
+			// Script type: split p.Command, pass it through the transformer, and then reassemble in the rewriter.
+			if args, err := shell.Split(p.Command); err == nil {
+				ic.arguments = args
 			} else {
-				// Script type: split p.Command, pass it through the transformer, and then reassemble in the rewriter.
-				if args, err := shell.Split(p.Command); err == nil {
-					ic.arguments = args
-				} else {
-					ic.arguments = []string{p.Command}
-				}
-				return ic, func(transformed []string) []string {
-					// reassemble back into a script with arguments
-					return append([]string{shJoin(transformed)}, p.Args...)
-				}
+				ic.arguments = []string{p.Command}
+			}
+			return ic, func(transformed []string) []string {
+				// reassemble back into a script with arguments
+				return append([]string{shJoin(transformed)}, p.Args...)
 			}
 		}
 	}

--- a/pkg/skaffold/debug/cnb.go
+++ b/pkg/skaffold/debug/cnb.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"encoding/json"
+	"fmt"
+
+	cnb "github.com/buildpacks/lifecycle"
+	shell "github.com/kballard/go-shellquote"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+)
+
+func init() {
+	// the CNB's launcher just launches the command
+	entrypointLaunchers = append(entrypointLaunchers, "/cnb/lifecycle/launcher")
+}
+
+// updateForCNBImage transforms an imageConfiguration for a Cloud Native Buildpacks-created image
+// for the configured process prior to handing off to another transformer.
+func updateForCNBImage(container *v1.Container, ic imageConfiguration, transformer func(container *v1.Container, ic imageConfiguration) (ContainerDebugConfiguration, string, error)) (ContainerDebugConfiguration, string, error) {
+	processType := "web"
+	if value, found := ic.env["CNB_PROCESS_TYPE"]; found && len(value) > 0 {
+		processType = value
+	}
+	m := cnb.BuildMetadata{}
+	// buildpacks/lifecycle 0.6.0 now embeds processes into special image label
+	if metadataJSON, found := ic.labels["io.buildpacks.build.metadata"]; !found {
+		return ContainerDebugConfiguration{}, "", fmt.Errorf("buildpacks build metadata not present; image built with older lifecycle?")
+	} else {
+		json.Unmarshal([]byte(metadataJSON), &m)
+	}
+	if len(m.Processes) == 0 {
+		return ContainerDebugConfiguration{}, "", fmt.Errorf("buildpacks build metadata is missing processes metadata")
+	}
+
+	for _, p := range m.Processes {
+		// the launcher accepts the first argument as a process type
+		if p.Type == processType || (len(ic.arguments) == 1 && p.Type == ic.arguments[0]) {
+			logrus.Debugf("Setting command for %q to %q process: %q + %q\n", ic.artifact, processType, p.Command, p.Args)
+			// retain the buildpacks launcher as the entrypoint
+			if p.Direct {
+				ic.arguments = append([]string{p.Command}, p.Args...)
+			} else {
+				// p.Command is a shell script executed via `sh -c "..."`, and p.Args are added as arguments to the script
+				// https://github.com/buildpacks/lifecycle/issues/218#issuecomment-567091462
+				if args, err := shell.Split(p.Command); err == nil {
+					ic.arguments = args
+				} else {
+					ic.arguments = []string{p.Command}
+				}
+			}
+			c, img, err := transformer(container, ic)
+			if err == nil {
+				if p.Direct {
+					container.Args = append([]string{"--"}, container.Args...)
+				} else {
+					// Args[0] is a shell script for sh -c
+					// Args[1:]] are arguments to that shell script
+					container.Args = append([]string{shJoin(container.Args)}, p.Args...)
+				}
+			}
+			return c, img, err
+		}
+	}
+	return ContainerDebugConfiguration{}, "", fmt.Errorf("could not find buildpack process of type %q", processType)
+}

--- a/pkg/skaffold/debug/cnb_test.go
+++ b/pkg/skaffold/debug/cnb_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"encoding/json"
+	"testing"
+
+	cnb "github.com/buildpacks/lifecycle"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestUpdateForCNBImage(t *testing.T) {
+	md := cnb.BuildMetadata{Processes: []cnb.Process{
+		{Type: "web", Command: "webProcess", Args: []string{"webArg1", "webArg2"}},
+		{Type: "diag", Command: "diagProcess"},
+		{Type: "dirct", Command: "command", Args: []string{"cmdArg1"}, Direct: true},
+	}}
+	md_marshalled, _ := json.Marshal(&md)
+	md_json := string(md_marshalled)
+	tests := []struct {
+		description string
+		input       imageConfiguration
+		shouldErr   bool
+		expected    v1.Container
+	}{
+		{
+			description: "error when missing build.metadata",
+			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}},
+			shouldErr:   true,
+		},
+		{
+			description: "defaults to web process when no process type",
+			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, labels: map[string]string{"io.buildpacks.build.metadata": md_json}},
+			shouldErr:   false,
+			expected:    v1.Container{Args: []string{"webProcess", "webArg1", "webArg2"}},
+		},
+		{
+			description: "CNB_PROCESS_TYPE=web",
+			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PROCESS_TYPE": "web"}, labels: map[string]string{"io.buildpacks.build.metadata": md_json}},
+			shouldErr:   false,
+			expected:    v1.Container{Args: []string{"webProcess", "webArg1", "webArg2"}},
+		},
+		{
+			description: "CNB_PROCESS_TYPE=diag",
+			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PROCESS_TYPE": "diag"}, labels: map[string]string{"io.buildpacks.build.metadata": md_json}},
+			shouldErr:   false,
+			expected:    v1.Container{Args: []string{"diagProcess"}},
+		},
+		{
+			description: "CNB_PROCESS_TYPE=dirct",
+			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PROCESS_TYPE": "dirct"}, labels: map[string]string{"io.buildpacks.build.metadata": md_json}},
+			shouldErr:   false,
+			expected:    v1.Container{Args: []string{"--", "command", "cmdArg1"}},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			dummy := func(c *v1.Container, ic imageConfiguration) (ContainerDebugConfiguration, string, error) {
+				c.Args = ic.arguments
+				return ContainerDebugConfiguration{}, "", nil
+			}
+
+			copy := v1.Container{}
+			_, _, err := updateForCNBImage(&copy, test.input, dummy)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, copy)
+		})
+	}
+}

--- a/pkg/skaffold/debug/cnb_test.go
+++ b/pkg/skaffold/debug/cnb_test.go
@@ -34,15 +34,15 @@ func TestUpdateForCNBImage(t *testing.T) {
 		{Type: "diag", Command: "diagProcess"},
 		{Type: "direct", Command: "command", Args: []string{"cmdArg1"}, Direct: true},
 	}}
-	md_marshalled, _ := json.Marshal(&md)
-	md_json := string(md_marshalled)
+	mdMarshalled, _ := json.Marshal(&md)
+	mdJSON := string(mdMarshalled)
 	// metadata with no default process type
 	mdnd := cnb.BuildMetadata{Processes: []launch.Process{
 		{Type: "diag", Command: "diagProcess"},
 		{Type: "direct", Command: "command", Args: []string{"cmdArg1"}, Direct: true},
 	}}
-	mdnd_marshalled, _ := json.Marshal(&mdnd)
-	mdnd_json := string(mdnd_marshalled)
+	mdndMarshalled, _ := json.Marshal(&mdnd)
+	mdndJSON := string(mdndMarshalled)
 
 	tests := []struct {
 		description string
@@ -62,49 +62,49 @@ func TestUpdateForCNBImage(t *testing.T) {
 		},
 		{
 			description: "direct command-lines are rewritten as direct command-lines",
-			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, arguments: []string{"--", "web", "arg1", "arg2"}, labels: map[string]string{"io.buildpacks.build.metadata": md_json}},
+			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, arguments: []string{"--", "web", "arg1", "arg2"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"--", "web", "arg1", "arg2"}},
 		},
 		{
 			description: "defaults to web process when no process type",
-			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, labels: map[string]string{"io.buildpacks.build.metadata": md_json}},
+			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"webProcess", "webArg1", "webArg2"}},
 		},
 		{
 			description: "resolves to default 'web' process",
-			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, labels: map[string]string{"io.buildpacks.build.metadata": md_json}},
+			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"webProcess", "webArg1", "webArg2"}},
 		},
 		{
 			description: "CNB_PROCESS_TYPE=web",
-			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PROCESS_TYPE": "web"}, labels: map[string]string{"io.buildpacks.build.metadata": md_json}},
+			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PROCESS_TYPE": "web"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"webProcess", "webArg1", "webArg2"}},
 		},
 		{
 			description: "CNB_PROCESS_TYPE=diag",
-			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PROCESS_TYPE": "diag"}, labels: map[string]string{"io.buildpacks.build.metadata": md_json}},
+			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PROCESS_TYPE": "diag"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"diagProcess"}},
 		},
 		{
 			description: "CNB_PROCESS_TYPE=direct",
-			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PROCESS_TYPE": "direct"}, labels: map[string]string{"io.buildpacks.build.metadata": md_json}},
+			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PROCESS_TYPE": "direct"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"--", "command", "cmdArg1"}},
 		},
 		{
 			description: "script command-line",
-			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, arguments: []string{"python main.py"}, labels: map[string]string{"io.buildpacks.build.metadata": md_json}},
+			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, arguments: []string{"python main.py"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"python main.py"}},
 		},
 		{
 			description: "no process and no args",
-			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, labels: map[string]string{"io.buildpacks.build.metadata": mdnd_json}},
+			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, labels: map[string]string{"io.buildpacks.build.metadata": mdndJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{},
 		},

--- a/pkg/skaffold/debug/transform.go
+++ b/pkg/skaffold/debug/transform.go
@@ -383,3 +383,21 @@ func setEnvVar(entries []v1.EnvVar, varName, value string) []v1.EnvVar {
 	}
 	return append(entries, entry)
 }
+
+// shJoin joins the arguments into a quoted form suitable to pass to `sh -c`.
+// Necessary as github.com/kballard/go-shellquote's `Join` quotes `$`.
+func shJoin(args []string) string {
+	result := ""
+	for i, arg := range args {
+		if i > 0 {
+			result = result + " "
+		}
+		if strings.ContainsAny(arg, " \t\v\"") {
+			arg := strings.ReplaceAll(arg, `"`, `\"`)
+			result = result + `"` + arg + `"`
+		} else {
+			result = result + arg
+		}
+	}
+	return result
+}

--- a/pkg/skaffold/debug/transform_go.go
+++ b/pkg/skaffold/debug/transform_go.go
@@ -70,7 +70,7 @@ func (t dlvTransformer) IsApplicable(config imageConfiguration) bool {
 	// nor to cause certain environment variables to be defined in the resulting image, look at the image's
 	// CNB metadata to see if any well-known Go-related buildpacks had been involved.
 	knownGoBuildpackIds := []string{
-		"google.go.runtime", "google.go.build", "google.go.gopath", "google.go.gomod", // GCP Buildpacks
+		"google.go.build", // GCP Buildpacks
 		"paketo-buildpacks/go-compiler", "paketo-buildpacks/go-mod", // Cloud Foundry
 		"heroku/go", // Heroku
 	}

--- a/pkg/skaffold/debug/transform_go.go
+++ b/pkg/skaffold/debug/transform_go.go
@@ -70,7 +70,7 @@ func (t dlvTransformer) IsApplicable(config imageConfiguration) bool {
 	// nor to cause certain environment variables to be defined in the resulting image, look at the image's
 	// CNB metadata to see if any well-known Go-related buildpacks had been involved.
 	knownGoBuildpackIds := []string{
-		"google.go.build", // GCP Buildpacks
+		"google.go.build",                                           // GCP Buildpacks
 		"paketo-buildpacks/go-compiler", "paketo-buildpacks/go-mod", // Cloud Foundry
 		"heroku/go", // Heroku
 	}

--- a/pkg/skaffold/debug/transform_jvm.go
+++ b/pkg/skaffold/debug/transform_jvm.go
@@ -43,7 +43,7 @@ func (t jdwpTransformer) IsApplicable(config imageConfiguration) bool {
 	if _, found := config.env["JAVA_VERSION"]; found {
 		return true
 	}
-	if len(config.entrypoint) > 0 {
+	if len(config.entrypoint) > 0 && !isEntrypointLauncher(config.entrypoint) {
 		return config.entrypoint[0] == "java" || strings.HasSuffix(config.entrypoint[0], "/java")
 	}
 	if len(config.arguments) > 0 {

--- a/pkg/skaffold/debug/transform_nodejs.go
+++ b/pkg/skaffold/debug/transform_nodejs.go
@@ -30,6 +30,9 @@ type nodeTransformer struct{}
 
 func init() {
 	containerTransforms = append(containerTransforms, nodeTransformer{})
+
+	// the `node` image's "docker-entrypoint.sh" launches the command
+	entrypointLaunchers = append(entrypointLaunchers, "docker-entrypoint.sh")
 }
 
 const (
@@ -59,7 +62,7 @@ func (t nodeTransformer) IsApplicable(config imageConfiguration) bool {
 	if _, found := config.env["NODE_VERSION"]; found {
 		return true
 	}
-	if len(config.entrypoint) > 0 {
+	if len(config.entrypoint) > 0 && !isEntrypointLauncher(config.entrypoint) {
 		return isLaunchingNode(config.entrypoint) || isLaunchingNpm(config.entrypoint)
 	} else if len(config.arguments) > 0 {
 		return isLaunchingNode(config.arguments) || isLaunchingNpm(config.arguments)

--- a/pkg/skaffold/debug/transform_nodejs.go
+++ b/pkg/skaffold/debug/transform_nodejs.go
@@ -87,10 +87,10 @@ func (t nodeTransformer) Apply(container *v1.Container, config imageConfiguratio
 		case len(config.entrypoint) > 0 && isLaunchingNpm(config.entrypoint):
 			container.Command = rewriteNpmCommandLine(config.entrypoint, *spec)
 
-		case len(config.entrypoint) == 0 && len(config.arguments) > 0 && isLaunchingNode(config.arguments):
+		case (len(config.entrypoint) == 0 || isEntrypointLauncher(config.entrypoint)) && len(config.arguments) > 0 && isLaunchingNode(config.arguments):
 			container.Args = rewriteNodeCommandLine(config.arguments, *spec)
 
-		case len(config.entrypoint) == 0 && len(config.arguments) > 0 && isLaunchingNpm(config.arguments):
+		case (len(config.entrypoint) == 0 || isEntrypointLauncher(config.entrypoint)) && len(config.arguments) > 0 && isLaunchingNpm(config.arguments):
 			container.Args = rewriteNpmCommandLine(config.arguments, *spec)
 
 		default:

--- a/pkg/skaffold/debug/transform_nodejs_test.go
+++ b/pkg/skaffold/debug/transform_nodejs_test.go
@@ -142,6 +142,11 @@ func TestNodeTransformer_IsApplicable(t *testing.T) {
 			result:      false,
 		},
 		{
+			description: "`node` docker-entrypoint.sh",
+			source:      imageConfiguration{entrypoint: []string{"docker-entrypoint.sh"}, arguments: []string{"npm", "run", "dev"}},
+			result:      true,
+		},
+		{
 			description: "nothing",
 			source:      imageConfiguration{},
 			result:      false,

--- a/pkg/skaffold/debug/transform_python.go
+++ b/pkg/skaffold/debug/transform_python.go
@@ -47,20 +47,19 @@ type ptvsdSpec struct {
 
 // isLaunchingPython determines if the arguments seems to be invoking python
 func isLaunchingPython(args []string) bool {
-	return args[0] == "python" || strings.HasSuffix(args[0], "/python") ||
-		args[0] == "python2" || strings.HasSuffix(args[0], "/python2") ||
-		args[0] == "python3" || strings.HasSuffix(args[0], "/python3")
+	return len(args) > 0 &&
+		(args[0] == "python" || strings.HasSuffix(args[0], "/python") ||
+			args[0] == "python2" || strings.HasSuffix(args[0], "/python2") ||
+			args[0] == "python3" || strings.HasSuffix(args[0], "/python3"))
 }
 
 func (t pythonTransformer) IsApplicable(config imageConfiguration) bool {
 	// We can only put Python in debug mode by modifying the python command line,
 	// so looking for Python-related environment variables is insufficient.
-	if len(config.entrypoint) > 0 {
+	if len(config.entrypoint) > 0 && !isEntrypointLauncher(config.entrypoint) {
 		return isLaunchingPython(config.entrypoint)
-	} else if len(config.arguments) > 0 {
-		return isLaunchingPython(config.arguments)
 	}
-	return false
+	return isLaunchingPython(config.arguments)
 }
 
 // Apply configures a container definition for Python with pydev/ptvsd

--- a/pkg/skaffold/debug/transform_test.go
+++ b/pkg/skaffold/debug/transform_test.go
@@ -206,3 +206,29 @@ func TestShJoin(t *testing.T) {
 		})
 	}
 }
+
+func TestIsEntrypointLauncher(t *testing.T) {
+	// make full copy of entrypointLaunchers
+	oldEntrypointLaunchers := append(entrypointLaunchers[:0:0], entrypointLaunchers...)
+	entrypointLaunchers = append(entrypointLaunchers, "foo")
+	t.Cleanup(func() {
+		entrypointLaunchers = oldEntrypointLaunchers
+	})
+
+	tests := []struct {
+		description string
+		entrypoint  []string
+		expected    bool
+	}{
+		{"nil", nil, false},
+		{"expected case", []string{"foo"}, true},
+		{"unexpected arg", []string{"foo", "bar"}, false},
+		{"unexpected entrypoint", []string{"bar"}, false},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			result := isEntrypointLauncher(test.entrypoint)
+			t.CheckDeepEqual(test.expected, result)
+		})
+	}
+}

--- a/pkg/skaffold/debug/transform_test.go
+++ b/pkg/skaffold/debug/transform_test.go
@@ -18,6 +18,7 @@ package debug
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -182,6 +183,26 @@ func TestSetEnvVar(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			result := setEnvVar(test.in, "name", "new-text")
 			t.CheckDeepEqual(test.expected, result)
+		})
+	}
+}
+
+func TestShJoin(t *testing.T) {
+	tests := []struct {
+		in     []string
+		result string
+	}{
+		{[]string{}, ""},
+		{[]string{"a"}, "a"},
+		{[]string{"a b"}, `"a b"`},
+		{[]string{`a"b`}, `"a\"b"`},
+		{[]string{`a"b`}, `"a\"b"`},
+		{[]string{"a", `a"b`, "b c"}, `a "a\"b" "b c"`},
+	}
+	for _, test := range tests {
+		testutil.Run(t, strings.Join(test.in, " "), func(t *testutil.T) {
+			result := shJoin(test.in)
+			t.CheckDeepEqual(test.result, result)
 		})
 	}
 }


### PR DESCRIPTION
**Description**

This PR adds support for Cloud Native Buildpacks for `skaffold debug`.  

At a high level, there are two fundamental changes:
  1. `pkg/skaffold/debug/transform*.go` adds support for configuring a set of _entrypoint launchers_: these are known `ENTRYPOINT`s that effectively launch the CMD value as the command-line, such that the `ENTRYPOINT` can be ignored.  The CNB launcher (`/cnb/lifecycle/launcher`) is such a launcher.  The `node` images also use a `docker-entrypoint.sh` script, which is also an entrypoint launcher. 
  2. `pkg/skaffold/debug/cnb.go` performs some resolution with the CNB image metadata to identify the command-line that will be executed, which is then passed through the normal transformations.

CNB images are normally configured with 1 or more _processes_: each process has a separate _type_ or name, and define a command and arguments.  Each process can also be marked as being _direct_, or whether it needs to be executed as an inline shell script.  If not specified, there is a default process type, `web`. CNB images specifically a launcher (`/cnb/lifecycle/launcher`) to identify and run the right command line.

**User facing changes (remove if N/A)**

`skaffold debug` has experimental support for debugging images produced by Cloud Native Buildpacks.

**Follow-up Work (remove if N/A)**

- Incorporate the node-wrapper from container-debug-support


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
