### PR TITLE
Set meter.Command before an error could occur with createNewRunner

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/server"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/survey"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
@@ -69,6 +70,7 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 			cmd.Root().SilenceUsage = true
 
 			opts.Command = cmd.Use
+			instrumentation.SetCommand(cmd.Use)
 
 			out = color.SetupColors(out, defaultColor, forceColors)
 			cmd.Root().SetOutput(out)

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -60,7 +60,7 @@ func createNewRunner(opts config.SkaffoldOptions) (runner.Runner, *latest.Skaffo
 		return nil, nil, err
 	}
 
-	instrumentation.InitMeter(runCtx, config)
+	instrumentation.InitMeterFromConfig(config)
 	runner, err := runner.NewForConfig(runCtx)
 	if err != nil {
 		event.InititializationFailed(err)

--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -46,6 +46,7 @@ import (
 	_ "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/secret/statik"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags"
 	"github.com/GoogleContainerTools/skaffold/proto"
@@ -88,10 +89,16 @@ var (
 		ErrorCode:     proto.StatusCode_OK,
 	}
 	shouldExportMetrics = os.Getenv("SKAFFOLD_EXPORT_METRICS") == "true"
+	meteredCommands     = util.NewStringSet()
+	doesBuild           = util.NewStringSet()
+	doesDeploy          = util.NewStringSet()
 	isOnline            bool
 )
 
 func init() {
+	meteredCommands.Insert("build", "delete", "deploy", "dev", "debug", "filter", "generate_pipeline", "render", "run", "test")
+	doesBuild.Insert("build", "render", "dev", "debug", "run")
+	doesDeploy.Insert("deploy", "dev", "debug", "run")
 	go func() {
 		if shouldExportMetrics {
 			r, err := http.Get("http://clients3.google.com/generate_204")
@@ -119,6 +126,12 @@ func InitMeterFromConfig(config *latest.SkaffoldConfig) {
 	meter.BuildArtifacts = len(config.Pipeline.Build.Artifacts)
 }
 
+func SetCommand(cmd string) {
+	if meteredCommands.Contains(cmd) {
+		meter.Command = cmd
+	}
+}
+
 func SetErrorCode(errorCode proto.StatusCode) {
 	meter.ErrorCode = errorCode
 }
@@ -139,7 +152,7 @@ func AddFlag(flag *flag.Flag) {
 }
 
 func ExportMetrics(exitCode int) error {
-	if !shouldExportMetrics {
+	if !shouldExportMetrics || meter.Command == "" {
 		return nil
 	}
 	home, err := homedir.Dir()
@@ -253,12 +266,10 @@ func createMetrics(ctx context.Context, meter skaffoldMeter) {
 	durationRecorder.Record(ctx, meter.Duration.Seconds(), labels...)
 	if meter.Command != "" {
 		commandMetrics(ctx, meter, m, randLabel)
-		doesBuild := map[string]bool{"build": true, "render": true, "dev": true, "debug": true, "run": true}
-		doesDeploy := map[string]bool{"deploy": true, "dev": true, "debug": true, "run": true}
-		if _, ok := doesBuild[meter.Command]; ok {
+		if doesBuild.Contains(meter.Command) {
 			builderMetrics(ctx, meter, m, randLabel)
 		}
-		if _, ok := doesDeploy[meter.Command]; ok {
+		if doesDeploy.Contains(meter.Command) {
 			deployerMetrics(ctx, meter, m, randLabel)
 		}
 	}

--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -45,7 +45,6 @@ import (
 	// import embedded secret for uploading metrics
 	_ "github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/secret/statik"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags"
@@ -104,8 +103,7 @@ func init() {
 	}()
 }
 
-func InitMeter(runCtx *runcontext.RunContext, config *latest.SkaffoldConfig) {
-	meter.Command = runCtx.Opts.Command
+func InitMeterFromConfig(config *latest.SkaffoldConfig) {
 	meter.PlatformType = yamltags.GetYamlTag(config.Build.BuildType)
 	for _, artifact := range config.Pipeline.Build.Artifacts {
 		if _, ok := meter.Builders[yamltags.GetYamlTag(artifact.ArtifactType)]; ok {

--- a/pkg/skaffold/util/stringset.go
+++ b/pkg/skaffold/util/stringset.go
@@ -44,3 +44,8 @@ func (s StringSet) ToList() []string {
 	sort.Strings(res)
 	return res
 }
+
+func (s StringSet) Contains(str string) bool {
+	_, ok := s[str]
+	return ok
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Merge after**: #5157

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This change is necessary so we can correctly report the frequency of errors that occur before creating the runner and associate a command with them.

- Add contains function to util.StringSet and use that instead of map[string]bool to check if a command builds/deploys/should collect metrics.
- Set meter.Command in cobra PersistentPreFuncE instead of createNewRunner as the command should be available before any errors occur when creating the runner

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
