### PR TITLE
Reduce volume of debug-level logging

### DIFF
--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -309,7 +309,7 @@ func recentlyPromptedOrTaken(cfg *ContextConfig) bool {
 func lessThan(date string, duration time.Duration) bool {
 	t, err := time.Parse(time.RFC3339, date)
 	if err != nil {
-		logrus.Debugf("could not parse data %s", date)
+		logrus.Debugf("could not parse date %s", date)
 		return false
 	}
 	return current().Sub(t) < duration

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -309,7 +309,7 @@ func recentlyPromptedOrTaken(cfg *ContextConfig) bool {
 func lessThan(date string, duration time.Duration) bool {
 	t, err := time.Parse(time.RFC3339, date)
 	if err != nil {
-		logrus.Debugf("could not parse date %s", date)
+		logrus.Debugf("could not parse date %q", date)
 		return false
 	}
 	return current().Sub(t) < duration

--- a/pkg/skaffold/yamltags/tags.go
+++ b/pkg/skaffold/yamltags/tags.go
@@ -30,7 +30,7 @@ type fieldSet map[string]struct{}
 func ValidateStruct(s interface{}) error {
 	parentStruct := reflect.Indirect(reflect.ValueOf(s))
 	t := parentStruct.Type()
-	logrus.Debugf("validating yamltags of struct %s", t.Name())
+	logrus.Tracef("validating yamltags of struct %s", t.Name())
 
 	// Loop through the fields on the struct, looking for tags.
 	for i := 0; i < t.NumField(); i++ {


### PR DESCRIPTION
Downgrade the yamltags-validation to _trace_ level: it seems of questionable utility.
```
INFO[0000] Skaffold &{Version:v1.12.0 ConfigVersion:skaffold/v2beta5 GitVersion: GitCommit:e680a831292e1c7efc54e0c6d40544ae141e6354 GitTreeState:clean BuildDate:2020-06-25T13:15:49Z GoVersion:go1.14.2 Compiler:gc Platform:darwin/amd64} 
DEBU[0000] Defaulting build type to local build         
DEBU[0000] validating yamltags of struct SkaffoldConfig 
DEBU[0000] validating yamltags of struct Metadata       
DEBU[0000] validating yamltags of struct Pipeline       
DEBU[0000] validating yamltags of struct BuildConfig    
DEBU[0000] validating yamltags of struct Artifact       
DEBU[0000] validating yamltags of struct ArtifactType   
DEBU[0000] validating yamltags of struct DockerArtifact 
DEBU[0000] validating yamltags of struct TagPolicy      
DEBU[0000] validating yamltags of struct GitTagger      
DEBU[0000] validating yamltags of struct BuildType      
DEBU[0000] validating yamltags of struct LocalBuild     
DEBU[0000] validating yamltags of struct DeployConfig   
DEBU[0000] validating yamltags of struct DeployType     
DEBU[0000] validating yamltags of struct KubectlDeploy  
DEBU[0000] validating yamltags of struct KubectlFlags   
INFO[0000] Using kubectl context: minikube              
DEBU[0000] Using builder: local                         
DEBU[0000] Running command: [minikube docker-env --shell none] 
```

Fix `date` reference and its quoting too within the local-configuration parsing.