### PR TITLE
Capture enum flags

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -50,10 +50,10 @@ func NewCmdBuild() *cobra.Command {
 		WithExample("Print the final image names", "build -q --dry-run").
 		WithCommonFlags().
 		WithFlags([]*Flag{
-			{Value: &quietFlag, Name: "quiet", Shorthand: "q", DefValue: false, Usage: "Suppress the build output and print image built on success. See --output to format output."},
+			{Value: &quietFlag, Name: "quiet", Shorthand: "q", DefValue: false, Usage: "Suppress the build output and print image built on success. See --output to format output.", IsEnum: true},
 			{Value: buildFormatFlag, Name: "output", Shorthand: "o", Usage: "Used in conjunction with --quiet flag. " + buildFormatFlag.Usage()},
 			{Value: &buildOutputFlag, Name: "file-output", DefValue: "", Usage: "Filename to write build images to"},
-			{Value: &opts.DryRun, Name: "dry-run", DefValue: false, Usage: "Don't build images, just compute the tag for each artifact."},
+			{Value: &opts.DryRun, Name: "dry-run", DefValue: false, Usage: "Don't build images, just compute the tag for each artifact.", IsEnum: true},
 		}).
 		WithHouseKeepingMessages().
 		NoArgs(doBuild)

--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
@@ -50,11 +49,11 @@ func NewCmdBuild() *cobra.Command {
 		WithExample("Build the artifacts and then deploy them", "build -q | skaffold deploy --build-artifacts -").
 		WithExample("Print the final image names", "build -q --dry-run").
 		WithCommonFlags().
-		WithFlags(func(f *pflag.FlagSet) {
-			f.BoolVarP(&quietFlag, "quiet", "q", false, "Suppress the build output and print image built on success. See --output to format output.")
-			f.VarP(buildFormatFlag, "output", "o", "Used in conjunction with --quiet flag. "+buildFormatFlag.Usage())
-			f.StringVar(&buildOutputFlag, "file-output", "", "Filename to write build images to")
-			f.BoolVar(&opts.DryRun, "dry-run", false, "Don't build images, just compute the tag for each artifact.")
+		WithFlags([]*Flag{
+			{Value: &quietFlag, Name: "quiet", Shorthand: "q", DefValue: false, Usage: "Suppress the build output and print image built on success. See --output to format output."},
+			{Value: buildFormatFlag, Name: "output", Shorthand: "o", Usage: "Used in conjunction with --quiet flag. " + buildFormatFlag.Usage()},
+			{Value: &buildOutputFlag, Name: "file-output", DefValue: "", Usage: "Filename to write build images to"},
+			{Value: &opts.DryRun, Name: "dry-run", DefValue: false, Usage: "Don't build images, just compute the tag for each artifact."},
 		}).
 		WithHouseKeepingMessages().
 		NoArgs(doBuild)

--- a/cmd/skaffold/app/cmd/commands.go
+++ b/cmd/skaffold/app/cmd/commands.go
@@ -32,7 +32,8 @@ type Builder interface {
 	WithDescription(description string) Builder
 	WithLongDescription(long string) Builder
 	WithExample(comment, command string) Builder
-	WithFlags(adder func(*pflag.FlagSet)) Builder
+	WithFlagAdder(adder func(*pflag.FlagSet)) Builder
+	WithFlags([]*Flag) Builder
 	WithHouseKeepingMessages() Builder
 	WithCommonFlags() Builder
 	Hidden() Builder
@@ -81,8 +82,20 @@ func (b *builder) WithHouseKeepingMessages() Builder {
 	return b
 }
 
-func (b *builder) WithFlags(adder func(*pflag.FlagSet)) Builder {
+func (b *builder) WithFlagAdder(adder func(*pflag.FlagSet)) Builder {
 	adder(b.cmd.Flags())
+	return b
+}
+
+func (b *builder) WithFlags(flags []*Flag) Builder {
+	for _, f := range flags {
+		fl := f.flag()
+		b.cmd.Flags().AddFlag(fl)
+	}
+	b.cmd.PreRun = func(cmd *cobra.Command, args []string) {
+		ParseFlags(cmd, flags)
+	}
+
 	return b
 }
 

--- a/cmd/skaffold/app/cmd/commands_test.go
+++ b/cmd/skaffold/app/cmd/commands_test.go
@@ -95,7 +95,7 @@ func TestNewCmdOutput(t *testing.T) {
 }
 
 func TestNewCmdWithFlags(t *testing.T) {
-	cmd := NewCmd("").WithFlags(func(flagSet *pflag.FlagSet) {
+	cmd := NewCmd("").WithFlagAdder(func(flagSet *pflag.FlagSet) {
 		flagSet.Bool("test", false, "usage")
 	}).NoArgs(nil)
 

--- a/cmd/skaffold/app/cmd/config.go
+++ b/cmd/skaffold/app/cmd/config.go
@@ -41,7 +41,7 @@ func NewCmdSet() *cobra.Command {
 		WithExample("Mark a registry as insecure", "config set insecure-registries <insecure1.io>").
 		WithExample("Globally set the default image repository", "config set default-repo <myrepo>").
 		WithExample("Disable pushing images for a given Kubernetes context", "config set --kube-context <mycluster> local-cluster true").
-		WithFlags(func(f *pflag.FlagSet) {
+		WithFlagAdder(func(f *pflag.FlagSet) {
 			config.AddCommonFlags(f)
 			config.AddSetUnsetFlags(f)
 		}).
@@ -51,7 +51,7 @@ func NewCmdSet() *cobra.Command {
 func NewCmdUnset() *cobra.Command {
 	return NewCmd("unset").
 		WithDescription("Unset a value in the global Skaffold config").
-		WithFlags(func(f *pflag.FlagSet) {
+		WithFlagAdder(func(f *pflag.FlagSet) {
 			config.AddCommonFlags(f)
 			config.AddSetUnsetFlags(f)
 		}).
@@ -61,7 +61,7 @@ func NewCmdUnset() *cobra.Command {
 func NewCmdList() *cobra.Command {
 	return NewCmd("list").
 		WithDescription("List all values set in the global Skaffold config").
-		WithFlags(func(f *pflag.FlagSet) {
+		WithFlagAdder(func(f *pflag.FlagSet) {
 			config.AddCommonFlags(f)
 			config.AddListFlags(f)
 		}).

--- a/cmd/skaffold/app/cmd/credits.go
+++ b/cmd/skaffold/app/cmd/credits.go
@@ -18,7 +18,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/credits"
 )
@@ -27,8 +26,8 @@ func NewCmdCredits() *cobra.Command {
 	return NewCmd("credits").
 		WithDescription("Export third party notices to given path (./skaffold-credits by default)").
 		WithExample("export third party licenses to ~/skaffold-credits", "credits -d ~/skaffold-credits").
-		WithFlags(func(f *pflag.FlagSet) {
-			f.StringVarP(&credits.Path, "dir", "d", "./skaffold-credits", "destination directory to place third party licenses")
+		WithFlags([]*Flag{
+			{Value: &credits.Path, Name: "dir", Shorthand: "d", DefValue: "./skaffold-credits", Usage: "destination directory to place third party licenses"},
 		}).
 		NoArgs(credits.Export)
 }

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -44,7 +44,7 @@ func NewCmdDeploy() *cobra.Command {
 		WithCommonFlags().
 		WithFlags([]*Flag{
 			{Value: &preBuiltImages, Name: "images", Shorthand: "i", Usage: "A list of pre-built images to deploy"},
-			{Value: &opts.SkipRender, Name: "skip-render", DefValue: false, Usage: "Don't render the manifests, just deploy them"},
+			{Value: &opts.SkipRender, Name: "skip-render", DefValue: false, Usage: "Don't render the manifests, just deploy them", IsEnum: true},
 		}).
 		WithHouseKeepingMessages().
 		NoArgs(doDeploy)

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -21,7 +21,6 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
@@ -43,9 +42,9 @@ func NewCmdDeploy() *cobra.Command {
 		WithExample("Build the artifacts and then deploy them", "build -q | skaffold deploy --build-artifacts -").
 		WithExample("Deploy without first rendering the manifests", "deploy --skip-render").
 		WithCommonFlags().
-		WithFlags(func(f *pflag.FlagSet) {
-			f.VarP(&preBuiltImages, "images", "i", "A list of pre-built images to deploy")
-			f.BoolVar(&opts.SkipRender, "skip-render", false, "Don't render the manifests, just deploy them")
+		WithFlags([]*Flag{
+			{Value: &preBuiltImages, Name: "images", Shorthand: "i", Usage: "A list of pre-built images to deploy"},
+			{Value: &opts.SkipRender, Name: "skip-render", DefValue: false, Usage: "Don't render the manifests, just deploy them"},
 		}).
 		WithHouseKeepingMessages().
 		NoArgs(doDeploy)

--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -22,7 +22,6 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/diagnose"
@@ -41,9 +40,8 @@ func NewCmdDiagnose() *cobra.Command {
 		WithExample("Search for configuration issues and print the effective configuration", "diagnose").
 		WithExample("Print the effective skaffold.yaml configuration for given profile", "diagnose --yaml-only --profile PROFILE").
 		WithCommonFlags().
-		WithFlags(func(f *pflag.FlagSet) {
-			f.BoolVar(&yamlOnly, "yaml-only", false, "Only prints the effective skaffold.yaml configuration")
-		}).
+		WithFlags([]*Flag{
+			{Value: &yamlOnly, Name: "yaml-only", DefValue: false, Usage: "Only prints the effective skaffold.yaml configuration"}}).
 		NoArgs(doDiagnose)
 }
 

--- a/cmd/skaffold/app/cmd/filter.go
+++ b/cmd/skaffold/app/cmd/filter.go
@@ -23,7 +23,6 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -47,9 +46,9 @@ func NewCmdFilter() *cobra.Command {
 		WithDescription("[alpha] Filter and transform a set of Kubernetes manifests from stdin").
 		WithLongDescription("Unlike `render`, this command does not build artifacts.").
 		WithCommonFlags().
-		WithFlags(func(f *pflag.FlagSet) {
-			f.VarP(&renderFromBuildOutputFile, "build-artifacts", "a", "File containing build result from a previous 'skaffold build --file-output'")
-			f.BoolVar(&debuggingFilters, "debugging", false, `Apply debug transforms similar to "skaffold debug"`)
+		WithFlags([]*Flag{
+			{Value: &renderFromBuildOutputFile, Name: "build-artifacts", Shorthand: "a", Usage: "File containing build result from a previous 'skaffold build --file-output'"},
+			{Value: &debuggingFilters, Name: "debugging", DefValue: false, Usage: `Apply debug transforms similar to "skaffold debug"`},
 		}).
 		NoArgs(func(ctx context.Context, out io.Writer) error {
 			return doFilter(ctx, out, debuggingFilters, renderFromBuildOutputFile.BuildArtifacts())

--- a/cmd/skaffold/app/cmd/filter.go
+++ b/cmd/skaffold/app/cmd/filter.go
@@ -48,7 +48,7 @@ func NewCmdFilter() *cobra.Command {
 		WithCommonFlags().
 		WithFlags([]*Flag{
 			{Value: &renderFromBuildOutputFile, Name: "build-artifacts", Shorthand: "a", Usage: "File containing build result from a previous 'skaffold build --file-output'"},
-			{Value: &debuggingFilters, Name: "debugging", DefValue: false, Usage: `Apply debug transforms similar to "skaffold debug"`},
+			{Value: &debuggingFilters, Name: "debugging", DefValue: false, Usage: `Apply debug transforms similar to "skaffold debug"`, IsEnum: true},
 		}).
 		NoArgs(func(ctx context.Context, out io.Writer) error {
 			return doFilter(ctx, out, debuggingFilters, renderFromBuildOutputFile.BuildArtifacts())

--- a/cmd/skaffold/app/cmd/find_configs.go
+++ b/cmd/skaffold/app/cmd/find_configs.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
@@ -41,11 +40,11 @@ var (
 func NewCmdFindConfigs() *cobra.Command {
 	return NewCmd("find-configs").
 		WithDescription("Find in a given directory all skaffold yamls files that are parseable or upgradeable with their versions.").
-		WithFlags(func(f *pflag.FlagSet) {
+		WithFlags([]*Flag{
 			// Default to current directory
-			f.StringVarP(&directory, "directory", "d", ".", "Root directory to lookup the config files.")
+			{Value: &directory, Name: "directory", Shorthand: "d", DefValue: ".", Usage: "Root directory to lookup the config files."},
 			// Output format of this Command
-			f.StringVarP(&format, "output", "o", "table", "Result format, default to table. [(-o|--output=)json|table]")
+			{Value: &format, Name: "output", Shorthand: "o", DefValue: "table", Usage: "Result format, default to table. [(-o|--output=)json|table]"},
 		}).
 		Hidden().
 		NoArgs(doFindConfigs)

--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
@@ -40,9 +39,9 @@ func NewCmdFix() *cobra.Command {
 		WithExample("Update \"skaffold.yaml\" in the current folder to the latest version", "fix").
 		WithExample("Update \"skaffold.yaml\" in the current folder to version \"skaffold/v1\"", "fix --version skaffold/v1").
 		WithCommonFlags().
-		WithFlags(func(f *pflag.FlagSet) {
-			f.BoolVar(&overwrite, "overwrite", false, "Overwrite original config with fixed config")
-			f.StringVar(&toVersion, "version", latest.Version, "Target schema version to upgrade to")
+		WithFlags([]*Flag{
+			{Value: &overwrite, Name: "overwrite", DefValue: false, Usage: "Overwrite original config with fixed config"},
+			{Value: &toVersion, Name: "version", DefValue: latest.Version, Usage: "Target schema version to upgrade to"},
 		}).
 		NoArgs(doFix)
 }

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 )
 
 var (
@@ -44,6 +45,7 @@ type Flag struct {
 	FlagAddMethod      string
 	DefinedOn          []string
 	Hidden             bool
+	IsEnum             bool
 
 	pflag *pflag.Flag
 }
@@ -99,6 +101,7 @@ var flagRegistry = []Flag{
 		DefValue:      true,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "build", "run", "debug"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "cache-file",
@@ -126,6 +129,7 @@ var flagRegistry = []Flag{
 		},
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "build", "run", "debug", "deploy"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "rpc-port",
@@ -159,6 +163,7 @@ var flagRegistry = []Flag{
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "build", "run", "debug", "deploy"},
+		IsEnum:        true,
 	},
 	{
 		Name:     "tail",
@@ -171,6 +176,7 @@ var flagRegistry = []Flag{
 		},
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "run", "debug", "deploy"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "force",
@@ -179,6 +185,7 @@ var flagRegistry = []Flag{
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"deploy", "dev", "run", "debug"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "skip-tests",
@@ -187,6 +194,7 @@ var flagRegistry = []Flag{
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "run", "debug", "build"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "cleanup",
@@ -195,6 +203,7 @@ var flagRegistry = []Flag{
 		DefValue:      true,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "run", "debug"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "no-prune",
@@ -203,6 +212,7 @@ var flagRegistry = []Flag{
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "run", "debug"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "no-prune-children",
@@ -211,6 +221,7 @@ var flagRegistry = []Flag{
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "run", "debug"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "port-forward",
@@ -219,6 +230,7 @@ var flagRegistry = []Flag{
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "debug", "deploy", "run"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "status-check",
@@ -227,6 +239,7 @@ var flagRegistry = []Flag{
 		DefValue:      true,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "debug", "deploy", "run"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "render-only",
@@ -235,6 +248,7 @@ var flagRegistry = []Flag{
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "run"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "render-output",
@@ -297,6 +311,7 @@ var flagRegistry = []Flag{
 		DefValue:      true,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "build", "delete", "diagnose"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "trigger",
@@ -305,6 +320,7 @@ var flagRegistry = []Flag{
 		DefValue:      "notify",
 		FlagAddMethod: "StringVar",
 		DefinedOn:     []string{"dev", "debug"},
+		IsEnum:        true,
 	},
 	{
 		Name:     "auto-build",
@@ -318,6 +334,7 @@ var flagRegistry = []Flag{
 		},
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "debug"},
+		IsEnum:        true,
 	},
 	{
 		Name:     "auto-sync",
@@ -331,6 +348,7 @@ var flagRegistry = []Flag{
 		},
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "debug"},
+		IsEnum:        true,
 	},
 	{
 		Name:     "auto-deploy",
@@ -344,6 +362,7 @@ var flagRegistry = []Flag{
 		},
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "debug"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "watch-image",
@@ -370,6 +389,7 @@ var flagRegistry = []Flag{
 		DefValue:      true,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"render"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "mute-logs",
@@ -378,6 +398,7 @@ var flagRegistry = []Flag{
 		DefValue:      []string{},
 		FlagAddMethod: "StringSliceVar",
 		DefinedOn:     []string{"dev", "run", "debug", "build", "deploy"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "wait-for-deletions",
@@ -386,6 +407,7 @@ var flagRegistry = []Flag{
 		DefValue:      true,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"deploy", "dev", "run", "debug"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "wait-for-deletions-max",
@@ -419,6 +441,7 @@ var flagRegistry = []Flag{
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"build", "debug", "delete", "deploy", "dev", "run"},
+		IsEnum:        true,
 	},
 	{
 		Name:          "build-artifacts",
@@ -480,10 +503,14 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		// Update default values.
 		for _, fl := range flagsForCommand {
+			flag := cmd.Flag(fl.Name)
 			if defValue, present := fl.DefValuePerCommand[cmd.Use]; present {
-				if flag := cmd.Flag(fl.Name); !flag.Changed {
+				if !flag.Changed {
 					flag.Value.Set(fmt.Sprintf("%v", defValue))
 				}
+			}
+			if fl.IsEnum {
+				instrumentation.AddFlag(flag)
 			}
 		}
 

--- a/cmd/skaffold/app/cmd/generate_pipeline.go
+++ b/cmd/skaffold/app/cmd/generate_pipeline.go
@@ -22,7 +22,6 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
@@ -38,8 +37,8 @@ func NewCmdGeneratePipeline() *cobra.Command {
 		Hidden().
 		WithDescription("[ALPHA] Generate tekton pipeline from skaffold.yaml").
 		WithCommonFlags().
-		WithFlags(func(f *pflag.FlagSet) {
-			f.StringSliceVar(&configFiles, "config-files", nil, "Select additional files whose artifacts to use when generating pipeline.")
+		WithFlags([]*Flag{
+			{Value: &configFiles, Name: "config-files", DefValue: []string{}, Usage: "Select additional files whose artifacts to use when generating pipeline."},
 		}).
 		NoArgs(doGeneratePipeline)
 }

--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -21,7 +21,6 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
@@ -54,28 +53,21 @@ func NewCmdInit() *cobra.Command {
 	return NewCmd("init").
 		WithDescription("[alpha] Generate configuration for deploying an application").
 		WithCommonFlags().
-		WithFlags(func(f *pflag.FlagSet) {
-			f.BoolVar(&skipBuild, "skip-build", false, "Skip generating build artifacts in Skaffold config")
-			f.BoolVar(&skipDeploy, "skip-deploy", false, "Skip generating deploy stanza in Skaffold config")
-			f.MarkHidden("skip-deploy")
-			f.BoolVar(&force, "force", false, "Force the generation of the Skaffold config")
-			f.StringVar(&composeFile, "compose-file", "", "Initialize from a docker-compose file")
-			f.StringVar(&defaultKustomization, "default-kustomization", "", "Default Kustomization overlay path (others will be added as profiles)")
-			f.StringArrayVarP(&cliArtifacts, "artifact", "a", nil, "'='-delimited Dockerfile/image pair, or JSON string, to generate build artifact\n(example: --artifact='{\"builder\":\"Docker\",\"payload\":{\"path\":\"/web/Dockerfile.web\"},\"image\":\"gcr.io/web-project/image\"}')")
-			f.StringArrayVarP(&cliKubernetesManifests, "kubernetes-manifest", "k", nil, "A path or a glob pattern to kubernetes manifests (can be non-existent) to be added to the kubectl deployer (overrides detection of kubernetes manifests). Repeat the flag for multiple entries. E.g.: skaffold init -k pod.yaml -k k8s/*.yml")
-			f.BoolVar(&analyze, "analyze", false, "Print all discoverable Dockerfiles and images in JSON format to stdout")
-			f.BoolVar(&enableNewInitFormat, "XXenableNewInitFormat", false, "")
-			f.MarkHidden("XXenableNewInitFormat")
-			f.BoolVar(&enableJibInit, "XXenableJibInit", false, "")
-			f.MarkHidden("XXenableJibInit")
-			f.BoolVar(&enableJibGradleInit, "XXenableJibGradleInit", false, "")
-			f.MarkHidden("XXenableJibGradleInit")
-			f.BoolVar(&enableBuildpacksInit, "XXenableBuildpacksInit", false, "")
-			f.MarkHidden("XXenableBuildpacksInit")
-			f.StringVar(&buildpacksBuilder, "XXdefaultBuildpacksBuilder", "gcr.io/buildpacks/builder:v1", "")
-			f.MarkHidden("XXdefaultBuildpacksBuilder")
-			f.BoolVar(&enableManifestGeneration, "XXenableManifestGeneration", false, "")
-			f.MarkHidden("XXenableManifestGeneration")
+		WithFlags([]*Flag{
+			{Value: &skipBuild, Name: "skip-build", DefValue: false, Usage: "Skip generating build artifacts in Skaffold config"},
+			{Value: &skipDeploy, Name: "skip-deploy", DefValue: false, Usage: "Skip generating deploy stanza in Skaffold config", Hidden: true},
+			{Value: &force, Name: "force", DefValue: false, Usage: "Force the generation of the Skaffold config"},
+			{Value: &composeFile, Name: "compose-file", DefValue: "", Usage: "Initialize from a docker-compose file"},
+			{Value: &defaultKustomization, Name: "default-kustomization", DefValue: "", Usage: "Default Kustomization overlay path (others will be added as profiles)"},
+			{Value: &cliArtifacts, Name: "artifact", Shorthand: "a", DefValue: []string{}, Usage: "'='-delimited Dockerfile/image pair, or JSON string, to generate build artifact\n(example: --artifact='{\"builder\":\"Docker\",\"payload\":{\"path\":\"/web/Dockerfile.web\"},\"image\":\"gcr.io/web-project/image\"}')"},
+			{Value: &cliKubernetesManifests, Name: "kubernetes-manifest", Shorthand: "k", DefValue: []string{}, Usage: "A path or a glob pattern to kubernetes manifests (can be non-existent) to be added to the kubectl deployer (overrides detection of kubernetes manifests). Repeat the flag for multiple entries. E.g.: skaffold init -k pod.yaml -k k8s/*.yml"},
+			{Value: &analyze, Name: "analyze", DefValue: false, Usage: "Print all discoverable Dockerfiles and images in JSON format to stdout"},
+			{Value: &enableNewInitFormat, Name: "XXenableNewInitFormat", DefValue: false, Usage: "", Hidden: true},
+			{Value: &enableJibInit, Name: "XXenableJibInit", DefValue: false, Usage: "", Hidden: true},
+			{Value: &enableJibGradleInit, Name: "XXenableJibGradleInit", DefValue: false, Usage: "", Hidden: true},
+			{Value: &enableBuildpacksInit, Name: "XXenableBuildpacksInit", DefValue: false, Usage: "", Hidden: true},
+			{Value: &buildpacksBuilder, Name: "XXdefaultBuildpacksBuilder", DefValue: "gcr.io/buildpacks/builder:v1", Usage: "", Hidden: true},
+			{Value: &enableManifestGeneration, Name: "XXenableManifestGeneration", DefValue: false, Usage: "", Hidden: true},
 		}).
 		NoArgs(doInit)
 }

--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -54,20 +54,20 @@ func NewCmdInit() *cobra.Command {
 		WithDescription("[alpha] Generate configuration for deploying an application").
 		WithCommonFlags().
 		WithFlags([]*Flag{
-			{Value: &skipBuild, Name: "skip-build", DefValue: false, Usage: "Skip generating build artifacts in Skaffold config"},
-			{Value: &skipDeploy, Name: "skip-deploy", DefValue: false, Usage: "Skip generating deploy stanza in Skaffold config", Hidden: true},
-			{Value: &force, Name: "force", DefValue: false, Usage: "Force the generation of the Skaffold config"},
+			{Value: &skipBuild, Name: "skip-build", DefValue: false, Usage: "Skip generating build artifacts in Skaffold config", IsEnum: true},
+			{Value: &skipDeploy, Name: "skip-deploy", DefValue: false, Usage: "Skip generating deploy stanza in Skaffold config", Hidden: true, IsEnum: true},
+			{Value: &force, Name: "force", DefValue: false, Usage: "Force the generation of the Skaffold config", IsEnum: true},
 			{Value: &composeFile, Name: "compose-file", DefValue: "", Usage: "Initialize from a docker-compose file"},
 			{Value: &defaultKustomization, Name: "default-kustomization", DefValue: "", Usage: "Default Kustomization overlay path (others will be added as profiles)"},
 			{Value: &cliArtifacts, Name: "artifact", Shorthand: "a", DefValue: []string{}, Usage: "'='-delimited Dockerfile/image pair, or JSON string, to generate build artifact\n(example: --artifact='{\"builder\":\"Docker\",\"payload\":{\"path\":\"/web/Dockerfile.web\"},\"image\":\"gcr.io/web-project/image\"}')"},
 			{Value: &cliKubernetesManifests, Name: "kubernetes-manifest", Shorthand: "k", DefValue: []string{}, Usage: "A path or a glob pattern to kubernetes manifests (can be non-existent) to be added to the kubectl deployer (overrides detection of kubernetes manifests). Repeat the flag for multiple entries. E.g.: skaffold init -k pod.yaml -k k8s/*.yml"},
-			{Value: &analyze, Name: "analyze", DefValue: false, Usage: "Print all discoverable Dockerfiles and images in JSON format to stdout"},
-			{Value: &enableNewInitFormat, Name: "XXenableNewInitFormat", DefValue: false, Usage: "", Hidden: true},
-			{Value: &enableJibInit, Name: "XXenableJibInit", DefValue: false, Usage: "", Hidden: true},
-			{Value: &enableJibGradleInit, Name: "XXenableJibGradleInit", DefValue: false, Usage: "", Hidden: true},
-			{Value: &enableBuildpacksInit, Name: "XXenableBuildpacksInit", DefValue: false, Usage: "", Hidden: true},
+			{Value: &analyze, Name: "analyze", DefValue: false, Usage: "Print all discoverable Dockerfiles and images in JSON format to stdout", IsEnum: true},
+			{Value: &enableNewInitFormat, Name: "XXenableNewInitFormat", DefValue: false, Usage: "", Hidden: true, IsEnum: true},
+			{Value: &enableJibInit, Name: "XXenableJibInit", DefValue: false, Usage: "", Hidden: true, IsEnum: true},
+			{Value: &enableJibGradleInit, Name: "XXenableJibGradleInit", DefValue: false, Usage: "", Hidden: true, IsEnum: true},
+			{Value: &enableBuildpacksInit, Name: "XXenableBuildpacksInit", DefValue: false, Usage: "", Hidden: true, IsEnum: true},
 			{Value: &buildpacksBuilder, Name: "XXdefaultBuildpacksBuilder", DefValue: "gcr.io/buildpacks/builder:v1", Usage: "", Hidden: true},
-			{Value: &enableManifestGeneration, Name: "XXenableManifestGeneration", DefValue: false, Usage: "", Hidden: true},
+			{Value: &enableManifestGeneration, Name: "XXenableManifestGeneration", DefValue: false, Usage: "", Hidden: true, IsEnum: true},
 		}).
 		NoArgs(doInit)
 }

--- a/cmd/skaffold/app/cmd/init_test.go
+++ b/cmd/skaffold/app/cmd/init_test.go
@@ -46,8 +46,8 @@ func TestFlagsToConfigVersion(t *testing.T) {
 			shouldErr:  true,
 			expectedConfig: config.Config{
 				ComposeFile:            "",
-				CliArtifacts:           nil,
-				CliKubernetesManifests: nil,
+				CliArtifacts:           []string{},
+				CliKubernetesManifests: []string{},
 				SkipBuild:              false,
 				SkipDeploy:             false,
 				Force:                  false,
@@ -107,8 +107,8 @@ func TestFlagsToConfigVersion(t *testing.T) {
 			},
 			expectedConfig: config.Config{
 				ComposeFile:            "",
-				CliArtifacts:           nil,
-				CliKubernetesManifests: nil,
+				CliArtifacts:           []string{},
+				CliKubernetesManifests: []string{},
 				SkipBuild:              false,
 				SkipDeploy:             false,
 				Force:                  false,
@@ -129,8 +129,8 @@ func TestFlagsToConfigVersion(t *testing.T) {
 			},
 			expectedConfig: config.Config{
 				ComposeFile:            "",
-				CliArtifacts:           nil,
-				CliKubernetesManifests: nil,
+				CliArtifacts:           []string{},
+				CliKubernetesManifests: []string{},
 				SkipBuild:              false,
 				SkipDeploy:             false,
 				Force:                  false,

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -44,11 +44,11 @@ func NewCmdRender() *cobra.Command {
 		WithExample("Hydrate Kubernetes manifests without building the images, using digest resolved from tag in remote registry ", "render --digest-source=remote").
 		WithCommonFlags().
 		WithFlags([]*Flag{
-			{Value: &showBuild, Name: "loud", DefValue: false, Usage: "Show the build logs and output"},
+			{Value: &showBuild, Name: "loud", DefValue: false, Usage: "Show the build logs and output", IsEnum: true},
 			{Value: &renderFromBuildOutputFile, Name: "build-artifacts", Shorthand: "a", Usage: "File containing build result from a previous 'skaffold build --file-output'"},
-			{Value: &offline, Name: "offline", DefValue: false, Usage: `Do not connect to Kubernetes API server for manifest creation and validation. This is helpful when no Kubernetes cluster is available (e.g. GitOps model). No metadata.namespace attribute is injected in this case - the manifest content does not get changed.`},
+			{Value: &offline, Name: "offline", DefValue: false, Usage: `Do not connect to Kubernetes API server for manifest creation and validation. This is helpful when no Kubernetes cluster is available (e.g. GitOps model). No metadata.namespace attribute is injected in this case - the manifest content does not get changed.`, IsEnum: true},
 			{Value: &renderOutputPath, Name: "output", DefValue: "", Usage: "file to write rendered manifests to"},
-			{Value: &opts.DigestSource, Name: "digest-source", DefValue: "local", Usage: "Set to 'local' to build images locally and use digests from built images; Set to 'remote' to resolve the digest of images by tag from the remote registry; Set to 'none' to use tags directly from the Kubernetes manifests"},
+			{Value: &opts.DigestSource, Name: "digest-source", DefValue: "local", Usage: "Set to 'local' to build images locally and use digests from built images; Set to 'remote' to resolve the digest of images by tag from the remote registry; Set to 'none' to use tags directly from the Kubernetes manifests", IsEnum: true},
 		}).
 		WithHouseKeepingMessages().
 		NoArgs(doRender)

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -44,12 +43,12 @@ func NewCmdRender() *cobra.Command {
 		WithDescription("[alpha] Perform all image builds, and output rendered Kubernetes manifests").
 		WithExample("Hydrate Kubernetes manifests without building the images, using digest resolved from tag in remote registry ", "render --digest-source=remote").
 		WithCommonFlags().
-		WithFlags(func(f *pflag.FlagSet) {
-			f.BoolVar(&showBuild, "loud", false, "Show the build logs and output")
-			f.VarP(&renderFromBuildOutputFile, "build-artifacts", "a", "File containing build result from a previous 'skaffold build --file-output'")
-			f.BoolVar(&offline, "offline", false, `Do not connect to Kubernetes API server for manifest creation and validation. This is helpful when no Kubernetes cluster is available (e.g. GitOps model). No metadata.namespace attribute is injected in this case - the manifest content does not get changed.`)
-			f.StringVar(&renderOutputPath, "output", "", "file to write rendered manifests to")
-			f.StringVar(&opts.DigestSource, "digest-source", "local", "Set to 'local' to build images locally and use digests from built images; Set to 'remote' to resolve the digest of images by tag from the remote registry; Set to 'none' to use tags directly from the Kubernetes manifests")
+		WithFlags([]*Flag{
+			{Value: &showBuild, Name: "loud", DefValue: false, Usage: "Show the build logs and output"},
+			{Value: &renderFromBuildOutputFile, Name: "build-artifacts", Shorthand: "a", Usage: "File containing build result from a previous 'skaffold build --file-output'"},
+			{Value: &offline, Name: "offline", DefValue: false, Usage: `Do not connect to Kubernetes API server for manifest creation and validation. This is helpful when no Kubernetes cluster is available (e.g. GitOps model). No metadata.namespace attribute is injected in this case - the manifest content does not get changed.`},
+			{Value: &renderOutputPath, Name: "output", DefValue: "", Usage: "file to write rendered manifests to"},
+			{Value: &opts.DigestSource, Name: "digest-source", DefValue: "local", Usage: "Set to 'local' to build images locally and use digests from built images; Set to 'remote' to resolve the digest of images by tag from the remote registry; Set to 'none' to use tags directly from the Kubernetes manifests"},
 		}).
 		WithHouseKeepingMessages().
 		NoArgs(doRender)

--- a/cmd/skaffold/app/cmd/schema.go
+++ b/cmd/skaffold/app/cmd/schema.go
@@ -21,7 +21,6 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd/schema"
 )
@@ -42,9 +41,8 @@ func NewCmdSchemaList() *cobra.Command {
 		WithDescription("List skaffold.yaml's json schema versions").
 		WithExample("List all the versions", "schema list").
 		WithExample("List all the versions, in json format", "schema list -o json").
-		WithFlags(func(f *pflag.FlagSet) {
-			f.StringVarP(&schema.OutputType, "output", "o", "plain", "Type of output: `plain` or `json`.")
-		}).
+		WithFlags([]*Flag{
+			{Value: &schema.OutputType, Name: "output", Shorthand: "o", DefValue: "plain", Usage: "Type of output: `plain` or `json`."}}).
 		NoArgs(schema.List)
 }
 

--- a/cmd/skaffold/app/cmd/version.go
+++ b/cmd/skaffold/app/cmd/version.go
@@ -21,7 +21,6 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
@@ -32,8 +31,8 @@ var versionFlag = flags.NewTemplateFlag("{{.Version}}\n", version.Info{})
 func NewCmdVersion() *cobra.Command {
 	return NewCmd("version").
 		WithDescription("Print the version information").
-		WithFlags(func(f *pflag.FlagSet) {
-			f.VarP(versionFlag, "output", "o", versionFlag.Usage())
+		WithFlags([]*Flag{
+			{Value: versionFlag, Name: "output", Shorthand: "o", Usage: versionFlag.Usage()},
 		}).
 		NoArgs(doVersion)
 }

--- a/pkg/skaffold/initializer/build/builders.go
+++ b/pkg/skaffold/initializer/build/builders.go
@@ -96,7 +96,7 @@ func NewInitializer(builders []InitBuilder, c config.Config) Initializer {
 	switch {
 	case c.SkipBuild:
 		return &emptyBuildInitializer{}
-	case c.CliArtifacts != nil:
+	case len(c.CliArtifacts) > 0:
 		return &cliBuildInitializer{
 			cliArtifacts:    c.CliArtifacts,
 			builders:        builders,

--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -20,6 +20,8 @@ import (
 	"runtime"
 	"time"
 
+	flag "github.com/spf13/pflag"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
@@ -36,7 +38,7 @@ type skaffoldMeter struct {
 	Arch           string
 	PlatformType   string
 	Deployers      []string
-	EnumFlags      map[string]interface{}
+	EnumFlags      map[string]*flag.Flag
 	Builders       map[string]bool
 	SyncType       map[string]bool
 	DevIterations  []devIteration
@@ -53,6 +55,7 @@ var (
 	meter = skaffoldMeter{
 		OS:            runtime.GOOS,
 		Arch:          runtime.GOARCH,
+		EnumFlags:     map[string]*flag.Flag{},
 		Builders:      map[string]bool{},
 		SyncType:      map[string]bool{},
 		DevIterations: []devIteration{},
@@ -89,4 +92,8 @@ func AddDevIterationErr(i int, errorCode proto.StatusCode) {
 		meter.DevIterations = append(meter.DevIterations, devIteration{intent: "error"})
 	}
 	meter.DevIterations[i].errorCode = errorCode
+}
+
+func AddFlag(flag *flag.Flag) {
+	meter.EnumFlags[flag.Name] = flag
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Merge after**: #5100

**Description**
Mark which flags are enums by adding an ```IsEnum``` field to ```cmd.Flag``` and using the ```cmd.Flag``` type in all relevant instances that defined flags. 

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->
write metrics, and upload them, create relevant documentation, and prompt users to opt-out.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
