### PR TITLE
Fix example for generate-pipeline to use "latest" as image tag

### DIFF
--- a/examples/generate-pipeline/expectedPipeline.yaml
+++ b/examples/generate-pipeline/expectedPipeline.yaml
@@ -42,7 +42,7 @@ spec:
     env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /secret/kaniko-secret
-    image: gcr.io/k8s-skaffold/skaffold:test-version
+    image: gcr.io/k8s-skaffold/skaffold:latest
     name: run-build
     resources: {}
     volumeMounts:
@@ -75,7 +75,7 @@ spec:
     command:
     - skaffold
     - deploy
-    image: gcr.io/k8s-skaffold/skaffold:test-version
+    image: gcr.io/k8s-skaffold/skaffold:latest
     name: run-deploy
     resources: {}
     workingDir: /workspace/source

--- a/integration/examples/generate-pipeline/expectedPipeline.yaml
+++ b/integration/examples/generate-pipeline/expectedPipeline.yaml
@@ -42,7 +42,7 @@ spec:
     env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /secret/kaniko-secret
-    image: gcr.io/k8s-skaffold/skaffold:test-version
+    image: gcr.io/k8s-skaffold/skaffold:latest
     name: run-build
     resources: {}
     volumeMounts:
@@ -75,7 +75,7 @@ spec:
     command:
     - skaffold
     - deploy
-    image: gcr.io/k8s-skaffold/skaffold:test-version
+    image: gcr.io/k8s-skaffold/skaffold:latest
     name: run-deploy
     resources: {}
     workingDir: /workspace/source

--- a/integration/generate_pipeline_test.go
+++ b/integration/generate_pipeline_test.go
@@ -82,7 +82,7 @@ func TestGeneratePipeline(t *testing.T) {
 
 			skaffoldEnv := []string{
 				"PIPELINE_GIT_URL=this-is-a-test",
-				"PIPELINE_SKAFFOLD_VERSION=test-version",
+				"PIPELINE_SKAFFOLD_VERSION=latest",
 			}
 			skaffold.GeneratePipeline(args...).WithStdin(test.input).WithEnv(skaffoldEnv).InDir(test.dir).RunOrFail(t)
 

--- a/integration/testdata/generate_pipeline/existing_oncluster/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/existing_oncluster/expectedPipeline.yaml
@@ -42,7 +42,7 @@ spec:
     env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /secret/kaniko-secret
-    image: gcr.io/k8s-skaffold/skaffold:test-version
+    image: gcr.io/k8s-skaffold/skaffold:latest
     name: run-build
     resources: {}
     volumeMounts:
@@ -75,7 +75,7 @@ spec:
     command:
     - skaffold
     - deploy
-    image: gcr.io/k8s-skaffold/skaffold:test-version
+    image: gcr.io/k8s-skaffold/skaffold:latest
     name: run-deploy
     resources: {}
     workingDir: /workspace/source

--- a/integration/testdata/generate_pipeline/existing_other/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/existing_other/expectedPipeline.yaml
@@ -42,7 +42,7 @@ spec:
     env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /secret/kaniko-secret
-    image: gcr.io/k8s-skaffold/skaffold:test-version
+    image: gcr.io/k8s-skaffold/skaffold:latest
     name: run-build
     resources: {}
     volumeMounts:
@@ -75,7 +75,7 @@ spec:
     command:
     - skaffold
     - deploy
-    image: gcr.io/k8s-skaffold/skaffold:test-version
+    image: gcr.io/k8s-skaffold/skaffold:latest
     name: run-deploy
     resources: {}
     workingDir: /workspace/source

--- a/integration/testdata/generate_pipeline/multiple_configs/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/multiple_configs/expectedPipeline.yaml
@@ -42,7 +42,7 @@ spec:
     env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /secret/kaniko-secret
-    image: gcr.io/k8s-skaffold/skaffold:test-version
+    image: gcr.io/k8s-skaffold/skaffold:latest
     name: run-build
     resources: {}
     volumeMounts:
@@ -86,7 +86,7 @@ spec:
     env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /secret/kaniko-secret
-    image: gcr.io/k8s-skaffold/skaffold:test-version
+    image: gcr.io/k8s-skaffold/skaffold:latest
     name: run-build
     resources: {}
     volumeMounts:
@@ -119,7 +119,7 @@ spec:
     command:
     - skaffold
     - deploy
-    image: gcr.io/k8s-skaffold/skaffold:test-version
+    image: gcr.io/k8s-skaffold/skaffold:latest
     name: run-deploy
     resources: {}
     workingDir: /workspace/source
@@ -145,7 +145,7 @@ spec:
     command:
     - skaffold
     - deploy
-    image: gcr.io/k8s-skaffold/skaffold:test-version
+    image: gcr.io/k8s-skaffold/skaffold:latest
     name: run-deploy
     resources: {}
     workingDir: /workspace/source

--- a/integration/testdata/generate_pipeline/no_profiles/expectedPipeline.yaml
+++ b/integration/testdata/generate_pipeline/no_profiles/expectedPipeline.yaml
@@ -42,7 +42,7 @@ spec:
     env:
     - name: GOOGLE_APPLICATION_CREDENTIALS
       value: /secret/kaniko-secret
-    image: gcr.io/k8s-skaffold/skaffold:test-version
+    image: gcr.io/k8s-skaffold/skaffold:latest
     name: run-build
     resources: {}
     volumeMounts:
@@ -75,7 +75,7 @@ spec:
     command:
     - skaffold
     - deploy
-    image: gcr.io/k8s-skaffold/skaffold:test-version
+    image: gcr.io/k8s-skaffold/skaffold:latest
     name: run-deploy
     resources: {}
     workingDir: /workspace/source


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4454 <!-- tracking issues that this PR will close -->

**Description**
Small change to skaffold generate-pipeline example to use the "latest" image tag. Was using "test-version" before which isn't a real thing.
<!-- Describe your changes here. The more detail, the easier the review! -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
