### PR TITLE
`golangci-lint` is automatically installed by `make linters`

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,12 +12,6 @@ You must install these tools:
    built in (version >= go 1.14)
 1. [`git`](https://help.github.com/articles/set-up-git/): For source control
 1. [`make`](https://www.gnu.org/software/make/): For building skaffold.
-1. [`golangci-lint`](https://github.com/golangci/golangci-lint): You can use the
-   helper [script](./hack/install_golint.sh) to get golangci-lint.
-
-    ```shell
-    ./hack/install_golint.sh
-    ```
 
 ## Getting started
 


### PR DESCRIPTION
Signed-off-by: David Gageot <david@gageot.net>
