### PR TITLE
skip test TestHouseKeepingMessagesShownForDev until 1.14.0

### DIFF
--- a/integration/housekeeing_messages_test.go
+++ b/integration/housekeeing_messages_test.go
@@ -31,6 +31,9 @@ func TestHouseKeepingMessagesNotShownForDiagnose(t *testing.T) {
 }
 
 func TestHouseKeepingMessagesShownForDev(t *testing.T) {
+	// TODO(marlongamez): remove after v1.14.0 is released
+	t.Skip()
+
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 	file := testutil.TempFile(t, "config", nil)
 	out := skaffold.Run("-c", file).InDir("examples/getting-started").RunOrFailOutput(t)


### PR DESCRIPTION
**Description**
Skips the TestHouseKeepingMessagesShownForDev test. Since we've disabled the survey message for now, this test is causing travis to fail.

**Follow-up Work (remove if N/A)**
Revert this change once we've reenabled the survey message
