### PR TITLE
Support minikube 1.13.0 and later with `--vm-driver=none`

### DIFF
--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -36,7 +36,9 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
 
-const minikubeBadUsageExitCode = 64
+// minikube 1.13.0 renumbered exit codes
+const minikubeDriverConfictExitCode = 51
+const oldMinikubeBadUsageExitCode = 64
 
 // For testing
 var (
@@ -104,9 +106,11 @@ type ExitCoder interface {
 func newMinikubeAPIClient(minikubeProfile string) ([]string, client.CommonAPIClient, error) {
 	env, err := getMinikubeDockerEnv(minikubeProfile)
 	if err != nil {
-		// When minikube uses the infamous `none` driver, it'll exit `minikube docker-env` with code 64.
+		// When minikube uses the infamous `none` driver, `minikube docker-env` will exit with
+		// code 51 (>= 1.13.0) or 64 (< 1.13.0).  Note that exit code 51 was unused prior to 1.13.0
+		// so it is safe to check here without knowing the minikube version.
 		var exitError ExitCoder
-		if errors.As(err, &exitError) && exitError.ExitCode() == minikubeBadUsageExitCode {
+		if errors.As(err, &exitError) && (exitError.ExitCode() == minikubeDriverConfictExitCode || exitError.ExitCode() == oldMinikubeBadUsageExitCode) {
 			// Let's ignore the error and fall back to local docker daemon.
 			logrus.Warnf("Could not get minikube docker env, falling back to local docker daemon: %s", err)
 			return newEnvAPIClient()


### PR DESCRIPTION
Fixes: #4868

**Description**
Minikube 1.13.0 changed its exit codes, such that `minikube docker-env` for a profie with `vm-driver=none` now exits with 51 (ExDriverConflict), and not 64 (`BadUsage`) like before.  Exit code 51 [was unused prior to minikube 1.13.0](https://github.com/tstromberg/minikube/commit/2c5e8fdaeed10bfdd1efc393f71adc08add33fb2#diff-76970ce10bc468800abc1ea1b03e407cL30-L43), so we can just check minikube's exit code for both values.
