### PR TITLE
change default status check timeout to 10 minutes

### DIFF
--- a/pkg/skaffold/deploy/status/status_check.go
+++ b/pkg/skaffold/deploy/status/status_check.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	defaultStatusCheckDeadline = 2 * time.Minute
+	defaultStatusCheckDeadline = 10 * time.Minute
 
 	// Poll period for checking set to 1 second
 	defaultPollPeriodInMilliseconds = 1000


### PR DESCRIPTION
Fixes: #5106

**Description**
Changes the default timeout of status check to 10 minutes, according to conversation on #5106 

**User facing changes (remove if N/A)**
Users deploying with skaffold using status-check will have a longer period of time before their deployment times out
