### PR TITLE
Fix dockerfile resolution

### DIFF
--- a/pkg/skaffold/docker/dependencies.go
+++ b/pkg/skaffold/docker/dependencies.go
@@ -32,7 +32,7 @@ import (
 func NormalizeDockerfilePath(context, dockerfile string) (string, error) {
 	// Expected case: should be found relative to the context directory.
 	// If it does not exist, check if it's found relative to the current directory in case it's shared.
-	// Otherwise return the path relative to the context directory, where it should have been.  
+	// Otherwise return the path relative to the context directory, where it should have been.
 	rel := filepath.Join(context, dockerfile)
 	if _, err := os.Stat(rel); os.IsNotExist(err) {
 		if _, err := os.Stat(dockerfile); err == nil || !os.IsNotExist(err) {

--- a/pkg/skaffold/docker/dependencies.go
+++ b/pkg/skaffold/docker/dependencies.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/docker/docker/builder/dockerignore"
 
@@ -31,14 +30,16 @@ import (
 
 // NormalizeDockerfilePath returns the absolute path to the dockerfile.
 func NormalizeDockerfilePath(context, dockerfile string) (string, error) {
-	if filepath.IsAbs(dockerfile) {
-		return dockerfile, nil
+	// Expected case: should be found relative to the context directory.
+	// If it does not exist, check if it's found relative to the current directory in case it's shared.
+	// Otherwise return the path relative to the context directory, where it should have been.  
+	rel := filepath.Join(context, dockerfile)
+	if _, err := os.Stat(rel); os.IsNotExist(err) {
+		if _, err := os.Stat(dockerfile); err == nil || !os.IsNotExist(err) {
+			return filepath.Abs(dockerfile)
+		}
 	}
-
-	if !strings.HasPrefix(dockerfile, context) {
-		dockerfile = filepath.Join(context, dockerfile)
-	}
-	return filepath.Abs(dockerfile)
+	return filepath.Abs(rel)
 }
 
 // GetDependencies finds the sources dependencies for the given docker artifact.

--- a/pkg/skaffold/docker/dependencies_test.go
+++ b/pkg/skaffold/docker/dependencies_test.go
@@ -19,6 +19,7 @@ package docker
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -557,5 +558,58 @@ func TestGetDependencies(t *testing.T) {
 			t.CheckError(test.shouldErr, err)
 			t.CheckDeepEqual(test.expected, deps)
 		})
+	}
+}
+
+func TestNormalizeDockerfilePath(t *testing.T) {
+	tests := []struct {
+		description string
+		files       []string
+		dockerfile  string
+
+		expected string // relative path
+	}{
+		{
+			description: "dockerfile found in context",
+			files:       []string{"Dockerfile", "context/Dockerfile"},
+			dockerfile:  "Dockerfile",
+			expected:    "context/Dockerfile",
+		},
+		{
+			description: "workspace dockerfile when missing in context",
+			files:       []string{"Dockerfile", "context/randomfile.txt"},
+			dockerfile:  "Dockerfile",
+			expected:    "Dockerfile",
+		},
+		{
+			description: "explicit dockerfile path",
+			files:       []string{"context/Dockerfile", "elsewhere/Dockerfile"},
+			dockerfile:  "elsewhere/Dockerfile",
+			expected:    "elsewhere/Dockerfile",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			d := t.NewTempDir()
+			t.Chdir(d.Root())
+
+			d.Mkdir("context")
+			d.Touch(test.files...)
+
+			f, err := NormalizeDockerfilePath(d.Path("context"), test.dockerfile)
+			t.CheckError(false, err)
+			checkSameFile(t, d.Path(test.expected), f)
+		})
+	}
+}
+
+func checkSameFile(t *testutil.T, expected, result string) {
+	t.Helper()
+	i1, err := os.Stat(expected)
+	t.CheckError(false, err)
+	i2, err := os.Stat(result)
+	t.CheckError(false, err)
+	if !os.SameFile(i1, i2) {
+		t.Errorf("returned wrong file\n   got: %s\nwanted: %s", result, expected)
 	}
 }

--- a/pkg/skaffold/docker/dependencies_test.go
+++ b/pkg/skaffold/docker/dependencies_test.go
@@ -576,6 +576,18 @@ func TestNormalizeDockerfilePath(t *testing.T) {
 			expected:    "context/Dockerfile",
 		},
 		{
+			description: "path to dockerfile resolved in context first",
+			files:       []string{"context/context/Dockerfile", "context/Dockerfile"},
+			dockerfile:  "context/Dockerfile",
+			expected:    "context/context/Dockerfile",
+		},
+		{
+			description: "path to dockerfile in working directory",
+			files:       []string{"context/Dockerfile"},
+			dockerfile:  "context/Dockerfile",
+			expected:    "context/Dockerfile",
+		},
+		{
 			description: "workspace dockerfile when missing in context",
 			files:       []string{"Dockerfile", "context/randomfile.txt"},
 			dockerfile:  "Dockerfile",


### PR DESCRIPTION
Fixes: #4243 

**Description**

`pkg/skaffold/docker.NormalizeDockerfilePath` attempted to handle the case where a user specified their dockerfile including the context directory:
```
- image: my/image
   context: project
   docker:
     dockerfile: "project/Dockerfile"
```

The code uses `strings.HasPrefix` to check if the dockerfile path included the context directory:
https://github.com/GoogleContainerTools/skaffold/blob/5444e54062a7771a88edf4588765bf4aed04bc17/pkg/skaffold/docker/dependencies.go#L33-L42

This breaks on @ sujit-kamireddy's example in #4243 where the context directory is a prefix of `Dockerfile`:
```yaml
- image: my/image
   context: Dock
```

(Although this situation may seem far-fetched, a context with `Docker` is not so unexpected.)

This code should first check if the context+dockerfilePath exists and only then use just the dockerfilePath alone.

**User facing changes (remove if N/A)**

There should be no changes.
