### PR TITLE
Fail Helm deployments early with missing templated values

### DIFF
--- a/docs/content/en/schemas/v2beta11.json
+++ b/docs/content/en/schemas/v2beta11.json
@@ -1445,8 +1445,8 @@
         },
         "name": {
           "type": "string",
-          "description": "name of the Helm release.",
-          "x-intellij-html-description": "name of the Helm release."
+          "description": "name of the Helm release. It accepts environment variables via the go template syntax.",
+          "x-intellij-html-description": "name of the Helm release. It accepts environment variables via the go template syntax."
         },
         "namespace": {
           "type": "string",

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -135,14 +135,7 @@ func (h *Deployer) Deploy(ctx context.Context, out io.Writer, builds []build.Art
 
 		// collect namespaces
 		for _, r := range results {
-			var namespace string
-			// `<no value>` is not allowed within a namespace
-			namespace, err = util.ExpandEnvTemplateOrFail(r.Namespace, nil)
-			if err != nil {
-				return nil, userErr("cannot parse the release namespace template", err)
-			}
-
-			if trimmed := strings.TrimSpace(namespace); trimmed != "" {
+			if trimmed := strings.TrimSpace(r.Namespace); trimmed != "" {
 				nsMap[trimmed] = struct{}{}
 			}
 		}
@@ -165,11 +158,10 @@ func (h *Deployer) Deploy(ctx context.Context, out io.Writer, builds []build.Art
 	}
 
 	// Collect namespaces in a string
-	namespaces := make([]string, 0, len(nsMap))
+	var namespaces []string
 	for ns := range nsMap {
 		namespaces = append(namespaces, ns)
 	}
-
 	return namespaces, nil
 }
 

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -530,7 +530,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all --namespace testReleaseFOOBARNamespace skaffold-helm --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --namespace testReleaseFOOBARNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
-				AndRunWithOutput("helm --kube-context kubecontext get all --namespace testReleaseFOOBARNamespace skaffold-helm --kubeconfig kubeconfig", helmReleaseInfo("skaffold-helm", "testReleaseFOOBARNamespace", validDeployYaml)), // just need a valid KRM object
+				AndRunWithOutput("helm --kube-context kubecontext get all --namespace testReleaseFOOBARNamespace skaffold-helm --kubeconfig kubeconfig", helmReleaseInfo("testReleaseFOOBARNamespace", validDeployYaml)), // just need a valid KRM object
 			helm:               testDeployEnvTemplateNamespacedConfig,
 			builds:             testBuilds,
 			expectedNamespaces: []string{"testReleaseFOOBARNamespace"},
@@ -588,7 +588,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all --namespace testReleaseFOOBARNamespace skaffold-helm --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --namespace testReleaseFOOBARNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
-				AndRunWithOutput("helm --kube-context kubecontext get all --namespace testReleaseFOOBARNamespace skaffold-helm --kubeconfig kubeconfig", helmReleaseInfo("skaffold-helm", "testReleaseFOOBARNamespace", validDeployYaml)), // just need a valid KRM object
+				AndRunWithOutput("helm --kube-context kubecontext get all --namespace testReleaseFOOBARNamespace skaffold-helm --kubeconfig kubeconfig", helmReleaseInfo("testReleaseFOOBARNamespace", validDeployYaml)), // just need a valid KRM object
 			helm:               testDeployEnvTemplateNamespacedConfig,
 			builds:             testBuilds,
 			expectedNamespaces: []string{"testReleaseFOOBARNamespace"},
@@ -926,7 +926,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRunErr("helm --kube-context kubecontext get all --namespace testReleaseNamespace skaffold-helm --kubeconfig kubeconfig", fmt.Errorf("not found")).
 				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext install skaffold-helm examples/test --namespace testReleaseNamespace --create-namespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
-				AndRunWithOutput("helm --kube-context kubecontext get all --namespace testReleaseNamespace skaffold-helm --kubeconfig kubeconfig", helmReleaseInfo("skaffold-helm", "testReleaseNamespace", validDeployYaml)), // just need a valid KRM object
+				AndRunWithOutput("helm --kube-context kubecontext get all --namespace testReleaseNamespace skaffold-helm --kubeconfig kubeconfig", helmReleaseInfo("testReleaseNamespace", validDeployYaml)), // just need a valid KRM object
 			helm:               testDeployCreateNamespaceConfig,
 			builds:             testBuilds,
 			expectedNamespaces: []string{"testReleaseNamespace"},
@@ -938,7 +938,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all --namespace testReleaseNamespace skaffold-helm --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --namespace testReleaseNamespace -f skaffold-overrides.yaml --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set some.key=somevalue --kubeconfig kubeconfig").
-				AndRunWithOutput("helm --kube-context kubecontext get all --namespace testReleaseNamespace skaffold-helm --kubeconfig kubeconfig", helmReleaseInfo("skaffold-helm", "testReleaseNamespace", validDeployYaml)), // just need a valid KRM object
+				AndRunWithOutput("helm --kube-context kubecontext get all --namespace testReleaseNamespace skaffold-helm --kubeconfig kubeconfig", helmReleaseInfo("testReleaseNamespace", validDeployYaml)), // just need a valid KRM object
 			helm:               testDeployCreateNamespaceConfig,
 			builds:             testBuilds,
 			expectedNamespaces: []string{"testReleaseNamespace"},
@@ -1450,8 +1450,8 @@ func (c *helmConfig) Pipeline() latest.Pipeline {
 }
 
 // helmReleaseInfo returns the result of `helm --namespace <namespace> get all <name>` with the given KRM manifest.
-func helmReleaseInfo(name, namespace, manifest string) string {
-	return fmt.Sprintf(`NAME: %s
+func helmReleaseInfo(namespace, manifest string) string {
+	return fmt.Sprintf(`NAME: skaffold-helm
 LAST DEPLOYED: Thu Dec 17 15:35:28 2020
 NAMESPACE: %s
 STATUS: deployed
@@ -1466,5 +1466,5 @@ image: skaffold-example:16bb174b9a147d3f574fb5fe967b7f5c873a0150182dbb0f72d1fb2f
 HOOKS:
 MANIFEST:
 ---
-%s`, name, namespace, manifest)
+%s`, namespace, manifest)
 }

--- a/pkg/skaffold/deploy/helm/util.go
+++ b/pkg/skaffold/deploy/helm/util.go
@@ -157,7 +157,7 @@ func (h *Deployer) releaseNamespace(r latest.HelmRelease) (string, error) {
 	if h.namespace != "" {
 		return h.namespace, nil
 	} else if r.Namespace != "" {
-		namespace, err := util.ExpandEnvTemplate(r.Namespace, nil)
+		namespace, err := util.ExpandEnvTemplateOrFail(r.Namespace, nil)
 		if err != nil {
 			return "", fmt.Errorf("cannot parse the release namespace template: %w", err)
 		}

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -629,6 +629,7 @@ type KptApplyOptions struct {
 // HelmRelease describes a helm release to be deployed.
 type HelmRelease struct {
 	// Name is the name of the Helm release.
+	// It accepts environment variables via the go template syntax.
 	Name string `yaml:"name,omitempty" yamltags:"required"`
 
 	// ChartPath is the path to the Helm chart.

--- a/pkg/skaffold/util/env_template.go
+++ b/pkg/skaffold/util/env_template.go
@@ -38,7 +38,16 @@ func ExpandEnvTemplate(s string, envMap map[string]string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to parse template: %q: %w", s, err)
 	}
+	return ExecuteEnvTemplate(tmpl, envMap)
+}
 
+// ExpandEnvTemplateOrFail parses and executes template s with an optional environment map, and errors if a reference cannot be satisfied.
+func ExpandEnvTemplateOrFail(s string, envMap map[string]string) (string, error) {
+	tmpl, err := ParseEnvTemplate(s)
+	if err != nil {
+		return "", fmt.Errorf("unable to parse template: %q: %w", s, err)
+	}
+	tmpl = tmpl.Option("missingkey=error")
 	return ExecuteEnvTemplate(tmpl, envMap)
 }
 
@@ -62,7 +71,7 @@ func ExecuteEnvTemplate(envTemplate *template.Template, customMap map[string]str
 	var buf bytes.Buffer
 	logrus.Debugf("Executing template %v with environment %v", envTemplate, envMap)
 	if err := envTemplate.Execute(&buf, envMap); err != nil {
-		return "", fmt.Errorf("executing template: %w", err)
+		return "", err
 	}
 	return buf.String(), nil
 }

--- a/testutil/cmd_helper.go
+++ b/testutil/cmd_helper.go
@@ -190,7 +190,7 @@ func (c *FakeCmd) RunCmd(cmd *exec.Cmd) error {
 	}
 
 	if r.command != command {
-		c.t.Errorf("\nexpected: %s\n\ngot: %s", r.command, command)
+		c.t.Errorf("\nwanted: %s\n\n   got: %s", r.command, command)
 	}
 
 	if r.output != nil {


### PR DESCRIPTION
Fixes #5072

**Description**

Fails Helm deployments early when release or namespaces reference missing templated values.

**User facing changes (remove if N/A)**
Helm deployments fail if the release name or namespaces are templated with missing values.
