### PR TITLE
write credits to directory specified by -d

### DIFF
--- a/cmd/skaffold/app/cmd/credits/export.go
+++ b/cmd/skaffold/app/cmd/credits/export.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/rakyll/statik/fs"
 
@@ -41,7 +42,7 @@ func Export(ctx context.Context, out io.Writer) error {
 	}
 
 	if err := fs.Walk(statikFS, "/skaffold-credits", func(filePath string, fileInfo os.FileInfo, err error) error {
-		newPath := path.Join(Path, "..", filePath)
+		newPath := path.Join(Path, strings.Replace(filePath, "skaffold-credits", "", 1))
 		if fileInfo.IsDir() {
 			err := os.Mkdir(newPath, 0755)
 			if err != nil && !os.IsExist(err) {

--- a/integration/credits_test.go
+++ b/integration/credits_test.go
@@ -39,3 +39,20 @@ func TestCredits(t *testing.T) {
 		t.CheckContains("Apache License", string(content))
 	})
 }
+
+func TestCreditsDir(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	testutil.Run(t, "credits", func(t *testutil.T) {
+		tmpDir := t.NewTempDir().Chdir()
+		tmpDir.Mkdir("test/skaffold-credits")
+
+		out, err := skaffold.Credits("-d", "test/skaffold-credits/credits").RunWithCombinedOutput(t.T)
+		t.CheckNoError(err)
+		t.CheckContains("Successfully exported third party notices", string(out))
+
+		content, err := ioutil.ReadFile(tmpDir.Path("test/skaffold-credits/credits/github.com/docker/docker/LICENSE"))
+		t.CheckNoError(err)
+		t.CheckContains("Apache License", string(content))
+	})
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5266  <!-- tracking issues that this PR will close -->

**Description**
The root statik fs file structure that is compiled in looks like
```bash
> ls .
skaffold-credits schemas secrets
```

In order to write the contents of skaffold-credits to the user specified dir, I just get rid of "skaffold-credits" from the beginning of the file path. This allows users to specify `skaffold credits -d skaffold-credits/skaffold-credits` if they want that for some reason.

**User facing changes**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
`skaffold credits -d dir` now writes to dir as expected
