### PR TITLE
hook up showing survey prompt if not taken or recently prompted

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -86,9 +86,9 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 
 			switch {
 			case quietFlag:
-				logrus.Debugf("Update check and survey prompt is disabled because of quiet mode")
+				logrus.Debugf("Update check and survey prompt disabled in quiet mode")
 			case analyze:
-				logrus.Debugf("Update check and survey prompt is disabled because of init --analyze")
+				logrus.Debugf("Update check and survey prompt when running `init --analyze`")
 			default:
 				go func() {
 					if err := updateCheck(updateMsg, opts.GlobalConfig); err != nil {
@@ -107,8 +107,8 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 			}
 			// check if survey prompt needs to be displayed
 			select {
-			case shdDisplay := <-surveyPrompt:
-				if shdDisplay {
+			case shouldDisplay := <-surveyPrompt:
+				if shouldDisplay {
 					if err := survey.New(opts.GlobalConfig).DisplaySurveyPrompt(cmd.OutOrStdout()); err != nil {
 						fmt.Fprintf(cmd.OutOrStderr(), "%v\n", err)
 					}

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/server"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/survey"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
@@ -47,6 +48,7 @@ var (
 
 func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 	updateMsg := make(chan string)
+	surveyPrompt := make(chan bool)
 	var shutdownAPIServer func() error
 
 	rootCmd := &cobra.Command{
@@ -84,14 +86,15 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 
 			switch {
 			case quietFlag:
-				logrus.Debugf("Update check is disabled because of quiet mode")
+				logrus.Debugf("Update check and survey prompt is disabled because of quiet mode")
 			case analyze:
-				logrus.Debugf("Update check is disabled because of init --analyze")
+				logrus.Debugf("Update check and survey prompt is disabled because of init --analyze")
 			default:
 				go func() {
 					if err := updateCheck(updateMsg, opts.GlobalConfig); err != nil {
 						logrus.Infof("update check failed: %s", err)
 					}
+					surveyPrompt <- config.ShouldDisplayPrompt(opts.GlobalConfig)
 				}()
 			}
 			return nil
@@ -100,6 +103,16 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 			select {
 			case msg := <-updateMsg:
 				fmt.Fprintf(cmd.OutOrStdout(), "%s\n", msg)
+			default:
+			}
+			// check if survey prompt needs to be displayed
+			select {
+			case shdDisplay := <-surveyPrompt:
+				if shdDisplay {
+					if err := survey.New(opts.GlobalConfig).DisplaySurveyPrompt(cmd.OutOrStdout()); err != nil {
+						fmt.Fprintf(cmd.OutOrStderr(), "%v\n", err)
+					}
+				}
 			default:
 			}
 

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -645,3 +645,63 @@ kubeContexts: []`,
 		})
 	}
 }
+
+func TestUpdateGlobalSurveyPrompted(t *testing.T) {
+	tests := []struct {
+		description string
+		cfg         string
+		expectedCfg *GlobalConfig
+	}{
+		{
+			description: "update global context when context is empty",
+			expectedCfg: &GlobalConfig{
+				Global:         &ContextConfig{Survey: &SurveyConfig{}},
+				ContextConfigs: []*ContextConfig{},
+			},
+		},
+		{
+			description: "update global context when survey config is not nil",
+			cfg: `
+global:
+  survey:
+    last-taken: "some date"
+kubeContexts: []`,
+			expectedCfg: &GlobalConfig{
+				Global:         &ContextConfig{Survey: &SurveyConfig{LastTaken: "some date"}},
+				ContextConfigs: []*ContextConfig{},
+			},
+		},
+		{
+			description: "update global context when survey config last prompted is in past",
+			cfg: `
+global:
+  survey:
+    last-prompted: "some date in past"
+kubeContexts: []`,
+			expectedCfg: &GlobalConfig{
+				Global:         &ContextConfig{Survey: &SurveyConfig{}},
+				ContextConfigs: []*ContextConfig{},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			cfg := t.TempFile("config", []byte(test.cfg))
+			testTime := time.Now()
+			t.Override(&ReadConfigFile, ReadConfigFileNoCache)
+			t.Override(&current, func() time.Time {
+				return testTime
+			})
+
+			// update the time
+			err := UpdateGlobalSurveyPrompted(cfg)
+			t.CheckNoError(err)
+
+			actualConfig, cfgErr := ReadConfigFile(cfg)
+			t.CheckNoError(cfgErr)
+			// update time in expected cfg.
+			test.expectedCfg.Global.Survey.LastPrompted = testTime.Format(time.RFC3339)
+			t.CheckDeepEqual(test.expectedCfg, actualConfig)
+		})
+	}
+}

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -413,6 +413,10 @@ func TestIsSurveyPromptDisabled(t *testing.T) {
 			cfg:         &ContextConfig{Survey: &SurveyConfig{DisablePrompt: util.BoolPtr(false)}},
 		},
 		{
+			description: "disable prompt is nil",
+			cfg:         &ContextConfig{Survey: &SurveyConfig{}},
+		},
+		{
 			description: "config is nil",
 			cfg:         nil,
 		},

--- a/pkg/skaffold/survey/survey.go
+++ b/pkg/skaffold/survey/survey.go
@@ -43,8 +43,9 @@ To permanently disable the survey prompt, run:
    skaffold config set --survey --global disable-prompt true`, URL)
 
 	// for testing
-	isStdOut = stdOut
-	open     = browser.OpenURL
+	isStdOut     = stdOut
+	open         = browser.OpenURL
+	updateConfig = config.UpdateGlobalSurveyPrompted
 )
 
 type Runner struct {
@@ -61,7 +62,7 @@ func (s *Runner) DisplaySurveyPrompt(out io.Writer) error {
 	if isStdOut(out) {
 		fmt.Fprintln(out, Prompt)
 	}
-	return config.UpdateGlobalSurveyPrompted(s.configFile)
+	return updateConfig(s.configFile)
 }
 
 func (s *Runner) OpenSurveyForm(_ context.Context, out io.Writer) error {

--- a/pkg/skaffold/survey/survey.go
+++ b/pkg/skaffold/survey/survey.go
@@ -57,10 +57,11 @@ func New(configFile string) *Runner {
 	}
 }
 
-func DisplaySurveyPrompt(out io.Writer) {
+func (s *Runner) DisplaySurveyPrompt(out io.Writer) error {
 	if isStdOut(out) {
 		fmt.Fprintln(out, Prompt)
 	}
+	return config.UpdateGlobalSurveyPrompted(s.configFile)
 }
 
 func (s *Runner) OpenSurveyForm(_ context.Context, out io.Writer) error {

--- a/pkg/skaffold/survey/survey_test.go
+++ b/pkg/skaffold/survey/survey_test.go
@@ -46,8 +46,9 @@ func TestDisplaySurveyForm(t *testing.T) {
 			t.Override(&isStdOut, mock)
 			mockOpen := func(string) error { return nil }
 			t.Override(&open, mockOpen)
+			t.Override(&updateConfig, func(_ string) error { return nil })
 			var buf bytes.Buffer
-			DisplaySurveyPrompt(&buf)
+			New("test").DisplaySurveyPrompt(&buf)
 			t.CheckDeepEqual(test.expected, buf.String())
 		})
 	}

--- a/pkg/skaffold/survey/test
+++ b/pkg/skaffold/survey/test
@@ -1,4 +1,0 @@
-global:
-  survey:
-    last-prompted: "2020-06-09T10:54:35-07:00"
-kubeContexts: []

--- a/pkg/skaffold/survey/test
+++ b/pkg/skaffold/survey/test
@@ -1,0 +1,4 @@
+global:
+  survey:
+    last-prompted: "2020-06-09T10:54:35-07:00"
+kubeContexts: []


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4046 

In this PR, skaffold will show the survey prompt to users if
1. The survey was not taken in last 3 months  **and**
2. The survey prompt was not show in last 2 weeks.

** UI Changes **

** Testing** 
1. Unit tests [here](https://github.com/GoogleContainerTools/skaffold/blob/6a514741b5414a272c27d3df42f32edf439abad6/pkg/skaffold/config/util_test.go#L469) cover all the below tests.

** Manual tests **

**1. Survey not taken in last 3 months or not prompted recently**
a. `~/.skaffold/config` :
```
(add_survey_check)cat ~/.skaffold/config 
global:
  survey: {}
kubeContexts: []
 (add_survey_check)
```
b. Run any skaffold command
```
../../out/skaffold run -d gcr.io/tejal-test
Generating tags...
...
You can also run [skaffold run --tail] to get the logs
Help improve Skaffold! Take a 10-second anonymous survey by running
   skaffold survey
(add_survey_check)
```

**2. Survey not taken in last 3 months but prompted recently**
a. Skaffold config 
```
(add_survey_check)cat ~/.skaffold/config 
global:
  survey:
    last-prompted: "2020-06-09T10:34:05-07:00"
kubeContexts: []
```
b. Run skaffold command and verify prompt is not shown. 
```
(add_survey_check)../../out/skaffold run -d gcr.io/tejal-test
Generating tags...
....
You can also run [skaffold run --tail] to get the logs
 (add_survey_check)
```

**3. Survey not taken in last 3 months but prompted but 2 weeks ago**
a. set survey prompted taken to last month
```
(add_survey_check)skaffold config set --survey --global last-prompted "2020-05-15T10:34:05-07:00"
set global value last-prompted to 2020-05-15T10:34:05-07:00
```

b. Run any skaffold command and verify the prompt is shown.
```
(add_survey_check)./../out/skaffold run -d gcr.io/tejal-test
Generating tags...
....
You can also run [skaffold run --tail] to get the logs
Help improve Skaffold! Take a 10-second anonymous survey by running
   skaffold survey

```

**4. Survey taken in last 3 months.**
a. Set survey taken in last 3 months and not recently prompted
```
skaffold config set --survey --global last-taken "2020-04-30T10:34:05-07:00"
set global value last-taken to 2020-04-30T10:34:05-07:00
```
```
skaffold config unset --survey --global last-prompted
unset global value last-prompted
```
```
cat ~/.skaffold/config 
global:
  survey:
    last-taken: "2020-04-30T10:34:05-07:00"
kubeContexts: []
tejaldesai@tejaldesai-macbookpro2 getting-started (add_survey_check)
```

b. Run skaffold command and verify the prompt is not displayed
```
(add_survey_check)../../out/skaffold run -d gcr.io/tejal-test
Generating tags...
 ...
Deployments stabilized in 132.179878ms
You can also run [skaffold run --tail] to get the logs
tejaldesai@tejaldesai-macbookpro2 getting-started (add_survey_check)
```