### PR TITLE
Disable telemetry reporting for nightlies

### DIFF
--- a/.github/workflows/integration-darwin.yml
+++ b/.github/workflows/integration-darwin.yml
@@ -99,4 +99,6 @@ jobs:
     - name: Run integration tests
       env:
         TOKEN: ${{ secrets.TOKEN }}
-      run: IT_PARTITION=${{ matrix.integration_test_partitions }} make integration-tests
+      run: |
+        skaffold config set --global collect-metrics false
+        IT_PARTITION=${{ matrix.integration_test_partitions }} make integration-tests

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -86,4 +86,6 @@ jobs:
     - name: Run integration tests
       env:
         TOKEN: ${{ secrets.TOKEN }}
-      run: sudo IT_PARTITION=${{ matrix.integration_test_partitions }} make integration-tests
+      run: |
+        skaffold config set --global collect-metrics false
+        sudo IT_PARTITION=${{ matrix.integration_test_partitions }} make integration-tests


### PR DESCRIPTION
**Description**
We suspect that some of our nightly numbers might be coming from our own nightly tests, which use our latest binaries.
