### PR TITLE
[refactor] move DoInit phases into functions

### DIFF
--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 )
 
@@ -40,36 +41,56 @@ func DoInit(ctx context.Context, out io.Writer, c config.Config) error {
 		}
 	}
 
+	a, err := AnalyzeProject(c)
+	if err != nil {
+		return err
+	}
+
+	newConfig, newManifests, err := Initialize(out, c, a)
+	if err != nil {
+		return err
+	}
+
+	return WriteData(out, c, newConfig, newManifests)
+}
+
+// AnalyzeProject scans the project directory for files and keeps track of what types of files it finds (builders, k8s manifests, etc.).
+func AnalyzeProject(c config.Config) (*analyze.ProjectAnalysis, error) {
 	a := analyze.NewAnalyzer(c)
 	if err := a.Analyze("."); err != nil {
-		return err
+		return nil, err
 	}
 
 	// helm projects can't currently be bootstrapped automatically by skaffold, so we fail fast and link to our docs instead.
 	if len(a.ChartPaths()) > 0 {
 		//nolint
-		return errors.New(`Projects set up to deploy with helm must be manually configured.
+		return nil, errors.New(`Projects set up to deploy with helm must be manually configured.
 
 See https://skaffold.dev/docs/pipeline-stages/deployers/helm/ for a detailed guide on setting your project up with skaffold.`)
 	}
 
+	return a, nil
+}
+
+// Initialize uses the information gathered by the analyzer to create a skaffold config and generate kubernetes manifests.
+func Initialize(out io.Writer, c config.Config, a *analyze.ProjectAnalysis) (*latest.SkaffoldConfig, map[string][]byte, error) {
 	deployInitializer := deploy.NewInitializer(a.Manifests(), a.KustomizeBases(), a.KustomizePaths(), c)
 	images := deployInitializer.GetImages()
 
 	buildInitializer := build.NewInitializer(a.Builders(), c)
 	if err := buildInitializer.ProcessImages(images); err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	if c.Analyze {
-		return buildInitializer.PrintAnalysis(out)
+		return nil, nil, buildInitializer.PrintAnalysis(out)
 	}
 
 	var generatedManifests map[string][]byte
 	if c.EnableManifestGeneration {
 		generatedManifestPairs, err := buildInitializer.GenerateManifests()
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		generatedManifests = make(map[string][]byte, len(generatedManifestPairs))
 		for pair, manifest := range generatedManifestPairs {
@@ -79,25 +100,31 @@ See https://skaffold.dev/docs/pipeline-stages/deployers/helm/ for a detailed gui
 	}
 
 	if err := deployInitializer.Validate(); err != nil {
-		return err
+		return nil, nil, err
 	}
 
-	pipeline, err := yaml.Marshal(generateSkaffoldConfig(buildInitializer, deployInitializer))
+	return generateSkaffoldConfig(buildInitializer, deployInitializer), generatedManifests, nil
+}
+
+// WriteData takes the given skaffold config and k8s manifests and writes them out to a file or the given io.Writer
+func WriteData(out io.Writer, c config.Config, newConfig *latest.SkaffoldConfig, newManifests map[string][]byte) error {
+	pipeline, err := yaml.Marshal(newConfig)
 	if err != nil {
 		return err
 	}
+
 	if c.Opts.ConfigurationFile == "-" {
 		out.Write(pipeline)
 		return nil
 	}
 
 	if !c.Force {
-		if done, err := prompt.WriteSkaffoldConfig(out, pipeline, generatedManifests, c.Opts.ConfigurationFile); done {
+		if done, err := prompt.WriteSkaffoldConfig(out, pipeline, newManifests, c.Opts.ConfigurationFile); done {
 			return err
 		}
 	}
 
-	for path, manifest := range generatedManifests {
+	for path, manifest := range newManifests {
 		if err = ioutil.WriteFile(path, manifest, 0644); err != nil {
 			return fmt.Errorf("writing k8s manifest to file: %w", err)
 		}

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -47,6 +47,8 @@ func DoInit(ctx context.Context, out io.Writer, c config.Config) error {
 	}
 
 	newConfig, newManifests, err := Initialize(out, c, a)
+	// If the --analyze flag is used, we return early with the result of PrintAnalysis()
+	// TODO(marlongamez): Figure out a cleaner way to do this. Might have to change return values to include the different Initializers.
 	if err != nil || c.Analyze {
 		return err
 	}
@@ -73,6 +75,7 @@ See https://skaffold.dev/docs/pipeline-stages/deployers/helm/ for a detailed gui
 }
 
 // Initialize uses the information gathered by the analyzer to create a skaffold config and generate kubernetes manifests.
+// The returned map[string][]byte represents a mapping from generated config name to its respective manifest data held in a []byte
 func Initialize(out io.Writer, c config.Config, a *analyze.ProjectAnalysis) (*latest.SkaffoldConfig, map[string][]byte, error) {
 	deployInitializer := deploy.NewInitializer(a.Manifests(), a.KustomizeBases(), a.KustomizePaths(), c)
 	images := deployInitializer.GetImages()


### PR DESCRIPTION
**Related**: #4915

**Description**
No funcional changes, just organizing some `skaffold init` related code into functions, which will be useful for later when implementing necessary changes for #4915

**Follow-up Work (remove if N/A)**
Implement flow for transparently running `skaffold init` when the user doesn't have a config