### PR TITLE
Add the IgnoreChanges flag to the GitTagger config

### DIFF
--- a/docs/content/en/schemas/v2beta10.json
+++ b/docs/content/en/schemas/v2beta10.json
@@ -1132,6 +1132,12 @@
     },
     "GitTagger": {
       "properties": {
+        "ignoreChanges": {
+          "type": "boolean",
+          "description": "specifies whether to omit the `-dirty` postfix if there are uncommitted changes.",
+          "x-intellij-html-description": "specifies whether to omit the <code>-dirty</code> postfix if there are uncommitted changes.",
+          "default": "false"
+        },
         "prefix": {
           "type": "string",
           "description": "adds a fixed prefix to the tag.",
@@ -1145,7 +1151,8 @@
       },
       "preferredOrder": [
         "variant",
-        "prefix"
+        "prefix",
+        "ignoreChanges"
       ],
       "additionalProperties": false,
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",

--- a/pkg/skaffold/build/tag/custom_template.go
+++ b/pkg/skaffold/build/tag/custom_template.go
@@ -63,7 +63,7 @@ func (t *customTemplateTagger) GenerateTag(workingDir, imageName string) (string
 func (t *customTemplateTagger) EvaluateComponents(workingDir, imageName string) (map[string]string, error) {
 	customMap := map[string]string{}
 
-	gitTagger, _ := NewGitCommit("", "")
+	gitTagger, _ := NewGitCommit("", "", false)
 	dateTimeTagger := NewDateTimeTagger("", "")
 
 	for k, v := range map[string]Tagger{"GIT": gitTagger, "DATE": dateTimeTagger, "SHA": &ChecksumTagger{}} {

--- a/pkg/skaffold/build/tag/git_commit_test.go
+++ b/pkg/skaffold/build/tag/git_commit_test.go
@@ -46,6 +46,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 		createGitRepo          func(string)
 		subDir                 string
 		shouldErr              bool
+		ignoreChanges          bool
 	}{
 		{
 			description:            "clean worktree without tag",
@@ -101,6 +102,27 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			},
 		},
 		{
+			description:            "dirty worktree with ignore changes flag",
+			variantTags:            "v_2",
+			variantCommitSha:       "aea33bcc86b5af8c8570ff45d8a643202d63c808",
+			variantAbbrevCommitSha: "aea33bc",
+			variantTreeSha:         "bc69d50cda6897a6f2054e64b9059f038dc6fb0e",
+			variantAbbrevTreeSha:   "bc69d50",
+			createGitRepo: func(dir string) {
+				gitInit(t, dir).
+					write("source.go", "code").
+					add("source.go").
+					commit("initial").
+					tag("v/1").
+					write("other.go", "other").
+					add("other.go").
+					commit("second commit").
+					tag("v/2").
+					write("other.go", "updated code")
+			},
+			ignoreChanges: true,
+		},
+		{
 			description:            "clean worktree with tags",
 			variantTags:            "v2",
 			variantCommitSha:       "aea33bcc86b5af8c8570ff45d8a643202d63c808",
@@ -118,6 +140,26 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 					commit("second commit").
 					tag("v2")
 			},
+		},
+		{
+			description:            "clean worktree with ignore changes flag",
+			variantTags:            "v2",
+			variantCommitSha:       "aea33bcc86b5af8c8570ff45d8a643202d63c808",
+			variantAbbrevCommitSha: "aea33bc",
+			variantTreeSha:         "bc69d50cda6897a6f2054e64b9059f038dc6fb0e",
+			variantAbbrevTreeSha:   "bc69d50",
+			createGitRepo: func(dir string) {
+				gitInit(t, dir).
+					write("source.go", "code").
+					add("source.go").
+					commit("initial").
+					tag("v1").
+					write("other.go", "other").
+					add("other.go").
+					commit("second commit").
+					tag("v2")
+			},
+			ignoreChanges: true,
 		},
 		{
 			description:            "treeSha only considers current tree content",
@@ -349,7 +391,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 				"TreeSha":         test.variantTreeSha,
 				"AbbrevTreeSha":   test.variantAbbrevTreeSha,
 			} {
-				tagger, err := NewGitCommit("", variant)
+				tagger, err := NewGitCommit("", variant, test.ignoreChanges)
 				t.CheckNoError(err)
 
 				tag, err := tagger.GenerateTag(workspace, "test")
@@ -408,7 +450,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 				"TreeSha":         test.variantTreeSha,
 				"AbbrevTreeSha":   test.variantAbbrevTreeSha,
 			} {
-				tagger, err := NewGitCommit("", variant)
+				tagger, err := NewGitCommit("", variant, false)
 				t.CheckNoError(err)
 
 				tag, err := GenerateFullyQualifiedImageName(tagger, workspace, "test")
@@ -420,7 +462,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 }
 
 func TestGitCommit_CustomTemplate(t *testing.T) {
-	gitCommitExample, _ := NewGitCommit("", "CommitSha")
+	gitCommitExample, _ := NewGitCommit("", "CommitSha", false)
 	tests := []struct {
 		description   string
 		template      string
@@ -478,30 +520,30 @@ func TestGitCommitSubDirectory(t *testing.T) {
 		gitInit(t.T, tmpDir.Root()).mkdir("sub/sub").commit("initial")
 		workspace := tmpDir.Path("sub/sub")
 
-		tagger, err := NewGitCommit("", "Tags")
+		tagger, err := NewGitCommit("", "Tags", false)
 		t.CheckNoError(err)
 		tag, err := tagger.GenerateTag(workspace, "test")
 		t.CheckNoError(err)
 		t.CheckDeepEqual("a7b32a6", tag)
 
-		tagger, err = NewGitCommit("", "CommitSha")
+		tagger, err = NewGitCommit("", "CommitSha", false)
 		t.CheckNoError(err)
 		tag, err = tagger.GenerateTag(workspace, "test")
 		t.CheckNoError(err)
 		t.CheckDeepEqual("a7b32a69335a6daa51bd89cc1bf30bd31df228ba", tag)
 
-		tagger, err = NewGitCommit("", "AbbrevCommitSha")
+		tagger, err = NewGitCommit("", "AbbrevCommitSha", false)
 		t.CheckNoError(err)
 		tag, err = tagger.GenerateTag(workspace, "test")
 		t.CheckNoError(err)
 		t.CheckDeepEqual("a7b32a6", tag)
 
-		tagger, err = NewGitCommit("", "TreeSha")
+		tagger, err = NewGitCommit("", "TreeSha", false)
 		t.CheckNoError(err)
 		_, err = tagger.GenerateTag(workspace, "test")
 		t.CheckErrorAndDeepEqual(true, err, "a7b32a6", tag)
 
-		tagger, err = NewGitCommit("", "AbbrevTreeSha")
+		tagger, err = NewGitCommit("", "AbbrevTreeSha", false)
 		t.CheckNoError(err)
 		_, err = tagger.GenerateTag(workspace, "test")
 		t.CheckErrorAndDeepEqual(true, err, "a7b32a6", tag)
@@ -514,13 +556,13 @@ func TestPrefix(t *testing.T) {
 		gitInit(t.T, tmpDir.Root()).commit("initial")
 		workspace := tmpDir.Path(".")
 
-		tagger, err := NewGitCommit("tag-", "Tags")
+		tagger, err := NewGitCommit("tag-", "Tags", false)
 		t.CheckNoError(err)
 		tag, err := tagger.GenerateTag(workspace, "test")
 		t.CheckNoError(err)
 		t.CheckDeepEqual("tag-a7b32a6", tag)
 
-		tagger, err = NewGitCommit("commit-", "CommitSha")
+		tagger, err = NewGitCommit("commit-", "CommitSha", false)
 		t.CheckNoError(err)
 		tag, err = tagger.GenerateTag(workspace, "test")
 		t.CheckNoError(err)
@@ -530,7 +572,7 @@ func TestPrefix(t *testing.T) {
 
 func TestInvalidVariant(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
-		_, err := NewGitCommit("", "Invalid")
+		_, err := NewGitCommit("", "Invalid", false)
 
 		t.CheckErrorContains("\"Invalid\" is not a valid git tagger variant", err)
 	})

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -262,7 +262,7 @@ func getTagger(runCtx *runcontext.RunContext) (tag.Tagger, error) {
 		return &tag.ChecksumTagger{}, nil
 
 	case t.GitTagger != nil:
-		return tag.NewGitCommit(t.GitTagger.Prefix, t.GitTagger.Variant)
+		return tag.NewGitCommit(t.GitTagger.Prefix, t.GitTagger.Variant, t.GitTagger.IgnoreChanges)
 
 	case t.DateTimeTagger != nil:
 		return tag.NewDateTimeTagger(t.DateTimeTagger.Format, t.DateTimeTagger.TimeZone), nil
@@ -300,7 +300,7 @@ func CreateComponents(t *latest.CustomTemplateTagger) (map[string]tag.Tagger, er
 			components[name] = &tag.ChecksumTagger{}
 
 		case c.GitTagger != nil:
-			components[name], _ = tag.NewGitCommit(c.GitTagger.Prefix, c.GitTagger.Variant)
+			components[name], _ = tag.NewGitCommit(c.GitTagger.Prefix, c.GitTagger.Variant, c.GitTagger.IgnoreChanges)
 
 		case c.DateTimeTagger != nil:
 			components[name] = tag.NewDateTimeTagger(c.DateTimeTagger.Format, c.DateTimeTagger.TimeZone)

--- a/pkg/skaffold/runner/new_test.go
+++ b/pkg/skaffold/runner/new_test.go
@@ -121,7 +121,7 @@ func TestGetDeployer(tOuter *testing.T) {
 }
 
 func TestCreateComponents(t *testing.T) {
-	gitExample, _ := tag.NewGitCommit("", "")
+	gitExample, _ := tag.NewGitCommit("", "", false)
 	envExample, _ := tag.NewEnvTemplateTagger("test")
 
 	tests := []struct {

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -148,6 +148,9 @@ type GitTagger struct {
 
 	// Prefix adds a fixed prefix to the tag.
 	Prefix string `yaml:"prefix,omitempty"`
+
+	// IgnoreChanges specifies whether to omit the `-dirty` postfix if there are uncommitted changes.
+	IgnoreChanges bool `yaml:"ignoreChanges,omitempty"`
 }
 
 // EnvTemplateTagger *beta* tags images with a configurable template string.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #4525 

Merge after: #5071

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR adds the `build.tagPolicy.gitCommit.ignoreChanges` option to the scaffold config to omit the `-dirty` postfix if there are uncommitted changes.
