### PR TITLE
Unhide XXenableManifestGeneration for skaffold init, remove unnecessary print line

### DIFF
--- a/cmd/skaffold/app/cmd/init.go
+++ b/cmd/skaffold/app/cmd/init.go
@@ -67,7 +67,7 @@ func NewCmdInit() *cobra.Command {
 			{Value: &enableJibGradleInit, Name: "XXenableJibGradleInit", DefValue: false, Usage: "", Hidden: true, IsEnum: true},
 			{Value: &enableBuildpacksInit, Name: "XXenableBuildpacksInit", DefValue: false, Usage: "", Hidden: true, IsEnum: true},
 			{Value: &buildpacksBuilder, Name: "XXdefaultBuildpacksBuilder", DefValue: "gcr.io/buildpacks/builder:v1", Usage: "", Hidden: true},
-			{Value: &enableManifestGeneration, Name: "XXenableManifestGeneration", DefValue: false, Usage: "", Hidden: true, IsEnum: true},
+			{Value: &enableManifestGeneration, Name: "generate-manifests", DefValue: false, Usage: "Allows skaffold to try and generate basic kubernetes resources to get your project started", IsEnum: true},
 		}).
 		NoArgs(doInit)
 }

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -714,6 +714,7 @@ Options:
       --default-kustomization='': Default Kustomization overlay path (others will be added as profiles)
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Force the generation of the Skaffold config
+      --generate-manifests=false: Allows skaffold to try and generate basic kubernetes resources to get your project started
   -k, --kubernetes-manifest=[]: A path or a glob pattern to kubernetes manifests (can be non-existent) to be added to the kubectl deployer (overrides detection of kubernetes manifests). Repeat the flag for multiple entries. E.g.: skaffold init -k pod.yaml -k k8s/*.yml
       --skip-build=false: Skip generating build artifacts in Skaffold config
 
@@ -732,6 +733,7 @@ Env vars:
 * `SKAFFOLD_DEFAULT_KUSTOMIZATION` (same as `--default-kustomization`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)
+* `SKAFFOLD_GENERATE_MANIFESTS` (same as `--generate-manifests`)
 * `SKAFFOLD_KUBERNETES_MANIFEST` (same as `--kubernetes-manifest`)
 * `SKAFFOLD_SKIP_BUILD` (same as `--skip-build`)
 

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -69,7 +69,7 @@ func TestInitManifestGeneration(t *testing.T) {
 		{
 			name:                  "hello",
 			dir:                   "testdata/init/hello",
-			args:                  []string{"--XXenableManifestGeneration"},
+			args:                  []string{"--generate-manifests"},
 			expectedManifestPaths: []string{"deployment.yaml"},
 		},
 		// TODO(nkubala): add this back when the --force flag is fixed

--- a/pkg/skaffold/initializer/build/util.go
+++ b/pkg/skaffold/initializer/build/util.go
@@ -17,8 +17,6 @@ limitations under the License.
 package build
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/tag"
@@ -77,7 +75,6 @@ func Artifacts(artifactInfos []ArtifactInfo) []*latest.Artifact {
 			workspace = filepath.Dir(info.Builder.Path())
 		}
 		if workspace != "." {
-			fmt.Fprintf(os.Stdout, "using non standard workspace: %s\n", workspace)
 			artifact.Workspace = workspace
 		}
 

--- a/pkg/skaffold/initializer/prompt/prompt.go
+++ b/pkg/skaffold/initializer/prompt/prompt.go
@@ -83,7 +83,7 @@ func portForwardResource(out io.Writer, imageName string) (int, error) {
 		Prompt: &survey.Input{Message: fmt.Sprintf("Select port to forward for %s (leave blank for none): ", imageName)},
 		Validate: func(val interface{}) error {
 			str := val.(string)
-			if _, err := strconv.Atoi(str); err != nil {
+			if _, err := strconv.Atoi(str); err != nil && str != "" {
 				return errors.New("response must be a number, or empty")
 			}
 			return nil


### PR DESCRIPTION
**Description**
This PR unhides and renames the flag for manifest generation when using `skaffold init`. It's been changed from `--XXenableManifestGeneration` to `--generate-manifests`. I think this feature is at a point where we can put it into the hands of the user and try to get some feedback on it.

I've also removed an unnecessary line that is being printed in some cases when running init. I don't think it provides any value to the user. Please let me know if you think we should keep it there.

There's also a small fix to validation function that validates user input for port forwarding info.

**User facing changes (remove if N/A)**
Users will now see the option if they run `skaffold init --help`
