### PR TITLE
add transparent init function

### DIFF
--- a/pkg/skaffold/initializer/transparent.go
+++ b/pkg/skaffold/initializer/transparent.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initializer
+
+import (
+	"context"
+	"io"
+
+	initConfig "github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+)
+
+var (
+	confirmInitOptions = prompt.ConfirmInitOptions
+)
+
+// Transparent executes the `skaffold init` flow, but always enables the --force flag.
+// It will also always prompt the user to confirm at the end of the flow.
+func Transparent(ctx context.Context, out io.Writer, c initConfig.Config) (*latest.SkaffoldConfig, error) {
+	// we set force to true because we want to have this happen invisibly to the user if possible
+	c.Force = true
+
+	if c.ComposeFile != "" {
+		if err := runKompose(ctx, c.ComposeFile); err != nil {
+			return nil, err
+		}
+	}
+
+	a, err := AnalyzeProject(c)
+	if err != nil {
+		return nil, err
+	}
+
+	newConfig, newManifests, err := Initialize(out, c, a)
+	// If the --analyze flag is used, we return early with the result of PrintAnalysis()
+	// TODO(marlongamez): Figure out a cleaner way to do this. Might have to change return values to include the different Initializers.
+	if err != nil || c.Analyze {
+		return nil, err
+	}
+
+	// Prompt the user with information about what will happen if they continue with this config.
+	if done, err := confirmInitOptions(out, newConfig); done {
+		return nil, err
+	}
+
+	if err := WriteData(out, c, newConfig, newManifests); err != nil {
+		return nil, err
+	}
+
+	return newConfig, nil
+}

--- a/pkg/skaffold/initializer/transparent_test.go
+++ b/pkg/skaffold/initializer/transparent_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package initializer
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	initconfig "github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestTransparentInit(t *testing.T) {
+	tests := []struct {
+		name             string
+		dir              string
+		config           initconfig.Config
+		expectedError    string
+		expectedExitCode int
+		doneResponse     bool
+	}{
+		//TODO: mocked kompose test
+		{
+			name: "getting-started",
+			dir:  "testdata/init/hello",
+			config: initconfig.Config{
+				Force: true,
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml.out",
+				},
+			},
+		},
+		{
+			name: "ignore existing tags",
+			dir:  "testdata/init/ignore-tags",
+			config: initconfig.Config{
+				Force: true,
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml.out",
+				},
+			},
+		},
+		{
+			name: "microservices (backwards compatibility)",
+			dir:  "testdata/init/microservices",
+			config: initconfig.Config{
+				Force: true,
+				CliArtifacts: []string{
+					"leeroy-app/Dockerfile=gcr.io/k8s-skaffold/leeroy-app",
+					"leeroy-web/Dockerfile=gcr.io/k8s-skaffold/leeroy-web",
+				},
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml.out",
+				},
+			},
+		},
+		{
+			name: "error writing config file",
+			dir:  "testdata/init/hello",
+			config: initconfig.Config{
+				Force: true,
+				Opts: config.SkaffoldOptions{
+					// erroneous config file as . is a directory
+					ConfigurationFile: ".",
+				},
+			},
+			expectedError:    "writing config to file: open .: is a directory",
+			expectedExitCode: 1,
+		},
+		{
+			name: "error no builders",
+			dir:  "testdata/init/no-builder",
+			config: initconfig.Config{
+				Force: true,
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml.out",
+				},
+			},
+			expectedError:    "please provide at least one build config",
+			expectedExitCode: 101,
+		},
+		{
+			name: "error no manifests",
+			dir:  "testdata/init/hello-no-manifest",
+			config: initconfig.Config{
+				Force: true,
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml.out",
+				},
+			},
+			expectedError:    "one or more valid Kubernetes manifests are required to run skaffold",
+			expectedExitCode: 102,
+		},
+		{
+			name: "builder/image ambiguity",
+			dir:  "testdata/init/microservices",
+			config: initconfig.Config{
+				Force: true,
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml.out",
+				},
+			},
+			expectedError:    "unable to automatically resolve builder/image pairs",
+			expectedExitCode: 104,
+		},
+		{
+			name: "kustomize",
+			dir:  "testdata/init/getting-started-kustomize",
+			config: initconfig.Config{
+				Force: true,
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml.out",
+				},
+			},
+		},
+		{
+			name: "helm fails",
+			dir:  "testdata/init/helm-deployment",
+			config: initconfig.Config{
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml.out",
+				},
+			},
+			expectedError: `Projects set up to deploy with helm must be manually configured.
+
+See https://skaffold.dev/docs/pipeline-stages/deployers/helm/ for a detailed guide on setting your project up with skaffold.`,
+			expectedExitCode: 1,
+		},
+		{
+			name: "user selects 'no'",
+			dir:  "testdata/init/hello",
+			config: initconfig.Config{
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml.out",
+				},
+			},
+			doneResponse: true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			t.Chdir(test.dir)
+
+			t.Override(&confirmInitOptions, func(_ io.Writer, _ *latest.SkaffoldConfig) (bool, error) {
+				return test.doneResponse, nil
+			})
+
+			got, err := Transparent(context.TODO(), os.Stdout, test.config)
+
+			switch {
+			case test.expectedError != "":
+				t.CheckErrorContains(test.expectedError, err)
+				t.CheckDeepEqual(exitCode(err), test.expectedExitCode)
+			case test.doneResponse == true:
+				t.CheckErrorAndDeepEqual(false, err, (*latest.SkaffoldConfig)(nil), got)
+			default:
+				t.CheckNoError(err)
+				checkGeneratedConfig(t, ".")
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Related**: https://github.com/GoogleContainerTools/skaffold/pull/4915, https://github.com/GoogleContainerTools/skaffold/pull/5141

**Description**
Adds the function that will be used for transparent init functionality along with its unit tests.

**Follow-up Work (remove if N/A)**
Plumb this into skaffold's code that tries to parse in the skaffold config from disk. If nothing is found, this function will be called to try and generate a config for the user.
