### PR TITLE
Increase the duration between survey prompts

### DIFF
--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -309,7 +309,7 @@ func recentlyPromptedOrTaken(cfg *ContextConfig) bool {
 	if cfg == nil || cfg.Survey == nil {
 		return false
 	}
-	return lessThan(cfg.Survey.LastTaken, 365*24*time.Hours) || lessThan(cfg.Survey.LastPrompted, 60*24*time.Hours)
+	return lessThan(cfg.Survey.LastTaken, 365*24*time.Hour) || lessThan(cfg.Survey.LastPrompted, 60*24*time.Hour)
 }
 
 func lessThan(date string, duration time.Duration) bool {

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -37,8 +37,6 @@ import (
 const (
 	defaultConfigDir  = ".skaffold"
 	defaultConfigFile = "config"
-	tenDays           = time.Hour * 24 * 10
-	threeMonths       = time.Hour * 24 * 90
 )
 
 var (
@@ -311,7 +309,7 @@ func recentlyPromptedOrTaken(cfg *ContextConfig) bool {
 	if cfg == nil || cfg.Survey == nil {
 		return false
 	}
-	return lessThan(cfg.Survey.LastTaken, threeMonths) || lessThan(cfg.Survey.LastPrompted, tenDays)
+	return lessThan(cfg.Survey.LastTaken, 365*24*time.Hours) || lessThan(cfg.Survey.LastPrompted, 60*24*time.Hours)
 }
 
 func lessThan(date string, duration time.Duration) bool {

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -498,11 +498,11 @@ func TestShouldDisplayPrompt(t *testing.T) {
 			},
 		},
 		{
-			description: "should display prompt when last prompted is before 2 weeks",
+			description: "should display prompt when last prompted is older than 3 months",
 			cfg: &ContextConfig{
 				Survey: &SurveyConfig{
 					DisablePrompt: util.BoolPtr(false),
-					LastPrompted:  "2019-01-10T00:00:00Z",
+					LastPrompted:  "2019-9-10T00:00:00Z",
 				},
 			},
 			expected: true,

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -502,7 +502,7 @@ func TestShouldDisplayPrompt(t *testing.T) {
 			cfg: &ContextConfig{
 				Survey: &SurveyConfig{
 					DisablePrompt: util.BoolPtr(false),
-					LastPrompted:  "2019-09-10T00:00:00Z",
+					LastPrompted:  "2018-09-10T00:00:00Z",
 				},
 			},
 			expected: true,

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -502,7 +502,7 @@ func TestShouldDisplayPrompt(t *testing.T) {
 			cfg: &ContextConfig{
 				Survey: &SurveyConfig{
 					DisablePrompt: util.BoolPtr(false),
-					LastPrompted:  "2019-9-10T00:00:00Z",
+					LastPrompted:  "2019-09-10T00:00:00Z",
 				},
 			},
 			expected: true,


### PR DESCRIPTION
* If `survey` command is run, prompt once a year
* If `survey` command is not run, prompt once every 2 months

Also use idiomatic Go layout for durations (integer * duration).