### PR TITLE
Expand home directory for setFiles in helm deployment

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -556,8 +556,12 @@ func constructOverrideArgs(r *latest.HelmRelease, builds []build.Artifact, args 
 	}
 
 	for k, v := range r.SetFiles {
-		record(v)
-		args = append(args, "--set-file", fmt.Sprintf("%s=%s", k, v))
+		exp, err := homedir.Expand(v)
+		if err != nil {
+			return nil, fmt.Errorf("unable to expand %q: %w", v, err)
+		}
+		record(exp)
+		args = append(args, "--set-file", fmt.Sprintf("%s=%s", k, exp))
 	}
 
 	envMap := map[string]string{}

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/mitchellh/go-homedir"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -112,7 +114,8 @@ var testDeployConfigSetFiles = latest.HelmDeploy{
 		},
 		Overrides: schemautil.HelmOverrides{Values: map[string]interface{}{"foo": "bar"}},
 		SetFiles: map[string]string{
-			"value": "/some/file.yaml",
+			"expanded": "~/file.yaml",
+			"value":    "/some/file.yaml",
 		},
 	}},
 }
@@ -399,6 +402,10 @@ func TestHelmDeploy(t *testing.T) {
 	tmpDir, err := ioutil.TempDir("", "TestHelmDeploy")
 	if err != nil {
 		t.Fatalf("tempdir: %v", err)
+	}
+	home, err := homedir.Dir()
+	if err != nil {
+		t.Fatalf("Cannot get homedir: %v", err)
 	}
 
 	tests := []struct {
@@ -784,7 +791,7 @@ func TestHelmDeploy(t *testing.T) {
 				CmdRunWithOutput("helm version --client", version20rc).
 				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
-				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set-file value=/some/file.yaml --kubeconfig kubeconfig").
+				AndRun(fmt.Sprintf("helm --kube-context kubecontext upgrade skaffold-helm examples/test -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set-file expanded=%s --set-file value=/some/file.yaml --kubeconfig kubeconfig", filepath.Join(home, "file.yaml"))).
 				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
 			helm:   testDeployConfigSetFiles,
 			builds: testBuilds,


### PR DESCRIPTION
This allows to pass values coming from files located under
the home directory, such as configuration or credentials.

Feel free to comment.