### PR TITLE
Add support for k3d (#2753)

### DIFF
--- a/docs/content/en/docs/environment/local-cluster.md
+++ b/docs/content/en/docs/environment/local-cluster.md
@@ -23,6 +23,7 @@ The following context names are checked:
 | minikube           | [`minikube`]       | |
 | kind-(.*)          | [`kind`]           | This pattern is used by kind >= v0.6.0 |
 | (.*)@kind          | [`kind`]           | This pattern was used by kind < v0.6.0 |
+| k3d-(.*)           | [`k3d`]            | |
 
 For any other name, Skaffold assumes that the cluster is remote and that images
 have to be pushed.
@@ -30,6 +31,7 @@ have to be pushed.
  [`minikube`]: https://github.com/kubernetes/minikube/
  [`Docker Desktop`]: https://www.docker.com/products/docker-desktop
  [`kind`]: https://github.com/kubernetes-sigs/kind
+ [`k3d`]: https://github.com/rancher/k3d
 
 ### Manual override
 

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -199,8 +199,13 @@ func isDefaultLocal(kubeContext string) bool {
 		return true
 	}
 
-	isKind, _ := IsKindCluster(kubeContext)
-	return isKind
+	if isKind, _ := IsKindCluster(kubeContext); isKind {
+		return true
+	}
+	if isK3d, _ := IsK3dCluster(kubeContext); isK3d {
+		return true
+	}
+	return false
 }
 
 // IsKindCluster checks that the given `kubeContext` is talking to `kind`.
@@ -224,6 +229,13 @@ func IsKindCluster(kubeContext string) (bool, string) {
 	default:
 		return false, ""
 	}
+}
+
+func IsK3dCluster(kubeContext string) (bool, string) {
+	if strings.HasPrefix(kubeContext, "k3d-") {
+		return true, strings.TrimPrefix(kubeContext, "k3d-")
+	}
+	return false, ""
 }
 
 func IsUpdateCheckEnabled(configfile string) bool {

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -311,6 +311,28 @@ func TestIsKindCluster(t *testing.T) {
 	}
 }
 
+func TestIsK3dCluster(t *testing.T) {
+	tests := []struct {
+		context       string
+		expectedName  string
+		expectedIsK3d bool
+	}{
+		{context: "k3d-k3s-default", expectedName: "k3s-default", expectedIsK3d: true},
+		{context: "k3d-other", expectedName: "other", expectedIsK3d: true},
+		{context: "kind-kind", expectedName: "", expectedIsK3d: false},
+		{context: "docker-for-desktop", expectedName: "", expectedIsK3d: false},
+		{context: "not-k3d", expectedName: "", expectedIsK3d: false},
+	}
+	for _, test := range tests {
+		testutil.Run(t, "", func(t *testutil.T) {
+			isKind, name := IsK3dCluster(test.context)
+
+			t.CheckDeepEqual(test.expectedIsK3d, isKind)
+			t.CheckDeepEqual(test.expectedName, name)
+		})
+	}
+}
+
 func TestIsSurveyPromptDisabled(t *testing.T) {
 	tests := []struct {
 		description string

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -62,6 +62,12 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 		}
 	}
 
+	if isK3d, k3dCluster := config.IsK3dCluster(r.runCtx.KubeContext); isK3d {
+		if err := r.loadImagesInK3dNodes(ctx, out, k3dCluster, artifacts); err != nil {
+			return fmt.Errorf("loading images into k3d nodes: %w", err)
+		}
+	}
+
 	deployResult := r.deployer.Deploy(ctx, out, artifacts, r.labellers)
 	r.hasDeployed = true
 	if err := deployResult.GetError(); err != nil {

--- a/pkg/skaffold/runner/load_images.go
+++ b/pkg/skaffold/runner/load_images.go
@@ -30,22 +30,36 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
-// loadImagesInKindNodes loads a list of artifact images into every node of kind cluster.
+// loadImagesInKindNodes loads artifact images into every node of a kind cluster.
 func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Writer, kindCluster string, artifacts []build.Artifact) error {
-	start := time.Now()
 	color.Default.Fprintln(out, "Loading images into kind cluster nodes...")
+	return r.loadImages(ctx, out, artifacts, func(tag string) *exec.Cmd {
+		return exec.CommandContext(ctx, "kind", "load", "docker-image", "--name", kindCluster, tag)
+	})
+}
+
+// loadImagesInK3dNodes loads artifact images into every node of a k3s cluster.
+func (r *SkaffoldRunner) loadImagesInK3dNodes(ctx context.Context, out io.Writer, k3dCluster string, artifacts []build.Artifact) error {
+	color.Default.Fprintln(out, "Loading images into k3d cluster nodes...")
+	return r.loadImages(ctx, out, artifacts, func(tag string) *exec.Cmd {
+		return exec.CommandContext(ctx, "k3d", "load", "image", "--cluster", k3dCluster, tag)
+	})
+}
+
+func (r *SkaffoldRunner) loadImages(ctx context.Context, out io.Writer, artifacts []build.Artifact, createCmd func(tag string) *exec.Cmd) error {
+	start := time.Now()
 
 	var knownImages []string
 
 	for _, artifact := range artifacts {
-		// Only `kind load` the images that this runner built
+		// Only load images that this runner built
 		if !r.wasBuilt(artifact.Tag) {
 			continue
 		}
 
 		color.Default.Fprintf(out, " - %s -> ", artifact.Tag)
 
-		// Only `kind load` the images that are unknown to the node
+		// Only load images that are unknown to the node
 		if knownImages == nil {
 			var err error
 			if knownImages, err = findKnownImages(ctx, r.kubectlCLI); err != nil {
@@ -57,10 +71,10 @@ func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Write
 			continue
 		}
 
-		cmd := exec.CommandContext(ctx, "kind", "load", "docker-image", "--name", kindCluster, artifact.Tag)
+		cmd := createCmd(artifact.Tag)
 		if output, err := util.RunCmdOut(cmd); err != nil {
 			color.Red.Fprintln(out, "Failed")
-			return fmt.Errorf("unable to load image with kind %q: %w, %s", artifact.Tag, err, output)
+			return fmt.Errorf("unable to load image %q into cluster: %w, %s", artifact.Tag, err, output)
 		}
 
 		color.Green.Fprintln(out, "Loaded")

--- a/pkg/skaffold/runner/load_images_test.go
+++ b/pkg/skaffold/runner/load_images_test.go
@@ -197,14 +197,17 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 
-			r := &SkaffoldRunner{
-				builds: test.built,
-				runCtx: &runcontext.RunContext{
-					Opts: config.SkaffoldOptions{
-						Namespace: "namespace",
-					},
-					KubeContext: "kubecontext",
+			runCtx := &runcontext.RunContext{
+				Opts: config.SkaffoldOptions{
+					Namespace: "namespace",
 				},
+				KubeContext: "kubecontext",
+			}
+
+			r := &SkaffoldRunner{
+				runCtx:     runCtx,
+				kubectlCLI: kubectl.NewFromRunContext(runCtx),
+				builds:     test.built,
 			}
 			err := r.loadImagesInK3dNodes(context.Background(), ioutil.Discard, test.k3dCluster, test.deployed)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #2753 

**Description**
This adds support for k3d ([k3s in docker](https://github.com/rancher/k3d)), which is very similar to kind in terms of cluster creation and image loading.

Tested with k3d v3.0.0 (currently in beta). Support could be added to older versions (<=1.7.0) as well, however clusters created with those do not have a distinguishable prefix in their name - any ideas how to solve this?