### PR TITLE
Print the effective skaffold.yaml configuration

### DIFF
--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -580,11 +580,19 @@ Run a diagnostic on Skaffold
 ```
 
 
+Examples:
+  # Search for configuration issues and print the effective configuration
+  skaffold diagnose
+
+  # Print the effective skaffold.yaml configuration for given profile
+  skaffold diagnose --yaml-only --profile PROFILE
+
 Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
+      --yaml-only=false: Only prints the effective skaffold.yaml configuration
 
 Usage:
   skaffold diagnose [options]
@@ -599,6 +607,7 @@ Env vars:
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
+* `SKAFFOLD_YAML_ONLY` (same as `--yaml-only`)
 
 ### skaffold fix
 


### PR DESCRIPTION
Example on `examples/nodejs`:

```
$ skaffold diagnose --only-config -p dev
apiVersion: skaffold/v2beta3
kind: Config
build:
  artifacts:
  - image: node-example
    context: backend
    sync:
      manual:
      - src: src/**/*.js
        dest: .
    docker:
      dockerfile: Dockerfile
      buildArgs:
        ENV: development
  tagPolicy:
    gitCommit: {}
  local:
    concurrency: 1
deploy:
  kubectl:
    manifests:
    - k8s/*.yaml
```

Signed-off-by: David Gageot <david@gageot.net>
