### PR TITLE
fix: `skaffold diagnose` outputs incorrect `yaml` for multiconfig projects

### DIFF
--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -64,6 +64,10 @@ func doDiagnose(ctx context.Context, out io.Writer) error {
 			color.Blue.Fprintln(out, "\nConfiguration")
 		}
 	}
+	// remove the dependency config references since they have already been imported and will be marshalled together.
+	for i := range configs {
+		configs[i].Dependencies = nil
+	}
 	buf, err := yaml.MarshalWithSeparator(configs)
 	if err != nil {
 		return fmt.Errorf("marshalling configuration: %w", err)

--- a/integration/diagnose_test.go
+++ b/integration/diagnose_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
+	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestDiagnose(t *testing.T) {
@@ -62,4 +63,14 @@ func folders(root string) ([]string, error) {
 	}
 
 	return folders, err
+}
+
+func TestMultiConfigDiagnose(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+	testutil.Run(t, "test multiconfig diagnose", func(t *testutil.T) {
+		out := skaffold.Diagnose("--yaml-only").InDir("testdata/diagnose/multi-config").RunOrFailOutput(t.T)
+		expected, err := ioutil.ReadFile("testdata/diagnose/multi-config/skaffold_merged.yaml")
+		t.CheckNoError(err)
+		t.CheckDeepEqual(expected, out)
+	})
 }

--- a/integration/testdata/diagnose/multi-config/skaffold.yaml
+++ b/integration/testdata/diagnose/multi-config/skaffold.yaml
@@ -1,0 +1,13 @@
+apiVersion: skaffold/v2beta13
+kind: Config
+requires:
+- path: ./skaffold2.yaml
+- path: ./skaffold3.yaml
+build:
+  artifacts:
+  - image: app1
+    context: /foo
+deploy:
+  kubectl:
+    manifests:
+    - /k8s/*

--- a/integration/testdata/diagnose/multi-config/skaffold2.yaml
+++ b/integration/testdata/diagnose/multi-config/skaffold2.yaml
@@ -1,0 +1,12 @@
+apiVersion: skaffold/v2beta13
+kind: Config
+metadata:
+  name: cfg2
+build:
+  artifacts:
+  - image: app2
+    context: /foo
+deploy:
+  kubectl:
+    manifests:
+    - /k8s/*

--- a/integration/testdata/diagnose/multi-config/skaffold3.yaml
+++ b/integration/testdata/diagnose/multi-config/skaffold3.yaml
@@ -1,0 +1,12 @@
+apiVersion: skaffold/v2beta13
+kind: Config
+metadata:
+  name: cfg3
+build:
+  artifacts:
+  - image: app3
+    context: /foo
+deploy:
+  kubectl:
+    manifests:
+    - /k8s/*

--- a/integration/testdata/diagnose/multi-config/skaffold_merged.yaml
+++ b/integration/testdata/diagnose/multi-config/skaffold_merged.yaml
@@ -1,0 +1,60 @@
+apiVersion: skaffold/v2beta13
+kind: Config
+metadata:
+  name: cfg2
+build:
+  artifacts:
+  - image: app2
+    context: /foo
+    docker:
+      dockerfile: Dockerfile
+  tagPolicy:
+    gitCommit: {}
+  local:
+    concurrency: 1
+deploy:
+  kubectl:
+    manifests:
+    - /k8s/*
+  logs:
+    prefix: container
+---
+apiVersion: skaffold/v2beta13
+kind: Config
+metadata:
+  name: cfg3
+build:
+  artifacts:
+  - image: app3
+    context: /foo
+    docker:
+      dockerfile: Dockerfile
+  tagPolicy:
+    gitCommit: {}
+  local:
+    concurrency: 1
+deploy:
+  kubectl:
+    manifests:
+    - /k8s/*
+  logs:
+    prefix: container
+---
+apiVersion: skaffold/v2beta13
+kind: Config
+build:
+  artifacts:
+  - image: app1
+    context: /foo
+    docker:
+      dockerfile: Dockerfile
+  tagPolicy:
+    gitCommit: {}
+  local:
+    concurrency: 1
+deploy:
+  kubectl:
+    manifests:
+    - /k8s/*
+  logs:
+    prefix: container


### PR DESCRIPTION
`skaffold diagnose --yaml-only` used on a multiconfig project outputs a merged list of all resolved configs.
For example:
_skaffold.yaml_:

```yaml
...
requires:
  - path: ./skaffold2.yaml
build:
  - image: foo1
...
```
_skaffold2.yaml_:
```yaml
...
build:
  - image: foo2
...
```
should produce:
```yaml
...
build:
  - image: foo1
...
---
...
build:
  - image: foo2
...
```
But it's actually producing:
```yaml
...
requires:
  - path: ./skaffold2.yaml
build:
  - image: foo1
...
---
...
build:
  - image: foo2
...
```
If this output yaml is used as the input for another skaffold run then the `skaffold2.yaml` artifacts are duplicated since it's reimported. 
This PR fixes this issue by removing the dependency list prior to marshalling.
