### PR TITLE
Support deprecated extensions/v1beta1 workload resources

### DIFF
--- a/pkg/skaffold/deploy/kubectl/visitor.go
+++ b/pkg/skaffold/deploy/kubectl/visitor.go
@@ -28,11 +28,14 @@ import (
 var transformableWhitelist = map[apimachinery.GroupKind]bool{
 	{Group: "", Kind: "Pod"}:                        true,
 	{Group: "apps", Kind: "DaemonSet"}:              true,
-	{Group: "apps", Kind: "Deployment"}:             true,
+	{Group: "apps", Kind: "Deployment"}:             true, // v1beta1, v1beta2: deprecated in K8s 1.9, removed in 1.16
 	{Group: "apps", Kind: "ReplicaSet"}:             true,
 	{Group: "apps", Kind: "StatefulSet"}:            true,
 	{Group: "batch", Kind: "CronJob"}:               true,
 	{Group: "batch", Kind: "Job"}:                   true,
+	{Group: "extensions", Kind: "DaemonSet"}:        true, // v1beta1: deprecated in K8s 1.9, removed in 1.16
+	{Group: "extensions", Kind: "Deployment"}:       true, // v1beta1: deprecated in K8s 1.9, removed in 1.16
+	{Group: "extensions", Kind: "ReplicaSet"}:       true, // v1beta1: deprecated in K8s 1.9, removed in 1.16
 	{Group: "serving.knative.dev", Kind: "Service"}: true,
 }
 

--- a/pkg/skaffold/deploy/kubectl/visitor_test.go
+++ b/pkg/skaffold/deploy/kubectl/visitor_test.go
@@ -158,6 +158,36 @@ spec:
 			expected: []string{"apiVersion=apps...", "kind=Depl...", "metadata=map[...", "name=app", "labels=map[...", "name=x", "spec=map[...", "replicas=0", "name=foo"},
 		},
 		{
+			description: "deprecated daemonset.extensions",
+			manifests: ManifestList{[]byte(`apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: app
+spec:
+  replicas: 0`)},
+			expected: []string{"apiVersion=exte...", "kind=Daem...", "metadata=map[...", "name=app", "spec=map[...", "replicas=0"},
+		},
+		{
+			description: "deprecated deployment.extensions",
+			manifests: ManifestList{[]byte(`apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  replicas: 0`)},
+			expected: []string{"apiVersion=exte...", "kind=Depl...", "metadata=map[...", "name=app", "spec=map[...", "replicas=0"},
+		},
+		{
+			description: "deprecated replicaset.extensions",
+			manifests: ManifestList{[]byte(`apiVersion: extensions/v1beta1
+kind: ReplicaSet
+metadata:
+  name: app
+spec:
+  replicas: 0`)},
+			expected: []string{"apiVersion=exte...", "kind=Repl...", "metadata=map[...", "name=app", "spec=map[...", "replicas=0"},
+		},
+		{
 			description: "invalid input",
 			manifests:   ManifestList{[]byte(`test:bar`)},
 			shouldErr:   true,


### PR DESCRIPTION
Kubernetes 1.9 deprecated workload objects in `extensions/v1beta1`, `apps/v1beta1`, and `apps/v1beta2`.  Skaffold continues to support workload objects in `apps/*` but not `extensions/*`.  Since `extensions/*` were deprecated at the same time, and are supported on GKE, we should support their use.

Note that `debug` doesn't support them but does warn.