### PR TITLE
Use buildkit in docker cli if useBuildkit=true

### DIFF
--- a/pkg/skaffold/build/docker/docker.go
+++ b/pkg/skaffold/build/docker/docker.go
@@ -46,7 +46,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, a *latest.Artifact, 
 
 	var imageID string
 
-	if b.useCLI {
+	if b.useCLI || b.useBuildKit {
 		imageID, err = b.dockerCLIBuild(ctx, out, a.Workspace, dockerfile, a.ArtifactType.DockerArtifact, opts)
 	} else {
 		imageID, err = b.localDocker.Build(ctx, out, a.Workspace, a.ArtifactType.DockerArtifact, opts)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5093 <!-- tracking issues that this PR will close -->

**Description**
Currently if setting ```useBuildkit: true```, skaffold does not actually use buildKit unless ```useDockerCLI:true``` is also present. Fix this by using the dockerCLI if ```useBuildkit: true```.


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
