### PR TITLE
fix status check event error reporting

### DIFF
--- a/pkg/skaffold/deploy/status_check.go
+++ b/pkg/skaffold/deploy/status_check.go
@@ -73,7 +73,6 @@ func StatusCheck(ctx context.Context, defaultLabeller *DefaultLabeller, runCtx *
 }
 
 func statusCheck(ctx context.Context, defaultLabeller *DefaultLabeller, runCtx *runcontext.RunContext, out io.Writer) error {
-
 	client, err := pkgkubernetes.Client()
 	if err != nil {
 		return fmt.Errorf("getting Kubernetes client: %w", err)

--- a/pkg/skaffold/deploy/status_check.go
+++ b/pkg/skaffold/deploy/status_check.go
@@ -106,8 +106,7 @@ func statusCheck(ctx context.Context, defaultLabeller *DefaultLabeller, runCtx *
 
 	// Wait for all deployment status to be fetched
 	wg.Wait()
-	err = getSkaffoldDeployStatus(rc.deployments)
-	return err
+	return getSkaffoldDeployStatus(rc.deployments)
 }
 
 func getDeployments(client kubernetes.Interface, ns string, l *DefaultLabeller, deadlineDuration time.Duration) ([]Resource, error) {

--- a/pkg/skaffold/deploy/status_check.go
+++ b/pkg/skaffold/deploy/status_check.go
@@ -62,17 +62,14 @@ type counter struct {
 	failed  int32
 }
 
-type StatusCheck struct {
-	err error
-}
-
-func Execute(ctx context.Context, defaultLabeller *DefaultLabeller, runCtx *runcontext.RunContext, out io.Writer) {
+func StatusCheck(ctx context.Context, defaultLabeller *DefaultLabeller, runCtx *runcontext.RunContext, out io.Writer) error {
 	event.StatusCheckEventStarted()
 	if err := statusCheck(ctx, defaultLabeller, runCtx, out); err != nil {
 		event.StatusCheckEventFailed(err)
-		return
+		return err
 	}
 	event.StatusCheckEventSucceeded()
+	return nil
 }
 
 func statusCheck(ctx context.Context, defaultLabeller *DefaultLabeller, runCtx *runcontext.RunContext, out io.Writer) error {

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -81,7 +81,7 @@ type SkaffoldRunner struct {
 
 // for testing
 var (
-	statusCheck = deploy.statusCheck
+	statusCheck = deploy.StatusCheck
 )
 
 // HasDeployed returns true if this runner has deployed something.

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -81,7 +81,7 @@ type SkaffoldRunner struct {
 
 // for testing
 var (
-	statusCheck = deploy.StatusCheck
+	statusCheck = deploy.statusCheck
 )
 
 // HasDeployed returns true if this runner has deployed something.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4100 

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Add a defer func to always add a event, failed or successful for `StatusCheck`

**User facing changes (remove if N/A)**
no. Event API Changes.

1. In case an intermediate error happened, ( in this case force via code change) you see a corresponding error event.
```
tejaldesai@tejaldesai-macbookpro2 microservices (pod_hookup)curl localhost:50052/v1/events
{"result":{"timestamp":"2020-05-04T23:24:08.171420Z","event":{"metaEvent":{"entry":"Starting Skaffold: \u0026{Version:v1.8.0-127-g7b7380859-dirty ConfigVersion:skaffold/v2beta3 GitVersion: GitCommit:7b73808593e6c262cfabfc24d279d425682cf920 GitTreeState:dirty BuildDate:2020-05-04T16:23:51Z GoVersion:go1.14.1 Compiler:gc Platform:darwin/amd64}","metadata":{"build":{"numberOfArtifacts":2,"builders":[{"type":"DOCKER","count":2}],"type":"LOCAL"},"deploy":{"deployers":[{"type":"KUBECTL","count":1}],"cluster":"GKE"}}}}}}
{"result":{"timestamp":"2020-05-04T23:24:09.536583Z","event":{"deployEvent":{"status":"In Progress"}},"entry":"Deploy started"}}
{"result":{"timestamp":"2020-05-04T23:24:10.518799Z","event":{"deployEvent":{"status":"Complete"}},"entry":"Deploy complete"}}
...

{"result":{"timestamp":"2020-05-04T23:31:02.383694Z","event":{"statusCheckEvent":{"status":"Started"}},"entry":"Status check started"}}
{"result":{"timestamp":"2020-05-04T23:31:02.384302Z","event":{"statusCheckEvent":{"status":"Failed","err":"force"}},"entry":"Status check failed"}}
curl: (18) transfer closed with outstanding read data remaining

tejaldesai@tejaldesai-macbookpro2 microservices (pod_hookup)
```

2. For success scenarios, the behavior is same as before
```
.....
{"result":{"timestamp":"2020-05-04T23:32:32.522157Z","event":{"statusCheckEvent":{"status":"Started"}},"entry":"Status check started"}}
{"result":{"timestamp":"2020-05-04T23:32:33.139690Z","event":{"resourceStatusCheckEvent":{"resource":"deployment/leeroy-app","status":"In Progress","message":"deployment/leeroy-app: "}},"entry":"Resource deployment/leeroy-app status updated to In Progress"}}
...

{"result":{"timestamp":"2020-05-04T23:32:34.550763Z","event":{"statusCheckEvent":
{"status":"Succeeded"}},"entry":"Status check succeeded"}}
```
**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
