### PR TITLE
Fix integration test flakes

### DIFF
--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -93,7 +93,7 @@ func TestDeployTail(t *testing.T) {
 	ns, _ := SetupNamespace(t)
 
 	// `--default-repo=` is used to cancel the default repo that is set by default.
-	out := skaffold.Deploy("--tail", "--images", "busybox:latest", "--default-repo=").InDir("testdata/deploy-hello-tail").InNs(ns.Name).RunBackground(t)
+	out := skaffold.Deploy("--tail", "--images", "busybox:latest", "--default-repo=").InDir("testdata/deploy-hello-tail").InNs(ns.Name).RunLive(t)
 
 	WaitForLogs(t, out, "Hello world!")
 }

--- a/integration/port_forward_test.go
+++ b/integration/port_forward_test.go
@@ -99,7 +99,9 @@ func TestRunPortForwardByPortName(t *testing.T) {
 // and tests that the pod eventually comes up at the same port again.
 func TestDevPortForwardDeletePod(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
-	t.Skip("Flakey on Travis with k3d and kind")
+
+	// pre-build images to avoid tripping the 1-minute timeout in getLocalPortFromPortForwardEvent()
+	skaffold.Build().InDir("examples/microservices").RunOrFail(t)
 
 	ns, _ := SetupNamespace(t)
 

--- a/integration/port_forward_test.go
+++ b/integration/port_forward_test.go
@@ -106,7 +106,8 @@ func TestDevPortForwardDeletePod(t *testing.T) {
 	ns, _ := SetupNamespace(t)
 
 	rpcAddr := randomPort()
-	skaffold.Dev("--port-forward", "--rpc-port", rpcAddr).InDir("examples/microservices").InNs(ns.Name).RunBackground(t)
+	r := skaffold.Dev("--port-forward", "--rpc-port", rpcAddr).InDir("examples/microservices").InNs(ns.Name).RunBackground(t)
+	logOnFailure(t, r)
 
 	_, entries := apiEvents(t, rpcAddr)
 

--- a/integration/port_forward_test.go
+++ b/integration/port_forward_test.go
@@ -106,8 +106,7 @@ func TestDevPortForwardDeletePod(t *testing.T) {
 	ns, _ := SetupNamespace(t)
 
 	rpcAddr := randomPort()
-	r := skaffold.Dev("--port-forward", "--rpc-port", rpcAddr).InDir("examples/microservices").InNs(ns.Name).RunBackground(t)
-	logOnFailure(t, r)
+	skaffold.Dev("--port-forward", "--rpc-port", rpcAddr).InDir("examples/microservices").InNs(ns.Name).RunBackground(t)
 
 	_, entries := apiEvents(t, rpcAddr)
 

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -292,7 +292,7 @@ func TestRunTailPod(t *testing.T) {
 
 	ns, _ := SetupNamespace(t)
 
-	out := skaffold.Run("--tail", "-p", "pod").InDir("testdata/hello").InNs(ns.Name).RunBackground(t)
+	out := skaffold.Run("--tail", "-p", "pod").InDir("testdata/hello").InNs(ns.Name).RunLive(t)
 
 	WaitForLogs(t, out,
 		"Hello world! 0",
@@ -306,7 +306,7 @@ func TestRunTailDeployment(t *testing.T) {
 
 	ns, _ := SetupNamespace(t)
 
-	out := skaffold.Run("--tail", "-p", "deployment").InDir("testdata/hello").InNs(ns.Name).RunBackground(t)
+	out := skaffold.Run("--tail", "-p", "deployment").InDir("testdata/hello").InNs(ns.Name).RunLive(t)
 
 	WaitForLogs(t, out,
 		"Hello world! 0",

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -108,7 +108,7 @@ func TestDevAutoSync(t *testing.T) {
 
 			ns, client := SetupNamespace(t)
 
-			output := skaffold.Dev("--trigger", "notify").WithConfig(test.configFile).InDir(dir).InNs(ns.Name).RunBackground(t)
+			output := skaffold.Dev("--trigger", "notify").WithConfig(test.configFile).InDir(dir).InNs(ns.Name).RunLive(t)
 
 			client.WaitForPodsReady("test-file-sync")
 

--- a/integration/util.go
+++ b/integration/util.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -375,14 +374,4 @@ func WaitForLogs(t *testing.T, out io.Reader, firstMessage string, moreMessages 
 			}
 		}
 	}
-}
-
-func logOnFailure(t *testing.T, r io.Reader) {
-	t.Cleanup(func() {
-		if t.Failed() {
-			b, _ := ioutil.ReadAll(r)
-			t.Log("Skaffold log:\n", strings.ReplaceAll(string(b), "\n", "\n> "))
-		}
-	})
-
 }

--- a/integration/util.go
+++ b/integration/util.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strconv"
@@ -374,4 +375,14 @@ func WaitForLogs(t *testing.T, out io.Reader, firstMessage string, moreMessages 
 			}
 		}
 	}
+}
+
+func logOnFailure(t *testing.T, r io.Reader) {
+	t.Cleanup(func() {
+		if t.Failed() {
+			b, _ := ioutil.ReadAll(r)
+			t.Log("Skaffold log:\n", strings.ReplaceAll(string(b), "\n", "\n> "))
+		}
+	})
+
 }


### PR DESCRIPTION
Several of our integration tests periodically flake (e.g., #4733).  The underlying cause is that our `RunBackground()` test helper forks using a pipe (a unix pipe), which is not consumed by many of our tests.  Unix pipes apply backpressure: they buffer a certain amount and then block until the pipe is consumed.  Most of our tests don't actually consume the output from `RunBackground()`.

This PR
- forks the `RunBackground()` helper to have a `RunLive()` that uses pipes, and changes the original `RunBackground()` to write stdout to a byte buffer.
- changes `TestDevPortForwardDeletePod()` to first perform a build of `example/microservices` separately. `getLocalPortFromPortForwardEvent()` has [a timeout of 1m](https://github.com/GoogleContainerTools/skaffold/blob/master/integration/dev_test.go#L247), but I've seen the build step  can sometimes take up to 2m!