### PR TITLE
Add input digest tagger

### DIFF
--- a/docs/content/en/schemas/v2beta11.json
+++ b/docs/content/en/schemas/v2beta11.json
@@ -1554,6 +1554,10 @@
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
+    "InputDigest": {
+      "description": "*beta* tags hashes the image content.",
+      "x-intellij-html-description": "<em>beta</em> tags hashes the image content."
+    },
     "JSONPatch": {
       "required": [
         "path"
@@ -2655,6 +2659,11 @@
           "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
           "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
         },
+        "inputDigest": {
+          "$ref": "#/definitions/ShaTagger",
+          "description": "*beta* tags images with their sha256 digest of their content.",
+          "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest of their content."
+        },
         "sha256": {
           "$ref": "#/definitions/ShaTagger",
           "description": "*beta* tags images with their sha256 digest.",
@@ -2666,7 +2675,8 @@
         "sha256",
         "envTemplate",
         "dateTime",
-        "customTemplate"
+        "customTemplate",
+        "inputDigest"
       ],
       "additionalProperties": false,
       "description": "contains all the configuration for the tagging step.",
@@ -2779,6 +2789,25 @@
           "preferredOrder": [
             "name",
             "customTemplate"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "inputDigest": {
+              "$ref": "#/definitions/ShaTagger",
+              "description": "*beta* tags images with their sha256 digest of their content.",
+              "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest of their content."
+            },
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "inputDigest"
           ],
           "additionalProperties": false
         }

--- a/pkg/skaffold/build/tag/custom.go
+++ b/pkg/skaffold/build/tag/custom.go
@@ -18,6 +18,7 @@ package tag
 
 import (
 	"errors"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
 type CustomTag struct {
@@ -25,7 +26,7 @@ type CustomTag struct {
 }
 
 // GenerateTag generates a tag using the custom tag.
-func (t *CustomTag) GenerateTag(_, _ string) (string, error) {
+func (t *CustomTag) GenerateTag(_ string, image *latest.Artifact) (string, error) {
 	tag := t.Tag
 	if tag == "" {
 		return "", errors.New("custom tag not provided")

--- a/pkg/skaffold/build/tag/custom_template.go
+++ b/pkg/skaffold/build/tag/custom_template.go
@@ -19,6 +19,7 @@ package tag
 import (
 	"bytes"
 	"fmt"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"text/template"
 
 	"github.com/sirupsen/logrus"
@@ -44,8 +45,8 @@ func NewCustomTemplateTagger(t string, components map[string]Tagger) (Tagger, er
 }
 
 // GenerateTag generates a tag from a template referencing tagging strategies.
-func (t *customTemplateTagger) GenerateTag(workingDir, imageName string) (string, error) {
-	customMap, err := t.EvaluateComponents(workingDir, imageName)
+func (t *customTemplateTagger) GenerateTag(workingDir string, image *latest.Artifact) (string, error) {
+	customMap, err := t.EvaluateComponents(workingDir, image)
 	if err != nil {
 		return "", err
 	}
@@ -60,14 +61,14 @@ func (t *customTemplateTagger) GenerateTag(workingDir, imageName string) (string
 }
 
 // EvaluateComponents creates a custom mapping of component names to their tagger string representation.
-func (t *customTemplateTagger) EvaluateComponents(workingDir, imageName string) (map[string]string, error) {
+func (t *customTemplateTagger) EvaluateComponents(workingDir string, image *latest.Artifact) (map[string]string, error) {
 	customMap := map[string]string{}
 
 	gitTagger, _ := NewGitCommit("", "", false)
 	dateTimeTagger := NewDateTimeTagger("", "")
 
 	for k, v := range map[string]Tagger{"GIT": gitTagger, "DATE": dateTimeTagger, "SHA": &ChecksumTagger{}} {
-		tag, _ := v.GenerateTag(workingDir, imageName)
+		tag, _ := v.GenerateTag(workingDir, image)
 		customMap[k] = tag
 	}
 
@@ -75,7 +76,7 @@ func (t *customTemplateTagger) EvaluateComponents(workingDir, imageName string) 
 		if _, ok := v.(*customTemplateTagger); ok {
 			return nil, fmt.Errorf("invalid component specified in custom template: %v", v)
 		}
-		tag, err := v.GenerateTag(workingDir, imageName)
+		tag, err := v.GenerateTag(workingDir, image)
 		if err != nil {
 			return nil, fmt.Errorf("evaluating custom template component: %w", err)
 		}

--- a/pkg/skaffold/build/tag/custom_template_test.go
+++ b/pkg/skaffold/build/tag/custom_template_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"testing"
 	"time"
 
@@ -102,8 +103,11 @@ func TestTagTemplate_GenerateTag(t *testing.T) {
 			c, err := NewCustomTemplateTagger(test.template, test.customMap)
 
 			t.CheckNoError(err)
+			testImage := &latest.Artifact{
+				ImageName: "test",
+			}
 
-			tag, err := c.GenerateTag(".", "test")
+			tag, err := c.GenerateTag(".", testImage)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, tag)
 		})

--- a/pkg/skaffold/build/tag/custom_test.go
+++ b/pkg/skaffold/build/tag/custom_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -42,8 +43,13 @@ func TestCustomTag_GenerateTag(t *testing.T) {
 			shouldErr:   true,
 		},
 	}
+
+	testImage := &latest.Artifact{
+		ImageName: "test",
+	}
+
 	for _, test := range tests {
-		tag, err := test.c.GenerateTag(".", "test")
+		tag, err := test.c.GenerateTag(".", testImage)
 		testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, tag)
 	}
 }

--- a/pkg/skaffold/build/tag/date_time.go
+++ b/pkg/skaffold/build/tag/date_time.go
@@ -18,6 +18,7 @@ package tag
 
 import (
 	"fmt"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"time"
 
 	"4d63.com/tz"
@@ -43,7 +44,7 @@ func NewDateTimeTagger(format, timezone string) Tagger {
 }
 
 // GenerateTag generates a tag using the current timestamp.
-func (t *dateTimeTagger) GenerateTag(_, _ string) (string, error) {
+func (t *dateTimeTagger) GenerateTag(_ string, image *latest.Artifact) (string, error) {
 	format := tagTime
 	if len(t.Format) > 0 {
 		format = t.Format

--- a/pkg/skaffold/build/tag/date_time_test.go
+++ b/pkg/skaffold/build/tag/date_time_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"testing"
 	"time"
 
@@ -68,7 +69,11 @@ func TestDateTime_GenerateTag(t *testing.T) {
 				timeFn:   func() time.Time { return test.buildTime },
 			}
 
-			tag, err := c.GenerateTag(".", "test")
+			testImage := &latest.Artifact{
+				ImageName: "test",
+			}
+
+			tag, err := c.GenerateTag(".", testImage)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.want, tag)
 		})

--- a/pkg/skaffold/build/tag/env_template.go
+++ b/pkg/skaffold/build/tag/env_template.go
@@ -19,6 +19,7 @@ package tag
 import (
 	"errors"
 	"fmt"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"strings"
 	"text/template"
 
@@ -43,10 +44,10 @@ func NewEnvTemplateTagger(t string) (Tagger, error) {
 }
 
 // GenerateTag generates a tag from a template referencing environment variables.
-func (t *envTemplateTagger) GenerateTag(_, imageName string) (string, error) {
+func (t *envTemplateTagger) GenerateTag(_ string, image *latest.Artifact) (string, error) {
 	// missingkey=error throws error when map is indexed with an undefined key
 	tag, err := util.ExecuteEnvTemplate(t.Template.Option("missingkey=error"), map[string]string{
-		"IMAGE_NAME":  imageName,
+		"IMAGE_NAME":  image.ImageName,
 		"DIGEST":      "_DEPRECATED_DIGEST_",
 		"DIGEST_ALGO": "_DEPRECATED_DIGEST_ALGO_",
 		"DIGEST_HEX":  "_DEPRECATED_DIGEST_HEX_",

--- a/pkg/skaffold/build/tag/env_template_test.go
+++ b/pkg/skaffold/build/tag/env_template_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -93,13 +94,17 @@ func TestEnvTemplateTagger_GenerateTag(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			fakeWarner := &warnings.Collect{}
+			testImage := &latest.Artifact{
+				ImageName: test.imageName,
+			}
+
 			t.Override(&warnings.Printf, fakeWarner.Warnf)
 			t.Override(&util.OSEnviron, func() []string { return test.env })
 
 			c, err := NewEnvTemplateTagger(test.template)
 			t.CheckNoError(err)
 
-			got, err := c.GenerateTag(".", test.imageName)
+			got, err := c.GenerateTag(".", testImage)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, got)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)

--- a/pkg/skaffold/build/tag/git_commit.go
+++ b/pkg/skaffold/build/tag/git_commit.go
@@ -19,6 +19,7 @@ package tag
 import (
 	"bytes"
 	"fmt"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -60,7 +61,7 @@ func NewGitCommit(prefix, variant string, ignoreChanges bool) (*GitCommit, error
 }
 
 // GenerateTag generates a tag from the git commit.
-func (t *GitCommit) GenerateTag(workingDir, _ string) (string, error) {
+func (t *GitCommit) GenerateTag(workingDir string, _ *latest.Artifact) (string, error) {
 	ref, err := t.runGitFn(workingDir)
 	if err != nil {
 		return "", fmt.Errorf("unable to find git commit: %w", err)

--- a/pkg/skaffold/build/tag/git_commit_test.go
+++ b/pkg/skaffold/build/tag/git_commit_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package tag
 
 import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -32,6 +33,10 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
+
+var imageTest = &latest.Artifact{
+	ImageName: "test",
+}
 
 // These tests do not run on windows
 // See: https://github.com/src-d/go-git/issues/378
@@ -394,7 +399,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 				tagger, err := NewGitCommit("", variant, test.ignoreChanges)
 				t.CheckNoError(err)
 
-				tag, err := tagger.GenerateTag(workspace, "test")
+				tag, err := tagger.GenerateTag(workspace, imageTest)
 
 				t.CheckErrorAndDeepEqual(test.shouldErr, err, expectedTag, tag)
 			}
@@ -453,7 +458,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 				tagger, err := NewGitCommit("", variant, false)
 				t.CheckNoError(err)
 
-				tag, err := GenerateFullyQualifiedImageName(tagger, workspace, "test")
+				tag, err := GenerateFullyQualifiedImageName(tagger, workspace, imageTest)
 
 				t.CheckErrorAndDeepEqual(test.shouldErr, err, expectedTag, tag)
 			}
@@ -506,7 +511,7 @@ func TestGitCommit_CustomTemplate(t *testing.T) {
 
 			t.CheckNoError(err)
 
-			tag, err := c.GenerateTag(workspace, "test")
+			tag, err := c.GenerateTag(workspace, imageTest)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, tag)
@@ -522,30 +527,30 @@ func TestGitCommitSubDirectory(t *testing.T) {
 
 		tagger, err := NewGitCommit("", "Tags", false)
 		t.CheckNoError(err)
-		tag, err := tagger.GenerateTag(workspace, "test")
+		tag, err := tagger.GenerateTag(workspace, imageTest)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("a7b32a6", tag)
 
 		tagger, err = NewGitCommit("", "CommitSha", false)
 		t.CheckNoError(err)
-		tag, err = tagger.GenerateTag(workspace, "test")
+		tag, err = tagger.GenerateTag(workspace, imageTest)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("a7b32a69335a6daa51bd89cc1bf30bd31df228ba", tag)
 
 		tagger, err = NewGitCommit("", "AbbrevCommitSha", false)
 		t.CheckNoError(err)
-		tag, err = tagger.GenerateTag(workspace, "test")
+		tag, err = tagger.GenerateTag(workspace, imageTest)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("a7b32a6", tag)
 
 		tagger, err = NewGitCommit("", "TreeSha", false)
 		t.CheckNoError(err)
-		_, err = tagger.GenerateTag(workspace, "test")
+		_, err = tagger.GenerateTag(workspace, imageTest)
 		t.CheckErrorAndDeepEqual(true, err, "a7b32a6", tag)
 
 		tagger, err = NewGitCommit("", "AbbrevTreeSha", false)
 		t.CheckNoError(err)
-		_, err = tagger.GenerateTag(workspace, "test")
+		_, err = tagger.GenerateTag(workspace, imageTest)
 		t.CheckErrorAndDeepEqual(true, err, "a7b32a6", tag)
 	})
 }
@@ -558,13 +563,13 @@ func TestPrefix(t *testing.T) {
 
 		tagger, err := NewGitCommit("tag-", "Tags", false)
 		t.CheckNoError(err)
-		tag, err := tagger.GenerateTag(workspace, "test")
+		tag, err := tagger.GenerateTag(workspace, imageTest)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("tag-a7b32a6", tag)
 
 		tagger, err = NewGitCommit("commit-", "CommitSha", false)
 		t.CheckNoError(err)
-		tag, err = tagger.GenerateTag(workspace, "test")
+		tag, err = tagger.GenerateTag(workspace, imageTest)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("commit-a7b32a69335a6daa51bd89cc1bf30bd31df228ba", tag)
 	})

--- a/pkg/skaffold/build/tag/imput_digest.go
+++ b/pkg/skaffold/build/tag/imput_digest.go
@@ -1,0 +1,84 @@
+package tag
+
+import (
+	"context"
+	"crypto/md5"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/sirupsen/logrus"
+	"io"
+	"os"
+	"sort"
+)
+
+type inputDigestTagger struct {
+	getDependencies func(ctx context.Context, artifact *latest.Artifact) ([]string, error)
+}
+
+func NewInputDigestTagger(getDependencies func(ctx context.Context, artifact *latest.Artifact) ([]string, error)) (Tagger, error) {
+	return &inputDigestTagger{
+		getDependencies: getDependencies,
+	}, nil
+}
+
+func (t *inputDigestTagger) GenerateTag(_ string, image *latest.Artifact) (string, error) {
+	ctx := context.Background()
+	var inputs []string
+
+	dependencies, err := t.getDependencies(ctx, image)
+	if err != nil {
+		return "", err
+	}
+
+	sort.Strings(dependencies)
+
+	for _, d := range dependencies {
+		h, err := fileHasher(d)
+		if err != nil {
+			if os.IsNotExist(err) {
+				logrus.Tracef("skipping dependency for artifact cache calculation, file not found %s: %s", d, err)
+				continue // Ignore files that don't exist
+			}
+
+			return "", fmt.Errorf("getting hash for %q: %w", d, err)
+		}
+		inputs = append(inputs, h)
+	}
+
+	return encode(inputs)
+}
+
+func encode(inputs []string) (string, error) {
+	// get a key for the hashes
+	hasher := sha256.New()
+	enc := json.NewEncoder(hasher)
+	if err := enc.Encode(inputs); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+// fileHasher hashes the contents and name of a file
+func fileHasher(p string) (string, error) {
+	h := md5.New()
+	fi, err := os.Lstat(p)
+	if err != nil {
+		return "", err
+	}
+	h.Write([]byte(fi.Mode().String()))
+	h.Write([]byte(fi.Name()))
+	if fi.Mode().IsRegular() {
+		f, err := os.Open(p)
+		if err != nil {
+			return "", err
+		}
+		defer f.Close()
+		if _, err := io.Copy(h, f); err != nil {
+			return "", err
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/pkg/skaffold/build/tag/imput_digest_test.go
+++ b/pkg/skaffold/build/tag/imput_digest_test.go
@@ -1,0 +1,46 @@
+package tag
+
+import (
+	"context"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+	"testing"
+)
+
+func TestInputDigest_GenerateTagWhenFileDoesntExist(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		depListner := func(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
+			c := []string{artifact.ImageName}
+			return c, nil
+		}
+
+		tagger, _ := NewInputDigestTagger(depListner)
+
+		artifact := &latest.Artifact{
+			ImageName: "image_name",
+		}
+
+		tag, _ := tagger.GenerateTag("", artifact)
+
+		t.CheckDeepEqual("38e0b9de817f645c4bec37c0d4a3e58baecccb040f5718dc069a72c7385a0bed", tag)
+	})
+}
+
+func TestInputDigest_GenerateTagWhenFileExist(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		depListner := func(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
+			c := []string{"imput_digest.go"}
+			return c, nil
+		}
+
+		tagger, _ := NewInputDigestTagger(depListner)
+
+		artifact := &latest.Artifact{
+			ImageName: "image_name",
+		}
+
+		tag, _ := tagger.GenerateTag("", artifact)
+
+		t.CheckDeepEqual("087a9e0c49f92961c5a7eab28cc304d5fb4e148dd9d3eb607c8d23698922722d", tag)
+	})
+}

--- a/pkg/skaffold/build/tag/sha256.go
+++ b/pkg/skaffold/build/tag/sha256.go
@@ -18,14 +18,15 @@ package tag
 
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
 // ChecksumTagger tags an image by the sha256 of the image tarball
 type ChecksumTagger struct{}
 
 // GenerateTag returns either the current tag or `latest`.
-func (t *ChecksumTagger) GenerateTag(_, imageName string) (string, error) {
-	parsed, err := docker.ParseReference(imageName)
+func (t *ChecksumTagger) GenerateTag(_ string, image *latest.Artifact) (string, error) {
+	parsed, err := docker.ParseReference(image.ImageName)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/skaffold/build/tag/sha256_test.go
+++ b/pkg/skaffold/build/tag/sha256_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -25,21 +26,30 @@ import (
 func TestSha256_GenerateTag(t *testing.T) {
 	c := &ChecksumTagger{}
 
-	tag, err := c.GenerateTag(".", "img:tag")
+	testImage := &latest.Artifact{
+		ImageName: "img:tag",
+	}
+
+	tag, err := c.GenerateTag(".", testImage)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "", tag)
 
-	tag, err = c.GenerateTag(".", "img")
+	testImage.ImageName = "img"
+	tag, err = c.GenerateTag(".", testImage)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "latest", tag)
 
-	tag, err = c.GenerateTag(".", "registry.example.com:8080/img:tag")
+	testImage.ImageName = "registry.example.com:8080/img:tag"
+	tag, err = c.GenerateTag(".", testImage)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "", tag)
 
-	tag, err = c.GenerateTag(".", "registry.example.com:8080/img")
+	testImage.ImageName = "registry.example.com:8080/img"
+	tag, err = c.GenerateTag(".", testImage)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "latest", tag)
 
-	tag, err = c.GenerateTag(".", "registry.example.com/img")
+	testImage.ImageName = "registry.example.com/img"
+	tag, err = c.GenerateTag(".", testImage)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "latest", tag)
 
-	tag, err = c.GenerateTag(".", "registry.example.com:8080:garbage")
+	testImage.ImageName = "registry.example.com:8080:garbage"
+	tag, err = c.GenerateTag(".", testImage)
 	testutil.CheckErrorAndDeepEqual(t, true, err, "", tag)
 }

--- a/pkg/skaffold/build/tag/tag.go
+++ b/pkg/skaffold/build/tag/tag.go
@@ -18,6 +18,7 @@ package tag
 
 import (
 	"fmt"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
@@ -29,7 +30,7 @@ type ImageTags map[string]string
 // Tagger is an interface for tag strategies to be implemented against
 type Tagger interface {
 	// GenerateTag generates a tag for an artifact.
-	GenerateTag(workingDir, imageName string) (string, error)
+	GenerateTag(workingDir string, image *latest.Artifact) (string, error)
 }
 
 const DeprecatedImageName = "_DEPRECATED_IMAGE_NAME_"
@@ -37,10 +38,14 @@ const DeprecatedImageName = "_DEPRECATED_IMAGE_NAME_"
 // GenerateFullyQualifiedImageName resolves the fully qualified image name for an artifact.
 // The workingDir is the root directory of the artifact with respect to the Skaffold root,
 // and imageName is the base name of the image.
-func GenerateFullyQualifiedImageName(t Tagger, workingDir, imageName string) (string, error) {
+func GenerateFullyQualifiedImageName(t Tagger, workingDir string, image *latest.Artifact) (string, error) {
 	// Supporting the use of the deprecated {{.IMAGE_NAME}} in envTemplate
+	deprecatedImage := &latest.Artifact{
+		ImageName: DeprecatedImageName,
+	}
+
 	if v, ok := t.(*envTemplateTagger); ok {
-		tag, err := v.GenerateTag(workingDir, DeprecatedImageName)
+		tag, err := v.GenerateTag(workingDir, deprecatedImage)
 
 		if err != nil {
 			return "", fmt.Errorf("generating envTemplate tag: %w", err)
@@ -49,21 +54,21 @@ func GenerateFullyQualifiedImageName(t Tagger, workingDir, imageName string) (st
 		if strings.Contains(tag, DeprecatedImageName) {
 			warnings.Printf("{{.IMAGE_NAME}} is deprecated, envTemplate's template should only specify the tag value. See https://skaffold.dev/docs/pipeline-stages/taggers/")
 
-			return strings.Replace(tag, DeprecatedImageName, imageName, -1), nil
+			return strings.Replace(tag, DeprecatedImageName, image.ImageName, -1), nil
 		}
 
-		return fmt.Sprintf("%s:%s", imageName, tag), nil
+		return fmt.Sprintf("%s:%s", image.ImageName, tag), nil
 	}
 
-	tag, err := t.GenerateTag(workingDir, imageName)
+	tag, err := t.GenerateTag(workingDir, image)
 	if err != nil {
 		return "", fmt.Errorf("generating tag: %w", err)
 	}
 
 	// Do not append :tag to imageName if tag is empty.
 	if tag == "" {
-		return imageName, nil
+		return image.ImageName, nil
 	}
 
-	return fmt.Sprintf("%s:%s", imageName, tag), nil
+	return fmt.Sprintf("%s:%s", image.ImageName, tag), nil
 }

--- a/pkg/skaffold/build/tag/tag_test.go
+++ b/pkg/skaffold/build/tag/tag_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"testing"
 	"time"
 
@@ -111,7 +112,11 @@ func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 			t.Override(&warnings.Printf, fakeWarner.Warnf)
 			t.Override(&util.OSEnviron, func() []string { return env })
 
-			tag, err := GenerateFullyQualifiedImageName(test.tagger, ".", test.imageName)
+			testImage := &latest.Artifact{
+				ImageName: test.imageName,
+			}
+
+			tag, err := GenerateFullyQualifiedImageName(test.tagger, ".", testImage)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, tag)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
 		})

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -159,7 +159,7 @@ func (r *SkaffoldRunner) imageTags(ctx context.Context, out io.Writer, artifacts
 
 		i := i
 		go func() {
-			tag, err := tag.GenerateFullyQualifiedImageName(r.tagger, artifacts[i].Workspace, artifacts[i].ImageName)
+			tag, err := tag.GenerateFullyQualifiedImageName(r.tagger, artifacts[i].Workspace, artifacts[i])
 			tagErrs[i] <- tagErr{tag: tag, err: err}
 		}()
 	}
@@ -180,7 +180,7 @@ func (r *SkaffoldRunner) imageTags(ctx context.Context, out io.Writer, artifacts
 				logrus.Debugln(t.err)
 				logrus.Debugln("Using a fall-back tagger")
 
-				fallbackTag, err := tag.GenerateFullyQualifiedImageName(&tag.ChecksumTagger{}, artifact.Workspace, imageName)
+				fallbackTag, err := tag.GenerateFullyQualifiedImageName(&tag.ChecksumTagger{}, artifact.Workspace, artifact)
 				if err != nil {
 					return nil, fmt.Errorf("generating checksum as fall-back tag for %q: %w", imageName, err)
 				}

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -134,10 +134,16 @@ type TagPolicy struct {
 
 	// CustomTemplateTagger *beta* tags images with a configurable template string *composed of other taggers*.
 	CustomTemplateTagger *CustomTemplateTagger `yaml:"customTemplate,omitempty" yamltags:"oneOf=tag"`
+
+	// InputDigest *beta* tags images with their sha256 digest of their content.
+	InputDigest *ShaTagger `yaml:"inputDigest,omitempty" yamltags:"oneOf=tag"`
 }
 
 // ShaTagger *beta* tags images with their sha256 digest.
 type ShaTagger struct{}
+
+// InputDigest *beta* tags hashes the image content.
+type InputDigest struct{}
 
 // GitTagger *beta* tags images with the git tag or commit of the artifact's workspace.
 type GitTagger struct {


### PR DESCRIPTION
Implementation of `inputDigest` tagger form the [Improve taggers](https://github.com/GoogleContainerTools/skaffold/blob/533f2844a6757700a78043d2936f1a4942aff9ca/docs/design_proposals/digest-tagger.md)

It does mostly what internal skaffold hasher is doing a minus couple of things:
 * Doesn't hash the build arguments (I don't believe they are not relevant. )
 * Doesn't hash test dependencies (I don't believe they are not relevant. )
 ---
Some areas to think of (maybe in this or in future PR's):
* following target in multi stage docker builds
* including image cotainerId in the tag. (But to get there the implementation of `docker.GetDependencies ` would have to change including its contract of the method)
* documentation what exactly is being used in the tag calculation (how only COPY and ADD commands can influence tag)