### PR TITLE
Move diagnose code out of the runner

### DIFF
--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -53,6 +53,20 @@ func withRunner(ctx context.Context, action func(runner.Runner, *latest.Skaffold
 
 // createNewRunner creates a Runner and returns the SkaffoldConfig associated with it.
 func createNewRunner(opts config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+	runCtx, config, err := runContext(opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	runner, err := runner.NewForConfig(runCtx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("creating runner: %w", err)
+	}
+
+	return runner, config, nil
+}
+
+func runContext(opts config.SkaffoldOptions) (*runcontext.RunContext, *latest.SkaffoldConfig, error) {
 	parsed, err := schema.ParseConfigAndUpgrade(opts.ConfigurationFile, latest.Version)
 	if err != nil {
 		if os.IsNotExist(errors.Unwrap(err)) {
@@ -87,12 +101,7 @@ func createNewRunner(opts config.SkaffoldOptions) (runner.Runner, *latest.Skaffo
 		return nil, nil, fmt.Errorf("getting run context: %w", err)
 	}
 
-	runner, err := runner.NewForConfig(runCtx)
-	if err != nil {
-		return nil, nil, fmt.Errorf("creating runner: %w", err)
-	}
-
-	return runner, config, nil
+	return runCtx, config, nil
 }
 
 func warnIfUpdateIsAvailable() {

--- a/pkg/skaffold/diagnose/diagnose_test.go
+++ b/pkg/skaffold/diagnose/diagnose_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package runner
+package diagnose
 
 import (
 	"context"

--- a/pkg/skaffold/diagnose/diagnose_test.go
+++ b/pkg/skaffold/diagnose/diagnose_test.go
@@ -18,8 +18,10 @@ package diagnose
 
 import (
 	"context"
+	"io/ioutil"
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -73,4 +75,28 @@ func TestSizeOfDockerContext(t *testing.T) {
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, actual)
 		})
 	}
+}
+
+func TestCheckArtifacts(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		tmpDir := t.NewTempDir().Write("Dockerfile", "FROM busybox")
+
+		runCtx := &runcontext.RunContext{
+			Cfg: latest.Pipeline{
+				Build: latest.BuildConfig{
+					Artifacts: []*latest.Artifact{{
+						Workspace: tmpDir.Root(),
+						ArtifactType: latest.ArtifactType{
+							DockerArtifact: &latest.DockerArtifact{
+								DockerfilePath: "Dockerfile",
+							},
+						},
+					}},
+				},
+			},
+		}
+		err := CheckArtifacts(context.Background(), runCtx, ioutil.Discard)
+
+		t.CheckNoError(err)
+	})
 }

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -40,7 +40,6 @@ const (
 
 // Runner is responsible for running the skaffold build, test and deploy config.
 type Runner interface {
-	DiagnoseArtifacts(context.Context, io.Writer) error
 	Dev(context.Context, io.Writer, []*latest.Artifact) error
 	ApplyDefaultRepo(tag string) (string, error)
 	BuildAndTest(context.Context, io.Writer, []*latest.Artifact) ([]build.Artifact, error)


### PR DESCRIPTION
This is mostly moving code out of `SkaffoldRunner` so that `skaffold diagnose` doesn't create a full fledged runner.
It's not needed  and can trigger failures that are useless when all we want to do is print the yaml config.

Fixes #4411

Signed-off-by: David Gageot <david@gageot.net>
