### PR TITLE
Sample has incorrect syntax for buildpacks

### DIFF
--- a/docs/content/en/samples/builders/buildpacks.yaml
+++ b/docs/content/en/samples/builders/buildpacks.yaml
@@ -1,7 +1,7 @@
-apiVersion: skaffold/v1
+apiVersion: skaffold/v2beta5
 kind: Config
 build:
   artifacts:
   - image: gcr.io/k8s-skaffold/skaffold-buildpacks
-    buildpack:
+    buildpacks:
       builder: "gcr.io/buildpacks/builder:v1"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**Description**
Doc change - Updating to the correct syntax from `buildpack:` to `buildpacks:`

**User facing changes (remove if N/A)**
Before:
```
  - image: gcr.io/k8s-skaffold/skaffold-buildpacks	  
    buildpack:
      builder: "gcr.io/buildpacks/builder:v1"
```
After:
```
  - image: gcr.io/k8s-skaffold/skaffold-buildpacks
    buildpacks:
      builder: "gcr.io/buildpacks/builder:v1"	      
```

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
