### PR TITLE
add integration test for `skaffold init --artifact`

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -120,6 +120,24 @@ func TestInitKustomize(t *testing.T) {
 	})
 }
 
+func TestInitWithCLIArtifact(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	testutil.Run(t, "init with cli artifact", func(t *testutil.T) {
+		dir := "testdata/init/hello-with-manifest"
+		ns, _ := SetupNamespace(t.T)
+
+		initArgs := append([]string{"--force"},
+			`--artifact={"builder":"Docker","payload":{"path":"../hello/Dockerfile"},"image":"dockerfile-image"}`)
+		skaffold.Init(initArgs...).InDir(dir).WithConfig("skaffold.yaml.out").RunOrFail(t.T)
+
+		checkGeneratedConfig(t, dir)
+
+		// Make sure the skaffold yaml is ok
+		skaffold.Run().InDir(dir).WithConfig("skaffold.yaml.out").InNs(ns.Name).RunOrFail(t.T)
+	})
+}
+
 func checkGeneratedConfig(t *testutil.T, dir string) {
 	expectedOutput, err := ioutil.ReadFile(filepath.Join(dir, "skaffold.yaml"))
 	t.CheckNoError(err)

--- a/integration/testdata/init/hello-with-manifest/k8s-pod.yaml
+++ b/integration/testdata/init/hello-with-manifest/k8s-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dockerfile-image
+spec:
+  containers:
+  - name: dockerfile-image
+    image: dockerfile-image

--- a/integration/testdata/init/hello-with-manifest/skaffold.yaml
+++ b/integration/testdata/init/hello-with-manifest/skaffold.yaml
@@ -1,0 +1,14 @@
+apiVersion: skaffold/v2beta11
+kind: Config
+metadata:
+  name: hello-with-manifest
+build:
+  artifacts:
+  - image: dockerfile-image
+    context: ../hello
+    docker:
+      dockerfile: Dockerfile
+deploy:
+  kubectl:
+    manifests:
+    - k8s-pod.yaml


### PR DESCRIPTION
<!-- Include if applicable: -->
**Related**: #5296 

**Description**
In skaffold v1.17.2 there was an error parsing artifacts passed via the `--artifact` flag. 

This PR adds test to ensure that if this scenario fails we are able to detect it before committing it by testing the --artifact flag and ensuring the command does not fail, and it produces a valid `skaffold.yaml`

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
