### PR TITLE
fix cloudbuild release to re-genreate secret and upload it to a GCS bucket

### DIFF
--- a/deploy/cloudbuild-release.yaml
+++ b/deploy/cloudbuild-release.yaml
@@ -2,12 +2,9 @@
 # see: https://cloud.google.com/container-builder/docs/configuring-builds/substitute-variable-values#using_default_substitutions
 steps:
 # Grab secret credentials from gcp bucket
-  - name: gcr.io/cloud-builders/gsutil
-    args:
-    - 'cp'
-    - '-r'
-    - 'gs://$PROJECT_ID-secrets'
-    - './secrets/'
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: 'bash'
+    args: ['deploy/setup-secret.sh','-p', $PROJECT_ID]
 
 # Build and tag skaffold builder
   - name: 'gcr.io/cloud-builders/docker'

--- a/deploy/setup-secret.sh
+++ b/deploy/setup-secret.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Copyright 2019 The Skaffold Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x
+# set default project id
+PROJECT_ID="k8s-skaffold"
+KEY_FILE="./secrets/keys.json"
+BUCKET_ID="k8s-skaffold-secrets"
+LATEST_GCS_PATH="keys.json"
+
+while getopts "p:" opt; do
+  case "$opt" in
+    p) PROJECT_ID=$OPTARG
+    ;;
+esac
+done
+
+VALID_KEYS=$(gcloud iam service-accounts keys list --iam-account=metrics-writer@${PROJECT_ID}.iam.gserviceaccount.com --project=${PROJECT_ID} --managed-by=user --filter="validBeforeTime.date('%Y-%m-%d', Z)>`date +%F`" --format="value(name)")
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    echo "No permissions to list keys."
+    exit 1
+fi
+
+if [ -z "$VALID_KEYS" ]; then
+    # create a new valid key
+    gcloud iam service-accounts keys create ${KEY_FILE} --iam-account=metrics-writer@${PROJECT_ID}.iam.gserviceaccount.com --project=${PROJECT_ID}
+    retVal=$?
+    if [ $retVal -ne 0 ]; then
+      echo "No key created."
+      exit 1
+    fi
+    KEY_ID=$(gcloud iam service-accounts keys list --iam-account=metrics-writer@${PROJECT_ID}.iam.gserviceaccount.com --project=${PROJECT_ID} --managed-by=user --filter="validBeforeTime.date('%Y-%m-%d', Z)>`date +%F`" --format="value(name)")
+    gsutil cp ${KEY_FILE} gs://${BUCKET_ID}/${KEY_ID}.json
+    gsutil cp ${KEY_FILE} gs://${BUCKET_ID}/${LATEST_GCS_PATH}
+else
+    # download the valid key from gcs
+    gsutil cp gs://${BUCKET_ID}/${LATEST_GCS_PATH} ${KEY_FILE}
+fi


### PR DESCRIPTION
Keys created for service account for security reasons are not valid forever.
As per internal policy, they are valid for short amt of time. (ping @tejal29 for more details)

Add a script in release process to
1) check if key is valid for given secret 
2) Create new key if no active keys are found and upload them to the GCS at two places
  a)k8s-skaffold-secrets/KEY_ID.json
  b) k8s-skaffold-secrets/key.json
 

Testing:
1. First run: https://console.cloud.google.com/cloud-build/builds/cbe1a244-df74-439e-88f5-8238590e0e4f?project=345011737331
2. Second run https://console.cloud.google.com/cloud-build/builds/bbc37aa0-c652-4eba-9901-2f8b510e2b59?project=345011737331