### PR TITLE
Pass correct build args to `CreateDockerTarContext`

### DIFF
--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -86,10 +86,7 @@ func (b *Builder) copyKanikoBuildContext(ctx context.Context, workspace string, 
 
 	buildCtx, buildCtxWriter := io.Pipe()
 	go func() {
-		err := docker.CreateDockerTarContext(ctx, buildCtxWriter, workspace, &latest.DockerArtifact{
-			BuildArgs:      artifact.BuildArgs,
-			DockerfilePath: artifact.DockerfilePath,
-		}, b.insecureRegistries)
+		err := docker.CreateDockerTarContext(ctx, buildCtxWriter, workspace, artifact.DockerfilePath, artifact.BuildArgs, b.insecureRegistries)
 		if err != nil {
 			buildCtxWriter.CloseWithError(fmt.Errorf("creating docker context: %w", err))
 			return

--- a/pkg/skaffold/diagnose/diagnose.go
+++ b/pkg/skaffold/diagnose/diagnose.go
@@ -136,7 +136,7 @@ func timeToComputeMTimes(deps []string) (time.Duration, error) {
 func sizeOfDockerContext(ctx context.Context, a *latest.Artifact, insecureRegistries map[string]bool) (int64, error) {
 	buildCtx, buildCtxWriter := io.Pipe()
 	go func() {
-		err := docker.CreateDockerTarContext(ctx, buildCtxWriter, a.Workspace, a.DockerArtifact, insecureRegistries)
+		err := docker.CreateDockerTarContext(ctx, buildCtxWriter, a.Workspace, a.DockerArtifact.DockerfilePath, a.DockerArtifact.BuildArgs, insecureRegistries)
 		if err != nil {
 			buildCtxWriter.CloseWithError(fmt.Errorf("creating docker context: %w", err))
 			return

--- a/pkg/skaffold/docker/context.go
+++ b/pkg/skaffold/docker/context.go
@@ -22,12 +22,11 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
-func CreateDockerTarContext(ctx context.Context, w io.Writer, workspace string, a *latest.DockerArtifact, insecureRegistries map[string]bool) error {
-	paths, err := GetDependencies(ctx, workspace, a.DockerfilePath, a.BuildArgs, insecureRegistries)
+func CreateDockerTarContext(ctx context.Context, w io.Writer, workspace string, dockerfilePath string, buildArgs map[string]*string, insecureRegistries map[string]bool) error {
+	paths, err := GetDependencies(ctx, workspace, dockerfilePath, buildArgs, insecureRegistries)
 	if err != nil {
 		return fmt.Errorf("getting relative tar paths: %w", err)
 	}

--- a/pkg/skaffold/docker/context_test.go
+++ b/pkg/skaffold/docker/context_test.go
@@ -46,7 +46,7 @@ func TestDockerContext(t *testing.T) {
 
 			reader, writer := io.Pipe()
 			go func() {
-				err := CreateDockerTarContext(context.Background(), writer, dir, artifact, nil)
+				err := CreateDockerTarContext(context.Background(), writer, dir, artifact.DockerfilePath, artifact.BuildArgs, nil)
 				if err != nil {
 					writer.CloseWithError(err)
 				} else {

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -171,7 +171,7 @@ func (l *localDaemon) Build(ctx context.Context, out io.Writer, workspace string
 
 	buildCtx, buildCtxWriter := io.Pipe()
 	go func() {
-		err := CreateDockerTarContext(ctx, buildCtxWriter, workspace, a, l.insecureRegistries)
+		err := CreateDockerTarContext(ctx, buildCtxWriter, workspace, a.DockerfilePath, buildArgs, l.insecureRegistries)
 		if err != nil {
 			buildCtxWriter.CloseWithError(fmt.Errorf("creating docker context: %w", err))
 			return


### PR DESCRIPTION
Modified function parameters for `CreateDockerTarContext` so that we can pass in the updated build args.