### PR TITLE
Prune deployment status updated without any pod statuses

### DIFF
--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -43,8 +43,8 @@ const (
 )
 
 var (
-	msgKubectlKilled     = "kubectl rollout status command interrupted"
-	MsgKubectlConnection = "kubectl connection error"
+	msgKubectlKilled     = "kubectl rollout status command interrupted\n"
+	MsgKubectlConnection = "kubectl connection error\n"
 
 	nonRetryContainerErrors = map[proto.StatusCode]struct{}{
 		proto.StatusCode_STATUSCHECK_IMAGE_PULL_ERR:       {},

--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -157,7 +157,11 @@ func (d *Deployment) ReportSinceLastUpdated() string {
 		return ""
 	}
 	var result strings.Builder
-	result.WriteString(fmt.Sprintf("%s %s: %s", tabHeader, d, d.status))
+	// Pod container statuses can be empty.
+	// This can happen when
+	// 1. No pods have been scheduled for the deployment
+	// 2. All containers are in running phase with no errors.
+	// In such case, avoid printing any status update for the deployment.
 	for _, p := range d.pods {
 		if s := p.ActionableError().Message; s != "" {
 			result.WriteString(fmt.Sprintf("%s %s %s: %s\n", tab, tabHeader, p, s))
@@ -166,7 +170,10 @@ func (d *Deployment) ReportSinceLastUpdated() string {
 			}
 		}
 	}
-	return result.String()
+	if result.String() == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s %s: %s%s", tabHeader, d, d.status, result.String())
 }
 
 func (d *Deployment) cleanupStatus(msg string) string {

--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -392,12 +392,15 @@ func TestPrintStatus(t *testing.T) {
 					proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_SUCCESS},
 				),
 				withStatus(
-					resource.NewDeployment("r2", "test", 1),
+					resource.NewDeployment("r2", "test", 1).
+						WithPodStatuses([]proto.StatusCode{proto.StatusCode_STATUSCHECK_IMAGE_PULL_ERR}),
 					proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_DEPLOYMENT_ROLLOUT_PENDING,
-						Message: "pending"},
+						Message: "pending\n"},
 				),
 			},
-			expectedOut: " - test:deployment/r2: pending\n",
+			expectedOut: ` - test:deployment/r2: pending
+    - test:pod/foo: pod failed
+`,
 		},
 		{
 			description: "multiple resources 1 not complete and retry-able error",
@@ -407,13 +410,16 @@ func TestPrintStatus(t *testing.T) {
 					proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_SUCCESS},
 				),
 				withStatus(
-					resource.NewDeployment("r2", "test", 1),
+					resource.NewDeployment("r2", "test", 1).
+						WithPodStatuses([]proto.StatusCode{proto.StatusCode_STATUSCHECK_IMAGE_PULL_ERR}),
 					proto.ActionableErr{
 						ErrCode: proto.StatusCode_STATUSCHECK_KUBECTL_CONNECTION_ERR,
 						Message: resource.MsgKubectlConnection},
 				),
 			},
-			expectedOut: " - test:deployment/r2: kubectl connection error\n",
+			expectedOut: ` - test:deployment/r2: kubectl connection error
+    - test:pod/foo: pod failed
+`,
 		},
 	}
 


### PR DESCRIPTION
Fixes #4450 

In this PR, don't report any updates to deployment status on CLI or via event API, if no pod updates are available.

**BEFORE** On master, 
```
- deployment/java-hello-world: waiting for rollout to finish: 0 of 1 updated replicas are available...
- deployment/java-hello-world: waiting for rollout to finish: 0 of 1 updated replicas are available...
   - pod/java-hello-world-57d69bf97f-kvhh5: creating container server
 - deployment/java-hello-world is ready.
```

If you see, there first deployment status reported did not contain any pod related information. 
This is likely because at this point no pods were scheduled.

**AFTER** with this change, 
```
Starting deploy...
 - deployment.apps/java-hello-world created
 - service/java-hello-world-external created
Waiting for deployments to stabilize...
 - deployment/java-hello-world: waiting for rollout to finish: 0 of 1 updated replicas are available...
    - pod/java-hello-world-76558b7bc5-sgqk9: creating container server
 - deployment/java-hello-world is ready.
Deployments stabilized in 1.858907891s
```

Events API:
```

{"result":{"timestamp":"2020-07-31T21:49:33.614251Z",
    "event":{"statusCheckEvent":{"status":"Started"}},"entry":"Status check started"}}
{"result":{"timestamp":"2020-07-31T21:49:34.371235Z",
     "event":{"resourceStatusCheckEvent":{
        "resource":"pod/java-hello-world-d9566dffc-gktt7","status":"In Progress","message":"creating container server","statusCode":"STATUSCHECK_CONTAINER_CREATING",  ...}
  
{"result":{"timestamp":"2020-07-31T21:49:34.779943Z",
     "event":{"resourceStatusCheckEvent":{
               "resource":"deployment/java-hello-world","status":"In Progress","message":"waiting for rollout to finish: 0 of 1 updated replicas are available...\n","statusCode":"STATUSCHECK_DEPLOYMENT_ROLLOUT_PENDING", ....}


{"result":{"timestamp":"2020-07-31T21:49:36.516903Z","event":{
     "resourceStatusCheckEvent":{
      "resource":"pod/java-hello-world-d9566dffc-gktt7",
      "status":"Succeeded","message":"Succeeded","statusCode":"STATUSCHECK_SUCCESS"}},
     "entry":"Resource pod/java-hello-world-d9566dffc-gktt7 status completed successfully"}}

{"result":{"timestamp":"2020-07-31T21:49:36.516934Z","event":{
      "resourceStatusCheckEvent":{
       "resource":"deployment/java-hello-world",
      "status":"Succeeded","message":"Succeeded","statusCode":"STATUSCHECK_SUCCESS"}}," .... }

{"result":{"timestamp":"2020-07-31T21:49:36.516958Z","event":{"statusCheckEvent":{"status":"Succeeded"}},"entry":"Status check succeeded"}}
{"result":{"timestamp":"2020-07-31T21:49:36.593360Z","event":{
     "devLoopEvent":{"status":"Succeeded"}},"entry":"DevInit Iteration 0 successful"}}

```
