### PR TITLE
Fix usage of set-env in Github release action

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -21,8 +21,8 @@ jobs:
         echo Malformed title for PR; failed to extract semVer tag
         return 1
         fi
-        echo ::set-env name=TAG_NAME::"v${t}"
-        echo ::set-env name=RELEASE_NAME::"v${t} Release"
+        echo TAG_NAME="v${t}" >> $GITHUB_ENV
+        echo RELEASE_NAME="v${t} Release" >> $GITHUB_ENV
 
     - name: Create and push Tag
       run: |


### PR DESCRIPTION
Update action due to https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/