### PR TITLE
Ask for notification of os.Interrupt

### DIFF
--- a/cmd/skaffold/app/signals.go
+++ b/cmd/skaffold/app/signals.go
@@ -26,6 +26,7 @@ import (
 func catchCtrlC(cancel context.CancelFunc) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals,
+		os.Interrupt,
 		syscall.SIGTERM,
 		syscall.SIGINT,
 		syscall.SIGPIPE,


### PR DESCRIPTION
Related to #4058 

Include `os.Interrupt` in case it enables some other termination-catching mechanism on Windows.