### PR TITLE
Automate release steps post changelog PR merge.

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -24,6 +24,13 @@ jobs:
         echo ::set-env name=TAG_NAME::"v${t}"
         echo ::set-env name=RELEASE_NAME::"v${t} Release"
 
+    - name: Create and push Tag
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git tag -a ${{ env.TAG_NAME }} -m "${{ env.RELEASE_NAME }}"
+        git push origin ${{ env.TAG_NAME }}
+
     - name: Install gsutil
       run: |
         curl -Lo $HOME/gsutil.tar.gz https://storage.googleapis.com/pub/gsutil.tar.gz

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,57 @@
+name: create draft release
+
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  build:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'draft-release')
+    name: Create Tag and Draft Release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Calculate Tag and release names
+      run: |
+        t=$(echo ${{ github.event.pull_request.title }} | sed -ne 's/.*\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p')
+        if [ -z "$t" ]; then
+        echo Malformed title for PR; failed to extract semVer tag
+        return 1
+        fi
+        echo ::set-env name=TAG_NAME::"v${t}"
+        echo ::set-env name=RELEASE_NAME::"v${t} Release"
+
+    - name: Install gsutil
+      run: |
+        curl -Lo $HOME/gsutil.tar.gz https://storage.googleapis.com/pub/gsutil.tar.gz
+        tar xfz $HOME/gsutil.tar.gz -C $HOME
+        echo ::add-path::$HOME/gsutil
+
+    - name: Download release artifacts
+      run: |
+        #Wait 60m for all artifacts to be available
+        retries=20
+        found=0
+        while [ $found -lt 10 -a $retries -gt 0 ]
+        do
+        sleep 3m
+        found=$(gsutil du  gs://skaffold/releases/${{ env.TAG_NAME }}/ | wc -l)
+        retries=$((retries-1))
+        done
+        gsutil -m cp -r gs://skaffold/releases/${{ env.TAG_NAME }}/ $HOME
+
+    - name: Create Release
+      shell: bash
+      run: |
+        curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
+        body=$(git log -p --follow -1 CHANGELOG.md | grep '^\+' | cut -c 2- | tail -n +2)
+        assets=()
+        for asset in $HOME/${{ env.TAG_NAME }}/*; do
+        assets+=("-a" "$asset")
+        done
+        bin/hub release create "${assets[@]}" -m "${{ env.RELEASE_NAME }}" -m "$body" --draft ${{ env.TAG_NAME }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4324  <!-- tracking issues that this PR will close -->


**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Current release has a lot of manual actions that can be broadly categorized into two steps:
- Create Release Changelog PR
- Create and Publish Github Release

This PR automates the second step. When the Changelog PR is merged it automatically creates the Github Release(as a draft) with all text and attachments. We will only need to hit publish button once we're ok with the draft. In time this manual verification can be skipped too.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
This requires that the Changelog PR is labelled with `draft-release` *before* being merged. Also the PR title should be `Release vX.x.x` or `vX.x.x release` since it parses the PR title for the tag semVer. 
**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->
In a subsequent PR I'll automate the first step of creating the Release Changelog PR. 

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
