### PR TITLE
add validation to ensure image names are unique

### DIFF
--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -111,7 +111,7 @@ func validateImageNames(configs []*latest.SkaffoldConfig) (errs []error) {
 			seen[a.ImageName] = true
 			parsed, err := docker.ParseReference(a.ImageName)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("invalid imageName '%s': %v", a.ImageName, err))
+				errs = append(errs, fmt.Errorf("invalid image %q: %w", a.ImageName, err))
 				continue
 			}
 

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -104,7 +104,7 @@ func validateImageNames(configs []*latest.SkaffoldConfig) (errs []error) {
 	for _, c := range configs {
 		for _, a := range c.Build.Artifacts {
 			if seen[a.ImageName] {
-				errs = append(errs, fmt.Errorf("duplicate imageName '%s': artifact image name need to be unique across all configurations", a.ImageName))
+				errs = append(errs, fmt.Errorf("found duplicate images %q: artifact image names must be unique across all configurations", a.ImageName))
 				continue
 			}
 

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -116,7 +116,7 @@ func validateImageNames(configs []*latest.SkaffoldConfig) (errs []error) {
 			}
 
 			if parsed.Tag != "" {
-				errs = append(errs, fmt.Errorf("invalid imageName '%s': no tag should be specified. Use taggers instead: https://skaffold.dev/docs/how-tos/taggers/", a.ImageName))
+				errs = append(errs, fmt.Errorf("invalid image %q: no tag should be specified. Use taggers instead: https://skaffold.dev/docs/how-tos/taggers/", a.ImageName))
 			}
 
 			if parsed.Digest != "" {

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -120,7 +120,7 @@ func validateImageNames(configs []*latest.SkaffoldConfig) (errs []error) {
 			}
 
 			if parsed.Digest != "" {
-				errs = append(errs, fmt.Errorf("invalid imageName '%s': no digest should be specified. Use taggers instead: https://skaffold.dev/docs/how-tos/taggers/", a.ImageName))
+				errs = append(errs, fmt.Errorf("invalid image %q: no digest should be specified. Use taggers instead: https://skaffold.dev/docs/how-tos/taggers/", a.ImageName))
 			}
 		}
 	}

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -768,6 +768,15 @@ func TestValidateImageNames(t *testing.T) {
 			shouldErr: false,
 		},
 		{
+			description: "duplicates",
+			artifacts: []*latest.Artifact{{
+				ImageName: "img",
+			}, {
+				ImageName: "img",
+			}},
+			shouldErr: true,
+		},
+		{
 			description: "shouldn't have a tag",
 			artifacts: []*latest.Artifact{{
 				ImageName: "img:tag",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Related: #5411 <!-- tracking issues that this PR will close -->

**Description**
We necessitate that all image names are unique. Surprisingly we didn't have a validation for it.

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
Users can't define artifacts with the same image name. However, even previously this was known and the process would fail eventually; now it'll fail upfront.