### PR TITLE
Add link-able anchors to skaffold.yaml docs

### DIFF
--- a/docs/content/en/docs/references/yaml/main.css
+++ b/docs/content/en/docs/references/yaml/main.css
@@ -74,3 +74,16 @@ em {
     border-radius: 3px;
     padding: 0 .2em;
 }
+
+a.anchor{
+    position: relative;
+    display: inline;
+    visibility: hidden;
+    top: -70px;
+}
+
+@media (max-width: 768px) {
+    a.anchor {
+        top: -10px;
+    }
+}


### PR DESCRIPTION
Example of anchor to the yaml documentation: http://34.94.104.146:1313/docs/references/yaml/#build-artifacts-sync

Signed-off-by: David Gageot <david@gageot.net>
