### PR TITLE
Use the PreRelease field semver.Version.Pre for update check and telemetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ endif
 GO_LDFLAGS = -X $(VERSION_PACKAGE).version=$(VERSION)
 GO_LDFLAGS += -X $(VERSION_PACKAGE).buildDate=$(shell date +'%Y-%m-%dT%H:%M:%SZ')
 GO_LDFLAGS += -X $(VERSION_PACKAGE).gitCommit=$(COMMIT)
-GO_LDFLAGS += -X $(VERSION_PACKAGE).gitTreeState=$(if $(shell git status --porcelain),dirty,clean)
 GO_LDFLAGS += -s -w
 
 GO_BUILD_TAGS_linux = osusergo netgo static_build release

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -98,19 +98,21 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 			shutdownAPIServer = shutdown
 
 			// Print version
-			version := version.Get()
-			logrus.Infof("Skaffold %+v", version)
+			versionInfo := version.Get()
+			logrus.Infof("Skaffold %+v", versionInfo)
 			if !isHouseKeepingMessagesAllowed(cmd) {
 				logrus.Debugf("Disable housekeeping messages for command explicitly")
 				return nil
 			}
 			switch {
+			case preReleaseVersion(versionInfo.Version):
+				logrus.Debugf("Update check, survey prompt and telemetry disabled for pre release version")
 			case !interactive:
-				logrus.Debugf("Update check and survey prompt disabled in non-interactive mode")
+				logrus.Debugf("Update check, survey prompt and telemetry disabled in non-interactive mode")
 			case quietFlag:
-				logrus.Debugf("Update check and survey prompt disabled in quiet mode")
+				logrus.Debugf("Update check, survey prompt and telemetry disabled in quiet mode")
 			case analyze:
-				logrus.Debugf("Update check and survey prompt disabled when running `init --analyze`")
+				logrus.Debugf("Update check, survey prompt and telemetry disabled disabled when running `init --analyze`")
 			default:
 				go func() {
 					msg, err := update.CheckVersion(opts.GlobalConfig)
@@ -285,4 +287,13 @@ func allowHouseKeepingMessages(cmd *cobra.Command) {
 		cmd.Annotations = make(map[string]string)
 	}
 	cmd.Annotations[HouseKeepingMessagesAllowedAnnotation] = "true"
+}
+
+func preReleaseVersion(s string) bool {
+	if v, err := version.ParseVersion(s); err == nil && len(v.Pre) > 0 {
+		return true
+	} else if err != nil {
+		return true
+	}
+	return false
 }

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -105,7 +105,7 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 				return nil
 			}
 			switch {
-			case preReleaseVersion(versionInfo.Version):
+			case preReleaseVersion(versionInfo.Version) && !update.EnableCheck:
 				logrus.Debugf("Update check, survey prompt and telemetry disabled for pre release version")
 			case !interactive:
 				logrus.Debugf("Update check, survey prompt and telemetry disabled in non-interactive mode")

--- a/cmd/skaffold/app/cmd/cmd_test.go
+++ b/cmd/skaffold/app/cmd/cmd_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestPreReleaseVersion(t *testing.T) {
+	tests := []struct {
+		description string
+		versionStr  string
+		expected    bool
+	}{
+		{
+			description: "pre release version",
+			versionStr:  "v1.20.0-42-g92900f245-dirty",
+			expected:    true,
+		},
+		{
+			description: "release version",
+			versionStr:  "v1.20.0",
+		},
+		{
+			description: "incorrect version indicates pre release or dev version",
+			versionStr:  "blah",
+			expected:    true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			actual := preReleaseVersion(test.versionStr)
+			t.CheckDeepEqual(test.expected, actual)
+		})
+	}
+}

--- a/hack/build.bat
+++ b/hack/build.bat
@@ -25,10 +25,8 @@ set GOOS=windows
 set GOARCH=amd64
 set CGO_ENABLED=1
 FOR /F "tokens=*" %%a in ('git describe --always --tags --dirty') do SET VERSION=%%a
-FOR /F "tokens=*" %%a in ('git status --porcelain') do SET DIRTY=%%a
-IF "%DIRTY" == "" SET TREE=clean ELSE SET TREE=dirty
 FOR /F "tokens=*" %%a in ('git rev-parse HEAD') do SET COMMIT=%%a
 for /f %%a in ('powershell -Command "Get-Date -format yyyy_MM_dd__HH_mm_ss"') do set BUILD_DATE=%%a
-set FLAG_LDFLAGS=" -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.version=%VERSION% -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.buildDate='%BUILD_DATE%' -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.gitCommit=%COMMIT% -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.gitTreeState=%TREE%  -extldflags \"\""
+set FLAG_LDFLAGS=" -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.version=%VERSION% -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.buildDate='%BUILD_DATE%' -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.gitCommit=%COMMIT% -extldflags \"\""
 
 go build -ldflags %FLAG_LDFLAGS% -o out/skaffold.exe github.com/GoogleContainerTools/skaffold/cmd/skaffold

--- a/integration/housekeeping_messages_test.go
+++ b/integration/housekeeping_messages_test.go
@@ -33,7 +33,7 @@ func TestHouseKeepingMessagesNotShownForDiagnose(t *testing.T) {
 func TestHouseKeepingMessagesShownForDev(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 	file := testutil.TempFile(t, "config", nil)
-	out := skaffold.Run("-c", file).InDir("examples/getting-started").RunOrFailOutput(t)
+	out := skaffold.Run("-c", file, "--update-check=true").InDir("examples/getting-started").RunOrFailOutput(t)
 	testutil.CheckContains(t, "Help improve Skaffold", string(out))
 	skaffold.Delete().InDir("examples/getting-started")
 }

--- a/pkg/skaffold/update/update.go
+++ b/pkg/skaffold/update/update.go
@@ -70,11 +70,6 @@ func checkVersion(config string, onError bool) (string, error) {
 // isUpdateCheckEnabled returns whether or not the update check is enabled
 // It is true by default, but setting it to any other value than true will disable the check
 func isUpdateCheckEnabled(configfile string) bool {
-	// Don't perform a version check on dirty trees
-	if version.Get().GitTreeState == "dirty" {
-		return false
-	}
-
 	return EnableCheck && isConfigUpdateCheckEnabled(configfile)
 }
 

--- a/pkg/skaffold/version/version.go
+++ b/pkg/skaffold/version/version.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
-var version, gitCommit, gitTreeState, buildDate string
+var version, gitCommit, buildDate string
 var platform = fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)
 
 type Info struct {
@@ -34,7 +34,6 @@ type Info struct {
 	ConfigVersion string
 	GitVersion    string
 	GitCommit     string
-	GitTreeState  string
 	BuildDate     string
 	GoVersion     string
 	Compiler      string
@@ -49,7 +48,6 @@ var Get = func() *Info {
 		Version:       version,
 		ConfigVersion: latest.Version,
 		GitCommit:     gitCommit,
-		GitTreeState:  gitTreeState,
 		BuildDate:     buildDate,
 		GoVersion:     runtime.Version(),
 		Compiler:      runtime.Compiler,


### PR DESCRIPTION
fixes #5515

In this Pr, 
We were relying on `version.GitTree` state being dirty to detect if skaffold binary is dev binary or released.
However, in https://github.com/GoogleContainerTools/skaffold/pull/5280/files#diff-6547f8c009c546989c6d4d936f8eecddf7815e8a40e1924e9a67fec8b24d7132R4, we added a step in the release process which leaves up the git workspace into a dirty state. 

The `semver.Version` has this field of `PreRelease` version which indicates a version is not released. 
1) For binaries built from skaffold dev branches, the git commit will be part of `semver.Version.Pre`
**Note**: in future if we plan to do a pre-release, we wont get any usage metrics for that. It should be fine.
 
Relying on `semver.Version.Pre` instead of `GitTree` being dirty to disable update checks for skaffold binaries under dev.

Also, disable sending telemetry for non released skaffold version by consolidating this logic at one place. 


Future work
- [ ] Add a test in our release pipeline to make sure, update check  is **never** skipped for released version.
- [ ] Determine if `telemetry` should be disabled in non interactive mode.


Testing notes
1) checkout this branchs
2) Make a skaffold binary with `version.version` as release version but `version.gitTreeState=dirty`
```
GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 \
	    go build -gcflags="all=-N -l" -tags "release " -ldflags "-X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.version=v1.20.0 -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.buildDate=2021-03-09T15:08:33Z -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.gitCommit=71bd9e69c61025944f34dee763a5b145e7c6afc9 -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.gitTreeState=dirty -s -w " -o out/skaffold github.com/GoogleContainerTools/skaffold/cmd/skaffold
```
3) make sure update check is not skipped. does not show ` DEBU[0000] Update check, survey prompt and telemetry disabled for pre release version `
```
cd examples/getting-started && ../../out/skaffold build -v=debug && cd examples/getting-started

```


Testing for a pre-release version or dev version
1) make
2)  you see update check disabled prompt
```
➜  skaffold git:(update_check_released_version) make
GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 \
	    go build -gcflags="all=-N -l" -tags "release " -ldflags "-X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.version=v1.20.0-43-g07a806d3c -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.buildDate=2021-03-09T16:05:26Z -X github.com/GoogleContainerTools/skaffold/pkg/skaffold/version.gitCommit=07a806d3cb76399adbd20fac9b8c0542eb4a91ff -s -w " -o out/skaffold github.com/GoogleContainerTools/skaffold/cmd/skaffold
➜  skaffold git:(update_check_released_version) cd examples/getting-started && ../../out/skaffold build -v=debug
INFO[0000] Skaffold &{Version:v1.20.0-43-g07a806d3c ConfigVersion:skaffold/v2beta13 GitVersion: GitCommit:07a806d3cb76399adbd20fac9b8c0542eb4a91ff BuildDate:2021-03-09T16:05:26Z GoVersion:go1.15.3 Compiler:gc Platform:darwin/amd64} 
DEBU[0000] Update check, survey prompt and telemetry disabled for pre release version 
```