### PR TITLE
Add suppress-logs flag

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -370,7 +370,7 @@ var FlagRegistry = []Flag{
 	},
 	{
 		Name:          "suppress-logs",
-		Usage:         "Suppress logs for specified stages in pipeline (build, deploy, status-check)",
+		Usage:         "Suppress logs for specified stages in pipeline (build, deploy, status-check, none, all)",
 		Value:         &opts.SuppressLogs,
 		DefValue:      []string{},
 		FlagAddMethod: "StringSliceVar",

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -368,6 +368,14 @@ var FlagRegistry = []Flag{
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"render"},
 	},
+	{
+		Name:          "suppress-logs",
+		Usage:         "Suppress logs for specified stages in pipeline (build, deploy, status-check)",
+		Value:         &opts.SuppressLogs,
+		DefValue:      []string{},
+		FlagAddMethod: "StringSliceVar",
+		DefinedOn:     []string{"dev", "run", "debug", "build", "deploy"},
+	},
 }
 
 func (fl *Flag) flag() *pflag.Flag {

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -148,6 +148,7 @@ Options:
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
+      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check)
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --toot=false: Emit a terminal beep after the deploy is complete
 
@@ -180,6 +181,7 @@ Env vars:
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
+* `SKAFFOLD_SUPPRESS_LOGS` (same as `--suppress-logs`)
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
 
@@ -355,6 +357,7 @@ Options:
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
+      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check)
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
@@ -393,6 +396,7 @@ Env vars:
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
+* `SKAFFOLD_SUPPRESS_LOGS` (same as `--suppress-logs`)
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
@@ -474,6 +478,7 @@ Options:
       --rpc-port=50051: tcp port to expose event API
       --skip-render=false: Don't render the manifests, just deploy them
       --status-check=true: Wait for deployed resources to stabilize
+      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check)
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
 
@@ -504,6 +509,7 @@ Env vars:
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_RENDER` (same as `--skip-render`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
+* `SKAFFOLD_SUPPRESS_LOGS` (same as `--suppress-logs`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
 
@@ -538,6 +544,7 @@ Options:
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
+      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check)
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
@@ -577,6 +584,7 @@ Env vars:
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
+* `SKAFFOLD_SUPPRESS_LOGS` (same as `--suppress-logs`)
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
@@ -788,6 +796,7 @@ Options:
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
+      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check)
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
@@ -825,6 +834,7 @@ Env vars:
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
+* `SKAFFOLD_SUPPRESS_LOGS` (same as `--suppress-logs`)
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -148,7 +148,7 @@ Options:
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
-      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check)
+      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check, none, all)
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --toot=false: Emit a terminal beep after the deploy is complete
 
@@ -357,7 +357,7 @@ Options:
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
-      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check)
+      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check, none, all)
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
@@ -478,7 +478,7 @@ Options:
       --rpc-port=50051: tcp port to expose event API
       --skip-render=false: Don't render the manifests, just deploy them
       --status-check=true: Wait for deployed resources to stabilize
-      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check)
+      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check, none, all)
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
 
@@ -544,7 +544,7 @@ Options:
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
-      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check)
+      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check, none, all)
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
@@ -796,7 +796,7 @@ Options:
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
-      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check)
+      --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check, none, all)
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -81,6 +81,7 @@ type SkaffoldOptions struct {
 	// remove minikubeProfile from here and instead detect it by matching the
 	// kubecontext API Server to minikube profiles
 	MinikubeProfile string
+	SuppressLogs    []string
 }
 
 // Prune returns true iff the user did NOT specify the --no-prune flag,


### PR DESCRIPTION
Fixes: #4512
Related: #4514, #4515, #4516

**Description**
This PR simply adds a --suppress-logs flag. It currently has no functionality, but this will be addressed by #4514, #4515, and #4516.

**Follow-up Work**
The 3 previously mentioned issues will need to be addressed in order to provide functionality.