### PR TITLE
Allow Argo Rollout resource manifests to be transformed (#5523)

### DIFF
--- a/pkg/skaffold/kubernetes/manifest/visitor.go
+++ b/pkg/skaffold/kubernetes/manifest/visitor.go
@@ -39,6 +39,7 @@ var transformableAllowlist = map[apimachinery.GroupKind]bool{
 	{Group: "serving.knative.dev", Kind: "Service"}: true,
 	{Group: "agones.dev", Kind: "Fleet"}:            true,
 	{Group: "agones.dev", Kind: "GameServer"}:       true,
+	{Group: "argoproj.io", Kind: "Rollout"}:         true,
 }
 
 // FieldVisitor represents the aggregation/transformation that should be performed on each traversed field.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5523  <!-- tracking issues that this PR will close -->

**Description**

This PR adds the resource kind `Rollout` in the group `argoproj.io` to the `transformableAllowList` to allow the manifest visitor to transform fields on such resources.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
