### PR TITLE
Add run-id to resources with annotation instead of label

### DIFF
--- a/pkg/diag/diag_test.go
+++ b/pkg/diag/diag_test.go
@@ -28,12 +28,14 @@ import (
 )
 
 type mockValidator struct {
+	runID       string
 	ns          []string
 	listOptions metav1.ListOptions
 }
 
-func (m *mockValidator) Validate(_ context.Context, ns string, opts metav1.ListOptions) ([]validator.Resource, error) {
+func (m *mockValidator) Validate(_ context.Context, ns, runID string, opts metav1.ListOptions) ([]validator.Resource, error) {
 	m.ns = append(m.ns, ns)
+	m.runID = runID
 	m.listOptions = opts
 	return nil, nil
 }
@@ -41,6 +43,7 @@ func (m *mockValidator) Validate(_ context.Context, ns string, opts metav1.ListO
 func TestRun(t *testing.T) {
 	tests := []struct {
 		description string
+		runID       string
 		labels      map[string]string
 		ns          []string
 		expected    *mockValidator
@@ -50,6 +53,7 @@ func TestRun(t *testing.T) {
 			ns:          []string{"foo", "bar", ""},
 			expected: &mockValidator{
 				ns:          []string{"foo", "bar"},
+				runID:       "",
 				listOptions: metav1.ListOptions{},
 			},
 		},
@@ -75,7 +79,7 @@ func TestRun(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			d := New(test.ns)
+			d := New(test.runID, test.ns)
 			for k, v := range test.labels {
 				d = d.WithLabel(k, v)
 			}

--- a/pkg/diag/validator/pod_test.go
+++ b/pkg/diag/validator/pod_test.go
@@ -656,7 +656,7 @@ func TestRun(t *testing.T) {
 			rs = append(rs, &v1.EventList{Items: test.events})
 			f := fakekubeclientset.NewSimpleClientset(rs...)
 
-			actual, err := testPodValidator(f, map[string]string{}).Validate(context.Background(), "test", metav1.ListOptions{})
+			actual, err := testPodValidator(f, map[string]string{}).Validate(context.Background(), "test", "", metav1.ListOptions{})
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual, cmp.AllowUnexported(Resource{}), cmp.Comparer(func(x, y error) bool {
 				if x == nil && y == nil {

--- a/pkg/diag/validator/validator.go
+++ b/pkg/diag/validator/validator.go
@@ -26,5 +26,5 @@ type Status string
 
 type Validator interface {
 	// Validate runs the validator and returns the list of resources with status.
-	Validate(ctx context.Context, ns string, opts metav1.ListOptions) ([]Resource, error)
+	Validate(ctx context.Context, ns, runID string, opts metav1.ListOptions) ([]Resource, error)
 }

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -68,6 +68,8 @@ const (
 	DefaultProjectDescriptor = "project.toml"
 
 	LeeroyAppResponse = "leeroooooy app!!\n"
+
+	RunIDAnnotation = "skaffold.dev/run-id"
 )
 
 var (

--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -49,14 +49,18 @@ type KptDeployer struct {
 	insecureRegistries map[string]bool
 	labels             map[string]string
 	globalConfig       string
+	runID              string
+	addRunIDAnnotation bool
 }
 
-func NewKptDeployer(ctx Config, labels map[string]string) *KptDeployer {
+func NewKptDeployer(cfg Config, labels map[string]string) *KptDeployer {
 	return &KptDeployer{
-		KptDeploy:          ctx.Pipeline().Deploy.KptDeploy,
-		insecureRegistries: ctx.GetInsecureRegistries(),
+		KptDeploy:          cfg.Pipeline().Deploy.KptDeploy,
+		insecureRegistries: cfg.GetInsecureRegistries(),
+		globalConfig:       cfg.GlobalConfig(),
+		runID:              cfg.GetRunID(),
+		addRunIDAnnotation: cfg.AddSkaffoldLabels(),
 		labels:             labels,
-		globalConfig:       ctx.GlobalConfig(),
 	}
 }
 
@@ -198,7 +202,7 @@ func (k *KptDeployer) renderManifests(ctx context.Context, _ io.Writer, builds [
 		}
 	}
 
-	return manifests.SetLabels(k.labels)
+	return manifests.SetLabels(k.addRunIDAnnotation, k.runID, k.labels)
 }
 
 // readConfigs uses `kpt fn source` to read config manifests from k.Dir

--- a/pkg/skaffold/deploy/kubectl/labels_test.go
+++ b/pkg/skaffold/deploy/kubectl/labels_test.go
@@ -38,6 +38,8 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
+  annotations:
+    skaffold.dev/run-id: run-id
   labels:
     key1: value1
     key2: value2
@@ -48,10 +50,43 @@ spec:
     name: example
 `)}
 
-	resultManifest, err := manifests.SetLabels(map[string]string{
+	resultManifest, err := manifests.SetLabels(true, "run-id", map[string]string{
 		"key1": "value1",
 		"key2": "value2",
 	})
+
+	testutil.CheckErrorAndDeepEqual(t, false, err, expected.String(), resultManifest.String())
+}
+
+func TestExistingAnnotations(t *testing.T) {
+	manifests := ManifestList{[]byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    existingAnnotation: here
+  name: getting-started
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/example
+    name: example
+`)}
+
+	expected := ManifestList{[]byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    existingAnnotation: here
+    skaffold.dev/run-id: run-id
+  name: getting-started
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/example
+    name: example
+`)}
+
+	resultManifest, err := manifests.SetLabels(true, "run-id", map[string]string{})
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected.String(), resultManifest.String())
 }
@@ -74,6 +109,8 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
+  annotations:
+    skaffold.dev/run-id: run-id
   labels:
     key0: value0
     key1: value1
@@ -85,7 +122,7 @@ spec:
     name: example
 `)}
 
-	resultManifest, err := manifests.SetLabels(map[string]string{
+	resultManifest, err := manifests.SetLabels(true, "run-id", map[string]string{
 		"key0": "should-be-ignored",
 		"key1": "value1",
 		"key2": "value2",
@@ -110,6 +147,8 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
+  annotations:
+    skaffold.dev/run-id: run-id
   name: getting-started
 spec:
   containers:
@@ -117,7 +156,7 @@ spec:
     name: example
 `)}
 
-	resultManifest, err := manifests.SetLabels(nil)
+	resultManifest, err := manifests.SetLabels(true, "run-id", nil)
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected.String(), resultManifest.String())
 }
@@ -132,11 +171,13 @@ metadata: 3
 apiVersion: v1
 kind: Pod
 metadata:
+  annotations:
+    skaffold.dev/run-id: run-id
   labels: 3
   name: getting-started
 `)}
 
-	resultManifest, err := manifests.SetLabels(map[string]string{"key0": "value0"})
+	resultManifest, err := manifests.SetLabels(true, "run-id", map[string]string{"key0": "value0"})
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, manifests.String(), resultManifest.String())
 }
@@ -163,6 +204,8 @@ spec:
 	expected := ManifestList{[]byte(`apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    skaffold.dev/run-id: run-id
   labels:
     key0: value0
     key1: value1
@@ -181,7 +224,7 @@ spec:
         metadata:
           type: object`)}
 
-	resultManifest, err := manifests.SetLabels(map[string]string{
+	resultManifest, err := manifests.SetLabels(true, "run-id", map[string]string{
 		"key0": "value0",
 		"key1": "value1",
 	})

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -97,6 +97,8 @@ type KustomizeDeployer struct {
 	insecureRegistries map[string]bool
 	labels             map[string]string
 	globalConfig       string
+	runID              string
+	addRunIDAnnotation bool
 }
 
 func NewKustomizeDeployer(cfg Config, labels map[string]string) *KustomizeDeployer {
@@ -105,6 +107,8 @@ func NewKustomizeDeployer(cfg Config, labels map[string]string) *KustomizeDeploy
 		kubectl:            deploy.NewCLI(cfg, cfg.Pipeline().Deploy.KustomizeDeploy.Flags),
 		insecureRegistries: cfg.GetInsecureRegistries(),
 		globalConfig:       cfg.GlobalConfig(),
+		runID:              cfg.GetRunID(),
+		addRunIDAnnotation: cfg.AddSkaffoldLabels(),
 		labels:             labels,
 	}
 }
@@ -169,7 +173,7 @@ func (k *KustomizeDeployer) renderManifests(ctx context.Context, out io.Writer, 
 		}
 	}
 
-	return manifests.SetLabels(k.labels)
+	return manifests.SetLabels(k.addRunIDAnnotation, k.runID, k.labels)
 }
 
 // Cleanup deletes what was deployed by calling Deploy.

--- a/pkg/skaffold/deploy/labeller.go
+++ b/pkg/skaffold/deploy/labeller.go
@@ -17,31 +17,23 @@ limitations under the License.
 package deploy
 
 import (
-	"fmt"
 	"strings"
-
-	"github.com/google/uuid"
 )
 
 const (
 	K8sManagedByLabelKey = "app.kubernetes.io/managed-by"
-	RunIDLabel           = "skaffold.dev/run-id"
 )
 
-var runID = uuid.New().String()
-
-// DefaultLabeller adds K8s style managed-by label and a run-specific UUID label
+// DefaultLabeller adds K8s style managed-by label and a run-specific UUID annotation
 type DefaultLabeller struct {
 	addSkaffoldLabels bool
 	customLabels      []string
-	runID             string
 }
 
 func NewLabeller(addSkaffoldLabels bool, customLabels []string) *DefaultLabeller {
 	return &DefaultLabeller{
 		addSkaffoldLabels: addSkaffoldLabels,
 		customLabels:      customLabels,
-		runID:             runID,
 	}
 }
 
@@ -50,7 +42,6 @@ func (d *DefaultLabeller) Labels() map[string]string {
 
 	if d.addSkaffoldLabels {
 		labels[K8sManagedByLabelKey] = "skaffold"
-		labels[RunIDLabel] = d.runID
 	}
 
 	for _, cl := range d.customLabels {
@@ -63,8 +54,4 @@ func (d *DefaultLabeller) Labels() map[string]string {
 	}
 
 	return labels
-}
-
-func (d *DefaultLabeller) RunIDSelector() string {
-	return fmt.Sprintf("%s=%s", RunIDLabel, d.Labels()[RunIDLabel])
 }

--- a/pkg/skaffold/deploy/labels_test.go
+++ b/pkg/skaffold/deploy/labels_test.go
@@ -106,7 +106,7 @@ func TestLabelDeployResults(t *testing.T) {
 			t.Override(&kubernetesclient.DynamicClient, mockDynamicClient(dynClient))
 
 			// Patch labels
-			labelDeployResults(test.appliedLabels, []Artifact{{Obj: dep}})
+			labelDeployResults(true, "", test.appliedLabels, []Artifact{{Obj: dep}})
 
 			// Check modified value
 			modified, err := dynClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Get("foo", metav1.GetOptions{})

--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -84,14 +84,14 @@ func (d *Deployment) UpdateStatus(ae proto.ActionableErr) {
 	}
 }
 
-func NewDeployment(name string, ns string, deadline time.Duration) *Deployment {
+func NewDeployment(name, ns, runID string, deadline time.Duration) *Deployment {
 	return &Deployment{
 		name:         name,
 		namespace:    ns,
 		rType:        deploymentType,
 		status:       newStatus(proto.ActionableErr{}),
 		deadline:     deadline,
-		podValidator: diag.New(nil),
+		podValidator: diag.New(runID, nil),
 	}
 }
 

--- a/pkg/skaffold/deploy/resource/deployment_test.go
+++ b/pkg/skaffold/deploy/resource/deployment_test.go
@@ -101,7 +101,7 @@ func TestDeploymentCheckStatus(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 
-			r := NewDeployment("dep", "test", 0)
+			r := NewDeployment("dep", "test", "", 0)
 			r.CheckStatus(context.Background(), &statusConfig{})
 
 			if test.cancelled {
@@ -281,7 +281,7 @@ func TestReportSinceLastUpdated(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			dep := NewDeployment("test", "test-ns", 1)
+			dep := NewDeployment("test", "test-ns", "", 1)
 			dep.pods = map[string]validator.Resource{
 				"foo": validator.NewResource(
 					"test",
@@ -336,7 +336,7 @@ func TestReportSinceLastUpdatedMultipleTimes(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			dep := NewDeployment("test", "test-ns", 1)
+			dep := NewDeployment("test", "test-ns", "", 1)
 			var actual string
 			for i, status := range test.podStatuses {
 				dep.UpdateStatus(proto.ActionableErr{

--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
@@ -38,11 +38,11 @@ type ForwarderManager struct {
 }
 
 // NewForwarderManager returns a new port manager which handles starting and stopping port forwarding
-func NewForwarderManager(out io.Writer, cli *kubectl.CLI, podSelector kubernetes.PodSelector, namespaces []string, label string, opts config.PortForwardOptions, userDefined []*latest.PortForwardResource) *ForwarderManager {
+func NewForwarderManager(out io.Writer, cli *kubectl.CLI, podSelector kubernetes.PodSelector, namespaces []string, runID string, opts config.PortForwardOptions, userDefined []*latest.PortForwardResource) *ForwarderManager {
 	entryManager := NewEntryManager(out, NewKubectlForwarder(out, cli))
 
 	var forwarders []Forwarder
-	forwarders = append(forwarders, NewResourceForwarder(entryManager, namespaces, label, userDefined))
+	forwarders = append(forwarders, NewResourceForwarder(entryManager, namespaces, runID, userDefined))
 	if opts.ForwardPods {
 		forwarders = append(forwarders, NewWatchingPodForwarder(entryManager, podSelector, namespaces))
 	}

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -18,7 +18,6 @@ package portforward
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"sync"
 	"testing"
@@ -33,7 +32,6 @@ import (
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -274,8 +272,8 @@ func TestRetrieveServices(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "svc1",
 						Namespace: "test",
-						Labels: map[string]string{
-							deploy.RunIDLabel: "9876-6789",
+						Annotations: map[string]string{
+							constants.RunIDAnnotation: "9876-6789",
 						},
 					},
 					Spec: v1.ServiceSpec{Ports: []v1.ServicePort{{Port: 8080}}},
@@ -283,8 +281,8 @@ func TestRetrieveServices(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "svc2",
 						Namespace: "test1",
-						Labels: map[string]string{
-							deploy.RunIDLabel: "9876-6789",
+						Annotations: map[string]string{
+							constants.RunIDAnnotation: "9876-6789",
 						},
 					},
 					Spec: v1.ServiceSpec{Ports: []v1.ServicePort{{Port: 8081}}},
@@ -313,8 +311,8 @@ func TestRetrieveServices(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "svc1",
 						Namespace: "test",
-						Labels: map[string]string{
-							deploy.RunIDLabel: "9876-6789",
+						Annotations: map[string]string{
+							constants.RunIDAnnotation: "9876-6789",
 						},
 					},
 					Spec: v1.ServiceSpec{Ports: []v1.ServicePort{{Port: 8080}}},
@@ -328,8 +326,8 @@ func TestRetrieveServices(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "svc1",
 						Namespace: "test",
-						Labels: map[string]string{
-							deploy.RunIDLabel: "9876-6789",
+						Annotations: map[string]string{
+							constants.RunIDAnnotation: "9876-6789",
 						},
 					},
 				},
@@ -346,7 +344,7 @@ func TestRetrieveServices(t *testing.T) {
 			client := fakekubeclientset.NewSimpleClientset(objs...)
 			t.Override(&kubernetesclient.Client, mockClient(client))
 
-			actual, err := retrieveServiceResources(fmt.Sprintf("%s=9876-6789", deploy.RunIDLabel), test.namespaces)
+			actual, err := retrieveServiceResources("9876-6789", test.namespaces)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)

--- a/pkg/skaffold/kubernetes/util.go
+++ b/pkg/skaffold/kubernetes/util.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 )
 
@@ -150,4 +151,16 @@ func parseImagesFromYaml(obj interface{}) []string {
 	}
 
 	return images
+}
+
+func HasRunIDAnnotation(annotations map[string]string, runID string) bool {
+	if runID == "" {
+		return true
+	}
+	for k, v := range annotations {
+		if k == constants.RunIDAnnotation && v == runID {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/skaffold/runner/deploy_test.go
+++ b/pkg/skaffold/runner/deploy_test.go
@@ -46,17 +46,17 @@ func TestDeploy(t *testing.T) {
 		shouldWait  bool
 	}{
 		{
-			description: "deploy shd perform status check",
+			description: "deploy should perform status check",
 			testBench:   &TestBench{},
 			statusCheck: true,
 			shouldWait:  true,
 		},
 		{
-			description: "deploy shd not perform status check",
+			description: "deploy should not perform status check",
 			testBench:   &TestBench{},
 		},
 		{
-			description: "deploy shd not perform status check when deployer is in error",
+			description: "deploy should not perform status check when deployer is in error",
 			testBench:   &TestBench{deployErrors: []error{errors.New("deploy error")}},
 			shouldErr:   true,
 			statusCheck: true,
@@ -95,7 +95,7 @@ func TestDeployNamespace(t *testing.T) {
 		expected    []string
 	}{
 		{
-			description: "deploy shd add all namespaces to run Context",
+			description: "deploy should add all namespaces to run context",
 			Namespaces:  []string{"test", "test-ns"},
 			testBench:   NewTestBench().WithDeployNamespaces([]string{"test-ns", "test-ns-1"}),
 			expected:    []string{"test", "test-ns", "test-ns-1"},

--- a/pkg/skaffold/runner/portforwarder.go
+++ b/pkg/skaffold/runner/portforwarder.go
@@ -31,7 +31,7 @@ func (r *SkaffoldRunner) createForwarder(out io.Writer) *portforward.ForwarderMa
 		r.kubectlCLI,
 		r.podSelector,
 		r.runCtx.GetNamespaces(),
-		r.labeller.RunIDSelector(),
+		r.runCtx.GetRunID(),
 		r.runCtx.Opts.PortForward,
 		r.runCtx.Pipeline().PortForward)
 }

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"sort"
 
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
@@ -33,10 +34,13 @@ const (
 	emptyNamespace = ""
 )
 
+var runID = uuid.New().String()
+
 type RunContext struct {
 	Opts config.SkaffoldOptions
 	Cfg  latest.Pipeline
 
+	RunID              string
 	KubeContext        string
 	Namespaces         []string
 	WorkingDir         string
@@ -65,6 +69,7 @@ func (rc *RunContext) DryRun() bool                              { return rc.Opt
 func (rc *RunContext) ForceDeploy() bool                         { return rc.Opts.Force }
 func (rc *RunContext) GetKubeConfig() string                     { return rc.Opts.KubeConfig }
 func (rc *RunContext) GetKubeNamespace() string                  { return rc.Opts.Namespace }
+func (rc *RunContext) GetRunID() string                          { return rc.RunID }
 func (rc *RunContext) GlobalConfig() string                      { return rc.Opts.GlobalConfig }
 func (rc *RunContext) MinikubeProfile() string                   { return rc.Opts.MinikubeProfile }
 func (rc *RunContext) DetectMinikube() bool                      { return rc.Opts.DetectMinikube }
@@ -118,6 +123,7 @@ func GetRunContext(opts config.SkaffoldOptions, cfg latest.Pipeline) (*RunContex
 		Opts:               opts,
 		Cfg:                cfg,
 		WorkingDir:         cwd,
+		RunID:              runID,
 		KubeContext:        kubeContext,
 		Namespaces:         namespaces,
 		InsecureRegistries: insecureRegistries,


### PR DESCRIPTION
fixes #3219
fixes #2745

this change moves the `skaffold.dev/run-id` label to an annotation. this should prevent misbehavior by skaffold when deploying/redeploying resources, since annotations are not considered by kubernetes when computing the state of a resource.

rather than using the `LabelSelector` option provided by client-go, this change implements a small filtering mechanism when retrieving resources in a namespace that loops through the annotations and ensures that one with the current run-id is present.

**this could have potentially negative performance impacts**, though I think it should be negligible in all cases except where there are many (~ hundreds) of resource deployed to a single namespace in a cluster.