### PR TITLE
Expose meaningful error text from yamlpatch

### DIFF
--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -234,8 +234,8 @@ func applyProfile(config *latest.SkaffoldConfig, profile latest.Profile) error {
 			Value: value,
 		}
 
-		if !tryPatch(patch, buf) {
-			return fmt.Errorf("invalid path: %s", patch.Path)
+		if err = tryPatch(patch, buf); err != nil {
+			return err
 		}
 
 		patches = append(patches, patch)
@@ -253,15 +253,15 @@ func applyProfile(config *latest.SkaffoldConfig, profile latest.Profile) error {
 // tryPatch is here to verify patches one by one before we
 // apply them because yamlpatch.Patch is known to panic when a path
 // is not valid.
-func tryPatch(patch yamlpatch.Operation, buf []byte) (valid bool) {
+func tryPatch(patch yamlpatch.Operation, buf []byte) (err error) {
 	defer func() {
 		if errPanic := recover(); errPanic != nil {
-			valid = false
+			err = fmt.Errorf("invalid path: %s", patch.Path)
 		}
 	}()
 
-	_, err := yamlpatch.Patch([]yamlpatch.Operation{patch}).Apply(buf)
-	return err == nil
+	_, err = yamlpatch.Patch([]yamlpatch.Operation{patch}).Apply(buf)
+	return err
 }
 
 func profilesByName(profiles []latest.Profile) map[string]latest.Profile {


### PR DESCRIPTION



<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5259

**Description**

The faulty JSONPatch tests now ensure that the resulting error message actually mentions the faulty value.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->


Per #5259, any failure from yamlpatch simply logs
> invalid path: <path element of the patch object>

even if the path itself was valid.

Now, for the example given there, we get

> Unexpected op: delete

Other example errors I got while messing with that file to introduce different errors:
> Unable to remove nonexistent key: service.ports

> yamlpatch remove operation does not apply: doc is missing path: /deploys/helm/releases/0/setValues/service.port

> yamlpatch add operation does not apply: doc is missing path: /deploys/helm/releases/0/setValues/service.port

The existing unit-test outputs
> yamlpatch replace operation does not apply: doc is missing key: /unknown

Note that I don't have an example of the "known to panic" case mentioned in the `tryPatch` documentation, so that still returns the same error text as previously.