### PR TITLE
Fix CustomTagger docs

### DIFF
--- a/docs/content/en/docs/references/yaml/main.js
+++ b/docs/content/en/docs/references/yaml/main.js
@@ -193,9 +193,14 @@ function* template(definitions, parentDefinition, ref, ident, parent) {
 
     // This definition is an array
     if (definition.items && definition.items.$ref) {
-      yield html`
-        ${template(definitions, definition, definition.items.$ref, ident + 1, path)}
-      `;
+      // don't infinitely recurse into nested tagger components
+      if (definition.items.$ref === "#/definitions/TaggerComponent") {
+        yield html ``;
+      } else {
+        yield html`
+          ${template(definitions, definition, definition.items.$ref, ident + 1, path)}
+        `;
+      }
     }
   }
 }

--- a/docs/content/en/schemas/v2beta6.json
+++ b/docs/content/en/schemas/v2beta6.json
@@ -2117,6 +2117,45 @@
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
+    "TagPolicy": {
+      "properties": {
+        "customTemplate": {
+          "$ref": "#/definitions/CustomTemplateTagger",
+          "description": "*beta* tags images with a configurable template string *composed of other taggers*.",
+          "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string <em>composed of other taggers</em>."
+        },
+        "dateTime": {
+          "$ref": "#/definitions/DateTimeTagger",
+          "description": "*beta* tags images with the build timestamp.",
+          "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
+        },
+        "envTemplate": {
+          "$ref": "#/definitions/EnvTemplateTagger",
+          "description": "*beta* tags images with a configurable template string.",
+          "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
+        },
+        "gitCommit": {
+          "$ref": "#/definitions/GitTagger",
+          "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
+          "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
+        },
+        "sha256": {
+          "$ref": "#/definitions/ShaTagger",
+          "description": "*beta* tags images with their sha256 digest.",
+          "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
+        }
+      },
+      "preferredOrder": [
+        "gitCommit",
+        "sha256",
+        "envTemplate",
+        "dateTime",
+        "customTemplate"
+      ],
+      "additionalProperties": false,
+      "description": "contains all the configuration for the tagging step.",
+      "x-intellij-html-description": "contains all the configuration for the tagging step."
+    },
     "TaggerComponent": {
       "anyOf": [
         {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -191,7 +191,7 @@ type TaggerComponent struct {
 	Name string `yaml:"name,omitempty"`
 
 	// Component is a tagging strategy to be used in CustomTemplateTagger.
-	Component TagPolicy `yaml:",inline"`
+	Component TagPolicy `yaml:",inline" yamltags:"skipTrim"`
 }
 
 // BuildType contains the specific implementation and parameters needed

--- a/pkg/skaffold/yamltags/tags.go
+++ b/pkg/skaffold/yamltags/tags.go
@@ -72,6 +72,10 @@ func processTags(yamltags string, val reflect.Value, parentStruct reflect.Value,
 				Field:  field,
 				Parent: parentStruct,
 			}
+		case "skipTrim":
+			yt = &skipTrimTag{
+				Field: field,
+			}
 		default:
 			logrus.Panicf("unknown yaml tag in %s", yamltags)
 		}
@@ -162,6 +166,24 @@ func (oot *oneOfTag) Process(val reflect.Value) error {
 		if !isZeroValue(field) {
 			return fmt.Errorf("only one element in set %s can be set. got %s and %s", oot.setName, otherField, oot.Field.Name)
 		}
+	}
+	return nil
+}
+
+type skipTrimTag struct {
+	Field reflect.StructField
+}
+
+func (tag *skipTrimTag) Load(s []string) error {
+	return nil
+}
+
+func (tag *skipTrimTag) Process(val reflect.Value) error {
+	if isZeroValue(val) {
+		if tags, ok := tag.Field.Tag.Lookup("yaml"); ok {
+			return fmt.Errorf("skipTrim value not set: %s", strings.Split(tags, ",")[0])
+		}
+		return fmt.Errorf("skipTrim value not set: %s", tag.Field.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
fixes #4614 

https://github.com/GoogleContainerTools/skaffold/pull/4588 added a new `TagPolicy`, `CustomTagger`, which contains one or more `TaggerComponent`s, each of which itself is a `TagPolicy`.

since the `TagPolicy` was inlined, our schema generator was removing it from the generated definition properties - this was causing a nil pointer exception in the javascript.

once this issue was fixed, we have another issue. our templater generates HTML for every schema definition, and nests HTML for every nested schema definition - this means that `TagPolicy` -> `CustomTagger` -> `TaggerComponent` -> `TagPolicy` causes an infinite loop in the schema generation.

the fix here is to add a new yamlTag, `skipTrim`, which skips trimming off inlined definitions when set. additionally, our templater will now special case `TaggerComponent` and yield empty HTML rather than recurse into nested definitions, avoiding the infinite loop.

**NOTE**: this will fail the schema version check, since this technically updates a released schema version. however, since this is just a yaml tag update and NOT a user facing change, I believe this should be safe. once this is merged to master, all subsequent schema version checks will pass (assuming they don't actually change the released schema).