### PR TITLE
Link relevant Cloud Shell tutorials in doc site

### DIFF
--- a/docs/content/en/docs/tutorials/_index.md
+++ b/docs/content/en/docs/tutorials/_index.md
@@ -27,4 +27,5 @@ Take a look at our other guides:
 |--------------------|
 | [Custom Build Script]({{< relref "/docs/tutorials/custom-builder" >}}) |
 | [Build Artifact Dependencies]({{< relref "/docs/tutorials/artifact-dependencies" >}}) |
+| [Override Buildpacks Run Image]({{< relref "/docs/tutorials/buildpacks-override" >}}) |
 | [Config Dependencies]({{< relref "/docs/tutorials/config-dependencies" >}}) |

--- a/docs/content/en/docs/tutorials/buildpacks-override.md
+++ b/docs/content/en/docs/tutorials/buildpacks-override.md
@@ -1,0 +1,9 @@
+---
+title: "Override the run image in buildpacks builder"
+linkTitle: "Overriding the buildpacks run image"
+weight: 100
+---
+
+This is a link to a guided Cloud Shell tutorial using skaffold's `artifact dependency` feature to override the [run image](https://buildpacks.io/docs/concepts/components/stack/) in the [buildpacks builder]({{<relref "/docs/pipeline-stages/builders/buildpacks" >}}):
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.png)](https://ssh.cloud.google.com/cloudshell/open?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_working_dir=codelab/03_buildpacks-runimage-override&cloudshell_workspace=codelab/03_buildpacks-runimage-override&cloudshell_tutorial=tutorial.md)

--- a/docs/content/en/docs/tutorials/config-dependencies.md
+++ b/docs/content/en/docs/tutorials/config-dependencies.md
@@ -4,7 +4,12 @@ linkTitle: "Config Dependencies"
 weight: 100
 ---
 
-This is a link to a guided Cloud Shell tutorial using skaffold's `config dependencies` feature:
+Skaffold's [config dependencies]({{<relref "/docs/design/config#configuration-dependencies" >}}) feature allows you to import configurations defined across multiple `skaffold.yaml` files (even across repositories) into a single configuration as its dependencies. This helps more readily integrate Skaffold with multi-microservice and multi-repository applications.
+
+For a guided Cloud Shell tutorial on setting up [local dependencies]({{<relref "/docs/design/config#local-config-dependency">}}), follow:
 
 [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/gsquared94/bank-of-anthos-demo&cloudshell_workspace=.&cloudshell_tutorial=tutorial.md)
 
+For a guided Cloud Shell tutorial on setting up [remote git dependencies]({{<relref "/docs/design/config#remote-config-dependency">}}), follow:
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/gsquared94/skaffold-remote-configs-demo&cloudshell_workspace=.&cloudshell_tutorial=tutorial.md)


### PR DESCRIPTION
Link the Cloud Shell tutorials in the doc site directly.

http://34.94.200.231:1313/docs/tutorials/config-dependencies/
http://34.94.200.231:1313/docs/tutorials/buildpacks-override/