### PR TITLE
Rename NewFromRunContext() to NewCLI()

### DIFF
--- a/integration/port_forward_test.go
+++ b/integration/port_forward_test.go
@@ -41,7 +41,7 @@ func TestPortForward(t *testing.T) {
 	cfg, err := kubectx.CurrentConfig()
 	failNowIfError(t, err)
 
-	kubectlCLI := kubectl.NewFromRunContext(&runcontext.RunContext{
+	kubectlCLI := kubectl.NewCLI(&runcontext.RunContext{
 		KubeContext: cfg.CurrentContext,
 		Opts: config.SkaffoldOptions{
 			Namespace: ns.Name,

--- a/pkg/skaffold/build/cluster/types.go
+++ b/pkg/skaffold/build/cluster/types.go
@@ -58,7 +58,7 @@ func NewBuilder(cfg Config) (*Builder, error) {
 
 	return &Builder{
 		ClusterDetails:     cfg.Pipeline().Build.Cluster,
-		kubectlcli:         kubectl.NewFromRunContext(cfg),
+		kubectlcli:         kubectl.NewCLI(cfg),
 		timeout:            timeout,
 		kubeContext:        cfg.GetKubeContext(),
 		insecureRegistries: cfg.GetInsecureRegistries(),

--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -49,7 +49,7 @@ type Config interface {
 
 func NewCLI(cfg Config, flags latest.KubectlFlags) CLI {
 	return CLI{
-		CLI:              pkgkubectl.NewFromRunContext(cfg),
+		CLI:              pkgkubectl.NewCLI(cfg),
 		Flags:            flags,
 		forceDeploy:      cfg.ForceDeploy(),
 		waitForDeletions: cfg.WaitForDeletions(),

--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -101,7 +101,7 @@ func (d *Deployment) WithValidator(pd diag.Diagnose) *Deployment {
 }
 
 func (d *Deployment) CheckStatus(ctx context.Context, cfg kubectl.Config) {
-	kubeCtl := kubectl.NewFromRunContext(cfg)
+	kubeCtl := kubectl.NewCLI(cfg)
 
 	b, err := kubeCtl.RunOut(ctx, "rollout", "status", "deployment", d.name, "--namespace", d.namespace, "--watch=false")
 	if ctx.Err() != nil {

--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -41,7 +41,7 @@ type Config interface {
 	GetKubeNamespace() string
 }
 
-func NewFromRunContext(cfg Config) *CLI {
+func NewCLI(cfg Config) *CLI {
 	return &CLI{
 		KubeContext: cfg.GetKubeContext(),
 		KubeConfig:  cfg.GetKubeConfig(),

--- a/pkg/skaffold/kubectl/cli_test.go
+++ b/pkg/skaffold/kubectl/cli_test.go
@@ -67,7 +67,7 @@ func TestCLI(t *testing.T) {
 				test.expectedCommand,
 			))
 
-			cli := NewFromRunContext(&runcontext.RunContext{
+			cli := NewCLI(&runcontext.RunContext{
 				Opts: config.SkaffoldOptions{
 					Namespace:  test.namespace,
 					KubeConfig: test.kubeconfig,
@@ -88,7 +88,7 @@ func TestCLI(t *testing.T) {
 				output,
 			))
 
-			cli := NewFromRunContext(&runcontext.RunContext{
+			cli := NewCLI(&runcontext.RunContext{
 				Opts: config.SkaffoldOptions{
 					Namespace:  test.namespace,
 					KubeConfig: test.kubeconfig,
@@ -110,7 +110,7 @@ func TestCLI(t *testing.T) {
 				output,
 			))
 
-			cli := NewFromRunContext(&runcontext.RunContext{
+			cli := NewCLI(&runcontext.RunContext{
 				Opts: config.SkaffoldOptions{
 					Namespace:  test.namespace,
 					KubeConfig: test.kubeconfig,

--- a/pkg/skaffold/runner/deploy_test.go
+++ b/pkg/skaffold/runner/deploy_test.go
@@ -146,7 +146,7 @@ func TestSkaffoldDeployRenderOnly(t *testing.T) {
 
 		r := SkaffoldRunner{
 			runCtx:     runCtx,
-			kubectlCLI: kubectl.NewFromRunContext(runCtx),
+			kubectlCLI: kubectl.NewCLI(runCtx),
 			deployer:   getDeployer(runCtx, nil),
 		}
 		var builds []build.Artifact

--- a/pkg/skaffold/runner/load_images_test.go
+++ b/pkg/skaffold/runner/load_images_test.go
@@ -184,7 +184,7 @@ func runImageLoadingTests(t *testing.T, tests []ImageLoadingTest, loadingFunc fu
 
 			r := &SkaffoldRunner{
 				runCtx:     runCtx,
-				kubectlCLI: kubectl.NewFromRunContext(runCtx),
+				kubectlCLI: kubectl.NewCLI(runCtx),
 				builds:     test.built,
 			}
 			err := loadingFunc(r, test)

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -43,7 +43,7 @@ import (
 
 // NewForConfig returns a new SkaffoldRunner for a SkaffoldConfig
 func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
-	kubectlCLI := kubectl.NewFromRunContext(runCtx)
+	kubectlCLI := kubectl.NewCLI(runCtx)
 
 	tagger, err := getTagger(runCtx)
 	if err != nil {

--- a/pkg/skaffold/sync/types.go
+++ b/pkg/skaffold/sync/types.go
@@ -48,7 +48,7 @@ type Config interface {
 
 func NewSyncer(cfg Config) Syncer {
 	return &podSyncer{
-		kubectl:    pkgkubectl.NewFromRunContext(cfg),
+		kubectl:    pkgkubectl.NewCLI(cfg),
 		namespaces: cfg.GetNamespaces(),
 	}
 }


### PR DESCRIPTION
We don't pass a RunContext anymore.

Signed-off-by: David Gageot <david@gageot.net>
