### PR TITLE
Link Typo

### DIFF
--- a/docs/content/en/docs/pipeline-stages/init.md
+++ b/docs/content/en/docs/pipeline-stages/init.md
@@ -24,7 +24,7 @@ than 500MB.
 If there are multiple build configuration files, Skaffold will prompt you to pair your build configuration files
 with any images detected in your deploy configuration.
 
-E.g. For an application with [two microservices] (https://github.com/GoogleContainerTools/skaffold/tree/master/examples/microservices):
+E.g. For an application with [two microservices](https://github.com/GoogleContainerTools/skaffold/tree/master/examples/microservices):
 
 ```bash
 skaffold init


### PR DESCRIPTION
An extra space was made between the `]` and the `(` resulting in a broken link

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
There was a small formatting issue which resulted in a broken link. Removed the space and the link was fixed.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
