### PR TITLE
Make docker CLI tests faster by mocking the call to docker auth

### DIFF
--- a/pkg/skaffold/build/docker/docker_test.go
+++ b/pkg/skaffold/build/docker/docker_test.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/docker/docker/api/types"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -80,6 +82,7 @@ func TestDockerCLIBuild(t *testing.T) {
 				"docker build . --file "+dockerfilePath+" -t tag --force-rm",
 				test.expectedEnv,
 			))
+			t.Override(&docker.DefaultAuthHelper, stubAuth{})
 			t.Override(&util.OSEnviron, func() []string { return []string{"KEY=VALUE"} })
 
 			builder := NewArtifactBuilder(fakeLocalDaemonWithExtraEnv(test.extraEnv), test.localBuild.UseDockerCLI, test.localBuild.UseBuildkit, false, false, test.mode, nil, mockArtifactResolver{make(map[string]string)})
@@ -113,4 +116,13 @@ func (r mockArtifactResolver) GetImageTag(imageName string) (string, bool) {
 	}
 	val, found := r.m[imageName]
 	return val, found
+}
+
+type stubAuth struct{}
+
+func (t stubAuth) GetAuthConfig(string) (types.AuthConfig, error) {
+	return types.AuthConfig{}, nil
+}
+func (t stubAuth) GetAllAuthConfigs(context.Context) (map[string]types.AuthConfig, error) {
+	return nil, nil
 }


### PR DESCRIPTION
Before, on master
```
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/docker	46.868s
=== Slow Tests ===
37.05s	TestDockerCLIBuild
8.05s	TestDockerCLIBuild/docker_build
8.04s	TestDockerBuildError
8.03s	TestDockerBuildError/docker_file_present
7.67s	TestDockerCLIBuild/extra_env
7.55s	TestDockerCLIBuild/buildkit
6.91s	TestDockerCLIBuild/buildkit_and_extra_env
6.87s	TestDockerCLIBuild/env_var_collisions
4.44s	TestGetAllAuthConfigs

```
After this change, 
```
ok  	github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/docker	1.453s
```

/cc @marlon-gamez 