### PR TITLE
Return error for invalid dockerfile instruction "COPY" with no arguments

### DIFF
--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -272,6 +272,9 @@ func readCopyCommand(value *parser.Node, envs []string, workdir string) (*copyCo
 
 		paths = append(paths, path)
 	}
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("invalid dockerfile instruction: %q", value.Original)
+	}
 
 	// All paths are sources except the last one
 	var srcs []string


### PR DESCRIPTION
Fixes #4791 