### PR TITLE
Provide Skaffold user-agent on update-checks and downloads

### DIFF
--- a/pkg/skaffold/update/update.go
+++ b/pkg/skaffold/update/update.go
@@ -18,14 +18,13 @@ package update
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"strings"
 
 	"github.com/blang/semver"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
 
@@ -100,17 +99,9 @@ func getLatestAndCurrentVersion() (semver.Version, semver.Version, error) {
 }
 
 func DownloadLatestVersion() (string, error) {
-	resp, err := http.Get(LatestVersionURL)
+	versionBytes, err := util.Download(LatestVersionURL)
 	if err != nil {
 		return "", fmt.Errorf("getting latest version info from GCS: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("http %d, error %q", resp.StatusCode, resp.Status)
-	}
-	versionBytes, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("reading version file from GCS: %w", err)
 	}
 	return strings.TrimSuffix(string(versionBytes), "\n"), nil
 }

--- a/pkg/skaffold/util/http.go
+++ b/pkg/skaffold/util/http.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
+)
+
+func Download(url string) ([]byte, error) {
+	client := http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating http request: %w", err)
+	}
+	req.Header.Set("User-Agent", version.UserAgent())
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("http %d, error %q", resp.StatusCode, resp.Status)
+	}
+	return ioutil.ReadAll(resp.Body)
+}

--- a/pkg/skaffold/util/http_test.go
+++ b/pkg/skaffold/util/http_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDownload_UserAgent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ua := r.Header.Get("User-Agent")
+		w.Write([]byte(ua))
+	}))
+	defer ts.Close()
+
+	// although we don't have a version number in tests, the user-agent string still
+	// has `skaffold/<GOOS>/<GOARCH>/`
+	testutil.CheckDeepEqual(t, true, strings.HasPrefix(version.UserAgent(), "skaffold/"))
+
+	v, err := Download(ts.URL)
+	testutil.CheckErrorAndDeepEqual(t, false, err, version.UserAgent(), string(v))
+}

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -22,8 +22,6 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -147,16 +145,6 @@ func StringPtr(s string) *string {
 
 func IsURL(s string) bool {
 	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
-}
-
-func Download(url string) ([]byte, error) {
-	resp, err := http.Get(url)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	return ioutil.ReadAll(resp.Body)
 }
 
 // VerifyOrCreateFile checks if a file exists at the given path,

--- a/pkg/skaffold/util/util_test.go
+++ b/pkg/skaffold/util/util_test.go
@@ -456,6 +456,15 @@ func TestIsFileIsDir(t *testing.T) {
 	testutil.CheckDeepEqual(t, false, IsDir(filepath.Join(tmpDir.Root(), "nonexistent")))
 }
 
+func TestIsURL(t *testing.T) {
+	testutil.CheckDeepEqual(t, false, IsURL("foo"))
+	testutil.CheckDeepEqual(t, false, IsURL("http:bar"))
+	testutil.CheckDeepEqual(t, false, IsURL("https:bar"))
+
+	testutil.CheckDeepEqual(t, true, IsURL("http://bar"))
+	testutil.CheckDeepEqual(t, true, IsURL("https://bar"))
+}
+
 func stringPointer(s string) *string {
 	return &s
 }


### PR DESCRIPTION
Fixes: #4963 
Related: #582, #1260, #2723

**Description**

- Cause update check to use `util.Download()`, and cause `util.Download()` to use Skaffold user-agent.
- Move HTTP related functions from util.go to new http.go
- Add simple tests

**User facing changes**
- Skaffold's update checks now use the Skaffold user-agent