### PR TITLE
add number of releases in helm config

### DIFF
--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -225,6 +225,10 @@ func deployerMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, r
 	for _, deployer := range meter.Deployers {
 		deployerCounter.Record(ctx, 1, randLabel, label.String("deployer", deployer))
 	}
+	if meter.HelmReleasesCount > 0 {
+		multiReleasesCounter := metric.Must(m).NewInt64ValueRecorder("helmReleases", metric.WithDescription("Multiple helm releases used"))
+		multiReleasesCounter.Record(ctx, 1, randLabel, label.Int("count", meter.HelmReleasesCount))
+	}
 }
 
 func builderMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, randLabel label.KeyValue) {

--- a/pkg/skaffold/instrumentation/export_test.go
+++ b/pkg/skaffold/instrumentation/export_test.go
@@ -71,6 +71,7 @@ func TestExportMetrics(t *testing.T) {
 		EnumFlags:         map[string]string{"test_run": "test_run_value"},
 		Builders:          map[string]int{"kustomize": 3, "buildpacks": 2},
 		BuildDependencies: map[string]int{"docker": 1},
+		HelmReleasesCount: 2,
 		DevIterations:     []devIteration{{"sync", 0}, {"build", 400}, {"build", 0}, {"sync", 200}, {"deploy", 0}},
 		ErrorCode:         proto.StatusCode_BUILD_CANCELLED,
 		StartTime:         startTime.Add(time.Hour * 24 * 30),
@@ -249,6 +250,7 @@ func checkOutput(t *testutil.T, meters []skaffoldMeter, b []byte) {
 	errorCount := make(map[interface{}]int)
 	builders := make(map[interface{}]int)
 	buildDeps := make(map[interface{}]int)
+	helmReleases := make(map[interface{}]int)
 	devIterations := make(map[interface{}]int)
 	deployers := make(map[interface{}]int)
 	enumFlags := make(map[interface{}]int)
@@ -324,6 +326,8 @@ func checkOutput(t *testutil.T, meters []skaffoldMeter, b []byte) {
 			errorCount[e]--
 		case "flags":
 			enumFlags[l.Labels["flag_name"]+":"+l.Labels["value"]]--
+		case "helmReleases":
+			helmReleases[l.Labels["helmReleases"]]++
 		default:
 			switch {
 			case MeteredCommands.Contains(l.Name):

--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -91,6 +91,9 @@ func InitMeterFromConfig(configs []*latest.SkaffoldConfig) {
 			}
 		}
 		meter.Deployers = append(meter.Deployers, yamltags.GetYamlKeys(config.Deploy.DeployType)...)
+		if h := config.Deploy.HelmDeploy; h != nil {
+			meter.HelmReleasesCount = len(h.Releases)
+		}
 		meter.BuildArtifacts += len(config.Pipeline.Build.Artifacts)
 	}
 	meter.PlatformType = strings.Join(platforms, ":")

--- a/pkg/skaffold/instrumentation/types.go
+++ b/pkg/skaffold/instrumentation/types.go
@@ -64,6 +64,9 @@ type skaffoldMeter struct {
 	// BuildDependencies Enum values for all the builders using build dependencies.
 	BuildDependencies map[string]int
 
+	// MultiHelmReleasesCount is the number of releases if helm deployer is present.
+	HelmReleasesCount int
+
 	// SyncType Sync type used in the build configuration: infer, auto, and/or manual.
 	SyncType map[string]bool
 


### PR DESCRIPTION
when re-designing config for helm, i saw we have 
```
helm:
  releases:
      - name: "release-foo"
      - name: "release-bar"
```

I was wondering how many users did have multiple helm releases defined in one app. 
If this is unused, it will simply config redesign a lot.

Also note: When doing some competitive config research, i found out, they don't support multiple releases since the `helm` is not used to deploy but `helm template | kubectl apply` is used.
