### PR TITLE
Implement devloop rebuild and redeploy for dependent artifacts

### DIFF
--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -61,10 +61,6 @@ func runDev(ctx context.Context, out io.Writer) error {
 			return nil
 		default:
 			err := withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
-				// TODO: [#4892] Remove this block after fixing devloop rebuild and redeploy logic for artifacts with dependencies
-				if err := checkForArtifactDependencies(config.Build.Artifacts); err != nil {
-					return err
-				}
 				err := r.Dev(ctx, out, config.Build.Artifacts)
 
 				if r.HasDeployed() {
@@ -94,13 +90,4 @@ func runDev(ctx context.Context, out io.Writer) error {
 			}
 		}
 	}
-}
-
-func checkForArtifactDependencies(artifacts []*latest.Artifact) error {
-	for _, a := range artifacts {
-		if len(a.Dependencies) > 0 {
-			return errors.New("defining dependencies between artifacts is not yet supported for `skaffold dev` and `skaffold debug`")
-		}
-	}
-	return nil
 }

--- a/integration/build_dependencies_test.go
+++ b/integration/build_dependencies_test.go
@@ -96,16 +96,6 @@ func TestBuild_WithDependencies(t *testing.T) {
 	}
 }
 
-func TestDev_WithDependencies(t *testing.T) {
-	MarkIntegrationTest(t, CanRunWithoutGcp)
-	if out, err := skaffold.Dev().InDir("testdata/build-dependencies").RunWithCombinedOutput(t); err == nil {
-		t.Fatal("expected build to fail")
-	} else if !strings.Contains(string(out), "defining dependencies between artifacts is not yet supported for `skaffold dev` and `skaffold debug`") {
-		logrus.Info("dev output: ", string(out))
-		t.Fatalf("dev failed but for wrong reason")
-	}
-}
-
 func checkImagesExist(t *testing.T) {
 	checkImageExists(t, "gcr.io/k8s-skaffold/image1:latest")
 	checkImageExists(t, "gcr.io/k8s-skaffold/image2:latest")

--- a/integration/dev_dependencies_test.go
+++ b/integration/dev_dependencies_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
+)
+
+func TestDev_WithDependencies(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+	t.Run("required artifact rebuild & redeploy also rebuilds & redeploys dependencies", func(t *testing.T) {
+		ns, client := SetupNamespace(t)
+
+		// TODO: [#4891] Remove "--cache-artifacts=false" after implementing proper image cache invalidation for artifacts with dependencies
+		skaffold.Dev("--cache-artifacts=false").InDir("testdata/build-dependencies").InNs(ns.Name).RunBackground(t)
+		client.waitForDeploymentsToStabilizeWithTimeout(3*time.Minute, "app1", "app2", "app3", "app4")
+
+		dep1 := client.GetDeployment("app1")
+		dep2 := client.GetDeployment("app2")
+		dep3 := client.GetDeployment("app3")
+		dep4 := client.GetDeployment("app4")
+
+		// Make a change to app3/foo so that dev is forced to delete the Deployment and redeploy app1, app2 and app3,
+		// since app2 depends on app3 and app1 depends on app2
+		Run(t, "testdata/build-dependencies/app3", "sh", "-c", "echo bar > foo")
+		defer Run(t, "testdata/build-dependencies/app3", "sh", "-c", "> foo")
+
+		// Make sure the old Deployment and the new Deployment are different
+		err := wait.PollImmediate(500*time.Millisecond, 10*time.Minute, func() (bool, error) {
+			client.waitForDeploymentsToStabilizeWithTimeout(3*time.Minute, "app1", "app2", "app3", "app4")
+			newDep1 := client.GetDeployment("app1")
+			newDep2 := client.GetDeployment("app2")
+			newDep3 := client.GetDeployment("app3")
+			newDep4 := client.GetDeployment("app4")
+			logrus.Infof("app1 - old gen: %d, new gen: %d", dep1.GetGeneration(), newDep1.GetGeneration())
+			logrus.Infof("app2 - old gen: %d, new gen: %d", dep2.GetGeneration(), newDep2.GetGeneration())
+			logrus.Infof("app3 - old gen: %d, new gen: %d", dep3.GetGeneration(), newDep3.GetGeneration())
+			logrus.Infof("app4 - old gen: %d, new gen: %d", dep4.GetGeneration(), newDep4.GetGeneration())
+			return dep1.GetGeneration() != newDep1.GetGeneration() &&
+				dep2.GetGeneration() != newDep2.GetGeneration() &&
+				dep3.GetGeneration() != newDep3.GetGeneration() &&
+				dep4.GetGeneration() == newDep4.GetGeneration(), nil
+		})
+		failNowIfError(t, err)
+	})
+}

--- a/integration/testdata/build-dependencies/kubernetes/k8s.app1.yaml
+++ b/integration/testdata/build-dependencies/kubernetes/k8s.app1.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app1
+spec:
+  selector:
+    matchLabels:
+      app: app1
+  template:
+    metadata:
+      labels:
+        app: app1
+    spec:
+      containers:
+      - name: app1
+        image: image1

--- a/integration/testdata/build-dependencies/kubernetes/k8s.app2.yaml
+++ b/integration/testdata/build-dependencies/kubernetes/k8s.app2.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app2
+spec:
+  selector:
+    matchLabels:
+      app: app2
+  template:
+    metadata:
+      labels:
+        app: app2
+    spec:
+      containers:
+      - name: app2
+        image: image2

--- a/integration/testdata/build-dependencies/kubernetes/k8s.app3.yaml
+++ b/integration/testdata/build-dependencies/kubernetes/k8s.app3.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app3
+spec:
+  selector:
+    matchLabels:
+      app: app3
+  template:
+    metadata:
+      labels:
+        app: app3
+    spec:
+      containers:
+      - name: app3
+        image: image3

--- a/integration/testdata/build-dependencies/kubernetes/k8s.app4.yaml
+++ b/integration/testdata/build-dependencies/kubernetes/k8s.app4.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app4
+spec:
+  selector:
+    matchLabels:
+      app: app4
+  template:
+    metadata:
+      labels:
+        app: app4
+    spec:
+      containers:
+      - name: app4
+        image: image4

--- a/integration/testdata/build-dependencies/skaffold.yaml
+++ b/integration/testdata/build-dependencies/skaffold.yaml
@@ -10,7 +10,7 @@ build:
     docker:
       noCache: true
       buildArgs:
-        SLEEP: "1"
+        SLEEP: "0"
         FAIL: "0"
     requires:
     - image: image2
@@ -20,7 +20,7 @@ build:
     docker:
       noCache: true
       buildArgs:
-        SLEEP: "3"
+        SLEEP: "1"
         FAIL: "0"
     requires:
     - image: image3
@@ -30,7 +30,7 @@ build:
     docker:
       noCache: true
       buildArgs:
-        SLEEP: "6"
+        SLEEP: "2"
         FAIL: "0"
 
   - image: image4
@@ -38,8 +38,14 @@ build:
     docker:
       noCache: true
       buildArgs:
-        SLEEP: "9"
+        SLEEP: "3"
         FAIL: "0"
+
+deploy:
+  kubectl:
+    manifests:
+    - 'kubernetes/*.yaml'
+
 profiles:
 - name: concurrency-0
   build:

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -129,7 +129,7 @@ func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer, logger *kuber
 func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) error {
 	event.DevLoopInProgress(r.devIteration)
 	defer func() { r.devIteration++ }()
-
+	g := getTransposeGraph(artifacts)
 	// Watch artifacts
 	start := time.Now()
 	color.Default.Fprintln(out, "Listing files to watch...")
@@ -151,14 +151,14 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 					return build.DependenciesForArtifact(ctx, artifact, r.runCtx)
 				},
 				func(e filemon.Events) {
-					s, err := sync.NewItem(ctx, artifact, e, r.builds, r.runCtx)
+					s, err := sync.NewItem(ctx, artifact, e, r.builds, r.runCtx, len(g[artifact.ImageName]))
 					switch {
 					case err != nil:
 						logrus.Warnf("error adding dirty artifact to changeset: %s", err.Error())
 					case s != nil:
 						r.changeSet.AddResync(s)
 					default:
-						r.changeSet.AddRebuild(artifact)
+						addRebuild(g, artifact, r.changeSet.AddRebuild, r.runCtx.Opts.IsTargetImage)
 					}
 				},
 			); err != nil {
@@ -245,4 +245,28 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	return r.listener.WatchForChanges(ctx, out, func() error {
 		return r.doDev(ctx, out, logger, forwarderManager)
 	})
+}
+
+// graph represents the artifact graph
+type graph map[string][]*latest.Artifact
+
+// getTransposeGraph builds the transpose of the graph represented by the artifacts slice, with edges directed from required artifact to the dependent artifact.
+func getTransposeGraph(artifacts []*latest.Artifact) graph {
+	g := make(map[string][]*latest.Artifact)
+	for _, a := range artifacts {
+		for _, d := range a.Dependencies {
+			g[d.ImageName] = append(g[d.ImageName], a)
+		}
+	}
+	return g
+}
+
+// addRebuild runs the `rebuild` function for all target artifacts in the transitive closure on the source `artifact` in graph `g`.
+func addRebuild(g graph, artifact *latest.Artifact, rebuild func(*latest.Artifact), isTarget func(*latest.Artifact) bool) {
+	if isTarget(artifact) {
+		rebuild(artifact)
+	}
+	for _, a := range g[artifact.ImageName] {
+		addRebuild(g, a, rebuild, isTarget)
+	}
 }

--- a/pkg/skaffold/runner/dev_test.go
+++ b/pkg/skaffold/runner/dev_test.go
@@ -286,6 +286,141 @@ func TestDev(t *testing.T) {
 	}
 }
 
+func TestDev_WithDependencies(t *testing.T) {
+	tests := []struct {
+		description     string
+		testBench       *TestBench
+		watchEvents     []filemon.Events
+		expectedActions []Actions
+	}{
+		{
+			description: "ignore subsequent build errors",
+			testBench:   NewTestBench().WithBuildErrors([]error{nil, errors.New("")}),
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{},
+			},
+		},
+		{
+			description: "ignore subsequent test errors",
+			testBench:   &TestBench{testErrors: []error{nil, errors.New("")}},
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{
+					Built: []string{"img1:2", "img2:2"},
+				},
+			},
+		},
+		{
+			description: "ignore subsequent deploy errors",
+			testBench:   &TestBench{deployErrors: []error{nil, errors.New("")}},
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{
+					Built:  []string{"img1:2", "img2:2"},
+					Tested: []string{"img1:2", "img2:2"},
+				},
+			},
+		},
+		{
+			description: "full cycle twice",
+			testBench:   &TestBench{},
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{
+					Built:    []string{"img1:2", "img2:2"},
+					Tested:   []string{"img1:2", "img2:2"},
+					Deployed: []string{"img1:2", "img2:2"},
+				},
+			},
+		},
+		{
+			description: "only change first artifact (should redeploy dependent artifact also)",
+			testBench:   &TestBench{},
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{
+					Built:    []string{"img1:2", "img2:2"},
+					Tested:   []string{"img1:2", "img2:2"},
+					Deployed: []string{"img1:2", "img2:2"},
+				},
+			},
+		},
+		{
+			description: "redeploy",
+			testBench:   &TestBench{},
+			watchEvents: []filemon.Events{
+				{Modified: []string{"manifest.yaml"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
+			t.Override(&client.Client, mockK8sClient)
+			test.testBench.cycles = len(test.watchEvents)
+
+			runner := createRunner(t, test.testBench, &TestMonitor{
+				events:    test.watchEvents,
+				testBench: test.testBench,
+			})
+
+			err := runner.Dev(context.Background(), ioutil.Discard, []*latest.Artifact{
+				{ImageName: "img1"},
+				{ImageName: "img2", Dependencies: []*latest.ArtifactDependency{{ImageName: "img1"}}},
+			})
+
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expectedActions, test.testBench.Actions())
+		})
+	}
+}
+
 func TestDevSync(t *testing.T) {
 	type fileSyncEventCalls struct {
 		InProgress int
@@ -371,6 +506,98 @@ func TestDevSync(t *testing.T) {
 					Sync: &latest.Sync{
 						Manual: []*latest.SyncRule{{Src: "file1", Dest: "file1"}},
 					},
+				},
+				{
+					ImageName: "img2",
+				},
+			})
+
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expectedActions, test.testBench.Actions())
+			t.CheckDeepEqual(test.expectedFileSyncEventCalls, actualFileSyncEventCalls)
+		})
+	}
+}
+
+func TestDevSync_WithDependencies(t *testing.T) {
+	type fileSyncEventCalls struct {
+		InProgress int
+		Failed     int
+		Succeeded  int
+	}
+
+	tests := []struct {
+		description                string
+		testBench                  *TestBench
+		watchEvents                []filemon.Events
+		expectedActions            []Actions
+		expectedFileSyncEventCalls fileSyncEventCalls
+	}{
+		{
+			description: "sync works for dependent artifact",
+			testBench:   &TestBench{},
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{
+					Synced: []string{"img1:1"},
+				},
+			},
+			expectedFileSyncEventCalls: fileSyncEventCalls{
+				InProgress: 1,
+				Failed:     0,
+				Succeeded:  1,
+			},
+		},
+		{
+			description: "sync for required artifact is ignored; rather rebuilt along with dependent artifacts",
+			testBench:   &TestBench{},
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file2"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{
+					Built:    []string{"img2:2", "img1:2"},
+					Tested:   []string{"img2:2", "img1:2"},
+					Deployed: []string{"img1:2", "img2:2"},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			var actualFileSyncEventCalls fileSyncEventCalls
+			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
+			t.Override(&client.Client, mockK8sClient)
+			t.Override(&fileSyncInProgress, func(int, string) { actualFileSyncEventCalls.InProgress++ })
+			t.Override(&fileSyncFailed, func(int, string, error) { actualFileSyncEventCalls.Failed++ })
+			t.Override(&fileSyncSucceeded, func(int, string) { actualFileSyncEventCalls.Succeeded++ })
+			t.Override(&sync.WorkingDir, func(string, docker.Config) (string, error) { return "/", nil })
+			test.testBench.cycles = len(test.watchEvents)
+
+			runner := createRunner(t, test.testBench, &TestMonitor{
+				events:    test.watchEvents,
+				testBench: test.testBench,
+			})
+
+			err := runner.Dev(context.Background(), ioutil.Discard, []*latest.Artifact{
+				{
+					ImageName: "img1",
+					Sync: &latest.Sync{
+						Manual: []*latest.SyncRule{{Src: "file1", Dest: "file1"}},
+					},
+					Dependencies: []*latest.ArtifactDependency{{ImageName: "img2"}},
 				},
 				{
 					ImageName: "img2",

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -48,8 +48,13 @@ var (
 	SyncMap    = syncMapForArtifact
 )
 
-func NewItem(ctx context.Context, a *latest.Artifact, e filemon.Events, builds []build.Artifact, cfg docker.Config) (*Item, error) {
+func NewItem(ctx context.Context, a *latest.Artifact, e filemon.Events, builds []build.Artifact, cfg docker.Config, dependentArtifactsCount int) (*Item, error) {
 	if !e.HasChanged() || a.Sync == nil {
+		return nil, nil
+	}
+
+	if dependentArtifactsCount > 0 {
+		logrus.Warnf("Ignoring sync rules for image %q as it is being used as a required artifact for other images.", a.ImageName)
 		return nil, nil
 	}
 

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -757,7 +757,7 @@ func TestNewSyncItem(t *testing.T) {
 				return map[string][]string{"file.class": {"/some/file.class"}}, nil, nil
 			})
 
-			actual, err := NewItem(ctx, test.artifact, test.evt, test.builds, &mockConfig{})
+			actual, err := NewItem(ctx, test.artifact, test.evt, test.builds, &mockConfig{}, 0)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, actual)
 		})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4892 <!-- tracking issues that this PR will close -->
**Related**: #4713 

**Description** (Part 3 of several PRs.)
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR implements proper devloop integration for artifacts with dependencies as described in the design for [supporting dependencies between build artifacts](https://github.com/GoogleContainerTools/skaffold/blob/master/docs/design_proposals/artifact-dependencies.md#dev-loop-integration).
**User facing changes**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
If user defines `artifact1` and `artifact2` where `artifact2` is a required artifact for `artifact1` then if there's a file change in `artifact2`'s workspace during an active dev loop that triggers a rebuild and redeploy for `artifact2` then it automatically also trigger a rebuild and redeploy for `artifact1` by virtue of being a dependency.

Also sync rules are ignored for all required artifacts. So if `artifact2` defined sync rules we'd get the warning message
```
Ignoring sync rules for image "artifact2" as it is being used as a required artifact for other images.
``` 
and instead queue a rebuild.

