### PR TITLE
Create nsis installer script

### DIFF
--- a/installers/windows/skaffold.nsi
+++ b/installers/windows/skaffold.nsi
@@ -1,0 +1,130 @@
+!define APP_NAME "Skaffold"
+!define COMP_NAME "Google"
+!define WEB_SITE "https://skaffold.dev"
+!define VERSION "$%SKAFFOLD_VERSION%"
+!define COPYRIGHT "Google Skaffold Authors, 2021"
+!define DESCRIPTION "Fast. Repeatable. Simple. Local Kubernetes Development"
+!define INSTALLER_NAME "skaffold_installer.exe"
+!define MAIN_APP_EXE "skaffold.exe"
+!define ICON "..\..\docs\static\favicons\favicon.ico"
+!define BANNER "..\..\logo\skaffold.jpg"
+!define LICENSE_TXT "..\..\LICENSE"
+
+!define INSTALL_DIR "$PROGRAMFILES64\${APP_NAME}"
+!define INSTALL_TYPE "SetShellVarContext all"
+!define REG_ROOT "HKLM"
+!define REG_APP_PATH "Software\Microsoft\Windows\CurrentVersion\App Paths\${MAIN_APP_EXE}"
+!define UNINSTALL_PATH "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}"
+
+######################################################################
+
+VIProductVersion "${VERSION}"
+VIAddVersionKey "ProductName"  "${APP_NAME}"
+VIAddVersionKey "CompanyName"  "${COMP_NAME}"
+VIAddVersionKey "LegalCopyright"  "${COPYRIGHT}"
+VIAddVersionKey "FileDescription"  "${DESCRIPTION}"
+VIAddVersionKey "FileVersion"  "${VERSION}"
+
+######################################################################
+
+SetCompressor /SOLID Lzma
+Name "${APP_NAME}"
+Caption "${APP_NAME}"
+OutFile "${INSTALLER_NAME}"
+BrandingText "${APP_NAME}"
+InstallDirRegKey "${REG_ROOT}" "${REG_APP_PATH}" ""
+InstallDir "${INSTALL_DIR}"
+
+######################################################################
+
+!define MUI_ICON "${ICON}"
+!define MUI_UNICON "${ICON}"
+!define MUI_WELCOMEFINISHPAGE_BITMAP "${BANNER}"
+!define MUI_UNWELCOMEFINISHPAGE_BITMAP "${BANNER}"
+
+######################################################################
+
+!include "MUI2.nsh"
+
+!define MUI_ABORTWARNING
+!define MUI_UNABORTWARNING
+
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_LICENSE "${LICENSE_TXT}"
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+!insertmacro MUI_UNPAGE_FINISH
+!insertmacro MUI_LANGUAGE "English"
+
+######################################################################
+
+Section -MainProgram
+	${INSTALL_TYPE}
+
+	SetOverwrite ifnewer
+	SetOutPath "$INSTDIR"
+	File /r "out\\"
+
+	Rename "$INSTDIR\\skaffold-windows-amd64.exe" "$INSTDIR\\skaffold.exe"
+
+	EnVar::AddValue "PATH" "$INSTDIR"
+	Pop $0
+	DetailPrint "EnVar::AddValue returned=|$0|"
+
+SectionEnd
+
+######################################################################
+
+Section -Icons_Reg
+SetOutPath "$INSTDIR"
+WriteUninstaller "$INSTDIR\uninstall.exe"
+
+CreateDirectory "$SMPROGRAMS\${APP_NAME}"
+CreateShortCut "$SMPROGRAMS\${APP_NAME}\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}"
+CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${MAIN_APP_EXE}"
+CreateShortCut "$SMPROGRAMS\${APP_NAME}\Uninstall ${APP_NAME}.lnk" "$INSTDIR\uninstall.exe"
+
+!ifdef WEB_SITE
+WriteIniStr "$INSTDIR\${APP_NAME} website.url" "InternetShortcut" "URL" "${WEB_SITE}"
+CreateShortCut "$SMPROGRAMS\${APP_NAME}\${APP_NAME} Website.lnk" "$INSTDIR\${APP_NAME} website.url"
+!endif
+
+WriteRegStr ${REG_ROOT} "${REG_APP_PATH}" "" "$INSTDIR\${MAIN_APP_EXE}"
+WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "DisplayName" "${APP_NAME}"
+WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "UninstallString" "$INSTDIR\uninstall.exe"
+WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "DisplayIcon" "$INSTDIR\${MAIN_APP_EXE}"
+WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "DisplayVersion" "${VERSION}"
+WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "Publisher" "${COMP_NAME}"
+
+!ifdef WEB_SITE
+WriteRegStr ${REG_ROOT} "${UNINSTALL_PATH}"  "URLInfoAbout" "${WEB_SITE}"
+!endif
+SectionEnd
+
+######################################################################
+
+Section Uninstall
+${INSTALL_TYPE}
+
+RmDir /r "$INSTDIR"
+
+; Delete a value from a variable
+EnVar::DeleteValue "PATH" "$INSTDIR"
+Pop $0
+DetailPrint "EnVar::DeleteValue returned=|$0|"
+
+Delete "$SMPROGRAMS\${APP_NAME}\${APP_NAME}.lnk"
+Delete "$SMPROGRAMS\${APP_NAME}\Uninstall ${APP_NAME}.lnk"
+!ifdef WEB_SITE
+Delete "$SMPROGRAMS\${APP_NAME}\${APP_NAME} Website.lnk"
+!endif
+Delete "$DESKTOP\${APP_NAME}.lnk"
+
+RmDir "$SMPROGRAMS\${APP_NAME}"
+
+DeleteRegKey ${REG_ROOT} "${REG_APP_PATH}"
+DeleteRegKey ${REG_ROOT} "${UNINSTALL_PATH}"
+SectionEnd


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: #5089

**Description**
Adds a basic nsis installer script that can be run by:
1. Install makensis
   1.  linux ```apt-get install  -y nsis nsis-doc nsis-pluginapi```
   2. mac ```brew install makensis```
   3. windows https://nsis.sourceforge.io/Download
2. Download https://nsis.sourceforge.io/EnVar_plug-in and unzip in the nsis install directory on whatever platform you are on 
3. compile the windows binary ```make ./out/skaffold-windows-amd64.exe```
4. Copy the binary and whatever other files to include in the installation in the installer out directory 
    ```bash
    mkdir installers/windows/out && cp ./out/skaffold-windows-amd64.exe installers/windows/out
    ```
5. Set skaffold version and run makensis ```SKAFFOLD_VERSION=1.18.0.0 makensis -V4 skaffold.nsi```
    1. skaffold version must be of the form X.X.X.X in order to be accepted by ```makensis```

The installer can:
- Install to a user specified directory
- Add that directory to the user's PATH
- Create an uninstaller for that uninstalls skaffold and removes the install directory from the user's PATH


**Follow-up Work**
Add a step in the release process to publish the installer alongside all the other binaries. Phase out chocolatey from use

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
