### PR TITLE
Fix #4725: Apply profiles and patches before skaffold config upgrade to latest

### DIFF
--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -38,8 +38,8 @@ import (
 
 // ApplyProfiles returns configuration modified by the application
 // of a list of profiles.
-func ApplyProfiles(c interface{}, opts cfg.SkaffoldOptions) error {
-	ver, err := apiversion.Parse(c.(util.VersionedConfig).GetVersion())
+func ApplyProfiles(c util.VersionedConfig, opts cfg.SkaffoldOptions) error {
+	ver, err := apiversion.Parse(c.GetVersion())
 	if err != nil {
 		return err
 	}

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -18,11 +18,13 @@ package schema
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	yamlpatch "github.com/krishicks/yaml-patch"
 	"k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion"
 	cfg "github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
@@ -750,8 +752,8 @@ func TestActivatedProfiles(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.SetEnvs(test.envs)
 			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "prod-context"})
-
-			activated, _, err := activatedProfiles(test.profiles, test.opts)
+			ver, _ := apiversion.Parse(latest.Version)
+			activated, _, err := activatedProfiles(reflect.ValueOf(test.profiles), ver, test.opts)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, activated)
 		})

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -184,13 +184,8 @@ func ParseConfig(filename string) (util.VersionedConfig, error) {
 	return cfg, nil
 }
 
-// ParseConfigAndUpgrade reads a configuration file and upgrades it to a given version.
-func ParseConfigAndUpgrade(filename, toVersion string) (util.VersionedConfig, error) {
-	cfg, err := ParseConfig(filename)
-	if err != nil {
-		return nil, err
-	}
-
+// UpgradeConfig upgrades the config to a given version.
+func UpgradeConfig(cfg util.VersionedConfig, toVersion string) (util.VersionedConfig, error) {
 	// Check that the target version exists
 	if _, present := SchemaVersions.Find(toVersion); !present {
 		return nil, fmt.Errorf("unknown api version: %q", toVersion)
@@ -223,4 +218,13 @@ func ParseConfigAndUpgrade(filename, toVersion string) (util.VersionedConfig, er
 	}
 
 	return cfg, nil
+}
+
+// ParseConfigAndUpgrade reads a configuration file and upgrades it to a given version.
+func ParseConfigAndUpgrade(filename, toVersion string) (util.VersionedConfig, error) {
+	cfg, err := ParseConfig(filename)
+	if err != nil {
+		return nil, err
+	}
+	return UpgradeConfig(cfg, toVersion)
 }

--- a/pkg/skaffold/util/util_test.go
+++ b/pkg/skaffold/util/util_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -178,14 +177,16 @@ func TestCloneThroughJSON(t *testing.T) {
 		expected    interface{}
 	}{
 		{
-			description: "google cloud build",
+			description: "simple object clone",
 			old: map[string]string{
 				"projectId": "unit-test",
 			},
-			new: &latest.GoogleCloudBuild{},
-			expected: &latest.GoogleCloudBuild{
-				ProjectID: "unit-test",
-			},
+			new: &struct {
+				ProjectID string `yaml:"projectId,omitempty"`
+			}{},
+			expected: &struct {
+				ProjectID string `yaml:"projectId,omitempty"`
+			}{ProjectID: "unit-test"},
 		},
 	}
 	for _, test := range tests {
@@ -209,10 +210,12 @@ func TestCloneThroughYAML(t *testing.T) {
 			old: map[string]string{
 				"projectId": "unit-test",
 			},
-			new: &latest.GoogleCloudBuild{},
-			expected: &latest.GoogleCloudBuild{
-				ProjectID: "unit-test",
-			},
+			new: &struct {
+				ProjectID string `yaml:"projectId,omitempty"`
+			}{},
+			expected: &struct {
+				ProjectID string `yaml:"projectId,omitempty"`
+			}{ProjectID: "unit-test"},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #4725

I'm applying the profiles **before** upgrading the config from current version to latest. Since the Profiles' `Pipeline` and `Patch` are always defined against the specified config version, this should always work.

Since `Profile` doesn't get upgraded we rely on a switch block to add a new case statement if the `Activation` and `JSONPatch` structs are updated in the future (pretty unlikely though).
```go
switch {
	// Custom activation not supported before v1beta4
	case version.LT(v1b4):
		isActive, isContextActivated = true, false
	// when modifying the `Activation` struct add a case condition here corresponding to the new version and a corresponding `checkActivation` function.
	default:
		var versionedActivation *v1beta4.Activation
		skutil.CloneThroughJSON(activation, &versionedActivation)
		isActive, isContextActivated, err = checkActivation(versionedActivation, opts)
	}
```

```go
switch {
	// Profile patches not supported before v1beta4
	case version.LT(v1b4):
		return fmt.Errorf("profile patches not supported in v%v", v1b4)
	// when modifying the `JSONPatch` struct add a case condition here corresponding to the new version and a corresponding `createPatchOperation` function.
	default:
		patch, err = createPatchOperation(profilePatches.Index(i), buf)
	}
```