### PR TITLE
remove example for KanikoArtifact.Env as master docs are broken

### DIFF
--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1068,7 +1068,6 @@ type KanikoArtifact struct {
 
 	// Env are environment variables passed to the kaniko pod.
 	// It also accepts environment variables via the go template syntax.
-	// For example: `{{name: "key1", value: "value1"}, {name: "key2", value: "value2"}, {name: "key3", value: "'{{.ENV_VARIABLE}}'"}"}`.
 	Env []v1.EnvVar `yaml:"env,omitempty"`
 
 	// Cache configures Kaniko caching. If a cache is specified, Kaniko will


### PR DESCRIPTION
fixes #4970 

Remove examples for `KanikoArtifact.Env` as a temporary solution. 

The reference docs on master are currently broken. The issue the schema generated for this example does not render properly. 
See investigation by @hermanbanken [here](https://github.com/GoogleContainerTools/skaffold/issues/4970#issuecomment-718548094)

In this PR, 
- remove the newly added example for this field.
- regenerate docs
