### PR TITLE
Remove default from resource name

### DIFF
--- a/pkg/diag/validator/resource.go
+++ b/pkg/diag/validator/resource.go
@@ -40,7 +40,10 @@ func (r Resource) Namespace() string { return r.namespace }
 func (r Resource) Status() Status    { return r.status }
 func (r Resource) Error() error      { return r.err }
 func (r Resource) String() string {
-	return fmt.Sprintf("{%s:%s/%s}", r.kind, r.namespace, r.name)
+	if r.namespace == "default" {
+		return fmt.Sprintf("%s/%s", r.kind, r.name)
+	}
+	return fmt.Sprintf("%s:%s/%s", r.namespace, r.kind, r.name)
 }
 
 // NewResource creates new Resource of kind

--- a/pkg/diag/validator/resource_test.go
+++ b/pkg/diag/validator/resource_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validator
+
+import (
+	"github.com/GoogleContainerTools/skaffold/testutil"
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestNewResource(t *testing.T) {
+	tests := []struct {
+		description  string
+		resource     objectWithMetadata
+		expected     Resource
+		expectedName string
+	}{
+		{
+			description: "pod in default namespace",
+			resource: &v1.Pod{
+				TypeMeta: metav1.TypeMeta{Kind: "pod"},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "foo",
+				},
+			},
+			expected:     Resource{"default", "pod", "foo", Status(""), nil, 0},
+			expectedName: "pod/foo",
+		},
+		{
+			description: "pod in another namespace",
+			resource: &v1.Pod{
+				TypeMeta: metav1.TypeMeta{Kind: "pod"},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "bar",
+				},
+			},
+			expected:     Resource{"test", "pod", "bar", Status(""), nil, 0},
+			expectedName: "test:pod/bar",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			actual := NewResourceFromObject(test.resource, Status(""), nil, 0)
+			t.CheckDeepEqual(test.expected, actual, cmp.AllowUnexported(Resource{}))
+			t.CheckDeepEqual(test.expectedName, actual.String(), cmp.AllowUnexported(Resource{}))
+		})
+	}
+
+}

--- a/pkg/diag/validator/resource_test.go
+++ b/pkg/diag/validator/resource_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package validator
 
 import (
-	"github.com/GoogleContainerTools/skaffold/testutil"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestNewResource(t *testing.T) {
@@ -63,5 +65,4 @@ func TestNewResource(t *testing.T) {
 			t.CheckDeepEqual(test.expectedName, actual.String(), cmp.AllowUnexported(Resource{}))
 		})
 	}
-
 }


### PR DESCRIPTION
Relates to #4223 
Should merge before #4223 

In this PR, do not print resource namespace if default. 
Added tests.