### PR TITLE
Fixes #5404: Skaffold configs downloaded from a url can define remote config dependencies

### DIFF
--- a/cmd/skaffold/app/cmd/parse_config.go
+++ b/cmd/skaffold/app/cmd/parse_config.go
@@ -219,6 +219,9 @@ func processEachDependency(d latest.ConfigDependency, cfgOpts configOpts, opts c
 			path = filepath.Join(path, "skaffold.yaml")
 		}
 	}
+
+	// if the current and previous configuration files are the same, then current config should be treated as a dependency config if the previous config was also a dependency config.
+	// Otherwise the current config is always a dependency config if the file path is different than the previous.
 	cfgOpts.isDependency = cfgOpts.isDependency || path != cfgOpts.file
 	cfgOpts.file = path
 	cfgOpts.selection = d.Names

--- a/cmd/skaffold/app/cmd/parse_config.go
+++ b/cmd/skaffold/app/cmd/parse_config.go
@@ -210,7 +210,7 @@ func processEachDependency(d latest.ConfigDependency, cfgOpts configOpts, opts c
 	if !util.IsURL(path) {
 		fi, err := os.Stat(path)
 		if err != nil {
-			if os.IsNotExist(errors.Unwrap(err)) {
+			if errors.Is(err, os.ErrNotExist) {
 				return nil, fmt.Errorf("could not find skaffold config %s that is referenced as a dependency in config %s", path, cfgOpts.file)
 			}
 			return nil, fmt.Errorf("parsing dependencies for skaffold config %s: %w", cfgOpts.file, err)

--- a/cmd/skaffold/app/cmd/parse_config_test.go
+++ b/cmd/skaffold/app/cmd/parse_config_test.go
@@ -443,13 +443,3 @@ requires:
 		})
 	}
 }
-
-func errorsComparer(a, b error) bool {
-	if a == nil && b == nil {
-		return true
-	}
-	if a == nil || b == nil {
-		return false
-	}
-	return a.Error() == b.Error()
-}

--- a/cmd/skaffold/app/cmd/parse_config_test.go
+++ b/cmd/skaffold/app/cmd/parse_config_test.go
@@ -362,14 +362,14 @@ requires:
 `}}},
 				{path: "doc1/skaffold.yaml", configs: []mockCfg{{name: "cfg10"}, {name: "cfg11"}, {name: "cfg00"}}},
 			},
-			err: `skaffold config named "cfg00" found in multiple files: "WORK_DIR/skaffold.yaml" and "WORK_DIR/doc1/skaffold.yaml"`,
+			err: fmt.Sprintf(`skaffold config named "cfg00" found in multiple files: %q and %q`,filepath.Join("WORK_DIR", "skaffold.yaml"), filepath.Join("WORK_DIR", "doc1", "skaffold.yaml")),
 		},
 		{
 			description: "duplicate config names in main config",
 			documents: []document{
 				{path: "skaffold.yaml", configs: []mockCfg{{name: "cfg00"}, {name: "cfg00"}}},
 			},
-			err: `multiple skaffold configs named "cfg00" found in file "WORK_DIR/skaffold.yaml"`,
+			err: fmt.Sprintf(`multiple skaffold configs named "cfg00" found in file %q`, filepath.Join("WORK_DIR", "skaffold.yaml")),
 		},
 		{
 			description: "remote dependencies",


### PR DESCRIPTION
Fixes #5404 

This PR makes two changes:
- Fix the config parsing logic that was erroneously checking that a dependency config file exists on disk even if it's a URL. 
- Add missing check that multiple configs in the same file cannot have the same name.