### PR TITLE
Change the order of properties in the doc

### DIFF
--- a/docs/content/en/schemas/v2beta4.json
+++ b/docs/content/en/schemas/v2beta4.json
@@ -1798,12 +1798,12 @@
       },
       "preferredOrder": [
         "name",
+        "activation",
+        "patches",
         "build",
         "test",
         "deploy",
-        "portForward",
-        "patches",
-        "activation"
+        "portForward"
       ],
       "additionalProperties": false,
       "description": "used to override any `build`, `test` or `deploy` configuration.",

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -655,17 +655,17 @@ type Profile struct {
 	// For example: `profile-prod`.
 	Name string `yaml:"name,omitempty" yamltags:"required"`
 
-	// Pipeline contains the definitions to replace the default skaffold pipeline.
-	Pipeline `yaml:",inline"`
+	// Activation criteria by which a profile can be auto-activated.
+	// The profile is auto-activated if any one of the activations are triggered.
+	// An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.
+	Activation []Activation `yaml:"activation,omitempty"`
 
 	// Patches lists patches applied to the configuration.
 	// Patches use the JSON patch notation.
 	Patches []JSONPatch `yaml:"patches,omitempty"`
 
-	// Activation criteria by which a profile can be auto-activated.
-	// The profile is auto-activated if any one of the activations are triggered.
-	// An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.
-	Activation []Activation `yaml:"activation,omitempty"`
+	// Pipeline contains the definitions to replace the default skaffold pipeline.
+	Pipeline `yaml:",inline"`
 }
 
 // JSONPatch patch to be applied by a profile.


### PR DESCRIPTION
This has no impact other than changing in which order the properties are shown in the `skaffold.yaml` reference documentation.

Signed-off-by: David Gageot <david@gageot.net>
