### PR TITLE
Kpt Deployer Config

### DIFF
--- a/docs/content/en/schemas/v2beta7.json
+++ b/docs/content/en/schemas/v2beta7.json
@@ -1603,8 +1603,8 @@
       "properties": {
         "dir": {
           "type": "string",
-          "description": "path to the directory to run kpt functions against and deploy to the cluster.",
-          "x-intellij-html-description": "path to the directory to run kpt functions against and deploy to the cluster."
+          "description": "path to the directory to run kpt functions against.",
+          "x-intellij-html-description": "path to the directory to run kpt functions against."
         },
         "fn": {
           "$ref": "#/definitions/KptFn",

--- a/docs/content/en/schemas/v2beta7.json
+++ b/docs/content/en/schemas/v2beta7.json
@@ -828,6 +828,11 @@
           "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
           "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
         },
+        "kpt": {
+          "$ref": "#/definitions/KptDeploy",
+          "description": "*beta* uses the `kpt` CLI to manage and deploy manifests.",
+          "x-intellij-html-description": "<em>beta</em> uses the <code>kpt</code> CLI to manage and deploy manifests."
+        },
         "kubeContext": {
           "type": "string",
           "description": "Kubernetes context that Skaffold should deploy to.",
@@ -861,6 +866,7 @@
         "helm",
         "kubectl",
         "kustomize",
+        "kpt",
         "statusCheckDeadlineSeconds",
         "kubeContext",
         "logs"
@@ -1592,6 +1598,73 @@
       "additionalProperties": false,
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
+    },
+    "KptDeploy": {
+      "properties": {
+        "dir": {
+          "type": "string",
+          "description": "path to the directory to run kpt functions against and deploy to the cluster.",
+          "x-intellij-html-description": "path to the directory to run kpt functions against and deploy to the cluster."
+        },
+        "fn": {
+          "$ref": "#/definitions/KptFn",
+          "description": "adds additional configurations for `kpt fn`.",
+          "x-intellij-html-description": "adds additional configurations for <code>kpt fn</code>."
+        },
+        "live": {
+          "$ref": "#/definitions/KptLive",
+          "description": "adds additional configurations for `kpt live`.",
+          "x-intellij-html-description": "adds additional configurations for <code>kpt live</code>."
+        }
+      },
+      "preferredOrder": [
+        "dir",
+        "fn",
+        "live"
+      ],
+      "additionalProperties": false,
+      "description": "*beta* uses the `kpt` CLI to manage and deploy manifests.",
+      "x-intellij-html-description": "<em>beta</em> uses the <code>kpt</code> CLI to manage and deploy manifests."
+    },
+    "KptFn": {
+      "properties": {
+        "fnPath": {
+          "type": "string",
+          "description": "path to a kpt function or pipeline.",
+          "x-intellij-html-description": "path to a kpt function or pipeline."
+        },
+        "image": {
+          "type": "string",
+          "description": "specifies an image to be run as a function.",
+          "x-intellij-html-description": "specifies an image to be run as a function."
+        }
+      },
+      "preferredOrder": [
+        "fnPath",
+        "image"
+      ],
+      "additionalProperties": false,
+      "description": "adds additional configurations used when calling `kpt fn`.",
+      "x-intellij-html-description": "adds additional configurations used when calling <code>kpt fn</code>."
+    },
+    "KptLive": {
+      "properties": {
+        "apply": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional flags passed on creations (`kpt live apply`).",
+          "x-intellij-html-description": "additional flags passed on creations (<code>kpt live apply</code>).",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "apply"
+      ],
+      "additionalProperties": false,
+      "description": "adds additional configurations used when calling `kpt live` on every command (Global), creations (Apply), or deletions (Destroy).",
+      "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live</code> on every command (Global), creations (Apply), or deletions (Destroy)."
     },
     "KubectlDeploy": {
       "properties": {

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -15,3 +15,82 @@ limitations under the License.
 */
 
 package deploy
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestKpt_Deploy(t *testing.T) {
+	tests := []struct {
+		description string
+		expected    []string
+		shouldErr   bool
+	}{
+		{
+			description: "nil",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			k := NewKptDeployer(&runcontext.RunContext{}, nil)
+			res, err := k.Deploy(nil, nil, nil)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, res)
+		})
+	}
+}
+
+func TestKpt_Dependencies(t *testing.T) {
+	tests := []struct {
+		description string
+		expected    []string
+		shouldErr   bool
+	}{
+		{
+			description: "nil",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			k := NewKptDeployer(&runcontext.RunContext{}, nil)
+			res, err := k.Dependencies()
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, res)
+		})
+	}
+}
+
+func TestKpt_Cleanup(t *testing.T) {
+	tests := []struct {
+		description string
+		shouldErr   bool
+	}{
+		{
+			description: "nil",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			k := NewKptDeployer(&runcontext.RunContext{}, nil)
+			err := k.Cleanup(nil, nil)
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}
+
+func TestKpt_Render(t *testing.T) {
+	tests := []struct {
+		description string
+		shouldErr   bool
+	}{
+		{},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			k := NewKptDeployer(&runcontext.RunContext{}, nil)
+			err := k.Render(nil, nil, nil, false, "")
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -205,6 +205,10 @@ func getDeployer(runCtx *runcontext.RunContext, labels map[string]string) deploy
 		deployers = append(deployers, deploy.NewKustomizeDeployer(runCtx, labels))
 	}
 
+	if d.KptDeploy != nil {
+		deployers = append(deployers, deploy.NewKptDeployer(runCtx, labels))
+	}
+
 	// avoid muxing overhead when only a single deployer is configured
 	if len(deployers) == 1 {
 		return deployers[0]

--- a/pkg/skaffold/runner/new_test.go
+++ b/pkg/skaffold/runner/new_test.go
@@ -17,12 +17,101 @@ limitations under the License.
 package runner
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
+
+func TestGetDeployer(t *testing.T) {
+	tests := []struct {
+		description string
+		cfg         latest.DeployType
+		expected    deploy.Deployer
+	}{
+		{
+			description: "no deployer",
+			expected:    deploy.DeployerMux{},
+		},
+		{
+			description: "helm deployer",
+			cfg:         latest.DeployType{HelmDeploy: &latest.HelmDeploy{}},
+			expected:    deploy.NewHelmDeployer(&runcontext.RunContext{}, nil),
+		},
+		{
+			description: "kubectl deployer",
+			cfg:         latest.DeployType{KubectlDeploy: &latest.KubectlDeploy{}},
+			expected: deploy.NewKubectlDeployer(&runcontext.RunContext{
+				Cfg: latest.Pipeline{
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							KubectlDeploy: &latest.KubectlDeploy{
+								Flags: latest.KubectlFlags{},
+							},
+						},
+					},
+				},
+			}, nil),
+		},
+		{
+			description: "kustomize deployer",
+			cfg:         latest.DeployType{KustomizeDeploy: &latest.KustomizeDeploy{}},
+			expected: deploy.NewKustomizeDeployer(&runcontext.RunContext{
+				Cfg: latest.Pipeline{
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							KustomizeDeploy: &latest.KustomizeDeploy{
+								Flags: latest.KubectlFlags{},
+							},
+						},
+					},
+				},
+			}, nil),
+		},
+		{
+			description: "kpt deployer",
+			cfg:         latest.DeployType{KptDeploy: &latest.KptDeploy{}},
+			expected:    deploy.NewKptDeployer(&runcontext.RunContext{}, nil),
+		},
+		{
+			description: "multiple deployers",
+			cfg: latest.DeployType{
+				HelmDeploy: &latest.HelmDeploy{},
+				KptDeploy:  &latest.KptDeploy{},
+			},
+			expected: deploy.DeployerMux{
+				deploy.NewHelmDeployer(&runcontext.RunContext{}, nil),
+				deploy.NewKptDeployer(&runcontext.RunContext{}, nil),
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			deployer := getDeployer(&runcontext.RunContext{
+				Cfg: latest.Pipeline{
+					Deploy: latest.DeployConfig{
+						DeployType: test.cfg,
+					},
+				},
+			}, nil)
+
+			t.CheckTypeEquality(test.expected, deployer)
+
+			if reflect.TypeOf(test.expected) == reflect.TypeOf(deploy.DeployerMux{}) {
+				expected := test.expected.(deploy.DeployerMux)
+				deployers := deployer.(deploy.DeployerMux)
+				t.CheckDeepEqual(len(expected), len(deployers))
+				for i, v := range expected {
+					t.CheckTypeEquality(v, deployers[i])
+				}
+			}
+		})
+	}
+}
 
 func TestCreateComponents(t *testing.T) {
 	gitExample, _ := tag.NewGitCommit("", "")

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -528,7 +528,7 @@ type KustomizeDeploy struct {
 
 // KptDeploy *beta* uses the `kpt` CLI to manage and deploy manifests.
 type KptDeploy struct {
-	// Dir is the path to the directory to run kpt functions against and deploy to the cluster.
+	// Dir is the path to the directory to run kpt functions against.
 	Dir string `yaml:"dir,omitempty"`
 
 	// Fn adds additional configurations for `kpt fn`.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -453,6 +453,9 @@ type DeployType struct {
 
 	// KustomizeDeploy *beta* uses the `kustomize` CLI to "patch" a deployment for a target environment.
 	KustomizeDeploy *KustomizeDeploy `yaml:"kustomize,omitempty"`
+
+	// KptDeploy *beta* uses the `kpt` CLI to manage and deploy manifests.
+	KptDeploy *KptDeploy `yaml:"kpt,omitempty"`
 }
 
 // KubectlDeploy *beta* uses a client side `kubectl apply` to deploy manifests.
@@ -521,6 +524,34 @@ type KustomizeDeploy struct {
 
 	// BuildArgs are additional args passed to `kustomize build`.
 	BuildArgs []string `yaml:"buildArgs,omitempty"`
+}
+
+// KptDeploy *beta* uses the `kpt` CLI to manage and deploy manifests.
+type KptDeploy struct {
+	// Dir is the path to the directory to run kpt functions against and deploy to the cluster.
+	Dir string `yaml:"dir,omitempty"`
+
+	// Fn adds additional configurations for `kpt fn`.
+	Fn KptFn `yaml:"fn,omitempty"`
+
+	// Live adds additional configurations for `kpt live`.
+	Live KptLive `yaml:"live,omitempty"`
+}
+
+// KptFn adds additional configurations used when calling `kpt fn`.
+type KptFn struct {
+	// FnPath is the path to a kpt function or pipeline.
+	FnPath string `yaml:"fnPath,omitempty"`
+
+	// Image specifies an image to be run as a function.
+	Image string `yaml:"image,omitempty"`
+}
+
+// KptLive adds additional configurations used when calling `kpt live`
+// on every command (Global), creations (Apply), or deletions (Destroy).
+type KptLive struct {
+	// Apply are additional flags passed on creations (`kpt live apply`).
+	Apply []string `yaml:"apply,omitempty"`
 }
 
 // HelmRelease describes a helm release to be deployed.

--- a/pkg/skaffold/schema/v2beta6/upgrade.go
+++ b/pkg/skaffold/schema/v2beta6/upgrade.go
@@ -24,6 +24,8 @@ import (
 
 // Upgrade upgrades a configuration to the next version.
 // Config changes from v2beta6 to v2beta7
+// 1. Additions:
+//		New KptDeploy, KptFn, and KptLive to support Kpt Deployer.
 func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
 	var newConfig next.SkaffoldConfig
 	pkgutil.CloneThroughJSON(c, &newConfig)


### PR DESCRIPTION
**Related**: #3904

**Description**
This is the config changes for the kpt deployer. The kpt deployer's implementation depends on this config.

**User facing changes (remove if N/A)**
Users will be able to specify using a kpt deployer in their skaffold.yaml. The functionality of the kpt deployer itself will not be implemented when this PR is merged. User facing docs not changed because we don't want users to use this deployer yet (functionality not implemented).

Here is what it will look like. 
```
deploy:
  kpt:
    dir: "foo"
    fn:
      fnPath: "foo"
      image: "foo"
    live:
      apply:
      - "foo"
      - "bar"
```

**Follow-up Work (remove if N/A)**
Functionality for the deployer coming next.
