### PR TITLE
Retrieve `debug` helper images from gcr.io/k8s-skaffold/skaffold-debug-support

### DIFF
--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -21,7 +21,8 @@ and entrypoints, and more.
 Some language runtimes require additional support files to enable debugging.
 For these languages, a special set of [runtime-specific images](https://github.com/GoogleContainerTools/container-debug-support)
 are configured as _init-containers_ to populate a shared-volume that is mounted into
-each of the appropriate containers.  These images are hosted at `gcr.io/gcp-dev-tools/duct-tape`.
+each of the appropriate containers.  These images are hosted at
+`gcr.io/k8s-skaffold/skaffold-debug-support`.
 
 ### Supported Language Runtimes
 

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -42,7 +42,7 @@ const (
 	DefaultBusyboxImage = "busybox"
 
 	// DefaultDebugHelpersRegistry is the default location used for the helper images for `debug`.
-	DefaultDebugHelpersRegistry = "gcr.io/gcp-dev-tools/duct-tape"
+	DefaultDebugHelpersRegistry = "gcr.io/k8s-skaffold/skaffold-debug-support"
 
 	DefaultSkaffoldDir = ".skaffold"
 	DefaultCacheFile   = "cache"

--- a/pkg/skaffold/debug/transform.go
+++ b/pkg/skaffold/debug/transform.go
@@ -25,7 +25,7 @@ a _container transformer_ interface. Each transformer implementation should do t
 4. The transform should return metadata to describe the remote connection information.
 
 Certain language runtimes require additional support files to enable remote debugging.
-These support files are provided through a set of support images defined at `gcr.io/gcp-dev-tools/duct-tape/`
+These support files are provided through a set of support images defined at `gcr.io/k8s-skaffold/skaffold-debug-support/`
 and defined at https://github.com/GoogleContainerTools/container-debug-support.
 The appropriate image ID is returned by the language transformer.  These support images
 are configured as initContainers on the pod and are expected to copy the debugging support


### PR DESCRIPTION
Fixes: #4520 

**Description**
gcr.io/gcp-dev-tools/duct-tape helpers moved to gcr.io/k8s-skaffold/skaffold-debug-support

**User facing changes (remove if N/A)**
- Skaffold's `debug` helper images are now pulled from `gcr.io/k8s-skaffold/skaffold-debug-support`