### PR TITLE
Log when values are taken from global config file

### DIFF
--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -73,6 +73,9 @@ func readConfigFileCached(filename string) (*GlobalConfig, error) {
 			return
 		}
 		configFile, configFileErr = ReadConfigFileNoCache(filenameOrDefault)
+		if configFileErr == nil {
+			logrus.Infof("Loaded Skaffold defaults from %q", filenameOrDefault)
+		}
 	})
 	return configFile, configFileErr
 }

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -161,7 +161,9 @@ func GetDefaultRepo(configFile string, cliValue *string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
+	if cfg.DefaultRepo != "" {
+		logrus.Infof("Using default-repo=%s from config", cfg.DefaultRepo)
+	}
 	return cfg.DefaultRepo, nil
 }
 
@@ -175,6 +177,7 @@ func GetLocalCluster(configFile string, minikubeProfile string) (bool, error) {
 	}
 	// when set, the local-cluster config takes precedence
 	if cfg.LocalCluster != nil {
+		logrus.Infof("Using local-cluster=%v from config", *cfg.LocalCluster)
 		return *cfg.LocalCluster, nil
 	}
 
@@ -190,7 +193,9 @@ func GetInsecureRegistries(configFile string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	if len(cfg.InsecureRegistries) > 0 {
+		logrus.Infof("Using insecure-registries=%v from config", cfg.InsecureRegistries)
+	}
 	return cfg.InsecureRegistries, nil
 }
 
@@ -200,11 +205,11 @@ func GetDebugHelpersRegistry(configFile string) (string, error) {
 		return "", err
 	}
 
-	if cfg.DebugHelpersRegistry == "" {
-		return constants.DefaultDebugHelpersRegistry, nil
+	if cfg.DebugHelpersRegistry != "" {
+		logrus.Infof("Using debug-helpers-registry=%s from config", cfg.DebugHelpersRegistry)
+		return cfg.DebugHelpersRegistry, nil
 	}
-
-	return cfg.DebugHelpersRegistry, nil
+	return constants.DefaultDebugHelpersRegistry, nil
 }
 
 func isDefaultLocal(kubeContext string) bool {


### PR DESCRIPTION
Log when values are resolved from the Skaffold global config file (typically ~/.skaffold/config).  At least simplifies diagnosing situations like the motivation for #4554.

```
$ skaffold dev -v info
WARN[0000] starting gRPC server on port 50053. (50051 is already in use) 
WARN[0000] starting gRPC HTTP server on port 50054. (50052 is already in use) 
INFO[0000] Skaffold &{Version: ConfigVersion:skaffold/v2beta6 GitVersion: GitCommit: GitTreeState: BuildDate: GoVersion:go1.14.3 Compiler:gc Platform:darwin/amd64} 
INFO[0000] Loaded Skaffold defaults from "/Users/bdealwis/.skaffold/config"
INFO[0000] Using kubectl context: docker-desktop        
INFO[0000] Using local-cluster=false from config        
...
```