### PR TITLE
Skip logging first error from parsing Helm release info

### DIFF
--- a/pkg/skaffold/deploy/util.go
+++ b/pkg/skaffold/deploy/util.go
@@ -61,7 +61,7 @@ func parseReleaseInfo(namespace string, b *bufio.Reader) []Artifact {
 	var results []Artifact
 
 	r := k8syaml.NewYAMLReader(b)
-	for {
+	for i := 0; ; i++ {
 		doc, err := r.Read()
 		if err == io.EOF {
 			break
@@ -77,7 +77,9 @@ func parseReleaseInfo(namespace string, b *bufio.Reader) []Artifact {
 		}
 		obj, err := parseRuntimeObject(objNamespace, doc)
 		if err != nil {
-			logrus.Infof(err.Error())
+			if i > 0 {
+				logrus.Infof(err.Error())
+			}
 		} else {
 			results = append(results, *obj)
 			logrus.Debugf("found deployed object: %+v", obj.Obj)


### PR DESCRIPTION
Fixes #3642

```console
$ skaffold dev -v info
[...]
Tags used in deployment:
 - skaffold-helm -> skaffold-helm:20f636429961b8a319cf1c419d51d71135c7cebb2a1b9f75782b767526637bde
Starting deploy...
INFO[0000] Deploying with helm v3.1.2 ...               
Helm release skaffold-helm not installed. Installing...
INFO[0000] Building helm dependencies...                
NAME: skaffold-helm
LAST DEPLOYED: Thu Jul 30 17:15:28 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
INFO[0001] Deploy complete in 1.204661169s              
Waiting for deployments to stabilize...
 - deployment/skaffold-helm: waiting for rollout to finish: 0 of 2 updated replicas are available...
 - deployment/skaffold-helm is ready.
```
