### PR TITLE
Remove hardcoded amd64 arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 GOPATH ?= $(shell go env GOPATH)
 GOOS ?= $(shell go env GOOS)
-GOARCH ?= amd64
+GOARCH ?= $(shell go env GOARCH)
 BUILD_DIR ?= ./out
 ORG = github.com/GoogleContainerTools
 PROJECT = skaffold


### PR DESCRIPTION
Fixes #5040 

This allows users to build arm64 Skaffold binaries.