### PR TITLE
Bump golangci-lint to v1.27.0

### DIFF
--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -18,7 +18,7 @@ set -e -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BIN=${DIR}/bin
-VERSION=1.26.0
+VERSION=1.27.0
 
 function install_linter() {
   echo "Installing GolangCI-Lint"


### PR DESCRIPTION
Signed-off-by: David Gageot <david@gageot.net>
