### PR TITLE
Pin to kaniko v0.20.0

### DIFF
--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -32,7 +32,7 @@ const (
 	defaultCloudBuildDockerImage = "gcr.io/cloud-builders/docker"
 	defaultCloudBuildMavenImage  = "gcr.io/cloud-builders/mvn"
 	defaultCloudBuildGradleImage = "gcr.io/cloud-builders/gradle"
-	defaultCloudBuildKanikoImage = "gcr.io/kaniko-project/executor"
+	defaultCloudBuildKanikoImage = "gcr.io/kaniko-project/executor:v0.20.0"
 	defaultCloudBuildPackImage   = "gcr.io/k8s-skaffold/pack"
 )
 

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -311,7 +311,7 @@ func withGoogleCloudBuild(id string, ops ...func(*latest.BuildConfig)) func(*lat
 			DockerImage: "gcr.io/cloud-builders/docker",
 			MavenImage:  "gcr.io/cloud-builders/mvn",
 			GradleImage: "gcr.io/cloud-builders/gradle",
-			KanikoImage: "gcr.io/kaniko-project/executor",
+			KanikoImage: "gcr.io/kaniko-project/executor:v0.20.0",
 			PackImage:   "gcr.io/k8s-skaffold/pack",
 		}}}
 		for _, op := range ops {


### PR DESCRIPTION
Looks like something in the [0.21.0 Kaniko release](https://github.com/GoogleContainerTools/kaniko/releases/tag/v0.21.0) broke GCB auth.