### PR TITLE
add --generate-manifests section to init docs

### DIFF
--- a/docs/content/en/docs/pipeline-stages/init.md
+++ b/docs/content/en/docs/pipeline-stages/init.md
@@ -97,7 +97,8 @@ When overlay directories are found, these will be listed in the generated Skaffo
 
 *Note: order is guaranteed, since Skaffold's directory parsing is always deterministic.*
 
-## `--generate-manifests` Flag {{< maturity "init.generate_manifests" >}}
+## `--generate-manifests` Flag 
+{{< maturity "init.generate_manifests" >}}
 `skaffold init` allows for use of a `--generate-manifests` flag, which will try to generate basic kubernetes manifests for a user's project to help get things up and running. 
 
 If bringing a project to skaffold that has no kubernetes manifests yet, it may be helpful to run `skaffold init` with this flag.

--- a/docs/content/en/docs/pipeline-stages/init.md
+++ b/docs/content/en/docs/pipeline-stages/init.md
@@ -97,6 +97,12 @@ When overlay directories are found, these will be listed in the generated Skaffo
 
 *Note: order is guaranteed, since Skaffold's directory parsing is always deterministic.*
 
+## `--generate-manifests` Flag {{< maturity "init.generate_manifests" >}}
+`skaffold init` allows for use of a `--generate-manifests` flag, which will try to generate basic kubernetes manifests for a user's project to help get things up and running. 
+
+If bringing a project to skaffold that has no kubernetes manifests yet, it may be helpful to run `skaffold init` with this flag.
+
+
 ## `--force` Flag
 `skaffold init` allows for use of a `--force` flag, which removes the prompts from vanilla `skaffold init`, and allows skaffold to make a best effort attempt to automatically generate a config for your project.
 

--- a/docs/data/maturity.json
+++ b/docs/data/maturity.json
@@ -208,6 +208,12 @@
     "maturity": "alpha",
     "description": "skaffold init recognizes k8s manifest and the image names in them"
   },
+  "init.generate_manifests": {
+    "area": "Init",
+    "feature": "generate manifests",
+    "maturity": "alpha",
+    "description": "skaffold init will try to generate kubernetes manifests for your project"
+  },
   "insecure_registry": {
     "dev": "x",
     "build": "x",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
**Description**
Adds a small section to docs for `skaffold init` explaining the `--generate-manifests` flag.


