### PR TITLE
Fix up `debug` test's kustomize profile to remove the `kubectl` deployer

### DIFF
--- a/integration/testdata/debug/skaffold.yaml
+++ b/integration/testdata/debug/skaffold.yaml
@@ -30,9 +30,11 @@ deploy:
 
 profiles:
 - name: kustomize
+  patches:
+  - op: remove
+    path: /deploy/kubectl
   deploy:
-      kustomize: {}
-      kubectl: {}
+    kustomize: {}
 # use GCP Buildpacks to build the individual projects
 - name: buildpacks
   build:


### PR DESCRIPTION
Fixes: #5255 

**Description**

The `debug` integration tests uses a single project with multiple profiles to test different scenarios, including the use of `kustomize`.  To use `kustomize` requires obliterating the `kubectl` deployer definition.  But the current definition is insufficient:
https://github.com/GoogleContainerTools/skaffold/blob/8848703c9da3b977e091d49465c7bbc29e64d662/integration/testdata/debug/skaffold.yaml#L31-L35

and the result is incorrect:
```
$ skaffold diagnose --yaml-only --profile kustomize
...
deploy:
  kubectl:
    manifests:
    - k8s/*.yaml
  kustomize:
    paths:
    - .
  logs:
    prefix: container
```

This PR changes the profile to instead use a JSONPatch to remove the `kubectl` deployer node.  The resulting deployer section is:
```
$ skaffold diagnose --yaml-only --profile kustomize
...
deploy:
  kustomize:
    paths:
    - .
  logs:
    prefix: container
```