### PR TITLE
Change default kaniko image to `gcr.io/k8s-skaffold/skaffold-helpers/busybox` from `busybox`

### DIFF
--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -39,7 +39,7 @@ const (
 
 	DefaultKustomizationPath = "."
 
-	DefaultBusyboxImage = "busybox"
+	DefaultBusyboxImage = "gcr.io/k8s-skaffold/skaffold-helpers/busybox"
 
 	// DefaultDebugHelpersRegistry is the default location used for the helper images for `debug`.
 	DefaultDebugHelpersRegistry = "gcr.io/k8s-skaffold/skaffold-debug-support"


### PR DESCRIPTION
Raising this PR to check integration tests with this change. Not intending to merge.