### PR TITLE
Makefile: install and integration should not require $GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,8 @@ ifeq ($(GCP_ONLY),true)
 		--project $(GCP_PROJECT)
 endif
 	@ echo "PATH=$(realpath $(BUILD_DIR)):$(PATH)"
+	@ ls -la "$(BUILD_DIR)"
+	@ echo "$(shell $(realpath $(BUILD_DIR)):$(PATH)" whereis skaffold)"
 	@ echo "***"
 	@ GCP_ONLY=$(GCP_ONLY) env PATH="$(BUILD_DIR):$(PATH)" ./hack/gotest.sh -v $(REPOPATH)/integration -timeout 20m $(INTEGRATION_TEST_ARGS)
 

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,7 @@ endif
 	@ echo "PATH=$(realpath $(BUILD_DIR)):$(PATH)"
 	@ ls -la "$(BUILD_DIR)"
 	@ echo "***"
+	@ env PATH="$(realpath BUILD_DIR):$(PATH)" skaffold -h
 	@ env PATH="$(realpath BUILD_DIR):$(PATH)" GCP_ONLY=$(GCP_ONLY) ./hack/gotest.sh -v $(REPOPATH)/integration -timeout 20m $(INTEGRATION_TEST_ARGS)
 
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ $(BUILD_DIR)/$(PROJECT): $(STATIK_FILES) $(GO_FILES) $(BUILD_DIR)
 
 .PHONY: install
 install: $(BUILD_DIR)/$(PROJECT)
-	cp $(BUILD_DIR)/$(PROJECT) $(GOPATH)/bin/$(PROJECT)
+	go install cmd/skaffold/skaffold.go 
 
 # Build for a release.
 .PRECIOUS: $(foreach platform, $(SUPPORTED_PLATFORMS), $(BUILD_DIR)/$(PROJECT)-$(platform))
@@ -123,14 +123,14 @@ quicktest:
 	@ ./hack/gotest.sh -short -timeout=60s $(SKAFFOLD_TEST_PACKAGES)
 
 .PHONY: integration
-integration: install
+integration: $(BUILD_DIR)/$(PROJECT)
 ifeq ($(GCP_ONLY),true)
 	gcloud container clusters get-credentials \
 		$(GKE_CLUSTER_NAME) \
 		--zone $(GKE_ZONE) \
 		--project $(GCP_PROJECT)
 endif
-	@ GCP_ONLY=$(GCP_ONLY) ./hack/gotest.sh -v $(REPOPATH)/integration -timeout 20m $(INTEGRATION_TEST_ARGS)
+	@ GCP_ONLY=$(GCP_ONLY) env PATH="$(BUILD_DIR):$(PATH)" ./hack/gotest.sh -v $(REPOPATH)/integration -timeout 20m $(INTEGRATION_TEST_ARGS)
 
 .PHONY: release
 release: cross $(BUILD_DIR)/VERSION

--- a/Makefile
+++ b/Makefile
@@ -127,9 +127,8 @@ ifeq ($(GCP_ONLY),true)
 endif
 	@ echo "PATH=$(realpath $(BUILD_DIR)):$(PATH)"
 	@ ls -la "$(BUILD_DIR)"
-	@ echo "$(shell $(realpath $(BUILD_DIR)):$(PATH)" whereis skaffold)"
 	@ echo "***"
-	@ GCP_ONLY=$(GCP_ONLY) env PATH="$(BUILD_DIR):$(PATH)" ./hack/gotest.sh -v $(REPOPATH)/integration -timeout 20m $(INTEGRATION_TEST_ARGS)
+	@ env PATH="$(realpath BUILD_DIR):$(PATH)" GCP_ONLY=$(GCP_ONLY) ./hack/gotest.sh -v $(REPOPATH)/integration -timeout 20m $(INTEGRATION_TEST_ARGS)
 
 .PHONY: release
 release: cross $(BUILD_DIR)/VERSION

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,7 @@ ifeq ($(GCP_ONLY),true)
 		--zone $(GKE_ZONE) \
 		--project $(GCP_PROJECT)
 endif
-	@ echo "PATH=$(realpath $(BUILD_DIR)):$(PATH)"
-	@ GCP_ONLY=$(GCP_ONLY) env PATH="$(BUILD_DIR):$(PATH)" ./hack/gotest.sh -v $(REPOPATH)/integration -timeout 20m $(INTEGRATION_TEST_ARGS)
+	@ GCP_ONLY=$(GCP_ONLY) env PATH="$(realpath BUILD_DIR):$(PATH)" ./hack/gotest.sh -v $(REPOPATH)/integration -timeout 20m $(INTEGRATION_TEST_ARGS)
 
 .PHONY: release
 release: cross $(BUILD_DIR)/VERSION

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ ifeq ($(GCP_ONLY),true)
 		--zone $(GKE_ZONE) \
 		--project $(GCP_PROJECT)
 endif
+	@ echo "PATH=$(realpath $(BUILD_DIR)):$(PATH)"
 	@ GCP_ONLY=$(GCP_ONLY) env PATH="$(BUILD_DIR):$(PATH)" ./hack/gotest.sh -v $(REPOPATH)/integration -timeout 20m $(INTEGRATION_TEST_ARGS)
 
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,9 @@ ifeq ($(GCP_ONLY),true)
 		--zone $(GKE_ZONE) \
 		--project $(GCP_PROJECT)
 endif
-	@ GCP_ONLY=$(GCP_ONLY) env PATH="$(realpath BUILD_DIR):$(PATH)" ./hack/gotest.sh -v $(REPOPATH)/integration -timeout 20m $(INTEGRATION_TEST_ARGS)
+	@ echo "PATH=$(realpath $(BUILD_DIR)):$(PATH)"
+	@ echo "***"
+	@ GCP_ONLY=$(GCP_ONLY) env PATH="$(BUILD_DIR):$(PATH)" ./hack/gotest.sh -v $(REPOPATH)/integration -timeout 20m $(INTEGRATION_TEST_ARGS)
 
 .PHONY: release
 release: cross $(BUILD_DIR)/VERSION

--- a/hack/gotest.sh
+++ b/hack/gotest.sh
@@ -20,6 +20,7 @@ set -e
 # - It prints the failures in RED
 # - It recaps the failures at the end
 # - It lists the 20 slowest tests
+env
 
 echo "go test $@"
 


### PR DESCRIPTION
* `make integration` now forcibly sets $PATH precedence to `./out`,  and no longer `install` step. 
 This allows `make integration` to function even if `$GOPATH/bin` is not in path.

* `make install` now works without $GOPATH - fixes this error:

```
GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build -tags "release" -ldflags " -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.version=v1.9.0-27-gb35b0f0e0 -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.buildDate=2020-05-13T15:42:46Z -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.gitCommit=b35b0f0e0443635798c6aa58e60d3dba7677ca0a -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.gitTreeState=dirty -s -w  -extldflags \"\"" -o out/skaffold github.com/GoogleContainerTools/skaffold/cmd/skaffold
cp ./out/skaffold /bin/skaffold
cp: /bin/skaffold: Operation not permitted
make: *** [install] Error 1
```

