### PR TITLE
disable status check in TestEventLog

### DIFF
--- a/integration/rpc_test.go
+++ b/integration/rpc_test.go
@@ -151,7 +151,7 @@ func TestEventLogHTTP(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			httpAddr := randomPort()
-			setupSkaffoldWithArgs(t, "--rpc-http-port", httpAddr)
+			setupSkaffoldWithArgs(t, "--rpc-http-port", httpAddr, "--status-check=false")
 			time.Sleep(500 * time.Millisecond) // give skaffold time to process all events
 
 			httpResponse, err := http.Get(fmt.Sprintf("http://localhost:%s%s", httpAddr, test.endpoint))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
Related to #4044 
In #4050 we only disabled `TestEventsRPC`, we need to do the same for `TestEventLog`