### PR TITLE
Add defer and close status-check log file correctly

### DIFF
--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -92,7 +92,7 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 	r.hasDeployed = true
 
 	statusCheckOut, postStatusCheckFn, err := deployutil.WithStatusCheckLogFile(time.Now().Format(deployutil.TimeFormat)+".log", out, r.runCtx.Muted())
-	postStatusCheckFn()
+	defer postStatusCheckFn()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In, #4907 @briandealwis had left code review comments to 
1) move `postStatusCheckFn()` as soon as it got defined and 
2) add a defer.

I only addressed part 1 creating a bug:  _**skaffold writing logs to a closed file**_.
Now addressing part 2. 

Thanks @nkubala for bringing this to my attention.

