### PR TITLE
Docs to accommodate the deprecation of envTemplate's use of {{.IMAGE_NAME}}

### DIFF
--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -93,16 +93,15 @@ process.
 
 The following `build` section, for example, instructs Skaffold to build a
 Docker image `gcr.io/k8s-skaffold/example` with the `envTemplate`
-tag policy. The tag template is `{{.IMAGE_NAME}}:{{.FOO}}`; when Skaffold
+tag policy. The tag template is `{{.FOO}}`; when Skaffold
 finishes building the image, it will check the list of available environment
 variables in the system for the variable `FOO`, and use its value to tag the
 image.
 
 {{< alert >}}
-<b>Note</b><br>
+<b>Deprecated</b><br>
 
-`IMAGE_NAME` is a built-in variable whose value is the `imageName` field in
-the `artifacts` part of the `build` section.
+The use of `IMAGE_NAME` as a built-in variable whose value is the `imageName` field in the `artifacts` part of the `build` section has been deprecated. Please use the envTemplate to express solely the tag value for the image.
 {{< /alert >}}
 
 ### Example

--- a/docs/content/en/samples/taggers/envTemplate.yaml
+++ b/docs/content/en/samples/taggers/envTemplate.yaml
@@ -1,6 +1,6 @@
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.IMAGE_NAME}}:{{.FOO}}"
+      template: "{{.FOO}}"
   artifacts:
   - image: gcr.io/k8s-skaffold/example

--- a/docs/content/en/samples/templating/env.yaml
+++ b/docs/content/en/samples/templating/env.yaml
@@ -1,6 +1,6 @@
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.IMAGE_NAME}}:{{.FOO}}"
+      template: "{{.FOO}}"
   artifacts:
   - image: gcr.io/k8s-skaffold/example

--- a/docs/content/en/schemas/v2beta6.json
+++ b/docs/content/en/schemas/v2beta6.json
@@ -955,10 +955,10 @@
       "properties": {
         "template": {
           "type": "string",
-          "description": "used to produce the image name and tag. See golang [text/template](https://golang.org/pkg/text/template/). The template is executed against the current environment, with those variables injected:   IMAGE_NAME   |  Name of the image being built, as supplied in the artifacts section.",
-          "x-intellij-html-description": "used to produce the image name and tag. See golang <a href=\"https://golang.org/pkg/text/template/\">text/template</a>. The template is executed against the current environment, with those variables injected:   IMAGE_NAME   |  Name of the image being built, as supplied in the artifacts section.",
+          "description": "used to produce the image name and tag. See golang [text/template](https://golang.org/pkg/text/template/). The template is executed against the current environment, with those variables injected.",
+          "x-intellij-html-description": "used to produce the image name and tag. See golang <a href=\"https://golang.org/pkg/text/template/\">text/template</a>. The template is executed against the current environment, with those variables injected.",
           "examples": [
-            "{{.RELEASE}}-{{.IMAGE_NAME}}"
+            "{{.RELEASE}}"
           ]
         }
       },

--- a/examples/tagging-with-environment-variables/README.md
+++ b/examples/tagging-with-environment-variables/README.md
@@ -1,6 +1,6 @@
 ### Example: using the envTemplate tag policy
 
-This example reuses the image name and uses an environment variable `FOO` to tag the image.
+This example uses an environment variable `FOO` to tag the image.
 The way you configure it in `skaffold.yaml` is the following build stanza:
 
 ```yaml
@@ -9,9 +9,8 @@ build:
      - image: skaffold-example
      tagPolicy:
        envTemplate:
-         template: "{{.IMAGE_NAME}}:{{.FOO}}"
+         template: "{{.FOO}}"
 ```
 
 1. define `tagPolicy` to be `envTemplate`
 2. use [go templates](https://golang.org/pkg/text/template) syntax
-3. The `IMAGE_NAME` variable is built-in and reuses the value defined in the artifacts' `image`.

--- a/examples/tagging-with-environment-variables/skaffold.yaml
+++ b/examples/tagging-with-environment-variables/skaffold.yaml
@@ -5,7 +5,7 @@ build:
   - image: skaffold-example
   tagPolicy:
     envTemplate:
-      template: "{{.IMAGE_NAME}}:{{.FOO}}"
+      template: "{{.FOO}}"
 deploy:
   kubectl:
     manifests:

--- a/integration/examples/tagging-with-environment-variables/README.md
+++ b/integration/examples/tagging-with-environment-variables/README.md
@@ -1,6 +1,6 @@
 ### Example: using the envTemplate tag policy
 
-This example reuses the image name and uses an environment variable `FOO` to tag the image.
+This example uses an environment variable `FOO` to tag the image.
 The way you configure it in `skaffold.yaml` is the following build stanza:
 
 ```yaml
@@ -9,9 +9,8 @@ build:
      - image: skaffold-example
      tagPolicy:
        envTemplate:
-         template: "{{.IMAGE_NAME}}:{{.FOO}}"
+         template: "{{.FOO}}"
 ```
 
 1. define `tagPolicy` to be `envTemplate`
 2. use [go templates](https://golang.org/pkg/text/template) syntax
-3. The `IMAGE_NAME` variable is built-in and reuses the value defined in the artifacts' `image`.

--- a/integration/examples/tagging-with-environment-variables/skaffold.yaml
+++ b/integration/examples/tagging-with-environment-variables/skaffold.yaml
@@ -5,7 +5,7 @@ build:
   - image: skaffold-example
   tagPolicy:
     envTemplate:
-      template: "{{.IMAGE_NAME}}:{{.FOO}}"
+      template: "{{.FOO}}"
 deploy:
   kubectl:
     manifests:

--- a/integration/testdata/tagPolicy/skaffold.yaml
+++ b/integration/testdata/tagPolicy/skaffold.yaml
@@ -27,5 +27,5 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.IMAGE_NAME}}:tag"
+        template: "tag"
 - name: args

--- a/integration/testdata/tagPolicy/skaffold.yaml
+++ b/integration/testdata/tagPolicy/skaffold.yaml
@@ -27,5 +27,5 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "tag"
+        template: "{{.IMAGE_NAME}}:tag"
 - name: args

--- a/pkg/skaffold/build/tag/git_commit_test.go
+++ b/pkg/skaffold/build/tag/git_commit_test.go
@@ -377,8 +377,6 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Parallel()
-
 			tmpDir := t.NewTempDir()
 			test.createGitRepo(tmpDir.Root())
 			workspace := tmpDir.Path(test.subDir)

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -152,9 +152,8 @@ type EnvTemplateTagger struct {
 	// Template used to produce the image name and tag.
 	// See golang [text/template](https://golang.org/pkg/text/template/).
 	// The template is executed against the current environment,
-	// with those variables injected:
-	//   IMAGE_NAME   |  Name of the image being built, as supplied in the artifacts section.
-	// For example: `{{.RELEASE}}-{{.IMAGE_NAME}}`.
+	// with those variables injected.
+	// For example: `{{.RELEASE}}`.
 	Template string `yaml:"template,omitempty" yamltags:"required"`
 }
 


### PR DESCRIPTION
**Description**
Changing the docs to accommodate the deprecation of envTemplate's use of {{.IMAGE_NAME}}. The link to that PR is: https://github.com/GoogleContainerTools/skaffold/pull/4533

Depends on PR #4533 