### PR TITLE
Disabling artifact caching for custom builder in the integration test

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -140,7 +140,7 @@ func TestRun(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			ns, client := SetupNamespace(t)
 
-			args := append(test.args, "-cache-artifacts=false")
+			args := append(test.args, "--cache-artifacts=false")
 			skaffold.Run(args...).InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunOrFail(t)
 
 			client.WaitForPodsReady(test.pods...)

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -108,6 +108,7 @@ func TestRun(t *testing.T) {
 		{
 			description: "custom builder",
 			dir:         "examples/custom",
+			args:        []string{"-cache-artifacts=false"},
 			pods:        []string{"getting-started"},
 		},
 		{

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -141,7 +141,8 @@ func TestRun(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			ns, client := SetupNamespace(t)
 
-			skaffold.Run(test.args...).InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunOrFail(t)
+			args := append(test.args, "-cache-artifacts=false")
+			skaffold.Run(args...).InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunOrFail(t)
 
 			client.WaitForPodsReady(test.pods...)
 			client.WaitForDeploymentsToStabilize(test.deployments...)

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -108,7 +108,6 @@ func TestRun(t *testing.T) {
 		{
 			description: "custom builder",
 			dir:         "examples/custom",
-			args:        []string{"-cache-artifacts=false"},
 			pods:        []string{"getting-started"},
 		},
 		{


### PR DESCRIPTION
Fixes: #5496
**Description**
Integration tests are passing with cached artifacts even when the actual tests are broken.

For example:
Custom build test is broken (#5492). But it is still passing in the integration tests as it is able to find the cached artifact.

Integration tests should run with --cache-artifacts=false

