### PR TITLE
chore: use setValues not values in helm docs example

### DIFF
--- a/docs/content/en/docs/pipeline-stages/deployers/helm.md
+++ b/docs/content/en/docs/pipeline-stages/deployers/helm.md
@@ -54,7 +54,7 @@ deploy:
   helm:
     releases:
     - name: my-release
-      setValues:
+      artifactOverrides:
         image: gcr.io/my-project/my-image # no tag present!
         # Skaffold continuously tags your image, so no need to put one here.
 ```

--- a/docs/content/en/docs/pipeline-stages/deployers/helm.md
+++ b/docs/content/en/docs/pipeline-stages/deployers/helm.md
@@ -54,7 +54,7 @@ deploy:
   helm:
     releases:
     - name: my-release
-      values:
+      setValues:
         image: gcr.io/my-project/my-image # no tag present!
         # Skaffold continuously tags your image, so no need to put one here.
 ```
@@ -100,5 +100,3 @@ The `helm` type offers the following options:
 Each `release` includes the following fields:
 
 {{< schema root="HelmRelease" >}}
-
-


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

Noticed when going through the docs recently that the example listed on the helm deployers page referenced the `values` field. If I understand if correctly, the field has been renamed to `setValues` now. While the example code folders in the repo seem to be aligned with the newer field name, the example given in the helm docs page was not, so I created this incredibly difficult, super arduous fix.

I didn't create an issue since I thought it was a fairly small change / edit, but if you'd like I can create an issue first to make sure this is a correct change.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

Before

![Screenshot from 2020-06-16 23-34-24](https://user-images.githubusercontent.com/4990214/84852251-5a667300-b02a-11ea-9179-6c840cc367ff.png)

After

![Screenshot from 2020-06-16 23-34-46](https://user-images.githubusercontent.com/4990214/84852265-681bf880-b02a-11ea-8a7e-703eb83b197d.png)


**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->

Don't think this section applies here.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->