### PR TITLE
Modify `TestRun` to rerun all tests as imported configs

### DIFF
--- a/integration/examples/bazel/skaffold.yaml
+++ b/integration/examples/bazel/skaffold.yaml
@@ -5,3 +5,7 @@ build:
   - image: skaffold-bazel
     bazel:
       target: //:skaffold_example.tar
+deploy:
+  kubectl:
+    manifests:
+      - k8s/*

--- a/integration/examples/buildpacks-java/skaffold.yaml
+++ b/integration/examples/buildpacks-java/skaffold.yaml
@@ -7,6 +7,10 @@ build:
       builder: "gcr.io/buildpacks/builder:v1"
       env:
       - GOOGLE_RUNTIME_VERSION=8
+deploy:
+  kubectl:
+    manifests:
+      - k8s/*
 profiles:
 - name: gcb
   build:

--- a/integration/examples/buildpacks-node/skaffold.yaml
+++ b/integration/examples/buildpacks-node/skaffold.yaml
@@ -5,3 +5,7 @@ build:
   - image: skaffold-buildpacks-node
     buildpacks:
       builder: "gcr.io/buildpacks/builder:v1"
+deploy:
+  kubectl:
+    manifests:
+      - k8s/*

--- a/integration/examples/buildpacks-python/skaffold.yaml
+++ b/integration/examples/buildpacks-python/skaffold.yaml
@@ -5,6 +5,10 @@ build:
   - image: skaffold-buildpacks
     buildpacks:
       builder: "gcr.io/buildpacks/builder:v1"
+deploy:
+  kubectl:
+    manifests:
+      - k8s/*
 profiles:
 - name: gcb
   build:

--- a/integration/examples/buildpacks/skaffold.yaml
+++ b/integration/examples/buildpacks/skaffold.yaml
@@ -7,6 +7,10 @@ build:
       builder: "gcr.io/buildpacks/builder:v1"
       env:
       - GOPROXY={{.GOPROXY}}
+deploy:
+  kubectl:
+    manifests:
+      - k8s/*
 profiles:
 - name: gcb
   build:

--- a/integration/examples/custom/skaffold.yaml
+++ b/integration/examples/custom/skaffold.yaml
@@ -11,3 +11,7 @@ build:
         - "**.go"
   tagPolicy:
     sha256: {}
+deploy:
+  kubectl:
+    manifests:
+      - k8s/*

--- a/integration/examples/jib-gradle/skaffold.yaml
+++ b/integration/examples/jib-gradle/skaffold.yaml
@@ -4,7 +4,10 @@ build:
   artifacts:
   - image: skaffold-jib-gradle
     jib: {}
-
+deploy:
+  kubectl:
+    manifests:
+      - k8s/*
 # optional profile to run the jib build on Google Cloud Build
 profiles:
   - name: gcb

--- a/integration/examples/nodejs/skaffold.yaml
+++ b/integration/examples/nodejs/skaffold.yaml
@@ -5,7 +5,10 @@ build:
   artifacts:
   - image: node-example
     context: backend
-
+deploy:
+  kubectl:
+    manifests:
+      - k8s/*
 profiles:
   - name: dev
     activation:

--- a/integration/testdata/jib/skaffold.yaml
+++ b/integration/testdata/jib/skaffold.yaml
@@ -6,7 +6,10 @@ build:
     jib:
       args:
       - --no-transfer-progress
-
+deploy:
+  kubectl:
+    manifests:
+      - k8s/*
 profiles:
   # optional profile to run the jib build on Google Cloud Build
   - name: gcb


### PR DESCRIPTION
Modify `TestRun` integration test to rerun all target tests by importing them as dependencies in a temp config.
```
kind: Config
apiVersion: skaffold/v2beta13
requires:
  - path: <test.dir>
```

Needed to add explicit `deploy` stanza since the default `kubectl` deployer isn't added to imported configs.

---

The motivation to add this test is to ensure new example/feature added to the list of test targets for `TestRun` also test that they work as dependencies. 