### PR TITLE
record deploy cmd

### DIFF
--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -72,7 +72,7 @@ func (c *CLI) Apply(ctx context.Context, out io.Writer, manifests ManifestList) 
 		return nil
 	}
 
-	args := []string{"-f", "-"}
+	args := []string{"-f", "-", "--record"}
 	if c.forceDeploy {
 		args = append(args, "--force", "--grace-period=0")
 	}

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -115,7 +115,7 @@ func TestKubectlDeploy(t *testing.T) {
 				CmdRunOut("kubectl version --client -ojson", kubectlVersion112).
 				AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run -oyaml -f deployment.yaml --validate=false", deploymentWebYAML).
 				AndRunInputOut("kubectl --context kubecontext --namespace testNamespace get -f - --ignore-not-found -ojson", deploymentWebYAMLv1, "").
-				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f - --validate=false"),
+				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f - --record --validate=false"),
 			builds: []build.Artifact{{
 				ImageName: "leeroy-web",
 				Tag:       "leeroy-web:v1",
@@ -131,7 +131,7 @@ func TestKubectlDeploy(t *testing.T) {
 				CmdRunOut("kubectl version --client -ojson", kubectlVersion112).
 				AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run -oyaml -f deployment.yaml", deploymentWebYAML).
 				AndRunInputOut("kubectl --context kubecontext --namespace testNamespace get -f - --ignore-not-found -ojson", deploymentWebYAMLv1, "").
-				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f - --force --grace-period=0"),
+				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f - --record --force --grace-period=0"),
 			builds: []build.Artifact{{
 				ImageName: "leeroy-web",
 				Tag:       "leeroy-web:v1",
@@ -148,7 +148,7 @@ func TestKubectlDeploy(t *testing.T) {
 				CmdRunOut("kubectl version --client -ojson", kubectlVersion112).
 				AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run -oyaml -f deployment.yaml", deploymentWebYAML).
 				AndRunInputOut("kubectl --context kubecontext --namespace testNamespace get -f - --ignore-not-found -ojson", deploymentWebYAMLv1, "").
-				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f -"),
+				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f - --record"),
 			builds: []build.Artifact{{
 				ImageName: "leeroy-web",
 				Tag:       "leeroy-web:v1",
@@ -164,7 +164,7 @@ func TestKubectlDeploy(t *testing.T) {
 				CmdRunOut("kubectl version --client -ojson", kubectlVersion118).
 				AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run=client -oyaml -f deployment.yaml", deploymentWebYAML).
 				AndRunInputOut("kubectl --context kubecontext --namespace testNamespace get -f - --ignore-not-found -ojson", deploymentWebYAMLv1, "").
-				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f -"),
+				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f - --record"),
 			builds: []build.Artifact{{
 				ImageName: "leeroy-web",
 				Tag:       "leeroy-web:v1",
@@ -179,7 +179,7 @@ func TestKubectlDeploy(t *testing.T) {
 			commands: testutil.
 				CmdRunOut("kubectl version --client -ojson", kubectlVersion112).
 				AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run -oyaml -f deployment.yaml -f http://remote.yaml", deploymentWebYAML).
-				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f -"),
+				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f - --record"),
 			builds: []build.Artifact{{
 				ImageName: "leeroy-web",
 				Tag:       "leeroy-web:v1",
@@ -193,7 +193,7 @@ func TestKubectlDeploy(t *testing.T) {
 			commands: testutil.
 				CmdRunOut("kubectl version --client -ojson", kubectlVersion112).
 				AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run -oyaml -f deployment.yaml", deploymentWebYAML).
-				AndRunErr("kubectl --context kubecontext --namespace testNamespace apply -f -", fmt.Errorf("")),
+				AndRunErr("kubectl --context kubecontext --namespace testNamespace apply -f - --record", fmt.Errorf("")),
 			builds: []build.Artifact{{
 				ImageName: "leeroy-web",
 				Tag:       "leeroy-web:v1",
@@ -214,7 +214,7 @@ func TestKubectlDeploy(t *testing.T) {
 				CmdRunOut("kubectl version --client -ojson", kubectlVersion112).
 				AndRunOut("kubectl --context kubecontext --namespace testNamespace create -v=0 --dry-run -oyaml -f deployment.yaml", deploymentWebYAML).
 				AndRunInputOut("kubectl --context kubecontext --namespace testNamespace get -v=0 -f - --ignore-not-found -ojson", deploymentWebYAMLv1, "").
-				AndRunErr("kubectl --context kubecontext --namespace testNamespace apply -v=0 --overwrite=true -f -", fmt.Errorf("")),
+				AndRunErr("kubectl --context kubecontext --namespace testNamespace apply -v=0 --overwrite=true -f - --record", fmt.Errorf("")),
 			builds: []build.Artifact{{
 				ImageName: "leeroy-web",
 				Tag:       "leeroy-web:v1",
@@ -355,7 +355,7 @@ func TestKubectlDeployerRemoteCleanup(t *testing.T) {
 			commands: testutil.
 				CmdRun("kubectl --context kubecontext --namespace testNamespace get pod/leeroy-web -o yaml").
 				AndRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true -f -").
-				AndRunInput("kubectl --context kubecontext --namespace testNamespace apply -f -", deploymentWebYAML),
+				AndRunInput("kubectl --context kubecontext --namespace testNamespace apply -f - --record", deploymentWebYAML),
 		},
 		{
 			description: "cleanup error",
@@ -406,10 +406,10 @@ func TestKubectlRedeploy(t *testing.T) {
 			CmdRunOut("kubectl version --client -ojson", kubectlVersion112).
 			AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run -oyaml -f "+tmpDir.Path("deployment-app.yaml")+" -f "+tmpDir.Path("deployment-web.yaml"), deploymentAppYAML+"\n"+deploymentWebYAML).
 			AndRunInputOut("kubectl --context kubecontext --namespace testNamespace get -f - --ignore-not-found -ojson", deploymentAppYAMLv1+"\n---\n"+deploymentWebYAMLv1, "").
-			AndRunInput("kubectl --context kubecontext --namespace testNamespace apply -f -", deploymentAppYAMLv1+"\n---\n"+deploymentWebYAMLv1).
+			AndRunInput("kubectl --context kubecontext --namespace testNamespace apply -f - --record", deploymentAppYAMLv1+"\n---\n"+deploymentWebYAMLv1).
 			AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run -oyaml -f "+tmpDir.Path("deployment-app.yaml")+" -f "+tmpDir.Path("deployment-web.yaml"), deploymentAppYAML+"\n"+deploymentWebYAML).
 			AndRunInputOut("kubectl --context kubecontext --namespace testNamespace get -f - --ignore-not-found -ojson", deploymentAppYAMLv2+"\n---\n"+deploymentWebYAMLv1, "").
-			AndRunInput("kubectl --context kubecontext --namespace testNamespace apply -f -", deploymentAppYAMLv2).
+			AndRunInput("kubectl --context kubecontext --namespace testNamespace apply -f - --record", deploymentAppYAMLv2).
 			AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run -oyaml -f "+tmpDir.Path("deployment-app.yaml")+" -f "+tmpDir.Path("deployment-web.yaml"), deploymentAppYAML+"\n"+deploymentWebYAML).
 			AndRunInputOut("kubectl --context kubecontext --namespace testNamespace get -f - --ignore-not-found -ojson", deploymentAppYAMLv2+"\n---\n"+deploymentWebYAMLv1, ""),
 		)
@@ -488,7 +488,7 @@ func TestKubectlWaitForDeletions(t *testing.T) {
 				]
 			}`).
 			AndRunInputOut("kubectl --context kubecontext --namespace testNamespace get -f - --ignore-not-found -ojson", deploymentWebYAMLv1, "").
-			AndRunInput("kubectl --context kubecontext --namespace testNamespace apply -f -", deploymentWebYAMLv1),
+			AndRunInput("kubectl --context kubecontext --namespace testNamespace apply -f - --record", deploymentWebYAMLv1),
 		)
 
 		cfg := &latest.KubectlDeploy{
@@ -788,7 +788,7 @@ func TestGCSManifests(t *testing.T) {
 				CmdRunOut(fmt.Sprintf("gsutil cp -r %s %s", "gs://dev/deployment.yaml", manifestTmpDir), "log").
 				AndRunOut("kubectl version --client -ojson", kubectlVersion112).
 				AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run -oyaml -f "+filepath.Join(manifestTmpDir, "deployment.yaml"), deploymentWebYAML).
-				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f -"),
+				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f - --record"),
 			skipRender: true,
 		}}
 	for _, test := range tests {

--- a/pkg/skaffold/deploy/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize_test.go
@@ -60,7 +60,7 @@ func TestKustomizeDeploy(t *testing.T) {
 				CmdRunOut("kubectl version --client -ojson", kubectlVersion112).
 				AndRunOut("kustomize build .", deploymentWebYAML).
 				AndRunInputOut("kubectl --context kubecontext --namespace testNamespace get -f - --ignore-not-found -ojson", deploymentWebYAMLv1, "").
-				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f - --force --grace-period=0"),
+				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f - --record --force --grace-period=0"),
 			builds: []build.Artifact{{
 				ImageName: "leeroy-web",
 				Tag:       "leeroy-web:v1",
@@ -77,7 +77,7 @@ func TestKustomizeDeploy(t *testing.T) {
 				AndRunOut("kustomize build a", deploymentWebYAML).
 				AndRunOut("kustomize build b", deploymentAppYAML).
 				AndRunInputOut("kubectl --context kubecontext --namespace testNamespace get -f - --ignore-not-found -ojson", deploymentWebYAMLv1+"\n---\n"+deploymentAppYAMLv1, "").
-				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f - --force --grace-period=0"),
+				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f - --record --force --grace-period=0"),
 			builds: []build.Artifact{
 				{
 					ImageName: "leeroy-web",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4667 

The pkg `FAIL github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib``can't build and I have no clue why.

```
go test -count=1 -race -short -timeout=90s ./pkg/skaffold/... ./cmd/... ./hack/... ./pkg/webhook/...
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/color     0.031s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion        0.136s
# github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib
pkg/skaffold/build/jib/jib_test.go:154:4: conversion from untyped int to PluginType (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
pkg/skaffold/build/jib/jib_test.go:155:4: conversion from untyped int to PluginType (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
pkg/skaffold/build/jib/jib_test.go:156:4: conversion from untyped int to PluginType (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/config    0.263s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/custom      0.196s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/bazel       0.241s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc        0.779s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/resource   0.112s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors    0.239s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks  0.227s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache       0.243s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/build     0.702s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/gcb 0.158s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/event     0.823s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cluster     0.244s
FAIL    github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib [build failed]
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/local       0.233s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon   0.089s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker    1.048s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl    0.205s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/gcp       0.128s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/generate_pipeline 0.184s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl   0.137s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context        0.256s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/build 0.331s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug     1.141s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/generator      0.129s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/analyze       0.332s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/logfile   0.152s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes        0.262s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/deploy        0.263s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy    1.822s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/debugging      0.146s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer       1.465s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext 0.110s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/pipeline  0.170s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/util       0.195s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util       0.080s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults   0.119s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/diagnose  2.939s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1 0.196s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha2   0.145s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha1   0.171s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward    0.805s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha4   0.235s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha3   0.238s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha5   0.149s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta1    0.123s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner    0.405s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta10   0.216s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta12   0.137s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta11   0.168s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta13   0.124s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta14   0.122s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta15   0.192s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta17   0.177s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta16   0.127s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta3    0.118s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta2    0.160s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta4    0.147s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta5    0.108s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema    2.299s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta8    0.136s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta7    0.220s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta6    0.243s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta9    0.144s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2alpha1   0.140s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2alpha2   0.151s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2alpha3   0.147s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2alpha4   0.205s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta1    0.167s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta2    0.203s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta3    0.264s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta4    0.163s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta5    0.136s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta6    0.164s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/survey    0.166s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/test/structure    0.167s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/validation 0.203s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/trigger   0.152s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/server    0.730s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/test      0.197s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/version   0.133s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/update    0.111s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags  0.126s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/util      0.468s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync      0.148s
ok      github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/config    0.135s
ok      github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags 0.085s
ok      github.com/GoogleContainerTools/skaffold/hack/versions/pkg/diff 0.247s
ok      github.com/GoogleContainerTools/skaffold/pkg/webhook/labels     0.161s
ok      github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/schema    0.165s
ok      github.com/GoogleContainerTools/skaffold/hack/versions/pkg/schema       0.083s
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag 11.247s
ok      github.com/GoogleContainerTools/skaffold/cmd/skaffold/app       0.199s
ok      github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd   0.814s
ok      github.com/GoogleContainerTools/skaffold/hack/man       0.224s
ok      github.com/GoogleContainerTools/skaffold/hack/schemas   1.090s

=== Slow Tests ===
9.57s   TestTagTemplate_GenerateTag
2.67s   TestCheckArtifacts
2.67s   TestCheckArtifacts/TestCheckArtifacts
1.35s   TestParseExamples
1.27s   TestTagTemplate_GenerateTag/only_text
1.19s   TestTagTemplate_GenerateTag/override_default_components
1.13s   TestTagTemplate_GenerateTag/default_component_name_SHA
1.11s   TestTagTemplate_GenerateTag/faulty_component,_envTemplate_has_undefined_references
1.10s   TestTagTemplate_GenerateTag/using_customTemplate_as_a_component
1.02s   TestDoInit
0.99s   TestTagTemplate_GenerateTag/only_component_(dateTime)_in_template,_providing_more_components_than_necessary
0.98s   TestSchemas
0.97s   TestTagTemplate_GenerateTag/envTemplate_and_sha256_as_components
0.95s   TestTagTemplate_GenerateTag/empty_template
0.86s   TestTagTemplate_GenerateTag/missing_required_components
0.70s   TestTagger_GenerateFullyQualifiedImageName/customTemplate
0.70s   TestTagger_GenerateFullyQualifiedImageName
0.68s   TestGitCommit_GenerateTag/additional_commit_in_other_artifact
0.68s   TestGitCommit_GenerateTag/rename
0.65s   TestGitCommit_GenerateTag/dirty_worktree_without_tag
exit status 1
make: *** [Makefile:107: test] Error 1
```