### PR TITLE
Remove Warning message "The additionalFlags field in kaniko is deprecated"

### DIFF
--- a/pkg/skaffold/build/cluster/pod.go
+++ b/pkg/skaffold/build/cluster/pod.go
@@ -244,9 +244,8 @@ func kanikoArgs(artifact *latest.KanikoArtifact, tag string, insecureRegistries 
 		"--destination", tag,
 		"-v", logLevel().String()}
 
-	// TODO: remove since AdditionalFlags will be deprecated (priyawadhwa@)
 	if artifact.AdditionalFlags != nil {
-		logrus.Warn("The additionalFlags field in kaniko is deprecated, please consult the current schema at skaffold.dev to update your skaffold.yaml.")
+		logrus.Trace("kaniko additionalFlags are ", strings.Join(artifact.AdditionalFlags, " "))
 		args = append(args, artifact.AdditionalFlags...)
 	}
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/4852

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
To avoid confusion remove the warning message `The additionalFlags field in kaniko is deprecated`

**User facing changes**

<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

Given a `skaffold.yaml`
```yaml
profiles:
- name: oncluster
  build:
    artifacts:
    - image: myregistry/myimage:mytag
      kaniko:
        image: gcr.io/kaniko-project/executor:v1.0.0
        flags: 
          - --snapshotMode=redo
          - --verbosity=info
```

* Before:
```
level=warning msg="The additionalFlags field in kaniko is deprecated, please consult the current schema at skaffold.dev to update your skaffold.yaml."
```
* After:

No warning messages

But if `--verbosity=TRACE` 

```
TRAC[0004] kaniko additionalFlags are --snapshotMode=redo --verbosity=info 
```
<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
