### PR TITLE
Improve the error message when a released schema is changed

### DIFF
--- a/hack/check-schema-changes.sh
+++ b/hack/check-schema-changes.sh
@@ -24,8 +24,4 @@
 # If the change is latest and it is released, we fail the PR for the same reason.
 # If the change is in latest and it is not released yet, it is fine to make changes.
 
-
-
-set +x
-
 go run hack/versions/cmd/schema_check/check.go

--- a/hack/versions/pkg/schema/version.go
+++ b/hack/versions/pkg/schema/version.go
@@ -31,7 +31,7 @@ import (
 
 func GetLatestVersion() (string, bool) {
 	current := strings.TrimPrefix(latest.Version, "skaffold/")
-	logrus.Infof("Current Skaffold version: %s", current)
+	logrus.Debugf("Current Skaffold version: %s", current)
 
 	config, err := ioutil.ReadFile("pkg/skaffold/schema/latest/config.go")
 	if err != nil {


### PR DESCRIPTION
Fixes #4168

**Old message:**

```
$ ./hack/check-schema-changes.sh
INFO[0000] structural changes in latest config, checking on Github if latest is released...
INFO[0000] Current Skaffold version: v2beta5
v2beta5 is released, it should NOT be changed!
ERRO[0000] --------
Structural change detected in a released config: pkg/skaffold/schema/latest/config.go
Please create a new PR first with a new version.
You can use 'hack/new_version.sh' to generate the new config version.
If you are running this locally, make sure you have the origin/master branch up to date!
Admin rights are required to merge this PR!
--------
diff --git a/pkg/skaffold/schema/latest/config.go b/pkg/skaffold/schema/latest/config.go
index 98f7921b4..e837615b6 100644
--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -403,6 +403,8 @@ type TestCase struct {
 type DeployConfig struct {
 	DeployType `yaml:",inline"`

+	Change bool
+
 	// StatusCheckDeadlineSeconds *beta* is the deadline for deployments to stabilize in seconds.
 	StatusCheckDeadlineSeconds int `yaml:"statusCheckDeadlineSeconds,omitempty"`

FATA[0000] structural changes detected
exit status 1
```

**New message:**

```
$ ./hack/check-schema-changes.sh
WARN[0000] Detected changes to the latest config. Checking on Github if it's released...
ERRO[0000] Schema "v2beta5" is already released. Changing it is not allowed.

What should I do?
-----------------
 + Please first create a new PR, with a new version, using 'hack/new_version.sh' script.
 + If you see this error and it seems incorrect, maybe you have an out-of-date "origin/master" local branch.
 + If this retroactive change is required and harmless to the users, you'll need Admin rights to merge this PR.

Invalid changes:
----------------
diff --git a/pkg/skaffold/schema/latest/config.go b/pkg/skaffold/schema/latest/config.go
index 98f7921b4..e837615b6 100644
--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -403,6 +403,8 @@ type TestCase struct {
 type DeployConfig struct {
 	DeployType `yaml:",inline"`

+	Change bool
+
 	// StatusCheckDeadlineSeconds *beta* is the deadline for deployments to stabilize in seconds.
 	StatusCheckDeadlineSeconds int `yaml:"statusCheckDeadlineSeconds,omitempty"`

exit status 1
```

Signed-off-by: David Gageot <david@gageot.net>
