### PR TITLE
Error on invalid artifact workspace

### DIFF
--- a/pkg/skaffold/schema/samples_test.go
+++ b/pkg/skaffold/schema/samples_test.go
@@ -74,7 +74,15 @@ func TestParseSamples(t *testing.T) {
 }
 
 func checkSkaffoldConfig(t *testutil.T, yaml []byte) {
-	configFile := t.TempFile("skaffold.yaml", yaml)
+	root := t.NewTempDir()
+	configFile := root.Path("skaffold.yaml")
+	root.Write("skaffold.yaml", string(yaml))
+	// create workspace directories referenced in these samples
+	for _, d := range []string{"app", "node", "python", "leeroy-web", "leeroy-app", "backend", "base-service", "world-service"} {
+		root.Mkdir(d)
+	}
+	root.Chdir()
+
 	cfg, err := ParseConfigAndUpgrade(configFile, latest.Version)
 	t.CheckNoError(err)
 

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 
@@ -35,6 +36,7 @@ var (
 // Process checks if the Skaffold pipeline is valid and returns all encountered errors as a concatenated string
 func Process(config *latest.SkaffoldConfig) error {
 	errs := visitStructs(config, validateYamltags)
+	errs = append(errs, validateWorkspaces(config.Build.Artifacts)...)
 	errs = append(errs, validateImageNames(config.Build.Artifacts)...)
 	errs = append(errs, validateDockerNetworkMode(config.Build.Artifacts)...)
 	errs = append(errs, validateCustomDependencies(config.Build.Artifacts)...)
@@ -52,6 +54,25 @@ func Process(config *latest.SkaffoldConfig) error {
 		messages = append(messages, err.Error())
 	}
 	return fmt.Errorf(strings.Join(messages, " | "))
+}
+
+// validateWorkspaces makes sure the artifact workspaces are valid directories.
+func validateWorkspaces(artifacts []*latest.Artifact) (errs []error) {
+	for _, a := range artifacts {
+		if a.Workspace != "" {
+			if info, err := os.Stat(a.Workspace); err != nil {
+		        // err could be permission-related
+				if os.IsNotExist(err) {
+					errs = append(errs, fmt.Errorf("image %q context %q does not exist", a.ImageName, a.Workspace))
+				} else {
+					errs = append(errs, fmt.Errorf("image %q context %q: %w", a.ImageName, a.Workspace, err))
+				}
+			} else if !info.IsDir() {
+				errs = append(errs, fmt.Errorf("image %q context %q is not a directory", a.ImageName, a.Workspace))
+			}
+		}
+	}
+	return
 }
 
 // validateImageNames makes sure the artifact image names are valid base names,

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -61,7 +61,7 @@ func validateWorkspaces(artifacts []*latest.Artifact) (errs []error) {
 	for _, a := range artifacts {
 		if a.Workspace != "" {
 			if info, err := os.Stat(a.Workspace); err != nil {
-		        // err could be permission-related
+				// err could be permission-related
 				if os.IsNotExist(err) {
 					errs = append(errs, fmt.Errorf("image %q context %q does not exist", a.ImageName, a.Workspace))
 				} else {

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -716,3 +716,69 @@ func TestValidateJibPluginType(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateWorkspaces(t *testing.T) {
+	tmpDir := testutil.NewTempDir(t).Touch("file")
+	tmpFile := tmpDir.Path("file")
+
+	tests := []struct {
+		description string
+		artifacts   []*latest.Artifact
+		shouldErr   bool
+	}{
+		{
+			description: "no workspace",
+			artifacts: []*latest.Artifact{
+				{
+					ImageName: "image",
+				},
+			},
+		},
+		{
+			description: "directory that exists",
+			artifacts: []*latest.Artifact{
+				{
+					ImageName: "image",
+					Workspace: tmpDir.Root(),
+				},
+			},
+		},
+		{
+			description: "error on non-existant location",
+			artifacts: []*latest.Artifact{
+				{
+					ImageName: "image",
+					Workspace: "doesnotexist",
+				},
+			},
+			shouldErr: true,
+		},
+		{
+			description: "error on file",
+			artifacts: []*latest.Artifact{
+				{
+					ImageName: "image",
+					Workspace: tmpFile,
+				},
+			},
+			shouldErr: true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			// disable yamltags validation
+			t.Override(&validateYamltags, func(interface{}) error { return nil })
+
+			err := Process(
+				&latest.SkaffoldConfig{
+					Pipeline: latest.Pipeline{
+						Build: latest.BuildConfig{
+							Artifacts: test.artifacts,
+						},
+					},
+				})
+
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -744,7 +744,7 @@ func TestValidateWorkspaces(t *testing.T) {
 			},
 		},
 		{
-			description: "error on non-existant location",
+			description: "error on non-existent location",
 			artifacts: []*latest.Artifact{
 				{
 					ImageName: "image",


### PR DESCRIPTION
Fixes: #4491

**Description**

Adds a validation step to ensure that all artifact workspaces exist.

*Invalid location*
```diff
--- examples/getting-started/skaffold.yaml
+++ examples/getting-started/skaffold.yaml
@@ -3,6 +3,7 @@ kind: Config
 build:
   artifacts:
   - image: skaffold-example
+    context: this/path/does/not/exist
 deploy:
   kubectl:
     manifests:
```

```console
$ skaffold build
invalid skaffold config: image "skaffold-example" context "this/path/does/not/exist" does not exist
```

----

*File*

```diff
diff --git examples/getting-started/skaffold.yaml examples/getting-started/skaffold.yaml
index cbf95a1a7..3cd2940ac 100644
--- examples/getting-started/skaffold.yaml
+++ examples/getting-started/skaffold.yaml
@@ -3,6 +3,7 @@ kind: Config
 build:
   artifacts:
   - image: skaffold-example
+    context: main.go
 deploy:
   kubectl:
     manifests:
```

```console
$ skaffold build
invalid skaffold config: image "skaffold-example" context "main.go" is not a directory
