### PR TITLE
buildkit support in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,39 +69,39 @@ jobs:
     - name: "kind integration partition 0"
       <<: *integration_test
       script:
-        - env IT_PARTITION=0 make integration-in-kind
+        - env IT_PARTITION=0 DOCKER_BUILDKIT=0 make integration-in-kind
     - name: "kind integration partition 1"
       <<: *integration_test
       script:
-        - env IT_PARTITION=1 make integration-in-kind
+        - env IT_PARTITION=1 DOCKER_BUILDKIT=0 make integration-in-kind
     - name: "kind integration partition 2"
       <<: *integration_test
       script:
-        - env IT_PARTITION=2 make integration-in-kind
+        - env IT_PARTITION=2 DOCKER_BUILDKIT=0 make integration-in-kind
     - name: "kind integration partition 3"
       <<: *integration_test
       script:
-        - env IT_PARTITION=3 make integration-in-kind
+        - env IT_PARTITION=3 DOCKER_BUILDKIT=0 make integration-in-kind
     - name: "k3d integration partition 0"
       <<: *integration_test
       <<: *upgrade_docker
       script:
-        - env IT_PARTITION=0 make integration-in-k3d
+        - env IT_PARTITION=0 DOCKER_BUILDKIT=1 make integration-in-k3d
     - name: "k3d integration partition 1"
       <<: *integration_test
       <<: *upgrade_docker
       script:
-        - env IT_PARTITION=1 make integration-in-k3d
+        - env IT_PARTITION=1 DOCKER_BUILDKIT=1 make integration-in-k3d
     - name: "k3d integration partition 2"
       <<: *integration_test
       <<: *upgrade_docker
       script:
-        - env IT_PARTITION=2 make integration-in-k3d
+        - env IT_PARTITION=2 DOCKER_BUILDKIT=1 make integration-in-k3d
     - name: "k3d integration partition 3"
       <<: *integration_test
       <<: *upgrade_docker
       script:
-        - env IT_PARTITION=3 make integration-in-k3d
+        - env IT_PARTITION=3 DOCKER_BUILDKIT=1 make integration-in-k3d
     - os: linux
       name: "diag/Linux unit"
       script:

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ integration-in-kind: skaffold-builder
 		-e KUBECONFIG=/tmp/kind-config \
 		-e INTEGRATION_TEST_ARGS=$(INTEGRATION_TEST_ARGS) \
 		-e IT_PARTITION=$(IT_PARTITION) \
+		-e DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) \
 		--network kind \
 		gcr.io/$(GCP_PROJECT)/skaffold-builder \
 		sh -eu -c ' \
@@ -226,6 +227,7 @@ integration-in-k3d: skaffold-builder
 		-v $(CURDIR)/hack/maven/settings.xml:/root/.m2/settings.xml \
 		-e INTEGRATION_TEST_ARGS=$(INTEGRATION_TEST_ARGS) \
 		-e IT_PARTITION=$(IT_PARTITION) \
+		-e DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) \
 		gcr.io/$(GCP_PROJECT)/skaffold-builder \
 		sh -c ' \
 			k3d cluster list | grep -q k3s-default || TERM=dumb k3d cluster create --image=$(K3D_NODE); \

--- a/integration/testdata/build/skaffold.yaml
+++ b/integration/testdata/build/skaffold.yaml
@@ -38,3 +38,8 @@ build:
     # Would have caught #2315
   - image: multi-stage
     context: multi-stage
+
+    # UseBuildkit
+    # https://github.com/GoogleContainerTools/skaffold/pull/5006#issuecomment-728276690
+  - image: secret
+    context: secret


### PR DESCRIPTION
Fixes: #4746 

**Description**
for integration test jobs that inherited `upgrade_docker` enable buildkit, disable buildkit on others

