### PR TITLE
export metrics related to user enum flags

### DIFF
--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -43,6 +43,10 @@ import (
 	"github.com/GoogleContainerTools/skaffold/proto"
 )
 
+const (
+	FlagsPrefix = "flags/"
+)
+
 func ExportMetrics(exitCode int) error {
 	if !shouldExportMetrics || meter.Command == "" {
 		return nil
@@ -173,7 +177,7 @@ func createMetrics(ctx context.Context, meter skaffoldMeter) {
 
 func flagMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, randLabel label.KeyValue) {
 	for k, v := range meter.EnumFlags {
-		flagCounter := metric.Must(m).NewInt64ValueRecorder("flags/"+strings.ReplaceAll(k, "-", "_"),
+		flagCounter := metric.Must(m).NewInt64ValueRecorder(FlagsPrefix+strings.ReplaceAll(k, "-", "_"),
 			metric.WithDescription(fmt.Sprintf("Flag metric for %s", k)))
 		labels := []label.KeyValue{
 			label.String("command", meter.Command),

--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	mexporter "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric"
@@ -156,6 +157,7 @@ func createMetrics(ctx context.Context, meter skaffoldMeter) {
 	durationRecorder.Record(ctx, meter.Duration.Seconds(), labels...)
 	if meter.Command != "" {
 		commandMetrics(ctx, meter, m, randLabel)
+		flagMetrics(ctx, meter, m, randLabel)
 		if doesBuild.Contains(meter.Command) {
 			builderMetrics(ctx, meter, m, randLabel)
 		}
@@ -166,6 +168,20 @@ func createMetrics(ctx context.Context, meter skaffoldMeter) {
 
 	if meter.ErrorCode != 0 {
 		errorMetrics(ctx, meter, m, randLabel)
+	}
+}
+
+func flagMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, randLabel label.KeyValue) {
+	for k, v := range meter.EnumFlags {
+		flagCounter := metric.Must(m).NewInt64ValueRecorder("flags/"+strings.ReplaceAll(k, "-", "_"),
+			metric.WithDescription(fmt.Sprintf("Flag metric for %s", k)))
+		labels := []label.KeyValue{
+			label.String("command", meter.Command),
+			label.String("value", v),
+			label.String("error", strconv.Itoa(int(meter.ErrorCode))),
+			randLabel,
+		}
+		flagCounter.Record(ctx, 1, labels...)
 	}
 }
 

--- a/pkg/skaffold/instrumentation/export_test.go
+++ b/pkg/skaffold/instrumentation/export_test.go
@@ -229,6 +229,7 @@ func checkOutput(t *testutil.T, meters []skaffoldMeter, b []byte) {
 	buildDeps := make(map[interface{}]int)
 	devIterations := make(map[interface{}]int)
 	deployers := make(map[interface{}]int)
+	enumFlags := make(map[interface{}]int)
 
 	testMaps := []map[interface{}]int{
 		osCount, versionCount, archCount, durationCount, commandCount, errorCount, builders, devIterations, deployers}
@@ -240,6 +241,11 @@ func checkOutput(t *testutil.T, meters []skaffoldMeter, b []byte) {
 		archCount[meter.Arch]++
 		commandCount[meter.Command]++
 		errorCount[meter.ErrorCode]++
+
+		for k, v := range meter.EnumFlags {
+			n := FlagsPrefix + strings.ReplaceAll(k, "-", "_")
+			enumFlags[n+":"+v]++
+		}
 
 		if doesBuild.Contains(meter.Command) {
 			for k, v := range meter.Builders {
@@ -295,6 +301,8 @@ func checkOutput(t *testutil.T, meters []skaffoldMeter, b []byte) {
 			switch {
 			case meteredCommands.Contains(l.Name):
 				commandCount[l.Name]--
+			case strings.HasPrefix(l.Name, "flags/"):
+				enumFlags[l.Name+":"+l.Labels["value"]]--
 			default:
 				t.Error("unexpected metric with name", l.Name)
 			}


### PR DESCRIPTION
Fixes: #5195  <!-- tracking issues that this PR will close -->

**Description**
This PR takes user enum flags run on commands that export metrics and exports them to GCP, prior they were just stored in the skaffoldMeter struct, but now they are exported from there.

To resolve #5195 , all appropriate flags will have their own metric descriptor and will be labeled with the command used, any error, and the value of the flag that was used.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
