### PR TITLE
Use runCtx instead of of config.Opts for suggesting suggestions. 

### DIFF
--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -46,7 +46,6 @@ var createRunner = createNewRunner
 
 func withRunner(ctx context.Context, out io.Writer, action func(runner.Runner, []*latest.SkaffoldConfig) error) error {
 	runner, config, err := createRunner(out, opts)
-	sErrors.SetSkaffoldOptions(opts)
 	if err != nil {
 		return err
 	}
@@ -62,6 +61,7 @@ func createNewRunner(out io.Writer, opts config.SkaffoldOptions) (runner.Runner,
 	if err != nil {
 		return nil, nil, err
 	}
+	sErrors.SetRunContext(*runCtx)
 
 	instrumentation.InitMeterFromConfig(configs)
 	runner, err := runner.NewForConfig(runCtx)

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -51,12 +51,13 @@ const (
 	DefaultRPCPort     = 50051
 	DefaultRPCHTTPPort = 50052
 
-	DefaultPortForwardNamespace = "default"
-	DefaultPortForwardAddress   = "127.0.0.1"
+	DefaultPortForwardAddress = "127.0.0.1"
 
 	DefaultProjectDescriptor = "project.toml"
 
 	LeeroyAppResponse = "leeroooooy app!!\n"
+
+	GithubIssueLink = "https://github.com/GoogleContainerTools/skaffold/issues/new"
 )
 
 var (

--- a/pkg/skaffold/errors/build_problems.go
+++ b/pkg/skaffold/errors/build_problems.go
@@ -18,6 +18,7 @@ package errors
 
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 )
 
@@ -36,8 +37,8 @@ var (
 	getConfigForCurrentContext = config.GetConfigForCurrentKubectx
 )
 
-func suggestBuildPushAccessDeniedAction(opts config.SkaffoldOptions) []*proto.Suggestion {
-	if defaultRepo := opts.DefaultRepo.Value(); defaultRepo != nil {
+func suggestBuildPushAccessDeniedAction(runCtx runcontext.RunContext) []*proto.Suggestion {
+	if defaultRepo := runCtx.Opts.DefaultRepo.Value(); defaultRepo != nil {
 		suggestions := []*proto.Suggestion{{
 			SuggestionCode: proto.SuggestionCode_CHECK_DEFAULT_REPO,
 			Action:         "Check your `--default-repo` value",
@@ -46,7 +47,7 @@ func suggestBuildPushAccessDeniedAction(opts config.SkaffoldOptions) []*proto.Su
 	}
 
 	// check if global repo is set
-	if cfg, err := getConfigForCurrentContext(opts.GlobalConfig); err == nil {
+	if cfg, err := getConfigForCurrentContext(runCtx.Opts.GlobalConfig); err == nil {
 		if defaultRepo := cfg.DefaultRepo; defaultRepo != "" {
 			suggestions := []*proto.Suggestion{{
 				SuggestionCode: proto.SuggestionCode_CHECK_DEFAULT_REPO_GLOBAL_CONFIG,

--- a/pkg/skaffold/errors/deploy_problems_test.go
+++ b/pkg/skaffold/errors/deploy_problems_test.go
@@ -37,7 +37,7 @@ func TestSuggestDeployFailedAction(t *testing.T) {
 			isMinikube:  true,
 			expected: []*proto.Suggestion{{
 				SuggestionCode: proto.SuggestionCode_CHECK_MINIKUBE_STATUS,
-				Action: "Check if minikube is running using `minikube status` command and try again.",
+				Action:         "Check if minikube is running using `minikube status` command and try again.",
 			}},
 		},
 		{

--- a/pkg/skaffold/errors/deploy_problems_test.go
+++ b/pkg/skaffold/errors/deploy_problems_test.go
@@ -19,10 +19,7 @@ package errors
 import (
 	"testing"
 
-	"k8s.io/client-go/tools/clientcmd/api"
-
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -30,26 +27,23 @@ import (
 func TestSuggestDeployFailedAction(t *testing.T) {
 	tests := []struct {
 		description string
-		opts        config.SkaffoldOptions
-		context     api.Config
-		isminikube  bool
+		context     string
+		isMinikube  bool
 		expected    []*proto.Suggestion
 	}{
 		{
-			description: "minicube status",
-			opts:        config.SkaffoldOptions{},
-			context:     api.Config{CurrentContext: "minikube"},
-			isminikube:  true,
+			description: "minikube status",
+			context:     "minikube",
+			isMinikube:  true,
 			expected: []*proto.Suggestion{{
 				SuggestionCode: proto.SuggestionCode_CHECK_MINIKUBE_STATUS,
-				Action:         "Check if minikube is running using `minikube status` command and try again",
+				Action: "Check if minikube is running using `minikube status` command and try again.",
 			}},
 		},
 		{
-			description: "minicube status named ctx",
-			opts:        config.SkaffoldOptions{},
-			context:     api.Config{CurrentContext: "test_cluster"},
-			isminikube:  true,
+			description: "minikube status named ctx",
+			context:     "test_cluster",
+			isMinikube:  true,
 			expected: []*proto.Suggestion{{
 				SuggestionCode: proto.SuggestionCode_CHECK_MINIKUBE_STATUS,
 				Action:         "Check if minikube is running using `minikube status -p test_cluster` command and try again.",
@@ -57,9 +51,8 @@ func TestSuggestDeployFailedAction(t *testing.T) {
 		},
 		{
 			description: "gke cluster",
-			opts:        config.SkaffoldOptions{},
-			context:     api.Config{},
-			isminikube:  false,
+			context:     "gke_test",
+			isMinikube:  false,
 			expected: []*proto.Suggestion{{
 				SuggestionCode: proto.SuggestionCode_CHECK_CLUSTER_CONNECTION,
 				Action:         "Check your connection for the cluster",
@@ -68,13 +61,13 @@ func TestSuggestDeployFailedAction(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&kubectx.CurrentConfig, func() (api.Config, error) {
-				return test.context, nil
-			})
+			runCtx := runcontext.RunContext{
+				KubeContext: test.context,
+			}
 			t.Override(&isMinikube, func(string) bool {
-				return test.isminikube
+				return test.isMinikube
 			})
-			actual := suggestDeployFailedAction(test.opts)
+			actual := suggestDeployFailedAction(runCtx)
 			t.CheckDeepEqual(test.expected, actual)
 		})
 	}

--- a/pkg/skaffold/errors/errors.go
+++ b/pkg/skaffold/errors/errors.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
@@ -36,12 +37,12 @@ const (
 	FileSync    = Phase("FileSync")
 	DevInit     = Phase("DevInit")
 	Cleanup     = Phase("Cleanup")
-
-	// Report issue text
-	reportIssueText = "If above error is unexpected, please open an issue https://github.com/GoogleContainerTools/skaffold/issues/new to report this error"
 )
 
 var (
+	// Report issue text
+	reportIssueText = fmt.Sprintf("If above error is unexpected, please open an issue %s to report this error", constants.GithubIssueLink)
+
 	setRunContextOnce sync.Once
 	runCtx            runcontext.RunContext
 

--- a/pkg/skaffold/errors/errors.go
+++ b/pkg/skaffold/errors/errors.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 )
 
@@ -42,10 +42,10 @@ const (
 )
 
 var (
-	setOptionsOnce sync.Once
-	skaffoldOpts   config.SkaffoldOptions
+	setRunContextOnce sync.Once
+	runCtx            runcontext.RunContext
 
-	reportIssueSuggestion = func(config.SkaffoldOptions) []*proto.Suggestion {
+	reportIssueSuggestion = func(runcontext.RunContext) []*proto.Suggestion {
 		return []*proto.Suggestion{{
 			SuggestionCode: proto.SuggestionCode_OPEN_ISSUE,
 			Action:         reportIssueText,
@@ -55,11 +55,11 @@ var (
 
 type Phase string
 
-// SetSkaffoldOptions set Skaffold config options once. These options are used later to
-// suggest actionable error messages based on skaffold run context
-func SetSkaffoldOptions(opts config.SkaffoldOptions) {
-	setOptionsOnce.Do(func() {
-		skaffoldOpts = opts
+// SetRunContext set Skaffold runCtx  once. This run context is used later to
+// suggest actionable error messages based on skaffold command line options and run context
+func SetRunContext(rc runcontext.RunContext) {
+	setRunContextOnce.Do(func() {
+		runCtx = rc
 	})
 }
 
@@ -83,7 +83,7 @@ func ShowAIError(err error) error {
 	for _, v := range append(knownProblems, knownInitProblems...) {
 		if v.regexp.MatchString(err.Error()) {
 			instrumentation.SetErrorCode(v.errCode)
-			if suggestions := v.suggestion(skaffoldOpts); suggestions != nil {
+			if suggestions := v.suggestion(runCtx); suggestions != nil {
 				description := fmt.Sprintf("%s\n", err)
 				if v.description != nil {
 					description = strings.Trim(v.description(err), ".")
@@ -98,9 +98,9 @@ func ShowAIError(err error) error {
 
 func IsOldImageManifestProblem(err error) (string, bool) {
 	if err != nil && oldImageManifest.regexp.MatchString(err.Error()) {
-		if s := oldImageManifest.suggestion(skaffoldOpts); s != nil {
+		if s := oldImageManifest.suggestion(runCtx); s != nil {
 			return fmt.Sprintf("%s. %s", oldImageManifest.description(err),
-				concatSuggestions(oldImageManifest.suggestion(skaffoldOpts))), true
+				concatSuggestions(oldImageManifest.suggestion(runCtx))), true
 		}
 		return "", true
 	}
@@ -116,7 +116,7 @@ func getErrorCodeFromError(phase Phase, err error) (proto.StatusCode, []*proto.S
 	if problems, ok := allErrors[phase]; ok {
 		for _, v := range problems {
 			if v.regexp.MatchString(err.Error()) {
-				return v.errCode, v.suggestion(skaffoldOpts)
+				return v.errCode, v.suggestion(runCtx)
 			}
 		}
 	}

--- a/pkg/skaffold/errors/errors.go
+++ b/pkg/skaffold/errors/errors.go
@@ -37,12 +37,12 @@ const (
 	FileSync    = Phase("FileSync")
 	DevInit     = Phase("DevInit")
 	Cleanup     = Phase("Cleanup")
+
+	// Report issue text
+	reportIssueText = "If above error is unexpected, please open an issue " + constants.GithubIssueLink + " to report this error"
 )
 
 var (
-	// Report issue text
-	reportIssueText = fmt.Sprintf("If above error is unexpected, please open an issue %s to report this error", constants.GithubIssueLink)
-
 	setRunContextOnce sync.Once
 	runCtx            runcontext.RunContext
 

--- a/pkg/skaffold/errors/init_problems.go
+++ b/pkg/skaffold/errors/init_problems.go
@@ -17,7 +17,7 @@ limitations under the License.
 package errors
 
 import (
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 )
 
@@ -31,7 +31,7 @@ var knownInitProblems = []problem{
 		regexp:      re(".*The control plane node must be running for this command.*"),
 		errCode:     proto.StatusCode_INIT_MINIKUBE_NOT_RUNNING_ERROR,
 		description: func(error) string { return "minikube is probably not running" },
-		suggestion: func(config.SkaffoldOptions) []*proto.Suggestion {
+		suggestion: func(runcontext.RunContext) []*proto.Suggestion {
 			return []*proto.Suggestion{{
 				SuggestionCode: proto.SuggestionCode_START_MINIKUBE,
 				Action:         `Try running "minikube start"`,

--- a/pkg/skaffold/errors/init_problems_test.go
+++ b/pkg/skaffold/errors/init_problems_test.go
@@ -42,7 +42,7 @@ var (
 			expectedAE: &proto.ActionableErr{
 				ErrCode:     proto.StatusCode_INIT_CREATE_TAGGER_ERROR,
 				Message:     "creating tagger: something went wrong",
-				Suggestions: reportIssueSuggestion(config.SkaffoldOptions{}),
+				Suggestions: reportIssueSuggestion(dummyRunCtx),
 			},
 		},
 		{
@@ -69,7 +69,7 @@ var (
 			expectedAE: &proto.ActionableErr{
 				ErrCode:     proto.StatusCode_INIT_CREATE_BUILDER_ERROR,
 				Message:     "creating runner: creating builder: something went wrong",
-				Suggestions: reportIssueSuggestion(config.SkaffoldOptions{}),
+				Suggestions: reportIssueSuggestion(dummyRunCtx),
 			},
 		},
 		{
@@ -81,7 +81,7 @@ var (
 			expectedAE: &proto.ActionableErr{
 				ErrCode:     proto.StatusCode_INIT_CREATE_ARTIFACT_DEP_ERROR,
 				Message:     "creating runner: unexpected artifact type `DockerrArtifact`",
-				Suggestions: reportIssueSuggestion(config.SkaffoldOptions{}),
+				Suggestions: reportIssueSuggestion(dummyRunCtx),
 			},
 		},
 		{
@@ -93,7 +93,7 @@ var (
 			expectedAE: &proto.ActionableErr{
 				ErrCode:     proto.StatusCode_INIT_CREATE_TEST_DEP_ERROR,
 				Message:     "creating runner: expanding test file paths: .src/test",
-				Suggestions: reportIssueSuggestion(config.SkaffoldOptions{}),
+				Suggestions: reportIssueSuggestion(dummyRunCtx),
 			},
 		},
 		{
@@ -105,7 +105,7 @@ var (
 			expectedAE: &proto.ActionableErr{
 				ErrCode:     proto.StatusCode_INIT_CACHE_ERROR,
 				Message:     "creating runner: initializing cache at some error",
-				Suggestions: reportIssueSuggestion(config.SkaffoldOptions{}),
+				Suggestions: reportIssueSuggestion(dummyRunCtx),
 			},
 		},
 	}


### PR DESCRIPTION
Relates to #5485

This is a refactor, to break change in smaller PR for #5485.
When adding deploy error codes #4933, i missed the part where `kubectx` gets called directly. We have that information in `runCtx`.  It easier to use the evaluated context there instead of re-writing logic to look up `kubeContext`

Pros
1) Remove dependency on `pkg/skaffold/config` and `pkg/skaffold/kubernetes/context` from errors. 
2) In upcoming PR, we need the logic to determine minikube vs remote cluster for "Internal System Error". Using runCtx is much easier than again evaluating kubecontext in `deploy/errors` package.
