### PR TITLE
Fix race condition when running tests for pkg/skaffold/instrumentation

### DIFF
--- a/cmd/skaffold/skaffold.go
+++ b/cmd/skaffold/skaffold.go
@@ -33,6 +33,7 @@ type ExitCoder interface {
 }
 
 func main() {
+	instrumentation.SetOnlineStatus()
 	var code int
 	if err := app.Run(os.Stdout, os.Stderr); err != nil {
 		if errors.Is(err, context.Canceled) {

--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -99,7 +99,9 @@ func init() {
 	doesDeploy.Insert("deploy", "dev", "debug", "run")
 }
 
-// SetOnlineStatus issues a GET request to see if the user is online
+// SetOnlineStatus issues a GET request to see if the user is online.
+// http://clients3.google.com/generate_204 is a well-known URL that returns an empty page and HTTP status 204
+// More info can be found here: https://www.chromium.org/chromium-os/chromiumos-design-docs/network-portal-detection
 func SetOnlineStatus() {
 	go func() {
 		if shouldExportMetrics {

--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -97,6 +97,10 @@ func init() {
 	meteredCommands.Insert("build", "delete", "deploy", "dev", "debug", "filter", "generate_pipeline", "render", "run", "test")
 	doesBuild.Insert("build", "render", "dev", "debug", "run")
 	doesDeploy.Insert("deploy", "dev", "debug", "run")
+}
+
+// SetOnlineStatus issues a GET request to see if the user is online
+func SetOnlineStatus() {
 	go func() {
 		if shouldExportMetrics {
 			r, err := http.Get("http://clients3.google.com/generate_204")


### PR DESCRIPTION
**Description**
Fixes a race condition that can occur when running tests for pkg/skaffold/instrumentation. To fix the issue of two threads accessing the `isOnline` variable, I've moved the responsibility of checking if the user is online to a new function and am calling that in skaffold's `main()`
