### PR TITLE
Document how to disable autosync for buildpacks

### DIFF
--- a/docs/content/en/docs/pipeline-stages/filesync.md
+++ b/docs/content/en/docs/pipeline-stages/filesync.md
@@ -78,28 +78,29 @@ File deletion will always cause a complete rebuild.
 
 ### Auto sync mode
 
-In auto sync mode, Skaffold automatically generates sync rules for known file types.  Changes to other file types will
-result in a complete rebuild.
+In auto sync mode, Skaffold automatically generates sync rules for known file types. 
+Changes to other file types will result in a complete rebuild.
 
 #### Buildpacks
 
-Skaffold requires special collaboration from the Buildpacks for the `auto` sync to work.
-The GCP Buildpacks builder [gcr.io/buildpacks/builder:v1](https://github.com/GoogleCloudPlatform/buildpacks)
-supports Skaffold syncing out of the box, currently for Go, NodeJS, and Java. 
-Auto sync is now enabled by default.
-
-Skaffold will automatically sync and relaunch applications for the following file types:
+Skaffold works with Cloud Native Buildpacks builders to automatically sync and relaunch
+applications on changes to certain types of files.
+The GCP Buildpacks builder ([gcr.io/buildpacks/builder:v1](https://github.com/GoogleCloudPlatform/buildpacks))
+supports syncing the following types of source files:
 
 - Go: *.go
 - Java: *.java, *.kt, *.scala, *.groovy, *.clj
 - NodeJS: *.js, *.mjs, *.coffee, *.litcoffee, *.json
 
+The GCP Buildpacks builder will detect the changed files and
+automatically rebuild and relaunch the application. 
 Changes to other file types trigger an image rebuild.
 
 ##### Disable Auto Sync for Buildpacks
 
-To disable auto sync, provide a manual sync rule; this sync rule can reference a file
-that does not exist.  For example:
+To disable auto sync, simply provide a manual sync rule.  It does
+not matter if the sync rule does not match any actual files.
+For example:
 
 ```
 artifacts:
@@ -114,6 +115,8 @@ artifacts:
 ```
 
 ##### How it works
+
+Skaffold requires special collaboration from buildpacks for the `auto` sync to work.
 
 Cloud Native Buildpacks set a `io.buildpacks.build.metadata` label on the images they create.
 This labels points to json description of the [Bill-of-Materials, aka BOM](https://github.com/buildpacks/spec/blob/master/buildpack.md#bill-of-materials-toml) of the build.

--- a/docs/content/en/docs/pipeline-stages/filesync.md
+++ b/docs/content/en/docs/pipeline-stages/filesync.md
@@ -84,8 +84,36 @@ result in a complete rebuild.
 #### Buildpacks
 
 Skaffold requires special collaboration from the Buildpacks for the `auto` sync to work.
-The [gcr.io/buildpacks/builder:v1](https://github.com/GoogleCloudPlatform/buildpacks) supports Skaffold
-out of the box, currently for Go, NodeJS, and Java.
+The GCP Buildpacks builder [gcr.io/buildpacks/builder:v1](https://github.com/GoogleCloudPlatform/buildpacks)
+supports Skaffold syncing out of the box, currently for Go, NodeJS, and Java. 
+Auto sync is now enabled by default.
+
+Skaffold will automatically sync and relaunch applications for the following file types:
+
+- Go: *.go
+- Java: *.java, *.kt, *.scala, *.groovy, *.clj
+- NodeJS: *.js, *.mjs, *.coffee, *.litcoffee, *.json
+
+Changes to other file types trigger an image rebuild.
+
+##### Disable Auto Sync for Buildpacks
+
+To disable auto sync, provide a manual sync rule; this sync rule can reference a file
+that does not exist.  For example:
+
+```
+artifacts:
+- image: xxx
+  buildpacks:
+    builder: gcr.io/buildpacks/builder:v1
+  # disable buildpacks auto-sync
+  sync: 
+    manual: 
+    - src: .
+      dest: .
+```
+
+##### How it works
 
 Cloud Native Buildpacks set a `io.buildpacks.build.metadata` label on the images they create.
 This labels points to json description of the [Bill-of-Materials, aka BOM](https://github.com/buildpacks/spec/blob/master/buildpack.md#bill-of-materials-toml) of the build.

--- a/examples/buildpacks/skaffold.yaml
+++ b/examples/buildpacks/skaffold.yaml
@@ -7,7 +7,6 @@ build:
       builder: "gcr.io/buildpacks/builder:v1"
       env:
       - GOPROXY={{.GOPROXY}}
-    sync: {manual:[{src: ".", dest: "."}]}
 profiles:
 - name: gcb
   build:

--- a/examples/buildpacks/skaffold.yaml
+++ b/examples/buildpacks/skaffold.yaml
@@ -7,6 +7,7 @@ build:
       builder: "gcr.io/buildpacks/builder:v1"
       env:
       - GOPROXY={{.GOPROXY}}
+    sync: {manual:[{src: ".", dest: "."}]}
 profiles:
 - name: gcb
   build:


### PR DESCRIPTION
**Description**

With #4656 landing in Skaffold 1.14.0, we automatically enable autosync for buildpacks artifacts.  This PR documents what file types are supported, and how to disable auto-sync.