### PR TITLE
Fail fast and point to docs for 'skaffold init' on helm projects

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -752,3 +752,7 @@ func pairParamsToArtifacts(builds []build.Artifact, params map[string]string) (m
 
 	return paramToBuildResult, nil
 }
+
+func IsHelmChart(path string) bool {
+	return filepath.Base(path) == "Chart.yaml"
+}

--- a/pkg/skaffold/initializer/analyze/analyze.go
+++ b/pkg/skaffold/initializer/analyze/analyze.go
@@ -43,6 +43,7 @@ type ProjectAnalysis struct {
 	configAnalyzer    *skaffoldConfigAnalyzer
 	kubeAnalyzer      *kubeAnalyzer
 	kustomizeAnalyzer *kustomizeAnalyzer
+	helmAnalyzer      *helmAnalyzer
 	builderAnalyzer   *builderAnalyzer
 	maxFileSize       int64
 }
@@ -63,10 +64,15 @@ func (a *ProjectAnalysis) KustomizeBases() []string {
 	return a.kustomizeAnalyzer.bases
 }
 
+func (a *ProjectAnalysis) ChartPaths() []string {
+	return a.helmAnalyzer.chartPaths
+}
+
 func (a *ProjectAnalysis) analyzers() []analyzer {
 	return []analyzer{
 		a.kubeAnalyzer,
 		a.kustomizeAnalyzer,
+		a.helmAnalyzer,
 		a.configAnalyzer,
 		a.builderAnalyzer,
 	}
@@ -77,6 +83,7 @@ func NewAnalyzer(c config.Config) *ProjectAnalysis {
 	return &ProjectAnalysis{
 		kubeAnalyzer:      &kubeAnalyzer{},
 		kustomizeAnalyzer: &kustomizeAnalyzer{},
+		helmAnalyzer:      &helmAnalyzer{},
 		builderAnalyzer: &builderAnalyzer{
 			findBuilders:         !c.SkipBuild,
 			enableJibInit:        c.EnableJibInit,

--- a/pkg/skaffold/initializer/analyze/helm.go
+++ b/pkg/skaffold/initializer/analyze/helm.go
@@ -18,7 +18,6 @@ package analyze
 
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 )
 
 // helmAnalyzer is a Visitor during the directory analysis that finds helm charts
@@ -28,7 +27,7 @@ type helmAnalyzer struct {
 }
 
 func (h *helmAnalyzer) analyzeFile(filePath string) error {
-	if !schema.IsSkaffoldConfig(filePath) && deploy.IsHelmChart(filePath) {
+	if deploy.IsHelmChart(filePath) {
 		h.chartPaths = append(h.chartPaths, filePath)
 	}
 	return nil

--- a/pkg/skaffold/initializer/analyze/helm.go
+++ b/pkg/skaffold/initializer/analyze/helm.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package analyze
+
+import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
+)
+
+// helmAnalyzer is a Visitor during the directory analysis that finds helm charts
+type helmAnalyzer struct {
+	directoryAnalyzer
+	chartPaths []string
+}
+
+func (h *helmAnalyzer) analyzeFile(filePath string) error {
+	if !schema.IsSkaffoldConfig(filePath) && deploy.IsHelmChart(filePath) {
+		h.chartPaths = append(h.chartPaths, filePath)
+	}
+	return nil
+}

--- a/pkg/skaffold/initializer/analyze/kustomize.go
+++ b/pkg/skaffold/initializer/analyze/kustomize.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 )
 
 // kustomizeAnalyzer is a Visitor during the directory analysis that finds kustomize files
@@ -33,7 +32,6 @@ type kustomizeAnalyzer struct {
 
 func (k *kustomizeAnalyzer) analyzeFile(path string) error {
 	switch {
-	case schema.IsSkaffoldConfig(path):
 	case deploy.IsKustomizationBase(path):
 		k.bases = append(k.bases, filepath.Dir(path))
 	case deploy.IsKustomizationPath(path):

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -48,7 +48,7 @@ func DoInit(ctx context.Context, out io.Writer, c config.Config) error {
 	// helm projects can't currently be bootstrapped automatically by skaffold, so we fail fast and link to our docs instead.
 	if len(a.ChartPaths()) > 0 {
 		//nolint
-		return errors.New(`Projects set up to deploy with helm must be configured with skaffold manually.
+		return errors.New(`Projects set up to deploy with helm must be manually configured.
 
 See https://skaffold.dev/docs/pipeline-stages/deployers/helm/ for a detailed guide on setting your project up with skaffold.`)
 	}

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -18,6 +18,7 @@ package initializer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -42,6 +43,14 @@ func DoInit(ctx context.Context, out io.Writer, c config.Config) error {
 	a := analyze.NewAnalyzer(c)
 	if err := a.Analyze("."); err != nil {
 		return err
+	}
+
+	// helm projects can't currently be bootstrapped automatically by skaffold, so we fail fast and link to our docs instead.
+	if len(a.ChartPaths()) > 0 {
+		//nolint
+		return errors.New(`Projects set up to deploy with helm must be configured with skaffold manually.
+
+See https://skaffold.dev/docs/pipeline-stages/deployers/helm/ for a detailed guide on setting your project up with skaffold.`)
 	}
 
 	deployInitializer := deploy.NewInitializer(a.Manifests(), a.KustomizeBases(), a.KustomizePaths(), c)

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -196,6 +196,16 @@ func TestDoInit(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "helm fails",
+			dir:  "testdata/init/helm-deployment",
+			config: initconfig.Config{
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml.out",
+				},
+			},
+			shouldErr: true,
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -204,7 +204,10 @@ func TestDoInit(t *testing.T) {
 					ConfigurationFile: "skaffold.yaml.out",
 				},
 			},
-			shouldErr: true,
+			expectedError: `Projects set up to deploy with helm must be manually configured.
+
+See https://skaffold.dev/docs/pipeline-stages/deployers/helm/ for a detailed guide on setting your project up with skaffold.`,
+			expectedExitCode: 1,
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/initializer/testdata/init/helm-deployment/Dockerfile
+++ b/pkg/skaffold/initializer/testdata/init/helm-deployment/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.12.9-alpine3.10 as builder
+COPY main.go .
+RUN go build -o /app main.go
+
+FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/pkg/skaffold/initializer/testdata/init/helm-deployment/README.md
+++ b/pkg/skaffold/initializer/testdata/init/helm-deployment/README.md
@@ -1,0 +1,37 @@
+### Example: deploy multiple releases with Helm
+
+You can deploy multiple releases with skaffold, each will need a chartPath, a values file, and namespace.
+Skaffold can inject intermediate build tags in the the values map in the skaffold.yaml.
+
+Let's walk through the skaffold yaml:
+
+We'll be building an image called `skaffold-helm`, and it's a dockerfile, so we'll add it to the artifacts.
+
+```yaml
+build:
+  artifacts:
+  - image: skaffold-helm
+```
+
+Now, we want to deploy this image with helm.
+We add a new release in the helm part of the deploy stanza.
+
+```yaml
+deploy:
+  helm:
+    releases:
+    - name: skaffold-helm
+      chartPath: charts
+      # namespace: skaffold
+      artifactOverrides:
+        image: skaffold-helm
+      valuesFiles:
+      - values.yaml
+```
+
+This part tells Skaffold to set the `image` parameter of the values file to the built `skaffold-helm` image and tag.
+
+```yaml
+      artifactOverrides:
+        image: skaffold-helm
+```

--- a/pkg/skaffold/initializer/testdata/init/helm-deployment/README.md
+++ b/pkg/skaffold/initializer/testdata/init/helm-deployment/README.md
@@ -1,7 +1,7 @@
 ### Example: deploy multiple releases with Helm
 
-You can deploy multiple releases with skaffold, each will need a chartPath, a values file, and namespace.
-Skaffold can inject intermediate build tags in the the values map in the skaffold.yaml.
+You can deploy multiple releases with Skaffold, each will need a chartPath, a values file, and an optional namespace.
+Skaffold can inject intermediate build tags in the the values map in the `skaffold.yaml`.
 
 Let's walk through the skaffold yaml:
 

--- a/pkg/skaffold/initializer/testdata/init/helm-deployment/charts/Chart.yaml
+++ b/pkg/skaffold/initializer/testdata/init/helm-deployment/charts/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Skaffold example with Helm
+name: skaffold-helm
+version: 0.1.0

--- a/pkg/skaffold/initializer/testdata/init/helm-deployment/charts/templates/deployment.yaml
+++ b/pkg/skaffold/initializer/testdata/init/helm-deployment/charts/templates/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ .Values.image }}

--- a/pkg/skaffold/initializer/testdata/init/helm-deployment/charts/values.yaml
+++ b/pkg/skaffold/initializer/testdata/init/helm-deployment/charts/values.yaml
@@ -1,0 +1,4 @@
+# Default values for skaffold-helm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 2

--- a/pkg/skaffold/initializer/testdata/init/helm-deployment/main.go
+++ b/pkg/skaffold/initializer/testdata/init/helm-deployment/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for counter := 0; ; counter++ {
+		fmt.Println("Hello world!", counter)
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/pkg/skaffold/initializer/testdata/init/helm-deployment/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/helm-deployment/skaffold.yaml
@@ -1,0 +1,12 @@
+apiVersion: skaffold/v2beta5
+kind: Config
+build:
+  artifacts:
+  - image: skaffold-helm
+deploy:
+  helm:
+    releases:
+    - name: skaffold-helm
+      chartPath: charts
+      artifactOverrides:
+        image: skaffold-helm


### PR DESCRIPTION
this changes `skaffold init` so that when run on projects configured with helm, it will fail fast rather than generating erroneous skaffold.yamls. it will also point to our docs for getting started with skaffold using a helm project. this is a much better UX than thinking that `skaffold init` has helped you start running skaffold, only to have it fail when you try and actually run.