### PR TITLE
Avoid MTU mismatches and image hangs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ git:
   submodules: false
 
 install:
-  - if [ $TRAVIS_OS_NAME = linux ]; then \
-      sysctl net.ipv4.tcp_mtu_probing; \
-      sudo sysctl -w net.ipv4.tcp_mtu_probing=1; \
+  - if [ $TRAVIS_OS_NAME = linux ]; then
+      sysctl net.ipv4.tcp_mtu_probing;
+      sudo sysctl -w net.ipv4.tcp_mtu_probing=1;
     fi
 
 _integration_test: &integration_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ _integration_test: &integration_test
   before_install:
     # Skip integration tests for `docs`-only changes (only works for PR-based dev workflows like Skaffold's).
     - git diff --name-only "$TRAVIS_BRANCH"... | grep -v '^docs/' || travis_terminate 0
+    - sysctl -a | grep mtu
   cache:
     directories:
       - $HOME/.cache/go-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,10 @@ git:
   submodules: false
 
 install:
-  - sudo sysctl -w net.ipv4.tcp_mtu_probing=1
+  - if [ $TRAVIS_OS_NAME = linux ]; then \
+      sysctl net.ipv4.tcp_mtu_probing; \
+      sudo sysctl -w net.ipv4.tcp_mtu_probing=1; \
+    fi
 
 _integration_test: &integration_test
   os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,15 @@ branches:
 git:
   submodules: false
 
+install:
+  - sudo sysctl -w net.ipv4.tcp_mtu_probing=1
+
 _integration_test: &integration_test
   os: linux
   language: minimal
   before_install:
     # Skip integration tests for `docs`-only changes (only works for PR-based dev workflows like Skaffold's).
     - git diff --name-only "$TRAVIS_BRANCH"... | grep -v '^docs/' || travis_terminate 0
-    - sysctl -a | grep mtu
   cache:
     directories:
       - $HOME/.cache/go-build

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,9 @@ integration-in-kind: skaffold-builder
 		sh -eu -c ' \
 			if ! kind get clusters | grep -q kind; then \
 			  trap "kind delete cluster" 0 1 2 15; \
-			  TERM=dumb kind create cluster; \
+			  sh hack/generate-kind-registries-yaml > /tmp/kind-registries.yaml; \
+			  cat /tmp/kind-registries.yaml; \
+			  TERM=dumb kind create cluster --config /tmp/kind-registries.yaml; \
 			fi; \
 			kind get kubeconfig --internal > /tmp/kind-config; \
 			make integration \

--- a/Makefile
+++ b/Makefile
@@ -209,9 +209,9 @@ integration-in-kind: skaffold-builder
 		sh -eu -c ' \
 			if ! kind get clusters | grep -q kind; then \
 			  trap "kind delete cluster" 0 1 2 15; \
-			  sh hack/generate-kind-registries-yaml > /tmp/kind-registries.yaml; \
-			  cat /tmp/kind-registries.yaml; \
-			  TERM=dumb kind create cluster --config /tmp/kind-registries.yaml; \
+			  sh hack/generate-kind-config.sh > /tmp/kind-config.yaml; \
+			  cat /tmp/kind-config.yaml; \
+			  TERM=dumb kind create cluster --config /tmp/kind-config.yaml; \
 			fi; \
 			kind get kubeconfig --internal > /tmp/kind-config; \
 			make integration \

--- a/Makefile
+++ b/Makefile
@@ -218,8 +218,10 @@ integration-in-kind: skaffold-builder
 .PHONY: integration-in-k3d
 integration-in-k3d: skaffold-builder
 	echo '{}' > /tmp/docker-config
+	# pre-pull image to avoid very odd hang seen in tests when Skaffold uses `k3d image import` to load images
+	docker pull rancher/k3d-tools:v3.4.0
 	# Custom docker networks are created with mtu 1500 (https://github.com/moby/moby/issues/34981#issuecomment-343616165)
-	# so pull out the MTU from the default network. 
+	# so pull out the MTU from the default network.
 	# Instruct k3d to use this specific network.
 	docker network inspect k3d >/dev/null 2>&1 || ( \
 		MTU=`docker network inspect bridge --format '{{index .Options "com.docker.network.driver.mtu"}}'` ; \

--- a/hack/generate-kind-config.sh
+++ b/hack/generate-kind-config.sh
@@ -1,3 +1,18 @@
 #!/bin/sh
+
+# Copyright 2019 The Skaffold Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Create a kind configuration to use the docker daemon's configured registry-mirrors.
 docker system info --format '{{printf "apiVersion: kind.x-k8s.io/v1alpha4\nkind: Cluster\ncontainerdConfigPatches:\n"}}{{range $reg, $config := .RegistryConfig.IndexConfigs}}{{if $config.Mirrors}}{{printf "- |-\n  [plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"%s\"]\n    endpoint = %q\n" $reg $config.Mirrors}}{{end}}{{end}}'

--- a/hack/generate-kind-config.sh
+++ b/hack/generate-kind-config.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Create a kind configuration to use the docker daemon's configured registry-mirrors.
+docker system info --format '{{printf "apiVersion: kind.x-k8s.io/v1alpha4\nkind: Cluster\ncontainerdConfigPatches:\n"}}{{range $reg, $config := .RegistryConfig.IndexConfigs}}{{if $config.Mirrors}}{{printf "- |-\n  [plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"%s\"]\n    endpoint = %q\n" $reg $config.Mirrors}}{{end}}{{end}}'


### PR DESCRIPTION
This PR makes two changes:
  1. It ensures our `kind` and `k3d` tests use the docker daemon's configured MTU.  `kind` uses the MTU of the default docker network (that is associated with the `eth0` adapter, if found).  `k3d` can be instructed to use a specific docker network.
  2. Despite the fix in #5220, I still saw hangs in the integration tests when loading built images in the k3d integration tests.  `k3d image import` involves running a `rancher/k3d-tools:v3.4.0` container, and the hang occurs when pulling this image, which suggests a latent MTU mismatch. This PR now pre-pulls the `rancher/k3d-tools:v3.4.0` image prior to running the tests.