### PR TITLE
Refactor Builder interfaces for better testability.

### DIFF
--- a/pkg/skaffold/build/docker/types.go
+++ b/pkg/skaffold/build/docker/types.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+)
+
+// Builder is an artifact builder that uses docker
+type Builder struct {
+	localDocker        docker.LocalDaemon
+	pushImages         bool
+	prune              bool
+	useCLI             bool
+	useBuildKit        bool
+	mode               config.RunMode
+	insecureRegistries map[string]bool
+	artifacts          ArtifactResolver
+}
+
+// ArtifactResolver provides an interface to resolve built artifact tags by image name.
+type ArtifactResolver interface {
+	GetImageTag(imageName string) (string, bool)
+}
+
+// NewBuilder returns an new instance of a docker builder
+func NewArtifactBuilder(localDocker docker.LocalDaemon, useCLI, useBuildKit, pushImages, prune bool, mode config.RunMode, insecureRegistries map[string]bool, r ArtifactResolver) *Builder {
+	return &Builder{
+		localDocker:        localDocker,
+		pushImages:         pushImages,
+		prune:              prune,
+		useCLI:             useCLI,
+		useBuildKit:        useBuildKit,
+		mode:               mode,
+		insecureRegistries: insecureRegistries,
+		artifacts:          r,
+	}
+}

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -23,8 +23,14 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/bazel"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/custom"
+	dockerbuilder "github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
@@ -334,13 +340,116 @@ func TestNewBuilder(t *testing.T) {
 	}
 }
 
+func TestGetArtifactBuilder(t *testing.T) {
+	tests := []struct {
+		description string
+		artifact    *latest.Artifact
+		expected    string
+		shouldErr   bool
+	}{
+		{
+			description: "docker builder",
+			artifact: &latest.Artifact{
+				ImageName: "gcr.io/test/image",
+				ArtifactType: latest.ArtifactType{
+					DockerArtifact: &latest.DockerArtifact{},
+				},
+			},
+			expected: "docker",
+		},
+		{
+			description: "jib builder",
+			artifact: &latest.Artifact{
+				ImageName: "gcr.io/test/image",
+				ArtifactType: latest.ArtifactType{
+					JibArtifact: &latest.JibArtifact{},
+				},
+			},
+			expected: "jib",
+		},
+		{
+			description: "buildpacks builder",
+			artifact: &latest.Artifact{
+				ImageName: "gcr.io/test/image",
+				ArtifactType: latest.ArtifactType{
+					BuildpackArtifact: &latest.BuildpackArtifact{},
+				},
+			},
+			expected: "buildpacks",
+		},
+		{
+			description: "bazel builder",
+			artifact: &latest.Artifact{
+				ImageName: "gcr.io/test/image",
+				ArtifactType: latest.ArtifactType{
+					BazelArtifact: &latest.BazelArtifact{},
+				},
+			},
+			expected: "bazel",
+		},
+		{
+			description: "custom builder",
+			artifact: &latest.Artifact{
+				ImageName: "gcr.io/test/image",
+				ArtifactType: latest.ArtifactType{
+					CustomArtifact: &latest.CustomArtifact{},
+				},
+			},
+			expected: "custom",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
+				return fakeLocalDaemon(&testutil.FakeAPIClient{}), nil
+			})
+			t.Override(&docker.EvalBuildArgs, func(mode config.RunMode, workspace string, a *latest.DockerArtifact, extra map[string]*string) (map[string]*string, error) {
+				return a.BuildArgs, nil
+			})
+
+			b, err := NewBuilder(&mockConfig{
+				local: latest.LocalBuild{
+					Concurrency: &constants.DefaultLocalConcurrency,
+				},
+			})
+			t.CheckNoError(err)
+			b.ArtifactStore(build.NewArtifactStore())
+
+			builder, err := newPerArtifactBuilder(b, test.artifact)
+			t.CheckNoError(err)
+
+			switch builder.(type) {
+			case *dockerbuilder.Builder:
+				t.CheckDeepEqual(test.expected, "docker")
+			case *bazel.Builder:
+				t.CheckDeepEqual(test.expected, "bazel")
+			case *buildpacks.Builder:
+				t.CheckDeepEqual(test.expected, "buildpacks")
+			case *custom.Builder:
+				t.CheckDeepEqual(test.expected, "custom")
+			case *jib.Builder:
+				t.CheckDeepEqual(test.expected, "jib")
+			}
+		})
+	}
+}
+
+func fakeLocalDaemon(api client.CommonAPIClient) docker.LocalDaemon {
+	return docker.NewLocalDaemon(api, nil, false, nil)
+}
+
 type mockConfig struct {
 	runcontext.RunContext // Embedded to provide the default values.
 	local                 latest.LocalBuild
+	mode                  config.RunMode
 }
 
 func (c *mockConfig) Pipeline() latest.Pipeline {
 	var pipeline latest.Pipeline
 	pipeline.Build.BuildType.LocalBuild = &c.local
 	return pipeline
+}
+
+func (c *mockConfig) Mode() config.RunMode {
+	return c.mode
 }


### PR DESCRIPTION
[local](https://github.com/GoogleContainerTools/skaffold/tree/master/pkg/skaffold/build/local) package takes on too many responsibilities -
- It defines the methods for artifact group builder `Build(..., []*latest.Artifact,...)`
- It defines the methods for single artifact docker builder `dockerBuilder(..., *latest.Artifact,...)`

This is a bit confusing and also causes [this](https://github.com/GoogleContainerTools/skaffold/blob/eace20c06f52b2d4bd3b57866ac18a639cc341e8/pkg/skaffold/build/local/local.go#L103) switch statement that undermines the need for any interface.

This refactor makes things more consistent and lets us unit test `local.go` better.