### PR TITLE
Release automation changes

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -6,6 +6,7 @@ on:
     - master
 jobs:
   check:
+    name: Check if release commit
     runs-on: ubuntu-latest
     outputs:
       applicable: ${{ steps.check-commit-message.outputs.applicable }}
@@ -13,12 +14,16 @@ jobs:
     - name: Check commit message
       id: check-commit-message
       run: |
-        str=${{ github.event.head_commit.message }}
+        str="${{ github.event.head_commit.message }}"
         regex="^release\s*:\s*(v[0-9]+\.[0-9]+\.[0-9]+|[0-9]+\.[0-9]+\.[0-9]+)\s*$"
-        if [[ $str =~ $regex ]]; then echo "::set-output name=applicable::true"; else echo "::set-output name=applicable::false"
+        if [[ $str =~ $regex ]]; then
+        echo "::set-output name=applicable::true"
+        echo This is a release commit.
+        fi
 
   release:
-    if: ${{ needs.check.outputs.applicable }} == "true"
+    needs: check
+    if: needs.check.outputs.applicable == 'true'
     name: Create Tag and Draft Release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,11 +1,24 @@
 name: create draft release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches:
+    - master
 jobs:
-  build:
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'draft-release')
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      applicable: ${{ steps.check-commit-message.outputs.applicable }}
+    steps:
+    - name: Check commit message
+      id: check-commit-message
+      run: |
+        str=${{ github.event.head_commit.message }}
+        regex="^release\s*:\s*(v[0-9]+\.[0-9]+\.[0-9]+|[0-9]+\.[0-9]+\.[0-9]+)\s*$"
+        if [[ $str =~ $regex ]]; then echo "::set-output name=applicable::true"; else echo "::set-output name=applicable::false"
+
+  release:
+    if: ${{ needs.check.outputs.applicable }} == "true"
     name: Create Tag and Draft Release
     runs-on: ubuntu-latest
     steps:
@@ -16,9 +29,9 @@ jobs:
 
     - name: Calculate Tag and release names
       run: |
-        t=$(echo ${{ github.event.pull_request.title }} | sed -ne 's/.*\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p')
+        t=$(echo ${{ github.event.head_commit.message }} | sed -ne 's/.*\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p')
         if [ -z "$t" ]; then
-        echo Malformed title for PR; failed to extract semVer tag
+        echo Malformed commit message; failed to extract semVer tag
         return 1
         fi
         echo TAG_NAME="v${t}" >> $GITHUB_ENV


### PR DESCRIPTION
This PR changes the github action trigger for release automation from `PR with label 'draft-release' getting merged` to `commit with message 'release: vX.x.x' getting pushed`. This solves 2 issues with current release automation:
- Release PRs created from forks didn't work since the github action triggered by forks didn't have permissions to create tags. Changing the trigger to be based on 'commits on master' will work even when release PRs are created from forks.
- Action triggered on PR merge was not repeatable manually in case of any error. Now we can simply push an empty commit if we want to retrigger the entire release pipeline again.

### User facing changes:

Previously, in order to trigger the release pipeline, we required adding the `draft-release` label to the release PR and also `Release vX.x.x` be the PR title. Now we only require that the PR head commit be `release: vX.x.x`.