### PR TITLE
Pin autoprefixer version at 9.8.6 for docs

### DIFF
--- a/deploy/webhook/Dockerfile
+++ b/deploy/webhook/Dockerfile
@@ -40,7 +40,8 @@ FROM node:10.15.3-stretch as runtime_deps
 ENV FIREBASE_TOOLS_VERSION 7.13.1
 RUN npm install -g firebase-tools@${FIREBASE_TOOLS_VERSION} postcss-cli
 WORKDIR /app/docs
-RUN npm install autoprefixer
+ENV AUTOPREFIXER_VERSION 9.8.6
+RUN npm install autoprefixer@${AUTOPREFIXER_VERSION}
 COPY --from=download-docsy /docsy ./themes/docsy
 COPY --from=download-hugo /hugo /usr/local/bin/
 COPY --from=download-kubectl /kubectl /usr/local/bin/


### PR DESCRIPTION
Our Travis builds have been broken because of a recent update to autoprefixer which isn't yet supported by postcss-cli (https://github.com/postcss/autoprefixer/issues/1359#issuecomment-694292709).
Pinning the version of autoprefixer to the version before will fix this 