### PR TITLE
`debug` nodejs results can result in duplicated environment variables

### DIFF
--- a/pkg/skaffold/debug/transform.go
+++ b/pkg/skaffold/debug/transform.go
@@ -311,7 +311,8 @@ func isPortAvailable(podSpec *v1.PodSpec, port int32) bool {
 // Returns a debugging configuration description with associated language runtime support
 // container image, or an error if the rewrite was unsuccessful.
 func transformContainer(container *v1.Container, config imageConfiguration, portAlloc portAllocator) (ContainerDebugConfiguration, string, error) {
-	// update image configuration values with those set in the k8s manifest
+	// Update the image configuration's environment with those set in the k8s manifest.
+	// (Environment variables in the k8s container's `env` add to the image configuration's `env` settings rather than replace.)
 	for _, envVar := range container.Env {
 		// FIXME handle ValueFrom?
 		if config.env == nil {

--- a/pkg/skaffold/debug/transform_nodejs_test.go
+++ b/pkg/skaffold/debug/transform_nodejs_test.go
@@ -294,8 +294,19 @@ func TestNodeTransformer_Apply(t *testing.T) {
 				entrypoint: []string{"docker-entrypoint.sh"},
 				arguments:  []string{"npm run script"}},
 			result: v1.Container{
-				Env:   []v1.EnvVar{{Name: "NODE_OPTIONS", Value: "--inspect=0.0.0.0:9229"}, {Name: "NODE_VERSION", Value: "10.12"}, {Name: "PATH", Value: "/dbg/nodejs/bin"}},
+				Env:   []v1.EnvVar{{Name: "NODE_OPTIONS", Value: "--inspect=0.0.0.0:9229"}, {Name: "PATH", Value: "/dbg/nodejs/bin"}},
 				Ports: []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
+			},
+			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
+		},
+		{
+			description:   "image environment not copied",
+			containerSpec: v1.Container{Env: []v1.EnvVar{{Name: "OTHER", Value: "VALUE"}}},
+			configuration: imageConfiguration{entrypoint: []string{"node"}, env: map[string]string{"RANDOM": "VALUE"}},
+			result: v1.Container{
+				Command: []string{"node", "--inspect=0.0.0.0:9229"},
+				Env:     []v1.EnvVar{{Name: "OTHER", Value: "VALUE"}, {Name: "PATH", Value: "/dbg/nodejs/bin"}},
+				Ports:   []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 			},
 			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},


### PR DESCRIPTION
Fixes #4351 

The NodeJS debug transformer was unnecessarily copying all of the image's environment variables into the transformed k8s container definition.  It only needs to add new or changed environment
variables to the transformed container.

I changed the order of the environment variables so as to be consistent with the tests, and avoid the need to sort the variable list.