### PR TITLE
Remove duplicated replica count.

### DIFF
--- a/examples/helm-deployment/charts/templates/deployment.yaml
+++ b/examples/helm-deployment/charts/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: {{ .Chart.Name }}
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: {{ .Chart.Name }}

--- a/integration/examples/helm-deployment/charts/templates/deployment.yaml
+++ b/integration/examples/helm-deployment/charts/templates/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: {{ .Chart.Name }}
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: {{ .Chart.Name }}


### PR DESCRIPTION
This leads to strange behaviour such as not being able to apply a label on resources and not being able to check the deployment's status.

Signed-off-by: David Gageot <david@gageot.net>
