### PR TITLE
Modify Travis directive restricting builds to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ go_import_path: /skaffold
 git:
   submodules: false
 
-branches:
-  only:
-    - master
-
 _integration_test: &integration_test
   os: linux
   language: minimal

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ language: go
 go: "1.15.x"
 go_import_path: /skaffold
 
+# skip release branches and version tags
+branches:
+  except:
+    - /^release\/.*/
+    - /^v\d+\..*$/
+
 git:
   submodules: false
 


### PR DESCRIPTION
The only-build-master directive prevents people from getting feedback on personal branches in forks, unless they are called `master`.  This settings requires creating PRs for experimentation which causes noise, even if they are marked as draft.

This setting was originally brought it for #2607 to avoid merge failures from release branches.  This PR instead uses a blocklist to prevent builds on release branches and version tags.