### PR TITLE
Configure Maven Wagon HTTP to retry on errors to successful connections

### DIFF
--- a/integration/examples/buildpacks-java/.mvn/jvm.config
+++ b/integration/examples/buildpacks-java/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true

--- a/integration/examples/jib-multimodule/.mvn/jvm.config
+++ b/integration/examples/jib-multimodule/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true

--- a/integration/examples/jib-sync/.mvn/jvm.config
+++ b/integration/examples/jib-sync/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true

--- a/integration/testdata/debug/java/.mvn/jvm.config
+++ b/integration/testdata/debug/java/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true 

--- a/integration/testdata/jib/.mvn/jvm.config
+++ b/integration/testdata/jib/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true


### PR DESCRIPTION
It may be that our artifact requests are seeming to succeed, but the responses are failing (thus the connection resets).  This PR configured Maven's Wagon HTTP to retry even if the initial request seemed to have succeeded.

Towards #5248 🤞  
