### PR TITLE
TagTemplate Feature w/ Docs

### DIFF
--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -145,7 +145,7 @@ You can learn more about what time format and time zone you can use in
 example, `dateTime`
 tag policy features two optional parameters: `format` and `timezone`.
 
-## `tagTemplate`: uses a combination of the previous taggers as tags
+## `tagTemplate`: uses a combination of the existing taggers as components in a template
 
 `tagTemplate` allows you to combine all previous taggers to create your own tagging policy.
 This policy requires that you specify a tag template,

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -163,7 +163,7 @@ it will evaluate `FOO` and `BAR` and use their values to tag the image.
 <b>Note</b><br>
 
 `GIT`, `DATE`, and `SHA` are special built-in component references that will evaluate to the default gitCommit, dateTime, and sha256 taggers, respectively.
-User can overwrite these values by defining a component with one of these names.
+Users can overwrite these values by defining a component with one of these names.
 {{< /alert >}}
 
 ### Example

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -150,7 +150,7 @@ tag policy features two optional parameters: `format` and `timezone`.
 `tagTemplate` allows you to combine all existing taggers to create a custom tagging policy.
 This policy requires that you specify a tag template,
 using a combination of plaintext and references to other tagging strategies which will be evaluated at runtime.
-These other tagging strategies are called components, which can be
+We refer to these individual parts as "components", which can be
 a `gitCommit`, `sha256`, `envTemplate`, or `dateTime` tagger.
 
 The following `build` section, for example, instructs Skaffold to build a Docker image

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -174,6 +174,6 @@ Suppose the current time is `15:04:09.999 January 2nd, 2006` and the abbreviated
 
 ### Configuration
 
-The tag template uses the [Go Programming Language Syntax](https://golang.org/pkg/text/template/).
+The tag template uses the [Golang Templating Syntax](https://golang.org/pkg/text/template/).
 As showcased in the example, `tagTemplate` tag policy features one
 **required** parameter, `template`, which is the tag template to use. To learn more about templating support in Skaffold.yaml see [Templated fields]({{< relref "../environment/templating.md" >}})

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -12,7 +12,7 @@ Skaffold supports multiple taggers or tag policies for tagging images:
  + the `sha256` tagger uses `latest` to tag images.
  + the `envTemplate` tagger uses environment variables to tag images.
  + the `datetime` tagger uses current date and time, with a configurable pattern.
- + the `tagTemplate` tagger uses a combination of the previous taggers to tag images.
+ + the `tagTemplate` tagger uses a combination of the existing taggers as components in a template.
 
 The default tagger, if none is specified in the `skaffold.yaml`, is the `gitCommit` tagger.
 

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -151,7 +151,7 @@ tag policy features two optional parameters: `format` and `timezone`.
 This policy requires that you specify a tag template,
 using a combination of plaintext and references to other tagging strategies which will be evaluated at runtime.
 We refer to these individual parts as "components", which can be
-a `gitCommit`, `sha256`, `envTemplate`, or `dateTime` tagger.
+any of the other existing supported tagging strategies. Nested `tagTemplate` components are not supported.
 
 The following `build` section, for example, instructs Skaffold to build a Docker image
 `gcr.io/k8s-skaffold/example` with the `tagTemplate` tag policy.

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -12,6 +12,7 @@ Skaffold supports multiple taggers or tag policies for tagging images:
  + the `sha256` tagger uses `latest` to tag images.
  + the `envTemplate` tagger uses environment variables to tag images.
  + the `datetime` tagger uses current date and time, with a configurable pattern.
+ + the `tagTemplate` tagger uses a combination of the previous taggers to tag images.
 
 The default tagger, if none is specified in the `skaffold.yaml`, is the `gitCommit` tagger.
 
@@ -143,3 +144,36 @@ You can learn more about what time format and time zone you can use in
 [Go Programming Language Documentation: Time package/LoadLocation Function](https://golang.org/pkg/time#LoadLocation) respectively. As showcased in the
 example, `dateTime`
 tag policy features two optional parameters: `format` and `timezone`.
+
+## `tagTemplate`: uses a combination of the previous taggers as tags
+
+`tagTemplate` allows you to combine all previous taggers to create your own tagging policy.
+This policy requires that you specify a tag template,
+where part of template can be replaced with the result of other tagging strategies during the tagging process.
+These other tagging strategies are called components, which can be
+a `gitCommit`, `sha256`, `envTemplate`, or `dateTime` tagger.
+
+The following `build` section, for example, instructs Skaffold to build a Docker image
+`gcr.io/k8s-skaffold/example` with the `tagTemplate` tag policy.
+The tag template is `{{.FOO}}_{{.BAR}}`. The components are a `dateTime` tagger
+named `FOO` and a `gitCommit` tagger named `BAR`. When Skaffold finishes building the image,
+it will evaluate `FOO` and `BAR` and use their values to tag the image.
+
+{{< alert >}}
+<b>Note</b><br>
+
+`GIT`, `DATE`, and `SHA` are built-in component values that will evaluate to the default gitCommit, dateTime, and sha256 taggers, respectively.
+User can overwrite these values by defining a component with one of these names.
+{{< /alert >}}
+
+### Example
+
+{{% readfile file="samples/taggers/tagTemplate.yaml" %}}
+
+Suppose current time is `15:04:09.999 January 2nd, 2006` and the abbreviated commit sha was `25c65e0`, the image built will be `gcr.io/k8s-skaffold/example:2006-01-02_25c65e0`.
+
+### Configuration
+
+The tag template uses the [Go Programming Language Syntax](https://golang.org/pkg/text/template/).
+As showcased in the example, `tagTemplate` tag policy features one
+**required** parameter, `template`, which is the tag template to use. To learn more about templating support in Skaffold.yaml see [Templated fields]({{< relref "../environment/templating.md" >}})

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -162,7 +162,7 @@ it will evaluate `FOO` and `BAR` and use their values to tag the image.
 {{< alert >}}
 <b>Note</b><br>
 
-`GIT`, `DATE`, and `SHA` are built-in component values that will evaluate to the default gitCommit, dateTime, and sha256 taggers, respectively.
+`GIT`, `DATE`, and `SHA` are special built-in component references that will evaluate to the default gitCommit, dateTime, and sha256 taggers, respectively.
 User can overwrite these values by defining a component with one of these names.
 {{< /alert >}}
 

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -149,7 +149,7 @@ tag policy features two optional parameters: `format` and `timezone`.
 
 `tagTemplate` allows you to combine all existing taggers to create a custom tagging policy.
 This policy requires that you specify a tag template,
-where part of template can be replaced with the result of other tagging strategies during the tagging process.
+using a combination of plaintext and references to other tagging strategies which will be evaluated at runtime.
 These other tagging strategies are called components, which can be
 a `gitCommit`, `sha256`, `envTemplate`, or `dateTime` tagger.
 

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -176,4 +176,4 @@ Suppose the current time is `15:04:09.999 January 2nd, 2006` and the abbreviated
 
 The tag template uses the [Golang Templating Syntax](https://golang.org/pkg/text/template/).
 As showcased in the example, `tagTemplate` tag policy features one
-**required** parameter, `template`, which is the tag template to use. To learn more about templating support in Skaffold.yaml see [Templated fields]({{< relref "../environment/templating.md" >}})
+**required** parameter, `template`, which is the tag template to use. To learn more about templating support in the skaffold.yaml, see [Templated fields]({{< relref "../environment/templating.md" >}})

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -170,7 +170,7 @@ User can overwrite these values by defining a component with one of these names.
 
 {{% readfile file="samples/taggers/tagTemplate.yaml" %}}
 
-Suppose current time is `15:04:09.999 January 2nd, 2006` and the abbreviated commit sha was `25c65e0`, the image built will be `gcr.io/k8s-skaffold/example:2006-01-02_25c65e0`.
+Suppose the current time is `15:04:09.999 January 2nd, 2006` and the abbreviated commit sha is `25c65e0`, the image built will be `gcr.io/k8s-skaffold/example:2006-01-02_25c65e0`.
 
 ### Configuration
 

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -12,7 +12,7 @@ Skaffold supports multiple taggers or tag policies for tagging images:
  + the `sha256` tagger uses `latest` to tag images.
  + the `envTemplate` tagger uses environment variables to tag images.
  + the `datetime` tagger uses current date and time, with a configurable pattern.
- + the `tagTemplate` tagger uses a combination of the existing taggers as components in a template.
+ + the `customTemplate` tagger uses a combination of the existing taggers as components in a template.
 
 The default tagger, if none is specified in the `skaffold.yaml`, is the `gitCommit` tagger.
 
@@ -145,16 +145,16 @@ You can learn more about what time format and time zone you can use in
 example, `dateTime`
 tag policy features two optional parameters: `format` and `timezone`.
 
-## `tagTemplate`: uses a combination of the existing taggers as components in a template
+## `customTemplate`: uses a combination of the existing taggers as components in a template
 
-`tagTemplate` allows you to combine all existing taggers to create a custom tagging policy.
+`customTemplate` allows you to combine all existing taggers to create a custom tagging policy.
 This policy requires that you specify a tag template,
 using a combination of plaintext and references to other tagging strategies which will be evaluated at runtime.
 We refer to these individual parts as "components", which can be
-any of the other existing supported tagging strategies. Nested `tagTemplate` components are not supported.
+any of the other existing supported tagging strategies. Nested `customTemplate` components are not supported.
 
 The following `build` section, for example, instructs Skaffold to build a Docker image
-`gcr.io/k8s-skaffold/example` with the `tagTemplate` tag policy.
+`gcr.io/k8s-skaffold/example` with the `customTemplate` tag policy.
 The tag template is `{{.FOO}}_{{.BAR}}`. The components are a `dateTime` tagger
 named `FOO` and a `gitCommit` tagger named `BAR`. When Skaffold finishes building the image,
 it will evaluate `FOO` and `BAR` and use their values to tag the image.
@@ -168,12 +168,12 @@ Users can overwrite these values by defining a component with one of these names
 
 ### Example
 
-{{% readfile file="samples/taggers/tagTemplate.yaml" %}}
+{{% readfile file="samples/taggers/customTemplate.yaml" %}}
 
 Suppose the current time is `15:04:09.999 January 2nd, 2006` and the abbreviated commit sha is `25c65e0`, the image built will be `gcr.io/k8s-skaffold/example:2006-01-02_25c65e0`.
 
 ### Configuration
 
 The tag template uses the [Golang Templating Syntax](https://golang.org/pkg/text/template/).
-As showcased in the example, `tagTemplate` tag policy features one
+As showcased in the example, `customTemplate` tag policy features one
 **required** parameter, `template`, which is the tag template to use. To learn more about templating support in the skaffold.yaml, see [Templated fields]({{< relref "../environment/templating.md" >}})

--- a/docs/content/en/docs/pipeline-stages/taggers.md
+++ b/docs/content/en/docs/pipeline-stages/taggers.md
@@ -147,7 +147,7 @@ tag policy features two optional parameters: `format` and `timezone`.
 
 ## `tagTemplate`: uses a combination of the existing taggers as components in a template
 
-`tagTemplate` allows you to combine all previous taggers to create your own tagging policy.
+`tagTemplate` allows you to combine all existing taggers to create a custom tagging policy.
 This policy requires that you specify a tag template,
 where part of template can be replaced with the result of other tagging strategies during the tagging process.
 These other tagging strategies are called components, which can be

--- a/docs/content/en/samples/taggers/customTemplate.yaml
+++ b/docs/content/en/samples/taggers/customTemplate.yaml
@@ -1,6 +1,6 @@
 build:
   tagPolicy:
-    tagTemplate:
+    customTemplate:
       template: "{{.FOO}}_{{.BAR}}"
       components:
       - name: FOO

--- a/docs/content/en/samples/taggers/tagTemplate.yaml
+++ b/docs/content/en/samples/taggers/tagTemplate.yaml
@@ -12,3 +12,4 @@ build:
           variant: AbbrevCommitSha
   artifacts:
   - image: gcr.io/k8s-skaffold/example
+  

--- a/docs/content/en/samples/taggers/tagTemplate.yaml
+++ b/docs/content/en/samples/taggers/tagTemplate.yaml
@@ -1,0 +1,14 @@
+build:
+  tagPolicy:
+    tagTemplate:
+      template: "{{.FOO}}_{{.BAR}}"
+      components:
+      - name: FOO
+        dateTime:
+          format: "2006-01-02"
+          timezone: "UTC"
+      - name: BAR
+        gitCommit:
+          variant: AbbrevCommitSha
+  artifacts:
+  - image: gcr.io/k8s-skaffold/example

--- a/docs/content/en/schemas/v2beta6.json
+++ b/docs/content/en/schemas/v2beta6.json
@@ -2087,38 +2087,149 @@
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
-    "TagPolicy": {
+    "TaggerComponent": {
+      "anyOf": [
+        {
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "gitCommit": {
+              "$ref": "#/definitions/GitTagger",
+              "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
+              "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
+            },
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "gitCommit"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            },
+            "sha256": {
+              "$ref": "#/definitions/ShaTagger",
+              "description": "*beta* tags images with their sha256 digest.",
+              "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "sha256"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "envTemplate": {
+              "$ref": "#/definitions/EnvTemplateTagger",
+              "description": "*beta* tags images with a configurable template string.",
+              "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
+            },
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "envTemplate"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "dateTime": {
+              "$ref": "#/definitions/DateTimeTagger",
+              "description": "*beta* tags images with the build timestamp.",
+              "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
+            },
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "dateTime"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            },
+            "tagTemplate": {
+              "$ref": "#/definitions/TemplateTagger",
+              "description": "*beta* tags images with a configurable template string *composed of other taggers*.",
+              "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string <em>composed of other taggers</em>."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "tagTemplate"
+          ],
+          "additionalProperties": false
+        }
+      ],
+      "description": "*beta* a component of TemplateTagger.",
+      "x-intellij-html-description": "<em>beta</em> a component of TemplateTagger."
+    },
+    "TemplateTagger": {
+      "required": [
+        "template"
+      ],
       "properties": {
-        "dateTime": {
-          "$ref": "#/definitions/DateTimeTagger",
-          "description": "*beta* tags images with the build timestamp.",
-          "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
+        "components": {
+          "items": {
+            "$ref": "#/definitions/TaggerComponent"
+          },
+          "type": "array",
+          "description": "TaggerComponents that the template (see field above) can be executed against.",
+          "x-intellij-html-description": "TaggerComponents that the template (see field above) can be executed against."
         },
-        "envTemplate": {
-          "$ref": "#/definitions/EnvTemplateTagger",
-          "description": "*beta* tags images with a configurable template string.",
-          "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
-        },
-        "gitCommit": {
-          "$ref": "#/definitions/GitTagger",
-          "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
-          "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
-        },
-        "sha256": {
-          "$ref": "#/definitions/ShaTagger",
-          "description": "*beta* tags images with their sha256 digest.",
-          "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
+        "template": {
+          "type": "string",
+          "description": "used to produce the image name and tag. See golang [text/template](https://golang.org/pkg/text/template/). The template is executed against the provided components with those variables injected.",
+          "x-intellij-html-description": "used to produce the image name and tag. See golang <a href=\"https://golang.org/pkg/text/template/\">text/template</a>. The template is executed against the provided components with those variables injected.",
+          "examples": [
+            "{{.DATE}}"
+          ]
         }
       },
       "preferredOrder": [
-        "gitCommit",
-        "sha256",
-        "envTemplate",
-        "dateTime"
+        "template",
+        "components"
       ],
       "additionalProperties": false,
-      "description": "contains all the configuration for the tagging step.",
-      "x-intellij-html-description": "contains all the configuration for the tagging step."
+      "description": "*beta* tags images with a configurable template string.",
+      "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
     "TestCase": {
       "required": [

--- a/pkg/skaffold/build/tag/custom_template.go
+++ b/pkg/skaffold/build/tag/custom_template.go
@@ -24,34 +24,34 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// templateTagger implements Tagger
-type templateTagger struct {
+// CustomTemplateTagger implements Tagger
+type CustomTemplateTagger struct {
 	Template   *template.Template
 	Components map[string]Tagger
 }
 
-// NewTemplateTagger creates a new TemplateTagger
-func NewTemplateTagger(t string, components map[string]Tagger) (Tagger, error) {
-	tmpl, err := ParseTagTemplate(t)
+// NewCustomTemplateTagger creates a new CustomTemplateTagger
+func NewCustomTemplateTagger(t string, components map[string]Tagger) (Tagger, error) {
+	tmpl, err := ParseCustomTemplate(t)
 	if err != nil {
 		return nil, fmt.Errorf("parsing template: %w", err)
 	}
 
-	return &templateTagger{
+	return &CustomTemplateTagger{
 		Template:   tmpl,
 		Components: components,
 	}, nil
 }
 
 // GenerateTag generates a tag from a template referencing tagging strategies.
-func (t *templateTagger) GenerateTag(workingDir, imageName string) (string, error) {
+func (t *CustomTemplateTagger) GenerateTag(workingDir, imageName string) (string, error) {
 	customMap, err := t.EvaluateComponents(workingDir, imageName)
 	if err != nil {
 		return "", err
 	}
 
 	// missingkey=error throws error when map is indexed with an undefined key
-	tag, err := ExecuteTagTemplate(t.Template.Option("missingkey=error"), customMap)
+	tag, err := ExecuteCustomTemplate(t.Template.Option("missingkey=error"), customMap)
 	if err != nil {
 		return "", err
 	}
@@ -60,7 +60,7 @@ func (t *templateTagger) GenerateTag(workingDir, imageName string) (string, erro
 }
 
 // EvaluateComponents creates a custom mapping of component names to their tagger string representation.
-func (t *templateTagger) EvaluateComponents(workingDir, imageName string) (map[string]string, error) {
+func (t *CustomTemplateTagger) EvaluateComponents(workingDir, imageName string) (map[string]string, error) {
 	customMap := map[string]string{}
 
 	gitTagger, _ := NewGitCommit("", "")
@@ -72,28 +72,28 @@ func (t *templateTagger) EvaluateComponents(workingDir, imageName string) (map[s
 	}
 
 	for k, v := range t.Components {
-		if _, ok := v.(*templateTagger); ok {
-			return nil, fmt.Errorf("invalid component specified in tag template: %v", v)
+		if _, ok := v.(*CustomTemplateTagger); ok {
+			return nil, fmt.Errorf("invalid component specified in custom template: %v", v)
 		}
 		tag, err := v.GenerateTag(workingDir, imageName)
 		if err != nil {
-			return nil, fmt.Errorf("evaluating tag template component: %w", err)
+			return nil, fmt.Errorf("evaluating custom template component: %w", err)
 		}
 		customMap[k] = tag
 	}
 	return customMap, nil
 }
 
-// ParseTagTemplate is a simple wrapper to parse an tag template.
-func ParseTagTemplate(t string) (*template.Template, error) {
-	return template.New("tagTemplate").Parse(t)
+// ParseCustomTemplate is a simple wrapper to parse an custom template.
+func ParseCustomTemplate(t string) (*template.Template, error) {
+	return template.New("customTemplate").Parse(t)
 }
 
-// ExecuteTagTemplate executes a tagTemplate against a custom map.
-func ExecuteTagTemplate(tagTemplate *template.Template, customMap map[string]string) (string, error) {
+// ExecuteCustomTemplate executes a customTemplate against a custom map.
+func ExecuteCustomTemplate(customTemplate *template.Template, customMap map[string]string) (string, error) {
 	var buf bytes.Buffer
-	logrus.Debugf("Executing tag template %v with custom map %v", tagTemplate, customMap)
-	if err := tagTemplate.Execute(&buf, customMap); err != nil {
+	logrus.Debugf("Executing custom template %v with custom map %v", customTemplate, customMap)
+	if err := customTemplate.Execute(&buf, customMap); err != nil {
 		return "", fmt.Errorf("executing template: %w", err)
 	}
 	return buf.String(), nil

--- a/pkg/skaffold/build/tag/custom_template.go
+++ b/pkg/skaffold/build/tag/custom_template.go
@@ -24,27 +24,27 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// CustomTemplateTagger implements Tagger
-type CustomTemplateTagger struct {
+// customTemplateTagger implements Tagger
+type customTemplateTagger struct {
 	Template   *template.Template
 	Components map[string]Tagger
 }
 
-// NewCustomTemplateTagger creates a new CustomTemplateTagger
+// NewCustomTemplateTagger creates a new customTemplateTagger
 func NewCustomTemplateTagger(t string, components map[string]Tagger) (Tagger, error) {
 	tmpl, err := ParseCustomTemplate(t)
 	if err != nil {
 		return nil, fmt.Errorf("parsing template: %w", err)
 	}
 
-	return &CustomTemplateTagger{
+	return &customTemplateTagger{
 		Template:   tmpl,
 		Components: components,
 	}, nil
 }
 
 // GenerateTag generates a tag from a template referencing tagging strategies.
-func (t *CustomTemplateTagger) GenerateTag(workingDir, imageName string) (string, error) {
+func (t *customTemplateTagger) GenerateTag(workingDir, imageName string) (string, error) {
 	customMap, err := t.EvaluateComponents(workingDir, imageName)
 	if err != nil {
 		return "", err
@@ -60,7 +60,7 @@ func (t *CustomTemplateTagger) GenerateTag(workingDir, imageName string) (string
 }
 
 // EvaluateComponents creates a custom mapping of component names to their tagger string representation.
-func (t *CustomTemplateTagger) EvaluateComponents(workingDir, imageName string) (map[string]string, error) {
+func (t *customTemplateTagger) EvaluateComponents(workingDir, imageName string) (map[string]string, error) {
 	customMap := map[string]string{}
 
 	gitTagger, _ := NewGitCommit("", "")
@@ -72,7 +72,7 @@ func (t *CustomTemplateTagger) EvaluateComponents(workingDir, imageName string) 
 	}
 
 	for k, v := range t.Components {
-		if _, ok := v.(*CustomTemplateTagger); ok {
+		if _, ok := v.(*customTemplateTagger); ok {
 			return nil, fmt.Errorf("invalid component specified in custom template: %v", v)
 		}
 		tag, err := v.GenerateTag(workingDir, imageName)

--- a/pkg/skaffold/build/tag/custom_template_test.go
+++ b/pkg/skaffold/build/tag/custom_template_test.go
@@ -37,7 +37,7 @@ func TestTagTemplate_GenerateTag(t *testing.T) {
 	invalidEnvTemplate, _ := NewEnvTemplateTagger("{{.BAR}}")
 	env := []string{"FOO=BAR"}
 
-	tagTemplateExample, _ := NewTemplateTagger("", nil)
+	customTemplateExample, _ := NewCustomTemplateTagger("", nil)
 
 	tests := []struct {
 		description string
@@ -67,9 +67,9 @@ func TestTagTemplate_GenerateTag(t *testing.T) {
 			expected:    "foo-BAR-latest",
 		},
 		{
-			description: "using tagTemplate as a component",
+			description: "using customTemplate as a component",
 			template:    "{{.FOO}}",
-			customMap:   map[string]Tagger{"FOO": tagTemplateExample},
+			customMap:   map[string]Tagger{"FOO": customTemplateExample},
 			shouldErr:   true,
 		},
 		{
@@ -99,7 +99,7 @@ func TestTagTemplate_GenerateTag(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.OSEnviron, func() []string { return env })
 
-			c, err := NewTemplateTagger(test.template, test.customMap)
+			c, err := NewCustomTemplateTagger(test.template, test.customMap)
 
 			t.CheckNoError(err)
 
@@ -110,7 +110,7 @@ func TestTagTemplate_GenerateTag(t *testing.T) {
 	}
 }
 
-func TestTagTemplate_NewTemplateTagger(t *testing.T) {
+func TestCustomTemplate_NewCustomTemplateTagger(t *testing.T) {
 	tests := []struct {
 		description string
 		template    string
@@ -140,13 +140,13 @@ func TestTagTemplate_NewTemplateTagger(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			_, err := NewTemplateTagger(test.template, test.customMap)
+			_, err := NewCustomTemplateTagger(test.template, test.customMap)
 			t.CheckError(test.shouldErr, err)
 		})
 	}
 }
 
-func TestTagTemplate_ExecuteTagTemplate(t *testing.T) {
+func TestCustomTemplate_ExecuteCustomTemplate(t *testing.T) {
 	tests := []struct {
 		description string
 		template    string
@@ -189,16 +189,16 @@ func TestTagTemplate_ExecuteTagTemplate(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			testTemplate, err := ParseTagTemplate(test.template)
+			testTemplate, err := ParseCustomTemplate(test.template)
 			t.CheckNoError(err)
 
-			got, err := ExecuteTagTemplate(testTemplate.Option("missingkey=error"), test.customMap)
+			got, err := ExecuteCustomTemplate(testTemplate.Option("missingkey=error"), test.customMap)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, got)
 		})
 	}
 }
 
-func TestTagTemplate_ParseTagTemplate(t *testing.T) {
+func TestCustomTemplate_ParseCustomTemplate(t *testing.T) {
 	tests := []struct {
 		description string
 		template    string
@@ -216,7 +216,7 @@ func TestTagTemplate_ParseTagTemplate(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			_, err := ParseTagTemplate(test.template)
+			_, err := ParseCustomTemplate(test.template)
 			t.CheckError(test.shouldErr, err)
 		})
 	}

--- a/pkg/skaffold/build/tag/git_commit_test.go
+++ b/pkg/skaffold/build/tag/git_commit_test.go
@@ -399,7 +399,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 	}
 }
 
-func TestGitCommit_TagTemplate(t *testing.T) {
+func TestGitCommit_CustomTemplate(t *testing.T) {
 	gitCommitExample, _ := NewGitCommit("", "CommitSha")
 	tests := []struct {
 		description   string
@@ -440,7 +440,7 @@ func TestGitCommit_TagTemplate(t *testing.T) {
 			test.createGitRepo(tmpDir.Root())
 			workspace := tmpDir.Path(test.subDir)
 
-			c, err := NewTemplateTagger(test.template, test.customMap)
+			c, err := NewCustomTemplateTagger(test.template, test.customMap)
 
 			t.CheckNoError(err)
 

--- a/pkg/skaffold/build/tag/tag_test.go
+++ b/pkg/skaffold/build/tag/tag_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -40,6 +41,8 @@ func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 		timeFn:   func() time.Time { return aLocalTimeStamp },
 	}
 	dateTimeExpected := "2015-03-07"
+
+	customTemplateExample, _ := NewCustomTemplateTagger("{{.DATE}}_{{.SHA}}", map[string]Tagger{"DATE": dateTimeExample})
 
 	tests := []struct {
 		description      string
@@ -95,6 +98,12 @@ func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 				timeFn:   func() time.Time { return aLocalTimeStamp },
 			},
 			shouldErr: true,
+		},
+		{
+			description: "customTemplate",
+			imageName:   "test",
+			tagger:      customTemplateExample,
+			expected:    fmt.Sprintf("test:%s_%s", dateTimeExpected, "latest"),
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/build/tag/tag_test.go
+++ b/pkg/skaffold/build/tag/tag_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package tag
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -103,7 +102,7 @@ func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 			description: "customTemplate",
 			imageName:   "test",
 			tagger:      customTemplateExample,
-			expected:    fmt.Sprintf("test:%s_%s", dateTimeExpected, "latest"),
+			expected:    "test:" + dateTimeExpected + "_latest",
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -230,22 +230,22 @@ func getTagger(runCtx *runcontext.RunContext) (tag.Tagger, error) {
 	case t.DateTimeTagger != nil:
 		return tag.NewDateTimeTagger(t.DateTimeTagger.Format, t.DateTimeTagger.TimeZone), nil
 
-	case t.TemplateTagger != nil:
-		components, err := CreateComponents(t.TemplateTagger)
+	case t.CustomTemplateTagger != nil:
+		components, err := CreateComponents(t.CustomTemplateTagger)
 
 		if err != nil {
 			return nil, fmt.Errorf("creating components: %w", err)
 		}
 
-		return tag.NewTemplateTagger(t.TemplateTagger.Template, components)
+		return tag.NewCustomTemplateTagger(t.CustomTemplateTagger.Template, components)
 
 	default:
 		return nil, fmt.Errorf("unknown tagger for strategy %+v", t)
 	}
 }
 
-// CreateComponents creates a map of taggers for TemplateTagger
-func CreateComponents(t *latest.TemplateTagger) (map[string]tag.Tagger, error) {
+// CreateComponents creates a map of taggers for CustomTemplateTagger
+func CreateComponents(t *latest.CustomTemplateTagger) (map[string]tag.Tagger, error) {
 	components := map[string]tag.Tagger{}
 
 	for _, taggerComponent := range t.Components {
@@ -268,11 +268,11 @@ func CreateComponents(t *latest.TemplateTagger) (map[string]tag.Tagger, error) {
 		case c.DateTimeTagger != nil:
 			components[name] = tag.NewDateTimeTagger(c.DateTimeTagger.Format, c.DateTimeTagger.TimeZone)
 
-		case c.TemplateTagger != nil:
-			return nil, fmt.Errorf("nested tagTemplate components are not supported in skaffold (%s)", name)
+		case c.CustomTemplateTagger != nil:
+			return nil, fmt.Errorf("nested customTemplate components are not supported in skaffold (%s)", name)
 
 		default:
-			return nil, fmt.Errorf("unknown component for tagTemplate: %s %+v", name, c)
+			return nil, fmt.Errorf("unknown component for custom template: %s %+v", name, c)
 		}
 	}
 

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -269,7 +269,7 @@ func CreateComponents(t *latest.TemplateTagger) (map[string]tag.Tagger, error) {
 			components[name] = tag.NewDateTimeTagger(c.DateTimeTagger.Format, c.DateTimeTagger.TimeZone)
 
 		case c.TemplateTagger != nil:
-			return nil, fmt.Errorf("cannot use tagTemplate as a component: %s %+v", name, c)
+			return nil, fmt.Errorf("nested tagTemplate components are not supported in skaffold (%s)", name)
 
 		default:
 			return nil, fmt.Errorf("unknown component for tagTemplate: %s %+v", name, c)

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -230,7 +230,51 @@ func getTagger(runCtx *runcontext.RunContext) (tag.Tagger, error) {
 	case t.DateTimeTagger != nil:
 		return tag.NewDateTimeTagger(t.DateTimeTagger.Format, t.DateTimeTagger.TimeZone), nil
 
+	case t.TagTemplateTagger != nil:
+		components, err := CreateComponents(t.TagTemplateTagger)
+
+		if err != nil {
+			return nil, fmt.Errorf("creating components: %w", err)
+		}
+
+		return tag.NewTemplateTagger(t.TagTemplateTagger.Template, components)
+
 	default:
 		return nil, fmt.Errorf("unknown tagger for strategy %+v", t)
 	}
+}
+
+// CreateComponents creates a map of taggers for TagTemplateTagger
+func CreateComponents(t *latest.TagTemplateTagger) (map[string]tag.Tagger, error) {
+	components := map[string]tag.Tagger{}
+
+	for _, taggerComponent := range t.Components {
+		name, c := taggerComponent.Name, taggerComponent.Component
+
+		if _, ok := components[name]; ok {
+			return nil, fmt.Errorf("multiple components with name %s", name)
+		}
+
+		switch {
+		case c.EnvTemplateTagger != nil:
+			components[name], _ = tag.NewEnvTemplateTagger(c.EnvTemplateTagger.Template)
+
+		case c.ShaTagger != nil:
+			components[name] = &tag.ChecksumTagger{}
+
+		case c.GitTagger != nil:
+			components[name], _ = tag.NewGitCommit(c.GitTagger.Prefix, c.GitTagger.Variant)
+
+		case c.DateTimeTagger != nil:
+			components[name] = tag.NewDateTimeTagger(c.DateTimeTagger.Format, c.DateTimeTagger.TimeZone)
+
+		case c.TagTemplateTagger != nil:
+			return nil, fmt.Errorf("cannot use tagTemplate as a component: %s %+v", name, c)
+
+		default:
+			return nil, fmt.Errorf("unknown component for tagTemplate: %s %+v", name, c)
+		}
+	}
+
+	return components, nil
 }

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -230,22 +230,22 @@ func getTagger(runCtx *runcontext.RunContext) (tag.Tagger, error) {
 	case t.DateTimeTagger != nil:
 		return tag.NewDateTimeTagger(t.DateTimeTagger.Format, t.DateTimeTagger.TimeZone), nil
 
-	case t.TagTemplateTagger != nil:
-		components, err := CreateComponents(t.TagTemplateTagger)
+	case t.TemplateTagger != nil:
+		components, err := CreateComponents(t.TemplateTagger)
 
 		if err != nil {
 			return nil, fmt.Errorf("creating components: %w", err)
 		}
 
-		return tag.NewTemplateTagger(t.TagTemplateTagger.Template, components)
+		return tag.NewTemplateTagger(t.TemplateTagger.Template, components)
 
 	default:
 		return nil, fmt.Errorf("unknown tagger for strategy %+v", t)
 	}
 }
 
-// CreateComponents creates a map of taggers for TagTemplateTagger
-func CreateComponents(t *latest.TagTemplateTagger) (map[string]tag.Tagger, error) {
+// CreateComponents creates a map of taggers for TemplateTagger
+func CreateComponents(t *latest.TemplateTagger) (map[string]tag.Tagger, error) {
 	components := map[string]tag.Tagger{}
 
 	for _, taggerComponent := range t.Components {
@@ -268,7 +268,7 @@ func CreateComponents(t *latest.TagTemplateTagger) (map[string]tag.Tagger, error
 		case c.DateTimeTagger != nil:
 			components[name] = tag.NewDateTimeTagger(c.DateTimeTagger.Format, c.DateTimeTagger.TimeZone)
 
-		case c.TagTemplateTagger != nil:
+		case c.TemplateTagger != nil:
 			return nil, fmt.Errorf("cannot use tagTemplate as a component: %s %+v", name, c)
 
 		default:

--- a/pkg/skaffold/runner/new_test.go
+++ b/pkg/skaffold/runner/new_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestCreateComponents(t *testing.T) {
+	gitExample, _ := tag.NewGitCommit("", "")
+	envExample, _ := tag.NewEnvTemplateTagger("test")
+
+	tests := []struct {
+		description       string
+		tagTemplateTagger *latest.TagTemplateTagger
+		expected          map[string]tag.Tagger
+		shouldErr         bool
+	}{
+		{
+			description: "correct component types",
+			tagTemplateTagger: &latest.TagTemplateTagger{
+				Components: []latest.TaggerComponent{
+					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
+					latest.TaggerComponent{Name: "FOE", Component: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}}},
+					latest.TaggerComponent{Name: "BAR", Component: latest.TagPolicy{EnvTemplateTagger: &latest.EnvTemplateTagger{Template: "test"}}},
+					latest.TaggerComponent{Name: "BAT", Component: latest.TagPolicy{DateTimeTagger: &latest.DateTimeTagger{}}},
+				},
+			},
+			expected: map[string]tag.Tagger{
+				"FOO": gitExample,
+				"FOE": &tag.ChecksumTagger{},
+				"BAR": envExample,
+				"BAT": tag.NewDateTimeTagger("", ""),
+			},
+		},
+		{
+			description: "tagTemplate is an invalid component",
+			tagTemplateTagger: &latest.TagTemplateTagger{
+				Components: []latest.TaggerComponent{
+					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{TagTemplateTagger: &latest.TagTemplateTagger{Template: "test"}}},
+				},
+			},
+			shouldErr: true,
+		},
+		{
+			description: "recurring names",
+			tagTemplateTagger: &latest.TagTemplateTagger{
+				Components: []latest.TaggerComponent{
+					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
+					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
+				},
+			},
+			shouldErr: true,
+		},
+		{
+			description: "unknown component",
+			tagTemplateTagger: &latest.TagTemplateTagger{
+				Components: []latest.TaggerComponent{
+					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{}},
+				},
+			},
+			shouldErr: true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			components, err := CreateComponents(test.tagTemplateTagger)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, len(test.expected), len(components))
+			for k, v := range test.expected {
+				t.CheckTypeEquality(v, components[k])
+			}
+		})
+	}
+}

--- a/pkg/skaffold/runner/new_test.go
+++ b/pkg/skaffold/runner/new_test.go
@@ -38,10 +38,10 @@ func TestCreateComponents(t *testing.T) {
 			description: "correct component types",
 			templateTagger: &latest.TemplateTagger{
 				Components: []latest.TaggerComponent{
-					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
-					latest.TaggerComponent{Name: "FOE", Component: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}}},
-					latest.TaggerComponent{Name: "BAR", Component: latest.TagPolicy{EnvTemplateTagger: &latest.EnvTemplateTagger{Template: "test"}}},
-					latest.TaggerComponent{Name: "BAT", Component: latest.TagPolicy{DateTimeTagger: &latest.DateTimeTagger{}}},
+					{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
+					{Name: "FOE", Component: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}}},
+					{Name: "BAR", Component: latest.TagPolicy{EnvTemplateTagger: &latest.EnvTemplateTagger{Template: "test"}}},
+					{Name: "BAT", Component: latest.TagPolicy{DateTimeTagger: &latest.DateTimeTagger{}}},
 				},
 			},
 			expected: map[string]tag.Tagger{
@@ -55,7 +55,7 @@ func TestCreateComponents(t *testing.T) {
 			description: "tagTemplate is an invalid component",
 			templateTagger: &latest.TemplateTagger{
 				Components: []latest.TaggerComponent{
-					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{TemplateTagger: &latest.TemplateTagger{Template: "test"}}},
+					{Name: "FOO", Component: latest.TagPolicy{TemplateTagger: &latest.TemplateTagger{Template: "test"}}},
 				},
 			},
 			shouldErr: true,
@@ -64,8 +64,8 @@ func TestCreateComponents(t *testing.T) {
 			description: "recurring names",
 			templateTagger: &latest.TemplateTagger{
 				Components: []latest.TaggerComponent{
-					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
-					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
+					{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
+					{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
 				},
 			},
 			shouldErr: true,
@@ -74,7 +74,7 @@ func TestCreateComponents(t *testing.T) {
 			description: "unknown component",
 			templateTagger: &latest.TemplateTagger{
 				Components: []latest.TaggerComponent{
-					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{}},
+					{Name: "FOO", Component: latest.TagPolicy{}},
 				},
 			},
 			shouldErr: true,

--- a/pkg/skaffold/runner/new_test.go
+++ b/pkg/skaffold/runner/new_test.go
@@ -29,14 +29,14 @@ func TestCreateComponents(t *testing.T) {
 	envExample, _ := tag.NewEnvTemplateTagger("test")
 
 	tests := []struct {
-		description       string
-		tagTemplateTagger *latest.TagTemplateTagger
-		expected          map[string]tag.Tagger
-		shouldErr         bool
+		description    string
+		templateTagger *latest.TemplateTagger
+		expected       map[string]tag.Tagger
+		shouldErr      bool
 	}{
 		{
 			description: "correct component types",
-			tagTemplateTagger: &latest.TagTemplateTagger{
+			templateTagger: &latest.TemplateTagger{
 				Components: []latest.TaggerComponent{
 					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
 					latest.TaggerComponent{Name: "FOE", Component: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}}},
@@ -53,16 +53,16 @@ func TestCreateComponents(t *testing.T) {
 		},
 		{
 			description: "tagTemplate is an invalid component",
-			tagTemplateTagger: &latest.TagTemplateTagger{
+			templateTagger: &latest.TemplateTagger{
 				Components: []latest.TaggerComponent{
-					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{TagTemplateTagger: &latest.TagTemplateTagger{Template: "test"}}},
+					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{TemplateTagger: &latest.TemplateTagger{Template: "test"}}},
 				},
 			},
 			shouldErr: true,
 		},
 		{
 			description: "recurring names",
-			tagTemplateTagger: &latest.TagTemplateTagger{
+			templateTagger: &latest.TemplateTagger{
 				Components: []latest.TaggerComponent{
 					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
 					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
@@ -72,7 +72,7 @@ func TestCreateComponents(t *testing.T) {
 		},
 		{
 			description: "unknown component",
-			tagTemplateTagger: &latest.TagTemplateTagger{
+			templateTagger: &latest.TemplateTagger{
 				Components: []latest.TaggerComponent{
 					latest.TaggerComponent{Name: "FOO", Component: latest.TagPolicy{}},
 				},
@@ -82,7 +82,7 @@ func TestCreateComponents(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			components, err := CreateComponents(test.tagTemplateTagger)
+			components, err := CreateComponents(test.templateTagger)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, len(test.expected), len(components))
 			for k, v := range test.expected {
 				t.CheckTypeEquality(v, components[k])

--- a/pkg/skaffold/runner/new_test.go
+++ b/pkg/skaffold/runner/new_test.go
@@ -29,14 +29,14 @@ func TestCreateComponents(t *testing.T) {
 	envExample, _ := tag.NewEnvTemplateTagger("test")
 
 	tests := []struct {
-		description    string
-		templateTagger *latest.TemplateTagger
-		expected       map[string]tag.Tagger
-		shouldErr      bool
+		description          string
+		customTemplateTagger *latest.CustomTemplateTagger
+		expected             map[string]tag.Tagger
+		shouldErr            bool
 	}{
 		{
 			description: "correct component types",
-			templateTagger: &latest.TemplateTagger{
+			customTemplateTagger: &latest.CustomTemplateTagger{
 				Components: []latest.TaggerComponent{
 					{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
 					{Name: "FOE", Component: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}}},
@@ -52,17 +52,17 @@ func TestCreateComponents(t *testing.T) {
 			},
 		},
 		{
-			description: "tagTemplate is an invalid component",
-			templateTagger: &latest.TemplateTagger{
+			description: "customTemplate is an invalid component",
+			customTemplateTagger: &latest.CustomTemplateTagger{
 				Components: []latest.TaggerComponent{
-					{Name: "FOO", Component: latest.TagPolicy{TemplateTagger: &latest.TemplateTagger{Template: "test"}}},
+					{Name: "FOO", Component: latest.TagPolicy{CustomTemplateTagger: &latest.CustomTemplateTagger{Template: "test"}}},
 				},
 			},
 			shouldErr: true,
 		},
 		{
 			description: "recurring names",
-			templateTagger: &latest.TemplateTagger{
+			customTemplateTagger: &latest.CustomTemplateTagger{
 				Components: []latest.TaggerComponent{
 					{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
 					{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
@@ -72,7 +72,7 @@ func TestCreateComponents(t *testing.T) {
 		},
 		{
 			description: "unknown component",
-			templateTagger: &latest.TemplateTagger{
+			customTemplateTagger: &latest.CustomTemplateTagger{
 				Components: []latest.TaggerComponent{
 					{Name: "FOO", Component: latest.TagPolicy{}},
 				},
@@ -82,7 +82,7 @@ func TestCreateComponents(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			components, err := CreateComponents(test.templateTagger)
+			components, err := CreateComponents(test.customTemplateTagger)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, len(test.expected), len(components))
 			for k, v := range test.expected {
 				t.CheckTypeEquality(v, components[k])

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -128,6 +128,9 @@ type TagPolicy struct {
 
 	// DateTimeTagger *beta* tags images with the build timestamp.
 	DateTimeTagger *DateTimeTagger `yaml:"dateTime,omitempty" yamltags:"oneOf=tag"`
+
+	// TagTemplateTagger *beta* tags images with a configurable template string *composed of other taggers*.
+	TagTemplateTagger *TagTemplateTagger `yaml:"tagTemplate,omitempty" yamltags:"oneOf=tag"`
 }
 
 // ShaTagger *beta* tags images with their sha256 digest.
@@ -168,6 +171,27 @@ type DateTimeTagger struct {
 	// See [Time.LoadLocation](https://golang.org/pkg/time/#Time.LoadLocation).
 	// Defaults to the local timezone.
 	TimeZone string `yaml:"timezone,omitempty"`
+}
+
+// TagTemplateTagger *beta* tags images with a configurable template string.
+type TagTemplateTagger struct {
+	// Template used to produce the image name and tag.
+	// See golang [text/template](https://golang.org/pkg/text/template/).
+	// The template is executed against the provided components with those variables injected.
+	// For example: `{{.DATE}}` where DATE references a TaggerComponent.
+	Template string `yaml:"template,omitempty" yamltags:"required"`
+
+	// Components lists TaggerComponents that the template (see field above) can be executed against.
+	Components []TaggerComponent `yaml:"components,omitempty"`
+}
+
+// TaggerComponent *beta* is a component of TagTemplateTagger.
+type TaggerComponent struct {
+	// Name is an identifier for the component.
+	Name string `yaml:"name,omitempty"`
+
+	// Component is a tagging strategy to be used in TagTemplateTagger.
+	Component TagPolicy `yaml:",inline"`
 }
 
 // BuildType contains the specific implementation and parameters needed

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -129,8 +129,8 @@ type TagPolicy struct {
 	// DateTimeTagger *beta* tags images with the build timestamp.
 	DateTimeTagger *DateTimeTagger `yaml:"dateTime,omitempty" yamltags:"oneOf=tag"`
 
-	// TagTemplateTagger *beta* tags images with a configurable template string *composed of other taggers*.
-	TagTemplateTagger *TagTemplateTagger `yaml:"tagTemplate,omitempty" yamltags:"oneOf=tag"`
+	// TemplateTagger *beta* tags images with a configurable template string *composed of other taggers*.
+	TemplateTagger *TemplateTagger `yaml:"tagTemplate,omitempty" yamltags:"oneOf=tag"`
 }
 
 // ShaTagger *beta* tags images with their sha256 digest.
@@ -173,8 +173,8 @@ type DateTimeTagger struct {
 	TimeZone string `yaml:"timezone,omitempty"`
 }
 
-// TagTemplateTagger *beta* tags images with a configurable template string.
-type TagTemplateTagger struct {
+// TemplateTagger *beta* tags images with a configurable template string.
+type TemplateTagger struct {
 	// Template used to produce the image name and tag.
 	// See golang [text/template](https://golang.org/pkg/text/template/).
 	// The template is executed against the provided components with those variables injected.
@@ -185,12 +185,12 @@ type TagTemplateTagger struct {
 	Components []TaggerComponent `yaml:"components,omitempty"`
 }
 
-// TaggerComponent *beta* is a component of TagTemplateTagger.
+// TaggerComponent *beta* is a component of TemplateTagger.
 type TaggerComponent struct {
 	// Name is an identifier for the component.
 	Name string `yaml:"name,omitempty"`
 
-	// Component is a tagging strategy to be used in TagTemplateTagger.
+	// Component is a tagging strategy to be used in TemplateTagger.
 	Component TagPolicy `yaml:",inline"`
 }
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -129,8 +129,8 @@ type TagPolicy struct {
 	// DateTimeTagger *beta* tags images with the build timestamp.
 	DateTimeTagger *DateTimeTagger `yaml:"dateTime,omitempty" yamltags:"oneOf=tag"`
 
-	// TemplateTagger *beta* tags images with a configurable template string *composed of other taggers*.
-	TemplateTagger *TemplateTagger `yaml:"tagTemplate,omitempty" yamltags:"oneOf=tag"`
+	// CustomTemplateTagger *beta* tags images with a configurable template string *composed of other taggers*.
+	CustomTemplateTagger *CustomTemplateTagger `yaml:"customTemplate,omitempty" yamltags:"oneOf=tag"`
 }
 
 // ShaTagger *beta* tags images with their sha256 digest.
@@ -173,8 +173,8 @@ type DateTimeTagger struct {
 	TimeZone string `yaml:"timezone,omitempty"`
 }
 
-// TemplateTagger *beta* tags images with a configurable template string.
-type TemplateTagger struct {
+// CustomTemplateTagger *beta* tags images with a configurable template string.
+type CustomTemplateTagger struct {
 	// Template used to produce the image name and tag.
 	// See golang [text/template](https://golang.org/pkg/text/template/).
 	// The template is executed against the provided components with those variables injected.
@@ -185,12 +185,12 @@ type TemplateTagger struct {
 	Components []TaggerComponent `yaml:"components,omitempty"`
 }
 
-// TaggerComponent *beta* is a component of TemplateTagger.
+// TaggerComponent *beta* is a component of CustomTemplateTagger.
 type TaggerComponent struct {
 	// Name is an identifier for the component.
 	Name string `yaml:"name,omitempty"`
 
-	// Component is a tagging strategy to be used in TemplateTagger.
+	// Component is a tagging strategy to be used in CustomTemplateTagger.
 	Component TagPolicy `yaml:",inline"`
 }
 

--- a/pkg/skaffold/schema/v2beta5/upgrade.go
+++ b/pkg/skaffold/schema/v2beta5/upgrade.go
@@ -24,6 +24,10 @@ import (
 
 // Upgrade upgrades a configuration to the next version.
 // Config changes from v2beta5 to v2beta6
+// 1. Additions:
+//		New structs TemplateTagger and TaggerComponent used by TagPolicy.
+// 2. Removals:
+// 3. Updates:
 func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
 	var newConfig next.SkaffoldConfig
 	pkgutil.CloneThroughJSON(c, &newConfig)

--- a/pkg/skaffold/schema/v2beta5/upgrade.go
+++ b/pkg/skaffold/schema/v2beta5/upgrade.go
@@ -25,7 +25,7 @@ import (
 // Upgrade upgrades a configuration to the next version.
 // Config changes from v2beta5 to v2beta6
 // 1. Additions:
-//		New structs TemplateTagger and TaggerComponent used by TagPolicy.
+//		New structs CustomTemplateTagger and TaggerComponent used by TagPolicy.
 func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
 	var newConfig next.SkaffoldConfig
 	pkgutil.CloneThroughJSON(c, &newConfig)

--- a/pkg/skaffold/schema/v2beta5/upgrade.go
+++ b/pkg/skaffold/schema/v2beta5/upgrade.go
@@ -26,8 +26,6 @@ import (
 // Config changes from v2beta5 to v2beta6
 // 1. Additions:
 //		New structs TemplateTagger and TaggerComponent used by TagPolicy.
-// 2. Removals:
-// 3. Updates:
 func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
 	var newConfig next.SkaffoldConfig
 	pkgutil.CloneThroughJSON(c, &newConfig)


### PR DESCRIPTION
Fixes: #4371 
**Related**: #4567

**Description**
This is a functional change introducing the tagging feature that is outlined in issue #4371  . Users can use this feature similar to other tagging features. The config will look like:
```
build:
  tagPolicy:
    tagTemplate:
      template: "{{.FOO}}-bar"
      components:
      - name: FOO
        dateTime:
          format: "2006-01-02"
          timezone: "UTC"
```
Built in components are GIT, DATE, and SHA which refer to gitCommit, dateTime, and sha default taggers, respectively. These can be overwritten by the user.