### PR TITLE
Collapse ImagePullBackOff and ErrImagePullBackOff together

### DIFF
--- a/pkg/diag/validator/pod.go
+++ b/pkg/diag/validator/pod.go
@@ -30,17 +30,18 @@ import (
 )
 
 const (
-	success           = "Succeeded"
-	running           = "Running"
-	actionableMessage = `could not determine pod status. Try kubectl describe -n %s po/%s`
-	errorPrefix       = `(?P<Prefix>)(?P<DaemonLog>Error response from daemon\:)(?P<Error>.*)`
-	taintsExp         = `\{(?P<taint>.*?):.*?}`
-	crashLoopBackOff  = "CrashLoopBackOff"
-	runContainerError = "RunContainerError"
-	imagePullErr      = "ErrImagePull"
-	imagePullBackOff  = "ImagePullBackOff"
-	containerCreating = "ContainerCreating"
-	podKind           = "pod"
+	success             = "Succeeded"
+	running             = "Running"
+	actionableMessage   = `could not determine pod status. Try kubectl describe -n %s po/%s`
+	errorPrefix         = `(?P<Prefix>)(?P<DaemonLog>Error response from daemon\:)(?P<Error>.*)`
+	taintsExp           = `\{(?P<taint>.*?):.*?}`
+	crashLoopBackOff    = "CrashLoopBackOff"
+	runContainerError   = "RunContainerError"
+	imagePullErr        = "ErrImagePull"
+	imagePullBackOff    = "ImagePullBackOff"
+	errImagePullBackOff = "ErrImagePullBackOff"
+	containerCreating   = "ContainerCreating"
+	podKind             = "pod"
 )
 
 var (
@@ -202,18 +203,14 @@ func (p *podStatus) String() string {
 }
 
 func extractErrorMessageFromWaitingContainerStatus(c v1.ContainerStatus) (proto.StatusCode, error) {
-	r := c.State.Waiting.Reason
-	if strings.HasSuffix(r, imagePullBackOff) {
-		r = imagePullBackOff
-	}
-	switch r {
+	switch c.State.Waiting.Reason {
 	// Extract meaning full error out of container statuses.
 	case containerCreating:
 		return proto.StatusCode_STATUSCHECK_CONTAINER_CREATING, fmt.Errorf("creating container %s", c.Name)
 	case crashLoopBackOff:
 		// TODO, in case of container restarting, return the original failure reason due to which container failed.
 		return proto.StatusCode_STATUSCHECK_CONTAINER_RESTARTING, fmt.Errorf("restarting failed container %s", c.Name)
-	case imagePullErr, imagePullBackOff:
+	case imagePullErr, imagePullBackOff, errImagePullBackOff:
 		return proto.StatusCode_STATUSCHECK_IMAGE_PULL_ERR, fmt.Errorf("container %s is waiting to start: %s can't be pulled", c.Name, c.Image)
 	case runContainerError:
 		match := runContainerRe.FindStringSubmatch(c.State.Waiting.Message)

--- a/pkg/diag/validator/pod_test.go
+++ b/pkg/diag/validator/pod_test.go
@@ -76,6 +76,62 @@ func TestRun(t *testing.T) {
 				proto.StatusCode_STATUSCHECK_IMAGE_PULL_ERR)},
 		},
 		{
+			description: "pod is Waiting condition due to ErrImageBackOffPullErr",
+			pods: []*v1.Pod{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test",
+				},
+				Status: v1.PodStatus{
+					Phase:      v1.PodPending,
+					Conditions: []v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionTrue}},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:  "foo-container",
+							Image: "foo-image",
+							State: v1.ContainerState{
+								Waiting: &v1.ContainerStateWaiting{
+									Reason:  "ErrImagePullBackOff",
+									Message: "rpc error: code = Unknown desc = Error response from daemon: pull access denied for leeroy-web1, repository does not exist or may require 'docker login': denied: requested access to the resource is denied",
+								},
+							},
+						},
+					},
+				},
+			}},
+			expected: []Resource{NewResource("test", "pod", "foo", "Pending",
+				fmt.Errorf("container foo-container is waiting to start: foo-image can't be pulled"),
+				proto.StatusCode_STATUSCHECK_IMAGE_PULL_ERR)},
+		},
+		{
+			description: "pod is Waiting due to Image Backoff Pull error",
+			pods: []*v1.Pod{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test",
+				},
+				Status: v1.PodStatus{
+					Phase:      v1.PodPending,
+					Conditions: []v1.PodCondition{{Type: v1.PodScheduled, Status: v1.ConditionTrue}},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:  "foo-container",
+							Image: "foo-image",
+							State: v1.ContainerState{
+								Waiting: &v1.ContainerStateWaiting{
+									Reason:  "ImagePullBackOff",
+									Message: "rpc error: code = Unknown desc = Error response from daemon: pull access denied for leeroy-web1, repository does not exist or may require 'docker login': denied: requested access to the resource is denied",
+								},
+							},
+						},
+					},
+				},
+			}},
+			expected: []Resource{NewResource("test", "pod", "foo", "Pending",
+				fmt.Errorf("container foo-container is waiting to start: foo-image can't be pulled"),
+				proto.StatusCode_STATUSCHECK_IMAGE_PULL_ERR)},
+		},
+		{
 			description: "pod is in Terminated State",
 			pods: []*v1.Pod{{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Relates to: #3917 

Both [ErrImagePullBackOff](https://github.com/kubernetes/kubernetes/blob/d0183703cbe715c879cb42db375c7373b7f2b6a1/pkg/kubelet/kubelet_test.go#L910) and [ImagePullBackOff](https://github.com/kubernetes/kubernetes/blob/d24fe8a801748953a5c34fd34faa8005c6ad1770/pkg/kubelet/images/types.go#L28) could appear in the `Reason` string.

Hence combining them together.
