### PR TITLE
Re-add colors to buildpacks and docker cli output

### DIFF
--- a/pkg/skaffold/build/buildpacks/lifecycle.go
+++ b/pkg/skaffold/build/buildpacks/lifecycle.go
@@ -32,6 +32,7 @@ import (
 	"github.com/buildpacks/pack/project"
 	"github.com/sirupsen/logrus"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
@@ -90,7 +91,7 @@ func (b *Builder) build(ctx context.Context, out io.Writer, a *latest.Artifact, 
 
 	builderImage, runImage, pullPolicy := resolveDependencyImages(artifact, b.artifacts, a.Dependencies, b.pushImages)
 
-	if err := runPackBuildFunc(ctx, out, b.localDocker, pack.BuildOptions{
+	if err := runPackBuildFunc(ctx, color.GetWriter(out), b.localDocker, pack.BuildOptions{
 		AppPath:      workspace,
 		Builder:      builderImage,
 		RunImage:     runImage,

--- a/pkg/skaffold/build/docker/docker.go
+++ b/pkg/skaffold/build/docker/docker.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -47,7 +48,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, a *latest.Artifact, 
 	var imageID string
 
 	if b.useCLI {
-		imageID, err = b.dockerCLIBuild(ctx, out, a.Workspace, dockerfile, a.ArtifactType.DockerArtifact, opts)
+		imageID, err = b.dockerCLIBuild(ctx, color.GetWriter(out), a.Workspace, dockerfile, a.ArtifactType.DockerArtifact, opts)
 	} else {
 		imageID, err = b.localDocker.Build(ctx, out, a.Workspace, a.ArtifactType.DockerArtifact, opts)
 	}

--- a/pkg/skaffold/color/formatter.go
+++ b/pkg/skaffold/color/formatter.go
@@ -151,3 +151,12 @@ func IsStdout(out io.Writer) bool {
 	}
 	return out == os.Stdout
 }
+
+// GetWriter returns the underlying writer if out is a colorableWriter
+func GetWriter(out io.Writer) io.Writer {
+	o, ok := out.(colorableWriter)
+	if ok {
+		return o.Writer
+	}
+	return out
+}

--- a/pkg/skaffold/color/formatter_test.go
+++ b/pkg/skaffold/color/formatter_test.go
@@ -125,3 +125,27 @@ func TestIsStdOut(t *testing.T) {
 		})
 	}
 }
+
+func TestGetWriter(t *testing.T) {
+	tests := []struct {
+		description string
+		out         io.Writer
+		expected    io.Writer
+	}{
+		{
+			description: "colorable os.Stdout returns os.Stdout",
+			out:         colorableWriter{os.Stdout},
+			expected:    os.Stdout,
+		},
+		{
+			description: "GetWriter returns original writer if not colorable",
+			out:         os.Stdout,
+			expected:    os.Stdout,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(true, test.expected == GetWriter(test.out))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**:  #5014 

**Description**
Because of #5014, buildpacks and docker buildkit were not receiving a terminal to write to and so they didnt color their output. Since buildpacks and docker don't have a flag to force output coloring from what i've seen, pass in the original writer that is wrapped by color.colorableWriter to buildpacks and docker.

**User facing changes**
Colors are back in buildpacks 

**Follow-up Work**
<!-- Mention any related follow up work to this PR. -->
Buildpacks and docker buildkit will still not have any colored output when builds are done in parallel since the underlying writer in that instance would be a pipe. This can be remedied if an option is added to either to force colors, or if instead of pipes being directly passed a pseudo terminal could be used for building in parallel on skaffold's side. 

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
