### PR TITLE
[kpt deployer] Add "local-config" annotation to kpt fn configs.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,9 +80,10 @@ require (
 	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c
 	k8s.io/api v0.18.1
 	k8s.io/apiextensions-apiserver v0.18.1 // indirect
-	k8s.io/apimachinery v0.18.1
+	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.18.1
 	k8s.io/kubectl v0.0.0-20190831163037-3b58a944563f
 	k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89
 	knative.dev/pkg v0.0.0-20200416021448-f68639f04b39 // indirect
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/skaffold/deploy/kpt.go
+++ b/pkg/skaffold/deploy/kpt.go
@@ -28,14 +28,15 @@ import (
 	"regexp"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "sigs.k8s.io/yaml"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	deploy "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	k8syaml "sigs.k8s.io/yaml"
 )
 
 const (
@@ -190,8 +191,8 @@ func (k *KptDeployer) renderManifests(ctx context.Context, _ io.Writer, builds [
 		return nil, nil
 	}
 
-	// Remove the kpt function from the manipulated resources.
-	manifests, err = k.ExcludeKptFn(manifests)
+	// exclude the kpt function from the manipulated resources.
+	manifests, err = k.excludeKptFn(manifests)
 	if err != nil {
 		return nil, fmt.Errorf("exclude kpt fn from manipulated resources: %w", err)
 	}
@@ -280,9 +281,9 @@ func (k *KptDeployer) kptFnRun(ctx context.Context) (deploy.ManifestList, error)
 	return manifests, nil
 }
 
-// ExcludeKptFn adds an annotation "config.kubernetes.io/local-config: 'true'" to kpt function.
+// excludeKptFn adds an annotation "config.kubernetes.io/local-config: 'true'" to kpt function.
 // This will exclude kpt functions from deployed to the cluster in kpt live apply.
-func (k *KptDeployer) ExcludeKptFn(manifest deploy.ManifestList) (deploy.ManifestList, error) {
+func (k *KptDeployer) excludeKptFn(manifest deploy.ManifestList) (deploy.ManifestList, error) {
 	var newManifest deploy.ManifestList
 	for _, yByte := range manifest {
 		// Convert yaml byte config to unstructured.Unstructured

--- a/pkg/skaffold/deploy/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt_test.go
@@ -27,9 +27,8 @@ import (
 	"strings"
 	"testing"
 
-	deploy "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
-
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	deploy "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -983,7 +982,7 @@ spec:
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			k := NewKptDeployer(&kptConfig{}, nil)
-			actualManifest, err := k.ExcludeKptFn(test.manifests)
+			actualManifest, err := k.excludeKptFn(test.manifests)
 			t.CheckErrorAndDeepEqual(false, err, test.expected.String(), actualManifest.String())
 		})
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -837,7 +837,7 @@ k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.18.1
 ## explicit
-# k8s.io/apimachinery v0.18.1 => k8s.io/apimachinery v0.17.4
+# k8s.io/apimachinery v0.19.2 => k8s.io/apimachinery v0.17.4
 ## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
@@ -1131,6 +1131,7 @@ knative.dev/pkg/kmeta
 knative.dev/pkg/kmp
 knative.dev/pkg/tracker
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml
 # github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.0.1+incompatible
 # github.com/containerd/containerd => github.com/containerd/containerd v1.3.4


### PR DESCRIPTION
**Related**  #3904

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Add a `config.kubernetes.io/local-config:true` annotation to each kpt fn config from the rendered resources. This allows kpt deployer to skip deploying the kpt fn config to the cluster in `skaffold dev` and `skaffold deploy`.

more context: The [declarative kpt fn](https://googlecontainertools.github.io/kpt/guides/consumer/function/#declarative-run)  is not config resource but an operation working on the resource. It should not be applied to the cluster. Applying the kpt fn to cluster could fail due to the different config requirements (e.g. kpt fn ConfigMap doesn't require the `.metadata.name` field to exist while normal ConfigMap does).   

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
