### PR TITLE
remove last traces of vendor

### DIFF
--- a/deploy/webhook/Dockerfile
+++ b/deploy/webhook/Dockerfile
@@ -49,7 +49,7 @@ COPY --from=download-kubectl /kubectl /usr/local/bin/
 FROM golang:1.14 as webhook
 WORKDIR /skaffold
 COPY . .
-RUN go build -mod=vendor -o /webhook webhook/webhook.go
+RUN go build -o /webhook webhook/webhook.go
 
 FROM runtime_deps
 COPY --from=webhook /webhook /webhook


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5123 <!-- tracking issues that this PR will close -->
**Related**: #5090 

**Description**
The build was failing because we no longer have the vendor folder, so by removing ```-mod-vendor``` the build now completes successfully. To verify just run ```skaffold -f deploy/webhook/skaffold.yaml build``` and the build will succeed unlike on master.

![image](https://user-images.githubusercontent.com/12650821/101923354-49438c80-3b9d-11eb-98b5-5cbc1a9c3133.png)


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
