### PR TITLE
Update Skaffold dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,6 @@ GSC_BUILD_PATH ?= gs://$(RELEASE_BUCKET)/builds/$(COMMIT)
 GSC_BUILD_LATEST ?= gs://$(RELEASE_BUCKET)/builds/latest
 GSC_RELEASE_PATH ?= gs://$(RELEASE_BUCKET)/releases/$(VERSION)
 GSC_RELEASE_LATEST ?= gs://$(RELEASE_BUCKET)/releases/latest
-KIND_NODE ?= kindest/node:v1.13.12@sha256:214476f1514e47fe3f6f54d0f9e24cfb1e4cda449529791286c7161b7f9c08e7
-K3D_NODE ?= rancher/k3s:v1.18.6-k3s1@sha256:a835d76608a2503af8b681bb5888499d7c3456902f6853c8c1031f4a884715ca
 
 GCP_ONLY ?= false
 GCP_PROJECT ?= k8s-skaffold
@@ -191,7 +189,6 @@ skaffold-builder:
 .PHONY: integration-in-kind
 integration-in-kind: skaffold-builder
 	echo '{}' > /tmp/docker-config
-	docker pull $(KIND_NODE)
 	docker network inspect kind >/dev/null 2>&1 || docker network create kind
 	docker run --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock \
@@ -207,7 +204,7 @@ integration-in-kind: skaffold-builder
 		sh -eu -c ' \
 			if ! kind get clusters | grep -q kind; then \
 			  trap "kind delete cluster" 0 1 2 15; \
-			  TERM=dumb kind create cluster --image=$(KIND_NODE); \
+			  TERM=dumb kind create cluster; \
 			fi; \
 			kind get kubeconfig --internal > /tmp/kind-config; \
 			make integration \
@@ -216,7 +213,6 @@ integration-in-kind: skaffold-builder
 .PHONY: integration-in-k3d
 integration-in-k3d: skaffold-builder
 	echo '{}' > /tmp/docker-config
-	docker pull $(K3D_NODE)
 	docker run --rm \
 		--network="host" \
 		-v /var/run/docker.sock:/var/run/docker.sock \
@@ -228,7 +224,7 @@ integration-in-k3d: skaffold-builder
 		-e IT_PARTITION=$(IT_PARTITION) \
 		gcr.io/$(GCP_PROJECT)/skaffold-builder \
 		sh -c ' \
-			k3d cluster list | grep -q k3s-default || TERM=dumb k3d cluster create --image=$(K3D_NODE); \
+			k3d cluster list | grep -q k3s-default || TERM=dumb k3d cluster create; \
 			make integration \
 		'
 

--- a/deploy/buildpacks/publish.sh
+++ b/deploy/buildpacks/publish.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-PACK_VERSION=v0.15.0
+PACK_VERSION=v0.15.1
 
 docker build . --build-arg PACK_VERSION=${PACK_VERSION} -t gcr.io/k8s-skaffold/pack:${PACK_VERSION} -t gcr.io/k8s-skaffold/pack:latest
 docker push gcr.io/k8s-skaffold/pack:${PACK_VERSION}

--- a/deploy/skaffold/Dockerfile
+++ b/deploy/skaffold/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This base image has to be updated manually after running `make build_deps`
-FROM gcr.io/k8s-skaffold/build_deps:f6315480079f9c0b355db413eef9322cf0410b18 as builder
+FROM gcr.io/k8s-skaffold/build_deps:99947454c311d61d348a3dbb14ed5cfd9b69de61 as builder
 WORKDIR /skaffold
 COPY . .
 

--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -14,36 +14,36 @@
 
 # Download kubectl
 FROM alpine:3.10 as download-kubectl
-# Track default version installed by Google Cloud SDK: 305.0.0 moved to 1.16
-ENV KUBECTL_VERSION v1.16.15
+# Track default version installed by Google Cloud SDK: 320.0.0 moved to 1.17(.14)
+ENV KUBECTL_VERSION v1.17.14
 ENV KUBECTL_URL https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
 RUN wget -O kubectl "${KUBECTL_URL}"
 RUN chmod +x kubectl
 
-# Download helm
+# Download helm (see https://github.com/helm/helm/releases/latest)
 FROM alpine:3.10 as download-helm
-ENV HELM_VERSION v3.3.4
+ENV HELM_VERSION v3.4.2
 ENV HELM_URL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz
 RUN wget -O helm.tar.gz "${HELM_URL}"
 RUN tar -xvf helm.tar.gz --strip-components 1
 
 # Download kustomize
 FROM alpine:3.10 as download-kustomize
-ENV KUSTOMIZE_VERSION 3.8.5
+ENV KUSTOMIZE_VERSION 3.8.9
 ENV KUSTOMIZE_URL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz
 RUN wget -O kustomize.tar.gz "${KUSTOMIZE_URL}"
 RUN tar -xvf kustomize.tar.gz
 
 # Download kompose
 FROM alpine:3.10 as download-kompose
-ENV KOMPOSE_VERSION v1.21.0
+ENV KOMPOSE_VERSION v1.22.0
 ENV KOMPOSE_URL https://github.com/kubernetes/kompose/releases/download/${KOMPOSE_VERSION}/kompose-linux-amd64
 RUN wget -O kompose "${KOMPOSE_URL}"
 RUN chmod +x kompose
 
-# Download container-structure-test
+# Download container-structure-test (https://github.com/GoogleContainerTools/container-structure-test/releases/latest)
 FROM alpine:3.10 as download-container-structure-test
-ENV CONTAINER_STRUCTURE_TEST_VERSION v1.9.1
+ENV CONTAINER_STRUCTURE_TEST_VERSION v1.10.0
 ENV CONTAINER_STRUCTURE_TEST_URL https://storage.googleapis.com/container-structure-test/${CONTAINER_STRUCTURE_TEST_VERSION}/container-structure-test-linux-amd64
 RUN wget -O container-structure-test "${CONTAINER_STRUCTURE_TEST_URL}"
 RUN chmod +x container-structure-test
@@ -57,21 +57,21 @@ RUN chmod +x kind
 
 # Download k3d
 FROM alpine:3.10 as download-k3d
-ENV K3D_VERSION v3.1.3
+ENV K3D_VERSION v3.4.0
 ENV K3D_URL https://github.com/rancher/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64
 RUN wget -O k3d "${K3D_URL}"
 RUN chmod +x k3d
 
 # Download gcloud
 FROM alpine:3.10 as download-gcloud
-ENV GCLOUD_VERSION 314.0.0
+ENV GCLOUD_VERSION 322.0.0
 ENV GCLOUD_URL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz
 RUN wget -O gcloud.tar.gz "${GCLOUD_URL}"
 RUN tar -zxf gcloud.tar.gz
 
 # Download bazel
 FROM alpine:3.10 as download-bazel
-ENV BAZEL_VERSION 3.6.0
+ENV BAZEL_VERSION 3.7.2
 ENV BAZEL_URL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-x86_64
 RUN wget -O bazel "${BAZEL_URL}"
 RUN chmod +x bazel


### PR DESCRIPTION
Update to latest stable versions.  A few notes:
  - Moved to Kubectl 1.17 to track the default version used in Google Cloud SDK 322.0.0
  - Kustomize 3.9.x uses a new underlying YAML library (kyaml), and 3.8.x is based on the older api-machinery code.
  - Drops the pre-pulling of the K3D and KIND node images as it's a bit of a pain to track these images.