### PR TITLE
Update Paketo buildpack references

### DIFF
--- a/pkg/skaffold/debug/transform_go.go
+++ b/pkg/skaffold/debug/transform_go.go
@@ -70,9 +70,9 @@ func (t dlvTransformer) IsApplicable(config imageConfiguration) bool {
 	// nor to cause certain environment variables to be defined in the resulting image, look at the image's
 	// CNB metadata to see if any well-known Go-related buildpacks had been involved.
 	knownGoBuildpackIds := []string{
-		"google.go.build",                                           // GCP Buildpacks
-		"paketo-buildpacks/go-compiler", "paketo-buildpacks/go-mod", // Cloud Foundry
-		"heroku/go", // Heroku
+		"google.go.build",           // GCP Buildpacks
+		"paketo-buildpacks/go-dist", // Paketo
+		"heroku/go",                 // Heroku
 	}
 	cnbBuildMetadata := config.labels["io.buildpacks.build.metadata"]
 	for _, id := range knownGoBuildpackIds {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
The `paketo-buildpacks/go-compiler` buildpack was renamed to `paketo-buildpacks/go-dist`. This `go-dist` buildpack will be sufficient to identify a Go application as it would be involved in any build of a Go application.

Additionally, it makes more sense to identify the project as Paketo. Its affiliation is with the Cloud Foundry foundation, not the project.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
This will allow all Go applications built with the Paketo buildpacks to be identified correctly for debug mode.
