### PR TITLE
add annotations feature to kaniko pod

### DIFF
--- a/docs/content/en/schemas/v2beta5.json
+++ b/docs/content/en/schemas/v2beta5.json
@@ -601,8 +601,8 @@
             "type": "string"
           },
           "type": "object",
-          "description": "defines arbitrary non-identifying metadata to a kaniko pod.",
-          "x-intellij-html-description": "defines arbitrary non-identifying metadata to a kaniko pod.",
+          "description": "describes the Kubernetes annotations for the pod.",
+          "x-intellij-html-description": "describes the Kubernetes annotations for the pod.",
           "default": "{}"
         },
         "concurrency": {
@@ -695,13 +695,13 @@
         "dockerConfig",
         "serviceAccount",
         "tolerations",
+        "annotations",
         "runAsUser",
         "resources",
         "concurrency",
         "volumes",
         "randomPullSecret",
-        "randomDockerConfigSecret",
-        "annotations"
+        "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
       "description": "*beta* describes how to do an on-cluster build.",

--- a/docs/content/en/schemas/v2beta5.json
+++ b/docs/content/en/schemas/v2beta5.json
@@ -596,6 +596,15 @@
           "description": "for kaniko pod.",
           "x-intellij-html-description": "for kaniko pod."
         },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "defines arbitrary non-identifying metadata to a kaniko pod.",
+          "x-intellij-html-description": "defines arbitrary non-identifying metadata to a kaniko pod.",
+          "default": "{}"
+        },
         "concurrency": {
           "type": "integer",
           "description": "how many artifacts can be built concurrently. 0 means \"no-limit\".",
@@ -691,7 +700,8 @@
         "concurrency",
         "volumes",
         "randomPullSecret",
-        "randomDockerConfigSecret"
+        "randomDockerConfigSecret",
+        "annotations"
       ],
       "additionalProperties": false,
       "description": "*beta* describes how to do an on-cluster build.",

--- a/examples/kaniko/skaffold.yaml
+++ b/examples/kaniko/skaffold.yaml
@@ -8,6 +8,9 @@ build:
   cluster:
     pullSecretName: e2esecret
     namespace: default
+#    annotations:
+#      iam.amazonaws.com/role: skaffold
+
 # If kaniko pod should be run on a tainted node, you can setup tolerations here.
 #    tolerations:
 #      - key: app

--- a/examples/kaniko/skaffold.yaml
+++ b/examples/kaniko/skaffold.yaml
@@ -8,15 +8,15 @@ build:
   cluster:
     pullSecretName: e2esecret
     namespace: default
-#    annotations:
-#      iam.amazonaws.com/role: skaffold
+#   annotations:
+#     test: test
 
 # If kaniko pod should be run on a tainted node, you can setup tolerations here.
-#    tolerations:
-#      - key: app
-#        operator: "Equal"
-#        value: skaffold
-#        effect: "NoSchedule"
+#   tolerations:
+#     - key: app
+#       operator: "Equal"
+#       value: skaffold
+#       effect: "NoSchedule"
 deploy:
   kubectl:
     manifests:

--- a/pkg/skaffold/build/cluster/pod.go
+++ b/pkg/skaffold/build/cluster/pod.go
@@ -45,6 +45,7 @@ func (b *Builder) kanikoPodSpec(artifact *latest.KanikoArtifact, tag string) (*v
 
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
+			Annotations:  b.ClusterDetails.Annotations,
 			GenerateName: "kaniko-",
 			Labels:       map[string]string{"skaffold-kaniko": "skaffold-kaniko"},
 			Namespace:    b.ClusterDetails.Namespace,

--- a/pkg/skaffold/build/cluster/pod_test.go
+++ b/pkg/skaffold/build/cluster/pod_test.go
@@ -233,6 +233,7 @@ func TestKanikoPodSpec(t *testing.T) {
 
 	expectedPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
+			Annotations:  map[string]string{"iam.amazonaws.com/role": "skaffold"},
 			GenerateName: "kaniko-",
 			Labels:       map[string]string{"skaffold-kaniko": "skaffold-kaniko"},
 			Namespace:    "ns",

--- a/pkg/skaffold/build/cluster/pod_test.go
+++ b/pkg/skaffold/build/cluster/pod_test.go
@@ -233,7 +233,7 @@ func TestKanikoPodSpec(t *testing.T) {
 
 	expectedPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations:  map[string]string{"iam.amazonaws.com/role": "skaffold"},
+			Annotations:  map[string]string{"test": "test"},
 			GenerateName: "kaniko-",
 			Labels:       map[string]string{"skaffold-kaniko": "skaffold-kaniko"},
 			Namespace:    "ns",

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -344,6 +344,9 @@ type ClusterDetails struct {
 
 	// RandomDockerConfigSecret adds a random UUID postfix to the default name of the docker secret to facilitate parallel builds, e.g. docker-cfgfd154022-c761-416f-8eb3-cf8258450b85.
 	RandomDockerConfigSecret bool `yaml:"randomDockerConfigSecret,omitempty"`
+
+	// Annotations defines arbitrary non-identifying metadata to a kaniko pod.
+	Annotations map[string]string `yaml:"annotations,omitempty"`
 }
 
 // DockerConfig contains information about the docker `config.json` to mount.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -324,6 +324,9 @@ type ClusterDetails struct {
 	// Tolerations describes the Kubernetes tolerations for the pod.
 	Tolerations []v1.Toleration `yaml:"tolerations,omitempty"`
 
+	// Annotations describes the Kubernetes annotations for the pod.
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+
 	// RunAsUser defines the UID to request for running the container.
 	// If omitted, no SeurityContext will be specified for the pod and will therefore be inherited
 	// from the service account.
@@ -344,9 +347,6 @@ type ClusterDetails struct {
 
 	// RandomDockerConfigSecret adds a random UUID postfix to the default name of the docker secret to facilitate parallel builds, e.g. docker-cfgfd154022-c761-416f-8eb3-cf8258450b85.
 	RandomDockerConfigSecret bool `yaml:"randomDockerConfigSecret,omitempty"`
-
-	// Annotations defines arbitrary non-identifying metadata to a kaniko pod.
-	Annotations map[string]string `yaml:"annotations,omitempty"`
 }
 
 // DockerConfig contains information about the docker `config.json` to mount.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #1759<!-- tracking issues that this PR will close -->

**Description**
Add `annotations` for kaniko pod when you build in cluster with skaffold and kaniko.  This could be helpful for someone who wants to add annotations to kaniko pod in order to give additional permission or something to it.

This is not required for running kaniko pod(because permission could be added via serviceaccount). 

**Follow-up Work (remove if N/A)**
For test, I added two annotations like below, and it worked in `skaffold/v2beta5`. 
```
 cluster:
    annotations:
      iam.amazonaws.com/role: skaffold
      test: test
```
![image](https://user-images.githubusercontent.com/59159138/83345544-35e27980-a34f-11ea-85a9-8e1849efb0fa.png)


**Question**
This only works in v2beta5 version so that I commented the annotations part in the unit test. How could I add this kind of feature to unit test if new version is not released and I changed the configurations? 

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
