### PR TITLE
rename BuilderImagePair struct

### DIFF
--- a/pkg/skaffold/initializer/build/builders.go
+++ b/pkg/skaffold/initializer/build/builders.go
@@ -47,17 +47,17 @@ type InitBuilder interface {
 	Path() string
 }
 
-// BuilderImagePair defines a builder and the image it builds
-type BuilderImagePair struct {
+// ArtifactInfo defines a builder and the image it builds
+type ArtifactInfo struct {
 	Builder   InitBuilder
 	ImageName string
 	Workspace string
 }
 
-// GeneratedBuilderImagePair pairs a discovered builder with a
+// GeneratedArtifactInfo pairs a discovered builder with a
 // generated image name, and the path to the manifest that should be generated
-type GeneratedBuilderImagePair struct {
-	BuilderImagePair
+type GeneratedArtifactInfo struct {
+	ArtifactInfo
 	ManifestPath string
 }
 
@@ -70,7 +70,7 @@ type Initializer interface {
 	// PrintAnalysis writes the project analysis to the provided out stream
 	PrintAnalysis(io.Writer) error
 	// GenerateManifests generates image names and manifests for all unresolved pairs
-	GenerateManifests() (map[GeneratedBuilderImagePair][]byte, error)
+	GenerateManifests() (map[GeneratedArtifactInfo][]byte, error)
 }
 
 type emptyBuildInitializer struct {
@@ -88,7 +88,7 @@ func (e *emptyBuildInitializer) PrintAnalysis(io.Writer) error {
 	return nil
 }
 
-func (e *emptyBuildInitializer) GenerateManifests() (map[GeneratedBuilderImagePair][]byte, error) {
+func (e *emptyBuildInitializer) GenerateManifests() (map[GeneratedArtifactInfo][]byte, error) {
 	return nil, nil
 }
 

--- a/pkg/skaffold/initializer/build/builders_test.go
+++ b/pkg/skaffold/initializer/build/builders_test.go
@@ -38,22 +38,22 @@ func TestResolveBuilderImages(t *testing.T) {
 		force                  bool
 		shouldMakeChoice       bool
 		shouldErr              bool
-		expectedPairs          []ArtifactInfo
-		expectedGeneratedPairs []GeneratedArtifactInfo
+		expectedInfos          []ArtifactInfo
+		expectedGeneratedInfos []GeneratedArtifactInfo
 	}{
 		{
 			description:      "nothing to choose from",
 			buildConfigs:     []InitBuilder{},
 			images:           []string{},
 			shouldMakeChoice: false,
-			expectedPairs:    nil,
+			expectedInfos:    nil,
 		},
 		{
 			description:      "don't prompt for single dockerfile and image",
 			buildConfigs:     []InitBuilder{docker.ArtifactConfig{File: "Dockerfile1"}},
 			images:           []string{"image1"},
 			shouldMakeChoice: false,
-			expectedPairs: []ArtifactInfo{
+			expectedInfos: []ArtifactInfo{
 				{
 					Builder:   docker.ArtifactConfig{File: "Dockerfile1"},
 					ImageName: "image1",
@@ -65,7 +65,7 @@ func TestResolveBuilderImages(t *testing.T) {
 			buildConfigs:     []InitBuilder{docker.ArtifactConfig{File: "Dockerfile1"}, jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), File: "build.gradle"}, jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibMaven), Project: "project", File: "pom.xml"}},
 			images:           []string{"image1", "image2"},
 			shouldMakeChoice: true,
-			expectedPairs: []ArtifactInfo{
+			expectedInfos: []ArtifactInfo{
 				{
 					Builder:   docker.ArtifactConfig{File: "Dockerfile1"},
 					ImageName: "image1",
@@ -75,7 +75,7 @@ func TestResolveBuilderImages(t *testing.T) {
 					ImageName: "image2",
 				},
 			},
-			expectedGeneratedPairs: []GeneratedArtifactInfo{
+			expectedGeneratedInfos: []GeneratedArtifactInfo{
 				{
 					ArtifactInfo: ArtifactInfo{
 						Builder:   jib.ArtifactConfig{BuilderName: "Jib Maven Plugin", File: "pom.xml", Project: "project"},
@@ -91,7 +91,7 @@ func TestResolveBuilderImages(t *testing.T) {
 			images:           []string{"image1"},
 			shouldMakeChoice: false,
 			force:            true,
-			expectedPairs: []ArtifactInfo{
+			expectedInfos: []ArtifactInfo{
 				{
 					Builder:   jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), File: "build.gradle"},
 					ImageName: "image1",
@@ -104,7 +104,7 @@ func TestResolveBuilderImages(t *testing.T) {
 			images:           []string{"image1"},
 			shouldMakeChoice: true,
 			force:            true,
-			expectedPairs: []ArtifactInfo{
+			expectedInfos: []ArtifactInfo{
 				{
 					Builder:   docker.ArtifactConfig{File: "Dockerfile1"},
 					ImageName: "image1",
@@ -123,7 +123,7 @@ func TestResolveBuilderImages(t *testing.T) {
 			description:  "one unresolved image",
 			buildConfigs: []InitBuilder{docker.ArtifactConfig{File: "foo"}},
 			images:       []string{},
-			expectedGeneratedPairs: []GeneratedArtifactInfo{
+			expectedGeneratedInfos: []GeneratedArtifactInfo{
 				{
 					ArtifactInfo: ArtifactInfo{
 						Builder:   docker.ArtifactConfig{File: "foo"},
@@ -153,8 +153,8 @@ func TestResolveBuilderImages(t *testing.T) {
 				unresolvedImages: test.images,
 			}
 			err := initializer.resolveBuilderImages()
-			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedPairs, initializer.artifactInfos, cmp.AllowUnexported())
-			t.CheckDeepEqual(test.expectedGeneratedPairs, initializer.generatedArtifactInfos, cmp.AllowUnexported())
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedInfos, initializer.artifactInfos, cmp.AllowUnexported())
+			t.CheckDeepEqual(test.expectedGeneratedInfos, initializer.generatedArtifactInfos, cmp.AllowUnexported())
 		})
 	}
 }
@@ -164,7 +164,7 @@ func TestAutoSelectBuilders(t *testing.T) {
 		description              string
 		builderConfigs           []InitBuilder
 		images                   []string
-		expectedPairs            []ArtifactInfo
+		expectedInfos            []ArtifactInfo
 		expectedBuildersLeft     []InitBuilder
 		expectedUnresolvedImages []string
 	}{
@@ -176,7 +176,7 @@ func TestAutoSelectBuilders(t *testing.T) {
 				jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibMaven), File: "pom.xml", Image: "not a k8s image"},
 			},
 			images:        []string{"image1", "image2"},
-			expectedPairs: nil,
+			expectedInfos: nil,
 			expectedBuildersLeft: []InitBuilder{
 				docker.ArtifactConfig{File: "Dockerfile"},
 				jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), File: "build.gradle"},
@@ -192,7 +192,7 @@ func TestAutoSelectBuilders(t *testing.T) {
 				jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibMaven), File: "pom.xml", Image: "image2"},
 			},
 			images: []string{"image1", "image2", "image3"},
-			expectedPairs: []ArtifactInfo{
+			expectedInfos: []ArtifactInfo{
 				{
 					Builder:   jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), File: "build.gradle", Image: "image1"},
 					ImageName: "image1",
@@ -212,7 +212,7 @@ func TestAutoSelectBuilders(t *testing.T) {
 				jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibMaven), File: "pom.xml", Image: "image1"},
 			},
 			images:        []string{"image1", "image2"},
-			expectedPairs: nil,
+			expectedInfos: nil,
 			expectedBuildersLeft: []InitBuilder{
 				jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), File: "build.gradle", Image: "image1"},
 				jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibMaven), File: "pom.xml", Image: "image1"},
@@ -223,7 +223,7 @@ func TestAutoSelectBuilders(t *testing.T) {
 			description:              "show unique image names",
 			builderConfigs:           nil,
 			images:                   []string{"image1", "image1"},
-			expectedPairs:            nil,
+			expectedInfos:            nil,
 			expectedBuildersLeft:     nil,
 			expectedUnresolvedImages: []string{"image1"},
 		},
@@ -233,7 +233,7 @@ func TestAutoSelectBuilders(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			pairs, builderConfigs, unresolvedImages := matchBuildersToImages(test.builderConfigs, test.images)
 
-			t.CheckDeepEqual(test.expectedPairs, pairs)
+			t.CheckDeepEqual(test.expectedInfos, pairs)
 			t.CheckDeepEqual(test.expectedBuildersLeft, builderConfigs)
 			t.CheckDeepEqual(test.expectedUnresolvedImages, unresolvedImages)
 		})
@@ -245,7 +245,7 @@ func TestProcessCliArtifacts(t *testing.T) {
 		description        string
 		artifacts          []string
 		shouldErr          bool
-		expectedPairs      []ArtifactInfo
+		expectedInfos      []ArtifactInfo
 		expectedWorkspaces []string
 	}{
 		{
@@ -264,7 +264,7 @@ func TestProcessCliArtifacts(t *testing.T) {
 				`/path/to/Dockerfile=image1`,
 				`/path/to/Dockerfile2=image2`,
 			},
-			expectedPairs: []ArtifactInfo{
+			expectedInfos: []ArtifactInfo{
 				{
 					Builder:   docker.ArtifactConfig{File: "/path/to/Dockerfile"},
 					ImageName: "image1",
@@ -283,7 +283,7 @@ func TestProcessCliArtifacts(t *testing.T) {
 				`{"builder":"Jib Maven Plugin","payload":{"path":"/path/to/pom.xml","project":"project-name","image":"testImage"},"image":"image3"}`,
 				`{"builder":"Buildpacks","payload":{"path":"/path/to/package.json"},"image":"image4"}`,
 			},
-			expectedPairs: []ArtifactInfo{
+			expectedInfos: []ArtifactInfo{
 				{
 					Builder:   docker.ArtifactConfig{File: "/path/to/Dockerfile"},
 					ImageName: "image1",
@@ -310,7 +310,7 @@ func TestProcessCliArtifacts(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			pairs, err := processCliArtifacts(test.artifacts)
 
-			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedPairs, pairs)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedInfos, pairs)
 		})
 	}
 }

--- a/pkg/skaffold/initializer/build/cli.go
+++ b/pkg/skaffold/initializer/build/cli.go
@@ -71,7 +71,7 @@ func (c *cliBuildInitializer) processCliArtifacts() error {
 }
 
 func processCliArtifacts(cliArtifacts []string) ([]ArtifactInfo, error) {
-	var pairs []ArtifactInfo
+	var artifactInfos []ArtifactInfo
 	for _, artifact := range cliArtifacts {
 		// Parses artifacts in 1 of 2 forms:
 		// 1. JSON in the form of: {"builder":"Name of Builder","payload":{...},"image":"image.name","context":"artifact.context"}.
@@ -89,7 +89,7 @@ func processCliArtifacts(cliArtifacts []string) ([]ArtifactInfo, error) {
 			if len(parts) != 2 {
 				return nil, fmt.Errorf("malformed artifact provided: %s", artifact)
 			}
-			pairs = append(pairs, ArtifactInfo{
+			artifactInfos = append(artifactInfos, ArtifactInfo{
 				Builder:   docker.ArtifactConfig{File: parts[0]},
 				ImageName: parts[1],
 			})
@@ -105,8 +105,8 @@ func processCliArtifacts(cliArtifacts []string) ([]ArtifactInfo, error) {
 			if err := json.Unmarshal([]byte(artifact), &parsed); err != nil {
 				return nil, err
 			}
-			pair := ArtifactInfo{Builder: parsed.Payload, ImageName: a.Image, Workspace: a.Workspace}
-			pairs = append(pairs, pair)
+			info := ArtifactInfo{Builder: parsed.Payload, ImageName: a.Image, Workspace: a.Workspace}
+			artifactInfos = append(artifactInfos, info)
 
 		// FIXME: shouldn't use a human-readable name?
 		case jib.PluginName(jib.JibGradle), jib.PluginName(jib.JibMaven):
@@ -117,8 +117,8 @@ func processCliArtifacts(cliArtifacts []string) ([]ArtifactInfo, error) {
 				return nil, err
 			}
 			parsed.Payload.BuilderName = a.Name
-			pair := ArtifactInfo{Builder: parsed.Payload, ImageName: a.Image, Workspace: a.Workspace}
-			pairs = append(pairs, pair)
+			info := ArtifactInfo{Builder: parsed.Payload, ImageName: a.Image, Workspace: a.Workspace}
+			artifactInfos = append(artifactInfos, info)
 
 		case buildpacks.Name:
 			parsed := struct {
@@ -127,12 +127,12 @@ func processCliArtifacts(cliArtifacts []string) ([]ArtifactInfo, error) {
 			if err := json.Unmarshal([]byte(artifact), &parsed); err != nil {
 				return nil, err
 			}
-			pair := ArtifactInfo{Builder: parsed.Payload, ImageName: a.Image, Workspace: a.Workspace}
-			pairs = append(pairs, pair)
+			info := ArtifactInfo{Builder: parsed.Payload, ImageName: a.Image, Workspace: a.Workspace}
+			artifactInfos = append(artifactInfos, info)
 
 		default:
 			return nil, fmt.Errorf("unknown builder type in CLI artifacts: %q", a.Name)
 		}
 	}
-	return pairs, nil
+	return artifactInfos, nil
 }

--- a/pkg/skaffold/initializer/build/init.go
+++ b/pkg/skaffold/initializer/build/init.go
@@ -64,13 +64,13 @@ func (d *defaultBuildInitializer) PrintAnalysis(out io.Writer) error {
 
 func (d *defaultBuildInitializer) GenerateManifests() (map[GeneratedArtifactInfo][]byte, error) {
 	generatedManifests := map[GeneratedArtifactInfo][]byte{}
-	for _, pair := range d.generatedArtifactInfos {
-		manifest, err := generator.Generate(pair.ImageName)
+	for _, info := range d.generatedArtifactInfos {
+		manifest, err := generator.Generate(info.ImageName)
 		if err != nil {
 			return nil, fmt.Errorf("generating kubernetes manifest: %w", err)
 		}
-		generatedManifests[pair] = manifest
-		d.artifactInfos = append(d.artifactInfos, pair.ArtifactInfo)
+		generatedManifests[info] = manifest
+		d.artifactInfos = append(d.artifactInfos, info.ArtifactInfo)
 	}
 	d.generatedArtifactInfos = nil
 	return generatedManifests, nil
@@ -80,8 +80,8 @@ func (d *defaultBuildInitializer) GenerateManifests() (map[GeneratedArtifactInfo
 // images match an image in the image list, and returns a list of the matching builder/image pairs. Also
 // separately returns the builder configs and images that didn't have any matches.
 func (d *defaultBuildInitializer) matchBuildersToImages(images []string) {
-	pairs, unresolvedBuilders, unresolvedImages := matchBuildersToImages(d.builders, images)
-	d.artifactInfos = pairs
+	artifactInfos, unresolvedBuilders, unresolvedImages := matchBuildersToImages(d.builders, images)
+	d.artifactInfos = artifactInfos
 	d.unresolvedImages = unresolvedImages
 	d.builders = unresolvedBuilders
 }

--- a/pkg/skaffold/initializer/build/init.go
+++ b/pkg/skaffold/initializer/build/init.go
@@ -26,14 +26,14 @@ import (
 )
 
 type defaultBuildInitializer struct {
-	builders                   []InitBuilder
-	builderImagePairs          []BuilderImagePair
-	generatedBuilderImagePairs []GeneratedBuilderImagePair
-	unresolvedImages           []string
-	skipBuild                  bool
-	force                      bool
-	enableNewFormat            bool
-	resolveImages              bool
+	builders               []InitBuilder
+	artifactInfos          []ArtifactInfo
+	generatedArtifactInfos []GeneratedArtifactInfo
+	unresolvedImages       []string
+	skipBuild              bool
+	force                  bool
+	enableNewFormat        bool
+	resolveImages          bool
 }
 
 func (d *defaultBuildInitializer) ProcessImages(images []string) error {
@@ -54,25 +54,25 @@ func (d *defaultBuildInitializer) ProcessImages(images []string) error {
 
 func (d *defaultBuildInitializer) BuildConfig() latest.BuildConfig {
 	return latest.BuildConfig{
-		Artifacts: Artifacts(d.builderImagePairs),
+		Artifacts: Artifacts(d.artifactInfos),
 	}
 }
 
 func (d *defaultBuildInitializer) PrintAnalysis(out io.Writer) error {
-	return printAnalysis(out, d.enableNewFormat, d.skipBuild, d.builderImagePairs, d.builders, d.unresolvedImages)
+	return printAnalysis(out, d.enableNewFormat, d.skipBuild, d.artifactInfos, d.builders, d.unresolvedImages)
 }
 
-func (d *defaultBuildInitializer) GenerateManifests() (map[GeneratedBuilderImagePair][]byte, error) {
-	generatedManifests := map[GeneratedBuilderImagePair][]byte{}
-	for _, pair := range d.generatedBuilderImagePairs {
+func (d *defaultBuildInitializer) GenerateManifests() (map[GeneratedArtifactInfo][]byte, error) {
+	generatedManifests := map[GeneratedArtifactInfo][]byte{}
+	for _, pair := range d.generatedArtifactInfos {
 		manifest, err := generator.Generate(pair.ImageName)
 		if err != nil {
 			return nil, fmt.Errorf("generating kubernetes manifest: %w", err)
 		}
 		generatedManifests[pair] = manifest
-		d.builderImagePairs = append(d.builderImagePairs, pair.BuilderImagePair)
+		d.artifactInfos = append(d.artifactInfos, pair.ArtifactInfo)
 	}
-	d.generatedBuilderImagePairs = nil
+	d.generatedArtifactInfos = nil
 	return generatedManifests, nil
 }
 
@@ -81,7 +81,7 @@ func (d *defaultBuildInitializer) GenerateManifests() (map[GeneratedBuilderImage
 // separately returns the builder configs and images that didn't have any matches.
 func (d *defaultBuildInitializer) matchBuildersToImages(images []string) {
 	pairs, unresolvedBuilders, unresolvedImages := matchBuildersToImages(d.builders, images)
-	d.builderImagePairs = pairs
+	d.artifactInfos = pairs
 	d.unresolvedImages = unresolvedImages
 	d.builders = unresolvedBuilders
 }

--- a/pkg/skaffold/initializer/build/json.go
+++ b/pkg/skaffold/initializer/build/json.go
@@ -24,7 +24,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 )
 
-func printAnalysis(out io.Writer, enableNewFormat bool, skipBuild bool, pairs []BuilderImagePair, unresolvedBuilderConfigs []InitBuilder, unresolvedImages []string) error {
+func printAnalysis(out io.Writer, enableNewFormat bool, skipBuild bool, pairs []ArtifactInfo, unresolvedBuilderConfigs []InitBuilder, unresolvedImages []string) error {
 	if !enableNewFormat {
 		return PrintAnalyzeOldFormat(out, skipBuild, pairs, unresolvedBuilderConfigs, unresolvedImages)
 	}
@@ -33,7 +33,7 @@ func printAnalysis(out io.Writer, enableNewFormat bool, skipBuild bool, pairs []
 }
 
 // TODO(nkubala): make these private again once DoInit() relinquishes control of the builder/image processing
-func PrintAnalyzeOldFormat(out io.Writer, skipBuild bool, pairs []BuilderImagePair, unresolvedBuilders []InitBuilder, unresolvedImages []string) error {
+func PrintAnalyzeOldFormat(out io.Writer, skipBuild bool, pairs []ArtifactInfo, unresolvedBuilders []InitBuilder, unresolvedImages []string) error {
 	if !skipBuild && len(unresolvedBuilders) == 0 {
 		return errors.New("one or more valid Dockerfiles must be present to build images with skaffold; please provide at least one Dockerfile and try again, or run `skaffold init --skip-build`")
 	}
@@ -60,7 +60,7 @@ func PrintAnalyzeOldFormat(out io.Writer, skipBuild bool, pairs []BuilderImagePa
 
 // printAnalyzeJSON takes the automatically resolved builder/image pairs, the unresolved images, and the unresolved builders, and generates
 // a JSON string containing builder config information,
-func PrintAnalyzeJSON(out io.Writer, skipBuild bool, pairs []BuilderImagePair, unresolvedBuilders []InitBuilder, unresolvedImages []string) error {
+func PrintAnalyzeJSON(out io.Writer, skipBuild bool, pairs []ArtifactInfo, unresolvedBuilders []InitBuilder, unresolvedImages []string) error {
 	if !skipBuild && len(unresolvedBuilders) == 0 {
 		return errors.New("one or more valid Dockerfiles must be present to build images with skaffold; please provide at least one Dockerfile and try again, or run `skaffold init --skip-build`")
 	}

--- a/pkg/skaffold/initializer/build/json_test.go
+++ b/pkg/skaffold/initializer/build/json_test.go
@@ -27,20 +27,20 @@ import (
 
 func TestPrintAnalyzeJSON(t *testing.T) {
 	tests := []struct {
-		description string
-		pairs       []ArtifactInfo
-		builders    []InitBuilder
-		images      []string
-		skipBuild   bool
-		shouldErr   bool
-		expected    string
+		description   string
+		artifactInfos []ArtifactInfo
+		builders      []InitBuilder
+		images        []string
+		skipBuild     bool
+		shouldErr     bool
+		expected      string
 	}{
 		{
-			description: "builders and images with pairs",
-			pairs:       []ArtifactInfo{{Builder: jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), Image: "image1", File: "build.gradle", Project: "project"}, ImageName: "image1"}},
-			builders:    []InitBuilder{docker.ArtifactConfig{File: "Dockerfile"}},
-			images:      []string{"image2"},
-			expected:    `{"builders":[{"name":"Jib Gradle Plugin","payload":{"image":"image1","path":"build.gradle","project":"project"}},{"name":"Docker","payload":{"path":"Dockerfile"}}],"images":[{"name":"image1","foundMatch":true},{"name":"image2","foundMatch":false}]}` + "\n",
+			description:   "builders and images with pairs",
+			artifactInfos: []ArtifactInfo{{Builder: jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), Image: "image1", File: "build.gradle", Project: "project"}, ImageName: "image1"}},
+			builders:      []InitBuilder{docker.ArtifactConfig{File: "Dockerfile"}},
+			images:        []string{"image2"},
+			expected:      `{"builders":[{"name":"Jib Gradle Plugin","payload":{"image":"image1","path":"build.gradle","project":"project"}},{"name":"Docker","payload":{"path":"Dockerfile"}}],"images":[{"name":"image1","foundMatch":true},{"name":"image2","foundMatch":false}]}` + "\n",
 		},
 		{
 			description: "builders and images with no pairs",
@@ -68,7 +68,7 @@ func TestPrintAnalyzeJSON(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			var out bytes.Buffer
 
-			err := PrintAnalyzeJSON(&out, test.skipBuild, test.pairs, test.builders, test.images)
+			err := PrintAnalyzeJSON(&out, test.skipBuild, test.artifactInfos, test.builders, test.images)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, out.String())
 		})
@@ -77,13 +77,13 @@ func TestPrintAnalyzeJSON(t *testing.T) {
 
 func TestPrintAnalyzeJSONNoJib(t *testing.T) {
 	tests := []struct {
-		description string
-		pairs       []ArtifactInfo
-		builders    []InitBuilder
-		images      []string
-		skipBuild   bool
-		shouldErr   bool
-		expected    string
+		description   string
+		artifactInfos []ArtifactInfo
+		builders      []InitBuilder
+		images        []string
+		skipBuild     bool
+		shouldErr     bool
+		expected      string
 	}{
 		{
 			description: "builders and images (backwards compatibility)",
@@ -111,7 +111,7 @@ func TestPrintAnalyzeJSONNoJib(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			var out bytes.Buffer
 
-			err := PrintAnalyzeOldFormat(&out, test.skipBuild, test.pairs, test.builders, test.images)
+			err := PrintAnalyzeOldFormat(&out, test.skipBuild, test.artifactInfos, test.builders, test.images)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, out.String())
 		})

--- a/pkg/skaffold/initializer/build/json_test.go
+++ b/pkg/skaffold/initializer/build/json_test.go
@@ -28,7 +28,7 @@ import (
 func TestPrintAnalyzeJSON(t *testing.T) {
 	tests := []struct {
 		description string
-		pairs       []BuilderImagePair
+		pairs       []ArtifactInfo
 		builders    []InitBuilder
 		images      []string
 		skipBuild   bool
@@ -37,7 +37,7 @@ func TestPrintAnalyzeJSON(t *testing.T) {
 	}{
 		{
 			description: "builders and images with pairs",
-			pairs:       []BuilderImagePair{{Builder: jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), Image: "image1", File: "build.gradle", Project: "project"}, ImageName: "image1"}},
+			pairs:       []ArtifactInfo{{Builder: jib.ArtifactConfig{BuilderName: jib.PluginName(jib.JibGradle), Image: "image1", File: "build.gradle", Project: "project"}, ImageName: "image1"}},
 			builders:    []InitBuilder{docker.ArtifactConfig{File: "Dockerfile"}},
 			images:      []string{"image2"},
 			expected:    `{"builders":[{"name":"Jib Gradle Plugin","payload":{"image":"image1","path":"build.gradle","project":"project"}},{"name":"Docker","payload":{"path":"Dockerfile"}}],"images":[{"name":"image1","foundMatch":true},{"name":"image2","foundMatch":false}]}` + "\n",
@@ -78,7 +78,7 @@ func TestPrintAnalyzeJSON(t *testing.T) {
 func TestPrintAnalyzeJSONNoJib(t *testing.T) {
 	tests := []struct {
 		description string
-		pairs       []BuilderImagePair
+		pairs       []ArtifactInfo
 		builders    []InitBuilder
 		images      []string
 		skipBuild   bool

--- a/pkg/skaffold/initializer/build/resolve.go
+++ b/pkg/skaffold/initializer/build/resolve.go
@@ -39,12 +39,12 @@ func (d *defaultBuildInitializer) resolveBuilderImages() error {
 	if len(d.builders) == 1 {
 		if len(d.unresolvedImages) == 0 {
 			// no image was parsed from k8s manifests, so we create an image name
-			d.generatedBuilderImagePairs = append(d.generatedBuilderImagePairs, getGeneratedBuilderPair(d.builders[0]))
+			d.generatedArtifactInfos = append(d.generatedArtifactInfos, getGeneratedBuilderPair(d.builders[0]))
 			return nil
 		}
 		// we already have the image, just use it and return
 		if len(d.unresolvedImages) == 1 {
-			d.builderImagePairs = append(d.builderImagePairs, BuilderImagePair{
+			d.artifactInfos = append(d.artifactInfos, ArtifactInfo{
 				Builder:   d.builders[0],
 				ImageName: d.unresolvedImages[0],
 			})
@@ -70,7 +70,7 @@ func (d *defaultBuildInitializer) resolveBuilderImagesForcefully() error {
 			}
 		}
 
-		d.builderImagePairs = append(d.builderImagePairs, BuilderImagePair{Builder: choice, ImageName: image})
+		d.artifactInfos = append(d.artifactInfos, ArtifactInfo{Builder: choice, ImageName: image})
 		d.unresolvedImages = []string{}
 		return nil
 	}
@@ -118,7 +118,7 @@ func (d *defaultBuildInitializer) resolveBuilderImagesInteractively() error {
 		}
 
 		if choice != NoBuilder {
-			d.builderImagePairs = append(d.builderImagePairs, BuilderImagePair{Builder: choiceMap[choice], ImageName: image})
+			d.artifactInfos = append(d.artifactInfos, ArtifactInfo{Builder: choiceMap[choice], ImageName: image})
 			choices = util.RemoveFromSlice(choices, choice)
 		}
 		d.unresolvedImages = util.RemoveFromSlice(d.unresolvedImages, image)
@@ -126,13 +126,13 @@ func (d *defaultBuildInitializer) resolveBuilderImagesInteractively() error {
 	if len(choices) > 0 {
 		// TODO(nkubala): should we ask user if they want to generate here?
 		for _, choice := range choices {
-			d.generatedBuilderImagePairs = append(d.generatedBuilderImagePairs, getGeneratedBuilderPair(choiceMap[choice]))
+			d.generatedArtifactInfos = append(d.generatedArtifactInfos, getGeneratedBuilderPair(choiceMap[choice]))
 		}
 	}
 	return nil
 }
 
-func getGeneratedBuilderPair(b InitBuilder) GeneratedBuilderImagePair {
+func getGeneratedBuilderPair(b InitBuilder) GeneratedArtifactInfo {
 	path := b.Path()
 	var imageName string
 	// if the builder is in a nested directory, use that as the image name AND the path to write the manifest
@@ -144,8 +144,8 @@ func getGeneratedBuilderPair(b InitBuilder) GeneratedBuilderImagePair {
 		imageName = fmt.Sprintf("%s-image", strings.ToLower(path))
 		path = "."
 	}
-	return GeneratedBuilderImagePair{
-		BuilderImagePair: BuilderImagePair{
+	return GeneratedArtifactInfo{
+		ArtifactInfo: ArtifactInfo{
 			Builder:   b,
 			ImageName: sanitizeImageName(imageName),
 		},

--- a/pkg/skaffold/initializer/build/util.go
+++ b/pkg/skaffold/initializer/build/util.go
@@ -25,10 +25,10 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
-func matchBuildersToImages(builders []InitBuilder, images []string) ([]BuilderImagePair, []InitBuilder, []string) {
+func matchBuildersToImages(builders []InitBuilder, images []string) ([]ArtifactInfo, []InitBuilder, []string) {
 	images = tag.StripTags(images)
 
-	var pairs []BuilderImagePair
+	var pairs []ArtifactInfo
 	var unresolvedImages = make(sortedSet)
 	for _, image := range images {
 		builderIdx := findExactlyOneMatchingBuilder(builders, image)
@@ -36,7 +36,7 @@ func matchBuildersToImages(builders []InitBuilder, images []string) ([]BuilderIm
 		// exactly one builder found for the image
 		if builderIdx != -1 {
 			// save the pair
-			pairs = append(pairs, BuilderImagePair{ImageName: image, Builder: builders[builderIdx]})
+			pairs = append(pairs, ArtifactInfo{ImageName: image, Builder: builders[builderIdx]})
 			// remove matched builder from builderConfigs
 			builders = append(builders[:builderIdx], builders[builderIdx+1:]...)
 		} else {
@@ -63,7 +63,7 @@ func findExactlyOneMatchingBuilder(builderConfigs []InitBuilder, image string) i
 }
 
 // Artifacts takes builder image pairs and workspaces and creates a list of latest.Artifacts from the data.
-func Artifacts(pairs []BuilderImagePair) []*latest.Artifact {
+func Artifacts(pairs []ArtifactInfo) []*latest.Artifact {
 	var artifacts []*latest.Artifact
 
 	for _, pair := range pairs {

--- a/pkg/skaffold/initializer/build/util.go
+++ b/pkg/skaffold/initializer/build/util.go
@@ -28,7 +28,7 @@ import (
 func matchBuildersToImages(builders []InitBuilder, images []string) ([]ArtifactInfo, []InitBuilder, []string) {
 	images = tag.StripTags(images)
 
-	var pairs []ArtifactInfo
+	var artifactInfos []ArtifactInfo
 	var unresolvedImages = make(sortedSet)
 	for _, image := range images {
 		builderIdx := findExactlyOneMatchingBuilder(builders, image)
@@ -36,7 +36,7 @@ func matchBuildersToImages(builders []InitBuilder, images []string) ([]ArtifactI
 		// exactly one builder found for the image
 		if builderIdx != -1 {
 			// save the pair
-			pairs = append(pairs, ArtifactInfo{ImageName: image, Builder: builders[builderIdx]})
+			artifactInfos = append(artifactInfos, ArtifactInfo{ImageName: image, Builder: builders[builderIdx]})
 			// remove matched builder from builderConfigs
 			builders = append(builders[:builderIdx], builders[builderIdx+1:]...)
 		} else {
@@ -44,7 +44,7 @@ func matchBuildersToImages(builders []InitBuilder, images []string) ([]ArtifactI
 			unresolvedImages.add(image)
 		}
 	}
-	return pairs, builders, unresolvedImages.values()
+	return artifactInfos, builders, unresolvedImages.values()
 }
 
 func findExactlyOneMatchingBuilder(builderConfigs []InitBuilder, image string) int {
@@ -63,18 +63,18 @@ func findExactlyOneMatchingBuilder(builderConfigs []InitBuilder, image string) i
 }
 
 // Artifacts takes builder image pairs and workspaces and creates a list of latest.Artifacts from the data.
-func Artifacts(pairs []ArtifactInfo) []*latest.Artifact {
+func Artifacts(artifactInfos []ArtifactInfo) []*latest.Artifact {
 	var artifacts []*latest.Artifact
 
-	for _, pair := range pairs {
+	for _, info := range artifactInfos {
 		artifact := &latest.Artifact{
-			ImageName:    pair.ImageName,
-			ArtifactType: pair.Builder.ArtifactType(),
+			ImageName:    info.ImageName,
+			ArtifactType: info.Builder.ArtifactType(),
 		}
 
-		workspace := pair.Workspace
+		workspace := info.Workspace
 		if workspace == "" {
-			workspace = filepath.Dir(pair.Builder.Path())
+			workspace = filepath.Dir(info.Builder.Path())
 		}
 		if workspace != "." {
 			fmt.Fprintf(os.Stdout, "using non standard workspace: %s\n", workspace)

--- a/pkg/skaffold/initializer/config_test.go
+++ b/pkg/skaffold/initializer/config_test.go
@@ -50,7 +50,7 @@ func (s stubDeploymentInitializer) AddManifestForImage(string, string) {
 }
 
 type stubBuildInitializer struct {
-	pairs []build.ArtifactInfo
+	artifactInfos []build.ArtifactInfo
 }
 
 func (s stubBuildInitializer) ProcessImages([]string) error {
@@ -63,7 +63,7 @@ func (s stubBuildInitializer) PrintAnalysis(io.Writer) error {
 
 func (s stubBuildInitializer) BuildConfig() latest.BuildConfig {
 	return latest.BuildConfig{
-		Artifacts: build.Artifacts(s.pairs),
+		Artifacts: build.Artifacts(s.artifactInfos),
 	}
 }
 
@@ -77,12 +77,12 @@ func TestGenerateSkaffoldConfig(t *testing.T) {
 		expectedSkaffoldConfig *latest.SkaffoldConfig
 		deployConfig           latest.DeployConfig
 		profiles               []latest.Profile
-		builderConfigPairs     []build.ArtifactInfo
+		builderConfigInfos     []build.ArtifactInfo
 		getWd                  func() (string, error)
 	}{
 		{
 			name:               "empty",
-			builderConfigPairs: []build.ArtifactInfo{},
+			builderConfigInfos: []build.ArtifactInfo{},
 			deployConfig:       latest.DeployConfig{},
 			getWd: func() (s string, err error) {
 				return filepath.Join("rootDir", "testConfig"), nil
@@ -98,7 +98,7 @@ func TestGenerateSkaffoldConfig(t *testing.T) {
 		},
 		{
 			name: "root dir + builder image pairs",
-			builderConfigPairs: []build.ArtifactInfo{
+			builderConfigInfos: []build.ArtifactInfo{
 				{
 					Builder: docker.ArtifactConfig{
 						File: "testDir/Dockerfile",
@@ -132,7 +132,7 @@ func TestGenerateSkaffoldConfig(t *testing.T) {
 		},
 		{
 			name:               "error working dir",
-			builderConfigPairs: []build.ArtifactInfo{},
+			builderConfigInfos: []build.ArtifactInfo{},
 			deployConfig:       latest.DeployConfig{},
 			getWd: func() (s string, err error) {
 				return "", errors.New("testError")
@@ -152,7 +152,7 @@ func TestGenerateSkaffoldConfig(t *testing.T) {
 				test.profiles,
 			}
 			buildInitializer := stubBuildInitializer{
-				test.builderConfigPairs,
+				test.builderConfigInfos,
 			}
 			t.Override(&getWd, test.getWd)
 			config := generateSkaffoldConfig(buildInitializer, deploymentInitializer)

--- a/pkg/skaffold/initializer/config_test.go
+++ b/pkg/skaffold/initializer/config_test.go
@@ -50,7 +50,7 @@ func (s stubDeploymentInitializer) AddManifestForImage(string, string) {
 }
 
 type stubBuildInitializer struct {
-	pairs []build.BuilderImagePair
+	pairs []build.ArtifactInfo
 }
 
 func (s stubBuildInitializer) ProcessImages([]string) error {
@@ -67,7 +67,7 @@ func (s stubBuildInitializer) BuildConfig() latest.BuildConfig {
 	}
 }
 
-func (s stubBuildInitializer) GenerateManifests() (map[build.GeneratedBuilderImagePair][]byte, error) {
+func (s stubBuildInitializer) GenerateManifests() (map[build.GeneratedArtifactInfo][]byte, error) {
 	panic("no thank you")
 }
 
@@ -77,12 +77,12 @@ func TestGenerateSkaffoldConfig(t *testing.T) {
 		expectedSkaffoldConfig *latest.SkaffoldConfig
 		deployConfig           latest.DeployConfig
 		profiles               []latest.Profile
-		builderConfigPairs     []build.BuilderImagePair
+		builderConfigPairs     []build.ArtifactInfo
 		getWd                  func() (string, error)
 	}{
 		{
 			name:               "empty",
-			builderConfigPairs: []build.BuilderImagePair{},
+			builderConfigPairs: []build.ArtifactInfo{},
 			deployConfig:       latest.DeployConfig{},
 			getWd: func() (s string, err error) {
 				return filepath.Join("rootDir", "testConfig"), nil
@@ -98,7 +98,7 @@ func TestGenerateSkaffoldConfig(t *testing.T) {
 		},
 		{
 			name: "root dir + builder image pairs",
-			builderConfigPairs: []build.BuilderImagePair{
+			builderConfigPairs: []build.ArtifactInfo{
 				{
 					Builder: docker.ArtifactConfig{
 						File: "testDir/Dockerfile",
@@ -132,7 +132,7 @@ func TestGenerateSkaffoldConfig(t *testing.T) {
 		},
 		{
 			name:               "error working dir",
-			builderConfigPairs: []build.BuilderImagePair{},
+			builderConfigPairs: []build.ArtifactInfo{},
 			deployConfig:       latest.DeployConfig{},
 			getWd: func() (s string, err error) {
 				return "", errors.New("testError")


### PR DESCRIPTION
**Related** #5000 

**Description**
This PR is simply just to rename a struct. The BuilderImagePair struct was modified in PR #5000, and the name isn't very fitting. I've renamed it to ArtifactInfo, as it carries data that will be used to create the Artifacts for a user's config.
