### PR TITLE
Use read-only getters on RunContext

### DIFF
--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -57,11 +57,11 @@ type DependencyLister func(ctx context.Context, artifact *latest.Artifact) ([]st
 
 // NewCache returns the current state of the cache
 func NewCache(runCtx *runcontext.RunContext, imagesAreLocal bool, dependencies DependencyLister) (Cache, error) {
-	if !runCtx.Opts.CacheArtifacts {
+	if !runCtx.CacheArtifacts() {
 		return &noCache{}, nil
 	}
 
-	cacheFile, err := resolveCacheFile(runCtx.Opts.CacheFile)
+	cacheFile, err := resolveCacheFile(runCtx.CacheFile())
 	if err != nil {
 		logrus.Warnf("Error resolving cache file, not using skaffold cache: %v", err)
 		return &noCache{}, nil
@@ -81,11 +81,11 @@ func NewCache(runCtx *runcontext.RunContext, imagesAreLocal bool, dependencies D
 	return &cache{
 		artifactCache:      artifactCache,
 		client:             client,
-		insecureRegistries: runCtx.InsecureRegistries,
+		insecureRegistries: runCtx.GetInsecureRegistries(),
 		cacheFile:          cacheFile,
 		imagesAreLocal:     imagesAreLocal,
 		hashForArtifact: func(ctx context.Context, a *latest.Artifact) (string, error) {
-			return getHashForArtifact(ctx, dependencies, a, runCtx.Opts.IsDevMode())
+			return getHashForArtifact(ctx, dependencies, a, runCtx.DevMode())
 		},
 	}, nil
 }

--- a/pkg/skaffold/build/cluster/types.go
+++ b/pkg/skaffold/build/cluster/types.go
@@ -41,18 +41,18 @@ type Builder struct {
 
 // NewBuilder creates a new Builder that builds artifacts on cluster.
 func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
-	timeout, err := time.ParseDuration(runCtx.Cfg.Build.Cluster.Timeout)
+	timeout, err := time.ParseDuration(runCtx.Pipeline().Build.Cluster.Timeout)
 	if err != nil {
 		return nil, fmt.Errorf("parsing timeout: %w", err)
 	}
 
 	return &Builder{
-		ClusterDetails:     runCtx.Cfg.Build.Cluster,
+		ClusterDetails:     runCtx.Pipeline().Build.Cluster,
 		kubectlcli:         kubectl.NewFromRunContext(runCtx),
 		timeout:            timeout,
-		kubeContext:        runCtx.KubeContext,
-		insecureRegistries: runCtx.InsecureRegistries,
-		muted:              runCtx.Opts.Muted,
+		kubeContext:        runCtx.GetKubeContext(),
+		insecureRegistries: runCtx.GetInsecureRegistries(),
+		muted:              runCtx.Muted(),
 	}, nil
 }
 

--- a/pkg/skaffold/build/gcb/types.go
+++ b/pkg/skaffold/build/gcb/types.go
@@ -86,10 +86,10 @@ type Builder struct {
 // NewBuilder creates a new Builder that builds artifacts with Google Cloud Build.
 func NewBuilder(runCtx *runcontext.RunContext) *Builder {
 	return &Builder{
-		GoogleCloudBuild:   runCtx.Cfg.Build.GoogleCloudBuild,
-		skipTests:          runCtx.Opts.SkipTests,
-		insecureRegistries: runCtx.InsecureRegistries,
-		muted:              runCtx.Opts.Muted,
+		GoogleCloudBuild:   runCtx.Pipeline().Build.GoogleCloudBuild,
+		skipTests:          runCtx.SkipTests(),
+		insecureRegistries: runCtx.GetInsecureRegistries(),
+		muted:              runCtx.Muted(),
 	}
 }
 

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -63,31 +63,31 @@ func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
 	// remove minikubeProfile from here and instead detect it by matching the
 	// kubecontext API Server to minikube profiles
 
-	localCluster, err := getLocalCluster(runCtx.Opts.GlobalConfig, runCtx.Opts.MinikubeProfile)
+	localCluster, err := getLocalCluster(runCtx.GlobalConfig(), runCtx.MinikubeProfile())
 	if err != nil {
 		return nil, fmt.Errorf("getting localCluster: %w", err)
 	}
 
 	var pushImages bool
-	if runCtx.Cfg.Build.LocalBuild.Push == nil {
+	if runCtx.Pipeline().Build.LocalBuild.Push == nil {
 		pushImages = !localCluster
 		logrus.Debugf("push value not present, defaulting to %t because localCluster is %t", pushImages, localCluster)
 	} else {
-		pushImages = *runCtx.Cfg.Build.LocalBuild.Push
+		pushImages = *runCtx.Pipeline().Build.LocalBuild.Push
 	}
 
 	return &Builder{
-		cfg:                *runCtx.Cfg.Build.LocalBuild,
-		kubeContext:        runCtx.KubeContext,
+		cfg:                *runCtx.Pipeline().Build.LocalBuild,
+		kubeContext:        runCtx.GetKubeContext(),
 		localDocker:        localDocker,
 		localCluster:       localCluster,
 		pushImages:         pushImages,
-		skipTests:          runCtx.Opts.SkipTests,
-		devMode:            runCtx.Opts.IsDevMode(),
-		prune:              runCtx.Opts.Prune(),
-		pruneChildren:      !runCtx.Opts.NoPruneChildren,
-		insecureRegistries: runCtx.InsecureRegistries,
-		muted:              runCtx.Opts.Muted,
+		skipTests:          runCtx.SkipTests(),
+		devMode:            runCtx.DevMode(),
+		prune:              runCtx.Prune(),
+		pruneChildren:      !runCtx.NoPruneChildren(),
+		insecureRegistries: runCtx.GetInsecureRegistries(),
+		muted:              runCtx.Muted(),
 	}, nil
 }
 

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -82,11 +82,11 @@ type HelmDeployer struct {
 // NewHelmDeployer returns a configured HelmDeployer
 func NewHelmDeployer(runCtx *runcontext.RunContext, labels map[string]string) *HelmDeployer {
 	return &HelmDeployer{
-		HelmDeploy:  runCtx.Cfg.Deploy.HelmDeploy,
-		kubeContext: runCtx.KubeContext,
-		kubeConfig:  runCtx.Opts.KubeConfig,
-		namespace:   runCtx.Opts.Namespace,
-		forceDeploy: runCtx.Opts.Force,
+		HelmDeploy:  runCtx.Pipeline().Deploy.HelmDeploy,
+		kubeContext: runCtx.GetKubeContext(),
+		kubeConfig:  runCtx.GetKubeConfig(),
+		namespace:   runCtx.GetKubeNamespace(),
+		forceDeploy: runCtx.ForceDeploy(),
 		labels:      labels,
 	}
 }

--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -58,13 +58,13 @@ type KubectlDeployer struct {
 // with the needed configuration for `kubectl apply`
 func NewKubectlDeployer(runCtx *runcontext.RunContext, labels map[string]string) *KubectlDeployer {
 	return &KubectlDeployer{
-		KubectlDeploy:      runCtx.Cfg.Deploy.KubectlDeploy,
-		workingDir:         runCtx.WorkingDir,
-		globalConfig:       runCtx.Opts.GlobalConfig,
-		defaultRepo:        runCtx.Opts.DefaultRepo.Value(),
-		kubectl:            deploy.NewCLI(runCtx, runCtx.Cfg.Deploy.KubectlDeploy.Flags),
-		insecureRegistries: runCtx.InsecureRegistries,
-		skipRender:         runCtx.Opts.SkipRender,
+		KubectlDeploy:      runCtx.Pipeline().Deploy.KubectlDeploy,
+		workingDir:         runCtx.GetWorkingDir(),
+		globalConfig:       runCtx.GlobalConfig(),
+		defaultRepo:        runCtx.DefaultRepo(),
+		kubectl:            deploy.NewCLI(runCtx, runCtx.Pipeline().Deploy.KubectlDeploy.Flags),
+		insecureRegistries: runCtx.GetInsecureRegistries(),
+		skipRender:         runCtx.SkipRender(),
 		labels:             labels,
 	}
 }

--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -46,8 +46,8 @@ func NewCLI(runCtx *runcontext.RunContext, flags latest.KubectlFlags) CLI {
 	return CLI{
 		CLI:              pkgkubectl.NewFromRunContext(runCtx),
 		Flags:            flags,
-		forceDeploy:      runCtx.Opts.Force,
-		waitForDeletions: runCtx.Opts.WaitForDeletions,
+		forceDeploy:      runCtx.ForceDeploy(),
+		waitForDeletions: runCtx.WaitForDeletions(),
 	}
 }
 

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -101,10 +101,10 @@ type KustomizeDeployer struct {
 
 func NewKustomizeDeployer(runCtx *runcontext.RunContext, labels map[string]string) *KustomizeDeployer {
 	return &KustomizeDeployer{
-		KustomizeDeploy:    runCtx.Cfg.Deploy.KustomizeDeploy,
-		kubectl:            deploy.NewCLI(runCtx, runCtx.Cfg.Deploy.KustomizeDeploy.Flags),
-		insecureRegistries: runCtx.InsecureRegistries,
-		globalConfig:       runCtx.Opts.GlobalConfig,
+		KustomizeDeploy:    runCtx.Pipeline().Deploy.KustomizeDeploy,
+		kubectl:            deploy.NewCLI(runCtx, runCtx.Pipeline().Deploy.KustomizeDeploy.Flags),
+		insecureRegistries: runCtx.GetInsecureRegistries(),
+		globalConfig:       runCtx.GlobalConfig(),
 		labels:             labels,
 	}
 }

--- a/pkg/skaffold/deploy/status_check.go
+++ b/pkg/skaffold/deploy/status_check.go
@@ -77,20 +77,20 @@ func statusCheck(ctx context.Context, defaultLabeller *DefaultLabeller, runCtx *
 	}
 
 	deployContext = map[string]string{
-		"clusterName": runCtx.KubeContext,
+		"clusterName": runCtx.GetKubeContext(),
 	}
 
 	deployments := make([]*resource.Deployment, 0)
-	for _, n := range runCtx.Namespaces {
+	for _, n := range runCtx.GetNamespaces() {
 		newDeployments, err := getDeployments(client, n, defaultLabeller,
-			getDeadline(runCtx.Cfg.Deploy.StatusCheckDeadlineSeconds))
+			getDeadline(runCtx.Pipeline().Deploy.StatusCheckDeadlineSeconds))
 		if err != nil {
 			return proto.StatusCode_STATUSCHECK_DEPLOYMENT_FETCH_ERR, fmt.Errorf("could not fetch deployments: %w", err)
 		}
 		deployments = append(deployments, newDeployments...)
 	}
 
-	deadline := statusCheckMaxDeadline(runCtx.Cfg.Deploy.StatusCheckDeadlineSeconds, deployments)
+	deadline := statusCheckMaxDeadline(runCtx.Pipeline().Deploy.StatusCheckDeadlineSeconds, deployments)
 
 	var wg sync.WaitGroup
 

--- a/pkg/skaffold/diagnose/diagnose.go
+++ b/pkg/skaffold/diagnose/diagnose.go
@@ -33,11 +33,11 @@ import (
 )
 
 func CheckArtifacts(ctx context.Context, runCtx *runcontext.RunContext, out io.Writer) error {
-	for _, artifact := range runCtx.Cfg.Build.Artifacts {
+	for _, artifact := range runCtx.Pipeline().Build.Artifacts {
 		color.Default.Fprintf(out, "\n%s: %s\n", typeOfArtifact(artifact), artifact.ImageName)
 
 		if artifact.DockerArtifact != nil {
-			size, err := sizeOfDockerContext(ctx, artifact, runCtx.InsecureRegistries)
+			size, err := sizeOfDockerContext(ctx, artifact, runCtx.GetInsecureRegistries())
 			if err != nil {
 				return fmt.Errorf("computing the size of the Docker context: %w", err)
 			}
@@ -45,11 +45,11 @@ func CheckArtifacts(ctx context.Context, runCtx *runcontext.RunContext, out io.W
 			fmt.Fprintf(out, " - Size of the context: %vbytes\n", size)
 		}
 
-		timeDeps1, deps, err := timeToListDependencies(ctx, artifact, runCtx.InsecureRegistries)
+		timeDeps1, deps, err := timeToListDependencies(ctx, artifact, runCtx.GetInsecureRegistries())
 		if err != nil {
 			return fmt.Errorf("listing artifact dependencies: %w", err)
 		}
-		timeDeps2, _, err := timeToListDependencies(ctx, artifact, runCtx.InsecureRegistries)
+		timeDeps2, _, err := timeToListDependencies(ctx, artifact, runCtx.GetInsecureRegistries())
 		if err != nil {
 			return fmt.Errorf("listing artifact dependencies: %w", err)
 		}
@@ -57,13 +57,13 @@ func CheckArtifacts(ctx context.Context, runCtx *runcontext.RunContext, out io.W
 		fmt.Fprintln(out, " - Dependencies:", len(deps), "files")
 		fmt.Fprintf(out, " - Time to list dependencies: %v (2nd time: %v)\n", timeDeps1, timeDeps2)
 
-		timeSyncMap1, err := timeToConstructSyncMap(artifact, runCtx.InsecureRegistries)
+		timeSyncMap1, err := timeToConstructSyncMap(artifact, runCtx.GetInsecureRegistries())
 		if err != nil {
 			if _, isNotSupported := err.(build.ErrSyncMapNotSupported); !isNotSupported {
 				return fmt.Errorf("construct artifact dependencies: %w", err)
 			}
 		}
-		timeSyncMap2, err := timeToConstructSyncMap(artifact, runCtx.InsecureRegistries)
+		timeSyncMap2, err := timeToConstructSyncMap(artifact, runCtx.GetInsecureRegistries())
 		if err != nil {
 			if _, isNotSupported := err.(build.ErrSyncMapNotSupported); !isNotSupported {
 				return fmt.Errorf("construct artifact dependencies: %w", err)

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -56,8 +56,8 @@ var (
 // NewAPIClientImpl guesses the docker client to use based on current Kubernetes context.
 func NewAPIClientImpl(runCtx *runcontext.RunContext) (LocalDaemon, error) {
 	dockerAPIClientOnce.Do(func() {
-		env, apiClient, err := newAPIClient(runCtx.KubeContext, runCtx.Opts.MinikubeProfile)
-		dockerAPIClient = NewLocalDaemon(apiClient, env, runCtx.Opts.Prune(), runCtx.InsecureRegistries)
+		env, apiClient, err := newAPIClient(runCtx.GetKubeContext(), runCtx.MinikubeProfile())
+		dockerAPIClient = NewLocalDaemon(apiClient, env, runCtx.Prune(), runCtx.GetInsecureRegistries())
 		dockerAPIClientErr = err
 	})
 

--- a/pkg/skaffold/generate_pipeline/generate_pipeline.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline.go
@@ -50,14 +50,14 @@ func Yaml(out io.Writer, runCtx *runcontext.RunContext, configFiles []*ConfigFil
 
 	// Generate build task for pipeline
 	var tasks []*tekton.Task
-	buildTasks, err := generateBuildTasks(runCtx.Opts.Namespace, configFiles)
+	buildTasks, err := generateBuildTasks(runCtx.GetKubeNamespace(), configFiles)
 	if err != nil {
 		return nil, fmt.Errorf("generating build task: %w", err)
 	}
 	tasks = append(tasks, buildTasks...)
 
 	// Generate deploy task for pipeline
-	deployTasks, err := generateDeployTasks(runCtx.Opts.Namespace, configFiles)
+	deployTasks, err := generateDeployTasks(runCtx.GetKubeNamespace(), configFiles)
 	if err != nil {
 		return nil, fmt.Errorf("generating deploy task: %w", err)
 	}

--- a/pkg/skaffold/generate_pipeline/profile.go
+++ b/pkg/skaffold/generate_pipeline/profile.go
@@ -63,7 +63,7 @@ confirmLoop:
 	}
 
 	color.Default.Fprintln(out, "Creating skaffold profile \"oncluster\"...")
-	profile, err := generateProfile(out, runCtx.Opts.Namespace, configFile.Config)
+	profile, err := generateProfile(out, runCtx.GetKubeNamespace(), configFile.Config)
 	if err != nil {
 		return fmt.Errorf("generating profile \"oncluster\": %w", err)
 	}

--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -38,9 +38,9 @@ type CLI struct {
 
 func NewFromRunContext(runCtx *runcontext.RunContext) *CLI {
 	return &CLI{
-		KubeContext: runCtx.KubeContext,
-		KubeConfig:  runCtx.Opts.KubeConfig,
-		Namespace:   runCtx.Opts.Namespace,
+		KubeContext: runCtx.GetKubeContext(),
+		KubeConfig:  runCtx.GetKubeConfig(),
+		Namespace:   runCtx.GetKubeNamespace(),
 	}
 }
 

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -34,7 +34,7 @@ import (
 // BuildAndTest builds and tests a list of artifacts.
 func (r *SkaffoldRunner) BuildAndTest(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 	// Use tags directly from the Kubernetes manifests.
-	if r.runCtx.Opts.DigestSource == noneDigestSource {
+	if r.runCtx.DigestSource() == noneDigestSource {
 		return []build.Artifact{}, nil
 	}
 
@@ -44,7 +44,7 @@ func (r *SkaffoldRunner) BuildAndTest(ctx context.Context, out io.Writer, artifa
 	}
 
 	// In dry-run mode or with --digest-source  set to 'remote', we don't build anything, just return the tag for each artifact.
-	if r.runCtx.Opts.DryRun || (r.runCtx.Opts.DigestSource == remoteDigestSource) {
+	if r.runCtx.DryRun() || (r.runCtx.DigestSource() == remoteDigestSource) {
 		var bRes []build.Artifact
 		for _, artifact := range artifacts {
 			bRes = append(bRes, build.Artifact{
@@ -68,7 +68,7 @@ func (r *SkaffoldRunner) BuildAndTest(ctx context.Context, out io.Writer, artifa
 			return nil, err
 		}
 
-		if !r.runCtx.Opts.SkipTests {
+		if !r.runCtx.SkipTests() {
 			if err = r.tester.Test(ctx, out, bRes); err != nil {
 				return nil, err
 			}
@@ -117,7 +117,7 @@ func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifa
 		return fmt.Errorf("starting logger: %w", err)
 	}
 
-	if r.runCtx.Opts.Tail || r.runCtx.Opts.PortForward.Enabled {
+	if r.runCtx.Tail() || r.runCtx.PortForward() {
 		color.Yellow.Fprintln(out, "Press Ctrl+C to exit")
 		<-ctx.Done()
 	}
@@ -139,7 +139,7 @@ type tagErr struct {
 
 // ApplyDefaultRepo applies the default repo to a given image tag.
 func (r *SkaffoldRunner) ApplyDefaultRepo(tag string) (string, error) {
-	return deploy.ApplyDefaultRepo(r.runCtx.Opts.GlobalConfig, r.runCtx.Opts.DefaultRepo.Value(), tag)
+	return deploy.ApplyDefaultRepo(r.runCtx.GlobalConfig(), r.runCtx.DefaultRepo(), tag)
 }
 
 // imageTags generates tags for a list of artifacts

--- a/pkg/skaffold/runner/debugging.go
+++ b/pkg/skaffold/runner/debugging.go
@@ -21,9 +21,9 @@ import (
 )
 
 func (r *SkaffoldRunner) createContainerManager() *debugging.ContainerManager {
-	if !r.runCtx.Opts.IsDebugMode() {
+	if !r.runCtx.DebugMode() {
 		return nil
 	}
 
-	return debugging.NewContainerManager(r.podSelector, r.runCtx.Namespaces)
+	return debugging.NewContainerManager(r.podSelector, r.runCtx.GetNamespaces())
 }

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -34,8 +34,8 @@ import (
 )
 
 func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []build.Artifact) error {
-	if r.runCtx.Opts.RenderOnly {
-		return r.Render(ctx, out, artifacts, false, r.runCtx.Opts.RenderOutput)
+	if r.runCtx.RenderOnly() {
+		return r.Render(ctx, out, artifacts, false, r.runCtx.RenderOutput())
 	}
 
 	color.Default.Fprintln(out, "Tags used in deployment:")
@@ -58,7 +58,7 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 		return fmt.Errorf("unable to connect to Kubernetes: %w", err)
 	}
 
-	if config.IsImageLoadingRequired(r.runCtx.KubeContext) {
+	if config.IsImageLoadingRequired(r.runCtx.GetKubeContext()) {
 		err := r.loadImagesIntoCluster(ctx, out, artifacts)
 		if err != nil {
 			return err
@@ -84,7 +84,7 @@ func (r *SkaffoldRunner) loadImagesIntoCluster(ctx context.Context, out io.Write
 		return err
 	}
 
-	if config.IsKindCluster(r.runCtx.KubeContext) {
+	if config.IsKindCluster(r.runCtx.GetKubeContext()) {
 		kindCluster := config.KindClusterName(currentContext.Cluster)
 
 		// With `kind`, docker images have to be loaded with the `kind` CLI.
@@ -93,7 +93,7 @@ func (r *SkaffoldRunner) loadImagesIntoCluster(ctx context.Context, out io.Write
 		}
 	}
 
-	if config.IsK3dCluster(r.runCtx.KubeContext) {
+	if config.IsK3dCluster(r.runCtx.GetKubeContext()) {
 		k3dCluster := config.K3dClusterName(currentContext.Cluster)
 
 		// With `k3d`, docker images have to be loaded with the `k3d` CLI.
@@ -111,7 +111,7 @@ func (r *SkaffoldRunner) getCurrentContext() (*api.Context, error) {
 		return nil, fmt.Errorf("unable to get kubernetes config: %w", err)
 	}
 
-	currentContext, present := currentCfg.Contexts[r.runCtx.KubeContext]
+	currentContext, present := currentCfg.Contexts[r.runCtx.GetKubeContext()]
 	if !present {
 		return nil, fmt.Errorf("unable to get current kubernetes context: %w", err)
 	}
@@ -132,7 +132,7 @@ func failIfClusterIsNotReachable() error {
 
 func (r *SkaffoldRunner) performStatusCheck(ctx context.Context, out io.Writer) error {
 	// Check if we need to perform deploy status
-	if !r.runCtx.Opts.StatusCheck {
+	if !r.runCtx.StatusCheck() {
 		return nil
 	}
 

--- a/pkg/skaffold/runner/deploy_test.go
+++ b/pkg/skaffold/runner/deploy_test.go
@@ -131,7 +131,7 @@ func TestDeployNamespace(t *testing.T) {
 				{ImageName: "img2", Tag: "img2:tag2"},
 			})
 
-			t.CheckDeepEqual(test.expected, runner.runCtx.Namespaces)
+			t.CheckDeepEqual(test.expected, runner.runCtx.GetNamespaces())
 		})
 	}
 }

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -148,10 +148,10 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 		default:
 			if err := r.monitor.Register(
 				func() ([]string, error) {
-					return build.DependenciesForArtifact(ctx, artifact, r.runCtx.InsecureRegistries)
+					return build.DependenciesForArtifact(ctx, artifact, r.runCtx.GetInsecureRegistries())
 				},
 				func(e filemon.Events) {
-					s, err := sync.NewItem(ctx, artifact, e, r.builds, r.runCtx.InsecureRegistries)
+					s, err := sync.NewItem(ctx, artifact, e, r.builds, r.runCtx.GetInsecureRegistries())
 					switch {
 					case err != nil:
 						logrus.Warnf("error adding dirty artifact to changeset: %s", err.Error())
@@ -188,11 +188,11 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 
 	// Watch Skaffold configuration
 	if err := r.monitor.Register(
-		func() ([]string, error) { return []string{r.runCtx.Opts.ConfigurationFile}, nil },
+		func() ([]string, error) { return []string{r.runCtx.ConfigurationFile()}, nil },
 		func(filemon.Events) { r.changeSet.needsReload = true },
 	); err != nil {
 		event.DevLoopFailedWithErrorCode(r.devIteration, proto.StatusCode_DEVINIT_REGISTER_CONFIG_DEP, err)
-		return fmt.Errorf("watching skaffold configuration %q: %w", r.runCtx.Opts.ConfigurationFile, err)
+		return fmt.Errorf("watching skaffold configuration %q: %w", r.runCtx.ConfigurationFile(), err)
 	}
 
 	logrus.Infoln("List generated in", time.Since(start))

--- a/pkg/skaffold/runner/generate_pipeline.go
+++ b/pkg/skaffold/runner/generate_pipeline.go
@@ -34,7 +34,7 @@ func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, co
 	// profiles to and what flags to add to task commands
 	baseConfig := []*pipeline.ConfigFile{
 		{
-			Path:    r.runCtx.Opts.ConfigurationFile,
+			Path:    r.runCtx.ConfigurationFile(),
 			Config:  config,
 			Profile: nil,
 		},

--- a/pkg/skaffold/runner/logger.go
+++ b/pkg/skaffold/runner/logger.go
@@ -24,7 +24,7 @@ import (
 )
 
 func (r *SkaffoldRunner) createLogger(out io.Writer, artifacts []build.Artifact) *kubernetes.LogAggregator {
-	if !r.runCtx.Opts.Tail {
+	if !r.runCtx.Tail() {
 		return nil
 	}
 
@@ -33,5 +33,5 @@ func (r *SkaffoldRunner) createLogger(out io.Writer, artifacts []build.Artifact)
 		imageNames = append(imageNames, artifact.Tag)
 	}
 
-	return kubernetes.NewLogAggregator(out, r.kubectlCLI, imageNames, r.podSelector, r.runCtx.Namespaces, r.runCtx.Cfg.Deploy.Logs)
+	return kubernetes.NewLogAggregator(out, r.kubectlCLI, imageNames, r.podSelector, r.runCtx.GetNamespaces(), r.runCtx.Pipeline().Deploy.Logs)
 }

--- a/pkg/skaffold/runner/portforwarder.go
+++ b/pkg/skaffold/runner/portforwarder.go
@@ -23,15 +23,15 @@ import (
 )
 
 func (r *SkaffoldRunner) createForwarder(out io.Writer) *portforward.ForwarderManager {
-	if !r.runCtx.Opts.PortForward.Enabled {
+	if !r.runCtx.PortForward() {
 		return nil
 	}
 
 	return portforward.NewForwarderManager(out,
 		r.kubectlCLI,
 		r.podSelector,
-		r.runCtx.Namespaces,
+		r.runCtx.GetNamespaces(),
 		r.labeller.RunIDSelector(),
 		r.runCtx.Opts.PortForward,
-		r.runCtx.Cfg.PortForward)
+		r.runCtx.Pipeline().PortForward)
 }

--- a/pkg/skaffold/runner/render.go
+++ b/pkg/skaffold/runner/render.go
@@ -28,16 +28,16 @@ import (
 
 func (r *SkaffoldRunner) Render(ctx context.Context, out io.Writer, builds []build.Artifact, offline bool, filepath string) error {
 	//Fetch the digest and append it to the tag with the format of "tag@digest"
-	if r.runCtx.Opts.DigestSource == remoteDigestSource {
+	if r.runCtx.DigestSource() == remoteDigestSource {
 		for i, a := range builds {
-			digest, err := docker.RemoteDigest(a.Tag, r.runCtx.InsecureRegistries)
+			digest, err := docker.RemoteDigest(a.Tag, r.runCtx.GetInsecureRegistries())
 			if err != nil {
 				return fmt.Errorf("failed to resolve the digest of %s, render aborted", a.Tag)
 			}
 			builds[i].Tag = build.TagWithDigest(a.Tag, digest)
 		}
 	}
-	if r.runCtx.Opts.DigestSource == noneDigestSource {
+	if r.runCtx.DigestSource() == noneDigestSource {
 		color.Default.Fprintln(out, "--digest-source set to 'none', tags listed in Kubernetes manifests will be used for render")
 	}
 	return r.deployer.Render(ctx, out, builds, offline, filepath)

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -34,10 +34,50 @@ type RunContext struct {
 	Cfg  latest.Pipeline
 
 	KubeContext        string
-	WorkingDir         string
 	Namespaces         []string
+	WorkingDir         string
 	InsecureRegistries map[string]bool
 }
+
+func (rc *RunContext) GetKubeContext() string                 { return rc.KubeContext }
+func (rc *RunContext) GetNamespaces() []string                { return rc.Namespaces }
+func (rc *RunContext) Pipeline() latest.Pipeline              { return rc.Cfg }
+func (rc *RunContext) GetInsecureRegistries() map[string]bool { return rc.InsecureRegistries }
+func (rc *RunContext) GetWorkingDir() string                  { return rc.WorkingDir }
+
+func (rc *RunContext) AddSkaffoldLabels() bool                   { return rc.Opts.AddSkaffoldLabels }
+func (rc *RunContext) AutoBuild() bool                           { return rc.Opts.AutoBuild }
+func (rc *RunContext) AutoDeploy() bool                          { return rc.Opts.AutoDeploy }
+func (rc *RunContext) AutoSync() bool                            { return rc.Opts.AutoSync }
+func (rc *RunContext) CacheArtifacts() bool                      { return rc.Opts.CacheArtifacts }
+func (rc *RunContext) CacheFile() string                         { return rc.Opts.CacheFile }
+func (rc *RunContext) ConfigurationFile() string                 { return rc.Opts.ConfigurationFile }
+func (rc *RunContext) CustomLabels() []string                    { return rc.Opts.CustomLabels }
+func (rc *RunContext) CustomTag() string                         { return rc.Opts.CustomTag }
+func (rc *RunContext) DebugMode() bool                           { return rc.Opts.IsDebugMode() }
+func (rc *RunContext) DefaultRepo() *string                      { return rc.Opts.DefaultRepo.Value() }
+func (rc *RunContext) DevMode() bool                             { return rc.Opts.IsDevMode() }
+func (rc *RunContext) DigestSource() string                      { return rc.Opts.DigestSource }
+func (rc *RunContext) DryRun() bool                              { return rc.Opts.DryRun }
+func (rc *RunContext) ForceDeploy() bool                         { return rc.Opts.Force }
+func (rc *RunContext) GetKubeConfig() string                     { return rc.Opts.KubeConfig }
+func (rc *RunContext) GetKubeNamespace() string                  { return rc.Opts.Namespace }
+func (rc *RunContext) GlobalConfig() string                      { return rc.Opts.GlobalConfig }
+func (rc *RunContext) MinikubeProfile() string                   { return rc.Opts.MinikubeProfile }
+func (rc *RunContext) Muted() config.Muted                       { return rc.Opts.Muted }
+func (rc *RunContext) NoPruneChildren() bool                     { return rc.Opts.NoPruneChildren }
+func (rc *RunContext) Notification() bool                        { return rc.Opts.Notification }
+func (rc *RunContext) PortForward() bool                         { return rc.Opts.PortForward.Enabled }
+func (rc *RunContext) Prune() bool                               { return rc.Opts.Prune() }
+func (rc *RunContext) RenderOnly() bool                          { return rc.Opts.RenderOnly }
+func (rc *RunContext) RenderOutput() string                      { return rc.Opts.RenderOutput }
+func (rc *RunContext) SkipRender() bool                          { return rc.Opts.SkipRender }
+func (rc *RunContext) SkipTests() bool                           { return rc.Opts.SkipTests }
+func (rc *RunContext) StatusCheck() bool                         { return rc.Opts.StatusCheck }
+func (rc *RunContext) Tail() bool                                { return rc.Opts.Tail }
+func (rc *RunContext) Trigger() string                           { return rc.Opts.Trigger }
+func (rc *RunContext) WaitForDeletions() config.WaitForDeletions { return rc.Opts.WaitForDeletions }
+func (rc *RunContext) WatchPollInterval() int                    { return rc.Opts.WatchPollInterval }
 
 func GetRunContext(opts config.SkaffoldOptions, cfg latest.Pipeline) (*RunContext, error) {
 	kubeConfig, err := kubectx.CurrentConfig()
@@ -80,13 +120,13 @@ func GetRunContext(opts config.SkaffoldOptions, cfg latest.Pipeline) (*RunContex
 	}, nil
 }
 
-func (r *RunContext) UpdateNamespaces(ns []string) {
+func (rc *RunContext) UpdateNamespaces(ns []string) {
 	if len(ns) == 0 {
 		return
 	}
 
 	nsMap := map[string]bool{}
-	for _, ns := range append(ns, r.Namespaces...) {
+	for _, ns := range append(ns, rc.Namespaces...) {
 		nsMap[ns] = true
 	}
 
@@ -96,5 +136,5 @@ func (r *RunContext) UpdateNamespaces(ns []string) {
 		updated = append(updated, k)
 	}
 	sort.Strings(updated)
-	r.Namespaces = updated
+	rc.Namespaces = updated
 }

--- a/pkg/skaffold/sync/types.go
+++ b/pkg/skaffold/sync/types.go
@@ -43,6 +43,6 @@ type podSyncer struct {
 func NewSyncer(runCtx *runcontext.RunContext) Syncer {
 	return &podSyncer{
 		kubectl:    kubectl.NewFromRunContext(runCtx),
-		namespaces: runCtx.Namespaces,
+		namespaces: runCtx.GetNamespaces(),
 	}
 }

--- a/pkg/skaffold/test/test.go
+++ b/pkg/skaffold/test/test.go
@@ -44,9 +44,9 @@ func NewTester(runCtx *runcontext.RunContext, imagesAreLocal bool) Tester {
 	}
 
 	return FullTester{
-		testCases:      runCtx.Cfg.Test,
-		muted:          runCtx.Opts.Muted,
-		workingDir:     runCtx.WorkingDir,
+		testCases:      runCtx.Pipeline().Test,
+		workingDir:     runCtx.GetWorkingDir(),
+		muted:          runCtx.Muted(),
 		localDaemon:    localDaemon,
 		imagesAreLocal: imagesAreLocal,
 	}

--- a/pkg/skaffold/trigger/triggers.go
+++ b/pkg/skaffold/trigger/triggers.go
@@ -42,28 +42,28 @@ type Trigger interface {
 }
 
 // NewTrigger creates a new trigger.
-func NewTrigger(runctx *runcontext.RunContext) (Trigger, error) {
-	switch strings.ToLower(runctx.Opts.Trigger) {
+func NewTrigger(runCtx *runcontext.RunContext) (Trigger, error) {
+	switch strings.ToLower(runCtx.Trigger()) {
 	case "polling":
 		return &pollTrigger{
-			Interval: time.Duration(runctx.Opts.WatchPollInterval) * time.Millisecond,
+			Interval: time.Duration(runCtx.WatchPollInterval()) * time.Millisecond,
 		}, nil
 	case "notify":
-		return newFSNotifyTrigger(runctx), nil
+		return newFSNotifyTrigger(runCtx), nil
 	case "manual":
 		return &manualTrigger{}, nil
 	default:
-		return nil, fmt.Errorf("unsupported trigger: %s", runctx.Opts.Trigger)
+		return nil, fmt.Errorf("unsupported trigger: %s", runCtx.Trigger())
 	}
 }
 
-func newFSNotifyTrigger(runctx *runcontext.RunContext) *fsNotifyTrigger {
+func newFSNotifyTrigger(runCtx *runcontext.RunContext) *fsNotifyTrigger {
 	workspaces := map[string]struct{}{}
-	for _, a := range runctx.Cfg.Build.Artifacts {
+	for _, a := range runCtx.Pipeline().Build.Artifacts {
 		workspaces[a.Workspace] = struct{}{}
 	}
 	return &fsNotifyTrigger{
-		Interval:   time.Duration(runctx.Opts.WatchPollInterval) * time.Millisecond,
+		Interval:   time.Duration(runCtx.WatchPollInterval()) * time.Millisecond,
 		workspaces: workspaces,
 	}
 }


### PR DESCRIPTION
This is a first step towards refactoring the RunContext.

**What’s nice about this step is that it’s not dangerous.**
We are just replacing fields with getters to later introduce interfaces.

Signed-off-by: David Gageot <david@gageot.net>
