### PR TITLE
Enable auto sync mode for Buildpacks artifacts

### DIFF
--- a/docs/content/en/docs/pipeline-stages/filesync.md
+++ b/docs/content/en/docs/pipeline-stages/filesync.md
@@ -20,7 +20,8 @@ Multiple types of sync are supported by Skaffold:
    This is supported by docker and kaniko artifacts and also for custom artifacts that declare a
    dependency on a Dockerfile.
 
- + `auto`: Skaffold automatically configures the sync.  This is only supported by Jib and Buildpacks artifacts.
++ `auto`: Skaffold automatically configures the sync.  This mode is only supported by Jib and Buildpacks artifacts.
+   Auto sync mode is enabled by default for Buildpacks artifacts.
 
 ### Manual sync mode
 
@@ -77,11 +78,14 @@ File deletion will always cause a complete rebuild.
 
 ### Auto sync mode
 
+In auto sync mode, Skaffold automatically generates sync rules for known file types.  Changes to other file types will
+result in a complete rebuild.
+
 #### Buildpacks
 
 Skaffold requires special collaboration from the Buildpacks for the `auto` sync to work.
 The [gcr.io/buildpacks/builder:v1](https://github.com/GoogleCloudPlatform/buildpacks) supports Skaffold
-out of the box, currently for Go and NodeJS.
+out of the box, currently for Go, NodeJS, and Java.
 
 Cloud Native Buildpacks set a `io.buildpacks.build.metadata` label on the images they create.
 This labels points to json description of the [Bill-of-Materials, aka BOM](https://github.com/buildpacks/spec/blob/master/buildpack.md#bill-of-materials-toml) of the build.

--- a/integration/examples/buildpacks-java/skaffold.yaml
+++ b/integration/examples/buildpacks-java/skaffold.yaml
@@ -7,8 +7,6 @@ build:
       builder: "gcr.io/buildpacks/builder:v1"
       env:
       - GOOGLE_RUNTIME_VERSION=8
-    sync:
-      auto: {}
 profiles:
 - name: gcb
   build:

--- a/integration/examples/buildpacks-node/skaffold.yaml
+++ b/integration/examples/buildpacks-node/skaffold.yaml
@@ -5,5 +5,3 @@ build:
   - image: skaffold-buildpacks-node
     buildpacks:
       builder: "gcr.io/buildpacks/builder:v1"
-    sync:
-      auto: {}

--- a/integration/examples/buildpacks/skaffold.yaml
+++ b/integration/examples/buildpacks/skaffold.yaml
@@ -7,8 +7,6 @@ build:
       builder: "gcr.io/buildpacks/builder:v1"
       env:
       - GOPROXY={{.GOPROXY}}
-    sync:
-      auto: {}
 profiles:
 - name: gcb
   build:

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -235,6 +235,8 @@ func setDefaultSync(a *latest.Artifact) {
 				a.Sync.Infer = []string{"**/*"}
 			}
 		}
+	} else if a.BuildpackArtifact != nil {
+		a.Sync = &latest.Sync{Auto: &latest.Auto{}}
 	}
 }
 

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -65,6 +65,12 @@ func TestSetDefaults(t *testing.T) {
 						},
 						Sync: &latest.Sync{},
 					},
+					{
+						ImageName: "sixth",
+						ArtifactType: latest.ArtifactType{
+							BuildpackArtifact: &latest.BuildpackArtifact{},
+						},
+					},
 				},
 			},
 		},
@@ -94,6 +100,12 @@ func TestSetDefaults(t *testing.T) {
 
 	testutil.CheckDeepEqual(t, "fifth", cfg.Build.Artifacts[4].ImageName)
 	testutil.CheckDeepEqual(t, &latest.Auto{}, cfg.Build.Artifacts[4].Sync.Auto)
+
+	testutil.CheckDeepEqual(t, "sixth", cfg.Build.Artifacts[5].ImageName)
+	testutil.CheckDeepEqual(t, []string{"."}, cfg.Build.Artifacts[5].BuildpackArtifact.Dependencies.Paths)
+	testutil.CheckDeepEqual(t, []string(nil), cfg.Build.Artifacts[5].BuildpackArtifact.Dependencies.Ignore)
+	testutil.CheckDeepEqual(t, "project.toml", cfg.Build.Artifacts[5].BuildpackArtifact.ProjectDescriptor)
+	testutil.CheckDeepEqual(t, &latest.Auto{}, cfg.Build.Artifacts[5].Sync.Auto)
 }
 
 func TestSetDefaultsOnCluster(t *testing.T) {


### PR DESCRIPTION
Fixes: #4651

**Description**

Change Buildpacks artifacts to default to automatic sync.  This is a safe change as:
  - The auto sync mechanism requires that the image contains buildpacks metadata defining the file types to be synced; if this metadata is not found (e.g., using something other than GCP Buildpacks) then no sync rules are defined and a full rebuild is triggered for each file change.
  - The GCP Buildpacks are conservative in their listed file types.

The default can be avoided by defining a manual or infer rule:

```yaml
   artifacts:
   - image: nodejs-hello-world
     buildpacks:
       builder: gcr.io/buildpacks/builder:v1
     sync:
      manual:
       # following rule never matches anything but prevents auto syncing
      - src: '...'
        dest: '...'
```


**User facing changes (remove if N/A)**

`Buildpacks artifacts now default to enabling auto sync`