### PR TITLE
Force correct font to make magnifying glass appear

### DIFF
--- a/docs/static/stylesheets/font.css
+++ b/docs/static/stylesheets/font.css
@@ -25,3 +25,8 @@
 .skaffold-font {
     font-family: 'Exo 2', Arial, Helvetica, sans-serif;
 }
+
+.td-search-input{
+    font-family: FontAwesome, "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+        Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" !important;
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4903 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Force use of FontAwesome with '!important' tag. Effectively this changes the font from "Font Awesome 5 Free" to "FontAwesome" which for some unknown reasons fixes the issue above. 

**User facing changes**
The magnifying glass now appears in the search bars across the skaffold site
<img width="600" alt="Screen Shot 2020-11-10 at 7 20 31 PM" src="https://user-images.githubusercontent.com/12650821/98749557-ea1a0e80-2389-11eb-9ee8-09400526fbee.png">

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
