### PR TITLE
Implement defining remote git dependencies in the skaffold configuration.

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -121,6 +121,14 @@ var flagRegistry = []Flag{
 		DefinedOn:     []string{"dev", "build", "run", "debug"},
 	},
 	{
+		Name:          "remote-cache-dir",
+		Usage:         "Specify the location of the git repositories cache (default $HOME/.skaffold/repos)",
+		Value:         &opts.RepoCacheDir,
+		DefValue:      "",
+		FlagAddMethod: "StringVar",
+		DefinedOn:     []string{"all"},
+	},
+	{
 		Name:          "insecure-registry",
 		Usage:         "Target registries for built images which are not secure",
 		Value:         &opts.InsecureRegistries,

--- a/cmd/skaffold/app/cmd/parse_config.go
+++ b/cmd/skaffold/app/cmd/parse_config.go
@@ -170,7 +170,7 @@ func processEachDependency(d latest.ConfigDependency, fPath string, required boo
 	if d.GitRepo != nil {
 		cachePath, err := cacheRepo(*d.GitRepo, opts, r)
 		if err != nil {
-			return nil, fmt.Errorf("cacheing remote dependency %s: %w", d.GitRepo, err)
+			return nil, fmt.Errorf("caching remote dependency %s: %w", d.GitRepo, err)
 		}
 		path = cachePath
 	}

--- a/cmd/skaffold/app/cmd/parse_config.go
+++ b/cmd/skaffold/app/cmd/parse_config.go
@@ -170,7 +170,7 @@ func processEachDependency(d latest.ConfigDependency, fPath string, required boo
 	if d.GitRepo != nil {
 		cachePath, err := cacheRepo(*d.GitRepo, opts, r)
 		if err != nil {
-			return nil, fmt.Errorf("caching remote dependency %s: %w", d.GitRepo, err)
+			return nil, fmt.Errorf("caching remote dependency %s: %w", d.GitRepo.Repo, err)
 		}
 		path = cachePath
 	}

--- a/cmd/skaffold/app/cmd/parse_config.go
+++ b/cmd/skaffold/app/cmd/parse_config.go
@@ -182,7 +182,7 @@ func processEachDependency(d latest.ConfigDependency, fPath string, required boo
 	fi, err := os.Stat(path)
 	if err != nil {
 		if os.IsNotExist(errors.Unwrap(err)) {
-			return nil, fmt.Errorf("could not find skaffold config %s that is referenced as a dependency in config %s", d.Path, fPath)
+			return nil, fmt.Errorf("could not find skaffold config %s that is referenced as a dependency in config %s", path, fPath)
 		}
 		return nil, fmt.Errorf("parsing dependencies for skaffold config %s: %w", fPath, err)
 	}

--- a/cmd/skaffold/app/cmd/parse_config.go
+++ b/cmd/skaffold/app/cmd/parse_config.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/git"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
@@ -45,9 +46,15 @@ type configOpts struct {
 	isDependency bool
 }
 
+type record struct {
+	appliedProfiles  map[string]string      // config -> list of applied profiles
+	configNameToFile map[string]string      // configName -> file path
+	cachedRepos      map[string]interface{} // git repo -> cache path or error
+}
+
 func getAllConfigs(opts config.SkaffoldOptions) ([]*latest.SkaffoldConfig, error) {
 	cOpts := configOpts{file: opts.ConfigurationFile, selection: nil, profiles: opts.Profiles, isRequired: false, isDependency: false}
-	cfgs, err := getConfigs(cOpts, opts, make(map[string]string), make(map[string]string))
+	cfgs, err := getConfigs(cOpts, opts, &record{appliedProfiles: make(map[string]string), configNameToFile: make(map[string]string), cachedRepos: make(map[string]interface{})})
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +68,7 @@ func getAllConfigs(opts config.SkaffoldOptions) ([]*latest.SkaffoldConfig, error
 }
 
 // getConfigs recursively parses all configs and their dependencies in the specified `skaffold.yaml`
-func getConfigs(cfgOpts configOpts, opts config.SkaffoldOptions, appliedProfiles map[string]string, configNameToFile map[string]string) ([]*latest.SkaffoldConfig, error) {
+func getConfigs(cfgOpts configOpts, opts config.SkaffoldOptions, r *record) ([]*latest.SkaffoldConfig, error) {
 	parsed, err := schema.ParseConfigAndUpgrade(cfgOpts.file, latest.Version)
 	if err != nil {
 		return nil, err
@@ -80,7 +87,7 @@ func getConfigs(cfgOpts configOpts, opts config.SkaffoldOptions, appliedProfiles
 	var configs []*latest.SkaffoldConfig
 	for i, cfg := range parsed {
 		config := cfg.(*latest.SkaffoldConfig)
-		processed, err := processEachConfig(config, cfgOpts, opts, appliedProfiles, configNameToFile, i)
+		processed, err := processEachConfig(config, cfgOpts, opts, r, i)
 		if err != nil {
 			return nil, err
 		}
@@ -90,14 +97,14 @@ func getConfigs(cfgOpts configOpts, opts config.SkaffoldOptions, appliedProfiles
 }
 
 // processEachConfig processes each parsed config by applying profiles and recursively processing it's dependencies
-func processEachConfig(config *latest.SkaffoldConfig, cfgOpts configOpts, opts config.SkaffoldOptions, appliedProfiles map[string]string, configNameToFile map[string]string, index int) ([]*latest.SkaffoldConfig, error) {
+func processEachConfig(config *latest.SkaffoldConfig, cfgOpts configOpts, opts config.SkaffoldOptions, r *record, index int) ([]*latest.SkaffoldConfig, error) {
 	// check that the same config name isn't repeated in multiple files.
 	if config.Metadata.Name != "" {
-		prevConfig, found := configNameToFile[config.Metadata.Name]
+		prevConfig, found := r.configNameToFile[config.Metadata.Name]
 		if found && prevConfig != cfgOpts.file {
 			return nil, fmt.Errorf("skaffold config named %q found in multiple files: %q and %q", config.Metadata.Name, prevConfig, cfgOpts.file)
 		}
-		configNameToFile[config.Metadata.Name] = cfgOpts.file
+		r.configNameToFile[config.Metadata.Name] = cfgOpts.file
 	}
 
 	// configSelection specifies the exact required configs in this file. Empty configSelection means that all configs are required.
@@ -124,13 +131,13 @@ func processEachConfig(config *latest.SkaffoldConfig, cfgOpts configOpts, opts c
 	}
 
 	sort.Strings(profiles)
-	if revisit, err := checkRevisit(config, profiles, appliedProfiles, cfgOpts.file, required, index); revisit {
+	if revisit, err := checkRevisit(config, profiles, r.appliedProfiles, cfgOpts.file, required, index); revisit {
 		return nil, err
 	}
 
 	var configs []*latest.SkaffoldConfig
 	for _, d := range config.Dependencies {
-		depConfigs, err := processEachDependency(d, cfgOpts.file, required, profiles, opts, appliedProfiles, configNameToFile)
+		depConfigs, err := processEachDependency(d, cfgOpts.file, required, profiles, opts, r)
 		if err != nil {
 			return nil, err
 		}
@@ -144,7 +151,7 @@ func processEachConfig(config *latest.SkaffoldConfig, cfgOpts configOpts, opts c
 }
 
 // processEachDependency parses a config dependency with the calculated set of activated profiles.
-func processEachDependency(d latest.ConfigDependency, fPath string, required bool, profiles []string, opts config.SkaffoldOptions, appliedProfiles, configNameToFile map[string]string) ([]*latest.SkaffoldConfig, error) {
+func processEachDependency(d latest.ConfigDependency, fPath string, required bool, profiles []string, opts config.SkaffoldOptions, r *record) ([]*latest.SkaffoldConfig, error) {
 	var depProfiles []string
 	for _, ap := range d.ActiveProfiles {
 		if len(ap.ActivatedBy) == 0 {
@@ -159,6 +166,15 @@ func processEachDependency(d latest.ConfigDependency, fPath string, required boo
 		}
 	}
 	path := d.Path
+
+	if d.GitRepo != nil {
+		cachePath, err := cacheRepo(*d.GitRepo, opts, r)
+		if err != nil {
+			return nil, fmt.Errorf("cacheing remote dependency %s: %w", d.GitRepo, err)
+		}
+		path = cachePath
+	}
+
 	if path == "" {
 		// empty path means configs in the same file
 		path = fPath
@@ -173,11 +189,34 @@ func processEachDependency(d latest.ConfigDependency, fPath string, required boo
 	if fi.IsDir() {
 		path = filepath.Join(path, "skaffold.yaml")
 	}
-	depConfigs, err := getConfigs(configOpts{file: path, selection: d.Names, profiles: depProfiles, isRequired: required, isDependency: path != fPath}, opts, appliedProfiles, configNameToFile)
+	depConfigs, err := getConfigs(configOpts{file: path, selection: d.Names, profiles: depProfiles, isRequired: required, isDependency: path != fPath}, opts, r)
 	if err != nil {
 		return nil, err
 	}
 	return depConfigs, nil
+}
+
+// cacheRepo downloads the referenced git repository to skaffold's cache if required and returns the path to the target configuration file in that repository.
+func cacheRepo(g latest.GitInfo, opts config.SkaffoldOptions, r *record) (string, error) {
+	key := fmt.Sprintf("%s:%s", g.Repo, g.Ref)
+	if p, found := r.cachedRepos[key]; found {
+		switch v := p.(type) {
+		case string:
+			return filepath.Join(v, g.Path), nil
+		case error:
+			return "", v
+		default:
+			return "", fmt.Errorf("unable to check download status of repo %s at ref %s", g.Repo, g.Ref)
+		}
+	} else {
+		p, err := git.SyncRepo(g, opts)
+		if err != nil {
+			r.cachedRepos[key] = err
+			return "", err
+		}
+		r.cachedRepos[key] = p
+		return filepath.Join(p, g.Path), nil
+	}
 }
 
 // checkRevisit ensures that each config is activated with the same set of active profiles

--- a/docs/content/en/docs/design/config.md
+++ b/docs/content/en/docs/design/config.md
@@ -69,18 +69,18 @@ deploy:
 ```
 
 If the `configs` list isn't defined then it imports all the configs defined in the file pointed by `path`. Additionally, if the `path` to the configuration isn't defined it assumes that all the required configs are defined in the same file as the current config.
-### Remote config dependency [Under Development]
+
+### Remote config dependency
 
 The required skaffold config can live in a remote git repository:
 
 ```yaml
-apiVersion: skaffold/v2beta11
+apiVersion: skaffold/v2beta12
 kind: Config
 requires:
   - configs: ["cfg1", "cfg2"]
     git:
-      provider: github.com
-      repo: GoogleContainerTools/skaffold
+      repo: http://github.com/GoogleContainerTools/skaffold.git
       path: getting-started/skaffold.yaml
       ref: master
 ```
@@ -92,7 +92,7 @@ The remote config gets treated like a local config after substituting the path w
   
 ### Profile Activation in required configs
 
-Additionally the `activeProfiles`  stanza can define the profiles to be activated in the required configs, via:
+Additionally the `activeProfiles` stanza can define the profiles to be activated in the required configs, via:
 
 ```yaml
 apiVersion: skaffold/v2beta11

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -152,6 +152,7 @@ Options:
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
   -q, --quiet=false: Suppress the build output and print image built on success. See --output to format output.
+      --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
@@ -188,6 +189,7 @@ Env vars:
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
 * `SKAFFOLD_QUIET` (same as `--quiet`)
+* `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
@@ -375,6 +377,7 @@ Options:
       --port-forward=false: Port-forward exposed container ports within pods
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
+      --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
@@ -425,6 +428,7 @@ Env vars:
 * `SKAFFOLD_PORT_FORWARD` (same as `--port-forward`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
+* `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
@@ -457,6 +461,7 @@ Options:
   -n, --namespace='': Run deployments in the specified namespace
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
+      --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
 
 Usage:
   skaffold delete [options]
@@ -477,6 +482,7 @@ Env vars:
 * `SKAFFOLD_NAMESPACE` (same as `--namespace`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
+* `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 
 ### skaffold deploy
 
@@ -517,6 +523,7 @@ Options:
       --port-forward=false: Port-forward exposed container ports within pods
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
+      --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
       --skip-render=false: Don't render the manifests, just deploy them
@@ -555,6 +562,7 @@ Env vars:
 * `SKAFFOLD_PORT_FORWARD` (same as `--port-forward`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
+* `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_RENDER` (same as `--skip-render`)
@@ -601,6 +609,7 @@ Options:
       --port-forward=false: Port-forward exposed container ports within pods
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
+      --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
       --render-only=false: Print rendered Kubernetes manifests instead of deploying them
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
@@ -652,6 +661,7 @@ Env vars:
 * `SKAFFOLD_PORT_FORWARD` (same as `--port-forward`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
+* `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 * `SKAFFOLD_RENDER_ONLY` (same as `--render-only`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
@@ -687,6 +697,7 @@ Options:
   -m, --module=[]: Filter Skaffold configs to only the provided named modules
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
+      --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
       --yaml-only=false: Only prints the effective skaffold.yaml configuration
 
 Usage:
@@ -703,6 +714,7 @@ Env vars:
 * `SKAFFOLD_MODULE` (same as `--module`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
+* `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 * `SKAFFOLD_YAML_ONLY` (same as `--yaml-only`)
 
 ### skaffold fix
@@ -723,6 +735,7 @@ Options:
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
   -m, --module=[]: Filter Skaffold configs to only the provided named modules
       --overwrite=false: Overwrite original config with fixed config
+      --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
       --version='skaffold/v2beta12': Target schema version to upgrade to
 
 Usage:
@@ -737,6 +750,7 @@ Env vars:
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_MODULE` (same as `--module`)
 * `SKAFFOLD_OVERWRITE` (same as `--overwrite`)
+* `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 * `SKAFFOLD_VERSION` (same as `--version`)
 
 ### skaffold init
@@ -757,6 +771,7 @@ Options:
       --generate-manifests=false: Allows skaffold to try and generate basic kubernetes resources to get your project started
   -k, --kubernetes-manifest=[]: A path or a glob pattern to kubernetes manifests (can be non-existent) to be added to the kubectl deployer (overrides detection of kubernetes manifests). Repeat the flag for multiple entries. E.g.: skaffold init -k pod.yaml -k k8s/*.yml
   -m, --module=[]: Filter Skaffold configs to only the provided named modules
+      --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
       --skip-build=false: Skip generating build artifacts in Skaffold config
 
 Usage:
@@ -777,6 +792,7 @@ Env vars:
 * `SKAFFOLD_GENERATE_MANIFESTS` (same as `--generate-manifests`)
 * `SKAFFOLD_KUBERNETES_MANIFEST` (same as `--kubernetes-manifest`)
 * `SKAFFOLD_MODULE` (same as `--module`)
+* `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 * `SKAFFOLD_SKIP_BUILD` (same as `--skip-build`)
 
 ### skaffold options
@@ -820,6 +836,7 @@ Options:
       --output='': file to write rendered manifests to
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
+      --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
 
 Usage:
   skaffold render [options]
@@ -843,6 +860,7 @@ Env vars:
 * `SKAFFOLD_OUTPUT` (same as `--output`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
+* `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 
 ### skaffold run
 
@@ -884,6 +902,7 @@ Options:
       --port-forward=false: Port-forward exposed container ports within pods
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
+      --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
       --render-only=false: Print rendered Kubernetes manifests instead of deploying them
       --render-output='': Writes '--render-only' output to the specified file
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
@@ -931,6 +950,7 @@ Env vars:
 * `SKAFFOLD_PORT_FORWARD` (same as `--port-forward`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
+* `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 * `SKAFFOLD_RENDER_ONLY` (same as `--render-only`)
 * `SKAFFOLD_RENDER_OUTPUT` (same as `--render-output`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
@@ -1040,6 +1060,7 @@ Options:
   -a, --build-artifacts=: File containing build result from a previous 'skaffold build --file-output'
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
   -m, --module=[]: Filter Skaffold configs to only the provided named modules
+      --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
 
 Usage:
   skaffold test [options]
@@ -1053,6 +1074,7 @@ Env vars:
 * `SKAFFOLD_BUILD_ARTIFACTS` (same as `--build-artifacts`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_MODULE` (same as `--module`)
+* `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 
 ### skaffold version
 

--- a/docs/content/en/schemas/v2beta12.json
+++ b/docs/content/en/schemas/v2beta12.json
@@ -809,6 +809,11 @@
           "x-intellij-html-description": "describes the names of the required configs.",
           "default": "[]"
         },
+        "git": {
+          "$ref": "#/definitions/GitInfo",
+          "description": "describes a remote git repository containing the required configs.",
+          "x-intellij-html-description": "describes a remote git repository containing the required configs."
+        },
         "path": {
           "type": "string",
           "description": "describes the path to the file containing the required configs.",
@@ -818,6 +823,7 @@
       "preferredOrder": [
         "configs",
         "path",
+        "git",
         "activeProfiles"
       ],
       "additionalProperties": false,
@@ -1177,6 +1183,36 @@
       "additionalProperties": false,
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
+    },
+    "GitInfo": {
+      "required": [
+        "repo"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "relative path from the repo root to the skaffold configuration file. eg. `getting-started/skaffold.yaml`.",
+          "x-intellij-html-description": "relative path from the repo root to the skaffold configuration file. eg. <code>getting-started/skaffold.yaml</code>."
+        },
+        "ref": {
+          "type": "string",
+          "description": "git ref the package should be cloned from. eg. `master` or `main`.",
+          "x-intellij-html-description": "git ref the package should be cloned from. eg. <code>master</code> or <code>main</code>."
+        },
+        "repo": {
+          "type": "string",
+          "description": "git repository the package should be cloned from.  e.g. `https://github.com/GoogleContainerTools/skaffold.git`.",
+          "x-intellij-html-description": "git repository the package should be cloned from.  e.g. <code>https://github.com/GoogleContainerTools/skaffold.git</code>."
+        }
+      },
+      "preferredOrder": [
+        "repo",
+        "path",
+        "ref"
+      ],
+      "additionalProperties": false,
+      "description": "contains information on the origin of skaffold configurations cloned from a git repository.",
+      "x-intellij-html-description": "contains information on the origin of skaffold configurations cloned from a git repository."
     },
     "GitTagger": {
       "properties": {

--- a/docs/content/en/schemas/v2beta12.json
+++ b/docs/content/en/schemas/v2beta12.json
@@ -805,8 +805,8 @@
             "type": "string"
           },
           "type": "array",
-          "description": "describes the names of the required configs.",
-          "x-intellij-html-description": "describes the names of the required configs.",
+          "description": "includes specific named configs within the file path. If empty, then all configs in the file are included.",
+          "x-intellij-html-description": "includes specific named configs within the file path. If empty, then all configs in the file are included.",
           "default": "[]"
         },
         "git": {

--- a/docs/content/en/schemas/v2beta12.json
+++ b/docs/content/en/schemas/v2beta12.json
@@ -1203,12 +1203,18 @@
           "type": "string",
           "description": "git repository the package should be cloned from.  e.g. `https://github.com/GoogleContainerTools/skaffold.git`.",
           "x-intellij-html-description": "git repository the package should be cloned from.  e.g. <code>https://github.com/GoogleContainerTools/skaffold.git</code>."
+        },
+        "sync": {
+          "type": "boolean",
+          "description": "when set to `true` will reset the cached repository to the latest commit from remote on every run. To use the cached repository with uncommitted changes or unpushed commits, it needs to be set to `false`.",
+          "x-intellij-html-description": "when set to <code>true</code> will reset the cached repository to the latest commit from remote on every run. To use the cached repository with uncommitted changes or unpushed commits, it needs to be set to <code>false</code>."
         }
       },
       "preferredOrder": [
         "repo",
         "path",
-        "ref"
+        "ref",
+        "sync"
       ],
       "additionalProperties": false,
       "description": "contains information on the origin of skaffold configurations cloned from a git repository.",

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -24,7 +24,7 @@ import sys
 
 
 SKIPPED_DIRS = ["Godeps", "third_party", ".git", "vendor", "examples", "testdata", "node_modules", "codelab"]
-SKIPPED_FILES = ["install_golint.sh", "skaffold.pb.go", "skaffold.pb.gw.go", "build.sh", "statik.go"]
+SKIPPED_FILES = ["install_golint.sh", "skaffold.pb.go", "skaffold.pb.gw.go", "build.sh", "statik.go", "gitutil.go"]
 
 parser = argparse.ArgumentParser()
 parser.add_argument("filenames", help="list of files to check, all files if unspecified", nargs='*')

--- a/integration/examples/remote-multi-config-microservices/README.md
+++ b/integration/examples/remote-multi-config-microservices/README.md
@@ -1,0 +1,50 @@
+### Example: Remote config µSvcs with Skaffold
+
+In this example:
+
+* Deploy microservice applications from a remote git repository using Skaffold.
+
+Skaffold can build and deploy from configurations defined in remote git repositories. In this example, we'll walk through using skaffold to deploy two applications, an exposed "web" frontend which calls an unexposed "app" backend from the [examples/multi-config-microservices](../multi-config-microservices) project as a remote dependency.
+
+**WARNING: If you're running this on a cloud cluster, this example will create a service and expose a webserver.
+It's highly suggested that you only run this example on a local, private cluster like minikube or Kubernetes in Docker for Desktop.**
+
+#### Running the example on minikube
+
+From this directory, run:
+
+```bash
+skaffold dev
+```
+
+Now, in a different terminal, hit the `leeroy-web` endpoint
+
+```bash
+$ curl $(minikube service leeroy-web --url)
+leeroooooy app!
+```
+Hitting `Ctrl + C` on the first terminal should kill the process and clean up the deployments.
+
+#### Configuration walkthrough
+
+The [`skaffold.yaml`](./skaffold.yaml) looks like:
+
+```yaml
+apiVersion: skaffold/v2beta11
+kind: Config
+requires:
+- git:
+    repo: https://github.com/GoogleContainerTools/skaffold
+    path: examples/multi-config-microservices/leeroy-app
+    ref: master
+
+- git:
+    repo: https://github.com/GoogleContainerTools/skaffold
+    path: examples/multi-config-microservices/leeroy-web
+    ref: master
+
+```
+
+There are two `git` dependencies from the same repository `GoogleContainerTools/skaffold`. You can add as many dependencies as you want across the same or different repositories; even between different branches of the same repository. Skaffold downloads each referenced repository (one copy per referenced branch) to its cache folder (`~/.skaffold/repos` by default).
+
+The remote dependency caches should not be modified directly by the user. Skaffold will reset the cache to the latest from the remote on each run.

--- a/integration/examples/remote-multi-config-microservices/README.md
+++ b/integration/examples/remote-multi-config-microservices/README.md
@@ -14,14 +14,14 @@ It's highly suggested that you only run this example on a local, private cluster
 From this directory, run:
 
 ```bash
-skaffold dev
+skaffold dev --port-forward
 ```
 
 Now, in a different terminal, hit the `leeroy-web` endpoint
 
 ```bash
-$ curl $(minikube service leeroy-web --url)
-leeroooooy app!
+$ curl localhost:9000
+leeroooooy app!!
 ```
 Hitting `Ctrl + C` on the first terminal should kill the process and clean up the deployments.
 

--- a/integration/examples/remote-multi-config-microservices/skaffold.yaml
+++ b/integration/examples/remote-multi-config-microservices/skaffold.yaml
@@ -4,6 +4,8 @@ requires:
 - git:
     repo: https://github.com/GoogleContainerTools/skaffold
     path: examples/multi-config-microservices/leeroy-app
+    sync: false
 - git:
     repo: https://github.com/GoogleContainerTools/skaffold
     path: examples/multi-config-microservices/leeroy-web
+    sync: false

--- a/integration/examples/remote-multi-config-microservices/skaffold.yaml
+++ b/integration/examples/remote-multi-config-microservices/skaffold.yaml
@@ -1,0 +1,9 @@
+apiVersion: skaffold/v2beta12
+kind: Config
+requires:
+- git:
+    repo: https://github.com/GoogleContainerTools/skaffold
+    path: examples/multi-config-microservices/leeroy-app
+- git:
+    repo: https://github.com/GoogleContainerTools/skaffold
+    path: examples/multi-config-microservices/leeroy-web

--- a/integration/examples/typescript/skaffold.yaml
+++ b/integration/examples/typescript/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v2beta11
+apiVersion: skaffold/v2beta12
 kind: Config
 
 build:

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -64,6 +64,11 @@ func TestRun(t *testing.T) {
 			deployments: []string{"leeroy-app", "leeroy-web"},
 		},
 		{
+			description: "remote-multi-config-microservices",
+			dir:         "examples/remote-multi-config-microservices",
+			deployments: []string{"leeroy-app", "leeroy-web"},
+		},
+		{
 			description: "envTagger",
 			dir:         "examples/tagging-with-environment-variables",
 			pods:        []string{"getting-started"},

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -94,8 +94,8 @@ type SkaffoldOptions struct {
 	// TODO(https://github.com/GoogleContainerTools/skaffold/issues/3668):
 	// remove minikubeProfile from here and instead detect it by matching the
 	// kubecontext API Server to minikube profiles
-	MinikubeProfile string
-
+	MinikubeProfile  string
+	RepoCacheDir     string
 	WaitForDeletions WaitForDeletions
 }
 

--- a/pkg/skaffold/git/gitutil.go
+++ b/pkg/skaffold/git/gitutil.go
@@ -1,18 +1,18 @@
-/*
-Copyright 2021 The Skaffold Authors
+// code modified from https://github.com/GoogleContainerTools/kpt/blob/master/internal/gitutil/gitutil.go
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package git
 
@@ -34,11 +34,9 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
-// code adapted from https://github.com/GoogleContainerTools/kpt/blob/master/internal/gitutil/gitutil.go
-
 // SyncRepo syncs the target git repository with skaffold's local cache and returns the path to the repository root directory.
 var SyncRepo = syncRepo
-var searchGitPath = func() (string, error) { return exec.LookPath("git") }
+var findGit = func() (string, error) { return exec.LookPath("git") }
 
 // defaultRef returns the default ref as "master" if master branch exists in
 // remote repository, falls back to "main" if master branch doesn't exist
@@ -63,7 +61,7 @@ func defaultRef(repo string) (string, error) {
 
 // BranchExists checks if branch is present in the input repo
 func branchExists(repo, branch string) (bool, error) {
-	gitProgram, err := searchGitPath()
+	gitProgram, err := findGit()
 	if err != nil {
 		return false, err
 	}
@@ -182,7 +180,7 @@ type gitCmd struct {
 // Run runs a git command.
 // Omit the 'git' part of the command.
 func (g *gitCmd) Run(args ...string) ([]byte, error) {
-	p, err := searchGitPath()
+	p, err := findGit()
 	if err != nil {
 		return nil, fmt.Errorf("no 'git' program on path: %w", err)
 	}

--- a/pkg/skaffold/git/gitutil.go
+++ b/pkg/skaffold/git/gitutil.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package git
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+// code adapted from https://github.com/GoogleContainerTools/kpt/blob/master/internal/gitutil/gitutil.go
+
+// SyncRepo syncs the target git repository with skaffold's local cache and returns the path to the repository root directory.
+var SyncRepo = syncRepo
+var searchGitPath = func() (string, error) { return exec.LookPath("git") }
+
+// defaultRef returns the default ref as "master" if master branch exists in
+// remote repository, falls back to "main" if master branch doesn't exist
+func defaultRef(repo string) (string, error) {
+	masterRef := "master"
+	mainRef := "main"
+	masterExists, err := branchExists(repo, masterRef)
+	if err != nil {
+		return "", err
+	}
+	mainExists, err := branchExists(repo, mainRef)
+	if err != nil {
+		return "", err
+	}
+	if masterExists {
+		return masterRef, nil
+	} else if mainExists {
+		return mainRef, nil
+	}
+	return "", fmt.Errorf("failed to get default branch for repo %s", repo)
+}
+
+// BranchExists checks if branch is present in the input repo
+func branchExists(repo, branch string) (bool, error) {
+	gitProgram, err := searchGitPath()
+	if err != nil {
+		return false, err
+	}
+	out, err := util.RunCmdOut(exec.Command(gitProgram, "ls-remote", repo, branch))
+	if err != nil {
+		// stdErr contains the error message for os related errors, git permission errors
+		// and if repo doesn't exist
+		return false, fmt.Errorf("failed to lookup %s branch for repo %s: %w", branch, repo, err)
+	}
+	// stdOut contains the branch information if the branch is present in remote repo
+	// stdOut is empty if the repo doesn't have the input branch
+	if strings.TrimSpace(string(out)) != "" {
+		return true, nil
+	}
+	return false, nil
+}
+
+// getRepoDir returns the cache directory name for a remote repo
+func getRepoDir(g latest.GitInfo) (string, error) {
+	inputs := []string{g.Repo, g.Ref}
+	hasher := sha256.New()
+	enc := json.NewEncoder(hasher)
+	if err := enc.Encode(inputs); err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))[:32], nil
+}
+
+func getRepoCacheDir(opts config.SkaffoldOptions) (string, error) {
+	if opts.RepoCacheDir != "" {
+		return opts.RepoCacheDir, nil
+	}
+
+	// cache location unspecified, use ~/.skaffold/repos
+	home, err := homedir.Dir()
+	if err != nil {
+		return "", fmt.Errorf("retrieving home directory: %w", err)
+	}
+	return filepath.Join(home, constants.DefaultSkaffoldDir, "repos"), nil
+}
+
+func syncRepo(g latest.GitInfo, opts config.SkaffoldOptions) (string, error) {
+	skaffoldCacheDir, err := getRepoCacheDir(opts)
+	r := gitCmd{Dir: skaffoldCacheDir}
+	if err != nil {
+		return "", fmt.Errorf("failed to clone repo %s: %w", g.Repo, err)
+	}
+	if err := os.MkdirAll(skaffoldCacheDir, 0700); err != nil {
+		return "", fmt.Errorf(
+			"failed to clone repo %s: trouble creating cache directory: %w", g.Repo, err)
+	}
+
+	ref := g.Ref
+	if ref == "" {
+		ref, err = defaultRef(g.Repo)
+		if err != nil {
+			return "", fmt.Errorf("failed to clone repo %s: trouble getting default branch: %w", g.Repo, err)
+		}
+	}
+
+	hash, err := getRepoDir(g)
+	if err != nil {
+		return "", fmt.Errorf("failed to clone git repo: unable to create directory name: %w", err)
+	}
+	repoCacheDir := filepath.Join(skaffoldCacheDir, hash)
+	if _, err := os.Stat(repoCacheDir); os.IsNotExist(err) {
+		if err := r.Run("clone", g.Repo, hash, "--branch", ref, "--depth", "1"); err != nil {
+			return "", fmt.Errorf("failed to clone repo: %w", err)
+		}
+	} else {
+		r.Dir = repoCacheDir
+		// reset the repo state
+		if err = r.Run("fetch", "origin", ref); err != nil {
+			return "", fmt.Errorf("failed to clone repo %s: unable to find any matching refs %s; run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", g.Repo, ref, err)
+		}
+		if err := r.Run("reset", "--hard", "origin/"+ref); err != nil {
+			return "", fmt.Errorf("failed to clone repo %s: trouble resetting branch to origin/%s; run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", g.Repo, ref, err)
+		}
+	}
+	return repoCacheDir, nil
+}
+
+// gitCmd runs git commands in a git repo.
+type gitCmd struct {
+	// Dir is the directory the commands are run in.
+	Dir string
+}
+
+// Run runs a git command.
+// Omit the 'git' part of the command.
+func (g *gitCmd) Run(args ...string) error {
+	p, err := searchGitPath()
+	if err != nil {
+		return fmt.Errorf("no 'git' program on path: %w", err)
+	}
+
+	cmd := exec.Command(p, args...)
+	cmd.Dir = g.Dir
+	w := logrus.StandardLogger().WriterLevel(logrus.DebugLevel)
+	cmd.Stdout = w
+	cmd.Stderr = w
+	return util.RunCmd(cmd)
+}

--- a/pkg/skaffold/git/gitutil_test.go
+++ b/pkg/skaffold/git/gitutil_test.go
@@ -64,7 +64,7 @@ func TestDefaultRef(t *testing.T) {
 			} else {
 				f = f.AndRunOut("git ls-remote https://github.com/foo.git main", "")
 			}
-			t.Override(&searchGitPath, func() (string, error) { return "git", nil })
+			t.Override(&findGit, func() (string, error) { return "git", nil })
 			t.Override(&util.DefaultExecCommand, f)
 			ref, err := defaultRef("https://github.com/foo.git")
 			t.CheckErrorAndDeepEqual(test.err != nil, err, test.expected, ref)
@@ -215,7 +215,7 @@ func TestSyncRepo(t *testing.T) {
 					f = f.AndRunOutErr(v.cmd, v.out, v.err)
 				}
 			}
-			t.Override(&searchGitPath, func() (string, error) { return "git", nil })
+			t.Override(&findGit, func() (string, error) { return "git", nil })
 			t.Override(&util.DefaultExecCommand, f)
 			path, err := syncRepo(test.g, opts)
 			var expected string

--- a/pkg/skaffold/git/gitutil_test.go
+++ b/pkg/skaffold/git/gitutil_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package git
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDefaultRef(t *testing.T) {
+	tests := []struct {
+		description  string
+		masterExists bool
+		mainExists   bool
+		expected     string
+		err          error
+	}{
+		{
+			description:  "master branch exists",
+			masterExists: true,
+			mainExists:   true,
+			expected:     "master",
+		},
+		{
+			description: "master branch does not exist; main branch exists",
+			mainExists:  true,
+			expected:    "main",
+		},
+		{
+			description: "master and main don't exist",
+			err:         errors.New("failed to get default branch for repo http://github.com/foo.git"),
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			var f *testutil.FakeCmd
+			if test.masterExists {
+				f = testutil.CmdRunOut("git ls-remote https://github.com/foo.git master", "8be3f718c015a5fe190bebf356079a25afe0ca57  refs/heads/master")
+			} else {
+				f = testutil.CmdRunOut("git ls-remote https://github.com/foo.git master", "")
+			}
+			if test.mainExists {
+				f = f.AndRunOut("git ls-remote https://github.com/foo.git main", "8be3f718c015a5fe190bebf356079a25afe0ca58  refs/heads/main")
+			} else {
+				f = f.AndRunOut("git ls-remote https://github.com/foo.git main", "")
+			}
+			t.Override(&searchGitPath, func() (string, error) { return "git", nil })
+			t.Override(&util.DefaultExecCommand, f)
+			ref, err := defaultRef("https://github.com/foo.git")
+			t.CheckErrorAndDeepEqual(test.err != nil, err, test.expected, ref)
+		})
+	}
+}
+
+func TestSyncRepo(t *testing.T) {
+	tests := []struct {
+		description string
+		g           latest.GitInfo
+		cmds        map[string]error
+		existing    bool
+		shouldErr   bool
+		expected    string
+	}{
+		{
+			description: "first time repo clone succeeds",
+			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
+			cmds: map[string]error{
+				"git clone http://github.com/foo.git iSEL5rQfK5EJ2yLhnW8tUgcVOvDC8Wjl --branch master --depth 1": nil,
+			},
+			expected: "iSEL5rQfK5EJ2yLhnW8tUgcVOvDC8Wjl",
+		},
+		{
+			description: "first time repo clone fails",
+			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
+			cmds: map[string]error{
+				"git clone http://github.com/foo.git iSEL5rQfK5EJ2yLhnW8tUgcVOvDC8Wjl --branch master --depth 1": errors.New("error"),
+			},
+			shouldErr: true,
+		},
+		{
+			description: "existing repo update succeeds",
+			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
+			existing:    true,
+			cmds: map[string]error{
+				"git fetch origin master":        nil,
+				"git reset --hard origin/master": nil,
+			},
+			expected: "iSEL5rQfK5EJ2yLhnW8tUgcVOvDC8Wjl",
+		},
+		{
+			description: "existing repo update fails on fetch",
+			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
+			existing:    true,
+			cmds: map[string]error{
+				"git fetch origin master": errors.New("error"),
+			},
+			shouldErr: true,
+		},
+		{
+			description: "existing repo update fails on reset",
+			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
+			existing:    true,
+			cmds: map[string]error{
+				"git fetch origin master":        nil,
+				"git reset --hard origin/master": errors.New("error"),
+			},
+			shouldErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			td := t.NewTempDir()
+			if test.existing {
+				td.Touch("iSEL5rQfK5EJ2yLhnW8tUgcVOvDC8Wjl/.git/")
+			}
+			opts := config.SkaffoldOptions{RepoCacheDir: td.Root()}
+			var f *testutil.FakeCmd
+			for k, v := range test.cmds {
+				if f == nil {
+					f = testutil.CmdRunErr(k, v)
+				} else {
+					f = f.AndRunErr(k, v)
+				}
+			}
+			t.Override(&searchGitPath, func() (string, error) { return "git", nil })
+			t.Override(&util.DefaultExecCommand, f)
+			path, err := syncRepo(test.g, opts)
+			var expected string
+			if !test.shouldErr {
+				expected = filepath.Join(td.Root(), test.expected)
+			}
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, expected, path)
+		})
+	}
+}

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -92,7 +92,7 @@ type GitInfo struct {
 
 // ConfigDependency describes a dependency on another skaffold configuration.
 type ConfigDependency struct {
-	// Names describes the names of the required configs.
+	// Names includes specific named configs within the file path. If empty, then all configs in the file are included.
 	Names []string `yaml:"configs,omitempty"`
 
 	// Path describes the path to the file containing the required configs.

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -75,13 +75,28 @@ type Pipeline struct {
 	PortForward []*PortForwardResource `yaml:"portForward,omitempty"`
 }
 
+// GitInfo contains information on the origin of skaffold configurations cloned from a git repository.
+type GitInfo struct {
+	// Repo is the git repository the package should be cloned from.  e.g. `https://github.com/GoogleContainerTools/skaffold.git`.
+	Repo string `yaml:"repo" yamltags:"required"`
+
+	// Path is the relative path from the repo root to the skaffold configuration file. eg. `getting-started/skaffold.yaml`.
+	Path string `yaml:"path,omitempty"`
+
+	// Ref is the git ref the package should be cloned from. eg. `master` or `main`.
+	Ref string `yaml:"ref,omitempty"`
+}
+
 // ConfigDependency describes a dependency on another skaffold configuration.
 type ConfigDependency struct {
 	// Names describes the names of the required configs.
 	Names []string `yaml:"configs,omitempty"`
 
 	// Path describes the path to the file containing the required configs.
-	Path string `yaml:"path" skaffold:"filepath"`
+	Path string `yaml:"path" skaffold:"filepath" yamltags:"oneOf=paths"`
+
+	// GitRepo describes a remote git repository containing the required configs.
+	GitRepo *GitInfo `yaml:"git" yamltags:"oneOf=paths"`
 
 	// ActiveProfiles describes the list of profiles to activate when resolving the required configs. These profiles must exist in the imported config.
 	ActiveProfiles []ProfileDependency `yaml:"activeProfiles,omitempty"`

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -85,6 +85,9 @@ type GitInfo struct {
 
 	// Ref is the git ref the package should be cloned from. eg. `master` or `main`.
 	Ref string `yaml:"ref,omitempty"`
+
+	// Sync when set to `true` will reset the cached repository to the latest commit from remote on every run. To use the cached repository with uncommitted changes or unpushed commits, it needs to be set to `false`.
+	Sync *bool `yaml:"sync,omitempty"`
 }
 
 // ConfigDependency describes a dependency on another skaffold configuration.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5302 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Implements defining remote git repositories as skaffold config dependencies.

```yaml
apiVersion: skaffold/v2beta12
kind: Config
requires:
- git:
    repo: https://github.com/GoogleContainerTools/skaffold
    path: examples/multi-config-microservices/leeroy-app
- git:
    repo: https://github.com/GoogleContainerTools/skaffold
    path: examples/multi-config-microservices/leeroy-web
```


The environment variable `SKAFFOLD_REMOTE_CACHE_DIR` or flag `--remote-cache-dir` specifies the download location for all remote repos. If undefined then it defaults to `~/.skaffold/repos`. 
The repo root directory name is a hash of the repo `uri` and the `branch/ref`.
Every execution of a remote module resets the cached repo to the referenced ref. The default ref is `master`. If `master` is not defined then it defaults to `main`.
The remote config gets treated like a local config after substituting the path with the actual path in the cache directory.
 
Look at the new [`remote-multi-config-microservices`](https://github.com/gsquared94/skaffold/tree/remote-config-dependencies-2/integration/examples/remote-multi-config-microservices) example