### PR TITLE
Update telemetry prompt links

### DIFF
--- a/pkg/skaffold/instrumentation/prompt.go
+++ b/pkg/skaffold/instrumentation/prompt.go
@@ -23,7 +23,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 )
 
-const Prompt = `To help improve the quality of this product, we collect anonymized usage data for details on what is tracked and how we use this data visit <https://skaffold.dev/docs/telemetry/>. This data is handled in accordance with our privacy policy <https://policies.google.com/privacy/>
+const Prompt = `To help improve the quality of this product, we collect anonymized usage data for details on what is tracked and how we use this data visit <https://skaffold.dev/docs/resources/telemetry/>. This data is handled in accordance with our privacy policy <https://policies.google.com/privacy>
 
 You may choose to opt out of this collection by running the following command:
 	skaffold config set --global collect-metrics false


### PR DESCRIPTION
**Description**

While running `skaffold dev`, I got the telemetry prompt and noticed that the documentation and the Google privacy policy links were returning 404s:

![Screen Shot 2021-02-03 at 4 33 50 PM](https://user-images.githubusercontent.com/9082799/106818251-a445ad00-663d-11eb-81fb-fea5bbebae76.png)

Trailing slash on the privacy policy:
![Screen Shot 2021-02-03 at 4 33 34 PM](https://user-images.githubusercontent.com/9082799/106818247-a3ad1680-663d-11eb-94ae-c00a9b0a80aa.png)

