### PR TITLE
Update _index.md

### DIFF
--- a/docs/content/en/docs/install/_index.md
+++ b/docs/content/en/docs/install/_index.md
@@ -34,7 +34,7 @@ sudo install skaffold /usr/local/bin/
 
 ```bash
 # For Linux ARM64
-curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-arm && \
+curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-arm64 && \
 sudo install skaffold /usr/local/bin/
 ```
 


### PR DESCRIPTION
URL for arm64 is missing the 64 suffix.

<!-- Thank you for your contribution! -->

**Description**
URL for arm64 is missing the 64 suffix.
