### PR TITLE
Kpt Deployer Dependencies() implementation and tests

### DIFF
--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -47,7 +48,19 @@ func (k *KptDeployer) Deploy(ctx context.Context, out io.Writer, builds []build.
 }
 
 func (k *KptDeployer) Dependencies() ([]string, error) {
-	return nil, nil
+	deps := newStringSet()
+	if len(k.Fn.FnPath) > 0 {
+		deps.insert(k.Fn.FnPath)
+	}
+
+	configDeps, err := getResources(k.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("finding dependencies in %s: %w", k.Dir, err)
+	}
+
+	deps.insert(configDeps...)
+
+	return deps.toList(), nil
 }
 
 func (k *KptDeployer) Cleanup(ctx context.Context, out io.Writer) error {
@@ -110,4 +123,36 @@ func kptCommandArgs(dir string, commands, flags, globalFlags []string) []string 
 	}
 
 	return args
+}
+
+// getResources returns a list of all file names in `root` that end in .yaml or .yml
+// and all local kustomization dependencies under root.
+func getResources(root string) ([]string, error) {
+	var files []string
+
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		return nil, err
+	}
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, _ error) error {
+		isResource, err := regexp.MatchString(`\.ya?ml$`, filepath.Base(path))
+		if err != nil {
+			return fmt.Errorf("matching regex: %w", err)
+		}
+
+		if info.IsDir() {
+			depsForKustomization, err := dependenciesForKustomization(path)
+			if err != nil {
+				return err
+			}
+
+			files = append(files, depsForKustomization...)
+		} else if isResource {
+			files = append(files, strings.ReplaceAll(path, "\\", "/"))
+		}
+
+		return nil
+	})
+
+	return files, err
 }

--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -135,9 +135,11 @@ func getResources(root string) ([]string, error) {
 	}
 
 	err := filepath.Walk(root, func(path string, info os.FileInfo, _ error) error {
+		// Using regex match is not entirely accurate in deciding whether something is a resource or not.
+		// Kpt should provide better functionality for determining whether files are resources.
 		isResource, err := regexp.MatchString(`\.ya?ml$`, filepath.Base(path))
 		if err != nil {
-			return fmt.Errorf("matching regex: %w", err)
+			return fmt.Errorf("matching %s with regex: %w", filepath.Base(path), err)
 		}
 
 		if info.IsDir() {
@@ -148,6 +150,7 @@ func getResources(root string) ([]string, error) {
 
 			files = append(files, depsForKustomization...)
 		} else if isResource {
+			// Windows uses `\` instead of `/` for paths. Replacing these will improve consistency for testing.
 			files = append(files, strings.ReplaceAll(path, "\\", "/"))
 		}
 

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -81,15 +81,15 @@ func TestKpt_Dependencies(t *testing.T) {
 			expected: []string{"foo.yaml"},
 		},
 		{
-			description: "dir with subdirs",
+			description: "dir with subdirs and file path variants",
 			cfg: &latest.KptDeploy{
 				Dir: ".",
 			},
 			createFiles: map[string]string{
-				"food.yml":          "",
-				"foo/bar.yaml":      "",
-				"foo/bat/bad.yml":   "",
-				"foo/bat/README.md": "",
+				"food.yml":           "",
+				"foo/bar.yaml":       "",
+				"foo/bat//bad.yml":   "",
+				"foo/bat\\README.md": "",
 			},
 			expected: []string{"foo/bar.yaml", "foo/bat/bad.yml", "food.yml"},
 		},

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -49,18 +49,124 @@ func TestKpt_Deploy(t *testing.T) {
 
 func TestKpt_Dependencies(t *testing.T) {
 	tests := []struct {
-		description string
-		expected    []string
-		shouldErr   bool
+		description    string
+		cfg            *latest.KptDeploy
+		createFiles    map[string]string
+		kustomizations map[string]string
+		expected       []string
+		shouldErr      bool
 	}{
 		{
-			description: "nil",
+			description: "bad dir",
+			cfg: &latest.KptDeploy{
+				Dir: "invalid_path",
+			},
+			shouldErr: true,
+		},
+		{
+			description: "empty dir and unspecified fnPath",
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+			},
+		},
+		{
+			description: "dir",
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+			},
+			createFiles: map[string]string{
+				"foo.yaml":  "",
+				"README.md": "",
+			},
+			expected: []string{"foo.yaml"},
+		},
+		{
+			description: "dir with subdirs",
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+			},
+			createFiles: map[string]string{
+				"food.yml":          "",
+				"foo/bar.yaml":      "",
+				"foo/bat/bad.yml":   "",
+				"foo/bat/README.md": "",
+			},
+			expected: []string{"foo/bar.yaml", "foo/bat/bad.yml", "food.yml"},
+		},
+		{
+			description: "fnpath",
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+				Fn:  latest.KptFn{FnPath: "kpt-func.yaml"},
+			},
+			expected: []string{"kpt-func.yaml"},
+		},
+		{
+			description: "fnpath and dir and kustomization",
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+				Fn:  latest.KptFn{FnPath: "kpt-func.yaml"},
+			},
+			createFiles: map[string]string{"foo.yml": ""},
+			kustomizations: map[string]string{"kustomization.yaml": `configMapGenerator:
+- files: [app1.properties]`},
+			expected: []string{"app1.properties", "foo.yml", "kpt-func.yaml", "kustomization.yaml"},
+		},
+		{
+			description: "dependencies that can only be detected as a kustomization",
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+			},
+			kustomizations: map[string]string{"kustomization.yaml": `configMapGenerator:
+- files: [app1.properties]`},
+			expected: []string{"app1.properties", "kustomization.yaml"},
+		},
+		{
+			description: "kustomization.yml variant",
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+			},
+			kustomizations: map[string]string{"kustomization.yml": `configMapGenerator:
+- files: [app1.properties]`},
+			expected: []string{"app1.properties", "kustomization.yml"},
+		},
+		{
+			description: "Kustomization variant",
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+			},
+			kustomizations: map[string]string{"Kustomization": `configMapGenerator:
+- files: [app1.properties]`},
+			expected: []string{"Kustomization", "app1.properties"},
+		},
+		{
+			description: "incorrectly named kustomization",
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+			},
+			kustomizations: map[string]string{"customization": `configMapGenerator:
+- files: [app1.properties]`},
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			k := NewKptDeployer(&runcontext.RunContext{}, nil)
+			tmpDir := t.NewTempDir().Chdir()
+
+			tmpDir.WriteFiles(test.createFiles)
+			tmpDir.WriteFiles(test.kustomizations)
+
+			k := NewKptDeployer(&runcontext.RunContext{
+				Cfg: latest.Pipeline{
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							KptDeploy: test.cfg,
+						},
+					},
+				},
+			}, nil)
+
 			res, err := k.Dependencies()
+
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, res)
 		})
 	}


### PR DESCRIPTION
**Related**: #3904

**Description**
This is the implementation and unit tests for the dependencies method of the kpt deployer. Dependencies include the functions being ran, the files used by those functions, and kustomizations.

**Follow-up Work**
No follow up work for this particular method. Follow up work for the Kpt deployer will include the other methods that are yet to be implemented.