### PR TITLE
print otel errors with logrus instead of straight to stderr

### DIFF
--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -251,6 +251,12 @@ type creds struct {
 	ProjectID string `json:"project_id"`
 }
 
+type errHandler struct{}
+
+func (h errHandler) Handle(err error) {
+	logrus.Debugf("Error with metrics: %v", err)
+}
+
 func initCloudMonitoringExporterMetrics() (*push.Controller, error) {
 	statikFS, err := statik.FS()
 	if err != nil {
@@ -275,6 +281,7 @@ func initCloudMonitoringExporterMetrics() (*push.Controller, error) {
 		return fmt.Sprintf("custom.googleapis.com/skaffold/%s", desc.Name())
 	}
 
+	global.SetErrorHandler(errHandler{})
 	return mexporter.InstallNewPipeline(
 		[]mexporter.Option{
 			mexporter.WithProjectID(c.ProjectID),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Description**
Currently if an error is thrown from open telemetry while uploading metrics it is just spit onto stderr.

By setting `global.SetErrorHandler` we can instead absorb those errors and print them into the debug logs so they are not shown unconditionally.

**User facing changes**
Errors from open telemetry are only shown when using `-v debug`

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
