### PR TITLE
Wait for pending deletions to complete before a deploy

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -373,6 +373,14 @@ var flagRegistry = []Flag{
 		FlagAddMethod: "StringSliceVar",
 		DefinedOn:     []string{"dev", "run", "debug", "build", "deploy"},
 	},
+	{
+		Name:          "wait-for-deletions",
+		Usage:         "Wait for pending deletions to complete before a deployment",
+		Value:         &opts.WaitForDeletions,
+		DefValue:      true,
+		FlagAddMethod: "BoolVar",
+		DefinedOn:     []string{"deploy", "dev", "run", "debug"},
+	},
 }
 
 func (fl *Flag) flag() *pflag.Flag {

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -363,6 +363,7 @@ Options:
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
       --trigger='notify': How is change detection triggered? (polling, notify, or manual)
+      --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
   -w, --watch-image=[]: Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts
   -i, --watch-poll-interval=1000: Interval (in ms) between two checks for file changes
 
@@ -402,6 +403,7 @@ Env vars:
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
 * `SKAFFOLD_TRIGGER` (same as `--trigger`)
+* `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)
 * `SKAFFOLD_WATCH_IMAGE` (same as `--watch-image`)
 * `SKAFFOLD_WATCH_POLL_INTERVAL` (same as `--watch-poll-interval`)
 
@@ -482,6 +484,7 @@ Options:
       --suppress-logs=[]: Suppress logs for specified stages in pipeline (build, deploy, status-check, none, all)
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
+      --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
 
 Usage:
   skaffold deploy [options]
@@ -513,6 +516,7 @@ Env vars:
 * `SKAFFOLD_SUPPRESS_LOGS` (same as `--suppress-logs`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
+* `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)
 
 ### skaffold dev
 
@@ -550,6 +554,7 @@ Options:
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
       --trigger='notify': How is change detection triggered? (polling, notify, or manual)
+      --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
   -w, --watch-image=[]: Choose which artifacts to watch. Artifacts with image names that contain the expression will be watched only. Default is to watch sources for all artifacts
   -i, --watch-poll-interval=1000: Interval (in ms) between two checks for file changes
 
@@ -590,6 +595,7 @@ Env vars:
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
 * `SKAFFOLD_TRIGGER` (same as `--trigger`)
+* `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)
 * `SKAFFOLD_WATCH_IMAGE` (same as `--watch-image`)
 * `SKAFFOLD_WATCH_POLL_INTERVAL` (same as `--watch-poll-interval`)
 
@@ -802,6 +808,7 @@ Options:
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
+      --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
 
 Usage:
   skaffold run [options]
@@ -840,6 +847,7 @@ Env vars:
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
+* `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)
 
 ### skaffold schema
 

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -52,6 +52,7 @@ type SkaffoldOptions struct {
 	ProfileAutoActivation bool
 	DryRun                bool
 	SkipRender            bool
+	WaitForDeletions      bool
 
 	// Add Skaffold-specific labels including runID, deployer labels, etc.
 	// `CustomLabels` are still applied if this is false. Must only be used in

--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -18,14 +18,25 @@ package kubectl
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
 	pkgkubectl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
+
+var WaitDeletion = struct {
+	MaxRetry int
+	Delay    time.Duration
+}{
+	MaxRetry: 30,
+	Delay:    2 * time.Second,
+}
 
 // CLI holds parameters to run kubectl.
 type CLI struct {
@@ -71,6 +82,67 @@ func (c *CLI) Apply(ctx context.Context, out io.Writer, manifests ManifestList) 
 	}
 
 	return nil
+}
+
+type getResult struct {
+	Items []struct {
+		Metadata struct {
+			Name              string `json:"name"`
+			DeletionTimestamp string `json:"deletionTimestamp"`
+		} `json:"metadata"`
+	} `json:"items"`
+}
+
+// WaitForDeletions waits for resource marked for deletion to complete their deletion.
+func (c *CLI) WaitForDeletions(ctx context.Context, out io.Writer, manifests ManifestList) error {
+	previousList := ""
+	previousCount := 0
+
+	for try := 0; try < WaitDeletion.MaxRetry; try++ {
+		// List resources in json format.
+		buf, err := c.RunOutInput(ctx, manifests.Reader(), "get", c.args(nil, "-f", "-", "--ignore-not-found", "-ojson")...)
+		if err != nil {
+			return err
+		}
+
+		// No resource found.
+		if len(buf) == 0 {
+			return nil
+		}
+
+		// Find which ones are marked for deletion. They have a `metadata.deletionTimestamp` field.
+		var result getResult
+		if err := json.Unmarshal(buf, &result); err != nil {
+			return err
+		}
+
+		var marked []string
+		for _, item := range result.Items {
+			if item.Metadata.DeletionTimestamp != "" {
+				marked = append(marked, item.Metadata.Name)
+			}
+		}
+		if len(marked) == 0 {
+			return nil
+		}
+
+		list := `"` + strings.Join(marked, `", "`) + `"`
+		logrus.Debugln("Resources are marked for deletion:", list)
+		if list != previousList {
+			if len(marked) == 1 {
+				fmt.Fprintf(out, "%s is marked for deletion, waiting for completion\n", list)
+			} else {
+				fmt.Fprintf(out, "%d resources are marked for deletion, waiting for completion: %s\n", len(marked), list)
+			}
+
+			previousList = list
+			previousCount = len(marked)
+		}
+
+		time.Sleep(WaitDeletion.Delay)
+	}
+
+	return fmt.Errorf("%d resources failed to complete their deletion before a new deployment: %s", previousCount, previousList)
 }
 
 // ReadManifests reads a list of manifests in yaml format.

--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -80,6 +80,13 @@ func (c *CLI) RunOut(ctx context.Context, command string, arg ...string) ([]byte
 	return util.RunCmdOut(cmd)
 }
 
+// RunOutInput shells out kubectl CLI with a given input stream.
+func (c *CLI) RunOutInput(ctx context.Context, in io.Reader, command string, arg ...string) ([]byte, error) {
+	cmd := c.Command(ctx, command, arg...)
+	cmd.Stdin = in
+	return util.RunCmdOut(cmd)
+}
+
 // CommandWithStrictCancellation ensures for windows OS that all child process get terminated on cancellation
 func (c *CLI) CommandWithStrictCancellation(ctx context.Context, command string, arg ...string) *Cmd {
 	args := c.args(command, "", arg...)


### PR DESCRIPTION
When Skaffold tries to deploy resources, it now checks that none of those resources are marked for deletion. In case, there are at least one, it'll wait for the deletion to complete.
If it doesn't do that, it's going to update resources that are marked for deletion and which are going to disappear in the background.

Fixes #4519

Signed-off-by: David Gageot <david@gageot.net>
