### PR TITLE
Add SKAFFOLD_CMDLINE environment variable to pass command-line

### DIFF
--- a/cmd/skaffold/app/skaffold.go
+++ b/cmd/skaffold/app/skaffold.go
@@ -18,7 +18,12 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"io"
+	"os"
+
+	shell "github.com/kballard/go-shellquote"
+	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd"
 )
@@ -30,5 +35,14 @@ func Run(out, stderr io.Writer) error {
 	catchCtrlC(cancel)
 
 	c := cmd.NewSkaffoldCommand(out, stderr)
+	if cmdLine := os.Getenv("SKAFFOLD_CMDLINE"); cmdLine != "" && len(os.Args) == 1 {
+		parsed, err := shell.Split(cmdLine)
+		if err != nil {
+			return fmt.Errorf("SKAFFOLD_CMDLINE is invalid: %w", err)
+		}
+		// XXX logged before logrus.SetLevel is called in NewSkaffoldCommand's PersistentPreRunE
+		logrus.Debugf("Retrieving command line from SKAFFOLD_CMDLINE: %q", parsed)
+		c.SetArgs(parsed)
+	}
 	return c.ExecuteContext(ctx)
 }

--- a/cmd/skaffold/app/skaffold_test.go
+++ b/cmd/skaffold/app/skaffold_test.go
@@ -53,3 +53,33 @@ func TestMainUnknownCommand(t *testing.T) {
 		t.CheckError(true, err)
 	})
 }
+
+func TestSkaffoldCmdline_MainHelp(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		var (
+			output    bytes.Buffer
+			errOutput bytes.Buffer
+		)
+
+		t.SetEnvs(map[string]string{"SKAFFOLD_CMDLINE": "help"})
+		t.Override(&os.Args, []string{"skaffold"})
+
+		err := Run(&output, &errOutput)
+
+		t.CheckNoError(err)
+		t.CheckContains("End-to-end pipelines", output.String())
+		t.CheckContains("Getting started with a new project", output.String())
+		t.CheckEmpty(errOutput.String())
+	})
+}
+
+func TestSkaffoldCmdline_MainUnknownCommand(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		t.Override(&os.Args, []string{"skaffold"})
+		t.SetEnvs(map[string]string{"SKAFFOLD_CMDLINE": "unknown"})
+
+		err := Run(ioutil.Discard, ioutil.Discard)
+
+		t.CheckError(true, err)
+	})
+}


### PR DESCRIPTION
**Related**: #2350 

**Description**

This PR adds support for a new `SKAFFOLD_CMDLINE` environment variable.  If found, Skaffold parses the value and treats it as the command-line.  This allows running Skaffold with no arguments.

Helm 3.1 adds support for specifying a _post-processor_, a 0-argument command that may transform the rendered Kubernetes manifests just prior to be deployed.  The `debug` support for Helm (coming soon) uses `skaffold` as the post-processor and uses `SKAFFOLD_CMDLINE` to set the command and arguments.

I think we can keep this as an internal feature.