### PR TITLE
implement optional private duct-tape image repo

### DIFF
--- a/docs/content/en/schemas/v2beta3.json
+++ b/docs/content/en/schemas/v2beta3.json
@@ -747,6 +747,21 @@
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
+    "DebugConfig": {
+      "properties": {
+        "ductTapeRepo": {
+          "type": "string",
+          "description": "overrides the image repository for the debugging duct-tape init images. Defaults to gcr.io/gcp-dev-tools/duct-tape .",
+          "x-intellij-html-description": "overrides the image repository for the debugging duct-tape init images. Defaults to gcr.io/gcp-dev-tools/duct-tape ."
+        }
+      },
+      "preferredOrder": [
+        "ductTapeRepo"
+      ],
+      "additionalProperties": false,
+      "description": "contains global configuration for `skaffold debug`.",
+      "x-intellij-html-description": "contains global configuration for <code>skaffold debug</code>."
+    },
     "DeployConfig": {
       "properties": {
         "helm": {
@@ -1747,6 +1762,11 @@
           "description": "describes how images are built.",
           "x-intellij-html-description": "describes how images are built."
         },
+        "debug": {
+          "$ref": "#/definitions/DebugConfig",
+          "description": "describes how images are deployed.",
+          "x-intellij-html-description": "describes how images are deployed."
+        },
         "deploy": {
           "$ref": "#/definitions/DeployConfig",
           "description": "describes how images are deployed.",
@@ -1791,6 +1811,7 @@
         "test",
         "deploy",
         "portForward",
+        "debug",
         "patches",
         "activation"
       ],
@@ -1889,6 +1910,11 @@
           "description": "describes how images are built.",
           "x-intellij-html-description": "describes how images are built."
         },
+        "debug": {
+          "$ref": "#/definitions/DebugConfig",
+          "description": "describes how images are deployed.",
+          "x-intellij-html-description": "describes how images are deployed."
+        },
         "deploy": {
           "$ref": "#/definitions/DeployConfig",
           "description": "describes how images are deployed.",
@@ -1938,6 +1964,7 @@
         "test",
         "deploy",
         "portForward",
+        "debug",
         "profiles"
       ],
       "additionalProperties": false,

--- a/pkg/skaffold/debug/debug_test.go
+++ b/pkg/skaffold/debug/debug_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -509,7 +510,7 @@ spec:
 				return imageConfiguration{}, nil
 			}
 
-			result, err := applyDebuggingTransforms(kubectl.ManifestList{[]byte(test.in)}, retriever)
+			result, err := applyDebuggingTransforms(kubectl.ManifestList{[]byte(test.in)}, retriever, latest.DebugConfig{DuctTapeRepo: "gcr.io/gcp-dev-tools/duct-tape"})
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.out, result.String())
 		})
@@ -529,7 +530,7 @@ func TestWorkingDir(t *testing.T) {
 		return imageConfiguration{workingDir: "/a/dir"}, nil
 	}
 
-	result := transformManifest(pod, retriever)
+	result := transformManifest(pod, retriever, latest.DebugConfig{DuctTapeRepo: "gcr.io/gcp-dev-tools/duct-tape"})
 	testutil.CheckDeepEqual(t, true, result)
 	debugConfig := pod.ObjectMeta.Annotations["debug.cloud.google.com/config"]
 	testutil.CheckDeepEqual(t, true, strings.Contains(debugConfig, `"workingDir":"/a/dir"`))
@@ -548,7 +549,7 @@ func TestArtifactImage(t *testing.T) {
 		return imageConfiguration{artifact: "gcr.io/random/image"}, nil
 	}
 
-	result := transformManifest(pod, retriever)
+	result := transformManifest(pod, retriever, latest.DebugConfig{DuctTapeRepo: "gcr.io/gcp-dev-tools/duct-tape"})
 	testutil.CheckDeepEqual(t, true, result)
 	debugConfig := pod.ObjectMeta.Annotations["debug.cloud.google.com/config"]
 	testutil.CheckDeepEqual(t, true, strings.Contains(debugConfig, `"artifact":"gcr.io/random/image"`))

--- a/pkg/skaffold/debug/transform_go_test.go
+++ b/pkg/skaffold/debug/transform_go_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -584,7 +585,7 @@ func TestTransformManifestDelve(t *testing.T) {
 			retriever := func(image string) (imageConfiguration, error) {
 				return imageConfiguration{}, nil
 			}
-			result := transformManifest(value, retriever)
+			result := transformManifest(value, retriever, latest.DebugConfig{DuctTapeRepo: "gcr.io/gcp-dev-tools/duct-tape"})
 
 			t.CheckDeepEqual(test.transformed, result)
 			t.CheckDeepEqual(test.out, value)

--- a/pkg/skaffold/debug/transform_jvm_test.go
+++ b/pkg/skaffold/debug/transform_jvm_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -497,7 +498,7 @@ func TestTransformManifestJVM(t *testing.T) {
 			retriever := func(image string) (imageConfiguration, error) {
 				return imageConfiguration{}, nil
 			}
-			result := transformManifest(value, retriever)
+			result := transformManifest(value, retriever, latest.DebugConfig{DuctTapeRepo: "gcr.io/gcp-dev-tools/duct-tape"})
 
 			t.CheckDeepEqual(test.transformed, result)
 			t.CheckDeepEqual(test.out, value)

--- a/pkg/skaffold/debug/transform_nodejs_test.go
+++ b/pkg/skaffold/debug/transform_nodejs_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -574,7 +575,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 			retriever := func(image string) (imageConfiguration, error) {
 				return imageConfiguration{}, nil
 			}
-			result := transformManifest(value, retriever)
+			result := transformManifest(value, retriever, latest.DebugConfig{DuctTapeRepo: "gcr.io/gcp-dev-tools/duct-tape"})
 
 			t.CheckDeepEqual(test.transformed, result)
 			t.CheckDeepEqual(test.out, value)

--- a/pkg/skaffold/debug/transform_python_test.go
+++ b/pkg/skaffold/debug/transform_python_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -582,7 +583,7 @@ func TestTransformManifestPython(t *testing.T) {
 			retriever := func(image string) (imageConfiguration, error) {
 				return imageConfiguration{}, nil
 			}
-			result := transformManifest(value, retriever)
+			result := transformManifest(value, retriever, latest.DebugConfig{DuctTapeRepo: "gcr.io/gcp-dev-tools/duct-tape"})
 
 			t.CheckDeepEqual(test.transformed, result)
 			t.CheckDeepEqual(test.out, value)

--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -46,6 +46,7 @@ type KubectlDeployer struct {
 	workingDir         string
 	kubectl            deploy.CLI
 	insecureRegistries map[string]bool
+	debugConfig        latest.DebugConfig
 }
 
 // NewKubectlDeployer returns a new KubectlDeployer for a DeployConfig filled
@@ -60,6 +61,7 @@ func NewKubectlDeployer(runCtx *runcontext.RunContext) *KubectlDeployer {
 			ForceDeploy: runCtx.Opts.Force,
 		},
 		insecureRegistries: runCtx.InsecureRegistries,
+		debugConfig:        runCtx.Cfg.Debug,
 	}
 }
 
@@ -257,7 +259,7 @@ func (k *KubectlDeployer) renderManifests(ctx context.Context, out io.Writer, bu
 	}
 
 	for _, transform := range manifestTransforms {
-		manifests, err = transform(manifests, builds, k.insecureRegistries)
+		manifests, err = transform(manifests, builds, k.insecureRegistries, k.debugConfig)
 		if err != nil {
 			return nil, fmt.Errorf("unable to transform manifests: %w", err)
 		}

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -84,6 +84,7 @@ type KustomizeDeployer struct {
 
 	kubectl            deploy.CLI
 	insecureRegistries map[string]bool
+	debugConfig        latest.DebugConfig
 	BuildArgs          []string
 }
 
@@ -96,6 +97,7 @@ func NewKustomizeDeployer(runCtx *runcontext.RunContext) *KustomizeDeployer {
 			ForceDeploy: runCtx.Opts.Force,
 		},
 		insecureRegistries: runCtx.InsecureRegistries,
+		debugConfig:        runCtx.Cfg.Debug,
 		BuildArgs:          runCtx.Cfg.Deploy.KustomizeDeploy.BuildArgs,
 	}
 }
@@ -162,7 +164,7 @@ func (k *KustomizeDeployer) renderManifests(ctx context.Context, out io.Writer, 
 	}
 
 	for _, transform := range manifestTransforms {
-		manifests, err = transform(manifests, builds, k.insecureRegistries)
+		manifests, err = transform(manifests, builds, k.insecureRegistries, k.debugConfig)
 		if err != nil {
 			return nil, fmt.Errorf("unable to transform manifests: %w", err)
 		}

--- a/pkg/skaffold/deploy/transformations.go
+++ b/pkg/skaffold/deploy/transformations.go
@@ -19,9 +19,10 @@ package deploy
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
-type ManifestTransform func(l kubectl.ManifestList, builds []build.Artifact, insecureRegistries map[string]bool) (kubectl.ManifestList, error)
+type ManifestTransform func(l kubectl.ManifestList, builds []build.Artifact, insecureRegistries map[string]bool, debugConfig latest.DebugConfig) (kubectl.ManifestList, error)
 
 // Transforms are applied to manifests
 var manifestTransforms []ManifestTransform

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -34,6 +34,7 @@ const (
 	defaultCloudBuildGradleImage = "gcr.io/cloud-builders/gradle"
 	defaultCloudBuildKanikoImage = "gcr.io/kaniko-project/executor"
 	defaultCloudBuildPackImage   = "gcr.io/k8s-skaffold/pack"
+	defaultDuctTapeRepo          = "gcr.io/gcp-dev-tools/duct-tape"
 )
 
 // Set makes sure default values are set on a SkaffoldConfig.
@@ -43,6 +44,7 @@ func Set(c *latest.SkaffoldConfig) error {
 	setDefaultTagger(c)
 	setDefaultKustomizePath(c)
 	setDefaultKubectlManifests(c)
+	setDefaultDebugConfig(c)
 
 	for _, a := range c.Build.Artifacts {
 		setDefaultWorkspace(a)
@@ -157,6 +159,10 @@ func setDefaultCloudBuildKanikoImage(gcb *latest.GoogleCloudBuild) {
 
 func setDefaultCloudBuildPackImage(gcb *latest.GoogleCloudBuild) {
 	gcb.PackImage = valueOrDefault(gcb.PackImage, defaultCloudBuildPackImage)
+}
+
+func setDefaultDebugConfig(c *latest.SkaffoldConfig) {
+	c.Debug.DuctTapeRepo = valueOrDefault(c.Debug.DuctTapeRepo, defaultDuctTapeRepo)
 }
 
 func setDefaultTagger(c *latest.SkaffoldConfig) {

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -93,6 +93,8 @@ func TestSetDefaults(t *testing.T) {
 
 	testutil.CheckDeepEqual(t, "fifth", cfg.Build.Artifacts[4].ImageName)
 	testutil.CheckDeepEqual(t, &latest.Auto{}, cfg.Build.Artifacts[4].Sync.Auto)
+
+	testutil.CheckDeepEqual(t, latest.DebugConfig{DuctTapeRepo: "gcr.io/gcp-dev-tools/duct-tape"}, cfg.Debug)
 }
 
 func TestSetDefaultsOnCluster(t *testing.T) {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -67,6 +67,9 @@ type Pipeline struct {
 
 	// PortForward describes user defined resources to port-forward.
 	PortForward []*PortForwardResource `yaml:"portForward,omitempty"`
+
+	// Debug describes how images are deployed.
+	Debug DebugConfig `yaml:"debug,omitempty"`
 }
 
 func (c *SkaffoldConfig) GetVersion() string {
@@ -96,6 +99,13 @@ type PortForwardResource struct {
 
 	// LocalPort is the local port to forward to. If the port is unavailable, Skaffold will choose a random open port to forward to. *Optional*.
 	LocalPort int `yaml:"localPort,omitempty"`
+}
+
+// DebugConfig contains global configuration for `skaffold debug`.
+type DebugConfig struct {
+	// DuctTapeRepo overrides the image repository for the debugging duct-tape init images.
+	// Defaults to gcr.io/gcp-dev-tools/duct-tape .
+	DuctTapeRepo string `yaml:"ductTapeRepo,omitempty"`
 }
 
 // BuildConfig contains all the configuration for the build steps.


### PR DESCRIPTION
Allow specifying an override for the duct-tape image repository used  in `skaffold debug`
This is required to use the debug feature in environments without public internet access (like ours)
