### PR TITLE
Ignore "" namespaces in collectHelmReleasesNamespaces

### DIFF
--- a/pkg/skaffold/runner/util/util.go
+++ b/pkg/skaffold/runner/util/util.go
@@ -68,7 +68,9 @@ func collectHelmReleasesNamespaces(cfg latest.Pipeline) []string {
 
 	if cfg.Deploy.HelmDeploy != nil {
 		for _, release := range cfg.Deploy.HelmDeploy.Releases {
-			namespaces = append(namespaces, release.Namespace)
+			if release.Namespace != "" {
+				namespaces = append(namespaces, release.Namespace)
+			}
 		}
 	}
 

--- a/pkg/skaffold/runner/util/util_test.go
+++ b/pkg/skaffold/runner/util/util_test.go
@@ -66,7 +66,7 @@ func TestGetAllPodNamespaces(t *testing.T) {
 					},
 				},
 			},
-			expected: []string{"", "ns", "ns2", "ns3"},
+			expected: []string{"ns", "ns2", "ns3"},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #3311 <!-- tracking issues that this PR will close -->
**Related**: N/A
**Merge before/after**: N/A

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This fixes an issue specific to helm deployments , when the skaffold enduser is running with RBAC restriction scoped to a single namespace. 

Behaviour on v1.12.1 - pod watcher logs this error  `starting logger: initializing pod watcher for "": unknown (get pods)` and exits. 

This also seems to, inadvertently 😄 , fix a new issue (potentially introduced as part of the fixes in this PR - #4460) whereby user with similar restrictions, single-ns scoped permissions, cannot list helm-released deployments anymore despite having `SKAFFOLD_NAMESPACE` env-variable or adding `--namepsace`/`-n` flag. This other issue logs the error below before exiting:
```
exiting dev mode because first deploy failed: could not fetch deployments: could not fetch deployments: deployments.apps is forbidden: User "<my-user>" cannot list resource "deployments" in API group "apps" at the cluster scope
```
The only work around for both these issue is to hardcode a `namespace` field in skaffold.yaml under `deploy.helm.releases`. 

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
Before: 
Running `skaffold dev` with a user permitted to only a single namespace would run into this error before exiting:
```starting logger: initializing pod watcher for "": unknown (get pods)```. 

The cause for this error appears related to the runner context that merges all namespaces into a single array (user RBAC, -n/--namespace `SKAFFOLD_NAMESPACE` and every helmRelease namespace specified). When the namespace field isn't included under `deploy.helm.releases`, this seems to add a blank (or `""`) namespace in the list of namespaces which may require cluster-scope permissions. 

There's a work-around for this before this fix - adding the namespace under each helm-release will make this work:
```
    deploy:
      helm:
        releases:
        - name: <release-name>
          namespace: <release-namespace>
```
However we have users sharing the same repo/skaffold.yaml and attempt to deploy each to their own namespace, therefore hardcoding the namespace isn't ideal.

After: 
Pod watcher and deployment status works without adding the namespace field under `deploy.helm.releases`. I've tested also using admin user (with cluster-wide rbac) and the behaviour works the same. Also tested multiple helmReleases with different namespaces, seems to work as well with this change. 

Question to the contributors on this project: was there an intended reason to have this behaviour? (i.e. having an empty ns in namespaces list) The reason I ask is as you can see I had to change the test as well and remove `""` from expected output.  

Let me know.

<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
