### PR TITLE
Extending Workflow for Kpt Deployer (accepting additional arguments)

### DIFF
--- a/docs/content/en/schemas/v2beta7.json
+++ b/docs/content/en/schemas/v2beta7.json
@@ -1639,11 +1639,16 @@
           "description": "a directory to read functions from instead of the configuration directory.",
           "x-intellij-html-description": "a directory to read functions from instead of the configuration directory."
         },
-        "image": {
+        "globalScope": {
           "type": "boolean",
           "description": "sets global scope for functions.",
           "x-intellij-html-description": "sets global scope for functions.",
           "default": "false"
+        },
+        "image": {
+          "type": "string",
+          "description": "an image to be run as a function in lieu of running functions from a directory.",
+          "x-intellij-html-description": "an image to be run as a function in lieu of running functions from a directory."
         },
         "mount": {
           "items": {
@@ -1671,7 +1676,7 @@
         "image",
         "networkName",
         "network",
-        "image",
+        "globalScope",
         "mount"
       ],
       "additionalProperties": false,
@@ -1680,7 +1685,7 @@
     },
     "KptLive": {
       "properties": {
-        "flags": {
+        "apply": {
           "$ref": "#/definitions/KptLiveApply",
           "description": "adds additional configurations for `kpt live apply` commands.",
           "x-intellij-html-description": "adds additional configurations for <code>kpt live apply</code> commands."
@@ -1699,7 +1704,7 @@
       "preferredOrder": [
         "inventoryID",
         "inventoryNamespace",
-        "flags"
+        "apply"
       ],
       "additionalProperties": false,
       "description": "adds additional configurations used when calling `kpt live`.",

--- a/docs/content/en/schemas/v2beta7.json
+++ b/docs/content/en/schemas/v2beta7.json
@@ -1640,14 +1640,39 @@
           "x-intellij-html-description": "a directory to read functions from instead of the configuration directory."
         },
         "image": {
+          "type": "boolean",
+          "description": "sets global scope for functions.",
+          "x-intellij-html-description": "sets global scope for functions.",
+          "default": "false"
+        },
+        "mount": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "a list of storage options to mount to the fn image.",
+          "x-intellij-html-description": "a list of storage options to mount to the fn image.",
+          "default": "[]"
+        },
+        "network": {
+          "type": "boolean",
+          "description": "enables network access for functions that declare it.",
+          "x-intellij-html-description": "enables network access for functions that declare it.",
+          "default": "false"
+        },
+        "networkName": {
           "type": "string",
-          "description": "an image to be run as a function in lieu of running functions from a directory.",
-          "x-intellij-html-description": "an image to be run as a function in lieu of running functions from a directory."
+          "description": "docker network to run the container in (default \"bridge\").",
+          "x-intellij-html-description": "docker network to run the container in (default &quot;bridge&quot;)."
         }
       },
       "preferredOrder": [
         "fnPath",
-        "image"
+        "image",
+        "networkName",
+        "network",
+        "image",
+        "mount"
       ],
       "additionalProperties": false,
       "description": "adds additional configurations used when calling `kpt fn`.",
@@ -1655,22 +1680,63 @@
     },
     "KptLive": {
       "properties": {
-        "apply": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "additional flags passed on creations (`kpt live apply`).",
-          "x-intellij-html-description": "additional flags passed on creations (<code>kpt live apply</code>).",
-          "default": "[]"
+        "flags": {
+          "$ref": "#/definitions/KptLiveApply",
+          "description": "adds additional configurations for `kpt live apply` commands.",
+          "x-intellij-html-description": "adds additional configurations for <code>kpt live apply</code> commands."
+        },
+        "inventoryID": {
+          "type": "string",
+          "description": "identifier for a group of applied resources. This configuration is used when users do not specify `KptDeploy.ApplyDir` and `.kpt-hydrated/inventory-template.yaml` does not exist.",
+          "x-intellij-html-description": "identifier for a group of applied resources. This configuration is used when users do not specify <code>KptDeploy.ApplyDir</code> and <code>.kpt-hydrated/inventory-template.yaml</code> does not exist."
+        },
+        "inventoryNamespace": {
+          "type": "string",
+          "description": "sets the namespace scope for `kpt live init`.",
+          "x-intellij-html-description": "sets the namespace scope for <code>kpt live init</code>."
         }
       },
       "preferredOrder": [
-        "apply"
+        "inventoryID",
+        "inventoryNamespace",
+        "flags"
       ],
       "additionalProperties": false,
-      "description": "adds additional configurations used when calling `kpt live` on every command (Global), creations (Apply), or deletions (Destroy).",
-      "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live</code> on every command (Global), creations (Apply), or deletions (Destroy)."
+      "description": "adds additional configurations used when calling `kpt live`.",
+      "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live</code>."
+    },
+    "KptLiveApply": {
+      "properties": {
+        "pollPeriod": {
+          "type": "string",
+          "description": "sets for the polling period for resource statuses. Default to 2s.",
+          "x-intellij-html-description": "sets for the polling period for resource statuses. Default to 2s."
+        },
+        "prunePropagationPolicy": {
+          "type": "string",
+          "description": "sets the propagation policy for pruning. Possible settings are Background, Foreground, Orphan. Default to \"Background\".",
+          "x-intellij-html-description": "sets the propagation policy for pruning. Possible settings are Background, Foreground, Orphan. Default to &quot;Background&quot;."
+        },
+        "pruneTimeout": {
+          "type": "string",
+          "description": "sets the time threshold to wait for all pruned resources to be deleted.",
+          "x-intellij-html-description": "sets the time threshold to wait for all pruned resources to be deleted."
+        },
+        "reconcileTimeout": {
+          "type": "string",
+          "description": "sets the time threshold to wait for all resources to reach the current status.",
+          "x-intellij-html-description": "sets the time threshold to wait for all resources to reach the current status."
+        }
+      },
+      "preferredOrder": [
+        "pollPeriod",
+        "prunePropagationPolicy",
+        "pruneTimeout",
+        "reconcileTimeout"
+      ],
+      "additionalProperties": false,
+      "description": "adds additional configurations used when calling `kpt live apply`.",
+      "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live apply</code>."
     },
     "KubectlDeploy": {
       "properties": {

--- a/docs/content/en/schemas/v2beta7.json
+++ b/docs/content/en/schemas/v2beta7.json
@@ -1623,8 +1623,8 @@
         }
       },
       "preferredOrder": [
-        "dir",
         "applyDir",
+        "dir",
         "fn",
         "live"
       ],
@@ -1675,8 +1675,8 @@
         "fnPath",
         "image",
         "networkName",
-        "network",
         "globalScope",
+        "network",
         "mount"
       ],
       "additionalProperties": false,
@@ -1702,9 +1702,9 @@
         }
       },
       "preferredOrder": [
+        "apply",
         "inventoryID",
-        "inventoryNamespace",
-        "apply"
+        "inventoryNamespace"
       ],
       "additionalProperties": false,
       "description": "adds additional configurations used when calling `kpt live`.",

--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -349,7 +349,7 @@ func getResources(root string) ([]string, error) {
 	return files, err
 }
 
-// getFlags returns a list of arguments that the user specified for the `kpt fn run` command.
+// getKptFnRunArgs returns a list of arguments that the user specified for the `kpt fn run` command.
 func (k *KptDeployer) getKptFnRunArgs() ([]string, error) {
 	// --dry-run sets the pipeline's output to STDOUT, otherwise output is set to sinkDir.
 	// For now, k.Dir will be treated as sinkDir (and sourceDir).
@@ -384,7 +384,7 @@ func (k *KptDeployer) getKptFnRunArgs() ([]string, error) {
 	}
 
 	if count > 1 {
-		return nil, errors.New("only one of `fn-path` or `image` configs can be specified at most")
+		return nil, errors.New("only one of `fn-path` or `image` may be specified")
 	}
 
 	return flags, nil

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -117,6 +117,42 @@ spec:
 				AndRunErr("kpt live apply .kpt-hydrated", errors.New("BUG")),
 			shouldErr: true,
 		},
+		{
+			description: "user specifies reconcile timeout and poll period",
+			cfg: &latest.KptDeploy{
+				Dir:      ".",
+				ApplyDir: "valid_path",
+				Live: latest.KptLive{
+					Apply: latest.KptLiveApply{
+						PollPeriod:       "5s",
+						ReconcileTimeout: "2m",
+					},
+				},
+			},
+			commands: testutil.
+				CmdRunOut("kpt fn source .", ``).
+				AndRunOut("kpt fn sink .pipeline", ``).
+				AndRunOut("kpt fn run .pipeline --dry-run", output).
+				AndRun("kpt live apply valid_path --poll-period 5s --reconcile-timeout 2m"),
+		},
+		{
+			description: "user specifies prune propagation policy and prune timeout",
+			cfg: &latest.KptDeploy{
+				Dir:      ".",
+				ApplyDir: "valid_path",
+				Live: latest.KptLive{
+					Apply: latest.KptLiveApply{
+						PrunePropagationPolicy: "Orphan",
+						PruneTimeout:           "2m",
+					},
+				},
+			},
+			commands: testutil.
+				CmdRunOut("kpt fn source .", ``).
+				AndRunOut("kpt fn sink .pipeline", ``).
+				AndRunOut("kpt fn run .pipeline --dry-run", output).
+				AndRun("kpt live apply valid_path --prune-propagation-policy Orphan --prune-timeout 2m"),
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
@@ -277,6 +313,7 @@ func TestKpt_Cleanup(t *testing.T) {
 	tests := []struct {
 		description string
 		applyDir    string
+		globalFlags []string
 		commands    util.Command
 		shouldErr   bool
 	}{
@@ -604,6 +641,52 @@ spec:
 				AndRunOutErr("kpt fn run .pipeline --dry-run", "invalid pipeline", errors.New("BUG")),
 			shouldErr: true,
 		},
+		{
+			description: "kpt fn run with --global-scope",
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+				Fn: latest.KptFn{
+					Image:       "gcr.io/example.com/my-fn:v1.0.0 -- foo=bar",
+					GlobalScope: true,
+				},
+			},
+			commands: testutil.
+				CmdRunOut("kpt fn source .", ``).
+				AndRunOut("kpt fn sink .pipeline", ``).
+				AndRunOut("kpt fn run .pipeline --dry-run --global-scope --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``),
+			expected: "\n",
+		},
+		{
+			description: "kpt fn run with --mount arguments",
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+				Fn: latest.KptFn{
+					Image: "gcr.io/example.com/my-fn:v1.0.0 -- foo=bar",
+					Mount: []string{"type=bind", "src=$(pwd)", "dst=/source"},
+				},
+			},
+			commands: testutil.
+				CmdRunOut("kpt fn source .", ``).
+				AndRunOut("kpt fn sink .pipeline", ``).
+				AndRunOut("kpt fn run .pipeline --dry-run --mount type=bind,src=$(pwd),dst=/source --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``),
+			expected: "\n",
+		},
+		{
+			description: "kpt fn run flag with --network and --network-name arguments",
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+				Fn: latest.KptFn{
+					Image:       "gcr.io/example.com/my-fn:v1.0.0 -- foo=bar",
+					Network:     true,
+					NetworkName: "foo",
+				},
+			},
+			commands: testutil.
+				CmdRunOut("kpt fn source .", ``).
+				AndRunOut("kpt fn sink .pipeline", ``).
+				AndRunOut("kpt fn run .pipeline --dry-run --network --network-name foo --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``),
+			expected: "\n",
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
@@ -639,6 +722,7 @@ func TestKpt_GetApplyDir(t *testing.T) {
 	tests := []struct {
 		description string
 		applyDir    string
+		live        latest.KptLive
 		expected    string
 		commands    util.Command
 		shouldErr   bool
@@ -657,6 +741,15 @@ func TestKpt_GetApplyDir(t *testing.T) {
 			description: "unspecified applyDir",
 			expected:    ".kpt-hydrated",
 			commands:    testutil.CmdRunOut("kpt live init .kpt-hydrated", ""),
+		},
+		{
+			description: "unspecified applyDir with specified inventory-id and namespace",
+			live: latest.KptLive{
+				InventoryID:        "1a23bcde-4f56-7891-a2bc-de34fabcde5f6",
+				InventoryNamespace: "foo",
+			},
+			expected: ".kpt-hydrated",
+			commands: testutil.CmdRunOut("kpt live init .kpt-hydrated --inventory-id 1a23bcde-4f56-7891-a2bc-de34fabcde5f6 --namespace foo", ""),
 		},
 		{
 			description: "existing template resource in .kpt-hydrated",
@@ -685,6 +778,7 @@ func TestKpt_GetApplyDir(t *testing.T) {
 						DeployType: latest.DeployType{
 							KptDeploy: &latest.KptDeploy{
 								ApplyDir: test.applyDir,
+								Live:     test.live,
 							},
 						},
 					},
@@ -722,8 +816,8 @@ func TestKpt_KptCommandArgs(t *testing.T) {
 			description: "empty dir",
 			commands:    []string{"live", "apply"},
 			flags:       []string{"--fn-path", "kpt-func.yaml"},
-			globalFlags: []string{"-h"},
-			expected:    strings.Split("live apply --fn-path kpt-func.yaml -h", " "),
+			globalFlags: []string{"-v", "3"},
+			expected:    strings.Split("live apply --fn-path kpt-func.yaml -v 3", " "),
 		},
 		{
 			description: "empty commands",

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -136,6 +136,24 @@ spec:
 				AndRun("kpt live apply valid_path --poll-period 5s --reconcile-timeout 2m"),
 		},
 		{
+			description: "user specifies invalid reconcile timeout and poll period",
+			cfg: &latest.KptDeploy{
+				Dir:      ".",
+				ApplyDir: "valid_path",
+				Live: latest.KptLive{
+					Apply: latest.KptLiveApply{
+						PollPeriod:       "foo",
+						ReconcileTimeout: "bar",
+					},
+				},
+			},
+			commands: testutil.
+				CmdRunOut("kpt fn source .", ``).
+				AndRunOut("kpt fn sink .pipeline", ``).
+				AndRunOut("kpt fn run .pipeline --dry-run", output).
+				AndRun("kpt live apply valid_path --poll-period foo --reconcile-timeout bar"),
+		},
+		{
 			description: "user specifies prune propagation policy and prune timeout",
 			cfg: &latest.KptDeploy{
 				Dir:      ".",
@@ -152,6 +170,24 @@ spec:
 				AndRunOut("kpt fn sink .pipeline", ``).
 				AndRunOut("kpt fn run .pipeline --dry-run", output).
 				AndRun("kpt live apply valid_path --prune-propagation-policy Orphan --prune-timeout 2m"),
+		},
+		{
+			description: "user specifies invalid prune propagation policy and prune timeout",
+			cfg: &latest.KptDeploy{
+				Dir:      ".",
+				ApplyDir: "valid_path",
+				Live: latest.KptLive{
+					Apply: latest.KptLiveApply{
+						PrunePropagationPolicy: "foo",
+						PruneTimeout:           "bar",
+					},
+				},
+			},
+			commands: testutil.
+				CmdRunOut("kpt fn source .", ``).
+				AndRunOut("kpt fn sink .pipeline", ``).
+				AndRunOut("kpt fn run .pipeline --dry-run", output).
+				AndRun("kpt live apply valid_path --prune-propagation-policy foo --prune-timeout bar"),
 		},
 	}
 	for _, test := range tests {
@@ -669,6 +705,21 @@ spec:
 				CmdRunOut("kpt fn source .", ``).
 				AndRunOut("kpt fn sink .pipeline", ``).
 				AndRunOut("kpt fn run .pipeline --dry-run --mount type=bind,src=$(pwd),dst=/source --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``),
+			expected: "\n",
+		},
+		{
+			description: "kpt fn run with invalid --mount arguments",
+			cfg: &latest.KptDeploy{
+				Dir: ".",
+				Fn: latest.KptFn{
+					Image: "gcr.io/example.com/my-fn:v1.0.0 -- foo=bar",
+					Mount: []string{"foo", "", "bar"},
+				},
+			},
+			commands: testutil.
+				CmdRunOut("kpt fn source .", ``).
+				AndRunOut("kpt fn sink .pipeline", ``).
+				AndRunOut("kpt fn run .pipeline --dry-run --mount foo,,bar --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``),
 			expected: "\n",
 		},
 		{

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -528,11 +528,11 @@ type KustomizeDeploy struct {
 
 // KptDeploy *beta* uses the `kpt` CLI to manage and deploy manifests.
 type KptDeploy struct {
-	// Dir is the path to the directory to run kpt functions against.
-	Dir string `yaml:"dir,omitempty"`
-
 	// ApplyDir is the path to the directory to deploy to the cluster.
 	ApplyDir string `yaml:"applyDir,omitempty"`
+
+	// Dir is the path to the directory to run kpt functions against.
+	Dir string `yaml:"dir,omitempty"`
 
 	// Fn adds additional configurations for `kpt fn`.
 	Fn KptFn `yaml:"fn,omitempty"`
@@ -552,11 +552,11 @@ type KptFn struct {
 	// NetworkName is the docker network to run the container in (default "bridge").
 	NetworkName string `yaml:"networkName,omitempty"`
 
-	// Network enables network access for functions that declare it.
-	Network bool `yaml:"network,omitempty"`
-
 	// GlobalScope sets global scope for functions.
 	GlobalScope bool `yaml:"globalScope,omitempty"`
+
+	// Network enables network access for functions that declare it.
+	Network bool `yaml:"network,omitempty"`
 
 	// Mount is a list of storage options to mount to the fn image.
 	Mount []string `yaml:"mount,omitempty"`
@@ -564,6 +564,9 @@ type KptFn struct {
 
 // KptLive adds additional configurations used when calling `kpt live`.
 type KptLive struct {
+	// Apply adds additional configurations for `kpt live apply` commands.
+	Apply KptLiveApply `yaml:"apply,omitempty"`
+
 	// InventoryID is the identifier for a group of applied resources.
 	// This configuration is used when users do not specify `KptDeploy.ApplyDir`
 	// and `.kpt-hydrated/inventory-template.yaml` does not exist.
@@ -571,9 +574,6 @@ type KptLive struct {
 
 	// InventoryNamespace sets the namespace scope for `kpt live init`.
 	InventoryNamespace string `yaml:"inventoryNamespace,omitempty"`
-
-	// Apply adds additional configurations for `kpt live apply` commands.
-	Apply KptLiveApply `yaml:"apply,omitempty"`
 }
 
 // KptLiveApply adds additional configurations used when calling `kpt live apply`.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -556,7 +556,7 @@ type KptFn struct {
 	Network bool `yaml:"network,omitempty"`
 
 	// GlobalScope sets global scope for functions.
-	GlobalScope bool `yaml:"image,omitempty"`
+	GlobalScope bool `yaml:"globalScope,omitempty"`
 
 	// Mount is a list of storage options to mount to the fn image.
 	Mount []string `yaml:"mount,omitempty"`
@@ -573,7 +573,7 @@ type KptLive struct {
 	InventoryNamespace string `yaml:"inventoryNamespace,omitempty"`
 
 	// Apply adds additional configurations for `kpt live apply` commands.
-	Apply KptLiveApply `yaml:"flags,omitempty"`
+	Apply KptLiveApply `yaml:"apply,omitempty"`
 }
 
 // KptLiveApply adds additional configurations used when calling `kpt live apply`.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -548,13 +548,48 @@ type KptFn struct {
 
 	// Image is an image to be run as a function in lieu of running functions from a directory.
 	Image string `yaml:"image,omitempty"`
+
+	// GlobalScope sets global scope for functions.
+	GlobalScope bool `yaml:"image,omitempty"`
+
+	// Mount is a list of storage options to mount to the fn image.
+	Mount []string `yaml:"mount,omitempty"`
+
+	// Network enables network access for functions that declare it.
+	Network bool `yaml:"network,omitempty"`
+
+	// NetworkName is the docker network to run the container in (default "bridge").
+	NetworkName string `yaml:"networkName,omitempty"`
 }
 
-// KptLive adds additional configurations used when calling `kpt live`
-// on every command (Global), creations (Apply), or deletions (Destroy).
+// KptLive adds additional configurations used when calling `kpt live`.
 type KptLive struct {
-	// Apply are additional flags passed on creations (`kpt live apply`).
-	Apply []string `yaml:"apply,omitempty"`
+	// InventoryID is the identifier for a group of applied resources.
+	// This configuration is used when users do not specify `KptDeploy.ApplyDir`
+	// and `.kpt-hydrated/inventory-template.yaml` does not exist.
+	InventoryID string `yaml:"inventoryID,omitempty"`
+
+	// InventoryNamespace sets the namespace scope for `kpt live init`.
+	InventoryNamespace string `yaml:"inventoryNamespace,omitempty"`
+
+	// Apply adds additional configurations for `kpt live apply` commands.
+	Apply KptLiveApply `yaml:"flags,omitempty"`
+}
+
+type KptLiveApply struct {
+	// PollPeriod sets for the polling period for resource statuses. Default to 2s.
+	PollPeriod string `yaml:"pollPeriod,omitempty"`
+
+	// PrunePropagationPolicy sets the propagation policy for pruning.
+	// Possible settings are Background, Foreground, Orphan.
+	// Default to "Background".
+	PrunePropagationPolicy string `yaml:"prunePropagationPolicy,omitempty"`
+
+	// PruneTimeout sets the time threshold to wait for all pruned resources to be deleted.
+	PruneTimeout string `yaml:"pruneTimeout,omitempty"`
+
+	// ReconcileTimeout sets the time threshold to wait for all resources to reach the current status.
+	ReconcileTimeout string `yaml:"reconcileTimeout,omitempty"`
 }
 
 // HelmRelease describes a helm release to be deployed.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -549,17 +549,17 @@ type KptFn struct {
 	// Image is an image to be run as a function in lieu of running functions from a directory.
 	Image string `yaml:"image,omitempty"`
 
+	// NetworkName is the docker network to run the container in (default "bridge").
+	NetworkName string `yaml:"networkName,omitempty"`
+
+	// Network enables network access for functions that declare it.
+	Network bool `yaml:"network,omitempty"`
+
 	// GlobalScope sets global scope for functions.
 	GlobalScope bool `yaml:"image,omitempty"`
 
 	// Mount is a list of storage options to mount to the fn image.
 	Mount []string `yaml:"mount,omitempty"`
-
-	// Network enables network access for functions that declare it.
-	Network bool `yaml:"network,omitempty"`
-
-	// NetworkName is the docker network to run the container in (default "bridge").
-	NetworkName string `yaml:"networkName,omitempty"`
 }
 
 // KptLive adds additional configurations used when calling `kpt live`.
@@ -576,6 +576,7 @@ type KptLive struct {
 	Apply KptLiveApply `yaml:"flags,omitempty"`
 }
 
+// KptLiveApply adds additional configurations used when calling `kpt live apply`.
 type KptLiveApply struct {
 	// PollPeriod sets for the polling period for resource statuses. Default to 2s.
 	PollPeriod string `yaml:"pollPeriod,omitempty"`


### PR DESCRIPTION
**Related**:  #3904

**Description**
This contains the implementation and additional test cases allowing users to specify additional arguments when running `kpt fn` or `kpt live` commands with Skaffold.

**User facing changes**
Users will have the option to specify additional arguments in their skaffold.yaml.

**Follow-up Work**
It may be a good idea to add more validation to the config in the future such as validating the values of these arguments to fit certain patterns and catch the error before the command is called.

Before:
```
deploy:
  kpt:
    dir: ...
    fn:
      fnPath: ...
      image: ...
    live:
      apply:
      - ...
      - ...
```

After:
```
deploy:
  kpt:
    dir: ...
    fn:
      fnPath: str
      image: str
      network: str
      networkName: str
      globalScope: str
      mount: []str
    live:
      inventoryID: str
      inventoryNamespace: str
      apply:
        pollperiod: str
        prunePropagationPolicy: str
        pruneTimeout: str
        reconcileTimeout: str
      
```