### PR TITLE
add collect metrics to the global config

### DIFF
--- a/cmd/skaffold/skaffold.go
+++ b/cmd/skaffold/skaffold.go
@@ -33,7 +33,6 @@ type ExitCoder interface {
 }
 
 func main() {
-	instrumentation.SetOnlineStatus()
 	var code int
 	if err := app.Run(os.Stdout, os.Stderr); err != nil {
 		if errors.Is(err, context.Canceled) {

--- a/pkg/skaffold/config/global_config.go
+++ b/pkg/skaffold/config/global_config.go
@@ -36,6 +36,7 @@ type ContextConfig struct {
 	Survey               *SurveyConfig `yaml:"survey,omitempty"`
 	KindDisableLoad      *bool         `yaml:"kind-disable-load,omitempty"`
 	K3dDisableLoad       *bool         `yaml:"k3d-disable-load,omitempty"`
+	CollectMetrics       *bool         `yaml:"collect-metrics,omitempty"`
 }
 
 // SurveyConfig is the survey config information

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -389,6 +389,26 @@ func UpdateGlobalSurveyPrompted(configFile string) error {
 	return err
 }
 
+func UpdateGlobalCollectMetrics(configFile string, collectMetrics bool) error {
+	configFile, err := ResolveConfigFile(configFile)
+	if err != nil {
+		return err
+	}
+	fullConfig, err := ReadConfigFile(configFile)
+	if err != nil {
+		return err
+	}
+	if fullConfig.Global == nil {
+		fullConfig.Global = &ContextConfig{}
+	}
+	fullConfig.Global.CollectMetrics = &collectMetrics
+	err = WriteFullConfig(configFile, fullConfig)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
 func WriteFullConfig(configFile string, cfg *GlobalConfig) error {
 	contents, err := yaml.Marshal(cfg)
 	if err != nil {

--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -123,12 +123,12 @@ var (
 		ExitCode:      0,
 		ErrorCode:     proto.StatusCode_OK,
 	}
-	shouldExportMetrics = os.Getenv("SKAFFOLD_EXPORT_METRICS") == "true"
 	meteredCommands     = util.NewStringSet()
 	doesBuild           = util.NewStringSet()
 	doesDeploy          = util.NewStringSet()
 	initExporter        = initCloudMonitoringExporterMetrics
 	isOnline            bool
+	shouldExportMetrics bool
 )
 
 func init() {

--- a/pkg/skaffold/instrumentation/prompt.go
+++ b/pkg/skaffold/instrumentation/prompt.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instrumentation
+
+import (
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+)
+
+const Prompt = `To help improve the quality of this product, we collect anonymized usage data for details on what is tracked and how we use this data visit <https://skaffold.dev/docs/telemetry/>. This data is handled in accordance with our privacy policy <https://policies.google.com/privacy/>
+
+You may choose to opt out of this collection by running the following command:
+	skaffold config set --global collect-metrics false
+`
+
+var (
+	// for testing
+	isStdOut     = color.IsStdout
+	updateConfig = config.UpdateGlobalCollectMetrics
+)
+
+func ShouldDisplayMetricsPrompt(configfile string) bool {
+	cfg, err := config.GetConfigForCurrentKubectx(configfile)
+	if err != nil {
+		return false
+	}
+	if cfg == nil || cfg.CollectMetrics == nil {
+		return true
+	}
+	shouldExportMetrics = *cfg.CollectMetrics
+	SetOnlineStatus()
+	return false
+}
+
+func DisplayMetricsPrompt(configFile string, out io.Writer) error {
+	if isStdOut(out) {
+		color.Green.Fprintf(out, Prompt)
+		return updateConfig(configFile, true)
+	}
+	return nil
+}

--- a/pkg/skaffold/instrumentation/prompt.go
+++ b/pkg/skaffold/instrumentation/prompt.go
@@ -33,10 +33,12 @@ var (
 	// for testing
 	isStdOut     = color.IsStdout
 	updateConfig = config.UpdateGlobalCollectMetrics
+	getConfig    = config.GetConfigForCurrentKubectx
+	setStatus    = SetOnlineStatus
 )
 
 func ShouldDisplayMetricsPrompt(configfile string) bool {
-	cfg, err := config.GetConfigForCurrentKubectx(configfile)
+	cfg, err := getConfig(configfile)
 	if err != nil {
 		return false
 	}
@@ -44,7 +46,7 @@ func ShouldDisplayMetricsPrompt(configfile string) bool {
 		return true
 	}
 	shouldExportMetrics = *cfg.CollectMetrics
-	SetOnlineStatus()
+	setStatus()
 	return false
 }
 

--- a/pkg/skaffold/instrumentation/prompt_test.go
+++ b/pkg/skaffold/instrumentation/prompt_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instrumentation
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDisplaySurveyForm(t *testing.T) {
+	tests := []struct {
+		description string
+		mockStdOut  bool
+		expected    string
+	}{
+		{
+			description: "std out",
+			mockStdOut:  true,
+			expected:    Prompt,
+		},
+		{
+			description: "not std out",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			mock := func(io.Writer) bool { return test.mockStdOut }
+			t.Override(&isStdOut, mock)
+			t.Override(&updateConfig, func(_ string, _ bool) error { return nil })
+			var buf bytes.Buffer
+			err := DisplayMetricsPrompt("", &buf)
+			t.CheckErrorAndDeepEqual(false, err, test.expected, buf.String())
+		})
+	}
+}


### PR DESCRIPTION
<!-- Include if applicable: -->
**Merge after**:  #5281 

**Description**
- Added field `collect-metrics` to the global config
- Check global config to see if `collect-metrics` is set and set to true and show prompt with telemetry info if it is not set
- If `collect-metrics` is set to true then collect and export user metrics
- Removes requirement of setting environment variable to enable metrics

**User facing changes**
If a user does not have `collect-metrics` set in their global config, they will see a prompt that will alert them that skaffold collects telemetry when they use skaffold and link them to where they can find out more, as well as detailing how they can disable it.

From that point on if `collect-metrics` is set to true metrics will be collected and exported.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
