### PR TITLE
gracefull shutdown RPC even when build is in error

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -39,17 +39,17 @@ import (
 )
 
 var (
-	opts         config.SkaffoldOptions
-	v            string
-	forceColors  bool
-	defaultColor int
-	overwrite    bool
+	opts              config.SkaffoldOptions
+	v                 string
+	forceColors       bool
+	defaultColor      int
+	overwrite         bool
+	shutdownAPIServer func() error
 )
 
 func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 	updateMsg := make(chan string)
 	surveyPrompt := make(chan bool)
-	var shutdownAPIServer func() error
 
 	rootCmd := &cobra.Command{
 		Use: "skaffold",
@@ -114,10 +114,6 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 					}
 				}
 			default:
-			}
-
-			if shutdownAPIServer != nil {
-				shutdownAPIServer()
 			}
 		},
 	}

--- a/cmd/skaffold/app/cmd/commands.go
+++ b/cmd/skaffold/app/cmd/commands.go
@@ -89,7 +89,8 @@ func (b *builder) ExactArgs(argCount int, action func(context.Context, io.Writer
 	b.cmd.Args = cobra.ExactArgs(argCount)
 	b.cmd.RunE = func(_ *cobra.Command, args []string) error {
 		err := handleWellKnownErrors(action(b.cmd.Context(), b.cmd.OutOrStdout(), args))
-		// clean up server.
+		// clean up server at end of the execution since post run hooks are only executed if
+		// RunE is successful
 		if shutdownAPIServer != nil {
 			shutdownAPIServer()
 		}
@@ -102,6 +103,8 @@ func (b *builder) NoArgs(action func(context.Context, io.Writer) error) *cobra.C
 	b.cmd.Args = cobra.NoArgs
 	b.cmd.RunE = func(*cobra.Command, []string) error {
 		err := handleWellKnownErrors(action(b.cmd.Context(), b.cmd.OutOrStdout()))
+		// clean up server at end of the execution since post run hooks are only executed if
+		// RunE is successful
 		if shutdownAPIServer != nil {
 			shutdownAPIServer()
 		}

--- a/cmd/skaffold/app/cmd/commands.go
+++ b/cmd/skaffold/app/cmd/commands.go
@@ -88,7 +88,12 @@ func (b *builder) Hidden() Builder {
 func (b *builder) ExactArgs(argCount int, action func(context.Context, io.Writer, []string) error) *cobra.Command {
 	b.cmd.Args = cobra.ExactArgs(argCount)
 	b.cmd.RunE = func(_ *cobra.Command, args []string) error {
-		return handleWellKnownErrors(action(b.cmd.Context(), b.cmd.OutOrStdout(), args))
+		err := handleWellKnownErrors(action(b.cmd.Context(), b.cmd.OutOrStdout(), args))
+		// clean up server.
+		if shutdownAPIServer != nil {
+			shutdownAPIServer()
+		}
+		return err
 	}
 	return &b.cmd
 }
@@ -96,7 +101,11 @@ func (b *builder) ExactArgs(argCount int, action func(context.Context, io.Writer
 func (b *builder) NoArgs(action func(context.Context, io.Writer) error) *cobra.Command {
 	b.cmd.Args = cobra.NoArgs
 	b.cmd.RunE = func(*cobra.Command, []string) error {
-		return handleWellKnownErrors(action(b.cmd.Context(), b.cmd.OutOrStdout()))
+		err := handleWellKnownErrors(action(b.cmd.Context(), b.cmd.OutOrStdout()))
+		if shutdownAPIServer != nil {
+			shutdownAPIServer()
+		}
+		return err
 	}
 	return &b.cmd
 }


### PR DESCRIPTION
Fixes: #3970 
Maybe fixes #3991
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
Another attempt to gracefully shutdown RPC.

1. This is mostly bringing back what #4010 did however, 
`GracefulStop` and `server.Shutdown` wait for all idle connections to close. 
IDES RPC client connections never terminate and go into idle state hence the above functions never return.
In this PR, the `GracefulStop` and `server.Shutdown` are wrapped in a timeout context. 
They wait for max 1 second which is enough to read the last events on the channel.

2. `shutdownAPIServer` was called in `PersistedPostRun`. 
However, `PersistentPostRun` is only called if a command's `RunE` does not result into any error.
https://github.com/spf13/cobra/blob/master/command.go#L843

To make sure, the servers shut down gracefully when an error occurs, we need to call the `shutdownAPIServer` in `RunE` command to execute.

**User facing changes (remove if N/A)**
No.

** events API changes ** 
On any example, please run a command where build would fail. 
e.g. `skaffold  dev --cache-artifacts=false` (remove global default repo setting)

On master 

*** Before ***

```
curl localhost:50052/v1/event_log
....
{"result":{"timestamp":"2020-06-24T05:18:10.565560Z","
        event":{"devLoopEvent":{"status":"In Progress"}},"entry":"DevInit Iteration 0 in progress"}}
{"result":{"timestamp":"2020-06-24T05:18:10.612157Z",
    "event":{"buildEvent":{"artifact":"leeroy-web","status":"In Progress"}},"entry":"Build started for artifact leeroy-web"}}
curl: (18) transfer closed with outstanding read data remaining

```
You never see the build failed and devloop iteration failed events for a failed build.

**On the branch**
```
curl localhost:50052/v1/event_log
....
{"result":{"timestamp":"2020-06-24T05:21:35.823218Z",
   "event":{"devLoopEvent":{"status":"In Progress"}},"entry":"DevInit Iteration 0 in progress"}}
{"result":{"timestamp":"2020-06-24T05:21:35.864723Z",
    "event":{"buildEvent":{"artifact":"leeroy-web","status":"In Progress"}},"entry":"Build started for artifact leeroy-web"}}
{"result":{"timestamp":"2020-06-24T05:21:42.684603Z",
    "event":{"buildEvent":{
                 "artifact":"leeroy-web",
                 "status":"Failed",
                 "err":"could not push image \"leeroy-web:v1.11.0-99-g473026664\": denied: requested access to the resource is denied",
                "errCode":"BUILD_UNKNOWN",
                 "actionableErr":{"errCode":"BUILD_UNKNOWN","message":"could not push image \"leeroy-web:v1.11.0-99-g473026664\": denied: requested access to the resource is denied"}}},"entry":"Build failed for artifact leeroy-web"}}

{"result":{"timestamp":"2020-06-24T05:21:42.684624Z",
      "event":{
             "devLoopEvent":{
             "status":"Failed",
             "err":{
              "errCode":"BUILD_UNKNOWN",
              "message":"couldn't build \"leeroy-web\": could not push image \"leeroy-web:v1.11.0-99-g473026664\": denied: requested access to the resource is denied"}}},
              "entry":"DevInit Iteration 0 failed with error code BUILD_UNKNOWN"}
}
```
On the branch you will see failure events.

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
