### PR TITLE
Create a custom unmarshler for Volumes and VolumeMounts to fix #4175

### DIFF
--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1179,13 +1179,13 @@ type JibArtifact struct {
 	BaseImage string `yaml:"fromImage,omitempty"`
 }
 
-// UnmarshalYAML provides a custom unmarshler to deal with
+// UnmarshalYAML provides a custom unmarshaller to deal with
 // https://github.com/GoogleContainerTools/skaffold/issues/4175
 func (clusterDetails *ClusterDetails) UnmarshalYAML(value *yaml.Node) error {
 	// We do this as follows
 	// 1. We zero out the fields in the node that require custom processing
-	// 2. We unmarshall all the non special fields using the aliased type resource
-	//    we use an alias type to avoid recursion caused by invoking this function infinetly
+	// 2. We unmarshal all the non special fields using the aliased type resource
+	//    we use an alias type to avoid recursion caused by invoking this function infinitely
 	// 3. We deserialize the special fields as required.
 	type ClusterDetailsForUnmarshaling ClusterDetails
 
@@ -1207,13 +1207,13 @@ func (clusterDetails *ClusterDetails) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
-// UnmarshalYAML provides a custom unmarshler to deal with
+// UnmarshalYAML provides a custom unmarshaller to deal with
 // https://github.com/GoogleContainerTools/skaffold/issues/4175
 func (ka *KanikoArtifact) UnmarshalYAML(value *yaml.Node) error {
 	// We do this as follows
 	// 1. We zero out the fields in the node that require custom processing
-	// 2. We unmarshall all the non special fields using the aliased type resource
-	//    we use an alias type to avoid recursion caused by invoking this function infinetly
+	// 2. We unmarshal all the non special fields using the aliased type resource
+	//    we use an alias type to avoid recursion caused by invoking this function infinitely
 	// 3. We deserialize the special fields as required.
 	type KanikoArtifactForUnmarshaling KanikoArtifact
 
@@ -1235,15 +1235,15 @@ func (ka *KanikoArtifact) UnmarshalYAML(value *yaml.Node) error {
 	return nil
 }
 
-// MarshalYAML provides a custom marshler to deal with
+// MarshalYAML provides a custom marshaller to deal with
 // https://github.com/GoogleContainerTools/skaffold/issues/4175
 func (clusterDetails *ClusterDetails) MarshalYAML() (interface{}, error) {
 	// We do this as follows
 	// 1. We zero out the fields in the node that require custom processing
 	// 2. We marshall all the non special fields using the aliased type resource
-	//    we use an alias type to avoid recursion caused by invoking this function infinetly
+	//    we use an alias type to avoid recursion caused by invoking this function infinitely
 	// 3. We unmarshal to a map
-	// 4. We marshall the special fields to json and unmarhsal to a map
+	// 4. We marshal the special fields to json and unmarshal to a map
 	//    * This leverages the json struct annotations to marshal as expected
 	// 5. We combine the two maps and return
 	type ClusterDetailsForUnmarshaling ClusterDetails
@@ -1295,15 +1295,15 @@ func (clusterDetails *ClusterDetails) MarshalYAML() (interface{}, error) {
 	return m, err
 }
 
-// MarshalYAML provides a custom marshler to deal with
+// MarshalYAML provides a custom marshaller to deal with
 // https://github.com/GoogleContainerTools/skaffold/issues/4175
 func (ka *KanikoArtifact) MarshalYAML() (interface{}, error) {
 	// We do this as follows
 	// 1. We zero out the fields in the node that require custom processing
-	// 2. We marshall all the non special fields using the aliased type resource
-	//    we use an alias type to avoid recursion caused by invoking this function infinetly
+	// 2. We marshal all the non special fields using the aliased type resource
+	//    we use an alias type to avoid recursion caused by invoking this function infinitely
 	// 3. We unmarshal to a map
-	// 4. We marshall the special fields to json and unmarhsal to a map
+	// 4. We marshal the special fields to json and unmarshal to a map
 	//    * This leverages the json struct annotations to marshal as expected
 	// 5. We combine the two maps and return
 	type KanikoArtifactForUnmarshaling KanikoArtifact

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -18,9 +18,11 @@ package latest
 
 import (
 	"encoding/json"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
+
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 // This config version is not yet released, it is SAFE TO MODIFY the structs in this file.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -18,10 +18,9 @@ package latest
 
 import (
 	"encoding/json"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
-
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 // This config version is not yet released, it is SAFE TO MODIFY the structs in this file.

--- a/pkg/skaffold/schema/util/yaml.go
+++ b/pkg/skaffold/schema/util/yaml.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"encoding/json"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// UnmarshalClusterVolumes provides a helper function to
+// for a custom unmarshler to deal with
+// https://github.com/GoogleContainerTools/skaffold/issues/4175
+func UnmarshalClusterVolumes(value *yaml.Node) (volumes []v1.Volume, remaining []byte, result error) {
+	clusterMap := make(map[string]interface{})
+
+	value.Decode(clusterMap)
+
+	if vMap, hasVolumes := clusterMap["volumes"]; hasVolumes {
+		volumes = []v1.Volume{}
+		volumesBuff, err := json.Marshal(vMap)
+
+		if err != nil {
+			result = err
+			return
+		}
+
+		if err := json.Unmarshal(volumesBuff, &volumes); err != nil {
+			result = err
+			return
+		}
+
+		delete(clusterMap, "volumes")
+	}
+
+	// Remarshal the remaining values
+	remaining, result = yaml.Marshal(clusterMap)
+
+	return
+}
+
+// UnmarshalKanikoArtifact provides a helper function to
+// for a custom unmarshler to deal with
+// https://github.com/GoogleContainerTools/skaffold/issues/4175
+func UnmarshalKanikoArtifact(value *yaml.Node) (mounts []v1.VolumeMount, remaining []byte, result error) {
+	kaMap := make(map[string]interface{})
+
+	value.Decode(kaMap)
+
+	if vMap, hasVolumes := kaMap["volumeMounts"]; hasVolumes {
+		mounts = []v1.VolumeMount{}
+		volumesBuff, err := json.Marshal(vMap)
+
+		if err != nil {
+			result = err
+			return
+		}
+
+		if err := json.Unmarshal(volumesBuff, &mounts); err != nil {
+			result = err
+			return
+		}
+
+		delete(kaMap, "volumeMounts")
+	}
+
+	// Remarshal the remaining values
+	remaining, result = yaml.Marshal(kaMap)
+	return
+}

--- a/pkg/skaffold/schema/util/yaml.go
+++ b/pkg/skaffold/schema/util/yaml.go
@@ -17,6 +17,7 @@ package util
 
 import (
 	"encoding/json"
+
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )

--- a/pkg/skaffold/schema/util/yaml.go
+++ b/pkg/skaffold/schema/util/yaml.go
@@ -54,7 +54,7 @@ func UnmarshalClusterVolumes(value *yaml.Node) (volumes []v1.Volume, remaining [
 }
 
 // UnmarshalKanikoArtifact provides a helper function to
-// for a custom unmarshler to deal with
+// for a custom unmarshaller to deal with
 // https://github.com/GoogleContainerTools/skaffold/issues/4175
 func UnmarshalKanikoArtifact(value *yaml.Node) (mounts []v1.VolumeMount, remaining []byte, result error) {
 	kaMap := make(map[string]interface{})

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -20,10 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"strings"
-
-	"github.com/sirupsen/logrus"
-
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -67,6 +63,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta9"
 	misc "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
+	"github.com/sirupsen/logrus"
+	"strings"
 )
 
 type APIVersion struct {

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -20,6 +20,10 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -63,8 +67,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta9"
 	misc "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
-	"github.com/sirupsen/logrus"
-	"strings"
 )
 
 type APIVersion struct {

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -190,7 +190,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 			expected: config(
 				withClusterBuild("some-secret", "/secret", "default", "", "20m",
 					withGitTagger(),
-					withKanikoArtifact("image1", "./examples/app1", "Dockerfile"),
+					withKanikoArtifact(),
 					withKanikoVolumeMount("docker-config", "/kaniko/.docker"),
 					withVolume(v1.Volume{
 						Name: "docker-config",
@@ -264,7 +264,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 			expected: config(
 				withClusterBuild("", "/secret", "default", "", "20m",
 					withGitTagger(),
-					withKanikoArtifact("image1", "./examples/app1", "Dockerfile"),
+					withKanikoArtifact(),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
 				withLogsPrefix("container"),
@@ -278,7 +278,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 				withClusterBuild("secret-name", "/secret", "nskaniko", "/secret.json", "120m",
 					withGitTagger(),
 					withDockerConfig("config-name", "/kaniko/.docker"),
-					withKanikoArtifact("image1", "./examples/app1", "Dockerfile"),
+					withKanikoArtifact(),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
 				withLogsPrefix("container"),
@@ -365,7 +365,7 @@ func TestMarshalConfig(t *testing.T) {
 			config: config(
 				withClusterBuild("some-secret", "/some/secret", "default", "", "20m",
 					withGitTagger(),
-					withKanikoArtifact("image1", "./examples/app1", "Dockerfile"),
+					withKanikoArtifact(),
 					withKanikoVolumeMount("docker-config", "/kaniko/.docker"),
 					withVolume(v1.Volume{
 						Name: "docker-config",
@@ -513,14 +513,14 @@ func withBazelArtifact(image, workspace, target string) func(*latest.BuildConfig
 	}
 }
 
-func withKanikoArtifact(image, workspace, dockerfile string) func(*latest.BuildConfig) {
+func withKanikoArtifact() func(*latest.BuildConfig) {
 	return func(cfg *latest.BuildConfig) {
 		cfg.Artifacts = append(cfg.Artifacts, &latest.Artifact{
-			ImageName: image,
-			Workspace: workspace,
+			ImageName: "image1",
+			Workspace: "./examples/app1",
 			ArtifactType: latest.ArtifactType{
 				KanikoArtifact: &latest.KanikoArtifact{
-					DockerfilePath: dockerfile,
+					DockerfilePath: "Dockerfile",
 					InitImage:      constants.DefaultBusyboxImage,
 					Image:          kaniko.DefaultImage,
 				},

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -392,7 +392,7 @@ func TestMarshalConfig(t *testing.T) {
 			// Unmarshal the YAML and make sure it equals the original.
 			// We can't compare the strings because the YAML serializer isn't deterministic.
 			// TestParseConfigAndUpgrade verifies that YAML -> Go works correctly.
-			// This test veries Go -> YAML -> Go returns the original structure. Since we know
+			// This test verifies Go -> YAML -> Go returns the original structure. Since we know
 			// YAML -> Go is working this ensures Go -> YAML is correct.
 			recovered := &latest.SkaffoldConfig{}
 

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -18,16 +18,18 @@ package schema
 
 import (
 	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/clientcmd/api"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
-	"testing"
 )
 
 const (
@@ -361,7 +363,7 @@ func TestMarshalConfig(t *testing.T) {
 		{
 			description: "Kaniko Volume Mount - ConfigMap",
 			config: config(
-				withClusterBuild("some-secret", "/secret", "default", "", "20m",
+				withClusterBuild("some-secret", "/some/secret", "default", "", "20m",
 					withGitTagger(),
 					withKanikoArtifact("image1", "./examples/app1", "Dockerfile"),
 					withKanikoVolumeMount("docker-config", "/kaniko/.docker"),
@@ -388,7 +390,7 @@ func TestMarshalConfig(t *testing.T) {
 			t.CheckNoError(err)
 
 			// Unmarshal the YAML and make sure it equals the original.
-			// We can't comapre the strings because the YAML serializer isn't deterministic.
+			// We can't compare the strings because the YAML serializer isn't deterministic.
 			// TestParseConfigAndUpgrade verifies that YAML -> Go works correctly.
 			// This test veries Go -> YAML -> Go returns the original structure. Since we know
 			// YAML -> Go is working this ensures Go -> YAML is correct.

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -18,18 +18,16 @@ package schema
 
 import (
 	"fmt"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
-	"testing"
-
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/clientcmd/api"
-
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+	"testing"
 )
 
 const (


### PR DESCRIPTION
Fixes: #4175 

**Description**

* As explained in #4175 structs imported from the K8s v1 core API library
  (e.g. volumes and volumeMounts) aren't parsed correctly because
  they use json tags whereas the skaffold data structures
  use the YAML tags.

* This PR fixes that by implementing a custom marshler for the Volumes and VolumeMounts
  fields. The custom marshler removes the problematic fields and parses
  the rest of the struct using the built in YAML parser.

  For the problematic fields these are first marshled using json to take advantage of the json
  tags and then unmarshaled using json to ensure they are unmarshaled based
  on the json tags.

* Due to the fact that the custom UnMarshal methods are implemented in the latest package the 
  custom marshal functions will only be applied if the skaffold config is the latest version i.e. v2beta10;
  if appropriate we could copy this to the v2beta9/config.go file to have it apply to the existing config.


