### PR TITLE
Add case-insensitive string enum support for config schema

### DIFF
--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -39,7 +39,7 @@ type SkaffoldConfig struct {
 	APIVersion string `yaml:"apiVersion" yamltags:"required"`
 
 	// Kind is always `Config`. Defaults to `Config`.
-	Kind string `yaml:"kind" yamltags:"required"`
+	Kind string `yaml:"kind" yamltags:"required,enum=Config"`
 
 	// Metadata holds additional information about the config.
 	Metadata Metadata `yaml:"metadata,omitempty"`
@@ -172,7 +172,7 @@ type GitTagger struct {
 	// `AbbrevCommitSha`: use the abbreviated git commit sha.
 	// `TreeSha`: use the full tree hash of the artifact workingdir.
 	// `AbbrevTreeSha`: use the abbreviated tree hash of the artifact workingdir.
-	Variant string `yaml:"variant,omitempty"`
+	Variant string `yaml:"variant,omitempty" yamltags:"enum=Tags=CommitSha=AbbrevCommitSha=TreeSha=AbbrevTreeSha"`
 
 	// Prefix adds a fixed prefix to the tag.
 	Prefix string `yaml:"prefix,omitempty"`
@@ -861,7 +861,7 @@ type Profile struct {
 type JSONPatch struct {
 	// Op is the operation carried by the patch: `add`, `remove`, `replace`, `move`, `copy` or `test`.
 	// Defaults to `replace`.
-	Op string `yaml:"op,omitempty"`
+	Op string `yaml:"op,omitempty" yamltags:"enum=add=remove=replace=move=copy=test"`
 
 	// Path is the position in the yaml where the operation takes place.
 	// For example, this targets the `dockerfile` of the first artifact built.
@@ -1203,7 +1203,7 @@ type JibArtifact struct {
 	// Type the Jib builder type; normally determined automatically. Valid types are
 	// `maven`: for Maven.
 	// `gradle`: for Gradle.
-	Type string `yaml:"type,omitempty"`
+	Type string `yaml:"type,omitempty" yamltags:"enum=maven=gradle"`
 
 	// BaseImage overrides the configured jib base image.
 	BaseImage string `yaml:"fromImage,omitempty"`

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -80,8 +80,8 @@ func TestValidateSchema(t *testing.T) {
 		{
 			description: "minimal config",
 			cfg: &latest.SkaffoldConfig{
-				APIVersion: "foo",
-				Kind:       "bar",
+				APIVersion: latest.Version,
+				Kind:       "Config",
 			},
 			shouldErr: false,
 		},

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -271,7 +271,9 @@ func TestValidateNetworkMode(t *testing.T) {
 				{
 					ImageName: "image/bazel",
 					ArtifactType: latest.ArtifactType{
-						BazelArtifact: &latest.BazelArtifact{},
+						BazelArtifact: &latest.BazelArtifact{
+							BuildTarget: "//:skaffold_example.tar",
+						},
 					},
 				},
 			},
@@ -424,11 +426,10 @@ func TestValidateNetworkMode(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			// disable yamltags validation
-			t.Override(&validateYamltags, func(interface{}) error { return nil })
-
 			err := Process(
 				[]*latest.SkaffoldConfig{{
+					APIVersion: latest.Version,
+					Kind:       "Config",
 					Pipeline: latest.Pipeline{
 						Build: latest.BuildConfig{
 							Artifacts: test.artifacts,
@@ -532,8 +533,6 @@ func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			// disable yamltags validation
-			t.Override(&validateYamltags, func(interface{}) error { return nil })
 			t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
 				fakeClient := &fakeCommonAPIClient{
 					CommonAPIClient: &testutil.FakeAPIClient{
@@ -646,11 +645,10 @@ func TestValidateSyncRules(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			// disable yamltags validation
-			t.Override(&validateYamltags, func(interface{}) error { return nil })
-
 			err := Process(
 				[]*latest.SkaffoldConfig{{
+					APIVersion: latest.Version,
+					Kind:       "Config",
 					Pipeline: latest.Pipeline{
 						Build: latest.BuildConfig{
 							Artifacts: test.artifacts,
@@ -791,11 +789,10 @@ func TestValidateImageNames(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			// disable yamltags validation
-			t.Override(&validateYamltags, func(interface{}) error { return nil })
-
 			err := Process(
 				[]*latest.SkaffoldConfig{{
+					APIVersion: latest.Version,
+					Kind:       "Config",
 					Pipeline: latest.Pipeline{
 						Build: latest.BuildConfig{
 							Artifacts: test.artifacts,
@@ -894,11 +891,10 @@ func TestValidateJibPluginType(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			// disable yamltags validation
-			t.Override(&validateYamltags, func(interface{}) error { return nil })
-
 			err := Process(
 				[]*latest.SkaffoldConfig{{
+					APIVersion: latest.Version,
+					Kind:       "Config",
 					Pipeline: latest.Pipeline{
 						Build: latest.BuildConfig{
 							Artifacts: test.artifacts,
@@ -926,11 +922,10 @@ func TestValidateLogsConfig(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.prefix, func(t *testutil.T) {
-			// disable yamltags validation
-			t.Override(&validateYamltags, func(interface{}) error { return nil })
-
 			err := Process(
 				[]*latest.SkaffoldConfig{{
+					APIVersion: latest.Version,
+					Kind:       "Config",
 					Pipeline: latest.Pipeline{
 						Deploy: latest.DeployConfig{
 							Logs: latest.LogsConfig{
@@ -1253,11 +1248,10 @@ func TestValidateTaggingPolicy(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			// disable yamltags validation
-			t.Override(&validateYamltags, func(interface{}) error { return nil })
-
 			err := Process(
 				[]*latest.SkaffoldConfig{{
+					APIVersion: latest.Version,
+					Kind:       "Config",
 					Pipeline: latest.Pipeline{
 						Build: test.cfg,
 					},

--- a/pkg/skaffold/yamltags/tags.go
+++ b/pkg/skaffold/yamltags/tags.go
@@ -157,10 +157,7 @@ func (rt *requiredTag) Load(s []string) error {
 
 func (rt *requiredTag) Process(val reflect.Value) error {
 	if isZeroValue(val) {
-		if tags, ok := rt.Field.Tag.Lookup("yaml"); ok {
-			return fmt.Errorf("required value not set: %s", strings.Split(tags, ",")[0])
-		}
-		return fmt.Errorf("required value not set: %s", rt.Field.Name)
+		return fmt.Errorf("required value not set: %s", YamlName(rt.Field))
 	}
 	return nil
 }
@@ -233,10 +230,7 @@ func (tag *skipTrimTag) Load(s []string) error {
 
 func (tag *skipTrimTag) Process(val reflect.Value) error {
 	if isZeroValue(val) {
-		if tags, ok := tag.Field.Tag.Lookup("yaml"); ok {
-			return fmt.Errorf("skipTrim value not set: %s", strings.Split(tags, ",")[0])
-		}
-		return fmt.Errorf("skipTrim value not set: %s", tag.Field.Name)
+		return fmt.Errorf("skipTrim value not set: %s", YamlName(tag.Field))
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: #5259

This was intended to resolve #5259, but profiles are handled specially, and except during `skaffold fix`, they are processed (in `getConfigs`) *before* they are validated (in `runContext`), which ensures the patched config is validated instead. It might be worth a PR to validate the configs before profile processing, although perhaps an invalid->valid patch by the profile is a reasonable thing to support.

In #5259, it was a newly-written Skaffold config, so `skaffold fix` happily reported it as valid, because it early-outs if the file doesn't need validating. That might be worth a different PR, to make `skaffold fix` validate even up-to-date files, since there's no other CLI command to _just_ validate the config without also applying profiles.

**Description**
This adds a new `yamltags` field, `enum=x=y=z` to allow case-insensitive validation of string enum fields in the config.

The string fields in the latest config that I was confident had fixed and locally-defined values are annotated. Very happy to remove any enum tag for which it's not desirable to check. I didn't mark the GCB values, as I believe they could change on the GCB end, and hence it doesn't make sense to validate them locally.

There's also a few enumish values (where some of the choices are a prefix or formatted value, rather than a fixed value), I didn't bother trying to validate those.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

A bunch of invalid configurations now either raise an error, or raise a different error earlier.

One open question: Currently the error does not report the list of acceptible values. Would that be better? Or is that too-noisy, given the schema docs still list the possible values and their meanings.

----

Given a trivial-but-incorrect skaffold.yaml
```
apiVersion: skaffold/v2beta11
kind: Configs
```

and `skaffold dev`

Before: Runs without complaint

After:
> invalid skaffold config: invalid enum value in kind: Configs

----

Given the slightly-invalid skaffold.yaml from #5259 (Note: this _does_ need upgrading here, because latest is now `v2beta11`)
```
apiVersion: skaffold/v2beta10
kind: Config
metadata:
  name: my-server
build:
  artifacts:
    - image: my-server
      docker: {}
deploy:
  helm:
    releases:
      - name: my-server
        chartPath: charts/my-server
        artifactOverrides:
          image: my-server
        setValues:
          service.type: LoadBalancer
          service.port: 8000
profiles:
  - name: NodePort
    patches:
      - op: replace
        path: /deploy/helm/releases/0/setValues/service.type
        value: NodePort
      - op: delete
        path: /deploy/helm/releases/0/setValues/service.port
```

and `skaffold fix`

Before: Outputs the same YAML. None of the fields needed updating, and no errors raised.

After:
> validating upgraded config: invalid enum value in op: delete

----

Given skaffold.yaml
```yaml
apiVersion: skaffold/v2beta10
kind: Config
metadata:
  name: my-server
build:
  tagPolicy:
    gitCommit:
      variant: commitshas
```

and `skaffold dev`

Before:
> creating runner: creating tagger: "commitshas" is not a valid git tagger variant
> . If above error is unexpected, please open an issue https://github.com/GoogleContainerTools/skaffold/issues/new to report this error.

After:
> invalid skaffold config: invalid enum value in variant: commitshas