### PR TITLE
Add golint support for M1 macs (darwin/arm64 arch)

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -249,7 +249,7 @@ func setFlagsFromEnvVariables(rootCmd *cobra.Command) {
 }
 
 func FlagToEnvVarName(f *pflag.Flag) string {
-	return fmt.Sprintf("SKAFFOLD_%s", strings.Replace(strings.ToUpper(f.Name), "-", "_", -1))
+	return fmt.Sprintf("SKAFFOLD_%s", strings.ReplaceAll(strings.ToUpper(f.Name), "-", "_"))
 }
 
 func setUpLogs(stdErr io.Writer, level string, timestamp bool) error {

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -54,7 +54,7 @@ type Flag struct {
 // When adding a new flag to the registry, please specify the
 // command/commands to which the flag belongs in `DefinedOn` field.
 // If the flag is a global flag, or belongs to all the subcommands,
-/// specify "all"
+// specify "all"
 // FlagAddMethod is method which defines a flag value with specified
 // name, default value, and usage string. e.g. `StringVar`, `BoolVar`
 var flagRegistry = []Flag{

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -18,7 +18,7 @@ set -e -o pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BIN=${DIR}/bin
-VERSION=1.30.0
+VERSION=1.37.1
 
 function install_linter() {
   echo "Installing GolangCI-Lint"

--- a/hack/install_golint.sh
+++ b/hack/install_golint.sh
@@ -64,6 +64,7 @@ is_supported_platform() {
   found=1
   case "$platform" in
     darwin/amd64) found=0 ;;
+    darwin/arm64) found=0 ;;
     darwin/386) found=0 ;;
     windows/amd64) found=0 ;;
     windows/386) found=0 ;;

--- a/hack/man/man_test.go
+++ b/hack/man/man_test.go
@@ -42,11 +42,11 @@ func TestPrintMan(t *testing.T) {
 	// Compare to current man page
 	header, err := ioutil.ReadFile(filepath.Join("..", "..", "docs", "content", "en", "docs", "references", "cli", "index_header"))
 	testutil.CheckError(t, false, err)
-	header = bytes.Replace(header, []byte("\r\n"), []byte("\n"), -1)
+	header = bytes.ReplaceAll(header, []byte("\r\n"), []byte("\n"))
 
 	expected, err := ioutil.ReadFile(filepath.Join("..", "..", "docs", "content", "en", "docs", "references", "cli", "_index.md"))
 	testutil.CheckError(t, false, err)
-	expected = bytes.Replace(expected, []byte("\r\n"), []byte("\n"), -1)
+	expected = bytes.ReplaceAll(expected, []byte("\r\n"), []byte("\n"))
 
 	if string(expected) != string(header)+output {
 		t.Error("You have skaffold command changes but haven't generated the CLI reference docs. Please run ./hack/generate-man.sh and commit the results!")

--- a/hack/schemas/main.go
+++ b/hack/schemas/main.go
@@ -159,7 +159,7 @@ func generateSchema(root string, dryRun bool, version schema.Version) (bool, err
 		return false, fmt.Errorf("unable to check that file exists %q: %w", output, err)
 	}
 
-	current = bytes.Replace(current, []byte("\r\n"), []byte("\n"), -1)
+	current = bytes.ReplaceAll(current, []byte("\r\n"), []byte("\n"))
 
 	if !dryRun {
 		if err := ioutil.WriteFile(output, buf, os.ModePerm); err != nil {
@@ -172,7 +172,7 @@ func generateSchema(root string, dryRun bool, version schema.Version) (bool, err
 }
 
 func yamlFieldName(field *ast.Field) string {
-	tag := strings.Replace(field.Tag.Value, "`", "", -1)
+	tag := strings.ReplaceAll(field.Tag.Value, "`", "")
 	tags := reflect.StructTag(tag)
 	yamlTag := tags.Get("yaml")
 
@@ -292,7 +292,7 @@ func (g *schemaGenerator) newDefinition(name string, t ast.Expr, comment string,
 		}
 	}
 
-	description := strings.TrimSpace(strings.Replace(comment, "\n", " ", -1))
+	description := strings.TrimSpace(strings.ReplaceAll(comment, "\n", " "))
 
 	// Extract default value
 	if m := regexpDefaults.FindStringSubmatch(description); m != nil {

--- a/hack/schemas/main_test.go
+++ b/hack/schemas/main_test.go
@@ -63,7 +63,7 @@ func TestGenerators(t *testing.T) {
 			expected, err := ioutil.ReadFile(expectedOutput)
 			t.CheckNoError(err)
 
-			expected = bytes.Replace(expected, []byte("\r\n"), []byte("\n"), -1)
+			expected = bytes.ReplaceAll(expected, []byte("\r\n"), []byte("\n"))
 
 			schemaLoader := gojsonschema.NewBytesLoader(actual)
 			_, err = gojsonschema.NewSchema(schemaLoader)

--- a/hack/struct-json/main.go
+++ b/hack/struct-json/main.go
@@ -94,7 +94,7 @@ func newDefinition(name string, t ast.Expr, comment string) *Definition {
 		}
 	}
 
-	description := strings.TrimSpace(strings.Replace(comment, "\n", " ", -1))
+	description := strings.TrimSpace(strings.ReplaceAll(comment, "\n", " "))
 	// Remove type prefix
 	description = regexp.MustCompile("^"+ogName+" (\\*.*\\* )?((is (the )?)|(are (the )?)|(lists ))?").ReplaceAllString(description, "$1")
 

--- a/integration/build_cluster_test.go
+++ b/integration/build_cluster_test.go
@@ -55,7 +55,7 @@ func TestBuildKanikoWithExplicitRepo(t *testing.T) {
 	skaffold.Build().WithRepo("").InDir("testdata/kaniko-explicit-repo").RunOrFail(t)
 }
 
-//see integration/testdata/README.md for details
+// see integration/testdata/README.md for details
 func TestBuildInCluster(t *testing.T) {
 	MarkIntegrationTest(t, NeedsGcp)
 

--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -315,7 +315,7 @@ func replaceInFile(target, replacement, filepath string) ([]byte, os.FileMode, e
 		return nil, 0, err
 	}
 
-	newContents := strings.Replace(string(original), target, replacement, -1)
+	newContents := strings.ReplaceAll(string(original), target, replacement)
 
 	err = ioutil.WriteFile(filepath, []byte(newContents), 0)
 

--- a/integration/rpc_test.go
+++ b/integration/rpc_test.go
@@ -144,7 +144,7 @@ func TestEventLogHTTP(t *testing.T) {
 		endpoint    string
 	}{
 		{
-			//TODO deprecate (https://github.com/GoogleContainerTools/skaffold/issues/3168)
+			// TODO deprecate (https://github.com/GoogleContainerTools/skaffold/issues/3168)
 			description: "/v1/event_log",
 			endpoint:    "/v1/event_log",
 		},

--- a/integration/util.go
+++ b/integration/util.go
@@ -216,7 +216,6 @@ func (k *NSKubernetesClient) waitForPods(podReady func(*v1.Pod) bool, podNames .
 		select {
 		case <-ctx.Done():
 			k.printDiskFreeSpace()
-			//k.debug("nodes")
 			k.debug("pods")
 			k.logs("pod", podNames)
 			k.t.Fatalf("Timed out waiting for pods %v in namespace %q", podNames, k.ns)
@@ -312,7 +311,6 @@ func (k *NSKubernetesClient) waitForDeploymentsToStabilizeWithTimeout(timeout ti
 		select {
 		case <-ctx.Done():
 			k.printDiskFreeSpace()
-			//k.debug("nodes")
 			k.debug("deployments.apps")
 			k.debug("pods")
 			k.logs("deployment.app", depNames)

--- a/pkg/skaffold/build/jib/init.go
+++ b/pkg/skaffold/build/jib/init.go
@@ -133,7 +133,7 @@ func validate(path string, enableGradleAnalysis bool) []ArtifactConfig {
 	var results []ArtifactConfig
 	for _, match := range matches {
 		// Escape windows path separators
-		line := bytes.Replace(match[1], []byte(`\`), []byte(`\\`), -1)
+		line := bytes.ReplaceAll(match[1], []byte(`\`), []byte(`\\`))
 		parsedJSON := jibJSON{}
 		if err := json.Unmarshal(line, &parsedJSON); err != nil {
 			logrus.Warnf("failed to parse jib json: %s", err.Error())

--- a/pkg/skaffold/build/jib/jib.go
+++ b/pkg/skaffold/build/jib/jib.go
@@ -205,7 +205,7 @@ func refreshDependencyList(files *filesLists, cmd exec.Cmd) error {
 		return errors.New("failed to get Jib dependencies")
 	}
 
-	line := bytes.Replace(matches[1], []byte(`\`), []byte(`\\`), -1)
+	line := bytes.ReplaceAll(matches[1], []byte(`\`), []byte(`\\`))
 	return json.Unmarshal(line, &files)
 }
 

--- a/pkg/skaffold/build/jib/sync_test.go
+++ b/pkg/skaffold/build/jib/sync_test.go
@@ -300,5 +300,5 @@ func getFileTime(file string, t *testing.T) time.Time {
 
 // for paths that contain "\", they must be escaped in json strings
 func escapeBackslashes(path string) string {
-	return strings.Replace(path, `\`, `\\`, -1)
+	return strings.ReplaceAll(path, `\`, `\\`)
 }

--- a/pkg/skaffold/build/kaniko/types.go
+++ b/pkg/skaffold/build/kaniko/types.go
@@ -79,7 +79,7 @@ const (
 	VerbosityFlag = "--verbosity"
 	// WhitelistVarRunFlag additional flag
 	WhitelistVarRunFlag = "--whitelist-var-run"
-	//DefaultImage is image used by the Kaniko pod by default
+	// DefaultImage is image used by the Kaniko pod by default
 	DefaultImage = "gcr.io/kaniko-project/executor:latest"
 	// DefaultSecretName for kaniko pod
 	DefaultSecretName = "kaniko-secret"

--- a/pkg/skaffold/build/tag/tag.go
+++ b/pkg/skaffold/build/tag/tag.go
@@ -49,7 +49,7 @@ func GenerateFullyQualifiedImageName(t Tagger, workingDir, imageName string) (st
 		if strings.Contains(tag, DeprecatedImageName) {
 			warnings.Printf("{{.IMAGE_NAME}} is deprecated, envTemplate's template should only specify the tag value. See https://skaffold.dev/docs/pipeline-stages/taggers/")
 
-			return strings.Replace(tag, DeprecatedImageName, imageName, -1), nil
+			return strings.ReplaceAll(tag, DeprecatedImageName, imageName), nil
 		}
 
 		return fmt.Sprintf("%s:%s", imageName, tag), nil

--- a/pkg/skaffold/debug/transform_go_test.go
+++ b/pkg/skaffold/debug/transform_go_test.go
@@ -293,9 +293,9 @@ func TestTransformManifestDelve(t *testing.T) {
 						}}}},
 			true,
 			&appsv1.Deployment{
-				//ObjectMeta: metav1.ObjectMeta{
-				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// ObjectMeta: metav1.ObjectMeta{
+				//  Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
+				// },
 				Spec: appsv1.DeploymentSpec{
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
@@ -336,9 +336,9 @@ func TestTransformManifestDelve(t *testing.T) {
 						}}}},
 			true,
 			&appsv1.ReplicaSet{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: appsv1.ReplicaSetSpec{
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
@@ -379,9 +379,9 @@ func TestTransformManifestDelve(t *testing.T) {
 						}}}},
 			true,
 			&appsv1.StatefulSet{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: appsv1.StatefulSetSpec{
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
@@ -421,9 +421,9 @@ func TestTransformManifestDelve(t *testing.T) {
 						}}}},
 			true,
 			&appsv1.DaemonSet{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: appsv1.DaemonSetSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -462,9 +462,9 @@ func TestTransformManifestDelve(t *testing.T) {
 						}}}},
 			true,
 			&batchv1.Job{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: batchv1.JobSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -504,9 +504,9 @@ func TestTransformManifestDelve(t *testing.T) {
 						}}}},
 			true,
 			&v1.ReplicationController{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: v1.ReplicationControllerSpec{
 					Replicas: int32p(1),
 					Template: &v1.PodTemplateSpec{

--- a/pkg/skaffold/debug/transform_jvm_test.go
+++ b/pkg/skaffold/debug/transform_jvm_test.go
@@ -280,9 +280,9 @@ func TestTransformManifestJVM(t *testing.T) {
 						}}}}},
 			true,
 			&appsv1.Deployment{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: appsv1.DeploymentSpec{
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
@@ -312,9 +312,9 @@ func TestTransformManifestJVM(t *testing.T) {
 						}}}}},
 			true,
 			&appsv1.ReplicaSet{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: appsv1.ReplicaSetSpec{
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
@@ -344,9 +344,9 @@ func TestTransformManifestJVM(t *testing.T) {
 						}}}}},
 			true,
 			&appsv1.StatefulSet{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: appsv1.StatefulSetSpec{
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
@@ -375,9 +375,9 @@ func TestTransformManifestJVM(t *testing.T) {
 						}}}}},
 			true,
 			&appsv1.DaemonSet{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: appsv1.DaemonSetSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -405,9 +405,9 @@ func TestTransformManifestJVM(t *testing.T) {
 						}}}}},
 			true,
 			&batchv1.Job{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: batchv1.JobSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -436,9 +436,9 @@ func TestTransformManifestJVM(t *testing.T) {
 						}}}}},
 			true,
 			&v1.ReplicationController{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: v1.ReplicationControllerSpec{
 					Replicas: int32p(1),
 					Template: &v1.PodTemplateSpec{

--- a/pkg/skaffold/debug/transform_nodejs_test.go
+++ b/pkg/skaffold/debug/transform_nodejs_test.go
@@ -392,9 +392,9 @@ func TestTransformManifestNodeJS(t *testing.T) {
 						}}}}}},
 			true,
 			&appsv1.Deployment{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: appsv1.DeploymentSpec{
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
@@ -469,9 +469,9 @@ func TestTransformManifestNodeJS(t *testing.T) {
 						}}}}}},
 			true,
 			&appsv1.StatefulSet{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: appsv1.StatefulSetSpec{
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
@@ -508,9 +508,9 @@ func TestTransformManifestNodeJS(t *testing.T) {
 						}}}}}},
 			true,
 			&appsv1.DaemonSet{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: appsv1.DaemonSetSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -547,9 +547,9 @@ func TestTransformManifestNodeJS(t *testing.T) {
 							}}}}}},
 			true,
 			&batchv1.Job{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: batchv1.JobSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -588,9 +588,9 @@ func TestTransformManifestNodeJS(t *testing.T) {
 						}}}}},
 			true,
 			&v1.ReplicationController{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: v1.ReplicationControllerSpec{
 					Replicas: int32p(1),
 					Template: &v1.PodTemplateSpec{

--- a/pkg/skaffold/debug/transform_python_test.go
+++ b/pkg/skaffold/debug/transform_python_test.go
@@ -295,9 +295,9 @@ func TestTransformManifestPython(t *testing.T) {
 						}}}},
 			true,
 			&appsv1.Deployment{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: appsv1.DeploymentSpec{
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
@@ -337,9 +337,9 @@ func TestTransformManifestPython(t *testing.T) {
 						}}}},
 			true,
 			&appsv1.ReplicaSet{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: appsv1.ReplicaSetSpec{
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
@@ -379,9 +379,9 @@ func TestTransformManifestPython(t *testing.T) {
 						}}}},
 			true,
 			&appsv1.StatefulSet{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: appsv1.StatefulSetSpec{
 					Replicas: int32p(1),
 					Template: v1.PodTemplateSpec{
@@ -420,9 +420,9 @@ func TestTransformManifestPython(t *testing.T) {
 						}}}},
 			true,
 			&appsv1.DaemonSet{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: appsv1.DaemonSetSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -460,9 +460,9 @@ func TestTransformManifestPython(t *testing.T) {
 						}}}},
 			true,
 			&batchv1.Job{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: batchv1.JobSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -501,9 +501,9 @@ func TestTransformManifestPython(t *testing.T) {
 						}}}},
 			true,
 			&v1.ReplicationController{
-				//ObjectMeta: metav1.ObjectMeta{
+				// ObjectMeta: metav1.ObjectMeta{
 				//	Labels: map[string]string{"debug.cloud.google.com/enabled": `yes`},
-				//},
+				// },
 				Spec: v1.ReplicationControllerSpec{
 					Replicas: int32p(1),
 					Template: &v1.PodTemplateSpec{

--- a/pkg/skaffold/initializer/analyze/directory.go
+++ b/pkg/skaffold/initializer/analyze/directory.go
@@ -32,5 +32,5 @@ func (a *directoryAnalyzer) enterDir(dir string) {
 }
 
 func (a *directoryAnalyzer) exitDir(_ string) {
-	//pass
+	// pass
 }

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -92,8 +92,8 @@ func (k *KubectlForwarder) forward(parentCtx context.Context, pfe *portForwardEn
 		pfe.terminationLock.Unlock()
 
 		if !isPortFree(util.Loopback, pfe.localPort) {
-			//assuming that Skaffold brokered ports don't overlap, this has to be an external process that started
-			//since the dev loop kicked off. We are notifying the user in the hope that they can fix it
+			// Assuming that Skaffold brokered ports don't overlap, this has to be an external process that started
+			// since the dev loop kicked off. We are notifying the user in the hope that they can fix it
 			color.Red.Fprintf(k.out, "failed to port forward %v, port %d is taken, retrying...\n", pfe, pfe.localPort)
 			notifiedUser = true
 			time.Sleep(waitPortNotFree)
@@ -120,20 +120,20 @@ func (k *KubectlForwarder) forward(parentCtx context.Context, pfe *portForwardEn
 				logrus.Debugf("couldn't start %v due to context cancellation", pfe)
 				return
 			}
-			//retry on exit at Start()
+			// Retry on exit at Start()
 			logrus.Debugf("error starting port forwarding %v: %s, output: %s", pfe, err, buf.String())
 			time.Sleep(500 * time.Millisecond)
 			continue
 		}
 
-		//kill kubectl on port forwarding error logs
+		// Kill kubectl on port forwarding error logs
 		go k.monitorLogs(ctx, &buf, cmd, pfe, errChan)
 		if err := cmd.Wait(); err != nil {
 			if ctx.Err() == context.Canceled {
 				logrus.Debugf("terminated %v due to context cancellation", pfe)
 				return
 			}
-			//to make sure that the log monitor gets cleared up
+			// To make sure that the log monitor gets cleared up
 			cancel()
 
 			s := buf.String()

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -149,7 +149,7 @@ func setupTrigger(triggerName string, setIntent func(bool), setAutoTrigger func(
 	setIntent(getAutoTrigger())
 	// give the server a callback to set the intent value when a user request is received
 	singleTriggerCallback(func() {
-		if !getAutoTrigger() { //if auto trigger is disabled, we're in manual mode
+		if !getAutoTrigger() { // if auto trigger is disabled, we're in manual mode
 			logrus.Debugf("%s intent received, calling back to runner", triggerName)
 			c <- true
 			setIntent(true)

--- a/pkg/skaffold/runner/render.go
+++ b/pkg/skaffold/runner/render.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (r *SkaffoldRunner) Render(ctx context.Context, out io.Writer, builds []build.Artifact, offline bool, filepath string) error {
-	//Fetch the digest and append it to the tag with the format of "tag@digest"
+	// Fetch the digest and append it to the tag with the format of "tag@digest"
 	if r.runCtx.DigestSource() == remoteDigestSource {
 		for i, a := range builds {
 			digest, err := docker.RemoteDigest(a.Tag, r.runCtx)

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -363,7 +363,7 @@ type KanikoCache struct {
 	// HostPath specifies a path on the host that is mounted to each pod as read only cache volume containing base images.
 	// If set, must exist on each node and prepopulated with kaniko-warmer.
 	HostPath string `yaml:"hostPath,omitempty"`
-	//TTL Cache timeout in hours.
+	// TTL Cache timeout in hours.
 	TTL string `yaml:"ttl,omitempty"`
 }
 

--- a/pkg/skaffold/schema/v1beta9/upgrade.go
+++ b/pkg/skaffold/schema/v1beta9/upgrade.go
@@ -88,7 +88,7 @@ func convertSyncRules(artifacts []*Artifact) [][]*next.SyncRule {
 			case strings.Contains(src, "***"):
 				dest, strip := simplify(dest, strings.Split(src, "***")[0])
 				syncRule = &next.SyncRule{
-					Src:   strings.Replace(src, "***", "**", -1),
+					Src:   strings.ReplaceAll(src, "***", "**"),
 					Dest:  dest,
 					Strip: strip,
 				}

--- a/pkg/skaffold/schema/v2beta10/config.go
+++ b/pkg/skaffold/schema/v2beta10/config.go
@@ -314,7 +314,7 @@ type KanikoCache struct {
 	// HostPath specifies a path on the host that is mounted to each pod as read only cache volume containing base images.
 	// If set, must exist on each node and prepopulated with kaniko-warmer.
 	HostPath string `yaml:"hostPath,omitempty"`
-	//TTL Cache timeout in hours.
+	// TTL Cache timeout in hours.
 	TTL string `yaml:"ttl,omitempty"`
 }
 

--- a/pkg/skaffold/schema/v2beta11/config.go
+++ b/pkg/skaffold/schema/v2beta11/config.go
@@ -345,7 +345,7 @@ type KanikoCache struct {
 	// HostPath specifies a path on the host that is mounted to each pod as read only cache volume containing base images.
 	// If set, must exist on each node and prepopulated with kaniko-warmer.
 	HostPath string `yaml:"hostPath,omitempty"`
-	//TTL Cache timeout in hours.
+	// TTL Cache timeout in hours.
 	TTL string `yaml:"ttl,omitempty"`
 }
 

--- a/pkg/skaffold/schema/v2beta12/config.go
+++ b/pkg/skaffold/schema/v2beta12/config.go
@@ -363,7 +363,7 @@ type KanikoCache struct {
 	// HostPath specifies a path on the host that is mounted to each pod as read only cache volume containing base images.
 	// If set, must exist on each node and prepopulated with kaniko-warmer.
 	HostPath string `yaml:"hostPath,omitempty"`
-	//TTL Cache timeout in hours.
+	// TTL Cache timeout in hours.
 	TTL string `yaml:"ttl,omitempty"`
 }
 

--- a/pkg/skaffold/schema/v2beta9/config.go
+++ b/pkg/skaffold/schema/v2beta9/config.go
@@ -314,7 +314,7 @@ type KanikoCache struct {
 	// HostPath specifies a path on the host that is mounted to each pod as read only cache volume containing base images.
 	// If set, must exist on each node and prepopulated with kaniko-warmer.
 	HostPath string `yaml:"hostPath,omitempty"`
-	//TTL Cache timeout in hours.
+	// TTL Cache timeout in hours.
 	TTL string `yaml:"ttl,omitempty"`
 }
 

--- a/pkg/skaffold/test/structure/structure.go
+++ b/pkg/skaffold/test/structure/structure.go
@@ -54,7 +54,7 @@ func New(cfg docker.Config, wd string, tc *latest.TestCase, imagesAreLocal func(
 	}, nil
 }
 
-/// Test is the entrypoint for running structure tests
+// Test is the entrypoint for running structure tests
 func (cst *Runner) Test(ctx context.Context, out io.Writer, bRes []build.Artifact) error {
 	if err := cst.runStructureTests(ctx, out, bRes); err != nil {
 		return containerStructureTestErr(err)

--- a/pkg/skaffold/util/cmd_test.go
+++ b/pkg/skaffold/util/cmd_test.go
@@ -38,7 +38,6 @@ func TestHelperProcess(*testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
 	}
-	defer os.Exit(0)
 
 	args := os.Args
 	for len(args) > 0 {
@@ -65,6 +64,8 @@ func TestHelperProcess(*testing.T) {
 		fmt.Fprintf(os.Stderr, "Unknown command %q\n", cmd)
 		os.Exit(2)
 	}
+
+	defer os.Exit(0)
 }
 
 func TestCmd_RunCmdOut(t *testing.T) {

--- a/pkg/skaffold/util/cmd_test.go
+++ b/pkg/skaffold/util/cmd_test.go
@@ -65,7 +65,7 @@ func TestHelperProcess(*testing.T) {
 		os.Exit(2)
 	}
 
-	defer os.Exit(0)
+	os.Exit(0)
 }
 
 func TestCmd_RunCmdOut(t *testing.T) {

--- a/pkg/skaffold/util/tar.go
+++ b/pkg/skaffold/util/tar.go
@@ -172,7 +172,7 @@ func addFileToTar(root string, src string, dst string, tw *tar.Writer, hm header
 
 // Code copied from https://github.com/moby/moby/blob/master/pkg/archive/archive_windows.go
 func chmodTarEntry(perm os.FileMode) os.FileMode {
-	//perm &= 0755 // this 0-ed out tar flags (like link, regular file, directory marker etc.)
+	// perm &= 0755 // this 0-ed out tar flags (like link, regular file, directory marker etc.)
 	permPart := perm & os.ModePerm
 	noPermPart := perm &^ os.ModePerm
 	// Add the x bit: make everything +x from windows

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -176,7 +176,7 @@ func RemoveFromSlice(s []string, target string) []string {
 // Expand replaces placeholders for a given key with a given value.
 // It supports the ${key} and the $key syntax.
 func Expand(text, key, value string) string {
-	text = strings.Replace(text, "${"+key+"}", value, -1)
+	text = strings.ReplaceAll(text, "${"+key+"}", value)
 
 	indices := regexp.MustCompile(`\$`+key).FindAllStringIndex(text, -1)
 

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -220,8 +220,6 @@ func Run(t *testing.T, name string, f func(t *T)) {
 	})
 }
 
-////
-
 func CheckContains(t *testing.T, expected, actual string) {
 	t.Helper()
 	if !strings.Contains(actual, expected) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/5434 <!-- tracking issues that this PR will close -->

**Description**
- Bump `golint` version to `1.37.1` which now supports `darwin/arm64` arch
- Add `darwin/arm64` to `hack/install_golint.sh`
- Fix golint/gocritic issues (spaces, use of ReplaceAll)
- Fix shadowing of `defer os.Exit(0)` `in cmd_test.go`

