### PR TITLE
Fix 4950: User-defined port forwarding resources ignore the namespace flag

### DIFF
--- a/integration/port_forward_test.go
+++ b/integration/port_forward_test.go
@@ -62,10 +62,22 @@ func TestRunPortForward(t *testing.T) {
 
 	_, entries := apiEvents(t, rpcAddr)
 
-	webAddress, webLocalPort := getLocalPortFromPortForwardEvent(t, entries, "leeroy-web", "deployment", ns.Name)
-	assertResponseFromPort(t, webAddress, webLocalPort, constants.LeeroyAppResponse)
-	appAddress, appLocalPort := getLocalPortFromPortForwardEvent(t, entries, "leeroy-app", "service", ns.Name)
-	assertResponseFromPort(t, appAddress, appLocalPort, constants.LeeroyAppResponse)
+	address, localPort := getLocalPortFromPortForwardEvent(t, entries, "leeroy-app", "service", ns.Name)
+	assertResponseFromPort(t, address, localPort, constants.LeeroyAppResponse)
+}
+
+func TestRunUserPortForwardResource(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	ns, _ := SetupNamespace(t)
+
+	rpcAddr := randomPort()
+	skaffold.Run("--port-forward", "--rpc-port", rpcAddr, "--enable-rpc").InDir("examples/microservices").InNs(ns.Name).RunBackground(t)
+
+	_, entries := apiEvents(t, rpcAddr)
+
+	address, localPort := getLocalPortFromPortForwardEvent(t, entries, "leeroy-web", "deployment", ns.Name)
+	assertResponseFromPort(t, address, localPort, constants.LeeroyAppResponse)
 }
 
 // TestDevPortForwardDeletePod tests that port forwarding works

--- a/integration/port_forward_test.go
+++ b/integration/port_forward_test.go
@@ -62,8 +62,10 @@ func TestRunPortForward(t *testing.T) {
 
 	_, entries := apiEvents(t, rpcAddr)
 
-	address, localPort := getLocalPortFromPortForwardEvent(t, entries, "leeroy-app", "service", ns.Name)
-	assertResponseFromPort(t, address, localPort, constants.LeeroyAppResponse)
+	webAddress, webLocalPort := getLocalPortFromPortForwardEvent(t, entries, "leeroy-web", "deployment", ns.Name)
+	assertResponseFromPort(t, webAddress, webLocalPort, constants.LeeroyAppResponse)
+	appAddress, appLocalPort := getLocalPortFromPortForwardEvent(t, entries, "leeroy-app", "service", ns.Name)
+	assertResponseFromPort(t, appAddress, appLocalPort, constants.LeeroyAppResponse)
 }
 
 // TestDevPortForwardDeletePod tests that port forwarding works

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -206,51 +206,87 @@ func TestUserDefinedResources(t *testing.T) {
 	svc := &latest.PortForwardResource{
 		Type:      constants.Service,
 		Name:      "svc1",
-		Namespace: "default",
+		Namespace: "test",
 		Port:      8080,
 	}
 
-	pod := &latest.PortForwardResource{
-		Type:      constants.Pod,
-		Name:      "pod",
-		Namespace: "default",
-		Port:      9000,
+	tests := []struct {
+		description       string
+		userResources     []*latest.PortForwardResource
+		namespaces        []string
+		expectedResources []string
+	}{
+		{
+			description: "one service and one user defined pod",
+			userResources: []*latest.PortForwardResource{
+				{Type: constants.Pod, Name: "pod", Namespace: "some", Port: 9000},
+			},
+			namespaces: []string{"test"},
+			expectedResources: []string{
+				"service-svc1-test-8080",
+				"pod-pod-some-9000",
+			},
+		},
+		{
+			userResources: []*latest.PortForwardResource{
+				{Type: constants.Pod, Name: "pod", Port: 9000},
+			},
+			namespaces: []string{"test"},
+			expectedResources: []string{
+				"service-svc1-test-8080",
+				"pod-pod-test-9000",
+			},
+		},
+		{
+			userResources: []*latest.PortForwardResource{
+				{Type: constants.Pod, Name: "pod", Port: 9000},
+			},
+			namespaces: []string{"test", "some"},
+			expectedResources: []string{
+				"service-svc1-test-8080",
+			},
+		},
+		{
+			userResources: []*latest.PortForwardResource{
+				{Type: constants.Pod, Name: "pod", Port: 9000},
+				{Type: constants.Pod, Name: "pod", Namespace: "some", Port: 9001},
+			},
+			namespaces: []string{"test", "some"},
+			expectedResources: []string{
+				"service-svc1-test-8080",
+				"pod-pod-some-9001",
+			},
+		},
 	}
 
-	expected := map[string]*portForwardEntry{
-		"service-svc1-default-8080": {
-			resource:  *svc,
-			localPort: 8080,
-		},
-		"pod-pod-default-9000": {
-			resource:  *pod,
-			localPort: 9000,
-		},
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			event.InitializeState(latest.Pipeline{}, "", true, true, true)
+			t.Override(&retrieveAvailablePort, mockRetrieveAvailablePort("127.0.0.1", map[int]struct{}{}, []int{8080, 9000}))
+			t.Override(&retrieveServices, func(string, []string) ([]*latest.PortForwardResource, error) {
+				return []*latest.PortForwardResource{svc}, nil
+			})
+
+			fakeForwarder := newTestForwarder()
+			entryManager := NewEntryManager(ioutil.Discard, fakeForwarder)
+
+			rf := NewResourceForwarder(entryManager, test.namespaces, "", test.userResources)
+			if err := rf.Start(context.Background()); err != nil {
+				t.Fatalf("error starting resource forwarder: %v", err)
+			}
+
+			// poll up to 10 seconds for the resources to be forwarded
+			err := wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+				return len(test.expectedResources) == fakeForwarder.forwardedResources.Length(), nil
+			})
+			for _, key := range test.expectedResources {
+				t.CheckNotNil(fakeForwarder.forwardedResources.resources[key])
+			}
+			if err != nil {
+				t.Fatalf("expected entries didn't match actual entries. Expected: \n %v Actual: \n %v", test.expectedResources, fakeForwarder.forwardedResources.resources)
+			}
+		})
 	}
-
-	testutil.Run(t, "one service and one user defined pod", func(t *testutil.T) {
-		event.InitializeState(latest.Pipeline{}, "", true, true, true)
-		t.Override(&retrieveAvailablePort, mockRetrieveAvailablePort("127.0.0.1", map[int]struct{}{}, []int{8080, 9000}))
-		t.Override(&retrieveServices, func(string, []string) ([]*latest.PortForwardResource, error) {
-			return []*latest.PortForwardResource{svc}, nil
-		})
-
-		fakeForwarder := newTestForwarder()
-		entryManager := NewEntryManager(ioutil.Discard, fakeForwarder)
-
-		rf := NewResourceForwarder(entryManager, []string{"test"}, "", []*latest.PortForwardResource{pod})
-		if err := rf.Start(context.Background()); err != nil {
-			t.Fatalf("error starting resource forwarder: %v", err)
-		}
-
-		// poll up to 10 seconds for the resources to be forwarded
-		err := wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
-			return len(expected) == fakeForwarder.forwardedResources.Length(), nil
-		})
-		if err != nil {
-			t.Fatalf("expected entries didn't match actual entries. Expected: \n %v Actual: \n %v", expected, fakeForwarder.forwardedResources.resources)
-		}
-	})
 }
 
 func mockClient(m kubernetes.Interface) func() (kubernetes.Interface, error) {

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -102,9 +102,6 @@ func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifa
 	logger := r.createLogger(out, artifacts)
 	defer logger.Stop()
 
-	forwarderManager := r.createForwarder(out)
-	defer forwarderManager.Stop()
-
 	// Logs should be retrieved up to just before the deploy
 	logger.SetSince(time.Now())
 
@@ -112,6 +109,9 @@ func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifa
 	if err := r.Deploy(ctx, out, artifacts); err != nil {
 		return err
 	}
+
+	forwarderManager := r.createForwarder(out)
+	defer forwarderManager.Stop()
 
 	if err := forwarderManager.Start(ctx); err != nil {
 		logrus.Warnln("Error starting port forwarding:", err)

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -213,9 +213,6 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	logger := r.createLogger(out, bRes)
 	defer logger.Stop()
 
-	forwarderManager := r.createForwarder(out)
-	defer forwarderManager.Stop()
-
 	debugContainerManager := r.createContainerManager()
 	defer debugContainerManager.Stop()
 
@@ -227,6 +224,9 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 		event.DevLoopFailedInPhase(r.devIteration, sErrors.Deploy, err)
 		return fmt.Errorf("exiting dev mode because first deploy failed: %w", err)
 	}
+
+	forwarderManager := r.createForwarder(out)
+	defer forwarderManager.Stop()
 
 	if err := forwarderManager.Start(ctx); err != nil {
 		logrus.Warnln("Error starting port forwarding:", err)

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -98,7 +98,6 @@ func Set(c *latest.SkaffoldConfig) error {
 	}
 
 	for _, pf := range c.PortForward {
-		setDefaultPortForwardNamespace(pf)
 		setDefaultLocalPort(pf)
 		setDefaultAddress(pf)
 	}
@@ -358,17 +357,6 @@ func currentNamespace() (string, error) {
 func setDefaultLocalPort(pf *latest.PortForwardResource) {
 	if pf.LocalPort == 0 {
 		pf.LocalPort = pf.Port
-	}
-}
-
-func setDefaultPortForwardNamespace(pf *latest.PortForwardResource) {
-	if pf.Namespace == "" {
-		ns, err := currentNamespace()
-		if err != nil {
-			pf.Namespace = constants.DefaultPortForwardNamespace
-			return
-		}
-		pf.Namespace = ns
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4950 
**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
