### PR TITLE
Upgrade Jib versions to 2.7.0 in examples and integration tests

### DIFF
--- a/examples/jib-gradle/build.gradle
+++ b/examples/jib-gradle/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'groovy'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
     id 'net.ltgt.apt-idea' version '0.18'
-    id 'com.google.cloud.tools.jib' version '2.6.0'
+    id 'com.google.cloud.tools.jib' version '2.7.0'
 }
 
 version '0.1'

--- a/examples/jib-multimodule/pom.xml
+++ b/examples/jib-multimodule/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <jib.maven-plugin-version>2.6.0</jib.maven-plugin-version>
+    <jib.maven-plugin-version>2.7.0</jib.maven-plugin-version>
   </properties>
 
   <dependencies>

--- a/examples/jib-sync/build.gradle
+++ b/examples/jib-sync/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.0.5.RELEASE'
     id 'io.spring.dependency-management' version '1.0.7.RELEASE'
-    id 'com.google.cloud.tools.jib' version '2.6.0'
+    id 'com.google.cloud.tools.jib' version '2.7.0'
 }
 
 repositories {

--- a/examples/jib-sync/pom.xml
+++ b/examples/jib-sync/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <jib.maven-plugin-version>2.6.0</jib.maven-plugin-version>
+    <jib.maven-plugin-version>2.7.0</jib.maven-plugin-version>
   </properties>
 
   <parent>

--- a/examples/jib/pom.xml
+++ b/examples/jib/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <jib.maven-plugin-version>2.6.0</jib.maven-plugin-version>
+        <jib.maven-plugin-version>2.7.0</jib.maven-plugin-version>
     </properties>
 
     <parent>

--- a/integration/examples/jib-gradle/build.gradle
+++ b/integration/examples/jib-gradle/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'groovy'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
     id 'net.ltgt.apt-idea' version '0.18'
-    id 'com.google.cloud.tools.jib' version '2.6.0'
+    id 'com.google.cloud.tools.jib' version '2.7.0'
 }
 
 version '0.1'

--- a/integration/examples/jib-multimodule/pom.xml
+++ b/integration/examples/jib-multimodule/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <jib.maven-plugin-version>2.6.0</jib.maven-plugin-version>
+    <jib.maven-plugin-version>2.7.0</jib.maven-plugin-version>
   </properties>
 
   <dependencies>

--- a/integration/examples/jib-sync/build.gradle
+++ b/integration/examples/jib-sync/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.0.5.RELEASE'
     id 'io.spring.dependency-management' version '1.0.7.RELEASE'
-    id 'com.google.cloud.tools.jib' version '2.6.0'
+    id 'com.google.cloud.tools.jib' version '2.7.0'
 }
 
 repositories {

--- a/integration/examples/jib-sync/pom.xml
+++ b/integration/examples/jib-sync/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <jib.maven-plugin-version>2.6.0</jib.maven-plugin-version>
+    <jib.maven-plugin-version>2.7.0</jib.maven-plugin-version>
   </properties>
 
   <parent>

--- a/integration/examples/jib/pom.xml
+++ b/integration/examples/jib/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <jib.maven-plugin-version>2.6.0</jib.maven-plugin-version>
+        <jib.maven-plugin-version>2.7.0</jib.maven-plugin-version>
     </properties>
 
     <parent>

--- a/integration/testdata/debug/java/pom.xml
+++ b/integration/testdata/debug/java/pom.xml
@@ -8,7 +8,7 @@
   <description>Simple Java server with Skaffold and Jib</description>
 
   <properties>
-    <jib.maven-plugin-version>2.6.0</jib.maven-plugin-version>
+    <jib.maven-plugin-version>2.7.0</jib.maven-plugin-version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>

--- a/integration/testdata/jib/pom.xml
+++ b/integration/testdata/jib/pom.xml
@@ -8,7 +8,7 @@
     <description>Simple Java server with Skaffold and Jib</description>
 
     <properties>
-        <jib.maven-plugin-version>2.6.0</jib.maven-plugin-version>
+        <jib.maven-plugin-version>2.7.0</jib.maven-plugin-version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>


### PR DESCRIPTION
Jib 2.7.0 has been released.