### PR TITLE
Add example to use docker buildx via the custom builder

### DIFF
--- a/examples/custom-buildx/Dockerfile
+++ b/examples/custom-buildx/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.16-alpine as builder
+COPY main.go .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+
+FROM alpine:3
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/examples/custom-buildx/Dockerfile
+++ b/examples/custom-buildx/Dockerfile
@@ -1,6 +1,8 @@
-# If using a cross-platform language toolchain like Go, then `--platform=$BUILDPLATFORM`
-# will result in a speed-up as the build will proceed on the native architecture rather
-# than emulation.
+# As Go supports cross-compilation, `--platform=$BUILDPLATFORM`
+# results in a dramatic speed-up as the build runs natively
+# instead of using emulation.
+# BUILD{PLATFORM,OS,ARCH} are set to your docker engine's platform
+# TARGET{PLATFORM,OS,ARCH} are set to the desired platform
 FROM --platform=$BUILDPLATFORM golang:alpine AS builder
 
 COPY main.go .

--- a/examples/custom-buildx/Dockerfile
+++ b/examples/custom-buildx/Dockerfile
@@ -1,8 +1,15 @@
-FROM golang:1.16-alpine as builder
+# If using a cross-platform language toolchain like Go, then `--platform=$BUILDPLATFORM`
+# will result in a speed-up as the build will proceed on the native architecture rather
+# than emulation.
+FROM --platform=$BUILDPLATFORM golang:alpine AS builder
+
 COPY main.go .
+
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+ARG TARGETOS
+ARG TARGETARCH
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/examples/custom-buildx/README.md
+++ b/examples/custom-buildx/README.md
@@ -47,7 +47,7 @@ $ cd skaffold/examples/custom-buildx
 
 Take a look at the [skaffold.yaml](skaffold.yaml), which uses a
 _custom builder_ to invoke `docker buildx` to containerize source
-code. 
+code.
 For more information about custom builders, see the Skaffold custom
 builder [documentation](https://skaffold.dev/docs/how-tos/builders/#custom-build-script-run-locally).
 Note that Skaffold builders are different from Docker Buildx builders.

--- a/examples/custom-buildx/README.md
+++ b/examples/custom-buildx/README.md
@@ -115,7 +115,7 @@ depending on the `$PUSH_IMAGE` flag.
 
 But Skaffold is unaware that the build result differs based on `$PUSH_IMAGE`.
 So on a local-build, Skaffold will cache the local-platform artifact,
-and that artifact will be used that for subsequent deployments even if
+and that artifact will be used that for subsequent deployments even if pushed
 to a remote registry (assuming the source is unchanged).  To avoid
 this scenario, disable Skaffold's artifact caching when the result
 is to be pushed to a remote registry:
@@ -123,4 +123,3 @@ is to be pushed to a remote registry:
 ```
 skaffold build --cache-artifacts=false
 ```
-

--- a/examples/custom-buildx/README.md
+++ b/examples/custom-buildx/README.md
@@ -6,7 +6,7 @@ platforms.
 
 This example shows how `docker buildx` can be used as a
 Skaffold _custom builder_ to create container images for
-for two different platforms: linux/arm64 and linux/amd64.
+for two different platforms: `linux/arm64` and `linux/amd64`.
 
 #### Before you begin
 
@@ -47,10 +47,17 @@ $ cd skaffold/examples/custom-buildx
 
 Take a look at the [skaffold.yaml](skaffold.yaml), which uses a
 _custom builder_ to invoke `docker buildx` to containerize source
-code.
+code for two platforms.
 For more information about custom builders, see the Skaffold custom
 builder [documentation](https://skaffold.dev/docs/how-tos/builders/#custom-build-script-run-locally).
-Note that Skaffold builders are different from Docker Buildx builders.
+Note that Skaffold builders are different from `docker buildx` builders.
+
+Next look at the Kubernetes [pod descriptor](k8s/pod.yaml) and notice
+the use of _node affinities_ to instruct Kubernetes to scheduler the workload
+on nodes running either `linux/arm64` or `linux/amd64`.  It is important
+to realize that Kubernetes does not examine the referenced container images
+to determine the possible platforms.
+
 
 ##### Step 3: Build and deploy the example
 

--- a/examples/custom-buildx/README.md
+++ b/examples/custom-buildx/README.md
@@ -97,11 +97,11 @@ Using `buildx` to build for multiple platforms has some subtle
 interactions with Skaffold's artifact caching.
 
 Skaffold normally caches the artifact after a successful container
-image build using the principle that a build should produce the
-same container image given the same source.  Skaffold records an
-association of the resulting image digest with a hash of the artifact
-source.  This principle is the same as how Docker and other builders
-cache image layers to speed up builds.
+image build.  Using the principle that given the same source inputs,
+a build should produce the same container image, Skaffold records
+an association of the resulting image digest with a hash of the
+artifact source.  This is the same principle used followed Docker
+and other builders to cache image layers to speed up builds.
 
 In this example, the build script configures Buildx differently
 depending on the `$PUSH_IMAGE` flag. 
@@ -113,12 +113,13 @@ depending on the `$PUSH_IMAGE` flag.
     the Docker Daemon, and so this example builds a single container
     image for the local platform.
 
-But Skaffold is unaware of the platforms built by this custom builder,
-and so on completion Skaffold will cache the built artifact.  So on
-a local-build, Skaffold will cache the local-platform artifact and
-use that for subsequent deployments (assuming the source is unchanged).
-To avoid this scenario, disable Skaffold's artifact cache when the
-result is to be pushed to a remote registry:
+But Skaffold is unaware that the build result differs based on `$PUSH_IMAGE`.
+So on a local-build, Skaffold will cache the local-platform artifact,
+and that artifact will be used that for subsequent deployments even if
+to a remote registry (assuming the source is unchanged).  To avoid
+this scenario, disable Skaffold's artifact caching when the result
+is to be pushed to a remote registry:
+
 ```
 skaffold build --cache-artifacts=false
 ```

--- a/examples/custom-buildx/README.md
+++ b/examples/custom-buildx/README.md
@@ -21,8 +21,8 @@ requires pushing images to a container registry such as
 #### Tutorial
 
 This tutorial will demonstrate how Skaffold can build a simple
-_Hello World_ Go application with `docker buildx` and deploy it to
-a Kubernetes cluster.
+_Hello World_ Go application for linux/amd64 and linux/arm64 using
+`docker buildx` and deploy it to a Kubernetes cluster.
 
 ##### Step 1: Configure _Docker Buildx_
 
@@ -64,14 +64,8 @@ With this command, Skaffold will build the artifact with `docker buildx`
 and deploy the application to Kubernetes.  You should be able to
 see *Hello, World!* printed every second in the Skaffold logs.
 
-If Skaffold fails with a message like the following, then Skaffold is
-attempting to load the multi-platform images into the Docker Daemon,
-is pushing the images
-to a registry instead.
-```
-error: failed to solve: rpc error: code = Unknown desc = docker exporter does not currently support exporting manifest lists
-exiting dev mode because first build failed: building custom artifact: exit status 1
-```
+We need to use `--default-repo` to push to a repository as Docker does
+not support loading multi-platform images with the same name.
 
 #### Cleanup
 

--- a/examples/custom-buildx/README.md
+++ b/examples/custom-buildx/README.md
@@ -123,3 +123,10 @@ is to be pushed to a remote registry:
 ```
 skaffold build --cache-artifacts=false
 ```
+
+##### Considerations with `skaffold dev`
+
+When using `skaffold dev` with a remote cluster, this example causes unnecessary
+work as it builds and pushes for multiple platforms on each change.  You could
+optimize for this case by using a Docker build through a [command-activated
+profile](https://skaffold.dev/docs/environment/profiles/#activation).

--- a/examples/custom-buildx/README.md
+++ b/examples/custom-buildx/README.md
@@ -55,6 +55,10 @@ For more information on configuring a custom builder, see the Skaffold custom
 builder [documentation](https://skaffold.dev/docs/how-tos/builders/#custom-build-script-run-locally).
 Note that Skaffold builders are different from `docker buildx` builders.
 
+Note that Buildx does not support loading images for multiple platforms
+o the Docker Daemon.  So this [`build.sh`](build.sh) only uses Buildx
+when pushing an image to a registry.  See the _Cautions_ section below.
+
 
 ##### Step 3: Configure node affinities
 
@@ -109,14 +113,14 @@ depending on the `$PUSH_IMAGE` flag.
   - When `true`, the result is to be pushed to a registry, and all
     registries support multi-platform images. 
   - When `false`, the result is to be loaded to the Docker Daemon. 
-    But Buildx does not support loading multi-platform images to
+    Buildx does not support loading multi-platform images to
     the Docker Daemon, and so this example builds a single container
     image for the local platform.
 
 But Skaffold is unaware that the build result differs based on `$PUSH_IMAGE`.
-So on a local-build, Skaffold will cache the local-platform artifact,
-and that artifact will be used that for subsequent deployments even if pushed
-to a remote registry (assuming the source is unchanged).  To avoid
+So on a local build (`$PUSH_IMAGE=false`), Skaffold will cache the single-platform image,
+and that single-platform image will be used for subsequent deployments _even when pushing
+to a remote registry_ providing the source is unchanged.  To avoid
 this scenario, disable Skaffold's artifact caching when the result
 is to be pushed to a remote registry:
 

--- a/examples/custom-buildx/README.md
+++ b/examples/custom-buildx/README.md
@@ -1,0 +1,82 @@
+### Example: use the custom builder with `docker buildx`
+
+[Docker Buildx](https://github.com/docker/buildx#buildx) is an
+experimental feature for building container images for multiple
+platforms.
+
+This example shows how `docker buildx` can be used as a
+Skaffold _custom builder_ to create container images for
+for two different platforms: linux/arm64 and linux/amd64.
+
+#### Before you begin
+
+For this tutorial to work you need to ensure Skaffold and a Kubernetes
+cluster are set up.  To learn more about how to set up Skaffold and
+a Kubernetes cluster, see the [getting started docs](https://skaffold.dev/docs/getting-started).
+
+Note that this example builds for two different platforms and
+requires pushing images to a container registry such as
+[Google Artifact Registry](https://cloud.google.com/artifact-registry).
+
+#### Tutorial
+
+This tutorial will demonstrate how Skaffold can build a simple
+_Hello World_ Go application with `docker buildx` and deploy it to
+a Kubernetes cluster.
+
+##### Step 1: Configure _Docker Buildx_
+
+To use `docker buildx` you must first create a named _builder_ with
+the set of platforms to be built.  Run the following to create a
+builder named `skaffold-builder` to build for `linux/arm64` and
+`linux/amd64`:
+
+```
+docker buildx create --name skaffold-builder --platform linux/arm64,linux/amd64
+```
+
+##### Step 2: Obtain the example
+
+First, clone the Skaffold [repo](https://github.com/GoogleContainerTools/skaffold)
+and navigate to the [`custom-buildx` example](https://github.com/GoogleContainerTools/skaffold/tree/master/examples/custom) for sample code:
+
+```shell
+$ git clone https://github.com/GoogleContainerTools/skaffold
+$ cd skaffold/examples/custom-buildx
+```
+
+Take a look at the [skaffold.yaml](skaffold.yaml), which uses a
+_custom builder_ to invoke `docker buildx` to containerize source
+code. 
+For more information about custom builders, see the Skaffold custom
+builder [documentation](https://skaffold.dev/docs/how-tos/builders/#custom-build-script-run-locally).
+Note that Skaffold builders are different from Docker Buildx builders.
+
+##### Step 3: Build and deploy the example
+
+Now, use Skaffold to deploy this application to your Kubernetes cluster:
+
+```shell
+$ skaffold run --tail --default-repo <your repo>
+```
+
+With this command, Skaffold will build the artifact with `docker buildx`
+and deploy the application to Kubernetes.  You should be able to
+see *Hello, World!* printed every second in the Skaffold logs.
+
+If Skaffold fails with a message like the following, then Skaffold is
+attempting to load the multi-platform images into the Docker Daemon,
+is pushing the images
+to a registry instead.
+```
+error: failed to solve: rpc error: code = Unknown desc = docker exporter does not currently support exporting manifest lists
+exiting dev mode because first build failed: building custom artifact: exit status 1
+```
+
+#### Cleanup
+
+To clean up your Kubernetes cluster, run:
+
+```shell
+$ skaffold delete
+```

--- a/examples/custom-buildx/README.md
+++ b/examples/custom-buildx/README.md
@@ -2,11 +2,10 @@
 
 [Docker Buildx](https://github.com/docker/buildx#buildx) is an
 experimental feature for building container images for multiple
-platforms.
+platforms.  This example shows how `docker buildx` can be used as
+a Skaffold _custom builder_ to create container images for the
+`linux/arm64` and `linux/amd64` platforms.
 
-This example shows how `docker buildx` can be used as a
-Skaffold _custom builder_ to create container images for
-for two different platforms: `linux/arm64` and `linux/amd64`.
 
 #### Before you begin
 
@@ -20,22 +19,12 @@ requires pushing images to a container registry such as
 
 #### Tutorial
 
-This tutorial will demonstrate how Skaffold can build a simple
-_Hello World_ Go application for linux/amd64 and linux/arm64 using
-`docker buildx` and deploy it to a Kubernetes cluster.
+This tutorial demonstrates how to use Skaffold's _custom builders_
+to build a simple _Hello World_ Go application for `linux/amd64`
+and `linux/arm64` using `docker buildx` and deploy it to a Kubernetes
+cluster.
 
-##### Step 1: Configure _Docker Buildx_
-
-To use `docker buildx` you must first create a named _builder_ with
-the set of platforms to be built.  Run the following to create a
-builder named `skaffold-builder` to build for `linux/arm64` and
-`linux/amd64`:
-
-```
-docker buildx create --name skaffold-builder --platform linux/arm64,linux/amd64
-```
-
-##### Step 2: Obtain the example
+##### Step 1: Obtain the example
 
 First, clone the Skaffold [repo](https://github.com/GoogleContainerTools/skaffold)
 and navigate to the [`custom-buildx` example](https://github.com/GoogleContainerTools/skaffold/tree/master/examples/custom) for sample code:
@@ -45,21 +34,38 @@ $ git clone https://github.com/GoogleContainerTools/skaffold
 $ cd skaffold/examples/custom-buildx
 ```
 
-Take a look at the [skaffold.yaml](skaffold.yaml), which uses a
-_custom builder_ to invoke `docker buildx` to containerize source
-code for two platforms.
-For more information about custom builders, see the Skaffold custom
+##### Step 2: Configure the custom builder
+
+Take a look at the [`skaffold.yaml`](skaffold.yaml), which uses a
+_custom builder_
+```yaml
+  - image: skaffold-examples-buildx
+    custom:
+      buildCommand: sh buildx.sh
+      dependencies:
+        paths: ["go.mod", "**.go", "buildx.sh"]
+```
+
+Simple build commands can be inlined into the `skaffold.yaml`, but
+in this example we have created a separate [`build.sh`](build.sh)
+script.  This script uses `docker buildx` to containerize
+source code for two platforms, `linux/amd64` and `linux/arm64`.
+
+For more information on configuring a custom builder, see the Skaffold custom
 builder [documentation](https://skaffold.dev/docs/how-tos/builders/#custom-build-script-run-locally).
 Note that Skaffold builders are different from `docker buildx` builders.
 
+
+##### Step 3: Configure node affinities
+
 Next look at the Kubernetes [pod descriptor](k8s/pod.yaml) and notice
-the use of _node affinities_ to instruct Kubernetes to scheduler the workload
+the use of _node affinities_ to instruct Kubernetes to schedule the workload
 on nodes running either `linux/arm64` or `linux/amd64`.  It is important
 to realize that Kubernetes does not examine the referenced container images
 to determine the possible platforms.
 
 
-##### Step 3: Build and deploy the example
+##### Step 4: Build and deploy the example
 
 Now, use Skaffold to deploy this application to your Kubernetes cluster:
 
@@ -69,10 +75,12 @@ $ skaffold run --tail --default-repo <your repo>
 
 With this command, Skaffold will build the artifact with `docker buildx`
 and deploy the application to Kubernetes.  You should be able to
-see *Hello, World!* printed every second in the Skaffold logs.
+see *Hello, World from <OS><ARCH>!* printed every second in the Skaffold logs.
 
-We need to use `--default-repo` to push to a repository as Docker does
-not support loading multi-platform images with the same name.
+We need to use `--default-repo` to push to a repository as the
+Docker Daemon does not support loading multi-platform images with
+the same name.
+
 
 #### Cleanup
 
@@ -81,3 +89,37 @@ To clean up your Kubernetes cluster, run:
 ```shell
 $ skaffold delete
 ```
+
+
+##### &#x26A0; Caution &#x26A0;
+
+Using `buildx` to build for multiple platforms has some subtle
+interactions with Skaffold's artifact caching.
+
+Skaffold normally caches the artifact after a successful container
+image build using the principle that a build should produce the
+same container image given the same source.  Skaffold records an
+association of the resulting image digest with a hash of the artifact
+source.  This principle is the same as how Docker and other builders
+cache image layers to speed up builds.
+
+In this example, the build script configures Buildx differently
+depending on the `$PUSH_IMAGE` flag. 
+
+  - When `true`, the result is to be pushed to a registry, and all
+    registries support multi-platform images. 
+  - When `false`, the result is to be loaded to the Docker Daemon. 
+    But Buildx does not support loading multi-platform images to
+    the Docker Daemon, and so this example builds a single container
+    image for the local platform.
+
+But Skaffold is unaware of the platforms built by this custom builder,
+and so on completion Skaffold will cache the built artifact.  So on
+a local-build, Skaffold will cache the local-platform artifact and
+use that for subsequent deployments (assuming the source is unchanged).
+To avoid this scenario, disable Skaffold's artifact cache when the
+result is to be pushed to a remote registry:
+```
+skaffold build --cache-artifacts=false
+```
+

--- a/examples/custom-buildx/buildx.sh
+++ b/examples/custom-buildx/buildx.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# This script demonstrates how to use `docker buildx` to build container
+# images for the linux/amd64 and linux/arm64 platforms.  It creates a
+# `docker buildx` builder instance when required.
+#
+# If you change the platforms, be sure to
+#
+#  (1) delete the buildx builder named `skaffold-builder`, and
+#  (2) update the corresponding node-affinities in k8s/pod.yaml.
+
+# The platforms to build.
+platforms="linux/amd64,linux/arm64" 
+
+# `buildx` uses named _builder_ instances configured for specific platforms.
+# This script creates a `skaffold-builder` as required.
+if ! docker buildx inspect skaffold-builder >/dev/null 2>&1; then
+  docker buildx create --name skaffold-builder --platform $platforms
+fi
+
+# Building for multiple platforms requires pushing to a registry
+# as the Docker Daemon cannot load multi-platform images. 
+if [ "$PUSH_IMAGE" = true ]; then
+  args="--platform $platforms --push"
+else
+  args="--load"
+fi
+
+set -x      # show the command-line
+docker buildx build --builder skaffold-builder --tag $IMAGE $args "$BUILD_CONTEXT"

--- a/examples/custom-buildx/go.mod
+++ b/examples/custom-buildx/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/custom
+
+go 1.13

--- a/examples/custom-buildx/k8s/pod.yaml
+++ b/examples/custom-buildx/k8s/pod.yaml
@@ -13,6 +13,8 @@ spec:
   #     kubernetes.io/os: linux
 
   # Node affinity is more flexible and may represent several possible conditions.
+  # Here we tell Kubernetes that we support both linux/arm64 and linux/amd64 but
+  # we prefer linux/arm64 if available.
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -24,6 +26,13 @@ spec:
             - key: kubernetes.io/arch
               operator: In
               values: [amd64,arm64] # this example builds linux/{amd64,arm64} images
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+            - key: kubernetes.io/arch
+              operator: In
+              values: [arm64]
 
   containers:
   - name: getting-started

--- a/examples/custom-buildx/k8s/pod.yaml
+++ b/examples/custom-buildx/k8s/pod.yaml
@@ -3,6 +3,28 @@ kind: Pod
 metadata:
   name: getting-started
 spec:
+  # See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  # for discussion on node-selectors and node-affinity.
+
+  # Node-selectors are an AND of all specified labels and is suitable for
+  # single-platform images.
+  #   nodeSelector:
+  #     kubernetes.io/arch: arm64
+  #     kubernetes.io/os: linux
+
+  # Node affinity is more flexible and may represent several possible conditions.
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:          # multiple nodeSelectorTerms are OR
+          - matchExpressions:       # multiple matchExpressions are AND
+            - key: kubernetes.io/os
+              operator: In
+              values: [linux]
+            - key: kubernetes.io/arch
+              operator: In
+              values: [amd64,arm64] # this example builds linux/{amd64,arm64} images
+
   containers:
   - name: getting-started
     image: skaffold-examples-buildx

--- a/examples/custom-buildx/k8s/pod.yaml
+++ b/examples/custom-buildx/k8s/pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+  - name: getting-started
+    image: skaffold-examples-buildx

--- a/examples/custom-buildx/main.go
+++ b/examples/custom-buildx/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/examples/custom-buildx/main.go
+++ b/examples/custom-buildx/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
+	"runtime"
 	"time"
 )
 
 func main() {
 	for {
-		fmt.Println("Hello world!")
+		fmt.Printf("Hello World from %s/%s!\n", runtime.GOOS, runtime.GOARCH)
 
 		time.Sleep(time.Second * 1)
 	}

--- a/examples/custom-buildx/skaffold.yaml
+++ b/examples/custom-buildx/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v2beta13
 kind: Config
 
 build:

--- a/examples/custom-buildx/skaffold.yaml
+++ b/examples/custom-buildx/skaffold.yaml
@@ -3,7 +3,8 @@ kind: Config
 
 build:
   # Note that building for multiple platforms requires pushing to a registry,
-  # as the Docker Daemon cannot load multi-platform images.
+  # as the Docker Daemon cannot load multi-platform images.  You will need to
+  # run with `--default-repo`.
   local:
     push: true
   artifacts:

--- a/examples/custom-buildx/skaffold.yaml
+++ b/examples/custom-buildx/skaffold.yaml
@@ -10,18 +10,19 @@ build:
   artifacts:
   - image: skaffold-examples-buildx
     custom:
-      # This buildCommand depends on a `docker buildx` builder to have been created
-      # with the name `skaffold-builder`:
+      # This buildCommand depends on a `docker buildx` builder to
+      # have been created with the name `skaffold-builder`:
       #   $ docker buildx create --name skaffold-builder --platform linux/amd64,linux/arm64
       #   $ skaffold build
-      buildCommand: '
+      # If you change the platforms, be sure to update the corresponding
+      # node-affinities in k8s/pod.yaml
+      buildCommand:
         docker buildx build
           --builder skaffold-builder
-          --platform ${PLATFORMS:-linux/arm64,linux/amd64}
+          --platform linux/arm64,linux/amd64
           --tag $IMAGE
           $(if [ "$PUSH_IMAGE" = true ]; then echo --push; else echo --load; fi)
           "$BUILD_CONTEXT"
-        '
       dependencies:
         paths:
         - "go.mod"

--- a/examples/custom-buildx/skaffold.yaml
+++ b/examples/custom-buildx/skaffold.yaml
@@ -2,30 +2,11 @@ apiVersion: skaffold/v2beta12
 kind: Config
 
 build:
-  # Note that building for multiple platforms requires pushing to a registry,
-  # as the Docker Daemon cannot load multi-platform images.  You will need to
-  # run with `--default-repo`.
-  local:
-    push: true
   artifacts:
   - image: skaffold-examples-buildx
     custom:
-      # This buildCommand depends on a `docker buildx` builder to
-      # have been created with the name `skaffold-builder`:
-      #   $ docker buildx create --name skaffold-builder --platform linux/amd64,linux/arm64
-      #   $ skaffold build
-      # If you change the platforms, be sure to update the corresponding
-      # node-affinities in k8s/pod.yaml
-      buildCommand:
-        docker buildx build
-          --builder skaffold-builder
-          --platform linux/arm64,linux/amd64
-          --tag $IMAGE
-          $(if [ "$PUSH_IMAGE" = true ]; then echo --push; else echo --load; fi)
-          "$BUILD_CONTEXT"
+      buildCommand: sh buildx.sh
       dependencies:
-        paths:
-        - "go.mod"
-        - "**.go"
+        paths: ["go.mod", "**.go", "buildx.sh"]
   tagPolicy:
     sha256: {}

--- a/examples/custom-buildx/skaffold.yaml
+++ b/examples/custom-buildx/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v2beta13
+apiVersion: skaffold/v2beta12
 kind: Config
 
 build:

--- a/integration/examples/custom-buildx/Dockerfile
+++ b/integration/examples/custom-buildx/Dockerfile
@@ -2,7 +2,11 @@ FROM golang:1.16-alpine as builder
 COPY main.go .
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+FROM --platform=$BUILDPLATFORM golang:alpine AS build                                                                       
+                                                                       
+ARG TARGETOS                                                                                                                
+ARG TARGETARCH                                                                                                                                                                                          
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH  go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go 
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/integration/examples/custom-buildx/Dockerfile
+++ b/integration/examples/custom-buildx/Dockerfile
@@ -1,12 +1,15 @@
-FROM golang:1.16-alpine as builder
+# If using a cross-platform language toolchain like Go, then `--platform=$BUILDPLATFORM`
+# will result in a speed-up as the build will proceed on the native architecture rather
+# than emulation.
+FROM --platform=$BUILDPLATFORM golang:alpine AS builder
+
 COPY main.go .
+
 # `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
 ARG SKAFFOLD_GO_GCFLAGS
-FROM --platform=$BUILDPLATFORM golang:alpine AS build                                                                       
-                                                                       
-ARG TARGETOS                                                                                                                
-ARG TARGETARCH                                                                                                                                                                                          
-RUN GOOS=$TARGETOS GOARCH=$TARGETARCH  go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go 
+ARG TARGETOS
+ARG TARGETARCH
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
 
 FROM alpine:3
 # Define GOTRACEBACK to mark this container as using the Go language runtime

--- a/integration/examples/custom-buildx/Dockerfile
+++ b/integration/examples/custom-buildx/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.16-alpine as builder
+COPY main.go .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+
+FROM alpine:3
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/examples/custom-buildx/Dockerfile
+++ b/integration/examples/custom-buildx/Dockerfile
@@ -1,6 +1,8 @@
-# If using a cross-platform language toolchain like Go, then `--platform=$BUILDPLATFORM`
-# will result in a speed-up as the build will proceed on the native architecture rather
-# than emulation.
+# As Go supports cross-compilation, `--platform=$BUILDPLATFORM`
+# results in a dramatic speed-up as the build runs natively
+# instead of using emulation.
+# BUILD{PLATFORM,OS,ARCH} are set to your docker engine's platform
+# TARGET{PLATFORM,OS,ARCH} are set to the desired platform
 FROM --platform=$BUILDPLATFORM golang:alpine AS builder
 
 COPY main.go .

--- a/integration/examples/custom-buildx/README.md
+++ b/integration/examples/custom-buildx/README.md
@@ -6,7 +6,7 @@ platforms.
 
 This example shows how `docker buildx` can be used as a
 Skaffold _custom builder_ to create container images for
-for two different platforms: linux/arm64 and linux/amd64.
+for two different platforms: `linux/arm64` and `linux/amd64`.
 
 #### Before you begin
 
@@ -47,10 +47,17 @@ $ cd skaffold/examples/custom-buildx
 
 Take a look at the [skaffold.yaml](skaffold.yaml), which uses a
 _custom builder_ to invoke `docker buildx` to containerize source
-code.
+code for two platforms.
 For more information about custom builders, see the Skaffold custom
 builder [documentation](https://skaffold.dev/docs/how-tos/builders/#custom-build-script-run-locally).
-Note that Skaffold builders are different from Docker Buildx builders.
+Note that Skaffold builders are different from `docker buildx` builders.
+
+Next look at the Kubernetes [pod descriptor](k8s/pod.yaml) and notice
+the use of _node affinities_ to instruct Kubernetes to scheduler the workload
+on nodes running either `linux/arm64` or `linux/amd64`.  It is important
+to realize that Kubernetes does not examine the referenced container images
+to determine the possible platforms.
+
 
 ##### Step 3: Build and deploy the example
 

--- a/integration/examples/custom-buildx/README.md
+++ b/integration/examples/custom-buildx/README.md
@@ -97,11 +97,11 @@ Using `buildx` to build for multiple platforms has some subtle
 interactions with Skaffold's artifact caching.
 
 Skaffold normally caches the artifact after a successful container
-image build using the principle that a build should produce the
-same container image given the same source.  Skaffold records an
-association of the resulting image digest with a hash of the artifact
-source.  This principle is the same as how Docker and other builders
-cache image layers to speed up builds.
+image build.  Using the principle that given the same source inputs,
+a build should produce the same container image, Skaffold records
+an association of the resulting image digest with a hash of the
+artifact source.  This is the same principle used followed Docker
+and other builders to cache image layers to speed up builds.
 
 In this example, the build script configures Buildx differently
 depending on the `$PUSH_IMAGE` flag. 
@@ -113,12 +113,13 @@ depending on the `$PUSH_IMAGE` flag.
     the Docker Daemon, and so this example builds a single container
     image for the local platform.
 
-But Skaffold is unaware of the platforms built by this custom builder,
-and so on completion Skaffold will cache the built artifact.  So on
-a local-build, Skaffold will cache the local-platform artifact and
-use that for subsequent deployments (assuming the source is unchanged).
-To avoid this scenario, disable Skaffold's artifact cache when the
-result is to be pushed to a remote registry:
+But Skaffold is unaware that the build result differs based on `$PUSH_IMAGE`.
+So on a local-build, Skaffold will cache the local-platform artifact,
+and that artifact will be used that for subsequent deployments even if
+to a remote registry (assuming the source is unchanged).  To avoid
+this scenario, disable Skaffold's artifact caching when the result
+is to be pushed to a remote registry:
+
 ```
 skaffold build --cache-artifacts=false
 ```

--- a/integration/examples/custom-buildx/README.md
+++ b/integration/examples/custom-buildx/README.md
@@ -1,0 +1,82 @@
+### Example: use the custom builder with `docker buildx`
+
+[Docker Buildx](https://github.com/docker/buildx#buildx) is an
+experimental feature for building container images for multiple
+platforms.
+
+This example shows how `docker buildx` can be used as a
+Skaffold _custom builder_ to create container images for
+for two different platforms: linux/arm64 and linux/amd64.
+
+#### Before you begin
+
+For this tutorial to work you need to ensure Skaffold and a Kubernetes
+cluster are set up.  To learn more about how to set up Skaffold and
+a Kubernetes cluster, see the [getting started docs](https://skaffold.dev/docs/getting-started).
+
+Note that this example builds for two different platforms and
+requires pushing images to a container registry such as
+[Google Artifact Registry](https://cloud.google.com/artifact-registry).
+
+#### Tutorial
+
+This tutorial will demonstrate how Skaffold can build a simple
+_Hello World_ Go application with `docker buildx` and deploy it to
+a Kubernetes cluster.
+
+##### Step 1: Configure _Docker Buildx_
+
+To use `docker buildx` you must first create a named _builder_ with
+the set of platforms to be built.  Run the following to create a
+builder named `skaffold-builder` to build for `linux/arm64` and
+`linux/amd64`:
+
+```
+docker buildx create --name skaffold-builder --platform linux/arm64,linux/amd64
+```
+
+##### Step 2: Obtain the example
+
+First, clone the Skaffold [repo](https://github.com/GoogleContainerTools/skaffold)
+and navigate to the [`custom-buildx` example](https://github.com/GoogleContainerTools/skaffold/tree/master/examples/custom) for sample code:
+
+```shell
+$ git clone https://github.com/GoogleContainerTools/skaffold
+$ cd skaffold/examples/custom-buildx
+```
+
+Take a look at the [skaffold.yaml](skaffold.yaml), which uses a
+_custom builder_ to invoke `docker buildx` to containerize source
+code. 
+For more information about custom builders, see the Skaffold custom
+builder [documentation](https://skaffold.dev/docs/how-tos/builders/#custom-build-script-run-locally).
+Note that Skaffold builders are different from Docker Buildx builders.
+
+##### Step 3: Build and deploy the example
+
+Now, use Skaffold to deploy this application to your Kubernetes cluster:
+
+```shell
+$ skaffold run --tail --default-repo <your repo>
+```
+
+With this command, Skaffold will build the artifact with `docker buildx`
+and deploy the application to Kubernetes.  You should be able to
+see *Hello, World!* printed every second in the Skaffold logs.
+
+If Skaffold fails with a message like the following, then Skaffold is
+attempting to load the multi-platform images into the Docker Daemon,
+is pushing the images
+to a registry instead.
+```
+error: failed to solve: rpc error: code = Unknown desc = docker exporter does not currently support exporting manifest lists
+exiting dev mode because first build failed: building custom artifact: exit status 1
+```
+
+#### Cleanup
+
+To clean up your Kubernetes cluster, run:
+
+```shell
+$ skaffold delete
+```

--- a/integration/examples/custom-buildx/README.md
+++ b/integration/examples/custom-buildx/README.md
@@ -2,11 +2,10 @@
 
 [Docker Buildx](https://github.com/docker/buildx#buildx) is an
 experimental feature for building container images for multiple
-platforms.
+platforms.  This example shows how `docker buildx` can be used as
+a Skaffold _custom builder_ to create container images for the
+`linux/arm64` and `linux/amd64` platforms.
 
-This example shows how `docker buildx` can be used as a
-Skaffold _custom builder_ to create container images for
-for two different platforms: `linux/arm64` and `linux/amd64`.
 
 #### Before you begin
 
@@ -20,22 +19,12 @@ requires pushing images to a container registry such as
 
 #### Tutorial
 
-This tutorial will demonstrate how Skaffold can build a simple
-_Hello World_ Go application for linux/amd64 and linux/arm64 using
-`docker buildx` and deploy it to a Kubernetes cluster.
+This tutorial demonstrates how to use Skaffold's _custom builders_
+to build a simple _Hello World_ Go application for `linux/amd64`
+and `linux/arm64` using `docker buildx` and deploy it to a Kubernetes
+cluster.
 
-##### Step 1: Configure _Docker Buildx_
-
-To use `docker buildx` you must first create a named _builder_ with
-the set of platforms to be built.  Run the following to create a
-builder named `skaffold-builder` to build for `linux/arm64` and
-`linux/amd64`:
-
-```
-docker buildx create --name skaffold-builder --platform linux/arm64,linux/amd64
-```
-
-##### Step 2: Obtain the example
+##### Step 1: Obtain the example
 
 First, clone the Skaffold [repo](https://github.com/GoogleContainerTools/skaffold)
 and navigate to the [`custom-buildx` example](https://github.com/GoogleContainerTools/skaffold/tree/master/examples/custom) for sample code:
@@ -45,21 +34,38 @@ $ git clone https://github.com/GoogleContainerTools/skaffold
 $ cd skaffold/examples/custom-buildx
 ```
 
-Take a look at the [skaffold.yaml](skaffold.yaml), which uses a
-_custom builder_ to invoke `docker buildx` to containerize source
-code for two platforms.
-For more information about custom builders, see the Skaffold custom
+##### Step 2: Configure the custom builder
+
+Take a look at the [`skaffold.yaml`](skaffold.yaml), which uses a
+_custom builder_
+```yaml
+  - image: skaffold-examples-buildx
+    custom:
+      buildCommand: sh buildx.sh
+      dependencies:
+        paths: ["go.mod", "**.go", "buildx.sh"]
+```
+
+Simple build commands can be inlined into the `skaffold.yaml`, but
+in this example we have created a separate [`build.sh`](build.sh)
+script.  This script uses `docker buildx` to containerize
+source code for two platforms, `linux/amd64` and `linux/arm64`.
+
+For more information on configuring a custom builder, see the Skaffold custom
 builder [documentation](https://skaffold.dev/docs/how-tos/builders/#custom-build-script-run-locally).
 Note that Skaffold builders are different from `docker buildx` builders.
 
+
+##### Step 3: Configure node affinities
+
 Next look at the Kubernetes [pod descriptor](k8s/pod.yaml) and notice
-the use of _node affinities_ to instruct Kubernetes to scheduler the workload
+the use of _node affinities_ to instruct Kubernetes to schedule the workload
 on nodes running either `linux/arm64` or `linux/amd64`.  It is important
 to realize that Kubernetes does not examine the referenced container images
 to determine the possible platforms.
 
 
-##### Step 3: Build and deploy the example
+##### Step 4: Build and deploy the example
 
 Now, use Skaffold to deploy this application to your Kubernetes cluster:
 
@@ -69,10 +75,12 @@ $ skaffold run --tail --default-repo <your repo>
 
 With this command, Skaffold will build the artifact with `docker buildx`
 and deploy the application to Kubernetes.  You should be able to
-see *Hello, World!* printed every second in the Skaffold logs.
+see *Hello, World from <OS><ARCH>!* printed every second in the Skaffold logs.
 
-We need to use `--default-repo` to push to a repository as Docker does
-not support loading multi-platform images with the same name.
+We need to use `--default-repo` to push to a repository as the
+Docker Daemon does not support loading multi-platform images with
+the same name.
+
 
 #### Cleanup
 
@@ -81,3 +89,37 @@ To clean up your Kubernetes cluster, run:
 ```shell
 $ skaffold delete
 ```
+
+
+##### &#x26A0; Caution &#x26A0;
+
+Using `buildx` to build for multiple platforms has some subtle
+interactions with Skaffold's artifact caching.
+
+Skaffold normally caches the artifact after a successful container
+image build using the principle that a build should produce the
+same container image given the same source.  Skaffold records an
+association of the resulting image digest with a hash of the artifact
+source.  This principle is the same as how Docker and other builders
+cache image layers to speed up builds.
+
+In this example, the build script configures Buildx differently
+depending on the `$PUSH_IMAGE` flag. 
+
+  - When `true`, the result is to be pushed to a registry, and all
+    registries support multi-platform images. 
+  - When `false`, the result is to be loaded to the Docker Daemon. 
+    But Buildx does not support loading multi-platform images to
+    the Docker Daemon, and so this example builds a single container
+    image for the local platform.
+
+But Skaffold is unaware of the platforms built by this custom builder,
+and so on completion Skaffold will cache the built artifact.  So on
+a local-build, Skaffold will cache the local-platform artifact and
+use that for subsequent deployments (assuming the source is unchanged).
+To avoid this scenario, disable Skaffold's artifact cache when the
+result is to be pushed to a remote registry:
+```
+skaffold build --cache-artifacts=false
+```
+

--- a/integration/examples/custom-buildx/README.md
+++ b/integration/examples/custom-buildx/README.md
@@ -21,8 +21,8 @@ requires pushing images to a container registry such as
 #### Tutorial
 
 This tutorial will demonstrate how Skaffold can build a simple
-_Hello World_ Go application with `docker buildx` and deploy it to
-a Kubernetes cluster.
+_Hello World_ Go application for linux/amd64 and linux/arm64 using
+`docker buildx` and deploy it to a Kubernetes cluster.
 
 ##### Step 1: Configure _Docker Buildx_
 
@@ -47,7 +47,7 @@ $ cd skaffold/examples/custom-buildx
 
 Take a look at the [skaffold.yaml](skaffold.yaml), which uses a
 _custom builder_ to invoke `docker buildx` to containerize source
-code. 
+code.
 For more information about custom builders, see the Skaffold custom
 builder [documentation](https://skaffold.dev/docs/how-tos/builders/#custom-build-script-run-locally).
 Note that Skaffold builders are different from Docker Buildx builders.
@@ -64,14 +64,8 @@ With this command, Skaffold will build the artifact with `docker buildx`
 and deploy the application to Kubernetes.  You should be able to
 see *Hello, World!* printed every second in the Skaffold logs.
 
-If Skaffold fails with a message like the following, then Skaffold is
-attempting to load the multi-platform images into the Docker Daemon,
-is pushing the images
-to a registry instead.
-```
-error: failed to solve: rpc error: code = Unknown desc = docker exporter does not currently support exporting manifest lists
-exiting dev mode because first build failed: building custom artifact: exit status 1
-```
+We need to use `--default-repo` to push to a repository as Docker does
+not support loading multi-platform images with the same name.
 
 #### Cleanup
 

--- a/integration/examples/custom-buildx/buildx.sh
+++ b/integration/examples/custom-buildx/buildx.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# This script demonstrates how to use `docker buildx` to build container
+# images for the linux/amd64 and linux/arm64 platforms.  It creates a
+# `docker buildx` builder instance when required.
+#
+# If you change the platforms, be sure to
+#
+#  (1) delete the buildx builder named `skaffold-builder`, and
+#  (2) update the corresponding node-affinities in k8s/pod.yaml.
+
+# The platforms to build.
+platforms="linux/amd64,linux/arm64" 
+
+# `buildx` uses named _builder_ instances configured for specific platforms.
+# This script creates a `skaffold-builder` as required.
+if ! docker buildx inspect skaffold-builder >/dev/null 2>&1; then
+  docker buildx create --name skaffold-builder --platform $platforms
+fi
+
+# Building for multiple platforms requires pushing to a registry
+# as the Docker Daemon cannot load multi-platform images. 
+if [ "$PUSH_IMAGE" = true ]; then
+  args="--platform $platforms --push"
+else
+  args="--load"
+fi
+
+set -x      # show the command-line
+docker buildx build --builder skaffold-builder --tag $IMAGE $args "$BUILD_CONTEXT"

--- a/integration/examples/custom-buildx/go.mod
+++ b/integration/examples/custom-buildx/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/custom
+
+go 1.13

--- a/integration/examples/custom-buildx/k8s/pod.yaml
+++ b/integration/examples/custom-buildx/k8s/pod.yaml
@@ -13,6 +13,8 @@ spec:
   #     kubernetes.io/os: linux
 
   # Node affinity is more flexible and may represent several possible conditions.
+  # Here we tell Kubernetes that we support both linux/arm64 and linux/amd64 but
+  # we prefer linux/arm64 if available.
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -24,6 +26,13 @@ spec:
             - key: kubernetes.io/arch
               operator: In
               values: [amd64,arm64] # this example builds linux/{amd64,arm64} images
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+            - key: kubernetes.io/arch
+              operator: In
+              values: [arm64]
 
   containers:
   - name: getting-started

--- a/integration/examples/custom-buildx/k8s/pod.yaml
+++ b/integration/examples/custom-buildx/k8s/pod.yaml
@@ -3,6 +3,28 @@ kind: Pod
 metadata:
   name: getting-started
 spec:
+  # See https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  # for discussion on node-selectors and node-affinity.
+
+  # Node-selectors are an AND of all specified labels and is suitable for
+  # single-platform images.
+  #   nodeSelector:
+  #     kubernetes.io/arch: arm64
+  #     kubernetes.io/os: linux
+
+  # Node affinity is more flexible and may represent several possible conditions.
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:          # multiple nodeSelectorTerms are OR
+          - matchExpressions:       # multiple matchExpressions are AND
+            - key: kubernetes.io/os
+              operator: In
+              values: [linux]
+            - key: kubernetes.io/arch
+              operator: In
+              values: [amd64,arm64] # this example builds linux/{amd64,arm64} images
+
   containers:
   - name: getting-started
     image: skaffold-examples-buildx

--- a/integration/examples/custom-buildx/k8s/pod.yaml
+++ b/integration/examples/custom-buildx/k8s/pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+  - name: getting-started
+    image: skaffold-examples-buildx

--- a/integration/examples/custom-buildx/main.go
+++ b/integration/examples/custom-buildx/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/examples/custom-buildx/main.go
+++ b/integration/examples/custom-buildx/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
+	"runtime"
 	"time"
 )
 
 func main() {
 	for {
-		fmt.Printf("hello multi platform, I am %s-%s\n", runtime.GOOS, runtime.GOARCH) 
+		fmt.Printf("Hello World from %s/%s!\n", runtime.GOOS, runtime.GOARCH)
 
 		time.Sleep(time.Second * 1)
 	}

--- a/integration/examples/custom-buildx/main.go
+++ b/integration/examples/custom-buildx/main.go
@@ -7,7 +7,7 @@ import (
 
 func main() {
 	for {
-		fmt.Println("Hello world!")
+		fmt.Printf("hello multi platform, I am %s-%s\n", runtime.GOOS, runtime.GOARCH) 
 
 		time.Sleep(time.Second * 1)
 	}

--- a/integration/examples/custom-buildx/skaffold.yaml
+++ b/integration/examples/custom-buildx/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v2beta12
+apiVersion: skaffold/v2beta13
 kind: Config
 
 build:

--- a/integration/examples/custom-buildx/skaffold.yaml
+++ b/integration/examples/custom-buildx/skaffold.yaml
@@ -3,7 +3,8 @@ kind: Config
 
 build:
   # Note that building for multiple platforms requires pushing to a registry,
-  # as the Docker Daemon cannot load multi-platform images.
+  # as the Docker Daemon cannot load multi-platform images.  You will need to
+  # run with `--default-repo`.
   local:
     push: true
   artifacts:

--- a/integration/examples/custom-buildx/skaffold.yaml
+++ b/integration/examples/custom-buildx/skaffold.yaml
@@ -1,0 +1,29 @@
+apiVersion: skaffold/v2beta11
+kind: Config
+
+build:
+  # Note that building for multiple platforms requires pushing to a registry,
+  # as the Docker Daemon cannot load multi-platform images.
+  local:
+    push: true
+  artifacts:
+  - image: skaffold-examples-buildx
+    custom:
+      # This buildCommand depends on a `docker buildx` builder to have been created
+      # with the name `skaffold-builder`:
+      #   $ docker buildx create --name skaffold-builder --platform linux/amd64,linux/arm64
+      #   $ skaffold build
+      buildCommand: '
+        docker buildx build
+          --builder skaffold-builder
+          --platform ${PLATFORMS:-linux/arm64,linux/amd64}
+          --tag $IMAGE
+          $(if [ "$PUSH_IMAGE" = true ]; then echo --push; else echo --load; fi)
+          "$BUILD_CONTEXT"
+        '
+      dependencies:
+        paths:
+        - "go.mod"
+        - "**.go"
+  tagPolicy:
+    sha256: {}

--- a/integration/examples/custom-buildx/skaffold.yaml
+++ b/integration/examples/custom-buildx/skaffold.yaml
@@ -10,18 +10,19 @@ build:
   artifacts:
   - image: skaffold-examples-buildx
     custom:
-      # This buildCommand depends on a `docker buildx` builder to have been created
-      # with the name `skaffold-builder`:
+      # This buildCommand depends on a `docker buildx` builder to
+      # have been created with the name `skaffold-builder`:
       #   $ docker buildx create --name skaffold-builder --platform linux/amd64,linux/arm64
       #   $ skaffold build
-      buildCommand: '
+      # If you change the platforms, be sure to update the corresponding
+      # node-affinities in k8s/pod.yaml
+      buildCommand:
         docker buildx build
           --builder skaffold-builder
-          --platform ${PLATFORMS:-linux/arm64,linux/amd64}
+          --platform linux/arm64,linux/amd64
           --tag $IMAGE
           $(if [ "$PUSH_IMAGE" = true ]; then echo --push; else echo --load; fi)
           "$BUILD_CONTEXT"
-        '
       dependencies:
         paths:
         - "go.mod"

--- a/integration/examples/custom-buildx/skaffold.yaml
+++ b/integration/examples/custom-buildx/skaffold.yaml
@@ -2,30 +2,11 @@ apiVersion: skaffold/v2beta13
 kind: Config
 
 build:
-  # Note that building for multiple platforms requires pushing to a registry,
-  # as the Docker Daemon cannot load multi-platform images.  You will need to
-  # run with `--default-repo`.
-  local:
-    push: true
   artifacts:
   - image: skaffold-examples-buildx
     custom:
-      # This buildCommand depends on a `docker buildx` builder to
-      # have been created with the name `skaffold-builder`:
-      #   $ docker buildx create --name skaffold-builder --platform linux/amd64,linux/arm64
-      #   $ skaffold build
-      # If you change the platforms, be sure to update the corresponding
-      # node-affinities in k8s/pod.yaml
-      buildCommand:
-        docker buildx build
-          --builder skaffold-builder
-          --platform linux/arm64,linux/amd64
-          --tag $IMAGE
-          $(if [ "$PUSH_IMAGE" = true ]; then echo --push; else echo --load; fi)
-          "$BUILD_CONTEXT"
+      buildCommand: sh buildx.sh
       dependencies:
-        paths:
-        - "go.mod"
-        - "**.go"
+        paths: ["go.mod", "**.go", "buildx.sh"]
   tagPolicy:
     sha256: {}

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -28,6 +28,8 @@ import (
 func TestRun(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 
+	// Note: `custom-buildx` is not included as it depends on having a
+	// `skaffold-builder` builder configured and a registry to push to.
 	tests := []struct {
 		description string
 		dir         string


### PR DESCRIPTION
**Description**
This example demonstrates how to use `docker buildx` as a Skaffold custom builder.

The one downside is that it requires setting up a `docker buildx` builder instance as a separate step.  Something like:

    docker buildx create --name skaffold-builder --platform linux/arm64,linux/amd64

We could create a more sophisticated build script that would examine the existing builder instances, but that's a bit more involved.
