### PR TITLE
refactor: move all update checks to single function; enforce honoring updateCheck flag

### DIFF
--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -107,7 +107,7 @@ func runContext(opts config.SkaffoldOptions) (*runcontext.RunContext, *latest.Sk
 func warnIfUpdateIsAvailable() {
 	warning, err := update.CheckVersionOnError(opts.GlobalConfig)
 	if err != nil {
-		logrus.Debugf("update check failed: %w", err)
+		logrus.Debugf("update check failed: %v", err)
 		return
 	}
 	if warning != "" {

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -107,7 +107,7 @@ func runContext(opts config.SkaffoldOptions) (*runcontext.RunContext, *latest.Sk
 func warnIfUpdateIsAvailable() {
 	warning, err := update.CheckVersionOnError(opts.GlobalConfig)
 	if err != nil {
-		logrus.Debugf("update check failed: %v", err)
+		logrus.Infof("update check failed: %s", err)
 		return
 	}
 	if warning != "" {

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -76,9 +76,7 @@ func runContext(opts config.SkaffoldOptions) (*runcontext.RunContext, *latest.Sk
 		// If the error is NOT that the file doesn't exist, then we warn the user
 		// that maybe they are using an outdated version of Skaffold that's unable to read
 		// the configuration.
-		if err = warnIfUpdateIsAvailable(); err != nil {
-			return nil, nil, err
-		}
+		warnIfUpdateIsAvailable()
 		return nil, nil, fmt.Errorf("parsing skaffold config: %w", err)
 	}
 
@@ -106,13 +104,13 @@ func runContext(opts config.SkaffoldOptions) (*runcontext.RunContext, *latest.Sk
 	return runCtx, config, nil
 }
 
-func warnIfUpdateIsAvailable() error {
+func warnIfUpdateIsAvailable() {
 	warning, err := update.CheckVersionOnError(opts.GlobalConfig)
 	if err != nil {
-		return fmt.Errorf("update check failed: %s", err)
+		logrus.Debugf("update check failed: %w", err)
+		return
 	}
 	if warning != "" {
 		logrus.Warn(warning)
 	}
-	return nil
 }

--- a/pkg/skaffold/update/update.go
+++ b/pkg/skaffold/update/update.go
@@ -40,9 +40,37 @@ var (
 
 const LatestVersionURL = "https://storage.googleapis.com/skaffold/releases/latest/VERSION"
 
-// IsUpdateCheckEnabled returns whether or not the update check is enabled
+// CheckVersion returns an update message when update check is enabled and skaffold binary in not latest
+func CheckVersion(config string) (string, error) {
+	return checkVersion(config, false)
+}
+
+// CheckVersionOnError returns an error message when update check is enabled and skaffold binary in not latest
+func CheckVersionOnError(config string) (string, error) {
+	return checkVersion(config, true)
+}
+
+func checkVersion(config string, onError bool) (string, error) {
+	if !isUpdateCheckEnabled(config) {
+		logrus.Debugf("Update check not enabled, skipping.")
+		return "", nil
+	}
+	latest, current, err := GetLatestAndCurrentVersion()
+	if err != nil {
+		return "", fmt.Errorf("get latest and current Skaffold version: %w", err)
+	}
+	if !latest.GT(current) {
+		return "", nil
+	}
+	if onError {
+		return fmt.Sprintf("Your Skaffold version might be too old. Download the latest version (%s) from:\n  %s\n", latest, releaseURL(latest)), nil
+	}
+	return fmt.Sprintf("There is a new version (%s) of Skaffold available. Download it from:\n  %s\n", latest, releaseURL(latest)), nil
+}
+
+// isUpdateCheckEnabled returns whether or not the update check is enabled
 // It is true by default, but setting it to any other value than true will disable the check
-func IsUpdateCheckEnabled(configfile string) bool {
+func isUpdateCheckEnabled(configfile string) bool {
 	// Don't perform a version check on dirty trees
 	if version.Get().GitTreeState == "dirty" {
 		return false
@@ -85,4 +113,8 @@ func DownloadLatestVersion() (string, error) {
 		return "", fmt.Errorf("reading version file from GCS: %w", err)
 	}
 	return strings.TrimSuffix(string(versionBytes), "\n"), nil
+}
+
+func releaseURL(v semver.Version) string {
+	return fmt.Sprintf("https://github.com/GoogleContainerTools/skaffold/releases/tag/v" + v.String())
 }

--- a/pkg/skaffold/update/update.go
+++ b/pkg/skaffold/update/update.go
@@ -57,7 +57,7 @@ func checkVersion(config string, onError bool) (string, error) {
 	}
 	latest, current, err := GetLatestAndCurrentVersion()
 	if err != nil {
-		return "", fmt.Errorf("get latest and current Skaffold version: %w", err)
+		return "", fmt.Errorf("getting latest and current skaffold versions: %w", err)
 	}
 	if !latest.GT(current) {
 		return "", nil

--- a/pkg/skaffold/update/update_test.go
+++ b/pkg/skaffold/update/update_test.go
@@ -17,51 +17,106 @@ limitations under the License.
 package update
 
 import (
+	"fmt"
 	"testing"
+
+	"github.com/blang/semver"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestIsUpdateCheckEnabled(t *testing.T) {
+func TestCheckVersions(t *testing.T) {
 	tests := []struct {
-		description string
-		enabled     bool
-		configCheck bool
-		expected    bool
+		description       string
+		checkVersionsFunc func() (semver.Version, semver.Version, error)
+		expected          []string
+		enabled           bool
+		configCheck       bool
+		shouldError       bool
 	}{
 		{
 			description: "globally disabled - disabled in config -> disabled",
 			enabled:     false,
 			configCheck: false,
-			expected:    false,
+			expected:    []string{"", ""},
 		},
 		{
 			description: "globally enabled - disabled in config -> disabled",
 			enabled:     true,
 			configCheck: false,
-			expected:    false,
+			expected:    []string{"", ""},
 		},
 		{
 			description: "globally disabled - enabled in config -> disabled",
 			enabled:     false,
 			configCheck: true,
-			expected:    false,
+			expected:    []string{"", ""},
 		},
 		{
-			description: "globally enabled - enabled in config -> enabled",
-			enabled:     true,
-			configCheck: true,
-			expected:    true,
+			description:       "globally enabled - enabled in config - latest version -> disabled",
+			enabled:           true,
+			configCheck:       true,
+			checkVersionsFunc: currentEqualsLatest,
+			expected:          []string{"", ""},
+		},
+		{
+			description:       "globally enabled - enabled in config - older version -> enabled",
+			enabled:           true,
+			configCheck:       true,
+			checkVersionsFunc: latestGreaterThanCurrent,
+			expected: []string{
+				"There is a new version (1.1.0) of Skaffold available. Download it from:\n  https://github.com/GoogleContainerTools/skaffold/releases/tag/v1.1.0\n",
+				"Your Skaffold version might be too old. Download the latest version (1.1.0) from:\n  https://github.com/GoogleContainerTools/skaffold/releases/tag/v1.1.0\n",
+			},
+		},
+		{
+			description:       "globally enabled - enabled in config - version check failed -> enabled",
+			enabled:           true,
+			configCheck:       true,
+			checkVersionsFunc: errorGettingVersions,
+			shouldError:       true,
+			expected:          []string{"", ""},
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&EnableCheck, test.enabled)
 			t.Override(&isConfigUpdateCheckEnabled, func(string) bool { return test.configCheck })
+			t.Override(&GetLatestAndCurrentVersion, test.checkVersionsFunc)
 
-			isEnabled := IsUpdateCheckEnabled("dummyconfig")
+			msg, err := CheckVersion("foo")
+			t.CheckErrorAndDeepEqual(test.shouldError, err, test.expected[0], msg)
 
-			t.CheckDeepEqual(test.expected, isEnabled)
+			msg, err = CheckVersionOnError("foo")
+			t.CheckErrorAndDeepEqual(test.shouldError, err, test.expected[1], msg)
 		})
 	}
+}
+
+func latestGreaterThanCurrent() (semver.Version, semver.Version, error) {
+	return semver.Version{
+			Major: 1,
+			Minor: 1,
+			Patch: 0,
+		}, semver.Version{
+			Major: 1,
+			Minor: 0,
+			Patch: 0,
+		}, nil
+}
+
+func currentEqualsLatest() (semver.Version, semver.Version, error) {
+	return semver.Version{
+			Major: 1,
+			Minor: 0,
+			Patch: 0,
+		}, semver.Version{
+			Major: 1,
+			Minor: 0,
+			Patch: 0,
+		}, nil
+}
+
+func errorGettingVersions() (semver.Version, semver.Version, error) {
+	return semver.Version{}, semver.Version{}, fmt.Errorf("error getting versions")
 }


### PR DESCRIPTION
Fixes #4673 
Honor `update-check` flag for all update check notifications. Consolidate function in a single place