### PR TITLE
Remove unwanted value recorded.

### DIFF
--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -179,7 +179,6 @@ func flagMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, randL
 			label.String("flag_name", k),
 			label.String("flag_value", v),
 			label.String("command", meter.Command),
-			label.String("value", v),
 			label.String("error", meter.ErrorCode.String()),
 			randLabel,
 		}


### PR DESCRIPTION
While doing Code walks, @IsaacPD mentioned,  both "flag_value" and "value" are duplicates and used for recording flag value 
```
			label.String("flag_value", v),
			label.String("command", meter.Command),
			label.String("value", v),
```

Removing "value" in favor of the other.

