### PR TITLE
Define readiness probe for kaniko insecure test

### DIFF
--- a/integration/testdata/kaniko-insecure-registry/insecure-registry/reg.yaml
+++ b/integration/testdata/kaniko-insecure-registry/insecure-registry/reg.yaml
@@ -32,4 +32,8 @@ spec:
         - name: registry
           image: devreg
           ports:
-            - containerPort: 50051
+            - containerPort: 5000
+          readinessProbe:
+            httpGet:
+              path: /v2/_catalog
+              port: 5000


### PR DESCRIPTION
Fixes: #4564 

**Description**
We see occasional test flakes in `TestBuildKanikoInsecureRegistry`.  In this test we start up a Docker registry and then try to push images to it.  This PR adds a readiness probe to the registry's deployment to ensure the registry is up and running; this works with Skaffold's status checks to ensure the initial `skaffold run` does not return until the registry is available.
