### PR TITLE
Recompute docker dependencies across dev loops.

### DIFF
--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -66,7 +66,7 @@ func (b *mockBuilder) BuildAndTest(ctx context.Context, out io.Writer, tags tag.
 		b.built = append(b.built, artifact)
 		tag := tags[artifact.ImageName]
 		opts := docker.BuildOptions{Tag: tag, Mode: config.RunModes.Dev}
-		_, err := b.dockerDaemon.Build(ctx, out, artifact.Workspace, artifact.DockerArtifact, opts)
+		_, err := b.dockerDaemon.Build(ctx, out, artifact.Workspace, artifact.ImageName, artifact.DockerArtifact, opts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/skaffold/build/cluster/cluster.go
+++ b/pkg/skaffold/build/cluster/cluster.go
@@ -66,7 +66,7 @@ func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *lat
 	requiredImages := docker.ResolveDependencyImages(a.Dependencies, b.artifactStore, true)
 	switch {
 	case a.KanikoArtifact != nil:
-		return b.buildWithKaniko(ctx, out, a.Workspace, a.KanikoArtifact, tag, requiredImages)
+		return b.buildWithKaniko(ctx, out, a.Workspace, a.ImageName, a.KanikoArtifact, tag, requiredImages)
 
 	case a.CustomArtifact != nil:
 		return custom.NewArtifactBuilder(nil, b.cfg, true, append(b.retrieveExtraEnv(), util.EnvPtrMapToSlice(requiredImages, "=")...)).Build(ctx, out, a, tag)

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -37,7 +37,7 @@ import (
 
 const initContainer = "kaniko-init-container"
 
-func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace string, artifact *latest.KanikoArtifact, tag string, requiredImages map[string]*string) (string, error) {
+func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace string, artifactName string, artifact *latest.KanikoArtifact, tag string, requiredImages map[string]*string) (string, error) {
 	generatedEnvs, err := generateEnvFromImage(tag)
 	if err != nil {
 		return "", fmt.Errorf("error processing generated env variables from image uri: %w", err)
@@ -77,7 +77,7 @@ func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace 
 		}
 	}()
 
-	if err := b.copyKanikoBuildContext(ctx, workspace, artifact, pods, pod.Name); err != nil {
+	if err := b.copyKanikoBuildContext(ctx, workspace, artifactName, artifact, pods, pod.Name); err != nil {
 		return "", fmt.Errorf("copying sources: %w", err)
 	}
 
@@ -97,7 +97,7 @@ func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace 
 // first copy over the buildcontext tarball into the init container tmp dir via kubectl cp
 // Via kubectl exec, we extract the tarball to the empty dir
 // Then, via kubectl exec, create the /tmp/complete file via kubectl exec to complete the init container
-func (b *Builder) copyKanikoBuildContext(ctx context.Context, workspace string, artifact *latest.KanikoArtifact, pods corev1.PodInterface, podName string) error {
+func (b *Builder) copyKanikoBuildContext(ctx context.Context, workspace string, artifactName string, artifact *latest.KanikoArtifact, pods corev1.PodInterface, podName string) error {
 	if err := kubernetes.WaitForPodInitialized(ctx, pods, podName); err != nil {
 		return fmt.Errorf("waiting for pod to initialize: %w", err)
 	}
@@ -105,7 +105,7 @@ func (b *Builder) copyKanikoBuildContext(ctx context.Context, workspace string, 
 	buildCtx, buildCtxWriter := io.Pipe()
 	go func() {
 		err := docker.CreateDockerTarContext(ctx, buildCtxWriter, docker.NewBuildConfig(
-			workspace, artifact.Image, artifact.DockerfilePath, artifact.BuildArgs), b.cfg)
+			workspace, artifactName, artifact.DockerfilePath, artifact.BuildArgs), b.cfg)
 		if err != nil {
 			buildCtxWriter.CloseWithError(fmt.Errorf("creating docker context: %w", err))
 			return

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -104,10 +104,8 @@ func (b *Builder) copyKanikoBuildContext(ctx context.Context, workspace string, 
 
 	buildCtx, buildCtxWriter := io.Pipe()
 	go func() {
-		err := docker.CreateDockerTarContext(ctx, buildCtxWriter, workspace, &latest.DockerArtifact{
-			BuildArgs:      artifact.BuildArgs,
-			DockerfilePath: artifact.DockerfilePath,
-		}, b.cfg)
+		err := docker.CreateDockerTarContext(ctx, buildCtxWriter, docker.NewBuildConfig(
+			workspace, artifact.Image, artifact.DockerfilePath, artifact.BuildArgs), b.cfg)
 		if err != nil {
 			buildCtxWriter.CloseWithError(fmt.Errorf("creating docker context: %w", err))
 			return

--- a/pkg/skaffold/build/custom/dependencies.go
+++ b/pkg/skaffold/build/custom/dependencies.go
@@ -30,11 +30,10 @@ import (
 )
 
 // GetDependencies returns dependencies listed for a custom artifact
-func GetDependencies(ctx context.Context, workspace string, a *latest.CustomArtifact, cfg docker.Config) ([]string, error) {
+func GetDependencies(ctx context.Context, workspace string, artifactName string, a *latest.CustomArtifact, cfg docker.Config) ([]string, error) {
 	switch {
 	case a.Dependencies.Dockerfile != nil:
-		dockerfile := a.Dependencies.Dockerfile
-		return docker.GetDependencies(ctx, workspace, dockerfile.Path, dockerfile.BuildArgs, cfg)
+		return docker.GetDependencies(ctx, getDockerBuildConfig(workspace, artifactName, a), cfg)
 
 	case a.Dependencies.Command != "":
 		split := strings.Split(a.Dependencies.Command, " ")
@@ -52,4 +51,9 @@ func GetDependencies(ctx context.Context, workspace string, a *latest.CustomArti
 	default:
 		return list.Files(workspace, a.Dependencies.Paths, a.Dependencies.Ignore)
 	}
+}
+
+func getDockerBuildConfig(ws string, artifact string, a *latest.CustomArtifact) docker.BuildConfig {
+	dockerfile := a.Dependencies.Dockerfile
+	return docker.NewBuildConfig(ws, artifact, dockerfile.Path, dockerfile.BuildArgs)
 }

--- a/pkg/skaffold/build/custom/dependencies_test.go
+++ b/pkg/skaffold/build/custom/dependencies_test.go
@@ -50,7 +50,7 @@ func TestGetDependenciesDockerfile(t *testing.T) {
 	}
 
 	expected := []string{"Dockerfile", filepath.FromSlash("baz/file"), "foo"}
-	deps, err := GetDependencies(context.Background(), tmpDir.Root(), customArtifact, nil)
+	deps, err := GetDependencies(context.Background(), tmpDir.Root(), "test", customArtifact, nil)
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected, deps)
 }
@@ -69,7 +69,7 @@ func TestGetDependenciesCommand(t *testing.T) {
 		}
 
 		expected := []string{"file1", "file2", "file3"}
-		deps, err := GetDependencies(context.Background(), "", customArtifact, nil)
+		deps, err := GetDependencies(context.Background(), "", "test", customArtifact, nil)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(expected, deps)
@@ -119,7 +119,7 @@ func TestGetDependenciesPaths(t *testing.T) {
 			tmpDir := t.NewTempDir().
 				Touch("foo", "bar", "baz/file")
 
-			deps, err := GetDependencies(context.Background(), tmpDir.Root(), &latest.CustomArtifact{
+			deps, err := GetDependencies(context.Background(), tmpDir.Root(), "test", &latest.CustomArtifact{
 				Dependencies: &latest.CustomDependencies{
 					Paths:  test.paths,
 					Ignore: test.ignore,

--- a/pkg/skaffold/build/dependencies.go
+++ b/pkg/skaffold/build/dependencies.go
@@ -48,7 +48,7 @@ func DependenciesForArtifact(ctx context.Context, a *latest.Artifact, cfg docker
 		if evalErr != nil {
 			return nil, fmt.Errorf("unable to evaluate build args: %w", evalErr)
 		}
-		paths, err = docker.GetDependencies(ctx, a.Workspace, a.DockerArtifact.DockerfilePath, args, cfg)
+		paths, err = docker.GetDependencies(ctx, docker.NewBuildConfig(a.Workspace, a.ImageName, a.DockerArtifact.DockerfilePath, args), cfg)
 
 	case a.KanikoArtifact != nil:
 		deps := docker.ResolveDependencyImages(a.Dependencies, r, false)
@@ -56,7 +56,7 @@ func DependenciesForArtifact(ctx context.Context, a *latest.Artifact, cfg docker
 		if evalErr != nil {
 			return nil, fmt.Errorf("unable to evaluate build args: %w", evalErr)
 		}
-		paths, err = docker.GetDependencies(ctx, a.Workspace, a.KanikoArtifact.DockerfilePath, args, cfg)
+		paths, err = docker.GetDependencies(ctx, docker.NewBuildConfig(a.Workspace, a.ImageName, a.KanikoArtifact.DockerfilePath, args), cfg)
 
 	case a.BazelArtifact != nil:
 		paths, err = bazel.GetDependencies(ctx, a.Workspace, a.BazelArtifact)
@@ -65,7 +65,7 @@ func DependenciesForArtifact(ctx context.Context, a *latest.Artifact, cfg docker
 		paths, err = jib.GetDependencies(ctx, a.Workspace, a.JibArtifact)
 
 	case a.CustomArtifact != nil:
-		paths, err = custom.GetDependencies(ctx, a.Workspace, a.CustomArtifact, cfg)
+		paths, err = custom.GetDependencies(ctx, a.Workspace, a.ImageName, a.CustomArtifact, cfg)
 
 	case a.BuildpackArtifact != nil:
 		paths, err = buildpacks.GetDependencies(ctx, a.Workspace, a.BuildpackArtifact)

--- a/pkg/skaffold/build/docker/docker.go
+++ b/pkg/skaffold/build/docker/docker.go
@@ -50,7 +50,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, a *latest.Artifact, 
 	if b.useCLI {
 		imageID, err = b.dockerCLIBuild(ctx, color.GetWriter(out), a.Workspace, dockerfile, a.ArtifactType.DockerArtifact, opts)
 	} else {
-		imageID, err = b.localDocker.Build(ctx, out, a.Workspace, a.ArtifactType.DockerArtifact, opts)
+		imageID, err = b.localDocker.Build(ctx, out, a.Workspace, a.ImageName, a.ArtifactType.DockerArtifact, opts)
 	}
 
 	if err != nil {

--- a/pkg/skaffold/diagnose/diagnose.go
+++ b/pkg/skaffold/diagnose/diagnose.go
@@ -136,7 +136,8 @@ func timeToComputeMTimes(deps []string) (time.Duration, error) {
 func sizeOfDockerContext(ctx context.Context, a *latest.Artifact, cfg docker.Config) (int64, error) {
 	buildCtx, buildCtxWriter := io.Pipe()
 	go func() {
-		err := docker.CreateDockerTarContext(ctx, buildCtxWriter, a.Workspace, a.DockerArtifact, cfg)
+		err := docker.CreateDockerTarContext(ctx, buildCtxWriter, docker.NewBuildConfig(
+			a.Workspace, a.ImageName, a.DockerArtifact.DockerfilePath, nil), cfg)
 		if err != nil {
 			buildCtxWriter.CloseWithError(fmt.Errorf("creating docker context: %w", err))
 			return

--- a/pkg/skaffold/docker/context.go
+++ b/pkg/skaffold/docker/context.go
@@ -22,22 +22,21 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
-func CreateDockerTarContext(ctx context.Context, w io.Writer, workspace string, a *latest.DockerArtifact, cfg Config) error {
-	paths, err := GetDependenciesCached(ctx, workspace, a.DockerfilePath, a.BuildArgs, cfg)
+func CreateDockerTarContext(ctx context.Context, w io.Writer, buildCfg BuildConfig, cfg Config) error {
+	paths, err := GetDependenciesCached(ctx, buildCfg, cfg)
 	if err != nil {
 		return fmt.Errorf("getting relative tar paths: %w", err)
 	}
 
 	var p []string
 	for _, path := range paths {
-		p = append(p, filepath.Join(workspace, path))
+		p = append(p, filepath.Join(buildCfg.workspace, path))
 	}
 
-	if err := util.CreateTar(w, workspace, p); err != nil {
+	if err := util.CreateTar(w, buildCfg.workspace, p); err != nil {
 		return fmt.Errorf("creating tar gz: %w", err)
 	}
 

--- a/pkg/skaffold/docker/context.go
+++ b/pkg/skaffold/docker/context.go
@@ -27,7 +27,7 @@ import (
 )
 
 func CreateDockerTarContext(ctx context.Context, w io.Writer, workspace string, a *latest.DockerArtifact, cfg Config) error {
-	paths, err := GetDependencies(ctx, workspace, a.DockerfilePath, a.BuildArgs, cfg)
+	paths, err := GetDependenciesCached(ctx, workspace, a.DockerfilePath, a.BuildArgs, cfg)
 	if err != nil {
 		return fmt.Errorf("getting relative tar paths: %w", err)
 	}

--- a/pkg/skaffold/docker/context_test.go
+++ b/pkg/skaffold/docker/context_test.go
@@ -46,7 +46,7 @@ func TestDockerContext(t *testing.T) {
 
 			reader, writer := io.Pipe()
 			go func() {
-				err := CreateDockerTarContext(context.Background(), writer, dir, artifact, nil)
+				err := CreateDockerTarContext(context.Background(), writer, NewBuildConfig(dir, "test", artifact.DockerfilePath, artifact.BuildArgs), nil)
 				if err != nil {
 					writer.CloseWithError(err)
 				} else {

--- a/pkg/skaffold/docker/dependencies.go
+++ b/pkg/skaffold/docker/dependencies.go
@@ -33,7 +33,25 @@ var (
 	dependencyCache = util.NewSyncStore()
 )
 
-// NormalizeDockerfilePath returns the absolute path to the dockerfile.
+// BuildConfig encapsulates all the build configuration required for performing a dockerbuild.
+type BuildConfig struct {
+	workspace      string
+	artifact       string
+	dockerfilePath string
+	args           map[string]*string
+}
+
+// NewBuildConfig returns a `BuildConfig` for a dockerfilePath build.
+func NewBuildConfig(ws string, a string, path string, args map[string]*string) BuildConfig {
+	return BuildConfig{
+		workspace:      ws,
+		artifact:       a,
+		dockerfilePath: path,
+		args:           args,
+	}
+}
+
+// NormalizeDockerfilePath returns the absolute path to the dockerfilePath.
 func NormalizeDockerfilePath(context, dockerfile string) (string, error) {
 	// Expected case: should be found relative to the context directory.
 	// If it does not exist, check if it's found relative to the current directory in case it's shared.
@@ -50,26 +68,26 @@ func NormalizeDockerfilePath(context, dockerfile string) (string, error) {
 // GetDependencies finds the sources dependency for the given docker artifact.
 // it caches the results for the computed dependency which can be used by `GetDependenciesCached`
 // All paths are relative to the workspace.
-func GetDependencies(ctx context.Context, workspace string, dockerfilePath string, buildArgs map[string]*string, cfg Config) ([]string, error) {
-	absDockerfilePath, err := NormalizeDockerfilePath(workspace, dockerfilePath)
+func GetDependencies(ctx context.Context, buildCfg BuildConfig, cfg Config) ([]string, error) {
+	absDockerfilePath, err := NormalizeDockerfilePath(buildCfg.workspace, buildCfg.dockerfilePath)
 	if err != nil {
-		return nil, fmt.Errorf("normalizing dockerfile path: %w", err)
+		return nil, fmt.Errorf("normalizing dockerfilePath path: %w", err)
 	}
-	result := getDependencies(workspace, dockerfilePath, absDockerfilePath, buildArgs, cfg)
-	dependencyCache.Store(absDockerfilePath, result)
+	result := getDependencies(buildCfg.workspace, buildCfg.dockerfilePath, absDockerfilePath, buildCfg.args, cfg)
+	dependencyCache.Store(buildCfg.artifact, result)
 	return resultPair(result)
 }
 
 // GetDependenciesCached reads from cache finds the sources dependency for the given docker artifact.
 // All paths are relative to the workspace.
-func GetDependenciesCached(ctx context.Context, workspace string, dockerfilePath string, buildArgs map[string]*string, cfg Config) ([]string, error) {
-	absDockerfilePath, err := NormalizeDockerfilePath(workspace, dockerfilePath)
+func GetDependenciesCached(ctx context.Context, buildCfg BuildConfig, cfg Config) ([]string, error) {
+	absDockerfilePath, err := NormalizeDockerfilePath(buildCfg.workspace, buildCfg.dockerfilePath)
 	if err != nil {
-		return nil, fmt.Errorf("normalizing dockerfile path: %w", err)
+		return nil, fmt.Errorf("normalizing dockerfilePath path: %w", err)
 	}
 
-	deps := dependencyCache.Exec(absDockerfilePath, func() interface{} {
-		return getDependencies(workspace, dockerfilePath, absDockerfilePath, buildArgs, cfg)
+	deps := dependencyCache.Exec(buildCfg.artifact, func() interface{} {
+		return getDependencies(buildCfg.workspace, buildCfg.dockerfilePath, absDockerfilePath, buildCfg.args, cfg)
 	})
 	return resultPair(deps)
 }

--- a/pkg/skaffold/docker/dependencies_test.go
+++ b/pkg/skaffold/docker/dependencies_test.go
@@ -577,7 +577,7 @@ func TestGetDependencies(t *testing.T) {
 			}
 
 			workspace := tmpDir.Path(test.workspace)
-			deps, err := GetDependencies(context.Background(), workspace, "Dockerfile", test.buildArgs, nil)
+			deps, err := GetDependencies(context.Background(), NewBuildConfig(workspace, "test", "Dockerfile", test.buildArgs), nil)
 
 			t.CheckError(test.shouldErr, err)
 			t.CheckDeepEqual(test.expected, deps)
@@ -674,7 +674,7 @@ func TestGetDependenciesCached(t *testing.T) {
 			retrieveImgMock: func(_ string, _ Config) (*v1.ConfigFile, error) {
 				return nil, fmt.Errorf("unexpected call")
 			},
-			dependencyCache: map[string]interface{}{"Dockerfile": []string{"random.go"}},
+			dependencyCache: map[string]interface{}{"dummy": []string{"random.go"}},
 			expected:        []string{"random.go"},
 		},
 		{
@@ -682,15 +682,14 @@ func TestGetDependenciesCached(t *testing.T) {
 			retrieveImgMock: func(_ string, _ Config) (*v1.ConfigFile, error) {
 				return &v1.ConfigFile{}, nil
 			},
-			dependencyCache: map[string]interface{}{"Dockerfile": fmt.Errorf("remote manifest fetch")},
+			dependencyCache: map[string]interface{}{"dummy": fmt.Errorf("remote manifest fetch")},
 			shouldErr:       true,
 		},
 		{
 			description:     "with cached results for dockerfile in another app",
 			retrieveImgMock: imageFetcher.fetch,
-			dependencyCache: map[string]interface{}{
-				filepath.Join("app", "Dockerfile"): []string{"random.go"}},
-			expected: []string{"Dockerfile", "server.go"},
+			dependencyCache: map[string]interface{}{"another": []string{"random.go"}},
+			expected:        []string{"Dockerfile", "server.go"},
 		},
 	}
 
@@ -704,11 +703,11 @@ func TestGetDependenciesCached(t *testing.T) {
 			tmpDir.Write("Dockerfile", copyServerGo)
 
 			for k, v := range test.dependencyCache {
-				dependencyCache.Exec(tmpDir.Path(k), func() interface{} {
+				dependencyCache.Exec(k, func() interface{} {
 					return v
 				})
 			}
-			deps, err := GetDependenciesCached(context.Background(), tmpDir.Root(), "Dockerfile", map[string]*string{}, nil)
+			deps, err := GetDependenciesCached(context.Background(), NewBuildConfig(tmpDir.Root(), "dummy", "Dockerfile", map[string]*string{}), nil)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, deps)
 		})
 	}

--- a/pkg/skaffold/docker/dependencies_test.go
+++ b/pkg/skaffold/docker/dependencies_test.go
@@ -708,7 +708,7 @@ func TestGetDependenciesCached(t *testing.T) {
 					return v
 				})
 			}
-			deps, err := GetDependencies(context.Background(), tmpDir.Root(), "Dockerfile", map[string]*string{}, nil)
+			deps, err := GetDependenciesCached(context.Background(), tmpDir.Root(), "Dockerfile", map[string]*string{}, nil)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, deps)
 		})
 	}

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -200,7 +200,7 @@ func TestBuild(t *testing.T) {
 
 			localDocker := NewLocalDaemon(test.api, nil, false, nil)
 			opts := BuildOptions{Tag: "finalimage", Mode: test.mode}
-			_, err := localDocker.Build(context.Background(), ioutil.Discard, test.workspace, test.artifact, opts)
+			_, err := localDocker.Build(context.Background(), ioutil.Discard, test.workspace, "final-image", test.artifact, opts)
 
 			if test.shouldErr {
 				t.CheckErrorContains(test.expectedError, err)

--- a/pkg/skaffold/util/store.go
+++ b/pkg/skaffold/util/store.go
@@ -56,7 +56,7 @@ func (o *SyncStore) Exec(key string, f func() interface{}) interface{} {
 
 // Store will store the results for a key in a cache
 // This function is not safe to use if multiple subroutines store the
-// result for the same artifact.
+// result for the same key.
 func (o *SyncStore) Store(key string, r interface{}) {
 	o.results.Store(key, r)
 }

--- a/pkg/skaffold/util/store.go
+++ b/pkg/skaffold/util/store.go
@@ -54,6 +54,15 @@ func (o *SyncStore) Exec(key string, f func() interface{}) interface{} {
 	return val
 }
 
+// Store will store the results for a key in a cache
+// It makes sure only one execution is in-flight for a given key at any time.
+func (o *SyncStore) Store(key string, r interface{}) {
+	o.sf.Do(fmt.Sprintf("%s-put", key), func() (interface{}, error) {
+		o.results.Store(key, r)
+		return nil, nil
+	})
+}
+
 // NewSyncStore returns a new instance of `SyncStore`
 func NewSyncStore() *SyncStore {
 	return &SyncStore{

--- a/pkg/skaffold/util/store.go
+++ b/pkg/skaffold/util/store.go
@@ -55,12 +55,10 @@ func (o *SyncStore) Exec(key string, f func() interface{}) interface{} {
 }
 
 // Store will store the results for a key in a cache
-// It makes sure only one execution is in-flight for a given key at any time.
+// This function is not safe to use if multiple subroutines store the
+// result for the same artifact.
 func (o *SyncStore) Store(key string, r interface{}) {
-	o.sf.Do(fmt.Sprintf("%s-put", key), func() (interface{}, error) {
-		o.results.Store(key, r)
-		return nil, nil
-	})
+	o.results.Store(key, r)
 }
 
 // NewSyncStore returns a new instance of `SyncStore`


### PR DESCRIPTION
fixes #5110 & #5115 

In #4896, we cache results for `docker.GetDependencies` since there were getting computed atleast 2 times for docker builds.
However, this PR ended up caching the results across dev loops. 

In this PR, 
- add `GetCachedDependencies` which will be used in subsequent calls. 
- change the key for caching dependencies result from "absolute dockerfile path" to "artifact" name
This fixes issue in #5115 where same dockerfile was used in different artifacts. 

### Alternate approach considered,
1. To create a  new [`dependencyCache`](https://github.com/GoogleContainerTools/skaffold/blob/e2a4106f6b2b328a7a3bc66f957361b625a43b9f/pkg/skaffold/docker/dependencies.go#L33) for each loop.

- this would have required a huge refactor as `docker.GetDependency` is a public method.

2. To invalidate the `dependencyCache` at end of each [dev loop](https://github.com/GoogleContainerTools/skaffold/blob/e2a4106f6b2b328a7a3bc66f957361b625a43b9f/pkg/skaffold/runner/dev.go#L122)
```
event.DevLoopComplete(r.devIteration)
// invalidate all cached GetDependencies.
docker.InvalidateDependencyCache()
logger.Unmute()

```
This would have required adding `pkg/skaffold/docker` package dependency in `pkg/skaffold/runner`.  If all dependencies were cached, we could have added `InvalidateDependencyCache()` to `Builder` interface. However only docker dependencies are cached, so went with the approach to add a new method `GetCachedDependencies` and use it when creating tar context


### Testing notes
1. make 
2. go to examples/hot-reload
3. `skaffold dev`
4. Add a new js file `touch node/src/new.js`
5. Verify a dev loop is started.

```
Watching for changes...
[node] Example app listening on port 3000!
INFO[0040] files added: [node/src/new.js] 
Syncing 1 files for node-example:682863e6ee15639b6fceb28c79308b206f6fb329188e18907fc0a766e77b2cc0
INFO[0040] Copying files: map[node/src/new.js:[/home/node/app/src/new.js]] to node-example:682863e6ee15639b6fceb28c79308b206f6fb329188e18907fc0a766e77b2cc0 

Watching for changes...
```


