### PR TITLE
Improve `completion` missing-arg help text

### DIFF
--- a/cmd/skaffold/app/cmd/completion.go
+++ b/cmd/skaffold/app/cmd/completion.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -62,7 +63,7 @@ func NewCmdCompletion() *cobra.Command {
 		Use: "completion SHELL",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return fmt.Errorf("requires 1 arg, found %d", len(args))
+				return fmt.Errorf("missing shell: %s", strings.Join(cmd.ValidArgs, ", "))
 			}
 			return cobra.OnlyValidArgs(cmd, args)
 		},


### PR DESCRIPTION
**Description**
Improves helper text for missing argument for `skaffold completion`.  This came up in the HaTS response data.

Before:
```console
$ skaffold completion
requires 1 arg, found 0
```

After:
```console
$ skaffold completion
missing shell: bash, zsh
```

(It's surprising to me that there is no helper function for this.)