### PR TITLE
helm: Do not parse initial 'helm get' section as a manifest

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -349,7 +349,7 @@ func (h *HelmDeployer) deployRelease(ctx context.Context, out io.Writer, r lates
 		return nil, fmt.Errorf("get release: %w", err)
 	}
 
-	artifacts := parseReleaseInfo(opts.namespace, bufio.NewReader(&b))
+	artifacts := parseHelmGet(opts.namespace, bufio.NewReader(&b))
 	return artifacts, nil
 }
 

--- a/pkg/skaffold/deploy/util.go
+++ b/pkg/skaffold/deploy/util.go
@@ -52,11 +52,13 @@ func parseRuntimeObject(namespace string, b []byte) (*Artifact, error) {
 	}, nil
 }
 
-func parseReleaseInfo(namespace string, b *bufio.Reader) []Artifact {
+func parseHelmGet(namespace string, b *bufio.Reader) []Artifact {
 	var results []Artifact
+	i := 0
 
 	r := k8syaml.NewYAMLReader(b)
 	for {
+		i++
 		doc, err := r.Read()
 		if err == io.EOF {
 			break
@@ -70,12 +72,19 @@ func parseReleaseInfo(namespace string, b *bufio.Reader) []Artifact {
 			logrus.Infof("error parsing object from string: %s", err.Error())
 			continue
 		}
+
+		// The initial section of "helm get" is not a Kubernetes manifest
+		if i == 1 {
+			continue
+		}
+
 		obj, err := parseRuntimeObject(objNamespace, doc)
 		if err != nil {
-			logrus.Infof(err.Error())
-		} else {
-			results = append(results, *obj)
+			logrus.Errorf("unable to parse runtime object in section %d: %v", i, err.Error())
+			continue
 		}
+
+		results = append(results, *obj)
 	}
 
 	return results

--- a/pkg/skaffold/deploy/util_test.go
+++ b/pkg/skaffold/deploy/util_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestParseReleaseInfo(t *testing.T) {
+func TestParseHelmGet(t *testing.T) {
 	tests := []struct {
 		description string
 		yaml        []byte
@@ -138,7 +138,7 @@ spec:
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			r := bufio.NewReader(bytes.NewBuffer(test.yaml))
 
-			actual := parseReleaseInfo(testNamespace, r)
+			actual := parseHelmGet(testNamespace, r)
 
 			t.CheckDeepEqual(test.expected, actual, cmpopts.IgnoreFields(Artifact{}, "Obj"))
 		})


### PR DESCRIPTION
This removes the scary `error decoding parsed yaml: Object 'Kind' is missing in ` message that appears with every Helm deployment.

This log message is caused due to skaffold parsing the front-matter of `helm get` output as if it was a Kubernetes manifest. This PR skips the initial section for object parsing, and raises the warning level for subsequent sections from `info` to `error`.

Fixes #3642

Using `examples/helm-deployment` with `skaffold run -v info`, you can see the difference:

## At head

```
INFO[0030] Building helm dependencies...                
NAME: skaffold-helm
LAST DEPLOYED: Thu May 21 11:44:36 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
INFO[0031] error decoding parsed yaml: Object 'Kind' is missing in 'NAME: skaffold-helm
LAST DEPLOYED: Thu May 21 11:44:36 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
USER-SUPPLIED VALUES:
image: skaffold-helm:9eeb2cd8a4cb941fc16f4fc1796d713da20308e5f391cd10a35b1aa4bb8f6e2a

COMPUTED VALUES:
image: skaffold-helm:9eeb2cd8a4cb941fc16f4fc1796d713da20308e5f391cd10a35b1aa4bb8f6e2a
ingress:
  annotations: null
  enabled: true
  hosts: null
  tls: null
replicaCount: 1
resources: {}
service:
  externalPort: 80
  internalPort: 80
  name: nginx
  type: NodePort

HOOKS:
MANIFEST:
' 
INFO[0031] Deploy complete in 1.403286918s              
Waiting for deployments to stabilize...
```

## With this PR

```
INFO[0000] Building helm dependencies...                
NAME: skaffold-helm
LAST DEPLOYED: Thu May 21 11:41:40 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
INFO[0001] Deploy complete in 1.149852761s              
Waiting for deployments to stabilize...
```
