### PR TITLE
Watch files for changes in the correct directory

### DIFF
--- a/pkg/skaffold/trigger/triggers.go
+++ b/pkg/skaffold/trigger/triggers.go
@@ -163,6 +163,7 @@ func (t *fsNotifyTrigger) LogWatchToUser(out io.Writer) {
 func (t *fsNotifyTrigger) Start(ctx context.Context) (<-chan bool, error) {
 	c := make(chan notify.EventInfo, 100)
 
+	// Workaround https://github.com/rjeczalik/notify/issues/96
 	wd, err := RealWorkDir()
 	if err != nil {
 		return nil, err

--- a/pkg/skaffold/trigger/triggers.go
+++ b/pkg/skaffold/trigger/triggers.go
@@ -163,14 +163,23 @@ func (t *fsNotifyTrigger) LogWatchToUser(out io.Writer) {
 func (t *fsNotifyTrigger) Start(ctx context.Context) (<-chan bool, error) {
 	c := make(chan notify.EventInfo, 100)
 
+	wd, err := RealWorkDir()
+	if err != nil {
+		return nil, err
+	}
+
 	// Watch current directory recursively
-	if err := notify.Watch("./...", c, notify.All); err != nil {
+	if err := notify.Watch(filepath.Join(wd, "..."), c, notify.All); err != nil {
 		return nil, err
 	}
 
 	// Watch all workspaces recursively
 	for w := range t.workspaces {
-		if err := notify.Watch(filepath.Join(w, "..."), c, notify.All); err != nil {
+		if w == "." {
+			continue
+		}
+
+		if err := notify.Watch(filepath.Join(wd, w, "..."), c, notify.All); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/skaffold/trigger/workdir.go
+++ b/pkg/skaffold/trigger/workdir.go
@@ -25,8 +25,9 @@ import (
 // working directory. That happens for example if one does:
 // `cd /home/me/MY-PROJECT` before running Skaffold,
 // instead of `cd /home/me/my-project`.
-// In such situation, the file watcher will fail to detect changes.
+// In such a situation, the file watcher will fail to detect changes.
 // To solve that, we force `os.Getwd()` not to use $PWD.
+// See: https://github.com/rjeczalik/notify/issues/96
 func RealWorkDir() (string, error) {
 	if runtime.GOOS == "darwin" {
 		if pwd, present := os.LookupEnv("PWD"); present {

--- a/pkg/skaffold/trigger/workdir.go
+++ b/pkg/skaffold/trigger/workdir.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package trigger
+
+import (
+	"os"
+	"runtime"
+)
+
+// On macOS, $PWD can have a different case that the actual current
+// working directory. That happens for example if one does:
+// `cd /home/me/MY-PROJECT` before running Skaffold,
+// instead of `cd /home/me/my-project`.
+// In such situation, the file watcher will fail to detect changes.
+// To solve that, we force `os.Getwd()` not to use $PWD.
+func RealWorkDir() (string, error) {
+	if runtime.GOOS == "darwin" {
+		if pwd, present := os.LookupEnv("PWD"); present {
+			os.Unsetenv("PWD")
+			defer os.Setenv("PWD", pwd)
+		}
+	}
+
+	return os.Getwd()
+}


### PR DESCRIPTION
On macOS, $PWD can have a different case that the actual current working directory. That happens for example if one does:
`cd /home/me/MY-PROJECT` before running Skaffold, instead of `cd /home/me/my-project`.

In such situation, the file watcher will fail to detect changes.

To solve that, we force `os.Getwd()` not to use $PWD.

Fixes #4018

Signed-off-by: David Gageot <david@gageot.net>
