### PR TITLE
write metrics to file

### DIFF
--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -46,6 +46,7 @@ const (
 
 	DefaultSkaffoldDir = ".skaffold"
 	DefaultCacheFile   = "cache"
+	DefaultMetricFile  = "metrics"
 
 	DefaultRPCPort     = 50051
 	DefaultRPCHTTPPort = 50052

--- a/pkg/skaffold/instrumentation/meter_test.go
+++ b/pkg/skaffold/instrumentation/meter_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instrumentation
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"github.com/GoogleContainerTools/skaffold/proto"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestExportMetrics(t *testing.T) {
+	startTime, _ := time.Parse(time.ANSIC, "Mon Jan 2 15:04:05 -0700 MST 2006")
+	validMeter := skaffoldMeter{
+		Command:        "build",
+		BuildArtifacts: 5,
+		Version:        "vTest.0",
+		Arch:           "test arch",
+		OS:             "test os",
+		Builders:       map[string]bool{"docker": true, "buildpacks": true},
+		EnumFlags:      map[string]*pflag.Flag{"test": {Name: "test", Shorthand: "t"}},
+		StartTime:      startTime,
+		Duration:       time.Minute,
+	}
+	validMeterBytes, _ := json.Marshal(validMeter)
+
+	tests := []struct {
+		name                string
+		meter               skaffoldMeter
+		savedMetrics        []byte
+		shouldSkip          bool
+		shouldFailUnmarshal bool
+	}{
+		{
+			name:       "skips exporting if command is not set",
+			shouldSkip: true,
+		},
+		{
+			name:  "saves meter to a new file",
+			meter: validMeter,
+		},
+		{
+			name: "meter is appended to previously saved metrics",
+			meter: skaffoldMeter{
+				Command:      "dev",
+				Version:      "vTest.1",
+				Arch:         "test arch 2",
+				OS:           "test os 2",
+				PlatformType: "test platform",
+				Deployers:    []string{"test helm", "test kpt"},
+				SyncType:     map[string]bool{"manual": true},
+				EnumFlags:    map[string]*pflag.Flag{"test_run": {Name: "test_run", Shorthand: "r"}},
+				ErrorCode:    proto.StatusCode_BUILD_CANCELLED,
+				StartTime:    startTime.Add(time.Hour * 24 * 30),
+				Duration:     time.Minute,
+			},
+			savedMetrics: validMeterBytes,
+		},
+		{
+			name:                "meter does not re-save invalid metrics",
+			meter:               validMeter,
+			savedMetrics:        []byte("[{\"Command\":\"run\", Invalid\": 10000000000010202301230}]"),
+			shouldFailUnmarshal: true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			t.Override(&skipExport, "true")
+			filename := "metrics"
+			tmp := t.NewTempDir()
+			var savedMetrics []skaffoldMeter
+			_ = json.Unmarshal(test.savedMetrics, &savedMetrics)
+
+			if len(test.savedMetrics) > 0 {
+				err := ioutil.WriteFile(tmp.Path(filename), test.savedMetrics, 0666)
+				if err != nil {
+					t.Error(err)
+				}
+			}
+			_ = exportMetrics(tmp.Path(filename), test.meter)
+
+			if test.shouldSkip {
+				_, err := os.Stat(filename)
+				t.CheckDeepEqual(true, os.IsNotExist(err))
+			} else {
+				b, _ := ioutil.ReadFile(tmp.Path(filename))
+				var actual []skaffoldMeter
+				_ = json.Unmarshal(b, &actual)
+				expected := append(savedMetrics, test.meter)
+				if test.shouldFailUnmarshal {
+					expected = []skaffoldMeter{test.meter}
+				}
+				t.CheckDeepEqual(expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description**
Get exit code from main function. Write skaffold meter struct to a file only if ```SKAFFOLD_METRICS``` environment variable is set and is ```true```. If metrics have been written before, append these metrics to the existing ones and write it out.

**Follow-up Work**
<!-- Mention any related follow up work to this PR. -->
Embed secret into skaffold, and upload metrics to cloud monitoring. Update deploy configuration to write service account keys into skaffold. Create relevant documentation, and prompt users to opt-out.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
