### PR TITLE
Install specific Bazel version and Skaffold version for nightly linux and darwin integration tests.

### DIFF
--- a/.github/workflows/integration-darwin.yml
+++ b/.github/workflows/integration-darwin.yml
@@ -40,12 +40,12 @@ jobs:
         curl -fLO "https://github.com/bazelbuild/bazel/releases/download/${{ matrix.bazel_version }}/bazel-${{ matrix.bazel_version }}-installer-darwin-x86_64.sh"
         chmod +x "bazel-${{ matrix.bazel_version }}-installer-darwin-x86_64.sh"
         ./bazel-${{ matrix.bazel_version }}-installer-darwin-x86_64.sh --user
+        echo ::add-path::${HOME}/bin
 
     - name: Install Kustomize
       run: |
         wget -O kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${{ matrix.kustomize_version }}/kustomize_v${{ matrix.kustomize_version }}_darwin_amd64.tar.gz
         sudo tar -xvf kustomize.tar.gz -C /usr/local/bin/
-        echo ::add-path::${HOME}/bin
 
     - name: Install Ko
       run: |

--- a/.github/workflows/integration-darwin.yml
+++ b/.github/workflows/integration-darwin.yml
@@ -12,12 +12,13 @@ jobs:
     strategy:
       matrix:
         kustomize_version: [3.5.4]
+        bazel_version: [3.2.0]
         ko_version: [0.4.0]
         kompose_version: [1.21.0]
         gcloud_sdk_version: [276.0.0]
         kubectl_version: [1.18.0]
         container_structure_tests_version: [1.8.0]
-        minikube_version: [1.11.0]
+        minikube_version: [1.12.1]
         integration_test_partitions: [0, 1, 2, 3]
     steps:
 
@@ -30,10 +31,21 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
+    - name: Skaffold binary version
+      run: |
+        echo ::set-env name=SKAFFOLD_VERSION::"$(git log --format="%H" -n 1)"
+
+    - name: Install Bazel
+      run: |
+        curl -fLO "https://github.com/bazelbuild/bazel/releases/download/${{ matrix.bazel_version }}/bazel-${{ matrix.bazel_version }}-installer-darwin-x86_64.sh"
+        chmod +x "bazel-${{ matrix.bazel_version }}-installer-darwin-x86_64.sh"
+        ./bazel-${{ matrix.bazel_version }}-installer-darwin-x86_64.sh --user
+
     - name: Install Kustomize
       run: |
         wget -O kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${{ matrix.kustomize_version }}/kustomize_v${{ matrix.kustomize_version }}_darwin_amd64.tar.gz
         sudo tar -xvf kustomize.tar.gz -C /usr/local/bin/
+        echo ::add-path::${HOME}/bin
 
     - name: Install Ko
       run: |
@@ -72,6 +84,10 @@ jobs:
         gcloud auth configure-docker
         echo '{}' > ${HOME}/.docker/config.json
 
+    - name: Check VBoxManage installed
+      run: |
+        /usr/local/bin/VBoxManage list hostinfo
+
     - name: Install Minikube and start cluster
       run: |
         curl -Lo minikube https://storage.googleapis.com/minikube/releases/v${{ matrix.minikube_version }}/minikube-darwin-amd64
@@ -85,7 +101,7 @@ jobs:
 
     - name: Install Skaffold release binary
       run: |
-        curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/latest/skaffold-darwin-amd64
+        curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/${{ env.SKAFFOLD_VERSION }}/skaffold-darwin-amd64
         sudo install skaffold /usr/local/bin/skaffold
 
     - name: Run integration tests

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         kustomize_version: [3.5.4]
         ko_version: [0.4.0]
+        bazel_version: [3.2.0]
         kompose_version: [1.21.0]
         gcloud_sdk_version: [276.0.0]
         container_structure_tests_version: [1.8.0]
@@ -28,6 +29,17 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+
+    - name: Skaffold binary version
+      run: |
+        echo ::set-env name=SKAFFOLD_VERSION::"$(git log --format="%H" -n 1)"
+
+    - name: Install Bazel
+      run: |
+        curl -fLO "https://github.com/bazelbuild/bazel/releases/download/${{ matrix.bazel_version }}/bazel-${{ matrix.bazel_version }}-installer-linux-x86_64.sh"
+        chmod +x bazel-${{ matrix.bazel_version }}-installer-linux-x86_64.sh
+        ./bazel-${{ matrix.bazel_version }}-installer-linux-x86_64.sh --user
+        echo ::add-path::${HOME}/bin
 
     - name: Install Kustomize
       run: |
@@ -76,7 +88,7 @@ jobs:
 
     - name: Install Skaffold release binary
       run: |
-        curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/latest/skaffold-linux-amd64
+        curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/${{ env.SKAFFOLD_VERSION }}/skaffold-linux-amd64
         sudo install skaffold /usr/local/bin/skaffold
 
     - name: Run integration tests


### PR DESCRIPTION
Fixes #4617 
1. Install supported Bazel version in the tests.
2. Install Skaffold binary specific to the code commit.
3. Update minikube version.