### PR TITLE
Do not color file output with `--muted-logs`

### DIFF
--- a/pkg/skaffold/color/formatter.go
+++ b/pkg/skaffold/color/formatter.go
@@ -35,6 +35,8 @@ func init() {
 	colors.Disable(true)
 }
 
+var colorfulWriter io.Writer
+
 // SetupColors enables/disables coloured output.
 func SetupColors(out io.Writer, defaultColor int, forceColors bool) {
 	_, isTerm := util.IsTerminal(out)
@@ -62,6 +64,7 @@ func SetupColors(out io.Writer, defaultColor int, forceColors bool) {
 		37: White,
 		0:  None,
 	}[defaultColor]
+	colorfulWriter = out
 }
 
 // Color can be used to format text so it can be printed to the terminal in color.
@@ -103,7 +106,7 @@ var (
 
 // Fprintln outputs the result to out, followed by a newline.
 func (c Color) Fprintln(out io.Writer, a ...interface{}) {
-	if c.color == nil {
+	if c.color == nil || out != colorfulWriter {
 		fmt.Fprintln(out, a...)
 		return
 	}
@@ -113,7 +116,7 @@ func (c Color) Fprintln(out io.Writer, a ...interface{}) {
 
 // Fprintf outputs the result to out.
 func (c Color) Fprintf(out io.Writer, format string, a ...interface{}) {
-	if c.color == nil {
+	if c.color == nil || out != colorfulWriter {
 		fmt.Fprintf(out, format, a...)
 		return
 	}

--- a/pkg/skaffold/color/formatter.go
+++ b/pkg/skaffold/color/formatter.go
@@ -18,13 +18,13 @@ package color
 
 import (
 	"fmt"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/logfile"
 	"io"
 	"strings"
 
 	colors "github.com/heroku/color"
 	"github.com/mattn/go-colorable"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/logfile"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 

--- a/pkg/skaffold/color/formatter_test.go
+++ b/pkg/skaffold/color/formatter_test.go
@@ -18,11 +18,12 @@ package color
 
 import (
 	"bytes"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/logfile"
 	"io"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/logfile"
 )
 
 func compareText(t *testing.T, expected, actual string) {

--- a/pkg/skaffold/color/formatter_test.go
+++ b/pkg/skaffold/color/formatter_test.go
@@ -89,3 +89,21 @@ func TestFprintlnChangeDefaultToUnknown(t *testing.T) {
 	Default.Fprintln(&b, "2", "less", "chars!")
 	compareText(t, "2 less chars!\n", b.String())
 }
+
+func TestFprintfOnlyWritesColorsToSetupWriter(t *testing.T) {
+	var b bytes.Buffer
+	var cb bytes.Buffer
+
+	SetupColors(&cb, DefaultColorCode, true)
+	Blue.Fprintf(&b, "This should %s be %s", "not", "blue")
+	compareText(t, "This should not be blue", b.String())
+}
+
+func TestFprintlnOnlyWritesColorsToSetupWriter(t *testing.T) {
+	var b bytes.Buffer
+	var cb bytes.Buffer
+
+	SetupColors(&cb, DefaultColorCode, true)
+	Blue.Fprintln(&b, "This should", "not", "be", "blue")
+	compareText(t, "This should not be blue\n", b.String())
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4913 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Wrap os.File in filelog.MutedLogger type that is checked on Color.Fprint to determine whether colors should be printed.

### **Example of change**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
Running ```skaffold run --mute-logs=all``` in skaffold/examples/ruby
**Before**: 
```
...
Starting deploy...
- writing logs to /var/.../skaffold/deploy/2020-11-02_18-49-06.log
...
```
In /var/.../skaffold/deploy/2020-11-02_18-49-06.log
```
^[[34mStarting deploy...^[[0m
 - service/ruby configured
 - deployment.apps/ruby configured
```

The logs contain ANSI escape codes which do not represent the actual content intended to be logged.

**After**:
```
...
Starting deploy...
- writing logs to /var/.../skaffold/deploy/2020-11-02_18-53-51.log
...
```
In /var/.../skaffold/deploy/2020-11-02_18-53-51.log
```
Starting deploy...
 - service/ruby configured
 - deployment.apps/ruby configured
```

The only thing logged is the intended output. 

<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
