### PR TITLE
[Refactor] Move FSNotify trigger into a separate package

### DIFF
--- a/pkg/skaffold/trigger/fsnotify/trigger.go
+++ b/pkg/skaffold/trigger/fsnotify/trigger.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fsnotify
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"time"
+
+	"github.com/rjeczalik/notify"
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+)
+
+// For testing
+var (
+	Watch = notify.Watch
+)
+
+func New(workspaces map[string]struct{}, isActive func() bool, duration int) *Trigger {
+	return &Trigger{
+		Interval:   time.Duration(duration) * time.Millisecond,
+		workspaces: workspaces,
+		isActive:   isActive,
+		watchFunc:  Watch,
+	}
+}
+
+// Trigger watches for changes with fsnotify
+type Trigger struct {
+	Interval   time.Duration
+	workspaces map[string]struct{}
+	isActive   func() bool
+	watchFunc  func(path string, c chan<- notify.EventInfo, events ...notify.Event) error
+}
+
+// IsActive returns the function to run if Trigger is active.
+func (t *Trigger) IsActive() func() bool {
+	return t.isActive
+}
+
+// Debounce tells the watcher to not debounce rapid sequence of changes.
+func (t *Trigger) Debounce() bool {
+	// This trigger has built-in debouncing.
+	return false
+}
+
+func (t *Trigger) LogWatchToUser(out io.Writer) {
+	if t.isActive() {
+		color.Yellow.Fprintln(out, "Watching for changes...")
+	} else {
+		color.Yellow.Fprintln(out, "Not watching for changes...")
+	}
+}
+
+// Start listening for file system changes
+func (t *Trigger) Start(ctx context.Context) (<-chan bool, error) {
+	c := make(chan notify.EventInfo, 100)
+
+	// Workaround https://github.com/rjeczalik/notify/issues/96
+	wd, err := RealWorkDir()
+	if err != nil {
+		return nil, err
+	}
+
+	// Watch current directory recursively
+	if err := t.watchFunc(filepath.Join(wd, "..."), c, notify.All); err != nil {
+		return nil, err
+	}
+
+	// Watch all workspaces recursively
+	for w := range t.workspaces {
+		if w == "." {
+			continue
+		}
+
+		if err := t.watchFunc(filepath.Join(wd, w, "..."), c, notify.All); err != nil {
+			return nil, err
+		}
+	}
+
+	// Since the file watcher runs in a separate go routine
+	// and can take some time to start, it can lose the very first change.
+	// As a mitigation, we act as if a change was detected.
+	go func() { c <- nil }()
+
+	trigger := make(chan bool)
+	go func() {
+		timer := time.NewTimer(1<<63 - 1) // Forever
+
+		for {
+			select {
+			case e := <-c:
+
+				// Ignore detected changes if not active or to be ignore.
+				if !t.isActive() && t.Ignore(e) {
+					continue
+				}
+				logrus.Debugln("Change detected", e)
+
+				// Wait t.Ienterval before triggering.
+				// This way, rapid stream of events will be grouped.
+				timer.Reset(t.Interval)
+			case <-timer.C:
+				trigger <- true
+			case <-ctx.Done():
+				timer.Stop()
+				return
+			}
+		}
+	}()
+
+	return trigger, nil
+}
+
+// Ignore checks if the change detected is to be ignored or not.
+// Currently, returns false i.e Allows all files changed.
+func (t *Trigger) Ignore(_ notify.EventInfo) bool {
+	return false
+}

--- a/pkg/skaffold/trigger/fsnotify/trigger_test.go
+++ b/pkg/skaffold/trigger/fsnotify/trigger_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fsnotify
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestLogWatchToUser(t *testing.T) {
+	tests := []struct {
+		description string
+		isActive    bool
+		expected    string
+	}{
+		{
+			description: "active notify Trigger",
+			isActive:    true,
+			expected:    "Watching for changes...\n",
+		},
+		{
+			description: "inactive notify Trigger",
+			isActive:    false,
+			expected:    "Not watching for changes...\n",
+		},
+	}
+	for _, test := range tests {
+		out := new(bytes.Buffer)
+
+		trigger := &Trigger{
+			Interval: 10,
+			isActive: func() bool {
+				return test.isActive
+			},
+		}
+		trigger.LogWatchToUser(out)
+
+		got, want := out.String(), test.expected
+		testutil.CheckDeepEqual(t, want, got)
+	}
+}
+
+func Test_Debounce(t *testing.T) {
+	tr := &Trigger{}
+	got, want := tr.Debounce(), false
+	testutil.CheckDeepEqual(t, want, got)
+}
+
+func Test_Ignore(t *testing.T) {
+	tr := &Trigger{}
+	testutil.CheckDeepEqual(t, false, tr.Ignore(nil))
+}

--- a/pkg/skaffold/trigger/fsnotify/workdir.go
+++ b/pkg/skaffold/trigger/fsnotify/workdir.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package trigger
+package fsnotify
 
 import (
 	"os"

--- a/pkg/skaffold/trigger/triggers.go
+++ b/pkg/skaffold/trigger/triggers.go
@@ -22,16 +22,15 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
 
-	"github.com/rjeczalik/notify"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	fsNotify "github.com/GoogleContainerTools/skaffold/pkg/skaffold/trigger/fsnotify"
 )
 
 // Trigger describes a mechanism that triggers the watch.
@@ -66,17 +65,12 @@ func NewTrigger(cfg Config, isActive func() bool) (Trigger, error) {
 	}
 }
 
-func newFSNotifyTrigger(cfg Config, isActive func() bool) *fsNotifyTrigger {
+func newFSNotifyTrigger(cfg Config, isActive func() bool) Trigger {
 	workspaces := map[string]struct{}{}
 	for _, a := range cfg.Pipeline().Build.Artifacts {
 		workspaces[a.Workspace] = struct{}{}
 	}
-	return &fsNotifyTrigger{
-		Interval:   time.Duration(cfg.WatchPollInterval()) * time.Millisecond,
-		workspaces: workspaces,
-		isActive:   isActive,
-		watchFunc:  notify.Watch,
-	}
+	return fsNotify.New(workspaces, isActive, cfg.WatchPollInterval())
 }
 
 // pollTrigger watches for changes on a given interval of time.
@@ -175,88 +169,6 @@ func (t *manualTrigger) Start(ctx context.Context) (<-chan bool, error) {
 	return trigger, nil
 }
 
-// notifyTrigger watches for changes with fsnotify
-type fsNotifyTrigger struct {
-	Interval   time.Duration
-	workspaces map[string]struct{}
-	isActive   func() bool
-	watchFunc  func(path string, c chan<- notify.EventInfo, events ...notify.Event) error
-}
-
-// Debounce tells the watcher to not debounce rapid sequence of changes.
-func (t *fsNotifyTrigger) Debounce() bool {
-	// This trigger has built-in debouncing.
-	return false
-}
-
-func (t *fsNotifyTrigger) LogWatchToUser(out io.Writer) {
-	if t.isActive() {
-		color.Yellow.Fprintln(out, "Watching for changes...")
-	} else {
-		color.Yellow.Fprintln(out, "Not watching for changes...")
-	}
-}
-
-// Start listening for file system changes
-func (t *fsNotifyTrigger) Start(ctx context.Context) (<-chan bool, error) {
-	c := make(chan notify.EventInfo, 100)
-
-	// Workaround https://github.com/rjeczalik/notify/issues/96
-	wd, err := RealWorkDir()
-	if err != nil {
-		return nil, err
-	}
-
-	// Watch current directory recursively
-	if err := t.watchFunc(filepath.Join(wd, "..."), c, notify.All); err != nil {
-		return nil, err
-	}
-
-	// Watch all workspaces recursively
-	for w := range t.workspaces {
-		if w == "." {
-			continue
-		}
-
-		if err := t.watchFunc(filepath.Join(wd, w, "..."), c, notify.All); err != nil {
-			return nil, err
-		}
-	}
-
-	// Since the file watcher runs in a separate go routine
-	// and can take some time to start, it can lose the very first change.
-	// As a mitigation, we act as if a change was detected.
-	go func() { c <- nil }()
-
-	trigger := make(chan bool)
-	go func() {
-		timer := time.NewTimer(1<<63 - 1) // Forever
-
-		for {
-			select {
-			case e := <-c:
-
-				// Ignore detected changes if not active
-				if !t.isActive() {
-					continue
-				}
-				logrus.Debugln("Change detected", e)
-
-				// Wait t.interval before triggering.
-				// This way, rapid stream of events will be grouped.
-				timer.Reset(t.Interval)
-			case <-timer.C:
-				trigger <- true
-			case <-ctx.Done():
-				timer.Stop()
-				return
-			}
-		}
-	}()
-
-	return trigger, nil
-}
-
 // StartTrigger attempts to start a trigger.
 // It will attempt to start as a polling trigger if it tried unsuccessfully to start a notify trigger.
 func StartTrigger(ctx context.Context, t Trigger) (<-chan bool, error) {
@@ -264,12 +176,12 @@ func StartTrigger(ctx context.Context, t Trigger) (<-chan bool, error) {
 	if err == nil {
 		return ret, err
 	}
-	if notifyTrigger, ok := t.(*fsNotifyTrigger); ok {
+	if fsnotify, ok := t.(*fsNotify.Trigger); ok {
 		logrus.Debugln("Couldn't start notify trigger. Falling back to a polling trigger")
 
 		t = &pollTrigger{
-			Interval: notifyTrigger.Interval,
-			isActive: notifyTrigger.isActive,
+			Interval: fsnotify.Interval,
+			isActive: fsnotify.IsActive(),
 		}
 		ret, err = t.Start(ctx)
 	}

--- a/pkg/skaffold/trigger/triggers_test.go
+++ b/pkg/skaffold/trigger/triggers_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rjeczalik/notify"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	fsNotify "github.com/GoogleContainerTools/skaffold/pkg/skaffold/trigger/fsnotify"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -50,14 +51,9 @@ func TestNewTrigger(t *testing.T) {
 			description:       "notify trigger",
 			trigger:           "notify",
 			watchPollInterval: 1,
-			expected: &fsNotifyTrigger{
-				Interval: 1 * time.Millisecond,
-				workspaces: map[string]struct{}{
-					"../workspace":            {},
-					"../some/other/workspace": {},
-				},
-				watchFunc: notify.Watch,
-			},
+			expected: fsNotify.New(map[string]struct{}{
+				"../workspace":            {},
+				"../some/other/workspace": {}}, nil, 1),
 		},
 		{
 			description: "manual trigger",
@@ -86,7 +82,7 @@ func TestNewTrigger(t *testing.T) {
 
 			t.CheckError(test.shouldErr, err)
 			if !test.shouldErr {
-				t.CheckDeepEqual(test.expected, got, cmp.AllowUnexported(fsNotifyTrigger{}), cmp.Comparer(ignoreFuncComparer), cmp.AllowUnexported(manualTrigger{}), cmp.AllowUnexported(pollTrigger{}))
+				t.CheckDeepEqual(test.expected, got, cmp.AllowUnexported(fsNotify.Trigger{}), cmp.Comparer(ignoreFuncComparer), cmp.AllowUnexported(manualTrigger{}), cmp.AllowUnexported(pollTrigger{}))
 			}
 		})
 	}
@@ -141,45 +137,6 @@ func TestPollTrigger_LogWatchToUser(t *testing.T) {
 	}
 }
 
-func TestNotifyTrigger_Debounce(t *testing.T) {
-	trigger := &fsNotifyTrigger{}
-	got, want := trigger.Debounce(), false
-	testutil.CheckDeepEqual(t, want, got)
-}
-
-func TestNotifyTrigger_LogWatchToUser(t *testing.T) {
-	tests := []struct {
-		description string
-		isActive    bool
-		expected    string
-	}{
-		{
-			description: "active notify trigger",
-			isActive:    true,
-			expected:    "Watching for changes...\n",
-		},
-		{
-			description: "inactive notify trigger",
-			isActive:    false,
-			expected:    "Not watching for changes...\n",
-		},
-	}
-	for _, test := range tests {
-		out := new(bytes.Buffer)
-
-		trigger := &fsNotifyTrigger{
-			Interval: 10,
-			isActive: func() bool {
-				return test.isActive
-			},
-		}
-		trigger.LogWatchToUser(out)
-
-		got, want := out.String(), test.expected
-		testutil.CheckDeepEqual(t, want, got)
-	}
-}
-
 func TestManualTrigger_Debounce(t *testing.T) {
 	trigger := &manualTrigger{}
 	got, want := trigger.Debounce(), false
@@ -222,33 +179,27 @@ func TestStartTrigger(t *testing.T) {
 	tests := []struct {
 		description string
 		trigger     Trigger
+		mockWatch   func(string, chan<- notify.EventInfo, ...notify.Event) error
 	}{
 		{
 			description: "fsNotify trigger works",
-			trigger: &fsNotifyTrigger{
-				Interval:   200 * time.Millisecond,
-				workspaces: nil,
-				isActive:   func() bool { return false },
-				watchFunc: func(string, chan<- notify.EventInfo, ...notify.Event) error {
-					return nil
-				},
+			trigger:     fsNotify.New(nil, func() bool { return false }, 1),
+			mockWatch: func(string, chan<- notify.EventInfo, ...notify.Event) error {
+				return nil
 			},
 		},
 		{
 			description: "fallback on polling trigger",
-			trigger: &fsNotifyTrigger{
-				Interval:   200 * time.Millisecond,
-				workspaces: nil,
-				isActive:   func() bool { return false },
-				watchFunc: func(string, chan<- notify.EventInfo, ...notify.Event) error {
-					return fmt.Errorf("failed to start watch trigger")
-				},
+			trigger:     fsNotify.New(nil, func() bool { return false }, 1),
+			mockWatch: func(string, chan<- notify.EventInfo, ...notify.Event) error {
+				return fmt.Errorf("failed to start watch trigger")
 			},
 		},
 	}
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&fsNotify.Watch, test.mockWatch)
 			_, err := StartTrigger(context.Background(), test.trigger)
 			time.Sleep(1 * time.Second)
 			t.CheckNoError(err)

--- a/pkg/skaffold/trigger/triggers_test.go
+++ b/pkg/skaffold/trigger/triggers_test.go
@@ -178,19 +178,16 @@ func TestManualTrigger_LogWatchToUser(t *testing.T) {
 func TestStartTrigger(t *testing.T) {
 	tests := []struct {
 		description string
-		trigger     Trigger
 		mockWatch   func(string, chan<- notify.EventInfo, ...notify.Event) error
 	}{
 		{
 			description: "fsNotify trigger works",
-			trigger:     fsNotify.New(nil, func() bool { return false }, 1),
 			mockWatch: func(string, chan<- notify.EventInfo, ...notify.Event) error {
 				return nil
 			},
 		},
 		{
 			description: "fallback on polling trigger",
-			trigger:     fsNotify.New(nil, func() bool { return false }, 1),
 			mockWatch: func(string, chan<- notify.EventInfo, ...notify.Event) error {
 				return fmt.Errorf("failed to start watch trigger")
 			},
@@ -200,7 +197,8 @@ func TestStartTrigger(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&fsNotify.Watch, test.mockWatch)
-			_, err := StartTrigger(context.Background(), test.trigger)
+			trigger := fsNotify.New(nil, func() bool { return false }, 1)
+			_, err := StartTrigger(context.Background(), trigger)
 			time.Sleep(1 * time.Second)
 			t.CheckNoError(err)
 		})


### PR DESCRIPTION
In preparation for #5140,
1. Move fsNotifyTrigger into its own package.
2. Add a function `Ignore` to configure the fsNotifyWatcher to ignore
   - files belonging to predefined dirs like .idea .vscode & .git [ follow up PR]
   - hidden file like .somefile.swp. [ follow up PR]

**User facing change**
None.

**Future Work**
1. Configure the `Ignore` to ignore files mentioned above
