### PR TITLE
Configure k3d to use registry-mirrors

### DIFF
--- a/hack/generate-k3d-registries.sh
+++ b/hack/generate-k3d-registries.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Copyright 2019 The Skaffold Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create a k3s/k3d registries.yaml to use the docker daemon's configured registry-mirrors.
+docker system info --format '{{printf "mirrors:\n"}}{{range $reg, $config := .RegistryConfig.IndexConfigs}}{{if $config.Mirrors}}{{printf "  %q:\n    endpoint:\n" $reg}}{{range $config.Mirrors}}{{printf "      - %q\n" .}}{{end}}{{end}}{{end}}'

--- a/hack/generate-k3d-registries.sh
+++ b/hack/generate-k3d-registries.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright 2019 The Skaffold Authors
+# Copyright 2021 The Skaffold Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Configure k3d to use the registry-mirrors configured in the Docker daemon as per `kind` in #5237.  This should further reduce Docker Hub problems such as #5342.