### PR TITLE
Use alternative service port-forwarding scheme

### DIFF
--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -143,9 +144,9 @@ func (k *KubectlForwarder) forward(parentCtx context.Context, pfe *portForwardEn
 func portForwardArgs(ctx context.Context, pfe *portForwardEntry) ([]string, error) {
 	args := []string{"--pod-running-timeout", "1s"}
 
-	switch pfe.resource.Type {
-	// Services need special handling: https://github.com/GoogleContainerTools/skaffold/issues/4522
-	case "service":
+	switch {
+	case pfe.resource.Type == "service" && os.Getenv("SKAFFOLD_DISABLE_SERVICE_FORWARDING") == "":
+		// Services need special handling: https://github.com/GoogleContainerTools/skaffold/issues/4522
 		podName, remotePort, err := findNewestPodForSvc(ctx, pfe.resource.Namespace, pfe.resource.Name, pfe.resource.Port)
 		if err != nil {
 			return nil, err

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -140,8 +140,9 @@ func (k *KubectlForwarder) forward(parentCtx context.Context, pfe *portForwardEn
 func portForwardArgs(ctx context.Context, pfe *portForwardEntry) []string {
 	args := []string{"--pod-running-timeout", "1s", "--namespace", pfe.resource.Namespace}
 
+	_, disableServiceForwarding := os.LookupEnv("SKAFFOLD_DISABLE_SERVICE_FORWARDING")
 	switch {
-	case pfe.resource.Type == "service" && os.Getenv("SKAFFOLD_DISABLE_SERVICE_FORWARDING") == "":
+	case pfe.resource.Type == "service" && !disableServiceForwarding:
 		// Services need special handling: https://github.com/GoogleContainerTools/skaffold/issues/4522
 		podName, remotePort, err := findNewestPodForSvc(ctx, pfe.resource.Namespace, pfe.resource.Name, pfe.resource.Port);
 		if err == nil {

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -144,7 +144,7 @@ func portForwardArgs(ctx context.Context, pfe *portForwardEntry) []string {
 	switch {
 	case pfe.resource.Type == "service" && !disableServiceForwarding:
 		// Services need special handling: https://github.com/GoogleContainerTools/skaffold/issues/4522
-		podName, remotePort, err := findNewestPodForSvc(ctx, pfe.resource.Namespace, pfe.resource.Name, pfe.resource.Port);
+		podName, remotePort, err := findNewestPodForSvc(ctx, pfe.resource.Namespace, pfe.resource.Name, pfe.resource.Port)
 		if err == nil {
 			args = append(args, fmt.Sprintf("pod/%s", podName), fmt.Sprintf("%d:%d", pfe.localPort, remotePort))
 			break
@@ -155,7 +155,6 @@ func portForwardArgs(ctx context.Context, pfe *portForwardEntry) []string {
 	default:
 		args = append(args, fmt.Sprintf("%s/%s", pfe.resource.Type, pfe.resource.Name), fmt.Sprintf("%d:%d", pfe.localPort, pfe.resource.Port))
 	}
-
 
 	if pfe.resource.Address != "" && pfe.resource.Address != util.Loopback {
 		args = append(args, []string{"--address", pfe.resource.Address}...)
@@ -242,8 +241,8 @@ func findNewestPodForService(ctx context.Context, ns, serviceName string, servic
 	for _, pod := range podsList.Items {
 		if pod.Status.Phase == corev1.PodPending || pod.Status.Phase == corev1.PodRunning {
 			pods = append(pods, pod)
-		} 
-	} 
+		}
+	}
 	sort.Slice(pods, newestPodsFirst(pods))
 
 	if logrus.IsLevelEnabled((logrus.TraceLevel)) {

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -239,14 +239,14 @@ func findNewestPodForService(ctx context.Context, ns, serviceName string, servic
 	if logrus.IsLevelEnabled((logrus.TraceLevel)) {
 		var names []string
 		for _, p := range pods.Items {
-			names = append(names, fmt.Sprintf("pod %s (phase:%v, created:%s)", p.Name, p.Status.Phase, p.CreationTimestamp))
+			names = append(names, fmt.Sprintf("(pod:%q phase:%v created:%v)", p.Name, p.Status.Phase, p.CreationTimestamp))
 		}
 		logrus.Tracef("service %s/%d maps to %d pods: %v", serviceName, servicePort, len(pods.Items), names)
 	}
 
 	for _, p := range pods.Items {
 		if targetPort := findTargetPort(svcPort, p); targetPort > 0 {
-			logrus.Debugf("Mapping service %s/%d to pod %s/%d", serviceName, servicePort, p.Name, targetPort)
+			logrus.Debugf("Forwarding service %s/%d to pod %s/%d", serviceName, servicePort, p.Name, targetPort)
 			return p.Name, targetPort, nil
 		}
 	}

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
@@ -356,8 +356,8 @@ func TestFindNewestPodForService(t *testing.T) {
 			},
 			serviceName: "notfound",
 			servicePort: 80,
-			shouldErr: true,
-			chosenPort: -1,
+			shouldErr:   true,
+			chosenPort:  -1,
 		},
 		{
 			description: "port not found",
@@ -368,16 +368,16 @@ func TestFindNewestPodForService(t *testing.T) {
 			},
 			serviceName: "svc",
 			servicePort: 90,
-			shouldErr: true,
-			chosenPort: -1,
+			shouldErr:   true,
+			chosenPort:  -1,
 		},
 		{
 			description: "port not found",
-			clientErr: errors.New("injected failure"),
+			clientErr:   errors.New("injected failure"),
 			serviceName: "svc",
 			servicePort: 90,
-			shouldErr: true,
-			chosenPort: -1,
+			shouldErr:   true,
+			chosenPort:  -1,
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
@@ -253,19 +253,19 @@ func TestFindServicePort(t *testing.T) {
 	}{
 		{
 			description: "simple case",
-			service:     mockService("svc", corev1.ServiceTypeLoadBalancer, []corev1.ServicePort{{Port: 90, TargetPort: intstr.FromInt(80)}, {Port: 80, TargetPort: intstr.FromInt(8080)}}),
+			service:     mockService("svc1", corev1.ServiceTypeLoadBalancer, []corev1.ServicePort{{Port: 90, TargetPort: intstr.FromInt(80)}, {Port: 80, TargetPort: intstr.FromInt(8080)}}),
 			port:        80,
 			expected:    corev1.ServicePort{Port: 80, TargetPort: intstr.FromInt(8080)},
 		},
 		{
 			description: "no ports",
-			service:     mockService("svc", corev1.ServiceTypeLoadBalancer, nil),
+			service:     mockService("svc2", corev1.ServiceTypeLoadBalancer, nil),
 			port:        80,
 			shouldErr:   true,
 		},
 		{
 			description: "no matching ports",
-			service:     mockService("svc", corev1.ServiceTypeLoadBalancer, []corev1.ServicePort{{Port: 90, TargetPort: intstr.FromInt(80)}, {Port: 80, TargetPort: intstr.FromInt(8080)}}),
+			service:     mockService("svc3", corev1.ServiceTypeLoadBalancer, []corev1.ServicePort{{Port: 90, TargetPort: intstr.FromInt(80)}, {Port: 80, TargetPort: intstr.FromInt(8080)}}),
 			port:        100,
 			shouldErr:   true,
 		},
@@ -350,7 +350,7 @@ func TestFindNewestPodForService(t *testing.T) {
 		{
 			description: "service not found",
 			clientResources: []pkgruntime.Object{
-				mockService("svc", corev1.ServiceTypeLoadBalancer, []corev1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(8080)}}),
+				mockService("svc", corev1.ServiceTypeClusterIP, []corev1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(8080)}}),
 				mockPod("new", []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}, time.Now().Add(-time.Minute)),
 				mockPod("old", []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}, time.Now().Add(-time.Hour)),
 			},
@@ -365,6 +365,16 @@ func TestFindNewestPodForService(t *testing.T) {
 				mockService("svc", corev1.ServiceTypeLoadBalancer, []corev1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(8080)}}),
 				mockPod("new", []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}, time.Now().Add(-time.Minute)),
 				mockPod("old", []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}, time.Now().Add(-time.Hour)),
+			},
+			serviceName: "svc",
+			servicePort: 90,
+			shouldErr:   true,
+			chosenPort:  -1,
+		},
+		{
+			description: "no matching pods",
+			clientResources: []pkgruntime.Object{
+				mockService("service", corev1.ServiceTypeLoadBalancer, []corev1.ServicePort{{Port: 80, TargetPort: intstr.FromInt(8080)}}),
 			},
 			serviceName: "svc",
 			servicePort: 90,

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
@@ -214,7 +214,7 @@ func TestPortForwardArgs(t *testing.T) {
 		{
 			description: "service could not be mapped to pod",
 			input:       newPortForwardEntry(0, latest.PortForwardResource{Type: "service", Name: "svc", Namespace: "ns", Port: 9}, "", "", "", "", 8080, false),
-			serviceErr:	 errors.New("error"),
+			serviceErr:  errors.New("error"),
 			result:      []string{"--pod-running-timeout", "1s", "--namespace", "ns", "service/svc", "8080:9"},
 		},
 	}


### PR DESCRIPTION
Fixes #4522 

When Skaffold redeploys new workload resources, it tears down and re-establishes port-forwards for services.  But `kubectl port-forward service/xxx` actually selects and forwards to a matching pod, in a way that favours older pods -- pods that are often about to be replaced during the rollout.  

This PR changes our `KubectlForwarder`, which is responsible for calling out to `kubectl port-forward`, to perform our own service-to-pod selection that favours newer pods, which are more likely to be from the rollout.

To simplify testing, I refactored `portForwardCommand()` to just return the command-line arguments to be added to `kubectl port-forward` and renamed it to `portForwardArgs()`.  I continued to pass in the context into `portForwardArgs()` as it _feels_ like I should be passing it into the client-go libraries.  I feel like I'm missing something.

This change should ensure that stale fetches are a thing of the past.  I've added an environment variable `SKAFFOLD_DISABLE_SERVICE_FORWARDING` to allow disabling this change should the need arise.

**User Visible changes**
- Skaffold uses a new approach for port-forwarding services that should reduce the chance of seeing stale content when deploying new changes. The old behavior can be restored by setting the `SKAFFOLD_DISABLE_SERVICE_FORWARDING` environment variable to any value.