### PR TITLE
run ./hack/generate-man.sh automatically in ./hack/new_version.sh

### DIFF
--- a/hack/new_version.sh
+++ b/hack/new_version.sh
@@ -20,6 +20,7 @@ go run ./hack/versions/cmd/new/version.go $@
 
 goimports -w ./pkg/skaffold/schema
 make generate-schemas
+./hack/generate-man.sh
 git --no-pager diff --minimal
 make quicktest
 


### PR DESCRIPTION
**Description**
This PR adds a line to `./hack/new_version.sh` to run `./hack/generate-man.sh`. Since this will have to be done when creating a new schema version anyway, we might as well do it in the designated script. This will also help since currently the run of make quicktest in the script will always fail since `generate-man.sh` hasn't been run