### PR TITLE
readability changes to init docs

### DIFF
--- a/docs/content/en/docs/pipeline-stages/init.md
+++ b/docs/content/en/docs/pipeline-stages/init.md
@@ -53,6 +53,8 @@ skaffold init --XXenableJibInit
 ## Deploy Config Initialization
 `skaffold init` support bootstrapping projects set up to deploy with [`kubectl`]({{<relref "/docs/pipeline-stages/deployers#deploying-with-kubectl" >}})
 or [`kustomize`]({{<relref "/docs/pipeline-stages/deployers#deploying-with-kubectl" >}}).
+
+### kubectl
 For projects deploying straight through `kubectl`, Skaffold will walk through all the `yaml` files in your project and find valid Kubernetes manifest files.
 
 These files will be added to `deploy` config in `skaffold.yaml`.
@@ -65,21 +67,22 @@ deploy:
     - leeroy-web/kubernetes/deployment.yaml
 ```
 
+### kustomize
 For projects deploying with `kustomize`, Skaffold will scan your project and look for `kustomization.yaml`s as well as Kubernetes manifests.
 It will attempt to infer the project structure based on the recommended project structure from the Kustomize project: thus, 
 **it is highly recommended to match your project structure to the recommended base/ and overlay/ structure from Kustomize!**
 
 This generally looks like this:
 
-```
-app/      <- application source code, along with build configuration
+```yaml
+app/      # application source code, along with build configuration
   main.go
   Dockerfile
 ...
-base/     <- base deploy configuration
+base/     # base deploy configuration
   kustomization.yaml
   deployment.yaml
-overlays/ <- one or more nested directories, each with modified environment configuration
+overlays/ # one or more nested directories, each with modified environment configuration
   dev/
     deployment.yaml
     kustomization.yaml


### PR DESCRIPTION
**Description**
I've added some subheaders underneath the deploy config section to make it easier for users to find information regarding `skaffold init` and `kubectl`/`kustomize`. I've also marked the code block showcasing the recommended `kustomize` project layout as yaml and changed the arrows to comments to make it stand out more.

**Follow-up Work (remove if N/A)**
I'd like to add a section outlining the functionality of the `--generate-manifests` flag after this gets merged.
