### PR TITLE
fix: use reflection in `GetYamlTags` instead of manipulating strings

### DIFF
--- a/pkg/skaffold/initializer/util/util.go
+++ b/pkg/skaffold/initializer/util/util.go
@@ -43,5 +43,5 @@ func ListDeployers(deploy *latest.DeployConfig) []string {
 		return []string{}
 	}
 
-	return yamltags.GetYamlTags(deploy.DeployType)
+	return yamltags.GetYamlKeys(deploy.DeployType)
 }

--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -90,7 +90,7 @@ func InitMeterFromConfig(configs []*latest.SkaffoldConfig) {
 				meter.SyncType[yamltags.GetYamlTag(artifact.Sync)] = true
 			}
 		}
-		meter.Deployers = append(meter.Deployers, yamltags.GetYamlTags(config.Deploy.DeployType)...)
+		meter.Deployers = append(meter.Deployers, yamltags.GetYamlKeys(config.Deploy.DeployType)...)
 		meter.BuildArtifacts += len(config.Pipeline.Build.Artifacts)
 	}
 	meter.PlatformType = strings.Join(platforms, ":")

--- a/pkg/skaffold/yamltags/tags.go
+++ b/pkg/skaffold/yamltags/tags.go
@@ -100,6 +100,9 @@ func GetYamlKeys(config interface{}) []string {
 }
 
 func getYamlKey(f reflect.StructField) string {
+	if f.PkgPath != "" { // field is unexported
+		return ""
+	}
 	t, ok := f.Tag.Lookup("yaml")
 	if !ok {
 		return lowerCaseFirst(f.Name)

--- a/pkg/skaffold/yamltags/tags.go
+++ b/pkg/skaffold/yamltags/tags.go
@@ -75,10 +75,10 @@ func GetYamlTag(value interface{}) string {
 	return rawStr[:i]
 }
 
-// GetYamlTags returns the first `yaml` tag value for each non-nested field of the given non-nil config parameter
+// GetYamlKeys returns the yaml key for each non-nested field of the given non-nil config parameter
 // For example if config is `latest.DeployType{HelmDeploy: &HelmDeploy{...}, KustomizeDeploy: &KustomizeDeploy{...}}`
 // then it returns `["helm", "kustomize"]`
-func GetYamlTags(config interface{}) []string {
+func GetYamlKeys(config interface{}) []string {
 	var tags []string
 	if config == nil {
 		return tags
@@ -91,7 +91,7 @@ func GetYamlTags(config interface{}) []string {
 		if v.Kind() == reflect.Ptr && v.IsNil() { // exclude ptr fields not explicitly defined in the configuration
 			continue
 		}
-		tag := firstYamlKey(f)
+		tag := getYamlKey(f)
 		if tag != "" {
 			tags = append(tags, tag)
 		}
@@ -99,7 +99,7 @@ func GetYamlTags(config interface{}) []string {
 	return tags
 }
 
-func firstYamlKey(f reflect.StructField) string {
+func getYamlKey(f reflect.StructField) string {
 	t, ok := f.Tag.Lookup("yaml")
 	if !ok {
 		return lowerCaseFirst(f.Name)

--- a/pkg/skaffold/yamltags/tags_test.go
+++ b/pkg/skaffold/yamltags/tags_test.go
@@ -243,7 +243,7 @@ func TestGetYamlTag(t *testing.T) {
 	}
 }
 
-func TestGetYamlTags(t *testing.T) {
+func TestGetYamlKeys(t *testing.T) {
 	a := "it's A"
 	b := "it's B"
 	c := "it's C"

--- a/pkg/skaffold/yamltags/tags_test.go
+++ b/pkg/skaffold/yamltags/tags_test.go
@@ -284,6 +284,27 @@ func TestGetYamlTags(t *testing.T) {
 			expectedTags: []string{"a"},
 		},
 		{
+			name: "no yaml tag",
+			yaml: struct {
+				Foo string
+			}{Foo: "bar"},
+			expectedTags: []string{"foo"},
+		},
+		{
+			name: "yaml flag `inline`",
+			yaml: struct {
+				Foo string `yaml:",inline"`
+			}{Foo: "bar"},
+			expectedTags: nil,
+		},
+		{
+			name: "empty yaml key",
+			yaml: struct {
+				Foo string `yaml:",omitempty"`
+			}{Foo: "bar"},
+			expectedTags: []string{"foo"},
+		},
+		{
 			name: "array fields are not included",
 			yaml: struct {
 				List []abc `yaml:"abcs"`

--- a/pkg/skaffold/yamltags/tags_test.go
+++ b/pkg/skaffold/yamltags/tags_test.go
@@ -315,7 +315,7 @@ func TestGetYamlTags(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
-			t.CheckDeepEqual(test.expectedTags, GetYamlTags(test.yaml))
+			t.CheckDeepEqual(test.expectedTags, GetYamlKeys(test.yaml))
 		})
 	}
 }

--- a/pkg/skaffold/yamltags/tags_test.go
+++ b/pkg/skaffold/yamltags/tags_test.go
@@ -286,9 +286,16 @@ func TestGetYamlTags(t *testing.T) {
 		{
 			name: "no yaml tag",
 			yaml: struct {
-				Foo string
-			}{Foo: "bar"},
-			expectedTags: []string{"foo"},
+				FooBar string
+			}{FooBar: "bar"},
+			expectedTags: []string{"fooBar"},
+		},
+		{
+			name: "unexported field",
+			yaml: struct {
+				fooBar string
+			}{fooBar: "bar"},
+			expectedTags: nil,
 		},
 		{
 			name: "yaml flag `inline`",

--- a/pkg/skaffold/yamltags/tags_test.go
+++ b/pkg/skaffold/yamltags/tags_test.go
@@ -277,8 +277,10 @@ func TestGetYamlTags(t *testing.T) {
 			expectedTags: []string{"c"},
 		},
 		{
-			name:         "non-pointer fields are returned in empty struct",
-			yaml:         struct{ A string }{},
+			name: "non-pointer fields are returned in empty struct",
+			yaml: struct {
+				A string `yaml:"a"`
+			}{},
 			expectedTags: []string{"a"},
 		},
 		{


### PR DESCRIPTION
Fixes: #5440 

Function `GetYamlTags` used in the skaffold metric collection code, was implemented using string manipulation (spoiler: always a bad idea).