### PR TITLE
fix WSL path check to be case insensitive

### DIFF
--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -17,7 +17,6 @@ limitations under the License.
 package docker
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -171,8 +170,8 @@ func detectWsl() (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("read /proc/version: %w", err)
 		}
-
-		if bytes.Contains(b, []byte("Microsoft")) {
+		str := strings.ToLower(string(b))
+		if strings.Contains(str, "microsoft") {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
Fixes: #4687 

**Description**
When running Ubuntu 18.04 (and possibly other distros) in WSL 2, the `/proc/version` casing changed from WSL 1, causing the `detectWsl` check to incorrectly return false.

**WSL 1**
Linux version 4.4.0-19041-Microsoft (Microsoft@Microsoft.com) (gcc version 5.4.0 (GCC) ) #1-Microsoft Fri Dec 06 14:06:00 PST 2019

**WSL 2**
Linux version 4.19.104-microsoft-standard (oe-user@oe-host) (gcc version 8.2.0 (GCC)) #1 SMP Wed Feb 19 06:37:35 UTC 2020
