### PR TITLE
`skaffold init` skips vendor and node_modules folders

### DIFF
--- a/pkg/skaffold/build/buildpacks/init.go
+++ b/pkg/skaffold/build/buildpacks/init.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
@@ -71,40 +70,28 @@ func (c ArtifactConfig) Path() string {
 
 // validate checks if a file is a valid Buildpack configuration.
 func validate(path string) bool {
-	valid := false
-
 	switch filepath.Base(path) {
 	// Buildpacks project descriptor.
 	case "project.toml":
-		valid = true
+		return true
 
 	// NodeJS.
 	case "package.json":
-		valid = true
+		return true
 
 	// Go.
 	case "go.mod":
-		valid = true
+		return true
 
 	// Java.
 	case "pom.xml", "build.gradle", "build.gradle.kts":
-		valid = true
+		return true
 
 	// Python.
 	// TODO(dgageot): When the Procfile is missing, we might want to inform the user
 	// that this still might be a valid python project.
 	case "requirements.txt":
 		if _, err := os.Stat(filepath.Join(filepath.Dir(path), "Procfile")); err == nil {
-			valid = true
-		}
-	}
-
-	return valid && !hasParent(path, "node_modules") && !hasParent(path, "vendor")
-}
-
-func hasParent(path, parent string) bool {
-	for _, p := range strings.Split(path, string(os.PathSeparator)) {
-		if p == parent {
 			return true
 		}
 	}

--- a/pkg/skaffold/build/buildpacks/init_test.go
+++ b/pkg/skaffold/build/buildpacks/init_test.go
@@ -109,26 +109,6 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-func TestValidateIgnored(t *testing.T) {
-	paths := []string{
-		filepath.Join("parent", "node_modules", "package.json"),
-		filepath.Join("node_modules", "package.json"),
-		filepath.Join("vendor", "go.mod"),
-		filepath.Join("parent", "vendor", "go.mod"),
-		filepath.Join("parent", "vendor", "project.toml"),
-		filepath.Join("parent", "vendor", "requirements.txt"),
-		filepath.Join("node_modules", "project.toml"),
-	}
-
-	for _, path := range paths {
-		testutil.Run(t, path, func(t *testutil.T) {
-			isValid := Validate(path)
-
-			t.CheckFalse(isValid)
-		})
-	}
-}
-
 func TestDescribe(t *testing.T) {
 	var tests = []struct {
 		description    string

--- a/pkg/skaffold/initializer/analyze/analyze.go
+++ b/pkg/skaffold/initializer/analyze/analyze.go
@@ -114,11 +114,17 @@ func (a *ProjectAnalysis) Analyze(dir string) error {
 
 	// Traverse files
 	for _, file := range dirents {
-		if util.IsHiddenFile(file.Name()) || util.IsHiddenDir(file.Name()) {
+		name := file.Name()
+
+		if file.IsDir() {
+			if util.IsHiddenDir(name) || skipFolder(name) {
+				continue
+			}
+		} else if util.IsHiddenFile(name) {
 			continue
 		}
 
-		filePath := filepath.Join(dir, file.Name())
+		filePath := filepath.Join(dir, name)
 
 		// If we found a directory, keep track of it until we've gone through all the files first
 		if file.IsDir() {
@@ -160,4 +166,8 @@ func (a *ProjectAnalysis) Analyze(dir string) error {
 	}
 
 	return nil
+}
+
+func skipFolder(name string) bool {
+	return name == "vendor" || name == "node_modules"
 }

--- a/pkg/skaffold/initializer/analyze/analyze_test.go
+++ b/pkg/skaffold/initializer/analyze/analyze_test.go
@@ -243,6 +243,44 @@ func TestAnalyze(t *testing.T) {
 			shouldErr: false,
 		},
 		{
+			description: "should skip vendor folder",
+			filesWithContents: map[string]string{
+				"Dockerfile":            emptyFile,
+				"vendor/Dockerfile":     emptyFile,
+				"vendor/pom.xml":        emptyFile,
+				"vendor/package.json":   emptyFile,
+				"sub/vendor/Dockerfile": emptyFile,
+			},
+			config: initconfig.Config{
+				Force:                false,
+				EnableBuildpacksInit: true,
+				EnableJibInit:        true,
+			},
+			expectedBuilders: []builder{
+				{name: "Docker", path: "Dockerfile"},
+			},
+			shouldErr: false,
+		},
+		{
+			description: "should skip node_modules folder",
+			filesWithContents: map[string]string{
+				"Dockerfile":                  emptyFile,
+				"node_modules/Dockerfile":     emptyFile,
+				"node_modules/pom.xml":        emptyFile,
+				"node_modules/package.json":   emptyFile,
+				"sub/node_modules/Dockerfile": emptyFile,
+			},
+			config: initconfig.Config{
+				Force:                false,
+				EnableBuildpacksInit: true,
+				EnableJibInit:        true,
+			},
+			expectedBuilders: []builder{
+				{name: "Docker", path: "Dockerfile"},
+			},
+			shouldErr: false,
+		},
+		{
 			description: "should skip large files",
 			filesWithContents: map[string]string{
 				"k8pod.yml":               validK8sManifest,


### PR DESCRIPTION
Fixes #3771
Fixes #3793

Signed-off-by: David Gageot <david@gageot.net>
