### PR TITLE
Minor clean up to debug tests

### DIFF
--- a/pkg/skaffold/debug/transform_go_test.go
+++ b/pkg/skaffold/debug/transform_go_test.go
@@ -68,6 +68,7 @@ func TestDlvTransformer_IsApplicable(t *testing.T) {
 	tests := []struct {
 		description string
 		source      imageConfiguration
+		launcher    string
 		result      bool
 	}{
 		{
@@ -96,6 +97,12 @@ func TestDlvTransformer_IsApplicable(t *testing.T) {
 			result:      true,
 		},
 		{
+			description: "launcher entrypoint",
+			source:      imageConfiguration{entrypoint: []string{"launcher"}, arguments: []string{"dlv", "exec", "--headless"}},
+			launcher:    "launcher",
+			result:      true,
+		},
+		{
 			description: "entrypoint /bin/sh",
 			source:      imageConfiguration{entrypoint: []string{"/bin/sh"}},
 			result:      false,
@@ -109,6 +116,7 @@ func TestDlvTransformer_IsApplicable(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&entrypointLaunchers, []string{test.launcher})
 			result := dlvTransformer{}.IsApplicable(test.source)
 
 			t.CheckDeepEqual(test.result, result)

--- a/pkg/skaffold/debug/transform_jvm.go
+++ b/pkg/skaffold/debug/transform_jvm.go
@@ -46,10 +46,8 @@ func (t jdwpTransformer) IsApplicable(config imageConfiguration) bool {
 	if len(config.entrypoint) > 0 && !isEntrypointLauncher(config.entrypoint) {
 		return config.entrypoint[0] == "java" || strings.HasSuffix(config.entrypoint[0], "/java")
 	}
-	if len(config.arguments) > 0 {
-		return config.arguments[0] == "java" || strings.HasSuffix(config.arguments[0], "/java")
-	}
-	return false
+	return len(config.arguments) > 0 &&
+		(config.arguments[0] == "java" || strings.HasSuffix(config.arguments[0], "/java"))
 }
 
 // captures the useful jdwp options (see `java -agentlib:jdwp=help`)

--- a/pkg/skaffold/debug/transform_jvm_test.go
+++ b/pkg/skaffold/debug/transform_jvm_test.go
@@ -33,6 +33,7 @@ func TestJdwpTransformer_IsApplicable(t *testing.T) {
 	tests := []struct {
 		description string
 		source      imageConfiguration
+		launcher    string
 		result      bool
 	}{
 		{
@@ -66,6 +67,12 @@ func TestJdwpTransformer_IsApplicable(t *testing.T) {
 			result:      true,
 		},
 		{
+			description: "launcher entrypoint",
+			source:      imageConfiguration{entrypoint: []string{"launcher"}, arguments: []string{"/usr/bin/java", "-jar", "foo.jar"}},
+			launcher:    "launcher",
+			result:      true,
+		},
+		{
 			description: "entrypoint /bin/sh",
 			source:      imageConfiguration{entrypoint: []string{"/bin/sh"}},
 			result:      false,
@@ -78,6 +85,7 @@ func TestJdwpTransformer_IsApplicable(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&entrypointLaunchers, []string{test.launcher})
 			result := jdwpTransformer{}.IsApplicable(test.source)
 
 			t.CheckDeepEqual(test.result, result)

--- a/pkg/skaffold/debug/transform_nodejs_test.go
+++ b/pkg/skaffold/debug/transform_nodejs_test.go
@@ -64,6 +64,7 @@ func TestNodeTransformer_IsApplicable(t *testing.T) {
 	tests := []struct {
 		description string
 		source      imageConfiguration
+		launcher    string
 		result      bool
 	}{
 		{
@@ -152,8 +153,9 @@ func TestNodeTransformer_IsApplicable(t *testing.T) {
 			result:      false,
 		},
 		{
-			description: "`node` docker-entrypoint.sh",
+			description: "entrypoint launcher", // `node` image docker-entrypoint.sh"
 			source:      imageConfiguration{entrypoint: []string{"docker-entrypoint.sh"}, arguments: []string{"npm", "run", "dev"}},
+			launcher:    "docker-entrypoint.sh",
 			result:      true,
 		},
 		{
@@ -164,6 +166,7 @@ func TestNodeTransformer_IsApplicable(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&entrypointLaunchers, []string{test.launcher})
 			result := nodeTransformer{}.IsApplicable(test.source)
 
 			t.CheckDeepEqual(test.result, result)

--- a/pkg/skaffold/debug/transform_python.go
+++ b/pkg/skaffold/debug/transform_python.go
@@ -73,10 +73,10 @@ func (t pythonTransformer) Apply(container *v1.Container, config imageConfigurat
 	if spec == nil {
 		spec = &ptvsdSpec{port: portAlloc(defaultPtvsdPort)}
 		switch {
-		case len(config.entrypoint) > 0 && isLaunchingPython(config.entrypoint):
+		case isLaunchingPython(config.entrypoint):
 			container.Command = rewritePythonCommandLine(config.entrypoint, *spec)
 
-		case len(config.entrypoint) == 0 && len(config.arguments) > 0 && isLaunchingPython(config.arguments):
+		case (len(config.entrypoint) == 0 || isEntrypointLauncher(config.entrypoint)) && isLaunchingPython(config.arguments):
 			container.Args = rewritePythonCommandLine(config.arguments, *spec)
 
 		default:

--- a/pkg/skaffold/debug/transform_python_test.go
+++ b/pkg/skaffold/debug/transform_python_test.go
@@ -61,6 +61,7 @@ func TestPythonTransformer_IsApplicable(t *testing.T) {
 	tests := []struct {
 		description string
 		source      imageConfiguration
+		launcher    string
 		result      bool
 	}{
 		{
@@ -109,6 +110,12 @@ func TestPythonTransformer_IsApplicable(t *testing.T) {
 			result:      true,
 		},
 		{
+			description: "entrypoint launcher",
+			source:      imageConfiguration{entrypoint: []string{"launcher"}, arguments: []string{"python3", "app.py"}},
+			launcher:    "launcher",
+			result:      true,
+		},
+		{
 			description: "entrypoint /bin/sh",
 			source:      imageConfiguration{entrypoint: []string{"/bin/sh"}},
 			result:      false,
@@ -122,6 +129,7 @@ func TestPythonTransformer_IsApplicable(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&entrypointLaunchers, []string{test.launcher})
 			result := pythonTransformer{}.IsApplicable(test.source)
 
 			t.CheckDeepEqual(test.result, result)

--- a/pkg/skaffold/debug/transform_test.go
+++ b/pkg/skaffold/debug/transform_test.go
@@ -208,25 +208,19 @@ func TestShJoin(t *testing.T) {
 }
 
 func TestIsEntrypointLauncher(t *testing.T) {
-	// make full copy of entrypointLaunchers
-	oldEntrypointLaunchers := append(entrypointLaunchers[:0:0], entrypointLaunchers...)
-	entrypointLaunchers = append(entrypointLaunchers, "foo")
-	t.Cleanup(func() {
-		entrypointLaunchers = oldEntrypointLaunchers
-	})
-
 	tests := []struct {
 		description string
 		entrypoint  []string
 		expected    bool
 	}{
 		{"nil", nil, false},
-		{"expected case", []string{"foo"}, true},
-		{"unexpected arg", []string{"foo", "bar"}, false},
-		{"unexpected entrypoint", []string{"bar"}, false},
+		{"expected case", []string{"launcher"}, true},
+		{"launchers do not take args", []string{"launcher", "bar"}, false},
+		{"non-launcher", []string{"/bin/sh"}, false},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&entrypointLaunchers, []string{"launcher"})
 			result := isEntrypointLauncher(test.entrypoint)
 			t.CheckDeepEqual(test.expected, result)
 		})


### PR DESCRIPTION
*Description*

- Ensures each language runtime has tests for entrypoint-launchers (entrypoints that are equivalent to just executing the arguments).  Python was missing such a test.
- Use testutil.Override() to configure entrypoint launchers for tests rather than rely on implicitly-configured launchers.
- Minor simplifications.

