### PR TITLE
Support short build logs

### DIFF
--- a/pkg/skaffold/build/cluster/cluster.go
+++ b/pkg/skaffold/build/cluster/cluster.go
@@ -45,7 +45,8 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, 
 		defer teardownDockerConfigSecret()
 	}
 
-	return build.InParallel(ctx, out, tags, artifacts, b.buildArtifact, b.ClusterDetails.Concurrency)
+	builder := build.WithLogFile(b.buildArtifact, b.suppressLogs)
+	return build.InParallel(ctx, out, tags, artifacts, builder, b.ClusterDetails.Concurrency)
 }
 
 func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {

--- a/pkg/skaffold/build/cluster/types.go
+++ b/pkg/skaffold/build/cluster/types.go
@@ -35,6 +35,7 @@ type Builder struct {
 	kubeContext        string
 	timeout            time.Duration
 	insecureRegistries map[string]bool
+	suppressLogs       []string
 }
 
 // NewBuilder creates a new Builder that builds artifacts on cluster.
@@ -50,6 +51,7 @@ func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
 		timeout:            timeout,
 		kubeContext:        runCtx.KubeContext,
 		insecureRegistries: runCtx.InsecureRegistries,
+		suppressLogs:       runCtx.Opts.SuppressLogs,
 	}, nil
 }
 

--- a/pkg/skaffold/build/gcb/cloud_build.go
+++ b/pkg/skaffold/build/gcb/cloud_build.go
@@ -46,7 +46,8 @@ import (
 
 // Build builds a list of artifacts with Google Cloud Build.
 func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
-	return build.InParallel(ctx, out, tags, artifacts, b.buildArtifactWithCloudBuild, b.GoogleCloudBuild.Concurrency)
+	builder := build.WithLogFile(b.buildArtifactWithCloudBuild, b.suppressLogs)
+	return build.InParallel(ctx, out, tags, artifacts, builder, b.GoogleCloudBuild.Concurrency)
 }
 
 func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {

--- a/pkg/skaffold/build/gcb/types.go
+++ b/pkg/skaffold/build/gcb/types.go
@@ -79,6 +79,7 @@ type Builder struct {
 	*latest.GoogleCloudBuild
 	skipTests          bool
 	insecureRegistries map[string]bool
+	suppressLogs       []string
 }
 
 // NewBuilder creates a new Builder that builds artifacts with Google Cloud Build.
@@ -87,6 +88,7 @@ func NewBuilder(runCtx *runcontext.RunContext) *Builder {
 		GoogleCloudBuild:   runCtx.Cfg.Build.GoogleCloudBuild,
 		skipTests:          runCtx.Opts.SkipTests,
 		insecureRegistries: runCtx.InsecureRegistries,
+		suppressLogs:       runCtx.Opts.SuppressLogs,
 	}
 }
 

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -42,7 +42,8 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, 
 	}
 	defer b.localDocker.Close()
 
-	return build.InParallel(ctx, out, tags, artifacts, b.buildArtifact, *b.cfg.Concurrency)
+	builder := build.WithLogFile(b.buildArtifact, b.suppressLogs)
+	return build.InParallel(ctx, out, tags, artifacts, builder, *b.cfg.Concurrency)
 }
 
 func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -43,6 +43,7 @@ type Builder struct {
 	kubeContext        string
 	builtImages        []string
 	insecureRegistries map[string]bool
+	suppressLogs       []string
 }
 
 // external dependencies are wrapped
@@ -85,6 +86,7 @@ func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
 		prune:              runCtx.Opts.Prune(),
 		pruneChildren:      !runCtx.Opts.NoPruneChildren,
 		insecureRegistries: runCtx.InsecureRegistries,
+		suppressLogs:       runCtx.Opts.SuppressLogs,
 	}, nil
 }
 

--- a/pkg/skaffold/build/logfile.go
+++ b/pkg/skaffold/build/logfile.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/logfile"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+// WithLogFile wraps an `artifactBuilder` so that it optionally outputs its logs to a file.
+func WithLogFile(builder ArtifactBuilder, suppressedLogs []string) ArtifactBuilder {
+	// TODO(dgageot): this should probably be moved somewhere else.
+	if !(util.StrSliceContains(suppressedLogs, "build") || util.StrSliceContains(suppressedLogs, "all")) {
+		return builder
+	}
+
+	return func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+		file, err := logfile.Create(artifact.ImageName + ".log")
+		if err != nil {
+			return "", fmt.Errorf("unable to create log file for %s: %w", artifact.ImageName, err)
+		}
+		fmt.Fprintln(out, " - writing logs to", file.Name())
+
+		// Print logs to a memory buffer and to a file.
+		var buf bytes.Buffer
+		w := io.MultiWriter(file, &buf)
+
+		// Run the build.
+		digest, err := builder(ctx, w, artifact, tag)
+
+		// After the build finishes, close the log file. If the build failed, print the full log to the console.
+		file.Close()
+		if err != nil {
+			buf.WriteTo(out)
+		}
+
+		return digest, err
+	}
+}

--- a/pkg/skaffold/build/logfile_test.go
+++ b/pkg/skaffold/build/logfile_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestWithLogFile(t *testing.T) {
+	tests := []struct {
+		description    string
+		builder        ArtifactBuilder
+		suppress       []string
+		shouldErr      bool
+		expectedDigest string
+		logsFound      []string
+		logsNotFound   []string
+	}{
+		{
+			description:    "all logs",
+			builder:        fakeBuilder,
+			suppress:       nil,
+			shouldErr:      false,
+			expectedDigest: "digest",
+			logsFound:      []string{"building img with tag img:123"},
+			logsNotFound:   []string{" - writing logs to ", filepath.Join("skaffold", "img.log")},
+		},
+		{
+			description:    "suppress build logs",
+			builder:        fakeBuilder,
+			suppress:       []string{"build"},
+			shouldErr:      false,
+			expectedDigest: "digest",
+			logsFound:      []string{" - writing logs to ", filepath.Join("skaffold", "img.log")},
+			logsNotFound:   []string{"building img with tag img:123"},
+		},
+		{
+			description:    "suppress all logs",
+			builder:        fakeBuilder,
+			suppress:       []string{"all"},
+			shouldErr:      false,
+			expectedDigest: "digest",
+			logsFound:      []string{" - writing logs to ", filepath.Join("skaffold", "img.log")},
+			logsNotFound:   []string{"building img with tag img:123"},
+		},
+		{
+			description:    "suppress only deploy logs",
+			builder:        fakeBuilder,
+			suppress:       []string{"deploy"},
+			shouldErr:      false,
+			expectedDigest: "digest",
+			logsFound:      []string{"building img with tag img:123"},
+			logsNotFound:   []string{" - writing logs to ", filepath.Join("skaffold", "img.log")},
+		},
+		{
+			description:    "failed build - all logs",
+			builder:        fakeFailingBuilder,
+			suppress:       nil,
+			shouldErr:      true,
+			expectedDigest: "",
+			logsFound:      []string{"failed to build img with tag img:123"},
+			logsNotFound:   []string{" - writing logs to ", filepath.Join("skaffold", "img.log")},
+		},
+		{
+			description:    "failed build - suppressed logs",
+			builder:        fakeFailingBuilder,
+			suppress:       []string{"build"},
+			shouldErr:      true,
+			expectedDigest: "",
+			logsFound:      []string{" - writing logs to ", filepath.Join("skaffold", "img.log"), "failed to build img with tag img:123"},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			var out bytes.Buffer
+
+			builder := WithLogFile(test.builder, test.suppress)
+			digest, err := builder(context.Background(), &out, &latest.Artifact{ImageName: "img"}, "img:123")
+
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedDigest, digest)
+			for _, found := range test.logsFound {
+				t.CheckContains(found, out.String())
+			}
+			for _, notFound := range test.logsNotFound {
+				t.CheckFalse(strings.Contains(out.String(), notFound))
+			}
+		})
+	}
+}
+
+func fakeBuilder(_ context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
+	fmt.Fprintln(out, "building", a.ImageName, "with tag", tag)
+	return "digest", nil
+}
+
+func fakeFailingBuilder(_ context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
+	fmt.Fprintln(out, "failed to build", a.ImageName, "with tag", tag)
+	return "", errors.New("bug")
+}

--- a/pkg/skaffold/build/parallel.go
+++ b/pkg/skaffold/build/parallel.go
@@ -31,7 +31,7 @@ import (
 
 const bufferedLinesPerArtifact = 10000
 
-type artifactBuilder func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error)
+type ArtifactBuilder func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error)
 
 // For testing
 var (
@@ -40,7 +40,7 @@ var (
 )
 
 // InParallel builds a list of artifacts in parallel but prints the logs in sequential order.
-func InParallel(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, buildArtifact artifactBuilder, concurrency int) ([]Artifact, error) {
+func InParallel(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, buildArtifact ArtifactBuilder, concurrency int) ([]Artifact, error) {
 	if len(artifacts) == 0 {
 		return nil, nil
 	}
@@ -87,7 +87,7 @@ func InParallel(ctx context.Context, out io.Writer, tags tag.ImageTags, artifact
 	return collectResults(out, artifacts, results, outputs)
 }
 
-func runBuild(ctx context.Context, cw io.WriteCloser, tags tag.ImageTags, artifact *latest.Artifact, results *sync.Map, build artifactBuilder) {
+func runBuild(ctx context.Context, cw io.WriteCloser, tags tag.ImageTags, artifact *latest.Artifact, results *sync.Map, build ArtifactBuilder) {
 	event.BuildInProgress(artifact.ImageName)
 
 	finalTag, err := getBuildResult(ctx, cw, tags, artifact, build)
@@ -110,7 +110,7 @@ func readOutputAndWriteToChannel(r io.Reader, lines chan string) {
 	close(lines)
 }
 
-func getBuildResult(ctx context.Context, cw io.Writer, tags tag.ImageTags, artifact *latest.Artifact, build artifactBuilder) (string, error) {
+func getBuildResult(ctx context.Context, cw io.Writer, tags tag.ImageTags, artifact *latest.Artifact, build ArtifactBuilder) (string, error) {
 	color.Default.Fprintf(cw, "Building [%s]...\n", artifact.ImageName)
 	tag, present := tags[artifact.ImageName]
 	if !present {

--- a/pkg/skaffold/build/parallel_test.go
+++ b/pkg/skaffold/build/parallel_test.go
@@ -35,7 +35,7 @@ import (
 func TestGetBuild(t *testing.T) {
 	tests := []struct {
 		description   string
-		buildArtifact artifactBuilder
+		buildArtifact ArtifactBuilder
 		tags          tag.ImageTags
 		expectedTag   string
 		expectedOut   string
@@ -197,7 +197,7 @@ func TestCollectResults(t *testing.T) {
 func TestInParallel(t *testing.T) {
 	tests := []struct {
 		description string
-		buildFunc   artifactBuilder
+		buildFunc   ArtifactBuilder
 		expected    string
 	}{
 		{
@@ -302,14 +302,14 @@ func TestInParallelConcurrency(t *testing.T) {
 func TestInParallelForArgs(t *testing.T) {
 	tests := []struct {
 		description   string
-		inSeqFunc     func(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, artifactBuilder) ([]Artifact, error)
-		buildArtifact artifactBuilder
+		inSeqFunc     func(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, ArtifactBuilder) ([]Artifact, error)
+		buildArtifact ArtifactBuilder
 		artifactLen   int
 		expected      []Artifact
 	}{
 		{
 			description: "runs in sequence for 1 artifact",
-			inSeqFunc: func(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, artifactBuilder) ([]Artifact, error) {
+			inSeqFunc: func(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, ArtifactBuilder) ([]Artifact, error) {
 				return []Artifact{{ImageName: "singleArtifact", Tag: "one"}}, nil
 			},
 			artifactLen: 1,

--- a/pkg/skaffold/build/sequence.go
+++ b/pkg/skaffold/build/sequence.go
@@ -28,7 +28,7 @@ import (
 )
 
 // InSequence builds a list of artifacts in sequence.
-func InSequence(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, buildArtifact artifactBuilder) ([]Artifact, error) {
+func InSequence(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, buildArtifact ArtifactBuilder) ([]Artifact, error) {
 	var builds []Artifact
 
 	for _, artifact := range artifacts {

--- a/pkg/skaffold/build/sequence_test.go
+++ b/pkg/skaffold/build/sequence_test.go
@@ -33,7 +33,7 @@ import (
 func TestInSequence(t *testing.T) {
 	tests := []struct {
 		description       string
-		buildArtifact     artifactBuilder
+		buildArtifact     ArtifactBuilder
 		tags              tag.ImageTags
 		expectedArtifacts []Artifact
 		expectedOut       string


### PR DESCRIPTION
This PR introduces an option for shorter output for the build phase.

Instead of always printing the full build log, it prints the path to a log file, logs the output to that file and only print the full output to the console if the build failed.

Signed-off-by: David Gageot <david@gageot.net>
