### PR TITLE
Show 'Watching for changes' message only when either of autoBuild, autoSync or autoDeploy is enabled; otherwise show "Not watching for changes"

### DIFF
--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -65,7 +65,9 @@ func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer, logger *kuber
 	defer r.monitor.Reset()
 	//notify user that change listener is active only if any one of build, sync or deploy will actually happen automatically
 	if r.intents.IsAnyAutoEnabled() {
-		defer r.listener.LogWatchToUser(out)
+		defer r.listener.LogWatchIsActive(out)
+	} else {
+		defer r.listener.LogWatchIsInactive(out)
 	}
 	event.DevLoopInProgress(r.devIteration)
 	defer func() { r.devIteration++ }()

--- a/pkg/skaffold/runner/intent.go
+++ b/pkg/skaffold/runner/intent.go
@@ -117,3 +117,9 @@ func (i *intents) GetIntents() (bool, bool, bool) {
 	defer i.lock.Unlock()
 	return i.build, i.sync, i.deploy
 }
+
+func (i *intents) IsAnyAutoEnabled() bool {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	return i.autoBuild || i.autoSync || i.autoDeploy
+}

--- a/pkg/skaffold/runner/listen.go
+++ b/pkg/skaffold/runner/listen.go
@@ -22,9 +22,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/sirupsen/logrus"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/trigger"
 )

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -170,11 +170,12 @@ func (t *TestBench) Actions() []Actions {
 	return append(t.actions, t.currentActions)
 }
 
-func (t *TestBench) WatchForChanges(ctx context.Context, out io.Writer, doDev func() error) error {
+func (t *TestBench) WatchForChanges(ctx context.Context, out io.Writer, fn func() (bool, func() error)) error {
 	// don't actually call the monitor here, because extra actions would be added
 	if err := t.firstMonitor(true); err != nil {
 		return err
 	}
+	_, doDev := fn()
 	for i := 0; i < t.cycles; i++ {
 		t.enterNewCycle()
 		t.currentCycle = i

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -186,7 +186,9 @@ func (t *TestBench) WatchForChanges(ctx context.Context, out io.Writer, fn func(
 	return nil
 }
 
-func (t *TestBench) LogWatchToUser(_ io.Writer) {}
+func (t *TestBench) LogWatchIsActive(_ io.Writer) {}
+
+func (t *TestBench) LogWatchIsInactive(_ io.Writer) {}
 
 func findTags(artifacts []build.Artifact) []string {
 	var tags []string


### PR DESCRIPTION
Fixes #4653, #4501 
 
- Shows `"Watching for changes"` output message only when any one of auto build, sync or deploy are enabled which is usually the case for `dev` and `run`. 
- Shows `"Not watching for changes"` output message when all of auto build, sync and deploy are turned off which is the case for `debug`