### PR TITLE
Exclude tmpcharts folder and helm generated .lock files from list of watched files

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -162,14 +162,28 @@ func (h *HelmDeployer) Dependencies() ([]string, error) {
 			continue
 		}
 
-		chartDepsDir := filepath.Join(release.ChartPath, "charts")
+		chartDepsDirs := []string{
+			"charts",
+			"tmpcharts",
+		}
 
-		// We can always add a dependency if it is not contained in our chartDepsDir.
+		// We can always add a dependency if it is not contained in our chartDepsDirs.
 		// However, if the file is in our chartDepsDir, we can only include the file
 		// if we are not running the helm dep build phase, as that modifies files inside
 		// the chartDepsDir and results in an infinite build loop.
 		isDep := func(path string, info walk.Dirent) (bool, error) {
-			return !info.IsDir() && (!strings.HasPrefix(path, chartDepsDir) || r.SkipBuildDependencies), nil
+			if info.IsDir() {
+				return false, nil
+			}
+
+			if !r.SkipBuildDependencies {
+				for _, v := range chartDepsDirs {
+					if strings.HasPrefix(path, filepath.Join(release.ChartPath, v)) {
+						return false, nil
+					}
+				}
+			}
+			return true, nil
 		}
 
 		if err := walk.From(release.ChartPath).When(isDep).AppendPaths(&deps); err != nil {

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -839,19 +839,31 @@ func TestHelmDependencies(t *testing.T) {
 		expected              func(folder *testutil.TempDir) []string
 	}{
 		{
-			description:           "charts download dir is included when skipBuildDependencies is true",
-			files:                 []string{"Chart.yaml", "charts/xyz.tar", "tmpcharts/xyz.tar", "templates/deploy.yaml"},
+			description:           "charts download dir and lock files are included when skipBuildDependencies is true",
+			files:                 []string{"Chart.yaml", "Chart.lock", "requirements.yaml", "requirements.lock", "charts/xyz.tar", "tmpcharts/xyz.tar", "templates/deploy.yaml"},
 			skipBuildDependencies: true,
 			expected: func(folder *testutil.TempDir) []string {
-				return []string{folder.Path("Chart.yaml"), folder.Path("charts/xyz.tar"), folder.Path("templates/deploy.yaml"), folder.Path("tmpcharts/xyz.tar")}
+				return []string{
+					folder.Path("Chart.lock"),
+					folder.Path("Chart.yaml"),
+					folder.Path("charts/xyz.tar"),
+					folder.Path("requirements.lock"),
+					folder.Path("requirements.yaml"),
+					folder.Path("templates/deploy.yaml"),
+					folder.Path("tmpcharts/xyz.tar"),
+				}
 			},
 		},
 		{
-			description:           "charts download dir is excluded when skipBuildDependencies is false",
-			files:                 []string{"Chart.yaml", "charts/xyz.tar", "tmpcharts/xyz.tar", "templates/deploy.yaml"},
+			description:           "charts download dir and lock files are excluded when skipBuildDependencies is false",
+			files:                 []string{"Chart.yaml", "Chart.lock", "requirements.yaml", "requirements.lock", "charts/xyz.tar", "tmpcharts/xyz.tar", "templates/deploy.yaml"},
 			skipBuildDependencies: false,
 			expected: func(folder *testutil.TempDir) []string {
-				return []string{folder.Path("Chart.yaml"), folder.Path("templates/deploy.yaml")}
+				return []string{
+					folder.Path("Chart.yaml"),
+					folder.Path("requirements.yaml"),
+					folder.Path("templates/deploy.yaml"),
+				}
 			},
 		},
 		{

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -839,16 +839,16 @@ func TestHelmDependencies(t *testing.T) {
 		expected              func(folder *testutil.TempDir) []string
 	}{
 		{
-			description:           "charts dir is included when skipBuildDependencies is true",
-			files:                 []string{"Chart.yaml", "charts/xyz.tar", "templates/deploy.yaml"},
+			description:           "charts download dir is included when skipBuildDependencies is true",
+			files:                 []string{"Chart.yaml", "charts/xyz.tar", "tmpcharts/xyz.tar", "templates/deploy.yaml"},
 			skipBuildDependencies: true,
 			expected: func(folder *testutil.TempDir) []string {
-				return []string{folder.Path("Chart.yaml"), folder.Path("charts/xyz.tar"), folder.Path("templates/deploy.yaml")}
+				return []string{folder.Path("Chart.yaml"), folder.Path("charts/xyz.tar"), folder.Path("templates/deploy.yaml"), folder.Path("tmpcharts/xyz.tar")}
 			},
 		},
 		{
-			description:           "charts dir is excluded when skipBuildDependencies is false",
-			files:                 []string{"Chart.yaml", "charts/xyz.tar", "templates/deploy.yaml"},
+			description:           "charts download dir is excluded when skipBuildDependencies is false",
+			files:                 []string{"Chart.yaml", "charts/xyz.tar", "tmpcharts/xyz.tar", "templates/deploy.yaml"},
 			skipBuildDependencies: false,
 			expected: func(folder *testutil.TempDir) []string {
 				return []string{folder.Path("Chart.yaml"), folder.Path("templates/deploy.yaml")}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
Exclude `tmpcharts` folder and helm generated `.lock` files from list of watched files
<!-- Include if applicable: -->
Fixes: #3565  <!-- tracking issues that this PR will close -->
**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
`helm dep up` makes changes to the `tmpcharts` in addition to `charts` subdirectory within a chart package. It also modifies `requirements.lock` file (helm 2) and `Chart.lock` file (helm 3). So we exclude these file from the file change monitor when `skipBuildDependencies` is not set to `true`

This is consistent with existing behavior of excluding `charts` subdirectory similarly.
<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
