### PR TITLE
Implement required artifact resolution in buildpacks builder

### DIFF
--- a/pkg/skaffold/build/buildpacks/build_test.go
+++ b/pkg/skaffold/build/buildpacks/build_test.go
@@ -50,6 +50,7 @@ func TestBuild(t *testing.T) {
 		pushImages      bool
 		shouldErr       bool
 		mode            config.RunMode
+		resolver        ArtifactResolver
 		expectedOptions *pack.BuildOptions
 	}{
 		{
@@ -58,6 +59,7 @@ func TestBuild(t *testing.T) {
 			tag:         "img:tag",
 			mode:        config.RunModes.Debug,
 			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{},
 			expectedOptions: &pack.BuildOptions{
 				AppPath:  ".",
 				Builder:  "my/builder",
@@ -72,6 +74,7 @@ func TestBuild(t *testing.T) {
 			tag:         "img:tag",
 			mode:        config.RunModes.Build,
 			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{},
 			expectedOptions: &pack.BuildOptions{
 				AppPath:  ".",
 				Builder:  "my/builder",
@@ -81,11 +84,13 @@ func TestBuild(t *testing.T) {
 				Image:    "img:latest",
 			},
 		},
+
 		{
 			description: "success with buildpacks for debug",
 			artifact:    withTrustedBuilder(withBuildpacks([]string{"my/buildpack", "my/otherBuildpack"}, buildpacksArtifact("my/otherBuilder", "my/otherRun"))),
 			tag:         "img:tag",
 			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{},
 			mode:        config.RunModes.Debug,
 			expectedOptions: &pack.BuildOptions{
 				AppPath:      ".",
@@ -102,6 +107,7 @@ func TestBuild(t *testing.T) {
 			artifact:    withTrustedBuilder(withBuildpacks([]string{"my/buildpack", "my/otherBuildpack"}, buildpacksArtifact("my/otherBuilder", "my/otherRun"))),
 			tag:         "img:tag",
 			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{},
 			mode:        config.RunModes.Build,
 			expectedOptions: &pack.BuildOptions{
 				AppPath:      ".",
@@ -119,6 +125,7 @@ func TestBuild(t *testing.T) {
 			artifact:    buildpacksArtifact("my/builder2", "my/run2"),
 			tag:         "img:tag",
 			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{},
 			mode:        config.RunModes.Build,
 			files: map[string]string{
 				"project.toml": `[[build.env]]
@@ -147,6 +154,7 @@ version = "1.0"
 			artifact:    withBuildpacks([]string{"my/buildpack", "my/otherBuildpack"}, buildpacksArtifact("my/builder3", "my/run3")),
 			tag:         "img:tag",
 			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{},
 			files: map[string]string{
 				"project.toml": `[[build.buildpacks]]
 id = "my/ignored"
@@ -167,6 +175,7 @@ id = "my/ignored"
 			tag:         "img:tag",
 			mode:        config.RunModes.Build,
 			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{},
 			files: map[string]string{
 				"project.toml": `[[build.env]]
 name = "KEY2"
@@ -189,6 +198,7 @@ value = "VALUE2"
 			artifact:    withSync(&latest.Sync{Auto: util.BoolPtr(true)}, buildpacksArtifact("another/builder", "another/run")),
 			tag:         "img:tag",
 			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{},
 			mode:        config.RunModes.Dev,
 			expectedOptions: &pack.BuildOptions{
 				AppPath:  ".",
@@ -205,6 +215,7 @@ value = "VALUE2"
 			artifact:    buildpacksArtifact("my/other-builder", "my/run"),
 			tag:         "img:tag",
 			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{},
 			mode:        config.RunModes.Dev,
 			expectedOptions: &pack.BuildOptions{
 				AppPath:  ".",
@@ -219,6 +230,7 @@ value = "VALUE2"
 			artifact:    buildpacksArtifact("my/builder", "my/run"),
 			tag:         "in valid ref",
 			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{},
 			shouldErr:   true,
 		},
 		{
@@ -229,6 +241,7 @@ value = "VALUE2"
 			api: &testutil.FakeAPIClient{
 				ErrImagePush: true,
 			},
+			resolver:  mockArtifactResolver{},
 			shouldErr: true,
 		},
 		{
@@ -236,6 +249,7 @@ value = "VALUE2"
 			artifact:    withEnv([]string{"INVALID"}, buildpacksArtifact("my/builder", "my/run")),
 			tag:         "img:tag",
 			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{},
 			shouldErr:   true,
 		},
 		{
@@ -243,6 +257,7 @@ value = "VALUE2"
 			artifact:    buildpacksArtifact("my/builder2", "my/run2"),
 			tag:         "img:tag",
 			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{},
 			files: map[string]string{
 				"project.toml": `INVALID`,
 			},
@@ -261,7 +276,7 @@ value = "VALUE2"
 				Add("img:latest", "builtImageID")
 			localDocker := fakeLocalDaemon(test.api)
 
-			builder := NewArtifactBuilder(localDocker, test.pushImages, test.mode)
+			builder := NewArtifactBuilder(localDocker, test.pushImages, test.mode, test.resolver)
 			_, err := builder.Build(context.Background(), ioutil.Discard, test.artifact, test.tag)
 
 			t.CheckError(test.shouldErr, err)
@@ -272,6 +287,144 @@ value = "VALUE2"
 	}
 }
 
+func TestBuildWithArtifactDependencies(t *testing.T) {
+	tests := []struct {
+		description     string
+		artifact        *latest.Artifact
+		tag             string
+		api             *testutil.FakeAPIClient
+		files           map[string]string
+		pushImages      bool
+		shouldErr       bool
+		mode            config.RunMode
+		resolver        ArtifactResolver
+		expectedOptions *pack.BuildOptions
+	}{
+		{
+			description: "custom builder image only with no push",
+			artifact:    withRequiredArtifacts([]*latest.ArtifactDependency{{ImageName: "builder-image", Alias: "BUILDER_IMAGE"}}, buildpacksArtifact("BUILDER_IMAGE", "my/run")),
+			tag:         "img:tag",
+			pushImages:  false,
+			mode:        config.RunModes.Build,
+			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{m: map[string]string{"builder-image": "my/custom-builder"}},
+			expectedOptions: &pack.BuildOptions{
+				AppPath:  ".",
+				Builder:  "my/custom-builder",
+				RunImage: "my/run",
+				NoPull:   true,
+				Env:      nonDebugModeArgs,
+				Image:    "img:latest",
+			},
+		},
+		{
+			description: "custom run image only with no push",
+			artifact:    withRequiredArtifacts([]*latest.ArtifactDependency{{ImageName: "run-image", Alias: "RUN_IMAGE"}}, buildpacksArtifact("my/builder", "RUN_IMAGE")),
+			tag:         "img:tag",
+			pushImages:  false,
+			mode:        config.RunModes.Build,
+			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{m: map[string]string{"run-image": "my/custom-run"}},
+			expectedOptions: &pack.BuildOptions{
+				AppPath:  ".",
+				Builder:  "my/builder",
+				RunImage: "my/custom-run",
+				NoPull:   true,
+				Env:      nonDebugModeArgs,
+				Image:    "img:latest",
+			},
+		},
+		{
+			description: "custom builder image only with push",
+			artifact:    withRequiredArtifacts([]*latest.ArtifactDependency{{ImageName: "builder-image", Alias: "BUILDER_IMAGE"}}, buildpacksArtifact("BUILDER_IMAGE", "my/run")),
+			tag:         "img:tag",
+			pushImages:  true,
+			mode:        config.RunModes.Build,
+			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{m: map[string]string{"builder-image": "my/custom-builder"}},
+			expectedOptions: &pack.BuildOptions{
+				AppPath:  ".",
+				Builder:  "my/custom-builder",
+				RunImage: "my/run",
+				NoPull:   false,
+				Env:      nonDebugModeArgs,
+				Image:    "img:latest",
+			},
+		},
+		{
+			description: "custom run image only with push",
+			artifact:    withRequiredArtifacts([]*latest.ArtifactDependency{{ImageName: "run-image", Alias: "RUN_IMAGE"}}, buildpacksArtifact("my/builder", "RUN_IMAGE")),
+			tag:         "img:tag",
+			pushImages:  true,
+			mode:        config.RunModes.Build,
+			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{m: map[string]string{"run-image": "my/custom-run"}},
+			expectedOptions: &pack.BuildOptions{
+				AppPath:  ".",
+				Builder:  "my/builder",
+				RunImage: "my/custom-run",
+				NoPull:   false,
+				Env:      nonDebugModeArgs,
+				Image:    "img:latest",
+			},
+		},
+		{
+			description: "custom run image and custom builder image with push",
+			artifact:    withRequiredArtifacts([]*latest.ArtifactDependency{{ImageName: "run-image", Alias: "RUN_IMAGE"}, {ImageName: "builder-image", Alias: "BUILDER_IMAGE"}}, buildpacksArtifact("BUILDER_IMAGE", "RUN_IMAGE")),
+			tag:         "img:tag",
+			pushImages:  true,
+			mode:        config.RunModes.Build,
+			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{m: map[string]string{"builder-image": "my/custom-builder", "run-image": "my/custom-run"}},
+			expectedOptions: &pack.BuildOptions{
+				AppPath:  ".",
+				Builder:  "my/custom-builder",
+				RunImage: "my/custom-run",
+				NoPull:   true,
+				Env:      nonDebugModeArgs,
+				Image:    "img:latest",
+			},
+		},
+		{
+			description: "custom run image and custom builder image with no push",
+			artifact:    withRequiredArtifacts([]*latest.ArtifactDependency{{ImageName: "run-image", Alias: "RUN_IMAGE"}, {ImageName: "builder-image", Alias: "BUILDER_IMAGE"}}, buildpacksArtifact("BUILDER_IMAGE", "RUN_IMAGE")),
+			tag:         "img:tag",
+			pushImages:  false,
+			mode:        config.RunModes.Build,
+			api:         &testutil.FakeAPIClient{},
+			resolver:    mockArtifactResolver{m: map[string]string{"builder-image": "my/custom-builder", "run-image": "my/custom-run"}},
+			expectedOptions: &pack.BuildOptions{
+				AppPath:  ".",
+				Builder:  "my/custom-builder",
+				RunImage: "my/custom-run",
+				NoPull:   true,
+				Env:      nonDebugModeArgs,
+				Image:    "img:latest",
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.NewTempDir().Touch("file").WriteFiles(test.files).Chdir()
+			pack := &fakePack{}
+			t.Override(&runPackBuildFunc, pack.runPack)
+			images.images = map[imageTuple]bool{}
+			test.api.
+				Add(test.artifact.BuildpackArtifact.Builder, "builderImageID").
+				Add(test.artifact.BuildpackArtifact.RunImage, "runImageID").
+				Add("img:latest", "builtImageID")
+			localDocker := fakeLocalDaemon(test.api)
+
+			builder := NewArtifactBuilder(localDocker, test.pushImages, test.mode, test.resolver)
+			_, err := builder.Build(context.Background(), ioutil.Discard, test.artifact, test.tag)
+
+			t.CheckError(test.shouldErr, err)
+			if test.expectedOptions != nil {
+				t.CheckDeepEqual(*test.expectedOptions, pack.Opts)
+			}
+		})
+	}
+}
 func buildpacksArtifact(builder, runImage string) *latest.Artifact {
 	return &latest.Artifact{
 		Workspace: ".",
@@ -302,7 +455,25 @@ func withTrustedBuilder(artifact *latest.Artifact) *latest.Artifact {
 	artifact.BuildpackArtifact.TrustBuilder = true
 	return artifact
 }
+
+func withRequiredArtifacts(deps []*latest.ArtifactDependency, artifact *latest.Artifact) *latest.Artifact {
+	artifact.Dependencies = deps
+	return artifact
+}
+
 func withBuildpacks(buildpacks []string, artifact *latest.Artifact) *latest.Artifact {
 	artifact.BuildpackArtifact.Buildpacks = buildpacks
 	return artifact
+}
+
+type mockArtifactResolver struct {
+	m map[string]string
+}
+
+func (r mockArtifactResolver) GetImageTag(imageName string) (string, bool) {
+	if r.m == nil {
+		return "", false
+	}
+	val, found := r.m[imageName]
+	return val, found
 }

--- a/pkg/skaffold/build/buildpacks/types.go
+++ b/pkg/skaffold/build/buildpacks/types.go
@@ -26,13 +26,20 @@ type Builder struct {
 	localDocker docker.LocalDaemon
 	pushImages  bool
 	mode        config.RunMode
+	artifacts   ArtifactResolver
+}
+
+// ArtifactResolver provides an interface to resolve built artifact tags by image name.
+type ArtifactResolver interface {
+	GetImageTag(imageName string) (string, bool)
 }
 
 // NewArtifactBuilder returns a new buildpack artifact builder
-func NewArtifactBuilder(localDocker docker.LocalDaemon, pushImages bool, mode config.RunMode) *Builder {
+func NewArtifactBuilder(localDocker docker.LocalDaemon, pushImages bool, mode config.RunMode, r ArtifactResolver) *Builder {
 	return &Builder{
 		localDocker: localDocker,
 		pushImages:  pushImages,
 		mode:        mode,
+		artifacts:   r,
 	}
 }

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -114,7 +114,7 @@ func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *lat
 		return custom.NewArtifactBuilder(b.localDocker, b.cfg, b.pushImages, b.retrieveExtraEnv()).Build(ctx, out, a, tag)
 
 	case a.BuildpackArtifact != nil:
-		return buildpacks.NewArtifactBuilder(b.localDocker, b.pushImages, b.mode).Build(ctx, out, a, tag)
+		return buildpacks.NewArtifactBuilder(b.localDocker, b.pushImages, b.mode, b.artifactStore).Build(ctx, out, a, tag)
 
 	default:
 		return "", fmt.Errorf("unexpected type %q for local artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: #4713, #4922

**Description** (Part 4 of several PRs.)
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR implements resolving required artifacts as either the builder image or the run image in buildpacks builder as described in the design for [supporting dependencies between build artifacts](https://github.com/GoogleContainerTools/skaffold/blob/master/docs/design_proposals/artifact-dependencies.md#buildpacks-builder).
