### PR TITLE
Make event handling sequential and set the correct timestamp

### DIFF
--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/timestamp"
 
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -40,7 +41,20 @@ const (
 	Terminated = "Terminated"
 )
 
-var handler = &eventHandler{}
+var handler = newHandler()
+
+func newHandler() *eventHandler {
+	h := &eventHandler{
+		eventChan: make(chan firedEvent),
+	}
+	go func() {
+		for {
+			ev := <-h.eventChan
+			h.handleExec(ev)
+		}
+	}()
+	return h
+}
 
 type eventHandler struct {
 	eventLog []proto.LogEntry
@@ -48,8 +62,13 @@ type eventHandler struct {
 
 	state     proto.State
 	stateLock sync.Mutex
-
+	eventChan chan firedEvent
 	listeners []*listener
+}
+
+type firedEvent struct {
+	event *proto.Event
+	ts    *timestamp.Timestamp
 }
 
 type listener struct {
@@ -361,7 +380,7 @@ func FileSyncSucceeded(fileCount int, image string) {
 
 // PortForwarded notifies that a remote port has been forwarded locally.
 func PortForwarded(localPort, remotePort int32, podName, containerName, namespace string, portName string, resourceType, resourceName, address string) {
-	go handler.handle(&proto.Event{
+	handler.handle(&proto.Event{
 		EventType: &proto.Event_PortEvent{
 			PortEvent: &proto.PortEvent{
 				LocalPort:     localPort,
@@ -380,7 +399,7 @@ func PortForwarded(localPort, remotePort int32, podName, containerName, namespac
 
 // DebuggingContainerStarted notifies that a debuggable container has appeared.
 func DebuggingContainerStarted(podName, containerName, namespace, artifact, runtime, workingDir string, debugPorts map[string]uint32) {
-	go handler.handle(&proto.Event{
+	handler.handle(&proto.Event{
 		EventType: &proto.Event_DebuggingContainerEvent{
 			DebuggingContainerEvent: &proto.DebuggingContainerEvent{
 				Status:        Started,
@@ -398,7 +417,7 @@ func DebuggingContainerStarted(podName, containerName, namespace, artifact, runt
 
 // DebuggingContainerTerminated notifies that a debuggable container has disappeared.
 func DebuggingContainerTerminated(podName, containerName, namespace, artifact, runtime, workingDir string, debugPorts map[string]uint32) {
-	go handler.handle(&proto.Event{
+	handler.handle(&proto.Event{
 		EventType: &proto.Event_DebuggingContainerEvent{
 			DebuggingContainerEvent: &proto.DebuggingContainerEvent{
 				Status:        Terminated,
@@ -421,7 +440,7 @@ func (ev *eventHandler) setState(state proto.State) {
 }
 
 func (ev *eventHandler) handleDeployEvent(e *proto.DeployEvent) {
-	go ev.handle(&proto.Event{
+	ev.handle(&proto.Event{
 		EventType: &proto.Event_DeployEvent{
 			DeployEvent: e,
 		},
@@ -429,7 +448,7 @@ func (ev *eventHandler) handleDeployEvent(e *proto.DeployEvent) {
 }
 
 func (ev *eventHandler) handleStatusCheckEvent(e *proto.StatusCheckEvent) {
-	go ev.handle(&proto.Event{
+	ev.handle(&proto.Event{
 		EventType: &proto.Event_StatusCheckEvent{
 			StatusCheckEvent: e,
 		},
@@ -437,7 +456,7 @@ func (ev *eventHandler) handleStatusCheckEvent(e *proto.StatusCheckEvent) {
 }
 
 func (ev *eventHandler) handleResourceStatusCheckEvent(e *proto.ResourceStatusCheckEvent) {
-	go ev.handle(&proto.Event{
+	ev.handle(&proto.Event{
 		EventType: &proto.Event_ResourceStatusCheckEvent{
 			ResourceStatusCheckEvent: e,
 		},
@@ -445,7 +464,7 @@ func (ev *eventHandler) handleResourceStatusCheckEvent(e *proto.ResourceStatusCh
 }
 
 func (ev *eventHandler) handleBuildEvent(e *proto.BuildEvent) {
-	go ev.handle(&proto.Event{
+	ev.handle(&proto.Event{
 		EventType: &proto.Event_BuildEvent{
 			BuildEvent: e,
 		},
@@ -453,7 +472,7 @@ func (ev *eventHandler) handleBuildEvent(e *proto.BuildEvent) {
 }
 
 func (ev *eventHandler) handleDevLoopEvent(e *proto.DevLoopEvent) {
-	go ev.handle(&proto.Event{
+	ev.handle(&proto.Event{
 		EventType: &proto.Event_DevLoopEvent{
 			DevLoopEvent: e,
 		},
@@ -461,7 +480,7 @@ func (ev *eventHandler) handleDevLoopEvent(e *proto.DevLoopEvent) {
 }
 
 func (ev *eventHandler) handleFileSyncEvent(e *proto.FileSyncEvent) {
-	go ev.handle(&proto.Event{
+	ev.handle(&proto.Event{
 		EventType: &proto.Event_FileSyncEvent{
 			FileSyncEvent: e,
 		},
@@ -484,12 +503,21 @@ func LogMetaEvent() {
 }
 
 func (ev *eventHandler) handle(event *proto.Event) {
+	go func(t *timestamp.Timestamp) {
+		ev.eventChan <- firedEvent{
+			event: event,
+			ts:    t,
+		}
+	}(ptypes.TimestampNow())
+}
+
+func (ev *eventHandler) handleExec(f firedEvent) {
 	logEntry := &proto.LogEntry{
-		Timestamp: ptypes.TimestampNow(),
-		Event:     event,
+		Timestamp: f.ts,
+		Event:     f.event,
 	}
 
-	switch e := event.GetEventType().(type) {
+	switch e := f.event.GetEventType().(type) {
 	case *proto.Event_BuildEvent:
 		be := e.BuildEvent
 		ev.stateLock.Lock()

--- a/pkg/skaffold/event/event_test.go
+++ b/pkg/skaffold/event/event_test.go
@@ -32,8 +32,8 @@ import (
 )
 
 func TestGetLogEvents(t *testing.T) {
-	for step := 0; step < 10000; step++ {
-		ev := &eventHandler{}
+	for step := 0; step < 1000; step++ {
+		ev := newHandler()
 
 		ev.logEvent(proto.LogEntry{Entry: "OLD"})
 		go func() {
@@ -58,9 +58,8 @@ func TestGetLogEvents(t *testing.T) {
 }
 
 func TestGetState(t *testing.T) {
-	ev := &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	ev := newHandler()
+	ev.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	ev.stateLock.Lock()
 	ev.state.BuildState.Artifacts["img"] = Complete
@@ -72,11 +71,10 @@ func TestGetState(t *testing.T) {
 }
 
 func TestDeployInProgress(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().DeployState.Status == NotStarted })
 	DeployInProgress()
@@ -84,11 +82,10 @@ func TestDeployInProgress(t *testing.T) {
 }
 
 func TestDeployFailed(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().DeployState.Status == NotStarted })
 	DeployFailed(errors.New("BUG"))
@@ -99,11 +96,10 @@ func TestDeployFailed(t *testing.T) {
 }
 
 func TestDeployComplete(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().DeployState.Status == NotStarted })
 	DeployComplete()
@@ -114,15 +110,14 @@ func TestDeployComplete(t *testing.T) {
 }
 
 func TestBuildInProgress(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{Build: latest.BuildConfig{
-			Artifacts: []*latest.Artifact{{
-				ImageName: "img",
-			}},
-		}}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{Build: latest.BuildConfig{
+		Artifacts: []*latest.Artifact{{
+			ImageName: "img",
+		}},
+	}}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().BuildState.Artifacts["img"] == NotStarted })
 	BuildInProgress("img")
@@ -130,15 +125,14 @@ func TestBuildInProgress(t *testing.T) {
 }
 
 func TestBuildFailed(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{Build: latest.BuildConfig{
-			Artifacts: []*latest.Artifact{{
-				ImageName: "img",
-			}},
-		}}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{Build: latest.BuildConfig{
+		Artifacts: []*latest.Artifact{{
+			ImageName: "img",
+		}},
+	}}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().BuildState.Artifacts["img"] == NotStarted })
 	BuildFailed("img", errors.New("BUG"))
@@ -149,15 +143,14 @@ func TestBuildFailed(t *testing.T) {
 }
 
 func TestBuildComplete(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{Build: latest.BuildConfig{
-			Artifacts: []*latest.Artifact{{
-				ImageName: "img",
-			}},
-		}}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{Build: latest.BuildConfig{
+		Artifacts: []*latest.Artifact{{
+			ImageName: "img",
+		}},
+	}}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().BuildState.Artifacts["img"] == NotStarted })
 	BuildComplete("img")
@@ -165,11 +158,10 @@ func TestBuildComplete(t *testing.T) {
 }
 
 func TestPortForwarded(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().ForwardedPorts[8080] == nil })
 	PortForwarded(8080, 8888, "pod", "container", "ns", "portname", "resourceType", "resourceName", "127.0.0.1")
@@ -177,11 +169,10 @@ func TestPortForwarded(t *testing.T) {
 }
 
 func TestStatusCheckEventStarted(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
 	StatusCheckEventStarted()
@@ -189,11 +180,10 @@ func TestStatusCheckEventStarted(t *testing.T) {
 }
 
 func TestStatusCheckEventInProgress(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
 	StatusCheckEventInProgress("[2/5 deployment(s) are still pending]")
@@ -201,11 +191,10 @@ func TestStatusCheckEventInProgress(t *testing.T) {
 }
 
 func TestStatusCheckEventSucceeded(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
 	statusCheckEventSucceeded()
@@ -213,11 +202,10 @@ func TestStatusCheckEventSucceeded(t *testing.T) {
 }
 
 func TestStatusCheckEventFailed(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
 	StatusCheckEventEnded(proto.StatusCode_STATUSCHECK_FAILED_SCHEDULING, errors.New("one or more deployments failed"))
@@ -228,11 +216,10 @@ func TestStatusCheckEventFailed(t *testing.T) {
 }
 
 func TestResourceStatusCheckEventUpdated(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
 	ResourceStatusCheckEventUpdated("ns:pod/foo", proto.ActionableErr{
@@ -243,11 +230,10 @@ func TestResourceStatusCheckEventUpdated(t *testing.T) {
 }
 
 func TestResourceStatusCheckEventSucceeded(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
 	resourceStatusCheckEventSucceeded("ns:pod/foo")
@@ -255,11 +241,10 @@ func TestResourceStatusCheckEventSucceeded(t *testing.T) {
 }
 
 func TestResourceStatusCheckEventFailed(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
 	resourceStatusCheckEventFailed("ns:pod/foo", proto.ActionableErr{
@@ -270,11 +255,10 @@ func TestResourceStatusCheckEventFailed(t *testing.T) {
 }
 
 func TestFileSyncInProgress(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().FileSyncState.Status == NotStarted })
 	FileSyncInProgress(5, "image")
@@ -282,11 +266,10 @@ func TestFileSyncInProgress(t *testing.T) {
 }
 
 func TestFileSyncFailed(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().FileSyncState.Status == NotStarted })
 	FileSyncFailed(5, "image", errors.New("BUG"))
@@ -294,11 +277,10 @@ func TestFileSyncFailed(t *testing.T) {
 }
 
 func TestFileSyncSucceeded(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	wait(t, func() bool { return handler.getState().FileSyncState.Status == NotStarted })
 	FileSyncSucceeded(5, "image")
@@ -306,11 +288,10 @@ func TestFileSyncSucceeded(t *testing.T) {
 }
 
 func TestDebuggingContainer(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
+	defer func() { handler = newHandler() }()
 
-	handler = &eventHandler{
-		state: emptyState(latest.Pipeline{}, "test", true, true, true),
-	}
+	handler = newHandler()
+	handler.state = emptyState(latest.Pipeline{}, "test", true, true, true)
 
 	found := func() bool {
 		for _, dc := range handler.getState().DebuggingContainers {
@@ -349,26 +330,26 @@ func wait(t *testing.T, condition func() bool) {
 }
 
 func TestResetStateOnBuild(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
-	handler = &eventHandler{
-		state: proto.State{
-			BuildState: &proto.BuildState{
-				Artifacts: map[string]string{
-					"image1": Complete,
-				},
+	defer func() { handler = newHandler() }()
+	handler = newHandler()
+	handler.state = proto.State{
+		BuildState: &proto.BuildState{
+			Artifacts: map[string]string{
+				"image1": Complete,
 			},
-			DeployState: &proto.DeployState{Status: Complete},
-			ForwardedPorts: map[int32]*proto.PortEvent{
-				2001: {
-					LocalPort:  2000,
-					RemotePort: 2001,
-					PodName:    "test/pod",
-				},
-			},
-			StatusCheckState: &proto.StatusCheckState{Status: Complete},
-			FileSyncState:    &proto.FileSyncState{Status: Succeeded},
 		},
+		DeployState: &proto.DeployState{Status: Complete},
+		ForwardedPorts: map[int32]*proto.PortEvent{
+			2001: {
+				LocalPort:  2000,
+				RemotePort: 2001,
+				PodName:    "test/pod",
+			},
+		},
+		StatusCheckState: &proto.StatusCheckState{Status: Complete},
+		FileSyncState:    &proto.FileSyncState{Status: Succeeded},
 	}
+
 	ResetStateOnBuild()
 	expected := proto.State{
 		BuildState: &proto.BuildState{
@@ -384,24 +365,23 @@ func TestResetStateOnBuild(t *testing.T) {
 }
 
 func TestResetStateOnDeploy(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
-	handler = &eventHandler{
-		state: proto.State{
-			BuildState: &proto.BuildState{
-				Artifacts: map[string]string{
-					"image1": Complete,
-				},
+	defer func() { handler = newHandler() }()
+	handler = newHandler()
+	handler.state = proto.State{
+		BuildState: &proto.BuildState{
+			Artifacts: map[string]string{
+				"image1": Complete,
 			},
-			DeployState: &proto.DeployState{Status: Complete},
-			ForwardedPorts: map[int32]*proto.PortEvent{
-				2001: {
-					LocalPort:  2000,
-					RemotePort: 2001,
-					PodName:    "test/pod",
-				},
-			},
-			StatusCheckState: &proto.StatusCheckState{Status: Complete},
 		},
+		DeployState: &proto.DeployState{Status: Complete},
+		ForwardedPorts: map[int32]*proto.PortEvent{
+			2001: {
+				LocalPort:  2000,
+				RemotePort: 2001,
+				PodName:    "test/pod",
+			},
+		},
+		StatusCheckState: &proto.StatusCheckState{Status: Complete},
 	}
 	ResetStateOnDeploy()
 	expected := proto.State{
@@ -427,28 +407,27 @@ func TestEmptyStateCheckState(t *testing.T) {
 }
 
 func TestUpdateStateAutoTriggers(t *testing.T) {
-	defer func() { handler = &eventHandler{} }()
-	handler = &eventHandler{
-		state: proto.State{
-			BuildState: &proto.BuildState{
-				Artifacts: map[string]string{
-					"image1": Complete,
-				},
-				AutoTrigger: false,
+	defer func() { handler = newHandler() }()
+	handler = newHandler()
+	handler.state = proto.State{
+		BuildState: &proto.BuildState{
+			Artifacts: map[string]string{
+				"image1": Complete,
 			},
-			DeployState: &proto.DeployState{Status: Complete, AutoTrigger: false},
-			ForwardedPorts: map[int32]*proto.PortEvent{
-				2001: {
-					LocalPort:  2000,
-					RemotePort: 2001,
-					PodName:    "test/pod",
-				},
+			AutoTrigger: false,
+		},
+		DeployState: &proto.DeployState{Status: Complete, AutoTrigger: false},
+		ForwardedPorts: map[int32]*proto.PortEvent{
+			2001: {
+				LocalPort:  2000,
+				RemotePort: 2001,
+				PodName:    "test/pod",
 			},
-			StatusCheckState: &proto.StatusCheckState{Status: Complete},
-			FileSyncState: &proto.FileSyncState{
-				Status:      "Complete",
-				AutoTrigger: false,
-			},
+		},
+		StatusCheckState: &proto.StatusCheckState{Status: Complete},
+		FileSyncState: &proto.FileSyncState{
+			Status:      "Complete",
+			AutoTrigger: false,
 		},
 	}
 	UpdateStateAutoBuildTrigger(true)


### PR DESCRIPTION
<!-- Include if applicable: -->
Related: #4578 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Log events are coming out of order and with incorrect timestamps:
![image](https://user-images.githubusercontent.com/39389231/89804454-d1634800-db51-11ea-9c43-2382ff3d42aa.png)


This fix makes all event handle go through a single goroutine and also updates timestamps to when the events actually occur vs when they are handled.

This results in the correct event order and timestamp:

![image](https://user-images.githubusercontent.com/39389231/89804125-60bc2b80-db51-11ea-8675-184c9583d682.png)
