### PR TITLE
Fix `skaffold build | skaffold deploy` with `SKAFFOLD_DEFAULT_REPO` rewrites image name twice

### DIFF
--- a/pkg/skaffold/docker/default_repo.go
+++ b/pkg/skaffold/docker/default_repo.go
@@ -50,15 +50,15 @@ func SubstituteDefaultRepoIntoImage(defaultRepo string, image string) (string, e
 }
 
 func replace(defaultRepo string, baseImage string) string {
+	if strings.HasPrefix(baseImage, defaultRepo) {
+		return baseImage
+	}
 	originalPrefix := prefixRegex.FindString(baseImage)
 	defaultRepoPrefix := prefixRegex.FindString(defaultRepo)
 	if originalPrefix != "" && defaultRepoPrefix != "" {
 		// prefixes match
 		if originalPrefix == defaultRepoPrefix {
 			return defaultRepo + "/" + baseImage[len(originalPrefix):]
-		}
-		if strings.HasPrefix(baseImage, defaultRepo) {
-			return baseImage
 		}
 		// prefixes don't match, concatenate and truncate
 		return truncate(defaultRepo + "/" + baseImage)

--- a/pkg/skaffold/docker/default_repo_test.go
+++ b/pkg/skaffold/docker/default_repo_test.go
@@ -78,6 +78,12 @@ func TestImageReplaceDefaultRepo(t *testing.T) {
 			expectedImage: "gcr.io/k8s-skaffold/skaffold-example",
 		},
 		{
+			description:   "image has shared prefix with defaultRepo, but not gcr",
+			image:         "myrepo/skaffold-example",
+			defaultRepo:   "myrepo",
+			expectedImage: "myrepo/skaffold-example",
+		},
+		{
 			description:   "keep tag",
 			image:         "img:tag",
 			defaultRepo:   "gcr.io/default",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4809
