### PR TITLE
Fix issue where default-repo wasn't being added to artifact tags (#5341)

### DIFF
--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -59,7 +59,7 @@ func doDeploy(ctx context.Context, out io.Writer) error {
 		for _, cfg := range configs {
 			artifacts = append(artifacts, cfg.Build.Artifacts...)
 		}
-		buildArtifacts, err := getBuildArtifactsAndSetTags(r, artifacts)
+		buildArtifacts, err := getBuildArtifactsAndSetTags(artifacts, r.ApplyDefaultRepo)
 		if err != nil {
 			tips.PrintUseRunVsDeploy(out)
 			return err

--- a/cmd/skaffold/app/cmd/test.go
+++ b/cmd/skaffold/app/cmd/test.go
@@ -44,7 +44,7 @@ func doTest(ctx context.Context, out io.Writer) error {
 		for _, c := range configs {
 			artifacts = append(artifacts, c.Build.Artifacts...)
 		}
-		buildArtifacts, err := getBuildArtifactsAndSetTags(r, artifacts)
+		buildArtifacts, err := getBuildArtifactsAndSetTags(artifacts, r.ApplyDefaultRepo)
 		if err != nil {
 			tips.PrintForTest(out)
 			return err


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5341, #5463

**Description**
Using the `--default-repo` option on `deploy` commands wasn't being honoured and the default tag was being deployed.

It's a simple bug... The for-loop in `getBuildArtifactsAndSetTags` is correctly prefixing the tag with the --default-repo option but was setting it on the for-loop variable (which is a pointer re-used in each loop), and not updating the actual `buildArtifacts` slice.

I haven't added any tests, this is my first contribution and not sure how to get a `runner.Runner` in a test environment. If you want tests adding for this change could somebody give me a point in the right direction 🙂 