### PR TITLE
Name debug helper containers more explicitly

### DIFF
--- a/pkg/skaffold/debug/transform.go
+++ b/pkg/skaffold/debug/transform.go
@@ -251,7 +251,7 @@ func transformPodSpec(metadata *metav1.ObjectMeta, podSpec *v1.PodSpec, retrieve
 		// the initContainers are responsible for populating the contents of `/dbg`
 		for imageID := range requiredSupportImages {
 			supportFilesInitContainer := v1.Container{
-				Name:         fmt.Sprintf("install-%s-support", imageID),
+				Name:         fmt.Sprintf("install-%s-debug-support", imageID),
 				Image:        fmt.Sprintf("%s/%s", debugHelpersRegistry, imageID),
 				VolumeMounts: []v1.VolumeMount{supportVolumeMount},
 			}

--- a/pkg/skaffold/debug/transform_go_test.go
+++ b/pkg/skaffold/debug/transform_go_test.go
@@ -268,7 +268,7 @@ func TestTransformManifestDelve(t *testing.T) {
 						VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 					}},
 					InitContainers: []v1.Container{{
-						Name:         "install-go-support",
+						Name:         "install-go-debug-support",
 						Image:        "HELPERS/go",
 						VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 					}},
@@ -311,7 +311,7 @@ func TestTransformManifestDelve(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-go-support",
+								Name:         "install-go-debug-support",
 								Image:        "HELPERS/go",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -354,7 +354,7 @@ func TestTransformManifestDelve(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-go-support",
+								Name:         "install-go-debug-support",
 								Image:        "HELPERS/go",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -397,7 +397,7 @@ func TestTransformManifestDelve(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-go-support",
+								Name:         "install-go-debug-support",
 								Image:        "HELPERS/go",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -438,7 +438,7 @@ func TestTransformManifestDelve(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-go-support",
+								Name:         "install-go-debug-support",
 								Image:        "HELPERS/go",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -479,7 +479,7 @@ func TestTransformManifestDelve(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-go-support",
+								Name:         "install-go-debug-support",
 								Image:        "HELPERS/go",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -522,7 +522,7 @@ func TestTransformManifestDelve(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-go-support",
+								Name:         "install-go-debug-support",
 								Image:        "HELPERS/go",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -575,7 +575,7 @@ func TestTransformManifestDelve(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-go-support",
+								Name:         "install-go-debug-support",
 								Image:        "HELPERS/go",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},

--- a/pkg/skaffold/debug/transform_nodejs_test.go
+++ b/pkg/skaffold/debug/transform_nodejs_test.go
@@ -370,7 +370,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 						VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 					}},
 					InitContainers: []v1.Container{{
-						Name:         "install-nodejs-support",
+						Name:         "install-nodejs-debug-support",
 						Image:        "HELPERS/nodejs",
 						VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 					}},
@@ -410,7 +410,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-nodejs-support",
+								Name:         "install-nodejs-debug-support",
 								Image:        "HELPERS/nodejs",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -447,7 +447,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-nodejs-support",
+								Name:         "install-nodejs-debug-support",
 								Image:        "HELPERS/nodejs",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -487,7 +487,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-nodejs-support",
+								Name:         "install-nodejs-debug-support",
 								Image:        "HELPERS/nodejs",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -525,7 +525,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-nodejs-support",
+								Name:         "install-nodejs-debug-support",
 								Image:        "HELPERS/nodejs",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -564,7 +564,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-nodejs-support",
+								Name:         "install-nodejs-debug-support",
 								Image:        "HELPERS/nodejs",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -606,7 +606,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-nodejs-support",
+								Name:         "install-nodejs-debug-support",
 								Image:        "HELPERS/nodejs",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -656,7 +656,7 @@ func TestTransformManifestNodeJS(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-nodejs-support",
+								Name:         "install-nodejs-debug-support",
 								Image:        "HELPERS/nodejs",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},

--- a/pkg/skaffold/debug/transform_python_test.go
+++ b/pkg/skaffold/debug/transform_python_test.go
@@ -271,7 +271,7 @@ func TestTransformManifestPython(t *testing.T) {
 						VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 					}},
 					InitContainers: []v1.Container{{
-						Name:         "install-python-support",
+						Name:         "install-python-debug-support",
 						Image:        "HELPERS/python",
 						VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 					}},
@@ -313,7 +313,7 @@ func TestTransformManifestPython(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-python-support",
+								Name:         "install-python-debug-support",
 								Image:        "HELPERS/python",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -355,7 +355,7 @@ func TestTransformManifestPython(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-python-support",
+								Name:         "install-python-debug-support",
 								Image:        "HELPERS/python",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -397,7 +397,7 @@ func TestTransformManifestPython(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-python-support",
+								Name:         "install-python-debug-support",
 								Image:        "HELPERS/python",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -437,7 +437,7 @@ func TestTransformManifestPython(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-python-support",
+								Name:         "install-python-debug-support",
 								Image:        "HELPERS/python",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -477,7 +477,7 @@ func TestTransformManifestPython(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-python-support",
+								Name:         "install-python-debug-support",
 								Image:        "HELPERS/python",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -519,7 +519,7 @@ func TestTransformManifestPython(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-python-support",
+								Name:         "install-python-debug-support",
 								Image:        "HELPERS/python",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
@@ -571,7 +571,7 @@ func TestTransformManifestPython(t *testing.T) {
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},
 							InitContainers: []v1.Container{{
-								Name:         "install-python-support",
+								Name:         "install-python-debug-support",
 								Image:        "HELPERS/python",
 								VolumeMounts: []v1.VolumeMount{{Name: "debugging-support-files", MountPath: "/dbg"}},
 							}},


### PR DESCRIPTION
**Description**
Cosmetic fix to improve names used for `skaffold debug` support images.  Previously images would be names `install-xxx-support`, but it's not clear these images were installing debug support tools.

Before:
```
Press Ctrl+C to exit
Not watching for changes...
[install-go-support] Installing runtime debugging support files in /dbg
[install-go-support] Installation complete
```

After:
```
Press Ctrl+C to exit
Not watching for changes...
[install-go-debug-support] Installing runtime debugging support files in /dbg
[install-go-debug-support] Installation complete
```
