### PR TITLE
escape backticks in commit message

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Check commit message
       id: check-commit-message
       run: |
-        str="${{ github.event.head_commit.message }}"
+        str='${{ github.event.head_commit.message }}'
         regex="^release\s*:\s*(v[0-9]+\.[0-9]+\.[0-9]+|[0-9]+\.[0-9]+\.[0-9]+)\s*$"
         if [[ "$str" =~ $regex ]]; then
         echo "::set-output name=applicable::true"


### PR DESCRIPTION
The Github Action `create draft release` fails if the commit message has backticks (`` ` ``)
refer: https://github.com/GoogleContainerTools/skaffold/runs/1745263390?check_suite_focus=true#step:2:2

Not sure if there's a general purpose way to escape all special characters in a github action expression substitution.