### PR TITLE
fix: lookup image id with tag rather than name during tryImport

### DIFF
--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -59,7 +59,7 @@ func (c *cache) lookup(ctx context.Context, a *latest.Artifact, tag string, h ar
 	entry, cacheHit := c.artifactCache[hash]
 	c.cacheMutex.RUnlock()
 	if !cacheHit {
-		if entry, err = c.tryImport(ctx, a, tag, hash); err != nil {
+		if entry, err = c.tryImport(ctx, tag, hash); err != nil {
 			logrus.Debugf("Could not import artifact from Docker, building instead (%s)", err)
 			return needsBuilding{hash: hash}
 		}
@@ -120,7 +120,7 @@ func (c *cache) lookupRemote(ctx context.Context, hash, tag string, entry ImageD
 	return needsBuilding{hash: hash}
 }
 
-func (c *cache) tryImport(ctx context.Context, a *latest.Artifact, tag string, hash string) (ImageDetails, error) {
+func (c *cache) tryImport(ctx context.Context, tag string, hash string) (ImageDetails, error) {
 	if !c.tryImportMissing {
 		return ImageDetails{}, fmt.Errorf("import of missing images disabled")
 	}
@@ -137,7 +137,7 @@ func (c *cache) tryImport(ctx context.Context, a *latest.Artifact, tag string, h
 		logrus.Debugf("Importing artifact %s from local docker", tag)
 	}
 
-	imageID, err := c.client.ImageID(ctx, a.ImageName)
+	imageID, err := c.client.ImageID(ctx, tag)
 	if err != nil {
 		return entry, err
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5162 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Lookup the imageID with the tag rather than the image name.

My guess at what is happening is that there are 2 images with the same name but different tags and thus it can't produce a singular image ID. In may case the 2 images where:
* The one created by `tagPolicy`
* The one with the immutable local-only skaffold tag (https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works)

In this case the `tag` also includes the image name so I don't think there is any chance that 2 images match again.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
