### PR TITLE
Improve error message when skaffold config not found

### DIFF
--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -70,7 +70,7 @@ func runContext(opts config.SkaffoldOptions) (*runcontext.RunContext, *latest.Sk
 	parsed, err := schema.ParseConfigAndUpgrade(opts.ConfigurationFile, latest.Version)
 	if err != nil {
 		if os.IsNotExist(errors.Unwrap(err)) {
-			return nil, nil, fmt.Errorf("[%s] not found. You might need to run `skaffold init`", opts.ConfigurationFile)
+			return nil, nil, fmt.Errorf("skaffold config file %s not found - check your current working directory, or try running `skaffold init`", opts.ConfigurationFile)
 		}
 
 		// If the error is NOT that the file doesn't exist, then we warn the user


### PR DESCRIPTION
before:
```
➜  skaffold dev
[skaffold.yaml] not found. You might need to run `skaffold init`
```

after:
```
➜  skaffold dev
skaffold config file skaffold.yaml not found - check your current working directory, or try running `skaffold init`
```