### PR TITLE
Revert "Gracefully shutdown RPC servers."

### DIFF
--- a/pkg/skaffold/server/server.go
+++ b/pkg/skaffold/server/server.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"net/http"
 	"sync"
-	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/sirupsen/logrus"
@@ -130,7 +129,7 @@ func newGRPCServer(port int) (func() error, error) {
 		}
 	}()
 	return func() error {
-		s.GracefulStop()
+		s.Stop()
 		return l.Close()
 	}, nil
 }
@@ -149,15 +148,7 @@ func newHTTPServer(port, proxyPort int) (func() error, error) {
 	}
 	logrus.Infof("starting gRPC HTTP server on port %d", port)
 
-	server := &http.Server{
-		Handler:     mux,
-		ReadTimeout: 10 * time.Second,
-	}
+	go http.Serve(l, mux)
 
-	go server.Serve(l)
-
-	return func() error {
-		server.SetKeepAlivesEnabled(false)
-		return server.Shutdown(context.Background())
-	}, nil
+	return l.Close, nil
 }


### PR DESCRIPTION
This reverts commit a9470f7f648e61e54c857cc5f72ad1f70513180a.

Reopens #3970 and #3991
