### PR TITLE
Fix Kaniko build args eval from config `env`.

### DIFF
--- a/pkg/skaffold/build/cluster/cluster.go
+++ b/pkg/skaffold/build/cluster/cluster.go
@@ -66,12 +66,7 @@ func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *lat
 	requiredImages := docker.ResolveDependencyImages(a.Dependencies, b.artifactStore, true)
 	switch {
 	case a.KanikoArtifact != nil:
-		buildArgs, err := docker.EvalBuildArgs(b.mode, a.Workspace, a.KanikoArtifact.DockerfilePath, a.KanikoArtifact.BuildArgs, requiredImages)
-		if err != nil {
-			return "", fmt.Errorf("unable to evaluate build args: %w", err)
-		}
-		a.KanikoArtifact.BuildArgs = buildArgs
-		return b.buildWithKaniko(ctx, out, a.Workspace, a.KanikoArtifact, tag)
+		return b.buildWithKaniko(ctx, out, a.Workspace, a.KanikoArtifact, tag, requiredImages)
 
 	case a.CustomArtifact != nil:
 		return custom.NewArtifactBuilder(nil, b.cfg, true, append(b.retrieveExtraEnv(), util.EnvPtrMapToSlice(requiredImages, "=")...)).Build(ctx, out, a, tag)

--- a/pkg/skaffold/build/cluster/pod.go
+++ b/pkg/skaffold/build/cluster/pod.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
@@ -240,11 +239,6 @@ func kanikoArgs(artifact *latest.KanikoArtifact, tag string, insecureRegistries 
 	}
 
 	// Create pod spec
-	buildArgs, err := docker.EvaluateBuildArgs(artifact.BuildArgs, envMapFromVars(artifact.Env))
-	if err != nil {
-		return nil, fmt.Errorf("unable to evaluate environment variables in build args: %w", err)
-	}
-	artifact.BuildArgs = buildArgs
 	args, err := kaniko.Args(artifact, tag, fmt.Sprintf("dir://%s", kaniko.DefaultEmptyDirMountPath))
 	if err != nil {
 		return nil, fmt.Errorf("unable build kaniko args: %w", err)

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -513,37 +513,6 @@ func ToCLIBuildArgs(a *latest.DockerArtifact, evaluatedArgs map[string]*string) 
 	return args, nil
 }
 
-// EvaluateBuildArgs evaluates templated build args.
-// An additional envMap can optionally be specified.
-// If multiple additional envMaps are specified, all but the first one will be ignored
-func EvaluateBuildArgs(args map[string]*string, envMap ...map[string]string) (map[string]*string, error) {
-	if args == nil {
-		return nil, nil
-	}
-
-	var env map[string]string
-	if len(envMap) > 0 {
-		env = envMap[0]
-	}
-
-	evaluated := map[string]*string{}
-	for k, v := range args {
-		if v == nil {
-			evaluated[k] = nil
-			continue
-		}
-
-		value, err := util.ExpandEnvTemplate(*v, env)
-		if err != nil {
-			return nil, fmt.Errorf("unable to get value for build arg %q: %w", k, err)
-		}
-
-		evaluated[k] = &value
-	}
-
-	return evaluated, nil
-}
-
 func (l *localDaemon) Prune(ctx context.Context, images []string, pruneChildren bool) ([]string, error) {
 	var pruned []string
 	var errRt error

--- a/pkg/skaffold/util/env_template.go
+++ b/pkg/skaffold/util/env_template.go
@@ -69,6 +69,11 @@ func ExecuteEnvTemplate(envTemplate *template.Template, customMap map[string]str
 
 // EvaluateEnvTemplateMap parses and executes all map values as templates based on OS environment variables
 func EvaluateEnvTemplateMap(args map[string]*string) (map[string]*string, error) {
+	return EvaluateEnvTemplateMapWithEnv(args, nil)
+}
+
+// EvaluateEnvTemplateMapWithEnv parses and executes all map values as templates based on OS and custom environment variables
+func EvaluateEnvTemplateMapWithEnv(args map[string]*string, env map[string]string) (map[string]*string, error) {
 	if args == nil {
 		return nil, nil
 	}
@@ -80,7 +85,7 @@ func EvaluateEnvTemplateMap(args map[string]*string) (map[string]*string, error)
 			continue
 		}
 
-		value, err := ExpandEnvTemplate(*v, nil)
+		value, err := ExpandEnvTemplate(*v, env)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get value for key %q: %w", k, err)
 		}


### PR DESCRIPTION
Kaniko builder config has an `env` section that wasn't getting evaluated correctly for the build args after my recent changes to introduce required artifacts as build args.

For a `kaniko build` step like:
```yaml
build:
  artifacts:
    - image: skaffold-example
      kaniko:
        env:
          - name: foo
            value: bar
        buildArgs:
          - arg1: {{ .foo }}
```
the value of `arg1` is evaluated twice, once with only `os.Environ` without the `env` in `cluster.go`:
```go
buildArgs, err := docker.EvalBuildArgs(b.mode, a.Workspace, a.KanikoArtifact.DockerfilePath, a.KanikoArtifact.BuildArgs, requiredImages)
```

later again with `env` in `pod.go`:
```go
buildArgs, err := docker.EvaluateBuildArgs(artifact.BuildArgs, envMapFromVars(artifact.Env))
```

But the first evaluation will resolve all `Go templates` and the later evaluation will not work to resolve key value pairs defined in `env` above. So the result is that `arg1` is applied to the builder with the value `""`.

The fix is to remove the duplicate code `docker. EvaluateBuildArgs` which attempts to do the same things as `docker.EvalBuildArgs`. So we define `EvalBuildArgs` and `EvalBuildArgsWithEnv` as an overload of that method.
