### PR TITLE
Fix `skaffold filter` to handle multiple yaml documents

### DIFF
--- a/cmd/skaffold/app/cmd/filter.go
+++ b/cmd/skaffold/app/cmd/filter.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -60,11 +59,7 @@ func NewCmdFilter() *cobra.Command {
 // Unlike `skaffold debug`, this filtering affects all images and not just the built artifacts.
 func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildArtifacts []build.Artifact) error {
 	return withRunner(ctx, func(r runner.Runner, cfg *latest.SkaffoldConfig) error {
-		bytes, err := ioutil.ReadAll(os.Stdin)
-		if err != nil {
-			return err
-		}
-		manifestList := manifest.ManifestList([][]byte{bytes})
+		manifestList := manifest.Load(os.Stdin)
 		if debuggingFilters {
 			// TODO(bdealwis): refactor this code
 			debugHelpersRegistry, err := config.GetDebugHelpersRegistry(opts.GlobalConfig)

--- a/cmd/skaffold/app/cmd/filter.go
+++ b/cmd/skaffold/app/cmd/filter.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 
@@ -59,16 +60,19 @@ func NewCmdFilter() *cobra.Command {
 // Unlike `skaffold debug`, this filtering affects all images and not just the built artifacts.
 func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildArtifacts []build.Artifact) error {
 	return withRunner(ctx, func(r runner.Runner, cfg *latest.SkaffoldConfig) error {
-		manifestList := manifest.Load(os.Stdin)
+		manifestList, err := manifest.Load(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("loading manifests: %w", err)
+		}
 		if debuggingFilters {
 			// TODO(bdealwis): refactor this code
 			debugHelpersRegistry, err := config.GetDebugHelpersRegistry(opts.GlobalConfig)
 			if err != nil {
-				return err
+				return fmt.Errorf("resolving debug helpers: %w", err)
 			}
 			insecureRegistries, err := getInsecureRegistries(opts, cfg)
 			if err != nil {
-				return err
+				return fmt.Errorf("retrieving insecure registries: %w", err)
 			}
 
 			manifestList, err = debugging.ApplyDebuggingTransforms(manifestList, buildArtifacts, manifest.Registries{
@@ -76,7 +80,7 @@ func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildA
 				InsecureRegistries:   insecureRegistries,
 			})
 			if err != nil {
-				return err
+				return fmt.Errorf("transforming manifests: %w", err)
 			}
 		}
 		out.Write([]byte(manifestList.String()))

--- a/pkg/skaffold/debug/debug_test.go
+++ b/pkg/skaffold/debug/debug_test.go
@@ -592,7 +592,9 @@ status: {}`,
 				return imageConfiguration{}, nil
 			}
 
-			result, err := applyDebuggingTransforms(manifest.Load(bytes.NewReader([]byte(test.in))), retriever, "HELPERS")
+			l, err := manifest.Load(bytes.NewReader([]byte(test.in)))
+			t.CheckError(false, err)
+			result, err := applyDebuggingTransforms(l, retriever, "HELPERS")
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.out, result.String())
 		})

--- a/pkg/skaffold/kubernetes/manifest/manifests.go
+++ b/pkg/skaffold/kubernetes/manifest/manifests.go
@@ -36,14 +36,15 @@ func Load(in io.Reader) (ManifestList, error) {
 	var docs [][]byte
 	for {
 		doc, err := r.Read()
-		if err == io.EOF {
-			break
-		} else {
+		switch {
+		case err == io.EOF:
+			return ManifestList(docs), nil
+		case err != nil:
 			return nil, err
+		default:
+			docs = append(docs, doc)
 		}
-		docs = append(docs, doc)
 	}
-	return ManifestList(docs), nil
 }
 
 func (l *ManifestList) String() string {

--- a/pkg/skaffold/kubernetes/manifest/manifests.go
+++ b/pkg/skaffold/kubernetes/manifest/manifests.go
@@ -31,17 +31,19 @@ import (
 type ManifestList [][]byte
 
 // Load uses the Kubernetes `apimachinery` to split YAML content into a set of YAML documents.
-func Load(in io.Reader) ManifestList {
+func Load(in io.Reader) (ManifestList, error) {
 	r := k8syaml.NewYAMLReader(bufio.NewReader(in))
 	var docs [][]byte
-	for i := 0; ; i++ {
+	for {
 		doc, err := r.Read()
 		if err == io.EOF {
 			break
+		} else {
+			return nil, err
 		}
 		docs = append(docs, doc)
 	}
-	return ManifestList(docs)
+	return ManifestList(docs), nil
 }
 
 func (l *ManifestList) String() string {

--- a/pkg/skaffold/kubernetes/manifest/manifests.go
+++ b/pkg/skaffold/kubernetes/manifest/manifests.go
@@ -17,15 +17,32 @@ limitations under the License.
 package manifest
 
 import (
+	"bufio"
 	"bytes"
 	"io"
 	"regexp"
 	"strings"
+
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // ManifestList is a list of yaml manifests.
 //nolint:golint
 type ManifestList [][]byte
+
+// Load uses the Kubernetes `apimachinery` to split YAML content into a set of YAML documents.
+func Load(in io.Reader) ManifestList {
+	r := k8syaml.NewYAMLReader(bufio.NewReader(in))
+	var docs [][]byte
+	for i := 0; ; i++ {
+		doc, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		docs = append(docs, doc)
+	}
+	return ManifestList(docs)
+}
 
 func (l *ManifestList) String() string {
 	var str string

--- a/pkg/skaffold/kubernetes/manifest/manifests_test.go
+++ b/pkg/skaffold/kubernetes/manifest/manifests_test.go
@@ -17,10 +17,33 @@ limitations under the License.
 package manifest
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
+
+func TestLoad(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{name: "empty", input: "", expected: []string{}},
+		{name: "single doc", input: "a: b", expected: []string{"a: b\n"}}, // note lf introduced
+		{name: "multiple docs", input: "a: b\n---\nc: d", expected: []string{"a: b\n", "c: d\n"}},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			result := Load(bytes.NewReader([]byte(test.input)))
+
+			t.CheckDeepEqual(len(test.expected), len(result))
+			for i := range test.expected {
+				t.CheckDeepEqual(test.expected[i], string(result[i]))
+			}
+		})
+	}
+}
 
 const pod1 = `apiVersion: v1
 kind: Pod

--- a/pkg/skaffold/kubernetes/manifest/manifests_test.go
+++ b/pkg/skaffold/kubernetes/manifest/manifests_test.go
@@ -35,8 +35,9 @@ func TestLoad(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
-			result := Load(bytes.NewReader([]byte(test.input)))
+			result, err := Load(bytes.NewReader([]byte(test.input)))
 
+			t.CheckError(false, err)
 			t.CheckDeepEqual(len(test.expected), len(result))
 			for i := range test.expected {
 				t.CheckDeepEqual(test.expected[i], string(result[i]))


### PR DESCRIPTION
Fixes: #4826, 
**Related**: #4827, #4732

**Description**
As discovered by @doriandekoning in #4826, the new Helm debug support does correctly handle the situation where a Helm chart may have multiple resources.

This PR does the following:
- it introduces a `manifest.Load()` function to create a `ManifestList` from a YAML input leveraging the `k8s.io/apimachinery`'s `YAMLReader`.
- `filter` now uses `manifest.Load()` to parse the manifests proferred on stdin
- adds a test for `debug` to verify that it applies to multiple manifests