### PR TITLE
Change all Start() to Start([]namespaces) to consume updated namespaces where resources get deployed.

### DIFF
--- a/pkg/skaffold/kubernetes/debugging/container_manager.go
+++ b/pkg/skaffold/kubernetes/debugging/container_manager.go
@@ -40,24 +40,24 @@ type ContainerManager struct {
 	events     chan kubernetes.PodEvent
 }
 
-func NewContainerManager(podSelector kubernetes.PodSelector, namespaces []string) *ContainerManager {
+func NewContainerManager(podSelector kubernetes.PodSelector) *ContainerManager {
 	// Create the channel here as Stop() may be called before Start() when a build fails, thus
 	// avoiding the possibility of closing a nil channel. Channels are cheap.
 	return &ContainerManager{
-		podWatcher: kubernetes.NewPodWatcher(podSelector, namespaces),
+		podWatcher: kubernetes.NewPodWatcher(podSelector),
 		active:     map[string]string{},
 		events:     make(chan kubernetes.PodEvent),
 	}
 }
 
-func (d *ContainerManager) Start(ctx context.Context) error {
+func (d *ContainerManager) Start(ctx context.Context, namespaces []string) error {
 	if d == nil {
 		// debug mode probably not enabled
 		return nil
 	}
 
 	d.podWatcher.Register(d.events)
-	stopWatcher, err := d.podWatcher.Start()
+	stopWatcher, err := d.podWatcher.Start(namespaces)
 	if err != nil {
 		return err
 	}

--- a/pkg/skaffold/kubernetes/debugging/container_manager_test.go
+++ b/pkg/skaffold/kubernetes/debugging/container_manager_test.go
@@ -88,6 +88,6 @@ func TestContainerManagerZeroValue(t *testing.T) {
 	var m *ContainerManager
 
 	// Should not raise a nil dereference
-	m.Start(context.Background())
+	m.Start(context.Background(), nil)
 	m.Stop()
 }

--- a/pkg/skaffold/kubernetes/log.go
+++ b/pkg/skaffold/kubernetes/log.go
@@ -54,12 +54,12 @@ type Config interface {
 }
 
 // NewLogAggregator creates a new LogAggregator for a given output.
-func NewLogAggregator(out io.Writer, cli *kubectl.CLI, imageNames []string, podSelector PodSelector, namespaces []string, config Config) *LogAggregator {
+func NewLogAggregator(out io.Writer, cli *kubectl.CLI, imageNames []string, podSelector PodSelector, config Config) *LogAggregator {
 	return &LogAggregator{
 		output:      out,
 		kubectlcli:  cli,
 		config:      config,
-		podWatcher:  NewPodWatcher(podSelector, namespaces),
+		podWatcher:  NewPodWatcher(podSelector),
 		colorPicker: NewColorPicker(imageNames),
 		events:      make(chan PodEvent),
 	}
@@ -76,14 +76,14 @@ func (a *LogAggregator) SetSince(t time.Time) {
 
 // Start starts a logger that listens to pods and tail their logs
 // if they are matched by the `podSelector`.
-func (a *LogAggregator) Start(ctx context.Context) error {
+func (a *LogAggregator) Start(ctx context.Context, namespaces []string) error {
 	if a == nil {
 		// Logs are not activated.
 		return nil
 	}
 
 	a.podWatcher.Register(a.events)
-	stopWatcher, err := a.podWatcher.Start()
+	stopWatcher, err := a.podWatcher.Start(namespaces)
 	if err != nil {
 		return err
 	}

--- a/pkg/skaffold/kubernetes/log_test.go
+++ b/pkg/skaffold/kubernetes/log_test.go
@@ -128,7 +128,7 @@ func TestLogAggregatorZeroValue(t *testing.T) {
 	var m *LogAggregator
 
 	// Should not raise a nil dereference
-	m.Start(context.Background())
+	m.Start(context.Background(), []string{})
 	m.Mute()
 	m.Unmute()
 	m.Stop()
@@ -187,7 +187,7 @@ func TestPrefix(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			logger := NewLogAggregator(nil, nil, nil, nil, nil, &mockConfig{log: latest.LogsConfig{
+			logger := NewLogAggregator(nil, nil, nil, nil, &mockConfig{log: latest.LogsConfig{
 				Prefix: test.prefix,
 			}})
 

--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager_test.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager_test.go
@@ -25,6 +25,6 @@ func TestForwarderManagerZeroValue(t *testing.T) {
 	var m *ForwarderManager
 
 	// Should not raise a nil dereference
-	m.Start(context.Background())
+	m.Start(context.Background(), nil)
 	m.Stop()
 }

--- a/pkg/skaffold/kubernetes/portforward/pod_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/pod_forwarder.go
@@ -47,17 +47,17 @@ type WatchingPodForwarder struct {
 }
 
 // NewWatchingPodForwarder returns a struct that tracks and port-forwards pods as they are created and modified
-func NewWatchingPodForwarder(entryManager *EntryManager, podSelector kubernetes.PodSelector, namespaces []string) *WatchingPodForwarder {
+func NewWatchingPodForwarder(entryManager *EntryManager, podSelector kubernetes.PodSelector) *WatchingPodForwarder {
 	return &WatchingPodForwarder{
 		entryManager: entryManager,
-		podWatcher:   newPodWatcher(podSelector, namespaces),
+		podWatcher:   newPodWatcher(podSelector),
 		events:       make(chan kubernetes.PodEvent),
 	}
 }
 
-func (p *WatchingPodForwarder) Start(ctx context.Context) error {
+func (p *WatchingPodForwarder) Start(ctx context.Context, namespaces []string) error {
 	p.podWatcher.Register(p.events)
-	stopWatcher, err := p.podWatcher.Start()
+	stopWatcher, err := p.podWatcher.Start(namespaces)
 	if err != nil {
 		return err
 	}

--- a/pkg/skaffold/kubernetes/portforward/pod_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/pod_forwarder_test.go
@@ -412,7 +412,7 @@ func TestAutomaticPortForwardPod(t *testing.T) {
 			entryManager := NewEntryManager(ioutil.Discard, nil)
 			entryManager.entryForwarder = test.forwarder
 
-			p := NewWatchingPodForwarder(entryManager, kubernetes.NewImageList(), nil)
+			p := NewWatchingPodForwarder(entryManager, kubernetes.NewImageList())
 			for _, pod := range test.pods {
 				err := p.portForwardPod(context.Background(), pod)
 				t.CheckError(test.shouldErr, err)
@@ -476,7 +476,7 @@ func TestStartPodForwarder(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			event.InitializeState([]latest.Pipeline{{}}, "", true, true, true)
 			t.Override(&topLevelOwnerKey, func(context.Context, metav1.Object, string) string { return "owner" })
-			t.Override(&newPodWatcher, func(kubernetes.PodSelector, []string) kubernetes.PodWatcher {
+			t.Override(&newPodWatcher, func(kubernetes.PodSelector) kubernetes.PodWatcher {
 				return &fakePodWatcher{
 					events: []kubernetes.PodEvent{test.event},
 				}
@@ -488,8 +488,8 @@ func TestStartPodForwarder(t *testing.T) {
 			fakeForwarder := newTestForwarder()
 			entryManager := NewEntryManager(ioutil.Discard, fakeForwarder)
 
-			p := NewWatchingPodForwarder(entryManager, imageList, nil)
-			p.Start(context.Background())
+			p := NewWatchingPodForwarder(entryManager, imageList)
+			p.Start(context.Background(), nil)
 
 			// wait for the pod resource to be forwarded
 			err := wait.PollImmediate(10*time.Millisecond, 100*time.Millisecond, func() (bool, error) {
@@ -512,7 +512,7 @@ func (f *fakePodWatcher) Register(receiver chan<- kubernetes.PodEvent) {
 	f.receiver = receiver
 }
 
-func (f *fakePodWatcher) Start() (func(), error) {
+func (f *fakePodWatcher) Start(namespaces []string) (func(), error) {
 	go func() {
 		for _, event := range f.events {
 			f.receiver <- event

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -130,8 +130,8 @@ func TestStart(t *testing.T) {
 			fakeForwarder := newTestForwarder()
 			entryManager := NewEntryManager(ioutil.Discard, fakeForwarder)
 
-			rf := NewResourceForwarder(entryManager, []string{"test"}, "", nil)
-			if err := rf.Start(context.Background()); err != nil {
+			rf := NewResourceForwarder(entryManager, "", nil)
+			if err := rf.Start(context.Background(), []string{"test"}); err != nil {
 				t.Fatalf("error starting resource forwarder: %v", err)
 			}
 
@@ -194,7 +194,7 @@ func TestGetCurrentEntryFunc(t *testing.T) {
 			entryManager.forwardedResources = forwardedResources{
 				resources: test.forwardedResources,
 			}
-			rf := NewResourceForwarder(entryManager, []string{"test"}, "", nil)
+			rf := NewResourceForwarder(entryManager, "", nil)
 			actualEntry := rf.getCurrentEntry(test.resource)
 
 			expectedEntry := test.expected
@@ -272,8 +272,8 @@ func TestUserDefinedResources(t *testing.T) {
 			fakeForwarder := newTestForwarder()
 			entryManager := NewEntryManager(ioutil.Discard, fakeForwarder)
 
-			rf := NewResourceForwarder(entryManager, test.namespaces, "", test.userResources)
-			if err := rf.Start(context.Background()); err != nil {
+			rf := NewResourceForwarder(entryManager, "", test.userResources)
+			if err := rf.Start(context.Background(), test.namespaces); err != nil {
 				t.Fatalf("error starting resource forwarder: %v", err)
 			}
 

--- a/pkg/skaffold/kubernetes/watcher_test.go
+++ b/pkg/skaffold/kubernetes/watcher_test.go
@@ -60,8 +60,8 @@ func (h *hasName) Select(pod *v1.Pod) bool {
 
 func TestPodWatcher(t *testing.T) {
 	testutil.Run(t, "need to register first", func(t *testutil.T) {
-		watcher := NewPodWatcher(&anyPod{}, []string{"ns"})
-		cleanup, err := watcher.Start()
+		watcher := NewPodWatcher(&anyPod{})
+		cleanup, err := watcher.Start([]string{"ns"})
 		defer cleanup()
 
 		t.CheckErrorContains("no receiver was registered", err)
@@ -70,9 +70,9 @@ func TestPodWatcher(t *testing.T) {
 	testutil.Run(t, "fail to get client", func(t *testutil.T) {
 		t.Override(&client.Client, func() (kubernetes.Interface, error) { return nil, errors.New("unable to get client") })
 
-		watcher := NewPodWatcher(&anyPod{}, []string{"ns"})
+		watcher := NewPodWatcher(&anyPod{})
 		watcher.Register(make(chan PodEvent))
-		cleanup, err := watcher.Start()
+		cleanup, err := watcher.Start([]string{"ns"})
 		defer cleanup()
 
 		t.CheckErrorContains("unable to get client", err)
@@ -86,9 +86,9 @@ func TestPodWatcher(t *testing.T) {
 			return true, nil, errors.New("unable to watch")
 		})
 
-		watcher := NewPodWatcher(&anyPod{}, []string{"ns"})
+		watcher := NewPodWatcher(&anyPod{})
 		watcher.Register(make(chan PodEvent))
-		cleanup, err := watcher.Start()
+		cleanup, err := watcher.Start([]string{"ns"})
 		defer cleanup()
 
 		t.CheckErrorContains("unable to watch", err)
@@ -102,9 +102,9 @@ func TestPodWatcher(t *testing.T) {
 			validNames: []string{"pod1", "pod2", "pod3"},
 		}
 		events := make(chan PodEvent)
-		watcher := NewPodWatcher(podSelector, []string{"ns1", "ns2"})
+		watcher := NewPodWatcher(podSelector)
 		watcher.Register(events)
-		cleanup, err := watcher.Start()
+		cleanup, err := watcher.Start([]string{"ns1", "ns2"})
 		defer cleanup()
 		t.CheckNoError(err)
 

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -103,16 +103,16 @@ func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifa
 	// Update which images are logged.
 	r.addTagsToPodSelector(artifacts)
 
-	logger := r.createLogger(out, artifacts)
-	defer logger.Stop()
-
-	// Logs should be retrieved up to just before the deploy
-	logger.SetSince(time.Now())
-
+	deployTime := time.Now()
 	// First deploy
 	if err := r.Deploy(ctx, out, artifacts); err != nil {
 		return err
 	}
+	logger := r.createLogger(out, artifacts)
+	defer logger.Stop()
+
+	// Logs should be retrieved up to just before the deploy
+	logger.SetSince(deployTime)
 
 	forwarderManager := r.createForwarder(out)
 	defer forwarderManager.Stop()

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -121,7 +121,7 @@ func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifa
 	}
 
 	// Start printing the logs after deploy is finished
-	if err := logger.Start(ctx,r.runCtx.GetNamespaces()); err != nil {
+	if err := logger.Start(ctx, r.runCtx.GetNamespaces()); err != nil {
 		return fmt.Errorf("starting logger: %w", err)
 	}
 

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -121,7 +121,7 @@ func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifa
 	}
 
 	// Start printing the logs after deploy is finished
-	if err := logger.Start(ctx, r.runCtx.Namespaces); err != nil {
+	if err := logger.Start(ctx,r.runCtx.GetNamespaces()); err != nil {
 		return fmt.Errorf("starting logger: %w", err)
 	}
 

--- a/pkg/skaffold/runner/debugging.go
+++ b/pkg/skaffold/runner/debugging.go
@@ -26,5 +26,5 @@ func (r *SkaffoldRunner) createContainerManager() *debugging.ContainerManager {
 		return nil
 	}
 
-	return debugging.NewContainerManager(r.podSelector, r.runCtx.GetNamespaces())
+	return debugging.NewContainerManager(r.podSelector)
 }

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -236,20 +236,20 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 		}
 	}
 
-	logger := r.createLogger(out, bRes)
-	defer logger.Stop()
-
-	debugContainerManager := r.createContainerManager()
-	defer debugContainerManager.Stop()
-
 	// Logs should be retrieved up to just before the deploy
-	logger.SetSince(time.Now())
-
+	deployTime := time.Now()
 	// First deploy
 	if err := r.Deploy(ctx, out, r.builds); err != nil {
 		event.DevLoopFailedInPhase(r.devIteration, sErrors.Deploy, err)
 		return fmt.Errorf("exiting dev mode because first deploy failed: %w", err)
 	}
+
+	logger := r.createLogger(out, bRes)
+	defer logger.Stop()
+	logger.SetSince(deployTime)
+
+	debugContainerManager := r.createContainerManager()
+	defer debugContainerManager.Stop()
 
 	forwarderManager := r.createForwarder(out)
 	defer forwarderManager.Stop()

--- a/pkg/skaffold/runner/logger.go
+++ b/pkg/skaffold/runner/logger.go
@@ -33,5 +33,5 @@ func (r *SkaffoldRunner) createLogger(out io.Writer, artifacts []build.Artifact)
 		imageNames = append(imageNames, artifact.Tag)
 	}
 
-	return kubernetes.NewLogAggregator(out, r.kubectlCLI, imageNames, r.podSelector, r.runCtx.GetNamespaces(), r.runCtx)
+	return kubernetes.NewLogAggregator(out, r.kubectlCLI, imageNames, r.podSelector, r.runCtx)
 }


### PR DESCRIPTION
Fixes #5480

Change all below Objects 
1) pod watcher 
2) logger
3) container Manager

Problem:
1) Watchers, Loggers are not loggings or watching resources configured in the k8 manifest config `namespace` if it is different than `--namespace` skaffold command line flag. 

Reason:
Skaffold is unaware of namespaces in the k8 manifests until after we deploy. During deploy, we read manifests, and collect all namespaces.
In #2640, we updated `Deploy` to return a list of namespaces so all watchers, deployment fetcher can query namespaces where resources get deployed and update the `runner.runCtx.Namespaces`. This was used in `deploy.StatusCheck` however not in Logger, containerManager etc.
Associated bug #2495

In this approach, we are passing the namespace after `deploy.Deploy` to all `Start` methods to watch pods, containers in deployed namespaces.

1) change the signature of `logger.Start` and `container_manager.Start` and use updated  namespace in `runner.runCtx.Namespaces`.

**Pros:**
1) The signature makes it clear we need to pass namespace
```
type PodWatcher interface {
	Register(receiver chan<- PodEvent)
-	Start() (func(), error)
+	Start(ns []string) (func(), error)
}
```
2) Remove `namespaces` from constructors for all above objects.

### Alternate method 
1) capturing the deploy time to pass on to the logger.

**Pros:**
1) small change

**Cons:** 
1) Developers have to remember to capture deploy time before deploy is called and  start logger after.

