### PR TITLE
Add support for no-option-value; surface per-option-defaults

### DIFF
--- a/cmd/skaffold/app/cmd/commands.go
+++ b/cmd/skaffold/app/cmd/commands.go
@@ -89,7 +89,7 @@ func (b *builder) WithFlagAdder(adder func(*pflag.FlagSet)) Builder {
 
 func (b *builder) WithFlags(flags []*Flag) Builder {
 	for _, f := range flags {
-		fl := f.flag()
+		fl := f.flag(b.cmd.Use)
 		b.cmd.Flags().AddFlag(fl)
 	}
 	b.cmd.PreRun = func(cmd *cobra.Command, args []string) {

--- a/cmd/skaffold/app/cmd/debug_test.go
+++ b/cmd/skaffold/app/cmd/debug_test.go
@@ -38,7 +38,7 @@ func TestNewCmdDebug(t *testing.T) {
 
 		t.CheckDeepEqual(true, opts.Tail)
 		t.CheckDeepEqual(false, opts.Force)
-		t.CheckDeepEqual(false, opts.EnableRPC)
+		t.CheckDeepEqual(true, opts.EnableRPC)
 	})
 }
 

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -142,7 +142,8 @@ var flagRegistry = []Flag{
 		Value:    &opts.EnableRPC,
 		DefValue: false,
 		DefValuePerCommand: map[string]interface{}{
-			"dev": true,
+			"dev":   true,
+			"debug": true,
 		},
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "build", "run", "debug", "deploy"},

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -35,6 +35,7 @@ var (
 
 // Flag defines a Skaffold CLI flag which contains a list of
 // subcommands the flag belongs to in `DefinedOn` field.
+// See https://pkg.go.dev/github.com/spf13/pflag#Flag
 type Flag struct {
 	Name               string
 	Shorthand          string
@@ -42,12 +43,11 @@ type Flag struct {
 	Value              interface{}
 	DefValue           interface{}
 	DefValuePerCommand map[string]interface{}
+	NoOptDefVal        string
 	FlagAddMethod      string
 	DefinedOn          []string
 	Hidden             bool
 	IsEnum             bool
-
-	pflag *pflag.Flag
 }
 
 // flagRegistry is a list of all Skaffold CLI flags.
@@ -511,18 +511,18 @@ func methodNameByType(v reflect.Value) string {
 	return ""
 }
 
-func (fl *Flag) flag() *pflag.Flag {
-	if fl.pflag != nil {
-		return fl.pflag
-	}
-
+func (fl *Flag) flag(cmdName string) *pflag.Flag {
 	methodName := fl.FlagAddMethod
 	if methodName == "" {
 		methodName = methodNameByType(reflect.ValueOf(fl.Value))
 	}
 	inputs := []interface{}{fl.Value, fl.Name}
 	if methodName != "Var" {
-		inputs = append(inputs, fl.DefValue)
+		if d, found := fl.DefValuePerCommand[cmdName]; found {
+			inputs = append(inputs, d)
+		} else {
+			inputs = append(inputs, fl.DefValue)
+		}
 	}
 	inputs = append(inputs, fl.Usage)
 
@@ -530,10 +530,12 @@ func (fl *Flag) flag() *pflag.Flag {
 
 	reflect.ValueOf(fs).MethodByName(methodName).Call(reflectValueOf(inputs))
 	f := fs.Lookup(fl.Name)
+	if len(fl.NoOptDefVal) > 0 {
+		// f.NoOptDefVal may be set depending on value type
+		f.NoOptDefVal = fl.NoOptDefVal
+	}
 	f.Shorthand = fl.Shorthand
 	f.Hidden = fl.Hidden
-
-	fl.pflag = f
 	return f
 }
 
@@ -572,7 +574,7 @@ func AddFlags(cmd *cobra.Command) {
 			continue
 		}
 
-		cmd.Flags().AddFlag(fl.flag())
+		cmd.Flags().AddFlag(fl.flag(cmd.Use))
 
 		flagsForCommand = append(flagsForCommand, fl)
 	}

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -138,7 +138,7 @@ var flagRegistry = []Flag{
 	},
 	{
 		Name:     "enable-rpc",
-		Usage:    "Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)",
+		Usage:    "Enable gRPC for exposing Skaffold events",
 		Value:    &opts.EnableRPC,
 		DefValue: false,
 		DefValuePerCommand: map[string]interface{}{
@@ -193,7 +193,7 @@ var flagRegistry = []Flag{
 	},
 	{
 		Name:     "tail",
-		Usage:    "Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)",
+		Usage:    "Stream logs from deployed objects",
 		Value:    &opts.Tail,
 		DefValue: false,
 		DefValuePerCommand: map[string]interface{}{

--- a/cmd/skaffold/app/cmd/flags_test.go
+++ b/cmd/skaffold/app/cmd/flags_test.go
@@ -75,3 +75,47 @@ func TestAddFlagsSmoke(t *testing.T) {
 		})
 	}
 }
+
+func TestMakeFlag(t *testing.T) {
+	var v string
+	f := Flag{
+		Name:          "flag",
+		Shorthand:     "f",
+		Value:         &v,
+		Hidden:        true,
+		FlagAddMethod: "StringVar",
+		DefValue:      "default",
+		DefValuePerCommand: map[string]interface{}{
+			"debug": "dbg",
+			"build": "bld",
+		},
+		NoOptDefVal: "nooptdefval",
+	}
+
+	testutil.Run(t, "just default value", func(t *testutil.T) {
+		test := f.flag("test")
+		t.CheckDeepEqual("flag", test.Name)
+		t.CheckDeepEqual("f", test.Shorthand)
+		t.CheckDeepEqual(true, test.Hidden)
+		t.CheckDeepEqual("default", test.DefValue)
+		t.CheckDeepEqual("nooptdefval", test.NoOptDefVal)
+	})
+
+	testutil.Run(t, "default value for debug", func(t *testutil.T) {
+		debug := f.flag("debug")
+		t.CheckDeepEqual("flag", debug.Name)
+		t.CheckDeepEqual("f", debug.Shorthand)
+		t.CheckDeepEqual(true, debug.Hidden)
+		t.CheckDeepEqual("dbg", debug.DefValue)
+		t.CheckDeepEqual("nooptdefval", debug.NoOptDefVal)
+	})
+
+	testutil.Run(t, "default value for build", func(t *testutil.T) {
+		build := f.flag("build")
+		t.CheckDeepEqual("flag", build.Name)
+		t.CheckDeepEqual("f", build.Shorthand)
+		t.CheckDeepEqual(true, build.Hidden)
+		t.CheckDeepEqual("bld", build.DefValue)
+		t.CheckDeepEqual("nooptdefval", build.NoOptDefVal)
+	})
+}

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -138,7 +138,7 @@ Options:
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
       --dry-run=false: Don't build images, just compute the tag for each artifact.
-      --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
+      --enable-rpc=false: Enable gRPC for exposing Skaffold events
       --event-log-file='': Save Skaffold events to the provided file after skaffold has finished executing, requires --enable-rpc=true
       --file-output='': Filename to write build images to
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
@@ -351,17 +351,17 @@ Examples:
 
 Options:
       --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
-      --auto-build=true: When set to false, builds wait for API request instead of running automatically
+      --auto-build=false: When set to false, builds wait for API request instead of running automatically
       --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
-      --auto-deploy=true: When set to false, deploys wait for API request instead of running automatically
-      --auto-sync=true: When set to false, syncs wait for API request instead of running automatically
+      --auto-deploy=false: When set to false, deploys wait for API request instead of running automatically
+      --auto-sync=false: When set to false, syncs wait for API request instead of running automatically
       --cache-artifacts=true: Set to false to disable default caching of artifacts
       --cache-file='': Specify the location of the cache file (default $HOME/.skaffold/cache)
       --cleanup=true: Delete deployments after dev or debug mode is interrupted
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
-      --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
+      --enable-rpc=true: Enable gRPC for exposing Skaffold events
       --event-log-file='': Save Skaffold events to the provided file after skaffold has finished executing, requires --enable-rpc=true
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime!
@@ -383,7 +383,7 @@ Options:
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
-      --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
+      --tail=true: Stream logs from deployed objects
       --toot=false: Emit a terminal beep after the deploy is complete
       --trigger='notify': How is change detection triggered? (polling, notify, or manual)
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
@@ -509,7 +509,7 @@ Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
-      --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
+      --enable-rpc=false: Enable gRPC for exposing Skaffold events
       --event-log-file='': Save Skaffold events to the provided file after skaffold has finished executing, requires --enable-rpc=true
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime!
@@ -529,7 +529,7 @@ Options:
       --skip-render=false: Don't render the manifests, just deploy them
       --status-check=true: Wait for deployed resources to stabilize
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
-      --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
+      --tail=false: Stream logs from deployed objects
       --toot=false: Emit a terminal beep after the deploy is complete
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
       --wait-for-deletions-delay=2s: Delay between two checks for pending deletions
@@ -593,7 +593,7 @@ Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
-      --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
+      --enable-rpc=true: Enable gRPC for exposing Skaffold events
       --event-log-file='': Save Skaffold events to the provided file after skaffold has finished executing, requires --enable-rpc=true
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime!
@@ -616,7 +616,7 @@ Options:
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
-      --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
+      --tail=true: Stream logs from deployed objects
       --toot=false: Emit a terminal beep after the deploy is complete
       --trigger='notify': How is change detection triggered? (polling, notify, or manual)
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
@@ -886,7 +886,7 @@ Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
-      --enable-rpc=false: Enable gRPC for exposing Skaffold events (true by default for `skaffold dev`)
+      --enable-rpc=false: Enable gRPC for exposing Skaffold events
       --event-log-file='': Save Skaffold events to the provided file after skaffold has finished executing, requires --enable-rpc=true
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime!
@@ -910,7 +910,7 @@ Options:
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
-      --tail=false: Stream logs from deployed objects (true by default for `skaffold dev` and `skaffold debug`)
+      --tail=false: Stream logs from deployed objects
       --toot=false: Emit a terminal beep after the deploy is complete
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
       --wait-for-deletions-delay=2s: Delay between two checks for pending deletions

--- a/examples/buildpacks/main.go
+++ b/examples/buildpacks/main.go
@@ -14,5 +14,5 @@ func main() {
 }
 
 func hello(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Hello, World!")
+	fmt.Fprintf(w, "Hello, World.")
 }


### PR DESCRIPTION
This PR brings in some small changes to our command-flag processing:

- add support for pflag's `NoOptDefVal` for options that transition from being a boolean to a flag-with-values
- create individual pflag instances for each command so that per-command defaults are surfaced in the help text
- make `--enable-rpc` default to true for `debug`, like it is for `dev`.
- remove now-unecessary `by default` usage text since the default is now shown in-line

The proposal in #4832, to revise Skaffold's port-forwarding behaviour, wants to promote `--port-forward` from being a boolean flag to a string-slice flag.  The `NoOptDefVal` allows `--port-forward` to continue to work even though.

The per-command defaults lets the help text for options like `--enable-rpc` (which has [a different default for `dev`](https://github.com/briandealwis/skaffold/blob/eb355d666c81d65a6d8afac0897cb19ed9cf5ecf/cmd/skaffold/app/cmd/flags.go#L140-L149)) show the actual default value:
```
$ skaffold help run | grep enable-rpc
      --enable-rpc=false: Enable gRPC for exposing Skaffold events
      --event-log-file='': Save Skaffold events to the provided file after skaffold has finished executing, requires --enable-rpc=true

$ skaffold help dev | grep enable-rpc
      --enable-rpc=true: Enable gRPC for exposing Skaffold events
      --event-log-file='': Save Skaffold events to the provided file after skaffold has finished executing, requires --enable-rpc=true
```
