### PR TITLE
Update k3d cli 'load image' to 'image import' (#4498)

### DIFF
--- a/pkg/skaffold/runner/load_images.go
+++ b/pkg/skaffold/runner/load_images.go
@@ -42,7 +42,7 @@ func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Write
 func (r *SkaffoldRunner) loadImagesInK3dNodes(ctx context.Context, out io.Writer, k3dCluster string, artifacts []build.Artifact) error {
 	color.Default.Fprintln(out, "Loading images into k3d cluster nodes...")
 	return r.loadImages(ctx, out, artifacts, func(tag string) *exec.Cmd {
-		return exec.CommandContext(ctx, "k3d", "load", "image", "--cluster", k3dCluster, tag)
+		return exec.CommandContext(ctx, "k3d", "image", "import", "--cluster", k3dCluster, tag)
 	})
 }
 

--- a/pkg/skaffold/runner/load_images_test.go
+++ b/pkg/skaffold/runner/load_images_test.go
@@ -114,7 +114,7 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 			deployed:    []build.Artifact{{Tag: "tag1"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
-				AndRunOut("k3d load image --cluster k3d tag1", "output: image loaded"),
+				AndRunOut("k3d image import --cluster k3d tag1", "output: image loaded"),
 		},
 		{
 			description: "load missing image",
@@ -123,7 +123,7 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 			deployed:    []build.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "tag1").
-				AndRunOut("k3d load image --cluster other-k3d tag2", "output: image loaded"),
+				AndRunOut("k3d image import --cluster other-k3d tag2", "output: image loaded"),
 		},
 		{
 			description: "inspect error",
@@ -141,7 +141,7 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 			deployed:    []build.Artifact{{Tag: "tag"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
-				AndRunOutErr("k3d load image --cluster k3d tag", "output: error!", errors.New("BUG")),
+				AndRunOutErr("k3d image import --cluster k3d tag", "output: error!", errors.New("BUG")),
 			shouldErr:     true,
 			expectedError: "output: error!",
 		},
@@ -152,7 +152,7 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 			deployed:    []build.Artifact{{Tag: "built"}, {Tag: "busybox"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
-				AndRunOut("k3d load image --cluster k3d built", ""),
+				AndRunOut("k3d image import --cluster k3d built", ""),
 		},
 		{
 			description: "no artifact",


### PR DESCRIPTION
Fixes: #4498

---

k3d v3.0.0 release changes their cli syntax from `k3d load image` to `k3d image import`. See https://github.com/rancher/k3d/releases/tag/v3.0.0

~~However this PR will break users using k3d < v3.0.0, I'm not sure this is the best solution.~~

Turn out that this PR will only break k3d v3.0.0.alpha ~ v3.0.0.rc6, I guess only change the command to `image import` without check version and use corresponding cli syntax is fair enough?

### v1

```
k3d import-images
```

### v3.0.0.alpha ~ v3.0.0.rc6

```
k3d load image
```

### v3.0.0.rc7 ~ v3.0.0

```
k3d image import
```