### PR TITLE
add dark mode option to skaffold website

### DIFF
--- a/docs/layouts/partials/hooks/head-end.html
+++ b/docs/layouts/partials/hooks/head-end.html
@@ -4,6 +4,7 @@
 <link href="/stylesheets/colors.css" rel="stylesheet">
 <link href="/stylesheets/infopanel.css" rel="stylesheet">
 <link href="/stylesheets/landing.css" rel="stylesheet">
+<link disabled href="/stylesheets/dark.css" id="dark-mode-theme" rel="stylesheet">
 
 <link href="https://fonts.googleapis.com/css?family=Exo+2" rel="stylesheet">
 
@@ -11,5 +12,6 @@
 <script src="/javascripts/fade.js"></script>
 
 <script src="https://kit.fontawesome.com/077204b73e.js" crossorigin="anonymous"></script>
+<script src="/javascripts/dark.js"></script>
 <link rel="stylesheet" type="text/css" href="/swagger/swagger-ui.css">
 <link rel="stylesheet" type="text/css" href="/swagger/custom.css">

--- a/docs/layouts/partials/navbar.html
+++ b/docs/layouts/partials/navbar.html
@@ -34,4 +34,6 @@
 		</ul>
 	</div>
 	<div class="skaffold-navbar navbar-nav d-none d-lg-block">{{ partial "search-input.html" . }}</div>
+	<div class="skaffold-navbar navbar-nav" ><a id="dark-mode-toggle" class="fa fa-moon-o" title="Enable Dark Mode"></a></div>
+	
 </nav>

--- a/docs/static/javascripts/dark.js
+++ b/docs/static/javascripts/dark.js
@@ -1,0 +1,31 @@
+// adapted from https://radu-matei.com/blog/dark-mode/
+window.onload = function(){
+  var toggle = document.getElementById("dark-mode-toggle");
+  var darkTheme = document.getElementById("dark-mode-theme");
+
+  // the default theme is light
+  var savedTheme = localStorage.getItem("dark-mode-storage") || "dark";
+  setTheme(savedTheme);
+
+  toggle.addEventListener("click", () => {
+    if (toggle.className === "fa fa-moon-o") {
+      setTheme("dark");
+    } else if (toggle.className === "fa fa-sun-o") {
+      setTheme("light");
+    }
+  });
+
+  function setTheme(mode) {
+    localStorage.setItem("dark-mode-storage", mode);
+  
+    if (mode === "dark") {
+      darkTheme.disabled = false;
+      toggle.className = "fa fa-sun-o";
+      toggle.title = "Enable Light Mode";
+    } else if (mode === "light") {
+      darkTheme.disabled = true;
+      toggle.className = "fa fa-moon-o";
+      toggle.title = "Enable Dark Mode";
+    }
+  }
+}

--- a/docs/static/stylesheets/dark.css
+++ b/docs/static/stylesheets/dark.css
@@ -1,0 +1,15 @@
+html {
+background-color: #171717 !important;
+}
+
+body {
+filter: invert(100%) hue-rotate(180deg) brightness(105%) contrast(85%);
+-webkit-filter: invert(100%) hue-rotate(180deg) brightness(105%) contrast(85%);
+}
+
+img,
+video,
+iframe {
+filter: hue-rotate(180deg) contrast(100%) invert(100%);
+-webkit-filter: hue-rotate(180deg) contrast(100%) invert(100%);
+}


### PR DESCRIPTION
Was wondering how to add dark mode to our docs website. WDYT? 🤷🏾‍♂️

![image](https://user-images.githubusercontent.com/39389231/107255587-53430980-69ed-11eb-86bb-c65e6db0321c.png)

![image](https://user-images.githubusercontent.com/39389231/107255556-48887480-69ed-11eb-8a94-afb8e25fc2e4.png)

link: http://34.94.21.130:1313