### PR TITLE
Failing to override value should be fatal

### DIFF
--- a/testutil/util.go
+++ b/testutil/util.go
@@ -292,11 +292,11 @@ func override(t *testing.T, dest, tmp interface{}) (err error) {
 		if r := recover(); r != nil {
 			switch x := r.(type) {
 			case string:
-				t.Errorf("unable to override value: %s", x)
+				t.Fatalf("unable to override value: %s", x)
 			case error:
-				t.Errorf("unable to override value: %w", x)
+				t.Fatalf("unable to override value: %s", x)
 			default:
-				t.Error("unable to override value")
+				t.Fatal("unable to override value")
 			}
 		}
 	}()


### PR DESCRIPTION
Makes it easier to understand why a test is failing when a `t.Override()` is not valid

Signed-off-by: David Gageot <david@gageot.net>
