### PR TITLE
Allow configuring skaffold binary location for integration tests

### DIFF
--- a/integration/skaffold/helper.go
+++ b/integration/skaffold/helper.go
@@ -274,7 +274,11 @@ func (b *RunBuilder) cmd(ctx context.Context) *exec.Cmd {
 	}
 	args = append(args, b.args...)
 
-	cmd := exec.CommandContext(ctx, "skaffold", args...)
+	skaffoldBinary := "skaffold"
+	if value, found := os.LookupEnv("SKAFFOLD_BINARY"); found {
+		skaffoldBinary = value
+	}
+	cmd := exec.CommandContext(ctx, skaffoldBinary, args...)
 	cmd.Env = append(removeSkaffoldEnvVariables(util.OSEnviron()), b.env...)
 	if b.stdin != nil {
 		cmd.Stdin = bytes.NewReader(b.stdin)


### PR DESCRIPTION
**Description**

Running Skaffold's integration tests in a debugger requires configuring `PATH` to also point to the location of the built binary. This is a pain when using the [VSCode Go debug launch configuration](https://github.com/golang/vscode-go/blob/master/docs/debugging.md#launch-configurations) as it doesn't provide a way to prepend a value to an existing environment variable.

This patch introduces a new `SKAFFOLD_BINARY` environment variable to point to the `skaffold` binary to be used by the integration tests.