### PR TITLE
Enable golint checks for linux/arm64

### DIFF
--- a/hack/install_golint.sh
+++ b/hack/install_golint.sh
@@ -69,6 +69,7 @@ is_supported_platform() {
     windows/386) found=0 ;;
     linux/amd64) found=0 ;;
     linux/386) found=0 ;;
+    linux/arm64) found=0 ;;
   esac
   return $found
 }


### PR DESCRIPTION
This PR fixes golangci-lint checks on linux/arm64.
Changes are trivial - just add "linux/arm64" to the list of supported platforms

**Tested on:**
```
ilyaz@pi64 --- src/skaffold ‹master› » uname -a 
Linux pi64 5.4.0-1018-raspi #20-Ubuntu SMP Sun Sep 6 05:11:16 UTC 2020 aarch64 aarch64 aarch64 GNU/Linux
```
   

**Before:**
```
ilyaz@pi64 --- src/skaffold ‹master› » hack/golangci-lint.sh 
Installing GolangCI-Lint
golangci/golangci-lint crit platform linux/arm64 is not supported.  Make sure this script is up-to-date and file request at https://github.com/golangci/golangci-lint/issues/new
```

**After:**
```
ilyaz@pi64 --- src/skaffold ‹master* M› » hack/golangci-lint.sh    
Installing GolangCI-Lint
golangci/golangci-lint info checking GitHub for tag 'v1.30.0'
golangci/golangci-lint info found version: 1.30.0 for v1.30.0/linux/arm64
golangci/golangci-lint info installed /home/ilyaz/src/skf_mem/skaffold/hack/bin/golangci-lint
```