### PR TITLE
CNB command-line should only be rewritten if changed

### DIFF
--- a/pkg/skaffold/debug/cnb.go
+++ b/pkg/skaffold/debug/cnb.go
@@ -69,10 +69,13 @@ func updateForCNBImage(container *v1.Container, ic imageConfiguration, transform
 		return ContainerDebugConfiguration{}, "", fmt.Errorf("buildpacks metadata has no processes")
 	}
 
-	// the buildpacks launcher is retained as the entrypoint
+	// The buildpacks launcher is retained as the entrypoint
 	ic, rewriter := adjustCommandLine(m, ic)
 	c, img, err := transformer(container, ic)
-	if err == nil && rewriter != nil {
+
+	// Only rewrite the container.Args if set: some transforms only alter env vars,
+	// and the image's arguments are not changed.
+	if err == nil && container.Args != nil && rewriter != nil {
 		container.Args = rewriter(container.Args)
 	}
 	return c, img, err


### PR DESCRIPTION
Fixes: #4166

**Description**

In `skaffold debug` we synthesize an `imageConfiguration` object for an image containing the  environment variables, image labels, command-line, and working directory, as derived from the container image's configuration and the corresponding Kubernetes manifest's container settings.  
For buildpacks images, we swizzle the image configuration by resolving the corresponding process definition and replacing the command-line with the process definition, perform the normal debug transforms, and then unswizzle as required for the CNB launching mechanism.

But some of our debug transforms don't actually change the command-line, and so our unswizzling performs a rewrite on a seemingly empty command-line, resulting in a broken command-line.

This change only unswizzles (or rewrites) the container's command-line if it was set.  If unset, then we'll use the command-line in the container image's configuration.