### PR TITLE
Implement resolving required artifacts as build-args in the docker builder

### DIFF
--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -40,8 +40,8 @@ func TestBuildDeploy(t *testing.T) {
 	// Parse the Build Output
 	buildArtifacts, err := flags.ParseBuildOutput(outputBytes)
 	failNowIfError(t, err)
-	if len(buildArtifacts.Builds) != 2 {
-		t.Fatalf("expected 2 artifacts to be built, but found %d", len(buildArtifacts.Builds))
+	if len(buildArtifacts.Builds) != 3 {
+		t.Fatalf("expected 3 artifacts to be built, but found %d", len(buildArtifacts.Builds))
 	}
 
 	var webTag, appTag string

--- a/integration/dev_dependencies_test.go
+++ b/integration/dev_dependencies_test.go
@@ -31,8 +31,7 @@ func TestDev_WithDependencies(t *testing.T) {
 	t.Run("required artifact rebuild & redeploy also rebuilds & redeploys dependencies", func(t *testing.T) {
 		ns, client := SetupNamespace(t)
 
-		// TODO: [#4891] Remove "--cache-artifacts=false" after implementing proper image cache invalidation for artifacts with dependencies
-		skaffold.Dev("--cache-artifacts=false").InDir("testdata/build-dependencies").InNs(ns.Name).RunBackground(t)
+		skaffold.Dev().InDir("testdata/build-dependencies").InNs(ns.Name).RunBackground(t)
 		client.waitForDeploymentsToStabilizeWithTimeout(3*time.Minute, "app1", "app2", "app3", "app4")
 
 		dep1 := client.GetDeployment("app1")

--- a/integration/examples/microservices/base/Dockerfile
+++ b/integration/examples/microservices/base/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.10
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]

--- a/integration/examples/microservices/leeroy-app/Dockerfile
+++ b/integration/examples/microservices/leeroy-app/Dockerfile
@@ -1,12 +1,9 @@
+ARG BASE
 FROM golang:1.12.9-alpine3.10 as builder
 COPY app.go .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app .
 
-FROM alpine:3.10
-# Define GOTRACEBACK to mark this container as using the Go language runtime
-# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
-ENV GOTRACEBACK=single
-CMD ["./app"]
+FROM $BASE
 COPY --from=builder /app .

--- a/integration/examples/microservices/leeroy-web/Dockerfile
+++ b/integration/examples/microservices/leeroy-web/Dockerfile
@@ -1,12 +1,9 @@
+ARG BASE
 FROM golang:1.12.9-alpine3.10 as builder
 COPY web.go .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /web .
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app .
 
-FROM alpine:3.10
-# Define GOTRACEBACK to mark this container as using the Go language runtime
-# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
-ENV GOTRACEBACK=single
-CMD ["./web"]
-COPY --from=builder /web .
+FROM $BASE
+COPY --from=builder /app .

--- a/integration/examples/microservices/skaffold.yaml
+++ b/integration/examples/microservices/skaffold.yaml
@@ -4,8 +4,16 @@ build:
   artifacts:
     - image: leeroy-web
       context: leeroy-web
+      requires:
+        - image: base
+          alias: BASE
     - image: leeroy-app
       context: leeroy-app
+      requires:
+        - image: base
+          alias: BASE
+    - image: base
+      context: base
 deploy:
   kubectl:
     manifests:

--- a/integration/testdata/build-dependencies/app1/Dockerfile
+++ b/integration/testdata/build-dependencies/app1/Dockerfile
@@ -1,4 +1,5 @@
-FROM busybox
+ARG image2
+FROM busybox as builder
 
 # SLEEP is to simulate build time
 ARG SLEEP=0
@@ -11,5 +12,8 @@ ENV FAIL=${FAIL}
 RUN echo "sleep ${SLEEP_TIMEOUT}"
 RUN sleep ${SLEEP_TIMEOUT}
 RUN [ "${FAIL}" == "0" ] || false
+
+FROM $image2
+COPY --from=builder . .
 
 CMD while true; do cat /foo; sleep 1; done

--- a/integration/testdata/build-dependencies/app2/Dockerfile
+++ b/integration/testdata/build-dependencies/app2/Dockerfile
@@ -1,4 +1,5 @@
-FROM busybox
+ARG IMAGE3
+FROM busybox as builder
 
 # SLEEP is to simulate build time
 ARG SLEEP=0
@@ -11,5 +12,8 @@ ENV FAIL=${FAIL}
 RUN echo "sleep ${SLEEP_TIMEOUT}"
 RUN sleep ${SLEEP_TIMEOUT}
 RUN [ "${FAIL}" == "0" ] || false
+
+FROM $IMAGE3
+COPY --from=builder . .
 
 CMD while true; do cat /foo; sleep 1; done

--- a/integration/testdata/build-dependencies/skaffold.yaml
+++ b/integration/testdata/build-dependencies/skaffold.yaml
@@ -13,7 +13,7 @@ build:
         SLEEP: "0"
         FAIL: "0"
     requires:
-    - image: image2 #test build-arg set to image field, when alias field is missing (`ARG image2`)
+    - image: image2 #test that build-arg set to image field when alias field is missing (`ARG image2`)
 
   - image: image2
     context: app2

--- a/integration/testdata/build-dependencies/skaffold.yaml
+++ b/integration/testdata/build-dependencies/skaffold.yaml
@@ -24,7 +24,7 @@ build:
         FAIL: "0"
     requires:
     - image: image3
-      alias: IMAGE3 #test build-arg set to alias field, when present (`ARG IMAGE3`).
+      alias: IMAGE3 #test that build-arg is set to alias field when present (`ARG IMAGE3`, not `image3`).
 
   - image: image3
     context: app3

--- a/integration/testdata/build-dependencies/skaffold.yaml
+++ b/integration/testdata/build-dependencies/skaffold.yaml
@@ -13,7 +13,7 @@ build:
         SLEEP: "0"
         FAIL: "0"
     requires:
-    - image: image2
+    - image: image2 #test build-arg set to image field, when alias field is missing (`ARG image2`)
 
   - image: image2
     context: app2
@@ -24,7 +24,7 @@ build:
         FAIL: "0"
     requires:
     - image: image3
-      alias: IMAGE3
+      alias: IMAGE3 #test build-arg set to alias field, when present (`ARG IMAGE3`).
 
   - image: image3
     context: app3

--- a/integration/testdata/build-dependencies/skaffold.yaml
+++ b/integration/testdata/build-dependencies/skaffold.yaml
@@ -24,6 +24,7 @@ build:
         FAIL: "0"
     requires:
     - image: image3
+      alias: IMAGE3
 
   - image: image3
     context: app3

--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -48,6 +48,7 @@ type ArtifactCache map[string]ImageDetails
 type cache struct {
 	artifactCache    ArtifactCache
 	artifactGraph    build.ArtifactGraph
+	artifactStore    build.ArtifactStore
 	cacheMutex       sync.RWMutex
 	client           docker.LocalDaemon
 	cfg              Config
@@ -69,7 +70,7 @@ type Config interface {
 }
 
 // NewCache returns the current state of the cache
-func NewCache(cfg Config, imagesAreLocal bool, tryImportMissing bool, dependencies DependencyLister, graph build.ArtifactGraph) (Cache, error) {
+func NewCache(cfg Config, imagesAreLocal bool, tryImportMissing bool, dependencies DependencyLister, graph build.ArtifactGraph, store build.ArtifactStore) (Cache, error) {
 	if !cfg.CacheArtifacts() {
 		return &noCache{}, nil
 	}
@@ -94,6 +95,7 @@ func NewCache(cfg Config, imagesAreLocal bool, tryImportMissing bool, dependenci
 	return &cache{
 		artifactCache:    artifactCache,
 		artifactGraph:    graph,
+		artifactStore:    store,
 		client:           client,
 		cfg:              cfg,
 		cacheFile:        cacheFile,

--- a/pkg/skaffold/build/cache/hash.go
+++ b/pkg/skaffold/build/cache/hash.go
@@ -163,7 +163,7 @@ func hashBuildArgs(artifact *latest.Artifact, mode config.RunMode) ([]string, er
 	var err error
 	switch {
 	case artifact.DockerArtifact != nil:
-		args, err = docker.EvalBuildArgs(mode, artifact.Workspace, artifact.DockerArtifact)
+		args, err = docker.EvalBuildArgs(mode, artifact.Workspace, artifact.DockerArtifact, nil)
 	case artifact.KanikoArtifact != nil:
 		args, err = util.EvaluateEnvTemplateMap(artifact.KanikoArtifact.BuildArgs)
 	case artifact.BuildpackArtifact != nil:

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -104,7 +104,7 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 		} else {
 			uniqueTag = build.TagWithDigest(tag, entry.Digest)
 		}
-
+		c.artifactStore.Record(artifact, uniqueTag)
 		alreadyBuilt = append(alreadyBuilt, build.Artifact{
 			ImageName: artifact.ImageName,
 			Tag:       uniqueTag,

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -46,8 +46,8 @@ func depLister(files map[string][]string) DependencyLister {
 
 type mockArtifactStore map[string]string
 
-func (m mockArtifactStore) GetImageTag(imageName string) (string, error) { return m[imageName], nil }
-func (m mockArtifactStore) Record(a *latest.Artifact, tag string)        { m[a.ImageName] = tag }
+func (m mockArtifactStore) GetImageTag(imageName string) (string, bool) { return m[imageName], true }
+func (m mockArtifactStore) Record(a *latest.Artifact, tag string)       { m[a.ImageName] = tag }
 func (m mockArtifactStore) GetArtifacts([]*latest.Artifact) ([]build.Artifact, error) {
 	return nil, nil
 }

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -44,10 +44,19 @@ func depLister(files map[string][]string) DependencyLister {
 	}
 }
 
+type mockArtifactStore map[string]string
+
+func (m mockArtifactStore) GetImageTag(imageName string) (string, error) { return m[imageName], nil }
+func (m mockArtifactStore) Record(a *latest.Artifact, tag string)        { m[a.ImageName] = tag }
+func (m mockArtifactStore) GetArtifacts([]*latest.Artifact) ([]build.Artifact, error) {
+	return nil, nil
+}
+
 type mockBuilder struct {
 	built        []*latest.Artifact
 	push         bool
 	dockerDaemon docker.LocalDaemon
+	store        build.ArtifactStore
 }
 
 func (b *mockBuilder) BuildAndTest(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
@@ -56,8 +65,8 @@ func (b *mockBuilder) BuildAndTest(ctx context.Context, out io.Writer, tags tag.
 	for _, artifact := range artifacts {
 		b.built = append(b.built, artifact)
 		tag := tags[artifact.ImageName]
-
-		_, err := b.dockerDaemon.Build(ctx, out, artifact.Workspace, artifact.DockerArtifact, tag, config.RunModes.Dev)
+		opts := docker.BuildOptions{Tag: tag, Mode: config.RunModes.Dev}
+		_, err := b.dockerDaemon.Build(ctx, out, artifact.Workspace, artifact.DockerArtifact, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -77,6 +86,7 @@ func (b *mockBuilder) BuildAndTest(ctx context.Context, out io.Writer, tags tag.
 				ImageName: artifact.ImageName,
 				Tag:       tag,
 			})
+			b.store.Record(artifact, tag)
 		}
 	}
 
@@ -121,7 +131,7 @@ func TestCacheBuildLocal(t *testing.T) {
 		})
 
 		// Mock args builder
-		t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact) (map[string]*string, error) {
+		t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact, extra map[string]*string) (map[string]*string, error) {
 			return a.BuildArgs, nil
 		})
 
@@ -129,11 +139,12 @@ func TestCacheBuildLocal(t *testing.T) {
 		cfg := &mockConfig{
 			cacheFile: tmpDir.Path("cache"),
 		}
-		artifactCache, err := NewCache(cfg, true, false, deps, build.ToArtifactGraph(artifacts))
+		store := make(mockArtifactStore)
+		artifactCache, err := NewCache(cfg, true, false, deps, build.ToArtifactGraph(artifacts), store)
 		t.CheckNoError(err)
 
 		// First build: Need to build both artifacts
-		builder := &mockBuilder{dockerDaemon: dockerDaemon, push: false}
+		builder := &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store}
 		bRes, err := artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.BuildAndTest)
 
 		t.CheckNoError(err)
@@ -142,7 +153,7 @@ func TestCacheBuildLocal(t *testing.T) {
 
 		// Second build: both artifacts are read from cache
 		// Artifacts should always be returned in their original order
-		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false}
+		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store}
 		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.BuildAndTest)
 
 		t.CheckNoError(err)
@@ -154,7 +165,7 @@ func TestCacheBuildLocal(t *testing.T) {
 		// Third build: change first artifact's dependency
 		// Artifacts should always be returned in their original order
 		tmpDir.Write("dep1", "new content")
-		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false}
+		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store}
 		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.BuildAndTest)
 
 		t.CheckNoError(err)
@@ -166,7 +177,7 @@ func TestCacheBuildLocal(t *testing.T) {
 		// Fourth build: change second artifact's dependency
 		// Artifacts should always be returned in their original order
 		tmpDir.Write("dep3", "new content")
-		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false}
+		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store}
 		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.BuildAndTest)
 
 		t.CheckNoError(err)
@@ -216,7 +227,7 @@ func TestCacheBuildRemote(t *testing.T) {
 		})
 
 		// Mock args builder
-		t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact) (map[string]*string, error) {
+		t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact, extra map[string]*string) (map[string]*string, error) {
 			return a.BuildArgs, nil
 		})
 
@@ -224,7 +235,7 @@ func TestCacheBuildRemote(t *testing.T) {
 		cfg := &mockConfig{
 			cacheFile: tmpDir.Path("cache"),
 		}
-		artifactCache, err := NewCache(cfg, false, false, deps, build.ToArtifactGraph(artifacts))
+		artifactCache, err := NewCache(cfg, false, false, deps, build.ToArtifactGraph(artifacts), make(mockArtifactStore))
 		t.CheckNoError(err)
 
 		// First build: Need to build both artifacts
@@ -300,7 +311,7 @@ func TestCacheFindMissing(t *testing.T) {
 		})
 
 		// Mock args builder
-		t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact) (map[string]*string, error) {
+		t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact, extra map[string]*string) (map[string]*string, error) {
 			return a.BuildArgs, nil
 		})
 
@@ -308,11 +319,11 @@ func TestCacheFindMissing(t *testing.T) {
 		cfg := &mockConfig{
 			cacheFile: tmpDir.Path("cache"),
 		}
-		artifactCache, err := NewCache(cfg, false, true, deps, build.ToArtifactGraph(artifacts))
+		artifactCache, err := NewCache(cfg, false, true, deps, build.ToArtifactGraph(artifacts), make(mockArtifactStore))
 		t.CheckNoError(err)
 
 		// Because the artifacts are in the docker registry, we expect them to be imported correctly.
-		builder := &mockBuilder{dockerDaemon: dockerDaemon, push: false}
+		builder := &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: make(mockArtifactStore)}
 		bRes, err := artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.BuildAndTest)
 
 		t.CheckNoError(err)

--- a/pkg/skaffold/build/cluster/cluster.go
+++ b/pkg/skaffold/build/cluster/cluster.go
@@ -46,10 +46,11 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, 
 	}
 
 	builder := build.WithLogFile(b.buildArtifact, b.cfg.Muted())
-	return build.InOrder(ctx, out, tags, artifacts, builder, b.ClusterDetails.Concurrency)
+	return build.InOrder(ctx, out, tags, artifacts, builder, b.ClusterDetails.Concurrency, b.artifactStore)
 }
 
 func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+	// TODO: [#4922] Implement required artifact resolution from the `artifactStore`
 	digest, err := b.runBuildForArtifact(ctx, out, artifact, tag)
 	if err != nil {
 		return "", err

--- a/pkg/skaffold/build/cluster/types.go
+++ b/pkg/skaffold/build/cluster/types.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
@@ -32,9 +33,10 @@ import (
 type Builder struct {
 	*latest.ClusterDetails
 
-	cfg        Config
-	kubectlcli *kubectl.CLI
-	timeout    time.Duration
+	cfg           Config
+	kubectlcli    *kubectl.CLI
+	timeout       time.Duration
+	artifactStore build.ArtifactStore
 }
 
 type Config interface {
@@ -59,6 +61,11 @@ func NewBuilder(cfg Config) (*Builder, error) {
 		kubectlcli:     kubectl.NewCLI(cfg, ""),
 		timeout:        timeout,
 	}, nil
+}
+
+func (b *Builder) WithArtifactStore(store build.ArtifactStore) *Builder {
+	b.artifactStore = store
+	return b
 }
 
 func (b *Builder) Prune(ctx context.Context, out io.Writer) error {

--- a/pkg/skaffold/build/cluster/types.go
+++ b/pkg/skaffold/build/cluster/types.go
@@ -63,9 +63,8 @@ func NewBuilder(cfg Config) (*Builder, error) {
 	}, nil
 }
 
-func (b *Builder) WithArtifactStore(store build.ArtifactStore) *Builder {
+func (b *Builder) ArtifactStore(store build.ArtifactStore) {
 	b.artifactStore = store
-	return b
 }
 
 func (b *Builder) Prune(ctx context.Context, out io.Writer) error {

--- a/pkg/skaffold/build/dependencies.go
+++ b/pkg/skaffold/build/dependencies.go
@@ -30,8 +30,13 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
+// ArtifactResolver provides an interface to resolve built artifact tags by image name.
+type ArtifactResolver interface {
+	GetImageTag(imageName string) (string, error)
+}
+
 // DependenciesForArtifact returns the dependencies for a given artifact.
-func DependenciesForArtifact(ctx context.Context, a *latest.Artifact, cfg docker.Config) ([]string, error) {
+func DependenciesForArtifact(ctx context.Context, a *latest.Artifact, cfg docker.Config, r ArtifactResolver) ([]string, error) {
 	var (
 		paths []string
 		err   error
@@ -39,7 +44,17 @@ func DependenciesForArtifact(ctx context.Context, a *latest.Artifact, cfg docker
 
 	switch {
 	case a.DockerArtifact != nil:
-		paths, err = docker.GetDependencies(ctx, a.Workspace, a.DockerArtifact.DockerfilePath, a.DockerArtifact.BuildArgs, cfg)
+		deps, _ := CreateBuildArgsFromArtifacts(a.Dependencies, r)
+		// Required artifacts cannot be resolved when `CreateBuildArgsFromArtifacts` runs prior to a completed build sequence (like `skaffold build` or the first iteration of `skaffold dev`).
+		// We can however ignore the error here as it only affects the behavior for Dockerfiles with ONBUILD instructions, and there's no functional change even for those scenarios.
+		// For single build scenarios like `build` and `run`, it is called for the cache hash calculations which are already handled in `artifactHasher`.
+		// For `dev` it will succeed on the first dev loop and list any additional dependencies found from the base artifact's ONBUILD instructions as a file added instead of modified (see `filemon.Events`)
+
+		args, evalErr := docker.EvalBuildArgs(cfg.Mode(), a.Workspace, a.DockerArtifact, deps)
+		if evalErr != nil {
+			return nil, fmt.Errorf("unable to evaluate build args: %w", evalErr)
+		}
+		paths, err = docker.GetDependencies(ctx, a.Workspace, a.DockerArtifact.DockerfilePath, args, cfg)
 
 	case a.KanikoArtifact != nil:
 		paths, err = docker.GetDependencies(ctx, a.Workspace, a.KanikoArtifact.DockerfilePath, a.KanikoArtifact.BuildArgs, cfg)
@@ -65,4 +80,21 @@ func DependenciesForArtifact(ctx context.Context, a *latest.Artifact, cfg docker
 	}
 
 	return util.AbsolutePaths(a.Workspace, paths), nil
+}
+
+// CreateBuildArgsFromArtifacts creates docker build args for an artifact from its required artifacts slice.
+func CreateBuildArgsFromArtifacts(deps []*latest.ArtifactDependency, r ArtifactResolver) (map[string]*string, error) {
+	if r == nil {
+		// `diagnose` is called without an artifact resolver. Return an empty map in this case.
+		return nil, nil
+	}
+	m := make(map[string]*string)
+	for _, d := range deps {
+		t, err := r.GetImageTag(d.ImageName)
+		if err != nil {
+			return nil, err
+		}
+		m[d.Alias] = &t
+	}
+	return m, nil
 }

--- a/pkg/skaffold/build/dependencies_test.go
+++ b/pkg/skaffold/build/dependencies_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package build
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -30,26 +29,24 @@ func TestCreateBuildArgsFromArtifacts(t *testing.T) {
 		description string
 		r           ArtifactResolver
 		deps        []*latest.ArtifactDependency
-		expected    map[string]*string
-		shouldErr   bool
+		args        map[string]*string
 	}{
 		{
 			description: "can resolve artifacts",
 			r:           mockArtifactResolver{m: map[string]string{"img1": "tag1", "img2": "tag2", "img3": "tag3", "img4": "tag4"}},
 			deps:        []*latest.ArtifactDependency{{ImageName: "img3", Alias: "alias3"}, {ImageName: "img4", Alias: "alias4"}},
-			expected:    map[string]*string{"alias3": util.StringPtr("tag3"), "alias4": util.StringPtr("tag4")},
+			args:        map[string]*string{"alias3": util.StringPtr("tag3"), "alias4": util.StringPtr("tag4")},
 		},
 		{
 			description: "cannot resolve artifacts",
 			r:           failingArtifactResolver{},
 			deps:        []*latest.ArtifactDependency{{ImageName: "img3", Alias: "alias3"}, {ImageName: "img4", Alias: "alias4"}},
-			shouldErr:   true,
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			args, err := CreateBuildArgsFromArtifacts(test.deps, test.r)
-			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, args)
+			args := CreateBuildArgsFromArtifacts(test.deps, test.r)
+			t.CheckDeepEqual(test.args, args)
 		})
 	}
 }
@@ -58,12 +55,12 @@ type mockArtifactResolver struct {
 	m map[string]string
 }
 
-func (r mockArtifactResolver) GetImageTag(imageName string) (string, error) {
-	return r.m[imageName], nil
+func (r mockArtifactResolver) GetImageTag(imageName string) (string, bool) {
+	return r.m[imageName], true
 }
 
 type failingArtifactResolver struct{}
 
-func (failingArtifactResolver) GetImageTag(string) (string, error) {
-	return "", errors.New("failed to retrieve image tag")
+func (failingArtifactResolver) GetImageTag(string) (string, bool) {
+	return "", false
 }

--- a/pkg/skaffold/build/dependencies_test.go
+++ b/pkg/skaffold/build/dependencies_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestCreateBuildArgsFromArtifacts(t *testing.T) {
+	tests := []struct {
+		description string
+		r           ArtifactResolver
+		deps        []*latest.ArtifactDependency
+		expected    map[string]*string
+		shouldErr   bool
+	}{
+		{
+			description: "can resolve artifacts",
+			r:           mockArtifactResolver{m: map[string]string{"img1": "tag1", "img2": "tag2", "img3": "tag3", "img4": "tag4"}},
+			deps:        []*latest.ArtifactDependency{{ImageName: "img3", Alias: "alias3"}, {ImageName: "img4", Alias: "alias4"}},
+			expected:    map[string]*string{"alias3": util.StringPtr("tag3"), "alias4": util.StringPtr("tag4")},
+		},
+		{
+			description: "cannot resolve artifacts",
+			r:           failingArtifactResolver{},
+			deps:        []*latest.ArtifactDependency{{ImageName: "img3", Alias: "alias3"}, {ImageName: "img4", Alias: "alias4"}},
+			shouldErr:   true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			args, err := CreateBuildArgsFromArtifacts(test.deps, test.r)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, args)
+		})
+	}
+}
+
+type mockArtifactResolver struct {
+	m map[string]string
+}
+
+func (r mockArtifactResolver) GetImageTag(imageName string) (string, error) {
+	return r.m[imageName], nil
+}
+
+type failingArtifactResolver struct{}
+
+func (failingArtifactResolver) GetImageTag(string) (string, error) {
+	return "", errors.New("failed to retrieve image tag")
+}

--- a/pkg/skaffold/build/dependencies_test.go
+++ b/pkg/skaffold/build/dependencies_test.go
@@ -39,13 +39,14 @@ func TestCreateBuildArgsFromArtifacts(t *testing.T) {
 		},
 		{
 			description: "cannot resolve artifacts",
-			r:           failingArtifactResolver{},
+			r:           mockArtifactResolver{m: make(map[string]string)},
+			args:        map[string]*string{"alias3": nil, "alias4": nil},
 			deps:        []*latest.ArtifactDependency{{ImageName: "img3", Alias: "alias3"}, {ImageName: "img4", Alias: "alias4"}},
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			args := CreateBuildArgsFromArtifacts(test.deps, test.r)
+			args := CreateBuildArgsFromArtifacts(test.deps, test.r, false)
 			t.CheckDeepEqual(test.args, args)
 		})
 	}
@@ -56,11 +57,6 @@ type mockArtifactResolver struct {
 }
 
 func (r mockArtifactResolver) GetImageTag(imageName string) (string, bool) {
-	return r.m[imageName], true
-}
-
-type failingArtifactResolver struct{}
-
-func (failingArtifactResolver) GetImageTag(string) (string, bool) {
-	return "", false
+	val, found := r.m[imageName]
+	return val, found
 }

--- a/pkg/skaffold/build/gcb/cloud_build.go
+++ b/pkg/skaffold/build/gcb/cloud_build.go
@@ -47,10 +47,11 @@ import (
 // Build builds a list of artifacts with Google Cloud Build.
 func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 	builder := build.WithLogFile(b.buildArtifactWithCloudBuild, b.muted)
-	return build.InOrder(ctx, out, tags, artifacts, builder, b.GoogleCloudBuild.Concurrency)
+	return build.InOrder(ctx, out, tags, artifacts, builder, b.GoogleCloudBuild.Concurrency, b.artifactStore)
 }
 
 func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+	// TODO: [#4922] Implement required artifact resolution from the `artifactStore`
 	cbclient, err := cloudbuild.NewService(ctx, gcp.ClientOptions()...)
 	if err != nil {
 		return "", fmt.Errorf("getting cloudbuild client: %w", err)
@@ -82,7 +83,7 @@ func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer
 		return "", fmt.Errorf("checking bucket is in correct project: %w", err)
 	}
 
-	dependencies, err := build.DependenciesForArtifact(ctx, artifact, b.cfg)
+	dependencies, err := build.DependenciesForArtifact(ctx, artifact, b.cfg, b.artifactStore)
 	if err != nil {
 		return "", fmt.Errorf("getting dependencies for %q: %w", artifact.ImageName, err)
 	}

--- a/pkg/skaffold/build/gcb/types.go
+++ b/pkg/skaffold/build/gcb/types.go
@@ -104,9 +104,8 @@ func NewBuilder(cfg Config) *Builder {
 	}
 }
 
-func (b *Builder) WithArtifactStore(store build.ArtifactStore) *Builder {
+func (b *Builder) ArtifactStore(store build.ArtifactStore) {
 	b.artifactStore = store
-	return b
 }
 
 func (b *Builder) Prune(ctx context.Context, out io.Writer) error {

--- a/pkg/skaffold/build/gcb/types.go
+++ b/pkg/skaffold/build/gcb/types.go
@@ -80,9 +80,10 @@ func NewStatusBackoff() *wait.Backoff {
 type Builder struct {
 	*latest.GoogleCloudBuild
 
-	cfg       Config
-	skipTests bool
-	muted     build.Muted
+	cfg           Config
+	skipTests     bool
+	muted         build.Muted
+	artifactStore build.ArtifactStore
 }
 
 type Config interface {
@@ -101,6 +102,11 @@ func NewBuilder(cfg Config) *Builder {
 		skipTests:        cfg.SkipTests(),
 		muted:            cfg.Muted(),
 	}
+}
+
+func (b *Builder) WithArtifactStore(store build.ArtifactStore) *Builder {
+	b.artifactStore = store
+	return b
 }
 
 func (b *Builder) Prune(ctx context.Context, out io.Writer) error {

--- a/pkg/skaffold/build/local/docker.go
+++ b/pkg/skaffold/build/local/docker.go
@@ -44,7 +44,7 @@ func (b *Builder) buildDocker(ctx context.Context, out io.Writer, a *latest.Arti
 	if err := b.pullCacheFromImages(ctx, out, a.ArtifactType.DockerArtifact); err != nil {
 		return "", fmt.Errorf("pulling cache-from images: %w", err)
 	}
-	opts := docker.BuildOptions{Tag: tag, Mode: mode, ExtraBuildArgs: build.CreateBuildArgsFromArtifacts(a.Dependencies, b.artifactStore)}
+	opts := docker.BuildOptions{Tag: tag, Mode: mode, ExtraBuildArgs: build.CreateBuildArgsFromArtifacts(a.Dependencies, b.artifactStore, true)}
 
 	var imageID string
 

--- a/pkg/skaffold/build/local/docker_test.go
+++ b/pkg/skaffold/build/local/docker_test.go
@@ -78,7 +78,7 @@ func TestDockerCLIBuild(t *testing.T) {
 			t.NewTempDir().Touch("Dockerfile").Chdir()
 			dockerfilePath, _ := filepath.Abs("Dockerfile")
 			t.Override(&docker.DefaultAuthHelper, testAuthHelper{})
-			t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact) (map[string]*string, error) {
+			t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact, extra map[string]*string) (map[string]*string, error) {
 				return a.BuildArgs, nil
 			})
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunEnv(

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -48,7 +48,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, 
 	}
 
 	builder := build.WithLogFile(b.buildArtifact, b.muted)
-	rt, err := build.InOrder(ctx, out, tags, artifacts, builder, *b.local.Concurrency)
+	rt, err := build.InOrder(ctx, out, tags, artifacts, builder, *b.local.Concurrency, b.artifactStore)
 
 	if b.prune {
 		if b.mode == config.RunModes.Build {

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -236,7 +236,7 @@ func TestLocalRun(t *testing.T) {
 			t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
 				return fakeLocalDaemon(test.api), nil
 			})
-			t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact) (map[string]*string, error) {
+			t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact, extra map[string]*string) (map[string]*string, error) {
 				return a.BuildArgs, nil
 			})
 			event.InitializeState(latest.Pipeline{
@@ -254,7 +254,7 @@ func TestLocalRun(t *testing.T) {
 				},
 			})
 			t.CheckNoError(err)
-
+			builder = builder.WithArtifactStore(build.NewArtifactStore())
 			res, err := builder.Build(context.Background(), ioutil.Discard, test.tags, test.artifacts)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, res)

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -254,7 +254,7 @@ func TestLocalRun(t *testing.T) {
 				},
 			})
 			t.CheckNoError(err)
-			builder = builder.WithArtifactStore(build.NewArtifactStore())
+			builder.ArtifactStore(build.NewArtifactStore())
 			res, err := builder.Build(context.Background(), ioutil.Discard, test.tags, test.artifacts)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, res)

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -47,6 +47,7 @@ type Builder struct {
 	insecureRegistries map[string]bool
 	muted              build.Muted
 	localPruner        *pruner
+	artifactStore      build.ArtifactStore
 }
 
 // external dependencies are wrapped
@@ -109,6 +110,11 @@ func NewBuilder(cfg Config) (*Builder, error) {
 		insecureRegistries: cfg.GetInsecureRegistries(),
 		muted:              cfg.Muted(),
 	}, nil
+}
+
+func (b *Builder) WithArtifactStore(store build.ArtifactStore) *Builder {
+	b.artifactStore = store
+	return b
 }
 
 func (b *Builder) PushImages() bool {

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -112,9 +112,8 @@ func NewBuilder(cfg Config) (*Builder, error) {
 	}, nil
 }
 
-func (b *Builder) WithArtifactStore(store build.ArtifactStore) *Builder {
+func (b *Builder) ArtifactStore(store build.ArtifactStore) {
 	b.artifactStore = store
-	return b
 }
 
 func (b *Builder) PushImages() bool {

--- a/pkg/skaffold/build/result.go
+++ b/pkg/skaffold/build/result.go
@@ -125,41 +125,41 @@ func newLogAggregator(out io.Writer, capacity int, concurrency int) logAggregato
 	return &logAggregatorImpl{out: out, capacity: capacity, messages: make(chan chan string, capacity)}
 }
 
-// builtArtifacts stores the results of each artifact build.
-type builtArtifacts interface {
+// ArtifactStore stores the results of each artifact build.
+type ArtifactStore interface {
 	Record(a *latest.Artifact, tag string)
-	GetTag(a *latest.Artifact) (string, error)
+	GetImageTag(imageName string) (string, error)
 	GetArtifacts(s []*latest.Artifact) ([]Artifact, error)
 }
 
-func newArtifactsStore() builtArtifacts {
-	return &builtArtifactsImpl{m: new(sync.Map)}
+func NewArtifactStore() ArtifactStore {
+	return &artifactStoreImpl{m: new(sync.Map)}
 }
 
-type builtArtifactsImpl struct {
+type artifactStoreImpl struct {
 	m *sync.Map
 }
 
-func (ba *builtArtifactsImpl) Record(a *latest.Artifact, tag string) {
+func (ba *artifactStoreImpl) Record(a *latest.Artifact, tag string) {
 	ba.m.Store(a.ImageName, tag)
 }
 
-func (ba *builtArtifactsImpl) GetTag(a *latest.Artifact) (string, error) {
-	v, ok := ba.m.Load(a.ImageName)
+func (ba *artifactStoreImpl) GetImageTag(imageName string) (string, error) {
+	v, ok := ba.m.Load(imageName)
 	if !ok {
-		return "", fmt.Errorf("could not find build result for image %s", a.ImageName)
+		return "", fmt.Errorf("could not find build result for image %s", imageName)
 	}
 	t, ok := v.(string)
 	if !ok {
-		logrus.Fatalf("invalid build output recorded for image %s", a.ImageName)
+		logrus.Fatalf("invalid build output recorded for image %s", imageName)
 	}
 	return t, nil
 }
 
-func (ba *builtArtifactsImpl) GetArtifacts(s []*latest.Artifact) ([]Artifact, error) {
+func (ba *artifactStoreImpl) GetArtifacts(s []*latest.Artifact) ([]Artifact, error) {
 	var builds []Artifact
 	for _, a := range s {
-		t, err := ba.GetTag(a)
+		t, err := ba.GetImageTag(a.ImageName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/skaffold/build/scheduler_test.go
+++ b/pkg/skaffold/build/scheduler_test.go
@@ -130,7 +130,7 @@ func TestFormatResults(t *testing.T) {
 			for k, v := range test.results {
 				m.Store(k, v)
 			}
-			results := &builtArtifactsImpl{m: m}
+			results := &artifactStoreImpl{m: m}
 			got, err := results.GetArtifacts(test.artifacts)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, got)
@@ -181,7 +181,7 @@ And new lines
 			}
 			initializeEvents()
 
-			InOrder(context.Background(), out, tags, artifacts, test.buildFunc, 0)
+			InOrder(context.Background(), out, tags, artifacts, test.buildFunc, 0, NewArtifactStore())
 
 			t.CheckDeepEqual(test.expected, out.String())
 		})
@@ -236,7 +236,7 @@ func TestInOrderConcurrency(t *testing.T) {
 			}
 
 			initializeEvents()
-			results, err := InOrder(context.Background(), ioutil.Discard, tags, artifacts, builder, test.limit)
+			results, err := InOrder(context.Background(), ioutil.Discard, tags, artifacts, builder, test.limit, NewArtifactStore())
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.artifacts, len(results))
@@ -359,7 +359,7 @@ func TestInOrderForArgs(t *testing.T) {
 
 			setDependencies(artifacts, test.dependency)
 			initializeEvents()
-			actual, err := InOrder(context.Background(), ioutil.Discard, tags, artifacts, test.buildArtifact, test.concurrency)
+			actual, err := InOrder(context.Background(), ioutil.Discard, tags, artifacts, test.buildArtifact, test.concurrency, NewArtifactStore())
 
 			t.CheckDeepEqual(test.expected, actual)
 			t.CheckDeepEqual(test.err, err, cmp.Comparer(errorsComparer))

--- a/pkg/skaffold/diagnose/diagnose.go
+++ b/pkg/skaffold/diagnose/diagnose.go
@@ -113,7 +113,7 @@ func typeOfArtifact(a *latest.Artifact) string {
 
 func timeToListDependencies(ctx context.Context, a *latest.Artifact, cfg docker.Config) (time.Duration, []string, error) {
 	start := time.Now()
-	paths, err := build.DependenciesForArtifact(ctx, a, cfg)
+	paths, err := build.DependenciesForArtifact(ctx, a, cfg, nil)
 	return time.Since(start), paths, err
 }
 

--- a/pkg/skaffold/docker/build_args.go
+++ b/pkg/skaffold/docker/build_args.go
@@ -37,7 +37,7 @@ var (
 	}
 )
 
-func evalBuildArgs(mode config.RunMode, workspace string, a *latest.DockerArtifact) (map[string]*string, error) {
+func evalBuildArgs(mode config.RunMode, workspace string, a *latest.DockerArtifact, extra map[string]*string) (map[string]*string, error) {
 	var defaults map[string]string
 	switch mode {
 	case config.RunModes.Debug:
@@ -51,6 +51,11 @@ func evalBuildArgs(mode config.RunMode, workspace string, a *latest.DockerArtifa
 	for k, v := range defaults {
 		result[k] = &v
 	}
+
+	for k, v := range extra {
+		result[k] = v
+	}
+
 	absDockerfilePath, err := NormalizeDockerfilePath(workspace, a.DockerfilePath)
 	if err != nil {
 		return nil, fmt.Errorf("normalizing dockerfile path: %w", err)

--- a/pkg/skaffold/docker/build_args_test.go
+++ b/pkg/skaffold/docker/build_args_test.go
@@ -184,7 +184,7 @@ FROM bar1`,
 			tmpDir.Write("./Dockerfile", test.dockerfile)
 			workspace := tmpDir.Path(".")
 
-			actual, err := EvalBuildArgs(test.mode, workspace, artifact)
+			actual, err := EvalBuildArgs(test.mode, workspace, artifact, nil)
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)
 		})

--- a/pkg/skaffold/docker/build_args_test.go
+++ b/pkg/skaffold/docker/build_args_test.go
@@ -31,6 +31,7 @@ func TestEvalBuildArgs(t *testing.T) {
 		dockerfile  string
 		mode        config.RunMode
 		buildArgs   map[string]*string
+		extra       map[string]*string
 		expected    map[string]*string
 	}{
 		{
@@ -70,6 +71,31 @@ FROM bar1`,
 				"foo1":                util.StringPtr("one"),
 				"foo2":                util.StringPtr("two"),
 				"foo3":                util.StringPtr("three"),
+			},
+		},
+		{
+			description: "debug with additional build args",
+			dockerfile: `ARG foo1
+ARG foo3
+ARG foo4
+ARG SKAFFOLD_GO_GCFLAGS
+FROM bar1`,
+			mode: config.RunModes.Debug,
+			buildArgs: map[string]*string{
+				"foo1": util.StringPtr("one"),
+				"foo2": util.StringPtr("two"),
+				"foo3": util.StringPtr("three"),
+			},
+			extra: map[string]*string{
+				"foo4": util.StringPtr("four"),
+				"foo5": util.StringPtr("five"),
+			},
+			expected: map[string]*string{
+				"SKAFFOLD_GO_GCFLAGS": util.StringPtr("all=-N -l"),
+				"foo1":                util.StringPtr("one"),
+				"foo2":                util.StringPtr("two"),
+				"foo3":                util.StringPtr("three"),
+				"foo4":                util.StringPtr("four"),
 			},
 		},
 		{
@@ -184,7 +210,7 @@ FROM bar1`,
 			tmpDir.Write("./Dockerfile", test.dockerfile)
 			workspace := tmpDir.Path(".")
 
-			actual, err := EvalBuildArgs(test.mode, workspace, artifact, nil)
+			actual, err := EvalBuildArgs(test.mode, workspace, artifact, test.extra)
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)
 		})

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/cluster"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
@@ -56,6 +57,7 @@ type Config interface {
 	GetKubeContext() string
 	MinikubeProfile() string
 	GetInsecureRegistries() map[string]bool
+	Mode() config.RunMode
 }
 
 // NewAPIClientImpl guesses the docker client to use based on current Kubernetes context.

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -80,6 +80,7 @@ type LocalDaemon interface {
 	RawClient() client.CommonAPIClient
 }
 
+// BuildOptions provides parameters related to the LocalDaemon build.
 type BuildOptions struct {
 	Tag            string
 	Mode           config.RunMode

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -191,13 +191,14 @@ func TestBuild(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&DefaultAuthHelper, testAuthHelper{})
-			t.Override(&EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact) (map[string]*string, error) {
+			t.Override(&EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact, extra map[string]*string) (map[string]*string, error) {
 				return util.EvaluateEnvTemplateMap(a.BuildArgs)
 			})
 			t.SetEnvs(test.env)
 
 			localDocker := NewLocalDaemon(test.api, nil, false, nil)
-			_, err := localDocker.Build(context.Background(), ioutil.Discard, test.workspace, test.artifact, "finalimage", test.mode)
+			opts := BuildOptions{Tag: "finalimage", Mode: test.mode}
+			_, err := localDocker.Build(context.Background(), ioutil.Discard, test.workspace, test.artifact, opts)
 
 			if test.shouldErr {
 				t.CheckErrorContains(test.expectedError, err)

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -206,6 +206,11 @@ func extractCopyCommands(nodes []*parser.Node, onlyLastImage bool, cfg Config) (
 		switch node.Value {
 		case command.From:
 			from := fromInstruction(node)
+			if from.image == "" {
+				// some build args like artifact dependencies are not available until the first build sequence has completed.
+				// skip check if there are unavailable images
+				continue
+			}
 			if from.as != "" {
 				// Stage names are case insensitive
 				stages[strings.ToLower(from.as)] = true
@@ -311,6 +316,12 @@ func expandOnbuildInstructions(nodes []*parser.Node, cfg Config) ([]*parser.Node
 			// onbuild should immediately follow the from command
 			expandedNodes = append(expandedNodes, nodes[n:m+1]...)
 			n = m + 1
+
+			if from.image == "" {
+				// some build args like artifact dependencies are not available until the first build sequence has completed.
+				// skip check if there are unavailable images
+				continue
+			}
 
 			var onbuildNodes []*parser.Node
 			if ons, found := onbuildNodesCache[strings.ToLower(from.image)]; found {

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -148,7 +148,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 		default:
 			if err := r.monitor.Register(
 				func() ([]string, error) {
-					return build.DependenciesForArtifact(ctx, artifact, r.runCtx)
+					return build.DependenciesForArtifact(ctx, artifact, r.runCtx, r.artifactStore)
 				},
 				func(e filemon.Events) {
 					s, err := sync.NewItem(ctx, artifact, e, r.builds, r.runCtx, len(g[artifact.ImageName]))

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -178,17 +178,23 @@ func getBuilder(runCtx *runcontext.RunContext, store build.ArtifactStore) (build
 		if err != nil {
 			return nil, false, err
 		}
-		builder.WithArtifactStore(store)
+		builder.ArtifactStore(store)
 		return builder, !builder.PushImages(), nil
 
 	case b.GoogleCloudBuild != nil:
 		logrus.Debugln("Using builder: google cloud")
-		return gcb.NewBuilder(runCtx).WithArtifactStore(store), false, nil
+		builder := gcb.NewBuilder(runCtx)
+		builder.ArtifactStore(store)
+		return builder, false, nil
 
 	case b.Cluster != nil:
 		logrus.Debugln("Using builder: cluster")
 		builder, err := cluster.NewBuilder(runCtx)
-		return builder.WithArtifactStore(store), false, err
+		if err != nil {
+			return nil, false, err
+		}
+		builder.ArtifactStore(store)
+		return builder, false, err
 
 	default:
 		return nil, false, fmt.Errorf("unknown builder for config %+v", b)

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -64,13 +64,13 @@ type SkaffoldRunner struct {
 	monitor  filemon.Monitor
 	listener Listener
 
-	kubectlCLI *kubectl.CLI
-	cache      cache.Cache
-	changeSet  changeSet
-	runCtx     *runcontext.RunContext
-	labeller   *label.DefaultLabeller
-	builds     []build.Artifact
-
+	kubectlCLI    *kubectl.CLI
+	cache         cache.Cache
+	changeSet     changeSet
+	runCtx        *runcontext.RunContext
+	labeller      *label.DefaultLabeller
+	builds        []build.Artifact
+	artifactStore build.ArtifactStore
 	// podSelector is used to determine relevant pods for logging and portForwarding
 	podSelector *kubernetes.ImageList
 

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cluster"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/gcb"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/local"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
@@ -278,6 +280,44 @@ func TestNewForConfig(t *testing.T) {
 				},
 			},
 			expectedBuilder:  &local.Builder{},
+			expectedTester:   &test.FullTester{},
+			expectedDeployer: &kubectl.Deployer{},
+		},
+		{
+			description: "gcb config",
+			pipeline: latest.Pipeline{
+				Build: latest.BuildConfig{
+					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
+					BuildType: latest.BuildType{
+						GoogleCloudBuild: &latest.GoogleCloudBuild{},
+					},
+				},
+				Deploy: latest.DeployConfig{
+					DeployType: latest.DeployType{
+						KubectlDeploy: &latest.KubectlDeploy{},
+					},
+				},
+			},
+			expectedBuilder:  &gcb.Builder{},
+			expectedTester:   &test.FullTester{},
+			expectedDeployer: &kubectl.Deployer{},
+		},
+		{
+			description: "cluster builder config",
+			pipeline: latest.Pipeline{
+				Build: latest.BuildConfig{
+					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
+					BuildType: latest.BuildType{
+						Cluster: &latest.ClusterDetails{Timeout: "100s"},
+					},
+				},
+				Deploy: latest.DeployConfig{
+					DeployType: latest.DeployType{
+						KubectlDeploy: &latest.KubectlDeploy{},
+					},
+				},
+			},
+			expectedBuilder:  &cluster.Builder{},
 			expectedTester:   &test.FullTester{},
 			expectedDeployer: &kubectl.Deployer{},
 		},


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: #4713, #4922

**Description** (Part 3 of several PRs.)
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR implements resolving required artifacts as build args in docker builder as described in the design for [supporting dependencies between build artifacts](https://github.com/GoogleContainerTools/skaffold/blob/master/docs/design_proposals/artifact-dependencies.md#docker-builder).
**User facing changes**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
Modified example `integration/examples/microservices` app to test the required artifacts resolution as build args. Should work for all commands, with all flags.
