### PR TITLE
#4322: Fix render not fully overwriting output files.

### DIFF
--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -210,19 +210,7 @@ func (k *KustomizeDeployer) Render(ctx context.Context, out io.Writer, builds []
 		return err
 	}
 
-	manifestOut := out
-	if filepath != "" {
-		f, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0666)
-		if err != nil {
-			return fmt.Errorf("opening file for writing manifests: %w", err)
-		}
-		defer f.Close()
-		f.WriteString(manifests.String() + "\n")
-		return nil
-	}
-
-	fmt.Fprintln(manifestOut, manifests.String())
-	return nil
+	return outputRenderedManifests(manifests.String(), filepath, out)
 }
 
 // UnmarshalYAML implements JSON unmarshalling by reading an inline yaml fragment.

--- a/pkg/skaffold/deploy/util.go
+++ b/pkg/skaffold/deploy/util.go
@@ -124,7 +124,7 @@ func outputRenderedManifests(renderedManifests string, output string, manifestOu
 }
 
 func dumpToFile(renderedManifests string, filepath string) error {
-	f, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0666)
+	f, err := os.Create(filepath)
 	if err != nil {
 		return fmt.Errorf("opening file for writing manifests: %w", err)
 	}


### PR DESCRIPTION
If the output file already existed, it was not being truncated to the
new output. If the existing content was larger than the new output, the
remainder of the existing output was left in the file corrupting the
contents.

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4322  <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
The changes are:

* Change the `os.OpenFile` call to `os.Create` in `util.go`
* Change `kustomise.go` to be consistent with the other deployers and use the `outputRenderedManifests` function of `util.go`
