### PR TITLE
Fix port forwarding on Windows

### DIFF
--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -80,6 +80,12 @@ func (c *CLI) RunOut(ctx context.Context, command string, arg ...string) ([]byte
 	return util.RunCmdOut(cmd)
 }
 
+// CommandWithStrictCancellation ensures for windows OS that all child process get terminated on cancellation
+func (c *CLI) CommandWithStrictCancellation(ctx context.Context, command string, arg ...string) *Cmd {
+	args := c.args(command, "", arg...)
+	return CommandContext(ctx, "kubectl", args...)
+}
+
 // args builds an argument list for calling kubectl and consistently
 // adds the `--context` and `--namespace` flags.
 func (c *CLI) args(command string, namespace string, arg ...string) []string {

--- a/pkg/skaffold/kubectl/cli_test.go
+++ b/pkg/skaffold/kubectl/cli_test.go
@@ -101,4 +101,26 @@ func TestCLI(t *testing.T) {
 			t.CheckDeepEqual(string(out), output)
 		})
 	}
+
+	// test cli.CommandWithStrictCancellation()
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunOut(
+				test.expectedCommand,
+				output,
+			))
+
+			cli := NewFromRunContext(&runcontext.RunContext{
+				Opts: config.SkaffoldOptions{
+					Namespace:  test.namespace,
+					KubeConfig: test.kubeconfig,
+				},
+				KubeContext: kubeContext,
+			})
+			cmd := cli.CommandWithStrictCancellation(context.Background(), "exec", "arg1", "arg2")
+			out, err := util.RunCmdOut(cmd.Cmd)
+			t.CheckNoError(err)
+			t.CheckDeepEqual(string(out), output)
+		})
+	}
 }

--- a/pkg/skaffold/kubectl/exec.go
+++ b/pkg/skaffold/kubectl/exec.go
@@ -1,0 +1,36 @@
+// +build !windows
+
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"context"
+	"os/exec"
+)
+
+type Cmd struct {
+	*exec.Cmd
+}
+
+func CommandContext(ctx context.Context, name string, arg ...string) *Cmd {
+	return &Cmd{Cmd: exec.CommandContext(ctx, name, arg...)}
+}
+
+func (c *Cmd) Terminate() error {
+	return c.Process.Kill()
+}

--- a/pkg/skaffold/kubectl/exec.go
+++ b/pkg/skaffold/kubectl/exec.go
@@ -7,7 +7,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,14 +23,17 @@ import (
 	"os/exec"
 )
 
+// Cmd is a wrapper on exec.Cmd
 type Cmd struct {
 	*exec.Cmd
 }
 
+// CommandContext creates a new Cmd
 func CommandContext(ctx context.Context, name string, arg ...string) *Cmd {
 	return &Cmd{Cmd: exec.CommandContext(ctx, name, arg...)}
 }
 
+// Terminate kills the underlying process
 func (c *Cmd) Terminate() error {
 	return c.Process.Kill()
 }

--- a/pkg/skaffold/kubectl/exec_windows.go
+++ b/pkg/skaffold/kubectl/exec_windows.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"context"
+	"os/exec"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type Cmd struct {
+	*exec.Cmd
+	handle windows.Handle
+	ctx    context.Context
+}
+
+type process struct {
+	Pid    int
+	Handle uintptr
+}
+
+func CommandContext(ctx context.Context, name string, arg ...string) *Cmd {
+	return &Cmd{Cmd: exec.Command(name, arg...), ctx: ctx}
+}
+
+func (c *Cmd) Start() (err error) {
+	handle := c.handle
+	handle, err = windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return
+	}
+
+	go func() {
+		<-c.ctx.Done()
+		c.Terminate()
+	}()
+
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err = windows.SetInformationJobObject(
+		handle,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info))); err != nil {
+		return
+	}
+
+	if err = c.Cmd.Start(); err != nil {
+		return
+	}
+
+	if err = windows.AssignProcessToJobObject(
+		handle,
+		windows.Handle((*process)(unsafe.Pointer(c.Process)).Handle)); err != nil {
+		return
+	}
+	return
+}
+
+func (c *Cmd) Terminate() error {
+	return windows.CloseHandle(c.handle)
+}

--- a/pkg/skaffold/kubectl/exec_windows.go
+++ b/pkg/skaffold/kubectl/exec_windows.go
@@ -40,7 +40,7 @@ func CommandContext(ctx context.Context, name string, arg ...string) *Cmd {
 }
 
 func (c *Cmd) Start() (err error) {
-	handle := c.handle
+	var handle windows.Handle
 	handle, err = windows.CreateJobObject(nil, nil)
 	if err != nil {
 		return
@@ -73,6 +73,7 @@ func (c *Cmd) Start() (err error) {
 		windows.Handle((*process)(unsafe.Pointer(c.Process)).Handle)); err != nil {
 		return
 	}
+	c.handle = handle
 	return
 }
 

--- a/pkg/skaffold/kubectl/exec_windows.go
+++ b/pkg/skaffold/kubectl/exec_windows.go
@@ -36,6 +36,7 @@ type process struct {
 	Handle uintptr
 }
 
+// CommandContext creates a new Cmd
 func CommandContext(ctx context.Context, name string, arg ...string) *Cmd {
 	return &Cmd{Cmd: exec.CommandContext(ctx, name, arg...), ctx: ctx}
 }

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
@@ -19,7 +19,6 @@ package portforward
 import (
 	"bytes"
 	"context"
-	"os/exec"
 	"sync"
 	"testing"
 	"time"
@@ -118,7 +117,7 @@ func TestMonitorErrorLogs(t *testing.T) {
 
 			ctx, cancel := context.WithCancel(context.Background())
 
-			cmd := exec.Command("sleep", "5")
+			cmd := kubectl.CommandContext(ctx, "sleep", "5")
 			if err := cmd.Start(); err != nil {
 				t.Fatal("error starting command")
 			}
@@ -153,13 +152,13 @@ func TestMonitorErrorLogs(t *testing.T) {
 	}
 }
 
-func assertCmdIsRunning(t *testutil.T, cmd *exec.Cmd) {
+func assertCmdIsRunning(t *testutil.T, cmd *kubectl.Cmd) {
 	if cmd.ProcessState != nil {
 		t.Fatal("cmd was killed but expected to continue running")
 	}
 }
 
-func assertCmdWasKilled(t *testutil.T, cmd *exec.Cmd) {
+func assertCmdWasKilled(t *testutil.T, cmd *kubectl.Cmd) {
 	if err := cmd.Wait(); err == nil {
 		t.Fatal("cmd was not killed but expected to be killed")
 	}
@@ -189,7 +188,7 @@ func TestDefaultAddressArg(t *testing.T) {
 	assertCmdContainsArgs(t, cmd, false, "--address")
 }
 
-func assertCmdContainsArgs(t *testing.T, cmd *exec.Cmd, expected bool, args ...string) {
+func assertCmdContainsArgs(t *testing.T, cmd *kubectl.Cmd, expected bool, args ...string) {
 	if len(args) == 0 {
 		return
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #3679  <!-- tracking issues that this PR will close -->
**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
On Windows OS, `kubectl portforward` command launches child processes that do not get cleaned up on the dev loop rerun. This way open ports keep getting locked up.

This PR introduces `kubectl.Cmd` which embeds `exec.Cmd`. The `Start` and `Run` methods are overridden for Windows OS (using build tags) to wrap around a job object and the job object handle is closed on cancellation to ensure all processes get killed. For non windows OSes it behaves identical to `exec.Cmd`. 
