### PR TITLE
Change codecov thresholds to avoid noise

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,32 +1,8 @@
-# we ignore packages and files indicating that it
-# is either not possible or not strategically important
-# to test these pieces with unittests and hence we can accept
-# contributions without unittests in these areas
-
-ignore:
-  # webhook is going to be replaced with a managed solution
-  - "webhook"
-  - "pkg/webhook"
-
-codecov:
-  notify:
-    require_ci_to_pass: no
-
 coverage:
-  precision: 2
-  round: down
-  range: "60...100"
-
   status:
-    project: no
-    patch: no
-    changes: no
-
-comment:
-  layout: "flags, files"
-  behavior: default
-  require_changes: false  # if true: only post the comment if coverage changes
-  require_base: no        # [yes :: must have a base report to post]
-  require_head: yes       # [yes :: must have a head report to post]
-  branches: null          # branch names that can post comment
-
+    project:
+      default:
+        threshold: 10%
+    patch:
+      default:
+        target: 50%


### PR DESCRIPTION
Add codecov.yml as used in [Cloud Tools for Eclipse](https://github.com/GoogleCloudPlatform/google-cloud-eclipse/commits/master/codecov.yml) to avoid spurious warnings due to floating-point rounding.