### PR TITLE
Added logic to handle nil during interface conversion of namespace.

### DIFF
--- a/pkg/skaffold/kubernetes/manifest/namespace_test.go
+++ b/pkg/skaffold/kubernetes/manifest/namespace_test.go
@@ -128,6 +128,34 @@ spec:
 `)},
 			expected: []string{},
 		}, {
+			description: "single Pod manifest with nil namespace",
+			manifests: ManifestList{[]byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+  namespace:
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/example
+    name: example
+`)},
+			expected: []string{},
+		}, {
+			description: "single Pod manifest with empty namespace",
+			manifests: ManifestList{[]byte(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+  namespace: ""
+spec:
+  containers:
+  - image: gcr.io/k8s-skaffold/example
+    name: example
+`)},
+			expected: []string{},
+		}, {
 			description: "empty manifest",
 			manifests:   ManifestList{[]byte(``)},
 			expected:    []string{},

--- a/pkg/skaffold/kubernetes/manifest/namespaces.go
+++ b/pkg/skaffold/kubernetes/manifest/namespaces.go
@@ -58,7 +58,11 @@ func (r *namespaceCollector) Visit(o map[string]interface{}, k string, v interfa
 		return true
 	}
 	if nsValue, present := metadata["namespace"]; present {
-		if ns := strings.TrimSpace(nsValue.(string)); ns != "" {
+		nsString, isOk := nsValue.(string)
+		if !isOk || nsString == "" {
+			return true
+		}
+		if ns := strings.TrimSpace(nsString); ns != "" {
 			r.namespaces[ns] = true
 		}
 	}

--- a/pkg/skaffold/kubernetes/manifest/namespaces.go
+++ b/pkg/skaffold/kubernetes/manifest/namespaces.go
@@ -58,8 +58,8 @@ func (r *namespaceCollector) Visit(o map[string]interface{}, k string, v interfa
 		return true
 	}
 	if nsValue, present := metadata["namespace"]; present {
-		nsString, isOk := nsValue.(string)
-		if !isOk || nsString == "" {
+		nsString, ok := nsValue.(string)
+		if !ok || nsString == "" {
 			return true
 		}
 		if ns := strings.TrimSpace(nsString); ns != "" {


### PR DESCRIPTION
Fixes: #4786 

**Description**
Added logic to handle nil during interface conversion of namespace

**User facing changes (remove if N/A)**
User will not receive the below error when namespace is nil.
`panic: interface conversion: interface {} is nil, not string`

Added unit test.
