### PR TITLE
`skaffold init` supports different exit codes

### DIFF
--- a/cmd/skaffold/skaffold.go
+++ b/cmd/skaffold/skaffold.go
@@ -27,13 +27,26 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 )
 
+type ExitCoder interface {
+	ExitCode() int
+}
+
 func main() {
 	if err := app.Run(os.Stdout, os.Stderr); err != nil {
 		if errors.Is(err, context.Canceled) {
 			logrus.Debugln("ignore error since context is cancelled:", err)
 		} else {
 			color.Red.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			os.Exit(exitCode(err))
 		}
 	}
+}
+
+func exitCode(err error) int {
+	var exitCoder ExitCoder
+	if errors.As(err, &exitCoder) {
+		return exitCoder.ExitCode()
+	}
+
+	return 1
 }

--- a/docs/content/en/docs/pipeline-stages/init.md
+++ b/docs/content/en/docs/pipeline-stages/init.md
@@ -9,18 +9,20 @@ featureId: init
 
 Skaffold auto-generates `build` and `deploy` config for supported builders and deployers.
 
-
 ## Build Config Initialization
-`skaffold init` currently supports build detection for two builders:
+
+`skaffold init` currently supports build detection for those builders:
 
 1. [Docker]({{<relref "/docs/pipeline-stages/builders/docker">}})
-2. [Jib]({{<relref "/docs/pipeline-stages/builders/jib">}})
+2. [Jib]({{<relref "/docs/pipeline-stages/builders/jib">}}) (with `--XXenableJibInit` flag)
+2. [Buildpacks]({{<relref "/docs/pipeline-stages/builders/buildpacks">}}) (with `--XXenableBuildpacksInit` flag)
 
-`skaffold init` will walk your project directory and look for any `Dockerfiles` 
-or `build.gradle/pom.xml`. Please note, `skaffold init` skips files that are larger than 500MB.
+`skaffold init` walks your project directory and looks for any build configuration files such as `Dockerfile`,
+`build.gradle/pom.xml`, `package.json`, `requirements.txt` or `go.mod`. `init` skips files that are larger
+than 500MB.
 
-If you have multiple `Dockerfile` or `build.gradle/pom.xml` files, Skaffold will prompt you to
-pair your build config files with any images detected in your deploy configuration.
+If there are multiple build configuration files, Skaffold will prompt you to pair your build configuration files
+with any images detected in your deploy configuration.
 
 E.g. For an application with [two microservices] (https://github.com/GoogleContainerTools/skaffold/tree/master/examples/microservices):
 
@@ -93,7 +95,7 @@ When overlay directories are found, these will be listed in the generated Skaffo
 *Note: order is guaranteed, since Skaffold's directory parsing is always deterministic.*
 
 ## Init API
-`skaffold init` also exposes an AP:I which tools like IDEs can integrate with via flags.
+`skaffold init` also exposes an API which tools like IDEs can integrate with via flags.
 
 This API can be used to 
 
@@ -176,3 +178,14 @@ deploy:
     - leeroy-app/kubernetes/deployment.yaml
     - leeroy-web/kubernetes/deployment.yaml
 ```
+
+### Exit Codes
+
+When `skaffold init` fails, it exits with an code that depends on the error:
+
+| Exit Code | Error |
+| ---- | --- |
+| 101 | No build configuration could be found |
+| 102 | No k8s manifest could be found or generated |
+| 102 | An existing skaffold.yaml was found |
+| 104 | Couldn't match builder with image names automatically |

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package integration
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -136,4 +138,24 @@ func checkGeneratedManifests(t *testutil.T, dir string, manifestPaths []string) 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(string(expectedOutput), string(output))
 	}
+}
+
+func TestInitFailures(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	testutil.Run(t, "no builder", func(t *testutil.T) {
+		out, err := skaffold.Init().InDir("testdata/init/no-builder").RunWithCombinedOutput(t.T)
+
+		t.CheckContains("please provide at least one build config", string(out))
+		t.CheckDeepEqual(101, exitCode(err))
+	})
+}
+
+func exitCode(err error) int {
+	var exitErr *exec.ExitError
+	if ok := errors.As(err, &exitErr); ok {
+		return exitErr.ExitCode()
+	}
+
+	return 1
 }

--- a/integration/testdata/init/no-builder/service.yaml
+++ b/integration/testdata/init/no-builder/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dockerfile-image
+  labels:
+    app: dockerfile-image
+spec:
+  clusterIP: None
+  selector:
+    app: dockerfile-image

--- a/pkg/skaffold/initializer/analyze/config.go
+++ b/pkg/skaffold/initializer/analyze/config.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 )
 
@@ -41,7 +42,8 @@ func (a *skaffoldConfigAnalyzer) analyzeFile(filePath string) error {
 	if !sameFiles {
 		return nil
 	}
-	return fmt.Errorf("pre-existing %s found (you may continue with --force)", filePath)
+
+	return errors.PreExistingConfigErr{Path: filePath}
 }
 
 func sameFiles(a, b string) (bool, error) {

--- a/pkg/skaffold/initializer/build/builders.go
+++ b/pkg/skaffold/initializer/build/builders.go
@@ -27,12 +27,6 @@ import (
 // an image we parse out from a Kubernetes manifest
 const NoBuilder = "None (image not built from these sources)"
 
-type Error string
-
-func (e Error) Error() string { return string(e) }
-
-const ErrorNoBuilder = Error("one or more valid builder configuration (Dockerfile or Jib configuration) must be present to build images with skaffold; please provide at least one build config and try again or run `skaffold init --skip-build`")
-
 // InitBuilder represents a builder that can be chosen by skaffold init.
 type InitBuilder interface {
 	// Name returns the name of the builder.

--- a/pkg/skaffold/initializer/build/cli.go
+++ b/pkg/skaffold/initializer/build/cli.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -38,7 +39,7 @@ type cliBuildInitializer struct {
 
 func (c *cliBuildInitializer) ProcessImages(images []string) error {
 	if len(c.builders) == 0 && len(c.cliArtifacts) == 0 {
-		return ErrorNoBuilder
+		return errors.NoBuilderErr{}
 	}
 	if err := c.processCliArtifacts(); err != nil {
 		return fmt.Errorf("processing cli artifacts: %w", err)

--- a/pkg/skaffold/initializer/build/init.go
+++ b/pkg/skaffold/initializer/build/init.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/generator"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
@@ -37,7 +38,7 @@ type defaultBuildInitializer struct {
 
 func (d *defaultBuildInitializer) ProcessImages(images []string) error {
 	if len(d.builders) == 0 {
-		return ErrorNoBuilder
+		return errors.NoBuilderErr{}
 	}
 	if d.skipBuild {
 		return nil

--- a/pkg/skaffold/initializer/build/resolve.go
+++ b/pkg/skaffold/initializer/build/resolve.go
@@ -17,13 +17,13 @@ limitations under the License.
 package build
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -53,7 +53,7 @@ func (d *defaultBuildInitializer) resolveBuilderImages() error {
 	}
 
 	if d.force {
-		return errors.New("unable to automatically resolve builder/image pairs; run `skaffold init` without `--force` to manually resolve ambiguities")
+		return errors.BuilderImageAmbiguitiesErr{}
 	}
 
 	return d.resolveBuilderImagesInteractively()

--- a/pkg/skaffold/initializer/deploy/init.go
+++ b/pkg/skaffold/initializer/deploy/init.go
@@ -18,14 +18,9 @@ package deploy
 
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
-
-type Error string
-
-func (e Error) Error() string { return string(e) }
-
-const NoManifest = Error("one or more valid Kubernetes manifests are required to run skaffold")
 
 // Initializer detects a deployment type and is able to extract image names from it
 type Initializer interface {
@@ -59,7 +54,7 @@ func (c *cliDeployInit) GetImages() []string {
 
 func (c *cliDeployInit) Validate() error {
 	if len(c.cliKubernetesManifests) == 0 {
-		return NoManifest
+		return errors.NoManifestErr{}
 	}
 	return nil
 }

--- a/pkg/skaffold/initializer/deploy/kubectl.go
+++ b/pkg/skaffold/initializer/deploy/kubectl.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
@@ -68,7 +69,7 @@ func (k *kubectl) GetImages() []string {
 // we have at least one manifest before generating a config
 func (k *kubectl) Validate() error {
 	if len(k.images) == 0 {
-		return NoManifest
+		return errors.NoManifestErr{}
 	}
 	return nil
 }

--- a/pkg/skaffold/initializer/deploy/kustomize.go
+++ b/pkg/skaffold/initializer/deploy/kustomize.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
@@ -140,7 +141,7 @@ func (k *kustomize) GetImages() []string {
 // we have at least one manifest before generating a config
 func (k *kustomize) Validate() error {
 	if len(k.images) == 0 {
-		return NoManifest
+		return errors.NoManifestErr{}
 	}
 	return nil
 }

--- a/pkg/skaffold/initializer/errors/errors.go
+++ b/pkg/skaffold/initializer/errors/errors.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import "fmt"
+
+// NoBuilderErr is an error returned by `skaffold init` when it couldn't find any build configuration.
+type NoBuilderErr struct{}
+
+func (e NoBuilderErr) ExitCode() int { return 101 }
+func (e NoBuilderErr) Error() string {
+	return "one or more valid builder configuration (Dockerfile or Jib configuration) must be present to build images with skaffold; please provide at least one build config and try again or run `skaffold init --skip-build`"
+}
+
+// NoManifestErr is an error returned by `skaffold init` when no valid Kubernetes manifest is found.
+type NoManifestErr struct{}
+
+func (e NoManifestErr) ExitCode() int { return 102 }
+func (e NoManifestErr) Error() string {
+	return "one or more valid Kubernetes manifests are required to run skaffold"
+}
+
+// PreExistingConfigErr is an error returned by `skaffold init` when a skaffold config file already exists.
+type PreExistingConfigErr struct {
+	Path string
+}
+
+func (e PreExistingConfigErr) ExitCode() int { return 103 }
+func (e PreExistingConfigErr) Error() string {
+	return fmt.Sprintf("pre-existing %s found (you may continue with --force)", e.Path)
+}
+
+// BuilderImageAmbiguitiesErr is an error returned by `skaffold init` when it can't resolve builder/image pairs.
+type BuilderImageAmbiguitiesErr struct{}
+
+func (e BuilderImageAmbiguitiesErr) ExitCode() int { return 104 }
+func (e BuilderImageAmbiguitiesErr) Error() string {
+	return "unable to automatically resolve builder/image pairs; run `skaffold init` without `--force` to manually resolve ambiguities"
+}

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -19,6 +19,7 @@ package initializer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -33,16 +34,18 @@ import (
 
 func TestDoInit(t *testing.T) {
 	tests := []struct {
-		name      string
-		dir       string
-		config    initconfig.Config
-		shouldErr bool
+		name             string
+		dir              string
+		config           initconfig.Config
+		expectedError    string
+		expectedExitCode int
 	}{
 		//TODO: mocked kompose test
 		{
 			name: "getting-started",
 			dir:  "testdata/init/hello",
 			config: initconfig.Config{
+				Force: true,
 				Opts: config.SkaffoldOptions{
 					ConfigurationFile: "skaffold.yaml.out",
 				},
@@ -52,6 +55,7 @@ func TestDoInit(t *testing.T) {
 			name: "ignore existing tags",
 			dir:  "testdata/init/ignore-tags",
 			config: initconfig.Config{
+				Force: true,
 				Opts: config.SkaffoldOptions{
 					ConfigurationFile: "skaffold.yaml.out",
 				},
@@ -61,6 +65,7 @@ func TestDoInit(t *testing.T) {
 			name: "microservices (backwards compatibility)",
 			dir:  "testdata/init/microservices",
 			config: initconfig.Config{
+				Force: true,
 				CliArtifacts: []string{
 					"leeroy-app/Dockerfile=gcr.io/k8s-skaffold/leeroy-app",
 					"leeroy-web/Dockerfile=gcr.io/k8s-skaffold/leeroy-web",
@@ -74,6 +79,7 @@ func TestDoInit(t *testing.T) {
 			name: "microservices",
 			dir:  "testdata/init/microservices",
 			config: initconfig.Config{
+				Force: true,
 				CliArtifacts: []string{
 					`{"builder":"Docker","payload":{"path":"leeroy-app/Dockerfile"},"image":"gcr.io/k8s-skaffold/leeroy-app"}`,
 					`{"builder":"Docker","payload":{"path":"leeroy-web/Dockerfile"},"image":"gcr.io/k8s-skaffold/leeroy-web"}`,
@@ -87,6 +93,7 @@ func TestDoInit(t *testing.T) {
 			name: "CLI artifacts + manifest placeholders",
 			dir:  "testdata/init/allcli",
 			config: initconfig.Config{
+				Force: true,
 				CliArtifacts: []string{
 					`{"builder":"Docker","payload":{"path":"Dockerfile"},"image":"passed-in-artifact"}`,
 				},
@@ -103,6 +110,7 @@ func TestDoInit(t *testing.T) {
 			name: "CLI artifacts but no manifests",
 			dir:  "testdata/init/allcli",
 			config: initconfig.Config{
+				Force: true,
 				CliArtifacts: []string{
 					`{"builder":"Docker","payload":{"path":"Dockerfile"},"image":"passed-in-artifact"}`,
 				},
@@ -110,13 +118,14 @@ func TestDoInit(t *testing.T) {
 					ConfigurationFile: "skaffold.yaml.out",
 				},
 			},
-			shouldErr: true,
+			expectedError:    "one or more valid Kubernetes manifests are required to run skaffold",
+			expectedExitCode: 102,
 		},
 		{
 			name: "error writing config file",
 			dir:  "testdata/init/microservices",
-
 			config: initconfig.Config{
+				Force: true,
 				CliArtifacts: []string{
 					`{"builder":"Docker","payload":{"path":"leeroy-app/Dockerfile"},"image":"gcr.io/k8s-skaffold/leeroy-app"}`,
 					`{"builder":"Docker","payload":{"path":"leeroy-web/Dockerfile"},"image":"gcr.io/k8s-skaffold/leeroy-web"}`,
@@ -126,24 +135,62 @@ func TestDoInit(t *testing.T) {
 					ConfigurationFile: ".",
 				},
 			},
-			shouldErr: true,
+			expectedError:    "writing config to file: open .: is a directory",
+			expectedExitCode: 1,
 		},
 		{
-			name: "error no manifests",
-			dir:  "testdata/init/hello-no-manifest",
-
+			name: "error no builders",
+			dir:  "testdata/init/no-builder",
 			config: initconfig.Config{
+				Force: true,
 				Opts: config.SkaffoldOptions{
 					ConfigurationFile: "skaffold.yaml.out",
 				},
 			},
-			shouldErr: true,
+			expectedError:    "please provide at least one build config",
+			expectedExitCode: 101,
+		},
+		{
+			name: "error no manifests",
+			dir:  "testdata/init/hello-no-manifest",
+			config: initconfig.Config{
+				Force: true,
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml.out",
+				},
+			},
+			expectedError:    "one or more valid Kubernetes manifests are required to run skaffold",
+			expectedExitCode: 102,
+		},
+		{
+			name: "existing config",
+			dir:  "testdata/init/hello",
+			config: initconfig.Config{
+				Force: false,
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml",
+				},
+			},
+			expectedError:    "pre-existing skaffold.yaml found",
+			expectedExitCode: 103,
+		},
+		{
+			name: "builder/image ambiguity",
+			dir:  "testdata/init/microservices",
+			config: initconfig.Config{
+				Force: true,
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml.out",
+				},
+			},
+			expectedError:    "unable to automatically resolve builder/image pairs",
+			expectedExitCode: 104,
 		},
 		{
 			name: "kustomize",
 			dir:  "testdata/init/getting-started-kustomize",
-
 			config: initconfig.Config{
+				Force: true,
 				Opts: config.SkaffoldOptions{
 					ConfigurationFile: "skaffold.yaml.out",
 				},
@@ -153,11 +200,14 @@ func TestDoInit(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
 			t.Chdir(test.dir)
-			// we still need as a "no-prompt" mode
-			test.config.Force = true
+
 			err := DoInit(context.TODO(), os.Stdout, test.config)
-			t.CheckError(test.shouldErr, err)
-			if !test.shouldErr {
+
+			if test.expectedError != "" {
+				t.CheckErrorContains(test.expectedError, err)
+				t.CheckDeepEqual(exitCode(err), test.expectedExitCode)
+			} else {
+				t.CheckNoError(err)
 				checkGeneratedConfig(t, ".")
 			}
 		})
@@ -246,4 +296,17 @@ func checkGeneratedConfig(t *testutil.T, dir string) {
 	output, err := schema.ParseConfig(filepath.Join(dir, "skaffold.yaml.out"))
 	t.CheckNoError(err)
 	t.CheckDeepEqual(expectedOutput, output)
+}
+
+type ExitCoder interface {
+	ExitCode() int
+}
+
+func exitCode(err error) int {
+	var exitErr ExitCoder
+	if ok := errors.As(err, &exitErr); ok {
+		return exitErr.ExitCode()
+	}
+
+	return 1
 }

--- a/pkg/skaffold/initializer/testdata/init/no-builder/service.yaml
+++ b/pkg/skaffold/initializer/testdata/init/no-builder/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dockerfile-image
+  labels:
+    app: dockerfile-image
+spec:
+  clusterIP: None
+  selector:
+    app: dockerfile-image


### PR DESCRIPTION
Fixes #4348

+ 101: no build configuration
+ 102: no k8s manifest
+ 103: pre existing skaffold.yaml
+ 104: builder/image pair ambiguity

Signed-off-by: David Gageot <david@gageot.net>

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
