### PR TITLE
Render uses Helm templated values-file

### DIFF
--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -261,10 +261,6 @@ func (h *Deployer) Render(ctx context.Context, out io.Writer, builds []build.Art
 
 		args = append(args[:1], append([]string{r.Name}, args[1:]...)...)
 
-		for _, vf := range r.ValuesFiles {
-			args = append(args, "--values", vf)
-		}
-
 		params, err := pairParamsToArtifacts(builds, r.ArtifactOverrides)
 		if err != nil {
 			return err

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -1267,6 +1267,19 @@ func TestHelmRender(t *testing.T) {
 				}},
 		},
 		{
+			description: "render with templated values file",
+			shouldErr:   false,
+			commands: testutil.
+				CmdRunWithOutput("helm version --client", version31).
+				AndRun("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 -f /some/file-FOOBAR.yaml --kubeconfig kubeconfig"),
+			helm: testDeployConfigValuesFilesTemplated,
+			builds: []build.Artifact{
+				{
+					ImageName: "skaffold-helm",
+					Tag:       "skaffold-helm:tag1",
+				}},
+		},
+		{
 			description: "render with namespace",
 			shouldErr:   false,
 			commands: testutil.CmdRunWithOutput("helm version --client", version31).


### PR DESCRIPTION
Fixes: #5163

**Description**
Helm's `render` implementation redundantly adds the values-files, even though it is already done in `constructOverrideArgs()`, which further allows templating of the file name.  This PR removes the redundant processing.