### PR TITLE
feat: add kind-disable-load and k3d-disable-load config values

### DIFF
--- a/cmd/skaffold/app/cmd/config/set_test.go
+++ b/cmd/skaffold/app/cmd/config/set_test.go
@@ -227,6 +227,80 @@ func TestSetAndUnsetConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "set kind disable load",
+			key:         "kind-disable-load",
+			value:       "true",
+			kubecontext: "this_is_a_context",
+			expectedSetCfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
+					{
+						Kubecontext:     "this_is_a_context",
+						KindDisableLoad: util.BoolPtr(true),
+					},
+				},
+			},
+			expectedUnsetCfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
+					{
+						Kubecontext: "this_is_a_context",
+					},
+				},
+			},
+		},
+		{
+			description: "set global kind disable load",
+			key:         "kind-disable-load",
+			value:       "true",
+			global:      true,
+			expectedSetCfg: &config.GlobalConfig{
+				Global: &config.ContextConfig{
+					KindDisableLoad: util.BoolPtr(true),
+				},
+				ContextConfigs: []*config.ContextConfig{},
+			},
+			expectedUnsetCfg: &config.GlobalConfig{
+				Global:         &config.ContextConfig{},
+				ContextConfigs: []*config.ContextConfig{},
+			},
+		},
+		{
+			description: "set k3d disable load",
+			key:         "k3d-disable-load",
+			value:       "true",
+			kubecontext: "this_is_a_context",
+			expectedSetCfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
+					{
+						Kubecontext:    "this_is_a_context",
+						K3dDisableLoad: util.BoolPtr(true),
+					},
+				},
+			},
+			expectedUnsetCfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
+					{
+						Kubecontext: "this_is_a_context",
+					},
+				},
+			},
+		},
+		{
+			description: "set global k3d disable load",
+			key:         "k3d-disable-load",
+			value:       "true",
+			global:      true,
+			expectedSetCfg: &config.GlobalConfig{
+				Global: &config.ContextConfig{
+					K3dDisableLoad: util.BoolPtr(true),
+				},
+				ContextConfigs: []*config.ContextConfig{},
+			},
+			expectedUnsetCfg: &config.GlobalConfig{
+				Global:         &config.ContextConfig{},
+				ContextConfigs: []*config.ContextConfig{},
+			},
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -278,12 +278,12 @@ func TestNewBuilder(t *testing.T) {
 	dummyDaemon := dummyLocalDaemon{}
 
 	tests := []struct {
-		description    string
-		shouldErr      bool
-		expectedPush   bool
-		localBuild     latest.LocalBuild
-		localClusterFn func(string, string, bool) (bool, error)
-		localDockerFn  func(docker.Config) (docker.LocalDaemon, error)
+		description   string
+		shouldErr     bool
+		expectedPush  bool
+		localBuild    latest.LocalBuild
+		cluster       config.Cluster
+		localDockerFn func(docker.Config) (docker.LocalDaemon, error)
 	}{
 		{
 			description: "failed to get docker client",
@@ -293,14 +293,11 @@ func TestNewBuilder(t *testing.T) {
 			shouldErr: true,
 		},
 		{
-			description: "pushImages becomes !localCluster when local:push is not defined",
+			description: "pushImages becomes cluster.PushImages when local:push is not defined",
 			localDockerFn: func(docker.Config) (docker.LocalDaemon, error) {
 				return dummyDaemon, nil
 			},
-			localClusterFn: func(string, string, bool) (b bool, e error) {
-				b = false //because this is false and localBuild.push is nil
-				return
-			},
+			cluster:      config.Cluster{PushImages: true},
 			expectedPush: true,
 		},
 		{
@@ -308,10 +305,7 @@ func TestNewBuilder(t *testing.T) {
 			localDockerFn: func(docker.Config) (docker.LocalDaemon, error) {
 				return dummyDaemon, nil
 			},
-			localClusterFn: func(string, string, bool) (b bool, e error) {
-				b = false
-				return
-			},
+			cluster: config.Cluster{PushImages: true},
 			localBuild: latest.LocalBuild{
 				Push: util.BoolPtr(false),
 			},
@@ -324,12 +318,10 @@ func TestNewBuilder(t *testing.T) {
 			if test.localDockerFn != nil {
 				t.Override(&docker.NewAPIClient, test.localDockerFn)
 			}
-			if test.localClusterFn != nil {
-				t.Override(&getLocalCluster, test.localClusterFn)
-			}
 
 			builder, err := NewBuilder(&mockConfig{
-				local: test.localBuild,
+				local:   test.localBuild,
+				cluster: test.cluster,
 			})
 
 			t.CheckError(test.shouldErr, err)
@@ -442,6 +434,7 @@ type mockConfig struct {
 	runcontext.RunContext // Embedded to provide the default values.
 	local                 latest.LocalBuild
 	mode                  config.RunMode
+	cluster               config.Cluster
 }
 
 func (c *mockConfig) Pipeline() latest.Pipeline {
@@ -452,4 +445,8 @@ func (c *mockConfig) Pipeline() latest.Pipeline {
 
 func (c *mockConfig) Mode() config.RunMode {
 	return c.mode
+}
+
+func (c *mockConfig) GetCluster() config.Cluster {
+	return c.cluster
 }

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -281,8 +281,8 @@ func TestNewBuilder(t *testing.T) {
 		description   string
 		shouldErr     bool
 		expectedPush  bool
-		localBuild    latest.LocalBuild
 		cluster       config.Cluster
+		localBuild    latest.LocalBuild
 		localDockerFn func(docker.Config) (docker.LocalDaemon, error)
 	}{
 		{

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/bazel"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
@@ -32,7 +34,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-	"github.com/sirupsen/logrus"
 )
 
 // Builder uses the host docker daemon to build and tag the image.
@@ -55,11 +56,6 @@ type Builder struct {
 	localPruner        *pruner
 	artifactStore      build.ArtifactStore
 }
-
-// external dependencies are wrapped
-// into private functions for testability
-
-var getCluster = config.GetCluster
 
 type Config interface {
 	docker.Config

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -61,6 +61,7 @@ type Builder struct {
 // into private functions for testability
 
 var getLocalCluster = config.GetLocalCluster
+var isImageLoadingRequired = config.IsImageLoadingRequired
 
 type Config interface {
 	docker.Config
@@ -91,10 +92,15 @@ func NewBuilder(cfg Config) (*Builder, error) {
 		return nil, fmt.Errorf("getting localCluster: %w", err)
 	}
 
+	imageLoadingRequired, err := isImageLoadingRequired(cfg.GlobalConfig())
+	if err != nil {
+		return nil, fmt.Errorf("getting imageLoadingRequired: %w", err)
+	}
+
 	var pushImages bool
 	if cfg.Pipeline().Build.LocalBuild.Push == nil {
-		pushImages = !localCluster
-		logrus.Debugf("push value not present, defaulting to %t because localCluster is %t", pushImages, localCluster)
+		pushImages = !localCluster && !imageLoadingRequired
+		logrus.Debugf("push value not present, defaulting to %t because localCluster is %t and imageLoadingRequired is %t", pushImages, localCluster, imageLoadingRequired)
 	} else {
 		pushImages = *cfg.Pipeline().Build.LocalBuild.Push
 	}

--- a/pkg/skaffold/config/global_config.go
+++ b/pkg/skaffold/config/global_config.go
@@ -34,6 +34,8 @@ type ContextConfig struct {
 	DebugHelpersRegistry string        `yaml:"debug-helpers-registry,omitempty"`
 	UpdateCheck          *bool         `yaml:"update-check,omitempty"`
 	Survey               *SurveyConfig `yaml:"survey,omitempty"`
+	KindDisableLoad      *bool         `yaml:"kind-disable-load,omitempty"`
+	K3dDisableLoad       *bool         `yaml:"k3d-disable-load,omitempty"`
 }
 
 // SurveyConfig is the survey config information

--- a/pkg/skaffold/config/types.go
+++ b/pkg/skaffold/config/types.go
@@ -58,3 +58,9 @@ func (m Muted) MuteDeploy() bool      { return m.mute("deploy") }
 func (m Muted) mute(phase string) bool {
 	return util.StrSliceContains(m.Phases, phase) || util.StrSliceContains(m.Phases, "all")
 }
+
+type Cluster struct {
+	Local      bool
+	PushImages bool
+	LoadImages bool
+}

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -214,6 +214,21 @@ func GetDebugHelpersRegistry(configFile string) (string, error) {
 	return constants.DefaultDebugHelpersRegistry, nil
 }
 
+// IsImageLoadingRequired checks if the cluster requires loading images into it
+func IsImageLoadingRequired(configFile string) (bool, error) {
+	cfg, err := GetConfigForCurrentKubectx(configFile)
+	if err != nil {
+		return false, err
+	}
+
+	kubeContext := cfg.Kubecontext
+	kindDisableLoad := cfg.KindDisableLoad != nil && *cfg.KindDisableLoad
+	k3dDisableLoad := cfg.K3dDisableLoad != nil && *cfg.K3dDisableLoad
+
+	return (IsKindCluster(kubeContext) && !kindDisableLoad) ||
+		(IsK3dCluster(kubeContext) && !k3dDisableLoad), nil
+}
+
 func isDefaultLocal(kubeContext string, detectMinikubeCluster bool) bool {
 	if kubeContext == constants.DefaultMinikubeContext ||
 		kubeContext == constants.DefaultDockerForDesktopContext ||
@@ -226,11 +241,6 @@ func isDefaultLocal(kubeContext string, detectMinikubeCluster bool) bool {
 		return cluster.GetClient().IsMinikube(kubeContext)
 	}
 	return false
-}
-
-// IsImageLoadingRequired checks if the cluster requires loading images into it
-func IsImageLoadingRequired(kubeContext string) bool {
-	return IsKindCluster(kubeContext) || IsK3dCluster(kubeContext)
 }
 
 // IsKindCluster checks that the given `kubeContext` is talking to `kind`.

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -227,12 +227,16 @@ func GetCluster(configFile string, minikubeProfile string, detectMinikube bool) 
 	kindDisableLoad := cfg.KindDisableLoad != nil && *cfg.KindDisableLoad
 	k3dDisableLoad := cfg.K3dDisableLoad != nil && *cfg.K3dDisableLoad
 
+	// load images for local kind/k3d cluster unless explicitly disabled
 	loadImages := local && ((isKindCluster && !kindDisableLoad) || (isK3dCluster && !k3dDisableLoad))
+
+	// push images for remote cluster or local kind/k3d cluster with image loading disabled
+	pushImages := !local || (isKindCluster && kindDisableLoad) || (isK3dCluster && k3dDisableLoad)
 
 	return Cluster{
 		Local:      local,
 		LoadImages: loadImages,
-		PushImages: !loadImages,
+		PushImages: pushImages,
 	}, nil
 }
 

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -303,53 +303,18 @@ func TestIsImageLoadingRequired(t *testing.T) {
 		cfg      *ContextConfig
 		expected bool
 	}{
-		{
-			cfg:      &ContextConfig{Kubecontext: "kind-other"},
-			expected: true,
-		},
-		{
-
-			cfg:      &ContextConfig{Kubecontext: "kind-other", KindDisableLoad: util.BoolPtr(true)},
-			expected: false,
-		},
-		{
-			cfg:      &ContextConfig{Kubecontext: "kind@kind"},
-			expected: true,
-		},
-		{
-			cfg:      &ContextConfig{Kubecontext: "k3d-k3s-default"},
-			expected: true,
-		},
-		{
-			cfg:      &ContextConfig{Kubecontext: "k3d-k3s-default", K3dDisableLoad: util.BoolPtr(true)},
-			expected: false,
-		},
-		{
-			cfg:      &ContextConfig{Kubecontext: "docker-for-desktop"},
-			expected: false,
-		},
-		{
-			cfg:      &ContextConfig{Kubecontext: "minikube"},
-			expected: false,
-		},
-		{
-			cfg:      &ContextConfig{Kubecontext: "docker-desktop"},
-			expected: false,
-		},
-		{
-			cfg:      &ContextConfig{Kubecontext: "anything-else"},
-			expected: false},
-		{
-			cfg:      &ContextConfig{Kubecontext: "kind@blah"},
-			expected: false},
-		{
-			cfg:      &ContextConfig{Kubecontext: "other-kind"},
-			expected: false,
-		},
-		{
-			cfg:      &ContextConfig{Kubecontext: "not-k3d"},
-			expected: false,
-		},
+		{cfg: &ContextConfig{Kubecontext: "kind-other"}, expected: true},
+		{cfg: &ContextConfig{Kubecontext: "kind-other", KindDisableLoad: util.BoolPtr(true)}, expected: false},
+		{cfg: &ContextConfig{Kubecontext: "kind@kind"}, expected: true},
+		{cfg: &ContextConfig{Kubecontext: "k3d-k3s-default"}, expected: true},
+		{cfg: &ContextConfig{Kubecontext: "k3d-k3s-default", K3dDisableLoad: util.BoolPtr(true)}, expected: false},
+		{cfg: &ContextConfig{Kubecontext: "docker-for-desktop"}, expected: false},
+		{cfg: &ContextConfig{Kubecontext: "minikube"}, expected: false},
+		{cfg: &ContextConfig{Kubecontext: "docker-desktop"}, expected: false},
+		{cfg: &ContextConfig{Kubecontext: "anything-else"}, expected: false},
+		{cfg: &ContextConfig{Kubecontext: "kind@blah"}, expected: false},
+		{cfg: &ContextConfig{Kubecontext: "other-kind"}, expected: false},
+		{cfg: &ContextConfig{Kubecontext: "not-k3d"}, expected: false},
 	}
 	for _, test := range tests {
 		testutil.Run(t, "", func(t *testutil.T) {

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -272,78 +272,95 @@ func (fakeClient) MinikubeExec(...string) (*exec.Cmd, error) { return nil, nil }
 
 func TestGetCluster(t *testing.T) {
 	tests := []struct {
-		cfg      *ContextConfig
-		profile  string
-		expected Cluster
+		description string
+		cfg         *ContextConfig
+		profile     string
+		expected    Cluster
 	}{
 		{
-			cfg:      &ContextConfig{Kubecontext: "kind-other"},
-			expected: Cluster{Local: true, LoadImages: true, PushImages: false},
+			description: "kind",
+			cfg:         &ContextConfig{Kubecontext: "kind-other"},
+			expected:    Cluster{Local: true, LoadImages: true, PushImages: false},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "kind-other", LocalCluster: util.BoolPtr(false)},
-			expected: Cluster{Local: false, LoadImages: false, PushImages: true},
+			description: "kind with local-cluster=false",
+			cfg:         &ContextConfig{Kubecontext: "kind-other", LocalCluster: util.BoolPtr(false)},
+			expected:    Cluster{Local: false, LoadImages: false, PushImages: true},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "kind-other", KindDisableLoad: util.BoolPtr(true)},
-			expected: Cluster{Local: true, LoadImages: false, PushImages: true},
+			description: "kind with kind-disable-load=true",
+			cfg:         &ContextConfig{Kubecontext: "kind-other", KindDisableLoad: util.BoolPtr(true)},
+			expected:    Cluster{Local: true, LoadImages: false, PushImages: true},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "kind@kind"},
-			expected: Cluster{Local: true, LoadImages: true, PushImages: false},
+			description: "kind with legacy name",
+			cfg:         &ContextConfig{Kubecontext: "kind@kind"},
+			expected:    Cluster{Local: true, LoadImages: true, PushImages: false},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "k3d-k3s-default"},
-			expected: Cluster{Local: true, LoadImages: true, PushImages: false},
+			description: "k3d",
+			cfg:         &ContextConfig{Kubecontext: "k3d-k3s-default"},
+			expected:    Cluster{Local: true, LoadImages: true, PushImages: false},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "k3d-k3s-default", LocalCluster: util.BoolPtr(false)},
-			expected: Cluster{Local: false, LoadImages: false, PushImages: true},
+			description: "k3d with local-cluster=false",
+			cfg:         &ContextConfig{Kubecontext: "k3d-k3s-default", LocalCluster: util.BoolPtr(false)},
+			expected:    Cluster{Local: false, LoadImages: false, PushImages: true},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "k3d-k3s-default", K3dDisableLoad: util.BoolPtr(true)},
-			expected: Cluster{Local: true, LoadImages: false, PushImages: true},
+			description: "k3d with disable-load=true",
+			cfg:         &ContextConfig{Kubecontext: "k3d-k3s-default", K3dDisableLoad: util.BoolPtr(true)},
+			expected:    Cluster{Local: true, LoadImages: false, PushImages: true},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "docker-for-desktop"},
-			expected: Cluster{Local: true, LoadImages: false, PushImages: true},
+			description: "docker-for-desktop",
+			cfg:         &ContextConfig{Kubecontext: "docker-for-desktop"},
+			expected:    Cluster{Local: true, LoadImages: false, PushImages: false},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "minikube"},
-			expected: Cluster{Local: true, LoadImages: false, PushImages: true},
+			description: "minikube",
+			cfg:         &ContextConfig{Kubecontext: "minikube"},
+			expected:    Cluster{Local: true, LoadImages: false, PushImages: false},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "docker-desktop"},
-			expected: Cluster{Local: true, LoadImages: false, PushImages: true},
+			description: "docker-desktop",
+			cfg:         &ContextConfig{Kubecontext: "docker-desktop"},
+			expected:    Cluster{Local: true, LoadImages: false, PushImages: false},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "some-cluster", LocalCluster: util.BoolPtr(true)},
-			expected: Cluster{Local: true, LoadImages: false, PushImages: true},
+			description: "generic cluster with local-cluster=true",
+			cfg:         &ContextConfig{Kubecontext: "some-cluster", LocalCluster: util.BoolPtr(true)},
+			expected:    Cluster{Local: true, LoadImages: false, PushImages: false},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "some-cluster", LocalCluster: util.BoolPtr(true)},
-			profile:  "someprofile",
-			expected: Cluster{Local: true, LoadImages: false, PushImages: true},
+			description: "generic cluster with minikube profile",
+			cfg:         &ContextConfig{Kubecontext: "some-cluster"},
+			profile:     "someprofile",
+			expected:    Cluster{Local: true, LoadImages: false, PushImages: false},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "anything-else"},
-			expected: Cluster{Local: false, LoadImages: false, PushImages: true},
+			description: "generic cluster",
+			cfg:         &ContextConfig{Kubecontext: "anything-else"},
+			expected:    Cluster{Local: false, LoadImages: false, PushImages: true},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "kind@blah"},
-			expected: Cluster{Local: false, LoadImages: false, PushImages: true},
+			description: "not a legacy kind cluster",
+			cfg:         &ContextConfig{Kubecontext: "kind@blah"},
+			expected:    Cluster{Local: false, LoadImages: false, PushImages: true},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "other-kind"},
-			expected: Cluster{Local: false, LoadImages: false, PushImages: true},
+			description: "not a kind cluster",
+			cfg:         &ContextConfig{Kubecontext: "other-kind"},
+			expected:    Cluster{Local: false, LoadImages: false, PushImages: true},
 		},
 		{
-			cfg:      &ContextConfig{Kubecontext: "not-k3d"},
-			expected: Cluster{Local: false, LoadImages: false, PushImages: true},
+			description: "not a k3d cluster",
+			cfg:         &ContextConfig{Kubecontext: "not-k3d"},
+			expected:    Cluster{Local: false, LoadImages: false, PushImages: true},
 		},
 	}
 	for _, test := range tests {
-		testutil.Run(t, "", func(t *testutil.T) {
+		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&GetConfigForCurrentKubectx, func(string) (*ContextConfig, error) { return test.cfg, nil })
 			t.Override(&cluster.GetClient, func() cluster.Client { return fakeClient{} })
 

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -59,7 +59,7 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 		return fmt.Errorf("unable to connect to Kubernetes: %w", err)
 	}
 
-	if r.runCtx.ImageLoadingRequired && r.imagesAreLocal {
+	if r.imagesAreLocal && r.runCtx.ImageLoadingRequired {
 		err := r.loadImagesIntoCluster(ctx, out, artifacts)
 		if err != nil {
 			return err

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -59,7 +59,7 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 		return fmt.Errorf("unable to connect to Kubernetes: %w", err)
 	}
 
-	if r.imagesAreLocal && config.IsImageLoadingRequired(r.runCtx.GetKubeContext()) {
+	if r.runCtx.ImageLoadingRequired && r.imagesAreLocal {
 		err := r.loadImagesIntoCluster(ctx, out, artifacts)
 		if err != nil {
 			return err

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -59,7 +59,7 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 		return fmt.Errorf("unable to connect to Kubernetes: %w", err)
 	}
 
-	if r.imagesAreLocal && r.runCtx.ImageLoadingRequired {
+	if r.imagesAreLocal && r.runCtx.Cluster.LoadImages {
 		err := r.loadImagesIntoCluster(ctx, out, artifacts)
 		if err != nil {
 			return err

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -37,10 +37,11 @@ type RunContext struct {
 	Opts config.SkaffoldOptions
 	Cfg  latest.Pipeline
 
-	KubeContext        string
-	Namespaces         []string
-	WorkingDir         string
-	InsecureRegistries map[string]bool
+	KubeContext          string
+	Namespaces           []string
+	WorkingDir           string
+	InsecureRegistries   map[string]bool
+	ImageLoadingRequired bool
 }
 
 func (rc *RunContext) GetKubeContext() string                 { return rc.KubeContext }
@@ -114,13 +115,19 @@ func GetRunContext(opts config.SkaffoldOptions, cfg latest.Pipeline) (*RunContex
 		insecureRegistries[r] = true
 	}
 
+	imageLoadingRequired, err := config.IsImageLoadingRequired(opts.GlobalConfig)
+	if err != nil {
+		logrus.Warnf("error reading image loading settings from global config: images will be not loaded")
+	}
+
 	return &RunContext{
-		Opts:               opts,
-		Cfg:                cfg,
-		WorkingDir:         cwd,
-		KubeContext:        kubeContext,
-		Namespaces:         namespaces,
-		InsecureRegistries: insecureRegistries,
+		Opts:                 opts,
+		Cfg:                  cfg,
+		WorkingDir:           cwd,
+		KubeContext:          kubeContext,
+		Namespaces:           namespaces,
+		InsecureRegistries:   insecureRegistries,
+		ImageLoadingRequired: imageLoadingRequired,
 	}, nil
 }
 

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -37,11 +37,11 @@ type RunContext struct {
 	Opts config.SkaffoldOptions
 	Cfg  latest.Pipeline
 
-	KubeContext          string
-	Namespaces           []string
-	WorkingDir           string
-	InsecureRegistries   map[string]bool
-	ImageLoadingRequired bool
+	KubeContext        string
+	Namespaces         []string
+	WorkingDir         string
+	InsecureRegistries map[string]bool
+	Cluster            config.Cluster
 }
 
 func (rc *RunContext) GetKubeContext() string                 { return rc.KubeContext }
@@ -49,6 +49,7 @@ func (rc *RunContext) GetNamespaces() []string                { return rc.Namesp
 func (rc *RunContext) Pipeline() latest.Pipeline              { return rc.Cfg }
 func (rc *RunContext) GetInsecureRegistries() map[string]bool { return rc.InsecureRegistries }
 func (rc *RunContext) GetWorkingDir() string                  { return rc.WorkingDir }
+func (rc *RunContext) GetCluster() config.Cluster             { return rc.Cluster }
 
 func (rc *RunContext) AddSkaffoldLabels() bool                   { return rc.Opts.AddSkaffoldLabels }
 func (rc *RunContext) AutoBuild() bool                           { return rc.Opts.AutoBuild }
@@ -68,7 +69,6 @@ func (rc *RunContext) GetKubeConfig() string                     { return rc.Opt
 func (rc *RunContext) GetKubeNamespace() string                  { return rc.Opts.Namespace }
 func (rc *RunContext) GlobalConfig() string                      { return rc.Opts.GlobalConfig }
 func (rc *RunContext) MinikubeProfile() string                   { return rc.Opts.MinikubeProfile }
-func (rc *RunContext) DetectMinikube() bool                      { return rc.Opts.DetectMinikube }
 func (rc *RunContext) Muted() config.Muted                       { return rc.Opts.Muted }
 func (rc *RunContext) NoPruneChildren() bool                     { return rc.Opts.NoPruneChildren }
 func (rc *RunContext) Notification() bool                        { return rc.Opts.Notification }
@@ -115,19 +115,22 @@ func GetRunContext(opts config.SkaffoldOptions, cfg latest.Pipeline) (*RunContex
 		insecureRegistries[r] = true
 	}
 
-	imageLoadingRequired, err := config.IsImageLoadingRequired(opts.GlobalConfig)
+	// TODO(https://github.com/GoogleContainerTools/skaffold/issues/3668):
+	// remove minikubeProfile from here and instead detect it by matching the
+	// kubecontext API Server to minikube profiles
+	cluster, err := config.GetCluster(opts.GlobalConfig, opts.MinikubeProfile, opts.DetectMinikube)
 	if err != nil {
-		logrus.Warnf("error reading image loading settings from global config: images will be not loaded")
+		return nil, fmt.Errorf("getting cluster: %w", err)
 	}
 
 	return &RunContext{
-		Opts:                 opts,
-		Cfg:                  cfg,
-		WorkingDir:           cwd,
-		KubeContext:          kubeContext,
-		Namespaces:           namespaces,
-		InsecureRegistries:   insecureRegistries,
-		ImageLoadingRequired: imageLoadingRequired,
+		Opts:               opts,
+		Cfg:                cfg,
+		WorkingDir:         cwd,
+		KubeContext:        kubeContext,
+		Namespaces:         namespaces,
+		InsecureRegistries: insecureRegistries,
+		Cluster:            cluster,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes: #3855

**Description**
Add two new configuration options `kind-disable-load` and `k3d-disable-load` to allow disabling image loading for local kind and k3d clusters.

This significantly improves deployment times to Kind.

**Configuration**
```sh
skaffold config set kind-disable-load true
skaffold config set default-repo localhost:5000
skaffold config set insecure-registries http://localhost:5000
```

**Demo**

* Clone [github.com/shaxbee/todo-app-skaffold](https://github.com/shaxbee/todo-app-skaffold).
* `make bootstrap`
* `skaffold run --force` (job is being deployed, therefore force flag is required)

