### PR TITLE
Kpt Deployer Deploy() Implementation/Tests

### DIFF
--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -134,7 +134,6 @@ func (k *KptDeployer) Cleanup(ctx context.Context, out io.Writer) error {
 	cmd.Stdout = out
 	cmd.Stderr = out
 	if err := util.RunCmd(cmd); err != nil {
-		// Kpt errors are written in STDOUT and surrounded by `\n`.
 		return err
 	}
 


### PR DESCRIPTION
**Related**: #3904

**Description**
This is the implementation and unit tests for the Deploy() method of the kpt deployer. This method uses the renderManifests() method to hydrate resources using kustomize and kpt, and then outputs these manifests to the applyDir, where `kpt live apply` will be called. If unspecified by the user, applyDir is defaulted to .kpt-hydrated. If a template resource is not found in .kpt-hydrated, `kpt live init` will be called to create one.

There is also a slight change to the Cleanup() method to improve its output message when deleting. `skaffold delete` will now include `kpt live destroy`'s output message. This is similar to the Deploy() method.

Eventually, we may deviate from consuming kpt as a CLI so this can change in the future.

**Follow-up Work**
Future work will include extending the existing features of the kpt deployer. This includes allowing users to specify source and sink directories, and various kpt command flags.