### PR TITLE
Moving structure test's dependency logic to NewTester()

### DIFF
--- a/pkg/skaffold/test/structure/structure.go
+++ b/pkg/skaffold/test/structure/structure.go
@@ -35,6 +35,7 @@ type Runner struct {
 	structureTests []string
 	image          string
 	testWorkingDir string
+	files          []string
 	localDaemon    docker.LocalDaemon
 	imagesAreLocal func(imageName string) (bool, error)
 }
@@ -45,16 +46,23 @@ func New(cfg docker.Config, wd string, tc *latest.TestCase, imagesAreLocal func(
 	if err != nil {
 		return nil, err
 	}
+
+	files, err := getFiles(wd, tc.StructureTests)
+	if err != nil {
+		return nil, expandingFilePathsErr(err)
+	}
+
 	return &Runner{
 		structureTests: tc.StructureTests,
 		image:          tc.ImageName,
 		testWorkingDir: wd,
+		files:          files,
 		localDaemon:    localDaemon,
 		imagesAreLocal: imagesAreLocal,
 	}, nil
 }
 
-/// Test is the entrypoint for running structure tests
+// Test is the entrypoint for running structure tests
 func (cst *Runner) Test(ctx context.Context, out io.Writer, bRes []build.Artifact) error {
 	if err := cst.runStructureTests(ctx, out, bRes); err != nil {
 		return containerStructureTestErr(err)
@@ -71,15 +79,10 @@ func (cst *Runner) runStructureTests(ctx context.Context, out io.Writer, bRes []
 		return nil
 	}
 
-	files, err := cst.TestDependencies()
-	if err != nil {
-		return err
-	}
-
-	logrus.Infof("Running structure tests for files %v", files)
+	logrus.Infof("Running structure tests for files %v", cst.files)
 
 	args := []string{"test", "-v", "warn", "--image", fqn}
-	for _, f := range files {
+	for _, f := range cst.files {
 		args = append(args, "--config", f)
 	}
 
@@ -97,12 +100,7 @@ func (cst *Runner) runStructureTests(ctx context.Context, out io.Writer, bRes []
 
 // TestDependencies returns dependencies listed for the structure tests
 func (cst *Runner) TestDependencies() ([]string, error) {
-	files, err := util.ExpandPathsGlob(cst.testWorkingDir, cst.structureTests)
-	if err != nil {
-		return nil, expandingFilePathsErr(err)
-	}
-
-	return files, nil
+	return cst.files, nil
 }
 
 // env returns a merged environment of the current process environment and any extra environment.
@@ -150,4 +148,13 @@ func resolveArtifactImageTag(imageName string, bRes []build.Artifact) (string, b
 	}
 
 	return "", false
+}
+
+func getFiles(path string, files []string) ([]string, error) {
+	files, err := util.ExpandPathsGlob(path, files)
+	if err != nil {
+		return nil, expandingFilePathsErr(err)
+	}
+
+	return files, nil
 }

--- a/pkg/skaffold/test/structure/structure.go
+++ b/pkg/skaffold/test/structure/structure.go
@@ -100,6 +100,11 @@ func (cst *Runner) runStructureTests(ctx context.Context, out io.Writer, bRes []
 
 // TestDependencies returns dependencies listed for the structure tests
 func (cst *Runner) TestDependencies() ([]string, error) {
+	files, err := getFiles(cst.testWorkingDir, cst.structureTests)
+	if err != nil {
+		return nil, expandingFilePathsErr(err)
+	}
+	cst.files = files
 	return cst.files, nil
 }
 

--- a/pkg/skaffold/test/structure/structure.go
+++ b/pkg/skaffold/test/structure/structure.go
@@ -92,7 +92,7 @@ func (cst *Runner) runStructureTests(ctx context.Context, out io.Writer, bRes []
 	cmd.Env = cst.env()
 
 	if err := util.RunCmd(cmd); err != nil {
-		return fmt.Errorf("error running ontainer-structure-test command: %w", err)
+		return fmt.Errorf("error running container-structure-test command: %w", err)
 	}
 
 	return nil

--- a/pkg/skaffold/test/test_factory_test.go
+++ b/pkg/skaffold/test/test_factory_test.go
@@ -81,16 +81,7 @@ func TestWrongPattern(t *testing.T) {
 			}},
 		}
 
-		tester, err := NewTester(cfg, func(imageName string) (bool, error) { return true, nil })
-		t.CheckNoError(err)
-
-		_, err = tester.TestDependencies()
-		t.CheckError(true, err)
-
-		err = tester.Test(context.Background(), ioutil.Discard, []build.Artifact{{
-			ImageName: "image",
-			Tag:       "image:tag",
-		}})
+		_, err := NewTester(cfg, func(imageName string) (bool, error) { return true, nil })
 		t.CheckError(true, err)
 	})
 }


### PR DESCRIPTION
Fixes: #

**Description**
Moving structure test's dependency file extraction logic to NewTester() to reduce code redundancy.

**User facing changes (remove if N/A)**
There are no user facing changes.

This is part of adding new custom tester to Skaffold pipeline tracked by #5333.

