### PR TITLE
Fix `skaffold debug` for helm charts with skaffold config file other than default `skaffold.yaml`

### DIFF
--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -76,6 +76,7 @@ type Deployer struct {
 	kubeContext string
 	kubeConfig  string
 	namespace   string
+	configFile  string
 
 	// packaging temporary directory, used for predictable test output
 	pkgTmpDir string
@@ -106,6 +107,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string) (*Deployer, error
 		kubeConfig:  cfg.GetKubeConfig(),
 		namespace:   cfg.GetKubeNamespace(),
 		forceDeploy: cfg.ForceDeploy(),
+		configFile:  cfg.ConfigurationFile(),
 		labels:      labels,
 		bV:          hv,
 		enableDebug: cfg.Mode() == config.RunModes.Debug,
@@ -346,6 +348,7 @@ func (h *Deployer) deployRelease(ctx context.Context, out io.Writer, r latest.He
 		// need to include current environment, specifically for HOME to lookup ~/.kube/config
 		env := util.EnvSliceToMap(util.OSEnviron(), "=")
 		env["SKAFFOLD_CMDLINE"] = shell.Join(cmdLine...)
+		env["SKAFFOLD_FILENAME"] = h.configFile
 		installEnv = util.EnvMapToSlice(env, "=")
 	}
 

--- a/pkg/skaffold/deploy/types/types.go
+++ b/pkg/skaffold/deploy/types/types.go
@@ -29,6 +29,7 @@ type Config interface {
 	Pipeline() latest.Pipeline
 	GetWorkingDir() string
 	GlobalConfig() string
+	ConfigurationFile() string
 	DefaultRepo() *string
 	SkipRender() bool
 }


### PR DESCRIPTION
Fixes #5133

Add `SKAFFOLD_FILENAME` environment variable while debugging so `--post-renderer` skaffold can run successfully.

Before on master 
```
cd examples/helm-deployment && mv skaffold.yaml test.yaml
skaffold  -f test.yaml debug
Helm release skaffold-helm not installed. Installing...
Error: error while running post render on files: error while running command /Users/tejaldesai/Downloads/google-cloud-sdk2/bin/skaffold. error output:
skaffold config file skaffold.yaml not found - check your current working directory, or try running `skaffold init`
: exit status 1
exiting dev mode because first deploy failed: install: exit status 1
```

On branch, 
```
 ../../out/skaffold -f test.yaml debug 
Tags used in deployment:
 - skaffold-helm -> skaffold-helm:a31ad23b8173b820bccafe6d15a75155be1862b564d214d8be5735ad045ff71c
Starting deploy...
Helm release skaffold-helm not installed. Installing...
NAME: skaffold-helm
LAST DEPLOYED: Fri Dec 11 09:52:51 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
Waiting for deployments to stabilize...
 - deployment/skaffold-helm: waiting for rollout to finish: 0 of 1 updated replicas are available...
 - deployment/skaffold-helm is ready.
Deployments stabilized in 6.214218497s
Press Ctrl+C to exit
Not watching for changes...
[install-go-debug-support] Installing runtime debugging support files in /dbg
[install-go-debug-support] Installation complete
[skaffold-helm] API server listening at: [::]:56268
```

```