### PR TITLE
Use ParseTolerant to parse Helm version because of missing patch version

### DIFF
--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -447,7 +447,7 @@ func (h *HelmDeployer) binVer(ctx context.Context) (semver.Version, error) {
 		return semver.Version{}, fmt.Errorf("unable to parse output: %q", raw)
 	}
 
-	v, err := semver.Make(matches[1])
+	v, err := semver.ParseTolerant(matches[1])
 	if err != nil {
 		return semver.Version{}, fmt.Errorf("semver make %q: %w", matches[1], err)
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4711 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Use semVer ParseTolerant version to parse the Helm binary version because it does not follow all semver rules.
