### PR TITLE
Do not display `helm` warnings for multi-config projects

### DIFF
--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -893,9 +893,8 @@ func TestHelmDeploy(t *testing.T) {
 			helm:   testDeployWithoutTags,
 			builds: testBuilds,
 			expectedWarnings: []string{
-				"See helm sample for how to replace image names with their actual tags: https://github.com/GoogleContainerTools/skaffold/blob/master/examples/helm-deployment/skaffold.yaml",
+				"See helm documentation on how to replace image names with their actual tags: https://skaffold.dev/docs/pipeline-stages/deployers/helm/#image-configuration",
 				"image [docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184] is not used.",
-				"image [skaffold-helm] is used instead.",
 			},
 		},
 		{

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -65,6 +65,11 @@ func (ps Pipelines) Select(imageName string) (latest.Pipeline, bool) {
 	return p, found
 }
 
+// IsMultiPipeline returns true if there are more than one constituent skaffold pipelines.
+func (ps Pipelines) IsMultiPipeline() bool {
+	return len(ps.pipelines) > 1
+}
+
 func (ps Pipelines) PortForwardResources() []*latest.PortForwardResource {
 	var pf []*latest.PortForwardResource
 	for _, p := range ps.pipelines {
@@ -185,6 +190,7 @@ func (rc *RunContext) Tail() bool                                { return rc.Opt
 func (rc *RunContext) Trigger() string                           { return rc.Opts.Trigger }
 func (rc *RunContext) WaitForDeletions() config.WaitForDeletions { return rc.Opts.WaitForDeletions }
 func (rc *RunContext) WatchPollInterval() int                    { return rc.Opts.WatchPollInterval }
+func (rc *RunContext) IsMultiConfig() bool                       { return rc.Pipelines.IsMultiPipeline() }
 
 func GetRunContext(opts config.SkaffoldOptions, pipelines []latest.Pipeline) (*RunContext, error) {
 	kubeConfig, err := kubectx.CurrentConfig()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Related: #5455 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
The `helm` deployer displays a warning when a built artifact is not used in the deployment. Like:
```
WARN[0052] image [frontend:427522d4bb023a3b888c2d960e4456c6d5c56eea686a69e7065bdf8e2830a0d9] is not used. 
WARN[0052] image [frontend] is used instead.            
WARN[0052] See helm sample for how to replace image names with their actual tags: https://github.com/GoogleContainerTools/skaffold/blob/master/examples/helm-deployment/skaffold.yaml 
```

This warning is not accurate for multi-config since all artifacts are managed in the same flat list and passed along to every deployer. This triggers this warning for every helm deployment imported as a dependency.


