### PR TITLE
Make hack/new_version.sh propose a realistic next version

### DIFF
--- a/hack/versions/cmd/new/version.go
+++ b/hack/versions/cmd/new/version.go
@@ -48,6 +48,7 @@ func main() {
 	}
 
 	next := readNextVersion(current)
+	logrus.Infof("Next Skaffold version: %s", next)
 
 	makeSchemaDir(current)
 

--- a/hack/versions/cmd/new/version.go
+++ b/hack/versions/cmd/new/version.go
@@ -116,17 +116,19 @@ func readNextVersion(current string) string {
 	var new string
 	if len(os.Args) <= 1 {
 		proposal := bumpVersion(current)
-		color.Red.Fprintf(os.Stdout, "Please enter new version (e.g. %s): ", proposal)
+		color.Red.Fprintf(os.Stdout, "Please enter new version (default: %s): ", proposal)
 		reader := bufio.NewReader(os.Stdin)
-		if line, err := reader.ReadString('\n'); err == nil {
+		if line, err := reader.ReadString('\n'); err != nil {
+			logrus.Fatalf("error reading input: %s", err)
+		} else if line != "" {
 			new = line
 		} else {
-			logrus.Fatalf("error reading input: %s", err)
+			new = proposal
 		}
 	} else {
 		new = os.Args[1]
 	}
-	return strings.TrimSuffix(new, "\n")
+	return strings.TrimSpace(new)
 }
 
 // bumpVersion increments a KRM-style version string (v1 -> v2alpha1, v2beta11 -> v2beta12).

--- a/hack/versions/cmd/new/version.go
+++ b/hack/versions/cmd/new/version.go
@@ -116,15 +116,13 @@ func makeSchemaDir(new string) {
 func readNextVersion(current string) string {
 	var new string
 	if len(os.Args) <= 1 {
-		proposal := bumpVersion(current)
-		color.Red.Fprintf(os.Stdout, "Please enter new version (default: %s): ", proposal)
+		new = bumpVersion(current)
+		color.Red.Fprintf(os.Stdout, "Please enter new version (default: %s): ", new)
 		reader := bufio.NewReader(os.Stdin)
 		if line, err := reader.ReadString('\n'); err != nil {
 			logrus.Fatalf("error reading input: %s", err)
-		} else if line != "" {
+		} else if strings.TrimSpace(line) != "" {
 			new = line
-		} else {
-			new = proposal
 		}
 	} else {
 		new = os.Args[1]

--- a/hack/versions/cmd/new/version.go
+++ b/hack/versions/cmd/new/version.go
@@ -47,6 +47,8 @@ func main() {
 		logrus.Fatalf("There is no need to create a new version, %s is still not released", current)
 	}
 
+	next := readNextVersion(current)
+
 	makeSchemaDir(current)
 
 	// Create a package for current version
@@ -55,8 +57,6 @@ func main() {
 		sed(path(current, info.Name()), "package latest", "package "+current)
 		return nil
 	})
-
-	next := readNextVersion(current)
 
 	// Create code to upgrade from current to new
 	cp(path(prev, "upgrade.go"), path(current, "upgrade.go"))


### PR DESCRIPTION
**Description**
This PR brings in a few Improvements to our `hack/new_version.sh` script:
  1. It attempts to calculate the next version (`v1` &rarr; `v2alpha1`, `v2alpha1` &rarr; `v2alpha2`).
  2. This proposed new version is the default.
  3. Defers making any changes to the file system until after the next version is obtained.  Otherwise a user can't <kbd>Ctrl</kbd><kbd>C</kbd> and then re-run as the schema directory for the current version had already been created.

```console
$ ./hack/new_version.sh
INFO[0000] Previous Skaffold version: v2beta11          
DEBU[0000] Current Skaffold version: v2beta12           
Please enter new version (default: v2beta13): <enter>
INFO[0003] Next Skaffold version: v2beta13              
```
