### PR TITLE
Don’t duplicate the definition of `portForward`, under the `profiles` section.

### DIFF
--- a/docs/content/en/docs/references/yaml/main.js
+++ b/docs/content/en/docs/references/yaml/main.js
@@ -61,8 +61,8 @@ function* template(definitions, parentDefinition, ref, ident, parent) {
     // Description
     const desc = definition['x-intellij-html-description'];
     
-    // Special case for profiles
-    if ((name === 'Profile') && (key === 'build' || key === 'test' || key === 'deploy')) {
+    // Don't duplicate definitions of top level sections such as build, test, deploy and portForward.
+    if ((name === 'Profile') && definitions['SkaffoldConfig'].properties[key]) {
       value = '{}';
       yield html`
         <tr>


### PR DESCRIPTION
In the `skaffold.yaml` reference documentation, under the `profiles` section, don’t duplicate the
top-level definition of `portForward`.

Also make sure it's not going to break again in the future when we add top-level items.

Signed-off-by: David Gageot <david@gageot.net>
