### PR TITLE
Use clean-slate Upgrade() function for creating new schema versions

### DIFF
--- a/hack/new_version.sh
+++ b/hack/new_version.sh
@@ -20,7 +20,7 @@ go run ./hack/versions/cmd/new/version.go $@
 
 goimports -w ./pkg/skaffold/schema
 make generate-schemas
-git --no-pager diff --minimal
+./hack/generate-man.sh
 make quicktest
 
 echo

--- a/hack/versions/cmd/new/version.go
+++ b/hack/versions/cmd/new/version.go
@@ -57,14 +57,21 @@ func main() {
 	next := readNextVersion()
 
 	// Create code to upgrade from current to new
-	cp(path(prev, "upgrade.go"), path(current, "upgrade.go"))
-	sed(path(current, "upgrade.go"), current, next)
-	sed(path(current, "upgrade.go"), prev, current)
+
+	original := "v2beta2" // arbitrarily chosen because it's a blank slate
+	originalNext := "v2beta3"
+
+	cp(path(original, "upgrade.go"), path(current, "upgrade.go"))
+	sed(path(current, "upgrade.go"), originalNext, "latest")
+	sed(path(current, "upgrade.go"), original, current)
 
 	// Create a test for the upgrade from current to new
-	cp(path(prev, "upgrade_test.go"), path(current, "upgrade_test.go"))
-	sed(path(current, "upgrade_test.go"), current, next)
-	sed(path(current, "upgrade_test.go"), prev, current)
+	cp(path(original, "upgrade_test.go"), path(current, "upgrade_test.go"))
+
+	// upgrade the import to latest, but the expected config string to the next version
+	sed(path(current, "upgrade_test.go"), "skaffold/schema/"+originalNext, "skaffold/schema/latest")
+	sed(path(current, "upgrade_test.go"), "skaffold/"+originalNext, "skaffold/"+next)
+	sed(path(current, "upgrade_test.go"), original, current)
 
 	// Previous version now upgrades to current instead of latest
 	sed(path(prev, "upgrade.go"), "latest", current)


### PR DESCRIPTION
we can use `v2beta2` as a boilerplate since it's a known clean-slate, and it won't change in the future. it's hacky, but it gets the job done.

also, run `./hack/generate-man.sh` after creating a new schema version since this will always need to happen.

fixes https://github.com/GoogleContainerTools/skaffold/issues/4255