### PR TITLE
Transition from Github Actions ::add-path

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -35,7 +35,7 @@ jobs:
       run: |
         curl -Lo $HOME/gsutil.tar.gz https://storage.googleapis.com/pub/gsutil.tar.gz
         tar xfz $HOME/gsutil.tar.gz -C $HOME
-        echo ::add-path::$HOME/gsutil
+        echo "$HOME/gsutil" >> $GITHUB_PATH
 
     - name: Download release artifacts
       run: |

--- a/.github/workflows/integration-darwin.yml
+++ b/.github/workflows/integration-darwin.yml
@@ -58,7 +58,7 @@ jobs:
         wget -O gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${{ matrix.gcloud_sdk_version }}-darwin-x86_64.tar.gz
         tar -xvf gcloud.tar.gz -C ${HOME}
         CLOUDSDK_PYTHON="python2.7" ${HOME}/google-cloud-sdk/install.sh --usage-reporting=false --bash-completion=false --disable-installation-options
-        echo ::add-path::${HOME}/google-cloud-sdk/bin
+        echo "${HOME}/google-cloud-sdk/bin" >> $GITHUB_PATH
 
     - name: Install Kubectl
       run: |

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -53,7 +53,7 @@ jobs:
         wget -O gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${{ matrix.gcloud_sdk_version }}-linux-x86_64.tar.gz
         sudo tar -xvf gcloud.tar.gz -C /
         sudo CLOUDSDK_PYTHON="python2.7" /google-cloud-sdk/install.sh --usage-reporting=false --bash-completion=false --disable-installation-options
-        echo "::add-path::/google-cloud-sdk/bin"
+        echo "/google-cloud-sdk/bin" >> $GITHUB_PATH
 
     - name: Configure GCloud with Docker
       run:  sudo gcloud auth configure-docker


### PR DESCRIPTION
Github Actions has [removed the `set-path` and `add-path` commands](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w).  We addressed `set-path` in #5057 but there were `add-path` elements too, and [some of our actions are now broken](https://github.com/GoogleContainerTools/skaffold/actions/runs/395020762).

This PR turns the `echo ::add-path:` elements into [modifications to the environment files](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path).