### PR TITLE
fix pulling secrets in cloudbuild release for latest builds

### DIFF
--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -2,12 +2,9 @@
 # see: https://cloud.google.com/container-builder/docs/configuring-builds/substitute-variable-values#using_default_substitutions
 steps:
 # Grab secret credentials from gcp bucket
-  - name: gcr.io/cloud-builders/gsutil
-    args:
-    - 'cp'
-    - '-r'
-    - 'gs://$PROJECT_ID-secrets'
-    - './secrets/'
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: 'bash'
+    args: ['deploy/setup-secret.sh','-p', $PROJECT_ID]
 
 # Build and tag skaffold builder
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
**Related**: #5314 

**Description**
Applies the changes of `cloudbuild-release.yaml` in #5314 to `cloudbuild.yaml` to fix the "Skaffold latest build" trigger. This trigger keeps failing with 
```
Starting Step #0
Step #0: Already have image (with digest): gcr.io/cloud-builders/gsutil
Step #0: CommandException: Destination URL must name a directory, bucket, or bucket
Step #0: subdirectory for the multiple source form of the cp command.
Finished Step #0
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/gsutil" failed: step exited with non-zero status: 1
```
since it was not modified to properly pull the keys from the gcs bucket. Uses `deploy/setup-secret.sh` instead to pull the secret.
