### PR TITLE
add tests for a container in a pod being in terminated state

### DIFF
--- a/pkg/diag/validator/pod.go
+++ b/pkg/diag/validator/pod.go
@@ -147,6 +147,9 @@ func getWaitingContainerStatus(po *v1.Pod, cs []v1.ContainerStatus) (proto.Statu
 		case c.State.Waiting != nil:
 			return extractErrorMessageFromWaitingContainerStatus(po, c)
 		case c.State.Terminated != nil:
+			if c.State.Terminated.ExitCode == 0 {
+				return proto.StatusCode_STATUSCHECK_SUCCESS, nil, nil
+			}
 			l := getPodLogs(po, c.Name)
 			return proto.StatusCode_STATUSCHECK_CONTAINER_TERMINATED, l, fmt.Errorf("container %s terminated with exit code %d", c.Name, c.State.Terminated.ExitCode)
 		}


### PR DESCRIPTION
Related to #4470 

Fix bullet number #2 in #4470 i.e on of the init containers terminated with 0 exit code. 

As diag package does not watch for pod changes but periodically polls pod status, it is possible, we miss the `PodInitializing` phases as fixed in #4471

This commit will ensure, if a init container or a container terminated successfully quickly status check returns success.