### PR TITLE
Make FakeAPIClient threadsafe

### DIFF
--- a/pkg/skaffold/build/buildpacks/fetcher_test.go
+++ b/pkg/skaffold/build/buildpacks/fetcher_test.go
@@ -54,7 +54,7 @@ func TestFetcher(t *testing.T) {
 			f := newFetcher(&out, docker)
 			f.Fetch(context.Background(), "image", true, test.pull)
 
-			t.CheckDeepEqual(test.expectedPulled, api.Pulled)
+			t.CheckDeepEqual(test.expectedPulled, api.Pulled())
 		})
 	}
 }

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -260,7 +260,7 @@ func TestLocalRun(t *testing.T) {
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, res)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
-			t.CheckDeepEqual(test.expectedPushed, test.api.Pushed)
+			t.CheckDeepEqual(test.expectedPushed, test.api.Pushed())
 		})
 	}
 }

--- a/testutil/fake_image_api.go
+++ b/testutil/fake_image_api.go
@@ -124,8 +124,8 @@ func (f *FakeAPIClient) ImageBuild(_ context.Context, _ io.Reader, options types
 		return types.ImageBuildResponse{}, fmt.Errorf("")
 	}
 
-	f.nextImageID++
-	imageID := fmt.Sprintf("sha256:%d", f.nextImageID)
+	next := atomic.AddInt32(&f.nextImageID, 1)
+	imageID := fmt.Sprintf("sha256:%d", next)
 
 	for _, tag := range options.Tags {
 		f.Add(tag, imageID)
@@ -246,8 +246,8 @@ func (f *FakeAPIClient) ImageLoad(ctx context.Context, input io.Reader, quiet bo
 		return types.ImageLoadResponse{}, fmt.Errorf("reading tar")
 	}
 
-	atomic.AddInt32(&f.nextImageID, 1)
-	imageID := fmt.Sprintf("sha256:%d", f.nextImageID)
+	next := atomic.AddInt32(&f.nextImageID, 1)
+	imageID := fmt.Sprintf("sha256:%d", next)
 	f.Add(ref, imageID)
 
 	return types.ImageLoadResponse{

--- a/testutil/fake_image_api.go
+++ b/testutil/fake_image_api.go
@@ -25,6 +25,8 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/registry"
@@ -44,7 +46,6 @@ const (
 type FakeAPIClient struct {
 	client.CommonAPIClient
 
-	tagToImageID    map[string]string
 	ErrImageBuild   bool
 	ErrImageInspect bool
 	ErrImagePush    bool
@@ -52,10 +53,13 @@ type FakeAPIClient struct {
 	ErrStream       bool
 	ErrVersion      bool
 
-	nextImageID int
-	Pushed      map[string]string
-	Pulled      []string
-	Built       []types.ImageBuildOptions
+	nextImageID  int32
+	tagToImageID sync.Map // map[string]string
+	pushed       sync.Map // map[string]string
+	pulled       sync.Map // map[string]string
+
+	mux   sync.Mutex
+	Built []types.ImageBuildOptions
 }
 
 func (f *FakeAPIClient) ServerVersion(ctx context.Context) (types.Version, error) {
@@ -66,16 +70,33 @@ func (f *FakeAPIClient) ServerVersion(ctx context.Context) (types.Version, error
 }
 
 func (f *FakeAPIClient) Add(tag, imageID string) *FakeAPIClient {
-	if f.tagToImageID == nil {
-		f.tagToImageID = make(map[string]string)
-	}
-
-	f.tagToImageID[imageID] = imageID
-	f.tagToImageID[tag] = imageID
+	f.tagToImageID.Store(imageID, imageID)
+	f.tagToImageID.Store(tag, imageID)
 	if !strings.Contains(tag, ":") {
-		f.tagToImageID[tag+":latest"] = imageID
+		f.tagToImageID.Store(tag+":latest", imageID)
 	}
 	return f
+}
+
+func (f *FakeAPIClient) Pulled() []string {
+	var p []string
+	f.pulled.Range(func(ref, _ interface{}) bool {
+		p = append(p, ref.(string))
+		return true
+	})
+	return p
+}
+
+func (f *FakeAPIClient) Pushed() map[string]string {
+	p := make(map[string]string)
+	f.pushed.Range(func(ref, id interface{}) bool {
+		p[ref.(string)] = id.(string)
+		return true
+	})
+	if len(p) == 0 {
+		return nil
+	}
+	return p
 }
 
 type notFoundError struct {
@@ -110,42 +131,62 @@ func (f *FakeAPIClient) ImageBuild(_ context.Context, _ io.Reader, options types
 		f.Add(tag, imageID)
 	}
 
+	f.mux.Lock()
 	f.Built = append(f.Built, options)
+	f.mux.Unlock()
 
 	return types.ImageBuildResponse{
 		Body: f.body(imageID),
 	}, nil
 }
 
-func (f *FakeAPIClient) ImageInspectWithRaw(_ context.Context, ref string) (types.ImageInspect, []byte, error) {
+func (f *FakeAPIClient) ImageInspectWithRaw(_ context.Context, refOrID string) (types.ImageInspect, []byte, error) {
 	if f.ErrImageInspect {
 		return types.ImageInspect{}, nil, fmt.Errorf("")
 	}
 
-	for tag, imageID := range f.tagToImageID {
-		if tag == ref || imageID == ref {
-			rawConfig := []byte(fmt.Sprintf(`{"Config":{"Image":"%s"}}`, imageID))
-
-			var repoDigests []string
-			if digest, found := f.Pushed[ref]; found {
-				repoDigests = append(repoDigests, ref+"@"+digest)
-			}
-
-			return types.ImageInspect{
-				ID:          imageID,
-				RepoDigests: repoDigests,
-			}, rawConfig, nil
-		}
+	ref, imageID, err := f.findImageID(refOrID)
+	if err != nil {
+		return types.ImageInspect{}, nil, err
 	}
 
-	return types.ImageInspect{}, nil, &notFoundError{}
+	rawConfig := []byte(fmt.Sprintf(`{"Config":{"Image":"%s"}}`, imageID))
+
+	var repoDigests []string
+	if digest, found := f.pushed.Load(ref); found {
+		repoDigests = append(repoDigests, ref+"@"+digest.(string))
+	}
+
+	return types.ImageInspect{
+		ID:          imageID,
+		RepoDigests: repoDigests,
+	}, rawConfig, nil
+}
+
+func (f *FakeAPIClient) findImageID(refOrID string) (string, string, error) {
+	if id, found := f.tagToImageID.Load(refOrID); found {
+		return refOrID, id.(string), nil
+	}
+	var ref, id string
+	f.tagToImageID.Range(func(r, i interface{}) bool {
+		if r == refOrID || i == refOrID {
+			ref = r.(string)
+			id = i.(string)
+			return false
+		}
+		return true
+	})
+	if ref == "" {
+		return "", "", &notFoundError{}
+	}
+	return ref, id, nil
 }
 
 func (f *FakeAPIClient) DistributionInspect(ctx context.Context, ref, encodedRegistryAuth string) (registry.DistributionInspect, error) {
-	if sha, found := f.Pushed[ref]; found {
+	if sha, found := f.pushed.Load(ref); found {
 		return registry.DistributionInspect{
 			Descriptor: v1.Descriptor{
-				Digest: digest.Digest(sha),
+				Digest: digest.Digest(sha.(string)),
 			},
 		}, nil
 	}
@@ -154,12 +195,12 @@ func (f *FakeAPIClient) DistributionInspect(ctx context.Context, ref, encodedReg
 }
 
 func (f *FakeAPIClient) ImageTag(_ context.Context, image, ref string) error {
-	imageID, ok := f.tagToImageID[image]
+	imageID, ok := f.tagToImageID.Load(image)
 	if !ok {
 		return fmt.Errorf("image %s not found", image)
 	}
 
-	f.Add(ref, imageID)
+	f.Add(ref, imageID.(string))
 	return nil
 }
 
@@ -168,22 +209,23 @@ func (f *FakeAPIClient) ImagePush(_ context.Context, ref string, _ types.ImagePu
 		return nil, fmt.Errorf("")
 	}
 
+	imageID, found := f.tagToImageID.Load(ref)
+	if !found {
+		return nil, errors.New("ref not found: " + ref)
+	}
 	sha256Digester := sha256.New()
-	if _, err := sha256Digester.Write([]byte(f.tagToImageID[ref])); err != nil {
+	if _, err := sha256Digester.Write([]byte(imageID.(string))); err != nil {
 		return nil, err
 	}
 
 	digest := "sha256:" + fmt.Sprintf("%x", sha256Digester.Sum(nil))[0:64]
-	if f.Pushed == nil {
-		f.Pushed = make(map[string]string)
-	}
-	f.Pushed[ref] = digest
 
+	f.pushed.Store(ref, digest)
 	return f.body(digest), nil
 }
 
 func (f *FakeAPIClient) ImagePull(_ context.Context, ref string, _ types.ImagePullOptions) (io.ReadCloser, error) {
-	f.Pulled = append(f.Pulled, ref)
+	f.pulled.Store(ref, ref)
 	if f.ErrImagePull {
 		return nil, fmt.Errorf("")
 	}
@@ -203,7 +245,7 @@ func (f *FakeAPIClient) ImageLoad(ctx context.Context, input io.Reader, quiet bo
 		return types.ImageLoadResponse{}, fmt.Errorf("reading tar")
 	}
 
-	f.nextImageID++
+	atomic.AddInt32(&f.nextImageID, 1)
 	imageID := fmt.Sprintf("sha256:%d", f.nextImageID)
 	f.Add(ref, imageID)
 

--- a/testutil/fake_image_api.go
+++ b/testutil/fake_image_api.go
@@ -209,9 +209,10 @@ func (f *FakeAPIClient) ImagePush(_ context.Context, ref string, _ types.ImagePu
 		return nil, fmt.Errorf("")
 	}
 
+	// use the digest if previously pushed
 	imageID, found := f.tagToImageID.Load(ref)
 	if !found {
-		return nil, errors.New("ref not found: " + ref)
+		imageID = ""
 	}
 	sha256Digester := sha256.New()
 	if _, err := sha256Digester.Write([]byte(imageID.(string))); err != nil {


### PR DESCRIPTION
**Description**

In fixing #4757 I discovered that we hit data race issues in the Docker `FakeAPIClient` when running `make test` locally.  We don't seem to be running tests with `-race`.  I could have papered over the issue with a sync.Mutex, but it felt like it would turn into a game of whackamole.

```
--- FAIL: TestCacheFindMissing (0.01s)
/pkg/skaffold/build/cache/TestCacheFindMissing/TestCacheFindMissing
==================
WARNING: DATA RACE
Read at 0x00c000180990 by goroutine 80:
  github.com/GoogleContainerTools/skaffold/testutil.(*FakeAPIClient).ImagePull()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/testutil/fake_image_api.go:186 +0x4d
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker.(*localDaemon).Pull()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/docker/image.go:336 +0x378
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).tryImport()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:129 +0x6a3
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).lookup()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:60 +0x5ac
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).lookupArtifacts.func1()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:41 +0x147

Previous write at 0x00c000180990 by goroutine 81:
  github.com/GoogleContainerTools/skaffold/testutil.(*FakeAPIClient).ImagePull()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/testutil/fake_image_api.go:186 +0xd9
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker.(*localDaemon).Pull()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/docker/image.go:336 +0x378
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).tryImport()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:129 +0x6a3
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).lookup()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:60 +0x5ac
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).lookupArtifacts.func1()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:41 +0x147

Goroutine 80 (running) created at:
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).lookupArtifacts()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:40 +0x16d
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).Build.func1()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/retrieve.go:44 +0x8d

Goroutine 81 (finished) created at:
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).lookupArtifacts()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:40 +0x16d
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).Build.func1()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/retrieve.go:44 +0x8d
==================
==================
WARNING: DATA RACE
Read at 0x00c000304340 by goroutine 80:
  runtime.growslice()
      /usr/local/go/src/runtime/slice.go:76 +0x0
  github.com/GoogleContainerTools/skaffold/testutil.(*FakeAPIClient).ImagePull()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/testutil/fake_image_api.go:186 +0x235
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker.(*localDaemon).Pull()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/docker/image.go:336 +0x378
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).tryImport()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:129 +0x6a3
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).lookup()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:60 +0x5ac
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).lookupArtifacts.func1()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:41 +0x147

Previous write at 0x00c000304340 by goroutine 81:
  github.com/GoogleContainerTools/skaffold/testutil.(*FakeAPIClient).ImagePull()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/testutil/fake_image_api.go:186 +0x9b
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker.(*localDaemon).Pull()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/docker/image.go:336 +0x378
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).tryImport()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:129 +0x6a3
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).lookup()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:60 +0x5ac
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).lookupArtifacts.func1()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:41 +0x147

Goroutine 80 (running) created at:
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).lookupArtifacts()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:40 +0x16d
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).Build.func1()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/retrieve.go:44 +0x8d

Goroutine 81 (finished) created at:
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).lookupArtifacts()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/lookup.go:40 +0x16d
  github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache.(*cache).Build.func1()
      /Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/build/cache/retrieve.go:44 +0x8d
==================
time="2020-09-15T17:07:38-04:00" level=info msg="Cache check complete in 2.422486ms"
    TestCacheFindMissing/TestCacheFindMissing: testing.go:906: race detected during execution of test
    TestCacheFindMissing: testing.go:906: race detected during execution of test
    --- FAIL: TestCacheFindMissing/TestCacheFindMissing (0.01s)
    : testing.go:906: race detected during execution of test

```
