### PR TITLE
Introduce `fromImage` field in jib builder interface.

### DIFF
--- a/docs/content/en/schemas/v2beta9.json
+++ b/docs/content/en/schemas/v2beta9.json
@@ -1503,6 +1503,11 @@
             "[\"--no-build-cache\"]"
           ]
         },
+        "fromImage": {
+          "type": "string",
+          "description": "overrides the default jib base image.",
+          "x-intellij-html-description": "overrides the default jib base image."
+        },
         "project": {
           "type": "string",
           "description": "selects which sub-project to build for multi-module builds.",
@@ -1521,7 +1526,8 @@
       "preferredOrder": [
         "project",
         "args",
-        "type"
+        "type",
+        "fromImage"
       ],
       "additionalProperties": false,
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",

--- a/docs/content/en/schemas/v2beta9.json
+++ b/docs/content/en/schemas/v2beta9.json
@@ -1505,8 +1505,8 @@
         },
         "fromImage": {
           "type": "string",
-          "description": "overrides the default jib base image.",
-          "x-intellij-html-description": "overrides the default jib base image."
+          "description": "overrides the configured jib base image.",
+          "x-intellij-html-description": "overrides the configured jib base image."
         },
         "project": {
           "type": "string",

--- a/integration/examples/jib-sync/README.md
+++ b/integration/examples/jib-sync/README.md
@@ -63,33 +63,22 @@ build:
 
 This example is designed around the functionality available in [Spring Boot Developer Tools](https://docs.spring.io/spring-boot/docs/current/reference/html/using-spring-boot.html#using-boot-devtools) for developing against running applications.
 
-Some additional steps in your java build are required for this to work:
-- Sync requires `tar` on the running container to copy files over. The default base image that Jib uses `gcr.io/distroless/java` does not include `tar` or any utilities. During development you must use a base image that includes `tar`, in this example we use the `debug` flavor of distroless: `gcr.io/distroless/java:debug` 
+Some additional steps are required for this to work:
+- Sync requires `tar` on the running container to copy files over. The default base image that Jib uses `gcr.io/distroless/java` does not include `tar` or any utilities. During development, you must use a base image that includes `tar`, in this example we use the `debug` flavor of distroless: `gcr.io/distroless/java:debug` 
 
-`maven`
-```xml
-<plugin>
-  <groupId>com.google.cloud.tools</groupId>
-  <artifactId>jib-maven-plugin</artifactId>
-  <version>${jib.maven-plugin-version}</version>
-  <configuration>
-    ...
-    <from>
-      <image>gcr.io/distroless/java:debug</image>
-    </from>
-  </configuration>
-</plugin>
+This can be done directly in the artifact configuration by overriding the `fromImage` property.
+
+```yaml
+build:
+  artifacts:
+  - image: skaffold-example
+    context: .
+    jib: 
+      fromImage: gcr.io/distroless/java:debug
+    sync: 
+      auto: {}
 ```
 
-`gradle`
-```groovy
-jib {
-  ...
-  from {
-    image = "gcr.io/distroless/java:debug"
-  }
-}
-```
 
 - You must include the `spring-boot-devtools` dependency at the `compile/implementation` scope, which is contrary to the configuration outlined in the [official docs](https://docs.spring.io/spring-boot/docs/current/reference/html/using-spring-boot.html#using-boot-devtools). Because jib is unaware of any special spring only configuration in your builds, we recommend using profiles to turn on or off devtools support in your jib container builds.
 
@@ -97,7 +86,7 @@ jib {
 ```xml
 <profiles>
   <profile>
-    <id>sync<id>
+    <id>sync</id>
     <dependencies>
       <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/integration/examples/jib-sync/build.gradle
+++ b/integration/examples/jib-sync/build.gradle
@@ -21,9 +21,3 @@ dependencies {
 
   testImplementation "org.springframework.boot:spring-boot-starter-test"
 }
-
-jib {
-  from {
-    image = "gcr.io/distroless/java:debug"
-  }
-}

--- a/integration/examples/jib-sync/pom.xml
+++ b/integration/examples/jib-sync/pom.xml
@@ -37,9 +37,6 @@
         <artifactId>jib-maven-plugin</artifactId>
         <version>${jib.maven-plugin-version}</version>
         <configuration>
-          <from>
-            <image>gcr.io/distroless/java:debug</image>
-          </from>
           <container>
             <jvmFlags>
               <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>

--- a/integration/examples/jib-sync/skaffold-gradle.yaml
+++ b/integration/examples/jib-sync/skaffold-gradle.yaml
@@ -7,6 +7,7 @@ build:
       type: gradle
       args: 
       - -Psync
+      fromImage: gcr.io/distroless/java:debug
     sync:
       auto: {}
 

--- a/integration/examples/jib-sync/skaffold-maven.yaml
+++ b/integration/examples/jib-sync/skaffold-maven.yaml
@@ -8,6 +8,7 @@ build:
       args: 
       - --no-transfer-progress
       - -Psync
+      fromImage: gcr.io/distroless/java:debug
     sync:
       auto: {}
 

--- a/integration/examples/jib-sync/src/main/java/hello/HelloController.java
+++ b/integration/examples/jib-sync/src/main/java/hello/HelloController.java
@@ -13,6 +13,6 @@ public class HelloController {
 
     @RequestMapping("/")
     public String index() throws Exception {
-        return "text-to-replace\n";
+        return "text-to-change\n";
     }
 }

--- a/integration/examples/jib-sync/src/main/java/hello/HelloController.java
+++ b/integration/examples/jib-sync/src/main/java/hello/HelloController.java
@@ -13,6 +13,6 @@ public class HelloController {
 
     @RequestMapping("/")
     public String index() throws Exception {
-        return "text-to-change\n";
+        return "text-to-replace\n";
     }
 }

--- a/pkg/skaffold/build/jib/gradle.go
+++ b/pkg/skaffold/build/jib/gradle.go
@@ -103,7 +103,9 @@ func GenerateGradleBuildArgs(task string, imageName string, a *latest.JibArtifac
 		// jib doesn't support marking specific registries as insecure
 		args = append(args, "-Djib.allowInsecureRegistries=true")
 	}
-
+	if a.BaseImage != "" {
+		args = append(args, fmt.Sprintf("-Djib.from.image=%s", a.BaseImage))
+	}
 	args = append(args, "--image="+imageName)
 	return args
 }

--- a/pkg/skaffold/build/jib/gradle_test.go
+++ b/pkg/skaffold/build/jib/gradle_test.go
@@ -56,6 +56,13 @@ func TestBuildJibGradleToDocker(t *testing.T) {
 			),
 		},
 		{
+			description: "build with custom base image",
+			artifact:    &latest.JibArtifact{BaseImage: "docker://busybox"},
+			commands: testutil.CmdRun(
+				"gradle fake-gradleBuildArgs-for-jibDockerBuild -Djib.from.image=docker://busybox --image=img:tag",
+			),
+		},
+		{
 			description: "fail build",
 			artifact:    &latest.JibArtifact{},
 			commands: testutil.CmdRunErr(
@@ -112,6 +119,13 @@ func TestBuildJibGradleToRegistry(t *testing.T) {
 			artifact:    &latest.JibArtifact{Project: "project"},
 			commands: testutil.CmdRun(
 				"gradle fake-gradleBuildArgs-for-project-for-jib --image=img:tag",
+			),
+		},
+		{
+			description: "build with custom base image",
+			artifact:    &latest.JibArtifact{BaseImage: "docker://busybox"},
+			commands: testutil.CmdRun(
+				"gradle fake-gradleBuildArgs-for-jib -Djib.from.image=docker://busybox --image=img:tag",
 			),
 		},
 		{
@@ -337,6 +351,8 @@ func TestGenerateGradleBuildArgs(t *testing.T) {
 		{"multi module", latest.JibArtifact{Project: "project"}, "image", false, nil, []string{"fake-gradleBuildArgs-for-project-for-testTask", "--image=image"}},
 		{"multi module without tests", latest.JibArtifact{Project: "project"}, "image", true, nil, []string{"fake-gradleBuildArgs-for-project-for-testTask-skipTests", "--image=image"}},
 		{"multi module without tests with insecure registries", latest.JibArtifact{Project: "project"}, "registry.tld/image", true, map[string]bool{"registry.tld": true}, []string{"fake-gradleBuildArgs-for-project-for-testTask-skipTests", "-Djib.allowInsecureRegistries=true", "--image=registry.tld/image"}},
+		{"single module with custom base image", latest.JibArtifact{BaseImage: "docker://busybox"}, "image", false, nil, []string{"fake-gradleBuildArgs-for-testTask", "-Djib.from.image=docker://busybox", "--image=image"}},
+		{"multi module with custom base image", latest.JibArtifact{Project: "project", BaseImage: "docker://busybox"}, "image", false, nil, []string{"fake-gradleBuildArgs-for-project-for-testTask", "-Djib.from.image=docker://busybox", "--image=image"}},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {

--- a/pkg/skaffold/build/jib/maven.go
+++ b/pkg/skaffold/build/jib/maven.go
@@ -104,6 +104,9 @@ func GenerateMavenBuildArgs(goal string, imageName string, a *latest.JibArtifact
 		// jib doesn't support marking specific registries as insecure
 		args = append(args, "-Djib.allowInsecureRegistries=true")
 	}
+	if a.BaseImage != "" {
+		args = append(args, fmt.Sprintf("-Djib.from.image=%s", a.BaseImage))
+	}
 	args = append(args, "-Dimage="+imageName)
 
 	return args

--- a/pkg/skaffold/build/jib/maven_test.go
+++ b/pkg/skaffold/build/jib/maven_test.go
@@ -56,6 +56,13 @@ func TestBuildJibMavenToDocker(t *testing.T) {
 			),
 		},
 		{
+			description: "build with custom base image",
+			artifact:    &latest.JibArtifact{BaseImage: "docker://busybox"},
+			commands: testutil.CmdRun(
+				"mvn fake-mavenBuildArgs-for-dockerBuild -Djib.from.image=docker://busybox -Dimage=img:tag",
+			),
+		},
+		{
 			description: "fail build",
 			artifact:    &latest.JibArtifact{},
 			commands: testutil.CmdRunErr(
@@ -109,6 +116,11 @@ func TestBuildJibMavenToRegistry(t *testing.T) {
 			description: "build with module",
 			artifact:    &latest.JibArtifact{Project: "module"},
 			commands:    testutil.CmdRun("mvn fake-mavenBuildArgs-for-module-for-build -Dimage=img:tag"),
+		},
+		{
+			description: "build with custom base image",
+			artifact:    &latest.JibArtifact{BaseImage: "docker://busybox"},
+			commands:    testutil.CmdRun("mvn fake-mavenBuildArgs-for-build -Djib.from.image=docker://busybox -Dimage=img:tag"),
 		},
 		{
 			description: "fail build",
@@ -325,6 +337,8 @@ func TestGenerateMavenBuildArgs(t *testing.T) {
 		{"multi module", latest.JibArtifact{Project: "module"}, "image", false, nil, []string{"fake-mavenBuildArgs-for-module-for-test-goal", "-Dimage=image"}},
 		{"multi module without tests", latest.JibArtifact{Project: "module"}, "image", true, nil, []string{"fake-mavenBuildArgs-for-module-for-test-goal-skipTests", "-Dimage=image"}},
 		{"multi module without tests with insecure-registry", latest.JibArtifact{Project: "module"}, "registry.tld/image", true, map[string]bool{"registry.tld": true}, []string{"fake-mavenBuildArgs-for-module-for-test-goal-skipTests", "-Djib.allowInsecureRegistries=true", "-Dimage=registry.tld/image"}},
+		{"single module with custom base image", latest.JibArtifact{BaseImage: "docker://busybox"}, "image", false, nil, []string{"fake-mavenBuildArgs-for-test-goal", "-Djib.from.image=docker://busybox", "-Dimage=image"}},
+		{"multi module with custom base image", latest.JibArtifact{Project: "module", BaseImage: "docker://busybox"}, "image", false, nil, []string{"fake-mavenBuildArgs-for-module-for-test-goal", "-Djib.from.image=docker://busybox", "-Dimage=image"}},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1077,4 +1077,7 @@ type JibArtifact struct {
 	// `maven`: for Maven.
 	// `gradle`: for Gradle.
 	Type string `yaml:"type,omitempty"`
+
+	// BaseImage overrides the default jib base image.
+	BaseImage string `yaml:"fromImage,omitempty"`
 }

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1078,6 +1078,6 @@ type JibArtifact struct {
 	// `gradle`: for Gradle.
 	Type string `yaml:"type,omitempty"`
 
-	// BaseImage overrides the default jib base image.
+	// BaseImage overrides the configured jib base image.
 	BaseImage string `yaml:"fromImage,omitempty"`
 }


### PR DESCRIPTION
**Related**: #4713 
This PR introduces `fromImage` as a property in the `jib` builder to override the configured base image. 
It's required in the implementation of [supporting artifact dependencies](https://github.com/GoogleContainerTools/skaffold/blob/master/docs/design_proposals/artifact-dependencies.md#jib-builder)


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
