### PR TITLE
Kpt Deployer Skeleton

### DIFF
--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deploy
+
+import (
+	"context"
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+)
+
+// KptDeployer deploys workflows with kpt CLI
+type KptDeployer struct {
+}
+
+func NewKptDeployer(runCtx *runcontext.RunContext, labels map[string]string) *KptDeployer {
+	return &KptDeployer{}
+}
+
+func (k *KptDeployer) Deploy(ctx context.Context, out io.Writer, builds []build.Artifact) ([]string, error) {
+	return nil, nil
+}
+
+func (k *KptDeployer) Dependencies() ([]string, error) {
+	return nil, nil
+}
+
+func (k *KptDeployer) Cleanup(ctx context.Context, out io.Writer) error {
+	return nil
+}
+
+func (k *KptDeployer) Render(ctx context.Context, out io.Writer, builds []build.Artifact, offline bool, filepath string) error {
+	return nil
+}

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deploy

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -15,3 +15,82 @@ limitations under the License.
 */
 
 package deploy
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestKpt_Deploy(t *testing.T) {
+	tests := []struct {
+		description string
+		expected    []string
+		shouldErr   bool
+	}{
+		{
+			description: "nil",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			k := NewKptDeployer(&runcontext.RunContext{}, nil)
+			res, err := k.Deploy(nil, nil, nil)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, res)
+		})
+	}
+}
+
+func TestKpt_Dependencies(t *testing.T) {
+	tests := []struct {
+		description string
+		expected    []string
+		shouldErr   bool
+	}{
+		{
+			description: "nil",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			k := NewKptDeployer(&runcontext.RunContext{}, nil)
+			res, err := k.Dependencies()
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, res)
+		})
+	}
+}
+
+func TestKpt_Cleanup(t *testing.T) {
+	tests := []struct {
+		description string
+		shouldErr   bool
+	}{
+		{
+			description: "nil",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			k := NewKptDeployer(&runcontext.RunContext{}, nil)
+			err := k.Cleanup(nil, nil)
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}
+
+func TestKpt_Render(t *testing.T) {
+	tests := []struct {
+		description string
+		shouldErr   bool
+	}{
+		{},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			k := NewKptDeployer(&runcontext.RunContext{}, nil)
+			err := k.Render(nil, nil, nil, false, "")
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package deploy
 
 import (
+	"context"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
@@ -36,7 +37,7 @@ func TestKpt_Deploy(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			k := NewKptDeployer(&runcontext.RunContext{}, nil)
-			res, err := k.Deploy(nil, nil, nil)
+			res, err := k.Deploy(context.Background(), nil, nil)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, res)
 		})
 	}
@@ -73,7 +74,7 @@ func TestKpt_Cleanup(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			k := NewKptDeployer(&runcontext.RunContext{}, nil)
-			err := k.Cleanup(nil, nil)
+			err := k.Cleanup(context.Background(), nil)
 			t.CheckError(test.shouldErr, err)
 		})
 	}
@@ -89,7 +90,7 @@ func TestKpt_Render(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			k := NewKptDeployer(&runcontext.RunContext{}, nil)
-			err := k.Render(nil, nil, nil, false, "")
+			err := k.Render(context.Background(), nil, nil, false, "")
 			t.CheckError(test.shouldErr, err)
 		})
 	}


### PR DESCRIPTION
**Related**: #3904

**Description**
This is the skeletion of the deployer interface for the upcoming kpt deployer feature. There are no user facing changes.

**Follow-up Work**
The follow up work to this will be the changes to the config because the deployer implementation depends on it. Afterward, there will be PRs to implement the functionality.