### PR TITLE
Add transparent init

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -65,7 +65,7 @@ func doBuild(ctx context.Context, out io.Writer) error {
 		buildOut = ioutil.Discard
 	}
 
-	return withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, config *latest.SkaffoldConfig) error {
 		bRes, err := r.Build(ctx, buildOut, targetArtifacts(opts, config))
 
 		if quietFlag || buildOutputFlag != "" {

--- a/cmd/skaffold/app/cmd/build_test.go
+++ b/cmd/skaffold/app/cmd/build_test.go
@@ -49,7 +49,7 @@ func (r *mockRunner) Stop() error {
 }
 
 func TestTagFlag(t *testing.T) {
-	mockCreateRunner := func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 		return &mockRunner{}, &latest.SkaffoldConfig{}, nil
 	}
 
@@ -68,7 +68,7 @@ func TestTagFlag(t *testing.T) {
 }
 
 func TestQuietFlag(t *testing.T) {
-	mockCreateRunner := func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 		return &mockRunner{}, &latest.SkaffoldConfig{}, nil
 	}
 
@@ -114,7 +114,7 @@ func TestQuietFlag(t *testing.T) {
 }
 
 func TestFileOutputFlag(t *testing.T) {
-	mockCreateRunner := func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 		return &mockRunner{}, &latest.SkaffoldConfig{}, nil
 	}
 
@@ -177,16 +177,16 @@ func TestFileOutputFlag(t *testing.T) {
 }
 
 func TestRunBuild(t *testing.T) {
-	errRunner := func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+	errRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 		return nil, nil, errors.New("some error")
 	}
-	mockCreateRunner := func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 		return &mockRunner{}, &latest.SkaffoldConfig{}, nil
 	}
 
 	tests := []struct {
 		description string
-		mock        func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error)
+		mock        func(io.Writer, config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error)
 		shouldErr   bool
 	}{
 		{

--- a/cmd/skaffold/app/cmd/debug_test.go
+++ b/cmd/skaffold/app/cmd/debug_test.go
@@ -48,7 +48,7 @@ func TestNewCmdDebug(t *testing.T) {
 func TestDebugIndependentFromDev(t *testing.T) {
 	mockRunner := &mockDevRunner{}
 	testutil.Run(t, "DevDebug", func(t *testutil.T) {
-		t.Override(&createRunner, func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+		t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 			return mockRunner, &latest.SkaffoldConfig{}, nil
 		})
 		t.Override(&opts, config.SkaffoldOptions{})

--- a/cmd/skaffold/app/cmd/delete.go
+++ b/cmd/skaffold/app/cmd/delete.go
@@ -35,7 +35,7 @@ func NewCmdDelete() *cobra.Command {
 }
 
 func doDelete(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, func(r runner.Runner, _ *latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, _ *latest.SkaffoldConfig) error {
 		return r.Cleanup(ctx, out)
 	})
 }

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -51,7 +51,7 @@ func NewCmdDeploy() *cobra.Command {
 }
 
 func doDeploy(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, config *latest.SkaffoldConfig) error {
 		if opts.SkipRender {
 			return r.DeployAndLog(ctx, out, []build.Artifact{})
 		}

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -60,7 +60,7 @@ func runDev(ctx context.Context, out io.Writer) error {
 		case <-ctx.Done():
 			return nil
 		default:
-			err := withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
+			err := withRunner(ctx, out, func(r runner.Runner, config *latest.SkaffoldConfig) error {
 				err := r.Dev(ctx, out, config.Build.Artifacts)
 
 				if r.HasDeployed() {

--- a/cmd/skaffold/app/cmd/dev_test.go
+++ b/cmd/skaffold/app/cmd/dev_test.go
@@ -95,7 +95,7 @@ func TestDoDev(t *testing.T) {
 				hasDeployed: test.hasDeployed,
 				errDev:      context.Canceled,
 			}
-			t.Override(&createRunner, func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+			t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 				return mockRunner, &latest.SkaffoldConfig{}, nil
 			})
 			t.Override(&opts, config.SkaffoldOptions{
@@ -145,7 +145,7 @@ func TestDevConfigChange(t *testing.T) {
 	testutil.Run(t, "test config change", func(t *testutil.T) {
 		mockRunner := &mockConfigChangeRunner{}
 
-		t.Override(&createRunner, func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+		t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 			return mockRunner, &latest.SkaffoldConfig{}, nil
 		})
 		t.Override(&opts, config.SkaffoldOptions{

--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -46,7 +46,7 @@ func NewCmdDiagnose() *cobra.Command {
 }
 
 func doDiagnose(ctx context.Context, out io.Writer) error {
-	runCtx, config, err := runContext(opts)
+	runCtx, config, err := runContext(out, opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/skaffold/app/cmd/filter.go
+++ b/cmd/skaffold/app/cmd/filter.go
@@ -58,7 +58,7 @@ func NewCmdFilter() *cobra.Command {
 // runFilter loads the Kubernetes manifests from stdin and applies the debug transformations.
 // Unlike `skaffold debug`, this filtering affects all images and not just the built artifacts.
 func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildArtifacts []build.Artifact) error {
-	return withRunner(ctx, func(r runner.Runner, cfg *latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, cfg *latest.SkaffoldConfig) error {
 		manifestList, err := manifest.Load(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("loading manifests: %w", err)

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -461,20 +461,22 @@ var flagRegistry = []Flag{
 		DefinedOn:     []string{"test", "deploy"},
 	},
 	{
-		Name:          "try-transparent-init",
+		Name:          "auto-create-config",
 		Usage:         "If true, skaffold will try to create a config for the user's run if it doesn't find one",
-		Value:         &opts.TryTransparentInit,
+		Value:         &opts.AutoCreateConfig,
 		DefValue:      true,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"debug", "dev", "run"},
+		IsEnum:        true,
 	},
 	{
-		Name:          "skip-confirmation",
+		Name:          "assume-yes",
 		Usage:         "If true, skaffold will skip yes/no confirmation from the user and default to yes",
-		Value:         &opts.SkipConfirmation,
+		Value:         &opts.AssumeYes,
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"debug", "dev", "run"},
+		IsEnum:        true,
 	},
 }
 

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -460,6 +460,22 @@ var flagRegistry = []Flag{
 		FlagAddMethod: "Var",
 		DefinedOn:     []string{"test", "deploy"},
 	},
+	{
+		Name:          "try-transparent-init",
+		Usage:         "If true, skaffold will try to create a config for the user's run if it doesn't find one",
+		Value:         &opts.TryTransparentInit,
+		DefValue:      true,
+		FlagAddMethod: "BoolVar",
+		DefinedOn:     []string{"debug", "dev", "run"},
+	},
+	{
+		Name:          "skip-confirmation",
+		Usage:         "If true, skaffold will skip yes/no confirmation from the user and default to yes",
+		Value:         &opts.SkipConfirmation,
+		DefValue:      false,
+		FlagAddMethod: "BoolVar",
+		DefinedOn:     []string{"debug", "dev", "run"},
+	},
 }
 
 func methodNameByType(v reflect.Value) string {

--- a/cmd/skaffold/app/cmd/generate_pipeline.go
+++ b/cmd/skaffold/app/cmd/generate_pipeline.go
@@ -44,7 +44,7 @@ func NewCmdGeneratePipeline() *cobra.Command {
 }
 
 func doGeneratePipeline(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, config *latest.SkaffoldConfig) error {
 		if err := r.GeneratePipeline(ctx, out, config, configFiles, "pipeline.yaml"); err != nil {
 			return fmt.Errorf("generating : %w", err)
 		}

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -60,7 +60,7 @@ func doRender(ctx context.Context, out io.Writer) error {
 		buildOut = out
 	}
 
-	return withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, config *latest.SkaffoldConfig) error {
 		var bRes []build.Artifact
 
 		if renderFromBuildOutputFile.String() != "" {

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -41,7 +41,7 @@ func NewCmdRun() *cobra.Command {
 }
 
 func doRun(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, config *latest.SkaffoldConfig) error {
 		bRes, err := r.Build(ctx, out, targetArtifacts(opts, config))
 		if err != nil {
 			return fmt.Errorf("failed to build: %w", err)

--- a/cmd/skaffold/app/cmd/run_test.go
+++ b/cmd/skaffold/app/cmd/run_test.go
@@ -69,7 +69,7 @@ func (r *mockRunRunner) DeployAndLog(context.Context, io.Writer, []build.Artifac
 func TestBuildImageFlag(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		mockRunner := &mockRunRunner{}
-		t.Override(&createRunner, func(config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+		t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
 			return mockRunner, &latest.SkaffoldConfig{
 				Pipeline: latest.Pipeline{
 					Build: latest.BuildConfig{

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -120,6 +120,11 @@ func skaffoldConfig(out io.Writer, opts config.SkaffoldOptions) ([]*latest.Skaff
 			if err != nil {
 				return nil, nil, fmt.Errorf("unable to generate skaffold config file automatically - try running `skaffold init`: %w", err)
 			}
+			if config == nil {
+				return nil, nil, fmt.Errorf("user not continuing")
+			}
+
+			defaults.Set(config, true)
 
 			return []*latest.SkaffoldConfig{config}, []latest.Pipeline{config.Pipeline}, nil
 		}

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -115,14 +115,14 @@ func skaffoldConfig(out io.Writer, opts config.SkaffoldOptions) ([]*latest.Skaff
 	parsed, err := schema.ParseConfigAndUpgrade(opts.ConfigurationFile, latest.Version)
 	if err != nil {
 		if os.IsNotExist(errors.Unwrap(err)) {
-			if opts.TryTransparentInit && initializer.ValidCmd(opts) {
+			if opts.AutoCreateConfig && initializer.ValidCmd(opts) {
 				color.Default.Fprintf(out, "Skaffold config file %s not found - Trying to create one for you...\n", opts.ConfigurationFile)
 				config, err := initializer.Transparent(context.Background(), out, initConfig.Config{Opts: opts})
 				if err != nil {
 					return nil, nil, fmt.Errorf("unable to generate skaffold config file automatically - try running `skaffold init`: %w", err)
 				}
 				if config == nil {
-					return nil, nil, fmt.Errorf("user not continuing")
+					return nil, nil, fmt.Errorf("unable to generate skaffold config file automatically - try running `skaffold init`: action cancelled by user")
 				}
 
 				defaults.Set(config, true)

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -41,8 +42,8 @@ import (
 // For tests
 var createRunner = createNewRunner
 
-func withRunner(ctx context.Context, action func(runner.Runner, *latest.SkaffoldConfig) error) error {
-	runner, config, err := createRunner(opts)
+func withRunner(ctx context.Context, out io.Writer, action func(runner.Runner, *latest.SkaffoldConfig) error) error {
+	runner, config, err := createRunner(out, opts)
 	sErrors.SetSkaffoldOptions(opts)
 	if err != nil {
 		return err
@@ -54,8 +55,8 @@ func withRunner(ctx context.Context, action func(runner.Runner, *latest.Skaffold
 }
 
 // createNewRunner creates a Runner and returns the SkaffoldConfig associated with it.
-func createNewRunner(opts config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
-	runCtx, config, err := runContext(opts)
+func createNewRunner(out io.Writer, opts config.SkaffoldOptions) (runner.Runner, *latest.SkaffoldConfig, error) {
+	runCtx, config, err := runContext(out, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -70,7 +71,7 @@ func createNewRunner(opts config.SkaffoldOptions) (runner.Runner, *latest.Skaffo
 	return runner, config, nil
 }
 
-func runContext(opts config.SkaffoldOptions) (*runcontext.RunContext, *latest.SkaffoldConfig, error) {
+func runContext(_ io.Writer, opts config.SkaffoldOptions) (*runcontext.RunContext, *latest.SkaffoldConfig, error) {
 	parsed, err := schema.ParseConfigAndUpgrade(opts.ConfigurationFile, latest.Version)
 	if err != nil {
 		if os.IsNotExist(errors.Unwrap(err)) {

--- a/cmd/skaffold/app/cmd/runner_test.go
+++ b/cmd/skaffold/app/cmd/runner_test.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"testing"
 
 	"github.com/blang/semver"
@@ -98,7 +99,7 @@ func TestCreateNewRunner(t *testing.T) {
 				Write("skaffold.yaml", fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latest.Version, test.config)).
 				Chdir()
 
-			_, _, err := createNewRunner(test.options)
+			_, _, err := createNewRunner(ioutil.Discard, test.options)
 
 			t.CheckError(test.shouldErr, err)
 			if test.expectedError != "" {

--- a/cmd/skaffold/app/cmd/test.go
+++ b/cmd/skaffold/app/cmd/test.go
@@ -39,7 +39,7 @@ func NewCmdTest() *cobra.Command {
 }
 
 func doTest(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, func(r runner.Runner, config *latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, config *latest.SkaffoldConfig) error {
 		buildArtifacts, err := getBuildArtifactsAndSetTags(r, config)
 		if err != nil {
 			tips.PrintForTest(out)

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -341,6 +341,8 @@ Env vars:
 
 
 Options:
+      --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
+      --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --cache-artifacts=true: Set to false to disable default caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
       --cleanup=true: Delete deployments after dev or debug mode is interrupted
@@ -364,14 +366,12 @@ Options:
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
-      --skip-confirmation=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
       --trigger='notify': How is change detection triggered? (polling, notify, or manual)
-      --try-transparent-init=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
       --wait-for-deletions-delay=2s: Delay between two checks for pending deletions
       --wait-for-deletions-max=1m0s: Max duration to wait for pending deletions
@@ -387,6 +387,8 @@ Use "skaffold options" for a list of global command-line options (applies to all
 ```
 Env vars:
 
+* `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
+* `SKAFFOLD_AUTO_CREATE_CONFIG` (same as `--auto-create-config`)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
 * `SKAFFOLD_CLEANUP` (same as `--cleanup`)
@@ -410,14 +412,12 @@ Env vars:
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
-* `SKAFFOLD_SKIP_CONFIRMATION` (same as `--skip-confirmation`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
 * `SKAFFOLD_TRIGGER` (same as `--trigger`)
-* `SKAFFOLD_TRY_TRANSPARENT_INIT` (same as `--try-transparent-init`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_DELAY` (same as `--wait-for-deletions-delay`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_MAX` (same as `--wait-for-deletions-max`)
@@ -555,6 +555,8 @@ Run a pipeline in development mode
 
 
 Options:
+      --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
+      --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --cache-artifacts=true: Set to false to disable default caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
       --cleanup=true: Delete deployments after dev or debug mode is interrupted
@@ -579,14 +581,12 @@ Options:
       --render-only=false: Print rendered Kubernetes manifests instead of deploying them
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
-      --skip-confirmation=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
       --trigger='notify': How is change detection triggered? (polling, notify, or manual)
-      --try-transparent-init=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
       --wait-for-deletions-delay=2s: Delay between two checks for pending deletions
       --wait-for-deletions-max=1m0s: Max duration to wait for pending deletions
@@ -602,6 +602,8 @@ Use "skaffold options" for a list of global command-line options (applies to all
 ```
 Env vars:
 
+* `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
+* `SKAFFOLD_AUTO_CREATE_CONFIG` (same as `--auto-create-config`)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
 * `SKAFFOLD_CLEANUP` (same as `--cleanup`)
@@ -626,14 +628,12 @@ Env vars:
 * `SKAFFOLD_RENDER_ONLY` (same as `--render-only`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
-* `SKAFFOLD_SKIP_CONFIRMATION` (same as `--skip-confirmation`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
 * `SKAFFOLD_TRIGGER` (same as `--trigger`)
-* `SKAFFOLD_TRY_TRANSPARENT_INIT` (same as `--try-transparent-init`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_DELAY` (same as `--wait-for-deletions-delay`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_MAX` (same as `--wait-for-deletions-max`)
@@ -823,6 +823,8 @@ Examples:
   skaffold run -p <profile>
 
 Options:
+      --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
+      --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
   -b, --build-image=[]: Only build artifacts with image names that contain the given substring. Default is to build sources for all artifacts
       --cache-artifacts=true: Set to false to disable default caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
@@ -849,13 +851,11 @@ Options:
       --render-output='': Writes '--render-only' output to the specified file
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
-      --skip-confirmation=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
-      --try-transparent-init=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
       --wait-for-deletions-delay=2s: Delay between two checks for pending deletions
       --wait-for-deletions-max=1m0s: Max duration to wait for pending deletions
@@ -869,6 +869,8 @@ Use "skaffold options" for a list of global command-line options (applies to all
 ```
 Env vars:
 
+* `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
+* `SKAFFOLD_AUTO_CREATE_CONFIG` (same as `--auto-create-config`)
 * `SKAFFOLD_BUILD_IMAGE` (same as `--build-image`)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
@@ -895,13 +897,11 @@ Env vars:
 * `SKAFFOLD_RENDER_OUTPUT` (same as `--render-output`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
-* `SKAFFOLD_SKIP_CONFIRMATION` (same as `--skip-confirmation`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
-* `SKAFFOLD_TRY_TRANSPARENT_INIT` (same as `--try-transparent-init`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_DELAY` (same as `--wait-for-deletions-delay`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_MAX` (same as `--wait-for-deletions-max`)

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -364,12 +364,14 @@ Options:
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
+      --skip-confirmation=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
       --trigger='notify': How is change detection triggered? (polling, notify, or manual)
+      --try-transparent-init=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
       --wait-for-deletions-delay=2s: Delay between two checks for pending deletions
       --wait-for-deletions-max=1m0s: Max duration to wait for pending deletions
@@ -408,12 +410,14 @@ Env vars:
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
+* `SKAFFOLD_SKIP_CONFIRMATION` (same as `--skip-confirmation`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
 * `SKAFFOLD_TRIGGER` (same as `--trigger`)
+* `SKAFFOLD_TRY_TRANSPARENT_INIT` (same as `--try-transparent-init`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_DELAY` (same as `--wait-for-deletions-delay`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_MAX` (same as `--wait-for-deletions-max`)
@@ -575,12 +579,14 @@ Options:
       --render-only=false: Print rendered Kubernetes manifests instead of deploying them
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
+      --skip-confirmation=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
       --trigger='notify': How is change detection triggered? (polling, notify, or manual)
+      --try-transparent-init=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
       --wait-for-deletions-delay=2s: Delay between two checks for pending deletions
       --wait-for-deletions-max=1m0s: Max duration to wait for pending deletions
@@ -620,12 +626,14 @@ Env vars:
 * `SKAFFOLD_RENDER_ONLY` (same as `--render-only`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
+* `SKAFFOLD_SKIP_CONFIRMATION` (same as `--skip-confirmation`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
 * `SKAFFOLD_TRIGGER` (same as `--trigger`)
+* `SKAFFOLD_TRY_TRANSPARENT_INIT` (same as `--try-transparent-init`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_DELAY` (same as `--wait-for-deletions-delay`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_MAX` (same as `--wait-for-deletions-max`)
@@ -841,11 +849,13 @@ Options:
       --render-output='': Writes '--render-only' output to the specified file
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
+      --skip-confirmation=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
       --toot=false: Emit a terminal beep after the deploy is complete
+      --try-transparent-init=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
       --wait-for-deletions-delay=2s: Delay between two checks for pending deletions
       --wait-for-deletions-max=1m0s: Max duration to wait for pending deletions
@@ -885,11 +895,13 @@ Env vars:
 * `SKAFFOLD_RENDER_OUTPUT` (same as `--render-output`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
+* `SKAFFOLD_SKIP_CONFIRMATION` (same as `--skip-confirmation`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
+* `SKAFFOLD_TRY_TRANSPARENT_INIT` (same as `--try-transparent-init`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_DELAY` (same as `--wait-for-deletions-delay`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_MAX` (same as `--wait-for-deletions-max`)

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -88,6 +88,9 @@ type SkaffoldOptions struct {
 	RPCPort            int
 	RPCHTTPPort        int
 
+	TryTransparentInit bool
+	SkipConfirmation   bool
+
 	// TODO(https://github.com/GoogleContainerTools/skaffold/issues/3668):
 	// remove minikubeProfile from here and instead detect it by matching the
 	// kubecontext API Server to minikube profiles

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -57,6 +57,8 @@ type SkaffoldOptions struct {
 	AutoSync              bool
 	AutoDeploy            bool
 	RenderOnly            bool
+	AutoCreateConfig      bool
+	AssumeYes             bool
 	RenderOutput          string
 	ProfileAutoActivation bool
 	DryRun                bool
@@ -87,9 +89,6 @@ type SkaffoldOptions struct {
 	Command            string
 	RPCPort            int
 	RPCHTTPPort        int
-
-	TryTransparentInit bool
-	SkipConfirmation   bool
 
 	// TODO(https://github.com/GoogleContainerTools/skaffold/issues/3668):
 	// remove minikubeProfile from here and instead detect it by matching the

--- a/pkg/skaffold/initializer/transparent.go
+++ b/pkg/skaffold/initializer/transparent.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	initConfig "github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -54,8 +55,10 @@ func Transparent(ctx context.Context, out io.Writer, c initConfig.Config) (*late
 	}
 
 	// Prompt the user with information about what will happen if they continue with this config.
-	if done, err := confirmInitOptions(out, newConfig); done {
-		return nil, err
+	if !c.Opts.SkipConfirmation {
+		if done, err := confirmInitOptions(out, newConfig); done {
+			return nil, err
+		}
 	}
 
 	if err := WriteData(out, c, newConfig, newManifests); err != nil {
@@ -63,4 +66,16 @@ func Transparent(ctx context.Context, out io.Writer, c initConfig.Config) (*late
 	}
 
 	return newConfig, nil
+}
+
+// Returns true if transparent init should run on the given opts.Command, false otherwise
+func ValidCmd(opts config.SkaffoldOptions) bool {
+	valid := map[string]struct{}{
+		"debug": {},
+		"dev":   {},
+		"run":   {},
+	}
+	_, ok := valid[opts.Command]
+
+	return ok
 }

--- a/pkg/skaffold/initializer/transparent.go
+++ b/pkg/skaffold/initializer/transparent.go
@@ -55,7 +55,7 @@ func Transparent(ctx context.Context, out io.Writer, c initConfig.Config) (*late
 	}
 
 	// Prompt the user with information about what will happen if they continue with this config.
-	if !c.Opts.SkipConfirmation {
+	if !c.Opts.AssumeYes {
 		if done, err := confirmInitOptions(out, newConfig); done {
 			return nil, err
 		}

--- a/pkg/skaffold/initializer/transparent_test.go
+++ b/pkg/skaffold/initializer/transparent_test.go
@@ -178,3 +178,32 @@ See https://skaffold.dev/docs/pipeline-stages/deployers/helm/ for a detailed gui
 		})
 	}
 }
+
+func TestValidCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      string
+		expected bool
+	}{
+		{
+			name:     "valid string",
+			cmd:      "dev",
+			expected: true,
+		},
+		{
+			name:     "invalid",
+			cmd:      "build",
+			expected: false,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			config := config.SkaffoldOptions{
+				Command: test.cmd,
+			}
+			valid := ValidCmd(config)
+
+			t.CheckDeepEqual(test.expected, valid)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1273 
**Related** #4915, #5037, #5141, #5155

**Description**
Adds the flow that handles users running commands without a skaffold config file being present. 

**User facing changes (remove if N/A)**
If users try to run a command without a skaffold config such as `skaffold dev`, skaffold will tell them that no config is found, and that it is trying to make one. If it succeeds, it will prompt the user, making sure that they want to continue.

