### PR TITLE
Rename BuildAndTest() method to Build()

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -66,7 +66,7 @@ func doBuild(ctx context.Context, out io.Writer) error {
 	}
 
 	return withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
-		bRes, err := r.BuildAndTest(ctx, buildOut, targetArtifacts(opts, config))
+		bRes, err := r.Build(ctx, buildOut, targetArtifacts(opts, config))
 
 		if quietFlag || buildOutputFlag != "" {
 			cmdOut := flags.BuildOutput{Builds: bRes}

--- a/cmd/skaffold/app/cmd/build_test.go
+++ b/cmd/skaffold/app/cmd/build_test.go
@@ -36,7 +36,7 @@ type mockRunner struct {
 	runner.Runner
 }
 
-func (r *mockRunner) BuildAndTest(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+func (r *mockRunner) Build(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 	out.Write([]byte("Build Completed"))
 	return []build.Artifact{{
 		ImageName: "gcr.io/skaffold/example",

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -67,7 +67,7 @@ func doRender(ctx context.Context, out io.Writer) error {
 			bRes = renderFromBuildOutputFile.BuildArtifacts()
 		} else {
 			var err error
-			bRes, err = r.BuildAndTest(ctx, buildOut, targetArtifacts(opts, config))
+			bRes, err = r.Build(ctx, buildOut, targetArtifacts(opts, config))
 			if err != nil {
 				return fmt.Errorf("executing build: %w", err)
 			}

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -42,7 +42,7 @@ func NewCmdRun() *cobra.Command {
 
 func doRun(ctx context.Context, out io.Writer) error {
 	return withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
-		bRes, err := r.BuildAndTest(ctx, out, targetArtifacts(opts, config))
+		bRes, err := r.Build(ctx, out, targetArtifacts(opts, config))
 		if err != nil {
 			return fmt.Errorf("failed to build: %w", err)
 		}

--- a/cmd/skaffold/app/cmd/run_test.go
+++ b/cmd/skaffold/app/cmd/run_test.go
@@ -49,7 +49,7 @@ type mockRunRunner struct {
 	artifactImageNames []string
 }
 
-func (r *mockRunRunner) BuildAndTest(_ context.Context, _ io.Writer, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+func (r *mockRunRunner) Build(_ context.Context, _ io.Writer, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 	var result []build.Artifact
 	for _, artifact := range artifacts {
 		imageName := artifact.ImageName

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -59,7 +59,7 @@ type mockBuilder struct {
 	store        build.ArtifactStore
 }
 
-func (b *mockBuilder) BuildAndTest(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+func (b *mockBuilder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 	var built []build.Artifact
 
 	for _, artifact := range artifacts {
@@ -145,7 +145,7 @@ func TestCacheBuildLocal(t *testing.T) {
 
 		// First build: Need to build both artifacts
 		builder := &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store}
-		bRes, err := artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.BuildAndTest)
+		bRes, err := artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(2, len(builder.built))
@@ -154,7 +154,7 @@ func TestCacheBuildLocal(t *testing.T) {
 		// Second build: both artifacts are read from cache
 		// Artifacts should always be returned in their original order
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store}
-		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.BuildAndTest)
+		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckEmpty(builder.built)
@@ -166,7 +166,7 @@ func TestCacheBuildLocal(t *testing.T) {
 		// Artifacts should always be returned in their original order
 		tmpDir.Write("dep1", "new content")
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store}
-		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.BuildAndTest)
+		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(1, len(builder.built))
@@ -178,7 +178,7 @@ func TestCacheBuildLocal(t *testing.T) {
 		// Artifacts should always be returned in their original order
 		tmpDir.Write("dep3", "new content")
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: store}
-		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.BuildAndTest)
+		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(1, len(builder.built))
@@ -240,7 +240,7 @@ func TestCacheBuildRemote(t *testing.T) {
 
 		// First build: Need to build both artifacts
 		builder := &mockBuilder{dockerDaemon: dockerDaemon, push: true}
-		bRes, err := artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.BuildAndTest)
+		bRes, err := artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(2, len(builder.built))
@@ -251,7 +251,7 @@ func TestCacheBuildRemote(t *testing.T) {
 
 		// Second build: both artifacts are read from cache
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: true}
-		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.BuildAndTest)
+		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckEmpty(builder.built)
@@ -262,7 +262,7 @@ func TestCacheBuildRemote(t *testing.T) {
 		// Third build: change one artifact's dependencies
 		tmpDir.Write("dep1", "new content")
 		builder = &mockBuilder{dockerDaemon: dockerDaemon, push: true}
-		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.BuildAndTest)
+		bRes, err = artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(1, len(builder.built))
@@ -324,7 +324,7 @@ func TestCacheFindMissing(t *testing.T) {
 
 		// Because the artifacts are in the docker registry, we expect them to be imported correctly.
 		builder := &mockBuilder{dockerDaemon: dockerDaemon, push: false, store: make(mockArtifactStore)}
-		bRes, err := artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.BuildAndTest)
+		bRes, err := artifactCache.Build(context.Background(), ioutil.Discard, tags, artifacts, builder.Build)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(0, len(builder.built))

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -32,8 +32,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
-// BuildAndTest builds and tests a list of artifacts.
-func (r *SkaffoldRunner) BuildAndTest(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) ([]build.Artifact, error) {
+// Build builds a list of artifacts.
+func (r *SkaffoldRunner) Build(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) ([]build.Artifact, error) {
 	// Use tags directly from the Kubernetes manifests.
 	if r.runCtx.DigestSource() == noneDigestSource {
 		return []build.Artifact{}, nil

--- a/pkg/skaffold/runner/build_deploy_test.go
+++ b/pkg/skaffold/runner/build_deploy_test.go
@@ -134,7 +134,7 @@ func TestBuildTestDeploy(t *testing.T) {
 			}}
 
 			runner := createRunner(t, test.testBench, nil)
-			bRes, err := runner.BuildAndTest(ctx, ioutil.Discard, artifacts)
+			bRes, err := runner.Build(ctx, ioutil.Discard, artifacts)
 			if err == nil {
 				err = runner.DeployAndLog(ctx, ioutil.Discard, bRes)
 			}
@@ -144,13 +144,13 @@ func TestBuildTestDeploy(t *testing.T) {
 	}
 }
 
-func TestBuildAndTestDryRun(t *testing.T) {
+func TestBuildDryRun(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		testBench := &TestBench{}
 		runner := createRunner(t, testBench, nil)
 		runner.runCtx.Opts.DryRun = true
 
-		bRes, err := runner.BuildAndTest(context.Background(), ioutil.Discard, []*latest.Artifact{
+		bRes, err := runner.Build(context.Background(), ioutil.Discard, []*latest.Artifact{
 			{ImageName: "img1"},
 			{ImageName: "img2"},
 		})
@@ -164,13 +164,13 @@ func TestBuildAndTestDryRun(t *testing.T) {
 	})
 }
 
-func TestBuildAndTestSkipBuild(t *testing.T) {
+func TestBuildSkipBuild(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		testBench := &TestBench{}
 		runner := createRunner(t, testBench, nil)
 		runner.runCtx.Opts.DigestSource = "none"
 
-		bRes, err := runner.BuildAndTest(context.Background(), ioutil.Discard, []*latest.Artifact{
+		bRes, err := runner.Build(context.Background(), ioutil.Discard, []*latest.Artifact{
 			{ImageName: "img1"},
 			{ImageName: "img2"},
 		})

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -102,7 +102,7 @@ func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer, logger *kuber
 			instrumentation.AddDevIteration("build")
 			meterUpdated = true
 		}
-		if _, err := r.BuildAndTest(ctx, out, r.changeSet.needsRebuild); err != nil {
+		if _, err := r.Build(ctx, out, r.changeSet.needsRebuild); err != nil {
 			logrus.Warnln("Skipping deploy due to error:", err)
 			event.DevLoopFailedInPhase(r.devIteration, sErrors.Build, err)
 			return nil
@@ -214,7 +214,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	}
 
 	// First build
-	bRes, err := r.BuildAndTest(ctx, out, artifacts)
+	bRes, err := r.Build(ctx, out, artifacts)
 	if err != nil {
 		event.DevLoopFailedInPhase(r.devIteration, sErrors.Build, err)
 		return fmt.Errorf("exiting dev mode because first build failed: %w", err)

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -44,7 +44,7 @@ const (
 type Runner interface {
 	Dev(context.Context, io.Writer, []*latest.Artifact) error
 	ApplyDefaultRepo(tag string) (string, error)
-	BuildAndTest(context.Context, io.Writer, []*latest.Artifact) ([]build.Artifact, error)
+	Build(context.Context, io.Writer, []*latest.Artifact) ([]build.Artifact, error)
 	Test(context.Context, io.Writer, []build.Artifact) error
 	DeployAndLog(context.Context, io.Writer, []build.Artifact) error
 	GeneratePipeline(context.Context, io.Writer, *latest.SkaffoldConfig, []string, string) error


### PR DESCRIPTION
Fixes: #5173

Description
Rename BuildAndTest() method to Build().

Current implementation of skaffold has test & build merged into a single method.

Testing phase involves splitting build and test and moving test to a separate command. This renaming is part of separating them.
