### PR TITLE
Fix support for Knative services

### DIFF
--- a/pkg/skaffold/deploy/kubectl/visitor.go
+++ b/pkg/skaffold/deploy/kubectl/visitor.go
@@ -52,6 +52,10 @@ var transformableWhitelist = []apimachinery.GroupKind{
 		Group: "batch",
 		Kind:  "Job",
 	},
+	{
+		Group: "serving.knative.dev",
+		Kind:  "Service",
+	},
 }
 
 // FieldVisitor represents the aggregation/transformation that should be performed on each traversed field.

--- a/pkg/skaffold/deploy/kubectl/visitor.go
+++ b/pkg/skaffold/deploy/kubectl/visitor.go
@@ -34,7 +34,6 @@ var transformableWhitelist = map[apimachinery.GroupKind]bool{
 	{Group: "batch", Kind: "Job"}:                   true,
 	{Group: "serving.knative.dev", Kind: "Service"}: true,
 }
-}
 
 // FieldVisitor represents the aggregation/transformation that should be performed on each traversed field.
 type FieldVisitor interface {

--- a/pkg/skaffold/deploy/kubectl/visitor.go
+++ b/pkg/skaffold/deploy/kubectl/visitor.go
@@ -23,39 +23,17 @@ import (
 	apimachinery "k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// transformableWhitelist is the set of kinds that can be transformed by Skaffold.
 var transformableWhitelist = map[apimachinery.GroupKind]bool{
-	{
-		Group: "",
-		Kind:  "Pod",
-	}: true,
-	{
-		Group: "apps",
-		Kind:  "DaemonSet",
-	}: true,
-	{
-		Group: "apps",
-		Kind:  "Deployment",
-	}: true,
-	{
-		Group: "apps",
-		Kind:  "ReplicaSet",
-	}: true,
-	{
-		Group: "apps",
-		Kind:  "StatefulSet",
-	}: true,
-	{
-		Group: "batch",
-		Kind:  "CronJob",
-	}: true,
-	{
-		Group: "batch",
-		Kind:  "Job",
-	}: true,
-	{
-		Group: "serving.knative.dev",
-		Kind:  "Service",
-	}: true,
+	{Group: "", Kind: "Pod"}:                        true,
+	{Group: "apps", Kind: "DaemonSet"}:              true,
+	{Group: "apps", Kind: "Deployment"}:             true,
+	{Group: "apps", Kind: "ReplicaSet"}:             true,
+	{Group: "apps", Kind: "StatefulSet"}:            true,
+	{Group: "batch", Kind: "CronJob"}:               true,
+	{Group: "batch", Kind: "Job"}:                   true,
+	{Group: "serving.knative.dev", Kind: "Service"}: true,
+}
 }
 
 // FieldVisitor represents the aggregation/transformation that should be performed on each traversed field.

--- a/pkg/skaffold/deploy/kubectl/visitor.go
+++ b/pkg/skaffold/deploy/kubectl/visitor.go
@@ -23,39 +23,39 @@ import (
 	apimachinery "k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var transformableWhitelist = []apimachinery.GroupKind{
+var transformableWhitelist = map[apimachinery.GroupKind]bool{
 	{
 		Group: "",
 		Kind:  "Pod",
-	},
+	}: true,
 	{
 		Group: "apps",
 		Kind:  "DaemonSet",
-	},
+	}: true,
 	{
 		Group: "apps",
 		Kind:  "Deployment",
-	},
+	}: true,
 	{
 		Group: "apps",
 		Kind:  "ReplicaSet",
-	},
+	}: true,
 	{
 		Group: "apps",
 		Kind:  "StatefulSet",
-	},
+	}: true,
 	{
 		Group: "batch",
 		Kind:  "CronJob",
-	},
+	}: true,
 	{
 		Group: "batch",
 		Kind:  "Job",
-	},
+	}: true,
 	{
 		Group: "serving.knative.dev",
 		Kind:  "Service",
-	},
+	}: true,
 }
 
 // FieldVisitor represents the aggregation/transformation that should be performed on each traversed field.
@@ -123,12 +123,7 @@ func shouldTransformManifest(manifest map[interface{}]interface{}) bool {
 		Kind:  gvk.Kind,
 	}
 
-	for _, allowedGroupKind := range transformableWhitelist {
-		if groupKind == allowedGroupKind {
-			return true
-		}
-	}
-	return false
+	return transformableWhitelist[groupKind]
 }
 
 // recursiveVisitorDecorator adds recursion to a FieldVisitor.

--- a/pkg/skaffold/deploy/kubectl/visitor_test.go
+++ b/pkg/skaffold/deploy/kubectl/visitor_test.go
@@ -174,6 +174,32 @@ spec:
     kind: MyKind`)},
 			expected: []string{"apiVersion=apie...", "kind=Cust...", "metadata=map[...", "spec=map[..."},
 		},
+		{
+			description: "replace knative serving image",
+			manifests: ManifestList{[]byte(`apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: mknservice
+spec:
+  template:
+    spec:
+      containers:
+      - image: orig`)},
+			pivotKey:    "image",
+			replaceWith: "repl",
+			expected: []string{"apiVersion=serv...", "kind=Serv...", "metadata=map[...", "name=mkns...",
+				"spec=map[...", "template=map[...", "spec=map[...",
+				"containers=[map...", "image=orig"},
+			expectedManifests: ManifestList{[]byte(`apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: mknservice
+spec:
+  template:
+    spec:
+      containers:
+      - image: repl`)},
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {

--- a/pkg/skaffold/deploy/kubectl/visitor_test.go
+++ b/pkg/skaffold/deploy/kubectl/visitor_test.go
@@ -93,26 +93,29 @@ rules:
 		},
 		{
 			description: "nested map in Pod",
-			manifests: ManifestList{[]byte(`kind: Pod
+			manifests: ManifestList{[]byte(`apiVersion: v1
+kind: Pod
 metadata:
   name: mpod
 spec:
   restartPolicy: Always`)},
-			expected: []string{"kind=Pod", "metadata=map[...", "name=mpod", "spec=map[...", "restartPolicy=Alwa..."},
+			expected: []string{"apiVersion=v1", "kind=Pod", "metadata=map[...", "name=mpod", "spec=map[...", "restartPolicy=Alwa..."},
 		},
 		{
 			description: "skip recursion at key",
 			pivotKey:    "metadata",
-			manifests: ManifestList{[]byte(`kind: Pod
+			manifests: ManifestList{[]byte(`apiVersion: v1
+kind: Pod
 metadata:
   name: mpod
 spec:
   restartPolicy: Always`)},
-			expected: []string{"kind=Pod", "metadata=map[...", "spec=map[...", "restartPolicy=Alwa..."},
+			expected: []string{"apiVersion=v1", "kind=Pod", "metadata=map[...", "spec=map[...", "restartPolicy=Alwa..."},
 		},
 		{
 			description: "nested array and map in Pod",
-			manifests: ManifestList{[]byte(`kind: Pod
+			manifests: ManifestList{[]byte(`apiVersion: v1
+kind: Pod
 metadata:
   name: mpod
 spec:
@@ -123,7 +126,7 @@ spec:
     name: c1
   - name: c2
   restartPolicy: Always`)},
-			expected: []string{"kind=Pod", "metadata=map[...", "name=mpod",
+			expected: []string{"apiVersion=v1", "kind=Pod", "metadata=map[...", "name=mpod",
 				"spec=map[...", "containers=[map...",
 				"name=c1", "env=map[...", "name=k", "value=v",
 				"name=c2", "restartPolicy=Alwa...",
@@ -133,7 +136,8 @@ spec:
 			description: "replace key",
 			pivotKey:    "name",
 			replaceWith: "repl",
-			manifests: ManifestList{[]byte(`kind: Deployment
+			manifests: ManifestList{[]byte(`apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
     name: x
@@ -143,14 +147,15 @@ spec:
 			// This behaviour is questionable but implemented like this for simplicity.
 			// In practice this is not a problem (currently) since only the fields
 			// "metadata" and "image" are matched in known kinds without ambiguous field names.
-			expectedManifests: ManifestList{[]byte(`kind: Deployment
+			expectedManifests: ManifestList{[]byte(`apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
     name: repl
   name: repl
 spec:
   replicas: 0`), []byte(`name: repl`)},
-			expected: []string{"kind=Depl...", "metadata=map[...", "name=app", "labels=map[...", "name=x", "spec=map[...", "replicas=0", "name=foo"},
+			expected: []string{"apiVersion=apps...", "kind=Depl...", "metadata=map[...", "name=app", "labels=map[...", "name=x", "spec=map[...", "replicas=0", "name=foo"},
 		},
 		{
 			description: "invalid input",


### PR DESCRIPTION
This re-instates support for image substitution with Knative services, which appears to have been broken when the fix for not substituting images in CRDs was implemented in #3833 
