### PR TITLE
Kpt Deployer applyDir implementation and tests

### DIFF
--- a/docs/content/en/schemas/v2beta7.json
+++ b/docs/content/en/schemas/v2beta7.json
@@ -1601,6 +1601,11 @@
     },
     "KptDeploy": {
       "properties": {
+        "applyDir": {
+          "type": "string",
+          "description": "path to the directory to deploy to the cluster.",
+          "x-intellij-html-description": "path to the directory to deploy to the cluster."
+        },
         "dir": {
           "type": "string",
           "description": "path to the directory to run kpt functions against.",
@@ -1619,6 +1624,7 @@
       },
       "preferredOrder": [
         "dir",
+        "applyDir",
         "fn",
         "live"
       ],

--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -18,18 +18,27 @@ package deploy
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // KptDeployer deploys workflows with kpt CLI
 type KptDeployer struct {
+	*latest.KptDeploy
 }
 
 func NewKptDeployer(runCtx *runcontext.RunContext, labels map[string]string) *KptDeployer {
-	return &KptDeployer{}
+	return &KptDeployer{
+		KptDeploy: runCtx.Pipeline().Deploy.KptDeploy,
+	}
 }
 
 func (k *KptDeployer) Deploy(ctx context.Context, out io.Writer, builds []build.Artifact) ([]string, error) {
@@ -46,4 +55,54 @@ func (k *KptDeployer) Cleanup(ctx context.Context, out io.Writer) error {
 
 func (k *KptDeployer) Render(ctx context.Context, out io.Writer, builds []build.Artifact, offline bool, filepath string) error {
 	return nil
+}
+
+// getApplyDir returns the path to applyDir if specified by the user. Otherwise, getApplyDir
+// creates a hidden directory in place of applyDir.
+func (k *KptDeployer) getApplyDir(ctx context.Context) (string, error) {
+	if k.ApplyDir != "" {
+		if _, err := os.Stat(k.ApplyDir); os.IsNotExist(err) {
+			return "", err
+		}
+		return k.ApplyDir, nil
+	}
+
+	applyDir := ".kpt-hydrated"
+
+	// 0755 is a permission setting where the owner can read, write, and execute.
+	// Others can read and execute but not modify the file.
+	if err := os.MkdirAll(applyDir, 0755); err != nil {
+		return "", fmt.Errorf("applyDir was unspecified. creating applyDir: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "kpt", kptCommandArgs(applyDir, []string{"live", "init"}, nil, nil)...)
+	util.RunCmd(cmd)
+
+	return applyDir, nil
+}
+
+// kptCommandArgs returns a list of additional arguments for the kpt command.
+func kptCommandArgs(dir string, commands, flags, globalFlags []string) []string {
+	var args []string
+
+	for _, v := range commands {
+		parts := strings.Split(v, " ")
+		args = append(args, parts...)
+	}
+
+	if len(dir) > 0 {
+		args = append(args, dir)
+	}
+
+	for _, v := range flags {
+		parts := strings.Split(v, " ")
+		args = append(args, parts...)
+	}
+
+	for _, v := range globalFlags {
+		parts := strings.Split(v, " ")
+		args = append(args, parts...)
+	}
+
+	return args
 }

--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -75,8 +76,12 @@ func (k *KptDeployer) getApplyDir(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("applyDir was unspecified. creating applyDir: %w", err)
 	}
 
-	cmd := exec.CommandContext(ctx, "kpt", kptCommandArgs(applyDir, []string{"live", "init"}, nil, nil)...)
-	util.RunCmd(cmd)
+	if _, err := os.Stat(filepath.Join(applyDir, "inventory-template.yaml")); os.IsNotExist(err) {
+		cmd := exec.CommandContext(ctx, "kpt", kptCommandArgs(applyDir, []string{"live", "init"}, nil, nil)...)
+		if err := util.RunCmd(cmd); err != nil {
+			return "", err
+		}
+	}
 
 	return applyDir, nil
 }

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -18,9 +18,13 @@ package deploy
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -92,6 +96,115 @@ func TestKpt_Render(t *testing.T) {
 			k := NewKptDeployer(&runcontext.RunContext{}, nil)
 			err := k.Render(context.Background(), nil, nil, false, "")
 			t.CheckError(test.shouldErr, err)
+		})
+	}
+}
+
+func TestKpt_GetApplyDir(t *testing.T) {
+	tests := []struct {
+		description string
+		applyDir    string
+		expected    string
+		commands    util.Command
+		shouldErr   bool
+	}{
+		{
+			description: "specified an invalid applyDir",
+			applyDir:    "invalid_path",
+			shouldErr:   true,
+		},
+		{
+			description: "specified a valid applyDir",
+			applyDir:    "resources",
+			expected:    "resources",
+		},
+		{
+			description: "unspecified applyDir",
+			expected:    ".kpt-hydrated",
+			commands:    testutil.CmdRun("kpt live init .kpt-hydrated"),
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&util.DefaultExecCommand, test.commands)
+			t.NewTempDir().Chdir()
+			if test.applyDir == test.expected {
+				os.Mkdir(test.applyDir, 0755)
+			}
+
+			k := NewKptDeployer(&runcontext.RunContext{
+				WorkingDir: ".",
+				Cfg: latest.Pipeline{
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							KptDeploy: &latest.KptDeploy{
+								ApplyDir: test.applyDir,
+							},
+						},
+					},
+				},
+			}, nil)
+
+			applyDir, err := k.getApplyDir(context.Background())
+
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, applyDir)
+		})
+	}
+}
+
+func TestKpt_KptCommandArgs(t *testing.T) {
+	tests := []struct {
+		description string
+		dir         string
+		commands    []string
+		flags       []string
+		globalFlags []string
+		expected    []string
+	}{
+		{
+			description: "empty",
+		},
+		{
+			description: "all inputs have len >0",
+			dir:         "test",
+			commands:    []string{"live", "apply"},
+			flags:       []string{"--fn-path", "kpt-func.yaml"},
+			globalFlags: []string{"-h"},
+			expected:    strings.Split("live apply test --fn-path kpt-func.yaml -h", " "),
+		},
+		{
+			description: "empty dir",
+			commands:    []string{"live", "apply"},
+			flags:       []string{"--fn-path", "kpt-func.yaml"},
+			globalFlags: []string{"-h"},
+			expected:    strings.Split("live apply --fn-path kpt-func.yaml -h", " "),
+		},
+		{
+			description: "empty commands",
+			dir:         "test",
+			flags:       []string{"--fn-path", "kpt-func.yaml"},
+			globalFlags: []string{"-h"},
+			expected:    strings.Split("test --fn-path kpt-func.yaml -h", " "),
+		},
+		{
+			description: "empty flags",
+			dir:         "test",
+			commands:    []string{"live", "apply"},
+			globalFlags: []string{"-h"},
+			expected:    strings.Split("live apply test -h", " "),
+		},
+		{
+			description: "empty globalFlags",
+			dir:         "test",
+			commands:    []string{"live", "apply"},
+			flags:       []string{"--fn-path", "kpt-func.yaml"},
+			expected:    strings.Split("live apply test --fn-path kpt-func.yaml", " "),
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			res := kptCommandArgs(test.dir, test.commands, test.flags, test.globalFlags)
+			t.CheckDeepEqual(test.expected, res)
 		})
 	}
 }

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -115,21 +115,30 @@ func TestKpt_GetApplyDir(t *testing.T) {
 		},
 		{
 			description: "specified a valid applyDir",
-			applyDir:    "resources",
-			expected:    "resources",
+			applyDir:    "valid_path",
+			expected:    "valid_path",
 		},
 		{
 			description: "unspecified applyDir",
 			expected:    ".kpt-hydrated",
 			commands:    testutil.CmdRun("kpt live init .kpt-hydrated"),
 		},
+		{
+			description: "existing template resource in .kpt-hydrated",
+			expected:    ".kpt-hydrated",
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
-			t.NewTempDir().Chdir()
+			tmpDir := t.NewTempDir().Chdir()
+
 			if test.applyDir == test.expected {
 				os.Mkdir(test.applyDir, 0755)
+			}
+
+			if test.description == "existing template resource in .kpt-hydrated" {
+				tmpDir.Touch(".kpt-hydrated/inventory-template.yaml")
 			}
 
 			k := NewKptDeployer(&runcontext.RunContext{

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -531,6 +531,9 @@ type KptDeploy struct {
 	// Dir is the path to the directory to run kpt functions against.
 	Dir string `yaml:"dir,omitempty"`
 
+	// ApplyDir is the path to the directory to deploy to the cluster.
+	ApplyDir string `yaml:"applyDir,omitempty"`
+
 	// Fn adds additional configurations for `kpt fn`.
 	Fn KptFn `yaml:"fn,omitempty"`
 


### PR DESCRIPTION
**Related**: #3904

**Description**
`getApplyDir` is a function which resolves the package to deploy to the cluster for kpt deployer. If unspecified, it will create a hidden directory .kpt-hydrated.

**User facing changes**
Users will have the ability to specify their own applyDir in skaffold.yaml.

**Follow-up Work**
Further implementation of kpt deployer will be next.