### PR TITLE
Kpt Deployer Cleanup() implementation and tests

### DIFF
--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -50,7 +50,17 @@ func (k *KptDeployer) Dependencies() ([]string, error) {
 	return nil, nil
 }
 
-func (k *KptDeployer) Cleanup(ctx context.Context, out io.Writer) error {
+func (k *KptDeployer) Cleanup(ctx context.Context, _ io.Writer) error {
+	applyDir, err := k.getApplyDir(ctx)
+	if err != nil {
+		return fmt.Errorf("getting applyDir: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "kpt", kptCommandArgs(applyDir, []string{"live", "destroy"}, nil, nil)...)
+	if err = util.RunCmd(cmd); err != nil {
+		return fmt.Errorf("kpt live destroy: %w", err)
+	}
+
 	return nil
 }
 

--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -50,6 +50,7 @@ func (k *KptDeployer) Dependencies() ([]string, error) {
 	return nil, nil
 }
 
+// Cleanup deletes what was deployed by calling `kpt live destroy`.
 func (k *KptDeployer) Cleanup(ctx context.Context, _ io.Writer) error {
 	applyDir, err := k.getApplyDir(ctx)
 	if err != nil {
@@ -57,8 +58,10 @@ func (k *KptDeployer) Cleanup(ctx context.Context, _ io.Writer) error {
 	}
 
 	cmd := exec.CommandContext(ctx, "kpt", kptCommandArgs(applyDir, []string{"live", "destroy"}, nil, nil)...)
-	if err = util.RunCmd(cmd); err != nil {
-		return fmt.Errorf("kpt live destroy: %w", err)
+	out, err := util.RunCmdOut(cmd)
+	if err != nil {
+		// Kpt errors are written in STDOUT and surrounded by `\n`.
+		return fmt.Errorf("kpt live destroy: %s", strings.Trim(string(out), "\n"))
 	}
 
 	return nil

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -126,6 +126,7 @@ func TestKpt_Cleanup(t *testing.T) {
 			}, nil)
 
 			err := k.Cleanup(context.Background(), ioutil.Discard)
+
 			t.CheckError(test.shouldErr, err)
 		})
 	}

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -84,19 +84,19 @@ func TestKpt_Cleanup(t *testing.T) {
 		{
 			description: "valid user specified applyDir w/o template resource",
 			applyDir:    "valid_path",
-			commands:    testutil.CmdRunErr("kpt live destroy valid_path", errors.New("BUG")),
+			commands:    testutil.CmdRunOutErr("kpt live destroy valid_path", "", errors.New("BUG")),
 			shouldErr:   true,
 		},
 		{
 			description: "valid user specified applyDir w/ template resource (emulated)",
 			applyDir:    "valid_path",
-			commands:    testutil.CmdRun("kpt live destroy valid_path"),
+			commands:    testutil.CmdRunOut("kpt live destroy valid_path", ""),
 		},
 		{
 			description: "unspecified applyDir",
 			commands: testutil.
 				CmdRun("kpt live init .kpt-hydrated").
-				AndRun("kpt live destroy .kpt-hydrated"),
+				AndRunOut("kpt live destroy .kpt-hydrated", ""),
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -18,10 +18,13 @@ package deploy
 
 import (
 	"context"
+	"errors"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -69,16 +72,60 @@ func TestKpt_Dependencies(t *testing.T) {
 func TestKpt_Cleanup(t *testing.T) {
 	tests := []struct {
 		description string
+		applyDir    string
+		commands    util.Command
 		shouldErr   bool
 	}{
 		{
-			description: "nil",
+			description: "invalid user specified applyDir",
+			applyDir:    "invalid_path",
+			shouldErr:   true,
+		},
+		{
+			description: "valid user specified applyDir w/o template resource",
+			applyDir:    "valid_path",
+			commands:    testutil.CmdRunErr("kpt live destroy valid_path", errors.New("BUG")),
+			shouldErr:   true,
+		},
+		{
+			description: "valid user specified applyDir w/ template resource (emulated)",
+			applyDir:    "valid_path",
+			commands:    testutil.CmdRun("kpt live destroy valid_path"),
+		},
+		{
+			description: "unspecified applyDir",
+			commands: testutil.
+				CmdRun("kpt live init .kpt-hydrated").
+				AndRun("kpt live destroy .kpt-hydrated"),
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			k := NewKptDeployer(&runcontext.RunContext{}, nil)
-			err := k.Cleanup(context.Background(), nil)
+			t.Override(&util.DefaultExecCommand, test.commands)
+			t.NewTempDir().Chdir()
+
+			if test.applyDir == "valid_path" {
+				os.Mkdir(test.applyDir, 0755)
+			}
+
+			k := NewKptDeployer(&runcontext.RunContext{
+				WorkingDir: ".",
+				Cfg: latest.Pipeline{
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							KptDeploy: &latest.KptDeploy{
+								ApplyDir: test.applyDir,
+							},
+						},
+					},
+				},
+				KubeContext: testKubeContext,
+				Opts: config.SkaffoldOptions{
+					Namespace: testNamespace,
+				},
+			}, nil)
+
+			err := k.Cleanup(context.Background(), ioutil.Discard)
 			t.CheckError(test.shouldErr, err)
 		})
 	}


### PR DESCRIPTION
Related: #3904

Description
This is the implementation and unit tests for the Cleanup() method of the kpt deployer. This involves running `kpt live destroy /DIR` where `/DIR` is applyDir (contains the hydrated resources).

Follow-up Work
No follow up work for this particular method. Follow up work for the Kpt deployer will include the other methods that are yet to be implemented.