### PR TITLE
Add yaml tag `filepath` that converts marked fields to absolute paths.

### DIFF
--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -108,7 +108,7 @@ func runContext(opts config.SkaffoldOptions) (*runcontext.RunContext, []*latest.
 		if opts.ConfigurationFile == "-" {
 			basePath, _ = os.Getwd()
 		} else {
-			basePath = filepath.Base(opts.ConfigurationFile)
+			basePath = filepath.Dir(opts.ConfigurationFile)
 		}
 
 		if err := yamltags.SetAbsFilePaths(config, basePath); err != nil {

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 
@@ -38,6 +37,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/validation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
+	skutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags"
 )
 
@@ -103,15 +103,12 @@ func runContext(opts config.SkaffoldOptions) (*runcontext.RunContext, []*latest.
 		if err := defaults.Set(config, setDefaultDeployer); err != nil {
 			return nil, nil, fmt.Errorf("setting default values: %w", err)
 		}
-
-		var basePath string
-		if opts.ConfigurationFile == "-" {
-			basePath, _ = os.Getwd()
-		} else {
-			basePath = filepath.Dir(opts.ConfigurationFile)
+		f, err := skutil.NewConfigFile(opts.ConfigurationFile)
+		if err != nil {
+			return nil, nil, err
 		}
 
-		if err := yamltags.SetAbsFilePaths(config, basePath); err != nil {
+		if err := yamltags.SetAbsFilePaths(config, f.Dir()); err != nil {
 			return nil, nil, fmt.Errorf("setting absolute filepaths: %w", err)
 		}
 		pipelines = append(pipelines, config.Pipeline)

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 
@@ -37,6 +38,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/validation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags"
 )
 
 // For tests
@@ -100,6 +102,17 @@ func runContext(opts config.SkaffoldOptions) (*runcontext.RunContext, []*latest.
 		}
 		if err := defaults.Set(config, setDefaultDeployer); err != nil {
 			return nil, nil, fmt.Errorf("setting default values: %w", err)
+		}
+
+		var basePath string
+		if opts.ConfigurationFile == "-" {
+			basePath, _ = os.Getwd()
+		} else {
+			basePath = filepath.Base(opts.ConfigurationFile)
+		}
+
+		if err := yamltags.SetAbsFilePaths(config, basePath); err != nil {
+			return nil, nil, fmt.Errorf("setting absolute filepaths: %w", err)
 		}
 		pipelines = append(pipelines, config.Pipeline)
 		configs = append(configs, config)

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -475,7 +475,7 @@ type DeployType struct {
 type KubectlDeploy struct {
 	// Manifests lists the Kubernetes yaml or json manifests.
 	// Defaults to `["k8s/*.yaml"]`.
-	Manifests []string `yaml:"manifests,omitempty"`
+	Manifests []string `yaml:"manifests,omitempty" yamltags:"filepath"`
 
 	// RemoteManifests lists Kubernetes manifests in remote clusters.
 	RemoteManifests []string `yaml:"remoteManifests,omitempty"`
@@ -532,7 +532,7 @@ type HelmDeployFlags struct {
 type KustomizeDeploy struct {
 	// KustomizePaths is the path to Kustomization files.
 	// Defaults to `["."]`.
-	KustomizePaths []string `yaml:"paths,omitempty"`
+	KustomizePaths []string `yaml:"paths,omitempty" yamltags:"filepath"`
 
 	// Flags are additional flags passed to `kubectl`.
 	Flags KubectlFlags `yaml:"flags,omitempty"`
@@ -550,7 +550,7 @@ type KptDeploy struct {
 	// By default, the Dir contains the application configurations,
 	// [kustomize config files](https://kubectl.docs.kubernetes.io/pages/examples/kustomize.html)
 	// and [declarative kpt functions](https://googlecontainertools.github.io/kpt/guides/consumer/function/#declarative-run).
-	Dir string `yaml:"dir" yamltags:"required"`
+	Dir string `yaml:"dir" yamltags:"required,filepath"`
 
 	// Fn adds additional configurations for `kpt fn`.
 	Fn KptFn `yaml:"fn,omitempty"`
@@ -563,7 +563,7 @@ type KptDeploy struct {
 type KptFn struct {
 	// FnPath is the directory to discover the declarative kpt functions.
 	// If not provided, kpt deployer uses `kpt.Dir`.
-	FnPath string `yaml:"fnPath,omitempty"`
+	FnPath string `yaml:"fnPath,omitempty" yamltags:"filepath"`
 
 	// Image is a kpt function image to run the configs imperatively. If provided, kpt.fn.fnPath
 	// will be ignored.
@@ -582,7 +582,7 @@ type KptFn struct {
 	Mount []string `yaml:"mount,omitempty"`
 
 	// SinkDir is the directory to where the manipulated resource output is stored.
-	SinkDir string `yaml:"sinkDir,omitempty"`
+	SinkDir string `yaml:"sinkDir,omitempty" yamltags:"filepath"`
 }
 
 // KptLive adds additional configurations used when calling `kpt live`.
@@ -633,10 +633,10 @@ type HelmRelease struct {
 	Name string `yaml:"name,omitempty" yamltags:"required"`
 
 	// ChartPath is the path to the Helm chart.
-	ChartPath string `yaml:"chartPath,omitempty" yamltags:"required"`
+	ChartPath string `yaml:"chartPath,omitempty" yamltags:"required,filepath"`
 
 	// ValuesFiles are the paths to the Helm `values` files.
-	ValuesFiles []string `yaml:"valuesFiles,omitempty"`
+	ValuesFiles []string `yaml:"valuesFiles,omitempty" yamltags:"filepath"`
 
 	// ArtifactOverrides are key value pairs where the
 	// key represents the parameter used in the `--set-string` Helm CLI flag to define a container
@@ -761,7 +761,7 @@ type Artifact struct {
 
 	// Workspace is the directory containing the artifact's sources.
 	// Defaults to `.`.
-	Workspace string `yaml:"context,omitempty"`
+	Workspace string `yaml:"context,omitempty" yamltags:"filepath"`
 
 	// Sync *beta* lists local files synced to pods instead
 	// of triggering an image build when modified.

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -65,7 +65,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta7"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta8"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta9"
-	misc "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	skutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 )
 
@@ -147,7 +147,11 @@ func IsSkaffoldConfig(file string) bool {
 // ParseConfig reads a configuration file.
 func ParseConfig(filename string) ([]util.VersionedConfig, error) {
 	// TODO: update this function to parse the input as multiple configs
-	buf, err := misc.ReadConfiguration(filename)
+	f, err := skutil.NewConfigFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	buf, err := f.Read()
 	if err != nil {
 		return nil, fmt.Errorf("read skaffold config: %w", err)
 	}

--- a/pkg/skaffold/util/config_test.go
+++ b/pkg/skaffold/util/config_test.go
@@ -28,11 +28,12 @@ func TestReadConfiguration(t *testing.T) {
 		t.NewTempDir().
 			Write("skaffold.yaml", "some yaml").
 			Chdir()
-
-		content, err := ReadConfiguration("skaffold.yaml")
-
+		f, err := NewConfigFile("skaffold.yaml")
+		t.CheckNoError(err)
+		content, err := f.Read()
 		t.CheckNoError(err)
 		t.CheckDeepEqual([]byte("some yaml"), content)
+		t.CheckDeepEqual(f.Dir(), ".")
 	})
 }
 
@@ -43,16 +44,17 @@ func TestReadConfigurationFallback(t *testing.T) {
 			Write("skaffold.yml", "some yaml").
 			Chdir()
 
-		content, err := ReadConfiguration("skaffold.yaml")
-
+		f, err := NewConfigFile("skaffold.yaml")
+		t.CheckNoError(err)
+		content, err := f.Read()
 		t.CheckNoError(err)
 		t.CheckDeepEqual([]byte("some yaml"), content)
+		t.CheckDeepEqual(f.Dir(), ".")
 	})
 }
 
 func TestReadConfigurationNotFound(t *testing.T) {
-	_, err := ReadConfiguration("unknown-config-file.yaml")
-
+	_, err := NewConfigFile("unknown-config-file.yaml")
 	testutil.CheckError(t, true, err)
 	if !os.IsNotExist(err) {
 		t.Error("error should say that file doesn't exist")
@@ -61,8 +63,9 @@ func TestReadConfigurationNotFound(t *testing.T) {
 
 func TestReadConfigurationRemote(t *testing.T) {
 	remoteFile := testutil.ServeFile(t, []byte("remote file"))
-
-	content, err := ReadConfiguration(remoteFile)
+	f, err := NewConfigFile(remoteFile)
+	testutil.CheckError(t, false, err)
+	content, err := f.Read()
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, []byte("remote file"), content)
 }

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -97,13 +97,11 @@ func ExpandPathsGlob(workingDir string, paths []string) ([]string, error) {
 	var set orderedFileSet
 
 	for _, p := range paths {
-		if filepath.IsAbs(p) {
-			// This is a absolute file reference
-			set.Add(p)
-			continue
+		path := p
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(workingDir, path)
 		}
 
-		path := filepath.Join(workingDir, p)
 		if _, err := os.Stat(path); err == nil {
 			// This is a file reference, so just add it
 			set.Add(path)

--- a/pkg/skaffold/yamltags/paths.go
+++ b/pkg/skaffold/yamltags/paths.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package yamltags
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// SetAbsFilePaths recursively sets all fields marked with the yamltag `filepath` to absolute paths
+func SetAbsFilePaths(s interface{}, base string) error {
+	errs := setAbsFilePaths(s, base)
+	if len(errs) == 0 {
+		return nil
+	}
+	var messages []string
+	for _, err := range errs {
+		messages = append(messages, err.Error())
+	}
+	return fmt.Errorf(strings.Join(messages, " | "))
+}
+
+func setAbsFilePaths(config interface{}, base string) []error {
+	if config == nil {
+		return nil
+	}
+	parentStruct := reflect.Indirect(reflect.ValueOf(config))
+
+	switch parentStruct.Kind() {
+	case reflect.Struct:
+		t := parentStruct.Type()
+		var errs []error
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			v := parentStruct.Field(i)
+			if filepathTagExists(f) {
+				switch v.Interface().(type) {
+				case string:
+					path := v.String()
+					if path == "" {
+						return nil
+					}
+					if filepath.IsAbs(path) {
+						return nil
+					}
+					v.SetString(filepath.Join(base, path))
+					logrus.Tracef("setting absolute path for config field %q", f.Name)
+				case []string:
+					for i := 0; i < v.Len(); i++ {
+						elem := v.Index(i)
+						path := elem.String()
+						if path == "" {
+							continue
+						}
+						if filepath.IsAbs(path) {
+							continue
+						}
+						elem.SetString(filepath.Join(base, path))
+						logrus.Tracef("setting absolute paths for config field %q index %d", f.Name, i)
+					}
+				default:
+					return []error{fmt.Errorf("yaml tag `filepath` needs struct field %q to be string or string slice", f.Name)}
+				}
+				return nil
+			}
+
+			if v.Kind() != reflect.Ptr {
+				v = v.Addr()
+			}
+			if elemErrs := setAbsFilePaths(v.Interface(), base); elemErrs != nil {
+				errs = append(errs, elemErrs...)
+			}
+		}
+		return errs
+	case reflect.Slice:
+		var errs []error
+		for i := 0; i < parentStruct.Len(); i++ {
+			elem := parentStruct.Index(i)
+			if elem.Kind() != reflect.Ptr {
+				elem = elem.Addr()
+			}
+			if elemErrs := setAbsFilePaths(elem.Interface(), base); elemErrs != nil {
+				errs = append(errs, elemErrs...)
+			}
+		}
+		return errs
+	default:
+		return nil
+	}
+}
+
+func filepathTagExists(f reflect.StructField) bool {
+	yamltags, ok := f.Tag.Lookup("yamltags")
+	if !ok {
+		return false
+	}
+	tags := strings.Split(yamltags, ",")
+	for _, t := range tags {
+		if t == "filepath" {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/skaffold/yamltags/paths_test.go
+++ b/pkg/skaffold/yamltags/paths_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package yamltags
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestSetAbsFilePaths(t *testing.T) {
+	tests := []struct {
+		description string
+		config      *latest.SkaffoldConfig
+		base        string
+		expected    *latest.SkaffoldConfig
+	}{
+		{
+			description: "relative path",
+			config: &latest.SkaffoldConfig{
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{
+						Artifacts: []*latest.Artifact{
+							{ImageName: "foo1", Workspace: "./foo"},
+							{ImageName: "foo2", Workspace: "/a/foo"},
+						},
+					},
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							KptDeploy:     &latest.KptDeploy{Dir: "."},
+							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{"foo/*", "/a/foo/*"}},
+						},
+					},
+				},
+			},
+			base: "/a/b",
+			expected: &latest.SkaffoldConfig{
+				Pipeline: latest.Pipeline{
+					Build: latest.BuildConfig{
+						Artifacts: []*latest.Artifact{
+							{ImageName: "foo1", Workspace: "/a/b/foo"},
+							{ImageName: "foo2", Workspace: "/a/foo"},
+						},
+					},
+					Deploy: latest.DeployConfig{
+						DeployType: latest.DeployType{
+							KptDeploy:     &latest.KptDeploy{Dir: "/a/b"},
+							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{"/a/b/foo/*", "/a/foo/*"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			err := SetAbsFilePaths(test.config, test.base)
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expected, test.config)
+		})
+	}
+}

--- a/pkg/skaffold/yamltags/paths_windows_test.go
+++ b/pkg/skaffold/yamltags/paths_windows_test.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 /*
 Copyright 2020 The Skaffold Authors
 
@@ -38,31 +36,31 @@ func TestSetAbsFilePaths(t *testing.T) {
 				Pipeline: latest.Pipeline{
 					Build: latest.BuildConfig{
 						Artifacts: []*latest.Artifact{
-							{ImageName: "foo1", Workspace: "./foo"},
-							{ImageName: "foo2", Workspace: "/a/foo"},
+							{ImageName: "foo1", Workspace: "foo"},
+							{ImageName: "foo2", Workspace: `C:\\a\foo`},
 						},
 					},
 					Deploy: latest.DeployConfig{
 						DeployType: latest.DeployType{
 							KptDeploy:     &latest.KptDeploy{Dir: "."},
-							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{"foo/*", "/a/foo/*"}},
+							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{`foo\*`, `C:\\a\foo\*`}},
 						},
 					},
 				},
 			},
-			base: "/a/b",
+			base: `C:\\a\b`,
 			expected: &latest.SkaffoldConfig{
 				Pipeline: latest.Pipeline{
 					Build: latest.BuildConfig{
 						Artifacts: []*latest.Artifact{
-							{ImageName: "foo1", Workspace: "/a/b/foo"},
-							{ImageName: "foo2", Workspace: "/a/foo"},
+							{ImageName: "foo1", Workspace: `C:\\a\b\foo`},
+							{ImageName: "foo2", Workspace: `C:\\a\foo`},
 						},
 					},
 					Deploy: latest.DeployConfig{
 						DeployType: latest.DeployType{
-							KptDeploy:     &latest.KptDeploy{Dir: "/a/b"},
-							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{"/a/b/foo/*", "/a/foo/*"}},
+							KptDeploy:     &latest.KptDeploy{Dir: `C:\\a\b`},
+							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{`C:\\a\b\foo\*`, `C:\\a\foo\*`}},
 						},
 					},
 				},

--- a/pkg/skaffold/yamltags/paths_windows_test.go
+++ b/pkg/skaffold/yamltags/paths_windows_test.go
@@ -37,30 +37,30 @@ func TestSetAbsFilePaths(t *testing.T) {
 					Build: latest.BuildConfig{
 						Artifacts: []*latest.Artifact{
 							{ImageName: "foo1", Workspace: "foo"},
-							{ImageName: "foo2", Workspace: `C:\\a\foo`},
+							{ImageName: "foo2", Workspace: `C:\a\foo`},
 						},
 					},
 					Deploy: latest.DeployConfig{
 						DeployType: latest.DeployType{
 							KptDeploy:     &latest.KptDeploy{Dir: "."},
-							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{`foo\*`, `C:\\a\foo\*`}},
+							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{`foo\*`, `C:\a\foo\*`}},
 						},
 					},
 				},
 			},
-			base: `C:\\a\b`,
+			base: `C:\a\b`,
 			expected: &latest.SkaffoldConfig{
 				Pipeline: latest.Pipeline{
 					Build: latest.BuildConfig{
 						Artifacts: []*latest.Artifact{
-							{ImageName: "foo1", Workspace: `C:\\a\b\foo`},
-							{ImageName: "foo2", Workspace: `C:\\a\foo`},
+							{ImageName: "foo1", Workspace: `C:\a\b\foo`},
+							{ImageName: "foo2", Workspace: `C:\a\foo`},
 						},
 					},
 					Deploy: latest.DeployConfig{
 						DeployType: latest.DeployType{
-							KptDeploy:     &latest.KptDeploy{Dir: `C:\\a\b`},
-							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{`C:\\a\b\foo\*`, `C:\\a\foo\*`}},
+							KptDeploy:     &latest.KptDeploy{Dir: `C:\a\b`},
+							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{`C:\a\b\foo\*`, `C:\a\foo\*`}},
 						},
 					},
 				},

--- a/pkg/skaffold/yamltags/tags.go
+++ b/pkg/skaffold/yamltags/tags.go
@@ -129,6 +129,9 @@ func processTags(yamltags string, val reflect.Value, parentStruct reflect.Value,
 			yt = &skipTrimTag{
 				Field: field,
 			}
+		case "filepath":
+			// filepath tag is processed separately in pkg/skaffold/yamltags/paths.go
+			return nil
 		default:
 			logrus.Panicf("unknown yaml tag in %s", yamltags)
 		}


### PR DESCRIPTION
Fixes: #5204

This PR introduces a new yaml tag `filepath` for [`config.go`](https://github.com/GoogleContainerTools/skaffold/blob/master/pkg/skaffold/schema/latest/config.go) which converts the marked field to an absolute path.
```go
type Artifact struct {
	// Workspace is the directory containing the artifact's sources.
	// Defaults to `.`.
	Workspace string `yaml:"context,omitempty" yamltags:"filepath"`
        ...
}

type KubectlDeploy struct {
	// Manifests lists the Kubernetes yaml or json manifests.
	// Defaults to `["k8s/*.yaml"]`.
	Manifests []string `yaml:"manifests,omitempty" yamltags:"filepath"`
        ...
}
```

 This is useful since the current code assumes all relative paths in the skaffold config are defined from the `os.Getwd()` directory. With https://github.com/GoogleContainerTools/skaffold/pull/5160 we'll open up support for multiple skaffold configs. Doing an upfront file path massaging avoids having to maintain the info for base paths for each config individually which can be error prone.

It also fixes this assumption that the current working directory isn't the skaffold config location but the skaffold executable dir.
(comment on [context.go](https://github.com/GoogleContainerTools/skaffold/blob/35214eb817bff5d541d101d36ad3046be81c183b/pkg/skaffold/runner/runcontext/context.go#L186))
```go
// TODO(dgageot): this should be the folder containing skaffold.yaml. Should also be moved elsewhere.
cwd, err := os.Getwd()
```

Followup: After this is merged, we can remove `WorkingDir` from `runcontext` and many `filepath.Join`s strewn throughout the codebase become redundant.
