### PR TITLE
Use gcr.io/google-appengine/openjdk:8 to avoid toomanyrequests

### DIFF
--- a/integration/testdata/debug/java/pom.xml
+++ b/integration/testdata/debug/java/pom.xml
@@ -22,7 +22,7 @@
         <version>${jib.maven-plugin-version}</version>
         <configuration>
           <from>
-            <image>openjdk</image> <!-- has jdb -->
+            <image>gcr.io/google-appengine/openjdk:8</image> <!-- has jdb -->
           </from>
           <container>
             <jvmFlags>


### PR DESCRIPTION
Change `integration/testdata/debug/java/pom.xml` to use `gcr.io/google-appengine/openjdk:8` as the base image instead of `openjdk` from Docker Hub to avoid hitting Docker Hub rate limits.