### PR TITLE
Simpler host:port formatting for port-forwards

### DIFF
--- a/pkg/skaffold/kubernetes/portforward/entry_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/entry_manager.go
@@ -113,7 +113,7 @@ func (b *EntryManager) forwardPortForwardEntry(ctx context.Context, entry *portF
 	if err := b.entryForwarder.Forward(ctx, entry); err == nil {
 		color.Green.Fprintln(
 			b.output,
-			fmt.Sprintf("Port forwarding %s/%s in namespace %s, remote port %s -> address %s port %d",
+			fmt.Sprintf("Port forwarding %s/%s in namespace %s, remote port %s -> %s:%d",
 				entry.resource.Type,
 				entry.resource.Name,
 				entry.resource.Namespace,


### PR DESCRIPTION
Fixes: #4718

**Description**
Format host and port for port-forwards as `host:port`.

Skip the fancier attempt to create a URL as `portForwardEntry` objects don't have the service object available anyways.
