### PR TITLE
Support '--ssh' option in 'docker build'

### DIFF
--- a/docs/content/en/schemas/v2beta10.json
+++ b/docs/content/en/schemas/v2beta10.json
@@ -1011,6 +1011,11 @@
           "description": "contains information about a local secret passed to `docker build`, along with optional destination information.",
           "x-intellij-html-description": "contains information about a local secret passed to <code>docker build</code>, along with optional destination information."
         },
+        "ssh": {
+          "type": "string",
+          "description": "used to pass in --ssh to docker build to use SSH agent. Format is \"default|<id>[=<socket>|<key>[,<key>]]\".",
+          "x-intellij-html-description": "used to pass in --ssh to docker build to use SSH agent. Format is &quot;default|<id>[=<socket>|<key>[,<key>]]&quot;."
+        },
         "target": {
           "type": "string",
           "description": "Dockerfile target name to build.",
@@ -1024,7 +1029,8 @@
         "network",
         "cacheFrom",
         "noCache",
-        "secret"
+        "secret",
+        "ssh"
       ],
       "additionalProperties": false,
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",

--- a/integration/testdata/build/ssh/Dockerfile
+++ b/integration/testdata/build/ssh/Dockerfile
@@ -1,0 +1,6 @@
+# syntax=docker/dockerfile:1.0.0-experimental
+
+FROM alpine:3.10
+
+# https://github.com/tonistiigi/buildkit/blob/1604b1b9ed70bcbc002033d8dd0e65ab13f13554/client/llb/exec.go#L138
+RUN --mount=type=ssh ls /run/buildkit/ssh_agent.*

--- a/integration/testdata/build/ssh/skaffold.yaml
+++ b/integration/testdata/build/ssh/skaffold.yaml
@@ -1,0 +1,10 @@
+apiVersion: skaffold/v2beta10
+kind: Config
+build:
+  local:
+    useBuildkit: true
+    push: false
+  artifacts:
+  - image: ssh
+    docker:
+      ssh: "default"

--- a/pkg/skaffold/build/gcb/docker.go
+++ b/pkg/skaffold/build/gcb/docker.go
@@ -64,8 +64,8 @@ func (b *Builder) cacheFromSteps(artifact *latest.DockerArtifact) []*cloudbuild.
 func (b *Builder) dockerBuildArgs(a *latest.Artifact, tag string, deps []*latest.ArtifactDependency) ([]string, error) {
 	d := a.DockerArtifact
 	// TODO(nkubala): remove when buildkit is supported in GCB (#4773)
-	if d.Secret != nil {
-		return nil, errors.New("docker build secrets not currently supported in GCB builds")
+	if d.Secret != nil || d.SSH != "" {
+		return nil, errors.New("docker build options, secrets and ssh, are not currently supported in GCB builds")
 	}
 	requiredImages := docker.ResolveDependencyImages(deps, b.artifactStore, true)
 	buildArgs, err := docker.EvalBuildArgs(b.cfg.Mode(), a.Workspace, d.DockerfilePath, d.BuildArgs, requiredImages)

--- a/pkg/skaffold/build/gcb/docker_test.go
+++ b/pkg/skaffold/build/gcb/docker_test.go
@@ -104,7 +104,7 @@ func TestDockerBuildSpec(t *testing.T) {
 			},
 		},
 		{
-			description: "buildkit features not supported in GCB",
+			description: "buildkit `secret` option not supported in GCB",
 			artifact: &latest.Artifact{
 				ArtifactType: latest.ArtifactType{
 					DockerArtifact: &latest.DockerArtifact{
@@ -112,6 +112,18 @@ func TestDockerBuildSpec(t *testing.T) {
 						Secret: &latest.DockerSecret{
 							ID: "secret",
 						},
+					},
+				},
+			},
+			shouldErr: true,
+		},
+		{
+			description: "buildkit `ssh` option not supported in GCB",
+			artifact: &latest.Artifact{
+				ArtifactType: latest.ArtifactType{
+					DockerArtifact: &latest.DockerArtifact{
+						DockerfilePath: "Dockerfile",
+						SSH:            "default",
 					},
 				},
 			},

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -167,8 +167,8 @@ func (l *localDaemon) ConfigFile(ctx context.Context, image string) (*v1.ConfigF
 }
 
 func (l *localDaemon) CheckCompatible(a *latest.DockerArtifact) error {
-	if a.Secret != nil {
-		return fmt.Errorf("docker build secrets require BuildKit - set `useBuildkit: true` in your config, or run with `DOCKER_BUILDKIT=1`")
+	if a.Secret != nil || a.SSH != "" {
+		return fmt.Errorf("docker build options, secrets and ssh, require BuildKit - set `useBuildkit: true` in your config, or run with `DOCKER_BUILDKIT=1`")
 	}
 	return nil
 }
@@ -508,6 +508,10 @@ func ToCLIBuildArgs(a *latest.DockerArtifact, evaluatedArgs map[string]*string) 
 			secretString += ",dst=" + a.Secret.Destination
 		}
 		args = append(args, "--secret", secretString)
+	}
+
+	if a.SSH != "" {
+		args = append(args, "--ssh", a.SSH)
 	}
 
 	return args, nil

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -355,6 +355,13 @@ func TestGetBuildArgs(t *testing.T) {
 			want: []string{"--secret", "id=mysecret,src=foo.src,dst=foo.dst"},
 		},
 		{
+			description: "ssh with no source",
+			artifact: &latest.DockerArtifact{
+				SSH: "default",
+			},
+			want: []string{"--ssh", "default"},
+		},
+		{
 			description: "all",
 			artifact: &latest.DockerArtifact{
 				BuildArgs: map[string]*string{

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1125,6 +1125,9 @@ type DockerArtifact struct {
 	// Secret contains information about a local secret passed to `docker build`,
 	// along with optional destination information.
 	Secret *DockerSecret `yaml:"secret,omitempty"`
+
+	// SSH is used to pass in --ssh to docker build to use SSH agent. Format is "default|<id>[=<socket>|<key>[,<key>]]".
+	SSH string `yaml:"ssh,omitempty"`
 }
 
 // DockerSecret contains information about a local secret passed to `docker build`,


### PR DESCRIPTION
This is a feature addition related to issue #2273.

**Related**: #2273
**Merge after**: #4659

**Description**
This is PR for the addition of a feature that allows us to use the `docker build --ssh` option.

[Docker document link](https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds)

Should I make sure to check the `useBuildkit` option?