### PR TITLE
GitTagger generates an invalid tag if there are uncommitted changes

### DIFF
--- a/pkg/skaffold/build/tag/git_commit.go
+++ b/pkg/skaffold/build/tag/git_commit.go
@@ -69,11 +69,13 @@ func (t *GitCommit) GenerateTag(workingDir, _ string) (string, error) {
 		return "", fmt.Errorf("getting git status: %w", err)
 	}
 
+	ref = sanitizeTag(ref)
+
 	if len(changes) > 0 {
 		return fmt.Sprintf("%s%s-dirty", t.prefix, ref), nil
 	}
 
-	return t.prefix + sanitizeTag(ref), nil
+	return t.prefix + ref, nil
 }
 
 // sanitizeTag takes a git tag and converts it to a docker tag by removing

--- a/pkg/skaffold/build/tag/git_commit_test.go
+++ b/pkg/skaffold/build/tag/git_commit_test.go
@@ -81,6 +81,26 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			},
 		},
 		{
+			description:            "dirty worktree with tag containing a slash",
+			variantTags:            "v_2-dirty",
+			variantCommitSha:       "aea33bcc86b5af8c8570ff45d8a643202d63c808-dirty",
+			variantAbbrevCommitSha: "aea33bc-dirty",
+			variantTreeSha:         "bc69d50cda6897a6f2054e64b9059f038dc6fb0e-dirty",
+			variantAbbrevTreeSha:   "bc69d50-dirty",
+			createGitRepo: func(dir string) {
+				gitInit(t, dir).
+					write("source.go", "code").
+					add("source.go").
+					commit("initial").
+					tag("v/1").
+					write("other.go", "other").
+					add("other.go").
+					commit("second commit").
+					tag("v/2").
+					write("other.go", "updated code")
+			},
+		},
+		{
 			description:            "clean worktree with tags",
 			variantTags:            "v2",
 			variantCommitSha:       "aea33bcc86b5af8c8570ff45d8a643202d63c808",


### PR DESCRIPTION
Fixes: #5033 