### PR TITLE
Fix propagation of buildpacks working directory

### DIFF
--- a/pkg/skaffold/debug/cnb.go
+++ b/pkg/skaffold/debug/cnb.go
@@ -80,6 +80,10 @@ func updateForCNBImage(container *v1.Container, ic imageConfiguration, transform
 	}
 
 	c, img, err := transformer(container, ic)
+	// must explicitly modify the working dir as the imageConfig is lost after we return
+	if c.WorkingDir == "" {
+		c.WorkingDir = ic.workingDir
+	}
 
 	// Only rewrite the container.Args if set: some transforms only alter env vars,
 	// and the image's arguments are not changed.

--- a/pkg/skaffold/debug/cnb_test.go
+++ b/pkg/skaffold/debug/cnb_test.go
@@ -138,7 +138,7 @@ func TestUpdateForCNBImage(t *testing.T) {
 		testutil.Run(t, test.description+" (args changed)", func(t *testutil.T) {
 			argsChangedTransform := func(c *v1.Container, ic imageConfiguration) (ContainerDebugConfiguration, string, error) {
 				c.Args = ic.arguments
-				return ContainerDebugConfiguration{WorkingDir: ic.workingDir}, "", nil
+				return ContainerDebugConfiguration{}, "", nil
 			}
 			copy := v1.Container{}
 			c, _, err := updateForCNBImage(&copy, test.input, argsChangedTransform)


### PR DESCRIPTION
**Description**

I backed out a critical commit to change the working directory in #4326 that was masked by a different change to the CNB tests.

More deeply: `debug` works by examining the container image run configuration (specifically the entrypoint + command, environment).  CNB images use a launcher process that retrieves the actual command from configuration files in the image; this information is also available as annotations on the image.  The CNB debug support wraps the normal debug transformation process, providing an image run configuration information that was rewritten from the CNB information.  It also needs to unwrap some of the changes.  One aspect that was missed here was to unwrap the reported working directory.