### PR TITLE
Unhide --auto-{build,deploy,sync} and update debug notes

### DIFF
--- a/cmd/skaffold/app/cmd/debug.go
+++ b/cmd/skaffold/app/cmd/debug.go
@@ -34,8 +34,10 @@ var doDebug = runDebug
 func NewCmdDebug() *cobra.Command {
 	return NewCmd("debug").
 		WithDescription("[beta] Run a pipeline in debug mode").
-		WithLongDescription("Similar to `dev`, but configures the pipeline for debugging.").
+		WithLongDescription("Similar to `dev`, but configures the pipeline for debugging. "+
+			"Auto-build and sync is disabled by default to prevent accidentally tearing down debug sessions.").
 		WithCommonFlags().
+		WithExample("Launch with port-forwarding", "debug --port-forward").
 		WithHouseKeepingMessages().
 		NoArgs(func(ctx context.Context, out io.Writer) error {
 			return doDebug(ctx, out)

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -342,7 +342,6 @@ var flagRegistry = []Flag{
 	{
 		Name:     "auto-build",
 		Usage:    "When set to false, builds wait for API request instead of running automatically",
-		Hidden:   true,
 		Value:    &opts.AutoBuild,
 		DefValue: true,
 		DefValuePerCommand: map[string]interface{}{
@@ -356,7 +355,6 @@ var flagRegistry = []Flag{
 	{
 		Name:     "auto-sync",
 		Usage:    "When set to false, syncs wait for API request instead of running automatically",
-		Hidden:   true,
 		Value:    &opts.AutoSync,
 		DefValue: true,
 		DefValuePerCommand: map[string]interface{}{
@@ -370,7 +368,6 @@ var flagRegistry = []Flag{
 	{
 		Name:     "auto-deploy",
 		Usage:    "When set to false, deploys wait for API request instead of running automatically",
-		Hidden:   true,
 		Value:    &opts.AutoDeploy,
 		DefValue: true,
 		DefValuePerCommand: map[string]interface{}{

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -343,9 +343,16 @@ Env vars:
 ```
 
 
+Examples:
+  # Launch with port-forwarding
+  skaffold debug --port-forward
+
 Options:
       --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
+      --auto-build=true: When set to false, builds wait for API request instead of running automatically
       --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
+      --auto-deploy=true: When set to false, deploys wait for API request instead of running automatically
+      --auto-sync=true: When set to false, syncs wait for API request instead of running automatically
       --cache-artifacts=true: Set to false to disable default caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
       --cleanup=true: Delete deployments after dev or debug mode is interrupted
@@ -392,7 +399,10 @@ Use "skaffold options" for a list of global command-line options (applies to all
 Env vars:
 
 * `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
+* `SKAFFOLD_AUTO_BUILD` (same as `--auto-build`)
 * `SKAFFOLD_AUTO_CREATE_CONFIG` (same as `--auto-create-config`)
+* `SKAFFOLD_AUTO_DEPLOY` (same as `--auto-deploy`)
+* `SKAFFOLD_AUTO_SYNC` (same as `--auto-sync`)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
 * `SKAFFOLD_CLEANUP` (same as `--cleanup`)
@@ -565,7 +575,10 @@ Run a pipeline in development mode
 
 Options:
       --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
+      --auto-build=true: When set to false, builds wait for API request instead of running automatically
       --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
+      --auto-deploy=true: When set to false, deploys wait for API request instead of running automatically
+      --auto-sync=true: When set to false, syncs wait for API request instead of running automatically
       --cache-artifacts=true: Set to false to disable default caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
       --cleanup=true: Delete deployments after dev or debug mode is interrupted
@@ -613,7 +626,10 @@ Use "skaffold options" for a list of global command-line options (applies to all
 Env vars:
 
 * `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
+* `SKAFFOLD_AUTO_BUILD` (same as `--auto-build`)
 * `SKAFFOLD_AUTO_CREATE_CONFIG` (same as `--auto-create-config`)
+* `SKAFFOLD_AUTO_DEPLOY` (same as `--auto-deploy`)
+* `SKAFFOLD_AUTO_SYNC` (same as `--auto-sync`)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_CACHE_FILE` (same as `--cache-file`)
 * `SKAFFOLD_CLEANUP` (same as `--cleanup`)

--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -9,7 +9,13 @@ aliases: [/docs/how-tos/debug]
 `skaffold debug` acts like `skaffold dev`, but it configures containers in pods
 for debugging as required for each container's runtime technology.
 The associated debugging ports are exposed and labelled so that they can be port-forwarded to the
-local machine.  IDEs can use Skaffold's events to automatically configure debug sessions.
+local machine.  IDEs like [Google's Cloud Code extensions](https://cloud.google.com/code) use Skaffold's events
+to automatically configure debug sessions.
+
+One notable difference from `skaffold dev` is that `debug` disables image rebuilding and
+syncing as it leads to users accidentally terminating debugging sessions by saving file changes.
+These behaviours can be re-enabled with the `--auto-build`, `--auto-deploy`, and `--auto-sync`
+flags.
 
 ## How It Works
 


### PR DESCRIPTION
**Description**

This PR:
  1. Unhides the `--auto-sync`, `--auto-build`, and `--auto-deploy` flags for `dev` and `debug`.
  2. Adds a note about these flags to the `debug` command helper.
  3. Adds a note about these flags to the `debug` docs.

**User facing changes (remove if N/A)**
- `skaffold dev` and `skaffold debug` support `--auto-build`, `--auto-deploy`, and `--auto-sync` to control how Skaffold reacts to file changes during a development session.
