### PR TITLE
Add default dockerfile path to skaffold config when using skaffold init

### DIFF
--- a/integration/examples/getting-started-kustomize/skaffold.yaml
+++ b/integration/examples/getting-started-kustomize/skaffold.yaml
@@ -6,6 +6,8 @@ build:
   artifacts:
   - image: skaffold-kustomize
     context: app
+    docker:
+      dockerfile: Dockerfile
 deploy:
   kustomize:
     paths:

--- a/integration/testdata/init/compose/skaffold.yaml
+++ b/integration/testdata/init/compose/skaffold.yaml
@@ -5,6 +5,8 @@ metadata:
 build:
   artifacts:
   - image: gcr.io/k8s-skaffold/compose
+    docker:
+      dockerfile: Dockerfile
 deploy:
   kubectl:
     manifests:

--- a/pkg/skaffold/docker/docker_init.go
+++ b/pkg/skaffold/docker/docker_init.go
@@ -25,7 +25,6 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/sirupsen/logrus"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
@@ -55,9 +54,6 @@ func (c ArtifactConfig) Describe() string {
 // ArtifactType returns the type of the artifact to be built.
 func (c ArtifactConfig) ArtifactType() latest.ArtifactType {
 	dockerfile := filepath.Base(c.File)
-	if dockerfile == constants.DefaultDockerfilePath {
-		return latest.ArtifactType{}
-	}
 
 	return latest.ArtifactType{
 		DockerArtifact: &latest.DockerArtifact{

--- a/pkg/skaffold/docker/docker_init_test.go
+++ b/pkg/skaffold/docker/docker_init_test.go
@@ -93,9 +93,13 @@ func TestArtifactType(t *testing.T) {
 		expectedType latest.ArtifactType
 	}{
 		{
-			description:  "default filename",
-			config:       ArtifactConfig{File: filepath.Join("path", "to", "Dockerfile")},
-			expectedType: latest.ArtifactType{},
+			description: "default filename",
+			config:      ArtifactConfig{File: filepath.Join("path", "to", "Dockerfile")},
+			expectedType: latest.ArtifactType{
+				DockerArtifact: &latest.DockerArtifact{
+					DockerfilePath: "Dockerfile",
+				},
+			},
 		},
 		{
 			description: "non-default filename",

--- a/pkg/skaffold/initializer/config_test.go
+++ b/pkg/skaffold/initializer/config_test.go
@@ -120,6 +120,9 @@ func TestGenerateSkaffoldConfig(t *testing.T) {
 							{
 								ImageName: "image1",
 								Workspace: "testDir",
+								ArtifactType: latest.ArtifactType{
+									DockerArtifact: &latest.DockerArtifact{DockerfilePath: "Dockerfile"},
+								},
 							},
 						},
 					},

--- a/pkg/skaffold/initializer/testdata/init/allcli/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/allcli/skaffold.yaml
@@ -5,6 +5,8 @@ metadata:
 build:
   artifacts:
     - image: passed-in-artifact
+      docker:
+        dockerfile: Dockerfile
 deploy:
   kubectl:
     manifests:

--- a/pkg/skaffold/initializer/testdata/init/getting-started-kustomize/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/getting-started-kustomize/skaffold.yaml
@@ -5,5 +5,7 @@ metadata:
 build:
   artifacts:
   - image: hello-world
+    docker:
+      dockerfile: Dockerfile
 deploy:
   kustomize: {}

--- a/pkg/skaffold/initializer/testdata/init/hello/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/hello/skaffold.yaml
@@ -5,6 +5,8 @@ metadata:
 build:
   artifacts:
   - image: skaffold-example
+    docker:
+      dockerfile: Dockerfile
 deploy:
   kubectl:
     manifests:

--- a/pkg/skaffold/initializer/testdata/init/ignore-tags/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/ignore-tags/skaffold.yaml
@@ -5,6 +5,8 @@ metadata:
 build:
   artifacts:
   - image: gcr.io/k8s-skaffold/skaffold-example
+    docker:
+      dockerfile: Dockerfile
 deploy:
   kubectl:
     manifests:

--- a/pkg/skaffold/initializer/testdata/init/microservices/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/microservices/skaffold.yaml
@@ -6,8 +6,12 @@ build:
   artifacts:
   - image: gcr.io/k8s-skaffold/leeroy-app
     context: leeroy-app
+    docker:
+      dockerfile: Dockerfile
   - image: gcr.io/k8s-skaffold/leeroy-web
     context: leeroy-web
+    docker:
+      dockerfile: Dockerfile
 deploy:
   kubectl:
     manifests:


### PR DESCRIPTION
Fixes #3766

**Description**
This PR is meant to address users who run `skaffold init` and are given the wrong context field in their skaffold config for docker artifacts. Currently the analyzer simply sets the context as the dockerfile location, but this may be different from the actual root of the project's source code.

Given a project structure like so:
```
proj-dir
├── README.md
└── app
    ├── deploy
    │   ├── Dockerfile
    │   └── k8s-pod.yaml
    └── main.go
```
Before, a user running `skaffold init` would get something like this:
```yaml
apiVersion: skaffold/v2beta9
kind: Config
metadata:
  name: getting-started
build:
  artifacts:
  - image: skaffold-example
    context: app/deploy
deploy:
  ...
```

Now, they will get something like 
```yaml
apiVersion: skaffold/v2beta9
kind: Config
metadata:
  name: getting-started
build:
  artifacts:
  - image: skaffold-example
    context: app/deploy
    docker:
      dockerfile: Dockerfile
deploy:
  ...
```

This will allow users to more easily alter the necessary fields of their config to work for their project, as mentioned in #3766

**Follow-up Work**
The issue at the root of this is really #3760. I'd like to list this as follow up work as tackling this issue will create a much better `skaffold init` experience by reducing the need for modification of the config after the fact.
