### PR TITLE
Ensure init generates /-delimted paths

### DIFF
--- a/pkg/skaffold/build/buildpacks/init.go
+++ b/pkg/skaffold/build/buildpacks/init.go
@@ -49,7 +49,7 @@ func (c ArtifactConfig) Describe() string {
 }
 
 // ArtifactType returns the type of the artifact to be built.
-func (c ArtifactConfig) ArtifactType() latest.ArtifactType {
+func (c ArtifactConfig) ArtifactType(_ string) latest.ArtifactType {
 	return latest.ArtifactType{
 		BuildpackArtifact: &latest.BuildpackArtifact{
 			Builder: c.Builder,

--- a/pkg/skaffold/build/buildpacks/init_test.go
+++ b/pkg/skaffold/build/buildpacks/init_test.go
@@ -149,7 +149,7 @@ func TestArtifactType(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			at := test.config.ArtifactType()
+			at := test.config.ArtifactType("ignored")	// buildpacks doesn't include file references in its artifacts
 
 			t.CheckDeepEqual(test.expectedType, at)
 		})

--- a/pkg/skaffold/build/buildpacks/init_test.go
+++ b/pkg/skaffold/build/buildpacks/init_test.go
@@ -149,7 +149,7 @@ func TestArtifactType(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			at := test.config.ArtifactType("ignored")	// buildpacks doesn't include file references in its artifacts
+			at := test.config.ArtifactType("ignored") // buildpacks doesn't include file references in its artifacts
 
 			t.CheckDeepEqual(test.expectedType, at)
 		})

--- a/pkg/skaffold/build/jib/init.go
+++ b/pkg/skaffold/build/jib/init.go
@@ -59,7 +59,7 @@ func (c ArtifactConfig) Describe() string {
 }
 
 // ArtifactType returns the type of the artifact to be built.
-func (c ArtifactConfig) ArtifactType() latest.ArtifactType {
+func (c ArtifactConfig) ArtifactType(_ string) latest.ArtifactType {
 	return latest.ArtifactType{
 		JibArtifact: &latest.JibArtifact{
 			Project: c.Project,

--- a/pkg/skaffold/build/jib/init_test.go
+++ b/pkg/skaffold/build/jib/init_test.go
@@ -242,7 +242,7 @@ func TestArtifactType(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			at := test.config.ArtifactType()
+			at := test.config.ArtifactType("ignored")	// jib doesn't include file references in its artifacts
 
 			t.CheckDeepEqual(test.expectedType, at)
 		})

--- a/pkg/skaffold/build/jib/init_test.go
+++ b/pkg/skaffold/build/jib/init_test.go
@@ -242,7 +242,7 @@ func TestArtifactType(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			at := test.config.ArtifactType("ignored")	// jib doesn't include file references in its artifacts
+			at := test.config.ArtifactType("ignored") // jib doesn't include file references in its artifacts
 
 			t.CheckDeepEqual(test.expectedType, at)
 		})

--- a/pkg/skaffold/docker/docker_init.go
+++ b/pkg/skaffold/docker/docker_init.go
@@ -53,10 +53,12 @@ func (c ArtifactConfig) Describe() string {
 
 // ArtifactType returns the type of the artifact to be built.
 func (c ArtifactConfig) ArtifactType(workspace string) latest.ArtifactType {
-	// attempt to relativize the path
-	dockerfile, err := filepath.Rel(workspace, c.File)
-	if err != nil {
-		dockerfile = filepath.Base(c.File)
+	dockerfile := filepath.Base(c.File)
+	if workspace != "" {
+		// attempt to relativize the path
+		if rel, err := filepath.Rel(workspace, c.File); err == nil {
+			dockerfile = rel
+		}
 	}
 
 	return latest.ArtifactType{

--- a/pkg/skaffold/docker/docker_init.go
+++ b/pkg/skaffold/docker/docker_init.go
@@ -52,12 +52,17 @@ func (c ArtifactConfig) Describe() string {
 }
 
 // ArtifactType returns the type of the artifact to be built.
-func (c ArtifactConfig) ArtifactType() latest.ArtifactType {
-	dockerfile := filepath.Base(c.File)
+func (c ArtifactConfig) ArtifactType(workspace string) latest.ArtifactType {
+	// attempt to relativize the path
+	dockerfile, err := filepath.Rel(workspace, c.File)
+	if err != nil {
+		dockerfile = filepath.Base(c.File)
+	}
 
 	return latest.ArtifactType{
 		DockerArtifact: &latest.DockerArtifact{
-			DockerfilePath: dockerfile,
+			// to make skaffold.yaml more portable across OS-es we should always generate /-delimited filePaths
+			DockerfilePath: filepath.ToSlash(dockerfile),
 		},
 	}
 }

--- a/pkg/skaffold/docker/docker_init_test.go
+++ b/pkg/skaffold/docker/docker_init_test.go
@@ -121,7 +121,6 @@ func TestArtifactType(t *testing.T) {
 				},
 			},
 		},
-
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {

--- a/pkg/skaffold/docker/docker_init_test.go
+++ b/pkg/skaffold/docker/docker_init_test.go
@@ -89,6 +89,7 @@ func TestDescribe(t *testing.T) {
 func TestArtifactType(t *testing.T) {
 	tests := []struct {
 		description  string
+		workspace    string
 		config       ArtifactConfig
 		expectedType latest.ArtifactType
 	}{
@@ -110,10 +111,21 @@ func TestArtifactType(t *testing.T) {
 				},
 			},
 		},
+		{
+			description: "with workspace",
+			config:      ArtifactConfig{File: filepath.Join("path", "to", "Dockerfile")},
+			workspace:   "path",
+			expectedType: latest.ArtifactType{
+				DockerArtifact: &latest.DockerArtifact{
+					DockerfilePath: "to/Dockerfile",
+				},
+			},
+		},
+
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			at := test.config.ArtifactType()
+			at := test.config.ArtifactType(test.workspace)
 
 			t.CheckDeepEqual(test.expectedType, at)
 		})

--- a/pkg/skaffold/initializer/analyze/analyze.go
+++ b/pkg/skaffold/initializer/analyze/analyze.go
@@ -152,7 +152,7 @@ func (a *ProjectAnalysis) Analyze(dir string) error {
 			}
 		}
 
-		// to make skaffold.yaml more portable across OS-es we should always generate / based filePaths
+		// to make skaffold.yaml more portable across OS-es we should always generate /-delimited filePaths
 		filePath = strings.ReplaceAll(filePath, string(os.PathSeparator), "/")
 		for _, analyzer := range a.analyzers() {
 			if err := analyzer.analyzeFile(filePath); err != nil {

--- a/pkg/skaffold/initializer/analyze/builder.go
+++ b/pkg/skaffold/initializer/analyze/builder.go
@@ -79,7 +79,8 @@ func (a *builderAnalyzer) detectBuilders(path string, detectJib bool) ([]build.I
 	if strings.Contains(strings.ToLower(base), "dockerfile") {
 		if docker.Validate(path) {
 			results = append(results, docker.ArtifactConfig{
-				File: path,
+				// Docker expects forward slashes (for Linux containers at least)
+				File: filepath.ToSlash(path),
 			})
 		}
 	}

--- a/pkg/skaffold/initializer/build/builders.go
+++ b/pkg/skaffold/initializer/build/builders.go
@@ -36,8 +36,8 @@ type InitBuilder interface {
 	// Must be unique between artifacts.
 	Describe() string
 
-	// ArtifactType returns the type of the artifact to be built.
-	ArtifactType() latest.ArtifactType
+	// ArtifactType returns the type of the artifact to be built.  Paths should be relative to the workspace.
+	ArtifactType(workspace string) latest.ArtifactType
 
 	// ConfiguredImage returns the target image configured by the builder, or an empty string if no image is configured.
 	// This should be a cheap operation.

--- a/pkg/skaffold/initializer/build/builders.go
+++ b/pkg/skaffold/initializer/build/builders.go
@@ -37,6 +37,7 @@ type InitBuilder interface {
 	Describe() string
 
 	// ArtifactType returns the type of the artifact to be built.  Paths should be relative to the workspace.
+	// To make skaffold.yaml more portable across OS-es we should always generate /-delimited filepaths.
 	ArtifactType(workspace string) latest.ArtifactType
 
 	// ConfiguredImage returns the target image configured by the builder, or an empty string if no image is configured.

--- a/pkg/skaffold/initializer/build/resolve.go
+++ b/pkg/skaffold/initializer/build/resolve.go
@@ -79,7 +79,7 @@ func (d *defaultBuildInitializer) resolveBuilderImagesForcefully() error {
 }
 
 func builderRank(builder InitBuilder) int {
-	a := builder.ArtifactType()
+	a := builder.ArtifactType("")
 	switch {
 	case a.DockerArtifact != nil:
 		return 1

--- a/pkg/skaffold/initializer/build/util.go
+++ b/pkg/skaffold/initializer/build/util.go
@@ -65,17 +65,16 @@ func Artifacts(artifactInfos []ArtifactInfo) []*latest.Artifact {
 	var artifacts []*latest.Artifact
 
 	for _, info := range artifactInfos {
-		artifact := &latest.Artifact{
-			ImageName:    info.ImageName,
-			ArtifactType: info.Builder.ArtifactType(),
-		}
-
 		workspace := info.Workspace
 		if workspace == "" {
 			workspace = filepath.Dir(info.Builder.Path())
 		}
+		artifact := &latest.Artifact{
+			ImageName:    info.ImageName,
+			ArtifactType: info.Builder.ArtifactType(workspace),
+		}
+
 		if workspace != "." {
-			fmt.Fprintf(os.Stdout, "using non standard workspace: %s\n", workspace)
 			// to make skaffold.yaml more portable across OS-es we should always generate /-delimited filePaths
 			artifact.Workspace = filepath.ToSlash(workspace)
 		}

--- a/pkg/skaffold/initializer/build/util.go
+++ b/pkg/skaffold/initializer/build/util.go
@@ -75,7 +75,9 @@ func Artifacts(artifactInfos []ArtifactInfo) []*latest.Artifact {
 			workspace = filepath.Dir(info.Builder.Path())
 		}
 		if workspace != "." {
-			artifact.Workspace = workspace
+			fmt.Fprintf(os.Stdout, "using non standard workspace: %s\n", workspace)
+			// to make skaffold.yaml more portable across OS-es we should always generate /-delimited filePaths
+			artifact.Workspace = filepath.ToSlash(workspace)
 		}
 
 		artifacts = append(artifacts, artifact)

--- a/pkg/skaffold/initializer/build/util.go
+++ b/pkg/skaffold/initializer/build/util.go
@@ -75,7 +75,7 @@ func Artifacts(artifactInfos []ArtifactInfo) []*latest.Artifact {
 		}
 
 		if workspace != "." {
-			// to make skaffold.yaml more portable across OS-es we should always generate /-delimited filePaths
+			// to make skaffold.yaml more portable across OS-es we should always generate /-delimited filepaths
 			artifact.Workspace = filepath.ToSlash(workspace)
 		}
 

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -92,9 +92,9 @@ func TestDoInit(t *testing.T) {
 			},
 		},
 		{
-			name: "windows paths use forward slashes",
+			name:       "windows paths use forward slashes",
 			shouldSkip: func() bool { return runtime.GOOS != "windows" },
-			dir:  `testdata\init\windows`,
+			dir:        `testdata\init\windows`,
 			config: initconfig.Config{
 				Force: true,
 				CliArtifacts: []string{

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -35,6 +36,7 @@ import (
 func TestDoInit(t *testing.T) {
 	tests := []struct {
 		name             string
+		shouldSkip       func() bool
 		dir              string
 		config           initconfig.Config
 		expectedError    string
@@ -83,6 +85,20 @@ func TestDoInit(t *testing.T) {
 				CliArtifacts: []string{
 					`{"builder":"Docker","payload":{"path":"leeroy-app/Dockerfile"},"image":"gcr.io/k8s-skaffold/leeroy-app"}`,
 					`{"builder":"Docker","payload":{"path":"leeroy-web/Dockerfile"},"image":"gcr.io/k8s-skaffold/leeroy-web"}`,
+				},
+				Opts: config.SkaffoldOptions{
+					ConfigurationFile: "skaffold.yaml.out",
+				},
+			},
+		},
+		{
+			name: "windows paths use forward slashes",
+			shouldSkip: func() bool { return runtime.GOOS != "windows" },
+			dir:  `testdata\init\windows`,
+			config: initconfig.Config{
+				Force: true,
+				CliArtifacts: []string{
+					`{"builder":"Docker","context":"apps\\web","payload":{"path":"apps\\web\\build\\Dockerfile"},"image":"gcr.io/k8s-skaffold/leeroy-app"}`,
 				},
 				Opts: config.SkaffoldOptions{
 					ConfigurationFile: "skaffold.yaml.out",
@@ -212,6 +228,10 @@ See https://skaffold.dev/docs/pipeline-stages/deployers/helm/ for a detailed gui
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
+			if test.shouldSkip != nil && test.shouldSkip() {
+				t.Logf("Skipped test %q", test.name)
+				return
+			}
 			t.Chdir(test.dir)
 
 			err := DoInit(context.TODO(), os.Stdout, test.config)

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -36,7 +36,7 @@ import (
 func TestDoInit(t *testing.T) {
 	tests := []struct {
 		name             string
-		shouldSkip       func() bool
+		shouldSkip       bool
 		dir              string
 		config           initconfig.Config
 		expectedError    string
@@ -93,7 +93,7 @@ func TestDoInit(t *testing.T) {
 		},
 		{
 			name:       "windows paths use forward slashes",
-			shouldSkip: func() bool { return runtime.GOOS != "windows" },
+			shouldSkip: runtime.GOOS != "windows",
 			dir:        `testdata\init\windows`,
 			config: initconfig.Config{
 				Force: true,
@@ -228,7 +228,7 @@ See https://skaffold.dev/docs/pipeline-stages/deployers/helm/ for a detailed gui
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
-			if test.shouldSkip != nil && test.shouldSkip() {
+			if test.shouldSkip {
 				t.Logf("Skipped test %q", test.name)
 				return
 			}

--- a/pkg/skaffold/initializer/init_test.go
+++ b/pkg/skaffold/initializer/init_test.go
@@ -98,7 +98,7 @@ func TestDoInit(t *testing.T) {
 			config: initconfig.Config{
 				Force: true,
 				CliArtifacts: []string{
-					`{"builder":"Docker","context":"apps\\web","payload":{"path":"apps\\web\\build\\Dockerfile"},"image":"gcr.io/k8s-skaffold/leeroy-app"}`,
+					`{"builder":"Docker","context":"apps\\web","payload":{"path":"apps\\web\\build\\Dockerfile"},"image":"gcr.io/k8s-skaffold/leeroy-web"}`,
 				},
 				Opts: config.SkaffoldOptions{
 					ConfigurationFile: "skaffold.yaml.out",

--- a/pkg/skaffold/initializer/testdata/init/windows/apps/web/build/Dockerfile
+++ b/pkg/skaffold/initializer/testdata/init/windows/apps/web/build/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.12.9-alpine3.10 as builder
+COPY web.go .
+RUN go build -o /web .
+
+FROM alpine:3.10
+CMD ["./web"]
+COPY --from=builder /web .

--- a/pkg/skaffold/initializer/testdata/init/windows/apps/web/deployment.yaml
+++ b/pkg/skaffold/initializer/testdata/init/windows/apps/web/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: leeroy-web
+  labels:
+    app: leeroy-web
+spec:
+  type: NodePort
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      name: leeroy-web
+  selector:
+    app: leeroy-web
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: leeroy-web
+  labels:
+    app: leeroy-web
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: leeroy-web
+  template:
+    metadata:
+      labels:
+        app: leeroy-web
+    spec:
+      containers:
+      - name: leeroy-web
+        image: gcr.io/k8s-skaffold/leeroy-web
+        ports:
+        - containerPort: 8080

--- a/pkg/skaffold/initializer/testdata/init/windows/apps/web/web.go
+++ b/pkg/skaffold/initializer/testdata/init/windows/apps/web/web.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"io"
+	"net/http"
+
+	"log"
+)
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	resp, err := http.Get("http://leeroy-app:50051")
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	log.Print("leeroy web server ready")
+	http.HandleFunc("/", handler)
+	http.ListenAndServe(":8080", nil)
+}

--- a/pkg/skaffold/initializer/testdata/init/windows/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/windows/skaffold.yaml
@@ -1,0 +1,14 @@
+apiVersion: skaffold/v2beta11
+kind: Config
+metadata:
+  name: windows
+build:
+  artifacts:
+  - image: gcr.io/k8s-skaffold/leeroy-web
+    context: apps/web
+    docker:
+      dockerfile: build/Dockerfile
+deploy:
+  kubectl:
+    manifests:
+    - apps/web/deployment.yaml


### PR DESCRIPTION
Fixes: #5074

**Description**
Ensure paths are written using forward slashes during `init`.  Adds a test for Windows.

The choice of where to maintain and use the workspace is a bit confusing.
- Each builder provides an `ArtifactConfig` to capture a detected artifact (e.g., [Jib](https://github.com/GoogleContainerTools/skaffold/blob/master/pkg/skaffold/build/jib/init.go#L40-L46)).
- Each `ArtifactConfig` implements an [`initializers/build.InitBuilder` interface](https://github.com/GoogleContainerTools/skaffold/blob/master/pkg/skaffold/initializer/build/builders.go#L30-L48).  The `ArtifactType()` method generates a config schema's [`ArtifactType`](https://github.com/GoogleContainerTools/skaffold/blob/master/pkg/skaffold/schema/latest/config.go#L873-L894) with the appropriate per- builder information.  This `ArtifactType` is contained with the artifact's workspace within the config schema's [`Artifact`](https://github.com/GoogleContainerTools/skaffold/blob/master/pkg/skaffold/schema/latest/config.go#L873-L894) object.

For now I pass the workspace into the per-builder `ArtifactConfig.ArtifactType(workspace)` functions.  It would seem to make sense for the workspace to be passed around within the per-builder `ArtifactConfig` objects, except that they don't actually generate the `Artifact` object.  So we'd still need to swizzle the workspace when [creating the corresponding `Artifact` objects](https://github.com/GoogleContainerTools/skaffold/blob/master/pkg/skaffold/initializer/build/util.go#L73-L79).  

But it might be worth having the `ArtifactConfig` objects be responsible for generating the `Artifact` object so that they could populate it with sync rules?
