### PR TITLE
Update mute-logs to not print output upon failure of build/deploy step

### DIFF
--- a/pkg/skaffold/build/logfile.go
+++ b/pkg/skaffold/build/logfile.go
@@ -45,7 +45,7 @@ func WithLogFile(builder ArtifactBuilder, muted Muted) ArtifactBuilder {
 		// Run the build.
 		digest, err := builder(ctx, file, artifact, tag)
 
-		// After the build finishes, close the log file. If the build failed, print the full log to the console.
+		// After the build finishes, close the log file.
 		file.Close()
 
 		return digest, err

--- a/pkg/skaffold/build/logfile.go
+++ b/pkg/skaffold/build/logfile.go
@@ -17,7 +17,6 @@ limitations under the License.
 package build
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -43,18 +42,11 @@ func WithLogFile(builder ArtifactBuilder, muted Muted) ArtifactBuilder {
 		}
 		fmt.Fprintln(out, " - writing logs to", file.Name())
 
-		// Print logs to a memory buffer and to a file.
-		var buf bytes.Buffer
-		w := io.MultiWriter(file, &buf)
-
 		// Run the build.
-		digest, err := builder(ctx, w, artifact, tag)
+		digest, err := builder(ctx, file, artifact, tag)
 
 		// After the build finishes, close the log file. If the build failed, print the full log to the console.
 		file.Close()
-		if err != nil {
-			buf.WriteTo(out)
-		}
 
 		return digest, err
 	}

--- a/pkg/skaffold/build/logfile_test.go
+++ b/pkg/skaffold/build/logfile_test.go
@@ -78,7 +78,8 @@ func TestWithLogFile(t *testing.T) {
 			muted:          muted(true),
 			shouldErr:      true,
 			expectedDigest: "",
-			logsFound:      []string{logFilename, logBuildFailed},
+			logsFound:      []string{logFilename},
+			logsNotFound:   []string{logBuildInProgress},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/build/logfile_test.go
+++ b/pkg/skaffold/build/logfile_test.go
@@ -79,7 +79,7 @@ func TestWithLogFile(t *testing.T) {
 			shouldErr:      true,
 			expectedDigest: "",
 			logsFound:      []string{logFilename},
-			logsNotFound:   []string{logBuildInProgress},
+			logsNotFound:   []string{logBuildFailed},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/deploy/util/logfile.go
+++ b/pkg/skaffold/deploy/util/logfile.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 
@@ -33,28 +32,21 @@ type Muted interface {
 }
 
 // WithLogFile returns a multiwriter that writes both to a file and a buffer, with the buffer being written to the provided output buffer in case of error
-func WithLogFile(filename string, out io.Writer, muted Muted) (io.Writer, func(error), error) {
+func WithLogFile(filename string, out io.Writer, muted Muted) (io.Writer, func(), error) {
 	if !muted.MuteDeploy() {
-		return out, func(error) {}, nil
+		return out, func() {}, nil
 	}
 
 	file, err := logfile.Create("deploy", filename)
 	if err != nil {
-		return out, func(error) {}, fmt.Errorf("unable to create log file for deploy step: %w", err)
+		return out, func() {}, fmt.Errorf("unable to create log file for deploy step: %w", err)
 	}
 
 	color.Default.Fprintln(out, "Starting deploy...")
 	fmt.Fprintln(out, "- writing logs to", file.Name())
 
-	// Print logs to a memory buffer and to a file.
-	var buf bytes.Buffer
-	w := io.MultiWriter(file, &buf)
-
 	// After the deploy finishes, close the log file. If the deploy failed, print the full log to output buffer.
-	return w, func(deployErr error) {
+	return file, func() {
 		file.Close()
-		if deployErr != nil {
-			buf.WriteTo(out)
-		}
 	}, err
 }

--- a/pkg/skaffold/deploy/util/logfile.go
+++ b/pkg/skaffold/deploy/util/logfile.go
@@ -31,7 +31,7 @@ type Muted interface {
 	MuteDeploy() bool
 }
 
-// WithLogFile returns a multiwriter that writes both to a file and a buffer, with the buffer being written to the provided output buffer in case of error
+// WithLogFile returns a file to write the deploy output to, and a function to be executed after the deploy step is complete.
 func WithLogFile(filename string, out io.Writer, muted Muted) (io.Writer, func(), error) {
 	if !muted.MuteDeploy() {
 		return out, func() {}, nil
@@ -45,7 +45,7 @@ func WithLogFile(filename string, out io.Writer, muted Muted) (io.Writer, func()
 	color.Default.Fprintln(out, "Starting deploy...")
 	fmt.Fprintln(out, "- writing logs to", file.Name())
 
-	// After the deploy finishes, close the log file. If the deploy failed, print the full log to output buffer.
+	// After the deploy finishes, close the log file.
 	return file, func() {
 		file.Close()
 	}, err

--- a/pkg/skaffold/deploy/util/logfile_test.go
+++ b/pkg/skaffold/deploy/util/logfile_test.go
@@ -73,7 +73,8 @@ func TestWithLogFile(t *testing.T) {
 			muted:              muted(true),
 			shouldErr:          true,
 			expectedNamespaces: nil,
-			logsFound:          []string{logFilename, logDeployFailed},
+			logsFound:          []string{logFilename},
+			logsNotFound:       []string{logDeployFailed},
 		},
 	}
 	for _, test := range tests {
@@ -87,7 +88,7 @@ func TestWithLogFile(t *testing.T) {
 
 			deployOut, postDeployFn, _ := WithLogFile("deploy.log", &mockOut, test.muted)
 			namespaces, err := deployer.Deploy(context.Background(), deployOut, nil)
-			postDeployFn(err)
+			postDeployFn()
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedNamespaces, namespaces)
 			for _, found := range test.logsFound {

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -74,7 +74,7 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 	event.DeployInProgress()
 	namespaces, err := r.deployer.Deploy(ctx, deployOut, artifacts)
 	r.hasDeployed = true
-	postDeployFn(err)
+	postDeployFn()
 	if err != nil {
 		event.DeployFailed(err)
 		return err


### PR DESCRIPTION
Fixes #4816 

Previously when using `--mute-logs` with skaffold commands, the output of a command would be dumped to a user's terminal upon failure of the current step. This PR aims to fix that, by only printing the error message. The user can then view the log file if they need more context or would like to see the whole output.

Tests have been updated to ensure that the normal output is not being printed upon failure of a step.
