### PR TITLE
Fix example `multi-config-microservices` broken due to missed runtime image update

### DIFF
--- a/examples/multi-config-microservices/base/Dockerfile
+++ b/examples/multi-config-microservices/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM gcr.io/distroless/base
 # Define GOTRACEBACK to mark this container as using the Go language runtime
 # for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
 ENV GOTRACEBACK=single

--- a/integration/examples/multi-config-microservices/base/Dockerfile
+++ b/integration/examples/multi-config-microservices/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM gcr.io/distroless/base
 # Define GOTRACEBACK to mark this container as using the Go language runtime
 # for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
 ENV GOTRACEBACK=single

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -59,6 +59,11 @@ func TestRun(t *testing.T) {
 			deployments: []string{"leeroy-app", "leeroy-web"},
 		},
 		{
+			description: "multi-config-microservices",
+			dir:         "examples/multi-config-microservices",
+			deployments: []string{"leeroy-app", "leeroy-web"},
+		},
+		{
 			description: "envTagger",
 			dir:         "examples/tagging-with-environment-variables",
 			pods:        []string{"getting-started"},


### PR DESCRIPTION
`examples/multi-config-microservices` was missed in https://github.com/GoogleContainerTools/skaffold/pull/5307. Additionally added project to integration test list.