### PR TITLE
Use standard `errors` package

### DIFF
--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -17,10 +17,9 @@ limitations under the License.
 package docker
 
 import (
+	"errors"
 	"fmt"
 	"testing"
-
-	"github.com/pkg/errors"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"


### PR DESCRIPTION
Signed-off-by: David Gageot <david@gageot.net>