### PR TITLE
Identify minikube cluster for any profile name

### DIFF
--- a/pkg/skaffold/cluster/minikube.go
+++ b/pkg/skaffold/cluster/minikube.go
@@ -67,7 +67,7 @@ func (clientImpl) IsMinikube(kubeContext string) bool {
 	if kubeContext == constants.DefaultMinikubeContext {
 		return true
 	}
-	if _, err := minikubeBinaryFunc();  err != nil {
+	if _, err := minikubeBinaryFunc(); err != nil {
 		logrus.Tracef("Minikube cluster not detected: %v", err)
 		return false
 	}

--- a/pkg/skaffold/cluster/minikube.go
+++ b/pkg/skaffold/cluster/minikube.go
@@ -67,8 +67,7 @@ func (clientImpl) IsMinikube(kubeContext string) bool {
 	if kubeContext == constants.DefaultMinikubeContext {
 		return true
 	}
-	_, err := minikubeBinaryFunc()
-	if err != nil {
+	if _, err := minikubeBinaryFunc();  err != nil {
 		logrus.Tracef("Minikube cluster not detected: %v", err)
 		return false
 	}

--- a/pkg/skaffold/cluster/minikube.go
+++ b/pkg/skaffold/cluster/minikube.go
@@ -65,24 +65,24 @@ func (clientImpl) IsMinikube(kubeContext string) bool {
 	}
 	_, err := minikubeBinaryFunc()
 	if err != nil {
-		logrus.Debugf("Minikube cluster not detected: %v", err)
+		logrus.Tracef("Minikube cluster not detected: %v", err)
 		return false
 	}
 
 	if ok, err := matchClusterCertPath(kubeContext); err != nil {
-		logrus.Debugf("failed to match cluster certificate path: %v", err)
+		logrus.Tracef("failed to match cluster certificate path: %v", err)
 	} else if ok {
 		logrus.Debugf("Minikube cluster detected: cluster certificate for context %q found inside the minikube directory", kubeContext)
 		return true
 	}
 
 	if ok, err := matchProfileAndServerURL(kubeContext); err != nil {
-		logrus.Debugf("failed to match minikube profile: %v", err)
+		logrus.Tracef("failed to match minikube profile: %v", err)
 	} else if ok {
 		logrus.Debugf("Minikube cluster detected: context %q has matching profile name or server url", kubeContext)
 		return true
 	}
-	logrus.Debugf("Minikube cluster not detected for context %q", kubeContext)
+	logrus.Tracef("Minikube cluster not detected for context %q", kubeContext)
 	return false
 }
 
@@ -138,7 +138,7 @@ func matchProfileAndServerURL(kubeContext string) (bool, error) {
 		return false, fmt.Errorf("getting kubernetes server url: %w", err)
 	}
 
-	logrus.Debugf("kubernetes server url: %s", apiServerURL)
+	logrus.Tracef("kubernetes server url: %s", apiServerURL)
 
 	ok, err := matchServerURLFor(kubeContext, apiServerURL)
 	if err != nil {

--- a/pkg/skaffold/cluster/minikube.go
+++ b/pkg/skaffold/cluster/minikube.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"os/exec"
+
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	k8s "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+var GetClient = getClient
+
+// To override during tests
+var (
+	minikubeBinaryFunc      = minikubeBinary
+	getRestClientConfigFunc = context.GetRestClientConfig
+)
+
+type Client interface {
+	// IsMinikube returns true if the given kubeContext maps to a minikube cluster
+	IsMinikube(kubeContext string) bool
+	// MinikubeExec returns the Cmd struct to execute minikube with given arguments
+	MinikubeExec(arg ...string) (*exec.Cmd, error)
+}
+
+type clientImpl struct{}
+
+func getClient() Client {
+	return clientImpl{}
+}
+
+func (clientImpl) IsMinikube(kubeContext string) bool {
+	// short circuit if context is 'minikube'
+	if kubeContext == constants.DefaultMinikubeContext {
+		return true
+	}
+	_, err := minikubeBinaryFunc()
+	if err != nil {
+		logrus.Debugf("Minikube cluster not detected: %v", err)
+		return false // minikube binary not found
+	}
+
+	if ok, err := matchNodeLabel(kubeContext); err != nil {
+		logrus.Debugf("failed to check minikube node labels: %v", err)
+	} else if ok {
+		logrus.Debugf("Minikube cluster detected: context %q nodes have minikube labels", kubeContext)
+		return true
+	}
+
+	if ok, err := matchProfileAndServerURL(kubeContext); err != nil {
+		logrus.Debugf("failed to match minikube profile: %v", err)
+	} else if ok {
+		logrus.Debugf("Minikube cluster detected: context %q has matching profile name or server url", kubeContext)
+		return true
+	}
+	logrus.Debugf("Minikube cluster not detected for context %q", kubeContext)
+	return false
+}
+
+func (clientImpl) MinikubeExec(arg ...string) (*exec.Cmd, error) {
+	return minikubeExec(arg...)
+}
+
+func minikubeExec(arg ...string) (*exec.Cmd, error) {
+	b, err := minikubeBinaryFunc()
+	if err != nil {
+		return nil, fmt.Errorf("getting minikube executable: %w", err)
+	}
+	return exec.Command(b, arg...), nil
+}
+
+func minikubeBinary() (string, error) {
+	execName := "minikube"
+	if found, _ := util.DetectWSL(); found {
+		execName = "minikube.exe"
+	}
+	filename, err := exec.LookPath(execName)
+	if err != nil {
+		return "", errors.New("unable to find minikube executable. Please add it to PATH environment variable")
+	}
+	if _, err := os.Stat(filename); os.IsNotExist(err) {
+		return "", fmt.Errorf("unable to find minikube executable. File not found %s", filename)
+	}
+	return filename, nil
+}
+
+func matchNodeLabel(kubeContext string) (bool, error) {
+	client, err := k8s.Client()
+	if err != nil {
+		return false, fmt.Errorf("getting Kubernetes client: %w", err)
+	}
+	opts := v1.ListOptions{
+		LabelSelector: fmt.Sprintf("minikube.k8s.io/name=%s", kubeContext),
+		Limit:         100,
+	}
+	l, err := client.CoreV1().Nodes().List(opts)
+	if err != nil {
+		return false, fmt.Errorf("listing nodes with matching label: %w", err)
+	}
+	return l != nil && len(l.Items) > 0, nil
+}
+
+// matchProfileAndServerURL checks if kubecontext matches any valid minikube profile
+// and for selected drivers if the k8s server url is same as any of the minikube nodes IPs
+func matchProfileAndServerURL(kubeContext string) (bool, error) {
+	config, err := getRestClientConfigFunc()
+	if err != nil {
+		return false, fmt.Errorf("getting kubernetes config: %w", err)
+	}
+	apiServerURL, _, err := rest.DefaultServerURL(config.Host, config.APIPath, schema.GroupVersion{}, false)
+
+	if err != nil {
+		return false, fmt.Errorf("getting kubernetes server url: %w", err)
+	}
+
+	logrus.Debugf("kubernetes server url: %s", apiServerURL)
+
+	ok, err := matchServerURLFor(kubeContext, apiServerURL)
+	if err != nil {
+		return false, fmt.Errorf("checking minikube node url: %w", err)
+	}
+	return ok, nil
+}
+
+func matchServerURLFor(kubeContext string, serverURL *url.URL) (bool, error) {
+	cmd, err := minikubeExec("profile", "list", "-o", "json")
+	if err != nil {
+		return false, fmt.Errorf("executing minikube command: %w", err)
+	}
+
+	out, err := util.RunCmdOut(cmd)
+	if err != nil {
+		return false, fmt.Errorf("getting minikube profiles: %w", err)
+	}
+
+	var data data
+	if err = json.Unmarshal(out, &data); err != nil {
+		log.Fatal(fmt.Errorf("failed to unmarshal data: %w", err))
+	}
+
+	for _, v := range data.Valid {
+		if v.Config.Name != kubeContext {
+			continue
+		}
+
+		if v.Config.Driver != "hyperkit" && v.Config.Driver != "virtualbox" {
+			// Since node IPs don't match server API for other drivers we assume profile name match is enough.
+			// TODO: Revisit once https://github.com/kubernetes/minikube/issues/6642 is fixed
+			return true, nil
+		}
+		for _, n := range v.Config.Nodes {
+			if serverURL.Host == fmt.Sprintf("%s:%d", n.IP, n.Port) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+type data struct {
+	Valid   []profile `json:"valid,omitempty"`
+	Invalid []profile `json:"invalid,omitempty"`
+}
+
+type profile struct {
+	Config config
+}
+
+type config struct {
+	Name   string
+	Driver string
+	Nodes  []node
+}
+
+type node struct {
+	IP   string
+	Port int32
+}

--- a/pkg/skaffold/cluster/minikube_test.go
+++ b/pkg/skaffold/cluster/minikube_test.go
@@ -95,6 +95,12 @@ func TestClientImpl_IsMinikube(t *testing.T) {
 			expected:           false,
 		},
 		{
+			description:        "cannot parse minikube profile list",
+			kubeContext:        "test-cluster",
+			minikubeProfileCmd: testutil.CmdRunOut("minikube profile list -o json", `{"foo":"bar"}`),
+			expected:           false,
+		},
+		{
 			description: "minikube with hyperkit driver node ip different from api server url",
 			kubeContext: "test-cluster",
 			config: rest.Config{

--- a/pkg/skaffold/cluster/minikube_test.go
+++ b/pkg/skaffold/cluster/minikube_test.go
@@ -18,24 +18,23 @@ package cluster
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	fakeclient "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/util/homedir"
 
-	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestClientImpl_IsMinikube(t *testing.T) {
+	home := homedir.HomeDir()
 	tests := []struct {
 		description        string
 		kubeContext        string
-		minikubeLabels     map[string]string
+		clusterInfo        clientcmdapi.Cluster
 		config             rest.Config
 		minikubeProfileCmd util.Command
 		minikubeNotInPath  bool
@@ -53,10 +52,20 @@ func TestClientImpl_IsMinikube(t *testing.T) {
 			expected:          false,
 		},
 		{
-			description:    "minikube label found on cluster node",
-			kubeContext:    "test-cluster",
-			minikubeLabels: map[string]string{"minikube.k8s.io/name": "test-cluster"},
-			expected:       true,
+			description: "cluster cert inside minikube dir",
+			kubeContext: "test-cluster",
+			clusterInfo: clientcmdapi.Cluster{
+				CertificateAuthority: filepath.Join(home, ".minikube", "ca.crt"),
+			},
+			expected: true,
+		},
+		{
+			description: "cluster cert outside minikube dir",
+			kubeContext: "test-cluster",
+			clusterInfo: clientcmdapi.Cluster{
+				CertificateAuthority: filepath.Join(home, "foo", "ca.crt"),
+			},
+			expected: false,
 		},
 		{
 			description: "minikube profile name with docker driver matches kubeContext",
@@ -98,43 +107,18 @@ func TestClientImpl_IsMinikube(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			dep := &v1.Node{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "meta/v1",
-					Kind:       "Node",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   test.kubeContext,
-					Labels: test.minikubeLabels,
-				},
-			}
-			// Mock Kubernetes
-			client := fakeclient.NewSimpleClientset(dep)
-			client.Resources = append(client.Resources, &metav1.APIResourceList{
-				GroupVersion: dep.APIVersion,
-				APIResources: []metav1.APIResource{{
-					Kind: dep.Kind,
-					Name: "nodes",
-				}},
-			})
 			if test.minikubeNotInPath {
 				t.Override(&minikubeBinaryFunc, func() (string, error) { return "", fmt.Errorf("minikube not in PATH") })
 			} else {
 				t.Override(&minikubeBinaryFunc, func() (string, error) { return "minikube", nil })
 			}
 			t.Override(&util.DefaultExecCommand, test.minikubeProfileCmd)
-			t.Override(&kubernetesclient.Client, mockClient(client))
 			t.Override(&getRestClientConfigFunc, func() (*rest.Config, error) { return &test.config, nil })
+			t.Override(&getClusterInfo, func(string) (*clientcmdapi.Cluster, error) { return &test.clusterInfo, nil })
 
 			ok := GetClient().IsMinikube(test.kubeContext)
 			t.CheckDeepEqual(test.expected, ok)
 		})
-	}
-}
-
-func mockClient(m kubernetes.Interface) func() (kubernetes.Interface, error) {
-	return func() (kubernetes.Interface, error) {
-		return m, nil
 	}
 }
 

--- a/pkg/skaffold/cluster/minikube_test.go
+++ b/pkg/skaffold/cluster/minikube_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	fakeclient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+
+	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestClientImpl_IsMinikube(t *testing.T) {
+	tests := []struct {
+		description        string
+		kubeContext        string
+		minikubeLabels     map[string]string
+		config             rest.Config
+		minikubeProfileCmd util.Command
+		minikubeNotInPath  bool
+		expected           bool
+	}{
+		{
+			description: "context is 'minikube'",
+			kubeContext: "minikube",
+			expected:    true,
+		},
+		{
+			description:       "'minikube' binary not found",
+			kubeContext:       "test-cluster",
+			minikubeNotInPath: true,
+			expected:          false,
+		},
+		{
+			description:    "minikube label found on cluster node",
+			kubeContext:    "test-cluster",
+			minikubeLabels: map[string]string{"minikube.k8s.io/name": "test-cluster"},
+			expected:       true,
+		},
+		{
+			description: "minikube profile name with docker driver matches kubeContext",
+			kubeContext: "test-cluster",
+			config: rest.Config{
+				Host: "127.0.0.1:32768",
+			},
+			minikubeProfileCmd: testutil.CmdRunOut("minikube profile list -o json", fmt.Sprintf(profileStr, "test-cluster", "docker", "172.17.0.3", 8443)),
+			expected:           true,
+		},
+		{
+			description: "minikube profile name with hyperkit driver node ip matches api server url",
+			kubeContext: "test-cluster",
+			config: rest.Config{
+				Host: "192.168.64.10:8443",
+			},
+			minikubeProfileCmd: testutil.CmdRunOut("minikube profile list -o json", fmt.Sprintf(profileStr, "test-cluster", "hyperkit", "192.168.64.10", 8443)),
+			expected:           true,
+		},
+		{
+			description: "minikube profile name different from kubeContext",
+			kubeContext: "test-cluster",
+			config: rest.Config{
+				Host: "127.0.0.1:32768",
+			},
+			minikubeProfileCmd: testutil.CmdRunOut("minikube profile list -o json", fmt.Sprintf(profileStr, "test-cluster2", "docker", "172.17.0.3", 8443)),
+			expected:           false,
+		},
+		{
+			description: "minikube with hyperkit driver node ip different from api server url",
+			kubeContext: "test-cluster",
+			config: rest.Config{
+				Host: "192.168.64.10:8443",
+			},
+			minikubeProfileCmd: testutil.CmdRunOut("minikube profile list -o json", fmt.Sprintf(profileStr, "test-cluster", "hyperkit", "192.168.64.11", 8443)),
+			expected:           false,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			dep := &v1.Node{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "meta/v1",
+					Kind:       "Node",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   test.kubeContext,
+					Labels: test.minikubeLabels,
+				},
+			}
+			// Mock Kubernetes
+			client := fakeclient.NewSimpleClientset(dep)
+			client.Resources = append(client.Resources, &metav1.APIResourceList{
+				GroupVersion: dep.APIVersion,
+				APIResources: []metav1.APIResource{{
+					Kind: dep.Kind,
+					Name: "nodes",
+				}},
+			})
+			if test.minikubeNotInPath {
+				t.Override(&minikubeBinaryFunc, func() (string, error) { return "", fmt.Errorf("minikube not in PATH") })
+			} else {
+				t.Override(&minikubeBinaryFunc, func() (string, error) { return "minikube", nil })
+			}
+			t.Override(&util.DefaultExecCommand, test.minikubeProfileCmd)
+			t.Override(&kubernetesclient.Client, mockClient(client))
+			t.Override(&getRestClientConfigFunc, func() (*rest.Config, error) { return &test.config, nil })
+
+			ok := GetClient().IsMinikube(test.kubeContext)
+			t.CheckDeepEqual(test.expected, ok)
+		})
+	}
+}
+
+func mockClient(m kubernetes.Interface) func() (kubernetes.Interface, error) {
+	return func() (kubernetes.Interface, error) {
+		return m, nil
+	}
+}
+
+var profileStr = `{"invalid": [],"valid": [{"Name": "minikube","Status": "Stopped","Config": {"Name": "%s","Driver": "%s","Nodes": [{"Name": "","IP": "%s","Port": %d}]}}]}`

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -28,6 +28,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/cluster"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -216,13 +217,11 @@ func GetDebugHelpersRegistry(configFile string) (string, error) {
 }
 
 func isDefaultLocal(kubeContext string) bool {
-	if kubeContext == constants.DefaultMinikubeContext ||
-		kubeContext == constants.DefaultDockerForDesktopContext ||
-		kubeContext == constants.DefaultDockerDesktopContext {
-		return true
-	}
-
-	return IsKindCluster(kubeContext) || IsK3dCluster(kubeContext)
+	return kubeContext == constants.DefaultDockerForDesktopContext ||
+		kubeContext == constants.DefaultDockerDesktopContext ||
+		cluster.GetClient().IsMinikube(kubeContext) ||
+		IsKindCluster(kubeContext) ||
+		IsK3dCluster(kubeContext)
 }
 
 // IsImageLoadingRequired checks if the cluster requires loading images into it

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -164,22 +163,8 @@ func getUserAgentHeader() map[string]string {
 	}
 }
 
-func detectWsl() (bool, error) {
-	if _, err := os.Stat("/proc/version"); err == nil {
-		b, err := ioutil.ReadFile("/proc/version")
-		if err != nil {
-			return false, fmt.Errorf("read /proc/version: %w", err)
-		}
-		str := strings.ToLower(string(b))
-		if strings.Contains(str, "microsoft") {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 func getMiniKubeFilename() (string, error) {
-	if found, _ := detectWsl(); found {
+	if found, _ := util.DetectWSL(); found {
 		filename, err := exec.LookPath("minikube.exe")
 		if err != nil {
 			return "", errors.New("unable to find minikube.exe. Please add it to PATH environment variable")
@@ -221,7 +206,7 @@ func getMinikubeDockerEnv(minikubeProfile string) (map[string]string, error) {
 		env[kv[0]] = kv[1]
 	}
 
-	if found, _ := detectWsl(); found {
+	if found, _ := util.DetectWSL(); found {
 		cmd := exec.Command("wslpath", env["DOCKER_CERT_PATH"])
 		out, err := util.RunCmdOut(cmd)
 		if err == nil {

--- a/pkg/skaffold/kubernetes/context/context.go
+++ b/pkg/skaffold/kubernetes/context/context.go
@@ -70,6 +70,19 @@ func GetRestClientConfig() (*restclient.Config, error) {
 	return getRestClientConfig(kubeContext, kubeConfigFile)
 }
 
+// GetClusterInfo returns the Cluster information for the given kubeContext
+func GetClusterInfo(kctx string) (*clientcmdapi.Cluster, error) {
+	rawConfig, err := getCurrentConfig()
+	if err != nil {
+		return nil, err
+	}
+	c, found := rawConfig.Clusters[kctx]
+	if !found {
+		return nil, fmt.Errorf("failed to get cluster info for kubeContext: `%s`", kctx)
+	}
+	return c, nil
+}
+
 func getRestClientConfig(kctx string, kcfg string) (*restclient.Config, error) {
 	logrus.Debugf("getting client config for kubeContext: `%s`", kctx)
 

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -329,6 +329,15 @@ func IsHiddenFile(filename string) bool {
 	return hasHiddenPrefix(filename)
 }
 
+// IsSubPath return true if targetpath is sub-path of basepath; doesn't check for symlinks
+func IsSubPath(basepath string, targetpath string) bool {
+	rel, err := filepath.Rel(basepath, targetpath)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+}
+
 func hasHiddenPrefix(s string) bool {
 	return strings.HasPrefix(s, hiddenPrefix)
 }

--- a/pkg/skaffold/util/util_test.go
+++ b/pkg/skaffold/util/util_test.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/mitchellh/go-homedir"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -365,6 +367,41 @@ func TestFormatMapToStringSlice2(t *testing.T) {
 			actual := EnvPtrMapToSlice(test.args, "=")
 
 			t.CheckDeepEqual(test.expected, actual)
+		})
+	}
+}
+
+func TestIsSubPath(t *testing.T) {
+	home, _ := homedir.Dir()
+	tests := []struct {
+		description string
+		basePath    string
+		targetPath  string
+		expected    bool
+	}{
+		{
+			description: "target path within base path",
+			basePath:    filepath.Join(home, ".minikube"),
+			targetPath:  filepath.Join(home, ".minikube", "ca.crt"),
+			expected:    true,
+		},
+		{
+			description: "target path outside base path",
+			basePath:    filepath.Join(home, "bar"),
+			targetPath:  filepath.Join(home, "foo", "bar"),
+			expected:    false,
+		},
+		{
+			description: "base path inside target path",
+			basePath:    filepath.Join(home, "foo", "bar"),
+			targetPath:  filepath.Join(home, "foo"),
+			expected:    false,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expected, IsSubPath(test.basePath, test.targetPath))
 		})
 	}
 }

--- a/pkg/skaffold/util/wsl.go
+++ b/pkg/skaffold/util/wsl.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+func DetectWSL() (bool, error) {
+	if _, err := os.Stat("/proc/version"); err == nil {
+		b, err := ioutil.ReadFile("/proc/version")
+		if err != nil {
+			return false, fmt.Errorf("read /proc/version: %w", err)
+		}
+
+		str := strings.ToLower(string(b))
+		if strings.Contains(str, "microsoft") {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
Fixes #3668

### Description
Currently we need to explicitly specify the minikube profile name as a skaffold flag or limit it to only 'minikube'. This PR introduces several checks for detecting a minikube cluster so that the flag will no longer be required and we can name the cluster anything.
We check:
- The context is 'minikube', or
- ~~The k8s nodes have a minikube label (refer https://github.com/kubernetes/minikube/pull/6717), or~~
- The cluster certificate path is within the `~/.minikube` directory (refer [this](https://github.com/GoogleContainerTools/skaffold/pull/4701#pullrequestreview-474795316) comment), or
- The `minikube profile list` returns a config name matching the context, and
- If the minikube driver is a VM then the node IP should also match the k8s api server url