### PR TITLE
Add `deploy.logs` section to skaffold.yaml

### DIFF
--- a/docs/content/en/schemas/v2beta6.json
+++ b/docs/content/en/schemas/v2beta6.json
@@ -816,6 +816,11 @@
           "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
           "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
         },
+        "logs": {
+          "$ref": "#/definitions/LogsConfig",
+          "description": "configures how container logs are printed as a result of a deployment.",
+          "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
+        },
         "statusCheckDeadlineSeconds": {
           "type": "integer",
           "description": "*beta* deadline for deployments to stabilize in seconds.",
@@ -827,7 +832,8 @@
         "kubectl",
         "kustomize",
         "statusCheckDeadlineSeconds",
-        "kubeContext"
+        "kubeContext",
+        "logs"
       ],
       "additionalProperties": false,
       "description": "contains all the configuration needed by the deploy steps.",
@@ -1708,6 +1714,28 @@
       "additionalProperties": false,
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
+    },
+    "LogsConfig": {
+      "properties": {
+        "prefix": {
+          "type": "string",
+          "description": "defines the prefix shown on each log line. Valid values are `container`: prefix logs lines with the name of the container. `podAndContainer`: prefix logs lines with the names of the pod and of the container. `auto`: same as `podAndContainer` except that the pod name is skipped if it's the same as the container name. `none`: don't add a prefix.",
+          "x-intellij-html-description": "defines the prefix shown on each log line. Valid values are <code>container</code>: prefix logs lines with the name of the container. <code>podAndContainer</code>: prefix logs lines with the names of the pod and of the container. <code>auto</code>: same as <code>podAndContainer</code> except that the pod name is skipped if it's the same as the container name. <code>none</code>: don't add a prefix.",
+          "default": "auto",
+          "enum": [
+            "container",
+            "podAndContainer",
+            "auto",
+            "none"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "prefix"
+      ],
+      "additionalProperties": false,
+      "description": "configures how container logs are printed as a result of a deployment.",
+      "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
     },
     "Metadata": {
       "properties": {

--- a/pkg/skaffold/kubernetes/log_test.go
+++ b/pkg/skaffold/kubernetes/log_test.go
@@ -25,8 +25,10 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -130,4 +132,82 @@ func TestLogAggregatorZeroValue(t *testing.T) {
 	m.Mute()
 	m.Unmute()
 	m.Stop()
+}
+
+func TestPrefix(t *testing.T) {
+	tests := []struct {
+		description    string
+		prefix         string
+		pod            v1.Pod
+		container      v1.ContainerStatus
+		expectedPrefix string
+	}{
+		{
+			description:    "auto (different names)",
+			prefix:         "auto",
+			pod:            podWithName("pod"),
+			container:      containerWithName("container"),
+			expectedPrefix: "[pod container]",
+		},
+		{
+			description:    "auto (same names)",
+			prefix:         "auto",
+			pod:            podWithName("hello"),
+			container:      containerWithName("hello"),
+			expectedPrefix: "[hello]",
+		},
+		{
+			description:    "container",
+			prefix:         "container",
+			pod:            podWithName("pod"),
+			container:      containerWithName("container"),
+			expectedPrefix: "[container]",
+		},
+		{
+			description:    "podAndContainer (different names)",
+			prefix:         "podAndContainer",
+			pod:            podWithName("pod"),
+			container:      containerWithName("container"),
+			expectedPrefix: "[pod container]",
+		},
+		{
+			description:    "podAndContainer (same names)",
+			prefix:         "podAndContainer",
+			pod:            podWithName("hello"),
+			container:      containerWithName("hello"),
+			expectedPrefix: "[hello hello]",
+		},
+		{
+			description:    "none",
+			prefix:         "none",
+			pod:            podWithName("hello"),
+			container:      containerWithName("hello"),
+			expectedPrefix: "",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			logger := NewLogAggregator(nil, nil, nil, nil, nil, latest.LogsConfig{
+				Prefix: test.prefix,
+			})
+
+			p := logger.prefix(&test.pod, test.container)
+
+			t.CheckDeepEqual(test.expectedPrefix, p)
+		})
+	}
+}
+
+func podWithName(n string) v1.Pod {
+	return v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: n,
+		},
+	}
+}
+
+func containerWithName(n string) v1.ContainerStatus {
+	return v1.ContainerStatus{
+		Name: n,
+	}
 }

--- a/pkg/skaffold/runner/logger.go
+++ b/pkg/skaffold/runner/logger.go
@@ -33,5 +33,5 @@ func (r *SkaffoldRunner) createLogger(out io.Writer, artifacts []build.Artifact)
 		imageNames = append(imageNames, artifact.Tag)
 	}
 
-	return kubernetes.NewLogAggregator(out, r.kubectlCLI, imageNames, r.podSelector, r.runCtx.Namespaces)
+	return kubernetes.NewLogAggregator(out, r.kubectlCLI, imageNames, r.podSelector, r.runCtx.Namespaces, r.runCtx.Cfg.Deploy.Logs)
 }

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -43,6 +43,7 @@ func Set(c *latest.SkaffoldConfig) error {
 	setDefaultTagger(c)
 	setDefaultKustomizePath(c)
 	setDefaultKubectlManifests(c)
+	setDefaultLogsConfig(c)
 
 	for _, a := range c.Build.Artifacts {
 		setDefaultWorkspace(a)
@@ -180,6 +181,12 @@ func setDefaultKustomizePath(c *latest.SkaffoldConfig) {
 func setDefaultKubectlManifests(c *latest.SkaffoldConfig) {
 	if c.Deploy.KubectlDeploy != nil && len(c.Deploy.KubectlDeploy.Manifests) == 0 {
 		c.Deploy.KubectlDeploy.Manifests = constants.DefaultKubectlManifests
+	}
+}
+
+func setDefaultLogsConfig(c *latest.SkaffoldConfig) {
+	if c.Deploy.Logs.Prefix == "" {
+		c.Deploy.Logs.Prefix = "container"
 	}
 }
 

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -407,3 +407,44 @@ func TestSetDefaultPortForwardAddress(t *testing.T) {
 	testutil.CheckDeepEqual(t, "0.0.0.0", cfg.PortForward[0].Address)
 	testutil.CheckDeepEqual(t, constants.DefaultPortForwardAddress, cfg.PortForward[1].Address)
 }
+
+func TestSetLogsConfig(t *testing.T) {
+	tests := []struct {
+		description string
+		input       latest.LogsConfig
+		expected    latest.LogsConfig
+	}{
+		{
+			description: "prefix defaults to 'container'",
+			input:       latest.LogsConfig{},
+			expected: latest.LogsConfig{
+				Prefix: "container",
+			},
+		},
+		{
+			description: "don't override existing prefix",
+			input: latest.LogsConfig{
+				Prefix: "none",
+			},
+			expected: latest.LogsConfig{
+				Prefix: "none",
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			cfg := latest.SkaffoldConfig{
+				Pipeline: latest.Pipeline{
+					Deploy: latest.DeployConfig{
+						Logs: test.input,
+					},
+				},
+			}
+
+			err := Set(&cfg)
+
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expected, cfg.Deploy.Logs)
+		})
+	}
+}

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -412,6 +412,9 @@ type DeployConfig struct {
 	// KubeContext is the Kubernetes context that Skaffold should deploy to.
 	// For example: `minikube`.
 	KubeContext string `yaml:"kubeContext,omitempty"`
+
+	// Logs configures how container logs are printed as a result of a deployment.
+	Logs LogsConfig `yaml:"logs,omitempty"`
 }
 
 // DeployType contains the specific implementation and parameters needed
@@ -601,6 +604,17 @@ type HelmFQNConfig struct {
 type HelmConventionConfig struct {
 	// ExplicitRegistry separates `image.registry` to the image config syntax. Useful for some charts e.g. `postgresql`.
 	ExplicitRegistry bool `yaml:"explicitRegistry,omitempty"`
+}
+
+// LogsConfig configures how container logs are printed as a result of a deployment.
+type LogsConfig struct {
+	// Prefix defines the prefix shown on each log line. Valid values are
+	// `container`: prefix logs lines with the name of the container.
+	// `podAndContainer`: prefix logs lines with the names of the pod and of the container.
+	// `auto`: same as `podAndContainer` except that the pod name is skipped if it's the same as the container name.
+	// `none`: don't add a prefix.
+	// Defaults to `auto`.
+	Prefix string `yaml:"prefix,omitempty"`
 }
 
 // Artifact are the items that need to be built, along with the context in which

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags"
 )
 
@@ -43,6 +44,7 @@ func Process(config *latest.SkaffoldConfig) error {
 	errs = append(errs, validateSyncRules(config.Build.Artifacts)...)
 	errs = append(errs, validatePortForwardResources(config.PortForward)...)
 	errs = append(errs, validateJibPluginTypes(config.Build.Artifacts)...)
+	errs = append(errs, validateLogPrefix(config.Deploy.Logs)...)
 	errs = append(errs, validateArtifactTypes(config.Build)...)
 
 	if len(errs) == 0 {
@@ -251,4 +253,15 @@ func validateArtifactTypes(bc latest.BuildConfig) (errs []error) {
 		}
 	}
 	return
+}
+
+// validateLogPrefix checks that logs are configured with a valid prefix.
+func validateLogPrefix(lc latest.LogsConfig) []error {
+	validPrefixes := []string{"", "auto", "container", "podAndContainer", "none"}
+
+	if !util.StrSliceContains(validPrefixes, lc.Prefix) {
+		return []error{fmt.Errorf("invalid log prefix '%s'. Valid values are 'auto', 'container', 'podAndContainer' or 'none'", lc.Prefix)}
+	}
+
+	return nil
 }

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -782,3 +782,37 @@ func TestValidateWorkspaces(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateLogsConfig(t *testing.T) {
+	tests := []struct {
+		prefix    string
+		cfg       latest.LogsConfig
+		shouldErr bool
+	}{
+		{prefix: "auto", shouldErr: false},
+		{prefix: "container", shouldErr: false},
+		{prefix: "podAndContainer", shouldErr: false},
+		{prefix: "none", shouldErr: false},
+		{prefix: "", shouldErr: false},
+		{prefix: "unknown", shouldErr: true},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.prefix, func(t *testutil.T) {
+			// disable yamltags validation
+			t.Override(&validateYamltags, func(interface{}) error { return nil })
+
+			err := Process(
+				&latest.SkaffoldConfig{
+					Pipeline: latest.Pipeline{
+						Deploy: latest.DeployConfig{
+							Logs: latest.LogsConfig{
+								Prefix: test.prefix,
+							},
+						},
+					},
+				})
+
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -107,6 +107,12 @@ deploy:
 deploy:
   statusCheckDeadlineSeconds: 10
 `
+
+	customLogPrefix = `
+deploy:
+  logs:
+    prefix: none
+`
 )
 
 func TestIsSkaffoldConfig(t *testing.T) {
@@ -166,6 +172,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 					withGitTagger(),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
+				withLogsPrefix("container"),
 			),
 		},
 		{
@@ -177,6 +184,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 					withGitTagger(),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
+				withLogsPrefix("container"),
 			),
 		},
 		{
@@ -189,6 +197,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 					withDockerArtifact("example", ".", "Dockerfile"),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
+				withLogsPrefix("container"),
 			),
 		},
 		{
@@ -202,6 +211,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 					withBazelArtifact("image2", "./examples/app2", "//:example.tar"),
 				),
 				withKubectlDeploy("dep.yaml", "svc.yaml"),
+				withLogsPrefix("container"),
 			),
 		},
 		{
@@ -214,6 +224,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 					withKanikoArtifact("image1", "./examples/app1", "Dockerfile"),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
+				withLogsPrefix("container"),
 			),
 		},
 		{
@@ -227,6 +238,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 					withKanikoArtifact("image1", "./examples/app1", "Dockerfile"),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
+				withLogsPrefix("container"),
 			),
 		},
 		{
@@ -263,6 +275,19 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 				),
 				withKubectlDeploy("k8s/*.yaml"),
 				withStatusCheckDeadline(10),
+				withLogsPrefix("container"),
+			),
+		},
+		{
+			apiVersion:  latest.Version,
+			description: "custom log prefix",
+			config:      customLogPrefix,
+			expected: config(
+				withLocalBuild(
+					withGitTagger(),
+				),
+				withKubectlDeploy("k8s/*.yaml"),
+				withLogsPrefix("none"),
 			),
 		},
 	}
@@ -445,6 +470,12 @@ func withPortForward(portForward ...*latest.PortForwardResource) func(*latest.Sk
 func withStatusCheckDeadline(deadline int) func(*latest.SkaffoldConfig) {
 	return func(cfg *latest.SkaffoldConfig) {
 		cfg.Deploy.StatusCheckDeadlineSeconds = deadline
+	}
+}
+
+func withLogsPrefix(prefix string) func(*latest.SkaffoldConfig) {
+	return func(cfg *latest.SkaffoldConfig) {
+		cfg.Deploy.Logs.Prefix = prefix
 	}
 }
 


### PR DESCRIPTION
And default to a smaller prefix for log lines.

Fixes #4504

Signed-off-by: David Gageot <david@gageot.net>

New default log prefix:
<img width="500" alt="Screenshot 2020-07-21 at 15 29 56" src="https://user-images.githubusercontent.com/153495/88060909-1c97c580-cb67-11ea-8123-eccb34f39d8d.png">

