### PR TITLE
wip: disable google search to use offline search

### DIFF
--- a/deploy/webhook/Dockerfile
+++ b/deploy/webhook/Dockerfile
@@ -14,7 +14,7 @@
 
 # Download Docsy theme for Hugo
 FROM alpine:3.10 as download-docsy
-ENV DOCSY_VERSION a7141a2eac26cb598b707cab87d224f9105c315d
+ENV DOCSY_VERSION 3c4280bae0db96cb272ddc4b4959b2beef9299af
 ENV DOCSY_URL https://github.com/google/docsy.git
 RUN apk add --no-cache git
 WORKDIR /docsy

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -85,7 +85,7 @@ github_repo = "https://github.com/GoogleContainerTools/skaffold"
 skaffold_version = "skaffold/v2beta11"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-gcs_engine_id = "013756393218025596041:3nojel67sum"
+# gcs_engine_id = "013756393218025596041:3nojel67sum"
 # enabling local search https://www.docsy.dev/docs/adding-content/navigation/#configure-local-search-with-lunr
 offlineSearch = true
 


### PR DESCRIPTION
left over from https://github.com/GoogleContainerTools/skaffold/issues/5292
dont merge till docsy's theme is updated as described here: https://www.docsy.dev/docs/updating/