### PR TITLE
Fix bazel integration tests on Github Actions

### DIFF
--- a/.github/workflows/integration-darwin.yml
+++ b/.github/workflows/integration-darwin.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         kustomize_version: [3.5.4]
-        bazel_version: [3.2.0]
         ko_version: [0.4.0]
         kompose_version: [1.21.0]
         gcloud_sdk_version: [276.0.0]
@@ -34,13 +33,6 @@ jobs:
     - name: Skaffold binary version
       run: |
         echo ::set-env name=SKAFFOLD_VERSION::"$(git log --format="%H" -n 1)"
-
-    - name: Install Bazel
-      run: |
-        curl -fLO "https://github.com/bazelbuild/bazel/releases/download/${{ matrix.bazel_version }}/bazel-${{ matrix.bazel_version }}-installer-darwin-x86_64.sh"
-        chmod +x "bazel-${{ matrix.bazel_version }}-installer-darwin-x86_64.sh"
-        ./bazel-${{ matrix.bazel_version }}-installer-darwin-x86_64.sh --user
-        echo ::add-path::${HOME}/bin
 
     - name: Install Kustomize
       run: |

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         kustomize_version: [3.5.4]
         ko_version: [0.4.0]
-        bazel_version: [3.2.0]
         kompose_version: [1.21.0]
         gcloud_sdk_version: [276.0.0]
         container_structure_tests_version: [1.8.0]
@@ -33,13 +32,6 @@ jobs:
     - name: Skaffold binary version
       run: |
         echo ::set-env name=SKAFFOLD_VERSION::"$(git log --format="%H" -n 1)"
-
-    - name: Install Bazel
-      run: |
-        curl -fLO "https://github.com/bazelbuild/bazel/releases/download/${{ matrix.bazel_version }}/bazel-${{ matrix.bazel_version }}-installer-linux-x86_64.sh"
-        chmod +x bazel-${{ matrix.bazel_version }}-installer-linux-x86_64.sh
-        ./bazel-${{ matrix.bazel_version }}-installer-linux-x86_64.sh --user
-        echo ::add-path::${HOME}/bin
 
     - name: Install Kustomize
       run: |

--- a/integration/examples/bazel/WORKSPACE
+++ b/integration/examples/bazel/WORKSPACE
@@ -33,6 +33,17 @@ load(
 container_repositories()
 
 load(
+    "@io_bazel_rules_docker//repositories:deps.bzl",
+    container_deps = "deps",
+)
+
+container_deps()
+
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+
+pip_deps()
+
+load(
     "@io_bazel_rules_docker//go:image.bzl",
     _go_image_repos = "repositories",
 )

--- a/integration/examples/bazel/WORKSPACE
+++ b/integration/examples/bazel/WORKSPACE
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "3efbd23e195727a67f87b2a04fb4388cc7a11a0c0c2cf33eec225fb8ffbb27ea",
-    strip_prefix = "rules_docker-0.14.2",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.2/rules_docker-v0.14.2.tar.gz"],
+    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
+    strip_prefix = "rules_docker-0.14.4",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz"],
 )
 
 http_archive(

--- a/integration/util.go
+++ b/integration/util.go
@@ -359,7 +359,7 @@ func WaitForLogs(t *testing.T, out io.Reader, firstMessage string, moreMessages 
 	current := 0
 	message := firstMessage
 
-	timer := time.NewTimer(30 * time.Second)
+	timer := time.NewTimer(90 * time.Second)
 	defer timer.Stop()
 	for {
 		select {


### PR DESCRIPTION
Fixes #4617 
Github Actions VMs have latest Bazel version preinstalled which is incompatible with our example's `bazelbuild/rules_docker`  version. Also increased log tailing tests timeout from 30s to 90s since they sometimes timeout.