### PR TITLE
Skip cluster integration tests if changes only in docs folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ _integration_test: &integration_test
   os: linux
   language: minimal
   before_install:
-    #Skip integration tests if changes are only in the `docs` directory. This only works for a pull-request based development workflow like Skaffold's. 
+    # Skip integration tests for `docs`-only changes (only works for PR-based dev workflows like Skaffold's).
     - git diff --name-only "$TRAVIS_BRANCH"... | grep -v '^docs/' || travis_terminate 0
   cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ _integration_test: &integration_test
   os: linux
   language: minimal
   before_install:
-    - git diff --name-only "$TRAVIS_BRANCH"...HEAD | grep -v '^docs/' || travis_terminate 0
+    #Skip integration tests if changes are only in the `docs` directory. This only works for a pull-request based development workflow like Skaffold's. 
+    - git diff --name-only "$TRAVIS_BRANCH"... | grep -v '^docs/' || travis_terminate 0
   cache:
     directories:
       - $HOME/.cache/go-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ branches:
 _integration_test: &integration_test
   os: linux
   language: minimal
+  before_install:
+    - git diff --name-only "$TRAVIS_BRANCH"...HEAD | grep -v '^docs/' || travis_terminate 0
   cache:
     directories:
       - $HOME/.cache/go-build


### PR DESCRIPTION
Fixes #4808 
Skips integration tests in kind and k3d clusters when the only change in a PR is in the `docs` folder.