### PR TITLE
Fixes for generating new schema version

### DIFF
--- a/cmd/skaffold/app/cmd/parse_config_test.go
+++ b/cmd/skaffold/app/cmd/parse_config_test.go
@@ -55,7 +55,7 @@ profiles:
 
 func createCfg(name string, imageName string, workspace string, requires []latest.ConfigDependency) *latest.SkaffoldConfig {
 	return &latest.SkaffoldConfig{
-		APIVersion:   "skaffold/v2beta11",
+		APIVersion:   latest.Version,
 		Kind:         "Config",
 		Dependencies: requires,
 		Metadata:     latest.Metadata{Name: name},

--- a/hack/versions/cmd/new/version.go
+++ b/hack/versions/cmd/new/version.go
@@ -76,13 +76,13 @@ func main() {
 	hackschema.UpdateVersionComment(path("latest", "config.go"), false)
 
 	// Update skaffold.yaml in integration tests
-	walk.From("integration").WhenNameContains("skaffold").WhenHasExt("yaml").MustDo(func(path string, _ walk.Dirent) error {
+	walk.From("integration").WhenNameContains("skaffold").WhenHasExt(".yaml").MustDo(func(path string, _ walk.Dirent) error {
 		sed(path, current, next)
 		return nil
 	})
 
 	// Update skaffold.yaml in init tests
-	walk.From("pkg/skaffold/initializer/testdata").WhenNameContains("skaffold").WhenHasExt("yaml").MustDo(func(path string, _ walk.Dirent) error {
+	walk.From("pkg/skaffold/initializer/testdata").WhenNameContains("skaffold").WhenHasExt(".yaml").MustDo(func(path string, _ walk.Dirent) error {
 		sed(path, current, next)
 		return nil
 	})

--- a/hack/versions/cmd/new/version.go
+++ b/hack/versions/cmd/new/version.go
@@ -76,13 +76,13 @@ func main() {
 	hackschema.UpdateVersionComment(path("latest", "config.go"), false)
 
 	// Update skaffold.yaml in integration tests
-	walk.From("integration").WhenNameContains("skaffold").WhenHasExt(".yaml").MustDo(func(path string, _ walk.Dirent) error {
+	walk.From("integration").WhenNameMatches("*skaffold*.yaml").MustDo(func(path string, _ walk.Dirent) error {
 		sed(path, current, next)
 		return nil
 	})
 
 	// Update skaffold.yaml in init tests
-	walk.From("pkg/skaffold/initializer/testdata").WhenNameContains("skaffold").WhenHasExt(".yaml").MustDo(func(path string, _ walk.Dirent) error {
+	walk.From("pkg/skaffold/initializer/testdata").WhenNameMatches("*skaffold*.yaml").MustDo(func(path string, _ walk.Dirent) error {
 		sed(path, current, next)
 		return nil
 	})

--- a/hack/versions/cmd/new/version.go
+++ b/hack/versions/cmd/new/version.go
@@ -76,13 +76,13 @@ func main() {
 	hackschema.UpdateVersionComment(path("latest", "config.go"), false)
 
 	// Update skaffold.yaml in integration tests
-	walk.From("integration").WhenHasName("skaffold.yaml").MustDo(func(path string, _ walk.Dirent) error {
+	walk.From("integration").WhenNameContains("skaffold", "yaml").MustDo(func(path string, _ walk.Dirent) error {
 		sed(path, current, next)
 		return nil
 	})
 
 	// Update skaffold.yaml in init tests
-	walk.From("pkg/skaffold/initializer/testdata").WhenHasName("skaffold.yaml").MustDo(func(path string, _ walk.Dirent) error {
+	walk.From("pkg/skaffold/initializer/testdata").WhenNameContains("skaffold", "yaml").MustDo(func(path string, _ walk.Dirent) error {
 		sed(path, current, next)
 		return nil
 	})

--- a/hack/versions/cmd/new/version.go
+++ b/hack/versions/cmd/new/version.go
@@ -76,13 +76,13 @@ func main() {
 	hackschema.UpdateVersionComment(path("latest", "config.go"), false)
 
 	// Update skaffold.yaml in integration tests
-	walk.From("integration").WhenNameContains("skaffold", "yaml").MustDo(func(path string, _ walk.Dirent) error {
+	walk.From("integration").WhenNameContains("skaffold").WhenHasExt("yaml").MustDo(func(path string, _ walk.Dirent) error {
 		sed(path, current, next)
 		return nil
 	})
 
 	// Update skaffold.yaml in init tests
-	walk.From("pkg/skaffold/initializer/testdata").WhenNameContains("skaffold", "yaml").MustDo(func(path string, _ walk.Dirent) error {
+	walk.From("pkg/skaffold/initializer/testdata").WhenNameContains("skaffold").WhenHasExt("yaml").MustDo(func(path string, _ walk.Dirent) error {
 		sed(path, current, next)
 		return nil
 	})

--- a/pkg/skaffold/walk/walk.go
+++ b/pkg/skaffold/walk/walk.go
@@ -49,6 +49,7 @@ type Builder interface {
 	WhenIsDir() Builder
 	WhenIsFile() Builder
 	WhenHasName(string) Builder
+	WhenHasExt(string) Builder
 	WhenNameContains(...string) Builder
 
 	// Actions
@@ -93,6 +94,10 @@ func (w *builder) WhenIsDir() Builder {
 
 func (w *builder) WhenHasName(name string) Builder {
 	return w.When(hasName(name))
+}
+
+func (w *builder) WhenHasExt(ext string) Builder {
+	return w.When(hasExt(ext))
 }
 
 func (w *builder) WhenNameContains(substr ...string) Builder {
@@ -154,6 +159,12 @@ func (w *builder) MustDo(action Action) {
 func hasName(name string) Predicate {
 	return func(_ string, info Dirent) (bool, error) {
 		return info.Name() == name, nil
+	}
+}
+
+func hasExt(ext string) Predicate {
+	return func(_ string, info Dirent) (bool, error) {
+		return filepath.Ext(info.Name()) == ext, nil
 	}
 }
 

--- a/pkg/skaffold/walk/walk.go
+++ b/pkg/skaffold/walk/walk.go
@@ -49,6 +49,7 @@ type Builder interface {
 	WhenIsDir() Builder
 	WhenIsFile() Builder
 	WhenHasName(string) Builder
+	WhenNameContains(...string) Builder
 
 	// Actions
 	Do(Action) error
@@ -92,6 +93,10 @@ func (w *builder) WhenIsDir() Builder {
 
 func (w *builder) WhenHasName(name string) Builder {
 	return w.When(hasName(name))
+}
+
+func (w *builder) WhenNameContains(substr ...string) Builder {
+	return w.When(nameContains(substr...))
 }
 
 func (w *builder) AppendPaths(values *[]string) error {
@@ -149,6 +154,18 @@ func (w *builder) MustDo(action Action) {
 func hasName(name string) Predicate {
 	return func(_ string, info Dirent) (bool, error) {
 		return info.Name() == name, nil
+	}
+}
+
+func nameContains(substrs ...string) Predicate {
+	return func(_ string, info Dirent) (bool, error) {
+		for _, substr := range substrs {
+			if !strings.Contains(info.Name(), substr) {
+				return false, nil
+			}
+		}
+
+		return true, nil
 	}
 }
 

--- a/pkg/skaffold/walk/walk.go
+++ b/pkg/skaffold/walk/walk.go
@@ -18,6 +18,7 @@ package walk
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -49,8 +50,7 @@ type Builder interface {
 	WhenIsDir() Builder
 	WhenIsFile() Builder
 	WhenHasName(string) Builder
-	WhenHasExt(string) Builder
-	WhenNameContains(...string) Builder
+	WhenNameMatches(string) Builder
 
 	// Actions
 	Do(Action) error
@@ -96,12 +96,8 @@ func (w *builder) WhenHasName(name string) Builder {
 	return w.When(hasName(name))
 }
 
-func (w *builder) WhenHasExt(ext string) Builder {
-	return w.When(hasExt(ext))
-}
-
-func (w *builder) WhenNameContains(substr ...string) Builder {
-	return w.When(nameContains(substr...))
+func (w *builder) WhenNameMatches(glob string) Builder {
+	return w.When(nameMatches(glob))
 }
 
 func (w *builder) AppendPaths(values *[]string) error {
@@ -162,21 +158,9 @@ func hasName(name string) Predicate {
 	}
 }
 
-func hasExt(ext string) Predicate {
+func nameMatches(glob string) Predicate {
 	return func(_ string, info Dirent) (bool, error) {
-		return filepath.Ext(info.Name()) == ext, nil
-	}
-}
-
-func nameContains(substrs ...string) Predicate {
-	return func(_ string, info Dirent) (bool, error) {
-		for _, substr := range substrs {
-			if !strings.Contains(info.Name(), substr) {
-				return false, nil
-			}
-		}
-
-		return true, nil
+		return path.Match(glob, info.Name())
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5289
**Related**: https://github.com/GoogleContainerTools/skaffold/pull/5279

**Description**
Adds a new check that can be used in the walk package to see if a filename contains given substrings. `WhenNameContains` will be used instead of the current check for `WhenHasName`, as there have been example config files added recently that don't have the name `skaffold.yaml`. We will now check that the filename contains `"skaffold"` and `"yaml"`.

I've also updated tests in `cmd/skaffold/app/cmd/parse_config_test.go` as they were checking for a fixed version and would break upon creating a new version of the config

