### PR TITLE
Set GOPATH in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+GOPATH ?= $(shell go env GOPATH)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= amd64
 BUILD_DIR ?= ./out

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ $(BUILD_DIR)/$(PROJECT): $(STATIK_FILES) $(GO_FILES) $(BUILD_DIR)
 
 .PHONY: install
 install: $(BUILD_DIR)/$(PROJECT)
+	mkdir -p $(GOPATH)/bin
 	cp $(BUILD_DIR)/$(PROJECT) $(GOPATH)/bin/$(PROJECT)
 
 .PRECIOUS: $(foreach platform, $(SUPPORTED_PLATFORMS), $(BUILD_DIR)/$(PROJECT)-$(platform))


### PR DESCRIPTION
Fixes: #4944

**Description**

`make install` or `make integration`  succeeds,
don't need to set GOPATH in bash_profile or run `GOPATH=~/go make install` like this 