### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,3 @@
 # Global owners
 
 * @GoogleContainerTools/skaffold-team
-
-# JIB owners
-
-**/**jib** @GoogleContainerTools/skaffold-team @loosebazooka @TadCordle @chanseokoh
-
-# kpt owners
-pkg/skaffold/deploy/**kpt** @GoogleContainerTools/skaffold-team @yuwenma
-
-# Debug owners
-
-pkg/skaffold/debug/** @GoogleContainerTools/skaffold-team @loosebazooka @quoctruong
-docs/content/en/docs/how-tos/debug/** @GoogleContainerTools/skaffold-team @loosebazooka @quoctruong
-integration/test-data/debug/** @GoogleContainerTools/skaffold-team @loosebazooka @quoctruong
-integration/debug_test.go @GoogleContainerTools/skaffold-team @loosebazooka @quoctruong


### PR DESCRIPTION
in theory this was a good idea, but in practice it's causing wrong reviewers to be auto-added for any change that touches files in any of these subdirectories. let's just remove the github owners rules, and tag reviewers as needed for any domain-specific changes.