### PR TITLE
Refactor and reuse util.StringSet

### DIFF
--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -19,7 +19,6 @@ package runcontext
 import (
 	"fmt"
 	"os"
-	"sort"
 
 	"github.com/sirupsen/logrus"
 
@@ -27,6 +26,7 @@ import (
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	runnerutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 const (
@@ -234,20 +234,8 @@ func (rc *RunContext) UpdateNamespaces(ns []string) {
 	if len(ns) == 0 {
 		return
 	}
-
-	nsMap := map[string]bool{}
-	for _, ns := range append(ns, rc.Namespaces...) {
-		if ns == emptyNamespace {
-			continue
-		}
-		nsMap[ns] = true
-	}
-
-	// Update RunContext Namespace
-	updated := make([]string, 0, len(nsMap))
-	for k := range nsMap {
-		updated = append(updated, k)
-	}
-	sort.Strings(updated)
-	rc.Namespaces = updated
+	set := util.NewStringSet()
+	set.Insert(append(rc.Namespaces, ns...)...)
+	set.Delete(emptyNamespace)
+	rc.Namespaces = set.ToList()
 }

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -234,8 +234,8 @@ func (rc *RunContext) UpdateNamespaces(ns []string) {
 	if len(ns) == 0 {
 		return
 	}
-	set := util.NewStringSet()
-	set.Insert(append(rc.Namespaces, ns...)...)
-	set.Delete(emptyNamespace)
-	rc.Namespaces = set.ToList()
+	namespaces := util.NewStringSet()
+	namespaces.Insert(append(rc.Namespaces, ns...)...)
+	namespaces.Delete(emptyNamespace)
+	rc.Namespaces = namespaces.ToList()
 }

--- a/pkg/skaffold/runner/runcontext/context_test.go
+++ b/pkg/skaffold/runner/runcontext/context_test.go
@@ -75,7 +75,6 @@ func TestRunContext_UpdateNamespaces(t *testing.T) {
 			description:   "update namespace when namespace is empty string and runContext is empty",
 			oldNamespaces: []string{},
 			newNamespaces: []string{""},
-			expected:      []string{},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/util/stringset.go
+++ b/pkg/skaffold/util/stringset.go
@@ -45,6 +45,13 @@ func (s StringSet) ToList() []string {
 	return res
 }
 
+// Delete deletes the specified string in the set
+// if set is nil or string is not present, its a no-op
+func (s StringSet) Delete(str string) {
+	delete(s, str)
+}
+
+// Contains checks if a specified string is present in the set.
 func (s StringSet) Contains(str string) bool {
 	_, ok := s[str]
 	return ok


### PR DESCRIPTION
Remove code redundancy and reuse `util.StringSet` to merge namespaces to array with de-dups.

The change in test is due to
1) util.StringSet.ToList will return nil []string instead of empty array of string.
This should not result into any nil point exception as we usually iterate over this array using `range` which should work with nil arrays.