### PR TITLE
Kpt Deployer Render() implementation and tests

### DIFF
--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -18,6 +18,7 @@ package deploy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,19 +28,32 @@ import (
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	deploy "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
+var (
+	kpt_hydrated = ".kpt-hydrated"
+)
+
 // KptDeployer deploys workflows with kpt CLI
 type KptDeployer struct {
 	*latest.KptDeploy
+
+	insecureRegistries map[string]bool
+	labels             map[string]string
+	globalConfig       string
 }
 
 func NewKptDeployer(runCtx *runcontext.RunContext, labels map[string]string) *KptDeployer {
 	return &KptDeployer{
-		KptDeploy: runCtx.Pipeline().Deploy.KptDeploy,
+		KptDeploy:          runCtx.Pipeline().Deploy.KptDeploy,
+		insecureRegistries: runCtx.GetInsecureRegistries(),
+		labels:             labels,
+		globalConfig:       runCtx.GlobalConfig(),
 	}
 }
 
@@ -47,6 +61,8 @@ func (k *KptDeployer) Deploy(ctx context.Context, out io.Writer, builds []build.
 	return nil, nil
 }
 
+// Dependencies returns a list of files that the deployer depends on. This does NOT include applyDir.
+// In dev mode, a redeploy will be triggered if one of these files is updated.
 func (k *KptDeployer) Dependencies() ([]string, error) {
 	deps := newStringSet()
 	if len(k.Fn.FnPath) > 0 {
@@ -80,12 +96,80 @@ func (k *KptDeployer) Cleanup(ctx context.Context, _ io.Writer) error {
 	return nil
 }
 
-func (k *KptDeployer) Render(ctx context.Context, out io.Writer, builds []build.Artifact, offline bool, filepath string) error {
-	return nil
+func (k *KptDeployer) Render(ctx context.Context, out io.Writer, builds []build.Artifact, _ bool, filepath string) error {
+	manifests, err := k.renderManifests(ctx, out, builds)
+	if err != nil {
+		return err
+	}
+
+	return outputRenderedManifests(manifests.String(), filepath, out)
+}
+
+func (k *KptDeployer) renderManifests(ctx context.Context, out io.Writer, builds []build.Artifact) (deploy.ManifestList, error) {
+	debugHelpersRegistry, err := config.GetDebugHelpersRegistry(k.globalConfig)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving debug helpers registry: %w", err)
+	}
+
+	manifests, err := k.runKpt(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("running kpt functions: %w", err)
+	}
+
+	if len(manifests) == 0 {
+		return nil, nil
+	}
+
+	manifests, err = manifests.ReplaceImages(builds)
+	if err != nil {
+		return nil, fmt.Errorf("replacing images in manifests: %w", err)
+	}
+
+	for _, transform := range manifestTransforms {
+		manifests, err = transform(manifests, builds, Registries{k.insecureRegistries, debugHelpersRegistry})
+		if err != nil {
+			return nil, fmt.Errorf("unable to transform manifests: %w", err)
+		}
+	}
+
+	return manifests.SetLabels(k.labels)
+}
+
+// runKpt does a dry run with the specified kpt functions (fn-path XOR image) against dir.
+// If neither fn-path or image are specified, functions will attempt to be discovered in dir.
+// An error is returned when both fn-path AND image are specified.
+func (k *KptDeployer) runKpt(ctx context.Context) (deploy.ManifestList, error) {
+	var manifests deploy.ManifestList
+
+	flags := []string{"--dry-run"}
+
+	if len(k.Fn.FnPath) > 0 {
+		flags = append(flags, "--fn-path", k.Fn.FnPath)
+	}
+	if len(k.Fn.Image) > 0 {
+		if len(flags) > 1 {
+			return nil, errors.New("Cannot specify both fn-path and image.")
+		}
+
+		flags = append(flags, "--image", k.Fn.Image)
+	}
+
+	cmd := exec.CommandContext(ctx, "kpt", kptCommandArgs(k.Dir, []string{"fn", "run"}, flags, nil)...)
+	out, err := util.RunCmdOut(cmd)
+	if err != nil {
+		// Kpt errors are written in STDOUT and surrounded by `\n`.
+		return nil, fmt.Errorf("kpt fn run: %s", strings.Trim(string(out), "\n"))
+	}
+
+	if len(out) > 0 {
+		manifests.Append(out)
+	}
+
+	return manifests, nil
 }
 
 // getApplyDir returns the path to applyDir if specified by the user. Otherwise, getApplyDir
-// creates a hidden directory in place of applyDir.
+// creates a hidden directory named .kpt-hydrated in place of applyDir.
 func (k *KptDeployer) getApplyDir(ctx context.Context) (string, error) {
 	if k.ApplyDir != "" {
 		if _, err := os.Stat(k.ApplyDir); os.IsNotExist(err) {
@@ -94,22 +178,22 @@ func (k *KptDeployer) getApplyDir(ctx context.Context) (string, error) {
 		return k.ApplyDir, nil
 	}
 
-	applyDir := ".kpt-hydrated"
-
 	// 0755 is a permission setting where the owner can read, write, and execute.
 	// Others can read and execute but not modify the file.
-	if err := os.MkdirAll(applyDir, 0755); err != nil {
+	if err := os.MkdirAll(kpt_hydrated, 0755); err != nil {
 		return "", fmt.Errorf("applyDir was unspecified. creating applyDir: %w", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(applyDir, "inventory-template.yaml")); os.IsNotExist(err) {
-		cmd := exec.CommandContext(ctx, "kpt", kptCommandArgs(applyDir, []string{"live", "init"}, nil, nil)...)
-		if err := util.RunCmd(cmd); err != nil {
-			return "", err
+	if _, err := os.Stat(filepath.Join(kpt_hydrated, "inventory-template.yaml")); os.IsNotExist(err) {
+		cmd := exec.CommandContext(ctx, "kpt", kptCommandArgs(kpt_hydrated, []string{"live", "init"}, nil, nil)...)
+		out, err := util.RunCmdOut(cmd)
+		if err != nil {
+			// Kpt errors are written in STDOUT and surrounded by `\n`.
+			return "", fmt.Errorf("kpt live destroy: %s", strings.Trim(string(out), "\n"))
 		}
 	}
 
-	return applyDir, nil
+	return kpt_hydrated, nil
 }
 
 // kptCommandArgs returns a list of additional arguments for the kpt command.

--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -157,8 +157,7 @@ func (k *KptDeployer) runKpt(ctx context.Context) (deploy.ManifestList, error) {
 	cmd := exec.CommandContext(ctx, "kpt", kptCommandArgs(k.Dir, []string{"fn", "run"}, flags, nil)...)
 	out, err := util.RunCmdOut(cmd)
 	if err != nil {
-		// Kpt errors are written in STDOUT and surrounded by `\n`.
-		return nil, fmt.Errorf("kpt fn run: %s", strings.Trim(string(out), "\n"))
+		return nil, err
 	}
 
 	if len(out) > 0 {
@@ -186,10 +185,8 @@ func (k *KptDeployer) getApplyDir(ctx context.Context) (string, error) {
 
 	if _, err := os.Stat(filepath.Join(kpt_hydrated, "inventory-template.yaml")); os.IsNotExist(err) {
 		cmd := exec.CommandContext(ctx, "kpt", kptCommandArgs(kpt_hydrated, []string{"live", "init"}, nil, nil)...)
-		out, err := util.RunCmdOut(cmd)
-		if err != nil {
-			// Kpt errors are written in STDOUT and surrounded by `\n`.
-			return "", fmt.Errorf("kpt live destroy: %s", strings.Trim(string(out), "\n"))
+		if _, err := util.RunCmdOut(cmd); err != nil {
+			return "", err
 		}
 	}
 

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package deploy
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io/ioutil"
@@ -24,6 +25,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -201,7 +203,7 @@ func TestKpt_Cleanup(t *testing.T) {
 		{
 			description: "unspecified applyDir",
 			commands: testutil.
-				CmdRun("kpt live init .kpt-hydrated").
+				CmdRunOut("kpt live init .kpt-hydrated", "").
 				AndRunOut("kpt live destroy .kpt-hydrated", ""),
 		},
 	}
@@ -239,17 +241,258 @@ func TestKpt_Cleanup(t *testing.T) {
 }
 
 func TestKpt_Render(t *testing.T) {
+	output1 := `apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/project/image1
+    name: image1
+`
+
+	output2 := `apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/project/image2
+    name: image2
+`
+
+	output3 := `apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/project/image1
+    name: image1
+  - image: gcr.io/project/image2
+    name: image2
+`
+
+	output4 := `apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/project/image1
+    name: image1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/project/image2
+    name: image2
+`
+
 	tests := []struct {
 		description string
+		builds      []build.Artifact
+		labels      map[string]string
+		cfg         *latest.KptDeploy
+		commands    util.Command
+		expected    string
 		shouldErr   bool
 	}{
-		{},
+		{
+			description: "no fnPath or image specified",
+			builds: []build.Artifact{
+				{
+					ImageName: "gcr.io/project/image1",
+					Tag:       "gcr.io/project/image1:tag1",
+				},
+			},
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+			},
+			commands: testutil.CmdRunOut("kpt fn run . --dry-run", output1),
+			expected: `apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/project/image1:tag1
+    name: image1
+`,
+		},
+		{
+			description: "fnPath specified",
+			builds: []build.Artifact{
+				{
+					ImageName: "gcr.io/project/image2",
+					Tag:       "gcr.io/project/image2:tag2",
+				},
+			},
+			cfg: &latest.KptDeploy{
+				Dir: "test",
+				Fn:  latest.KptFn{FnPath: "kpt-func.yaml"},
+			},
+			commands: testutil.CmdRunOut("kpt fn run test --dry-run --fn-path kpt-func.yaml", output2),
+			expected: `apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/project/image2:tag2
+    name: image2
+`,
+		},
+		{
+			description: "image specified",
+			builds: []build.Artifact{
+				{
+					ImageName: "gcr.io/project/image1",
+					Tag:       "gcr.io/project/image1:tag1",
+				},
+				{
+					ImageName: "gcr.io/project/image2",
+					Tag:       "gcr.io/project/image2:tag2",
+				},
+			},
+			cfg: &latest.KptDeploy{
+				Dir: "test",
+				Fn:  latest.KptFn{Image: "gcr.io/example.com/my-fn:v1.0.0 -- foo=bar"},
+			},
+			commands: testutil.CmdRunOut("kpt fn run test --dry-run --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", output3),
+			expected: `apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/project/image1:tag1
+    name: image1
+  - image: gcr.io/project/image2:tag2
+    name: image2
+`,
+		},
+		{
+			description: "multiple resources outputted",
+			builds: []build.Artifact{
+				{
+					ImageName: "gcr.io/project/image1",
+					Tag:       "gcr.io/project/image1:tag1",
+				},
+				{
+					ImageName: "gcr.io/project/image2",
+					Tag:       "gcr.io/project/image2:tag2",
+				},
+			},
+			cfg: &latest.KptDeploy{
+				Dir: "test",
+				Fn:  latest.KptFn{FnPath: "kpt-func.yaml"},
+			},
+			commands: testutil.CmdRunOut("kpt fn run test --dry-run --fn-path kpt-func.yaml", output4),
+			expected: `apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/project/image1:tag1
+    name: image1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/project/image2:tag2
+    name: image2
+`,
+		},
+		{
+			description: "user labels",
+			builds: []build.Artifact{
+				{
+					ImageName: "gcr.io/project/image1",
+					Tag:       "gcr.io/project/image1:tag1",
+				},
+			},
+			labels: map[string]string{"user/label": "test"},
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+			},
+			commands: testutil.CmdRunOut("kpt fn run . --dry-run", output1),
+			expected: `apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    user/label: test
+  namespace: default
+spec:
+  containers:
+  - image: gcr.io/project/image1:tag1
+    name: image1
+`,
+		},
+		{
+			description: "empty output from pipeline",
+			builds: []build.Artifact{
+				{
+					ImageName: "gcr.io/project/image1",
+					Tag:       "gcr.io/project/image1:tag1",
+				},
+			},
+			labels: map[string]string{"user/label": "test"},
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+			},
+			commands: testutil.CmdRunOut("kpt fn run . --dry-run", ``),
+			expected: "\n",
+		},
+		{
+			description: "kpt fn run fails",
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+			},
+			commands:  testutil.CmdRunOutErr("kpt fn run . --dry-run", "invalid pipeline", errors.New("BUG")),
+			shouldErr: true,
+		},
+		{
+			description: "both fnPath and image specified",
+			cfg: &latest.KptDeploy{
+				Dir: "test",
+				Fn: latest.KptFn{
+					FnPath: "kpt-func.yaml",
+					Image:  "gcr.io/example.com/my-fn:v1.0.0 -- foo=bar"},
+			},
+			shouldErr: true,
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			k := NewKptDeployer(&runcontext.RunContext{}, nil)
-			err := k.Render(context.Background(), nil, nil, false, "")
-			t.CheckError(test.shouldErr, err)
+			t.Override(&util.DefaultExecCommand, test.commands)
+
+			k := NewKptDeployer(&runcontext.RunContext{
+				WorkingDir: ".",
+				Cfg: latest.Pipeline{
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							KptDeploy: test.cfg,
+						},
+					},
+				},
+				KubeContext: testKubeContext,
+				Opts: config.SkaffoldOptions{
+					Namespace: testNamespace,
+				},
+			}, test.labels)
+
+			var b bytes.Buffer
+			err := k.Render(context.Background(), &b, test.builds, true, "")
+
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, b.String())
 		})
 	}
 }
@@ -275,7 +518,7 @@ func TestKpt_GetApplyDir(t *testing.T) {
 		{
 			description: "unspecified applyDir",
 			expected:    ".kpt-hydrated",
-			commands:    testutil.CmdRun("kpt live init .kpt-hydrated"),
+			commands:    testutil.CmdRunOut("kpt live init .kpt-hydrated", ""),
 		},
 		{
 			description: "existing template resource in .kpt-hydrated",


### PR DESCRIPTION
**Related**:  #3904

**Description**
This is the implementation and unit tests for the Render() method of the kpt deployer. This involves running `kpt fn run` on a specified function pipeline.

Along with this, there are also slight modifications to getApplyDir to provide better error handling.

**Follow-up Work**
Kustomization capabilities will come soon for kpt deployer's render stage.