### PR TITLE
proposal for user generated tagger.

### DIFF
--- a/docs/design_proposals/digest-tagger.md
+++ b/docs/design_proposals/digest-tagger.md
@@ -1,4 +1,4 @@
-# Improve taggers
+1# Improve taggers
 
 * Author(s): David Gageot (@dgageot)
 * Date: 4 September 2019
@@ -63,6 +63,17 @@ Here are some rules about how tagging currently works:
    such tagger by computing the digest of the whole workspace. We should instead compute
    the digest of the artifact's dependencies, including the artifact's configuration. This
    is exactly what the caching mechanism currently does.
+ + An `userGenerated` is added. This is for special cases where the user can pass command 
+   that will execute and output the tag for a given image. It will make some room for integration
+   with maven, gradel, bazel (and probably other build tools) that can fallow more precisely 
+   dependency graph of a given executable. With time these plugins could become integrated 
+   into a skaffold code base. Or at least be officially supported. It is also important to note 
+   that this is a more complicated case. If a plugin model is to be adopted the tagger configuration 
+   can't happen on a global level. Because different images will use different plugins. Even a simple
+   projects will have (as an example) react and java docker images. And those will use different 
+   methods for tag generation. So, the artifact object has be extended, to allow overriding of the 
+   global tagger with a custom one. For now, it will be a bash command that can only output a 
+   singe string that will becomes image's tag.
  + `envTemplate` learns how to replace `{{.DIGEST}}` with a digest of the artifact's
     inputs as computed by the `inputDigest` tagger.
  + **No matter the tagger, Skaffold will keep on using immutable references in manifests**.


### PR DESCRIPTION
Some more context for the design proposal. Because at the moment we are already using our own skaffold distro with the mention tagger. Imagine you have a java project with 5 modules:

project:

- commons 1
- commons 2
- executable 1
- executable 2
- executable 3

And following dependencies. 
```
         executable 3                                  executable 2
         /            \                                 /          \            
executable 1       commons 2                      executable 1      commons 1
```
And using multistage docker file that looks like this (a bit of a pseudo code):
```
FROM remoterepo/images/maven_cach:3.6 AS deps_maven_build
COPY /project /project
WORKDIR /project
RUN mvn clean install -Dmaven.javadoc.skip=true -Dmaven.test.skip=true

FROM gcr.io/distroless/java:11 AS executable_3
COPY --chown=1000:1000 --from=deps_maven_build /executable_2.jar /

FROM gcr.io/distroless/java:11 AS executable_2
COPY --chown=1000:1000 --from=deps_maven_build /executable_3.jar /
```
Now forget the existing taggers. `GitTreeSha`  will generate a tag base on a too narrow or too wide scope. And the rest is useless. Even the proposed `inputDigest` tagger will not do the job because it will hash every file that is touched by the `COPY` command in front of it. 

Any build tool (in this case maven ) has the full knowledge of the dependency graph that is part of a given executable. I think adding this tagger would create an interesting point of integration. I wrote a plugin for maven and it works extremely well. I think a similar thing can be written for gradle, bazel, npm, cmake, rake etc....

Looking for what the community has to say. 

I created the [PR](https://github.com/piotr-szybicki/skaffold/pull/1) in my own fork how could that work.

