### PR TITLE
allow specifying regex in global config kubecontext

### DIFF
--- a/cmd/skaffold/app/cmd/config/set.go
+++ b/cmd/skaffold/app/cmd/config/set.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 const (
@@ -147,7 +148,7 @@ func writeConfig(cfg *config.ContextConfig) error {
 	} else {
 		found := false
 		for i, contextCfg := range fullConfig.ContextConfigs {
-			if contextCfg.Kubecontext == kubecontext {
+			if util.RegexEqual(contextCfg.Kubecontext, kubecontext) {
 				fullConfig.ContextConfigs[i] = cfg
 				found = true
 			}

--- a/cmd/skaffold/app/cmd/config/util.go
+++ b/cmd/skaffold/app/cmd/config/util.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 func resolveKubectlContext() {
@@ -74,7 +75,7 @@ func getConfigForKubectx() (*config.ContextConfig, error) {
 		return cfg.Global, nil
 	}
 	for _, contextCfg := range cfg.ContextConfigs {
-		if contextCfg.Kubecontext == kubecontext {
+		if util.RegexEqual(contextCfg.Kubecontext, kubecontext) {
 			return contextCfg, nil
 		}
 	}

--- a/docs/content/en/docs/design/global-config.md
+++ b/docs/content/en/docs/design/global-config.md
@@ -6,7 +6,7 @@ featureId: global_config
 
 ---
 
-Some context specific settings can be configured in a global configuration file, which defaults to `~/.skaffold/config`. Options can be configured globally or for specific Kubernetes contexts.
+Some context specific settings can be configured in a global configuration file, which defaults to `~/.skaffold/config`. Options can be configured globally or for specific Kubernetes contexts. Context name matching supports regex, e.g.: `.*-cluster.*-regex.*-test.*`
 
 The options are:
 

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -132,7 +132,7 @@ func getConfigForKubeContextWithGlobalDefaults(cfg *GlobalConfig, kubeContext st
 
 	var mergedConfig ContextConfig
 	for _, contextCfg := range cfg.ContextConfigs {
-		if contextCfg.Kubecontext == kubeContext {
+		if util.RegexEqual(contextCfg.Kubecontext, kubeContext) {
 			logrus.Debugf("found config for context %q", kubeContext)
 			mergedConfig = *contextCfg
 		}

--- a/pkg/skaffold/util/regex.go
+++ b/pkg/skaffold/util/regex.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	re "regexp"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// RegexEqual matches the string 'actual' against a regex compiled from 'expected'
+// If 'expected' is not a valid regex, string comparison is used as fallback
+func RegexEqual(expected, actual string) bool {
+	if strings.HasPrefix(expected, "!") {
+		notExpected := expected[1:]
+
+		return !regexMatch(notExpected, actual)
+	}
+
+	return regexMatch(expected, actual)
+}
+
+func regexMatch(expected, actual string) bool {
+	if actual == expected {
+		return true
+	}
+
+	matcher, err := re.Compile(expected)
+	if err != nil {
+		logrus.Infof("context activation criteria '%s' is not a valid regexp, falling back to string", expected)
+		return false
+	}
+
+	return matcher.MatchString(actual)
+}

--- a/pkg/skaffold/util/regex_test.go
+++ b/pkg/skaffold/util/regex_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestKubectxEqual(t *testing.T) {
+	ctxRe := ".*-i.*-am.*-test.*"
+	ctxRePos := "wohoo-i-am-test-or"
+	ctxReNeg := "test-am-i"
+	testutil.CheckDeepEqual(t, true, RegexEqual(ctxRe, ctxRePos))
+	testutil.CheckDeepEqual(t, false, RegexEqual(ctxRe, ctxReNeg))
+
+	ctxStr := "^s^"
+	ctxStrPos := "^s^"
+	ctxStrNeg := "test-am-i"
+	testutil.CheckDeepEqual(t, true, RegexEqual(ctxStr, ctxStrPos))
+	testutil.CheckDeepEqual(t, false, RegexEqual(ctxStr, ctxStrNeg))
+}


### PR DESCRIPTION
Replicate the kubecontext matching behaviour from profiles to global config