### PR TITLE
Add user-friendly validation of builder/artifact compatibility

### DIFF
--- a/pkg/skaffold/build/cluster/cluster.go
+++ b/pkg/skaffold/build/cluster/cluster.go
@@ -66,7 +66,7 @@ func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *lat
 		return custom.NewArtifactBuilder(nil, b.insecureRegistries, true, b.retrieveExtraEnv()).Build(ctx, out, a, tag)
 
 	default:
-		return "", fmt.Errorf("unexpected type %q for artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
+		return "", fmt.Errorf("unexpected type %q for in-cluster artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
 	}
 }
 

--- a/pkg/skaffold/build/cluster/cluster.go
+++ b/pkg/skaffold/build/cluster/cluster.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/custom"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -56,16 +57,16 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *la
 	return build.TagWithDigest(tag, digest), nil
 }
 
-func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
 	switch {
-	case artifact.KanikoArtifact != nil:
-		return b.buildWithKaniko(ctx, out, artifact.Workspace, artifact.KanikoArtifact, tag)
+	case a.KanikoArtifact != nil:
+		return b.buildWithKaniko(ctx, out, a.Workspace, a.KanikoArtifact, tag)
 
-	case artifact.CustomArtifact != nil:
-		return custom.NewArtifactBuilder(nil, b.insecureRegistries, true, b.retrieveExtraEnv()).Build(ctx, out, artifact, tag)
+	case a.CustomArtifact != nil:
+		return custom.NewArtifactBuilder(nil, b.insecureRegistries, true, b.retrieveExtraEnv()).Build(ctx, out, a, tag)
 
 	default:
-		return "", fmt.Errorf("unsupported artifact type: %+v", artifact.ArtifactType)
+		return "", fmt.Errorf("unexpected type %q for artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
 	}
 }
 

--- a/pkg/skaffold/build/dependencies.go
+++ b/pkg/skaffold/build/dependencies.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/custom"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -56,7 +57,7 @@ func DependenciesForArtifact(ctx context.Context, a *latest.Artifact, insecureRe
 		paths, err = buildpacks.GetDependencies(ctx, a.Workspace, a.BuildpackArtifact)
 
 	default:
-		return nil, fmt.Errorf("undefined artifact type: %+v", a.ArtifactType)
+		return nil, fmt.Errorf("undefined type %q for artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
 	}
 
 	if err != nil {

--- a/pkg/skaffold/build/dependencies.go
+++ b/pkg/skaffold/build/dependencies.go
@@ -57,7 +57,7 @@ func DependenciesForArtifact(ctx context.Context, a *latest.Artifact, insecureRe
 		paths, err = buildpacks.GetDependencies(ctx, a.Workspace, a.BuildpackArtifact)
 
 	default:
-		return nil, fmt.Errorf("undefined type %q for artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
+		return nil, fmt.Errorf("unexpected artifact type %q:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
 	}
 
 	if err != nil {

--- a/pkg/skaffold/build/gcb/spec.go
+++ b/pkg/skaffold/build/gcb/spec.go
@@ -63,13 +63,10 @@ func (b *Builder) buildSpecForArtifact(a *latest.Artifact, tag string) (cloudbui
 	case a.JibArtifact != nil:
 		return b.jibBuildSpec(a, tag)
 
-	case a.BazelArtifact != nil, a.CustomArtifact != nil:
-		return cloudbuild.Build{}, fmt.Errorf("Found a '%s' artifact, which is incompatible with the 'gcb' builder:\n\n%s\n\nTo use the '%s' builder, remove the 'googleCloudBuild' stanza from the 'build' section of your configuration. For information, see https://skaffold.dev/docs/pipeline-stages/builders/", misc.ArtifactType(a), misc.FormatArtifact(a), misc.ArtifactType(a))
-
 	case a.BuildpackArtifact != nil:
 		return b.buildpackBuildSpec(a.BuildpackArtifact, tag)
 
 	default:
-		return cloudbuild.Build{}, fmt.Errorf("undefined type %q for artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
+		return cloudbuild.Build{}, fmt.Errorf("unexpected type %q for artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
 	}
 }

--- a/pkg/skaffold/build/gcb/spec.go
+++ b/pkg/skaffold/build/gcb/spec.go
@@ -17,11 +17,11 @@ limitations under the License.
 package gcb
 
 import (
-	"errors"
 	"fmt"
 
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -52,27 +52,24 @@ func (b *Builder) buildSpec(artifact *latest.Artifact, tag, bucket, object strin
 	return buildSpec, nil
 }
 
-func (b *Builder) buildSpecForArtifact(artifact *latest.Artifact, tag string) (cloudbuild.Build, error) {
+func (b *Builder) buildSpecForArtifact(a *latest.Artifact, tag string) (cloudbuild.Build, error) {
 	switch {
-	case artifact.KanikoArtifact != nil:
-		return b.kanikoBuildSpec(artifact.KanikoArtifact, tag)
+	case a.KanikoArtifact != nil:
+		return b.kanikoBuildSpec(a.KanikoArtifact, tag)
 
-	case artifact.DockerArtifact != nil:
-		return b.dockerBuildSpec(artifact.DockerArtifact, tag)
+	case a.DockerArtifact != nil:
+		return b.dockerBuildSpec(a.DockerArtifact, tag)
 
-	case artifact.JibArtifact != nil:
-		return b.jibBuildSpec(artifact, tag)
+	case a.JibArtifact != nil:
+		return b.jibBuildSpec(a, tag)
 
-	case artifact.BazelArtifact != nil:
-		return cloudbuild.Build{}, errors.New("skaffold can't build a bazel artifact with Google Cloud Build")
+	case a.BazelArtifact != nil, a.CustomArtifact != nil:
+		return cloudbuild.Build{}, fmt.Errorf("Found a '%s' artifact, which is incompatible with the 'gcb' builder:\n\n%s\n\nTo use the '%s' builder, remove the 'googleCloudBuild' stanza from the 'build' section of your configuration. For information, see https://skaffold.dev/docs/pipeline-stages/builders/", misc.ArtifactType(a), misc.FormatArtifact(a), misc.ArtifactType(a))
 
-	case artifact.CustomArtifact != nil:
-		return cloudbuild.Build{}, errors.New("skaffold can't build a custom artifact with Google Cloud Build")
-
-	case artifact.BuildpackArtifact != nil:
-		return b.buildpackBuildSpec(artifact.BuildpackArtifact, tag)
+	case a.BuildpackArtifact != nil:
+		return b.buildpackBuildSpec(a.BuildpackArtifact, tag)
 
 	default:
-		return cloudbuild.Build{}, fmt.Errorf("undefined artifact type: %+v", artifact.ArtifactType)
+		return cloudbuild.Build{}, fmt.Errorf("undefined type %q for artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
 	}
 }

--- a/pkg/skaffold/build/gcb/spec.go
+++ b/pkg/skaffold/build/gcb/spec.go
@@ -67,6 +67,6 @@ func (b *Builder) buildSpecForArtifact(a *latest.Artifact, tag string) (cloudbui
 		return b.buildpackBuildSpec(a.BuildpackArtifact, tag)
 
 	default:
-		return cloudbuild.Build{}, fmt.Errorf("unexpected type %q for artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
+		return cloudbuild.Build{}, fmt.Errorf("unexpected type %q for gcb artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
 	}
 }

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/custom"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -44,8 +45,8 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, 
 	return build.InParallel(ctx, out, tags, artifacts, b.buildArtifact, *b.cfg.Concurrency)
 }
 
-func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
-	digestOrImageID, err := b.runBuildForArtifact(ctx, out, artifact, tag)
+func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
+	digestOrImageID, err := b.runBuildForArtifact(ctx, out, a, tag)
 	if err != nil {
 		return "", err
 	}
@@ -53,7 +54,7 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *la
 	if b.pushImages {
 		// only track images for pruning when building with docker
 		// if we're pushing a bazel image, it was built directly to the registry
-		if artifact.DockerArtifact != nil {
+		if a.DockerArtifact != nil {
 			imageID, err := b.getImageIDForTag(ctx, tag)
 			if err != nil {
 				logrus.Warnf("unable to inspect image: built images may not be cleaned up correctly by skaffold")
@@ -72,7 +73,7 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *la
 	return build.TagWithImageID(ctx, tag, imageID, b.localDocker)
 }
 
-func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
 	if !b.pushImages {
 		// All of the builders will rely on a local Docker:
 		// + Either to build the image,
@@ -84,23 +85,26 @@ func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, artifa
 	}
 
 	switch {
-	case artifact.DockerArtifact != nil:
-		return b.buildDocker(ctx, out, artifact, tag)
+	case a.DockerArtifact != nil:
+		return b.buildDocker(ctx, out, a, tag)
 
-	case artifact.BazelArtifact != nil:
-		return bazel.NewArtifactBuilder(b.localDocker, b.insecureRegistries, b.pushImages).Build(ctx, out, artifact, tag)
+	case a.BazelArtifact != nil:
+		return bazel.NewArtifactBuilder(b.localDocker, b.insecureRegistries, b.pushImages).Build(ctx, out, a, tag)
 
-	case artifact.JibArtifact != nil:
-		return jib.NewArtifactBuilder(b.localDocker, b.insecureRegistries, b.pushImages, b.skipTests).Build(ctx, out, artifact, tag)
+	case a.JibArtifact != nil:
+		return jib.NewArtifactBuilder(b.localDocker, b.insecureRegistries, b.pushImages, b.skipTests).Build(ctx, out, a, tag)
 
-	case artifact.CustomArtifact != nil:
-		return custom.NewArtifactBuilder(b.localDocker, b.insecureRegistries, b.pushImages, b.retrieveExtraEnv()).Build(ctx, out, artifact, tag)
+	case a.CustomArtifact != nil:
+		return custom.NewArtifactBuilder(b.localDocker, b.insecureRegistries, b.pushImages, b.retrieveExtraEnv()).Build(ctx, out, a, tag)
 
-	case artifact.BuildpackArtifact != nil:
-		return buildpacks.NewArtifactBuilder(b.localDocker, b.pushImages, b.devMode).Build(ctx, out, artifact, tag)
+	case a.BuildpackArtifact != nil:
+		return buildpacks.NewArtifactBuilder(b.localDocker, b.pushImages, b.devMode).Build(ctx, out, a, tag)
+
+	case a.KanikoArtifact != nil:
+		return "", fmt.Errorf("Found a '%s' artifact, which is incompatible with the 'local' builder:\n\n%s\n\nTo use the '%s' builder, add the 'cluster' stanza to the 'build' section of your configuration. For information, see https://skaffold.dev/docs/pipeline-stages/builders/", misc.ArtifactType(a), misc.FormatArtifact(a), misc.ArtifactType(a))
 
 	default:
-		return "", fmt.Errorf("undefined artifact type: %+v", artifact.ArtifactType)
+		return "", fmt.Errorf("undefined type %q for artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
 	}
 }
 

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -101,7 +101,7 @@ func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *lat
 		return buildpacks.NewArtifactBuilder(b.localDocker, b.pushImages, b.devMode).Build(ctx, out, a, tag)
 
 	default:
-		return "", fmt.Errorf("unexpected artifact type %q:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
+		return "", fmt.Errorf("unexpected type %q for local artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
 	}
 }
 

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -100,11 +100,8 @@ func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *lat
 	case a.BuildpackArtifact != nil:
 		return buildpacks.NewArtifactBuilder(b.localDocker, b.pushImages, b.devMode).Build(ctx, out, a, tag)
 
-	case a.KanikoArtifact != nil:
-		return "", fmt.Errorf("Found a '%s' artifact, which is incompatible with the 'local' builder:\n\n%s\n\nTo use the '%s' builder, add the 'cluster' stanza to the 'build' section of your configuration. For information, see https://skaffold.dev/docs/pipeline-stages/builders/", misc.ArtifactType(a), misc.FormatArtifact(a), misc.ArtifactType(a))
-
 	default:
-		return "", fmt.Errorf("undefined type %q for artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
+		return "", fmt.Errorf("unexpected artifact type %q:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))
 	}
 }
 

--- a/pkg/skaffold/build/misc/artifact_type.go
+++ b/pkg/skaffold/build/misc/artifact_type.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2020 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/skaffold/build/misc/artifact_type.go
+++ b/pkg/skaffold/build/misc/artifact_type.go
@@ -19,8 +19,18 @@ package misc
 import (
 	"fmt"
 	"strings"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
+)
+
+const (
+	Docker    = "docker"
+	Kaniko    = "kaniko"
+	Bazel     = "bazel"
+	Jib       = "jib"
+	Custom    = "custom"
+	Buildpack = "buildpack"
 )
 
 // ArtifactType returns a string representing the type found in an artifact. Used for error messages.
@@ -28,22 +38,21 @@ import (
 func ArtifactType(a *latest.Artifact) string {
 	switch {
 	case a.DockerArtifact != nil:
-		return "docker"
+		return Docker
 	case a.KanikoArtifact != nil:
-		return "kaniko"
+		return Kaniko
 	case a.BazelArtifact != nil:
-		return "bazel"
+		return Bazel
 	case a.JibArtifact != nil:
-		return "jib"
+		return Jib
 	case a.CustomArtifact != nil:
-		return "custom"
+		return Custom
 	case a.BuildpackArtifact != nil:
-		return "buildpack"
+		return Buildpack
 	default:
 		return ""
 	}
 }
-
 
 // FormatArtifact returns a string representation of an artifact for usage in error messages
 func FormatArtifact(a *latest.Artifact) string {

--- a/pkg/skaffold/build/misc/artifact_type.go
+++ b/pkg/skaffold/build/misc/artifact_type.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package misc
+
+import (
+	"fmt"
+	"strings"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
+)
+
+// ArtifactType returns a string representing the type found in an artifact. Used for error messages.
+// (this would normally be implemented as a String() method on the type, but types are versioned)
+func ArtifactType(a *latest.Artifact) string {
+	switch {
+	case a.DockerArtifact != nil:
+		return "docker"
+	case a.KanikoArtifact != nil:
+		return "kaniko"
+	case a.BazelArtifact != nil:
+		return "bazel"
+	case a.JibArtifact != nil:
+		return "jib"
+	case a.CustomArtifact != nil:
+		return "custom"
+	case a.BuildpackArtifact != nil:
+		return "buildpack"
+	default:
+		return ""
+	}
+}
+
+
+// FormatArtifact returns a string representation of an artifact for usage in error messages
+func FormatArtifact(a *latest.Artifact) string {
+	buf, err := yaml.Marshal(a)
+	if err != nil {
+		return fmt.Sprintf("%+v", a)
+	}
+	return strings.TrimSpace(string(buf))
+}

--- a/pkg/skaffold/build/misc/artifact_type_test.go
+++ b/pkg/skaffold/build/misc/artifact_type_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2020 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/skaffold/build/misc/artifact_type_test.go
+++ b/pkg/skaffold/build/misc/artifact_type_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package misc
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestArtifactType(t *testing.T) {
+	tests := []struct {
+		description string
+		want        string
+		artifact    *latest.Artifact
+	}{
+		{"docker", "docker", &latest.Artifact{
+			ArtifactType: latest.ArtifactType{
+				DockerArtifact: &latest.DockerArtifact{},
+			},
+		}},
+		{"kaniko", "kaniko", &latest.Artifact{
+			ArtifactType: latest.ArtifactType{
+				KanikoArtifact: &latest.KanikoArtifact{},
+			},
+		}},
+		{"docker+kaniko", "docker", &latest.Artifact{
+			ArtifactType: latest.ArtifactType{
+				DockerArtifact: &latest.DockerArtifact{},
+				KanikoArtifact: &latest.KanikoArtifact{},
+			},
+		}},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			got := ArtifactType(test.artifact)
+			if got != test.want {
+				t.Errorf("ArtifactType(%+v) = %q; want %q", test.artifact, got, test.want)
+			}
+		})
+	}
+}
+
+func TestFormatArtifact(t *testing.T) {
+	tests := []struct {
+		description string
+		want        string
+		artifact    *latest.Artifact
+	}{
+		{"docker", "docker: {}", &latest.Artifact{
+			ArtifactType: latest.ArtifactType{
+				DockerArtifact: &latest.DockerArtifact{},
+			},
+		}},
+		{"kaniko", "kaniko: {}", &latest.Artifact{
+			ArtifactType: latest.ArtifactType{
+				KanikoArtifact: &latest.KanikoArtifact{},
+			},
+		}},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			got := FormatArtifact(test.artifact)
+			if got != test.want {
+				t.Errorf("FormatArtifact(%+v) = %q; want %q", test.artifact, got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -211,21 +211,21 @@ func validateArtifactTypes(bc latest.BuildConfig) (errs []error) {
 	switch {
 	case bc.LocalBuild != nil:
 		for _, a := range bc.Artifacts {
-			if misc.ArtifactType(a) == "kaniko" {
-				errs = append(errs, fmt.Errorf("Found a '%s' artifact, which is incompatible with the 'local' builder:\n\n%s\n\nTo use the '%s' builder, add the 'cluster' stanza to the 'build' section of your configuration. For information, see https://skaffold.dev/docs/pipeline-stages/builders/", misc.ArtifactType(a), misc.FormatArtifact(a), misc.ArtifactType(a)))
+			if misc.ArtifactType(a) == misc.Kaniko {
+				errs = append(errs, fmt.Errorf("found a '%s' artifact, which is incompatible with the 'local' builder:\n\n%s\n\nTo use the '%s' builder, add the 'cluster' stanza to the 'build' section of your configuration. For information, see https://skaffold.dev/docs/pipeline-stages/builders/", misc.ArtifactType(a), misc.FormatArtifact(a), misc.ArtifactType(a)))
 			}
 		}
 	case bc.GoogleCloudBuild != nil:
 		for _, a := range bc.Artifacts {
 			at := misc.ArtifactType(a)
-			if at != "kaniko" && at != "docker" && at != "jib" && at != "buildpack" {
-				errs = append(errs, fmt.Errorf("Found a '%s' artifact, which is incompatible with the 'gcb' builder:\n\n%s\n\nTo use the '%s' builder, remove the 'googleCloudBuild' stanza from the 'build' section of your configuration. For information, see https://skaffold.dev/docs/pipeline-stages/builders/", misc.ArtifactType(a), misc.FormatArtifact(a), misc.ArtifactType(a)))
+			if at != misc.Kaniko && at != misc.Docker && at != misc.Jib && at != misc.Buildpack {
+				errs = append(errs, fmt.Errorf("found a '%s' artifact, which is incompatible with the 'gcb' builder:\n\n%s\n\nTo use the '%s' builder, remove the 'googleCloudBuild' stanza from the 'build' section of your configuration. For information, see https://skaffold.dev/docs/pipeline-stages/builders/", misc.ArtifactType(a), misc.FormatArtifact(a), misc.ArtifactType(a)))
 			}
 		}
 	case bc.Cluster != nil:
 		for _, a := range bc.Artifacts {
-			if misc.ArtifactType(a) != "kaniko" && misc.ArtifactType(a) != "custom" {
-				errs = append(errs, fmt.Errorf("Found a '%s' artifact, which is incompatible with the 'cluster' builder:\n\n%s\n\nTo use the '%s' builder, remove the 'cluster' stanza from the 'build' section of your configuration. For information, see https://skaffold.dev/docs/pipeline-stages/builders/", misc.ArtifactType(a), misc.FormatArtifact(a), misc.ArtifactType(a)))
+			if misc.ArtifactType(a) != misc.Kaniko && misc.ArtifactType(a) != misc.Custom {
+				errs = append(errs, fmt.Errorf("found a '%s' artifact, which is incompatible with the 'cluster' builder:\n\n%s\n\nTo use the '%s' builder, remove the 'cluster' stanza from the 'build' section of your configuration. For information, see https://skaffold.dev/docs/pipeline-stages/builders/", misc.ArtifactType(a), misc.FormatArtifact(a), misc.ArtifactType(a)))
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #4161 

## Example case

If `cluster` is removed from `examples/kaniko/skaffold.yaml`, and `skaffold build` is run.

## Old error message

`couldn't build "skaffold-example": undefined artifact type: {DockerArtifact:<nil> BazelArtifact:<nil> JibArtifact:<nil> KanikoArtifact:0xc000542be0 BuildpackArtifact:<nil> CustomArtifact:<nil>}`

## New error message

```
invalid skaffold config: Found a 'kaniko' artifact, which is incompatible with the 'local' builder:

image: skaffold-example
context: .
kaniko:
  dockerfile: Dockerfile
  initImage: busybox
  image: gcr.io/kaniko-project/executor:v0.20.0@sha256:f9a4a760166682c7c7aeda3cc263570682e00848ab47737ed8ffcc3abd2da6c3
  cache: {}

To use the 'kaniko' builder, add the 'cluster' stanza to the 'build' section of your configuration. For information, see https://skaffold.dev/docs/pipeline-stages/builders/
```
