### PR TITLE
Allow multiple configs in single skaffold.yaml

### DIFF
--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -157,7 +157,7 @@ func ParseConfig(filename string) ([]util.VersionedConfig, error) {
 	}
 	buf, err = removeYamlAnchors(buf)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to re-marshal YAML without dotted keys: %w", err)
 	}
 	return parseConfig(buf, factory)
 }
@@ -275,8 +275,12 @@ func removeYamlAnchors(buf []byte) ([]byte, error) {
 		}
 		err = encoder.Encode(parsed)
 		if err != nil {
-			return nil, fmt.Errorf("unable to re-marshal YAML without dotted keys: %w", err)
+			return nil, err
 		}
+	}
+	err := encoder.Close()
+	if err != nil {
+		return nil, err
 	}
 	return out.Bytes(), nil
 }

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta8"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -31,6 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta8"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -187,7 +187,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 		shouldErr   bool
 	}{
 		{
-			apiVersion: []string{latest.Version},
+			apiVersion:  []string{latest.Version},
 			description: "Kaniko Volume Mount - ConfigMap",
 			config:      []string{kanikoConfigMap},
 			expected: []util.VersionedConfig{config(


### PR DESCRIPTION

**Related**:  [Skaffold Multiple Configs support ](https://tinyurl.com/skaffold-multiple-configs)
This PR implements defining multiple skaffold pipelines in a single file. Maintaining multiple configurations is already implemented in #5160