### PR TITLE
Enabling '--secret' option in 'docker build'

### DIFF
--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -454,6 +454,10 @@ func GetBuildArgs(a *latest.DockerArtifact) ([]string, error) {
 		args = append(args, "--no-cache")
 	}
 
+	if a.Secret != "" {
+		args = append(args, "--secret", strings.ToLower(a.Secret))
+	}
+
 	return args, nil
 }
 

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -134,6 +134,7 @@ func TestBuild(t *testing.T) {
 				Target:      "target",
 				NetworkMode: "None",
 				NoCache:     true,
+				Secret:      "id=mysecret,src=mysecret.txt",
 			},
 			expected: types.ImageBuildOptions{
 				Tags:       []string{"finalimage"},
@@ -148,6 +149,7 @@ func TestBuild(t *testing.T) {
 				Target:      "target",
 				NetworkMode: "none",
 				NoCache:     true,
+				Secret:      "id=mysecret,src=mysecret.txt",
 			},
 		},
 		{

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -930,6 +930,9 @@ type DockerArtifact struct {
 
 	// NoCache used to pass in --no-cache to docker build to prevent caching.
 	NoCache bool `yaml:"noCache,omitempty"`
+
+	// Secret is passed as an argument to the --secret option.
+	Secret string `yaml:"secret,omitempty"`
 }
 
 // BazelArtifact describes an artifact built with [Bazel](https://bazel.build/).

--- a/pkg/skaffold/schema/v2beta6/config.go
+++ b/pkg/skaffold/schema/v2beta6/config.go
@@ -930,6 +930,9 @@ type DockerArtifact struct {
 
 	// NoCache used to pass in --no-cache to docker build to prevent caching.
 	NoCache bool `yaml:"noCache,omitempty"`
+
+	// Secret is passed as an argument to the --secret option.
+	Secret string `yaml:"secret,omitempty"`
 }
 
 // BazelArtifact describes an artifact built with [Bazel](https://bazel.build/).

--- a/vendor/github.com/docker/docker/api/types/client.go
+++ b/vendor/github.com/docker/docker/api/types/client.go
@@ -145,6 +145,7 @@ type ImageBuildOptions struct {
 	SuppressOutput bool
 	RemoteContext  string
 	NoCache        bool
+	Secret         string
 	Remove         bool
 	ForceRemove    bool
 	PullParent     bool


### PR DESCRIPTION
This is a feature addition related to issue #2273.

**Related**: #2273

**Description**
This is PR for the addition of a feature that allows us to use the `docker build --secret` option.

[Docker document link](https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information)

Should I make sure to check the `useBuildkit` option?
