### PR TITLE
improve deployment waiting logic in integration tests

### DIFF
--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -198,9 +198,11 @@ func nowInChicago() string {
 
 type Fataler interface {
 	Fatal(args ...interface{})
+	Helper()
 }
 
 func failNowIfError(t Fataler, err error) {
+	t.Helper()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -26,8 +26,8 @@ import (
 )
 
 func TestBuildDeploy(t *testing.T) {
-	if testing.Short() || RunOnGCP() {
-		t.Skip("skipping kind integration test")
+	if testing.Short() || !RunOnGCP() {
+		t.Skip("skipping GCP integration test")
 	}
 
 	ns, client := SetupNamespace(t)

--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -26,13 +26,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/clientcmd"
+
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/proto"
 	"github.com/GoogleContainerTools/skaffold/testutil"
-	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 func TestDevNotification(t *testing.T) {

--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -19,7 +19,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -27,13 +26,13 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/clientcmd"
-
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/proto"
 	"github.com/GoogleContainerTools/skaffold/testutil"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 func TestDevNotification(t *testing.T) {

--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestDev(t *testing.T) {
+func TestDevNotification(t *testing.T) {
 	if testing.Short() || RunOnGCP() {
 		t.Skip("skipping kind integration test")
 	}

--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -65,17 +65,13 @@ func TestDev(t *testing.T) {
 
 			skaffold.Dev("--trigger", test.trigger).InDir("testdata/dev").InNs(ns.Name).RunBackground(t)
 
-			dep := client.GetDeployment("test-dev")
+			client.WaitForDeploymentsToStabilizeWithTimeout(30*time.Second, "test-dev")
 
 			// Make a change to foo so that dev is forced to delete the Deployment and redeploy
 			Run(t, "testdata/dev", "sh", "-c", "echo bar > foo")
 
 			// Make sure the old Deployment and the new Deployment are different
-			err := wait.PollImmediate(time.Millisecond*500, 10*time.Minute, func() (bool, error) {
-				newDep := client.GetDeployment("test-dev")
-				return dep.GetGeneration() != newDep.GetGeneration(), nil
-			})
-			failNowIfError(t, err)
+			client.WaitForDeploymentsToStabilizeWithTimeout(30*time.Second, "test-dev")
 		})
 	}
 }

--- a/integration/util.go
+++ b/integration/util.go
@@ -182,6 +182,7 @@ func (k *NSKubernetesClient) WaitForPodsInPhase(expectedPhase v1.PodPhase, podNa
 
 // GetDeployment gets a deployment by name.
 func (k *NSKubernetesClient) GetDeployment(depName string) *appsv1.Deployment {
+	k.t.Helper()
 	k.WaitForDeploymentsToStabilize(depName)
 
 	dep, err := k.Deployments().Get(depName, metav1.GetOptions{})
@@ -193,13 +194,19 @@ func (k *NSKubernetesClient) GetDeployment(depName string) *appsv1.Deployment {
 
 // WaitForDeploymentsToStabilize waits for a list of deployments to become stable.
 func (k *NSKubernetesClient) WaitForDeploymentsToStabilize(depNames ...string) {
+	k.t.Helper()
+	k.WaitForDeploymentsToStabilizeWithTimeout(30 * time.Second, depNames...)
+}
+
+func (k *NSKubernetesClient) WaitForDeploymentsToStabilizeWithTimeout(timeout time.Duration, depNames ...string) {
+	k.t.Helper()
 	if len(depNames) == 0 {
 		return
 	}
 
 	logrus.Infoln("Waiting for deployments", depNames, "to stabilize")
 
-	ctx, cancelTimeout := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancelTimeout := context.WithTimeout(context.Background(), timeout)
 	defer cancelTimeout()
 
 	w, err := k.Deployments().Watch(metav1.ListOptions{})
@@ -222,7 +229,12 @@ func (k *NSKubernetesClient) WaitForDeploymentsToStabilize(depNames ...string) {
 
 		case event := <-w.ResultChan():
 			dp := event.Object.(*appsv1.Deployment)
-			logrus.Infof("Deployment %s: Generation %d/%d, Replicas %d/%d", dp.Name, dp.Status.ObservedGeneration, dp.Generation, dp.Status.Replicas, *(dp.Spec.Replicas))
+			desiredReplicas := *(dp.Spec.Replicas)
+			logrus.Infof("Deployment %s: Generation %d/%d, Replicas %d/%d, Available %d/%d",
+				dp.Name,
+				dp.Status.ObservedGeneration, dp.Generation,
+				dp.Status.Replicas, desiredReplicas,
+				dp.Status.AvailableReplicas, desiredReplicas)
 
 			deployments[dp.Name] = dp
 
@@ -270,7 +282,7 @@ func (k *NSKubernetesClient) ExternalIP(serviceName string) string {
 }
 
 func isStable(dp *appsv1.Deployment) bool {
-	return dp.Generation <= dp.Status.ObservedGeneration && *(dp.Spec.Replicas) == dp.Status.Replicas
+	return dp.Generation <= dp.Status.ObservedGeneration && *(dp.Spec.Replicas) == dp.Status.Replicas && *(dp.Spec.Replicas) == dp.Status.AvailableReplicas
 }
 
 func WaitForLogs(t *testing.T, out io.Reader, firstMessage string, moreMessages ...string) {

--- a/integration/util.go
+++ b/integration/util.go
@@ -195,7 +195,7 @@ func (k *NSKubernetesClient) GetDeployment(depName string) *appsv1.Deployment {
 // WaitForDeploymentsToStabilize waits for a list of deployments to become stable.
 func (k *NSKubernetesClient) WaitForDeploymentsToStabilize(depNames ...string) {
 	k.t.Helper()
-	k.waitForDeploymentsToStabilizeWithTimeout(30 * time.Second, depNames...)
+	k.waitForDeploymentsToStabilizeWithTimeout(30*time.Second, depNames...)
 }
 
 func (k *NSKubernetesClient) waitForDeploymentsToStabilizeWithTimeout(timeout time.Duration, depNames ...string) {

--- a/integration/util.go
+++ b/integration/util.go
@@ -195,10 +195,10 @@ func (k *NSKubernetesClient) GetDeployment(depName string) *appsv1.Deployment {
 // WaitForDeploymentsToStabilize waits for a list of deployments to become stable.
 func (k *NSKubernetesClient) WaitForDeploymentsToStabilize(depNames ...string) {
 	k.t.Helper()
-	k.WaitForDeploymentsToStabilizeWithTimeout(30 * time.Second, depNames...)
+	k.waitForDeploymentsToStabilizeWithTimeout(30 * time.Second, depNames...)
 }
 
-func (k *NSKubernetesClient) WaitForDeploymentsToStabilizeWithTimeout(timeout time.Duration, depNames ...string) {
+func (k *NSKubernetesClient) waitForDeploymentsToStabilizeWithTimeout(timeout time.Duration, depNames ...string) {
 	k.t.Helper()
 	if len(depNames) == 0 {
 		return


### PR DESCRIPTION
- Wait was too long, in `WaitForDeploymentsToStabilize` - it took 5 mins to fail a test, now it's 30 seconds
- Failure was hard to trace back to the test, as there were missing t.Helper() invocations in the chain
- `WaitForDeploymentsToStabilize` was not checking availability - `TestBuildAndDeploy` never really worked in kind - `skaffold build` first builds (but doesn't load to Kind! or push!) then we call `skaffold deploy` which works, but the pods always fail with `ErrImgPull` - we just didn't see it fail as `WaitForDeploymentsToStabilize` was only checking replicacount, and not available replica count. 