### PR TITLE
Simpify devLoopEvent message text

### DIFF
--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -628,11 +628,11 @@ func (ev *eventHandler) handleExec(f firedEvent) {
 		de := e.DevLoopEvent
 		switch de.Status {
 		case InProgress:
-			logEntry.Entry = fmt.Sprintf("DevInit Iteration %d in progress", de.Iteration)
+			logEntry.Entry = "Update initiated due to file change"
 		case Succeeded:
-			logEntry.Entry = fmt.Sprintf("DevInit Iteration %d successful", de.Iteration)
+			logEntry.Entry = "Update successful"
 		case Failed:
-			logEntry.Entry = fmt.Sprintf("DevInit Iteration %d failed with error code %v", de.Iteration, de.Err.ErrCode)
+			logEntry.Entry = fmt.Sprintf("Update failed with error code %v", de.Err.ErrCode)
 		}
 	default:
 		return

--- a/pkg/skaffold/event/event_test.go
+++ b/pkg/skaffold/event/event_test.go
@@ -475,7 +475,7 @@ func TestDevLoopFailedInPhase(t *testing.T) {
 				handler.logLock.Lock()
 				logEntry := handler.eventLog[len(handler.eventLog)-1]
 				handler.logLock.Unlock()
-				return logEntry.Entry == fmt.Sprintf("DevInit Iteration 1 failed with error code %v", proto.StatusCode_BUILD_PUSH_ACCESS_DENIED)
+				return logEntry.Entry == fmt.Sprintf("Update failed with error code %v", proto.StatusCode_BUILD_PUSH_ACCESS_DENIED)
 			},
 		},
 		{
@@ -489,7 +489,7 @@ func TestDevLoopFailedInPhase(t *testing.T) {
 				handler.logLock.Lock()
 				logEntry := handler.eventLog[len(handler.eventLog)-1]
 				handler.logLock.Unlock()
-				return logEntry.Entry == fmt.Sprintf("DevInit Iteration 1 failed with error code %v", proto.StatusCode_DEPLOY_UNKNOWN)
+				return logEntry.Entry == fmt.Sprintf("Update failed with error code %v", proto.StatusCode_DEPLOY_UNKNOWN)
 			},
 		},
 		{
@@ -504,7 +504,7 @@ func TestDevLoopFailedInPhase(t *testing.T) {
 				handler.logLock.Lock()
 				logEntry := handler.eventLog[len(handler.eventLog)-1]
 				handler.logLock.Unlock()
-				return logEntry.Entry == fmt.Sprintf("DevInit Iteration 1 failed with error code %v", proto.StatusCode_STATUSCHECK_UNHEALTHY)
+				return logEntry.Entry == fmt.Sprintf("Update failed with error code %v", proto.StatusCode_STATUSCHECK_UNHEALTHY)
 			},
 		},
 	}


### PR DESCRIPTION
Fixes: #4662 

**Description**

Simplify the devLoopEvent messages.  Removed the iteration as the user just wants to know about the current iteration.

As per [friction log](https://docs.google.com/document/d/1DcJtAs8345td8WKu1P02PPZTiBqhREN60wBkZprb3no/edit?disco=AAAAJ203H6M).

**User facing changes (remove if N/A)**
- devLoopEvent message text are simplified
