### PR TITLE
mute status check logs

### DIFF
--- a/pkg/skaffold/deploy/util/logfile_test.go
+++ b/pkg/skaffold/deploy/util/logfile_test.go
@@ -53,7 +53,7 @@ func TestWithLogFile(t *testing.T) {
 			logsNotFound:       []string{logFilename},
 		},
 		{
-			description:        "mute build logs",
+			description:        "mute deploy logs",
 			muted:              muted(true),
 			shouldErr:          false,
 			expectedNamespaces: []string{"ns"},
@@ -101,6 +101,76 @@ func TestWithLogFile(t *testing.T) {
 	}
 }
 
+func TestWithStatusCheckLogFile(t *testing.T) {
+	logDeploySucceeded := " - deployment/leeroy-app is ready. [1/2 deployment(s) still pending]"
+	logDeployFailed := " - deployment/leeroy-app failed. could not pull image"
+	logFilename := "- writing logs to " + filepath.Join(os.TempDir(), "skaffold", "status-check", "status-check.log")
+
+	tests := []struct {
+		description        string
+		muted              Muted
+		shouldErr          bool
+		expectedNamespaces []string
+		logsFound          []string
+		logsNotFound       []string
+	}{
+		{
+			description:        "all logs",
+			muted:              mutedStatusCheck(false),
+			shouldErr:          false,
+			expectedNamespaces: []string{"ns"},
+			logsFound:          []string{logDeploySucceeded},
+			logsNotFound:       []string{logFilename},
+		},
+		{
+			description:        "mute status check logs",
+			muted:              mutedStatusCheck(true),
+			shouldErr:          false,
+			expectedNamespaces: []string{"ns"},
+			logsFound:          []string{logFilename},
+			logsNotFound:       []string{logDeploySucceeded},
+		},
+		{
+			description:        "failed status-check - all logs",
+			muted:              mutedStatusCheck(false),
+			shouldErr:          true,
+			expectedNamespaces: nil,
+			logsFound:          []string{logDeployFailed},
+			logsNotFound:       []string{logFilename},
+		},
+		{
+			description:        "failed status-check - muted logs",
+			muted:              mutedStatusCheck(true),
+			shouldErr:          true,
+			expectedNamespaces: nil,
+			logsFound:          []string{logFilename},
+			logsNotFound:       []string{logDeployFailed},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			var mockOut bytes.Buffer
+
+			var deployer = mockStatusChecker{
+				muted:     test.muted,
+				shouldErr: test.shouldErr,
+			}
+
+			deployOut, postDeployFn, _ := WithStatusCheckLogFile("status-check.log", &mockOut, test.muted)
+			namespaces, err := deployer.Deploy(context.Background(), deployOut, nil)
+			postDeployFn()
+
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedNamespaces, namespaces)
+			for _, found := range test.logsFound {
+				t.CheckContains(found, mockOut.String())
+			}
+			for _, notFound := range test.logsNotFound {
+				t.CheckFalse(strings.Contains(mockOut.String(), notFound))
+			}
+		})
+	}
+}
+
 // Used just to show how output gets routed to different writers with the log file
 type mockDeployer struct {
 	muted     Muted
@@ -117,8 +187,38 @@ func (fd *mockDeployer) Deploy(ctx context.Context, out io.Writer, _ []build.Art
 	return []string{"ns"}, nil
 }
 
+// Used just to show how output gets routed to different writers with the log file
+type mockStatusChecker struct {
+	muted     Muted
+	shouldErr bool
+}
+
+func (fd *mockStatusChecker) Deploy(ctx context.Context, out io.Writer, _ []build.Artifact) ([]string, error) {
+	if fd.shouldErr {
+		fmt.Fprintln(out, " - deployment/leeroy-app failed. could not pull image")
+		return nil, errors.New("- deployment/leeroy-app failed. could not pull image")
+	}
+
+	fmt.Fprintln(out, "  - deployment/leeroy-app is ready. [1/2 deployment(s) still pending]")
+	return []string{"ns"}, nil
+}
+
 type muted bool
 
 func (m muted) MuteDeploy() bool {
+	return bool(m)
+}
+
+func (m muted) MuteStatusCheck() bool {
+	return false
+}
+
+type mutedStatusCheck bool
+
+func (m mutedStatusCheck) MuteDeploy() bool {
+	return false
+}
+
+func (m mutedStatusCheck) MuteStatusCheck() bool {
 	return bool(m)
 }

--- a/pkg/skaffold/deploy/util/logfile_test.go
+++ b/pkg/skaffold/deploy/util/logfile_test.go
@@ -46,7 +46,7 @@ func TestWithLogFile(t *testing.T) {
 	}{
 		{
 			description:        "all logs",
-			muted:              muted(false),
+			muted:              mutedDeploy(false),
 			shouldErr:          false,
 			expectedNamespaces: []string{"ns"},
 			logsFound:          []string{logDeploySucceeded},
@@ -54,7 +54,7 @@ func TestWithLogFile(t *testing.T) {
 		},
 		{
 			description:        "mute deploy logs",
-			muted:              muted(true),
+			muted:              mutedDeploy(true),
 			shouldErr:          false,
 			expectedNamespaces: []string{"ns"},
 			logsFound:          []string{logFilename},
@@ -62,15 +62,15 @@ func TestWithLogFile(t *testing.T) {
 		},
 		{
 			description:        "failed deploy - all logs",
-			muted:              muted(false),
+			muted:              mutedDeploy(false),
 			shouldErr:          true,
 			expectedNamespaces: nil,
 			logsFound:          []string{logDeployFailed},
 			logsNotFound:       []string{logFilename},
 		},
 		{
-			description:        "failed deploy - muted logs",
-			muted:              muted(true),
+			description:        "failed deploy - mutedDeploy logs",
+			muted:              mutedDeploy(true),
 			shouldErr:          true,
 			expectedNamespaces: nil,
 			logsFound:          []string{logFilename},
@@ -139,7 +139,7 @@ func TestWithStatusCheckLogFile(t *testing.T) {
 			logsNotFound:       []string{logFilename},
 		},
 		{
-			description:        "failed status-check - muted logs",
+			description:        "failed status-check - mutedDeploy logs",
 			muted:              mutedStatusCheck(true),
 			shouldErr:          true,
 			expectedNamespaces: nil,
@@ -203,13 +203,13 @@ func (fd *mockStatusChecker) Deploy(ctx context.Context, out io.Writer, _ []buil
 	return []string{"ns"}, nil
 }
 
-type muted bool
+type mutedDeploy bool
 
-func (m muted) MuteDeploy() bool {
+func (m mutedDeploy) MuteDeploy() bool {
 	return bool(m)
 }
 
-func (m muted) MuteStatusCheck() bool {
+func (m mutedDeploy) MuteStatusCheck() bool {
 	return false
 }
 

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -81,13 +81,13 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 	}
 
 	statusCheckOut, postStatusCheckFn, err := deployutil.WithStatusCheckLogFile(time.Now().Format(deployutil.TimeFormat)+".log", out, r.runCtx.Muted())
+	postStatusCheckFn()
 	if err != nil {
 		return err
 	}
 	event.DeployComplete()
 	r.runCtx.UpdateNamespaces(namespaces)
 	sErr := r.performStatusCheck(ctx, statusCheckOut)
-	postStatusCheckFn()
 	return sErr
 }
 

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -80,9 +80,15 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 		return err
 	}
 
+	statusCheckOut, postStatusCheckFn, err := deployutil.WithStatusCheckLogFile(time.Now().Format(deployutil.TimeFormat)+".log", out, r.runCtx.Muted())
+	if err != nil {
+		return err
+	}
 	event.DeployComplete()
 	r.runCtx.UpdateNamespaces(namespaces)
-	return r.performStatusCheck(ctx, out)
+	sErr := r.performStatusCheck(ctx, statusCheckOut)
+	postStatusCheckFn()
+	return sErr
 }
 
 func (r *SkaffoldRunner) loadImagesIntoCluster(ctx context.Context, out io.Writer, artifacts []build.Artifact) error {


### PR DESCRIPTION
Fixes #4516

Wire up status check to mute logs if `--mute-log=status-check` is present.

Testing notes:
1. run `make`
2. `../../out/skaffold dev --mute-logs=status-check`

```
....
Waiting for deployments to stabilize...
- writing logs to /var/folders/gk/s778hvkj0lb0zl95ywvw0snr00cfc0/T/skaffold/status-check/2020-10-13_16-12-10.log
Press Ctrl+C to exit
Watching for changes...
[leeroy-app] 2020/10/13 22:51:13 leeroy app server ready
[leeroy-web] 2020/10/13 22:51:13 leeroy web server ready
```
3. Verify the log contents.

```

➜  github-dashing git:(docker-support) ✗ cat /var/folders/gk/s778hvkj0lb0zl95ywvw0snr00cfc0/T/skaffold/status-check/2020-10-13_16-12-10.log
Waiting for deployments to stabilize...
 - deployment/leeroy-web is ready. [1/2 deployment(s) still pending]
 - deployment/leeroy-app is ready.
Deployments stabilized in 2.611142551s
➜  github-dashing git:(docker-support) ✗
```
