### PR TITLE
add user prompt for selecting ports when using --XXenableManifestGeneration with skaffold init

### DIFF
--- a/integration/skaffold/helper.go
+++ b/integration/skaffold/helper.go
@@ -169,7 +169,7 @@ func (b *RunBuilder) WithProfiles(profiles []string) *RunBuilder {
 
 // RunBackground runs the skaffold command in the background.  The Skaffold output
 // is accumulated and logged on test failure.
-func (b *RunBuilder) RunBackground(t *testing.T) io.Reader {
+func (b *RunBuilder) RunBackground(t *testing.T) {
 	t.Helper()
 	out := bytes.Buffer{}
 	b.runForked(t, &out)
@@ -179,7 +179,6 @@ func (b *RunBuilder) RunBackground(t *testing.T) io.Reader {
 			t.Log("Skaffold log:\n", strings.ReplaceAll(out.String(), "\n", "\n> "))
 		}
 	})
-	return &out
 }
 
 // RunLive runs the skaffold command in the background with live output.

--- a/pkg/skaffold/initializer/build/builders.go
+++ b/pkg/skaffold/initializer/build/builders.go
@@ -70,7 +70,7 @@ type Initializer interface {
 	// PrintAnalysis writes the project analysis to the provided out stream
 	PrintAnalysis(io.Writer) error
 	// GenerateManifests generates image names and manifests for all unresolved pairs
-	GenerateManifests() (map[GeneratedArtifactInfo][]byte, error)
+	GenerateManifests(io.Writer, bool) (map[GeneratedArtifactInfo][]byte, error)
 }
 
 type emptyBuildInitializer struct {
@@ -88,7 +88,7 @@ func (e *emptyBuildInitializer) PrintAnalysis(io.Writer) error {
 	return nil
 }
 
-func (e *emptyBuildInitializer) GenerateManifests() (map[GeneratedArtifactInfo][]byte, error) {
+func (e *emptyBuildInitializer) GenerateManifests(io.Writer, bool) (map[GeneratedArtifactInfo][]byte, error) {
 	return nil, nil
 }
 

--- a/pkg/skaffold/initializer/build/cli.go
+++ b/pkg/skaffold/initializer/build/cli.go
@@ -57,7 +57,7 @@ func (c *cliBuildInitializer) PrintAnalysis(out io.Writer) error {
 	return printAnalysis(out, c.enableNewFormat, c.skipBuild, c.artifactInfos, c.builders, nil)
 }
 
-func (c *cliBuildInitializer) GenerateManifests() (map[GeneratedArtifactInfo][]byte, error) {
+func (c *cliBuildInitializer) GenerateManifests(io.Writer, bool) (map[GeneratedArtifactInfo][]byte, error) {
 	return nil, nil
 }
 

--- a/pkg/skaffold/initializer/build/init.go
+++ b/pkg/skaffold/initializer/build/init.go
@@ -84,7 +84,7 @@ func (d *defaultBuildInitializer) GenerateManifests(out io.Writer, force bool) (
 		port := 8080
 		var err error
 		if !force {
-			port, err = prompt.PortForwardResource(out, info.ImageName)
+			port, err = prompt.PortForwardResourceFunc(out, info.ImageName)
 			if err != nil {
 				return nil, fmt.Errorf("getting port input: %w", err)
 			}

--- a/pkg/skaffold/initializer/build/init_test.go
+++ b/pkg/skaffold/initializer/build/init_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"io"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDefaultInitializerGenerateManifests(t *testing.T) {
+	tests := []struct {
+		description       string
+		generatedInfos    []GeneratedArtifactInfo
+		mockPorts         []int
+		expectedManifests []string
+		force             bool
+		shouldErr         bool
+	}{
+		{
+			description: "one manifest, force",
+			generatedInfos: []GeneratedArtifactInfo{
+				{
+					ArtifactInfo{
+						ImageName: "image1",
+					},
+					"path/to/manifest",
+				},
+			},
+			expectedManifests: []string{
+				`apiVersion: v1
+kind: Service
+metadata:
+  name: image1
+  labels:
+    app: image1
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+  clusterIP: None
+  selector:
+    app: image1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image1
+  labels:
+    app: image1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: image1
+  template:
+    metadata:
+      labels:
+        app: image1
+    spec:
+      containers:
+      - name: image1
+        image: image1
+`,
+			},
+			force: true,
+		},
+		{
+			description: "2 manifests, 1 port 0, interactive",
+			generatedInfos: []GeneratedArtifactInfo{
+				{
+					ArtifactInfo{
+						ImageName: "image1",
+					},
+					"path/to/manifest1",
+				},
+				{
+					ArtifactInfo{
+						ImageName: "image2",
+					},
+					"path/to/manifest2",
+				},
+			},
+			mockPorts: []int{8080, 0},
+			expectedManifests: []string{
+				`apiVersion: v1
+kind: Service
+metadata:
+  name: image1
+  labels:
+    app: image1
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+  clusterIP: None
+  selector:
+    app: image1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image1
+  labels:
+    app: image1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: image1
+  template:
+    metadata:
+      labels:
+        app: image1
+    spec:
+      containers:
+      - name: image1
+        image: image1
+`,
+				`apiVersion: v1
+kind: Service
+metadata:
+  name: image2
+  labels:
+    app: image2
+spec:
+  clusterIP: None
+  selector:
+    app: image2
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image2
+  labels:
+    app: image2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: image2
+  template:
+    metadata:
+      labels:
+        app: image2
+    spec:
+      containers:
+      - name: image2
+        image: image2
+`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			mockPortIdx := 0
+			t.Override(&prompt.PortForwardResourceFunc, func(_ io.Writer, imageName string) (int, error) {
+				port := test.mockPorts[mockPortIdx]
+				mockPortIdx++
+
+				return port, nil
+			})
+
+			d := defaultBuildInitializer{
+				generatedArtifactInfos: test.generatedInfos,
+			}
+
+			manifests, err := d.GenerateManifests(nil, test.force)
+
+			expected := make(map[GeneratedArtifactInfo][]byte)
+			for i, info := range test.generatedInfos {
+				expected[info] = []byte(test.expectedManifests[i])
+			}
+
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, expected, manifests)
+		})
+	}
+}

--- a/pkg/skaffold/initializer/config_test.go
+++ b/pkg/skaffold/initializer/config_test.go
@@ -67,7 +67,7 @@ func (s stubBuildInitializer) BuildConfig() (latest.BuildConfig, []*latest.PortF
 	}, nil
 }
 
-func (s stubBuildInitializer) GenerateManifests() (map[build.GeneratedArtifactInfo][]byte, error) {
+func (s stubBuildInitializer) GenerateManifests(io.Writer, bool) (map[build.GeneratedArtifactInfo][]byte, error) {
 	panic("no thank you")
 }
 

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -89,7 +89,7 @@ func Initialize(out io.Writer, c config.Config, a *analyze.ProjectAnalysis) (*la
 		return nil, nil, buildInitializer.PrintAnalysis(out)
 	}
 
-	newManifests, err := generateManifests(c, buildInitializer, deployInitializer)
+	newManifests, err := generateManifests(out, c, buildInitializer, deployInitializer)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -101,10 +101,10 @@ func Initialize(out io.Writer, c config.Config, a *analyze.ProjectAnalysis) (*la
 	return generateSkaffoldConfig(buildInitializer, deployInitializer), newManifests, nil
 }
 
-func generateManifests(c config.Config, bInitializer build.Initializer, dInitializer deploy.Initializer) (map[string][]byte, error) {
+func generateManifests(out io.Writer, c config.Config, bInitializer build.Initializer, dInitializer deploy.Initializer) (map[string][]byte, error) {
 	var generatedManifests map[string][]byte
 	if c.EnableManifestGeneration {
-		generatedManifestPairs, err := bInitializer.GenerateManifests()
+		generatedManifestPairs, err := bInitializer.GenerateManifests(out, c.Force)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/skaffold/initializer/prompt/prompt.go
+++ b/pkg/skaffold/initializer/prompt/prompt.go
@@ -29,7 +29,8 @@ import (
 
 // For testing
 var (
-	BuildConfigFunc = buildConfig
+	BuildConfigFunc         = buildConfig
+	PortForwardResourceFunc = portForwardResource
 )
 
 func buildConfig(image string, choices []string) (string, error) {
@@ -81,7 +82,7 @@ confirmLoop:
 }
 
 // PortForwardResource prompts the user to give a port to forward the current resource on
-func PortForwardResource(out io.Writer, imageName string) (int, error) {
+func portForwardResource(out io.Writer, imageName string) (int, error) {
 	reader := bufio.NewReader(os.Stdin)
 
 	fmt.Fprintf(out, "Select port to forward for %s (leave blank for none): ", imageName)

--- a/pkg/skaffold/initializer/prompt/prompt.go
+++ b/pkg/skaffold/initializer/prompt/prompt.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 
 	"gopkg.in/AlecAivazis/survey.v1"
@@ -77,4 +78,24 @@ confirmLoop:
 		}
 	}
 	return false, nil
+}
+
+// PortForwardResource prompts the user to give a port to forward the current resource on
+func PortForwardResource(out io.Writer, imageName string) (int, error) {
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Fprintf(out, "Select port to forward for %s (leave blank for none): ", imageName)
+
+	response, err := reader.ReadString('\n')
+	if err != nil {
+		return 0, fmt.Errorf("reading user confirmation: %w", err)
+	}
+
+	response = strings.ToLower(strings.TrimSpace(response))
+	if response == "" {
+		return 0, nil
+	}
+
+	responseInt, _ := strconv.Atoi(response)
+	return responseInt, nil
 }

--- a/pkg/skaffold/kubernetes/generator/generate.go
+++ b/pkg/skaffold/kubernetes/generator/generate.go
@@ -29,8 +29,8 @@ type Container struct {
 }
 
 // Generate generates kubernetes resources for the given image, and returns the generated manifest string
-func Generate(name string) ([]byte, *Container, error) {
-	c := Container{name, name, 8080}
+func Generate(name string, port int) ([]byte, *Container, error) {
+	c := Container{name, name, port}
 
 	t, err := template.New("deployment").Parse(yamlTemplate)
 	if err != nil {

--- a/pkg/skaffold/kubernetes/generator/template.go
+++ b/pkg/skaffold/kubernetes/generator/template.go
@@ -23,9 +23,11 @@ metadata:
   labels:
     app: {{.Name}}
 spec:
+{{- if .Port}}
   ports:
   - port: {{.Port}}
     protocol: TCP
+{{- end}}
   clusterIP: None
   selector:
     app: {{.Name}}


### PR DESCRIPTION
**Description**
Allows the user to specify port-forward settings when using `skaffold init --XXenableManifestGeneration`

For each image that skaffold generates a k8s manifest for, it will prompt the user as follows:
```
Select port to forward for {{IMAGE_NAME}} (leave blank for none): 
```

**Follow-up Work (remove if N/A)**
unhide the `--XXenableManifestGeneration` flag

