### PR TITLE
Kpt Deployer Dependencies Unittests

### DIFF
--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -163,8 +163,7 @@ func getResources(root string) ([]string, error) {
 
 			files = append(files, depsForKustomization...)
 		} else if isResource {
-			// Windows uses `\` instead of `/` for paths. Replacing these will improve consistency for testing.
-			files = append(files, strings.ReplaceAll(path, "\\", "/"))
+			files = append(files, path)
 		}
 
 		return nil

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -170,7 +170,7 @@ func TestKpt_Dependencies(t *testing.T) {
 
 			res, err := k.Dependencies()
 
-			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, res)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, tmpDir.Paths(test.expected...), tmpDir.Paths(res...))
 		})
 	}
 }


### PR DESCRIPTION
**Related**: #4696

**Description**
Small change to the dependencies function and tests. Deals with the use of `\` for describing paths in windows.