### PR TITLE
Add warning about chocolatey shim

### DIFF
--- a/docs/content/en/docs/install/_index.md
+++ b/docs/content/en/docs/install/_index.md
@@ -132,7 +132,7 @@ This package is not maintained by the Skaffold team.
 
 {{< alert title="Caution" >}}
 
-Chocolatey's installation mechanism interferes with <kbd>Ctrl</kbd><kbd>C</kbd> handling
+Chocolatey's installation mechanism interferes with <kbd>Ctrl</kbd>+<kbd>C</kbd> handling
 and [prevents Skaffold from cleaning up deployments](https://github.com/GoogleContainerTools/skaffold/issues/4815).
 This cannot be fixed by Skaffold.
 For more information about this defect see

--- a/docs/content/en/docs/install/_index.md
+++ b/docs/content/en/docs/install/_index.md
@@ -123,8 +123,21 @@ We also release a **bleeding edge** build, built from the latest commit:
 
 https://storage.googleapis.com/skaffold/builds/latest/skaffold-windows-amd64.exe
 
+---
 
 ### Chocolatey
+
+Skaffold can be installed using the [Chocolatey package manager](https://chocolatey.org/packages/skaffold).
+This package is not maintained by the Skaffold team.
+
+{{< alert title="Caution" >}}
+
+Chocolatey's installation mechanism interferes with <kbd>Ctrl</kbd><kbd>C</kbd> handling
+and prevents Skaffold from cleaning up deployments.  This cannot be fixed by Skaffold.
+For more information about this defect see
+[chocolatey/shimgen#32](https://github.com/chocolatey/shimgen/issues/32).
+
+{{< /alert >}}
 
 ```bash
 choco install -y skaffold

--- a/docs/content/en/docs/install/_index.md
+++ b/docs/content/en/docs/install/_index.md
@@ -133,7 +133,8 @@ This package is not maintained by the Skaffold team.
 {{< alert title="Caution" >}}
 
 Chocolatey's installation mechanism interferes with <kbd>Ctrl</kbd><kbd>C</kbd> handling
-and prevents Skaffold from cleaning up deployments.  This cannot be fixed by Skaffold.
+and [prevents Skaffold from cleaning up deployments](https://github.com/GoogleContainerTools/skaffold/issues/4815).
+This cannot be fixed by Skaffold.
 For more information about this defect see
 [chocolatey/shimgen#32](https://github.com/chocolatey/shimgen/issues/32).
 


### PR DESCRIPTION
Add warning to the installation docs on Chocolatey's shim defect (#4815).