### PR TITLE
 remove const var kustomizeFurtherGuidance

### DIFF
--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -88,7 +88,7 @@ func NewDeployer(cfg types.Config, labels map[string]string) *Deployer {
 
 var sanityCheck = versionCheck
 
-// versionCheck returns an error if the kpt and kustomize versions are not compatible with skaffold.
+// versionCheck guarantees the kpt and kustomize versions are compatible with skaffold.
 func versionCheck(dir string, stdout io.Writer) error {
 	kptCmd := exec.Command("kpt", "version")
 	out, err := util.RunCmdOut(kptCmd)

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -57,7 +57,7 @@ const (
 
 	kustomizeDownloadLink  = "https://kubernetes-sigs.github.io/kustomize/installation/"
 	kustomizeMinVersion    = "v3.2.3"
-	kustomizeVersionRegexP = `{Version:(\S+) GitCommit:\S+ BuildDate:\S+ GoOs:\S+ GoArch:\S+}`
+	kustomizeVersionRegexP = `{Version:(kustomize/)?(\S+) GitCommit:\S+ BuildDate:\S+ GoOs:\S+ GoArch:\S+}`
 )
 
 // Deployer deploys workflows with kpt CLI
@@ -81,7 +81,7 @@ func NewDeployer(cfg types.Config, labels map[string]string) *Deployer {
 
 var sanityCheck = versionCheck
 
-// versionCheck guarantees the kpt and kustomize versions are compatible with skaffold.
+// versionCheck checks if the kpt and kustomize versions meet the minimum requirements.
 func versionCheck(dir string, stdout io.Writer) error {
 	kptCmd := exec.Command("kpt", "version")
 	out, err := util.RunCmdOut(kptCmd)
@@ -116,18 +116,18 @@ func versionCheck(dir string, stdout io.Writer) error {
 		// {Version:$VERSION GitCommit:$COMMIT BuildDate:1970-01-01T00:00:00Z GoOs:darwin GoArch:amd64}
 		re := regexp.MustCompile(kustomizeVersionRegexP)
 		match := re.FindStringSubmatch(versionInfo)
-		if len(match) != 2 {
-			color.Yellow.Fprintf(stdout, "unknown kustomize version %q\n"+
+		if len(match) != 3 {
+			color.Yellow.Fprintf(stdout, "unable to determine kustomize version from %q\n"+
 				"Your kustomize may be not from the official release\n"+
 				"Please make sure your local kustomize version >= the official version %v, "+
 				"otherwise some features may not be well supported. "+
 				"You can download the official version from %v\n", string(out),
 				kustomizeMinVersion, kustomizeDownloadLink)
-		} else if !semver.IsValid(match[1]) || semver.Compare(match[1], kustomizeMinVersion) < 0 {
+		} else if !semver.IsValid(match[2]) || semver.Compare(match[2], kustomizeMinVersion) < 0 {
 			color.Yellow.Fprintf(stdout, "you are using kustomize version %q\n"+
 				"Please make sure your local kustomize version >= the official version %v, "+
 				"otherwise some features may not be well supported. "+
-				"You can download the official version from %v\n", match[1],
+				"You can download the official version from %v\n", match[2],
 				kustomizeMinVersion, kustomizeDownloadLink)
 		}
 	}

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -60,13 +60,6 @@ const (
 	kustomizeVersionRegexP = `{Version:(\S+) GitCommit:\S+ BuildDate:\S+ GoOs:\S+ GoArch:\S+}`
 )
 
-var (
-	kustomizeFurtherGuidance = fmt.Sprintf("Please make sure your local "+
-		"kustomize version >= the official version %v, otherwise some features may not be "+
-		"well supported. You can download the official version "+
-		"from %v", kustomizeMinVersion, kustomizeDownloadLink)
-)
-
 // Deployer deploys workflows with kpt CLI
 type Deployer struct {
 	*latest.KptDeploy
@@ -125,11 +118,17 @@ func versionCheck(dir string, stdout io.Writer) error {
 		match := re.FindStringSubmatch(versionInfo)
 		if len(match) != 2 {
 			color.Yellow.Fprintf(stdout, "unknown kustomize version %q\n"+
-				"Your kustomize may be not from the official release\n%v\n", string(out),
-				kustomizeFurtherGuidance)
+				"Your kustomize may be not from the official release\n"+
+				"Please make sure your local kustomize version >= the official version %v, "+
+				"otherwise some features may not be well supported. "+
+				"You can download the official version from %v\n", string(out),
+				kustomizeMinVersion, kustomizeDownloadLink)
 		} else if !semver.IsValid(match[1]) || semver.Compare(match[1], kustomizeMinVersion) < 0 {
-			color.Yellow.Fprintf(stdout, "you are using kustomize version %q\n%v\n",
-				match[1], kustomizeFurtherGuidance)
+			color.Yellow.Fprintf(stdout, "you are using kustomize version %q\n"+
+				"Please make sure your local kustomize version >= the official version %v, "+
+				"otherwise some features may not be well supported. "+
+				"You can download the official version from %v\n", match[1],
+				kustomizeMinVersion, kustomizeDownloadLink)
 		}
 	}
 	return nil

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -118,17 +118,12 @@ func versionCheck(dir string, stdout io.Writer) error {
 		match := re.FindStringSubmatch(versionInfo)
 		if len(match) != 3 {
 			color.Yellow.Fprintf(stdout, "unable to determine kustomize version from %q\n"+
-				"Your kustomize may be not from the official release\n"+
-				"Please make sure your local kustomize version >= the official version %v, "+
-				"otherwise some features may not be well supported. "+
-				"You can download the official version from %v\n", string(out),
-				kustomizeMinVersion, kustomizeDownloadLink)
+				"You can download the official kustomize (recommended >= %v) from %v\n",
+				string(out), kustomizeMinVersion, kustomizeDownloadLink)
 		} else if !semver.IsValid(match[2]) || semver.Compare(match[2], kustomizeMinVersion) < 0 {
-			color.Yellow.Fprintf(stdout, "you are using kustomize version %q\n"+
-				"Please make sure your local kustomize version >= the official version %v, "+
-				"otherwise some features may not be well supported. "+
-				"You can download the official version from %v\n", match[2],
-				kustomizeMinVersion, kustomizeDownloadLink)
+			color.Yellow.Fprintf(stdout, "you are using kustomize version %q "+
+				"(recommended >= %v). You can download the official kustomize from %v\n",
+				match[2], kustomizeMinVersion, kustomizeDownloadLink)
 		}
 	}
 	return nil

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -1090,11 +1090,9 @@ func TestVersionCheck(t *testing.T) {
 			kustomizations: map[string]string{"Kustomization": `resources:
 					- foo.yaml`},
 			shouldErr: false,
-			out: fmt.Sprintf("you are using kustomize version \"v0.0.1\"\n"+
-				"Please make sure your local kustomize version >= the official version %v, "+
-				"otherwise some features may not be well supported. "+
-				"You can download the official version from %v\n", kustomizeMinVersion,
-				kustomizeDownloadLink),
+			out: fmt.Sprintf("you are using kustomize version \"v0.0.1\" "+
+				"(recommended >= %v). You can download the official kustomize from %v\n",
+				kustomizeMinVersion, kustomizeDownloadLink),
 		},
 		{
 			description: "kustomize version is unknown",
@@ -1104,11 +1102,9 @@ func TestVersionCheck(t *testing.T) {
 			kustomizations: map[string]string{"Kustomization": `resources:
 					- foo.yaml`},
 			shouldErr: false,
-			out: fmt.Sprintf("you are using kustomize version \"unknown\"\n"+
-				"Please make sure your local kustomize version >= the official version %v, "+
-				"otherwise some features may not be well supported. "+
-				"You can download the official version from %v\n", kustomizeMinVersion,
-				kustomizeDownloadLink),
+			out: fmt.Sprintf("you are using kustomize version \"unknown\" "+
+				"(recommended >= %v). You can download the official kustomize from %v\n",
+				kustomizeMinVersion, kustomizeDownloadLink),
 		},
 		{
 			description: "kustomize version is non-official",
@@ -1119,11 +1115,8 @@ func TestVersionCheck(t *testing.T) {
 					- foo.yaml`},
 			shouldErr: false,
 			out: fmt.Sprintf("unable to determine kustomize version from \"UNKNOWN\"\n"+
-				"Your kustomize may be not from the official release\n"+
-				"Please make sure your local kustomize version >= the official version %v, "+
-				"otherwise some features may not be well supported. "+
-				"You can download the official version from %v\n", kustomizeMinVersion,
-				kustomizeDownloadLink),
+				"You can download the official kustomize (recommended >= %v) from %v\n",
+				kustomizeMinVersion, kustomizeDownloadLink),
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -1055,7 +1055,7 @@ func TestVersionCheck(t *testing.T) {
 				CmdRunOut("kpt version", `0.34.0`).
 				AndRunOutErr("kustomize version", "", errors.New("BUG")),
 			kustomizations: map[string]string{"Kustomization": `resources:
-				- foo.yaml`},
+					- foo.yaml`},
 			shouldErr: true,
 			error: fmt.Errorf("kustomize is not installed yet\nSee kpt installation: %v",
 				kustomizeDownloadLink),
@@ -1065,7 +1065,7 @@ func TestVersionCheck(t *testing.T) {
 			commands: testutil.
 				CmdRunOut("kpt version", `0.1.0`),
 			kustomizations: map[string]string{"Kustomization": `resources:
-				- foo.yaml`},
+					- foo.yaml`},
 			shouldErr: true,
 			error: fmt.Errorf("you are using kpt \"0.1.0\"\n"+
 				"Please update your kpt version to >= %v\nSee kpt installation: %v",
@@ -1076,7 +1076,7 @@ func TestVersionCheck(t *testing.T) {
 			commands: testutil.
 				CmdRunOut("kpt version", `unknown`),
 			kustomizations: map[string]string{"Kustomization": `resources:
-				- foo.yaml`},
+					- foo.yaml`},
 			shouldErr: true,
 			error: fmt.Errorf("unknown kpt version unknown\nPlease upgrade your "+
 				"local kpt CLI to a version >= %v\nSee kpt installation: %v",
@@ -1088,7 +1088,7 @@ func TestVersionCheck(t *testing.T) {
 				CmdRunOut("kpt version", `0.34.0`).
 				AndRunOut("kustomize version", `{Version:v0.0.1 GitCommit:a0072a2cf92bf5399565e84c621e1e7c5c1f1094 BuildDate:2020-06-15T20:19:07Z GoOs:darwin GoArch:amd64}`),
 			kustomizations: map[string]string{"Kustomization": `resources:
-				- foo.yaml`},
+					- foo.yaml`},
 			shouldErr: false,
 			out: fmt.Sprintf("you are using kustomize version \"v0.0.1\"\n"+
 				"Please make sure your local kustomize version >= the official version %v, "+
@@ -1102,7 +1102,7 @@ func TestVersionCheck(t *testing.T) {
 				CmdRunOut("kpt version", `0.34.0`).
 				AndRunOut("kustomize version", `{Version:unknown GitCommit:a0072a2cf92bf5399565e84c621e1e7c5c1f1094 BuildDate:2020-06-15T20:19:07Z GoOs:darwin GoArch:amd64}`),
 			kustomizations: map[string]string{"Kustomization": `resources:
-				- foo.yaml`},
+					- foo.yaml`},
 			shouldErr: false,
 			out: fmt.Sprintf("you are using kustomize version \"unknown\"\n"+
 				"Please make sure your local kustomize version >= the official version %v, "+
@@ -1116,9 +1116,9 @@ func TestVersionCheck(t *testing.T) {
 				CmdRunOut("kpt version", `0.34.0`).
 				AndRunOut("kustomize version", `UNKNOWN`),
 			kustomizations: map[string]string{"Kustomization": `resources:
-				- foo.yaml`},
+					- foo.yaml`},
 			shouldErr: false,
-			out: fmt.Sprintf("unknown kustomize version \"UNKNOWN\"\n"+
+			out: fmt.Sprintf("unable to determine kustomize version from \"UNKNOWN\"\n"+
 				"Your kustomize may be not from the official release\n"+
 				"Please make sure your local kustomize version >= the official version %v, "+
 				"otherwise some features may not be well supported. "+

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -1090,8 +1090,11 @@ func TestVersionCheck(t *testing.T) {
 			kustomizations: map[string]string{"Kustomization": `resources:
 				- foo.yaml`},
 			shouldErr: false,
-			out: fmt.Sprintf("you are using kustomize version \"v0.0.1\"\n%v\n",
-				kustomizeFurtherGuidance),
+			out: fmt.Sprintf("you are using kustomize version \"v0.0.1\"\n"+
+				"Please make sure your local kustomize version >= the official version %v, "+
+				"otherwise some features may not be well supported. "+
+				"You can download the official version from %v\n", kustomizeMinVersion,
+				kustomizeDownloadLink),
 		},
 		{
 			description: "kustomize version is unknown",
@@ -1101,8 +1104,11 @@ func TestVersionCheck(t *testing.T) {
 			kustomizations: map[string]string{"Kustomization": `resources:
 				- foo.yaml`},
 			shouldErr: false,
-			out: fmt.Sprintf("you are using kustomize version \"unknown\"\n%v\n",
-				kustomizeFurtherGuidance),
+			out: fmt.Sprintf("you are using kustomize version \"unknown\"\n"+
+				"Please make sure your local kustomize version >= the official version %v, "+
+				"otherwise some features may not be well supported. "+
+				"You can download the official version from %v\n", kustomizeMinVersion,
+				kustomizeDownloadLink),
 		},
 		{
 			description: "kustomize version is non-official",
@@ -1113,8 +1119,11 @@ func TestVersionCheck(t *testing.T) {
 				- foo.yaml`},
 			shouldErr: false,
 			out: fmt.Sprintf("unknown kustomize version \"UNKNOWN\"\n"+
-				"Your kustomize may be not from the official release\n%v\n",
-				kustomizeFurtherGuidance),
+				"Your kustomize may be not from the official release\n"+
+				"Please make sure your local kustomize version >= the official version %v, "+
+				"otherwise some features may not be well supported. "+
+				"You can download the official version from %v\n", kustomizeMinVersion,
+				kustomizeDownloadLink),
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Fixes: #4981 #3904

Description
Improve the kpt version check. We don't block users using an old kustomize version since we believe kpt can better deal with the kustomize versioning once using a builtin kustomize .