### PR TITLE
Change cloud build release script to pull metric credentials keys for release

### DIFF
--- a/deploy/cloudbuild-release.yaml
+++ b/deploy/cloudbuild-release.yaml
@@ -1,6 +1,15 @@
 # using default substitutions, provided by Google Cloud Build
 # see: https://cloud.google.com/container-builder/docs/configuring-builds/substitute-variable-values#using_default_substitutions
 steps:
+# Grab secret credentials from gcp bucket
+  - name: gcr.io/cloud-builders/gsutil
+    args:
+    - 'cp'
+    - '-r'
+    - 'gs://$PROJECT_ID-secrets'
+    - './secrets/'
+
+# Build and tag skaffold builder
   - name: 'gcr.io/cloud-builders/docker'
     args:
     - 'build'

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -1,6 +1,15 @@
 # using default substitutions, provided by Google Cloud Build
 # see: https://cloud.google.com/container-builder/docs/configuring-builds/substitute-variable-values#using_default_substitutions
 steps:
+# Grab secret credentials from gcp bucket
+  - name: gcr.io/cloud-builders/gsutil
+    args:
+    - 'cp'
+    - '-r'
+    - 'gs://$PROJECT_ID-secrets'
+    - './secrets/'
+
+# Build and tag skaffold builder
   - name: 'gcr.io/cloud-builders/docker'
     args:
     - 'build'

--- a/deploy/skaffold/Dockerfile
+++ b/deploy/skaffold/Dockerfile
@@ -20,4 +20,5 @@ COPY . .
 FROM builder as release
 ARG VERSION
 RUN make clean out/skaffold VERSION=$VERSION && mv out/skaffold /usr/bin/skaffold
+RUN rm -rf secrets $SECRET cmd/skaffold/app/cmd/statik/statik.go
 RUN skaffold credits -d /THIRD_PARTY_NOTICES


### PR DESCRIPTION
**Description**
This changes asserts the existence of a google cloud storage bucket `gs://$PROJECT_ID-secrets` from which the necessary credentials for uploading metrics will exist and be pulled for the cloud build release context. 

This bucket has already been populated by myself, and the changes to the release process have been updated in the release doc.

**User facing changes**
If the environment variable `SKAFFOLD_EXPORT_METRICS` is set to `true` then metrics will be exported to the project specified by the credentials in `gs://$PROJECT_ID-secrets` (k8s-skaffold in our case)

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
