### PR TITLE
prune empty namespaces from runCtx

### DIFF
--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -29,6 +29,10 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
+const (
+	emptyNamespace = ""
+)
+
 type RunContext struct {
 	Opts config.SkaffoldOptions
 	Cfg  latest.Pipeline
@@ -127,6 +131,9 @@ func (rc *RunContext) UpdateNamespaces(ns []string) {
 
 	nsMap := map[string]bool{}
 	for _, ns := range append(ns, rc.Namespaces...) {
+		if ns == emptyNamespace {
+			continue
+		}
 		nsMap[ns] = true
 	}
 

--- a/pkg/skaffold/runner/runcontext/context_test.go
+++ b/pkg/skaffold/runner/runcontext/context_test.go
@@ -59,6 +59,24 @@ func TestRunContext_UpdateNamespaces(t *testing.T) {
 			namespaces:  []string{},
 			expected:    []string{},
 		},
+		{
+			description: "update namespace when runcontext namespace has an empty string",
+			runContext:  &RunContext{Namespaces: []string{""}},
+			namespaces:  []string{"another"},
+			expected:    []string{"another"},
+		},
+		{
+			description: "update namespace when namespace is empty string",
+			runContext:  &RunContext{Namespaces: []string{"test"}},
+			namespaces:  []string{""},
+			expected:    []string{"test"},
+		},
+		{
+			description: "update namespace when namespace is empty string and runContext is empty",
+			runContext:  &RunContext{Namespaces: []string{}},
+			namespaces:  []string{""},
+			expected:    []string{},
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {


### PR DESCRIPTION
Fixes #4450 

When debugging, i found out both `""` and `default` were added in the `runCtx.Namespaces` due to which, the same deployment was discovered twice.

In this PR, when calling `UpdateNamespaces`, we prune any empty namespace `""`.

