### PR TITLE
Prevent the cache from sending “Build in progress” events.

### DIFF
--- a/integration/cache_test.go
+++ b/integration/cache_test.go
@@ -31,13 +31,14 @@ func TestCacheAPITriggers(t *testing.T) {
 		t.Skip("skipping kind integration test")
 	}
 
-	// Run skaffold build first to cache artifacts.
+	// Run skaffold build first to fail quickly on a build failure
 	skaffold.Build().InDir("examples/getting-started").RunOrFail(t)
 
 	ns, _ := SetupNamespace(t)
-
 	rpcAddr := randomPort()
-	skaffold.Dev("--rpc-port", rpcAddr).InDir("examples/getting-started").InNs(ns.Name).RunBackground(t)
+
+	// Disable caching to ensure we get a "build in progress" event each time.
+	skaffold.Dev("--cache-artifacts=false", "--rpc-port", rpcAddr).InDir("examples/getting-started").InNs(ns.Name).RunBackground(t)
 
 	// Ensure we see a build triggered in the event log
 	_, entries := apiEvents(t, rpcAddr)

--- a/integration/rpc_test.go
+++ b/integration/rpc_test.go
@@ -337,7 +337,8 @@ func setupSkaffoldWithArgs(t *testing.T, args ...string) {
 	// start a skaffold dev loop on an example
 	ns, _ := SetupNamespace(t)
 
-	skaffold.Dev(args...).InDir("testdata/dev").InNs(ns.Name).RunBackground(t)
+	// Disable caching to ensure we get a "build in progress" event each time.
+	skaffold.Dev(append([]string{"--cache-artifacts=false"}, args...)...).InDir("testdata/dev").InNs(ns.Name).RunBackground(t)
 
 	t.Cleanup(func() {
 		Run(t, "testdata/dev", "rm", "foo")

--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -23,13 +23,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-)
-
-var (
-	// For testing
-	buildInProgress = event.BuildInProgress
 )
 
 func (c *cache) lookupArtifacts(ctx context.Context, tags tag.ImageTags, artifacts []*latest.Artifact) []cacheDetails {
@@ -41,7 +35,6 @@ func (c *cache) lookupArtifacts(ctx context.Context, tags tag.ImageTags, artifac
 
 		i := i
 		go func() {
-			buildInProgress(artifacts[i].ImageName)
 			details[i] = c.lookup(ctx, artifacts[i], tags[artifacts[i].ImageName])
 			wg.Done()
 		}()

--- a/pkg/skaffold/build/cache/lookup_test.go
+++ b/pkg/skaffold/build/cache/lookup_test.go
@@ -103,8 +103,6 @@ func TestLookupLocal(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&buildInProgress, func(string) {})
-
 			cache := &cache{
 				imagesAreLocal:  true,
 				artifactCache:   test.cache,
@@ -188,7 +186,6 @@ func TestLookupRemote(t *testing.T) {
 					return "", errors.New("unknown remote tag")
 				}
 			})
-			t.Override(&buildInProgress, func(string) {})
 
 			cache := &cache{
 				imagesAreLocal:  false,

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -28,13 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-)
-
-var (
-	// For testing
-	buildComplete = event.BuildComplete
 )
 
 func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, buildAndTest BuildAndTestFn) ([]build.Artifact, error) {
@@ -94,7 +88,6 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 		}
 
 		// Image is already built
-		buildComplete(artifact.ImageName)
 		entry := c.artifactCache[result.Hash()]
 		tag := tags[artifact.ImageName]
 

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -90,9 +90,6 @@ func (t stubAuth) GetAllAuthConfigs() (map[string]types.AuthConfig, error) { ret
 
 func TestCacheBuildLocal(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
-		t.Override(&buildComplete, func(string) {})
-		t.Override(&buildInProgress, func(string) {})
-
 		tmpDir := t.NewTempDir().
 			Write("dep1", "content1").
 			Write("dep2", "content2").
@@ -176,9 +173,6 @@ func TestCacheBuildLocal(t *testing.T) {
 
 func TestCacheBuildRemote(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
-		t.Override(&buildComplete, func(string) {})
-		t.Override(&buildInProgress, func(string) {})
-
 		tmpDir := t.NewTempDir().
 			Write("dep1", "content1").
 			Write("dep2", "content2").


### PR DESCRIPTION
Only the builder sends “Build in progress” events.
Fixes #3812

Signed-off-by: David Gageot <david@gageot.net>