### PR TITLE
Only load images into k3d and kind when images are local

### DIFF
--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -59,7 +59,7 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 		return fmt.Errorf("unable to connect to Kubernetes: %w", err)
 	}
 
-	if config.IsImageLoadingRequired(r.runCtx.GetKubeContext()) {
+	if r.imagesAreLocal && config.IsImageLoadingRequired(r.runCtx.GetKubeContext()) {
 		err := r.loadImagesIntoCluster(ctx, out, artifacts)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes: #4841

**Description**
Skaffold shouldn't attempt to load images into `kind` or `k3d` when the images were not built locally.
