### PR TITLE
Add option for helm deployments to create namespace

### DIFF
--- a/docs/content/en/schemas/v2beta8.json
+++ b/docs/content/en/schemas/v2beta8.json
@@ -1295,9 +1295,8 @@
         },
         "createNamespace": {
           "type": "boolean",
-          "description": "if `true`, Skaffold will send `--create-namespace` flag to Helm CLI.",
-          "x-intellij-html-description": "if <code>true</code>, Skaffold will send <code>--create-namespace</code> flag to Helm CLI.",
-          "default": "false"
+          "description": "if `true`, Skaffold will send `--create-namespace` flag to Helm CLI. `--create-namespace` flag is available in Helm since version 3.2. Defaults is `false`.",
+          "x-intellij-html-description": "if <code>true</code>, Skaffold will send <code>--create-namespace</code> flag to Helm CLI. <code>--create-namespace</code> flag is available in Helm since version 3.2. Defaults is <code>false</code>."
         },
         "imageStrategy": {
           "$ref": "#/definitions/HelmImageStrategy",

--- a/docs/content/en/schemas/v2beta8.json
+++ b/docs/content/en/schemas/v2beta8.json
@@ -1293,6 +1293,12 @@
           "description": "path to the Helm chart.",
           "x-intellij-html-description": "path to the Helm chart."
         },
+        "createNamespace": {
+          "type": "boolean",
+          "description": "if `true`, Skaffold will send `--create-namespace` flag to Helm CLI.",
+          "x-intellij-html-description": "if <code>true</code>, Skaffold will send <code>--create-namespace</code> flag to Helm CLI.",
+          "default": "false"
+        },
         "imageStrategy": {
           "$ref": "#/definitions/HelmImageStrategy",
           "description": "adds image configurations to the Helm `values` file.",
@@ -1394,6 +1400,7 @@
         "setValues",
         "setValueTemplates",
         "setFiles",
+        "createNamespace",
         "wait",
         "recreatePods",
         "skipBuildDependencies",

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -507,7 +508,10 @@ func installArgs(r latest.HelmRelease, builds []build.Artifact, valuesSet map[st
 		args = append(args, "--namespace", o.namespace)
 	}
 
-	if r.CreateNamespace && o.helmVersion.GE(helm32Version) && !o.upgrade {
+	if r.CreateNamespace != nil && *r.CreateNamespace && !o.upgrade {
+		if o.helmVersion.LT(helm32Version) {
+			return nil, errors.New("the createNamespace option is not available in the current Helm version. Update Helm to version 3.2 or higher")
+		}
 		args = append(args, "--create-namespace")
 	}
 

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -53,7 +53,8 @@ var (
 	versionRegex = regexp.MustCompile(`v(\d[\w.\-]+)`)
 
 	// helm3Version represents the version cut-off for helm3 behavior
-	helm3Version = semver.MustParse("3.0.0-beta.0")
+	helm3Version  = semver.MustParse("3.0.0-beta.0")
+	helm32Version = semver.MustParse("3.2.0")
 
 	// error to throw when helm version can't be determined
 	versionErrorString = "failed to determine binary version: %w"
@@ -504,6 +505,10 @@ func installArgs(r latest.HelmRelease, builds []build.Artifact, valuesSet map[st
 
 	if o.namespace != "" {
 		args = append(args, "--namespace", o.namespace)
+	}
+
+	if r.CreateNamespace && o.helmVersion.GE(helm32Version) && !o.upgrade {
+		args = append(args, "--create-namespace")
 	}
 
 	params, err := pairParamsToArtifacts(builds, r.ArtifactOverrides)

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -272,7 +272,7 @@ var testTwoReleases = latest.HelmDeploy{
 	}},
 }
 
-var crateNamespaceFlag = true
+var createNamespaceFlag = true
 var testDeployCreateNamespaceConfig = latest.HelmDeploy{
 	Releases: []latest.HelmRelease{{
 		Name:      "skaffold-helm",
@@ -285,7 +285,7 @@ var testDeployCreateNamespaceConfig = latest.HelmDeploy{
 			"some.key": "somevalue",
 		},
 		Namespace:       "testReleaseNamespace",
-		CreateNamespace: &crateNamespaceFlag,
+		CreateNamespace: &createNamespaceFlag,
 	}},
 }
 

--- a/pkg/skaffold/deploy/helm_test.go
+++ b/pkg/skaffold/deploy/helm_test.go
@@ -272,6 +272,7 @@ var testTwoReleases = latest.HelmDeploy{
 	}},
 }
 
+var crateNamespaceFlag = true
 var testDeployCreateNamespaceConfig = latest.HelmDeploy{
 	Releases: []latest.HelmRelease{{
 		Name:      "skaffold-helm",
@@ -284,7 +285,7 @@ var testDeployCreateNamespaceConfig = latest.HelmDeploy{
 			"some.key": "somevalue",
 		},
 		Namespace:       "testReleaseNamespace",
-		CreateNamespace: true,
+		CreateNamespace: &crateNamespaceFlag,
 	}},
 }
 
@@ -838,15 +839,14 @@ func TestHelmDeploy(t *testing.T) {
 			builds: testBuilds,
 		},
 		{
-			description: "helm3.1 get failure should install without createNamespace not upgrade",
+			description: "helm3.1 should fail to deploy with createNamespace option",
 			commands: testutil.
 				CmdRunWithOutput("helm version --client", version31).
 				AndRunErr("helm --kube-context kubecontext get all --namespace testReleaseNamespace skaffold-helm --kubeconfig kubeconfig", fmt.Errorf("not found")).
-				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
-				AndRun("helm --kube-context kubecontext install skaffold-helm examples/test --namespace testReleaseNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
-				AndRun("helm --kube-context kubecontext get all --namespace testReleaseNamespace skaffold-helm --kubeconfig kubeconfig"),
-			helm:   testDeployCreateNamespaceConfig,
-			builds: testBuilds,
+				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig"),
+			helm:      testDeployCreateNamespaceConfig,
+			builds:    testBuilds,
+			shouldErr: true,
 		},
 		{
 			description: "helm3.2 get failure should install with createNamespace not upgrade",

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -628,6 +628,10 @@ type HelmRelease struct {
 	// If present, Skaffold will send `--set-file` flag to Helm CLI and append all pairs after the flag.
 	SetFiles map[string]string `yaml:"setFiles,omitempty"`
 
+	// CreateNamespace if `true`, Skaffold will send `--create-namespace` flag to Helm CLI.
+	// Defaults to `false`.
+	CreateNamespace bool `yaml:"createNamespace,omitempty"`
+
 	// Wait if `true`, Skaffold will send `--wait` flag to Helm CLI.
 	// Defaults to `false`.
 	Wait bool `yaml:"wait,omitempty"`

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -629,8 +629,9 @@ type HelmRelease struct {
 	SetFiles map[string]string `yaml:"setFiles,omitempty"`
 
 	// CreateNamespace if `true`, Skaffold will send `--create-namespace` flag to Helm CLI.
-	// Defaults to `false`.
-	CreateNamespace bool `yaml:"createNamespace,omitempty"`
+	// `--create-namespace` flag is available in Helm since version 3.2.
+	// Defaults is `false`.
+	CreateNamespace *bool `yaml:"createNamespace,omitempty"`
 
 	// Wait if `true`, Skaffold will send `--wait` flag to Helm CLI.
 	// Defaults to `false`.


### PR DESCRIPTION
Fixes: #4482

**Description**
This PR adds the ability to create a namespace for Helm deploy command if Helm version is 3.2+.
