### PR TITLE
Suppress clutter from docker-credential-gcloud error messages

### DIFF
--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -326,7 +326,7 @@ func (l *localDaemon) Pull(ctx context.Context, out io.Writer, ref string) error
 	} else {
 		defer os.Unsetenv("CLOUDSDK_CORE_VERBOSITY")
 	}
-	os.Setenv("CLOUDSDK_CORE_VERBOSITY", "none")
+	os.Setenv("CLOUDSDK_CORE_VERBOSITY", "critical")
 
 	// Eargerly create credentials.
 	registryAuth, err := l.encodedRegistryAuth(ctx, DefaultAuthHelper, ref)

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -312,11 +313,25 @@ func (l *localDaemon) isAlreadyPushed(ctx context.Context, ref, registryAuth str
 
 // Pull pulls an image reference from a registry.
 func (l *localDaemon) Pull(ctx context.Context, out io.Writer, ref string) error {
+	// We first try pulling the image with credentials.  If that fails then retry
+	// without credentials in case the image is public.
+
+	// Set CLOUDSDK_CORE_VERBOSITY to suppress error messages emitted by docker-credential-gcloud
+	// when the user is not authenticated or lacks credentials to pull the given image.  The errors
+	// are irrelevant when the image is public (e.g., `gcr.io/buildpacks/builder:v1`).`
+	// If the image is private, the error from GCR directs the user to the GCR authentication
+	// page which provides steps to rememdy the situation.
+	if v, found := os.LookupEnv("CLOUDSDK_CORE_VERBOSITY"); found {
+		defer os.Setenv("CLOUDSDK_CORE_VERBOSITY", v)
+	} else {
+		defer os.Unsetenv("CLOUDSDK_CORE_VERBOSITY")
+	}
+	os.Setenv("CLOUDSDK_CORE_VERBOSITY", "none")
+
 	// Eargerly create credentials.
 	registryAuth, err := l.encodedRegistryAuth(ctx, DefaultAuthHelper, ref)
 	// Let's ignore the error because maybe the image is public
 	// and can be pulled without credentials.
-
 	rc, err := l.apiClient.ImagePull(ctx, ref, types.ImagePullOptions{
 		RegistryAuth: registryAuth,
 		PrivilegeFunc: func() (string, error) {


### PR DESCRIPTION
Follows on #4451 

**Description**

The change in #4451 makes Skaffold's image-pulling follow the approach used with `docker pull`: first try with credentials, and then without credentials.  When pulling from GCR, that first pull may result in an error being emitted from `docker-credential-gcloud` when there is no user or credentials have been revoked.

This happens surprisingly often — even when users have not run `gcloud auth configure-docker` — as Skaffold tries [using `docker-credential-gcloud` for *.gcr.io](https://github.com/GoogleContainerTools/skaffold/blob/master/pkg/skaffold/docker/authenticators.go#L100-L105).  This is the case with Cloud Code as the Cloud SDK is automatically installed, but users may not yet have performed an action requiring authentication (e.g., to deploy to GCP).

This PR sets `CLOUDSDK_CORE_VERBOSITY=none` prior to pulling images to suppress error messages emitted from `docker-credential-gcloud`.  These messages are unnecessary as should the image pull fail, the error reported from the registry and shown to the user contains sufficient information to rectify the situation.


Before:
```console
$GCLOUDSDK/bin/skaffold build
Generating tags...
 - skaffold-buildpacks -> skaffold-buildpacks:v1.13.1-49-g98ba2d818
Checking cache...
 - skaffold-buildpacks: Not found. Building
Found [minikube] context, using local docker daemon.
Building [skaffold-buildpacks]...
ERROR: (gcloud.auth.docker-helper) You do not currently have an active account selected.
Please run:

  $ gcloud auth login

to obtain new credentials.

If you have already logged in with a different account:

    $ gcloud config set account ACCOUNT

to select an already authenticated account to use.
v1: Pulling from buildpacks/builder
ab0f59294661: Pulling fs layer 
c2ae8b336f77: Pulling fs layer 
```

Now:
```console
$ skaffold build
Generating tags...
 - skaffold-buildpacks -> skaffold-buildpacks:v1.13.1-48-g28d305c44
Checking cache...
 - skaffold-buildpacks: Not found. Building
Found [minikube] context, using local docker daemon.
Building [skaffold-buildpacks]...
v1: Pulling from buildpacks/builder
ab0f59294661: Pull complete 
c2ae8b336f77: Pull complete 
3c2cba919283: Pull complete 
```

Error when pulling from a private repository:
```console
$ skaffold build
Generating tags...
 - skaffold-buildpacks -> skaffold-buildpacks:v1.13.1-50-g456977b80-dirty
Checking cache...
 - skaffold-buildpacks: Not found. Building
Found [minikube] context, using local docker daemon.
Building [skaffold-buildpacks]...
couldn't build "skaffold-buildpacks": failed to fetch builder image 'gcr.io/<private-project>/first:latest': pulling image from repository: Error response from daemon: unauthorized: You don't have the needed permissions to perform this operation, and you may have invalid credentials. To authenticate your request, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication
```