### PR TITLE
Add support for k3d

### DIFF
--- a/docs/content/en/docs/environment/local-cluster.md
+++ b/docs/content/en/docs/environment/local-cluster.md
@@ -23,6 +23,7 @@ The following context names are checked:
 | minikube           | [`minikube`]       | |
 | kind-(.*)          | [`kind`]           | This pattern is used by kind >= v0.6.0 |
 | (.*)@kind          | [`kind`]           | This pattern was used by kind < v0.6.0 |
+| k3d-(.*)           | [`k3d`]            | This pattern is used by k3d >= v3.0.0 |
 
 For any other name, Skaffold assumes that the cluster is remote and that images
 have to be pushed.
@@ -30,6 +31,7 @@ have to be pushed.
  [`minikube`]: https://github.com/kubernetes/minikube/
  [`Docker Desktop`]: https://www.docker.com/products/docker-desktop
  [`kind`]: https://github.com/kubernetes-sigs/kind
+ [`k3d`]: https://github.com/rancher/k3d
 
 ### Manual override
 

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -199,7 +199,12 @@ func isDefaultLocal(kubeContext string) bool {
 		return true
 	}
 
-	return IsKindCluster(kubeContext)
+	return IsKindCluster(kubeContext) || IsK3dCluster(kubeContext)
+}
+
+// IsImageLoadingRequired checks if the cluster requires loading images into it
+func IsImageLoadingRequired(kubeContext string) bool {
+	return IsKindCluster(kubeContext) || IsK3dCluster(kubeContext)
 }
 
 // IsKindCluster checks that the given `kubeContext` is talking to `kind`.
@@ -242,6 +247,19 @@ func KindClusterName(clusterName string) string {
 		return strings.TrimPrefix(clusterName, "kind-")
 	}
 
+	return clusterName
+}
+
+// IsK3dCluster checks that the given `kubeContext` is talking to `k3d`.
+func IsK3dCluster(kubeContext string) bool {
+	return strings.HasPrefix(kubeContext, "k3d-")
+}
+
+// K3dClusterName returns the internal name of a k3d cluster.
+func K3dClusterName(clusterName string) string {
+	if strings.HasPrefix(clusterName, "k3d-") {
+		return strings.TrimPrefix(clusterName, "k3d-")
+	}
 	return clusterName
 }
 

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -271,19 +271,45 @@ func TestIsDefaultLocal(t *testing.T) {
 	}{
 		{context: "kind-other", expectedLocal: true},
 		{context: "kind@kind", expectedLocal: true},
+		{context: "k3d-k3s-default", expectedLocal: true},
 		{context: "docker-for-desktop", expectedLocal: true},
 		{context: "minikube", expectedLocal: true},
-		{context: "docker-for-desktop", expectedLocal: true},
 		{context: "docker-desktop", expectedLocal: true},
 		{context: "anything-else", expectedLocal: false},
 		{context: "kind@blah", expectedLocal: false},
 		{context: "other-kind", expectedLocal: false},
+		{context: "not-k3d", expectedLocal: false},
 	}
 	for _, test := range tests {
 		testutil.Run(t, "", func(t *testutil.T) {
 			local := isDefaultLocal(test.context)
 
 			t.CheckDeepEqual(test.expectedLocal, local)
+		})
+	}
+}
+
+func TestIsImageLoadingRequired(t *testing.T) {
+	tests := []struct {
+		context                      string
+		expectedImageLoadingRequired bool
+	}{
+		{context: "kind-other", expectedImageLoadingRequired: true},
+		{context: "kind@kind", expectedImageLoadingRequired: true},
+		{context: "k3d-k3s-default", expectedImageLoadingRequired: true},
+		{context: "docker-for-desktop", expectedImageLoadingRequired: false},
+		{context: "minikube", expectedImageLoadingRequired: false},
+		{context: "docker-desktop", expectedImageLoadingRequired: false},
+		{context: "anything-else", expectedImageLoadingRequired: false},
+		{context: "kind@blah", expectedImageLoadingRequired: false},
+		{context: "other-kind", expectedImageLoadingRequired: false},
+		{context: "not-k3d", expectedImageLoadingRequired: false},
+	}
+	for _, test := range tests {
+		testutil.Run(t, "", func(t *testutil.T) {
+			imageLoadingRequired := IsImageLoadingRequired(test.context)
+
+			t.CheckDeepEqual(test.expectedImageLoadingRequired, imageLoadingRequired)
 		})
 	}
 }
@@ -325,6 +351,43 @@ func TestKindClusterName(t *testing.T) {
 			kindCluster := KindClusterName(test.kubeCluster)
 
 			t.CheckDeepEqual(test.expectedName, kindCluster)
+		})
+	}
+}
+
+func TestIsK3dCluster(t *testing.T) {
+	tests := []struct {
+		context       string
+		expectedIsK3d bool
+	}{
+		{context: "k3d-k3s-default", expectedIsK3d: true},
+		{context: "k3d-other", expectedIsK3d: true},
+		{context: "kind-kind", expectedIsK3d: false},
+		{context: "docker-for-desktop", expectedIsK3d: false},
+		{context: "not-k3d", expectedIsK3d: false},
+	}
+	for _, test := range tests {
+		testutil.Run(t, "", func(t *testutil.T) {
+			isK3d := IsK3dCluster(test.context)
+
+			t.CheckDeepEqual(test.expectedIsK3d, isK3d)
+		})
+	}
+}
+
+func TestK3dClusterName(t *testing.T) {
+	tests := []struct {
+		kubeCluster  string
+		expectedName string
+	}{
+		{kubeCluster: "k3d-k3s-default", expectedName: "k3s-default"},
+		{kubeCluster: "k3d-other", expectedName: "other"},
+	}
+	for _, test := range tests {
+		testutil.Run(t, "", func(t *testutil.T) {
+			k3dCluster := K3dClusterName(test.kubeCluster)
+
+			t.CheckDeepEqual(test.expectedName, k3dCluster)
 		})
 	}
 }

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
@@ -56,22 +57,10 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 		return fmt.Errorf("unable to connect to Kubernetes: %w", err)
 	}
 
-	if config.IsKindCluster(r.runCtx.KubeContext) {
-		currentCfg, err := kubectx.CurrentConfig()
+	if config.IsImageLoadingRequired(r.runCtx.KubeContext) {
+		err := r.loadImagesIntoCluster(ctx, out, artifacts)
 		if err != nil {
-			return fmt.Errorf("unable to get kubernetes config: %w", err)
-		}
-
-		currentContext, present := currentCfg.Contexts[r.runCtx.KubeContext]
-		if !present {
-			return fmt.Errorf("unable to get current kubernetes context: %w", err)
-		}
-
-		kindCluster := config.KindClusterName(currentContext.Cluster)
-
-		// With `kind`, docker images have to be loaded with the `kind` CLI.
-		if err := r.loadImagesInKindNodes(ctx, out, kindCluster, artifacts); err != nil {
-			return fmt.Errorf("loading images into kind nodes: %w", err)
+			return err
 		}
 	}
 
@@ -82,6 +71,46 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 	}
 	r.runCtx.UpdateNamespaces(deployResult.Namespaces())
 	return r.performStatusCheck(ctx, out)
+}
+
+func (r *SkaffoldRunner) loadImagesIntoCluster(ctx context.Context, out io.Writer, artifacts []build.Artifact) error {
+	currentContext, err := r.getCurrentContext()
+	if err != nil {
+		return err
+	}
+
+	if config.IsKindCluster(r.runCtx.KubeContext) {
+		kindCluster := config.KindClusterName(currentContext.Cluster)
+
+		// With `kind`, docker images have to be loaded with the `kind` CLI.
+		if err := r.loadImagesInKindNodes(ctx, out, kindCluster, artifacts); err != nil {
+			return fmt.Errorf("loading images into kind nodes: %w", err)
+		}
+	}
+
+	if config.IsK3dCluster(r.runCtx.KubeContext) {
+		k3dCluster := config.K3dClusterName(currentContext.Cluster)
+
+		// With `k3d`, docker images have to be loaded with the `k3d` CLI.
+		if err := r.loadImagesInK3dNodes(ctx, out, k3dCluster, artifacts); err != nil {
+			return fmt.Errorf("loading images into k3d nodes: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *SkaffoldRunner) getCurrentContext() (*api.Context, error) {
+	currentCfg, err := kubectx.CurrentConfig()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get kubernetes config: %w", err)
+	}
+
+	currentContext, present := currentCfg.Contexts[r.runCtx.KubeContext]
+	if !present {
+		return nil, fmt.Errorf("unable to get current kubernetes context: %w", err)
+	}
+	return currentContext, nil
 }
 
 // failIfClusterIsNotReachable checks that Kubernetes is reachable.

--- a/pkg/skaffold/runner/load_images.go
+++ b/pkg/skaffold/runner/load_images.go
@@ -30,22 +30,36 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
-// loadImagesInKindNodes loads a list of artifact images into every node of kind cluster.
+// loadImagesInKindNodes loads artifact images into every node of a kind cluster.
 func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Writer, kindCluster string, artifacts []build.Artifact) error {
-	start := time.Now()
 	color.Default.Fprintln(out, "Loading images into kind cluster nodes...")
+	return r.loadImages(ctx, out, artifacts, func(tag string) *exec.Cmd {
+		return exec.CommandContext(ctx, "kind", "load", "docker-image", "--name", kindCluster, tag)
+	})
+}
+
+// loadImagesInK3dNodes loads artifact images into every node of a k3s cluster.
+func (r *SkaffoldRunner) loadImagesInK3dNodes(ctx context.Context, out io.Writer, k3dCluster string, artifacts []build.Artifact) error {
+	color.Default.Fprintln(out, "Loading images into k3d cluster nodes...")
+	return r.loadImages(ctx, out, artifacts, func(tag string) *exec.Cmd {
+		return exec.CommandContext(ctx, "k3d", "load", "image", "--cluster", k3dCluster, tag)
+	})
+}
+
+func (r *SkaffoldRunner) loadImages(ctx context.Context, out io.Writer, artifacts []build.Artifact, createCmd func(tag string) *exec.Cmd) error {
+	start := time.Now()
 
 	var knownImages []string
 
 	for _, artifact := range artifacts {
-		// Only `kind load` the images that this runner built
+		// Only load images that this runner built
 		if !r.wasBuilt(artifact.Tag) {
 			continue
 		}
 
 		color.Default.Fprintf(out, " - %s -> ", artifact.Tag)
 
-		// Only `kind load` the images that are unknown to the node
+		// Only load images that are unknown to the node
 		if knownImages == nil {
 			var err error
 			if knownImages, err = findKnownImages(ctx, r.kubectlCLI); err != nil {
@@ -57,10 +71,10 @@ func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Write
 			continue
 		}
 
-		cmd := exec.CommandContext(ctx, "kind", "load", "docker-image", "--name", kindCluster, artifact.Tag)
+		cmd := createCmd(artifact.Tag)
 		if output, err := util.RunCmdOut(cmd); err != nil {
 			color.Red.Fprintln(out, "Failed")
-			return fmt.Errorf("unable to load image with kind %q: %w, %s", artifact.Tag, err, output)
+			return fmt.Errorf("unable to load image %q into cluster: %w, %s", artifact.Tag, err, output)
 		}
 
 		color.Green.Fprintln(out, "Loaded")


### PR DESCRIPTION
Fixes: #2753 
Previous PR: #4216 (created a new one to change commit author email)

**Description**
This adds support for k3d (k3s in docker), which is very similar to kind in terms of cluster creation and image loading.

Tested with k3d v3.0.0 (currently in beta). Older versions (<=1.7.0) have a similar image loading mechanism, however clusters created with those do not have any distinguishable prefix (k3d-) in their name.