### PR TITLE
skaffold init --force supports cases with 1 image and multiple builders

### DIFF
--- a/docs/content/en/docs/pipeline-stages/init.md
+++ b/docs/content/en/docs/pipeline-stages/init.md
@@ -94,6 +94,13 @@ When overlay directories are found, these will be listed in the generated Skaffo
 
 *Note: order is guaranteed, since Skaffold's directory parsing is always deterministic.*
 
+## `--force` Flag
+`skaffold init` allows for use of a `--force` flag, which removes the prompts from vanilla `skaffold init`, and allows skaffold to make a best effort attempt to automatically generate a config for your project.
+
+In a situation where one image is detected, but multiple possible builders are detected, skaffold will choose a builder as follows: Docker > Jib > Bazel > Buildpacks.
+
+*Note: This feature is still under development, and doesn't currently support use cases such as multiple images in a project.*
+
 ## Init API
 `skaffold init` also exposes an API which tools like IDEs can integrate with via flags.
 

--- a/pkg/skaffold/initializer/build/builders_test.go
+++ b/pkg/skaffold/initializer/build/builders_test.go
@@ -99,6 +99,19 @@ func TestResolveBuilderImages(t *testing.T) {
 			},
 		},
 		{
+			description:      "successful force - 1 image 2 builders",
+			buildConfigs:     []InitBuilder{docker.ArtifactConfig{File: "Dockerfile1"}, jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), File: "build.gradle"}},
+			images:           []string{"image1"},
+			shouldMakeChoice: true,
+			force:            true,
+			expectedPairs: []BuilderImagePair{
+				{
+					Builder:   docker.ArtifactConfig{File: "Dockerfile1"},
+					ImageName: "image1",
+				},
+			},
+		},
+		{
 			description:      "error with ambiguous force",
 			buildConfigs:     []InitBuilder{docker.ArtifactConfig{File: "Dockerfile1"}, jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), File: "build.gradle"}},
 			images:           []string{"image1", "image2"},

--- a/pkg/skaffold/initializer/build/resolve.go
+++ b/pkg/skaffold/initializer/build/resolve.go
@@ -53,10 +53,45 @@ func (d *defaultBuildInitializer) resolveBuilderImages() error {
 	}
 
 	if d.force {
-		return errors.BuilderImageAmbiguitiesErr{}
+		return d.resolveBuilderImagesForcefully()
 	}
 
 	return d.resolveBuilderImagesInteractively()
+}
+
+func (d *defaultBuildInitializer) resolveBuilderImagesForcefully() error {
+	// In the case of 1 image and multiple builders, respects the ordering Docker > Jib > Bazel > Buildpacks
+	if len(d.unresolvedImages) == 1 {
+		image := d.unresolvedImages[0]
+		choice := d.builders[0]
+		for _, builder := range d.builders {
+			if builderRank(builder) < builderRank(choice) {
+				choice = builder
+			}
+		}
+
+		d.builderImagePairs = append(d.builderImagePairs, BuilderImagePair{Builder: choice, ImageName: image})
+		d.unresolvedImages = util.RemoveFromSlice(d.unresolvedImages, image)
+		return nil
+	}
+
+	return errors.BuilderImageAmbiguitiesErr{}
+}
+
+func builderRank(builder InitBuilder) int {
+	a := builder.ArtifactType()
+	switch {
+	case a.DockerArtifact != nil:
+		return 1
+	case a.JibArtifact != nil:
+		return 2
+	case a.BazelArtifact != nil:
+		return 3
+	case a.BuildpackArtifact != nil:
+		return 4
+	}
+
+	return 5
 }
 
 func (d *defaultBuildInitializer) resolveBuilderImagesInteractively() error {

--- a/pkg/skaffold/initializer/build/resolve.go
+++ b/pkg/skaffold/initializer/build/resolve.go
@@ -71,7 +71,7 @@ func (d *defaultBuildInitializer) resolveBuilderImagesForcefully() error {
 		}
 
 		d.builderImagePairs = append(d.builderImagePairs, BuilderImagePair{Builder: choice, ImageName: image})
-		d.unresolvedImages = util.RemoveFromSlice(d.unresolvedImages, image)
+		d.unresolvedImages = []string{}
 		return nil
 	}
 


### PR DESCRIPTION
Fixes #3661

**Description**
Allows for `skaffold init --force` to work in situations where it detects one image and multiple builders. Previously, the user would see the following
```
FATA[0000] unable to automatically resolve builder/image pairs; run `skaffold init` without `--force` to manually resolve ambiguities
```
Now, a builder will be chosen with the following priority: Docker > Jib > Bazel > Buildpacks
This ordering was decided upon from input on both #3661 and https://kubernetes.slack.com/archives/CABQMSZA6/p1602786450111700.

**Follow-up Work**
It would be nice to do something in the case of multiple images and builders. I've opened #4912 to talk about this.

