### PR TITLE
Debug probes

### DIFF
--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -17,7 +17,7 @@ syncing as it leads to users accidentally terminating debugging sessions by savi
 These behaviours can be re-enabled with the `--auto-build`, `--auto-deploy`, and `--auto-sync`
 flags.
 
-## How It Works
+## How It works
 
 `skaffold debug` examines the built artifacts to determine the underlying language runtime technology.
 Kubernetes manifests that reference these artifacts are transformed on-the-fly to enable the
@@ -30,6 +30,21 @@ are configured as _init-containers_ to populate a shared-volume that is mounted 
 each of the appropriate containers.  These images are hosted at
 `gcr.io/k8s-skaffold/skaffold-debug-support`; alternative locations can be
 specified in [Skaffold's global configuration]({{< relref "/docs/design/global-config.md" >}}).
+
+`debug` makes some other adjustments to simplify the debug experience:
+
+  - *Replica Counts*: `debug` rewrites  the replica counts to 1 for
+    deployments, replica sets, and stateful sets.  This results in
+    requests being considered one at a time.
+
+  - *Kubernetes Probes*:  `debug` changes the timeouts on HTTP-based
+    [liveness, readiness, and startup probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+    to 600 seconds (10 minutes) from the default of 1 second. 
+    This change allows probes to be debugged, and avoids negative
+    consequences from probes blocked when the app is already suspended
+    during a debugging session.
+    Failed liveness probes in particular result in the container
+    being terminated and restarted.
 
 ### Supported Language Runtimes
 

--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -41,10 +41,21 @@ specified in [Skaffold's global configuration]({{< relref "/docs/design/global-c
     [liveness, readiness, and startup probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
     to 600 seconds (10 minutes) from the default of 1 second. 
     This change allows probes to be debugged, and avoids negative
-    consequences from probes blocked when the app is already suspended
+    consequences from blocked probes when the app is already suspended
     during a debugging session.
     Failed liveness probes in particular result in the container
     being terminated and restarted.
+
+	The probe timeout value can be set on a per-podspec basis by setting
+	a `debug.cloud.google.com/probe/timeouts` annotation on the podspec's metadata
+	with a valid duration (see [Go's time.ParseDuration()](https://pkg.go.dev/time#ParseDuration)).
+    This probe timeout-rewriting can be skipped entirely by using `skip`.  For example:
+    ```yaml
+    metadata:
+      annotations:
+        debug.cloud.google.com/probe/timeouts: skip
+    spec: ...
+    ```
 
 ### Supported Language Runtimes
 

--- a/pkg/skaffold/debug/debug_test.go
+++ b/pkg/skaffold/debug/debug_test.go
@@ -639,9 +639,9 @@ func TestArtifactImage(t *testing.T) {
 	testutil.CheckDeepEqual(t, true, strings.Contains(debugConfig, `"artifact":"gcr.io/random/image"`))
 }
 
-// TestTransformPodSpecSkips verifies that transformPodSpec skips podspecs that have a
+// TestSkipAnnotatedPodSpec verifies that transformPodSpec skips podspecs that have a
 // `debug.cloud.google.com/config` annotation.
-func TestTransformPodSpecSkips(t *testing.T) {
+func TestSkipAnnotatedPodSpec(t *testing.T) {
 	defer func(c []containerTransformer) { containerTransforms = c }(containerTransforms)
 	containerTransforms = append(containerTransforms, testTransformer{})
 

--- a/pkg/skaffold/debug/transform.go
+++ b/pkg/skaffold/debug/transform.go
@@ -55,6 +55,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	shell "github.com/kballard/go-shellquote"
 	"github.com/sirupsen/logrus"
@@ -116,7 +117,12 @@ const (
 	debuggingSupportFilesVolume = "debugging-support-files"
 
 	// DebugConfigAnnotation is the name of the podspec annotation that records debugging configuration information.
+	// The annotation should be a JSON-encoded map of container-name to a `ContainerDebugConfiguration` object.
 	DebugConfigAnnotation = "debug.cloud.google.com/config"
+
+	// DebugProbesAnnotation is the name of the podspec annotation that disables rewriting of probe timeouts.
+	// The annotation value should be `skip`.
+	DebugProbeTimeoutsAnnotation = "debug.cloud.google.com/probe/timeouts"
 )
 
 // containerTransforms are the set of configured transformers
@@ -199,26 +205,38 @@ func transformManifest(obj runtime.Object, retrieveImageConfiguration configurat
 // transformPodSpec attempts to configure a podspec for debugging.
 // Returns true if changed, false otherwise.
 func transformPodSpec(metadata *metav1.ObjectMeta, podSpec *v1.PodSpec, retrieveImageConfiguration configurationRetriever, debugHelpersRegistry string) bool {
+	// order matters as rewriteProbes only affects containers marked for debugging
 	containers := rewriteContainers(metadata, podSpec, retrieveImageConfiguration, debugHelpersRegistry)
-	timeouts := rewriteProbes(metadata, podSpec) // must rewriteProbes after
+	timeouts := rewriteProbes(metadata, podSpec)
 	return containers || timeouts
 }
 
 // rewriteProbes rewrites k8s probes to expand timeouts to 10 minutes to allow debugging local probes.
 func rewriteProbes(metadata *metav1.ObjectMeta, podSpec *v1.PodSpec) bool {
+	var minTimeout time.Duration = 10 * time.Minute // make it configurable?
+	if annotation, found := metadata.Annotations[DebugProbeTimeoutsAnnotation]; found {
+		if annotation == "skip" {
+			logrus.Debugf("skipping probe rewrite on %q by request", metadata.Name)
+			return false
+		}
+		if d, err := time.ParseDuration(annotation); err != nil {
+			logrus.Warnf("invalid probe timeout value for %q: %q: %v", metadata.Name, annotation, err)
+		} else {
+			minTimeout = d
+		}
+	}
 	annotation, found := metadata.Annotations[DebugConfigAnnotation]
 	if !found {
-		logrus.Warn("no debug config found")
+		logrus.Debugf("skipping probe rewrite on %q: not configured for debugging", metadata.Name)
 		return false
 	}
 	var config map[string]ContainerDebugConfiguration
 	if err := json.Unmarshal([]byte(annotation), &config); err != nil {
-		logrus.Warn("error unmarshalling config", err)
+		logrus.Warnf("error unmarshalling debugging configuration for %q: %v", metadata.Name, err)
 		return false
 	}
 
 	changed := false
-	var minTimeout int32 = 10 * 60 // make it configurable?
 	for i := range podSpec.Containers {
 		c := &podSpec.Containers[i]
 		// only affect containers listed in debug-config
@@ -235,11 +253,11 @@ func rewriteProbes(metadata *metav1.ObjectMeta, podSpec *v1.PodSpec) bool {
 	return changed
 }
 
-func rewriteHTTPGetProbe(probe *v1.Probe, minTimeout int32) bool {
-	if probe == nil || probe.HTTPGet == nil || minTimeout < probe.TimeoutSeconds {
+func rewriteHTTPGetProbe(probe *v1.Probe, minTimeout time.Duration) bool {
+	if probe == nil || probe.HTTPGet == nil || int32(minTimeout.Seconds()) < probe.TimeoutSeconds {
 		return false
 	}
-	probe.TimeoutSeconds = minTimeout
+	probe.TimeoutSeconds = int32(minTimeout.Seconds())
 	return true
 }
 

--- a/pkg/skaffold/debug/transform.go
+++ b/pkg/skaffold/debug/transform.go
@@ -223,9 +223,9 @@ func rewriteProbes(metadata *metav1.ObjectMeta, podSpec *v1.PodSpec) bool {
 		c := &podSpec.Containers[i]
 		// only affect containers listed in debug-config
 		if _, found := config[c.Name]; found {
-			lp := rewriteHttpGetProbe(c.LivenessProbe, minTimeout)
-			rp := rewriteHttpGetProbe(c.ReadinessProbe, minTimeout)
-			sp := rewriteHttpGetProbe(c.StartupProbe, minTimeout)
+			lp := rewriteHTTPGetProbe(c.LivenessProbe, minTimeout)
+			rp := rewriteHTTPGetProbe(c.ReadinessProbe, minTimeout)
+			sp := rewriteHTTPGetProbe(c.StartupProbe, minTimeout)
 			if lp || rp || sp {
 				logrus.Infof("Updated probe timeouts for %s/%s", metadata.Name, c.Name)
 			}
@@ -235,7 +235,7 @@ func rewriteProbes(metadata *metav1.ObjectMeta, podSpec *v1.PodSpec) bool {
 	return changed
 }
 
-func rewriteHttpGetProbe(probe *v1.Probe, minTimeout int32) bool {
+func rewriteHTTPGetProbe(probe *v1.Probe, minTimeout int32) bool {
 	if probe == nil || probe.HTTPGet == nil || minTimeout < probe.TimeoutSeconds {
 		return false
 	}

--- a/pkg/skaffold/debug/transform_test.go
+++ b/pkg/skaffold/debug/transform_test.go
@@ -334,7 +334,7 @@ func TestUpdateForShDashC(t *testing.T) {
 	}
 }
 
-func TestRewriteHttpGetProbe(t *testing.T) {
+func TestRewriteHTTPGetProbe(t *testing.T) {
 	const minTimeout int32 = 10 * 60
 	tests := []struct {
 		description string
@@ -368,7 +368,7 @@ func TestRewriteHttpGetProbe(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			p := test.input
-			if rewriteHttpGetProbe(&p, minTimeout) {
+			if rewriteHTTPGetProbe(&p, minTimeout) {
 				t.CheckDeepEqual(test.expected, p)
 			} else {
 				t.CheckDeepEqual(test.input, p) // should not have changed

--- a/pkg/skaffold/debug/transform_test.go
+++ b/pkg/skaffold/debug/transform_test.go
@@ -480,5 +480,4 @@ func TestRewriteProbes(t *testing.T) {
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
Fixes: #5425

**Description**
Cause `skaffold debug` to rewrite any readiness/liveness/startup probes using HTTP-Get to set the timeout value to 10 minutes (from the default of 1s).  This change allows debugging calls from such probes, and also avoids timeouts when a probe is made but the application is suspended because of an ongoing debug session.

**User facing changes (remove if N/A)**
- `skaffold debug` alters Kubernetes HTTP-Get probes to have a 10 minute timeout to allow debugging probe calls

**Follow-up Work (remove if N/A)**
Consider making this configurable somehow.