### PR TITLE
yaml encoders should be flushed.

### DIFF
--- a/pkg/skaffold/yaml/yaml.go
+++ b/pkg/skaffold/yaml/yaml.go
@@ -54,6 +54,9 @@ func Marshal(in interface{}) (out []byte, err error) {
 	if err := encoder.Encode(in); err != nil {
 		return nil, err
 	}
+	if err = encoder.Close(); err != nil {
+		return nil, err
+	}
 	return b.Bytes(), nil
 }
 
@@ -78,6 +81,8 @@ func MarshalWithSeparator(in interface{}) (out []byte, err error) {
 			return nil, err
 		}
 	}
-
+	if err = encoder.Close(); err != nil {
+		return nil, err
+	}
 	return b.Bytes(), nil
 }


### PR DESCRIPTION
From [doc](https://godoc.org/gopkg.in/yaml.v3#NewEncoder): `The Encoder should be closed after use to flush all data to w. `