### PR TITLE
Don’t globally set log level in tests

### DIFF
--- a/hack/versions/pkg/diff/godiff_test.go
+++ b/hack/versions/pkg/diff/godiff_test.go
@@ -23,13 +23,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestCmpGoStructs(t *testing.T) {
-	logrus.SetLevel(logrus.DebugLevel)
 	tests := []struct {
 		description string
 		a           string
@@ -274,7 +271,7 @@ func TestCompareSchemas(t *testing.T) {
 			b:           "v1beta13",
 		},
 	}
-	logrus.SetLevel(logrus.DebugLevel)
+
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			wd, err := os.Getwd()

--- a/pkg/skaffold/kubernetes/context/context_test.go
+++ b/pkg/skaffold/kubernetes/context/context_test.go
@@ -183,7 +183,6 @@ func TestGetRestClientConfig(t *testing.T) {
 	})
 
 	testutil.Run(t, "REST client in-cluster", func(t *testutil.T) {
-		logrus.SetLevel(logrus.DebugLevel)
 		t.SetEnvs(map[string]string{"KUBECONFIG": "non-valid"})
 		resetConfig()
 


### PR DESCRIPTION
Signed-off-by: David Gageot <david@gageot.net>
