### PR TITLE
Add digest source 'tag' to use tag without digest

### DIFF
--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -48,7 +48,7 @@ func NewCmdRender() *cobra.Command {
 			{Value: &renderFromBuildOutputFile, Name: "build-artifacts", Shorthand: "a", Usage: "File containing build result from a previous 'skaffold build --file-output'"},
 			{Value: &offline, Name: "offline", DefValue: false, Usage: `Do not connect to Kubernetes API server for manifest creation and validation. This is helpful when no Kubernetes cluster is available (e.g. GitOps model). No metadata.namespace attribute is injected in this case - the manifest content does not get changed.`, IsEnum: true},
 			{Value: &renderOutputPath, Name: "output", DefValue: "", Usage: "file to write rendered manifests to"},
-			{Value: &opts.DigestSource, Name: "digest-source", DefValue: "local", Usage: "Set to 'local' to build images locally and use digests from built images; Set to 'remote' to resolve the digest of images by tag from the remote registry; Set to 'none' to use tags directly from the Kubernetes manifests", IsEnum: true},
+			{Value: &opts.DigestSource, Name: "digest-source", DefValue: "local", Usage: "Set to 'local' to build images locally and use digests from built images; Set to 'remote' to resolve the digest of images by tag from the remote registry; Set to 'none' to use tags directly from the Kubernetes manifests. Set to 'tag' to use tags directly from the build.", IsEnum: true},
 		}).
 		WithHouseKeepingMessages().
 		NoArgs(doRender)

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -826,7 +826,7 @@ Options:
       --add-skaffold-labels=true: Add Skaffold-specific labels to rendered manifest. If false, custom labels are still applied. Helpful for GitOps model where Skaffold is not the deployer.
   -a, --build-artifacts=: File containing build result from a previous 'skaffold build --file-output'
   -d, --default-repo='': Default repository value (overrides global config)
-      --digest-source='local': Set to 'local' to build images locally and use digests from built images; Set to 'remote' to resolve the digest of images by tag from the remote registry; Set to 'none' to use tags directly from the Kubernetes manifests
+      --digest-source='local': Set to 'local' to build images locally and use digests from built images; Set to 'remote' to resolve the digest of images by tag from the remote registry; Set to 'none' to use tags directly from the Kubernetes manifests. Set to 'tag' to use tags directly from the build.
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
   -l, --label=[]: Add custom labels to deployed objects. Set multiple times for multiple labels
       --loud=false: Show the build logs and output

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -49,7 +49,7 @@ func (r *SkaffoldRunner) Build(ctx context.Context, out io.Writer, artifacts []*
 		return nil, err
 	}
 
-	// In dry-run mode or with --digest-source  set to 'remote', we don't build anything, just return the tag for each artifact.
+	// In dry-run mode or with --digest-source  set to 'remote' or 'tag', we don't build anything, just return the tag for each artifact.
 	if r.runCtx.DryRun() || (r.runCtx.DigestSource() == remoteDigestSource) ||
 		(r.runCtx.DigestSource() == tagDigestSource) {
 		var bRes []build.Artifact

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -50,7 +50,8 @@ func (r *SkaffoldRunner) Build(ctx context.Context, out io.Writer, artifacts []*
 	}
 
 	// In dry-run mode or with --digest-source  set to 'remote', we don't build anything, just return the tag for each artifact.
-	if r.runCtx.DryRun() || (r.runCtx.DigestSource() == remoteDigestSource) {
+	if r.runCtx.DryRun() || (r.runCtx.DigestSource() == remoteDigestSource) ||
+		(r.runCtx.DigestSource() == tagDigestSource) {
 		var bRes []build.Artifact
 		for _, artifact := range artifacts {
 			bRes = append(bRes, build.Artifact{

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -38,6 +38,7 @@ import (
 const (
 	remoteDigestSource = "remote"
 	noneDigestSource   = "none"
+	tagDigestSource    = "tag"
 )
 
 // Runner is responsible for running the skaffold build, test and deploy config.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: #3649 

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
A new option `skaffold render --digest-source=tag` was added, which will render the manifests with built tags. The difference between 'none' and 'tag' is that the former one will keep whatever artifacts are in the original manifests, while the latter will update them with proper tags, without sha256 digests.

This could be very helpful when rendering one-for-all release manifests in multi-arch deployment scenarios, although extra cares should be taken in this case to not move any released tags.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
User gets a new option `skaffold render --digest-source=tag`
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
