### PR TITLE
move field reported to changed

### DIFF
--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -114,9 +114,10 @@ func (d *Deployment) IsStatusCheckComplete() bool {
 }
 
 func (d *Deployment) ReportSinceLastUpdated() string {
-	if !d.status.changed {
+	if d.status.reported && !d.status.changed {
 		return ""
 	}
+	d.status.reported = true
 	return fmt.Sprintf("%s: %s", d, d.status)
 }
 

--- a/pkg/skaffold/deploy/resource/deployment_test.go
+++ b/pkg/skaffold/deploy/resource/deployment_test.go
@@ -206,7 +206,7 @@ func TestReportSinceLastUpdated(t *testing.T) {
 			dep.UpdateStatus(test.message, test.err)
 
 			t.CheckDeepEqual(test.expected, dep.ReportSinceLastUpdated())
-			t.CheckTrue(dep.status.reported)
+			t.CheckTrue(dep.status.changed)
 		})
 	}
 }
@@ -231,9 +231,10 @@ func TestReportSinceLastUpdatedMultipleTimes(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			dep := NewDeployment("test", "test-ns", 1)
-			dep.UpdateStatus("cannot pull image", nil)
 			var actual string
 			for i := 0; i < test.times; i++ {
+				// update to same status
+				dep.UpdateStatus("cannot pull image", nil)
 				actual = dep.ReportSinceLastUpdated()
 			}
 			t.CheckDeepEqual(test.expected, actual)

--- a/pkg/skaffold/deploy/resource/status.go
+++ b/pkg/skaffold/deploy/resource/status.go
@@ -17,9 +17,10 @@ limitations under the License.
 package resource
 
 type Status struct {
-	err     error
-	details string
-	changed bool
+	err      error
+	details  string
+	changed  bool
+	reported bool
 }
 
 func (rs Status) Error() error {

--- a/pkg/skaffold/deploy/resource/status.go
+++ b/pkg/skaffold/deploy/resource/status.go
@@ -17,9 +17,9 @@ limitations under the License.
 package resource
 
 type Status struct {
-	err      error
-	details  string
-	reported bool
+	err     error
+	details string
+	changed bool
 }
 
 func (rs Status) Error() error {
@@ -47,5 +47,6 @@ func newStatus(msg string, err error) Status {
 	return Status{
 		details: msg,
 		err:     err,
+		changed: true,
 	}
 }


### PR DESCRIPTION
**Description**
I am working on hooking up pod statuses into skaffold.
With pod statuses now coming in, we need a variable to track if a pod status which is part of deployment is changed to print out deployment and pod statuses together like this.
```
- deployment/leeroy-web is ready. [1/2 deployment(s) still pending]
 - deployment/leeroy-app: waiting for rollout to finish: 1 old replicas are pending termination...
    - pod/leeroy-app-85dfb77b44-md2dd: container leeroy-app is waiting to start: leeroy-app1 can't be pulled
 - deployment/leeroy-app: waiting for rollout to finish: 1 old replicas are pending termination...
    - pod/leeroy-app-85dfb77b44-wemde: container leeroy-app in error: Back-off pulling image "leeroy-app1"
```
Repurposing the previous `reported` to indicate if a deployment status  was changed because a new pod came status was available or new pod came up.