### PR TITLE
fix termination event not being sent

### DIFF
--- a/pkg/skaffold/errors/errors.go
+++ b/pkg/skaffold/errors/errors.go
@@ -108,7 +108,12 @@ func IsOldImageManifestProblem(err error) (string, bool) {
 }
 
 func getErrorCodeFromError(phase Phase, err error) (proto.StatusCode, []*proto.Suggestion) {
-	uErr := errors.Unwrap(err)
+	uErr := func(err error) error {
+		if e := errors.Unwrap(err); e != nil {
+			return e
+		}
+		return err
+	}(err)
 	if t, ok := uErr.(Error); ok {
 		return t.StatusCode(), t.Suggestions()
 	}

--- a/pkg/skaffold/errors/errors.go
+++ b/pkg/skaffold/errors/errors.go
@@ -108,18 +108,14 @@ func IsOldImageManifestProblem(err error) (string, bool) {
 }
 
 func getErrorCodeFromError(phase Phase, err error) (proto.StatusCode, []*proto.Suggestion) {
-	uErr := func(err error) error {
-		if e := errors.Unwrap(err); e != nil {
-			return e
-		}
-		return err
-	}(err)
-	if t, ok := uErr.(Error); ok {
-		return t.StatusCode(), t.Suggestions()
+	var sErr Error
+	if errors.As(err, &sErr) {
+		return sErr.StatusCode(), sErr.Suggestions()
 	}
+
 	if problems, ok := allErrors[phase]; ok {
 		for _, v := range problems {
-			if v.regexp.MatchString(uErr.Error()) {
+			if v.regexp.MatchString(err.Error()) {
 				return v.errCode, v.suggestion(skaffoldOpts)
 			}
 		}

--- a/pkg/skaffold/errors/errors.go
+++ b/pkg/skaffold/errors/errors.go
@@ -17,6 +17,7 @@ limitations under the License.
 package errors
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -107,12 +108,13 @@ func IsOldImageManifestProblem(err error) (string, bool) {
 }
 
 func getErrorCodeFromError(phase Phase, err error) (proto.StatusCode, []*proto.Suggestion) {
-	if t, ok := err.(Error); ok {
+	uErr := errors.Unwrap(err)
+	if t, ok := uErr.(Error); ok {
 		return t.StatusCode(), t.Suggestions()
 	}
 	if problems, ok := allErrors[phase]; ok {
 		for _, v := range problems {
-			if v.regexp.MatchString(err.Error()) {
+			if v.regexp.MatchString(uErr.Error()) {
 				return v.errCode, v.suggestion(skaffoldOpts)
 			}
 		}

--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -532,8 +532,7 @@ func (ev *eventHandler) handle(event *proto.Event) {
 			event: event,
 			ts:    t,
 		}
-		switch event.GetEventType().(type) {
-		case *proto.Event_TerminationEvent:
+		if _, ok :=event.GetEventType().(*proto.Event_TerminationEvent); ok {
 			// close the event channel indicating there are no more events to all the
 			// receivers
 			close(ev.eventChan)

--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -56,12 +56,11 @@ func newHandler() *eventHandler {
 	}
 	go func() {
 		for {
-			ev, isNotClosed := <-h.eventChan
-			if isNotClosed {
-				h.handleExec(ev)
-			} else {
+			ev, open := <-h.eventChan
+			if !open {
 				break
 			}
+			h.handleExec(ev)
 		}
 	}()
 	return h

--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -532,7 +532,7 @@ func (ev *eventHandler) handle(event *proto.Event) {
 			event: event,
 			ts:    t,
 		}
-		if _, ok :=event.GetEventType().(*proto.Event_TerminationEvent); ok {
+		if _, ok := event.GetEventType().(*proto.Event_TerminationEvent); ok {
 			// close the event channel indicating there are no more events to all the
 			// receivers
 			close(ev.eventChan)

--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -654,10 +654,7 @@ func (ev *eventHandler) handleExec(f firedEvent) {
 		case Failed:
 			logEntry.Entry = fmt.Sprintf("Update failed with error code %v", de.Err.ErrCode)
 		}
-	default:
-		return
 	}
-
 	ev.logEvent(*logEntry)
 }
 
@@ -739,6 +736,7 @@ func InititializationFailed(err error) {
 			},
 		},
 	})
+	handler.handle(nil)
 }
 
 // SaveEventsToFile saves the current event log to the filepath provided


### PR DESCRIPTION
In #4926 I added a new event to send a termination event to detect failures in skaffold setup. 
However, during more rigorous testing, i saw some abnormalities where the event was received.
1. Send a nil event to indicate close of channel when skaffold terminates
2. Log all events.



Steps to Reproduce:
1. Please compile skaffold on this branch using `make`
2. Check if helm is installed and uninstall it or simple move.
3. if yes, 
  ```
   sudo mv /usr/local/bin/helm ~/workspace/helm1
  ```
4. Open a new terminal 
```
watch -n 0.5  "curl -H "Expect: any" localhost:50052/v1/events >> t.txt" 
```
5..  Checkout a skaffold helm example  run `skaffold dev`
```
cd examples/helm-deployment
../../out/skaffold dev
```
6. Open t.txt and verify if "TerminationEvent" is done
```
{"result":{"timestamp":"2021-01-20T23:56:59.856262Z","event":{"metaEvent":{"entry":"Starting Skaffold: \u0026{Version:v1.17.1-75-g1f519d095-dirty ConfigVersion:skaffold/v2beta11 GitVersion: GitCommit:1f519d095243f08f3b3c4db72f3c585d763b4454 GitTreeState:dirty BuildDate:2021-01-20T15:47:23Z GoVersion:go1.15.3 Compiler:gc Platform:darwin/amd64}","metadata":{"build":{"numberOfArtifacts":1,"builders":[{"type":"DOCKER","count":1}],"type":"LOCAL"},"deploy":{"deployers":[{"type":"HELM","count":1}],"cluster":"MINIKUBE"}}}}}}
{"result":{"timestamp":"2021-01-20T23:56:59.857213Z","event":{
   "terminationEvent":{"status":"Failed","err":{"errCode":"DEPLOY_HELM_VERSION_ERR","message":"creating deployer: Helm not found. Please install helm via https://helm.sh/docs/intro/install.","suggestions":[{"suggestionCode":"INSTALL_HELM","action":"Please install helm via https://helm.sh/docs/intro/install"}]}}}}}
{"result":{"timestamp":"2021-01-20T23:56:59.857219Z"}}

```