### PR TITLE
Add prompt for users to pick manifests to generate during `skaffold init --generate-manifests`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	4d63.com/tz v1.1.0
 	cloud.google.com/go v0.72.0 // indirect
 	cloud.google.com/go/storage v1.10.0
-	github.com/AlecAivazis/survey/v2 v2.0.5
+	github.com/AlecAivazis/survey/v2 v2.2.7
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.13.0
 	github.com/Microsoft/go-winio v0.4.15 // indirect
 	github.com/blang/semver v3.5.1+incompatible
@@ -83,7 +83,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20201202151023-55d61f90c1ce
 	google.golang.org/grpc v1.33.2
-	gopkg.in/AlecAivazis/survey.v1 v1.8.8
 	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	k8s.io/api v0.19.4

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/360EntSecGroup-Skylar/excelize v1.4.1/go.mod h1:vnax29X2usfl7HHkBrX5E
 github.com/AkihiroSuda/containerd-fuse-overlayfs v1.0.0/go.mod h1:0mMDvQFeLbbn1Wy8P2j3hwFhqBq+FKn8OZPno8WLmp8=
 github.com/AlecAivazis/survey/v2 v2.0.5 h1:xpZp+Q55wi5C7Iaze+40onHnEkex1jSc34CltJjOoPM=
 github.com/AlecAivazis/survey/v2 v2.0.5/go.mod h1:WYBhg6f0y/fNYUuesWQc0PKbJcEliGcYHB9sNT3Bg74=
+github.com/AlecAivazis/survey/v2 v2.2.7 h1:5NbxkF4RSKmpywYdcRgUmos1o+roJY8duCLZXbVjoig=
+github.com/AlecAivazis/survey/v2 v2.2.7/go.mod h1:9DYvHgXtiXm6nCn+jXnOXLKbH+Yo9u8fAS/SduGdoPk=
 github.com/Azure/azure-amqp-common-go/v2 v2.1.0/go.mod h1:R8rea+gJRuJR6QxTir/XuEd+YuKoUiazDC/N96FiDEU=
 github.com/Azure/azure-pipeline-go v0.2.1/go.mod h1:UGSo8XybXnIGZ3epmeBw7Jdz+HiUVpqIlpz/HKHylF4=
 github.com/Azure/azure-pipeline-go v0.2.2/go.mod h1:4rQ/NZncSvGqNkkOsNpOU1tgoNuIlp9AfUH5G1tvCHc=

--- a/pkg/skaffold/initializer/build/builders_test.go
+++ b/pkg/skaffold/initializer/build/builders_test.go
@@ -139,6 +139,9 @@ func TestResolveBuilderImages(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&prompt.ChooseBuildersFunc, func(choices []string) ([]string, error) {
+				return choices, nil
+			})
 			// Overrides prompt.BuildConfigFunc to choose first option rather than using the interactive menu
 			t.Override(&prompt.BuildConfigFunc, func(image string, choices []string) (string, error) {
 				if !test.shouldMakeChoice {

--- a/pkg/skaffold/initializer/build/resolve.go
+++ b/pkg/skaffold/initializer/build/resolve.go
@@ -124,8 +124,7 @@ func (d *defaultBuildInitializer) resolveBuilderImagesInteractively() error {
 		d.unresolvedImages = util.RemoveFromSlice(d.unresolvedImages, image)
 	}
 	if len(choices) > 0 {
-		// TODO(nkubala): should we ask user if they want to generate here?
-		chosen, err := prompt.ChooseBuilders(choices)
+		chosen, err := prompt.ChooseBuildersFunc(choices)
 		if err != nil {
 			return err
 		}

--- a/pkg/skaffold/initializer/build/resolve.go
+++ b/pkg/skaffold/initializer/build/resolve.go
@@ -125,7 +125,12 @@ func (d *defaultBuildInitializer) resolveBuilderImagesInteractively() error {
 	}
 	if len(choices) > 0 {
 		// TODO(nkubala): should we ask user if they want to generate here?
-		for _, choice := range choices {
+		chosen, err := prompt.ChooseBuilders(choices)
+		if err != nil {
+			return err
+		}
+
+		for _, choice := range chosen {
 			d.generatedArtifactInfos = append(d.generatedArtifactInfos, getGeneratedBuilderPair(choiceMap[choice]))
 		}
 	}

--- a/pkg/skaffold/initializer/prompt/prompt.go
+++ b/pkg/skaffold/initializer/prompt/prompt.go
@@ -32,6 +32,7 @@ import (
 // For testing
 var (
 	BuildConfigFunc         = buildConfig
+	ChooseBuildersFunc      = chooseBuilders
 	PortForwardResourceFunc = portForwardResource
 	askOne                  = survey.AskOne
 	ask                     = survey.Ask
@@ -76,8 +77,8 @@ func WriteSkaffoldConfig(out io.Writer, pipeline []byte, generatedManifests map[
 	return !response, nil
 }
 
-// ChooseBuilders prompts the user to select which builders they'd like to create associated kubernetes manifests for
-func ChooseBuilders(builders []string) ([]string, error) {
+// chooseBuilders prompts the user to select which builders they'd like to create associated kubernetes manifests for
+func chooseBuilders(builders []string) ([]string, error) {
 	chosen := []string{}
 	prompt := &survey.MultiSelect{
 		Message: "Which builders would you like to create kubernetes resources for?",

--- a/pkg/skaffold/initializer/prompt/prompt.go
+++ b/pkg/skaffold/initializer/prompt/prompt.go
@@ -76,11 +76,26 @@ func WriteSkaffoldConfig(out io.Writer, pipeline []byte, generatedManifests map[
 	return !response, nil
 }
 
+// ChooseBuilders prompts the user to select which builders they'd like to create associated kubernetes manifests for
+func ChooseBuilders(builders []string) ([]string, error) {
+	chosen := []string{}
+	prompt := &survey.MultiSelect{
+		Message: "Which builders would you like to create kubernetes resources for?",
+		Options: builders,
+	}
+	err := askOne(prompt, &chosen)
+	if err != nil {
+		return []string{}, fmt.Errorf("getting user choices")
+	}
+
+	return chosen, err
+}
+
 // PortForwardResource prompts the user to give a port to forward the current resource on
 func portForwardResource(out io.Writer, imageName string) (int, error) {
 	var response string
 	prompt := &survey.Question{
-		Prompt: &survey.Input{Message: fmt.Sprintf("Select port to forward for %s (leave blank for none): ", imageName)},
+		Prompt: &survey.Input{Message: fmt.Sprintf("Select port to forward for %s (leave blank for none):", imageName)},
 		Validate: func(val interface{}) error {
 			str := val.(string)
 			if _, err := strconv.Atoi(str); err != nil && str != "" {

--- a/pkg/skaffold/initializer/prompt/prompt_test.go
+++ b/pkg/skaffold/initializer/prompt/prompt_test.go
@@ -75,6 +75,54 @@ func TestWriteSkaffoldConfig(t *testing.T) {
 	}
 }
 
+func TestChooseBuilders(t *testing.T) {
+	tests := []struct {
+		description    string
+		choices        []string
+		promptResponse []string
+		expected       []string
+		shouldErr      bool
+	}{
+		{
+			description:    "couple chosen",
+			choices:        []string{"a", "b", "c"},
+			promptResponse: []string{"a", "c"},
+			expected:       []string{"a", "c"},
+			shouldErr:      false,
+		},
+		{
+			description:    "none chosen",
+			choices:        []string{"a", "b", "c"},
+			promptResponse: []string{},
+			expected:       []string{},
+			shouldErr:      false,
+		},
+		{
+			description:    "error",
+			choices:        []string{"a", "b", "c"},
+			promptResponse: []string{"a", "b"},
+			expected:       []string{},
+			shouldErr:      true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&askOne, func(_ survey.Prompt, response interface{}, _ ...survey.AskOpt) error {
+				r := response.(*[]string)
+				*r = test.promptResponse
+
+				if test.shouldErr {
+					return errors.New("error")
+				}
+				return nil
+			})
+
+			chosen, err := ChooseBuildersFunc(test.choices)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, chosen)
+		})
+	}
+}
+
 func TestPortForwardResource(t *testing.T) {
 	tests := []struct {
 		description    string


### PR DESCRIPTION
Fixes: #5310 

**Description**
This adds a new prompt to let users select which kubernetes manifests they'd like to create when running `skaffold init --generate-manifests`

**User facing changes (remove if N/A)**
Users will see a new prompt when running `init` with `--generate-manifests` that looks like this 
```bash
? Which builders would you like to create kubernetes resources for?  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]
> [ ]  Docker (base/Dockerfile)
  [ ]  Docker (leeroy-app/Dockerfile)
  [ ]  Docker (leeroy-web/Dockerfile)
```