### PR TITLE
Go 1.12 is not supported by Delve 1.5.x

### DIFF
--- a/integration/examples/helm-deployment/Dockerfile
+++ b/integration/examples/helm-deployment/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.12.9-alpine3.10 as builder
+FROM golang:1.15-alpine as builder
 COPY main.go .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
 RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
 
-FROM alpine:3.10
+FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime
 # for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
 ENV GOTRACEBACK=single


### PR DESCRIPTION
`TestDebug/helm` is failing as Delve doesn't support Go 1.12:
```
time="2021-01-21T03:25:21Z" level=warning msg="[kubectl -n skaffoldrps5k logs deployment.app/skaffold-helm]"
API server listening at: [::]:56268
Version of Go is too old for this version of Delve (minimum supported version 1.13, suppress this error with --check-go-version=false)
```

Towards #5249 — but we should probably change this across the board.

