### PR TITLE
Fix setting of defaults for flags

### DIFF
--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -32,9 +32,10 @@ import (
 )
 
 var (
-	quietFlag       bool
-	buildFormatFlag = flags.NewTemplateFlag("{{json .}}", flags.BuildOutput{})
-	buildOutputFlag string
+	quietFlag                  bool
+	defaultBuildFormatTemplate = "{{json .}}"
+	buildFormatFlag            = flags.NewTemplateFlag(defaultBuildFormatTemplate, flags.BuildOutput{})
+	buildOutputFlag            string
 )
 
 // NewCmdBuild describes the CLI command to build artifacts.
@@ -51,7 +52,7 @@ func NewCmdBuild() *cobra.Command {
 		WithCommonFlags().
 		WithFlags([]*Flag{
 			{Value: &quietFlag, Name: "quiet", Shorthand: "q", DefValue: false, Usage: "Suppress the build output and print image built on success. See --output to format output.", IsEnum: true},
-			{Value: buildFormatFlag, Name: "output", Shorthand: "o", Usage: "Used in conjunction with --quiet flag. " + buildFormatFlag.Usage()},
+			{Value: buildFormatFlag, Name: "output", Shorthand: "o", DefValue: defaultBuildFormatTemplate, Usage: "Used in conjunction with --quiet flag. " + buildFormatFlag.Usage()},
 			{Value: &buildOutputFlag, Name: "file-output", DefValue: "", Usage: "Filename to write build images to"},
 			{Value: &opts.DryRun, Name: "dry-run", DefValue: false, Usage: "Don't build images, just compute the tag for each artifact.", IsEnum: true},
 		}).

--- a/cmd/skaffold/app/cmd/commands.go
+++ b/cmd/skaffold/app/cmd/commands.go
@@ -93,7 +93,7 @@ func (b *builder) WithFlags(flags []*Flag) Builder {
 		b.cmd.Flags().AddFlag(fl)
 	}
 	b.cmd.PreRun = func(cmd *cobra.Command, args []string) {
-		ParseFlags(cmd, flags)
+		ResetFlagDefaults(cmd, flags)
 	}
 
 	return b

--- a/cmd/skaffold/app/cmd/version.go
+++ b/cmd/skaffold/app/cmd/version.go
@@ -26,13 +26,14 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
 
-var versionFlag = flags.NewTemplateFlag("{{.Version}}\n", version.Info{})
+var versionDefaultTemplate = "{{.Version}}\n"
+var versionFlag = flags.NewTemplateFlag(versionDefaultTemplate, version.Info{})
 
 func NewCmdVersion() *cobra.Command {
 	return NewCmd("version").
 		WithDescription("Print the version information").
 		WithFlags([]*Flag{
-			{Value: versionFlag, Name: "output", Shorthand: "o", Usage: versionFlag.Usage()},
+			{Value: versionFlag, Name: "output", Shorthand: "o", DefValue: versionDefaultTemplate, Usage: versionFlag.Usage()},
 		}).
 		NoArgs(doVersion)
 }


### PR DESCRIPTION
**Related**: #5447

**Description**
With the `--port-forward` refactoring (#4832), I'm turning `port-forward` into a string-slice argument with different per-command defaults.  The default will generally be `user`,  but for `skaffold debug` it will be `user,debug`.  

#5447 fixed how per-command default values were surfaced in help text. But in processing the arguments, the port-forward values for `skaffold debug` were being set to `[]string{"[user debug]"}` rather than `[]string{"user","debug"}`.

It turns out the helper function that actually set the per-command defaults (`ParseFlags()`) doesn't handle string-slice arguments and would use [`String()` on a `[]string{"user","debug"}`](https://github.com/briandealwis/skaffold/blob/f6da11b12fa5018ce438dca7cdbe99bfddb01b2a/cmd/skaffold/app/cmd/flags.go#L558).

By way of background, the cobra+pflags packages define a set of flags for a set of commands.  Each flag has a pointer to a _value holder_ (e.g., pointer to `string` for a string value), and a default value.  The value holder is set to the default when the flag is defined.  So if multiple flags are defined with the same pointer (e.g., the `run`, `dev`, and `debug` commands all define `--port-forward`  but with different defaults, and the value holder is the global SkaffoldOptions.PortForward string slice) then the value holder will be the default for the last command processed.  To remedy this, [our command setup calls `ParseFlags()` to reset the flag defaults](https://github.com/briandealwis/skaffold/blob/f6da11b12fa5018ce438dca7cdbe99bfddb01b2a/cmd/skaffold/app/cmd/flags.go#L584-L585) before processing the command-line arguments.

This PR:

  1. Causes `ParseFlags()` to *always* reset the flag value, instead of just for per-command defaults.  This value is set  each time a command flag is created to the flag's default value, and so the value will be set to the last command flag's default.
  2. Causes `ParseFlags()` to handle string-slice values by using `SliceValue.Replace()`.
  1. Renames `ParseFlags` to `ResetFlagDefaults()`.
  2. Adds tests to verify the values are set to the expected values.

