### PR TITLE
new init prompt function and helper functions

### DIFF
--- a/pkg/skaffold/initializer/prompt/prompt.go
+++ b/pkg/skaffold/initializer/prompt/prompt.go
@@ -25,6 +25,9 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/util"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
 // For testing
@@ -99,4 +102,33 @@ func portForwardResource(out io.Writer, imageName string) (int, error) {
 
 	responseInt, _ := strconv.Atoi(response)
 	return responseInt, nil
+}
+
+// ConfirmInitOptions prompts the user to confirm that they are okay with what skaffold will do if they
+// run with the current config
+func ConfirmInitOptions(out io.Writer, config *latest.SkaffoldConfig) (bool, error) {
+	builders := strings.Join(util.ListBuilders(&config.Build), ",")
+	deployers := strings.Join(util.ListDeployers(&config.Deploy), ",")
+
+	var response string
+	prompt := &survey.Select{
+		Message: fmt.Sprintf(`If you choose to continue, skaffold will do the following:
+  - Create a skaffold config file for you
+  - Build your application using %s
+  - Deploy your application to your current kubernetes context using %s
+  
+  Would you like to continue?`, builders, deployers),
+		Options:  []string{"yes", "no"},
+		PageSize: 5,
+	}
+	err := survey.AskOne(prompt, &response, nil)
+	if err != nil {
+		return true, err
+	}
+
+	if response == "no" {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/pkg/skaffold/initializer/prompt/prompt.go
+++ b/pkg/skaffold/initializer/prompt/prompt.go
@@ -111,25 +111,22 @@ func ConfirmInitOptions(out io.Writer, config *latest.SkaffoldConfig) (bool, err
 	builders := strings.Join(util.ListBuilders(&config.Build), ",")
 	deployers := strings.Join(util.ListDeployers(&config.Deploy), ",")
 
-	var response string
-	prompt := &survey.Select{
-		Message: fmt.Sprintf(`If you choose to continue, skaffold will do the following:
+	fmt.Fprintf(out, `If you choose to continue, skaffold will do the following:
   - Create a skaffold config file for you
   - Build your application using %s
   - Deploy your application to your current kubernetes context using %s
-  
-  Would you like to continue?`, builders, deployers),
-		Options:  []string{"yes", "no"},
-		PageSize: 5,
+
+`, builders, deployers)
+
+	var response bool
+	prompt := &survey.Confirm{
+		Message: "Would you like to continue?",
 	}
 	err := askOne(prompt, &response, nil)
 	if err != nil {
 		return true, err
 	}
 
-	if response == "no" {
-		return true, nil
-	}
-
-	return false, nil
+	// invert response because "no" == done and "yes" == !done
+	return !response, nil
 }

--- a/pkg/skaffold/initializer/prompt/prompt.go
+++ b/pkg/skaffold/initializer/prompt/prompt.go
@@ -34,6 +34,7 @@ import (
 var (
 	BuildConfigFunc         = buildConfig
 	PortForwardResourceFunc = portForwardResource
+	askOne                  = survey.AskOne
 )
 
 func buildConfig(image string, choices []string) (string, error) {
@@ -121,7 +122,7 @@ func ConfirmInitOptions(out io.Writer, config *latest.SkaffoldConfig) (bool, err
 		Options:  []string{"yes", "no"},
 		PageSize: 5,
 	}
-	err := survey.AskOne(prompt, &response, nil)
+	err := askOne(prompt, &response, nil)
 	if err != nil {
 		return true, err
 	}

--- a/pkg/skaffold/initializer/prompt/prompt_test.go
+++ b/pkg/skaffold/initializer/prompt/prompt_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prompt
+
+import (
+	"errors"
+	"io/ioutil"
+	"testing"
+
+	"github.com/AlecAivazis/survey/v2"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestConfirmInitOptions(t *testing.T) {
+	tests := []struct {
+		description    string
+		config         *latest.SkaffoldConfig
+		promptResponse string
+		expected       bool
+		shouldErr      bool
+	}{
+		{
+			description:    "yes response",
+			config:         &latest.SkaffoldConfig{},
+			promptResponse: "yes",
+			expected:       false,
+			shouldErr:      false,
+		},
+		{
+			description:    "no response",
+			config:         &latest.SkaffoldConfig{},
+			promptResponse: "no",
+			expected:       true,
+			shouldErr:      false,
+		},
+		{
+			description:    "error",
+			config:         &latest.SkaffoldConfig{},
+			promptResponse: "no",
+			expected:       true,
+			shouldErr:      true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&askOne, func(_ survey.Prompt, response interface{}, _ ...survey.AskOpt) error {
+				r := response.(*string)
+				*r = test.promptResponse
+
+				if test.shouldErr {
+					return errors.New("error")
+				}
+				return nil
+			})
+
+			got, err := ConfirmInitOptions(ioutil.Discard, test.config)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, got)
+		})
+	}
+}

--- a/pkg/skaffold/initializer/prompt/prompt_test.go
+++ b/pkg/skaffold/initializer/prompt/prompt_test.go
@@ -31,36 +31,36 @@ func TestConfirmInitOptions(t *testing.T) {
 	tests := []struct {
 		description    string
 		config         *latest.SkaffoldConfig
-		promptResponse string
-		expected       bool
+		promptResponse bool
+		expectedDone   bool
 		shouldErr      bool
 	}{
 		{
 			description:    "yes response",
 			config:         &latest.SkaffoldConfig{},
-			promptResponse: "yes",
-			expected:       false,
+			promptResponse: true,
+			expectedDone:   false,
 			shouldErr:      false,
 		},
 		{
 			description:    "no response",
 			config:         &latest.SkaffoldConfig{},
-			promptResponse: "no",
-			expected:       true,
+			promptResponse: false,
+			expectedDone:   true,
 			shouldErr:      false,
 		},
 		{
 			description:    "error",
 			config:         &latest.SkaffoldConfig{},
-			promptResponse: "no",
-			expected:       true,
+			promptResponse: false,
+			expectedDone:   true,
 			shouldErr:      true,
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&askOne, func(_ survey.Prompt, response interface{}, _ ...survey.AskOpt) error {
-				r := response.(*string)
+				r := response.(*bool)
 				*r = test.promptResponse
 
 				if test.shouldErr {
@@ -69,8 +69,8 @@ func TestConfirmInitOptions(t *testing.T) {
 				return nil
 			})
 
-			got, err := ConfirmInitOptions(ioutil.Discard, test.config)
-			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, got)
+			done, err := ConfirmInitOptions(ioutil.Discard, test.config)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedDone, done)
 		})
 	}
 }

--- a/pkg/skaffold/initializer/util/util.go
+++ b/pkg/skaffold/initializer/util/util.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags"
 )
 
 // ListBuilders returns a list of builder names being used in the given build config.
@@ -42,19 +43,5 @@ func ListDeployers(deploy *latest.DeployConfig) []string {
 		return []string{}
 	}
 
-	results := util.NewStringSet()
-	if deploy.HelmDeploy != nil {
-		results.Insert("helm")
-	}
-	if deploy.KptDeploy != nil {
-		results.Insert("kpt")
-	}
-	if deploy.KubectlDeploy != nil {
-		results.Insert("kubectl")
-	}
-	if deploy.KustomizeDeploy != nil {
-		results.Insert("kustomize")
-	}
-
-	return results.ToList()
+	return yamltags.GetYamlTags(deploy.DeployType)
 }

--- a/pkg/skaffold/initializer/util/util.go
+++ b/pkg/skaffold/initializer/util/util.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+// ListBuilders returns a list of builder names being used in the given build config.
+func ListBuilders(build *latest.BuildConfig) []string {
+	if build == nil {
+		return []string{}
+	}
+
+	results := util.NewStringSet()
+	for _, artifact := range build.Artifacts {
+		results.Insert(misc.ArtifactType(artifact))
+	}
+
+	return results.ToList()
+}
+
+// ListDeployers returns a list of deployer names being used in the given deploy config.
+func ListDeployers(deploy *latest.DeployConfig) []string {
+	if deploy == nil {
+		return []string{}
+	}
+
+	results := util.NewStringSet()
+	if deploy.HelmDeploy != nil {
+		results.Insert("helm")
+	}
+	if deploy.KptDeploy != nil {
+		results.Insert("kpt")
+	}
+	if deploy.KubectlDeploy != nil {
+		results.Insert("kubectl")
+	}
+	if deploy.KustomizeDeploy != nil {
+		results.Insert("kustomize")
+	}
+
+	return results.ToList()
+}

--- a/pkg/skaffold/initializer/util/util_test.go
+++ b/pkg/skaffold/initializer/util/util_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestListBuilders(t *testing.T) {
+	tests := []struct {
+		description string
+		build       *latest.BuildConfig
+		expected    []string
+	}{
+		{
+			description: "nil config",
+			build:       nil,
+			expected:    []string{},
+		},
+		{
+			description: "multiple same builder config",
+			build: &latest.BuildConfig{
+				Artifacts: []*latest.Artifact{
+					{ImageName: "img1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+					{ImageName: "img2", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+				},
+			},
+			expected: []string{"docker"},
+		},
+		{
+			description: "different builders config",
+			build: &latest.BuildConfig{
+				Artifacts: []*latest.Artifact{
+					{ImageName: "img1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+					{ImageName: "img2", ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{}}},
+				},
+			},
+			expected: []string{"docker", "jib"},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			got := ListBuilders(test.build)
+			t.CheckDeepEqual(test.expected, got)
+		})
+	}
+}
+
+func TestListDeployers(t *testing.T) {
+	tests := []struct {
+		description string
+		deploy      *latest.DeployConfig
+		expected    []string
+	}{
+		{
+			description: "nil config",
+			deploy:      nil,
+			expected:    []string{},
+		},
+		{
+			description: "single deployer config",
+			deploy: &latest.DeployConfig{
+				DeployType: latest.DeployType{
+					KubectlDeploy: &latest.KubectlDeploy{},
+				},
+			},
+			expected: []string{"kubectl"},
+		},
+		{
+			description: "multiple deployers config",
+			deploy: &latest.DeployConfig{
+				DeployType: latest.DeployType{
+					HelmDeploy:    &latest.HelmDeploy{},
+					KubectlDeploy: &latest.KubectlDeploy{},
+				},
+			},
+			expected: []string{"helm", "kubectl"},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			got := ListDeployers(test.deploy)
+			t.CheckDeepEqual(test.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
**Related**: https://github.com/GoogleContainerTools/skaffold/pull/4915

**Description**
This PR adds the functions that will be used to implement the transparent init feature.
The main is the ConfirmInitOptions() prompt function.

There are also some new util functions defined in pkg/skaffold/initializer/util

**Follow-up Work**
Use these functions to implement transparent init
