### PR TITLE
Configure maven connection pool TTL to avoid connection resets from stale connections

### DIFF
--- a/integration/examples/buildpacks-java/.mvn/jvm.config
+++ b/integration/examples/buildpacks-java/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/integration/examples/jib-multimodule/.mvn/jvm.config
+++ b/integration/examples/jib-multimodule/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/integration/examples/jib-multimodule/.mvn/wrapper/maven-wrapper.properties
+++ b/integration/examples/jib-multimodule/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip

--- a/integration/examples/jib-sync/.mvn/jvm.config
+++ b/integration/examples/jib-sync/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/integration/examples/jib-sync/.mvn/wrapper/maven-wrapper.properties
+++ b/integration/examples/jib-sync/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip

--- a/integration/examples/jib/.mvn/wrapper/maven-wrapper.properties
+++ b/integration/examples/jib/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip

--- a/integration/testdata/debug/java/.mvn/jvm.config
+++ b/integration/testdata/debug/java/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/integration/testdata/debug/java/.mvn/wrapper/maven-wrapper.properties
+++ b/integration/testdata/debug/java/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip

--- a/integration/testdata/jib/.mvn/jvm.config
+++ b/integration/testdata/jib/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120

--- a/integration/testdata/jib/.mvn/wrapper/maven-wrapper.properties
+++ b/integration/testdata/jib/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip


### PR DESCRIPTION
**Description**
Updates Maven wrapper properties to pull down Maven 3.6.3 to ensure we have latest bug fixes.
Adds JVM command-switches to change the Maven Wagon HTTP transport's TTL to 2 minutes.

Fixes: #5248 🤞 
