### PR TITLE
Only print port forward success message on actual success

### DIFF
--- a/pkg/skaffold/kubernetes/portforward/entry_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/entry_manager.go
@@ -110,18 +110,20 @@ func (b *EntryManager) forwardPortForwardEntry(ctx context.Context, entry *portF
 	}
 	b.forwardedResources.Store(entry.key(), entry)
 
-	b.entryForwarder.Forward(ctx, entry)
-
-	color.Green.Fprintln(
-		b.output,
-		fmt.Sprintf("Port forwarding %s/%s in namespace %s, remote port %d -> address %s port %d",
-			entry.resource.Type,
-			entry.resource.Name,
-			entry.resource.Namespace,
-			entry.resource.Port,
-			entry.resource.Address,
-			entry.localPort))
-	portForwardEvent(entry)
+	if err := b.entryForwarder.Forward(ctx, entry); err == nil {
+		color.Green.Fprintln(
+			b.output,
+			fmt.Sprintf("Port forwarding %s/%s in namespace %s, remote port %d -> address %s port %d",
+				entry.resource.Type,
+				entry.resource.Name,
+				entry.resource.Namespace,
+				entry.resource.Port,
+				entry.resource.Address,
+				entry.localPort))
+		portForwardEvent(entry)
+	} else {
+		color.Red.Fprintln(b.output, err)
+	}
 }
 
 // Stop terminates all kubectl port-forward commands.

--- a/pkg/skaffold/kubernetes/portforward/entry_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/entry_manager.go
@@ -120,10 +120,10 @@ func (b *EntryManager) forwardPortForwardEntry(ctx context.Context, entry *portF
 				entry.resource.Port,
 				entry.resource.Address,
 				entry.localPort))
-		portForwardEvent(entry)
 	} else {
 		color.Red.Fprintln(b.output, err)
 	}
+	portForwardEvent(entry)
 }
 
 // Stop terminates all kubectl port-forward commands.

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -40,7 +40,7 @@ import (
 )
 
 type EntryForwarder interface {
-	Forward(parentCtx context.Context, pfe *portForwardEntry)
+	Forward(parentCtx context.Context, pfe *portForwardEntry) error
 	Terminate(p *portForwardEntry)
 }
 
@@ -70,11 +70,16 @@ var (
 // It kills the command on errors in the kubectl port-forward log
 // It restarts the command if it was not cancelled by skaffold
 // It retries in case the port is taken
-func (k *KubectlForwarder) Forward(parentCtx context.Context, pfe *portForwardEntry) {
-	go k.forward(parentCtx, pfe)
+func (k *KubectlForwarder) Forward(parentCtx context.Context, pfe *portForwardEntry) error {
+	errChan := make(chan error, 1)
+	go k.forward(parentCtx, pfe, errChan)
+	select {
+	case err := <-errChan:
+		return err
+	}
 }
 
-func (k *KubectlForwarder) forward(parentCtx context.Context, pfe *portForwardEntry) {
+func (k *KubectlForwarder) forward(parentCtx context.Context, pfe *portForwardEntry, errChan chan error) {
 	var notifiedUser bool
 	defer deferFunc()
 
@@ -123,7 +128,7 @@ func (k *KubectlForwarder) forward(parentCtx context.Context, pfe *portForwardEn
 		}
 
 		//kill kubectl on port forwarding error logs
-		go k.monitorErrorLogs(ctx, &buf, cmd, pfe)
+		go k.monitorLogs(ctx, &buf, cmd, pfe, errChan)
 		if err := cmd.Wait(); err != nil {
 			if ctx.Err() == context.Canceled {
 				logrus.Debugf("terminated %v due to context cancellation", pfe)
@@ -132,6 +137,7 @@ func (k *KubectlForwarder) forward(parentCtx context.Context, pfe *portForwardEn
 			//to make sure that the log monitor gets cleared up
 			cancel()
 			logrus.Debugf("port forwarding %v got terminated: %s, output: %s", pfe, err, buf.String())
+			errChan<-fmt.Errorf("port forwarding %v got terminated: output: %s", pfe, buf.String())
 			time.Sleep(500 * time.Millisecond)
 		}
 	}
@@ -178,7 +184,7 @@ func (*KubectlForwarder) Terminate(p *portForwardEntry) {
 // Monitor monitors the logs for a kubectl port forward command
 // If it sees an error, it calls back to the EntryManager to
 // retry the entire port forward operation.
-func (*KubectlForwarder) monitorErrorLogs(ctx context.Context, logs io.Reader, cmd *kubectl.Cmd, p *portForwardEntry) {
+func (*KubectlForwarder) monitorLogs(ctx context.Context, logs io.Reader, cmd *kubectl.Cmd, p *portForwardEntry, err chan error) {
 	ticker := time.NewTicker(waitErrorLogs)
 	defer ticker.Stop()
 
@@ -204,6 +210,11 @@ func (*KubectlForwarder) monitorErrorLogs(ctx context.Context, logs io.Reader, c
 					logrus.Tracef("failed to kill port forwarding %v, err: %s", p, err)
 				}
 				return
+			} else if strings.Contains(s, fmt.Sprintf("Forwarding from %s:%d -> %d",
+				p.resource.Address,
+				p.resource.Port,
+				p.localPort)) {
+				err <- nil
 			}
 		}
 	}

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -135,7 +135,9 @@ func (k *KubectlForwarder) forward(parentCtx context.Context, pfe *portForwardEn
 			//to make sure that the log monitor gets cleared up
 			cancel()
 			logrus.Debugf("port forwarding %v got terminated: %s, output: %s", pfe, err, buf.String())
-			errChan <- fmt.Errorf("port forwarding %v got terminated: output: %s", pfe, buf.String())
+			if !strings.Contains(buf.String(), "address already in use") {
+				errChan <- fmt.Errorf("port forwarding %v got terminated: output: %s", pfe, buf.String())
+			}
 			time.Sleep(500 * time.Millisecond)
 		}
 	}
@@ -209,8 +211,7 @@ func (*KubectlForwarder) monitorLogs(ctx context.Context, logs io.Reader, cmd *k
 				}
 				err <- fmt.Errorf("port forwarding %v got terminated: output: %s", p, s)
 				return
-			} else if strings.Contains(s, "Forwarding from") ||
-				strings.Contains(s, "address already in use"){
+			} else if strings.Contains(s, "Forwarding from") {
 				err <- nil
 			}
 		}

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -209,7 +209,8 @@ func (*KubectlForwarder) monitorLogs(ctx context.Context, logs io.Reader, cmd *k
 				}
 				err <- fmt.Errorf("port forwarding %v got terminated: output: %s", p, s)
 				return
-			} else if strings.Contains(s, "Forwarding from") {
+			} else if strings.Contains(s, "Forwarding from") ||
+				strings.Contains(s, "address already in use"){
 				err <- nil
 			}
 		}

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -209,10 +209,7 @@ func (*KubectlForwarder) monitorLogs(ctx context.Context, logs io.Reader, cmd *k
 				}
 				err <- fmt.Errorf("port forwarding %v got terminated: output: %s", p, s)
 				return
-			} else if strings.Contains(s, fmt.Sprintf("Forwarding from %s:%d -> %d",
-				p.resource.Address,
-				p.resource.Port,
-				p.localPort)) {
+			} else if strings.Contains(s, "Forwarding from") {
 				err <- nil
 			}
 		}

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -134,10 +134,12 @@ func (k *KubectlForwarder) forward(parentCtx context.Context, pfe *portForwardEn
 			}
 			//to make sure that the log monitor gets cleared up
 			cancel()
-			logrus.Debugf("port forwarding %v got terminated: %s, output: %s", pfe, err, buf.String())
-			if !strings.Contains(buf.String(), "address already in use") {
+
+			s := buf.String()
+			logrus.Debugf("port forwarding %v got terminated: %s, output: %s", pfe, err, s)
+			if !strings.Contains(s, "address already in use") {
 				select {
-				case errChan <- fmt.Errorf("port forwarding %v got terminated: output: %s", pfe, buf.String()):
+				case errChan <- fmt.Errorf("port forwarding %v got terminated: output: %s", pfe, s):
 				default:
 				}
 			}

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -46,9 +46,10 @@ type testForwarder struct {
 	forwardedPorts     util.PortSet
 }
 
-func (f *testForwarder) Forward(ctx context.Context, pfe *portForwardEntry) {
+func (f *testForwarder) Forward(ctx context.Context, pfe *portForwardEntry) error {
 	f.forwardedResources.Store(pfe.key(), pfe)
 	f.forwardedPorts.Set(pfe.localPort)
+	return nil
 }
 
 func (f *testForwarder) Monitor(*portForwardEntry, func()) {}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
Fixes: #4897 

**Description**
Added error return value for EntryForwarder, use this value to determine when to print the appropriate logs to the user on whether a port has been forwarded. 

KubectlForwarder returns its error by watching the logs for ```kubectl port-forward``` and looking for an indication of success to a errChan that is being watched.

**User facing changes**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
If ```kubectl port-forward``` fails, due to a reason other than conflicting ports, on the first run this is now presented to the user. The port forwarding confirmation message now happens after container logs appear in most cases, which could result in the message being lost if the terminal is flooded with logs.


**Example Difference**
Running ```skaffold dev --port-forward``` in skaffold/examples/buildpacks with the following yaml which has invalid resource "wb"

```yaml
apiVersion: skaffold/v2beta8
kind: Config
build:
  artifacts:
  - image: skaffold-buildpacks
    buildpacks:
      builder: "gcr.io/buildpacks/builder:v1"
      env:
      - GOPROXY={{.GOPROXY}}
profiles:
- name: gcb
  build:
    googleCloudBuild: {}
portForward:
  - resourceType: deployment
    resourceName: wb
    port: 8080
    localPort: 8080
```
Before:
![Screen Shot 2020-11-02 at 12 29 59 PM (2)](https://user-images.githubusercontent.com/12650821/97899396-41274000-1d07-11eb-9141-1b8f023be1df.png)

Prints that the resource was successfully port forward despite not actually being valid or port forwarded

After:
![Screen Shot 2020-11-02 at 12 25 46 PM (2)](https://user-images.githubusercontent.com/12650821/97899584-7d5aa080-1d07-11eb-96c8-e5128f3dd91b.png)

Correctly prints and displays that there is an error with the name of the resource and port forwarding failed, allowing the user to correct the issue that arised and trigger another dev loop to attempt again.

**Caveats**
In the event that a port becomes unavailable in between the time that the port is checked and ```kubectl port-forward``` is run, the target behavior is as follows.

```Watching for changes...
INFO[0003] Streaming logs from pod: web-78548fbc59-hgjdl container: web 
DEBU[0003] Running command: [kubectl --context minikube logs --since=3s -f web-78548fbc59-hgjdl -c web --namespace default] 
INFO[0003] Streaming logs from pod: web-777c857955-td9xq container: web 
DEBU[0003] Running command: [kubectl --context minikube logs --since=3s -f web-777c857955-td9xq -c web --namespace default] 
[web] 2020/10/29 19:10:44 Listening on port 8080
DEBU[0033] Running command: [kubectl --context minikube port-forward --pod-running-timeout 1s --namespace default deployment/web 8080:8080] 
DEBU[0033] port forwarding deployment-web-default-8080 got terminated: exit status 1, output: Unable to listen on port 8080: Listeners failed to create with the following errors: [unable to create listener: Error listen tcp4 127.0.0.1:8080: bind: address already in use unable to create listener: Error listen tcp6 [::1]:8080: bind: address already in use]
error: unable to listen on any of the requested ports: [{8080 8080}] 
failed to port forward deployment-web-default-8080, port 8080 is taken, retrying...
failed to port forward deployment-web-default-8080, port 8080 is taken, retrying...
failed to port forward deployment-web-default-8080, port 8080 is taken, retrying...
failed to port forward deployment-web-default-8080, port 8080 is taken, retrying...
failed to port forward deployment-web-default-8080, port 8080 is taken, retrying...
port forwarding deployment-web-default-8080 recovered on port 8080
DEBU[0089] Running command: [kubectl --context minikube port-forward --pod-running-timeout 1s --namespace default deployment/web 8080:8080] 
TRAC[0090] [port-forward] Forwarding from 127.0.0.1:8080 -> 8080 
Port forwarding deployment/web in namespace default, remote port 8080 -> address 127.0.0.1 port 8080
```

The only difference here vs. before is that ```Port forwarding deployment/web in namespace default, remote port 8080 -> address 127.0.0.1 port 8080``` is only printed after the ports have been resolved. The case where kubectl discovers that a port is taken already seems rare though since there are two checks prior if a port is taken or not. I will be sure that the kubectl error does not surface as well but only our own message.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
