### PR TITLE
Ensure Windows console color enablement

### DIFF
--- a/pkg/skaffold/color/formatter.go
+++ b/pkg/skaffold/color/formatter.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	colors "github.com/heroku/color"
+	"github.com/mattn/go-colorable"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -37,7 +38,13 @@ func init() {
 // SetupColors enables/disables coloured output.
 func SetupColors(out io.Writer, defaultColor int, forceColors bool) {
 	_, isTerm := util.IsTerminal(out)
-	colors.Disable(!isTerm && !forceColors)
+	useColors := isTerm || forceColors
+	if useColors {
+		// Use EnableColorsStdout to enable use of color on Windows
+		useColors = false // value is updated if color-enablement is successful
+		colorable.EnableColorsStdout(&useColors)
+	}
+	colors.Disable(!useColors)
 
 	// Maintain compatibility with the old color coding.
 	Default = map[int]Color{


### PR DESCRIPTION
Fixes: #4783

**Description**

Explicitly call [`mattn/go-colorable`](https://github.com/mattn/go-colorable)'s [`colorable.EnableColorsStdout()`](https://github.com/mattn/go-colorable/blob/master/colorable_windows.go#L1025) to ensure Windows consoles are placed in a mode to decipher ANSI colour sequences.

In #3757, we switched to using [`heroku/color`](https://github.com/heroku/color) to provide colour definitions.  Although `heroku/color` uses [`mattn/go-colorable`](https://github.com/mattn/go-colorable), it doesn't call `EnableColorsStdout()`, and besides we are just using `heroku/color`'s colour definitions rather than their console output and io.Writer  wrappers.  

Before:
![Screen Shot 2020-09-17 at 3 20 55 PM](https://user-images.githubusercontent.com/202851/93518106-62b89d80-f8fa-11ea-9097-33e343bd5c02.png)

After:
![Screen Shot 2020-09-17 at 3 20 17 PM](https://user-images.githubusercontent.com/202851/93518122-66e4bb00-f8fa-11ea-96ec-85fccafdf222.png)
