### PR TITLE
skaffold deploy -t flag

### DIFF
--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -89,19 +89,9 @@ func getArtifactsToDeploy(out io.Writer, fromFile, fromCLI []build.Artifact, art
 	deployed = build.MergeWithPreviousBuilds(fromCLI, deployed)
 	deployed = build.MergeWithPreviousBuilds(fromFile, deployed)
 
-	if opts.CustomTag != "" {
-		for i := range deployed {
-			artifact := &deployed[i]
-			if artifact.Tag == "" {
-				artifact.Tag = artifact.ImageName + ":" + opts.CustomTag
-			} else {
-				newTag, err := tag.SetImageTag(artifact.Tag, opts.CustomTag)
-				if err != nil {
-					return nil, err
-				}
-				artifact.Tag = newTag
-			}
-		}
+	deployed, err := applyCustomTag(deployed)
+	if err != nil {
+		return nil, err
 	}
 
 	// Check that every image has a non empty tag
@@ -113,4 +103,24 @@ func getArtifactsToDeploy(out io.Writer, fromFile, fromCLI []build.Artifact, art
 	}
 
 	return deployed, nil
+}
+
+func applyCustomTag(artifacts []build.Artifact) ([]build.Artifact, error) {
+	if opts.CustomTag != "" {
+		var result []build.Artifact
+		for _, artifact := range artifacts {
+			if artifact.Tag == "" {
+				artifact.Tag = artifact.ImageName + ":" + opts.CustomTag
+			} else {
+				newTag, err := tag.SetImageTag(artifact.Tag, opts.CustomTag)
+				if err != nil {
+					return nil, err
+				}
+				artifact.Tag = newTag
+			}
+			result = append(result, artifact)
+		}
+		return result, nil
+	}
+	return artifacts, nil
 }

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -271,7 +271,7 @@ var flagRegistry = []Flag{
 		Value:         &opts.CustomTag,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",
-		DefinedOn:     []string{"build", "debug", "dev", "run"},
+		DefinedOn:     []string{"build", "debug", "dev", "run", "deploy"},
 	},
 	{
 		Name:          "minikube-profile",

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -493,6 +493,7 @@ Options:
       --rpc-port=50051: tcp port to expose event API
       --skip-render=false: Don't render the manifests, just deploy them
       --status-check=true: Wait for deployed resources to stabilize
+  -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
@@ -528,6 +529,7 @@ Env vars:
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_RENDER` (same as `--skip-render`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
+* `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)

--- a/pkg/skaffold/build/tag/util.go
+++ b/pkg/skaffold/build/tag/util.go
@@ -40,3 +40,18 @@ func StripTags(taggedImages []string) []string {
 	}
 	return images
 }
+
+func SetImageTag(image, tag string) (string, error) {
+	parsed, err := docker.ParseReference(image)
+	if err != nil {
+		return "", err
+	}
+	image = parsed.BaseName
+	if tag != "" {
+		image = image + ":" + tag
+	}
+	if parsed.Digest != "" {
+		image = image + "@" + parsed.Digest
+	}
+	return image, nil
+}

--- a/pkg/skaffold/build/tag/util_test.go
+++ b/pkg/skaffold/build/tag/util_test.go
@@ -59,3 +59,57 @@ func TestStripTags(t *testing.T) {
 		})
 	}
 }
+
+func TestSetImageTag(t *testing.T) {
+	tests := []struct {
+		description   string
+		image         string
+		tag           string
+		expectedImage string
+		shouldErr     bool
+	}{
+		{
+			description:   "image with tag",
+			image:         "gcr.io/foo/bar:latest",
+			tag:           "test-1",
+			expectedImage: "gcr.io/foo/bar:test-1",
+		},
+		{
+			description:   "image with tag and digest",
+			image:         "gcr.io/foo/bar:latest@sha256:79e160161fd8190acae2d04d8f296a27a562c8a59732c64ac71c99009a6e89bc",
+			tag:           "test-2",
+			expectedImage: "gcr.io/foo/bar:test-2@sha256:79e160161fd8190acae2d04d8f296a27a562c8a59732c64ac71c99009a6e89bc",
+		},
+		{
+			description:   "image without tag and digest",
+			image:         "gcr.io/foo/bar",
+			tag:           "test-3",
+			expectedImage: "gcr.io/foo/bar:test-3",
+		},
+		{
+			description:   "empty tag",
+			image:         "gcr.io/foo/bar:test-4",
+			expectedImage: "gcr.io/foo/bar",
+		},
+		{
+			description:   "image with digest",
+			image:         "gcr.io/foo/bar@sha256:79e160161fd8190acae2d04d8f296a27a562c8a59732c64ac71c99009a6e89bc",
+			tag:           "test-5",
+			expectedImage: "gcr.io/foo/bar:test-5@sha256:79e160161fd8190acae2d04d8f296a27a562c8a59732c64ac71c99009a6e89bc",
+		},
+		{
+			description: "invalid reference",
+			image:       "!!invalid!!",
+			shouldErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Parallel()
+
+			image, err := SetImageTag(test.image, test.tag)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedImage, image)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4455 

**Description**
This PR adds the `--tag` flag to the deploy command. If the '--tag' flag is present, then the tags for all artifacts are overridden. 

Perhaps the deploy command should only use the new tag for artifacts for which the image tag is not explicitly specified. Let me know if I need to change anything.