### PR TITLE
Add `ImageOptions` to artifact builder.

### DIFF
--- a/cmd/skaffold/app/cmd/debug.go
+++ b/cmd/skaffold/app/cmd/debug.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/spf13/cobra"
 
 	debugging "github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
@@ -43,6 +44,7 @@ func NewCmdDebug() *cobra.Command {
 
 func runDebug(ctx context.Context, out io.Writer) error {
 	opts.PortForward.ForwardPods = true
+	build.CurrentConfiguration = build.Debug
 	deploy.AddManifestTransform(debugging.ApplyDebuggingTransforms)
 
 	return doDev(ctx, out)

--- a/cmd/skaffold/app/cmd/debug.go
+++ b/cmd/skaffold/app/cmd/debug.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/spf13/cobra"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	debugging "github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 )

--- a/cmd/skaffold/app/cmd/debug.go
+++ b/cmd/skaffold/app/cmd/debug.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	debugging "github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 )
@@ -44,7 +43,6 @@ func NewCmdDebug() *cobra.Command {
 
 func runDebug(ctx context.Context, out io.Writer) error {
 	opts.PortForward.ForwardPods = true
-	build.CurrentConfiguration = build.Debug
 	deploy.AddManifestTransform(debugging.ApplyDebuggingTransforms)
 
 	return doDev(ctx, out)

--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -39,19 +39,7 @@ func TestDebug(t *testing.T) {
 		{
 			description: "kubectl",
 			deployments: []string{"java"},
-			pods:        []string{"nodejs", "npm", "python3", "go"},
-		},
-		{
-			description: "kustomize",
-			args:        []string{"--profile", "kustomize"},
-			deployments: []string{"java"},
-			pods:        []string{"nodejs", "npm", "python3", "go"},
-		},
-		{
-			description: "buildpacks",
-			args:        []string{"--profile", "buildpacks"},
-			deployments: []string{"java"},
-			pods:        []string{"nodejs", "npm", "python3", "go"},
+			pods:        []string{"go"},
 		},
 	}
 	for _, test := range tests {

--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -39,7 +39,19 @@ func TestDebug(t *testing.T) {
 		{
 			description: "kubectl",
 			deployments: []string{"java"},
-			pods:        []string{"go"},
+			pods:        []string{"nodejs", "npm", "python3", "go"},
+		},
+		{
+			description: "kustomize",
+			args:        []string{"--profile", "kustomize"},
+			deployments: []string{"java"},
+			pods:        []string{"nodejs", "npm", "python3", "go"},
+		},
+		{
+			description: "buildpacks",
+			args:        []string{"--profile", "buildpacks"},
+			deployments: []string{"java"},
+			pods:        []string{"nodejs", "npm", "python3", "go"},
 		},
 	}
 	for _, test := range tests {

--- a/integration/examples/getting-started/Dockerfile
+++ b/integration/examples/getting-started/Dockerfile
@@ -1,11 +1,11 @@
 FROM golang:1.12.9-alpine3.10 as builder
 
 # These flag values are provided when building for debug
-ARG GO_GCFLAGS
-ARG GO_LDFLAGS
+ARG SKAFFOLD_GO_GCFLAGS
+ARG SKAFFOLD_GO_LDFLAGS
 
 COPY main.go .
-RUN eval go build --gcflags="${GO_GCFLAGS}" --ldflags="${GO_LDFLAGS}" -o /app main.go
+RUN eval go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -ldflags="${SKAFFOLD_GO_LDFLAGS}" -o /app main.go
 
 FROM alpine:3.10
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/integration/examples/getting-started/Dockerfile
+++ b/integration/examples/getting-started/Dockerfile
@@ -1,6 +1,11 @@
 FROM golang:1.12.9-alpine3.10 as builder
+
+# These flag values are provided when building for debug
+ARG GO_GCFLAGS
+ARG GO_LDFLAGS
+
 COPY main.go .
-RUN go build -o /app main.go
+RUN eval go build --gcflags="${GO_GCFLAGS}" --ldflags="${GO_LDFLAGS}" -o /app main.go
 
 FROM alpine:3.10
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/integration/testdata/debug/go/Dockerfile
+++ b/integration/testdata/debug/go/Dockerfile
@@ -1,9 +1,10 @@
 FROM golang:1.12 as builder
+ARG SKAFFOLD_GO_GCFLAGS
 
 COPY app.go .
-# Must use eval to handle GOGCFLAGS with spaces like `-gcflags='all=-N -l'`
-ARG GO_GCFLAGS
-RUN eval go build --gcflags="${GO_GCFLAGS}" -o /app .
+RUN echo "SKAFFOLD_GO_GCFLAGS: ${SKAFFOLD_GO_GCFLAGS}"
+# Must use eval to handle GOGCFLAGS with spaces like `all=-N -l`
+RUN eval go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app .
 
 FROM gcr.io/distroless/base
 # `skaffold debug` uses GOTRACEBACK as an indicator of the Go runtime

--- a/integration/testdata/debug/go/Dockerfile
+++ b/integration/testdata/debug/go/Dockerfile
@@ -1,10 +1,10 @@
 FROM golang:1.12 as builder
-ARG SKAFFOLD_GO_GCFLAGS
 
 COPY app.go .
-RUN echo "SKAFFOLD_GO_GCFLAGS: ${SKAFFOLD_GO_GCFLAGS}"
-# Must use eval to handle GOGCFLAGS with spaces like `all=-N -l`
-RUN eval go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app .
+ARG SKAFFOLD_GO_GCFLAGS
+ARG SKAFFOLD_LD_GCFLAGS
+# Must use eval to handle gcflags with spaces like `all=-N -l`
+RUN eval go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -ldflags="${SKAFFOLD_GO_LDFLAGS}" -o /app .
 
 FROM gcr.io/distroless/base
 # `skaffold debug` uses GOTRACEBACK as an indicator of the Go runtime

--- a/integration/testdata/debug/go/Dockerfile
+++ b/integration/testdata/debug/go/Dockerfile
@@ -2,8 +2,8 @@ FROM golang:1.12 as builder
 
 COPY app.go .
 # Must use eval to handle GOGCFLAGS with spaces like `-gcflags='all=-N -l'`
-ARG GOGCFLAGS
-RUN eval go build "${GOGCFLAGS}" -o /app .
+ARG GO_GCFLAGS
+RUN eval go build "${GO_GCFLAGS}" -o /app .
 
 FROM gcr.io/distroless/base
 # `skaffold debug` uses GOTRACEBACK as an indicator of the Go runtime

--- a/integration/testdata/debug/go/Dockerfile
+++ b/integration/testdata/debug/go/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.12 as builder
 COPY app.go .
 # Must use eval to handle GOGCFLAGS with spaces like `-gcflags='all=-N -l'`
 ARG GO_GCFLAGS
-RUN eval go build "${GO_GCFLAGS}" -o /app .
+RUN eval go build --gcflags="${GO_GCFLAGS}" -o /app .
 
 FROM gcr.io/distroless/base
 # `skaffold debug` uses GOTRACEBACK as an indicator of the Go runtime

--- a/integration/testdata/debug/skaffold.yaml
+++ b/integration/testdata/debug/skaffold.yaml
@@ -15,9 +15,6 @@ build:
     context: python3
   - image: skaffold-debug-go
     context: go
-    docker:
-      buildArgs:
-        GOGCFLAGS: "-gcflags='all=-N -l'"
 
 deploy:
   kubectl:

--- a/integration/testdata/debug/skaffold.yaml
+++ b/integration/testdata/debug/skaffold.yaml
@@ -54,5 +54,3 @@ profiles:
       context: go
       buildpacks:
         builder: "gcr.io/buildpacks/builder:v1"
-        env:
-        - GOOGLE_GCFLAGS="-gcflags='all=-N -l'"

--- a/pkg/skaffold/build/build.go
+++ b/pkg/skaffold/build/build.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -37,7 +36,7 @@ type Artifact struct {
 type Builder interface {
 	Labels() map[string]string
 
-	Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]Artifact, error)
+	Build(ctx context.Context, out io.Writer, artifacts []*latest.Artifact, options []BuilderOptions) ([]Artifact, error)
 
 	// Prune removes images built with Skaffold
 	Prune(context.Context, io.Writer) error

--- a/pkg/skaffold/build/buildpacks/build.go
+++ b/pkg/skaffold/build/buildpacks/build.go
@@ -26,18 +26,18 @@ import (
 
 // Build builds an artifact with Cloud Native Buildpacks:
 // https://buildpacks.io/
-func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
-	built, err := b.build(ctx, out, artifact, tag)
+func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest.Artifact, opts BuildOptions) (string, error) {
+	built, err := b.build(ctx, out, artifact, opts)
 	if err != nil {
 		return "", err
 	}
 
-	if err := b.localDocker.Tag(ctx, built, tag); err != nil {
-		return "", fmt.Errorf("tagging %s->%q: %w", built, tag, err)
+	if err := b.localDocker.Tag(ctx, built, opts.Tag); err != nil {
+		return "", fmt.Errorf("tagging %s->%q: %w", built, opts.Tag, err)
 	}
 
 	if b.pushImages {
-		return b.localDocker.Push(ctx, out, tag)
+		return b.localDocker.Push(ctx, out, opts.Tag)
 	}
-	return b.localDocker.ImageID(ctx, tag)
+	return b.localDocker.ImageID(ctx, opts.Tag)
 }

--- a/pkg/skaffold/build/buildpacks/options.go
+++ b/pkg/skaffold/build/buildpacks/options.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buildpacks
+
+import "github.com/buildpacks/pack"
+
+var buildArgsForDebug = map[string]string{
+	"GOOGLE_GOGCFLAGS": "'all=-N -l'", // disable build optimization for Golang
+	// TODO: Add for other languages
+}
+
+var buildArgsForDev = map[string]string{
+	"GOOGLE_GOLDFLAGS": "-w", // omit debug information in build output for Golang
+	// TODO: Add for other languages
+}
+
+type BuildOptionsModifier func(*pack.BuildOptions) *pack.BuildOptions
+
+type BuildOptions struct {
+	Tag       string
+	modifiers []BuildOptionsModifier
+}
+
+func (b *BuildOptions) AddModifier(m BuildOptionsModifier) *BuildOptions {
+	b.modifiers = append(b.modifiers, m)
+	return b
+}
+
+func (b *BuildOptions) ApplyModifiers(opts *pack.BuildOptions) *pack.BuildOptions {
+	for _, modifier := range b.modifiers {
+		opts = modifier(opts)
+	}
+	return opts
+}
+
+func OptimizeBuildForDebug(opts *pack.BuildOptions) *pack.BuildOptions {
+	if opts == nil {
+		opts = &pack.BuildOptions{}
+	}
+
+	if opts.Env == nil {
+		opts.Env = make(map[string]string)
+	}
+
+	for k, v := range buildArgsForDebug {
+		if _, exists := opts.Env[k]; !exists {
+			opts.Env[k] = v
+		}
+	}
+	return opts
+}
+
+func OptimizeBuildForDev(opts *pack.BuildOptions) *pack.BuildOptions {
+	if opts == nil {
+		opts = &pack.BuildOptions{}
+	}
+
+	if opts.Env == nil {
+		opts.Env = make(map[string]string)
+	}
+
+	for k, v := range buildArgsForDev {
+		if _, exists := opts.Env[k]; !exists {
+			opts.Env[k] = v
+		}
+	}
+	return opts
+}

--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 
@@ -49,7 +50,7 @@ type cache struct {
 	insecureRegistries map[string]bool
 	cacheFile          string
 	imagesAreLocal     bool
-	hashForArtifact    func(ctx context.Context, a *latest.Artifact) (string, error)
+	hashForArtifact    func(ctx context.Context, a *latest.Artifact, opts *build.ImageOptions) (string, error)
 }
 
 // DependencyLister fetches a list of dependencies for an artifact
@@ -84,8 +85,8 @@ func NewCache(runCtx *runcontext.RunContext, imagesAreLocal bool, dependencies D
 		insecureRegistries: runCtx.InsecureRegistries,
 		cacheFile:          cacheFile,
 		imagesAreLocal:     imagesAreLocal,
-		hashForArtifact: func(ctx context.Context, a *latest.Artifact) (string, error) {
-			return getHashForArtifact(ctx, dependencies, a, runCtx.Opts.IsDevMode())
+		hashForArtifact: func(ctx context.Context, a *latest.Artifact, opts *build.ImageOptions) (string, error) {
+			return getHashForArtifact(ctx, dependencies, a, opts, runCtx.Opts.IsDevMode())
 		},
 	}, nil
 }

--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -22,10 +22,10 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"

--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -50,7 +50,7 @@ type cache struct {
 	insecureRegistries map[string]bool
 	cacheFile          string
 	imagesAreLocal     bool
-	hashForArtifact    func(ctx context.Context, a *latest.Artifact, opts *build.ImageOptions) (string, error)
+	hashForArtifact    func(ctx context.Context, a *latest.Artifact, opts build.BuilderOptions) (string, error)
 }
 
 // DependencyLister fetches a list of dependencies for an artifact
@@ -85,7 +85,7 @@ func NewCache(runCtx *runcontext.RunContext, imagesAreLocal bool, dependencies D
 		insecureRegistries: runCtx.InsecureRegistries,
 		cacheFile:          cacheFile,
 		imagesAreLocal:     imagesAreLocal,
-		hashForArtifact: func(ctx context.Context, a *latest.Artifact, opts *build.ImageOptions) (string, error) {
+		hashForArtifact: func(ctx context.Context, a *latest.Artifact, opts build.BuilderOptions) (string, error) {
 			return getHashForArtifact(ctx, dependencies, a, opts, runCtx.Opts.IsDevMode())
 		},
 	}, nil

--- a/pkg/skaffold/build/cache/hash.go
+++ b/pkg/skaffold/build/cache/hash.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
@@ -40,7 +41,7 @@ var (
 	artifactConfigFunction = artifactConfig
 )
 
-func getHashForArtifact(ctx context.Context, depLister DependencyLister, a *latest.Artifact, devMode bool) (string, error) {
+func getHashForArtifact(ctx context.Context, depLister DependencyLister, a *latest.Artifact, opts *build.ImageOptions, devMode bool) (string, error) {
 	var inputs []string
 
 	// Append the artifact's configuration
@@ -87,6 +88,15 @@ func getHashForArtifact(ctx context.Context, depLister DependencyLister, a *late
 			return "", fmt.Errorf("evaluating build args: %w", err)
 		}
 		inputs = append(inputs, evaluatedEnv...)
+	}
+
+	// add image options hash
+	if opts != nil {
+		if h, err := opts.Hash(); err != nil {
+			return "", fmt.Errorf("evaluating build args: %w", err)
+		} else {
+			inputs = append(inputs, h)
+		}
 	}
 
 	// get a key for the hashes

--- a/pkg/skaffold/build/cache/hash.go
+++ b/pkg/skaffold/build/cache/hash.go
@@ -41,7 +41,7 @@ var (
 	artifactConfigFunction = artifactConfig
 )
 
-func getHashForArtifact(ctx context.Context, depLister DependencyLister, a *latest.Artifact, opts *build.ImageOptions, devMode bool) (string, error) {
+func getHashForArtifact(ctx context.Context, depLister DependencyLister, a *latest.Artifact, opts build.BuilderOptions, devMode bool) (string, error) {
 	var inputs []string
 
 	// Append the artifact's configuration
@@ -91,13 +91,11 @@ func getHashForArtifact(ctx context.Context, depLister DependencyLister, a *late
 	}
 
 	// add image options hash
-	if opts != nil {
-		h, err := opts.Hash()
-		if err != nil {
-			return "", fmt.Errorf("evaluating build args: %w", err)
-		}
-		inputs = append(inputs, h)
+	h, err := opts.Hash()
+	if err != nil {
+		return "", fmt.Errorf("evaluating build args: %w", err)
 	}
+	inputs = append(inputs, h)
 
 	// get a key for the hashes
 	hasher := sha256.New()

--- a/pkg/skaffold/build/cache/hash.go
+++ b/pkg/skaffold/build/cache/hash.go
@@ -27,9 +27,9 @@ import (
 	"os"
 	"sort"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/sirupsen/logrus"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -92,11 +92,11 @@ func getHashForArtifact(ctx context.Context, depLister DependencyLister, a *late
 
 	// add image options hash
 	if opts != nil {
-		if h, err := opts.Hash(); err != nil {
+		h, err := opts.Hash()
+		if err != nil {
 			return "", fmt.Errorf("evaluating build args: %w", err)
-		} else {
-			inputs = append(inputs, h)
 		}
+		inputs = append(inputs, h)
 	}
 
 	// get a key for the hashes

--- a/pkg/skaffold/build/cache/hash_test.go
+++ b/pkg/skaffold/build/cache/hash_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -143,7 +142,7 @@ func TestGetHashForArtifact(t *testing.T) {
 			t.Override(&artifactConfigFunction, fakeArtifactConfig)
 
 			depLister := stubDependencyLister(test.dependencies)
-			actual, err := getHashForArtifact(context.Background(), depLister, test.artifact, build.CreateBuilderOptions(""), test.devMode)
+			actual, err := getHashForArtifact(context.Background(), depLister, test.artifact, nil, test.devMode)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)

--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -22,12 +22,11 @@ import (
 	"sync"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
-func (c *cache) lookupArtifacts(ctx context.Context, tags tag.ImageTags, artifacts []*latest.Artifact) []cacheDetails {
+func (c *cache) lookupArtifacts(ctx context.Context, artifacts []*latest.Artifact, options []build.BuilderOptions) []cacheDetails {
 	details := make([]cacheDetails, len(artifacts))
 
 	var wg sync.WaitGroup
@@ -36,7 +35,7 @@ func (c *cache) lookupArtifacts(ctx context.Context, tags tag.ImageTags, artifac
 
 		i := i
 		go func() {
-			details[i] = c.lookup(ctx, artifacts[i], build.CreateBuilderOptions(tags[artifacts[i].ImageName]))
+			details[i] = c.lookup(ctx, artifacts[i], options[i])
 			wg.Done()
 		}()
 	}
@@ -45,7 +44,7 @@ func (c *cache) lookupArtifacts(ctx context.Context, tags tag.ImageTags, artifac
 	return details
 }
 
-func (c *cache) lookup(ctx context.Context, a *latest.Artifact, opts *build.ImageOptions) cacheDetails {
+func (c *cache) lookup(ctx context.Context, a *latest.Artifact, opts build.BuilderOptions) cacheDetails {
 	hash, err := c.hashForArtifact(ctx, a, opts)
 	if err != nil {
 		return failed{err: fmt.Errorf("getting hash for artifact %q: %s", a.ImageName, err)}

--- a/pkg/skaffold/build/cache/lookup_test.go
+++ b/pkg/skaffold/build/cache/lookup_test.go
@@ -31,7 +31,7 @@ import (
 func TestLookupLocal(t *testing.T) {
 	tests := []struct {
 		description string
-		hasher      func(context.Context, *latest.Artifact, *build.ImageOptions) (string, error)
+		hasher      func(context.Context, *latest.Artifact, build.BuilderOptions) (string, error)
 		cache       map[string]ImageDetails
 		api         *testutil.FakeAPIClient
 		expected    cacheDetails
@@ -110,8 +110,10 @@ func TestLookupLocal(t *testing.T) {
 				client:          docker.NewLocalDaemon(test.api, nil, false, nil),
 				hashForArtifact: test.hasher,
 			}
-			details := cache.lookupArtifacts(context.Background(), map[string]string{"artifact": "tag"}, []*latest.Artifact{{
+			details := cache.lookupArtifacts(context.Background(), []*latest.Artifact{{
 				ImageName: "artifact",
+			}}, []build.BuilderOptions{{
+				Tag: "tag",
 			}})
 
 			// cmp.Diff cannot access unexported fields in *exec.Cmd, so use reflect.DeepEqual here directly
@@ -125,7 +127,7 @@ func TestLookupLocal(t *testing.T) {
 func TestLookupRemote(t *testing.T) {
 	tests := []struct {
 		description string
-		hasher      func(context.Context, *latest.Artifact, *build.ImageOptions) (string, error)
+		hasher      func(context.Context, *latest.Artifact, build.BuilderOptions) (string, error)
 		cache       map[string]ImageDetails
 		api         *testutil.FakeAPIClient
 		expected    cacheDetails
@@ -194,8 +196,10 @@ func TestLookupRemote(t *testing.T) {
 				client:          docker.NewLocalDaemon(test.api, nil, false, nil),
 				hashForArtifact: test.hasher,
 			}
-			details := cache.lookupArtifacts(context.Background(), map[string]string{"artifact": "tag"}, []*latest.Artifact{{
+			details := cache.lookupArtifacts(context.Background(), []*latest.Artifact{{
 				ImageName: "artifact",
+			}}, []build.BuilderOptions{{
+				Tag: "tag",
 			}})
 
 			// cmp.Diff cannot access unexported fields in *exec.Cmd, so use reflect.DeepEqual here directly
@@ -206,14 +210,14 @@ func TestLookupRemote(t *testing.T) {
 	}
 }
 
-func mockHasher(value string) func(context.Context, *latest.Artifact, *build.ImageOptions) (string, error) {
-	return func(context.Context, *latest.Artifact, *build.ImageOptions) (string, error) {
+func mockHasher(value string) func(context.Context, *latest.Artifact, build.BuilderOptions) (string, error) {
+	return func(context.Context, *latest.Artifact, build.BuilderOptions) (string, error) {
 		return value, nil
 	}
 }
 
-func failingHasher(errMessage string) func(context.Context, *latest.Artifact, *build.ImageOptions) (string, error) {
-	return func(context.Context, *latest.Artifact, *build.ImageOptions) (string, error) {
+func failingHasher(errMessage string) func(context.Context, *latest.Artifact, build.BuilderOptions) (string, error) {
+	return func(context.Context, *latest.Artifact, build.BuilderOptions) (string, error) {
 		return "", errors.New(errMessage)
 	}
 }

--- a/pkg/skaffold/build/cache/lookup_test.go
+++ b/pkg/skaffold/build/cache/lookup_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -30,7 +31,7 @@ import (
 func TestLookupLocal(t *testing.T) {
 	tests := []struct {
 		description string
-		hasher      func(context.Context, *latest.Artifact) (string, error)
+		hasher      func(context.Context, *latest.Artifact, *build.ImageOptions) (string, error)
 		cache       map[string]ImageDetails
 		api         *testutil.FakeAPIClient
 		expected    cacheDetails
@@ -124,7 +125,7 @@ func TestLookupLocal(t *testing.T) {
 func TestLookupRemote(t *testing.T) {
 	tests := []struct {
 		description string
-		hasher      func(context.Context, *latest.Artifact) (string, error)
+		hasher      func(context.Context, *latest.Artifact, *build.ImageOptions) (string, error)
 		cache       map[string]ImageDetails
 		api         *testutil.FakeAPIClient
 		expected    cacheDetails
@@ -205,14 +206,14 @@ func TestLookupRemote(t *testing.T) {
 	}
 }
 
-func mockHasher(value string) func(context.Context, *latest.Artifact) (string, error) {
-	return func(context.Context, *latest.Artifact) (string, error) {
+func mockHasher(value string) func(context.Context, *latest.Artifact, *build.ImageOptions) (string, error) {
+	return func(context.Context, *latest.Artifact, *build.ImageOptions) (string, error) {
 		return value, nil
 	}
 }
 
-func failingHasher(errMessage string) func(context.Context, *latest.Artifact) (string, error) {
-	return func(context.Context, *latest.Artifact) (string, error) {
+func failingHasher(errMessage string) func(context.Context, *latest.Artifact, *build.ImageOptions) (string, error) {
+	return func(context.Context, *latest.Artifact, *build.ImageOptions) (string, error) {
 		return "", errors.New(errMessage)
 	}
 }

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -57,7 +57,7 @@ func (b *mockBuilder) BuildAndTest(ctx context.Context, out io.Writer, tags tag.
 		b.built = append(b.built, artifact)
 		tag := tags[artifact.ImageName]
 
-		_, err := b.dockerDaemon.Build(ctx, out, artifact.Workspace, artifact.DockerArtifact, tag)
+		_, err := b.dockerDaemon.Build(ctx, out, artifact.Workspace, artifact.DockerArtifact, &docker.BuildOptions{Tag: tag})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -56,7 +56,7 @@ func (b *mockBuilder) BuildAndTest(ctx context.Context, out io.Writer, artifacts
 		b.built = append(b.built, artifact)
 		tag := options[i].Tag
 
-		_, err := b.dockerDaemon.Build(ctx, out, artifact.Workspace, artifact.DockerArtifact, &docker.BuildOptions{Tag: tag})
+		_, err := b.dockerDaemon.Build(ctx, out, artifact.Workspace, artifact.DockerArtifact, docker.BuildOptions{Tag: tag})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/skaffold/build/cache/types.go
+++ b/pkg/skaffold/build/cache/types.go
@@ -21,18 +21,17 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
-type BuildAndTestFn func(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact) ([]build.Artifact, error)
+type BuildAndTestFn func(context.Context, io.Writer, []*latest.Artifact, []build.BuilderOptions) ([]build.Artifact, error)
 
 type Cache interface {
-	Build(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, BuildAndTestFn) ([]build.Artifact, error)
+	Build(context.Context, io.Writer, []*latest.Artifact, []build.BuilderOptions, BuildAndTestFn) ([]build.Artifact, error)
 }
 
 type noCache struct{}
 
-func (n *noCache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, buildAndTest BuildAndTestFn) ([]build.Artifact, error) {
-	return buildAndTest(ctx, out, tags, artifacts)
+func (n *noCache) Build(ctx context.Context, out io.Writer, artifacts []*latest.Artifact, options []build.BuilderOptions, buildAndTest BuildAndTestFn) ([]build.Artifact, error) {
+	return buildAndTest(ctx, out, artifacts, options)
 }

--- a/pkg/skaffold/build/cluster/cluster.go
+++ b/pkg/skaffold/build/cluster/cluster.go
@@ -48,13 +48,13 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, 
 	return build.InParallel(ctx, out, tags, artifacts, b.buildArtifact, b.ClusterDetails.Concurrency)
 }
 
-func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
-	digest, err := b.runBuildForArtifact(ctx, out, artifact, tag)
+func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, opts *build.ImageOptions) (string, error) {
+	digest, err := b.runBuildForArtifact(ctx, out, artifact, opts.Tag)
 	if err != nil {
 		return "", err
 	}
 
-	return build.TagWithDigest(tag, digest), nil
+	return build.TagWithDigest(opts.Tag, digest), nil
 }
 
 func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {

--- a/pkg/skaffold/build/cluster/cluster.go
+++ b/pkg/skaffold/build/cluster/cluster.go
@@ -24,13 +24,12 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/custom"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
 // Build builds a list of artifacts with Kaniko.
-func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+func (b *Builder) Build(ctx context.Context, out io.Writer, artifacts []*latest.Artifact, options []build.BuilderOptions) ([]build.Artifact, error) {
 	teardownPullSecret, err := b.setupPullSecret(out)
 	if err != nil {
 		return nil, fmt.Errorf("setting up pull secret: %w", err)
@@ -45,10 +44,10 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, 
 		defer teardownDockerConfigSecret()
 	}
 
-	return build.InParallel(ctx, out, tags, artifacts, b.buildArtifact, b.ClusterDetails.Concurrency)
+	return build.InParallel(ctx, out, artifacts, options, b.buildArtifact, b.ClusterDetails.Concurrency)
 }
 
-func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, opts *build.ImageOptions) (string, error) {
+func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, opts build.BuilderOptions) (string, error) {
 	digest, err := b.runBuildForArtifact(ctx, out, artifact, opts.Tag)
 	if err != nil {
 		return "", err

--- a/pkg/skaffold/build/gcb/cloud_build.go
+++ b/pkg/skaffold/build/gcb/cloud_build.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
@@ -45,11 +44,11 @@ import (
 )
 
 // Build builds a list of artifacts with Google Cloud Build.
-func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
-	return build.InParallel(ctx, out, tags, artifacts, b.buildArtifactWithCloudBuild, b.GoogleCloudBuild.Concurrency)
+func (b *Builder) Build(ctx context.Context, out io.Writer, artifacts []*latest.Artifact, options []build.BuilderOptions) ([]build.Artifact, error) {
+	return build.InParallel(ctx, out, artifacts, options, b.buildArtifactWithCloudBuild, b.GoogleCloudBuild.Concurrency)
 }
 
-func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer, artifact *latest.Artifact, opts *build.ImageOptions) (string, error) {
+func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer, artifact *latest.Artifact, opts build.BuilderOptions) (string, error) {
 	cbclient, err := cloudbuild.NewService(ctx, gcp.ClientOptions()...)
 	if err != nil {
 		return "", fmt.Errorf("getting cloudbuild client: %w", err)

--- a/pkg/skaffold/build/gcb/docker.go
+++ b/pkg/skaffold/build/gcb/docker.go
@@ -26,8 +26,8 @@ import (
 )
 
 // dockerBuildSpec lists the build steps required to build a docker image.
-func (b *Builder) dockerBuildSpec(artifact *latest.DockerArtifact, tag string) (cloudbuild.Build, error) {
-	args, err := b.dockerBuildArgs(artifact, tag)
+func (b *Builder) dockerBuildSpec(artifact *latest.DockerArtifact, opts *docker.BuildOptions) (cloudbuild.Build, error) {
+	args, err := b.dockerBuildArgs(artifact, opts)
 	if err != nil {
 		return cloudbuild.Build{}, err
 	}
@@ -40,7 +40,7 @@ func (b *Builder) dockerBuildSpec(artifact *latest.DockerArtifact, tag string) (
 
 	return cloudbuild.Build{
 		Steps:  steps,
-		Images: []string{tag},
+		Images: []string{opts.Tag},
 	}, nil
 }
 
@@ -60,13 +60,13 @@ func (b *Builder) cacheFromSteps(artifact *latest.DockerArtifact) []*cloudbuild.
 }
 
 // dockerBuildArgs lists the arguments passed to `docker` to build a given image.
-func (b *Builder) dockerBuildArgs(artifact *latest.DockerArtifact, tag string) ([]string, error) {
-	ba, err := docker.GetBuildArgs(artifact)
+func (b *Builder) dockerBuildArgs(artifact *latest.DockerArtifact, opts *docker.BuildOptions) ([]string, error) {
+	ba, err := docker.GetBuildArgs(artifact, opts)
 	if err != nil {
 		return nil, fmt.Errorf("getting docker build args: %w", err)
 	}
 
-	args := []string{"build", "--tag", tag, "-f", artifact.DockerfilePath}
+	args := []string{"build", "--tag", opts.Tag, "-f", artifact.DockerfilePath}
 	args = append(args, ba...)
 	args = append(args, ".")
 

--- a/pkg/skaffold/build/gcb/docker.go
+++ b/pkg/skaffold/build/gcb/docker.go
@@ -26,7 +26,7 @@ import (
 )
 
 // dockerBuildSpec lists the build steps required to build a docker image.
-func (b *Builder) dockerBuildSpec(artifact *latest.DockerArtifact, opts *docker.BuildOptions) (cloudbuild.Build, error) {
+func (b *Builder) dockerBuildSpec(artifact *latest.DockerArtifact, opts docker.BuildOptions) (cloudbuild.Build, error) {
 	args, err := b.dockerBuildArgs(artifact, opts)
 	if err != nil {
 		return cloudbuild.Build{}, err
@@ -60,7 +60,7 @@ func (b *Builder) cacheFromSteps(artifact *latest.DockerArtifact) []*cloudbuild.
 }
 
 // dockerBuildArgs lists the arguments passed to `docker` to build a given image.
-func (b *Builder) dockerBuildArgs(artifact *latest.DockerArtifact, opts *docker.BuildOptions) ([]string, error) {
+func (b *Builder) dockerBuildArgs(artifact *latest.DockerArtifact, opts docker.BuildOptions) ([]string, error) {
 	ba, err := docker.GetBuildArgs(artifact, opts)
 	if err != nil {
 		return nil, fmt.Errorf("getting docker build args: %w", err)

--- a/pkg/skaffold/build/gcb/docker_test.go
+++ b/pkg/skaffold/build/gcb/docker_test.go
@@ -80,7 +80,7 @@ func TestPullCacheFrom(t *testing.T) {
 	builder := newBuilder(latest.GoogleCloudBuild{
 		DockerImage: "docker/docker",
 	})
-	desc, err := builder.dockerBuildSpec(artifact, &docker.BuildOptions{Tag: "nginx2"})
+	desc, err := builder.dockerBuildSpec(artifact, docker.BuildOptions{Tag: "nginx2"})
 
 	expected := []*cloudbuild.BuildStep{{
 		Name:       "docker/docker",

--- a/pkg/skaffold/build/gcb/docker_test.go
+++ b/pkg/skaffold/build/gcb/docker_test.go
@@ -19,6 +19,7 @@ package gcb
 import (
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -79,7 +80,7 @@ func TestPullCacheFrom(t *testing.T) {
 	builder := newBuilder(latest.GoogleCloudBuild{
 		DockerImage: "docker/docker",
 	})
-	desc, err := builder.dockerBuildSpec(artifact, "nginx2")
+	desc, err := builder.dockerBuildSpec(artifact, &docker.BuildOptions{Tag: "nginx2"})
 
 	expected := []*cloudbuild.BuildStep{{
 		Name:       "docker/docker",

--- a/pkg/skaffold/build/gcb/docker_test.go
+++ b/pkg/skaffold/build/gcb/docker_test.go
@@ -19,9 +19,9 @@ package gcb
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"

--- a/pkg/skaffold/build/gcb/spec.go
+++ b/pkg/skaffold/build/gcb/spec.go
@@ -19,10 +19,10 @@ package gcb
 import (
 	"fmt"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 

--- a/pkg/skaffold/build/gcb/spec.go
+++ b/pkg/skaffold/build/gcb/spec.go
@@ -59,7 +59,7 @@ func (b *Builder) buildSpecForArtifact(a *latest.Artifact, tag string) (cloudbui
 		return b.kanikoBuildSpec(a.KanikoArtifact, tag)
 
 	case a.DockerArtifact != nil:
-		return b.dockerBuildSpec(a.DockerArtifact, &docker.BuildOptions{Tag: tag})
+		return b.dockerBuildSpec(a.DockerArtifact, docker.BuildOptions{Tag: tag})
 
 	case a.JibArtifact != nil:
 		return b.jibBuildSpec(a, tag)

--- a/pkg/skaffold/build/gcb/spec.go
+++ b/pkg/skaffold/build/gcb/spec.go
@@ -19,6 +19,7 @@ package gcb
 import (
 	"fmt"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
@@ -58,7 +59,7 @@ func (b *Builder) buildSpecForArtifact(a *latest.Artifact, tag string) (cloudbui
 		return b.kanikoBuildSpec(a.KanikoArtifact, tag)
 
 	case a.DockerArtifact != nil:
-		return b.dockerBuildSpec(a.DockerArtifact, tag)
+		return b.dockerBuildSpec(a.DockerArtifact, &docker.BuildOptions{Tag: tag})
 
 	case a.JibArtifact != nil:
 		return b.jibBuildSpec(a, tag)

--- a/pkg/skaffold/build/local/docker.go
+++ b/pkg/skaffold/build/local/docker.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
 
-func (b *Builder) buildDocker(ctx context.Context, out io.Writer, a *latest.Artifact, opts *docker.BuildOptions) (string, error) {
+func (b *Builder) buildDocker(ctx context.Context, out io.Writer, a *latest.Artifact, opts docker.BuildOptions) (string, error) {
 	// Fail fast if the Dockerfile can't be found.
 	dockerfile, err := docker.NormalizeDockerfilePath(a.Workspace, a.DockerArtifact.DockerfilePath)
 	if err != nil {
@@ -66,7 +66,7 @@ func (b *Builder) retrieveExtraEnv() []string {
 	return b.localDocker.ExtraEnv()
 }
 
-func (b *Builder) dockerCLIBuild(ctx context.Context, out io.Writer, workspace string, a *latest.DockerArtifact, opts *docker.BuildOptions) (string, error) {
+func (b *Builder) dockerCLIBuild(ctx context.Context, out io.Writer, workspace string, a *latest.DockerArtifact, opts docker.BuildOptions) (string, error) {
 	dockerfilePath, err := docker.NormalizeDockerfilePath(workspace, a.DockerfilePath)
 	if err != nil {
 		return "", fmt.Errorf("normalizing dockerfile path: %w", err)

--- a/pkg/skaffold/build/local/docker_test.go
+++ b/pkg/skaffold/build/local/docker_test.go
@@ -93,7 +93,7 @@ func TestDockerCLIBuild(t *testing.T) {
 				},
 			}
 
-			_, err = builder.buildDocker(context.Background(), ioutil.Discard, artifact, "tag")
+			_, err = builder.buildDocker(context.Background(), ioutil.Discard, artifact, &docker.BuildOptions{Tag: "tag"})
 			t.CheckNoError(err)
 		})
 	}

--- a/pkg/skaffold/build/local/docker_test.go
+++ b/pkg/skaffold/build/local/docker_test.go
@@ -93,7 +93,7 @@ func TestDockerCLIBuild(t *testing.T) {
 				},
 			}
 
-			_, err = builder.buildDocker(context.Background(), ioutil.Discard, artifact, &docker.BuildOptions{Tag: "tag"})
+			_, err = builder.buildDocker(context.Background(), ioutil.Discard, artifact, docker.BuildOptions{Tag: "tag"})
 			t.CheckNoError(err)
 		})
 	}

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -32,6 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 

--- a/pkg/skaffold/build/options.go
+++ b/pkg/skaffold/build/options.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+)
+
+// Configuration denotes build configuration for the artifact builder as either Release or Debug
+type Configuration int
+
+const (
+	Release = iota
+	Debug
+)
+
+// ImageOptions provides options for the artifact builder
+type ImageOptions struct {
+	// FIXME: Tag should be []string but we don't support multiple tags yet
+	Tag           string             // image tag
+	Configuration Configuration      // build image for release or debug
+	Args          map[string]*string // additional builder specific args
+}
+
+var CurrentConfiguration Configuration
+
+func CreateBuilderOptions(tag string) *ImageOptions {
+	return &ImageOptions{
+		Tag:           tag,
+		Configuration: CurrentConfiguration,
+	}
+}
+
+// Hash returns the hash of given image option, useful for image caching
+func (opts *ImageOptions) Hash() (string, error) {
+	var inputs []string
+	if opts == nil {
+		return "", nil
+	}
+
+	inputs = append(inputs, strconv.Itoa(int(opts.Configuration)))
+	if opts.Args != nil {
+		inputs = append(inputs, convertBuildArgsToStringArray(opts.Args)...)
+	}
+
+	hasher := sha256.New()
+	enc := json.NewEncoder(hasher)
+	if err := enc.Encode(inputs); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func convertBuildArgsToStringArray(buildArgs map[string]*string) []string {
+	var args []string
+	for k, v := range buildArgs {
+		if v == nil {
+			args = append(args, k)
+			continue
+		}
+		args = append(args, fmt.Sprintf("%s=%s", k, *v))
+	}
+	sort.Strings(args)
+	return args
+}

--- a/pkg/skaffold/build/options.go
+++ b/pkg/skaffold/build/options.go
@@ -22,44 +22,33 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strconv"
 )
 
-// Configuration denotes build configuration for the artifact builder as either Release or Debug
-type Configuration int
+// Configuration denotes build configuration for the artifact builder as either Dev or Debug
+type Configuration string
 
 const (
-	Release = iota
-	Debug
+	Dev   = Configuration("dev")
+	Debug = Configuration("debug")
 )
 
-// ImageOptions provides options for the artifact builder
-type ImageOptions struct {
-	// FIXME: Tag should be []string but we don't support multiple tags yet
+// BuilderOptions provides options for the artifact builder
+type BuilderOptions struct {
 	Tag           string             // image tag
-	Configuration Configuration      // build image for release or debug
-	Args          map[string]*string // additional builder specific args
-}
-
-var CurrentConfiguration Configuration
-
-func CreateBuilderOptions(tag string) *ImageOptions {
-	return &ImageOptions{
-		Tag:           tag,
-		Configuration: CurrentConfiguration,
-	}
+	Configuration Configuration      // build image for dev or debug
+	BuildArgs     map[string]*string // additional builder specific args
 }
 
 // Hash returns the hash of given image option, useful for image caching
-func (opts *ImageOptions) Hash() (string, error) {
+func (opts *BuilderOptions) Hash() (string, error) {
 	var inputs []string
 	if opts == nil {
 		return "", nil
 	}
 
-	inputs = append(inputs, strconv.Itoa(int(opts.Configuration)))
-	if opts.Args != nil {
-		inputs = append(inputs, convertBuildArgsToStringArray(opts.Args)...)
+	inputs = append(inputs, string(opts.Configuration))
+	if opts.BuildArgs != nil {
+		inputs = append(inputs, convertBuildArgsToStringArray(opts.BuildArgs)...)
 	}
 
 	hasher := sha256.New()

--- a/pkg/skaffold/build/parallel.go
+++ b/pkg/skaffold/build/parallel.go
@@ -31,7 +31,7 @@ import (
 
 const bufferedLinesPerArtifact = 10000
 
-type artifactBuilder func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error)
+type artifactBuilder func(ctx context.Context, out io.Writer, artifact *latest.Artifact, opts *ImageOptions) (string, error)
 
 // For testing
 var (
@@ -116,7 +116,7 @@ func getBuildResult(ctx context.Context, cw io.Writer, tags tag.ImageTags, artif
 	if !present {
 		return "", fmt.Errorf("unable to find tag for image %s", artifact.ImageName)
 	}
-	return build(ctx, cw, artifact, tag)
+	return build(ctx, cw, artifact, CreateBuilderOptions(tag))
 }
 
 func collectResults(out io.Writer, artifacts []*latest.Artifact, results *sync.Map, outputs []chan string) ([]Artifact, error) {

--- a/pkg/skaffold/build/sequence.go
+++ b/pkg/skaffold/build/sequence.go
@@ -41,7 +41,7 @@ func InSequence(ctx context.Context, out io.Writer, tags tag.ImageTags, artifact
 			return nil, fmt.Errorf("unable to find tag for image %s", artifact.ImageName)
 		}
 
-		finalTag, err := buildArtifact(ctx, out, artifact, tag)
+		finalTag, err := buildArtifact(ctx, out, artifact, CreateBuilderOptions(tag))
 		if err != nil {
 			event.BuildFailed(artifact.ImageName, err)
 			return nil, fmt.Errorf("couldn't build %q: %w", artifact.ImageName, err)

--- a/pkg/skaffold/build/sequence.go
+++ b/pkg/skaffold/build/sequence.go
@@ -21,27 +21,21 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
 // InSequence builds a list of artifacts in sequence.
-func InSequence(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, buildArtifact artifactBuilder) ([]Artifact, error) {
+func InSequence(ctx context.Context, out io.Writer, artifacts []*latest.Artifact, options []BuilderOptions, buildArtifact artifactBuilder) ([]Artifact, error) {
 	var builds []Artifact
 
-	for _, artifact := range artifacts {
+	for i, artifact := range artifacts {
 		color.Default.Fprintf(out, "Building [%s]...\n", artifact.ImageName)
 
 		event.BuildInProgress(artifact.ImageName)
 
-		tag, present := tags[artifact.ImageName]
-		if !present {
-			return nil, fmt.Errorf("unable to find tag for image %s", artifact.ImageName)
-		}
-
-		finalTag, err := buildArtifact(ctx, out, artifact, CreateBuilderOptions(tag))
+		finalTag, err := buildArtifact(ctx, out, artifact, options[i])
 		if err != nil {
 			event.BuildFailed(artifact.ImageName, err)
 			return nil, fmt.Errorf("couldn't build %q: %w", artifact.ImageName, err)

--- a/pkg/skaffold/build/sequence_test.go
+++ b/pkg/skaffold/build/sequence_test.go
@@ -41,8 +41,8 @@ func TestInSequence(t *testing.T) {
 	}{
 		{
 			description: "build succeeds",
-			buildArtifact: func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
-				return fmt.Sprintf("%s@sha256:abac", tag), nil
+			buildArtifact: func(ctx context.Context, out io.Writer, artifact *latest.Artifact, opts *ImageOptions) (string, error) {
+				return fmt.Sprintf("%s@sha256:abac", opts.Tag), nil
 			},
 			tags: tag.ImageTags{
 				"skaffold/image1": "skaffold/image1:v0.0.1",
@@ -56,7 +56,7 @@ func TestInSequence(t *testing.T) {
 		},
 		{
 			description: "build fails",
-			buildArtifact: func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+			buildArtifact: func(ctx context.Context, out io.Writer, artifact *latest.Artifact, opts *ImageOptions) (string, error) {
 				return "", fmt.Errorf("build fails")
 			},
 			tags: tag.ImageTags{
@@ -135,8 +135,8 @@ type concatTagger struct {
 // doBuild calculate the tag based by concatinating the tag values for artifact
 // builds seen so far. It mimics artifact dependency where the next build result
 // depends on the previous build result.
-func (t *concatTagger) doBuild(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
-	t.tag += tag
+func (t *concatTagger) doBuild(ctx context.Context, out io.Writer, artifact *latest.Artifact, opts *ImageOptions) (string, error) {
+	t.tag += opts.Tag
 	return fmt.Sprintf("%s:%s", artifact.ImageName, t.tag), nil
 }
 

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -193,6 +193,12 @@ func (l *localDaemon) Build(ctx context.Context, out io.Writer, workspace string
 	}
 
 	imageOpts = opts.ApplyModifiers(imageOpts)
+
+	if logrus.GetLevel() <= logrus.DebugLevel {
+		d, _ := json.Marshal(imageOpts.BuildArgs)
+		logrus.Debugf("docker build args: %s\n", string(d))
+	}
+
 	resp, err := l.apiClient.ImageBuild(ctx, body, *imageOpts)
 	if err != nil {
 		return "", fmt.Errorf("docker build: %w", err)

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -61,7 +61,7 @@ type LocalDaemon interface {
 	ExtraEnv() []string
 	ServerVersion(ctx context.Context) (types.Version, error)
 	ConfigFile(ctx context.Context, image string) (*v1.ConfigFile, error)
-	Build(ctx context.Context, out io.Writer, workspace string, a *latest.DockerArtifact, opts *BuildOptions) (string, error)
+	Build(ctx context.Context, out io.Writer, workspace string, a *latest.DockerArtifact, opts BuildOptions) (string, error)
 	Push(ctx context.Context, out io.Writer, ref string) (string, error)
 	Pull(ctx context.Context, out io.Writer, ref string) error
 	Load(ctx context.Context, out io.Writer, input io.Reader, ref string) (string, error)
@@ -155,7 +155,7 @@ func (l *localDaemon) ConfigFile(ctx context.Context, image string) (*v1.ConfigF
 }
 
 // Build performs a docker build and returns the imageID.
-func (l *localDaemon) Build(ctx context.Context, out io.Writer, workspace string, a *latest.DockerArtifact, opts *BuildOptions) (string, error) {
+func (l *localDaemon) Build(ctx context.Context, out io.Writer, workspace string, a *latest.DockerArtifact, opts BuildOptions) (string, error) {
 	logrus.Debugf("Running docker build: context: %s, dockerfile: %s", workspace, a.DockerfilePath)
 
 	// Like `docker build`, we ignore the errors
@@ -413,7 +413,7 @@ func (l *localDaemon) ImageRemove(ctx context.Context, image string, opts types.
 }
 
 // GetBuildArgs gives the build args flags for docker build.
-func GetBuildArgs(a *latest.DockerArtifact, opts *BuildOptions) ([]string, error) {
+func GetBuildArgs(a *latest.DockerArtifact, opts BuildOptions) ([]string, error) {
 	var args []string
 
 	buildArgs, err := EvaluateBuildArgs(a.BuildArgs)

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -190,7 +190,7 @@ func TestBuild(t *testing.T) {
 			t.SetEnvs(test.env)
 
 			localDocker := NewLocalDaemon(test.api, nil, false, nil)
-			_, err := localDocker.Build(context.Background(), ioutil.Discard, test.workspace, test.artifact, "finalimage")
+			_, err := localDocker.Build(context.Background(), ioutil.Discard, test.workspace, test.artifact, &BuildOptions{Tag: "finalimage"})
 
 			if test.shouldErr {
 				t.CheckErrorContains(test.expectedError, err)
@@ -322,7 +322,7 @@ func TestGetBuildArgs(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.OSEnviron, func() []string { return test.env })
 
-			result, err := GetBuildArgs(test.artifact)
+			result, err := GetBuildArgs(test.artifact, &BuildOptions{Tag: ""})
 
 			t.CheckError(test.shouldErr, err)
 			if !test.shouldErr {

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -190,7 +190,7 @@ func TestBuild(t *testing.T) {
 			t.SetEnvs(test.env)
 
 			localDocker := NewLocalDaemon(test.api, nil, false, nil)
-			_, err := localDocker.Build(context.Background(), ioutil.Discard, test.workspace, test.artifact, &BuildOptions{Tag: "finalimage"})
+			_, err := localDocker.Build(context.Background(), ioutil.Discard, test.workspace, test.artifact, BuildOptions{Tag: "finalimage"})
 
 			if test.shouldErr {
 				t.CheckErrorContains(test.expectedError, err)
@@ -322,7 +322,7 @@ func TestGetBuildArgs(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.OSEnviron, func() []string { return test.env })
 
-			result, err := GetBuildArgs(test.artifact, &BuildOptions{Tag: ""})
+			result, err := GetBuildArgs(test.artifact, BuildOptions{Tag: ""})
 
 			t.CheckError(test.shouldErr, err)
 			if !test.shouldErr {

--- a/pkg/skaffold/docker/options.go
+++ b/pkg/skaffold/docker/options.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import "github.com/docker/docker/api/types"
+
+var buildArgsForDebug = map[string]string{
+	"GO_GCFLAGS": "'all=-N -l'", // disable build optimization for Golang
+	// TODO: Add for other languages
+}
+
+var buildArgsForRelease = map[string]string{
+	"GO_LDFLAGS": "-w", // omit debug information in build output for Golang
+	// TODO: Add for other languages
+}
+
+type BuildOptionsModifier func(*types.ImageBuildOptions) *types.ImageBuildOptions
+
+type BuildOptions struct {
+	Tag       string
+	modifiers []BuildOptionsModifier
+}
+
+func (b *BuildOptions) AddModifier(m BuildOptionsModifier) *BuildOptions {
+	b.modifiers = append(b.modifiers, m)
+	return b
+}
+
+func (b *BuildOptions) ApplyModifiers(opts *types.ImageBuildOptions) *types.ImageBuildOptions {
+	for _, modifier := range b.modifiers {
+		opts = modifier(opts)
+	}
+	return opts
+}
+
+func OptimizeBuildForDebug(opts *types.ImageBuildOptions) *types.ImageBuildOptions {
+	if opts == nil {
+		opts = &types.ImageBuildOptions{}
+	}
+
+	if opts.BuildArgs == nil {
+		opts.BuildArgs = make(map[string]*string)
+	}
+
+	for k, v := range buildArgsForDebug {
+		if opts.BuildArgs[k] == nil {
+			opts.BuildArgs[k] = &v
+		}
+	}
+
+	return opts
+}
+
+func OptimizeBuildForRelease(opts *types.ImageBuildOptions) *types.ImageBuildOptions {
+	if opts == nil {
+		opts = &types.ImageBuildOptions{}
+	}
+
+	if opts.BuildArgs == nil {
+		opts.BuildArgs = make(map[string]*string)
+	}
+
+	for k, v := range buildArgsForRelease {
+		if opts.BuildArgs[k] == nil {
+			opts.BuildArgs[k] = &v
+		}
+	}
+
+	return opts
+}

--- a/pkg/skaffold/docker/options.go
+++ b/pkg/skaffold/docker/options.go
@@ -16,15 +16,17 @@ limitations under the License.
 
 package docker
 
-import "github.com/docker/docker/api/types"
+import (
+	"github.com/docker/docker/api/types"
+)
 
 var buildArgsForDebug = map[string]string{
-	"GO_GCFLAGS": "'all=-N -l'", // disable build optimization for Golang
+	"SKAFFOLD_GO_GCFLAGS": "'all=-N -l'", // disable build optimization for Golang
 	// TODO: Add for other languages
 }
 
-var buildArgsForRelease = map[string]string{
-	"GO_LDFLAGS": "-w", // omit debug information in build output for Golang
+var buildArgsForDev = map[string]string{
+	"SKAFFOLD_GO_LDFLAGS": "-w", // omit debug information in build output for Golang
 	// TODO: Add for other languages
 }
 
@@ -61,11 +63,10 @@ func OptimizeBuildForDebug(opts *types.ImageBuildOptions) *types.ImageBuildOptio
 			opts.BuildArgs[k] = &v
 		}
 	}
-
 	return opts
 }
 
-func OptimizeBuildForRelease(opts *types.ImageBuildOptions) *types.ImageBuildOptions {
+func OptimizeBuildForDev(opts *types.ImageBuildOptions) *types.ImageBuildOptions {
 	if opts == nil {
 		opts = &types.ImageBuildOptions{}
 	}
@@ -74,7 +75,7 @@ func OptimizeBuildForRelease(opts *types.ImageBuildOptions) *types.ImageBuildOpt
 		opts.BuildArgs = make(map[string]*string)
 	}
 
-	for k, v := range buildArgsForRelease {
+	for k, v := range buildArgsForDev {
 		if opts.BuildArgs[k] == nil {
 			opts.BuildArgs[k] = &v
 		}

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/local"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
@@ -101,7 +100,7 @@ func (t *TestBench) enterNewCycle() {
 	t.currentActions = Actions{}
 }
 
-func (t *TestBench) Build(_ context.Context, _ io.Writer, _ tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+func (t *TestBench) Build(_ context.Context, _ io.Writer, artifacts []*latest.Artifact, _ []build.BuilderOptions) ([]build.Artifact, error) {
 	if len(t.buildErrors) > 0 {
 		err := t.buildErrors[0]
 		t.buildErrors = t.buildErrors[1:]

--- a/pkg/skaffold/runner/timings.go
+++ b/pkg/skaffold/runner/timings.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -55,13 +54,13 @@ func (w withTimings) Labels() map[string]string {
 	return labels.Merge(w.Builder.Labels(), w.Deployer.Labels())
 }
 
-func (w withTimings) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+func (w withTimings) Build(ctx context.Context, out io.Writer, artifacts []*latest.Artifact, options []build.BuilderOptions) ([]build.Artifact, error) {
 	if len(artifacts) == 0 && w.cacheArtifacts {
 		return nil, nil
 	}
 	start := time.Now()
 
-	bRes, err := w.Builder.Build(ctx, out, tags, artifacts)
+	bRes, err := w.Builder.Build(ctx, out, artifacts, options)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/runner/timings_test.go
+++ b/pkg/skaffold/runner/timings_test.go
@@ -27,7 +27,6 @@ import (
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/test"
@@ -39,7 +38,7 @@ type mockBuilder struct {
 	err bool
 }
 
-func (m *mockBuilder) Build(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact) ([]build.Artifact, error) {
+func (m *mockBuilder) Build(context.Context, io.Writer, []*latest.Artifact, []build.BuilderOptions) ([]build.Artifact, error) {
 	if m.err {
 		return nil, errors.New("Unable to build")
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4370  <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR introduces `ImageOptions` to the different builders and currently only partially implements it for docker builder and buildpacks.
It recognizes `Dev` and `Debug` as build configurations and passes different build args like `GO_GCFLAGS` when building the artifact for debug vs dev. It also updates hashcode formula for image caching so that images for `Dev` vs `Debug` are cached separately.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
Dockerfile can expose `ARG SKAFFOLD_GO_GCFLAGS` and `ARG SKAFFOLD_GO_LDFLAGS` and expect Skaffold to supply meaningful values.
Buildpacks auto set `GOOGLE_GCFLAGS` and `GOOGLE_LDFLAGS` (so far).

Note: _The artifact cached during `skaffold dev` will have a different hashcode than `skaffold debug` for all builders going forward_

