### PR TITLE
[Refactor] Fail at helm initialization when helm client version is less than 3.0.0. 

### DIFF
--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -420,7 +420,7 @@ spec:
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			deployer := helm.NewDeployer(&runcontext.RunContext{
+			deployer, err := helm.NewDeployer(&runcontext.RunContext{
 				Cfg: latest.Pipeline{
 					Deploy: latest.DeployConfig{
 						DeployType: latest.DeployType{
@@ -431,8 +431,11 @@ spec:
 					},
 				},
 			}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 			var b bytes.Buffer
-			err := deployer.Render(context.Background(), &b, test.builds, true, "")
+			err = deployer.Render(context.Background(), &b, test.builds, true, "")
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expectedOut, b.String())

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -431,9 +431,7 @@ spec:
 					},
 				},
 			}, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
+			t.RequireNoError(err)
 			var b bytes.Buffer
 			err = deployer.Render(context.Background(), &b, test.builds, true, "")
 

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -114,7 +114,6 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string) (*Deployer, error
 
 // Deploy deploys the build results to the Kubernetes cluster
 func (h *Deployer) Deploy(ctx context.Context, out io.Writer, builds []build.Artifact) ([]string, error) {
-
 	logrus.Infof("Deploying with helm v%s ...", h.bV)
 
 	var dRes []types.Artifact

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -89,7 +89,7 @@ type Deployer struct {
 	bV semver.Version
 }
 
-// NewDeployer returns a configured Deployer if current version of helm is greater than 3.0.0
+// NewDeployer returns a configured Deployer.  Returns an error if current version of helm is less than 3.0.0.
 func NewDeployer(cfg kubectl.Config, labels map[string]string) (*Deployer, error) {
 	hv, err := binVer()
 	if err != nil {

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -93,11 +93,11 @@ type Deployer struct {
 func NewDeployer(cfg kubectl.Config, labels map[string]string) (*Deployer, error) {
 	hv, err := binVer()
 	if err != nil {
-		return nil, fmt.Errorf(versionErrorString, err)
+		return nil, versionGetErr(err)
 	}
 
 	if hv.LT(helm3Version) {
-		return nil, fmt.Errorf("skaffold requires Helm version 3.0.0-beta.0 or greater")
+		return nil, minVersionErr()
 	}
 
 	return &Deployer{

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -89,8 +89,17 @@ type Deployer struct {
 	bV semver.Version
 }
 
-// NewDeployer returns a configured Deployer
-func NewDeployer(cfg kubectl.Config, labels map[string]string) *Deployer {
+// NewDeployer returns a configured Deployer if current version of helm is greater than 3.0.0
+func NewDeployer(cfg kubectl.Config, labels map[string]string) (*Deployer, error) {
+	hv, err := binVer()
+	if err != nil {
+		return nil, fmt.Errorf(versionErrorString, err)
+	}
+
+	if hv.LT(helm3Version) {
+		return nil, fmt.Errorf("skaffold requires Helm version 3.0.0-beta.0 or greater")
+	}
+
 	return &Deployer{
 		HelmDeploy:  cfg.Pipeline().Deploy.HelmDeploy,
 		kubeContext: cfg.GetKubeContext(),
@@ -98,21 +107,15 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string) *Deployer {
 		namespace:   cfg.GetKubeNamespace(),
 		forceDeploy: cfg.ForceDeploy(),
 		labels:      labels,
+		bV:          hv,
 		enableDebug: cfg.Mode() == config.RunModes.Debug,
-	}
+	}, nil
 }
 
 // Deploy deploys the build results to the Kubernetes cluster
 func (h *Deployer) Deploy(ctx context.Context, out io.Writer, builds []build.Artifact) ([]string, error) {
-	hv, err := h.binVer(ctx)
-	if err != nil {
-		return nil, versionGetErr(fmt.Errorf(versionErrorString, err))
-	}
-	if err = h.checkMinVersion(hv); err != nil {
-		return nil, err
-	}
 
-	logrus.Infof("Deploying with helm v%s ...", hv)
+	logrus.Infof("Deploying with helm v%s ...", h.bV)
 
 	var dRes []types.Artifact
 	nsMap := map[string]struct{}{}
@@ -120,7 +123,7 @@ func (h *Deployer) Deploy(ctx context.Context, out io.Writer, builds []build.Art
 
 	// Deploy every release
 	for _, r := range h.Releases {
-		results, err := h.deployRelease(ctx, out, r, builds, valuesSet, hv)
+		results, err := h.deployRelease(ctx, out, r, builds, valuesSet, h.bV)
 		if err != nil {
 			releaseName, _ := util.ExpandEnvTemplate(r.Name, nil)
 			return nil, userErr(fmt.Sprintf("deploying %q", releaseName), err)
@@ -226,14 +229,6 @@ func (h *Deployer) Dependencies() ([]string, error) {
 
 // Cleanup deletes what was deployed by calling Deploy.
 func (h *Deployer) Cleanup(ctx context.Context, out io.Writer) error {
-	hv, err := h.binVer(ctx)
-	if err != nil {
-		return fmt.Errorf(versionErrorString, err)
-	}
-	if err = h.checkMinVersion(hv); err != nil {
-		return err
-	}
-
 	for _, r := range h.Releases {
 		releaseName, err := util.ExpandEnvTemplate(r.Name, nil)
 		if err != nil {
@@ -258,14 +253,6 @@ func (h *Deployer) Cleanup(ctx context.Context, out io.Writer) error {
 
 // Render generates the Kubernetes manifests and writes them out
 func (h *Deployer) Render(ctx context.Context, out io.Writer, builds []build.Artifact, offline bool, filepath string) error {
-	hv, err := h.binVer(ctx)
-	if err != nil {
-		return versionGetErr(err)
-	}
-	if err = h.checkMinVersion(hv); err != nil {
-		return err
-	}
-
 	renderedManifests := new(bytes.Buffer)
 
 	for _, r := range h.Releases {
@@ -336,10 +323,8 @@ func (h *Deployer) deployRelease(ctx context.Context, out io.Writer, r latest.He
 
 	var installEnv []string
 	if h.enableDebug {
-		if hv, err := h.binVer(ctx); err != nil {
-			return nil, err
-		} else if hv.LT(helm31Version) {
-			return nil, fmt.Errorf("debug requires at least Helm 3.1 (current: %v)", hv)
+		if h.bV.LT(helm31Version) {
+			return nil, fmt.Errorf("debug requires at least Helm 3.1 (current: %v)", h.bV)
 		}
 		var binary string
 		if binary, err = osExecutable(); err != nil {

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -953,7 +953,6 @@ func TestHelmDeploy(t *testing.T) {
 			_, err = deployer.Deploy(context.Background(), ioutil.Discard, test.builds)
 			t.CheckError(test.shouldErr, err)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
-
 		})
 	}
 }
@@ -1022,7 +1021,7 @@ func TestHelmCleanup(t *testing.T) {
 				helm:      test.helm,
 				namespace: test.namespace,
 			}, nil)
-			if err != nil{
+			if err != nil {
 				t.Fatal(err)
 			}
 
@@ -1337,7 +1336,9 @@ func TestHelmRender(t *testing.T) {
 				helm:      test.helm,
 				namespace: test.namespace,
 			}, nil)
-
+			if err != nil {
+				t.Fatal(err)
+			}
 			err = deployer.Render(context.Background(), ioutil.Discard, test.builds, true, file)
 			t.CheckError(test.shouldErr, err)
 

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -420,18 +420,14 @@ func TestBinVer(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", test.helmVersion))
-
-			deployer := NewDeployer(&helmConfig{
-				helm: testDeployConfig,
-			}, nil)
-			ver, err := deployer.binVer(context.TODO())
+			ver, err := binVer()
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, ver.String())
 		})
 	}
 }
 
-func TestMinVersion(t *testing.T) {
+func TestNewDeployer(t *testing.T) {
 	tests := []struct {
 		description string
 		helmVersion string
@@ -442,18 +438,16 @@ func TestMinVersion(t *testing.T) {
 		{"Helm 3.0.0-beta.0", version30b, false},
 		{"Helm 3.0", version30, false},
 		{"Helm 3.1.1", version31, false},
+		{"helm3 unparseable version", "gobbledygook", true},
 	}
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", test.helmVersion))
 
-			deployer := NewDeployer(&helmConfig{
+			_, err := NewDeployer(&helmConfig{
 				helm: testDeployConfig,
 			}, nil)
-			ver, _ := deployer.binVer(context.TODO())
-
-			err := deployer.checkMinVersion(ver)
 			t.CheckError(test.shouldErr, err)
 		})
 	}
@@ -481,15 +475,7 @@ func TestHelmDeploy(t *testing.T) {
 		expectedWarnings []string
 		envs             map[string]string
 	}{
-		{
-			description: "deploy fails with version 2.1",
-			commands: testutil.
-				CmdRunWithOutput("helm version --client", version21).
-				AndRun("helm --kube-context kubecontext get skaffold-helm --kubeconfig kubeconfig"),
-			helm:      testDeployConfig,
-			builds:    testBuilds,
-			shouldErr: true,
-		},
+
 		{
 			description: "helm3.0beta deploy success",
 			commands: testutil.
@@ -626,13 +612,6 @@ func TestHelmDeploy(t *testing.T) {
 			helm:      testDeployNamespacedConfig,
 			namespace: kubectl.TestNamespace,
 			builds:    testBuilds,
-		},
-		{
-			description: "helm3 unparseable version",
-			commands:    testutil.CmdRunWithOutput("helm version --client", "gobbledygook"),
-			helm:        testDeployConfig,
-			builds:      testBuilds,
-			shouldErr:   true,
 		},
 		{
 			description: "deploy success with recreatePods",
@@ -958,19 +937,23 @@ func TestHelmDeploy(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.Override(&osExecutable, func() (string, error) { return "SKAFFOLD-BINARY", nil })
 
-			deployer := NewDeployer(&helmConfig{
+			deployer, err := NewDeployer(&helmConfig{
 				helm:      test.helm,
 				namespace: test.namespace,
 				force:     test.force,
 			}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			if test.configure != nil {
 				test.configure(deployer)
 			}
 			deployer.pkgTmpDir = tmpDir
-			_, err := deployer.Deploy(context.Background(), ioutil.Discard, test.builds)
-
+			_, err = deployer.Deploy(context.Background(), ioutil.Discard, test.builds)
 			t.CheckError(test.shouldErr, err)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
+
 		})
 	}
 }
@@ -982,18 +965,9 @@ func TestHelmCleanup(t *testing.T) {
 		helm             latest.HelmDeploy
 		namespace        string
 		builds           []build.Artifact
-		shouldErr        bool
 		expectedWarnings []string
 		envs             map[string]string
 	}{
-		{
-			description: "cleanup fails on helm 2",
-			commands: testutil.
-				CmdRunWithOutput("helm version --client", version20rc),
-			helm:      testDeployConfig,
-			builds:    testBuilds,
-			shouldErr: true,
-		},
 		{
 			description: "helm3 cleanup success",
 			commands: testutil.
@@ -1044,13 +1018,16 @@ func TestHelmCleanup(t *testing.T) {
 			t.Override(&util.OSEnviron, func() []string { return []string{"FOO=FOOBAR"} })
 			t.Override(&util.DefaultExecCommand, test.commands)
 
-			deployer := NewDeployer(&helmConfig{
+			deployer, err := NewDeployer(&helmConfig{
 				helm:      test.helm,
 				namespace: test.namespace,
 			}, nil)
-			err := deployer.Cleanup(context.Background(), ioutil.Discard)
+			if err != nil{
+				t.Fatal(err)
+			}
 
-			t.CheckError(test.shouldErr, err)
+			deployer.Cleanup(context.Background(), ioutil.Discard)
+
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
 		})
 	}
@@ -1140,10 +1117,12 @@ func TestHelmDependencies(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", version30))
+
 			tmpDir := t.NewTempDir().
 				Touch(test.files...)
 
-			deployer := NewDeployer(&helmConfig{
+			deployer, err := NewDeployer(&helmConfig{
 				helm: latest.HelmDeploy{
 					Releases: []latest.HelmRelease{{
 						Name:                  "skaffold-helm",
@@ -1156,7 +1135,9 @@ func TestHelmDependencies(t *testing.T) {
 						Remote:                test.remote,
 					}},
 				}}, nil)
-
+			if err != nil {
+				t.Fatal(err)
+			}
 			deps, err := deployer.Dependencies()
 
 			t.CheckNoError(err)
@@ -1248,25 +1229,6 @@ func TestHelmRender(t *testing.T) {
 		envs        map[string]string
 		namespace   string
 	}{
-		{
-			description: "error if version can't be retrieved",
-			shouldErr:   true,
-			commands:    testutil.CmdRunErr("helm version --client", fmt.Errorf("yep not working")),
-			helm:        testDeployConfig,
-		},
-		{
-			description: "render fails on version 2.1",
-			shouldErr:   true,
-			commands: testutil.
-				CmdRunWithOutput("helm version --client", version21),
-			helm: testDeployConfig,
-			builds: []build.Artifact{
-				{
-					ImageName: "skaffold-helm",
-					Tag:       "skaffold-helm:tag1",
-				},
-			},
-		},
 		{
 			description: "normal render v3",
 			shouldErr:   false,
@@ -1370,14 +1332,13 @@ func TestHelmRender(t *testing.T) {
 			}
 
 			t.Override(&util.OSEnviron, func() []string { return []string{"FOO=FOOBAR"} })
-
-			deployer := NewDeployer(&helmConfig{
+			t.Override(&util.DefaultExecCommand, test.commands)
+			deployer, err := NewDeployer(&helmConfig{
 				helm:      test.helm,
 				namespace: test.namespace,
 			}, nil)
 
-			t.Override(&util.DefaultExecCommand, test.commands)
-			err := deployer.Render(context.Background(), ioutil.Discard, test.builds, true, file)
+			err = deployer.Render(context.Background(), ioutil.Discard, test.builds, true, file)
 			t.CheckError(test.shouldErr, err)
 
 			if file != "" {
@@ -1443,9 +1404,13 @@ func TestGenerateSkaffoldDebugFilter(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			h := NewDeployer(&helmConfig{
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", version31))
+			h, err := NewDeployer(&helmConfig{
 				helm: testDeployConfig,
 			}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 			result := h.generateSkaffoldDebugFilter(test.buildFile)
 			t.CheckDeepEqual(test.result, result)
 		})

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -942,9 +942,7 @@ func TestHelmDeploy(t *testing.T) {
 				namespace: test.namespace,
 				force:     test.force,
 			}, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
+			t.RequireNoError(err)
 
 			if test.configure != nil {
 				test.configure(deployer)
@@ -1021,9 +1019,7 @@ func TestHelmCleanup(t *testing.T) {
 				helm:      test.helm,
 				namespace: test.namespace,
 			}, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
+			t.RequireNoError(err)
 
 			deployer.Cleanup(context.Background(), ioutil.Discard)
 
@@ -1134,9 +1130,7 @@ func TestHelmDependencies(t *testing.T) {
 						Remote:                test.remote,
 					}},
 				}}, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
+			t.RequireNoError(err)
 			deps, err := deployer.Dependencies()
 
 			t.CheckNoError(err)
@@ -1336,9 +1330,7 @@ func TestHelmRender(t *testing.T) {
 				helm:      test.helm,
 				namespace: test.namespace,
 			}, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
+			t.RequireNoError(err)
 			err = deployer.Render(context.Background(), ioutil.Discard, test.builds, true, file)
 			t.CheckError(test.shouldErr, err)
 
@@ -1409,9 +1401,7 @@ func TestGenerateSkaffoldDebugFilter(t *testing.T) {
 			h, err := NewDeployer(&helmConfig{
 				helm: testDeployConfig,
 			}, nil)
-			if err != nil {
-				t.Fatal(err)
-			}
+			t.RequireNoError(err)
 			result := h.generateSkaffoldDebugFilter(test.buildFile)
 			t.CheckDeepEqual(test.result, result)
 		})

--- a/pkg/skaffold/deploy/helm/util.go
+++ b/pkg/skaffold/deploy/helm/util.go
@@ -78,8 +78,8 @@ func sortKeys(m map[string]string) []string {
 
 // binVer returns the version of the helm binary found in PATH.
 func binVer() (semver.Version, error) {
-	// Only 3.0.0-beta doesn't support --client
-	b, err := version()
+	cmd := exec.Command("helm", "version", "--client")
+	b, err := util.RunCmdOut(cmd)
 	if err != nil {
 		return semver.Version{}, fmt.Errorf("helm version command failed %q: %w", string(b), err)
 	}
@@ -219,9 +219,4 @@ func (h *Deployer) exec(ctx context.Context, out io.Writer, useSecrets bool, env
 	cmd.Stderr = out
 
 	return util.RunCmd(cmd)
-}
-
-func version() ([]byte, error) {
-	cmd := exec.Command("helm", "version", "--client")
-	return util.RunCmdOut(cmd)
 }

--- a/pkg/skaffold/deploy/helm/util.go
+++ b/pkg/skaffold/deploy/helm/util.go
@@ -200,7 +200,6 @@ func envVarForImage(imageName string, digest string) map[string]string {
 
 // exec executes the helm command, writing combined stdout/stderr to the provided writer
 func (h *Deployer) exec(ctx context.Context, out io.Writer, useSecrets bool, env []string, args ...string) error {
-
 	args = append([]string{"--kube-context", h.kubeContext}, args...)
 	args = append(args, h.Flags.Global...)
 

--- a/pkg/skaffold/deploy/helm/util.go
+++ b/pkg/skaffold/deploy/helm/util.go
@@ -17,7 +17,6 @@ limitations under the License.
 package helm
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -77,38 +76,19 @@ func sortKeys(m map[string]string) []string {
 	return s
 }
 
-// binVer returns the version of the helm binary found in PATH. May be cached.
-func (h *Deployer) binVer(ctx context.Context) (semver.Version, error) {
-	// Return the cached version value if non-zero
-	if h.bV.Major != 0 || h.bV.Minor != 0 {
-		return h.bV, nil
-	}
-
-	var b bytes.Buffer
+// binVer returns the version of the helm binary found in PATH.
+func binVer() (semver.Version, error) {
 	// Only 3.0.0-beta doesn't support --client
-	if err := h.exec(ctx, &b, false, nil, "version", "--client"); err != nil {
-		return semver.Version{}, fmt.Errorf("helm version command failed %q: %w", b.String(), err)
+	b, err := version()
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("helm version command failed %q: %w", string(b), err)
 	}
-	raw := b.String()
+	raw := string(b)
 	matches := versionRegex.FindStringSubmatch(raw)
 	if len(matches) == 0 {
 		return semver.Version{}, fmt.Errorf("unable to parse output: %q", raw)
 	}
-
-	v, err := semver.ParseTolerant(matches[1])
-	if err != nil {
-		return semver.Version{}, fmt.Errorf("semver make %q: %w", matches[1], err)
-	}
-
-	h.bV = v
-	return h.bV, nil
-}
-
-func (h *Deployer) checkMinVersion(v semver.Version) error {
-	if v.LT(helm3Version) {
-		return minVersionErr()
-	}
-	return nil
+	return semver.ParseTolerant(matches[1])
 }
 
 // imageSetFromConfig calculates the --set-string value from the helm config
@@ -179,7 +159,7 @@ func (h *Deployer) releaseNamespace(r latest.HelmRelease) (string, error) {
 	} else if r.Namespace != "" {
 		namespace, err := util.ExpandEnvTemplate(r.Namespace, nil)
 		if err != nil {
-			return "", userErr("cannot parse the release namespace template", err)
+			return "", fmt.Errorf("cannot parse the release namespace template: %w", err)
 		}
 		return namespace, nil
 	}
@@ -220,17 +200,16 @@ func envVarForImage(imageName string, digest string) map[string]string {
 
 // exec executes the helm command, writing combined stdout/stderr to the provided writer
 func (h *Deployer) exec(ctx context.Context, out io.Writer, useSecrets bool, env []string, args ...string) error {
-	if args[0] != "version" {
-		args = append([]string{"--kube-context", h.kubeContext}, args...)
-		args = append(args, h.Flags.Global...)
 
-		if h.kubeConfig != "" {
-			args = append(args, "--kubeconfig", h.kubeConfig)
-		}
+	args = append([]string{"--kube-context", h.kubeContext}, args...)
+	args = append(args, h.Flags.Global...)
 
-		if useSecrets {
-			args = append([]string{"secrets"}, args...)
-		}
+	if h.kubeConfig != "" {
+		args = append(args, "--kubeconfig", h.kubeConfig)
+	}
+
+	if useSecrets {
+		args = append([]string{"secrets"}, args...)
 	}
 
 	cmd := exec.CommandContext(ctx, "helm", args...)
@@ -241,4 +220,9 @@ func (h *Deployer) exec(ctx context.Context, out io.Writer, useSecrets bool, env
 	cmd.Stderr = out
 
 	return util.RunCmd(cmd)
+}
+
+func version() ([]byte, error) {
+	cmd := exec.Command("helm", "version", "--client")
+	return util.RunCmdOut(cmd)
 }

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/helm"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -29,7 +30,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/local"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/helm"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kpt"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
@@ -215,7 +215,11 @@ func getDeployer(cfg kubectl.Config, labels map[string]string) (deploy.Deployer,
 	var deployers deploy.DeployerMux
 
 	if d.HelmDeploy != nil {
-		deployers = append(deployers, helm.NewDeployer(cfg, labels))
+		h, err := helm.NewDeployer(cfg, labels)
+		if err != nil {
+			return nil, err
+		}
+		deployers = append(deployers, h)
 	}
 
 	if d.KptDeploy != nil {

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/helm"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -30,6 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/local"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/helm"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kpt"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"

--- a/pkg/skaffold/runner/new_test.go
+++ b/pkg/skaffold/runner/new_test.go
@@ -52,7 +52,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				expected:    &helm.Deployer{},
 			},
 			{
-				description: "helm deployer with less 3.0.0 version",
+				description: "helm deployer with less than 3.0.0 version",
 				cfg:         latest.DeployType{HelmDeploy: &latest.HelmDeploy{}},
 				helmVersion: "2.0.0",
 				shouldErr:   true,

--- a/pkg/skaffold/runner/new_test.go
+++ b/pkg/skaffold/runner/new_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -36,16 +37,25 @@ func TestGetDeployer(tOuter *testing.T) {
 		tests := []struct {
 			description string
 			cfg         latest.DeployType
+			helmVersion string
 			expected    deploy.Deployer
+			shouldErr   bool
 		}{
 			{
 				description: "no deployer",
 				expected:    deploy.DeployerMux{},
 			},
 			{
-				description: "helm deployer",
+				description: "helm deployer with 3.0.0 version",
 				cfg:         latest.DeployType{HelmDeploy: &latest.HelmDeploy{}},
-				expected:    helm.NewDeployer(&runcontext.RunContext{}, nil),
+				helmVersion: `version.BuildInfo{Version:"v3.0.0"}`,
+				expected:    &helm.Deployer{},
+			},
+			{
+				description: "helm deployer with less 3.0.0 version",
+				cfg:         latest.DeployType{HelmDeploy: &latest.HelmDeploy{}},
+				helmVersion: "2.0.0",
+				shouldErr:   true,
 			},
 			{
 				description: "kubectl deployer",
@@ -88,14 +98,22 @@ func TestGetDeployer(tOuter *testing.T) {
 					HelmDeploy: &latest.HelmDeploy{},
 					KptDeploy:  &latest.KptDeploy{},
 				},
+				helmVersion: `version.BuildInfo{Version:"v3.0.0"}`,
 				expected: deploy.DeployerMux{
-					helm.NewDeployer(&runcontext.RunContext{}, nil),
+					&helm.Deployer{},
 					kpt.NewDeployer(&runcontext.RunContext{}, nil),
 				},
 			},
 		}
 		for _, test := range tests {
 			testutil.Run(tOuter, test.description, func(t *testutil.T) {
+				if test.helmVersion != "" {
+					t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput(
+						"helm version --client",
+						test.helmVersion,
+					))
+				}
+
 				deployer, err := getDeployer(&runcontext.RunContext{
 					Cfg: latest.Pipeline{
 						Deploy: latest.DeployConfig{
@@ -104,7 +122,7 @@ func TestGetDeployer(tOuter *testing.T) {
 					},
 				}, nil)
 
-				t.RequireNoError(err)
+				t.CheckError(test.shouldErr, err)
 				t.CheckTypeEquality(test.expected, deployer)
 
 				if reflect.TypeOf(test.expected) == reflect.TypeOf(deploy.DeployerMux{}) {

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/helm"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
@@ -379,14 +378,12 @@ func TestNewForConfig(t *testing.T) {
 					DeployType: latest.DeployType{
 						KubectlDeploy:   &latest.KubectlDeploy{},
 						KustomizeDeploy: &latest.KustomizeDeploy{},
-						HelmDeploy:      &latest.HelmDeploy{},
 					},
 				},
 			},
 			expectedBuilder: &local.Builder{},
 			expectedTester:  &test.FullTester{},
 			expectedDeployer: deploy.DeployerMux([]deploy.Deployer{
-				&helm.Deployer{},
 				&kubectl.Deployer{},
 				&kustomize.Deployer{},
 			}),


### PR DESCRIPTION
This PR is refactoring the code to move helm min version check to one place. 

While, adding distinct error codes for helm, i realized the `helm version --client` is done [3 times](https://github.com/GoogleContainerTools/skaffold/search?q=checkMinVersion). 

Moving this check to when helm deployer is initialized.

User changes: 
None

