### PR TITLE
Fix Bug that prevents showing survey prompt

### DIFF
--- a/pkg/skaffold/color/formatter.go
+++ b/pkg/skaffold/color/formatter.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2020 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package color
 import (
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	colors "github.com/heroku/color"
@@ -141,4 +142,12 @@ func IsColorable(out io.Writer) bool {
 	default:
 		return false
 	}
+}
+
+func IsStdout(out io.Writer) bool {
+	o, ok := out.(colorableWriter)
+	if ok {
+		return o.Writer == os.Stdout
+	}
+	return out == os.Stdout
 }

--- a/pkg/skaffold/color/formatter_test.go
+++ b/pkg/skaffold/color/formatter_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2020 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,6 +18,9 @@ package color
 
 import (
 	"bytes"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+	"io"
+	"os"
 	"testing"
 )
 
@@ -88,4 +91,36 @@ func TestFprintlnChangeDefaultToUnknown(t *testing.T) {
 	cw := SetupColors(&b, -1, true)
 	Default.Fprintln(cw, "2", "less", "chars!")
 	compareText(t, "2 less chars!\n", b.String())
+}
+
+func TestIsStdOut(t *testing.T) {
+	tests := []struct {
+		description string
+		out         io.Writer
+		expected    bool
+	}{
+		{
+			description: "std out passed",
+			out:         os.Stdout,
+			expected:    true,
+		},
+		{
+			description: "out nil",
+			out:         nil,
+		},
+		{
+			description: "out bytes buffer",
+			out:         new(bytes.Buffer),
+		},
+		{
+			description: "colorable std out passed",
+			out:         NewWriter(os.Stdout),
+			expected:    true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expected, IsStdout(test.out))
+		})
+	}
 }

--- a/pkg/skaffold/color/formatter_test.go
+++ b/pkg/skaffold/color/formatter_test.go
@@ -18,10 +18,11 @@ package color
 
 import (
 	"bytes"
-	"github.com/GoogleContainerTools/skaffold/testutil"
 	"io"
 	"os"
 	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func compareText(t *testing.T, expected, actual string) {

--- a/pkg/skaffold/survey/survey.go
+++ b/pkg/skaffold/survey/survey.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/pkg/browser"
 	"github.com/sirupsen/logrus"
@@ -47,7 +46,7 @@ Tip: To permanently disable the survey prompt, run:
    skaffold config set --survey --global disable-prompt true`, URL)
 
 	// for testing
-	isStdOut     = stdOut
+	isStdOut     = color.IsStdout
 	open         = browser.OpenURL
 	updateConfig = config.UpdateGlobalSurveyPrompted
 )
@@ -81,8 +80,4 @@ func (s *Runner) OpenSurveyForm(_ context.Context, out io.Writer) error {
 	// Currently we will only update the global survey taken
 	// When prompting for the survey, we need to use the same field.
 	return config.UpdateGlobalSurveyTaken(s.configFile)
-}
-
-func stdOut(out io.Writer) bool {
-	return out == os.Stdout
 }

--- a/pkg/skaffold/survey/survey_test.go
+++ b/pkg/skaffold/survey/survey_test.go
@@ -19,7 +19,6 @@ package survey
 import (
 	"bytes"
 	"io"
-	"os"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -50,33 +49,6 @@ func TestDisplaySurveyForm(t *testing.T) {
 			var buf bytes.Buffer
 			New("test").DisplaySurveyPrompt(&buf)
 			t.CheckDeepEqual(test.expected, buf.String())
-		})
-	}
-}
-
-func TestIsStdOut(t *testing.T) {
-	tests := []struct {
-		description string
-		out         io.Writer
-		expected    bool
-	}{
-		{
-			description: "std out passed",
-			out:         os.Stdout,
-			expected:    true,
-		},
-		{
-			description: "out nil",
-			out:         nil,
-		},
-		{
-			description: "out bytes buffer",
-			out:         new(bytes.Buffer),
-		},
-	}
-	for _, test := range tests {
-		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.CheckDeepEqual(test.expected, isStdOut(test.out))
 		})
 	}
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
Fix bug I introduced where the survey prompt will only show if os.Stdout does not support colors i.e. when ```color.SetupColors(out, forceColors)``` does not wrap ```out```. 

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Fixed by actually checking if the passed io.Writer is a wrapped colorableWriter. Added a test case to ensure that ```color.IsStdout(color.NewWriter(os.Stdout))``` returns true

**Before (master)**:
With an empty global config and running ```skaffold build``` in examples/getting-started, the survey prompt does not show up. This is because  ```survey.isStdout(out)``` returns false when out = colorableWriter{os.Stdout}.

**After**:
Survey prompt shows up given the same conditions above.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
