### PR TITLE
Clarify 'survey' command text

### DIFF
--- a/cmd/skaffold/app/cmd/survey.go
+++ b/cmd/skaffold/app/cmd/survey.go
@@ -27,7 +27,7 @@ import (
 
 func NewCmdSurvey() *cobra.Command {
 	return NewCmd("survey").
-		WithDescription("Show Skaffold survey url").
+		WithDescription("Opens a web browser to fill out the Skaffold survey").
 		NoArgs(showSurvey)
 }
 

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -87,7 +87,7 @@ Other Commands:
   credits           Export third party notices to given path (./skaffold-credits by default)
   diagnose          Run a diagnostic on Skaffold
   schema            List and print json schemas used to validate skaffold.yaml configuration
-  survey            Show Skaffold survey url
+  survey            Opens a web browser to fill out the Skaffold survey
   version           Print the version information
 
 Use "skaffold <command> --help" for more information about a given command.
@@ -930,7 +930,7 @@ Env vars:
 
 ### skaffold survey
 
-Show Skaffold survey url
+Opens a web browser to fill out the Skaffold survey
 
 ```
 

--- a/pkg/skaffold/survey/survey.go
+++ b/pkg/skaffold/survey/survey.go
@@ -37,9 +37,12 @@ const (
 
 var (
 	Form = fmt.Sprintf(`Thank you for offering your feedback on Skaffold! Understanding your experiences and opinions helps us make Skaffold better for you and other users.
-   Our survey can be found here: %s
 
-To permanently disable the survey prompt, run:
+Skaffold will now attempt to open the survey in your default web browser. You may also manually open it using this link:
+
+%s
+
+Tip: To permanently disable the survey prompt, run:
    skaffold config set --survey --global disable-prompt true`, URL)
 
 	// for testing


### PR DESCRIPTION
## Old Behavior

skaffold help survey

```
Show Skaffold survey url

Usage:
  skaffold survey [flags] [options]

Use "skaffold options" for a list of global command-line options (applies to all commands).
```

skaffold survey

```
Thank you for offering your feedback on Skaffold! Understanding your experiences and opinions helps us make Skaffold better for you and other users.
   Our survey can be found here: https://forms.gle/BMTbGQXLWSdn7vEs6

To permanently disable the survey prompt, run:
   skaffold config set --survey --global disable-prompt true
```

## New behavior

skaffold help survey

```
Opens a web browser to fill out the Skaffold survey

Usage:
  skaffold survey [flags] [options]

Use "skaffold options" for a list of global command-line options (applies to all commands).
```

skaffold survey

```
Thank you for offering your feedback on Skaffold! Understanding your experiences and opinions helps us make Skaffold better for you and other users.

Skaffold will now attempt to open the survey in your default web browser. You may also manually open it using this link:

https://forms.gle/BMTbGQXLWSdn7vEs6

To permanently disable the survey prompt, run:
   skaffold config set --survey --global disable-prompt true
``` 