### PR TITLE
fix logic that set absolute paths in the parsed configuration

### DIFF
--- a/pkg/skaffold/tags/paths.go
+++ b/pkg/skaffold/tags/paths.go
@@ -58,11 +58,8 @@ func makeFilePathsAbsolute(config interface{}, base string) []error {
 				switch v.Interface().(type) {
 				case string:
 					path := v.String()
-					if path == "" {
-						return errs
-					}
-					if filepath.IsAbs(path) {
-						return errs
+					if path == "" || filepath.IsAbs(path) {
+						continue
 					}
 					v.SetString(filepath.Join(base, path))
 					logrus.Tracef("setting absolute path for config field %q", f.Name)
@@ -70,10 +67,7 @@ func makeFilePathsAbsolute(config interface{}, base string) []error {
 					for i := 0; i < v.Len(); i++ {
 						elem := v.Index(i)
 						path := elem.String()
-						if path == "" {
-							continue
-						}
-						if filepath.IsAbs(path) {
+						if path == "" || filepath.IsAbs(path) {
 							continue
 						}
 						elem.SetString(filepath.Join(base, path))
@@ -82,7 +76,7 @@ func makeFilePathsAbsolute(config interface{}, base string) []error {
 				default:
 					return []error{fmt.Errorf("yaml tag `filepath` needs struct field %q to be string or string slice", f.Name)}
 				}
-				return errs
+				continue
 			}
 
 			if v.Kind() != reflect.Ptr {

--- a/pkg/skaffold/tags/paths_test.go
+++ b/pkg/skaffold/tags/paths_test.go
@@ -46,6 +46,7 @@ func TestSetAbsFilePaths(t *testing.T) {
 						DeployType: latest.DeployType{
 							KptDeploy:     &latest.KptDeploy{Dir: "."},
 							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{"foo/*", "/a/foo/*"}},
+							HelmDeploy:    &latest.HelmDeploy{Releases: []latest.HelmRelease{{ChartPath: "../charts", ValuesFiles: []string{"./values1.yaml", "./values2.yaml"}}}},
 						},
 					},
 				},
@@ -63,6 +64,7 @@ func TestSetAbsFilePaths(t *testing.T) {
 						DeployType: latest.DeployType{
 							KptDeploy:     &latest.KptDeploy{Dir: "/a/b"},
 							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{"/a/b/foo/*", "/a/foo/*"}},
+							HelmDeploy:    &latest.HelmDeploy{Releases: []latest.HelmRelease{{ChartPath: "/a/charts", ValuesFiles: []string{"/a/b/values1.yaml", "/a/b/values2.yaml"}}}},
 						},
 					},
 				},


### PR DESCRIPTION
Fixes: #5396 

## Test

Setup the files

```.
├── frontend
│   └── web-app
│       └── skaffold.yaml
└── skaffold.yaml
```
where:
_/skaffold.yaml_:
```yaml
apiVersion: skaffold/v2beta12
kind: Config
metadata:
  name: hikingo

requires:
- path: ./frontend/web-app
```

_frontend/web-app/skaffold.yaml_:
```yaml
apiVersion: skaffold/v2beta12
kind: Config
metadata:
  name: web-app
build:
  artifacts:
  - image: xyz
deploy:
  helm:
    releases:
    - name: web-app
      chartPath: ../../infra/charts/microservice
      artifactOverrides:
        image: xyz
      valuesFiles:
      - ./helm-values.yaml
```

From root directory run:
```
skaffold diagnose --yaml-only
```

**Before fix Output**

```yaml
...
deploy:
  helm:
    releases:
    - name: web-app
      chartPath: /Users/gaghosh/Code/Hack/repro-5396/infra/charts/microservice
      valuesFiles:
      - ./helm-values.yaml      // <==== failed to set absolute path here
...
```

**After fix Output**

```yaml
...
deploy:
  helm:
    releases:
    - name: web-app
      chartPath: /Users/gaghosh/Code/Hack/repro-5396/infra/charts/microservice
      valuesFiles:
      - /Users/gaghosh/Code/Hack/repro-5396/frontend/web-app/helm-values.yaml
...
```