### PR TITLE
add functions that will be used for transparent init feature

### DIFF
--- a/pkg/skaffold/initializer/prompt/prompt.go
+++ b/pkg/skaffold/initializer/prompt/prompt.go
@@ -25,6 +25,9 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/util"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
 // For testing
@@ -99,4 +102,33 @@ func portForwardResource(out io.Writer, imageName string) (int, error) {
 
 	responseInt, _ := strconv.Atoi(response)
 	return responseInt, nil
+}
+
+// ConfirmInitOptions prompts the user to confirm that they are okay with what skaffold will do if they
+// run with the current config
+func ConfirmInitOptions(out io.Writer, config *latest.SkaffoldConfig) (bool, error) {
+	builders := strings.Join(util.ListBuilders(&config.Build), ",")
+	deployers := strings.Join(util.ListDeployers(&config.Deploy), ",")
+
+	var response string
+	prompt := &survey.Select{
+		Message: fmt.Sprintf(`If you choose to continue, skaffold will do the following:
+  - Create a skaffold config file for you
+  - Build your application using %s
+  - Deploy your application to your current kubernetes context using %s
+  
+  Would you like to continue?`, builders, deployers),
+		Options:  []string{"yes", "no"},
+		PageSize: 5,
+	}
+	err := survey.AskOne(prompt, &response, nil)
+	if err != nil {
+		return true, err
+	}
+
+	if response == "no" {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/pkg/skaffold/initializer/transparent.go
+++ b/pkg/skaffold/initializer/transparent.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initializer
+
+import (
+	"context"
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	initConfig "github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+)
+
+// Transparent executes the `skaffold init` flow, but always enables the --force flag.
+// It will also always prompt the user to confirm at the end of the flow.
+func Transparent(ctx context.Context, out io.Writer, opts config.SkaffoldOptions) (*latest.SkaffoldConfig, error) {
+	c := initConfig.Config{
+		Force: true,
+		Opts:  opts,
+	}
+
+	if c.ComposeFile != "" {
+		if err := runKompose(ctx, c.ComposeFile); err != nil {
+			return nil, err
+		}
+	}
+
+	a, err := AnalyzeProject(c)
+	if err != nil {
+		return nil, err
+	}
+
+	newConfig, newManifests, err := Initialize(out, c, a)
+	// If the --analyze flag is used, we return early with the result of PrintAnalysis()
+	// TODO(marlongamez): Figure out a cleaner way to do this. Might have to change return values to include the different Initializers.
+	if err != nil || c.Analyze {
+		return nil, err
+	}
+
+	if done, err := prompt.ConfirmInitOptions(out, newConfig); done {
+		return nil, err
+	}
+
+	if err := WriteData(out, c, newConfig, newManifests); err != nil {
+		return nil, err
+	}
+
+	return newConfig, nil
+}

--- a/pkg/skaffold/initializer/util/util.go
+++ b/pkg/skaffold/initializer/util/util.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+// ListBuilders returns a list of builder names being used in the given build config.
+func ListBuilders(build *latest.BuildConfig) []string {
+	if build == nil {
+		return []string{}
+	}
+
+	results := util.NewStringSet()
+	for _, artifact := range build.Artifacts {
+		results.Insert(misc.ArtifactType(artifact))
+	}
+
+	return results.ToList()
+}
+
+// ListDeployers returns a list of deployer names being used in the given deploy config.
+func ListDeployers(deploy *latest.DeployConfig) []string {
+	if deploy == nil {
+		return []string{}
+	}
+
+	results := util.NewStringSet()
+	if deploy.HelmDeploy != nil {
+		results.Insert("helm")
+	}
+	if deploy.KptDeploy != nil {
+		results.Insert("kpt")
+	}
+	if deploy.KubectlDeploy != nil {
+		results.Insert("kubectl")
+	}
+	if deploy.KustomizeDeploy != nil {
+		results.Insert("kustomize")
+	}
+
+	return results.ToList()
+}

--- a/pkg/skaffold/initializer/util/util_test.go
+++ b/pkg/skaffold/initializer/util/util_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestListBuilders(t *testing.T) {
+	tests := []struct {
+		description string
+		build       *latest.BuildConfig
+		expected    []string
+	}{
+		{
+			description: "nil config",
+			build:       nil,
+			expected:    []string{},
+		},
+		{
+			description: "multiple same builder config",
+			build: &latest.BuildConfig{
+				Artifacts: []*latest.Artifact{
+					{ImageName: "img1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+					{ImageName: "img2", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+				},
+			},
+			expected: []string{"docker"},
+		},
+		{
+			description: "different builders config",
+			build: &latest.BuildConfig{
+				Artifacts: []*latest.Artifact{
+					{ImageName: "img1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+					{ImageName: "img2", ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{}}},
+				},
+			},
+			expected: []string{"docker", "jib"},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			got := ListBuilders(test.build)
+			t.CheckDeepEqual(test.expected, got)
+		})
+	}
+}
+
+func TestListDeployers(t *testing.T) {
+	tests := []struct {
+		description string
+		deploy      *latest.DeployConfig
+		expected    []string
+	}{
+		{
+			description: "nil config",
+			deploy:      nil,
+			expected:    []string{},
+		},
+		{
+			description: "single deployer config",
+			deploy: &latest.DeployConfig{
+				DeployType: latest.DeployType{
+					KubectlDeploy: &latest.KubectlDeploy{},
+				},
+			},
+			expected: []string{"kubectl"},
+		},
+		{
+			description: "multiple deployers config",
+			deploy: &latest.DeployConfig{
+				DeployType: latest.DeployType{
+					HelmDeploy:    &latest.HelmDeploy{},
+					KubectlDeploy: &latest.KubectlDeploy{},
+				},
+			},
+			expected: []string{"helm", "kubectl"},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			got := ListDeployers(test.deploy)
+			t.CheckDeepEqual(test.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
**Related**: https://github.com/GoogleContainerTools/skaffold/pull/4915

**Description**
This PR adds the functions that will be used to implement the transparent init feature.
The main functions here are the Transparent() function (could be named better), and the ConfirmInitOptions() prompt function.

There are also some new util functions defined in pkg/skaffold/initializer/util

**Follow-up Work (remove if N/A)**
Use these functions to implement transparent init
