### PR TITLE
Fix TestPluginType_IsKnown unit test

### DIFF
--- a/pkg/skaffold/build/jib/jib_test.go
+++ b/pkg/skaffold/build/jib/jib_test.go
@@ -154,9 +154,9 @@ func TestPluginType_IsKnown(t *testing.T) {
 	}{
 		{JibMaven, true},
 		{JibGradle, true},
-		{PluginType(0), false},
-		{PluginType(-1), false},
-		{PluginType(3), false},
+		{PluginType("ant"), false},
+		{PluginType("make"), false},
+		{PluginType(""), false},
 	}
 	for _, test := range tests {
 		testutil.Run(t, string(test.value), func(t *testutil.T) {


### PR DESCRIPTION
This PR fixes the compilation warning in the pkg/skaffold/build/jib/TestGetDependencies unit test

## Before:
```shell
izuyev@izuyev-macbookpro --- z/skaffold ‹master➔› » hack/gotest.sh ./pkg/skaffold/build/jib/...                                                                                                                                                           1 ↵
go test ./pkg/skaffold/build/jib/...
# github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib
pkg/skaffold/build/jib/jib_test.go:157:4: conversion from untyped int to PluginType (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
pkg/skaffold/build/jib/jib_test.go:158:4: conversion from untyped int to PluginType (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
pkg/skaffold/build/jib/jib_test.go:159:4: conversion from untyped int to PluginType (string) yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
FAIL   github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib [build failed]

=== Slow Tests ===
exit status 1
```

## After:

```shell
izuyev@izuyev-macbookpro --- z/skaffold ‹fix_jib_test_warn› » hack/gotest.sh ./pkg/skaffold/build/jib/...
go test ./pkg/skaffold/build/jib/...
ok      github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib 2.631s

=== Slow Tests ===
0.02s   TestValidate
0.01s   TestGetDependencies
0.01s   TestDeterminePluginType
0.01s   TestBuildJibMavenToRegistry
izuyev@izuyev-macbookpro --- z/skaffold ‹fix_jib_test_warn› » 
```