### PR TITLE
Integrate functionality of SetValues & SetValuesTemplates into Values

### DIFF
--- a/integration/helm_test.go
+++ b/integration/helm_test.go
@@ -40,5 +40,10 @@ func TestHelmDeploy(t *testing.T) {
 	testutil.CheckDeepEqual(t, dep.Name, dep.ObjectMeta.Labels["release"])
 	testutil.CheckDeepEqual(t, "helm", dep.ObjectMeta.Labels["skaffold.dev/deployer"])
 
+	// check if host is properly applied
+	ingress := client.GetIngress("skaffold-helm-" + ns.Name)
+	testutil.CheckDeepEqual(t, len(ingress.Spec.Rules), 1)
+	testutil.CheckDeepEqual(t, ingress.Spec.Rules[0].Host, "chart-example."+ns.Name+".local")
+
 	skaffold.Delete().InDir("testdata/helm").InNs(ns.Name).WithEnv(env).RunOrFail(t)
 }

--- a/integration/testdata/helm/skaffold.yaml
+++ b/integration/testdata/helm/skaffold.yaml
@@ -16,6 +16,7 @@ deploy:
       #- helm-skaffold-values.yaml
       values:
         image: gcr.io/k8s-skaffold/skaffold-helm
+        ingress.hosts[0]: chart-example.{{.TEXT_NS}}.local
       #recreatePods will pass --recreate-pods to helm upgrade
       #recreatePods: true
       #overrides builds an override values.yaml file to run with the helm deploy


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #3316 <!-- tracking issues that this PR will close -->

**Description**
This is the first of 2 merge requests I want to do.

This first one just includes all the logic `setValues` & `setValuesTemplates` implement into the `values` field for the skaffold Helm deployer.

This basically means that you can use the `values` for more than just replacing image tag's now.
Skaffold knows when one of those values is a image you are building and will take care of replacing the correct image + tag value. The rest of key-value pairs are treated as you would expect.

It also adds support for templated values, something it was only available in the `setValuesTemplates` field before.

**User facing changes**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
`values` field in the helm deployer can now be used for more than just image tag replacement. It also adds environment variable support.

**Follow-up Work**
My plan is in an upcoming MR to deprecate the `setValues` & `setValuesTemplates` keys in favour of just `values`, but I wanted to keep the MR as small as posible.

