### PR TITLE
Makefile: evaluate os/arch based on target name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,17 +75,21 @@ install: $(BUILD_DIR)/$(PROJECT)
 cross: $(foreach platform, $(SUPPORTED_PLATFORMS), $(BUILD_DIR)/$(PROJECT)-$(platform))
 
 $(BUILD_DIR)/$(PROJECT)-%: $(STATIK_FILES) $(GO_FILES) $(BUILD_DIR) deploy/cross/Dockerfile
-	GOOS="$(firstword $(subst -, ,$*))" GOARCH="$(lastword $(subst -, ,$(subst .exe,,$*)))" \
+	$(eval os = $(firstword $(subst -, ,$*)))
+	$(eval arch = $(lastword $(subst -, ,$(subst .exe,,$*))))
+
 	docker build \
-		--build-arg GOOS=$(GOOS) \
-		--build-arg GOARCH=$(GOARCH) \
-		--build-arg TAGS=$(GO_BUILD_TAGS_$(GOOS)) \
-		--build-arg LDFLAGS=$(GO_LDFLAGS_$(GOOS)) \
+		--build-arg GOOS=$(os) \
+		--build-arg GOARCH=$(arch) \
+		--build-arg TAGS=$(GO_BUILD_TAGS_$(os)) \
+		--build-arg LDFLAGS=$(GO_LDFLAGS_$(arch)) \
 		-f deploy/cross/Dockerfile \
 		-t skaffold/cross \
 		.
+
 	docker run --rm skaffold/cross cat /build/skaffold > $@
 	shasum -a 256 $@ > $@.sha256
+	file $@
 
 .PHONY: $(BUILD_DIR)/VERSION
 $(BUILD_DIR)/VERSION: $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ $(BUILD_DIR)/$(PROJECT)-%: $(STATIK_FILES) $(GO_FILES) $(BUILD_DIR) deploy/cross
 
 	docker run --rm skaffold/cross cat /build/skaffold > $@
 	shasum -a 256 $@ | tee $@.sha256
-	file $@
+	file $@ || true
 
 .PHONY: $(BUILD_DIR)/VERSION
 $(BUILD_DIR)/VERSION: $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -77,18 +77,20 @@ cross: $(foreach platform, $(SUPPORTED_PLATFORMS), $(BUILD_DIR)/$(PROJECT)-$(pla
 $(BUILD_DIR)/$(PROJECT)-%: $(STATIK_FILES) $(GO_FILES) $(BUILD_DIR) deploy/cross/Dockerfile
 	$(eval os = $(firstword $(subst -, ,$*)))
 	$(eval arch = $(lastword $(subst -, ,$(subst .exe,,$*))))
+	$(eval ldflags = $(GO_LDFLAGS_$(os)))
+	$(eval tags = $(GO_BUILD_TAGS_$(os)))
 
 	docker build \
 		--build-arg GOOS=$(os) \
 		--build-arg GOARCH=$(arch) \
-		--build-arg TAGS=$(GO_BUILD_TAGS_$(os)) \
-		--build-arg LDFLAGS=$(GO_LDFLAGS_$(arch)) \
+		--build-arg TAGS=$(tags) \
+		--build-arg LDFLAGS=$(ldflags) \
 		-f deploy/cross/Dockerfile \
 		-t skaffold/cross \
 		.
 
 	docker run --rm skaffold/cross cat /build/skaffold > $@
-	shasum -a 256 $@ > $@.sha256
+	shasum -a 256 $@ | tee $@.sha256
 	file $@
 
 .PHONY: $(BUILD_DIR)/VERSION


### PR DESCRIPTION
Previously, the Makefile was setting a correct GOOS and GOARCH environment variables, but for flag values, it was passing in the native Makefile variables, set to the local OS and architecture that was executing the Makefile.

For example, running `make out/skaffold-linux-amd64` on a macOS machine output:

```
GOOS="linux" GOARCH="amd64" \
	docker build \
		--build-arg GOOS=darwin \
		--build-arg GOARCH=amd64 \
		--build-arg TAGS="release" \
		--build-arg LDFLAGS=" -X 
```

In this PR, I change from setting an environment variable, to setting a local variable ("os" and "arch"), which is evaluated from the Makefile rule. This local variable is then passed in correctly as command-line arguments. The previous example now emits:

```
docker build \
		--build-arg GOOS=linux \
		--build-arg GOARCH=amd64 \
		--build-arg TAGS="osusergo netgo static_build release" \
		--build-arg LDFLAGS=" -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.version=v1.10.0-4-gfafbfc163-dirty -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.buildDate=2020-05-20T11:28:19Z -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.gitCommit=fafbfc1636db2cfa49bcd0eb1ba0bd02fa921bb3 -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.gitTreeState=dirty -s -w  -extldflags \"-static\"" \
		-f deploy/cross/Dockerfile \
		-t skaffold/cross \
		.
```

You'll notice that TAGS and LDFLAGS are now properly evaluated as well.

Fixes #4234