### PR TITLE
bump go version to 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 
 language: go
-go: "1.14.x"
+go: "1.15.x"
 go_import_path: /skaffold
 
 git:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleContainerTools/skaffold
 
-go 1.14
+go 1.15
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.0.1+incompatible


### PR DESCRIPTION
Fixes #4784

Just bumps the version of go in go.mod
