### PR TITLE
Ensure file sync works in multi-namespace environments

### DIFF
--- a/pkg/skaffold/runner/util/util.go
+++ b/pkg/skaffold/runner/util/util.go
@@ -38,11 +38,13 @@ func GetAllPodNamespaces(configNamespace string, pipelines []latest.Pipeline) ([
 			return nil, fmt.Errorf("getting k8s configuration: %w", err)
 		}
 
+		// The empty string is here to ensure that the File Sync feature
+		// works with multi-namespace environments
+		nsMap[""] = true
+
 		context, ok := config.Contexts[config.CurrentContext]
 		if ok {
 			nsMap[context.Namespace] = true
-		} else {
-			nsMap[""] = true
 		}
 	} else {
 		nsMap[configNamespace] = true

--- a/pkg/skaffold/runner/util/util_test.go
+++ b/pkg/skaffold/runner/util/util_test.go
@@ -42,7 +42,7 @@ func TestGetAllPodNamespaces(t *testing.T) {
 		{
 			description:    "kube context's namespace",
 			currentContext: "prod-context",
-			expected:       []string{"prod"},
+			expected:       []string{"", "prod"},
 		},
 		{
 			description:    "default namespace",


### PR DESCRIPTION
Fixes: #4246


**Description**
Some kubernetes contexts set a default namespace. This breaks the file sync feature in a way that it prevented files being synced to _any other_ namespace (Helm was probably working, but the heuristic didn't work for  `deploy.kustomize` and `deploy.kubectl` deployment methods).

I am not sure if this causes some unexpected behaviour. The tests seem happy with this, so I'm somewhat confident nothing broke. I've only added the "empty" namespace when no `--namespace` is passed (ie the default value is `""`).

I'm not fully convinced the heuristic of parsing kubeconfig to get the default namespace is needed at all, though. Everything seems content with just `""`. So, I'm happy to remove the heuristic altogether, but since I'm not familiar with why it was added, I didn't want to do it prematurely.