### PR TITLE
Add port forwarding config when generating manifests through init

### DIFF
--- a/integration/testdata/init/hello/deployment.yaml.expected
+++ b/integration/testdata/init/hello/deployment.yaml.expected
@@ -5,6 +5,9 @@ metadata:
   labels:
     app: dockerfile-image
 spec:
+  ports:
+  - port: 8080
+    protocol: TCP
   clusterIP: None
   selector:
     app: dockerfile-image

--- a/pkg/skaffold/initializer/build/builders.go
+++ b/pkg/skaffold/initializer/build/builders.go
@@ -66,7 +66,7 @@ type Initializer interface {
 	// contained in the initializer with the provided images from the deploy initializer
 	ProcessImages([]string) error
 	// BuildConfig returns the processed build config to be written to the skaffold.yaml
-	BuildConfig() latest.BuildConfig
+	BuildConfig() (latest.BuildConfig, []*latest.PortForwardResource)
 	// PrintAnalysis writes the project analysis to the provided out stream
 	PrintAnalysis(io.Writer) error
 	// GenerateManifests generates image names and manifests for all unresolved pairs
@@ -80,8 +80,8 @@ func (e *emptyBuildInitializer) ProcessImages([]string) error {
 	return nil
 }
 
-func (e *emptyBuildInitializer) BuildConfig() latest.BuildConfig {
-	return latest.BuildConfig{}
+func (e *emptyBuildInitializer) BuildConfig() (latest.BuildConfig, []*latest.PortForwardResource) {
+	return latest.BuildConfig{}, nil
 }
 
 func (e *emptyBuildInitializer) PrintAnalysis(io.Writer) error {

--- a/pkg/skaffold/initializer/build/cli.go
+++ b/pkg/skaffold/initializer/build/cli.go
@@ -47,10 +47,10 @@ func (c *cliBuildInitializer) ProcessImages(images []string) error {
 	return nil
 }
 
-func (c *cliBuildInitializer) BuildConfig() latest.BuildConfig {
+func (c *cliBuildInitializer) BuildConfig() (latest.BuildConfig, []*latest.PortForwardResource) {
 	return latest.BuildConfig{
 		Artifacts: Artifacts(c.artifactInfos),
-	}
+	}, nil
 }
 
 func (c *cliBuildInitializer) PrintAnalysis(out io.Writer) error {

--- a/pkg/skaffold/initializer/build/init.go
+++ b/pkg/skaffold/initializer/build/init.go
@@ -23,12 +23,14 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/generator"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 type defaultBuildInitializer struct {
 	builders               []InitBuilder
 	artifactInfos          []ArtifactInfo
 	generatedArtifactInfos []GeneratedArtifactInfo
+	manifests              []*generator.Container
 	unresolvedImages       []string
 	skipBuild              bool
 	force                  bool
@@ -52,10 +54,20 @@ func (d *defaultBuildInitializer) ProcessImages(images []string) error {
 	return nil
 }
 
-func (d *defaultBuildInitializer) BuildConfig() latest.BuildConfig {
+func (d *defaultBuildInitializer) BuildConfig() (latest.BuildConfig, []*latest.PortForwardResource) {
+	pf := []*latest.PortForwardResource{}
+
+	for _, manifestInfo := range d.manifests {
+		pf = append(pf, &latest.PortForwardResource{
+			Type: "service",
+			Name: manifestInfo.Name,
+			Port: util.FromInt(manifestInfo.Port),
+		})
+	}
+
 	return latest.BuildConfig{
 		Artifacts: Artifacts(d.artifactInfos),
-	}
+	}, pf
 }
 
 func (d *defaultBuildInitializer) PrintAnalysis(out io.Writer) error {
@@ -65,11 +77,12 @@ func (d *defaultBuildInitializer) PrintAnalysis(out io.Writer) error {
 func (d *defaultBuildInitializer) GenerateManifests() (map[GeneratedArtifactInfo][]byte, error) {
 	generatedManifests := map[GeneratedArtifactInfo][]byte{}
 	for _, info := range d.generatedArtifactInfos {
-		manifest, err := generator.Generate(info.ImageName)
+		manifest, manifestInfo, err := generator.Generate(info.ImageName)
 		if err != nil {
 			return nil, fmt.Errorf("generating kubernetes manifest: %w", err)
 		}
 		generatedManifests[info] = manifest
+		d.manifests = append(d.manifests, manifestInfo)
 		d.artifactInfos = append(d.artifactInfos, info.ArtifactInfo)
 	}
 	d.generatedArtifactInfos = nil

--- a/pkg/skaffold/initializer/config.go
+++ b/pkg/skaffold/initializer/config.go
@@ -46,6 +46,7 @@ func generateSkaffoldConfig(b build.Initializer, d deploy.Initializer) *latest.S
 	}
 
 	deploy, profiles := d.DeployConfig()
+	build, portForward := b.BuildConfig()
 
 	return &latest.SkaffoldConfig{
 		APIVersion: latest.Version,
@@ -54,8 +55,9 @@ func generateSkaffoldConfig(b build.Initializer, d deploy.Initializer) *latest.S
 			Name: name,
 		},
 		Pipeline: latest.Pipeline{
-			Build:  b.BuildConfig(),
-			Deploy: deploy,
+			Build:       build,
+			Deploy:      deploy,
+			PortForward: portForward,
 		},
 		Profiles: profiles,
 	}

--- a/pkg/skaffold/initializer/config_test.go
+++ b/pkg/skaffold/initializer/config_test.go
@@ -61,10 +61,10 @@ func (s stubBuildInitializer) PrintAnalysis(io.Writer) error {
 	panic("no sir")
 }
 
-func (s stubBuildInitializer) BuildConfig() latest.BuildConfig {
+func (s stubBuildInitializer) BuildConfig() (latest.BuildConfig, []*latest.PortForwardResource) {
 	return latest.BuildConfig{
 		Artifacts: build.Artifacts(s.artifactInfos),
-	}
+	}, nil
 }
 
 func (s stubBuildInitializer) GenerateManifests() (map[build.GeneratedArtifactInfo][]byte, error) {

--- a/pkg/skaffold/kubernetes/generator/generate.go
+++ b/pkg/skaffold/kubernetes/generator/generate.go
@@ -22,10 +22,6 @@ import (
 	"html/template"
 )
 
-var (
-	port = 8080
-)
-
 type Container struct {
 	Name  string
 	Image string
@@ -34,8 +30,7 @@ type Container struct {
 
 // Generate generates kubernetes resources for the given image, and returns the generated manifest string
 func Generate(name string) ([]byte, *Container, error) {
-	c := Container{name, name, port}
-	port++
+	c := Container{name, name, 8080}
 
 	t, err := template.New("deployment").Parse(yamlTemplate)
 	if err != nil {

--- a/pkg/skaffold/kubernetes/generator/generate.go
+++ b/pkg/skaffold/kubernetes/generator/generate.go
@@ -22,24 +22,30 @@ import (
 	"html/template"
 )
 
+var (
+	port = 8080
+)
+
 type Container struct {
 	Name  string
 	Image string
+	Port  int
 }
 
 // Generate generates kubernetes resources for the given image, and returns the generated manifest string
-func Generate(name string) ([]byte, error) {
-	c := Container{name, name}
+func Generate(name string) ([]byte, *Container, error) {
+	c := Container{name, name, port}
+	port++
 
 	t, err := template.New("deployment").Parse(yamlTemplate)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing pod template: %w", err)
+		return nil, nil, fmt.Errorf("error parsing pod template: %w", err)
 	}
 
 	var buf bytes.Buffer
 	if err = t.Execute(&buf, c); err != nil {
-		return nil, fmt.Errorf("error executing template: %w", err)
+		return nil, nil, fmt.Errorf("error executing template: %w", err)
 	}
 
-	return buf.Bytes(), nil
+	return buf.Bytes(), &c, nil
 }

--- a/pkg/skaffold/kubernetes/generator/generate_test.go
+++ b/pkg/skaffold/kubernetes/generator/generate_test.go
@@ -38,6 +38,9 @@ metadata:
   labels:
     app: foo
 spec:
+  ports: 
+  - port: 8080
+    protocol: TCP
   clusterIP: None
   selector:
     app: foo
@@ -68,7 +71,7 @@ spec:
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			for _, image := range test.images {
-				manifest, err := Generate(image)
+				manifest, _, err := Generate(image)
 
 				t.CheckNoError(err)
 				t.CheckDeepEqual(test.expectedManifest, string(manifest))

--- a/pkg/skaffold/kubernetes/generator/generate_test.go
+++ b/pkg/skaffold/kubernetes/generator/generate_test.go
@@ -38,7 +38,7 @@ metadata:
   labels:
     app: foo
 spec:
-  ports: 
+  ports:
   - port: 8080
     protocol: TCP
   clusterIP: None

--- a/pkg/skaffold/kubernetes/generator/template.go
+++ b/pkg/skaffold/kubernetes/generator/template.go
@@ -23,6 +23,9 @@ metadata:
   labels:
     app: {{.Name}}
 spec:
+  ports: 
+  - port: {{.Port}}
+    protocol: TCP
   clusterIP: None
   selector:
     app: {{.Name}}

--- a/pkg/skaffold/kubernetes/generator/template.go
+++ b/pkg/skaffold/kubernetes/generator/template.go
@@ -23,7 +23,7 @@ metadata:
   labels:
     app: {{.Name}}
 spec:
-  ports: 
+  ports:
   - port: {{.Port}}
     protocol: TCP
   clusterIP: None


### PR DESCRIPTION
**Description**
This PR modifies `skaffold init` behavior to include port-forwarding config when using `--XXenableManifestGeneration`. Both the skaffold config and generated manifests will contain the required config to use port-forwarding when running skaffold. In the case of multiple manifests being generated for multiple images, skaffold will assume each remote port is on 8080. This will result in the ports getting mapped like so when skaffold uses `kubectl port-forward`:
```
remote port 8080 -> 127.0.0.1:8080
remote port 8080 -> 127.0.0.1:8081
```
The reasoning behind this vs sequentially assigning ports is that this is more likely to hit whatever app is listening on 8080 and properly port-forward that one.

**Follow-up Work**
Add a wizard for allowing the user to specify the port mapping when running `skaffold init --XXenableManifestGeneration` without `--force`. After this is done, I think we can then unhide the flag.