### PR TITLE
Fix up doc: debug works for buildpacks

### DIFF
--- a/docs/content/en/docs/pipeline-stages/builders/_index.md
+++ b/docs/content/en/docs/pipeline-stages/builders/_index.md
@@ -23,7 +23,7 @@ controls how artifacts are built. To use a specific tool for building
 artifacts, add the value representing the tool and options for using that tool
 to the `build` section.
 
-For a detailed discussion on [Skaffold Configuration]({{< relref "/docs/design/config.md" >}}),
+For detailed per-builder [Skaffold Configuration]({{< relref "/docs/design/config.md" >}}) options,
 see [skaffold.yaml References]({{< relref "/docs/references/yaml" >}}).
 
 ## Local Build

--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -302,10 +302,7 @@ The API's _state_ ([gRPC](../references/api/grpc/#skaffoldservice), [REST](../re
 `skaffold debug` requires being able to examine and alter the
 command-line used in the container entrypoint.  This transformation
 will not work with images that use intermediate launch scripts or
-binaries.  For example, `debug` currently does not work with an image produced
-by the Cloud Native Buildpacks builder as it uses a `launcher`
-binary to run commands that are specified in a set of configuration
-files.
+binaries.
 
 ### Supported Deployers
 


### PR DESCRIPTION
Minor doc tweaks:
  - debug does work for buildpacks
  - the builder configuration text was a bit confusing since the skaffold.yaml reference page doesn't have any discussion.