### PR TITLE
Send update-check message to stderr

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -113,7 +113,7 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
 			select {
 			case msg := <-updateMsg:
-				fmt.Fprintf(cmd.OutOrStdout(), "%s\n", msg)
+				fmt.Fprintf(cmd.OutOrStderr(), "%s\n", msg)
 			default:
 			}
 			// check if survey prompt needs to be displayed


### PR DESCRIPTION
Our new-version message is sent to stdout and so is mixed up with command output, as noted in https://github.com/GoogleContainerTools/skaffold/issues/3582#issuecomment-633527167:

https://github.com/GoogleContainerTools/skaffold/blob/5a5c6030bb6eaa052f34f2eefa2ea9c227b55341/cmd/skaffold/app/cmd/cmd.go#L115-L116

We should be sending the new-version message to stderr, just like our survey prompt:

https://github.com/GoogleContainerTools/skaffold/blob/5a5c6030bb6eaa052f34f2eefa2ea9c227b55341/cmd/skaffold/app/cmd/cmd.go#L123-L124