### PR TITLE
Add skaffold meter struct

### DIFF
--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
@@ -59,6 +60,7 @@ func createNewRunner(opts config.SkaffoldOptions) (runner.Runner, *latest.Skaffo
 		return nil, nil, err
 	}
 
+	instrumentation.InitMeter(runCtx, config)
 	runner, err := runner.NewForConfig(runCtx)
 	if err != nil {
 		event.InititializationFailed(err)

--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instrumentation
+
+import (
+	"time"
+
+	"github.com/GoogleContainerTools/skaffold/proto"
+)
+
+type skaffoldMeter struct {
+	ExitCode       int
+	BuildArtifacts int
+	Command        string
+	Version        string
+	OS             string
+	Arch           string
+	PlatformType   string
+	Deployers      []string
+	EnumFlags      map[string]interface{}
+	Builders       map[string]bool
+	SyncType       map[string]bool
+	DevIterations  map[string]int
+	StartTime      time.Time
+	ErrorCode      proto.StatusCode
+}

--- a/pkg/skaffold/yamltags/tags.go
+++ b/pkg/skaffold/yamltags/tags.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 )
 
 type fieldSet map[string]struct{}
@@ -55,6 +57,21 @@ func YamlName(field reflect.StructField) string {
 		}
 	}
 	return field.Name
+}
+
+// GetYamlTag returns the first yaml tag used in the raw yaml text of the given struct
+func GetYamlTag(value interface{}) string {
+	buf, err := yaml.Marshal(value)
+	if err != nil {
+		logrus.Warnf("error marshaling %-v", value)
+		return ""
+	}
+	rawStr := string(buf)
+	i := strings.Index(rawStr, ":")
+	if i == -1 {
+		return ""
+	}
+	return rawStr[:i]
 }
 
 func processTags(yamltags string, val reflect.Value, parentStruct reflect.Value, field reflect.StructField) error {

--- a/pkg/skaffold/yamltags/tags_test.go
+++ b/pkg/skaffold/yamltags/tags_test.go
@@ -197,3 +197,48 @@ func TestYamlName(t *testing.T) {
 	testutil.CheckDeepEqual(t, "named", YamlName(reflect.TypeOf(object).Field(1)))
 	testutil.CheckDeepEqual(t, "Missing", YamlName(reflect.TypeOf(object).Field(2)))
 }
+
+type abc struct {
+	A *string `yaml:"a,omitempty"`
+	B *string `yaml:"b,omitempty"`
+	C *string `yaml:"c,omitempty"`
+}
+
+func TestGetYamlTag(t *testing.T) {
+	a := "it's A"
+	b := "it's B"
+	c := "it's C"
+
+	tests := []struct {
+		name        string
+		yaml        interface{}
+		expectedTag string
+	}{
+		{
+			name:        "test get first field",
+			yaml:        abc{A: &a},
+			expectedTag: "a",
+		},
+		{
+			name:        "test get second field",
+			yaml:        abc{B: &b},
+			expectedTag: "b",
+		},
+		{
+			name:        "test get third field",
+			yaml:        abc{C: &c},
+			expectedTag: "c",
+		},
+		{
+			name:        "test returns empty string on empty struct",
+			yaml:        abc{},
+			expectedTag: "",
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expectedTag, GetYamlTag(test.yaml))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
Create and initialize struct to persist relevant metrics about the execution of the program.

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Initialize global variable with values that can be collected at the start of execution. Use InitMeter function to set values that need to be retrieved from the skaffold config and run context. Parse values from the Skaffold Config by using the raw yaml string as the label. Descriptions of the values in the struct:

```go
// ExitCode stores what exit code skaffold throws
ExitCode       int
// BuildArtifacts contains how many build artifacts in configuration
BuildArtifacts int
// Command is the command used for the iteration
Command        string
// Version of skaffold being used i.e. v1.17
Version        string
// OS that skaffold is running on (darwin, win, linux, etc.)
OS             string
// Arch that skaffold is running on (amd64, arm64, etc.)
Arch           string
// PlatformType being deployed to (local, cluster, googleCloudBuild)
PlatformType   string
// Deployers used for deployment
Deployers      []string
// EnumFlags flags with predefined values used in invocation
EnumFlags      map[string]interface{}
// Builders used to build artifacts
Builders       map[string]bool
// SyncType tracks whether infer, auto, and/or manual are being used
SyncType       map[string]bool
// DevIterations counts the triggers for each dev iteration (sync, build, or deploy)
DevIterations  map[string]int
// StartTime the start time of the skaffold program, used to track how long skaffold took to finish executing
StartTime      time.Time
// ErrorCode returned when skaffold throws an error
ErrorCode      proto.StatusCode
```

**Follow-up Work**
<!-- Mention any related follow up work to this PR. -->
Populate the values for EnumFlags, Deployers, ErrorCode, and DevIterations, write metrics, and upload them, create relevant documentation, and prompt users to opt-out.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
