### PR TITLE
Implement artifact resolution in Docker and Buildpack builders

### DIFF
--- a/integration/examples/microservices/base/Dockerfile
+++ b/integration/examples/microservices/base/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]

--- a/integration/examples/microservices/leeroy-app/Dockerfile
+++ b/integration/examples/microservices/leeroy-app/Dockerfile
@@ -1,12 +1,9 @@
+ARG BASE
 FROM golang:1.12.9-alpine3.10 as builder
 COPY app.go .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app .
 
-FROM alpine:3.10
-# Define GOTRACEBACK to mark this container as using the Go language runtime
-# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
-ENV GOTRACEBACK=single
-CMD ["./app"]
+FROM $BASE
 COPY --from=builder /app .

--- a/integration/examples/microservices/leeroy-web/Dockerfile
+++ b/integration/examples/microservices/leeroy-web/Dockerfile
@@ -1,12 +1,9 @@
+ARG BASE
 FROM golang:1.12.9-alpine3.10 as builder
 COPY web.go .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /web .
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app .
 
-FROM alpine:3.10
-# Define GOTRACEBACK to mark this container as using the Go language runtime
-# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
-ENV GOTRACEBACK=single
-CMD ["./web"]
-COPY --from=builder /web .
+FROM $BASE
+COPY --from=builder /app .

--- a/integration/examples/microservices/skaffold.yaml
+++ b/integration/examples/microservices/skaffold.yaml
@@ -4,8 +4,16 @@ build:
   artifacts:
     - image: leeroy-web
       context: leeroy-web
+      requires:
+        - image: base
+          alias: BASE
     - image: leeroy-app
       context: leeroy-app
+      requires:
+        - image: base
+          alias: BASE
+    - image: base
+      context: base
 deploy:
   kubectl:
     manifests:

--- a/pkg/skaffold/build/build.go
+++ b/pkg/skaffold/build/build.go
@@ -30,12 +30,17 @@ type Artifact struct {
 	Tag       string `json:"tag"`
 }
 
+// ArtifactResolver provides an interface to resolve built artifacts by image name.
+type ArtifactResolver interface {
+	GetImageTag(imageName string) (string, error)
+}
+
 // Builder is an interface to the Build API of Skaffold.
 // It must build and make the resulting image accessible to the cluster.
 // This could include pushing to a authorized repository or loading the nodes with the image.
 // If artifacts is supplied, the builder should only rebuild those artifacts.
 type Builder interface {
-	Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]Artifact, error)
+	Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, store BuiltArtifacts) ([]Artifact, error)
 
 	// Prune removes images built with Skaffold
 	Prune(context.Context, io.Writer) error

--- a/pkg/skaffold/build/buildpacks/build.go
+++ b/pkg/skaffold/build/buildpacks/build.go
@@ -26,8 +26,8 @@ import (
 
 // Build builds an artifact with Cloud Native Buildpacks:
 // https://buildpacks.io/
-func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
-	built, err := b.build(ctx, out, artifact, tag)
+func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string, r ArtifactResolver) (string, error) {
+	built, err := b.build(ctx, out, artifact, tag, r)
 	if err != nil {
 		return "", err
 	}
@@ -40,4 +40,8 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest.Art
 		return b.localDocker.Push(ctx, out, tag)
 	}
 	return b.localDocker.ImageID(ctx, tag)
+}
+
+type ArtifactResolver interface {
+	GetImageTag(imageName string) (string, error)
 }

--- a/pkg/skaffold/build/buildpacks/build_test.go
+++ b/pkg/skaffold/build/buildpacks/build_test.go
@@ -261,7 +261,7 @@ value = "VALUE2"
 			localDocker := fakeLocalDaemon(test.api)
 
 			builder := NewArtifactBuilder(localDocker, test.pushImages, test.mode)
-			_, err := builder.Build(context.Background(), ioutil.Discard, test.artifact, test.tag)
+			_, err := builder.Build(context.Background(), ioutil.Discard, test.artifact, test.tag, nil)
 
 			t.CheckError(test.shouldErr, err)
 			if test.expectedOptions != nil {

--- a/pkg/skaffold/build/cache/hash.go
+++ b/pkg/skaffold/build/cache/hash.go
@@ -107,7 +107,7 @@ func hashBuildArgs(artifact *latest.Artifact, mode config.RunMode) ([]string, er
 	var err error
 	switch {
 	case artifact.DockerArtifact != nil:
-		args, err = docker.EvalBuildArgs(mode, artifact.Workspace, artifact.DockerArtifact)
+		args, err = docker.EvalBuildArgs(mode, artifact.Workspace, artifact.DockerArtifact, nil)
 	case artifact.KanikoArtifact != nil:
 		args, err = util.EvaluateEnvTemplateMap(artifact.KanikoArtifact.BuildArgs)
 	case artifact.BuildpackArtifact != nil:

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -32,7 +32,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
-func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, buildAndTest BuildAndTestFn) ([]build.Artifact, error) {
+func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, store build.BuiltArtifacts, buildAndTest BuildAndTestFn) ([]build.Artifact, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -104,7 +104,7 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 		} else {
 			uniqueTag = build.TagWithDigest(tag, entry.Digest)
 		}
-
+		store.Record(artifact, uniqueTag)
 		alreadyBuilt = append(alreadyBuilt, build.Artifact{
 			ImageName: artifact.ImageName,
 			Tag:       uniqueTag,
@@ -113,7 +113,7 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 
 	logrus.Infoln("Cache check complete in", time.Since(start))
 
-	bRes, err := buildAndTest(ctx, out, tags, needToBuild)
+	bRes, err := buildAndTest(ctx, out, tags, needToBuild, store)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/build/cache/types.go
+++ b/pkg/skaffold/build/cache/types.go
@@ -25,14 +25,14 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
-type BuildAndTestFn func(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact) ([]build.Artifact, error)
+type BuildAndTestFn func(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, build.BuiltArtifacts) ([]build.Artifact, error)
 
 type Cache interface {
-	Build(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, BuildAndTestFn) ([]build.Artifact, error)
+	Build(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, build.BuiltArtifacts, BuildAndTestFn) ([]build.Artifact, error)
 }
 
 type noCache struct{}
 
-func (n *noCache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, buildAndTest BuildAndTestFn) ([]build.Artifact, error) {
-	return buildAndTest(ctx, out, tags, artifacts)
+func (n *noCache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, store build.BuiltArtifacts, buildAndTest BuildAndTestFn) ([]build.Artifact, error) {
+	return buildAndTest(ctx, out, tags, artifacts, store)
 }

--- a/pkg/skaffold/build/cluster/cluster.go
+++ b/pkg/skaffold/build/cluster/cluster.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Build builds a list of artifacts with Kaniko.
-func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, store build.BuiltArtifacts) ([]build.Artifact, error) {
 	teardownPullSecret, err := b.setupPullSecret(out)
 	if err != nil {
 		return nil, fmt.Errorf("setting up pull secret: %w", err)
@@ -46,10 +46,11 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, 
 	}
 
 	builder := build.WithLogFile(b.buildArtifact, b.cfg.Muted())
-	return build.InOrder(ctx, out, tags, artifacts, builder, b.ClusterDetails.Concurrency)
+	return build.InOrder(ctx, out, tags, artifacts, builder, b.ClusterDetails.Concurrency, store)
 }
 
-func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string, _ build.ArtifactResolver) (string, error) {
+	// TODO: [#4922] Implement required artifact resolution from the `ArtifactResolver`
 	digest, err := b.runBuildForArtifact(ctx, out, artifact, tag)
 	if err != nil {
 		return "", err

--- a/pkg/skaffold/build/local/docker.go
+++ b/pkg/skaffold/build/local/docker.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -30,7 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
 
-func (b *Builder) buildDocker(ctx context.Context, out io.Writer, a *latest.Artifact, tag string, mode config.RunMode) (string, error) {
+func (b *Builder) buildDocker(ctx context.Context, out io.Writer, a *latest.Artifact, tag string, mode config.RunMode, r build.ArtifactResolver) (string, error) {
 	// Fail fast if the Dockerfile can't be found.
 	dockerfile, err := docker.NormalizeDockerfilePath(a.Workspace, a.DockerArtifact.DockerfilePath)
 	if err != nil {
@@ -47,9 +48,9 @@ func (b *Builder) buildDocker(ctx context.Context, out io.Writer, a *latest.Arti
 	var imageID string
 
 	if b.local.UseDockerCLI || b.local.UseBuildkit {
-		imageID, err = b.dockerCLIBuild(ctx, out, a.Workspace, a.ArtifactType.DockerArtifact, tag)
+		imageID, err = b.dockerCLIBuild(ctx, out, a.Workspace, a.ArtifactType.DockerArtifact, a.Dependencies, tag, r)
 	} else {
-		imageID, err = b.localDocker.Build(ctx, out, a.Workspace, a.ArtifactType.DockerArtifact, tag, mode)
+		imageID, err = b.localDocker.Build(ctx, out, a.Workspace, a.ArtifactType.DockerArtifact, a.Dependencies, tag, mode, r)
 	}
 
 	if err != nil {
@@ -67,14 +68,18 @@ func (b *Builder) retrieveExtraEnv() []string {
 	return b.localDocker.ExtraEnv()
 }
 
-func (b *Builder) dockerCLIBuild(ctx context.Context, out io.Writer, workspace string, a *latest.DockerArtifact, tag string) (string, error) {
+func (b *Builder) dockerCLIBuild(ctx context.Context, out io.Writer, workspace string, a *latest.DockerArtifact, dependencies []*latest.ArtifactDependency, tag string, r build.ArtifactResolver) (string, error) {
 	dockerfilePath, err := docker.NormalizeDockerfilePath(workspace, a.DockerfilePath)
 	if err != nil {
 		return "", fmt.Errorf("normalizing dockerfile path: %w", err)
 	}
 
 	args := []string{"build", workspace, "--file", dockerfilePath, "-t", tag}
-	ba, err := docker.EvalBuildArgs(b.mode, workspace, a)
+	deps, err := docker.ResolveArtifactDependencies(dependencies, r)
+	if err != nil {
+		return "", fmt.Errorf("unable to resolve required artifacts: %w", err)
+	}
+	ba, err := docker.EvalBuildArgs(b.mode, workspace, a, deps)
 	if err != nil {
 		return "", fmt.Errorf("unable to evaluate build args: %w", err)
 	}

--- a/pkg/skaffold/build/local/docker_test.go
+++ b/pkg/skaffold/build/local/docker_test.go
@@ -33,6 +33,13 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
+type fakeArtifactResolver struct {
+}
+
+func (fakeArtifactResolver) GetImageTag(string) (string, error) {
+	return "", nil
+}
+
 func TestDockerCLIBuild(t *testing.T) {
 	tests := []struct {
 		description string
@@ -78,7 +85,7 @@ func TestDockerCLIBuild(t *testing.T) {
 			t.NewTempDir().Touch("Dockerfile").Chdir()
 			dockerfilePath, _ := filepath.Abs("Dockerfile")
 			t.Override(&docker.DefaultAuthHelper, testAuthHelper{})
-			t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact) (map[string]*string, error) {
+			t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact, additionalArgs map[string]string) (map[string]*string, error) {
 				return a.BuildArgs, nil
 			})
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunEnv(
@@ -105,7 +112,7 @@ func TestDockerCLIBuild(t *testing.T) {
 				},
 			}
 
-			_, err = builder.buildDocker(context.Background(), ioutil.Discard, artifact, "tag", test.mode)
+			_, err = builder.buildDocker(context.Background(), ioutil.Discard, artifact, "tag", test.mode, fakeArtifactResolver{})
 			t.CheckNoError(err)
 		})
 	}

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -236,7 +236,7 @@ func TestLocalRun(t *testing.T) {
 			t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
 				return fakeLocalDaemon(test.api), nil
 			})
-			t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact) (map[string]*string, error) {
+			t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact, additionalArgs map[string]string) (map[string]*string, error) {
 				return a.BuildArgs, nil
 			})
 			event.InitializeState(latest.Pipeline{
@@ -255,7 +255,7 @@ func TestLocalRun(t *testing.T) {
 			})
 			t.CheckNoError(err)
 
-			res, err := builder.Build(context.Background(), ioutil.Discard, test.tags, test.artifacts)
+			res, err := builder.Build(context.Background(), ioutil.Discard, test.tags, test.artifacts, build.NewBuiltArtifacts())
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, res)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)

--- a/pkg/skaffold/build/logfile.go
+++ b/pkg/skaffold/build/logfile.go
@@ -35,7 +35,7 @@ func WithLogFile(builder ArtifactBuilder, muted Muted) ArtifactBuilder {
 		return builder
 	}
 
-	return func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+	return func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string, r ArtifactResolver) (string, error) {
 		file, err := logfile.Create("build", artifact.ImageName+".log")
 		if err != nil {
 			return "", fmt.Errorf("unable to create log file for %s: %w", artifact.ImageName, err)
@@ -43,7 +43,7 @@ func WithLogFile(builder ArtifactBuilder, muted Muted) ArtifactBuilder {
 		fmt.Fprintln(out, " - writing logs to", file.Name())
 
 		// Run the build.
-		digest, err := builder(ctx, file, artifact, tag)
+		digest, err := builder(ctx, file, artifact, tag, r)
 
 		// After the build finishes, close the log file.
 		file.Close()

--- a/pkg/skaffold/build/logfile_test.go
+++ b/pkg/skaffold/build/logfile_test.go
@@ -87,7 +87,7 @@ func TestWithLogFile(t *testing.T) {
 			var out bytes.Buffer
 
 			builder := WithLogFile(test.builder, test.muted)
-			digest, err := builder(context.Background(), &out, &latest.Artifact{ImageName: "img"}, "img:123")
+			digest, err := builder(context.Background(), &out, &latest.Artifact{ImageName: "img"}, "img:123", nil)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedDigest, digest)
 			for _, found := range test.logsFound {
@@ -100,12 +100,12 @@ func TestWithLogFile(t *testing.T) {
 	}
 }
 
-func fakeBuilder(_ context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
+func fakeBuilder(_ context.Context, out io.Writer, a *latest.Artifact, tag string, _ ArtifactResolver) (string, error) {
 	fmt.Fprintln(out, "building", a.ImageName, "with tag", tag)
 	return "digest", nil
 }
 
-func fakeFailingBuilder(_ context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
+func fakeFailingBuilder(_ context.Context, out io.Writer, a *latest.Artifact, tag string, _ ArtifactResolver) (string, error) {
 	fmt.Fprintln(out, "failed to build", a.ImageName, "with tag", tag)
 	return "", errors.New("bug")
 }

--- a/pkg/skaffold/diagnose/diagnose.go
+++ b/pkg/skaffold/diagnose/diagnose.go
@@ -113,7 +113,7 @@ func typeOfArtifact(a *latest.Artifact) string {
 
 func timeToListDependencies(ctx context.Context, a *latest.Artifact, cfg docker.Config) (time.Duration, []string, error) {
 	start := time.Now()
-	paths, err := build.DependenciesForArtifact(ctx, a, cfg)
+	paths, err := build.DependenciesForArtifact(ctx, a, cfg, nil)
 	return time.Since(start), paths, err
 }
 

--- a/pkg/skaffold/docker/build_args_test.go
+++ b/pkg/skaffold/docker/build_args_test.go
@@ -184,7 +184,7 @@ FROM bar1`,
 			tmpDir.Write("./Dockerfile", test.dockerfile)
 			workspace := tmpDir.Path(".")
 
-			actual, err := EvalBuildArgs(test.mode, workspace, artifact)
+			actual, err := EvalBuildArgs(test.mode, workspace, artifact, nil)
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)
 		})

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/cluster"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
@@ -56,6 +57,7 @@ type Config interface {
 	GetKubeContext() string
 	MinikubeProfile() string
 	GetInsecureRegistries() map[string]bool
+	Mode() config.RunMode
 }
 
 // NewAPIClientImpl guesses the docker client to use based on current Kubernetes context.

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -191,13 +191,13 @@ func TestBuild(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&DefaultAuthHelper, testAuthHelper{})
-			t.Override(&EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact) (map[string]*string, error) {
+			t.Override(&EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact, additionalArgs map[string]string) (map[string]*string, error) {
 				return util.EvaluateEnvTemplateMap(a.BuildArgs)
 			})
 			t.SetEnvs(test.env)
 
 			localDocker := NewLocalDaemon(test.api, nil, false, nil)
-			_, err := localDocker.Build(context.Background(), ioutil.Discard, test.workspace, test.artifact, "finalimage", test.mode)
+			_, err := localDocker.Build(context.Background(), ioutil.Discard, test.workspace, test.artifact, nil, "finalimage", test.mode, nil)
 
 			if test.shouldErr {
 				t.CheckErrorContains(test.expectedError, err)

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -206,6 +206,11 @@ func extractCopyCommands(nodes []*parser.Node, onlyLastImage bool, cfg Config) (
 		switch node.Value {
 		case command.From:
 			from := fromInstruction(node)
+			if from.image == "" {
+				// some build args like artifact dependencies are not available until the first build sequence has completed.
+				// skip check if there are unavailable images
+				continue
+			}
 			if from.as != "" {
 				// Stage names are case insensitive
 				stages[strings.ToLower(from.as)] = true
@@ -311,6 +316,12 @@ func expandOnbuildInstructions(nodes []*parser.Node, cfg Config) ([]*parser.Node
 			// onbuild should immediately follow the from command
 			expandedNodes = append(expandedNodes, nodes[n:m+1]...)
 			n = m + 1
+
+			if from.image == "" {
+				// some build args like artifact dependencies are not available until the first build sequence has completed.
+				// skip check if there are unavailable images
+				continue
+			}
 
 			var onbuildNodes []*parser.Node
 			if ons, found := onbuildNodesCache[strings.ToLower(from.image)]; found {

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -61,14 +61,14 @@ func (r *SkaffoldRunner) BuildAndTest(ctx context.Context, out io.Writer, artifa
 		return bRes, nil
 	}
 
-	bRes, err := r.cache.Build(ctx, out, tags, artifacts, func(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+	bRes, err := r.cache.Build(ctx, out, tags, artifacts, r.artifactStore, func(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, store build.BuiltArtifacts) ([]build.Artifact, error) {
 		if len(artifacts) == 0 {
 			return nil, nil
 		}
 
 		r.hasBuilt = true
 
-		bRes, err := r.builder.Build(ctx, out, tags, artifacts)
+		bRes, err := r.builder.Build(ctx, out, tags, artifacts, store)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -148,7 +148,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 		default:
 			if err := r.monitor.Register(
 				func() ([]string, error) {
-					return build.DependenciesForArtifact(ctx, artifact, r.runCtx)
+					return build.DependenciesForArtifact(ctx, artifact, r.runCtx, r.artifactStore)
 				},
 				func(e filemon.Events) {
 					s, err := sync.NewItem(ctx, artifact, e, r.builds, r.runCtx, len(g[artifact.ImageName]))

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -73,9 +73,9 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating deployer: %w", err)
 	}
-
+	store := build.NewBuiltArtifacts()
 	depLister := func(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
-		buildDependencies, err := build.DependenciesForArtifact(ctx, artifact, runCtx)
+		buildDependencies, err := build.DependenciesForArtifact(ctx, artifact, runCtx, store)
 		if err != nil {
 			return nil, err
 		}
@@ -127,6 +127,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		runCtx:         runCtx,
 		intents:        intents,
 		imagesAreLocal: imagesAreLocal,
+		artifactStore:  store,
 	}, nil
 }
 

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -64,12 +64,13 @@ type SkaffoldRunner struct {
 	monitor  filemon.Monitor
 	listener Listener
 
-	kubectlCLI *kubectl.CLI
-	cache      cache.Cache
-	changeSet  changeSet
-	runCtx     *runcontext.RunContext
-	labeller   *label.DefaultLabeller
-	builds     []build.Artifact
+	kubectlCLI    *kubectl.CLI
+	cache         cache.Cache
+	changeSet     changeSet
+	runCtx        *runcontext.RunContext
+	labeller      *label.DefaultLabeller
+	builds        []build.Artifact
+	artifactStore build.BuiltArtifacts
 
 	// podSelector is used to determine relevant pods for logging and portForwarding
 	podSelector *kubernetes.ImageList

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -103,7 +103,7 @@ func (t *TestBench) enterNewCycle() {
 	t.currentActions = Actions{}
 }
 
-func (t *TestBench) Build(_ context.Context, _ io.Writer, _ tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+func (t *TestBench) Build(_ context.Context, _ io.Writer, _ tag.ImageTags, artifacts []*latest.Artifact, _ build.BuiltArtifacts) ([]build.Artifact, error) {
 	if len(t.buildErrors) > 0 {
 		err := t.buildErrors[0]
 		t.buildErrors = t.buildErrors[1:]

--- a/pkg/skaffold/runner/timings.go
+++ b/pkg/skaffold/runner/timings.go
@@ -50,13 +50,13 @@ type withTimings struct {
 	cacheArtifacts bool
 }
 
-func (w withTimings) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+func (w withTimings) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, store build.BuiltArtifacts) ([]build.Artifact, error) {
 	if len(artifacts) == 0 && w.cacheArtifacts {
 		return nil, nil
 	}
 	start := time.Now()
 
-	bRes, err := w.Builder.Build(ctx, out, tags, artifacts)
+	bRes, err := w.Builder.Build(ctx, out, tags, artifacts, store)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/runner/timings_test.go
+++ b/pkg/skaffold/runner/timings_test.go
@@ -39,7 +39,7 @@ type mockBuilder struct {
 	err bool
 }
 
-func (m *mockBuilder) Build(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact) ([]build.Artifact, error) {
+func (m *mockBuilder) Build(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, build.BuiltArtifacts) ([]build.Artifact, error) {
 	if m.err {
 		return nil, errors.New("Unable to build")
 	}
@@ -111,7 +111,7 @@ func TestTimingsBuild(t *testing.T) {
 			builder, _, _ := WithTimings(b, nil, nil, false)
 
 			var out bytes.Buffer
-			_, err := builder.Build(context.Background(), &out, nil, nil)
+			_, err := builder.Build(context.Background(), &out, nil, nil, nil)
 
 			t.CheckError(test.shouldErr, err)
 			t.CheckMatches(test.shouldOutput, out.String())


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: #4713, #4922
**Merge after**: #4893 

**Description** (Part 3 of several PRs.)
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR implements resolving required artifacts as build args in docker builder; and as builder or run image in buildpacks, as described in the design for [supporting dependencies between build artifacts](https://github.com/GoogleContainerTools/skaffold/blob/master/docs/design_proposals/artifact-dependencies.md#docker-builder).
**User facing changes**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
Modified example `integration/examples/microservices` app to test the required artifacts resolution as build args. Commands working:
```
skaffold dev --cache-artifacts=false --port-forward
```
```
skaffold build --cache-artifacts=false
```

#4893 will make this work with cache so it's a prereq PR. Will rebase and add tests after that gets in but general code review welcome!
