### PR TITLE
fix: skaffold debug does not work for helm deployments with multiple …

### DIFF
--- a/cmd/skaffold/app/cmd/filter.go
+++ b/cmd/skaffold/app/cmd/filter.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -64,7 +65,12 @@ func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildA
 		if err != nil {
 			return err
 		}
-		manifestList := manifest.ManifestList([][]byte{bytes})
+
+		var manifestList manifest.ManifestList
+		for _, manifestStr := range strings.Split(string(bytes), "---") {
+			manifestList = append(manifestList, []byte(manifestStr))
+		}
+
 		if debuggingFilters {
 			// TODO(bdealwis): refactor this code
 			debugHelpersRegistry, err := config.GetDebugHelpersRegistry(opts.GlobalConfig)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Fixes:** #4826 <!-- tracking issues that this PR will close -->
**Related**:https://github.com/GoogleContainerTools/skaffold/pull/4732 
**Merge before/after**: _None_
**Description**
This mr splits the rendered helm resources in the `skaffold filter` command on `---` which separates resources. Currently only the first resource is modified, this causes the debug command not to work.  In this mr the input on `filter` (the rendered helm resources) is split on `---` and to each resource the debugging transformations are applied.

<!-- Describe your changes here. The more detail, the easier the review! -->

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
I'd like to add some tests but there are currently no meaning full tests for the filter command (as far as I can see) which I can extend.  
