### PR TITLE
Handle nil PortForward item on setting defaults

### DIFF
--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -98,7 +98,7 @@ func Set(c *latest.SkaffoldConfig) error {
 
 	for i, pf := range c.PortForward {
 		if pf == nil {
-			return fmt.Errorf("portForward[%d] of config name with '%s' is empty, Please check if it has valid values", i, c.Metadata.Name)
+			return fmt.Errorf("portForward[%d] of config with name '%s' is empty, Please check if it has valid values", i, c.Metadata.Name)
 		}
 		setDefaultLocalPort(pf)
 		setDefaultAddress(pf)

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -96,7 +96,10 @@ func Set(c *latest.SkaffoldConfig) error {
 		return err
 	}
 
-	for _, pf := range c.PortForward {
+	for i, pf := range c.PortForward {
+		if pf == nil {
+			return fmt.Errorf("Config's portForward[%d] is empty, Please check if it has valid values", i)
+		}
 		setDefaultLocalPort(pf)
 		setDefaultAddress(pf)
 	}
@@ -360,6 +363,9 @@ func currentNamespace() (string, error) {
 }
 
 func setDefaultLocalPort(pf *latest.PortForwardResource) {
+	if pf == nil {
+		logrus.Debugf("PortFoward resource is nil")
+	}
 	if pf.LocalPort == 0 {
 		if pf.Port.Type == schemautil.Int {
 			pf.LocalPort = pf.Port.IntVal

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -363,9 +363,6 @@ func currentNamespace() (string, error) {
 }
 
 func setDefaultLocalPort(pf *latest.PortForwardResource) {
-	if pf == nil {
-		logrus.Debugf("PortFoward resource is nil")
-	}
 	if pf.LocalPort == 0 {
 		if pf.Port.Type == schemautil.Int {
 			pf.LocalPort = pf.Port.IntVal

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -98,7 +98,7 @@ func Set(c *latest.SkaffoldConfig) error {
 
 	for i, pf := range c.PortForward {
 		if pf == nil {
-			return fmt.Errorf("config's portForward[%d] is empty, Please check if it has valid values", i)
+			return fmt.Errorf("portForward[%d] of config name with '%s' is empty, Please check if it has valid values", i, c.Metadata.Name)
 		}
 		setDefaultLocalPort(pf)
 		setDefaultAddress(pf)

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -98,7 +98,7 @@ func Set(c *latest.SkaffoldConfig) error {
 
 	for i, pf := range c.PortForward {
 		if pf == nil {
-			return fmt.Errorf("Config's portForward[%d] is empty, Please check if it has valid values", i)
+			return fmt.Errorf("config's portForward[%d] is empty, Please check if it has valid values", i)
 		}
 		setDefaultLocalPort(pf)
 		setDefaultAddress(pf)

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -351,7 +351,6 @@ func TestSetPortForwardOnEmptyPortForwardResource(t *testing.T) {
 		},
 	}
 	err := Set(cfg)
-	SetDefaultDeployer(cfg)
 	testutil.CheckError(t, true, err)
 }
 

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package defaults
 
 import (
-	"fmt"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -352,7 +351,6 @@ func TestSetPortForwardOnEmptyPortForwardResource(t *testing.T) {
 		},
 	}
 	err := Set(cfg)
-	fmt.Println(err.Error())
 	SetDefaultDeployer(cfg)
 	testutil.CheckError(t, true, err)
 }

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package defaults
 
 import (
+	"fmt"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd/api"
@@ -339,6 +340,21 @@ func TestSetPortForwardLocalPort(t *testing.T) {
 	testutil.CheckError(t, false, err)
 	testutil.CheckDeepEqual(t, 8080, cfg.PortForward[0].LocalPort)
 	testutil.CheckDeepEqual(t, 9000, cfg.PortForward[1].LocalPort)
+}
+
+func TestSetPortForwardOnEmptyPortForwardResource(t *testing.T) {
+	cfg := &latest.SkaffoldConfig{
+		Pipeline: latest.Pipeline{
+			Build: latest.BuildConfig{},
+			PortForward: []*latest.PortForwardResource{
+				nil,
+			},
+		},
+	}
+	err := Set(cfg)
+	fmt.Println(err.Error())
+	SetDefaultDeployer(cfg)
+	testutil.CheckError(t, true, err)
 }
 
 func TestSetDefaultPortForwardAddress(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5363 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

Handles default-setting with list of `PortForward`s containing `nil` item.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

When user run with following `skaffold.yaml`:

```yaml
apiVersion: skaffold/v2beta10
kind: Config
metadata:
  name: bug
portForward:
 -
```

Then, will get looks like:

```bash
parsing skaffold config: setting default values: Config's portForward[0] is empty, Please check if it has valid values
```

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
