### PR TITLE
substitute periods in sanitizeImageName()

### DIFF
--- a/pkg/skaffold/initializer/build/builders_test.go
+++ b/pkg/skaffold/initializer/build/builders_test.go
@@ -79,7 +79,7 @@ func TestResolveBuilderImages(t *testing.T) {
 				{
 					ArtifactInfo: ArtifactInfo{
 						Builder:   jib.ArtifactConfig{BuilderName: "Jib Maven Plugin", File: "pom.xml", Project: "project"},
-						ImageName: "pom.xml-image",
+						ImageName: "pom-xml-image",
 					},
 					ManifestPath: "deployment.yaml",
 				},

--- a/pkg/skaffold/initializer/build/resolve.go
+++ b/pkg/skaffold/initializer/build/resolve.go
@@ -155,7 +155,7 @@ func getGeneratedBuilderPair(b InitBuilder) GeneratedArtifactInfo {
 
 func sanitizeImageName(imageName string) string {
 	// Replace unsupported characters with `_`
-	sanitized := regexp.MustCompile(`[^a-zA-Z0-9-._]`).ReplaceAllString(imageName, `-`)
+	sanitized := regexp.MustCompile(`[^a-zA-Z0-9-_]`).ReplaceAllString(imageName, `-`)
 
 	// Truncate to 128 characters
 	if len(sanitized) > 128 {

--- a/pkg/skaffold/initializer/build/resolve_test.go
+++ b/pkg/skaffold/initializer/build/resolve_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package build
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestSanitizeImageName(t *testing.T) {
+	tests := []struct {
+		description string
+		imageName   string
+		expected    string
+	}{
+		{
+			description: "Already Good",
+			imageName:   "image-name",
+			expected:    "image-name",
+		},
+		{
+			description: "Needs Fixing Slashes",
+			imageName:   "image/name/slash",
+			expected:    "image-name-slash",
+		},
+		{
+			description: "Needs Fixing Periods",
+			imageName:   "image.name.period",
+			expected:    "image-name-period",
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			sanitized := sanitizeImageName(test.imageName)
+
+			t.CheckDeepEqual(test.expected, sanitized)
+		})
+	}
+}


### PR DESCRIPTION
**Description**
When generating manifests during `skaffold init`, skaffold creates the kubernetes resource name based off of the image name is creates, which may contain periods. Since resources that have periods in their name can't applied properly, this PR modifies the `sanitizeImageName` function to replace periods.
