### PR TITLE
Skaffold init support for polyglot-maven projects

### DIFF
--- a/pkg/skaffold/build/jib/init.go
+++ b/pkg/skaffold/build/jib/init.go
@@ -93,25 +93,9 @@ func validate(path string, enableGradleAnalysis bool) []ArtifactConfig {
 		builderType = JibMaven
 		executable = "mvn"
 		wrapper = "mvnw"
-		searchString = "<artifactId>jib-maven-plugin</artifactId>"
+		searchString = "jib-maven-plugin"
 		taskName = "jib:_skaffold-init"
 		consoleFlag = "--batch-mode"
-
-		// Polyglot maven support: support pom files of different extension types
-		switch filepath.Ext(path) {
-		case ".atom", ".java", ".rb", ".kt", ".kts", ".ktm": // all define the plugin with similar syntax
-			searchString = ":jib-maven-plugin"
-		case ".clj":
-			searchString = "/jib-maven-plugin"
-		case ".groovy":
-			searchString = "artifactId 'jib-maven-plugin'"
-		case ".scala":
-			searchString = `% "jib-maven-plugin"`
-		case ".xml":
-			searchString = "<artifactId>jib-maven-plugin</artifactId>"
-		case ".yaml", ".yml":
-			searchString = "artifactId: jib-maven-plugin"
-		}
 
 	case enableGradleAnalysis && (strings.HasSuffix(path, "build.gradle") || strings.HasSuffix(path, "build.gradle.kts")):
 		builderType = JibGradle

--- a/pkg/skaffold/build/jib/init_test.go
+++ b/pkg/skaffold/build/jib/init_test.go
@@ -137,6 +137,28 @@ BEGIN JIB JSON
 				{BuilderName: PluginName(JibMaven), File: "path/to/pom.xml", Project: "project2"},
 			},
 		},
+		{
+			description:  "jib maven pom.atom single module",
+			path:         "path/to/pom.atom",
+			fileContents: "com.google.cloud.tools:jib-maven-plugin",
+			command:      "mvn jib:_skaffold-init -q --batch-mode",
+			stdout: `BEGIN JIB JSON
+{"image":"image","project":"project"}`,
+			expectedConfig: []ArtifactConfig{
+				{BuilderName: PluginName(JibMaven), File: "path/to/pom.atom", Image: "image", Project: "project"},
+			},
+		},
+		{
+			description:  "jib maven pom.scala single module",
+			path:         "path/to/pom.scala",
+			fileContents: `"com.google.cloud.tools" % "jib-maven-plugin"`,
+			command:      "mvn jib:_skaffold-init -q --batch-mode",
+			stdout: `BEGIN JIB JSON
+{"image":"image","project":"project"}`,
+			expectedConfig: []ArtifactConfig{
+				{BuilderName: PluginName(JibMaven), File: "path/to/pom.scala", Image: "image", Project: "project"},
+			},
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/skaffold/issues/4335

Adds support for `skaffold init` to detect jib as a builder in different pom file extensions that are supported by https://github.com/takari/polyglot-maven.

I've added tests for a couple of extensions, but wasn't sure if I should for each case because I didn't want to clutter the tests with what is essentially just testing string matching