### PR TITLE
Deprecating EnvTemplate's use of {{.IMAGE_NAME}}

### DIFF
--- a/integration/testdata/tagPolicy/skaffold.yaml
+++ b/integration/testdata/tagPolicy/skaffold.yaml
@@ -27,5 +27,5 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.IMAGE_NAME}}:tag"
+        template: "tag"
 - name: args

--- a/pkg/skaffold/build/tag/tag.go
+++ b/pkg/skaffold/build/tag/tag.go
@@ -35,19 +35,21 @@ type Tagger interface {
 	GenerateTag(workingDir, imageName string) (string, error)
 }
 
+const DEPRECATED_IMAGE_NAME = "_DEPRECATED_IMAGE_NAME_"
+
 // GenerateFullyQualifiedImageName resolves the fully qualified image name for an artifact.
 // The workingDir is the root directory of the artifact with respect to the Skaffold root,
 // and imageName is the base name of the image.
 func GenerateFullyQualifiedImageName(t Tagger, workingDir, imageName string) (string, error) {
 	// Supporting the use of the deprecated {{.IMAGE_NAME}} in envTemplate
 	if v, ok := t.(*envTemplateTagger); ok {
-		tag, err := v.GenerateTag(workingDir, "_DEPRECATED_IMAGE_NAME_")
+		tag, err := v.GenerateTag(workingDir, DEPRECATED_IMAGE_NAME)
 
 		if err != nil {
 			return "", fmt.Errorf("generating deprecated envTemplate tag: %w", err)
 		}
 
-		if strings.Contains(tag, "_DEPRECATED_IMAGE_NAME_") {
+		if strings.Contains(tag, DEPRECATED_IMAGE_NAME) {
 			warnings.Printf("{{.IMAGE_NAME}} is deprecated, envTemplate's template should only specify the tag value. See https://skaffold.dev/docs/pipeline-stages/taggers/")
 
 			tag, _ = v.GenerateTag(workingDir, imageName)

--- a/pkg/skaffold/build/tag/tag.go
+++ b/pkg/skaffold/build/tag/tag.go
@@ -46,20 +46,22 @@ func GenerateFullyQualifiedImageName(t Tagger, workingDir, imageName string) (st
 		tag, err := v.GenerateTag(workingDir, DeprecatedImageName)
 
 		if err != nil {
-			return "", fmt.Errorf("generating deprecated envTemplate tag: %w", err)
+			return "", fmt.Errorf("generating envTemplate tag: %w", err)
 		}
 
 		if strings.Contains(tag, DeprecatedImageName) {
 			warnings.Printf("{{.IMAGE_NAME}} is deprecated, envTemplate's template should only specify the tag value. See https://skaffold.dev/docs/pipeline-stages/taggers/")
 
-			tag, _ = v.GenerateTag(workingDir, imageName)
+			tag, err = v.GenerateTag(workingDir, imageName)
+
+			if err != nil {
+				return "", fmt.Errorf("generating deprecated envTemplate tag: %w", err)
+			}
 
 			return tag, nil
 		}
-
 		return fmt.Sprintf("%s:%s", imageName, tag), nil
 	}
-
 	tag, err := t.GenerateTag(workingDir, imageName)
 
 	if err != nil {

--- a/pkg/skaffold/build/tag/tag.go
+++ b/pkg/skaffold/build/tag/tag.go
@@ -52,18 +52,13 @@ func GenerateFullyQualifiedImageName(t Tagger, workingDir, imageName string) (st
 		if strings.Contains(tag, DeprecatedImageName) {
 			warnings.Printf("{{.IMAGE_NAME}} is deprecated, envTemplate's template should only specify the tag value. See https://skaffold.dev/docs/pipeline-stages/taggers/")
 
-			tag, err = v.GenerateTag(workingDir, imageName)
-
-			if err != nil {
-				return "", fmt.Errorf("generating deprecated envTemplate tag: %w", err)
-			}
-
-			return tag, nil
+			return strings.Replace(tag, DeprecatedImageName, imageName, -1), nil
 		}
+
 		return fmt.Sprintf("%s:%s", imageName, tag), nil
 	}
-	tag, err := t.GenerateTag(workingDir, imageName)
 
+	tag, err := t.GenerateTag(workingDir, imageName)
 	if err != nil {
 		return "", fmt.Errorf("generating tag: %w", err)
 	}

--- a/pkg/skaffold/build/tag/tag.go
+++ b/pkg/skaffold/build/tag/tag.go
@@ -35,7 +35,7 @@ type Tagger interface {
 	GenerateTag(workingDir, imageName string) (string, error)
 }
 
-const DEPRECATED_IMAGE_NAME = "_DEPRECATED_IMAGE_NAME_"
+const DeprecatedImageName = "_DEPRECATED_IMAGE_NAME_"
 
 // GenerateFullyQualifiedImageName resolves the fully qualified image name for an artifact.
 // The workingDir is the root directory of the artifact with respect to the Skaffold root,
@@ -43,13 +43,13 @@ const DEPRECATED_IMAGE_NAME = "_DEPRECATED_IMAGE_NAME_"
 func GenerateFullyQualifiedImageName(t Tagger, workingDir, imageName string) (string, error) {
 	// Supporting the use of the deprecated {{.IMAGE_NAME}} in envTemplate
 	if v, ok := t.(*envTemplateTagger); ok {
-		tag, err := v.GenerateTag(workingDir, DEPRECATED_IMAGE_NAME)
+		tag, err := v.GenerateTag(workingDir, DeprecatedImageName)
 
 		if err != nil {
 			return "", fmt.Errorf("generating deprecated envTemplate tag: %w", err)
 		}
 
-		if strings.Contains(tag, DEPRECATED_IMAGE_NAME) {
+		if strings.Contains(tag, DeprecatedImageName) {
 			warnings.Printf("{{.IMAGE_NAME}} is deprecated, envTemplate's template should only specify the tag value. See https://skaffold.dev/docs/pipeline-stages/taggers/")
 
 			tag, _ = v.GenerateTag(workingDir, imageName)


### PR DESCRIPTION
**Description**
This is the coding logic and additional test cases for deprecating envTemplate's use of {{.IMAGE_NAME}} in its template. Users should be using envTemplate to indicate solely the tag value for their images.

**User facing changes)**
Users will now see a warning that {{.IMAGE_NAME}} is deprecated when using {{.IMAGE_NAME}} in their envTemplate tagger.
The warning will look like 
`{{.IMAGE_NAME}} is deprecated, envTemplate's template should only specify the tag value. See https://skaffold.dev/docs/pipeline-stages/taggers/`

**Follow-up Work**
Changes to docs to accompany this deprecation: https://github.com/GoogleContainerTools/skaffold/pull/4532

