### PR TITLE
Fix: Skaffold reloads unchanged, existing image again into the cluster

### DIFF
--- a/pkg/skaffold/runner/load_images.go
+++ b/pkg/skaffold/runner/load_images.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/distribution/reference"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
@@ -66,7 +68,11 @@ func (r *SkaffoldRunner) loadImages(ctx context.Context, out io.Writer, artifact
 				return fmt.Errorf("unable to retrieve node's images: %w", err)
 			}
 		}
-		if util.StrSliceContains(knownImages, artifact.Tag) {
+		normalizedImageRef, err := reference.ParseNormalizedNamed(artifact.Tag)
+		if err != nil {
+			return err
+		}
+		if util.StrSliceContains(knownImages, normalizedImageRef.String()) {
 			color.Green.Fprintln(out, "Found")
 			continue
 		}

--- a/pkg/skaffold/runner/load_images_test.go
+++ b/pkg/skaffold/runner/load_images_test.go
@@ -57,8 +57,16 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			built:       []build.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			deployed:    []build.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "tag1").
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag1").
 				AndRunOut("kind load docker-image --name other-kind tag2", "output: image loaded"),
+		},
+		{
+			description: "no new images",
+			cluster:     "kind",
+			built:       []build.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
+			deployed:    []build.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag0 docker.io/library/tag1 docker.io/library/tag2 gcr.io/test/tag3 someregistry.com/tag4"),
 		},
 		{
 			description: "inspect error",
@@ -122,8 +130,16 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 			built:       []build.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			deployed:    []build.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "tag1").
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag1").
 				AndRunOut("k3d image import --cluster other-k3d tag2", "output: image loaded"),
+		},
+		{
+			description: "no new images",
+			cluster:     "k3d",
+			built:       []build.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
+			deployed:    []build.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag0 docker.io/library/tag1 docker.io/library/tag2 gcr.io/test/tag3 someregistry.com/tag4"),
 		},
 		{
 			description: "inspect error",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Related: #4955 

**Description**
the command `kubectl get nodes -ojsonpath = '{@.items[*].status.images[*].names[*]}'` returns a list with normalized image refs. The returned image may differ from `artifact.Tag`. This PR adds image normalization before checking already loaded images.

