### PR TITLE
Verify `debug` integration tests using readiness and liveness probes

### DIFF
--- a/integration/testdata/debug/go/k8s/pod.yaml
+++ b/integration/testdata/debug/go/k8s/pod.yaml
@@ -8,3 +8,16 @@ spec:
     image: skaffold-debug-go
     ports:
     - containerPort: 8080
+    # connect to the dlv APIv2 port
+    startupProbe:
+      tcpSocket:
+        port: 56268
+      initialDelaySeconds: 2
+      periodSeconds: 10
+    # connect to the app port
+    livenessProbe:
+      httpGet:
+        path: /
+        port: 8080
+      failureThreshold: 30
+      periodSeconds: 10

--- a/integration/testdata/debug/go/k8s/pod.yaml
+++ b/integration/testdata/debug/go/k8s/pod.yaml
@@ -9,7 +9,7 @@ spec:
     ports:
     - containerPort: 8080
     # connect to the dlv APIv2 port
-    startupProbe:
+    readinessProbe:
       tcpSocket:
         port: 56268
       initialDelaySeconds: 2

--- a/integration/testdata/debug/jib/k8s/web.yaml
+++ b/integration/testdata/debug/jib/k8s/web.yaml
@@ -15,4 +15,17 @@ spec:
       - name: web
         image: skaffold-debug-jib
         ports:
-          - containerPort: 8080
+        - containerPort: 8080
+            # connect to the JDWP port
+        startupProbe:
+          tcpSocket:
+            port: 5005
+          initialDelaySeconds: 2
+          periodSeconds: 10
+        # connect to the app port
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          failureThreshold: 30
+          periodSeconds: 10

--- a/integration/testdata/debug/jib/k8s/web.yaml
+++ b/integration/testdata/debug/jib/k8s/web.yaml
@@ -18,7 +18,7 @@ spec:
         - containerPort: 8080
         # connect to the JDWP port: this causes an handshake failure message
         # to be reported by the JVM which is ok
-        startupProbe:
+        readinessProbe:
           tcpSocket:
             port: 5005
           initialDelaySeconds: 2

--- a/integration/testdata/debug/jib/k8s/web.yaml
+++ b/integration/testdata/debug/jib/k8s/web.yaml
@@ -16,7 +16,8 @@ spec:
         image: skaffold-debug-jib
         ports:
         - containerPort: 8080
-            # connect to the JDWP port
+        # connect to the JDWP port: this causes an handshake failure message
+        # to be reported by the JVM which is ok
         startupProbe:
           tcpSocket:
             port: 5005

--- a/integration/testdata/debug/nodejs/k8s/pod.yaml
+++ b/integration/testdata/debug/nodejs/k8s/pod.yaml
@@ -9,7 +9,7 @@ spec:
     ports:
     - containerPort: 3000
     # connect to the devtools debugger endpoint
-    startupProbe:
+    readinessProbe:
       httpGet:
         path: /json
         port: 9229

--- a/integration/testdata/debug/nodejs/k8s/pod.yaml
+++ b/integration/testdata/debug/nodejs/k8s/pod.yaml
@@ -8,3 +8,17 @@ spec:
     image: skaffold-debug-nodejs
     ports:
     - containerPort: 3000
+    # connect to the devtools debugger endpoint
+    startupProbe:
+      httpGet:
+        path: /json
+        port: 9229
+      initialDelaySeconds: 2
+      periodSeconds: 10
+    # connect to the app port
+    livenessProbe:
+      httpGet:
+        path: /
+        port: 3000
+      failureThreshold: 30
+      periodSeconds: 10

--- a/integration/testdata/debug/npm/k8s/pod.yaml
+++ b/integration/testdata/debug/npm/k8s/pod.yaml
@@ -9,7 +9,7 @@ spec:
     ports:
     - containerPort: 3000
     # connect to the devtools debugger endpoint
-    startupProbe:
+    readinessProbe:
       httpGet:
         path: /json
         port: 9229

--- a/integration/testdata/debug/npm/k8s/pod.yaml
+++ b/integration/testdata/debug/npm/k8s/pod.yaml
@@ -8,3 +8,17 @@ spec:
     image: skaffold-debug-npm
     ports:
     - containerPort: 3000
+    # connect to the devtools debugger endpoint
+    startupProbe:
+      httpGet:
+        path: /json
+        port: 9229
+      initialDelaySeconds: 2
+      periodSeconds: 10
+    # connect to the app port
+    livenessProbe:
+      httpGet:
+        path: /
+        port: 3000
+      failureThreshold: 30
+      periodSeconds: 10

--- a/integration/testdata/debug/python3/k8s/pod.yaml
+++ b/integration/testdata/debug/python3/k8s/pod.yaml
@@ -9,7 +9,7 @@ spec:
     ports:
     - containerPort: 5000
     # connect to the debug-adapter port
-    startupProbe:
+    readinessProbe:
       tcpSocket:
         port: 5678
       initialDelaySeconds: 2

--- a/integration/testdata/debug/python3/k8s/pod.yaml
+++ b/integration/testdata/debug/python3/k8s/pod.yaml
@@ -8,3 +8,16 @@ spec:
     image: skaffold-debug-python3
     ports:
     - containerPort: 5000
+    # connect to the debug-adapter port
+    startupProbe:
+      tcpSocket:
+        port: 5678
+      initialDelaySeconds: 2
+      periodSeconds: 10
+    # connect to the app port
+    livenessProbe:
+      httpGet:
+        path: /
+        port: 5000
+      failureThreshold: 30
+      periodSeconds: 10


### PR DESCRIPTION
Motivated in part by the following comment https://github.com/GoogleContainerTools/skaffold/pull/4086#issuecomment-623797576, this PR updates the `integration/testdata/debug` projects to define startup and liveness probes to verify that the underlying runtime debugger endpoints and application endpoints are established.  These probes use Kubernetes to probe the pod to ensure the debugger runtime is setup and that the application is running and serving.

The `tcpSocket` startup probe for the Jib test causes the JVM to emit a _handshake failed_ message which is expected and harmless.

