### PR TITLE
Extended Kaniko support

### DIFF
--- a/docs/content/en/schemas/v2beta9.json
+++ b/docs/content/en/schemas/v2beta9.json
@@ -1633,6 +1633,17 @@
           "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
           "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
         },
+        "cleanup": {
+          "type": "boolean",
+          "description": "to clean the filesystem at the end of the build.",
+          "x-intellij-html-description": "to clean the filesystem at the end of the build.",
+          "default": "false"
+        },
+        "digestFile": {
+          "type": "string",
+          "description": "to to specify a file in the container. This file will receive the digest of a built image. This can be used to automatically track the exact image built by kaniko.",
+          "x-intellij-html-description": "to to specify a file in the container. This file will receive the digest of a built image. This can be used to automatically track the exact image built by kaniko."
+        },
         "dockerfile": {
           "type": "string",
           "description": "locates the Dockerfile relative to workspace.",
@@ -1655,15 +1666,92 @@
           "x-intellij-html-description": "additional flags to be passed to Kaniko command line. See <a href=\"https://github.com/GoogleContainerTools/kaniko#additional-flags\">Kaniko Additional Flags</a>. Deprecated - instead the named, unique fields should be used, e.g. <code>buildArgs</code>, <code>cache</code>, <code>target</code>.",
           "default": "[]"
         },
+        "force": {
+          "type": "boolean",
+          "description": "building outside of a container.",
+          "x-intellij-html-description": "building outside of a container.",
+          "default": "false"
+        },
         "image": {
           "type": "string",
           "description": "Docker image used by the Kaniko pod. Defaults to the latest released version of `gcr.io/kaniko-project/executor`.",
           "x-intellij-html-description": "Docker image used by the Kaniko pod. Defaults to the latest released version of <code>gcr.io/kaniko-project/executor</code>."
         },
+        "imageNameWithDigestFile": {
+          "type": "string",
+          "description": "to a file to save the image name with digest of the built image to.",
+          "x-intellij-html-description": "to a file to save the image name with digest of the built image to."
+        },
         "initImage": {
           "type": "string",
           "description": "image used to run init container which mounts kaniko context.",
           "x-intellij-html-description": "image used to run init container which mounts kaniko context."
+        },
+        "insecure": {
+          "type": "boolean",
+          "description": "if you want to push images to a plain HTTP registry.",
+          "x-intellij-html-description": "if you want to push images to a plain HTTP registry.",
+          "default": "false"
+        },
+        "insecurePull": {
+          "type": "boolean",
+          "description": "if you want to pull images from a plain HTTP registry.",
+          "x-intellij-html-description": "if you want to pull images from a plain HTTP registry.",
+          "default": "false"
+        },
+        "insecureRegistry": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "to use plain HTTP requests when accessing a registry.",
+          "x-intellij-html-description": "to use plain HTTP requests when accessing a registry.",
+          "default": "[]"
+        },
+        "label": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "key: value to set some metadata to the final image. This is equivalent as using the LABEL within the Dockerfile.",
+          "x-intellij-html-description": "key: value to set some metadata to the final image. This is equivalent as using the LABEL within the Dockerfile.",
+          "default": "{}"
+        },
+        "logFormat": {
+          "type": "string",
+          "description": "<text|color|json> to set the log format.",
+          "x-intellij-html-description": "<text|color|json> to set the log format."
+        },
+        "logTimestamp": {
+          "type": "boolean",
+          "description": "to add timestamps to log format.",
+          "x-intellij-html-description": "to add timestamps to log format.",
+          "default": "false"
+        },
+        "noPush": {
+          "type": "boolean",
+          "description": "if you only want to build the image, without pushing to a registry.",
+          "x-intellij-html-description": "if you only want to build the image, without pushing to a registry.",
+          "default": "false"
+        },
+        "ociLayoutPath": {
+          "type": "string",
+          "description": "to specify a directory in the container where the OCI image layout of a built image will be placed. This can be used to automatically track the exact image built by kaniko.",
+          "x-intellij-html-description": "to specify a directory in the container where the OCI image layout of a built image will be placed. This can be used to automatically track the exact image built by kaniko."
+        },
+        "registryCertificate": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "to to provide a certificate for TLS communication with a given registry. my.registry.url: /path/to/the/certificate.cert is the expected format.",
+          "x-intellij-html-description": "to to provide a certificate for TLS communication with a given registry. my.registry.url: /path/to/the/certificate.cert is the expected format.",
+          "default": "{}"
+        },
+        "registryMirror": {
+          "type": "string",
+          "description": "if you want to use a registry mirror instead of default `index.docker.io`.",
+          "x-intellij-html-description": "if you want to use a registry mirror instead of default <code>index.docker.io</code>."
         },
         "reproducible": {
           "type": "boolean",
@@ -1671,16 +1759,64 @@
           "x-intellij-html-description": "used to strip timestamps out of the built image.",
           "default": "false"
         },
+        "singleSnapshot": {
+          "type": "boolean",
+          "description": "takes a single snapshot of the filesystem at the end of the build. So only one layer will be appended to the base image.",
+          "x-intellij-html-description": "takes a single snapshot of the filesystem at the end of the build. So only one layer will be appended to the base image.",
+          "default": "false"
+        },
         "skipTLS": {
           "type": "boolean",
-          "description": "skips TLS verification when pulling and pushing the image.",
-          "x-intellij-html-description": "skips TLS verification when pulling and pushing the image.",
+          "description": "skips TLS certificate validation when pushing to a registry.",
+          "x-intellij-html-description": "skips TLS certificate validation when pushing to a registry.",
           "default": "false"
+        },
+        "skipTLSVerifyPull": {
+          "type": "boolean",
+          "description": "skips TLS certificate validation when pulling from a registry.",
+          "x-intellij-html-description": "skips TLS certificate validation when pulling from a registry.",
+          "default": "false"
+        },
+        "skipTLSVerifyRegistry": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "skips TLS certificate validation when accessing a registry.",
+          "x-intellij-html-description": "skips TLS certificate validation when accessing a registry.",
+          "default": "[]"
+        },
+        "skipUnusedStages": {
+          "type": "boolean",
+          "description": "builds only used stages if defined to true. Otherwise it builds by default all stages, even the unnecessaries ones until it reaches the target stage / end of Dockerfile.",
+          "x-intellij-html-description": "builds only used stages if defined to true. Otherwise it builds by default all stages, even the unnecessaries ones until it reaches the target stage / end of Dockerfile.",
+          "default": "false"
+        },
+        "snapshotMode": {
+          "type": "string",
+          "description": "how Kaniko will snapshot the filesystem.",
+          "x-intellij-html-description": "how Kaniko will snapshot the filesystem."
+        },
+        "tarPath": {
+          "type": "string",
+          "description": "path to save the image as a tarball at path instead of pushing the image.",
+          "x-intellij-html-description": "path to save the image as a tarball at path instead of pushing the image."
         },
         "target": {
           "type": "string",
-          "description": "Dockerfile target name to build.",
-          "x-intellij-html-description": "Dockerfile target name to build."
+          "description": "to indicate which build stage is the target build stage.",
+          "x-intellij-html-description": "to indicate which build stage is the target build stage."
+        },
+        "useNewRun": {
+          "type": "boolean",
+          "description": "to Use the experimental run implementation for detecting changes without requiring file system snapshots. In some cases, this may improve build performance by 75%.",
+          "x-intellij-html-description": "to Use the experimental run implementation for detecting changes without requiring file system snapshots. In some cases, this may improve build performance by 75%.",
+          "default": "false"
+        },
+        "verbosity": {
+          "type": "string",
+          "description": "<panic|fatal|error|warn|info|debug|trace> to set the logging level.",
+          "x-intellij-html-description": "<panic|fatal|error|warn|info|debug|trace> to set the logging level."
         },
         "volumeMounts": {
           "items": {},
@@ -1688,19 +1824,48 @@
           "description": "volume mounts passed to kaniko pod.",
           "x-intellij-html-description": "volume mounts passed to kaniko pod.",
           "default": "[]"
+        },
+        "whitelistVarRun": {
+          "type": "boolean",
+          "description": "used to ignore `/var/run` when taking image snapshot. Set it to false to preserve /var/run/* in destination image.",
+          "x-intellij-html-description": "used to ignore <code>/var/run</code> when taking image snapshot. Set it to false to preserve /var/run/* in destination image.",
+          "default": "false"
         }
       },
       "preferredOrder": [
-        "flags",
+        "cleanup",
+        "insecure",
+        "insecurePull",
+        "noPush",
+        "force",
+        "logTimestamp",
+        "reproducible",
+        "singleSnapshot",
+        "skipTLS",
+        "skipTLSVerifyPull",
+        "skipUnusedStages",
+        "useNewRun",
+        "whitelistVarRun",
         "dockerfile",
         "target",
-        "buildArgs",
-        "env",
         "initImage",
         "image",
+        "digestFile",
+        "imageNameWithDigestFile",
+        "logFormat",
+        "ociLayoutPath",
+        "registryMirror",
+        "snapshotMode",
+        "tarPath",
+        "verbosity",
+        "flags",
+        "insecureRegistry",
+        "skipTLSVerifyRegistry",
+        "env",
         "cache",
-        "reproducible",
-        "skipTLS",
+        "registryCertificate",
+        "label",
+        "buildArgs",
         "volumeMounts"
       ],
       "additionalProperties": false,
@@ -1718,11 +1883,17 @@
           "type": "string",
           "description": "a remote repository to store cached layers. If none is specified, one will be inferred from the image name. See [Kaniko Caching](https://github.com/GoogleContainerTools/kaniko#caching).",
           "x-intellij-html-description": "a remote repository to store cached layers. If none is specified, one will be inferred from the image name. See <a href=\"https://github.com/GoogleContainerTools/kaniko#caching\">Kaniko Caching</a>."
+        },
+        "ttl": {
+          "type": "string",
+          "description": "Cache timeout in hours.",
+          "x-intellij-html-description": "Cache timeout in hours."
         }
       },
       "preferredOrder": [
         "repo",
-        "hostPath"
+        "hostPath",
+        "ttl"
       ],
       "additionalProperties": false,
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",

--- a/docs/content/en/schemas/v2beta9.json
+++ b/docs/content/en/schemas/v2beta9.json
@@ -1657,15 +1657,6 @@
           "x-intellij-html-description": "environment variables passed to the kaniko pod.",
           "default": "[]"
         },
-        "flags": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "additional flags to be passed to Kaniko command line. See [Kaniko Additional Flags](https://github.com/GoogleContainerTools/kaniko#additional-flags). Deprecated - instead the named, unique fields should be used, e.g. `buildArgs`, `cache`, `target`.",
-          "x-intellij-html-description": "additional flags to be passed to Kaniko command line. See <a href=\"https://github.com/GoogleContainerTools/kaniko#additional-flags\">Kaniko Additional Flags</a>. Deprecated - instead the named, unique fields should be used, e.g. <code>buildArgs</code>, <code>cache</code>, <code>target</code>.",
-          "default": "[]"
-        },
         "force": {
           "type": "boolean",
           "description": "building outside of a container.",
@@ -1858,7 +1849,6 @@
         "snapshotMode",
         "tarPath",
         "verbosity",
-        "flags",
         "insecureRegistry",
         "skipTLSVerifyRegistry",
         "env",

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
@@ -100,7 +100,7 @@ func (b *Builder) copyKanikoBuildContext(ctx context.Context, workspace string, 
 	// Send context by piping into `tar`.
 	// In case of an error, print the command's output. (The `err` itself is useless: exit status 1).
 	var out bytes.Buffer
-	if err := b.kubectlcli.Run(ctx, buildCtx, &out, "exec", "-i", podName, "-c", initContainer, "-n", b.Namespace, "--", "tar", "-xf", "-", "-C", constants.DefaultKanikoEmptyDirMountPath); err != nil {
+	if err := b.kubectlcli.Run(ctx, buildCtx, &out, "exec", "-i", podName, "-c", initContainer, "-n", b.Namespace, "--", "tar", "-xf", "-", "-C", kaniko.DefaultEmptyDirMountPath); err != nil {
 		return fmt.Errorf("uploading build context: %s", out.String())
 	}
 

--- a/pkg/skaffold/build/cluster/logs.go
+++ b/pkg/skaffold/build/cluster/logs.go
@@ -29,7 +29,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 )
 
 // logLevel makes sure kaniko logs at least at Info level and at most Debug level (trace doesn't work with Kaniko)
@@ -56,7 +56,7 @@ func streamLogs(ctx context.Context, out io.Writer, name string, pods corev1.Pod
 		for atomic.LoadInt32(&retry) == 1 {
 			r, err := pods.GetLogs(name, &v1.PodLogOptions{
 				Follow:    true,
-				Container: constants.DefaultKanikoContainerName,
+				Container: kaniko.DefaultContainerName,
 			}).Stream()
 			if err != nil {
 				logrus.Debugln("unable to get kaniko pod logs:", err)
@@ -88,7 +88,7 @@ func streamLogs(ctx context.Context, out io.Writer, name string, pods corev1.Pod
 		// get latest logs if pod was terminated before logs have been streamed
 		if atomic.LoadInt64(&written) == 0 {
 			r, err := pods.GetLogs(name, &v1.PodLogOptions{
-				Container: constants.DefaultKanikoContainerName,
+				Container: kaniko.DefaultContainerName,
 			}).Stream()
 			if err == nil {
 				io.Copy(out, r)

--- a/pkg/skaffold/build/cluster/pod.go
+++ b/pkg/skaffold/build/cluster/pod.go
@@ -244,12 +244,6 @@ func kanikoArgs(artifact *latest.KanikoArtifact, tag string, insecureRegistries 
 		return nil, fmt.Errorf("unable build kaniko args: %w", err)
 	}
 
-	// TODO: remove since AdditionalFlags will be deprecated (priyawadhwa@)
-	if artifact.AdditionalFlags != nil {
-		logrus.Warn("The additionalFlags field in kaniko is deprecated, please consult the current schema at skaffold.dev to update your skaffold.yaml.")
-		args = append(args, artifact.AdditionalFlags...)
-	}
-
 	logrus.Trace("kaniko arguments are ", strings.Join(args, " "))
 
 	return args, nil

--- a/pkg/skaffold/build/cluster/pod.go
+++ b/pkg/skaffold/build/cluster/pod.go
@@ -18,18 +18,15 @@ package cluster
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
 
@@ -40,8 +37,8 @@ func (b *Builder) kanikoPodSpec(artifact *latest.KanikoArtifact, tag string) (*v
 	}
 
 	vm := v1.VolumeMount{
-		Name:      constants.DefaultKanikoEmptyDirName,
-		MountPath: constants.DefaultKanikoEmptyDirMountPath,
+		Name:      kaniko.DefaultEmptyDirName,
+		MountPath: kaniko.DefaultEmptyDirMountPath,
 	}
 
 	pod := &v1.Pod{
@@ -61,7 +58,7 @@ func (b *Builder) kanikoPodSpec(artifact *latest.KanikoArtifact, tag string) (*v
 				Resources:       resourceRequirements(b.ClusterDetails.Resources),
 			}},
 			Containers: []v1.Container{{
-				Name:            constants.DefaultKanikoContainerName,
+				Name:            kaniko.DefaultContainerName,
 				Image:           artifact.Image,
 				ImagePullPolicy: v1.PullIfNotPresent,
 				Args:            args,
@@ -81,17 +78,17 @@ func (b *Builder) kanikoPodSpec(artifact *latest.KanikoArtifact, tag string) (*v
 
 	// Add secret for pull secret
 	if b.ClusterDetails.PullSecretName != "" {
-		addSecretVolume(pod, constants.DefaultKanikoSecretName, b.ClusterDetails.PullSecretMountPath, b.ClusterDetails.PullSecretName)
+		addSecretVolume(pod, kaniko.DefaultSecretName, b.ClusterDetails.PullSecretMountPath, b.ClusterDetails.PullSecretName)
 	}
 
 	// Add host path volume for cache
 	if artifact.Cache != nil && artifact.Cache.HostPath != "" {
-		addHostPathVolume(pod, constants.DefaultKanikoCacheDirName, constants.DefaultKanikoCacheDirMountPath, artifact.Cache.HostPath)
+		addHostPathVolume(pod, kaniko.DefaultCacheDirName, kaniko.DefaultCacheDirMountPath, artifact.Cache.HostPath)
 	}
 
 	if b.ClusterDetails.DockerConfig != nil {
 		// Add secret for docker config if specified
-		addSecretVolume(pod, constants.DefaultKanikoDockerConfigSecretName, constants.DefaultKanikoDockerConfigPath, b.ClusterDetails.DockerConfig.SecretName)
+		addSecretVolume(pod, kaniko.DefaultDockerConfigSecretName, kaniko.DefaultDockerConfigPath, b.ClusterDetails.DockerConfig.SecretName)
 	}
 
 	// Add Service Account
@@ -237,12 +234,15 @@ func resourceRequirements(rr *latest.ResourceRequirements) v1.ResourceRequiremen
 }
 
 func kanikoArgs(artifact *latest.KanikoArtifact, tag string, insecureRegistries map[string]bool) ([]string, error) {
+	for reg := range insecureRegistries {
+		artifact.InsecureRegistry = append(artifact.InsecureRegistry, reg)
+	}
+
 	// Create pod spec
-	args := []string{
-		"--dockerfile", artifact.DockerfilePath,
-		"--context", fmt.Sprintf("dir://%s", constants.DefaultKanikoEmptyDirMountPath),
-		"--destination", tag,
-		"-v", logLevel().String()}
+	args, err := kaniko.Args(artifact, tag, fmt.Sprintf("dir://%s", kaniko.DefaultEmptyDirMountPath))
+	if err != nil {
+		return nil, fmt.Errorf("unable build kaniko args: %w", err)
+	}
 
 	// TODO: remove since AdditionalFlags will be deprecated (priyawadhwa@)
 	if artifact.AdditionalFlags != nil {
@@ -250,65 +250,7 @@ func kanikoArgs(artifact *latest.KanikoArtifact, tag string, insecureRegistries 
 		args = append(args, artifact.AdditionalFlags...)
 	}
 
-	buildArgs, err := util.EvaluateEnvTemplateMap(artifact.BuildArgs)
-	if err != nil {
-		return nil, fmt.Errorf("unable to evaluate build args: %w", err)
-	}
-
-	if buildArgs != nil {
-		var keys []string
-		for k := range buildArgs {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-
-		for _, k := range keys {
-			v := buildArgs[k]
-			if v == nil {
-				args = append(args, "--build-arg", k)
-			} else {
-				args = append(args, "--build-arg", fmt.Sprintf("%s=%s", k, *v))
-			}
-		}
-	}
-
-	if artifact.Target != "" {
-		args = append(args, "--target", artifact.Target)
-	}
-
-	if artifact.Cache != nil {
-		args = append(args, "--cache=true")
-		if artifact.Cache.Repo != "" {
-			args = append(args, "--cache-repo", artifact.Cache.Repo)
-		}
-		if artifact.Cache.HostPath != "" {
-			args = append(args, "--cache-dir", constants.DefaultKanikoCacheDirMountPath)
-		}
-	}
-
-	if artifact.Reproducible {
-		args = append(args, "--reproducible")
-	}
-
-	for reg := range insecureRegistries {
-		args = append(args, "--insecure-registry", reg)
-	}
-
-	if artifact.SkipTLS {
-		reg, err := artifactRegistry(tag)
-		if err != nil {
-			return nil, err
-		}
-		args = append(args, "--skip-tls-verify-registry", reg)
-	}
+	logrus.Trace("kaniko arguments are ", strings.Join(args, " "))
 
 	return args, nil
-}
-
-func artifactRegistry(i string) (string, error) {
-	ref, err := name.ParseReference(i)
-	if err != nil {
-		return "", err
-	}
-	return ref.Context().RegistryStr(), nil
 }

--- a/pkg/skaffold/build/cluster/secret.go
+++ b/pkg/skaffold/build/cluster/secret.go
@@ -26,8 +26,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	typedV1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
 )
 
@@ -74,10 +74,10 @@ func (b *Builder) createSecretFromFile(secrets typedV1.SecretInterface) (func(),
 			Labels: map[string]string{"skaffold-kaniko": "skaffold-kaniko"},
 		},
 		Data: map[string][]byte{
-			constants.DefaultKanikoSecretName: secretData,
+			kaniko.DefaultSecretName: secretData,
 		},
 	}
-	b.PullSecretPath = constants.DefaultKanikoSecretName
+	b.PullSecretPath = kaniko.DefaultSecretName
 	if _, err := secrets.Create(secret); err != nil {
 		return nil, fmt.Errorf("creating pull secret %q: %w", b.PullSecretName, err)
 	}

--- a/pkg/skaffold/build/gcb/kaniko.go
+++ b/pkg/skaffold/build/gcb/kaniko.go
@@ -17,41 +17,16 @@ limitations under the License.
 package gcb
 
 import (
-	"fmt"
-	"sort"
-
 	"google.golang.org/api/cloudbuild/v1"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 func (b *Builder) kanikoBuildSpec(artifact *latest.KanikoArtifact, tag string) (cloudbuild.Build, error) {
-	buildArgs, err := b.kanikoBuildArgs(artifact)
+	kanikoArgs, err := kaniko.Args(artifact, tag, "")
 	if err != nil {
 		return cloudbuild.Build{}, err
-	}
-
-	kanikoArgs := []string{
-		"--destination", tag,
-		"--dockerfile", artifact.DockerfilePath,
-	}
-	kanikoArgs = append(kanikoArgs, buildArgs...)
-
-	if artifact.Cache != nil {
-		kanikoArgs = append(kanikoArgs, "--cache")
-
-		if artifact.Cache.Repo != "" {
-			kanikoArgs = append(kanikoArgs, "--cache-repo", artifact.Cache.Repo)
-		}
-	}
-
-	if artifact.Reproducible {
-		kanikoArgs = append(kanikoArgs, "--reproducible")
-	}
-
-	if artifact.Target != "" {
-		kanikoArgs = append(kanikoArgs, "--target", artifact.Target)
 	}
 
 	return cloudbuild.Build{
@@ -60,29 +35,4 @@ func (b *Builder) kanikoBuildSpec(artifact *latest.KanikoArtifact, tag string) (
 			Args: kanikoArgs,
 		}},
 	}, nil
-}
-
-func (b *Builder) kanikoBuildArgs(artifact *latest.KanikoArtifact) ([]string, error) {
-	buildArgs, err := util.EvaluateEnvTemplateMap(artifact.BuildArgs)
-	if err != nil {
-		return nil, fmt.Errorf("unable to evaluate build args: %w", err)
-	}
-
-	var keys []string
-	for k := range buildArgs {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	var buildArgFlags []string
-	for _, k := range keys {
-		v := buildArgs[k]
-		if v == nil {
-			buildArgFlags = append(buildArgFlags, "--build-arg", k)
-		} else {
-			buildArgFlags = append(buildArgFlags, "--build-arg", fmt.Sprintf("%s=%s", k, *v))
-		}
-	}
-
-	return buildArgFlags, nil
 }

--- a/pkg/skaffold/build/gcb/kaniko_test.go
+++ b/pkg/skaffold/build/gcb/kaniko_test.go
@@ -21,6 +21,7 @@ import (
 
 	"google.golang.org/api/cloudbuild/v1"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -49,38 +50,305 @@ func TestKanikoBuildSpec(t *testing.T) {
 				},
 			},
 			expectedArgs: []string{
-				"--build-arg", "arg1=value1",
-				"--build-arg", "arg2",
+				kaniko.BuildArgsFlag, "arg1=value1",
+				kaniko.BuildArgsFlag, "arg2",
 			},
 		},
 		{
-			description: "with cache layer",
+			description: "with Cache",
 			artifact: &latest.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Cache:          &latest.KanikoCache{},
 			},
 			expectedArgs: []string{
-				"--cache",
+				kaniko.CacheFlag,
 			},
 		},
 		{
-			description: "with reproduceible",
+			description: "with Cleanup",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Cleanup:        true,
+			},
+			expectedArgs: []string{
+				kaniko.CleanupFlag,
+			},
+		},
+		{
+			description: "with DigestFile",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				DigestFile:     "/tmp/digest",
+			},
+			expectedArgs: []string{
+				kaniko.DigestFileFlag, "/tmp/digest",
+			},
+		},
+		{
+			description: "with Force",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Force:          true,
+			},
+			expectedArgs: []string{
+				kaniko.ForceFlag,
+			},
+		},
+		{
+			description: "with ImageNameWithDigestFile",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath:          "Dockerfile",
+				ImageNameWithDigestFile: "/tmp/imageName",
+			},
+			expectedArgs: []string{
+				kaniko.ImageNameWithDigestFileFlag, "/tmp/imageName",
+			},
+		},
+		{
+			description: "with Insecure",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Insecure:       true,
+			},
+			expectedArgs: []string{
+				kaniko.InsecureFlag,
+			},
+		},
+		{
+			description: "with InsecurePull",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				InsecurePull:   true,
+			},
+			expectedArgs: []string{
+				kaniko.InsecurePullFlag,
+			},
+		},
+		{
+			description: "with InsecureRegistry",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				InsecureRegistry: []string{
+					"s1.registry.url:5000",
+					"s2.registry.url:5000",
+				},
+			},
+			expectedArgs: []string{
+				kaniko.InsecureRegistryFlag, "s1.registry.url:5000",
+				kaniko.InsecureRegistryFlag, "s2.registry.url:5000",
+			},
+		},
+		{
+			description: "with LogFormat",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				LogFormat:      "json",
+			},
+			expectedArgs: []string{
+				kaniko.LogFormatFlag, "json",
+			},
+		},
+		{
+			description: "with LogTimestamp",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				LogTimestamp:   true,
+			},
+			expectedArgs: []string{
+				kaniko.LogTimestampFlag,
+			},
+		},
+		{
+			description: "with NoPush",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				NoPush:         true,
+			},
+			expectedArgs: []string{
+				kaniko.NoPushFlag,
+			},
+		},
+		{
+			description: "with OCILayoutPath",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				OCILayoutPath:  "/tmp/builtImage",
+			},
+			expectedArgs: []string{
+				kaniko.OCILayoutFlag, "/tmp/builtImage",
+			},
+		},
+		{
+			description: "with RegistryCertificate",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				RegistryCertificate: map[string]*string{
+					"s1.registry.url": util.StringPtr("/etc/certs/certificate1.cert"),
+					"s2.registry.url": util.StringPtr("/etc/certs/certificate2.cert"),
+				},
+			},
+			expectedArgs: []string{
+				kaniko.RegistryCertificateFlag, "s1.registry.url=/etc/certs/certificate1.cert",
+				kaniko.RegistryCertificateFlag, "s2.registry.url=/etc/certs/certificate2.cert",
+			},
+		},
+		{
+			description: "with RegistryMirror",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				RegistryMirror: "mirror.gcr.io",
+			},
+			expectedArgs: []string{
+				kaniko.RegistryMirrorFlag, "mirror.gcr.io",
+			},
+		},
+		{
+			description: "with Reproducible",
 			artifact: &latest.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Reproducible:   true,
 			},
 			expectedArgs: []string{
-				"--reproducible",
+				kaniko.ReproducibleFlag,
 			},
 		},
 		{
-			description: "with target",
+			description: "with SingleSnapshot",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				SingleSnapshot: true,
+			},
+			expectedArgs: []string{
+				kaniko.SingleSnapshotFlag,
+			},
+		},
+		{
+			description: "with SkipTLS",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				SkipTLS:        true,
+			},
+			expectedArgs: []string{
+				kaniko.SkipTLSFlag,
+				kaniko.SkipTLSVerifyRegistryFlag, "gcr.io",
+			},
+		},
+		{
+			description: "with SkipTLSVerifyPull",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath:    "Dockerfile",
+				SkipTLSVerifyPull: true,
+			},
+			expectedArgs: []string{
+				kaniko.SkipTLSVerifyPullFlag,
+			},
+		},
+		{
+			description: "with SkipTLSVerifyRegistry",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				SkipTLSVerifyRegistry: []string{
+					"s1.registry.url:5000",
+					"s2.registry.url:5000",
+				},
+			},
+			expectedArgs: []string{
+				kaniko.SkipTLSVerifyRegistryFlag, "s1.registry.url:5000",
+				kaniko.SkipTLSVerifyRegistryFlag, "s2.registry.url:5000",
+			},
+		},
+		{
+			description: "with SkipUnusedStages",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath:   "Dockerfile",
+				SkipUnusedStages: true,
+			},
+			expectedArgs: []string{
+				kaniko.SkipUnusedStagesFlag,
+			},
+		},
+		{
+			description: "with Target",
 			artifact: &latest.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Target:         "builder",
 			},
 			expectedArgs: []string{
-				"--target", "builder",
+				kaniko.TargetFlag, "builder",
+			},
+		},
+		{
+			description: "with SnapshotMode",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				SnapshotMode:   "redo",
+			},
+			expectedArgs: []string{
+				"--snapshotMode", "redo",
+			},
+		},
+		{
+			description: "with TarPath",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				TarPath:        "/workspace/tars",
+			},
+			expectedArgs: []string{
+				kaniko.TarPathFlag, "/workspace/tars",
+			},
+		},
+		{
+			description: "with UseNewRun",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				UseNewRun:      true,
+			},
+			expectedArgs: []string{
+				kaniko.UseNewRunFlag,
+			},
+		},
+		{
+			description: "with Verbosity",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Verbosity:      "trace",
+			},
+			expectedArgs: []string{
+				kaniko.VerbosityFlag, "trace",
+			},
+		},
+		{
+			description: "with WhitelistVarRun",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath:  "Dockerfile",
+				WhitelistVarRun: true,
+			},
+			expectedArgs: []string{
+				kaniko.WhitelistVarRunFlag,
+			},
+		},
+		{
+			description: "with WhitelistVarRun",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath:  "Dockerfile",
+				WhitelistVarRun: true,
+			},
+			expectedArgs: []string{
+				kaniko.WhitelistVarRunFlag,
+			},
+		},
+		{
+			description: "with Labels",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Label: map[string]*string{
+					"label1": util.StringPtr("value1"),
+					"label2": nil,
+				},
+			},
+			expectedArgs: []string{
+				kaniko.LabelFlag, "label1=value1",
+				kaniko.LabelFlag, "label2",
 			},
 		},
 	}
@@ -95,7 +363,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 	})
 
 	defaultExpectedArgs := []string{
-		"--destination", "nginx",
+		"--destination", "gcr.io/nginx",
 		"--dockerfile", "Dockerfile",
 	}
 
@@ -107,7 +375,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 				},
 			}
 
-			desc, err := builder.buildSpec(artifact, "nginx", "bucket", "object")
+			desc, err := builder.buildSpec(artifact, "gcr.io/nginx", "bucket", "object")
 
 			expected := cloudbuild.Build{
 				LogsBucket: "bucket",

--- a/pkg/skaffold/build/kaniko/args.go
+++ b/pkg/skaffold/build/kaniko/args.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kaniko
+
+import (
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/name"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+// Args returns kaniko command arguments
+func Args(artifact *latest.KanikoArtifact, tag, context string) ([]string, error) {
+	args := []string{
+		"--destination", tag,
+		"--dockerfile", artifact.DockerfilePath,
+	}
+
+	if context != "" {
+		args = append(args, "--context", context)
+	}
+
+	buildArgs, err := util.MapToFlag(artifact.BuildArgs, BuildArgsFlag)
+	if err != nil {
+		return args, err
+	}
+
+	args = append(args, buildArgs...)
+
+	if artifact.Cache != nil {
+		args = append(args, CacheFlag)
+
+		if artifact.Cache.Repo != "" {
+			args = append(args, CacheRepoFlag, artifact.Cache.Repo)
+		}
+		if artifact.Cache.HostPath != "" {
+			args = append(args, CacheDirFlag, artifact.Cache.HostPath)
+		}
+		if artifact.Cache.TTL != "" {
+			args = append(args, CacheTTLFlag, artifact.Cache.TTL)
+		}
+	}
+
+	if artifact.Target != "" {
+		args = append(args, TargetFlag, artifact.Target)
+	}
+
+	if artifact.Cleanup {
+		args = append(args, CleanupFlag)
+	}
+
+	if artifact.DigestFile != "" {
+		args = append(args, DigestFileFlag, artifact.DigestFile)
+	}
+
+	if artifact.Force {
+		args = append(args, ForceFlag)
+	}
+
+	if artifact.ImageNameWithDigestFile != "" {
+		args = append(args, ImageNameWithDigestFileFlag, artifact.ImageNameWithDigestFile)
+	}
+
+	if artifact.Insecure {
+		args = append(args, InsecureFlag)
+	}
+
+	if artifact.InsecurePull {
+		args = append(args, InsecurePullFlag)
+	}
+
+	if artifact.LogFormat != "" {
+		args = append(args, LogFormatFlag, artifact.LogFormat)
+	}
+
+	if artifact.LogTimestamp {
+		args = append(args, LogTimestampFlag)
+	}
+
+	if artifact.NoPush {
+		args = append(args, NoPushFlag)
+	}
+
+	if artifact.OCILayoutPath != "" {
+		args = append(args, OCILayoutFlag, artifact.OCILayoutPath)
+	}
+
+	if artifact.RegistryMirror != "" {
+		args = append(args, RegistryMirrorFlag, artifact.RegistryMirror)
+	}
+
+	if artifact.Reproducible {
+		args = append(args, ReproducibleFlag)
+	}
+
+	if artifact.SingleSnapshot {
+		args = append(args, SingleSnapshotFlag)
+	}
+
+	if artifact.SkipTLS {
+		args = append(args, SkipTLSFlag)
+		reg, err := artifactRegistry(tag)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, SkipTLSVerifyRegistryFlag, reg)
+	}
+
+	if artifact.SkipTLSVerifyPull {
+		args = append(args, SkipTLSVerifyPullFlag)
+	}
+
+	if artifact.SkipUnusedStages {
+		args = append(args, SkipUnusedStagesFlag)
+	}
+
+	if artifact.SnapshotMode != "" {
+		args = append(args, SnapshotModeFlag, artifact.SnapshotMode)
+	}
+
+	if artifact.TarPath != "" {
+		args = append(args, TarPathFlag, artifact.TarPath)
+	}
+
+	if artifact.UseNewRun {
+		args = append(args, UseNewRunFlag)
+	}
+
+	if artifact.Verbosity != "" {
+		args = append(args, VerbosityFlag, artifact.Verbosity)
+	}
+
+	if artifact.WhitelistVarRun {
+		args = append(args, WhitelistVarRunFlag)
+	}
+
+	var iRegArgs []string
+	for _, r := range artifact.InsecureRegistry {
+		iRegArgs = append(iRegArgs, InsecureRegistryFlag, r)
+	}
+	args = append(args, iRegArgs...)
+
+	var sRegArgs []string
+	for _, r := range artifact.SkipTLSVerifyRegistry {
+		sRegArgs = append(sRegArgs, SkipTLSVerifyRegistryFlag, r)
+	}
+	args = append(args, sRegArgs...)
+
+	registryCertificate, err := util.MapToFlag(artifact.RegistryCertificate, RegistryCertificateFlag)
+	if err != nil {
+		return args, err
+	}
+
+	args = append(args, registryCertificate...)
+
+	labels, err := util.MapToFlag(artifact.Label, LabelFlag)
+	if err != nil {
+		return args, err
+	}
+
+	args = append(args, labels...)
+
+	return args, nil
+}
+
+func artifactRegistry(i string) (string, error) {
+	ref, err := name.ParseReference(i)
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve registry url from artifact: %w", err)
+	}
+	return ref.Context().RegistryStr(), nil
+}

--- a/pkg/skaffold/build/kaniko/args_test.go
+++ b/pkg/skaffold/build/kaniko/args_test.go
@@ -418,9 +418,6 @@ func TestArgs(t *testing.T) {
 }
 
 func Test_artifactRegistry(t *testing.T) {
-	type args struct {
-		i string
-	}
 	tests := []struct {
 		name    string
 		i       string

--- a/pkg/skaffold/build/kaniko/args_test.go
+++ b/pkg/skaffold/build/kaniko/args_test.go
@@ -1,0 +1,453 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package kaniko
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestArgs(t *testing.T) {
+	tests := []struct {
+		description  string
+		artifact     *latest.KanikoArtifact
+		expectedArgs []string
+		wantErr      bool
+	}{
+		{
+			description: "simple build",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+			},
+			expectedArgs: []string{},
+			wantErr:      false,
+		},
+		{
+			description: "with BuildArgs",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				BuildArgs: map[string]*string{
+					"arg1": util.StringPtr("value1"),
+					"arg2": nil,
+				},
+			},
+			expectedArgs: []string{
+				BuildArgsFlag, "arg1=value1",
+				BuildArgsFlag, "arg2",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with Cache",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Cache:          &latest.KanikoCache{},
+			},
+			expectedArgs: []string{
+				CacheFlag,
+			},
+			wantErr: false,
+		},
+		{
+			description: "with Cache Options",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Cache: &latest.KanikoCache{
+					Repo:     "gcr.io/ngnix",
+					HostPath: "/cache",
+					TTL:      "2",
+				},
+			},
+			expectedArgs: []string{
+				CacheFlag,
+				CacheRepoFlag, "gcr.io/ngnix",
+				CacheDirFlag, "/cache",
+				CacheTTLFlag, "2",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with Cleanup",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Cleanup:        true,
+			},
+			expectedArgs: []string{
+				CleanupFlag,
+			},
+			wantErr: false,
+		},
+		{
+			description: "with DigestFile",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				DigestFile:     "/tmp/digest",
+			},
+			expectedArgs: []string{
+				DigestFileFlag, "/tmp/digest",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with Force",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Force:          true,
+			},
+			expectedArgs: []string{
+				ForceFlag,
+			},
+			wantErr: false,
+		},
+		{
+			description: "with ImageNameWithDigestFile",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath:          "Dockerfile",
+				ImageNameWithDigestFile: "/tmp/imageName",
+			},
+			expectedArgs: []string{
+				ImageNameWithDigestFileFlag, "/tmp/imageName",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with Insecure",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Insecure:       true,
+			},
+			expectedArgs: []string{
+				InsecureFlag,
+			},
+			wantErr: false,
+		},
+		{
+			description: "with InsecurePull",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				InsecurePull:   true,
+			},
+			expectedArgs: []string{
+				InsecurePullFlag,
+			},
+			wantErr: false,
+		},
+		{
+			description: "with InsecureRegistry",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				InsecureRegistry: []string{
+					"s1.registry.url:5000",
+					"s2.registry.url:5000",
+				},
+			},
+			expectedArgs: []string{
+				InsecureRegistryFlag, "s1.registry.url:5000",
+				InsecureRegistryFlag, "s2.registry.url:5000",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with LogFormat",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				LogFormat:      "json",
+			},
+			expectedArgs: []string{
+				LogFormatFlag, "json",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with LogTimestamp",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				LogTimestamp:   true,
+			},
+			expectedArgs: []string{
+				LogTimestampFlag,
+			},
+			wantErr: false,
+		},
+		{
+			description: "with NoPush",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				NoPush:         true,
+			},
+			expectedArgs: []string{
+				NoPushFlag,
+			},
+			wantErr: false,
+		},
+		{
+			description: "with OCILayoutPath",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				OCILayoutPath:  "/tmp/builtImage",
+			},
+			expectedArgs: []string{
+				OCILayoutFlag, "/tmp/builtImage",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with RegistryCertificate",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				RegistryCertificate: map[string]*string{
+					"s1.registry.url": util.StringPtr("/etc/certs/certificate1.cert"),
+					"s2.registry.url": util.StringPtr("/etc/certs/certificate2.cert"),
+				},
+			},
+			expectedArgs: []string{
+				RegistryCertificateFlag, "s1.registry.url=/etc/certs/certificate1.cert",
+				RegistryCertificateFlag, "s2.registry.url=/etc/certs/certificate2.cert",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with RegistryMirror",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				RegistryMirror: "mirror.gcr.io",
+			},
+			expectedArgs: []string{
+				RegistryMirrorFlag, "mirror.gcr.io",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with Reproducible",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Reproducible:   true,
+			},
+			expectedArgs: []string{
+				ReproducibleFlag,
+			},
+			wantErr: false,
+		},
+		{
+			description: "with SingleSnapshot",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				SingleSnapshot: true,
+			},
+			expectedArgs: []string{
+				SingleSnapshotFlag,
+			},
+			wantErr: false,
+		},
+		{
+			description: "with SkipTLS",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				SkipTLS:        true,
+			},
+			expectedArgs: []string{
+				SkipTLSFlag,
+				SkipTLSVerifyRegistryFlag, "gcr.io",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with SkipTLSVerifyPull",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath:    "Dockerfile",
+				SkipTLSVerifyPull: true,
+			},
+			expectedArgs: []string{
+				SkipTLSVerifyPullFlag,
+			},
+			wantErr: false,
+		},
+		{
+			description: "with SkipTLSVerifyRegistry",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				SkipTLSVerifyRegistry: []string{
+					"s1.registry.url:443",
+					"s2.registry.url:443",
+				},
+			},
+			expectedArgs: []string{
+				SkipTLSVerifyRegistryFlag, "s1.registry.url:443",
+				SkipTLSVerifyRegistryFlag, "s2.registry.url:443",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with SkipUnusedStages",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath:   "Dockerfile",
+				SkipUnusedStages: true,
+			},
+			expectedArgs: []string{
+				SkipUnusedStagesFlag,
+			},
+			wantErr: false,
+		},
+		{
+			description: "with Target",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Target:         "builder",
+			},
+			expectedArgs: []string{
+				TargetFlag, "builder",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with SnapshotMode",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				SnapshotMode:   "redo",
+			},
+			expectedArgs: []string{
+				"--snapshotMode", "redo",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with TarPath",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				TarPath:        "/workspace/tars",
+			},
+			expectedArgs: []string{
+				TarPathFlag, "/workspace/tars",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with UseNewRun",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				UseNewRun:      true,
+			},
+			expectedArgs: []string{
+				UseNewRunFlag,
+			},
+			wantErr: false,
+		},
+		{
+			description: "with Verbosity",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Verbosity:      "trace",
+			},
+			expectedArgs: []string{
+				VerbosityFlag, "trace",
+			},
+			wantErr: false,
+		},
+		{
+			description: "with WhitelistVarRun",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath:  "Dockerfile",
+				WhitelistVarRun: true,
+			},
+			expectedArgs: []string{
+				WhitelistVarRunFlag,
+			},
+			wantErr: false,
+		},
+		{
+			description: "with WhitelistVarRun",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath:  "Dockerfile",
+				WhitelistVarRun: true,
+			},
+			expectedArgs: []string{
+				WhitelistVarRunFlag,
+			},
+			wantErr: false,
+		},
+		{
+			description: "with Labels",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Label: map[string]*string{
+					"label1": util.StringPtr("value1"),
+					"label2": nil,
+				},
+			},
+			expectedArgs: []string{
+				LabelFlag, "label1=value1",
+				LabelFlag, "label2",
+			},
+			wantErr: false,
+		},
+	}
+
+	defaultExpectedArgs := []string{
+		"--destination", "gcr.io/nginx",
+		"--dockerfile", "Dockerfile",
+		"--context", fmt.Sprintf("dir://%s", DefaultEmptyDirMountPath),
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			got, err := Args(test.artifact, "gcr.io/nginx", fmt.Sprintf("dir://%s", DefaultEmptyDirMountPath))
+			if (err != nil) != test.wantErr {
+				t.Errorf("Args() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			t.CheckDeepEqual(got, append(defaultExpectedArgs, test.expectedArgs...))
+		})
+	}
+}
+
+func Test_artifactRegistry(t *testing.T) {
+	type args struct {
+		i string
+	}
+	tests := []struct {
+		name    string
+		i       string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Regular",
+			i:       "gcr.io/nginx",
+			want:    "gcr.io",
+			wantErr: false,
+		},
+		{
+			name:    "with Project",
+			i:       "gcr.io/google_containers/nginx",
+			want:    "gcr.io",
+			wantErr: false,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			got, err := artifactRegistry(test.i)
+			if (err != nil) != test.wantErr {
+				t.Errorf("artifactRegistry() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			t.CheckDeepEqual(got, test.want)
+		})
+	}
+}

--- a/pkg/skaffold/build/kaniko/types.go
+++ b/pkg/skaffold/build/kaniko/types.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kaniko
+
+const (
+	// BuildArgsFlag additional flag
+	BuildArgsFlag = "--build-arg"
+	// CacheFlag additional flag
+	CacheFlag = "--cache"
+	// CacheDirFlag additional flag
+	CacheDirFlag = "--cache-dir"
+	// CacheRepoFlag additional flag
+	CacheRepoFlag = "--cache-repo"
+	// CacheTTLFlag additional flag
+	CacheTTLFlag = "--cache-ttl"
+	// TargetFlag additional flag
+	TargetFlag = "--target"
+	// CleanupFlag additional flag
+	CleanupFlag = "--cleanup"
+	// DigestFileFlag additional flag
+	DigestFileFlag = "--digest-file"
+	// ForceFlag additional flag
+	ForceFlag = "--force"
+	// ImageNameWithDigestFileFlag  additional flag
+	ImageNameWithDigestFileFlag = "--image-name-with-digest-file"
+	// InsecureFlag additional flag
+	InsecureFlag = "--insecure"
+	// InsecurePullFlag additional flag
+	InsecurePullFlag = "--insecure-pull"
+	// InsecureRegistryFlag additional flag
+	InsecureRegistryFlag = "--insecure-registry"
+	// LabelFlag additional flag
+	LabelFlag = "--label"
+	// LogFormatFlag additional flag
+	LogFormatFlag = "--log-format"
+	// LogTimestampFlag additional flag
+	LogTimestampFlag = "--log-timestamp"
+	// NoPushFlag additional flag
+	NoPushFlag = "--no-push"
+	// OCILayoutFlag additional flag
+	OCILayoutFlag = "--oci-layout-path"
+	// RegistryCertificateFlag additional flag
+	RegistryCertificateFlag = "--registry-certificate"
+	// RegistryMirrorFlag additional flag
+	RegistryMirrorFlag = "--registry-mirror"
+	// ReproducibleFlag additional flag
+	ReproducibleFlag = "--reproducible"
+	// SingleSnapshotFlag additional flag
+	SingleSnapshotFlag = "--single-snapshot"
+	// SkipTLSFlag additional flag
+	SkipTLSFlag = "--skip-tls-verify"
+	// SkipTLSVerifyPullFlag additional flag
+	SkipTLSVerifyPullFlag = "--skip-tls-verify-pull"
+	// SkipTLSVerifyRegistryFlag additional flag
+	SkipTLSVerifyRegistryFlag = "--skip-tls-verify-registry"
+	// SkipUnusedStagesFlag additional flag
+	SkipUnusedStagesFlag = "--skip-unused-stages"
+	// SnapshotModeFlag additional flag
+	SnapshotModeFlag = "--snapshotMode"
+	// TarPathFlag additional flag
+	TarPathFlag = "--tarPath"
+	// UseNewRunFlag additional flag
+	UseNewRunFlag = "--use-new-run"
+	// VerbosityFlag additional flag
+	VerbosityFlag = "--verbosity"
+	// WhitelistVarRunFlag additional flag
+	WhitelistVarRunFlag = "--whitelist-var-run"
+	//DefaultImage is image used by the Kaniko pod by default
+	DefaultImage = "gcr.io/kaniko-project/executor:latest"
+	// DefaultSecretName for kaniko pod
+	DefaultSecretName = "kaniko-secret"
+	// DefaultTimeout for kaniko pod
+	DefaultTimeout = "20m"
+	// DefaultContainerName for kaniko pod
+	DefaultContainerName = "kaniko"
+	// DefaultEmptyDirName for kaniko pod
+	DefaultEmptyDirName = "kaniko-emptydir"
+	// DefaultEmptyDirMountPath for kaniko pod
+	DefaultEmptyDirMountPath = "/kaniko/buildcontext"
+	// DefaultCacheDirName for kaniko pod
+	DefaultCacheDirName = "kaniko-cache"
+	// DefaultCacheDirMountPath for kaniko pod
+	DefaultCacheDirMountPath = "/cache"
+	// DefaultDockerConfigSecretName for kaniko pod
+	DefaultDockerConfigSecretName = "docker-cfg"
+	// DefaultDockerConfigPath for kaniko pod
+	DefaultDockerConfigPath = "/kaniko/.docker"
+	// DefaultSecretMountPath for kaniko pod
+	DefaultSecretMountPath = "/secret"
+)

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -39,18 +39,6 @@ const (
 
 	DefaultKustomizationPath = "."
 
-	DefaultKanikoImage                  = "gcr.io/kaniko-project/executor:v0.20.0@sha256:f9a4a760166682c7c7aeda3cc263570682e00848ab47737ed8ffcc3abd2da6c3"
-	DefaultKanikoSecretName             = "kaniko-secret"
-	DefaultKanikoTimeout                = "20m"
-	DefaultKanikoContainerName          = "kaniko"
-	DefaultKanikoEmptyDirName           = "kaniko-emptydir"
-	DefaultKanikoEmptyDirMountPath      = "/kaniko/buildcontext"
-	DefaultKanikoCacheDirName           = "kaniko-cache"
-	DefaultKanikoCacheDirMountPath      = "/cache"
-	DefaultKanikoDockerConfigSecretName = "docker-cfg"
-	DefaultKanikoDockerConfigPath       = "/kaniko/.docker"
-	DefaultKanikoSecretMountPath        = "/secret"
-
 	DefaultBusyboxImage = "busybox"
 
 	// DefaultDebugHelpersRegistry is the default location used for the helper images for `debug`.

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -23,6 +23,7 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -32,7 +33,7 @@ const (
 	defaultCloudBuildDockerImage = "gcr.io/cloud-builders/docker"
 	defaultCloudBuildMavenImage  = "gcr.io/cloud-builders/mvn"
 	defaultCloudBuildGradleImage = "gcr.io/cloud-builders/gradle"
-	defaultCloudBuildKanikoImage = constants.DefaultKanikoImage
+	defaultCloudBuildKanikoImage = kaniko.DefaultImage
 	defaultCloudBuildPackImage   = "gcr.io/k8s-skaffold/pack"
 )
 
@@ -269,12 +270,12 @@ func setDefaultClusterNamespace(cluster *latest.ClusterDetails) error {
 }
 
 func setDefaultClusterTimeout(cluster *latest.ClusterDetails) error {
-	cluster.Timeout = valueOrDefault(cluster.Timeout, constants.DefaultKanikoTimeout)
+	cluster.Timeout = valueOrDefault(cluster.Timeout, kaniko.DefaultTimeout)
 	return nil
 }
 
 func setDefaultClusterPullSecret(cluster *latest.ClusterDetails) error {
-	cluster.PullSecretMountPath = valueOrDefault(cluster.PullSecretMountPath, constants.DefaultKanikoSecretMountPath)
+	cluster.PullSecretMountPath = valueOrDefault(cluster.PullSecretMountPath, kaniko.DefaultSecretMountPath)
 	if cluster.PullSecretPath != "" {
 		absPath, err := homedir.Expand(cluster.PullSecretPath)
 		if err != nil {
@@ -286,7 +287,7 @@ func setDefaultClusterPullSecret(cluster *latest.ClusterDetails) error {
 			uid, _ := uuid.NewUUID()
 			random = uid.String()
 		}
-		cluster.PullSecretName = valueOrDefault(cluster.PullSecretName, constants.DefaultKanikoSecretName+random)
+		cluster.PullSecretName = valueOrDefault(cluster.PullSecretName, kaniko.DefaultSecretName+random)
 		return nil
 	}
 	return nil
@@ -303,7 +304,7 @@ func setDefaultClusterDockerConfigSecret(cluster *latest.ClusterDetails) error {
 		random = uid.String()
 	}
 
-	cluster.DockerConfig.SecretName = valueOrDefault(cluster.DockerConfig.SecretName, constants.DefaultKanikoDockerConfigSecretName+random)
+	cluster.DockerConfig.SecretName = valueOrDefault(cluster.DockerConfig.SecretName, kaniko.DefaultDockerConfigSecretName+random)
 
 	if cluster.DockerConfig.Path == "" {
 		return nil
@@ -325,7 +326,7 @@ func defaultToKanikoArtifact(artifact *latest.Artifact) {
 }
 
 func setKanikoArtifactDefaults(a *latest.KanikoArtifact) {
-	a.Image = valueOrDefault(a.Image, constants.DefaultKanikoImage)
+	a.Image = valueOrDefault(a.Image, kaniko.DefaultImage)
 	a.DockerfilePath = valueOrDefault(a.DockerfilePath, constants.DefaultDockerfilePath)
 	a.InitImage = valueOrDefault(a.InitImage, constants.DefaultBusyboxImage)
 }

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -163,7 +164,7 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual("ns", cfg.Build.Cluster.Namespace)
-		t.CheckDeepEqual(constants.DefaultKanikoTimeout, cfg.Build.Cluster.Timeout)
+		t.CheckDeepEqual(kaniko.DefaultTimeout, cfg.Build.Cluster.Timeout)
 
 		// artifact types
 		t.CheckNotNil(cfg.Pipeline.Build.Artifacts[0].KanikoArtifact)
@@ -187,7 +188,7 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 
 		t.CheckNoError(err)
 
-		t.CheckDeepEqual(constants.DefaultKanikoSecretMountPath, cfg.Build.Cluster.PullSecretMountPath)
+		t.CheckDeepEqual(kaniko.DefaultSecretMountPath, cfg.Build.Cluster.PullSecretMountPath)
 
 		// pull secret mount path set
 		path := "/path"

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1063,11 +1063,6 @@ type KanikoArtifact struct {
 	// Verbosity <panic|fatal|error|warn|info|debug|trace> to set the logging level.
 	Verbosity string `yaml:"verbosity,omitempty"`
 
-	// AdditionalFlags are additional flags to be passed to Kaniko command line.
-	// See [Kaniko Additional Flags](https://github.com/GoogleContainerTools/kaniko#additional-flags).
-	// Deprecated - instead the named, unique fields should be used, e.g. `buildArgs`, `cache`, `target`.
-	AdditionalFlags []string `yaml:"flags,omitempty"`
-
 	// InsecureRegistry is to use plain HTTP requests when accessing a registry.
 	InsecureRegistry []string `yaml:"insecureRegistry,omitempty"`
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -314,6 +314,8 @@ type KanikoCache struct {
 	// HostPath specifies a path on the host that is mounted to each pod as read only cache volume containing base images.
 	// If set, must exist on each node and prepopulated with kaniko-warmer.
 	HostPath string `yaml:"hostPath,omitempty"`
+	//TTL Cache timeout in hours.
+	TTL string `yaml:"ttl,omitempty"`
 }
 
 // ClusterDetails *beta* describes how to do an on-cluster build.
@@ -977,25 +979,56 @@ type DockerfileDependency struct {
 // KanikoArtifact describes an artifact built from a Dockerfile,
 // with kaniko.
 type KanikoArtifact struct {
-	// AdditionalFlags are additional flags to be passed to Kaniko command line.
-	// See [Kaniko Additional Flags](https://github.com/GoogleContainerTools/kaniko#additional-flags).
-	// Deprecated - instead the named, unique fields should be used, e.g. `buildArgs`, `cache`, `target`.
-	AdditionalFlags []string `yaml:"flags,omitempty"`
+
+	// Cleanup to clean the filesystem at the end of the build.
+	Cleanup bool `yaml:"cleanup,omitempty"`
+
+	// Insecure if you want to push images to a plain HTTP registry.
+	Insecure bool `yaml:"insecure,omitempty"`
+
+	// InsecurePull if you want to pull images from a plain HTTP registry.
+	InsecurePull bool `yaml:"insecurePull,omitempty"`
+
+	// NoPush if you only want to build the image, without pushing to a registry.
+	NoPush bool `yaml:"noPush,omitempty"`
+
+	// Force building outside of a container.
+	Force bool `yaml:"force,omitempty"`
+
+	// LogTimestamp to add timestamps to log format.
+	LogTimestamp bool `yaml:"logTimestamp,omitempty"`
+
+	// Reproducible is used to strip timestamps out of the built image.
+	Reproducible bool `yaml:"reproducible,omitempty"`
+
+	// SingleSnapshot is takes a single snapshot of the filesystem at the end of the build.
+	// So only one layer will be appended to the base image.
+	SingleSnapshot bool `yaml:"singleSnapshot,omitempty"`
+
+	// SkipTLS skips TLS certificate validation when pushing to a registry.
+	SkipTLS bool `yaml:"skipTLS,omitempty"`
+
+	// SkipTLSVerifyPull skips TLS certificate validation when pulling from a registry.
+	SkipTLSVerifyPull bool `yaml:"skipTLSVerifyPull,omitempty"`
+
+	// SkipUnusedStages builds only used stages if defined to true.
+	// Otherwise it builds by default all stages, even the unnecessaries ones until it reaches the target stage / end of Dockerfile.
+	SkipUnusedStages bool `yaml:"skipUnusedStages,omitempty"`
+
+	// UseNewRun to Use the experimental run implementation for detecting changes without requiring file system snapshots.
+	// In some cases, this may improve build performance by 75%.
+	UseNewRun bool `yaml:"useNewRun,omitempty"`
+
+	// WhitelistVarRun is used to ignore `/var/run` when taking image snapshot.
+	// Set it to false to preserve /var/run/* in destination image.
+	WhitelistVarRun bool `yaml:"whitelistVarRun,omitempty"`
 
 	// DockerfilePath locates the Dockerfile relative to workspace.
 	// Defaults to `Dockerfile`.
 	DockerfilePath string `yaml:"dockerfile,omitempty"`
 
-	// Target is the Dockerfile target name to build.
+	// Target is to indicate which build stage is the target build stage.
 	Target string `yaml:"target,omitempty"`
-
-	// BuildArgs are arguments passed to the docker build.
-	// It also accepts environment variables via the go template syntax.
-	// For example: `{"key1": "value1", "key2": "value2", "key3": "'{{.ENV_VARIABLE}}'"}`.
-	BuildArgs map[string]*string `yaml:"buildArgs,omitempty"`
-
-	// Env are environment variables passed to the kaniko pod.
-	Env []v1.EnvVar `yaml:"env,omitempty"`
 
 	// InitImage is the image used to run init container which mounts kaniko context.
 	InitImage string `yaml:"initImage,omitempty"`
@@ -1004,15 +1037,62 @@ type KanikoArtifact struct {
 	// Defaults to the latest released version of `gcr.io/kaniko-project/executor`.
 	Image string `yaml:"image,omitempty"`
 
+	// DigestFile to to specify a file in the container. This file will receive the digest of a built image.
+	// This can be used to automatically track the exact image built by kaniko.
+	DigestFile string `yaml:"digestFile,omitempty"`
+
+	// ImageNameWithDigestFile to a file to save the image name with digest of the built image to.
+	ImageNameWithDigestFile string `yaml:"imageNameWithDigestFile,omitempty"`
+
+	// LogFormat <text|color|json> to set the log format.
+	LogFormat string `yaml:"logFormat,omitempty"`
+
+	// OCILayoutPath is to specify a directory in the container where the OCI image layout of a built image will be placed.
+	// This can be used to automatically track the exact image built by kaniko.
+	OCILayoutPath string `yaml:"ociLayoutPath,omitempty"`
+
+	// RegistryMirror if you want to use a registry mirror instead of default `index.docker.io`.
+	RegistryMirror string `yaml:"registryMirror,omitempty"`
+
+	// SnapshotMode is how Kaniko will snapshot the filesystem.
+	SnapshotMode string `yaml:"snapshotMode,omitempty"`
+
+	// TarPath is path to save the image as a tarball at path instead of pushing the image.
+	TarPath string `yaml:"tarPath,omitempty"`
+
+	// Verbosity <panic|fatal|error|warn|info|debug|trace> to set the logging level.
+	Verbosity string `yaml:"verbosity,omitempty"`
+
+	// AdditionalFlags are additional flags to be passed to Kaniko command line.
+	// See [Kaniko Additional Flags](https://github.com/GoogleContainerTools/kaniko#additional-flags).
+	// Deprecated - instead the named, unique fields should be used, e.g. `buildArgs`, `cache`, `target`.
+	AdditionalFlags []string `yaml:"flags,omitempty"`
+
+	// InsecureRegistry is to use plain HTTP requests when accessing a registry.
+	InsecureRegistry []string `yaml:"insecureRegistry,omitempty"`
+
+	// SkipTLSVerifyRegistry skips TLS certificate validation when accessing a registry.
+	SkipTLSVerifyRegistry []string `yaml:"skipTLSVerifyRegistry,omitempty"`
+
+	// Env are environment variables passed to the kaniko pod.
+	Env []v1.EnvVar `yaml:"env,omitempty"`
+
 	// Cache configures Kaniko caching. If a cache is specified, Kaniko will
 	// use a remote cache which will speed up builds.
 	Cache *KanikoCache `yaml:"cache,omitempty"`
 
-	// Reproducible is used to strip timestamps out of the built image.
-	Reproducible bool `yaml:"reproducible,omitempty"`
+	// RegistryCertificate is to to provide a certificate for TLS communication with a given registry.
+	// my.registry.url: /path/to/the/certificate.cert is the expected format.
+	RegistryCertificate map[string]*string `yaml:"registryCertificate,omitempty"`
 
-	// SkipTLS skips TLS verification when pulling and pushing the image.
-	SkipTLS bool `yaml:"skipTLS,omitempty"`
+	// Label key: value to set some metadata to the final image.
+	// This is equivalent as using the LABEL within the Dockerfile.
+	Label map[string]*string `yaml:"label,omitempty"`
+
+	// BuildArgs are arguments passed to the docker build.
+	// It also accepts environment variables via the go template syntax.
+	// For example: `{"key1": "value1", "key2": "value2", "key3": "'{{.ENV_VARIABLE}}'"}`.
+	BuildArgs map[string]*string `yaml:"buildArgs,omitempty"`
 
 	// VolumeMounts are volume mounts passed to kaniko pod.
 	VolumeMounts []v1.VolumeMount `yaml:"volumeMounts,omitempty"`

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -23,8 +23,8 @@ import (
 	yamlpatch "github.com/krishicks/yaml-patch"
 	"k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	cfg "github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
@@ -142,7 +142,7 @@ func TestApplyProfiles(t *testing.T) {
 									DockerImage: "gcr.io/cloud-builders/docker",
 									MavenImage:  "gcr.io/cloud-builders/mvn",
 									GradleImage: "gcr.io/cloud-builders/gradle",
-									KanikoImage: constants.DefaultKanikoImage,
+									KanikoImage: kaniko.DefaultImage,
 									PackImage:   "gcr.io/k8s-skaffold/pack",
 								},
 							},

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -336,7 +337,7 @@ func withGoogleCloudBuild(id string, ops ...func(*latest.BuildConfig)) func(*lat
 			DockerImage: "gcr.io/cloud-builders/docker",
 			MavenImage:  "gcr.io/cloud-builders/mvn",
 			GradleImage: "gcr.io/cloud-builders/gradle",
-			KanikoImage: constants.DefaultKanikoImage,
+			KanikoImage: kaniko.DefaultImage,
 			PackImage:   "gcr.io/k8s-skaffold/pack",
 		}}}
 		for _, op := range ops {
@@ -430,7 +431,7 @@ func withKanikoArtifact(image, workspace, dockerfile string) func(*latest.BuildC
 				KanikoArtifact: &latest.KanikoArtifact{
 					DockerfilePath: dockerfile,
 					InitImage:      constants.DefaultBusyboxImage,
-					Image:          constants.DefaultKanikoImage,
+					Image:          kaniko.DefaultImage,
 				},
 			},
 		})

--- a/pkg/skaffold/util/env_template_test.go
+++ b/pkg/skaffold/util/env_template_test.go
@@ -78,3 +78,62 @@ func TestEnvTemplate_ExecuteEnvTemplate(t *testing.T) {
 		})
 	}
 }
+
+func TestMapToFlag(t *testing.T) {
+	foo := "foo"
+	bar := "bar"
+	type args struct {
+		m    map[string]*string
+		flag string
+	}
+	tests := []struct {
+		description string
+		args        args
+		want        []string
+		wantErr     bool
+	}{
+		{
+			description: "All keys have value",
+			args: args{
+				m: map[string]*string{
+					"FOO": &foo,
+					"BAR": &bar,
+				},
+				flag: "--flag",
+			},
+			want:    []string{"--flag", "BAR=bar", "--flag", "FOO=foo"},
+			wantErr: false,
+		},
+		{
+			description: "Only keys",
+			args: args{
+				m: map[string]*string{
+					"FOO": nil,
+					"BAR": nil,
+				},
+				flag: "--flag",
+			},
+			want:    []string{"--flag", "BAR", "--flag", "FOO"},
+			wantErr: false,
+		},
+		{
+			description: "Mixed",
+			args: args{
+				m: map[string]*string{
+					"FOO": &foo,
+					"BAR": nil,
+				},
+				flag: "--flag",
+			},
+			want:    []string{"--flag", "BAR", "--flag", "FOO=foo"},
+			wantErr: false,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			got, err := MapToFlag(test.args.m, test.args.flag)
+			t.CheckNoError(err)
+			t.CheckErrorAndDeepEqual(test.wantErr, err, test.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/4852 <!-- tracking issues that this PR will close -->
**Related**: https://github.com/GoogleContainerTools/skaffold/pull/4853

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Implement kaniko flags as skaffold config items.

**User facing changes (remove if N/A)**
Support for `additionalFlags` aka
```yaml
        flags: 
```
is *removed*
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->

**Example:** 
***Before***
```yaml
    artifacts:
    - image: registry.io/image:tag
      kaniko:
        flags: 
          - --snapshotMode=redo
          - --cleanup=true
          - --verbosity=debug
```
***Now***
```yaml
    artifacts:
    - image: registry.io/image:tag
      kaniko:
        snapshotMode: redo
        cleanup: true
        verbosity: debug
```

<!-- Be sure all docs have been updated as well! -->

**Limitations/Scope**
<!-- Mention any related follow up work to this PR. -->
Does not implement kaniko `--git` tag nor related.

**Notes**
It looks long but is due to the number of flags implemented.
