### PR TITLE
fix usage of set-env in Github integration actions

### DIFF
--- a/.github/workflows/integration-darwin.yml
+++ b/.github/workflows/integration-darwin.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Skaffold binary version
       run: |
-        echo ::set-env name=SKAFFOLD_VERSION::"$(git log --format="%H" -n 1)"
+        echo SKAFFOLD_VERSION="$(git log --format="%H" -n 1)" >> $GITHUB_ENV
 
     - name: Install Kustomize
       run: |

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Skaffold binary version
       run: |
-        echo ::set-env name=SKAFFOLD_VERSION::"$(git log --format="%H" -n 1)"
+        echo SKAFFOLD_VERSION="$(git log --format="%H" -n 1)" >> $GITHUB_ENV
 
     - name: Install Kustomize
       run: |


### PR DESCRIPTION
**Description**
Update action due to https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This fixes these failing actions
https://github.com/GoogleContainerTools/skaffold/actions/runs/420481722
https://github.com/GoogleContainerTools/skaffold/actions/runs/420472524
