### PR TITLE
track the platform type at the launch level

### DIFF
--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -150,6 +150,7 @@ func createMetrics(ctx context.Context, meter skaffoldMeter) {
 		label.String("arch", meter.Arch),
 		label.String("command", meter.Command),
 		label.String("error", strconv.Itoa(int(meter.ErrorCode))),
+		label.String("platform_type", meter.PlatformType),
 		randLabel,
 	}
 

--- a/pkg/skaffold/instrumentation/export_test.go
+++ b/pkg/skaffold/instrumentation/export_test.go
@@ -230,9 +230,10 @@ func checkOutput(t *testutil.T, meters []skaffoldMeter, b []byte) {
 	devIterations := make(map[interface{}]int)
 	deployers := make(map[interface{}]int)
 	enumFlags := make(map[interface{}]int)
+	platform := make(map[interface{}]int)
 
 	testMaps := []map[interface{}]int{
-		osCount, versionCount, archCount, durationCount, commandCount, errorCount, builders, devIterations, deployers}
+		platform, osCount, versionCount, archCount, durationCount, commandCount, errorCount, builders, devIterations, deployers}
 
 	for _, meter := range meters {
 		osCount[meter.OS]++
@@ -241,6 +242,7 @@ func checkOutput(t *testutil.T, meters []skaffoldMeter, b []byte) {
 		archCount[meter.Arch]++
 		commandCount[meter.Command]++
 		errorCount[meter.ErrorCode]++
+		platform[meter.PlatformType]++
 
 		for k, v := range meter.EnumFlags {
 			n := FlagsPrefix + strings.ReplaceAll(k, "-", "_")
@@ -277,6 +279,7 @@ func checkOutput(t *testutil.T, meters []skaffoldMeter, b []byte) {
 			archCount[l.Labels["arch"]]--
 			osCount[l.Labels["os"]]--
 			versionCount[l.Labels["version"]]--
+			platform[l.Labels["platform_type"]]--
 			e, _ := strconv.Atoi(l.Labels["error"])
 			if e == int(proto.StatusCode_OK) {
 				errorCount[proto.StatusCode(e)]--

--- a/pkg/skaffold/instrumentation/types.go
+++ b/pkg/skaffold/instrumentation/types.go
@@ -45,7 +45,7 @@ type skaffoldMeter struct {
 	// Arch Architecture running Skaffold e.g. amd64, arm64, etc.
 	Arch string
 
-	// PlatformType Where Skaffold is deploying to (sync, build, or Google Cloud Build).
+	// PlatformType Where Skaffold is deploying to (local, cluster, or Google Cloud Build).
 	PlatformType string
 
 	// Deployers All the deployers used in the Skaffold execution.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5352  <!-- tracking issues that this PR will close -->

**Description**
Add label to launch metric that describes the platform type that is being used. With this there are only 3 more labels that can be added to the launches metric.

