### PR TITLE
Make skaffold run actually respect cleanup flag

### DIFF
--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -50,6 +50,9 @@ func doRun(ctx context.Context, out io.Writer) error {
 		err = r.DeployAndLog(ctx, out, bRes)
 		if err == nil {
 			tips.PrintForRun(out, opts)
+			if opts.Cleanup {
+				return r.Cleanup(context.Background(), out)
+			}
 		}
 
 		return err


### PR DESCRIPTION
the `--cleanup` flag has been available on `skaffold run`, but has never actually done anything. this plumbs the flag down to the command so that it will actually clean up resources when the process is exited.

this is really only useful when running with `--tail`, such that `skaffold run --tail --cleanup=true` will allow users to build/deploy once and view the logs, and then exit while cleaning up after themselves.

fixes #1008 