### PR TITLE
Add a dry-run to `skaffold build`

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -48,12 +48,14 @@ func NewCmdBuild() *cobra.Command {
 		WithExample("Build artifacts whose image name contains <db>", "build -b <db>").
 		WithExample("Quietly build artifacts and output the image names as json", "build -q > build_result.json").
 		WithExample("Build the artifacts and then deploy them", "build -q | skaffold deploy --build-artifacts -").
+		WithExample("Print the final image names", "build -q --dry-run").
 		WithCommonFlags().
 		WithFlags(func(f *pflag.FlagSet) {
 			f.StringSliceVarP(&opts.TargetImages, "build-image", "b", nil, "Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts")
 			f.BoolVarP(&quietFlag, "quiet", "q", false, "Suppress the build output and print image built on success. See --output to format output.")
 			f.VarP(buildFormatFlag, "output", "o", "Used in conjunction with --quiet flag. "+buildFormatFlag.Usage())
 			f.StringVar(&buildOutputFlag, "file-output", "", "Filename to write build images to")
+			f.BoolVar(&opts.DryRun, "dry-run", false, "Don't build images, just compute the tag for each artifact.")
 		}).
 		NoArgs(doBuild)
 }

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -122,12 +122,16 @@ Examples:
   # Build the artifacts and then deploy them
   skaffold build -q | skaffold deploy --build-artifacts -
 
+  # Print the final image names
+  skaffold build -q --dry-run
+
 Options:
   -b, --build-image=[]: Choose which artifacts to build. Artifacts with image names that contain the expression will be built only. Default is to build sources for all artifacts
       --cache-artifacts=true: Set to false to disable default caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
+      --dry-run=false: Don't build images, just compute the tag for each artifact.
       --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
       --file-output='': Filename to write build images to
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
@@ -159,6 +163,7 @@ Env vars:
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
 * `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
+* `SKAFFOLD_DRY_RUN` (same as `--dry-run`)
 * `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILE_OUTPUT` (same as `--file-output`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -50,6 +50,7 @@ type SkaffoldOptions struct {
 	AutoDeploy            bool
 	RenderOnly            bool
 	ProfileAutoActivation bool
+	DryRun                bool
 	PortForward           PortForwardOptions
 	CustomTag             string
 	Namespace             string
@@ -66,6 +67,7 @@ type SkaffoldOptions struct {
 	Command               string
 	RPCPort               int
 	RPCHTTPPort           int
+
 	// TODO(https://github.com/GoogleContainerTools/skaffold/issues/3668):
 	// remove minikubeProfile from here and instead detect it by matching the
 	// kubecontext API Server to minikube profiles

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -39,6 +39,20 @@ func (r *SkaffoldRunner) BuildAndTest(ctx context.Context, out io.Writer, artifa
 		return nil, err
 	}
 
+	// In dry-run mode, we don't build anything, just return the tag for each artifact.
+	if r.runCtx.Opts.DryRun {
+		var bRes []build.Artifact
+
+		for _, artifact := range artifacts {
+			bRes = append(bRes, build.Artifact{
+				ImageName: artifact.ImageName,
+				Tag:       tags[artifact.ImageName],
+			})
+		}
+
+		return bRes, nil
+	}
+
 	bRes, err := r.cache.Build(ctx, out, tags, artifacts, func(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 		if len(artifacts) == 0 {
 			return nil, nil


### PR DESCRIPTION
Example output on the micro-services sample:

```
$ skaffold build -q --dry-run -d gcr.io/prefix
{"builds":[{"imageName":"leeroy-web","tag":"gcr.io/prefix/leeroy-web:v1.8.0-67-g337af4362"},{"imageName":"leeroy-app","tag":"gcr.io/prefix/leeroy-app:v1.8.0-67-g337af4362"}]}
```

Fixes #3546

Signed-off-by: David Gageot <david@gageot.net>
