### PR TITLE
Explicitly specify commands that should show surveys and update messages post execution

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -57,7 +57,7 @@ func NewCmdBuild() *cobra.Command {
 			f.StringVar(&buildOutputFlag, "file-output", "", "Filename to write build images to")
 			f.BoolVar(&opts.DryRun, "dry-run", false, "Don't build images, just compute the tag for each artifact.")
 		}).
-		AllowHouseKeepingMessages().
+		WithHouseKeepingMessages().
 		NoArgs(doBuild)
 }
 

--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -57,6 +57,7 @@ func NewCmdBuild() *cobra.Command {
 			f.StringVar(&buildOutputFlag, "file-output", "", "Filename to write build images to")
 			f.BoolVar(&opts.DryRun, "dry-run", false, "Don't build images, just compute the tag for each artifact.")
 		}).
+		AllowHouseKeepingMessages().
 		NoArgs(doBuild)
 }
 

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -89,7 +89,10 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 			// Print version
 			version := version.Get()
 			logrus.Infof("Skaffold %+v", version)
-
+			if !isHouseKeepingMessagesAllowed(cmd) {
+				logrus.Debugf("Disable housekeeping messages for command explicitly")
+				return nil
+			}
 			switch {
 			case !interactive:
 				logrus.Debugf("Update check and survey prompt disabled in non-interactive mode")
@@ -108,15 +111,6 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 			return nil
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
-			if !isHouseKeepingMessagesAllowed(cmd) {
-				logrus.Debugf("Disable housekeeping messages for command explicitly")
-				select {
-				case <-updateMsg:
-				case <-surveyPrompt:
-				default:
-				}
-				return
-			}
 			select {
 			case msg := <-updateMsg:
 				fmt.Fprintf(cmd.OutOrStdout(), "%s\n", msg)

--- a/cmd/skaffold/app/cmd/commands.go
+++ b/cmd/skaffold/app/cmd/commands.go
@@ -33,7 +33,7 @@ type Builder interface {
 	WithLongDescription(long string) Builder
 	WithExample(comment, command string) Builder
 	WithFlags(adder func(*pflag.FlagSet)) Builder
-	AllowHouseKeepingMessages() Builder
+	WithHouseKeepingMessages() Builder
 	WithCommonFlags() Builder
 	Hidden() Builder
 	ExactArgs(argCount int, action func(context.Context, io.Writer, []string) error) *cobra.Command
@@ -76,7 +76,7 @@ func (b *builder) WithCommonFlags() Builder {
 	return b
 }
 
-func (b *builder) AllowHouseKeepingMessages() Builder {
+func (b *builder) WithHouseKeepingMessages() Builder {
 	allowHouseKeepingMessages(&b.cmd)
 	return b
 }

--- a/cmd/skaffold/app/cmd/commands.go
+++ b/cmd/skaffold/app/cmd/commands.go
@@ -33,6 +33,7 @@ type Builder interface {
 	WithLongDescription(long string) Builder
 	WithExample(comment, command string) Builder
 	WithFlags(adder func(*pflag.FlagSet)) Builder
+	AllowHouseKeepingMessages() Builder
 	WithCommonFlags() Builder
 	Hidden() Builder
 	ExactArgs(argCount int, action func(context.Context, io.Writer, []string) error) *cobra.Command
@@ -72,6 +73,11 @@ func (b *builder) WithExample(comment, command string) Builder {
 
 func (b *builder) WithCommonFlags() Builder {
 	AddFlags(&b.cmd)
+	return b
+}
+
+func (b *builder) AllowHouseKeepingMessages() Builder {
+	allowHouseKeepingMessages(&b.cmd)
 	return b
 }
 

--- a/cmd/skaffold/app/cmd/commands_test.go
+++ b/cmd/skaffold/app/cmd/commands_test.go
@@ -105,6 +105,11 @@ func TestNewCmdWithFlags(t *testing.T) {
 	testutil.CheckDeepEqual(t, "usage", flags["test"].Usage)
 }
 
+func TestNewCmdWithHouseKeepingMessages(t *testing.T) {
+	cmd := NewCmd("run").WithHouseKeepingMessages().NoArgs(nil)
+	testutil.CheckDeepEqual(t, map[string]string{HouseKeepingMessagesAllowedAnnotation: "true"}, cmd.Annotations)
+}
+
 func TestNewCmdWithCommonFlags(t *testing.T) {
 	cmd := NewCmd("run").WithCommonFlags().NoArgs(nil)
 

--- a/cmd/skaffold/app/cmd/completion.go
+++ b/cmd/skaffold/app/cmd/completion.go
@@ -58,7 +58,7 @@ func completion(cmd *cobra.Command, args []string) {
 
 // NewCmdCompletion returns the cobra command that outputs shell completion code
 func NewCmdCompletion() *cobra.Command {
-	cmd := &cobra.Command{
+	return &cobra.Command{
 		Use: "completion SHELL",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
@@ -71,8 +71,6 @@ func NewCmdCompletion() *cobra.Command {
 		Long:      longDescription,
 		Run:       completion,
 	}
-	setCommandOutputEvaluated(cmd)
-	return cmd
 }
 
 func runCompletionZsh(cmd *cobra.Command, out io.Writer) {

--- a/cmd/skaffold/app/cmd/completion.go
+++ b/cmd/skaffold/app/cmd/completion.go
@@ -58,7 +58,7 @@ func completion(cmd *cobra.Command, args []string) {
 
 // NewCmdCompletion returns the cobra command that outputs shell completion code
 func NewCmdCompletion() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use: "completion SHELL",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
@@ -71,6 +71,8 @@ func NewCmdCompletion() *cobra.Command {
 		Long:      longDescription,
 		Run:       completion,
 	}
+	setCommandOutputEvaluated(cmd)
+	return cmd
 }
 
 func runCompletionZsh(cmd *cobra.Command, out io.Writer) {

--- a/cmd/skaffold/app/cmd/debug.go
+++ b/cmd/skaffold/app/cmd/debug.go
@@ -36,7 +36,7 @@ func NewCmdDebug() *cobra.Command {
 		WithDescription("[beta] Run a pipeline in debug mode").
 		WithLongDescription("Similar to `dev`, but configures the pipeline for debugging.").
 		WithCommonFlags().
-		AllowHouseKeepingMessages().
+		WithHouseKeepingMessages().
 		NoArgs(func(ctx context.Context, out io.Writer) error {
 			return doDebug(ctx, out)
 		})

--- a/cmd/skaffold/app/cmd/debug.go
+++ b/cmd/skaffold/app/cmd/debug.go
@@ -36,6 +36,7 @@ func NewCmdDebug() *cobra.Command {
 		WithDescription("[beta] Run a pipeline in debug mode").
 		WithLongDescription("Similar to `dev`, but configures the pipeline for debugging.").
 		WithCommonFlags().
+		AllowHouseKeepingMessages().
 		NoArgs(func(ctx context.Context, out io.Writer) error {
 			return doDebug(ctx, out)
 		})

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -50,7 +50,7 @@ func NewCmdDeploy() *cobra.Command {
 			f.VarP(&deployFromBuildOutputFile, "build-artifacts", "a", "File containing build result from a previous 'skaffold build --file-output'")
 			f.BoolVar(&opts.SkipRender, "skip-render", false, "Don't render the manifests, just deploy them")
 		}).
-		AllowHouseKeepingMessages().
+		WithHouseKeepingMessages().
 		NoArgs(doDeploy)
 }
 

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -50,6 +50,7 @@ func NewCmdDeploy() *cobra.Command {
 			f.VarP(&deployFromBuildOutputFile, "build-artifacts", "a", "File containing build result from a previous 'skaffold build --file-output'")
 			f.BoolVar(&opts.SkipRender, "skip-render", false, "Don't render the manifests, just deploy them")
 		}).
+		AllowHouseKeepingMessages().
 		NoArgs(doDeploy)
 }
 

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -36,6 +36,7 @@ func NewCmdDev() *cobra.Command {
 	return NewCmd("dev").
 		WithDescription("Run a pipeline in development mode").
 		WithCommonFlags().
+		AllowHouseKeepingMessages().
 		NoArgs(doDev)
 }
 

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -36,7 +36,7 @@ func NewCmdDev() *cobra.Command {
 	return NewCmd("dev").
 		WithDescription("Run a pipeline in development mode").
 		WithCommonFlags().
-		AllowHouseKeepingMessages().
+		WithHouseKeepingMessages().
 		NoArgs(doDev)
 }
 

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -51,6 +51,7 @@ func NewCmdRender() *cobra.Command {
 			f.StringVar(&renderOutputPath, "output", "", "file to write rendered manifests to")
 			f.StringVar(&opts.DigestSource, "digest-source", "local", "Set to 'local' to build images locally and use digests from built images; Set to 'remote' to resolve the digest of images by tag from the remote registry; Set to 'none' to use tags directly from the Kubernetes manifests")
 		}).
+		AllowHouseKeepingMessages().
 		NoArgs(doRender)
 }
 

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -51,7 +51,7 @@ func NewCmdRender() *cobra.Command {
 			f.StringVar(&renderOutputPath, "output", "", "file to write rendered manifests to")
 			f.StringVar(&opts.DigestSource, "digest-source", "local", "Set to 'local' to build images locally and use digests from built images; Set to 'remote' to resolve the digest of images by tag from the remote registry; Set to 'none' to use tags directly from the Kubernetes manifests")
 		}).
-		AllowHouseKeepingMessages().
+		WithHouseKeepingMessages().
 		NoArgs(doRender)
 }
 

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -36,6 +36,7 @@ func NewCmdRun() *cobra.Command {
 		WithExample("Build, test, deploy and tail the logs", "run --tail").
 		WithExample("Run with a given profile", "run -p <profile>").
 		WithCommonFlags().
+		AllowHouseKeepingMessages().
 		NoArgs(doRun)
 }
 

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -36,7 +36,7 @@ func NewCmdRun() *cobra.Command {
 		WithExample("Build, test, deploy and tail the logs", "run --tail").
 		WithExample("Run with a given profile", "run -p <profile>").
 		WithCommonFlags().
-		AllowHouseKeepingMessages().
+		WithHouseKeepingMessages().
 		NoArgs(doRun)
 }
 

--- a/integration/housekeeing_messages_test.go
+++ b/integration/housekeeing_messages_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestHouseKeepingMessagesNotShownForDiagnose(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+	file := testutil.TempFile(t, "config", nil)
+	out := skaffold.Diagnose("-c", file).InDir("examples/getting-started").RunOrFailOutput(t)
+	testutil.CheckNotContains(t, "Help improve Skaffold!", string(out))
+}
+
+func TestHouseKeepingMessagesShownForDev(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+	file := testutil.TempFile(t, "config", nil)
+	out := skaffold.Run("-c", file).InDir("examples/getting-started").RunOrFailOutput(t)
+	testutil.CheckContains(t, "Help improve Skaffold!", string(out))
+	skaffold.Delete().InDir("examples/getting-started")
+}

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -230,6 +230,14 @@ func CheckContains(t *testing.T, expected, actual string) {
 	}
 }
 
+func CheckNotContains(t *testing.T, excluded, actual string) {
+	t.Helper()
+	if strings.Contains(actual, excluded) {
+		t.Errorf("excluded output %s found in output: %s", excluded, actual)
+		return
+	}
+}
+
 func CheckDeepEqual(t *testing.T, expected, actual interface{}, opts ...cmp.Option) {
 	t.Helper()
 	if diff := cmp.Diff(actual, expected, opts...); diff != "" {


### PR DESCRIPTION
Fixes #4620 

Removes erroneous text generated in command `skaffold completion zsh`
Before:
```
...
compdef _skaffold skaffold
Help improve Skaffold! Take a 10-second anonymous survey by running
   skaffold survey
```
After:
```
...
compdef _skaffold skaffold
```