### PR TITLE
Support multi-level repos for Artifact Registry

### DIFF
--- a/docs/content/en/docs/environment/image-registries.md
+++ b/docs/content/en/docs/environment/image-registries.md
@@ -40,7 +40,7 @@ the full image name is rewritten on top of the default-repo so similar image nam
 
 Automated image name rewriting strategies are determined based on the default-repo and the original image repository:
 
-* default-repo does not begin with gcr.io
+* default-repo domain does not contain `gcr.io` or `-docker.pkg.dev`
   * **strategy**: 		escape & concat & truncate to 256
 
     ```
@@ -49,7 +49,7 @@ Automated image name rewriting strategies are determined based on the default-re
      rewritten image:   aws_account_id.dkr.ecr.region.amazonaws.com/gcr_io_k8s-skaffold_skaffold-example1
     ```
 
-* default-repo begins with "gcr.io" (special case - as GCR allows for infinite deep image repo names)
+* default-repo contain `gcr.io` or `-docker.pkg.dev` (special cases - as GCR and AR allow for arbitrarily deep directory structure in image repo names)
   * **strategy**: concat unless prefix matches
   * **example1**: prefix doesn't match:
 
@@ -63,14 +63,14 @@ Automated image name rewriting strategies are determined based on the default-re
     ```
       original image: 	gcr.io/k8s-skaffold/skaffold-example1
       default-repo: 	gcr.io/k8s-skaffold
-      rewritten image:  gcr.io/k8s-skaffold/skaffold-example1	
+      rewritten image:  gcr.io/k8s-skaffold/skaffold-example1
     ```
   * **example3**: shared prefix:
 
     ```
       original image: 	gcr.io/k8s-skaffold/skaffold-example1
       default-repo: 	gcr.io/k8s-skaffold/myimage
-      rewritten image:  gcr.io/k8s-skaffold/myimage/skaffold-example1	
+      rewritten image:  gcr.io/k8s-skaffold/myimage/skaffold-example1
     ```
 
 ## Insecure image registries
@@ -86,15 +86,15 @@ There are several levels of granularity to allow insecure communication with som
     ```bash
     skaffold dev --insecure-registry insecure1.io --insecure-registry insecure2.io
     ```
-    
+
 1. Per Skaffold run via `SKAFFOLD_INSECURE_REGISTRY` environment variable
 
     ```bash
     SKAFFOLD_INSECURE_REGISTRY='insecure1.io,insecure2.io' skaffold dev
     ```
-    
+
 1. Per project via the Skaffold pipeline config `skaffold.yaml`
-    
+
     ```yaml
     build:
         insecureRegistries:
@@ -108,8 +108,8 @@ There are several levels of granularity to allow insecure communication with som
     skaffold config set insecure-registries insecure1.io           # for the current kube-context
     skaffold config set --global insecure-registries insecure2.io  # for any kube-context
     ```
-    
+
     Note that multiple set commands _add_ to the existing list of insecure registries.
     To clear the list, run `skaffold config unset insecure-registries`.
-    
+
 Skaffold will join the lists of insecure registries, if configured via multiple sources.

--- a/pkg/skaffold/docker/default_repo.go
+++ b/pkg/skaffold/docker/default_repo.go
@@ -19,13 +19,15 @@ package docker
 import (
 	"regexp"
 	"strings"
+
+	"github.com/docker/distribution/reference"
 )
 
 const maxLength = 255
 
 var (
 	escapeRegex = regexp.MustCompile(`[/._:@]`)
-	prefixRegex = regexp.MustCompile(`(.*\.)?gcr.io/[a-zA-Z0-9-_]+/?`)
+	prefixRegex = regexp.MustCompile(`^` + reference.DomainRegexp.String() + `/[a-z0-9]+/?`)
 )
 
 func SubstituteDefaultRepoIntoImage(defaultRepo string, image string) (string, error) {
@@ -68,7 +70,7 @@ func replace(defaultRepo string, baseImage string) string {
 }
 
 func registrySupportsMultiLevelRepos(repo string) bool {
-	return strings.Contains(repo, "gcr.io")
+	return strings.Contains(repo, "gcr.io") || strings.Contains(repo, "-docker.pkg.dev")
 }
 
 func truncate(image string) string {

--- a/pkg/skaffold/docker/default_repo.go
+++ b/pkg/skaffold/docker/default_repo.go
@@ -27,9 +27,9 @@ const maxLength = 255
 
 var (
 	escapeRegex = regexp.MustCompile(`[/._:@]`)
-         // gcpProjectIDRegex matches a GCP Project ID as according to console.cloud.google.com.
-         gcpProjectIDRegex = `[a-z][a-z0-9-]{4,28}[a-z0-9]`
-         // prefixRegex is used to match a GCR or AR reference, which must have a project ID.
+	// gcpProjectIDRegex matches a GCP Project ID as according to console.cloud.google.com.
+	gcpProjectIDRegex = `[a-z][a-z0-9-]{4,28}[a-z0-9]`
+	// prefixRegex is used to match a GCR or AR reference, which must have a project ID.
 	prefixRegex = regexp.MustCompile(`^` + reference.DomainRegexp.String() + `/` + gcpProjectIDRegex + `/?`)
 )
 

--- a/pkg/skaffold/docker/default_repo.go
+++ b/pkg/skaffold/docker/default_repo.go
@@ -27,7 +27,10 @@ const maxLength = 255
 
 var (
 	escapeRegex = regexp.MustCompile(`[/._:@]`)
-	prefixRegex = regexp.MustCompile(`^` + reference.DomainRegexp.String() + `/[a-z0-9]+/?`)
+         // gcpProjectIDRegex matches a GCP Project ID as according to console.cloud.google.com.
+         gcpProjectIDRegex = `[a-z][a-z0-9-]{4,28}[a-z0-9]`
+         // prefixRegex is used to match a GCR or AR reference, which must have a project ID.
+	prefixRegex = regexp.MustCompile(`^` + reference.DomainRegexp.String() + `/` + gcpProjectIDRegex + `/?`)
 )
 
 func SubstituteDefaultRepoIntoImage(defaultRepo string, image string) (string, error) {

--- a/pkg/skaffold/docker/default_repo_test.go
+++ b/pkg/skaffold/docker/default_repo_test.go
@@ -37,6 +37,12 @@ func TestImageReplaceDefaultRepo(t *testing.T) {
 			expectedImage: "gcr.io/default/gcr.io/some/registry",
 		},
 		{
+			description:   "basic AR concatenation",
+			image:         "github.com/org/app",
+			defaultRepo:   "us-central1-docker.pkg.dev/default",
+			expectedImage: "us-central1-docker.pkg.dev/default/github.com/org/app",
+		},
+		{
 			description:   "no default repo set",
 			image:         "gcr.io/some/registry",
 			expectedImage: "gcr.io/some/registry",


### PR DESCRIPTION
**Description**
This change adds Artifact Registry (AR) as another special case for [image name rewriting](https://skaffold.dev/docs/environment/image-registries/), similar to Container Registry (GCR).

Both GCR and AR support arbitrarily deep image repo names. This change looks for `gcr.io` or `-docker.pkg.dev` in the registry domain.

**Related**: #4878

**User facing changes**
Updates to documentation on image name rewriting.