### PR TITLE
Prepare for the sharing of the PodWatcher

### DIFF
--- a/pkg/skaffold/kubernetes/debugging/container_manager.go
+++ b/pkg/skaffold/kubernetes/debugging/container_manager.go
@@ -19,43 +19,34 @@ package debugging
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 )
 
 var (
 	// For testing
-	aggregatePodWatcher = kubernetes.AggregatePodWatcher
-
 	notifyDebuggingContainerStarted    = event.DebuggingContainerStarted
 	notifyDebuggingContainerTerminated = event.DebuggingContainerTerminated
 )
 
 type ContainerManager struct {
-	cli         *kubectl.CLI
-	podSelector kubernetes.PodSelector
-	namespaces  []string
-	active      map[string]string // set of containers that have been notified
-	aggregate   chan watch.Event
+	podWatcher kubernetes.PodWatcher
+	active     map[string]string // set of containers that have been notified
+	events     chan kubernetes.PodEvent
 }
 
-func NewContainerManager(cli *kubectl.CLI, podSelector kubernetes.PodSelector, namespaces []string) *ContainerManager {
+func NewContainerManager(podSelector kubernetes.PodSelector, namespaces []string) *ContainerManager {
 	// Create the channel here as Stop() may be called before Start() when a build fails, thus
 	// avoiding the possibility of closing a nil channel. Channels are cheap.
 	return &ContainerManager{
-		cli:         cli,
-		podSelector: podSelector,
-		namespaces:  namespaces,
-		active:      map[string]string{},
-		aggregate:   make(chan watch.Event),
+		podWatcher: kubernetes.NewAggregatePodWatcher(podSelector, namespaces),
+		active:     map[string]string{},
+		events:     make(chan kubernetes.PodEvent),
 	}
 }
 
@@ -64,51 +55,41 @@ func (d *ContainerManager) Start(ctx context.Context) error {
 		// debug mode probably not enabled
 		return nil
 	}
-	stopWatchers, err := aggregatePodWatcher(d.namespaces, d.aggregate)
+
+	d.podWatcher.Register(d.events)
+	stopWatcher, err := d.podWatcher.Start()
 	if err != nil {
-		stopWatchers()
-		return fmt.Errorf("initializing debugging container watcher: %w", err)
+		return err
 	}
 
 	go func() {
-		defer stopWatchers()
+		defer stopWatcher()
 
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case evt, ok := <-d.aggregate:
+			case evt, ok := <-d.events:
 				if !ok {
 					return
 				}
-				// If the event's type is "ERROR", warn and continue.
-				if evt.Type == watch.Error {
-					logrus.Warnf("got unexpected event of type %s", evt.Type)
-					continue
-				}
-				// Grab the pod from the event.
-				pod, ok := evt.Object.(*v1.Pod)
-				if !ok {
-					continue
-				}
-				// Unlike other event watchers, we ignore event types as checkPod() uses only container status
-				if d.podSelector.Select(pod) {
-					d.checkPod(ctx, pod)
-				}
+
+				d.checkPod(evt.Pod)
 			}
 		}
 	}()
+
 	return nil
 }
 
 func (d *ContainerManager) Stop() {
 	// if nil then debug mode probably not enabled
 	if d != nil {
-		close(d.aggregate)
+		close(d.events)
 	}
 }
 
-func (d *ContainerManager) checkPod(_ context.Context, pod *v1.Pod) {
+func (d *ContainerManager) checkPod(pod *v1.Pod) {
 	debugConfigString, found := pod.Annotations[debug.DebugConfigAnnotation]
 	if !found {
 		return

--- a/pkg/skaffold/kubernetes/debugging/container_manager_test.go
+++ b/pkg/skaffold/kubernetes/debugging/container_manager_test.go
@@ -55,9 +55,9 @@ func TestContainerManager(t *testing.T) {
 		state := &pod.Status.ContainerStatuses[0].State
 
 		// should never be active until running
-		m.checkPod(context.Background(), &pod)
+		m.checkPod(&pod)
 		t.CheckDeepEqual(0, len(m.active))
-		m.checkPod(context.Background(), &pod)
+		m.checkPod(&pod)
 		t.CheckDeepEqual(0, len(m.active))
 		t.CheckDeepEqual(0, startCount)
 		t.CheckDeepEqual(0, terminatedCount)
@@ -66,7 +66,7 @@ func TestContainerManager(t *testing.T) {
 		state.Waiting = nil
 		state.Running = &v1.ContainerStateRunning{}
 
-		m.checkPod(context.Background(), &pod)
+		m.checkPod(&pod)
 		t.CheckDeepEqual(1, len(m.active))
 		_, found := m.active["ns/pod/test"]
 		t.CheckDeepEqual(true, found)
@@ -77,7 +77,7 @@ func TestContainerManager(t *testing.T) {
 		state.Running = nil
 		state.Terminated = &v1.ContainerStateTerminated{}
 
-		m.checkPod(context.Background(), &pod)
+		m.checkPod(&pod)
 		t.CheckDeepEqual(0, len(m.active))
 		t.CheckDeepEqual(1, startCount)
 		t.CheckDeepEqual(1, terminatedCount)

--- a/pkg/skaffold/kubernetes/log.go
+++ b/pkg/skaffold/kubernetes/log.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
@@ -37,13 +36,12 @@ import (
 type LogAggregator struct {
 	output      io.Writer
 	kubectlcli  *kubectl.CLI
-	podSelector PodSelector
-	namespaces  []string
+	podWatcher  PodWatcher
 	colorPicker ColorPicker
 
 	muted             int32
 	sinceTime         time.Time
-	cancel            context.CancelFunc
+	events            chan PodEvent
 	trackedContainers trackedContainers
 	outputLock        sync.Mutex
 }
@@ -53,9 +51,9 @@ func NewLogAggregator(out io.Writer, cli *kubectl.CLI, imageNames []string, podS
 	return &LogAggregator{
 		output:      out,
 		kubectlcli:  cli,
-		podSelector: podSelector,
-		namespaces:  namespaces,
+		podWatcher:  NewAggregatePodWatcher(podSelector, namespaces),
 		colorPicker: NewColorPicker(imageNames),
+		events:      make(chan PodEvent),
 		trackedContainers: trackedContainers{
 			ids: map[string]bool{},
 		},
@@ -79,38 +77,26 @@ func (a *LogAggregator) Start(ctx context.Context) error {
 		return nil
 	}
 
-	cancelCtx, cancel := context.WithCancel(ctx)
-	a.cancel = cancel
-
-	aggregate := make(chan watch.Event)
-	stopWatchers, err := AggregatePodWatcher(a.namespaces, aggregate)
+	a.podWatcher.Register(a.events)
+	stopWatcher, err := a.podWatcher.Start()
 	if err != nil {
-		stopWatchers()
-		return fmt.Errorf("initializing aggregate pod watcher: %w", err)
+		return err
 	}
 
 	go func() {
-		defer stopWatchers()
+		defer stopWatcher()
 
 		for {
 			select {
-			case <-cancelCtx.Done():
+			case <-ctx.Done():
 				return
-			case evt, ok := <-aggregate:
+			case evt, ok := <-a.events:
 				if !ok {
 					return
 				}
 
-				pod, ok := evt.Object.(*v1.Pod)
-				if !ok {
-					continue
-				}
-
-				if !a.podSelector.Select(pod) {
-					continue
-				}
-
 				// TODO(dgageot): Add EphemeralContainerStatuses
+				pod := evt.Pod
 				for _, c := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
 					if c.ContainerID == "" {
 						if c.State.Waiting != nil && c.State.Waiting.Message != "" {
@@ -120,7 +106,7 @@ func (a *LogAggregator) Start(ctx context.Context) error {
 					}
 
 					if !a.trackedContainers.add(c.ContainerID) {
-						go a.streamContainerLogs(cancelCtx, pod, c)
+						go a.streamContainerLogs(ctx, pod, c)
 					}
 				}
 			}
@@ -137,9 +123,7 @@ func (a *LogAggregator) Stop() {
 		return
 	}
 
-	if a.cancel != nil {
-		a.cancel()
-	}
+	close(a.events)
 }
 
 func sinceSeconds(d time.Duration) int64 {

--- a/pkg/skaffold/kubernetes/watcher.go
+++ b/pkg/skaffold/kubernetes/watcher.go
@@ -17,15 +17,49 @@ limitations under the License.
 package kubernetes
 
 import (
+	"errors"
 	"fmt"
 
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-// AggregatePodWatcher returns a watcher for multiple namespaces.
-func AggregatePodWatcher(namespaces []string, aggregate chan<- watch.Event) (func(), error) {
-	watchers := make([]watch.Interface, 0, len(namespaces))
+type PodWatcher interface {
+	Register(receiver chan<- PodEvent)
+	Start() (func(), error)
+}
+
+// aggregatePodWatcher is a pod watcher for multiple namespaces.
+type aggregatePodWatcher struct {
+	podSelector PodSelector
+	namespaces  []string
+	receivers   []chan<- PodEvent
+}
+
+type PodEvent struct {
+	Type watch.EventType
+	Pod  *v1.Pod
+}
+
+func NewAggregatePodWatcher(podSelector PodSelector, namespaces []string) PodWatcher {
+	return &aggregatePodWatcher{
+		podSelector: podSelector,
+		namespaces:  namespaces,
+	}
+}
+
+func (w *aggregatePodWatcher) Register(receiver chan<- PodEvent) {
+	w.receivers = append(w.receivers, receiver)
+}
+
+func (w *aggregatePodWatcher) Start() (func(), error) {
+	if len(w.receivers) == 0 {
+		return func() {}, errors.New("no receiver was registered")
+	}
+
+	var watchers []watch.Interface
 	stopWatchers := func() {
 		for _, w := range watchers {
 			w.Stop()
@@ -39,7 +73,7 @@ func AggregatePodWatcher(namespaces []string, aggregate chan<- watch.Event) (fun
 
 	var forever int64 = 3600 * 24 * 365 * 100
 
-	for _, ns := range namespaces {
+	for _, ns := range w.namespaces {
 		watcher, err := kubeclient.CoreV1().Pods(ns).Watch(metav1.ListOptions{
 			TimeoutSeconds: &forever,
 		})
@@ -51,8 +85,29 @@ func AggregatePodWatcher(namespaces []string, aggregate chan<- watch.Event) (fun
 		watchers = append(watchers, watcher)
 
 		go func() {
-			for msg := range watcher.ResultChan() {
-				aggregate <- msg
+			for evt := range watcher.ResultChan() {
+				// If the event's type is "ERROR", warn and continue.
+				if evt.Type == watch.Error {
+					logrus.Warnf("got unexpected event of type %s", evt.Type)
+					continue
+				}
+
+				// Grab the pod from the event.
+				pod, ok := evt.Object.(*v1.Pod)
+				if !ok {
+					continue
+				}
+
+				if !w.podSelector.Select(pod) {
+					continue
+				}
+
+				for _, receiver := range w.receivers {
+					receiver <- PodEvent{
+						Type: evt.Type,
+						Pod:  pod,
+					}
+				}
 			}
 		}()
 	}

--- a/pkg/skaffold/kubernetes/watcher_test.go
+++ b/pkg/skaffold/kubernetes/watcher_test.go
@@ -18,6 +18,7 @@ package kubernetes
 
 import (
 	"errors"
+	"sort"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -34,11 +35,42 @@ func pod(name string) *v1.Pod {
 	return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name}}
 }
 
+func service(name string) *v1.Service {
+	return &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+type anyPod struct{}
+
+func (p *anyPod) Select(pod *v1.Pod) bool { return true }
+
+type hasName struct {
+	validNames []string
+}
+
+func (h *hasName) Select(pod *v1.Pod) bool {
+	for _, validName := range h.validNames {
+		if validName == pod.Name {
+			return true
+		}
+	}
+	return false
+}
+
 func TestAggregatePodWatcher(t *testing.T) {
+	testutil.Run(t, "need to register first", func(t *testutil.T) {
+		watcher := NewAggregatePodWatcher(&anyPod{}, []string{"ns"})
+		cleanup, err := watcher.Start()
+		defer cleanup()
+
+		t.CheckErrorContains("no receiver was registered", err)
+	})
+
 	testutil.Run(t, "fail to get client", func(t *testutil.T) {
 		t.Override(&Client, func() (kubernetes.Interface, error) { return nil, errors.New("unable to get client") })
 
-		cleanup, err := AggregatePodWatcher([]string{"ns"}, nil)
+		watcher := NewAggregatePodWatcher(&anyPod{}, []string{"ns"})
+		watcher.Register(make(chan PodEvent))
+		cleanup, err := watcher.Start()
 		defer cleanup()
 
 		t.CheckErrorContains("unable to get client", err)
@@ -52,29 +84,47 @@ func TestAggregatePodWatcher(t *testing.T) {
 			return true, nil, errors.New("unable to watch")
 		})
 
-		cleanup, err := AggregatePodWatcher([]string{"ns"}, nil)
+		watcher := NewAggregatePodWatcher(&anyPod{}, []string{"ns"})
+		watcher.Register(make(chan PodEvent))
+		cleanup, err := watcher.Start()
 		defer cleanup()
 
 		t.CheckErrorContains("unable to watch", err)
 	})
 
-	testutil.Run(t, "watch 3 events", func(t *testutil.T) {
+	testutil.Run(t, "filter 3 events", func(t *testutil.T) {
 		clientset := fake.NewSimpleClientset()
 		t.Override(&Client, func() (kubernetes.Interface, error) { return clientset, nil })
 
-		events := make(chan watch.Event)
-		cleanup, err := AggregatePodWatcher([]string{"ns1", "ns2"}, events)
+		podSelector := &hasName{
+			validNames: []string{"pod1", "pod2", "pod3"},
+		}
+		events := make(chan PodEvent)
+		watcher := NewAggregatePodWatcher(podSelector, []string{"ns1", "ns2"})
+		watcher.Register(events)
+		cleanup, err := watcher.Start()
 		defer cleanup()
 		t.CheckNoError(err)
 
-		// Send three events
+		// Send three pod events among other events
 		clientset.CoreV1().Pods("ns1").Create(pod("pod1"))
+		clientset.CoreV1().Pods("ignored").Create(pod("ignored"))     // Different namespace
+		clientset.CoreV1().Services("ns1").Create(service("ignored")) // Not a pod
+		clientset.CoreV1().Pods("ns2").Create(pod("ignored"))         // Rejected by podSelector
 		clientset.CoreV1().Pods("ns2").Create(pod("pod2"))
 		clientset.CoreV1().Pods("ns2").Create(pod("pod3"))
 
 		// Retrieve three events
-		<-events
-		<-events
-		<-events
+		var podEvents []PodEvent
+		podEvents = append(podEvents, <-events)
+		podEvents = append(podEvents, <-events)
+		podEvents = append(podEvents, <-events)
+		close(events)
+
+		// Order is not guaranteed since we watch multiple names concurrently.
+		sort.Slice(podEvents, func(i, j int) bool { return podEvents[i].Pod.Name < podEvents[j].Pod.Name })
+		t.CheckDeepEqual("pod1", podEvents[0].Pod.Name)
+		t.CheckDeepEqual("pod2", podEvents[1].Pod.Name)
+		t.CheckDeepEqual("pod3", podEvents[2].Pod.Name)
 	})
 }

--- a/pkg/skaffold/runner/debugging.go
+++ b/pkg/skaffold/runner/debugging.go
@@ -25,5 +25,5 @@ func (r *SkaffoldRunner) createContainerManager() *debugging.ContainerManager {
 		return nil
 	}
 
-	return debugging.NewContainerManager(r.kubectlCLI, r.podSelector, r.runCtx.Namespaces)
+	return debugging.NewContainerManager(r.podSelector, r.runCtx.Namespaces)
 }


### PR DESCRIPTION
This first step just refactors the code to remove dome duplication.
Next step will be to share a single PodWatcher.

Signed-off-by: David Gageot <david@gageot.net>
