### PR TITLE
Do not report version updates if run from Google Cloud SDK

### DIFF
--- a/cmd/skaffold/app/cmd/cmd_test.go
+++ b/cmd/skaffold/app/cmd/cmd_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestInCloudSdk(t *testing.T) {
+	root := testutil.NewTempDir(t)
+	normalSkaffold := root.Path("bin/skaffold")
+	cloudSdkBinSkaffold := root.Path("google-cloud-sdk/bin/skaffold")
+	root.Touch(normalSkaffold, cloudSdkBinSkaffold)
+
+	testutil.CheckDeepEqual(t, false, inCloudSdk(normalSkaffold))
+	testutil.CheckDeepEqual(t, true, inCloudSdk(cloudSdkBinSkaffold))
+	testutil.CheckDeepEqual(t, false, inCloudSdk(""))
+}


### PR DESCRIPTION
Fixes: #4500
**Related**: #4506

**Description**

Do not output new-version-found messages when installed via the Google Cloud SDK since the user should be getting updates through the Cloud SDK.  We can still prompt for surveys.

**User facing changes (remove if N/A)**
No new-version updates when run from Cloud SDK.
