### PR TITLE
Update devLoop event messages

### DIFF
--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -548,7 +548,7 @@ func (ev *eventHandler) handleExec(f firedEvent) {
 		case InProgress:
 			logEntry.Entry = "Deploy started"
 		case Complete:
-			logEntry.Entry = "Deploy complete"
+			logEntry.Entry = "Deploy completed"
 		case Failed:
 			logEntry.Entry = "Deploy failed"
 			// logEntry.Err = de.Err
@@ -634,9 +634,9 @@ func (ev *eventHandler) handleExec(f firedEvent) {
 		de := e.DevLoopEvent
 		switch de.Status {
 		case InProgress:
-			logEntry.Entry = "Update initiated due to file change"
+			logEntry.Entry = "Update initiated"
 		case Succeeded:
-			logEntry.Entry = "Update successful"
+			logEntry.Entry = "Update succeeded"
 		case Failed:
 			logEntry.Entry = fmt.Sprintf("Update failed with error code %v", de.Err.ErrCode)
 		}


### PR DESCRIPTION
**Description**
@seanmcbreen noted that initiating a _Run_ from CC-VSC led to output indicating that an update had been initiated due to a file change.  These messages are taken devloop-related log.  

This PR change this particular message to "_Update initiated_", and fixes some tenses in other messages to be consistent.