### PR TITLE
Enable watch trigger only when at least one of autoBuild, autoSync or autoDeploy is enabled

### DIFF
--- a/pkg/skaffold/runner/intent.go
+++ b/pkg/skaffold/runner/intent.go
@@ -117,3 +117,9 @@ func (i *intents) GetIntents() (bool, bool, bool) {
 	defer i.lock.Unlock()
 	return i.build, i.sync, i.deploy
 }
+
+func (i *intents) IsAnyAutoEnabled() bool {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	return i.autoBuild || i.autoSync || i.autoDeploy
+}

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -84,16 +84,15 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		deployer = WithNotification(deployer)
 	}
 
-	trigger, err := trigger.NewTrigger(runCtx)
-	if err != nil {
-		return nil, fmt.Errorf("creating watch trigger: %w", err)
-	}
-
 	event.InitializeState(runCtx.Pipeline(), runCtx.GetKubeContext(), runCtx.AutoBuild(), runCtx.AutoDeploy(), runCtx.AutoSync())
 	event.LogMetaEvent()
 
 	monitor := filemon.NewMonitor()
 	intents, intentChan := setupIntents(runCtx)
+	trigger, err := trigger.NewTrigger(runCtx, intents.IsAnyAutoEnabled)
+	if err != nil {
+		return nil, fmt.Errorf("creating watch trigger: %w", err)
+	}
 
 	return &SkaffoldRunner{
 		builder:  builder,

--- a/pkg/skaffold/trigger/triggers.go
+++ b/pkg/skaffold/trigger/triggers.go
@@ -91,7 +91,7 @@ func (t *pollTrigger) LogWatchToUser(out io.Writer) {
 	}
 }
 
-// Start starts a timer if active.
+// Start starts a timer.
 func (t *pollTrigger) Start(ctx context.Context) (<-chan bool, error) {
 	trigger := make(chan bool)
 
@@ -100,6 +100,8 @@ func (t *pollTrigger) Start(ctx context.Context) (<-chan bool, error) {
 		for {
 			select {
 			case <-ticker.C:
+
+				// Ignore if trigger is inactive
 				if !t.isActive() {
 					continue
 				}


### PR DESCRIPTION
Fixes #4653, #4501 
 
- Shows **`"Watching for changes"`** output message along with **file change debug level logs** only when at least one of auto build, sync or deploy are enabled which is usually the case for `dev` and `run`. 
- Shows **`"Not watching for changes"`** output message when all of auto build, sync and deploy are turned off which is the case for `debug`