### PR TITLE
allow error from kind at image loading to propagate

### DIFF
--- a/pkg/skaffold/runner/kind.go
+++ b/pkg/skaffold/runner/kind.go
@@ -59,9 +59,9 @@ func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Write
 		}
 
 		cmd := exec.CommandContext(ctx, "kind", "load", "docker-image", "--name", kindCluster, artifact.Tag)
-		if err := util.RunCmd(cmd); err != nil {
+		if output, err := util.RunCmdOut(cmd); err != nil {
 			color.Red.Fprintln(out, "Failed")
-			return fmt.Errorf("unable to load image with kind %q: %w", artifact.Tag, err)
+			return fmt.Errorf("unable to load image with kind %q: %w, %s", artifact.Tag, err, output)
 		}
 
 		color.Green.Fprintln(out, "Loaded")

--- a/pkg/skaffold/runner/kind_test.go
+++ b/pkg/skaffold/runner/kind_test.go
@@ -46,7 +46,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			deployed:    []build.Artifact{{Tag: "tag1"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
-				AndRun("kind load docker-image --name kind tag1"),
+				AndRunOut("kind load docker-image --name kind tag1", "output: image loaded"),
 		},
 		{
 			description: "load missing image",
@@ -55,7 +55,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			deployed:    []build.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "tag1").
-				AndRun("kind load docker-image --name other-kind tag2"),
+				AndRunOut("kind load docker-image --name other-kind tag2", "output: image loaded"),
 		},
 		{
 			description: "inspect error",
@@ -73,9 +73,9 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			deployed:    []build.Artifact{{Tag: "tag"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
-				AndRunErr("kind load docker-image --name kind tag", errors.New("BUG")),
+				AndRunOutErr("kind load docker-image --name kind tag", "output: error!", errors.New("BUG")),
 			shouldErr:     true,
-			expectedError: "unable to load",
+			expectedError: "output: error!",
 		},
 		{
 			description: "ignore image that's not built",
@@ -84,7 +84,7 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			deployed:    []build.Artifact{{Tag: "built"}, {Tag: "busybox"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
-				AndRun("kind load docker-image --name kind built"),
+				AndRunOut("kind load docker-image --name kind built", ""),
 		},
 		{
 			description: "no artifact",


### PR DESCRIPTION
This came up during integration testing. 

Previous output: 
```
 loading images into kind nodes: unable to load image with kind "gcr.io/k8s-skaffold/skaffold-example:ad4adf2213c59a487ebf578f5f67c4a0ba030ac36ce16f4ac6d75f04a273e35f": exit status 1
```

This PR's output: 
```
 loading images into kind nodes: unable to load image with kind "gcr.io/k8s-skaffold/skaffold-example:6838e8133d96ef77de6d3702179c597411c038cb99de06360a58cbdbac5721f8": running [kind load docker-image --name modified-context gcr.io/k8s-skaffold/skaffold-example:6838e8133d96ef77de6d3702179c597411c038cb99de06360a58cbdbac5721f8]
         - stdout: ""
         - stderr: "ERROR: no nodes found for cluster \"modified-context\"\n"
         - cause: exit status 1, 
```