### PR TITLE
Introduce Config interfaces

### DIFF
--- a/cmd/skaffold/app/cmd/runner_test.go
+++ b/cmd/skaffold/app/cmd/runner_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -86,7 +85,7 @@ func TestCreateNewRunner(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
+			t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
 				return nil, nil
 			})
 			t.Override(&update.GetLatestAndCurrentVersion, func() (semver.Version, semver.Version, error) {

--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -25,9 +25,9 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
@@ -55,13 +55,21 @@ type cache struct {
 // DependencyLister fetches a list of dependencies for an artifact
 type DependencyLister func(ctx context.Context, artifact *latest.Artifact) ([]string, error)
 
+type Config interface {
+	docker.Config
+
+	CacheArtifacts() bool
+	CacheFile() string
+	Mode() config.RunMode
+}
+
 // NewCache returns the current state of the cache
-func NewCache(runCtx *runcontext.RunContext, imagesAreLocal bool, dependencies DependencyLister) (Cache, error) {
-	if !runCtx.CacheArtifacts() {
+func NewCache(cfg Config, imagesAreLocal bool, dependencies DependencyLister) (Cache, error) {
+	if !cfg.CacheArtifacts() {
 		return &noCache{}, nil
 	}
 
-	cacheFile, err := resolveCacheFile(runCtx.CacheFile())
+	cacheFile, err := resolveCacheFile(cfg.CacheFile())
 	if err != nil {
 		logrus.Warnf("Error resolving cache file, not using skaffold cache: %v", err)
 		return &noCache{}, nil
@@ -73,7 +81,7 @@ func NewCache(runCtx *runcontext.RunContext, imagesAreLocal bool, dependencies D
 		return &noCache{}, nil
 	}
 
-	client, err := docker.NewAPIClient(runCtx)
+	client, err := docker.NewAPIClient(cfg)
 	if imagesAreLocal && err != nil {
 		return nil, fmt.Errorf("getting local Docker client: %w", err)
 	}
@@ -81,11 +89,11 @@ func NewCache(runCtx *runcontext.RunContext, imagesAreLocal bool, dependencies D
 	return &cache{
 		artifactCache:      artifactCache,
 		client:             client,
-		insecureRegistries: runCtx.GetInsecureRegistries(),
+		insecureRegistries: cfg.GetInsecureRegistries(),
 		cacheFile:          cacheFile,
 		imagesAreLocal:     imagesAreLocal,
 		hashForArtifact: func(ctx context.Context, a *latest.Artifact) (string, error) {
-			return getHashForArtifact(ctx, dependencies, a, runCtx.Mode())
+			return getHashForArtifact(ctx, dependencies, a, cfg.Mode())
 		},
 	}, nil
 }

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -118,7 +118,7 @@ func TestCacheBuildLocal(t *testing.T) {
 		// Mock Docker
 		t.Override(&docker.DefaultAuthHelper, stubAuth{})
 		dockerDaemon := docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, nil)
-		t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
 			return dockerDaemon, nil
 		})
 
@@ -205,7 +205,7 @@ func TestCacheBuildRemote(t *testing.T) {
 
 		// Mock Docker
 		dockerDaemon := docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, nil)
-		t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
 			return dockerDaemon, nil
 		})
 		t.Override(&docker.DefaultAuthHelper, stubAuth{})

--- a/pkg/skaffold/build/cluster/types.go
+++ b/pkg/skaffold/build/cluster/types.go
@@ -23,8 +23,9 @@ import (
 	"time"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -39,20 +40,29 @@ type Builder struct {
 	muted              build.Muted
 }
 
+type Config interface {
+	kubectl.Config
+	docker.Config
+
+	Pipeline() latest.Pipeline
+	GetKubeContext() string
+	Muted() config.Muted
+}
+
 // NewBuilder creates a new Builder that builds artifacts on cluster.
-func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
-	timeout, err := time.ParseDuration(runCtx.Pipeline().Build.Cluster.Timeout)
+func NewBuilder(cfg Config) (*Builder, error) {
+	timeout, err := time.ParseDuration(cfg.Pipeline().Build.Cluster.Timeout)
 	if err != nil {
 		return nil, fmt.Errorf("parsing timeout: %w", err)
 	}
 
 	return &Builder{
-		ClusterDetails:     runCtx.Pipeline().Build.Cluster,
-		kubectlcli:         kubectl.NewFromRunContext(runCtx),
+		ClusterDetails:     cfg.Pipeline().Build.Cluster,
+		kubectlcli:         kubectl.NewFromRunContext(cfg),
 		timeout:            timeout,
-		kubeContext:        runCtx.GetKubeContext(),
-		insecureRegistries: runCtx.GetInsecureRegistries(),
-		muted:              runCtx.Muted(),
+		kubeContext:        cfg.GetKubeContext(),
+		insecureRegistries: cfg.GetInsecureRegistries(),
+		muted:              cfg.Muted(),
 	}, nil
 }
 

--- a/pkg/skaffold/build/cluster/types_test.go
+++ b/pkg/skaffold/build/cluster/types_test.go
@@ -40,7 +40,7 @@ func TestNewBuilder(t *testing.T) {
 	tests := []struct {
 		description     string
 		shouldErr       bool
-		runCtx          *runcontext.RunContext
+		runCtx          Config
 		expectedBuilder *Builder
 	}{
 		{

--- a/pkg/skaffold/build/gcb/types.go
+++ b/pkg/skaffold/build/gcb/types.go
@@ -24,7 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -83,13 +84,21 @@ type Builder struct {
 	muted              build.Muted
 }
 
+type Config interface {
+	docker.Config
+
+	Pipeline() latest.Pipeline
+	SkipTests() bool
+	Muted() config.Muted
+}
+
 // NewBuilder creates a new Builder that builds artifacts with Google Cloud Build.
-func NewBuilder(runCtx *runcontext.RunContext) *Builder {
+func NewBuilder(cfg Config) *Builder {
 	return &Builder{
-		GoogleCloudBuild:   runCtx.Pipeline().Build.GoogleCloudBuild,
-		skipTests:          runCtx.SkipTests(),
-		insecureRegistries: runCtx.GetInsecureRegistries(),
-		muted:              runCtx.Muted(),
+		GoogleCloudBuild:   cfg.Pipeline().Build.GoogleCloudBuild,
+		skipTests:          cfg.SkipTests(),
+		insecureRegistries: cfg.GetInsecureRegistries(),
+		muted:              cfg.Muted(),
 	}
 }
 

--- a/pkg/skaffold/build/jib/types.go
+++ b/pkg/skaffold/build/jib/types.go
@@ -26,6 +26,12 @@ type Builder struct {
 	skipTests          bool
 }
 
+type Config interface {
+	docker.Config
+
+	SkipTests() bool
+}
+
 // NewArtifactBuilder returns a new customjib artifact builder
 func NewArtifactBuilder(localDocker docker.LocalDaemon, insecureRegistries map[string]bool, pushImages, skipTests bool) *Builder {
 	return &Builder{

--- a/pkg/skaffold/build/local/docker_test.go
+++ b/pkg/skaffold/build/local/docker_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/cluster"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -86,7 +85,7 @@ func TestDockerCLIBuild(t *testing.T) {
 			))
 			t.Override(&cluster.GetClient, func() cluster.Client { return fakeMinikubeClient{} })
 			t.Override(&util.OSEnviron, func() []string { return []string{"KEY=VALUE"} })
-			t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
+			t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
 				return docker.NewLocalDaemon(&testutil.FakeAPIClient{}, test.extraEnv, false, nil), nil
 			})
 

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -232,7 +232,7 @@ func TestLocalRun(t *testing.T) {
 			t.Override(&docker.DefaultAuthHelper, testAuthHelper{})
 			fakeWarner := &warnings.Collect{}
 			t.Override(&warnings.Printf, fakeWarner.Warnf)
-			t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
+			t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
 				return docker.NewLocalDaemon(test.api, nil, false, nil), nil
 			})
 			t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact) (map[string]*string, error) {
@@ -274,18 +274,18 @@ func TestNewBuilder(t *testing.T) {
 		localBuild      latest.LocalBuild
 		expectedBuilder *Builder
 		localClusterFn  func(string, string) (bool, error)
-		localDockerFn   func(*runcontext.RunContext) (docker.LocalDaemon, error)
+		localDockerFn   func(docker.Config) (docker.LocalDaemon, error)
 	}{
 		{
 			description: "failed to get docker client",
-			localDockerFn: func(*runcontext.RunContext) (docker.LocalDaemon, error) {
+			localDockerFn: func(docker.Config) (docker.LocalDaemon, error) {
 				return nil, errors.New("dummy docker error")
 			},
 			shouldErr: true,
 		},
 		{
 			description: "pushImages becomes !localCluster when local:push is not defined",
-			localDockerFn: func(*runcontext.RunContext) (docker.LocalDaemon, error) {
+			localDockerFn: func(docker.Config) (docker.LocalDaemon, error) {
 				return dummyDaemon, nil
 			},
 			localClusterFn: func(string, string) (b bool, e error) {
@@ -308,7 +308,7 @@ func TestNewBuilder(t *testing.T) {
 		},
 		{
 			description: "pushImages defined in config (local:push)",
-			localDockerFn: func(*runcontext.RunContext) (docker.LocalDaemon, error) {
+			localDockerFn: func(docker.Config) (docker.LocalDaemon, error) {
 				return dummyDaemon, nil
 			},
 			localClusterFn: func(string, string) (b bool, e error) {

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -26,7 +26,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -52,9 +51,21 @@ type Builder struct {
 
 var getLocalCluster = config.GetLocalCluster
 
+type Config interface {
+	docker.Config
+
+	Pipeline() latest.Pipeline
+	GlobalConfig() string
+	GetKubeContext() string
+	SkipTests() bool
+	Mode() config.RunMode
+	NoPruneChildren() bool
+	Muted() config.Muted
+}
+
 // NewBuilder returns an new instance of a local Builder.
-func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
-	localDocker, err := docker.NewAPIClient(runCtx)
+func NewBuilder(cfg Config) (*Builder, error) {
+	localDocker, err := docker.NewAPIClient(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("getting docker client: %w", err)
 	}
@@ -63,31 +74,31 @@ func NewBuilder(runCtx *runcontext.RunContext) (*Builder, error) {
 	// remove minikubeProfile from here and instead detect it by matching the
 	// kubecontext API Server to minikube profiles
 
-	localCluster, err := getLocalCluster(runCtx.GlobalConfig(), runCtx.MinikubeProfile())
+	localCluster, err := getLocalCluster(cfg.GlobalConfig(), cfg.MinikubeProfile())
 	if err != nil {
 		return nil, fmt.Errorf("getting localCluster: %w", err)
 	}
 
 	var pushImages bool
-	if runCtx.Pipeline().Build.LocalBuild.Push == nil {
+	if cfg.Pipeline().Build.LocalBuild.Push == nil {
 		pushImages = !localCluster
 		logrus.Debugf("push value not present, defaulting to %t because localCluster is %t", pushImages, localCluster)
 	} else {
-		pushImages = *runCtx.Pipeline().Build.LocalBuild.Push
+		pushImages = *cfg.Pipeline().Build.LocalBuild.Push
 	}
 
 	return &Builder{
-		cfg:                *runCtx.Pipeline().Build.LocalBuild,
-		kubeContext:        runCtx.GetKubeContext(),
+		cfg:                *cfg.Pipeline().Build.LocalBuild,
+		kubeContext:        cfg.GetKubeContext(),
 		localDocker:        localDocker,
 		localCluster:       localCluster,
 		pushImages:         pushImages,
-		skipTests:          runCtx.Opts.SkipTests,
-		mode:               runCtx.Mode(),
-		prune:              runCtx.Opts.Prune(),
-		pruneChildren:      !runCtx.Opts.NoPruneChildren,
-		insecureRegistries: runCtx.InsecureRegistries,
-		muted:              runCtx.Muted(),
+		skipTests:          cfg.SkipTests(),
+		mode:               cfg.Mode(),
+		prune:              cfg.Prune(),
+		pruneChildren:      !cfg.NoPruneChildren(),
+		insecureRegistries: cfg.GetInsecureRegistries(),
+		muted:              cfg.Muted(),
 	}, nil
 }
 

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -41,7 +41,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
@@ -80,13 +79,13 @@ type HelmDeployer struct {
 }
 
 // NewHelmDeployer returns a configured HelmDeployer
-func NewHelmDeployer(runCtx *runcontext.RunContext, labels map[string]string) *HelmDeployer {
+func NewHelmDeployer(cfg Config, labels map[string]string) *HelmDeployer {
 	return &HelmDeployer{
-		HelmDeploy:  runCtx.Pipeline().Deploy.HelmDeploy,
-		kubeContext: runCtx.GetKubeContext(),
-		kubeConfig:  runCtx.GetKubeConfig(),
-		namespace:   runCtx.GetKubeNamespace(),
-		forceDeploy: runCtx.ForceDeploy(),
+		HelmDeploy:  cfg.Pipeline().Deploy.HelmDeploy,
+		kubeContext: cfg.GetKubeContext(),
+		kubeConfig:  cfg.GetKubeConfig(),
+		namespace:   cfg.GetKubeNamespace(),
+		forceDeploy: cfg.ForceDeploy(),
 		labels:      labels,
 	}
 }

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -403,7 +403,7 @@ func TestHelmDeploy(t *testing.T) {
 	tests := []struct {
 		description      string
 		commands         util.Command
-		runContext       *runcontext.RunContext
+		runContext       Config
 		builds           []build.Artifact
 		shouldErr        bool
 		expectedWarnings []string
@@ -833,7 +833,7 @@ func TestHelmCleanup(t *testing.T) {
 	tests := []struct {
 		description      string
 		commands         util.Command
-		runContext       *runcontext.RunContext
+		runContext       Config
 		builds           []build.Artifact
 		shouldErr        bool
 		expectedWarnings []string
@@ -1081,7 +1081,7 @@ func TestHelmRender(t *testing.T) {
 		description string
 		shouldErr   bool
 		commands    util.Command
-		runContext  *runcontext.RunContext
+		runContext  Config
 		outputFile  string
 		expected    string
 		builds      []build.Artifact

--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -32,7 +32,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	deploy "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -52,12 +51,12 @@ type KptDeployer struct {
 	globalConfig       string
 }
 
-func NewKptDeployer(runCtx *runcontext.RunContext, labels map[string]string) *KptDeployer {
+func NewKptDeployer(ctx Config, labels map[string]string) *KptDeployer {
 	return &KptDeployer{
-		KptDeploy:          runCtx.Pipeline().Deploy.KptDeploy,
-		insecureRegistries: runCtx.GetInsecureRegistries(),
+		KptDeploy:          ctx.Pipeline().Deploy.KptDeploy,
+		insecureRegistries: ctx.GetInsecureRegistries(),
 		labels:             labels,
-		globalConfig:       runCtx.GlobalConfig(),
+		globalConfig:       ctx.GlobalConfig(),
 	}
 }
 

--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -33,9 +33,9 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	deploy "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -54,17 +54,28 @@ type KubectlDeployer struct {
 	skipRender         bool
 }
 
+type Config interface {
+	deploy.Config
+	docker.Config
+
+	Pipeline() latest.Pipeline
+	GetWorkingDir() string
+	GlobalConfig() string
+	DefaultRepo() *string
+	SkipRender() bool
+}
+
 // NewKubectlDeployer returns a new KubectlDeployer for a DeployConfig filled
 // with the needed configuration for `kubectl apply`
-func NewKubectlDeployer(runCtx *runcontext.RunContext, labels map[string]string) *KubectlDeployer {
+func NewKubectlDeployer(cfg Config, labels map[string]string) *KubectlDeployer {
 	return &KubectlDeployer{
-		KubectlDeploy:      runCtx.Pipeline().Deploy.KubectlDeploy,
-		workingDir:         runCtx.GetWorkingDir(),
-		globalConfig:       runCtx.GlobalConfig(),
-		defaultRepo:        runCtx.DefaultRepo(),
-		kubectl:            deploy.NewCLI(runCtx, runCtx.Pipeline().Deploy.KubectlDeploy.Flags),
-		insecureRegistries: runCtx.GetInsecureRegistries(),
-		skipRender:         runCtx.SkipRender(),
+		KubectlDeploy:      cfg.Pipeline().Deploy.KubectlDeploy,
+		workingDir:         cfg.GetWorkingDir(),
+		globalConfig:       cfg.GlobalConfig(),
+		defaultRepo:        cfg.DefaultRepo(),
+		kubectl:            deploy.NewCLI(cfg, cfg.Pipeline().Deploy.KubectlDeploy.Flags),
+		insecureRegistries: cfg.GetInsecureRegistries(),
+		skipRender:         cfg.SkipRender(),
 		labels:             labels,
 	}
 }

--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	pkgkubectl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -42,12 +41,18 @@ type CLI struct {
 	previousApply    ManifestList
 }
 
-func NewCLI(runCtx *runcontext.RunContext, flags latest.KubectlFlags) CLI {
+type Config interface {
+	pkgkubectl.Config
+	ForceDeploy() bool
+	WaitForDeletions() config.WaitForDeletions
+}
+
+func NewCLI(cfg Config, flags latest.KubectlFlags) CLI {
 	return CLI{
-		CLI:              pkgkubectl.NewFromRunContext(runCtx),
+		CLI:              pkgkubectl.NewFromRunContext(cfg),
 		Flags:            flags,
-		forceDeploy:      runCtx.ForceDeploy(),
-		waitForDeletions: runCtx.WaitForDeletions(),
+		forceDeploy:      cfg.ForceDeploy(),
+		waitForDeletions: cfg.WaitForDeletions(),
 	}
 }
 

--- a/pkg/skaffold/deploy/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize.go
@@ -34,7 +34,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	deploy "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
@@ -100,12 +99,12 @@ type KustomizeDeployer struct {
 	globalConfig       string
 }
 
-func NewKustomizeDeployer(runCtx *runcontext.RunContext, labels map[string]string) *KustomizeDeployer {
+func NewKustomizeDeployer(cfg Config, labels map[string]string) *KustomizeDeployer {
 	return &KustomizeDeployer{
-		KustomizeDeploy:    runCtx.Pipeline().Deploy.KustomizeDeploy,
-		kubectl:            deploy.NewCLI(runCtx, runCtx.Pipeline().Deploy.KustomizeDeploy.Flags),
-		insecureRegistries: runCtx.GetInsecureRegistries(),
-		globalConfig:       runCtx.GlobalConfig(),
+		KustomizeDeploy:    cfg.Pipeline().Deploy.KustomizeDeploy,
+		kubectl:            deploy.NewCLI(cfg, cfg.Pipeline().Deploy.KustomizeDeploy.Flags),
+		insecureRegistries: cfg.GetInsecureRegistries(),
+		globalConfig:       cfg.GlobalConfig(),
 		labels:             labels,
 	}
 }

--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -28,7 +28,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/diag/validator"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/proto"
 )
 
@@ -101,8 +100,8 @@ func (d *Deployment) WithValidator(pd diag.Diagnose) *Deployment {
 	return d
 }
 
-func (d *Deployment) CheckStatus(ctx context.Context, runCtx *runcontext.RunContext) {
-	kubeCtl := kubectl.NewFromRunContext(runCtx)
+func (d *Deployment) CheckStatus(ctx context.Context, cfg kubectl.Config) {
+	kubeCtl := kubectl.NewFromRunContext(cfg)
 
 	b, err := kubeCtl.RunOut(ctx, "rollout", "status", "deployment", d.name, "--namespace", d.namespace, "--watch=false")
 	if ctx.Err() != nil {

--- a/pkg/skaffold/diagnose/diagnose.go
+++ b/pkg/skaffold/diagnose/diagnose.go
@@ -27,17 +27,22 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 )
 
-func CheckArtifacts(ctx context.Context, runCtx *runcontext.RunContext, out io.Writer) error {
-	for _, artifact := range runCtx.Pipeline().Build.Artifacts {
+type Config interface {
+	docker.Config
+
+	Pipeline() latest.Pipeline
+}
+
+func CheckArtifacts(ctx context.Context, cfg Config, out io.Writer) error {
+	for _, artifact := range cfg.Pipeline().Build.Artifacts {
 		color.Default.Fprintf(out, "\n%s: %s\n", typeOfArtifact(artifact), artifact.ImageName)
 
 		if artifact.DockerArtifact != nil {
-			size, err := sizeOfDockerContext(ctx, artifact, runCtx.GetInsecureRegistries())
+			size, err := sizeOfDockerContext(ctx, artifact, cfg.GetInsecureRegistries())
 			if err != nil {
 				return fmt.Errorf("computing the size of the Docker context: %w", err)
 			}
@@ -45,11 +50,11 @@ func CheckArtifacts(ctx context.Context, runCtx *runcontext.RunContext, out io.W
 			fmt.Fprintf(out, " - Size of the context: %vbytes\n", size)
 		}
 
-		timeDeps1, deps, err := timeToListDependencies(ctx, artifact, runCtx.GetInsecureRegistries())
+		timeDeps1, deps, err := timeToListDependencies(ctx, artifact, cfg.GetInsecureRegistries())
 		if err != nil {
 			return fmt.Errorf("listing artifact dependencies: %w", err)
 		}
-		timeDeps2, _, err := timeToListDependencies(ctx, artifact, runCtx.GetInsecureRegistries())
+		timeDeps2, _, err := timeToListDependencies(ctx, artifact, cfg.GetInsecureRegistries())
 		if err != nil {
 			return fmt.Errorf("listing artifact dependencies: %w", err)
 		}
@@ -57,13 +62,13 @@ func CheckArtifacts(ctx context.Context, runCtx *runcontext.RunContext, out io.W
 		fmt.Fprintln(out, " - Dependencies:", len(deps), "files")
 		fmt.Fprintf(out, " - Time to list dependencies: %v (2nd time: %v)\n", timeDeps1, timeDeps2)
 
-		timeSyncMap1, err := timeToConstructSyncMap(artifact, runCtx.GetInsecureRegistries())
+		timeSyncMap1, err := timeToConstructSyncMap(artifact, cfg.GetInsecureRegistries())
 		if err != nil {
 			if _, isNotSupported := err.(build.ErrSyncMapNotSupported); !isNotSupported {
 				return fmt.Errorf("construct artifact dependencies: %w", err)
 			}
 		}
-		timeSyncMap2, err := timeToConstructSyncMap(artifact, runCtx.GetInsecureRegistries())
+		timeSyncMap2, err := timeToConstructSyncMap(artifact, cfg.GetInsecureRegistries())
 		if err != nil {
 			if _, isNotSupported := err.(build.ErrSyncMapNotSupported); !isNotSupported {
 				return fmt.Errorf("construct artifact dependencies: %w", err)

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -32,7 +32,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/cluster"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
@@ -50,11 +49,18 @@ var (
 	dockerAPIClientErr  error
 )
 
+type Config interface {
+	Prune() bool
+	GetKubeContext() string
+	MinikubeProfile() string
+	GetInsecureRegistries() map[string]bool
+}
+
 // NewAPIClientImpl guesses the docker client to use based on current Kubernetes context.
-func NewAPIClientImpl(runCtx *runcontext.RunContext) (LocalDaemon, error) {
+func NewAPIClientImpl(cfg Config) (LocalDaemon, error) {
 	dockerAPIClientOnce.Do(func() {
-		env, apiClient, err := newAPIClient(runCtx.GetKubeContext(), runCtx.MinikubeProfile())
-		dockerAPIClient = NewLocalDaemon(apiClient, env, runCtx.Prune(), runCtx.GetInsecureRegistries())
+		env, apiClient, err := newAPIClient(cfg.GetKubeContext(), cfg.MinikubeProfile())
+		dockerAPIClient = NewLocalDaemon(apiClient, env, cfg.Prune(), cfg.GetInsecureRegistries())
 		dockerAPIClientErr = err
 	})
 

--- a/pkg/skaffold/generate_pipeline/generate_pipeline.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline.go
@@ -30,7 +30,6 @@ import (
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/pipeline"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -41,7 +40,7 @@ type ConfigFile struct {
 	Profile *latest.Profile
 }
 
-func Yaml(out io.Writer, runCtx *runcontext.RunContext, configFiles []*ConfigFile) (*bytes.Buffer, error) {
+func Yaml(out io.Writer, namespace string, configFiles []*ConfigFile) (*bytes.Buffer, error) {
 	// Generate git resource for pipeline
 	gitResource, err := generateGitResource()
 	if err != nil {
@@ -50,14 +49,14 @@ func Yaml(out io.Writer, runCtx *runcontext.RunContext, configFiles []*ConfigFil
 
 	// Generate build task for pipeline
 	var tasks []*tekton.Task
-	buildTasks, err := generateBuildTasks(runCtx.GetKubeNamespace(), configFiles)
+	buildTasks, err := generateBuildTasks(namespace, configFiles)
 	if err != nil {
 		return nil, fmt.Errorf("generating build task: %w", err)
 	}
 	tasks = append(tasks, buildTasks...)
 
 	// Generate deploy task for pipeline
-	deployTasks, err := generateDeployTasks(runCtx.GetKubeNamespace(), configFiles)
+	deployTasks, err := generateDeployTasks(namespace, configFiles)
 	if err != nil {
 		return nil, fmt.Errorf("generating deploy task: %w", err)
 	}

--- a/pkg/skaffold/generate_pipeline/profile.go
+++ b/pkg/skaffold/generate_pipeline/profile.go
@@ -28,11 +28,10 @@ import (
 	yamlv2 "gopkg.in/yaml.v2"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
-func CreateSkaffoldProfile(out io.Writer, runCtx *runcontext.RunContext, configFile *ConfigFile) error {
+func CreateSkaffoldProfile(out io.Writer, namespace string, configFile *ConfigFile) error {
 	reader := bufio.NewReader(os.Stdin)
 
 	// Check for existing oncluster profile, if none exists then prompt to create one
@@ -63,7 +62,7 @@ confirmLoop:
 	}
 
 	color.Default.Fprintln(out, "Creating skaffold profile \"oncluster\"...")
-	profile, err := generateProfile(out, runCtx.GetKubeNamespace(), configFile.Config)
+	profile, err := generateProfile(out, namespace, configFile.Config)
 	if err != nil {
 		return fmt.Errorf("generating profile \"oncluster\": %w", err)
 	}

--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -22,7 +22,6 @@ import (
 	"os/exec"
 	"sync"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -36,11 +35,17 @@ type CLI struct {
 	versionOnce sync.Once
 }
 
-func NewFromRunContext(runCtx *runcontext.RunContext) *CLI {
+type Config interface {
+	GetKubeContext() string
+	GetKubeConfig() string
+	GetKubeNamespace() string
+}
+
+func NewFromRunContext(cfg Config) *CLI {
 	return &CLI{
-		KubeContext: runCtx.GetKubeContext(),
-		KubeConfig:  runCtx.GetKubeConfig(),
-		Namespace:   runCtx.GetKubeNamespace(),
+		KubeContext: cfg.GetKubeContext(),
+		KubeConfig:  cfg.GetKubeConfig(),
+		Namespace:   cfg.GetKubeNamespace(),
 	}
 }
 

--- a/pkg/skaffold/runner/deploy_test.go
+++ b/pkg/skaffold/runner/deploy_test.go
@@ -66,9 +66,8 @@ func TestDeploy(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
-
 			t.Override(&client.Client, mockK8sClient)
-			t.Override(&newStatusCheck, func(*runcontext.RunContext, *deploy.DefaultLabeller) deploy.StatusChecker {
+			t.Override(&newStatusCheck, func(deploy.StatusCheckConfig, *deploy.DefaultLabeller) deploy.StatusChecker {
 				return dummyStatusChecker{}
 			})
 
@@ -118,7 +117,7 @@ func TestDeployNamespace(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
 			t.Override(&client.Client, mockK8sClient)
-			t.Override(&newStatusCheck, func(*runcontext.RunContext, *deploy.DefaultLabeller) deploy.StatusChecker {
+			t.Override(&newStatusCheck, func(deploy.StatusCheckConfig, *deploy.DefaultLabeller) deploy.StatusChecker {
 				return dummyStatusChecker{}
 			})
 

--- a/pkg/skaffold/runner/generate_pipeline.go
+++ b/pkg/skaffold/runner/generate_pipeline.go
@@ -48,13 +48,13 @@ func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, co
 	// Will run the profile setup multiple times and require user input for each specified config
 	color.Default.Fprintln(out, "Running profile setup...")
 	for _, configFile := range configFiles {
-		if err := pipeline.CreateSkaffoldProfile(out, r.runCtx, configFile); err != nil {
+		if err := pipeline.CreateSkaffoldProfile(out, r.runCtx.GetKubeNamespace(), configFile); err != nil {
 			return fmt.Errorf("setting up profile: %w", err)
 		}
 	}
 
 	color.Default.Fprintln(out, "Generating Pipeline...")
-	pipelineYaml, err := pipeline.Yaml(out, r.runCtx, configFiles)
+	pipelineYaml, err := pipeline.Yaml(out, r.runCtx.GetKubeNamespace(), configFiles)
 	if err != nil {
 		return fmt.Errorf("generating pipeline yaml contents: %w", err)
 	}

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -179,33 +179,33 @@ func getBuilder(runCtx *runcontext.RunContext) (build.Builder, bool, error) {
 	}
 }
 
-func getTester(runCtx *runcontext.RunContext, imagesAreLocal bool) test.Tester {
-	return test.NewTester(runCtx, imagesAreLocal)
+func getTester(cfg test.Config, imagesAreLocal bool) test.Tester {
+	return test.NewTester(cfg, imagesAreLocal)
 }
 
-func getSyncer(runCtx *runcontext.RunContext) sync.Syncer {
-	return sync.NewSyncer(runCtx)
+func getSyncer(cfg sync.Config) sync.Syncer {
+	return sync.NewSyncer(cfg)
 }
 
-func getDeployer(runCtx *runcontext.RunContext, labels map[string]string) deploy.Deployer {
-	d := runCtx.Pipeline().Deploy
+func getDeployer(cfg deploy.Config, labels map[string]string) deploy.Deployer {
+	d := cfg.Pipeline().Deploy
 
 	var deployers deploy.DeployerMux
 
 	if d.HelmDeploy != nil {
-		deployers = append(deployers, deploy.NewHelmDeployer(runCtx, labels))
+		deployers = append(deployers, deploy.NewHelmDeployer(cfg, labels))
 	}
 
 	if d.KptDeploy != nil {
-		deployers = append(deployers, deploy.NewKptDeployer(runCtx, labels))
+		deployers = append(deployers, deploy.NewKptDeployer(cfg, labels))
 	}
 
 	if d.KubectlDeploy != nil {
-		deployers = append(deployers, deploy.NewKubectlDeployer(runCtx, labels))
+		deployers = append(deployers, deploy.NewKubectlDeployer(cfg, labels))
 	}
 
 	if d.KustomizeDeploy != nil {
-		deployers = append(deployers, deploy.NewKustomizeDeployer(runCtx, labels))
+		deployers = append(deployers, deploy.NewKustomizeDeployer(cfg, labels))
 	}
 
 	// avoid muxing overhead when only a single deployer is configured

--- a/pkg/skaffold/sync/types.go
+++ b/pkg/skaffold/sync/types.go
@@ -19,8 +19,8 @@ package sync
 import (
 	"context"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
+	pkgkubectl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 )
 
 type syncMap map[string][]string
@@ -36,13 +36,19 @@ type Syncer interface {
 }
 
 type podSyncer struct {
-	kubectl    *kubectl.CLI
+	kubectl    *pkgkubectl.CLI
 	namespaces []string
 }
 
-func NewSyncer(runCtx *runcontext.RunContext) Syncer {
+type Config interface {
+	kubectl.Config
+
+	GetNamespaces() []string
+}
+
+func NewSyncer(cfg Config) Syncer {
 	return &podSyncer{
-		kubectl:    kubectl.NewFromRunContext(runCtx),
-		namespaces: runCtx.GetNamespaces(),
+		kubectl:    pkgkubectl.NewFromRunContext(cfg),
+		namespaces: cfg.GetNamespaces(),
 	}
 }

--- a/pkg/skaffold/test/test.go
+++ b/pkg/skaffold/test/test.go
@@ -26,27 +26,35 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/logfile"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/test/structure"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
+type Config interface {
+	docker.Config
+
+	Pipeline() latest.Pipeline
+	GetWorkingDir() string
+	Muted() config.Muted
+}
+
 // NewTester parses the provided test cases from the Skaffold config,
 // and returns a Tester instance with all the necessary test runners
 // to run all specified tests.
-func NewTester(runCtx *runcontext.RunContext, imagesAreLocal bool) Tester {
-	localDaemon, err := docker.NewAPIClient(runCtx)
+func NewTester(cfg Config, imagesAreLocal bool) Tester {
+	localDaemon, err := docker.NewAPIClient(cfg)
 	if err != nil {
 		return nil
 	}
 
 	return FullTester{
-		testCases:      runCtx.Pipeline().Test,
-		workingDir:     runCtx.GetWorkingDir(),
-		muted:          runCtx.Muted(),
+		testCases:      cfg.Pipeline().Test,
+		workingDir:     cfg.GetWorkingDir(),
+		muted:          cfg.Muted(),
 		localDaemon:    localDaemon,
 		imagesAreLocal: imagesAreLocal,
 	}

--- a/pkg/skaffold/test/test_test.go
+++ b/pkg/skaffold/test/test_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestNoTestDependencies(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
-		t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) { return nil, nil })
+		t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) { return nil, nil })
 
 		runCtx := &runcontext.RunContext{}
 		deps, err := NewTester(runCtx, true).TestDependencies()
@@ -105,7 +105,7 @@ func TestNoTest(t *testing.T) {
 
 func TestIgnoreDockerNotFound(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
-		t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
 			return nil, errors.New("not found")
 		})
 
@@ -159,7 +159,7 @@ func TestTestSuccessRemoteImage(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		t.NewTempDir().Touch("test.yaml").Chdir()
 		t.Override(&util.DefaultExecCommand, testutil.CmdRun("container-structure-test test -v warn --image image:tag --config test.yaml"))
-		t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
 			return docker.NewLocalDaemon(&testutil.FakeAPIClient{}, nil, false, nil), nil
 		})
 
@@ -186,7 +186,7 @@ func TestTestFailureRemoteImage(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		t.NewTempDir().Touch("test.yaml").Chdir()
 		t.Override(&util.DefaultExecCommand, testutil.CmdRun("container-structure-test test -v warn --image image:tag --config test.yaml"))
-		t.Override(&docker.NewAPIClient, func(*runcontext.RunContext) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
 			return docker.NewLocalDaemon(&testutil.FakeAPIClient{ErrImagePull: true}, nil, false, nil), nil
 		})
 


### PR DESCRIPTION
This is an additional non-dangerous step towards getting rid of RunContext as much as possible.

It introduces a `Config` interface for each constructor that used to depend on a RunContext. This acts as a "facade" on the RunContext and can only access information by their getter, making them more read-only. This break some hard coupling that we have which is also nice.

Signed-off-by: David Gageot <david@gageot.net>
