### PR TITLE
Make the dev loop interruptible.

### DIFF
--- a/pkg/skaffold/runner/listen_test.go
+++ b/pkg/skaffold/runner/listen_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package runner
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -58,7 +59,7 @@ func TestSkipDevLoopOnMonitorError(t *testing.T) {
 	}
 
 	var devLoopWasCalled bool
-	err := listener.do(func() error {
+	err := listener.do(context.Background(), func(context.Context) error {
 		devLoopWasCalled = true
 		return nil
 	})
@@ -72,7 +73,7 @@ func TestContinueOnDevLoopError(t *testing.T) {
 		Trigger: &fakeTriggger{},
 	}
 
-	err := listener.do(func() error {
+	err := listener.do(context.Background(), func(context.Context) error {
 		return errors.New("devloop error")
 	})
 
@@ -85,7 +86,7 @@ func TestReportDevLoopError(t *testing.T) {
 		Trigger: &fakeTriggger{},
 	}
 
-	err := listener.do(func() error {
+	err := listener.do(context.Background(), func(context.Context) error {
 		return ErrorConfigurationChanged
 	})
 

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -52,7 +52,7 @@ type TestBench struct {
 	deployErrors []error
 	namespaces   []string
 
-	devLoop        func(context.Context, io.Writer, func() error) error
+	devLoop        func(context.Context, io.Writer, func(context.Context) error) error
 	firstMonitor   func(bool) error
 	cycles         int
 	currentCycle   int
@@ -170,7 +170,7 @@ func (t *TestBench) Actions() []Actions {
 	return append(t.actions, t.currentActions)
 }
 
-func (t *TestBench) WatchForChanges(ctx context.Context, out io.Writer, doDev func() error) error {
+func (t *TestBench) WatchForChanges(ctx context.Context, out io.Writer, doDev func(context.Context) error) error {
 	// don't actually call the monitor here, because extra actions would be added
 	if err := t.firstMonitor(true); err != nil {
 		return err
@@ -234,11 +234,11 @@ func createRunner(t *testutil.T, testBench *TestBench, monitor filemon.Monitor) 
 	runner.listener = testBench
 	runner.monitor = monitor
 
-	testBench.devLoop = func(ctx context.Context, out io.Writer, doDev func() error) error {
+	testBench.devLoop = func(ctx context.Context, out io.Writer, doDev func(ctx context.Context) error) error {
 		if err := monitor.Run(true); err != nil {
 			return err
 		}
-		return doDev()
+		return doDev(ctx)
 	}
 
 	testBench.firstMonitor = func(bool) error {


### PR DESCRIPTION
Wether it’s during the build, the deploy or the status check, the dev loop can now be interrupted on a file change.

Fix #3908
Fix #916

If it’s the `skaffold.yaml` that’s modified, instead of restarting the dev loop right away, we first validate that the config is valid.

Fix #4225

Signed-off-by: David Gageot <david@gageot.net>
