### PR TITLE
Return deployment status code when status check can't retrieve pods from cluster

### DIFF
--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -268,6 +268,9 @@ func (d *Deployment) fetchPods(ctx context.Context) error {
 // Return first pod status in error.
 // TODO: should we return all distinct error codes in future?
 func (d *Deployment) FirstPodErrOccurred() proto.StatusCode {
+	if len(d.pods) == 0 {
+		return d.Status().ActionableError().ErrCode
+	}
 	for _, p := range d.pods {
 		if s := p.ActionableError().ErrCode; s != proto.StatusCode_STATUSCHECK_SUCCESS {
 			return s

--- a/pkg/skaffold/deploy/status_check_test.go
+++ b/pkg/skaffold/deploy/status_check_test.go
@@ -275,6 +275,18 @@ func TestGetDeployStatus(t *testing.T) {
 			description: "0 deployments",
 			counter:     &counter{},
 		},
+		{
+			description: "unable to retrieve pods for deployment",
+			counter:     &counter{total: 1, failed: 1},
+			deployments: []*resource.Deployment{
+				withStatus(
+					resource.NewDeployment("deployment", "test", 1),
+					proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_DEPLOYMENT_FETCH_ERR},
+				),
+			},
+			shouldErr:    true,
+			expectedCode: proto.StatusCode_STATUSCHECK_DEPLOYMENT_FETCH_ERR,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
fixes https://github.com/GoogleContainerTools/skaffold/issues/4672

this fixes an issue with the status checker where it mistakenly thought everything was fine when it detected a failure, but found no failures with any associated pods in a deployment. this happened when skaffold was unable to connect to the cluster, resulting in zero pods being retrieved for a deployment. skaffold will now use the status code for the deployment itself when this scenario happens, rather than returning `OK`.