### PR TITLE
Refactor Tag: GenerateTag method and GenerateFQIN function

### DIFF
--- a/pkg/skaffold/build/tag/custom.go
+++ b/pkg/skaffold/build/tag/custom.go
@@ -34,7 +34,7 @@ func (t *CustomTag) Labels() map[string]string {
 }
 
 // GenerateTag generates a tag using the custom tag.
-func (t *CustomTag) GenerateTag(workingDir, imageName string) (string, error) {
+func (t *CustomTag) GenerateTag(_, _ string) (string, error) {
 	tag := t.Tag
 	if tag == "" {
 		return "", errors.New("custom tag not provided")

--- a/pkg/skaffold/build/tag/custom.go
+++ b/pkg/skaffold/build/tag/custom.go
@@ -18,7 +18,6 @@ package tag
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 )
@@ -27,18 +26,18 @@ type CustomTag struct {
 	Tag string
 }
 
-func (c *CustomTag) Labels() map[string]string {
+// Labels are labels specific to the custom tagger.
+func (t *CustomTag) Labels() map[string]string {
 	return map[string]string{
 		constants.Labels.TagPolicy: "custom",
 	}
 }
 
-// GenerateFullyQualifiedImageName tags an image with the custom tag
-func (c *CustomTag) GenerateFullyQualifiedImageName(workingDir, imageName string) (string, error) {
-	tag := c.Tag
+// GenerateTag generates a tag using the custom tag.
+func (t *CustomTag) GenerateTag(workingDir, imageName string) (string, error) {
+	tag := t.Tag
 	if tag == "" {
 		return "", errors.New("custom tag not provided")
 	}
-
-	return fmt.Sprintf("%s:%s", imageName, tag), nil
+	return tag, nil
 }

--- a/pkg/skaffold/build/tag/custom_test.go
+++ b/pkg/skaffold/build/tag/custom_test.go
@@ -22,12 +22,28 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestCustomTag_GenerateFullyQualifiedImageName(t *testing.T) {
-	c := &CustomTag{
-		Tag: "1.2.3-beta",
+func TestCustomTag_GenerateTag(t *testing.T) {
+	tests := []struct {
+		description string
+		c           *CustomTag
+		expected    string
+		shouldErr   bool
+	}{
+		{
+			description: "valid custom tag",
+			c: &CustomTag{
+				Tag: "1.2.3-beta",
+			},
+			expected: "1.2.3-beta",
+		},
+		{
+			description: "invalid custom tag",
+			c:           &CustomTag{},
+			shouldErr:   true,
+		},
 	}
-
-	tag, err := c.GenerateFullyQualifiedImageName(".", "test")
-
-	testutil.CheckErrorAndDeepEqual(t, false, err, "test:1.2.3-beta", tag)
+	for _, test := range tests {
+		tag, err := test.c.GenerateTag(".", "test")
+		testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, tag)
+	}
 }

--- a/pkg/skaffold/build/tag/date_time.go
+++ b/pkg/skaffold/build/tag/date_time.go
@@ -44,22 +44,23 @@ func NewDateTimeTagger(format, timezone string) Tagger {
 	}
 }
 
-func (tagger *dateTimeTagger) Labels() map[string]string {
+// Labels are labels specific to the dateTime tagger.
+func (t *dateTimeTagger) Labels() map[string]string {
 	return map[string]string{
 		constants.Labels.TagPolicy: "dateTimeTagger",
 	}
 }
 
-// GenerateFullyQualifiedImageName tags an image with the supplied image name and the current timestamp
-func (tagger *dateTimeTagger) GenerateFullyQualifiedImageName(workingDir, imageName string) (string, error) {
+// GenerateTag generates a tag using the current timestamp.
+func (t *dateTimeTagger) GenerateTag(workingDir, imageName string) (string, error) {
 	format := tagTime
-	if len(tagger.Format) > 0 {
-		format = tagger.Format
+	if len(t.Format) > 0 {
+		format = t.Format
 	}
 
 	timezone := "Local"
-	if len(tagger.TimeZone) > 0 {
-		timezone = tagger.TimeZone
+	if len(t.TimeZone) > 0 {
+		timezone = t.TimeZone
 	}
 
 	loc, err := tz.LoadLocation(timezone)
@@ -67,5 +68,5 @@ func (tagger *dateTimeTagger) GenerateFullyQualifiedImageName(workingDir, imageN
 		return "", fmt.Errorf("bad timezone provided: \"%s\", error: %s", timezone, err)
 	}
 
-	return fmt.Sprintf("%s:%s", imageName, tagger.timeFn().In(loc).Format(format)), nil
+	return t.timeFn().In(loc).Format(format), nil
 }

--- a/pkg/skaffold/build/tag/date_time.go
+++ b/pkg/skaffold/build/tag/date_time.go
@@ -52,7 +52,7 @@ func (t *dateTimeTagger) Labels() map[string]string {
 }
 
 // GenerateTag generates a tag using the current timestamp.
-func (t *dateTimeTagger) GenerateTag(workingDir, imageName string) (string, error) {
+func (t *dateTimeTagger) GenerateTag(_, _ string) (string, error) {
 	format := tagTime
 	if len(t.Format) > 0 {
 		format = t.Format

--- a/pkg/skaffold/build/tag/date_time.go
+++ b/pkg/skaffold/build/tag/date_time.go
@@ -65,7 +65,7 @@ func (t *dateTimeTagger) GenerateTag(workingDir, imageName string) (string, erro
 
 	loc, err := tz.LoadLocation(timezone)
 	if err != nil {
-		return "", fmt.Errorf("bad timezone provided: \"%s\", error: %s", timezone, err)
+		return "", fmt.Errorf("bad timezone provided: %q, error: %s", timezone, err)
 	}
 
 	return t.timeFn().In(loc).Format(format), nil

--- a/pkg/skaffold/build/tag/env_template.go
+++ b/pkg/skaffold/build/tag/env_template.go
@@ -43,14 +43,15 @@ func NewEnvTemplateTagger(t string) (Tagger, error) {
 	}, nil
 }
 
+// Labels are labels specific to the envTemplate tagger.
 func (t *envTemplateTagger) Labels() map[string]string {
 	return map[string]string{
 		constants.Labels.TagPolicy: "envTemplateTagger",
 	}
 }
 
-// GenerateFullyQualifiedImageName tags an image with the custom tag
-func (t *envTemplateTagger) GenerateFullyQualifiedImageName(workingDir, imageName string) (string, error) {
+// GenerateTag generates a tag from a template referencing environment variable.
+func (t *envTemplateTagger) GenerateTag(workingDir, imageName string) (string, error) {
 	tag, err := util.ExecuteEnvTemplate(t.Template.Option("missingkey=error"), map[string]string{
 		"IMAGE_NAME":  imageName,
 		"DIGEST":      "_DEPRECATED_DIGEST_",

--- a/pkg/skaffold/build/tag/env_template.go
+++ b/pkg/skaffold/build/tag/env_template.go
@@ -50,7 +50,7 @@ func (t *envTemplateTagger) Labels() map[string]string {
 	}
 }
 
-// GenerateTag generates a tag from a template referencing environment variable.
+// GenerateTag generates a tag from a template referencing environment variables.
 func (t *envTemplateTagger) GenerateTag(workingDir, imageName string) (string, error) {
 	tag, err := util.ExecuteEnvTemplate(t.Template.Option("missingkey=error"), map[string]string{
 		"IMAGE_NAME":  imageName,

--- a/pkg/skaffold/build/tag/env_template.go
+++ b/pkg/skaffold/build/tag/env_template.go
@@ -51,7 +51,7 @@ func (t *envTemplateTagger) Labels() map[string]string {
 }
 
 // GenerateTag generates a tag from a template referencing environment variables.
-func (t *envTemplateTagger) GenerateTag(workingDir, imageName string) (string, error) {
+func (t *envTemplateTagger) GenerateTag(_, imageName string) (string, error) {
 	tag, err := util.ExecuteEnvTemplate(t.Template.Option("missingkey=error"), map[string]string{
 		"IMAGE_NAME":  imageName,
 		"DIGEST":      "_DEPRECATED_DIGEST_",

--- a/pkg/skaffold/build/tag/env_template_test.go
+++ b/pkg/skaffold/build/tag/env_template_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestEnvTemplateTagger_GenerateFullyQualifiedImageName(t *testing.T) {
+func TestEnvTemplateTagger_GenerateTag(t *testing.T) {
 	tests := []struct {
 		description      string
 		template         string
@@ -99,7 +99,7 @@ func TestEnvTemplateTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 			c, err := NewEnvTemplateTagger(test.template)
 			t.CheckNoError(err)
 
-			got, err := c.GenerateFullyQualifiedImageName("", test.imageName)
+			got, err := c.GenerateTag(".", test.imageName)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, got)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)

--- a/pkg/skaffold/build/tag/git_commit.go
+++ b/pkg/skaffold/build/tag/git_commit.go
@@ -59,15 +59,15 @@ func NewGitCommit(prefix, variant string) (*GitCommit, error) {
 }
 
 // Labels are labels specific to the git tagger.
-func (c *GitCommit) Labels() map[string]string {
+func (t *GitCommit) Labels() map[string]string {
 	return map[string]string{
 		constants.Labels.TagPolicy: "git-commit",
 	}
 }
 
-// GenerateFullyQualifiedImageName tags an image with the supplied image name and the git commit.
-func (c *GitCommit) GenerateFullyQualifiedImageName(workingDir string, imageName string) (string, error) {
-	ref, err := c.runGitFn(workingDir)
+// GenerateTag generates a tag from the git commit.
+func (t *GitCommit) GenerateTag(workingDir, imageName string) (string, error) {
+	ref, err := t.runGitFn(workingDir)
 	if err != nil {
 		return "", fmt.Errorf("unable to find git commit: %w", err)
 	}
@@ -78,10 +78,10 @@ func (c *GitCommit) GenerateFullyQualifiedImageName(workingDir string, imageName
 	}
 
 	if len(changes) > 0 {
-		return fmt.Sprintf("%s:%s%s-dirty", imageName, c.prefix, ref), nil
+		return fmt.Sprintf("%s%s-dirty", t.prefix, ref), nil
 	}
 
-	return fmt.Sprintf("%s:%s%s", imageName, c.prefix, sanitizeTag(ref)), nil
+	return t.prefix + sanitizeTag(ref), nil
 }
 
 // sanitizeTag takes a git tag and converts it to a docker tag by removing

--- a/pkg/skaffold/build/tag/git_commit.go
+++ b/pkg/skaffold/build/tag/git_commit.go
@@ -66,7 +66,7 @@ func (t *GitCommit) Labels() map[string]string {
 }
 
 // GenerateTag generates a tag from the git commit.
-func (t *GitCommit) GenerateTag(workingDir, imageName string) (string, error) {
+func (t *GitCommit) GenerateTag(workingDir, _ string) (string, error) {
 	ref, err := t.runGitFn(workingDir)
 	if err != nil {
 		return "", fmt.Errorf("unable to find git commit: %w", err)

--- a/pkg/skaffold/build/tag/git_commit_test.go
+++ b/pkg/skaffold/build/tag/git_commit_test.go
@@ -35,7 +35,7 @@ import (
 
 // These tests do not run on windows
 // See: https://github.com/src-d/go-git/issues/378
-func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
+func TestGitCommit_GenerateTag(t *testing.T) {
 	tests := []struct {
 		description            string
 		variantTags            string
@@ -49,11 +49,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 	}{
 		{
 			description:            "clean worktree without tag",
-			variantTags:            "test:eefe1b9",
-			variantCommitSha:       "test:eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed",
-			variantAbbrevCommitSha: "test:eefe1b9",
-			variantTreeSha:         "test:3bed02ca656e336307e4eb4d80080d7221cba62c",
-			variantAbbrevTreeSha:   "test:3bed02c",
+			variantTags:            "eefe1b9",
+			variantCommitSha:       "eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed",
+			variantAbbrevCommitSha: "eefe1b9",
+			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c",
+			variantAbbrevTreeSha:   "3bed02c",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -63,11 +63,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		},
 		{
 			description:            "clean worktree with tag containing a slash",
-			variantTags:            "test:v_2",
-			variantCommitSha:       "test:aea33bcc86b5af8c8570ff45d8a643202d63c808",
-			variantAbbrevCommitSha: "test:aea33bc",
-			variantTreeSha:         "test:bc69d50cda6897a6f2054e64b9059f038dc6fb0e",
-			variantAbbrevTreeSha:   "test:bc69d50",
+			variantTags:            "v_2",
+			variantCommitSha:       "aea33bcc86b5af8c8570ff45d8a643202d63c808",
+			variantAbbrevCommitSha: "aea33bc",
+			variantTreeSha:         "bc69d50cda6897a6f2054e64b9059f038dc6fb0e",
+			variantAbbrevTreeSha:   "bc69d50",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -82,11 +82,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		},
 		{
 			description:            "clean worktree with tags",
-			variantTags:            "test:v2",
-			variantCommitSha:       "test:aea33bcc86b5af8c8570ff45d8a643202d63c808",
-			variantAbbrevCommitSha: "test:aea33bc",
-			variantTreeSha:         "test:bc69d50cda6897a6f2054e64b9059f038dc6fb0e",
-			variantAbbrevTreeSha:   "test:bc69d50",
+			variantTags:            "v2",
+			variantCommitSha:       "aea33bcc86b5af8c8570ff45d8a643202d63c808",
+			variantAbbrevCommitSha: "aea33bc",
+			variantTreeSha:         "bc69d50cda6897a6f2054e64b9059f038dc6fb0e",
+			variantAbbrevTreeSha:   "bc69d50",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -101,11 +101,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		},
 		{
 			description:            "treeSha only considers current tree content",
-			variantTags:            "test:v1",
-			variantCommitSha:       "test:b2f7a7d62794237ac293eb07c6bcae3736b96231",
-			variantAbbrevCommitSha: "test:b2f7a7d",
-			variantTreeSha:         "test:3bed02ca656e336307e4eb4d80080d7221cba62c",
-			variantAbbrevTreeSha:   "test:3bed02c",
+			variantTags:            "v1",
+			variantCommitSha:       "b2f7a7d62794237ac293eb07c6bcae3736b96231",
+			variantAbbrevCommitSha: "b2f7a7d",
+			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c",
+			variantAbbrevTreeSha:   "3bed02c",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "other code").
@@ -119,11 +119,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		},
 		{
 			description:            "dirty worktree without tag",
-			variantTags:            "test:eefe1b9-dirty",
-			variantCommitSha:       "test:eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed-dirty",
-			variantAbbrevCommitSha: "test:eefe1b9-dirty",
-			variantTreeSha:         "test:3bed02ca656e336307e4eb4d80080d7221cba62c-dirty",
-			variantAbbrevTreeSha:   "test:3bed02c-dirty",
+			variantTags:            "eefe1b9-dirty",
+			variantCommitSha:       "eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed-dirty",
+			variantAbbrevCommitSha: "eefe1b9-dirty",
+			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c-dirty",
+			variantAbbrevTreeSha:   "3bed02c-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -134,11 +134,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		},
 		{
 			description:            "dirty worktree with tag",
-			variantTags:            "test:v1-dirty",
-			variantCommitSha:       "test:eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed-dirty",
-			variantAbbrevCommitSha: "test:eefe1b9-dirty",
-			variantTreeSha:         "test:3bed02ca656e336307e4eb4d80080d7221cba62c-dirty",
-			variantAbbrevTreeSha:   "test:3bed02c-dirty",
+			variantTags:            "v1-dirty",
+			variantCommitSha:       "eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed-dirty",
+			variantAbbrevCommitSha: "eefe1b9-dirty",
+			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c-dirty",
+			variantAbbrevTreeSha:   "3bed02c-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -150,11 +150,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		},
 		{
 			description:            "untracked",
-			variantTags:            "test:eefe1b9-dirty",
-			variantCommitSha:       "test:eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed-dirty",
-			variantAbbrevCommitSha: "test:eefe1b9-dirty",
-			variantTreeSha:         "test:3bed02ca656e336307e4eb4d80080d7221cba62c-dirty",
-			variantAbbrevTreeSha:   "test:3bed02c-dirty",
+			variantTags:            "eefe1b9-dirty",
+			variantCommitSha:       "eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed-dirty",
+			variantAbbrevCommitSha: "eefe1b9-dirty",
+			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c-dirty",
+			variantAbbrevTreeSha:   "3bed02c-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -165,11 +165,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		},
 		{
 			description:            "tag plus one commit",
-			variantTags:            "test:v1-1-g3cec6b9",
-			variantCommitSha:       "test:3cec6b950895704a8a69b610a199b242a3bd370f",
-			variantAbbrevCommitSha: "test:3cec6b9",
-			variantTreeSha:         "test:81eea360f7f81bc5c187498a8d6c4337e0361374",
-			variantAbbrevTreeSha:   "test:81eea36",
+			variantTags:            "v1-1-g3cec6b9",
+			variantCommitSha:       "3cec6b950895704a8a69b610a199b242a3bd370f",
+			variantAbbrevCommitSha: "3cec6b9",
+			variantTreeSha:         "81eea360f7f81bc5c187498a8d6c4337e0361374",
+			variantAbbrevTreeSha:   "81eea36",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -183,11 +183,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		},
 		{
 			description:            "deleted file",
-			variantTags:            "test:279d53f-dirty",
-			variantCommitSha:       "test:279d53fcc3ae34503aec382a49a41f6db6de9a66-dirty",
-			variantAbbrevCommitSha: "test:279d53f-dirty",
-			variantTreeSha:         "test:039c20a072ceb72fb72d5883315df91659bb8ae4-dirty",
-			variantAbbrevTreeSha:   "test:039c20a-dirty",
+			variantTags:            "279d53f-dirty",
+			variantCommitSha:       "279d53fcc3ae34503aec382a49a41f6db6de9a66-dirty",
+			variantAbbrevCommitSha: "279d53f-dirty",
+			variantTreeSha:         "039c20a072ceb72fb72d5883315df91659bb8ae4-dirty",
+			variantAbbrevTreeSha:   "039c20a-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source1.go", "code1").
@@ -199,11 +199,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		},
 		{
 			description:            "rename",
-			variantTags:            "test:eefe1b9-dirty",
-			variantCommitSha:       "test:eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed-dirty",
-			variantAbbrevCommitSha: "test:eefe1b9-dirty",
-			variantTreeSha:         "test:3bed02ca656e336307e4eb4d80080d7221cba62c-dirty",
-			variantAbbrevTreeSha:   "test:3bed02c-dirty",
+			variantTags:            "eefe1b9-dirty",
+			variantCommitSha:       "eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed-dirty",
+			variantAbbrevCommitSha: "eefe1b9-dirty",
+			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c-dirty",
+			variantAbbrevTreeSha:   "3bed02c-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -214,11 +214,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		},
 		{
 			description:            "clean artifact1 in tagged repo",
-			variantTags:            "test:v1",
-			variantCommitSha:       "test:b610928dc27484cc56990bc77622aab0dbd67131",
-			variantAbbrevCommitSha: "test:b610928",
-			variantTreeSha:         "test:3bed02ca656e336307e4eb4d80080d7221cba62c",
-			variantAbbrevTreeSha:   "test:3bed02c",
+			variantTags:            "v1",
+			variantCommitSha:       "b610928dc27484cc56990bc77622aab0dbd67131",
+			variantAbbrevCommitSha: "b610928",
+			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c",
+			variantAbbrevTreeSha:   "3bed02c",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("artifact1").write("artifact1/source.go", "code").
@@ -230,11 +230,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		},
 		{
 			description:            "clean artifact2 in tagged repo",
-			variantTags:            "test:v1",
-			variantCommitSha:       "test:b610928dc27484cc56990bc77622aab0dbd67131",
-			variantAbbrevCommitSha: "test:b610928",
-			variantTreeSha:         "test:36651c832d8bf5ca1e84c6dc23bb8678fa51cf3e",
-			variantAbbrevTreeSha:   "test:36651c8",
+			variantTags:            "v1",
+			variantCommitSha:       "b610928dc27484cc56990bc77622aab0dbd67131",
+			variantAbbrevCommitSha: "b610928",
+			variantTreeSha:         "36651c832d8bf5ca1e84c6dc23bb8678fa51cf3e",
+			variantAbbrevTreeSha:   "36651c8",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("artifact1").write("artifact1/source.go", "code").
@@ -246,11 +246,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		},
 		{
 			description:            "clean artifact in dirty repo",
-			variantTags:            "test:v1",
-			variantCommitSha:       "test:b610928dc27484cc56990bc77622aab0dbd67131",
-			variantAbbrevCommitSha: "test:b610928",
-			variantTreeSha:         "test:3bed02ca656e336307e4eb4d80080d7221cba62c",
-			variantAbbrevTreeSha:   "test:3bed02c",
+			variantTags:            "v1",
+			variantCommitSha:       "b610928dc27484cc56990bc77622aab0dbd67131",
+			variantAbbrevCommitSha: "b610928",
+			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c",
+			variantAbbrevTreeSha:   "3bed02c",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("artifact1").write("artifact1/source.go", "code").
@@ -263,11 +263,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		},
 		{
 			description:            "updated artifact in dirty repo",
-			variantTags:            "test:v1-dirty",
-			variantCommitSha:       "test:b610928dc27484cc56990bc77622aab0dbd67131-dirty",
-			variantAbbrevCommitSha: "test:b610928-dirty",
-			variantTreeSha:         "test:36651c832d8bf5ca1e84c6dc23bb8678fa51cf3e-dirty",
-			variantAbbrevTreeSha:   "test:36651c8-dirty",
+			variantTags:            "v1-dirty",
+			variantCommitSha:       "b610928dc27484cc56990bc77622aab0dbd67131-dirty",
+			variantAbbrevCommitSha: "b610928-dirty",
+			variantTreeSha:         "36651c832d8bf5ca1e84c6dc23bb8678fa51cf3e-dirty",
+			variantAbbrevTreeSha:   "36651c8-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("artifact1").write("artifact1/source.go", "code").
@@ -280,11 +280,11 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		},
 		{
 			description:            "additional commit in other artifact",
-			variantTags:            "test:0d16f59",
-			variantCommitSha:       "test:0d16f59900bd63dd39425d6085d3f1333b66804f",
-			variantAbbrevCommitSha: "test:0d16f59",
-			variantTreeSha:         "test:3bed02ca656e336307e4eb4d80080d7221cba62c",
-			variantAbbrevTreeSha:   "test:3bed02c",
+			variantTags:            "0d16f59",
+			variantCommitSha:       "0d16f59900bd63dd39425d6085d3f1333b66804f",
+			variantAbbrevCommitSha: "0d16f59",
+			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c",
+			variantAbbrevTreeSha:   "3bed02c",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("artifact1").write("artifact1/source.go", "code").
@@ -332,7 +332,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 				tagger, err := NewGitCommit("", variant)
 				t.CheckNoError(err)
 
-				tag, err := tagger.GenerateFullyQualifiedImageName(workspace, "test")
+				tag, err := tagger.GenerateTag(workspace, "test")
 
 				t.CheckErrorAndDeepEqual(test.shouldErr, err, expectedTag, tag)
 			}
@@ -348,31 +348,31 @@ func TestGitCommitSubDirectory(t *testing.T) {
 
 		tagger, err := NewGitCommit("", "Tags")
 		t.CheckNoError(err)
-		tag, err := tagger.GenerateFullyQualifiedImageName(workspace, "test")
+		tag, err := tagger.GenerateTag(workspace, "test")
 		t.CheckNoError(err)
-		t.CheckDeepEqual("test:a7b32a6", tag)
+		t.CheckDeepEqual("a7b32a6", tag)
 
 		tagger, err = NewGitCommit("", "CommitSha")
 		t.CheckNoError(err)
-		tag, err = tagger.GenerateFullyQualifiedImageName(workspace, "test")
+		tag, err = tagger.GenerateTag(workspace, "test")
 		t.CheckNoError(err)
-		t.CheckDeepEqual("test:a7b32a69335a6daa51bd89cc1bf30bd31df228ba", tag)
+		t.CheckDeepEqual("a7b32a69335a6daa51bd89cc1bf30bd31df228ba", tag)
 
 		tagger, err = NewGitCommit("", "AbbrevCommitSha")
 		t.CheckNoError(err)
-		tag, err = tagger.GenerateFullyQualifiedImageName(workspace, "test")
+		tag, err = tagger.GenerateTag(workspace, "test")
 		t.CheckNoError(err)
-		t.CheckDeepEqual("test:a7b32a6", tag)
+		t.CheckDeepEqual("a7b32a6", tag)
 
 		tagger, err = NewGitCommit("", "TreeSha")
 		t.CheckNoError(err)
-		_, err = tagger.GenerateFullyQualifiedImageName(workspace, "test")
-		t.CheckErrorAndDeepEqual(true, err, "test:a7b32a6", tag)
+		_, err = tagger.GenerateTag(workspace, "test")
+		t.CheckErrorAndDeepEqual(true, err, "a7b32a6", tag)
 
 		tagger, err = NewGitCommit("", "AbbrevTreeSha")
 		t.CheckNoError(err)
-		_, err = tagger.GenerateFullyQualifiedImageName(workspace, "test")
-		t.CheckErrorAndDeepEqual(true, err, "test:a7b32a6", tag)
+		_, err = tagger.GenerateTag(workspace, "test")
+		t.CheckErrorAndDeepEqual(true, err, "a7b32a6", tag)
 	})
 }
 
@@ -384,15 +384,15 @@ func TestPrefix(t *testing.T) {
 
 		tagger, err := NewGitCommit("tag-", "Tags")
 		t.CheckNoError(err)
-		tag, err := tagger.GenerateFullyQualifiedImageName(workspace, "test")
+		tag, err := tagger.GenerateTag(workspace, "test")
 		t.CheckNoError(err)
-		t.CheckDeepEqual("test:tag-a7b32a6", tag)
+		t.CheckDeepEqual("tag-a7b32a6", tag)
 
 		tagger, err = NewGitCommit("commit-", "CommitSha")
 		t.CheckNoError(err)
-		tag, err = tagger.GenerateFullyQualifiedImageName(workspace, "test")
+		tag, err = tagger.GenerateTag(workspace, "test")
 		t.CheckNoError(err)
-		t.CheckDeepEqual("test:commit-a7b32a69335a6daa51bd89cc1bf30bd31df228ba", tag)
+		t.CheckDeepEqual("commit-a7b32a69335a6daa51bd89cc1bf30bd31df228ba", tag)
 	})
 }
 

--- a/pkg/skaffold/build/tag/git_commit_test.go
+++ b/pkg/skaffold/build/tag/git_commit_test.go
@@ -393,7 +393,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 				tagger, err := NewGitCommit("", variant)
 				t.CheckNoError(err)
 
-				tag, err := tagger.GenerateTag(workspace, "test")
+				tag, err := GenerateFullyQualifiedImageName(tagger, workspace, "test")
 
 				t.CheckErrorAndDeepEqual(test.shouldErr, err, expectedTag, tag)
 			}

--- a/pkg/skaffold/build/tag/sha256.go
+++ b/pkg/skaffold/build/tag/sha256.go
@@ -25,13 +25,15 @@ import (
 type ChecksumTagger struct{}
 
 // Labels are labels specific to the sha256 tagger.
-func (c *ChecksumTagger) Labels() map[string]string {
+func (t *ChecksumTagger) Labels() map[string]string {
 	return map[string]string{
 		constants.Labels.TagPolicy: "sha256",
 	}
 }
 
-func (c *ChecksumTagger) GenerateFullyQualifiedImageName(workingDir, imageName string) (string, error) {
+// GenerateTag returns either the current tag or `latest`. This tagger relies on the fact
+// that Skaffold references the image using its sha256 digest during deploy.
+func (t *ChecksumTagger) GenerateTag(workingDir, imageName string) (string, error) {
 	parsed, err := docker.ParseReference(imageName)
 	if err != nil {
 		return "", err
@@ -39,9 +41,9 @@ func (c *ChecksumTagger) GenerateFullyQualifiedImageName(workingDir, imageName s
 
 	if parsed.Tag == "" {
 		// No supplied tag, so use "latest".
-		return imageName + ":latest", nil
+		return "latest", nil
 	}
 
-	// They already have a tag.
-	return imageName, nil
+	//imageName already has a tag
+	return "", nil
 }

--- a/pkg/skaffold/build/tag/sha256.go
+++ b/pkg/skaffold/build/tag/sha256.go
@@ -32,7 +32,7 @@ func (t *ChecksumTagger) Labels() map[string]string {
 }
 
 // GenerateTag returns either the current tag or `latest`.
-func (t *ChecksumTagger) GenerateTag(workingDir, imageName string) (string, error) {
+func (t *ChecksumTagger) GenerateTag(_, imageName string) (string, error) {
 	parsed, err := docker.ParseReference(imageName)
 	if err != nil {
 		return "", err
@@ -43,6 +43,6 @@ func (t *ChecksumTagger) GenerateTag(workingDir, imageName string) (string, erro
 		return "latest", nil
 	}
 
-	//imageName already has a tag
+	// imageName already has a tag
 	return "", nil
 }

--- a/pkg/skaffold/build/tag/sha256.go
+++ b/pkg/skaffold/build/tag/sha256.go
@@ -31,8 +31,7 @@ func (t *ChecksumTagger) Labels() map[string]string {
 	}
 }
 
-// GenerateTag returns either the current tag or `latest`. This tagger relies on the fact
-// that Skaffold references the image using its sha256 digest during deploy.
+// GenerateTag returns either the current tag or `latest`.
 func (t *ChecksumTagger) GenerateTag(workingDir, imageName string) (string, error) {
 	parsed, err := docker.ParseReference(imageName)
 	if err != nil {

--- a/pkg/skaffold/build/tag/sha256_test.go
+++ b/pkg/skaffold/build/tag/sha256_test.go
@@ -22,24 +22,24 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestGenerateFullyQualifiedImageName(t *testing.T) {
+func TestSha256_GenerateTag(t *testing.T) {
 	c := &ChecksumTagger{}
 
-	tag, err := c.GenerateFullyQualifiedImageName(".", "img:tag")
-	testutil.CheckErrorAndDeepEqual(t, false, err, "img:tag", tag)
+	tag, err := c.GenerateTag(".", "img:tag")
+	testutil.CheckErrorAndDeepEqual(t, false, err, "", tag)
 
-	tag, err = c.GenerateFullyQualifiedImageName(".", "img")
-	testutil.CheckErrorAndDeepEqual(t, false, err, "img:latest", tag)
+	tag, err = c.GenerateTag(".", "img")
+	testutil.CheckErrorAndDeepEqual(t, false, err, "latest", tag)
 
-	tag, err = c.GenerateFullyQualifiedImageName(".", "registry.example.com:8080/img:tag")
-	testutil.CheckErrorAndDeepEqual(t, false, err, "registry.example.com:8080/img:tag", tag)
+	tag, err = c.GenerateTag(".", "registry.example.com:8080/img:tag")
+	testutil.CheckErrorAndDeepEqual(t, false, err, "", tag)
 
-	tag, err = c.GenerateFullyQualifiedImageName(".", "registry.example.com:8080/img")
-	testutil.CheckErrorAndDeepEqual(t, false, err, "registry.example.com:8080/img:latest", tag)
+	tag, err = c.GenerateTag(".", "registry.example.com:8080/img")
+	testutil.CheckErrorAndDeepEqual(t, false, err, "latest", tag)
 
-	tag, err = c.GenerateFullyQualifiedImageName(".", "registry.example.com/img")
-	testutil.CheckErrorAndDeepEqual(t, false, err, "registry.example.com/img:latest", tag)
+	tag, err = c.GenerateTag(".", "registry.example.com/img")
+	testutil.CheckErrorAndDeepEqual(t, false, err, "latest", tag)
 
-	tag, err = c.GenerateFullyQualifiedImageName(".", "registry.example.com:8080:garbage")
+	tag, err = c.GenerateTag(".", "registry.example.com:8080:garbage")
 	testutil.CheckErrorAndDeepEqual(t, true, err, "", tag)
 }

--- a/pkg/skaffold/build/tag/tag.go
+++ b/pkg/skaffold/build/tag/tag.go
@@ -46,7 +46,7 @@ func GenerateFullyQualifiedImageName(t Tagger, workingDir, imageName string) (st
 		return tag, nil
 	}
 
-	if tag == "" { //Do not append :tag to imageName if tag is empty.
+	if tag == "" { // Do not append :tag to imageName if tag is empty.
 		return imageName, nil
 	}
 

--- a/pkg/skaffold/build/tag/tag.go
+++ b/pkg/skaffold/build/tag/tag.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package tag
 
+import (
+	"fmt"
+)
+
 // ImageTags maps image names to tags
 type ImageTags map[string]string
 
@@ -24,8 +28,29 @@ type Tagger interface {
 	// Labels produces labels to indicate the used tagger in deployed pods.
 	Labels() map[string]string
 
-	// GenerateFullyQualifiedImageName resolves the fully qualified image name for an artifact.
-	// The workingDir is the root directory of the artifact with respect to the Skaffold root,
-	// and imageName is the base name of the image.
-	GenerateFullyQualifiedImageName(workingDir string, imageName string) (string, error)
+	// GenerateTag generates a tag for an artifact.
+	GenerateTag(workingDir, imageName string) (string, error)
+}
+
+// GenerateFullyQualifiedImageName resolves the fully qualified image name for an artifact.
+// The workingDir is the root directory of the artifact with respect to the Skaffold root,
+// and imageName is the base name of the image.
+func GenerateFullyQualifiedImageName(t Tagger, workingDir, imageName string) (string, error) {
+	tag, err := t.GenerateTag(workingDir, imageName)
+
+	if err != nil {
+		return "", fmt.Errorf("generating tag: %w", err)
+	}
+
+	if _, ok := t.(*envTemplateTagger); ok { // envTemplate's GenerateTag is currently designed to return the full image name
+		return tag, nil
+	}
+
+	// It makes more sense to return imageName rather than imageName: (when tag is empty).
+	// This primarily concerns sha256.
+	if tag == "" {
+		return imageName, nil
+	}
+
+	return fmt.Sprintf("%s:%s", imageName, tag), nil
 }

--- a/pkg/skaffold/build/tag/tag.go
+++ b/pkg/skaffold/build/tag/tag.go
@@ -46,9 +46,7 @@ func GenerateFullyQualifiedImageName(t Tagger, workingDir, imageName string) (st
 		return tag, nil
 	}
 
-	// It makes more sense to return imageName rather than imageName: (when tag is empty).
-	// This primarily concerns sha256.
-	if tag == "" {
+	if tag == "" { //Do not append :tag to imageName if tag is empty.
 		return imageName, nil
 	}
 

--- a/pkg/skaffold/build/tag/tag_test.go
+++ b/pkg/skaffold/build/tag/tag_test.go
@@ -26,15 +26,6 @@ import (
 )
 
 func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
-	//This is for testing gitCommit
-	createGitRepo := func(dir string) {
-		gitInit(t, dir).
-			write("source.go", "code").
-			add("source.go").
-			commit("initial")
-	}
-	gitCommitExample, _ := NewGitCommit("foo-", "AbbrevCommitSha")
-
 	// This is for testing envTemplate
 	envTemplateExample, _ := NewEnvTemplateTagger("{{.IMAGE_NAME}}:{{.FOO}}")
 	invalidEnvTemplate, _ := NewEnvTemplateTagger("{{.IMAGE_NAME}}:{{.BAR}}")
@@ -57,12 +48,6 @@ func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 		expectedWarnings []string
 		shouldErr        bool
 	}{
-		{
-			description: "gitCommit",
-			imageName:   "test",
-			tagger:      gitCommitExample,
-			expected:    "test:foo-eefe1b9",
-		},
 		{
 			description: "sha256 w/o tag",
 			imageName:   "test",
@@ -100,11 +85,7 @@ func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 			t.Override(&warnings.Printf, fakeWarner.Warnf)
 			t.Override(&util.OSEnviron, func() []string { return env })
 
-			tmpDir := t.NewTempDir()
-			createGitRepo(tmpDir.Root())
-			workspace := tmpDir.Path("")
-
-			tag, err := GenerateFullyQualifiedImageName(test.tagger, workspace, test.imageName)
+			tag, err := GenerateFullyQualifiedImageName(test.tagger, ".", test.imageName)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, tag)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
 		})

--- a/pkg/skaffold/build/tag/tag_test.go
+++ b/pkg/skaffold/build/tag/tag_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tag
+
+import (
+	"testing"
+	"time"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
+	//This is for testing gitCommit
+	createGitRepo := func(dir string) {
+		gitInit(t, dir).
+			write("source.go", "code").
+			add("source.go").
+			commit("initial")
+	}
+	gitCommitExample, _ := NewGitCommit("foo-", "AbbrevCommitSha")
+
+	// This is for testing envTemplate
+	envTemplateExample, _ := NewEnvTemplateTagger("{{.IMAGE_NAME}}:{{.FOO}}")
+	invalidEnvTemplate, _ := NewEnvTemplateTagger("{{.IMAGE_NAME}}:{{.BAR}}")
+	env := []string{"FOO=BAR"}
+
+	// This is for testing dateTime
+	aLocalTimeStamp := time.Date(2015, 03, 07, 11, 06, 39, 123456789, time.Local)
+	dateTimeExample := &dateTimeTagger{
+		Format:   "2006-01-02",
+		TimeZone: "UTC",
+		timeFn:   func() time.Time { return aLocalTimeStamp },
+	}
+	dateTimeExpected := "2015-03-07"
+
+	tests := []struct {
+		description      string
+		imageName        string
+		tagger           Tagger
+		expected         string
+		expectedWarnings []string
+		shouldErr        bool
+	}{
+		{
+			description: "gitCommit",
+			imageName:   "test",
+			tagger:      gitCommitExample,
+			expected:    "test:foo-eefe1b9",
+		},
+		{
+			description: "sha256 w/o tag",
+			imageName:   "test",
+			tagger:      &ChecksumTagger{},
+			expected:    "test:latest",
+		},
+		{
+			description: "sha256 w/ tag",
+			imageName:   "test:tag",
+			tagger:      &ChecksumTagger{},
+			expected:    "test:tag",
+		},
+		{
+			description: "envTemplate w/ image",
+			imageName:   "test",
+			tagger:      envTemplateExample,
+			expected:    "test:BAR",
+		},
+		{
+			description: "error from GenerateTag",
+			imageName:   "test",
+			tagger:      invalidEnvTemplate,
+			shouldErr:   true,
+		},
+		{
+			description: "dateTime",
+			imageName:   "test",
+			tagger:      dateTimeExample,
+			expected:    "test:" + dateTimeExpected,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			fakeWarner := &warnings.Collect{}
+			t.Override(&warnings.Printf, fakeWarner.Warnf)
+			t.Override(&util.OSEnviron, func() []string { return env })
+
+			tmpDir := t.NewTempDir()
+			createGitRepo(tmpDir.Root())
+			workspace := tmpDir.Path("")
+
+			tag, err := GenerateFullyQualifiedImageName(test.tagger, workspace, test.imageName)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, tag)
+			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
+		})
+	}
+}

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -154,7 +154,7 @@ func (r *SkaffoldRunner) imageTags(ctx context.Context, out io.Writer, artifacts
 
 		i := i
 		go func() {
-			tag, err := r.tagger.GenerateFullyQualifiedImageName(artifacts[i].Workspace, artifacts[i].ImageName)
+			tag, err := tag.GenerateFullyQualifiedImageName(r.tagger, artifacts[i].Workspace, artifacts[i].ImageName)
 			tagErrs[i] <- tagErr{tag: tag, err: err}
 		}()
 	}
@@ -175,7 +175,7 @@ func (r *SkaffoldRunner) imageTags(ctx context.Context, out io.Writer, artifacts
 				logrus.Debugln(t.err)
 				logrus.Debugln("Using a fall-back tagger")
 
-				fallbackTag, err := (&tag.ChecksumTagger{}).GenerateFullyQualifiedImageName(artifact.Workspace, imageName)
+				fallbackTag, err := tag.GenerateFullyQualifiedImageName(&tag.ChecksumTagger{}, artifact.Workspace, imageName)
 				if err != nil {
 					return nil, fmt.Errorf("generating checksum as fall-back tag for %q: %w", imageName, err)
 				}


### PR DESCRIPTION
**Description**
This is a non-functional change. Previously, taggers only had the option to generate the entire image name. This change provides a method for taggers to only generate the tag portion. This refactoring is in preparation for another change. This PR also addresses the comments left on https://github.com/GoogleContainerTools/skaffold/pull/4480.

**Follow-up Work (remove if N/A)**
This refactoring is in preparation for the feature associated with issue #4371.
I plan to deprecate the usage of `{{.IMAGE_NAME}}` in the `envTemplate` tagger to improve its consistency with the other taggers.
