### PR TITLE
Default digest source to 'remote' in render

### DIFF
--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -48,7 +48,6 @@ func NewCmdRender() *cobra.Command {
 			{Value: &renderFromBuildOutputFile, Name: "build-artifacts", Shorthand: "a", Usage: "File containing build result from a previous 'skaffold build --file-output'"},
 			{Value: &offline, Name: "offline", DefValue: false, Usage: `Do not connect to Kubernetes API server for manifest creation and validation. This is helpful when no Kubernetes cluster is available (e.g. GitOps model). No metadata.namespace attribute is injected in this case - the manifest content does not get changed.`, IsEnum: true},
 			{Value: &renderOutputPath, Name: "output", Shorthand: "o", DefValue: "", Usage: "file to write rendered manifests to"},
-			{Value: &opts.DigestSource, Name: "digest-source", DefValue: "remote", Usage: "Set to 'remote' to skip builds and resolve the digest of images by tag from the remote registry. Set to 'local' to build images locally and use digests from built images. Set to 'tag' to use tags directly from the build. Set to 'none' to use tags directly from the Kubernetes manifests.", IsEnum: true},
 		}).
 		NoArgs(doRender)
 }

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -54,6 +54,7 @@ func NewCmdRender() *cobra.Command {
 }
 
 func doRender(ctx context.Context, out io.Writer) error {
+	// TODO(nkubala): remove this from opts in favor of a param to Build()
 	opts.RenderOnly = true
 	buildOut := ioutil.Discard
 	if showBuild {

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -48,7 +48,7 @@ func NewCmdRender() *cobra.Command {
 			{Value: &renderFromBuildOutputFile, Name: "build-artifacts", Shorthand: "a", Usage: "File containing build result from a previous 'skaffold build --file-output'"},
 			{Value: &offline, Name: "offline", DefValue: false, Usage: `Do not connect to Kubernetes API server for manifest creation and validation. This is helpful when no Kubernetes cluster is available (e.g. GitOps model). No metadata.namespace attribute is injected in this case - the manifest content does not get changed.`, IsEnum: true},
 			{Value: &renderOutputPath, Name: "output", Shorthand: "o", DefValue: "", Usage: "file to write rendered manifests to"},
-			{Value: &opts.DigestSource, Name: "digest-source", DefValue: "remote", Usage: "Set to 'remote' to resolve the digest of images by tag from the remote registry. Set to 'local' to build images locally and use digests from built images. Set to 'tag' to use tags directly from the build. Set to 'none' to use tags directly from the Kubernetes manifests.", IsEnum: true},
+			{Value: &opts.DigestSource, Name: "digest-source", DefValue: "remote", Usage: "Set to 'remote' to skip builds and resolve the digest of images by tag from the remote registry. Set to 'local' to build images locally and use digests from built images. Set to 'tag' to use tags directly from the build. Set to 'none' to use tags directly from the Kubernetes manifests.", IsEnum: true},
 		}).
 		NoArgs(doRender)
 }

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -48,12 +48,13 @@ func NewCmdRender() *cobra.Command {
 			{Value: &renderFromBuildOutputFile, Name: "build-artifacts", Shorthand: "a", Usage: "File containing build result from a previous 'skaffold build --file-output'"},
 			{Value: &offline, Name: "offline", DefValue: false, Usage: `Do not connect to Kubernetes API server for manifest creation and validation. This is helpful when no Kubernetes cluster is available (e.g. GitOps model). No metadata.namespace attribute is injected in this case - the manifest content does not get changed.`, IsEnum: true},
 			{Value: &renderOutputPath, Name: "output", Shorthand: "o", DefValue: "", Usage: "file to write rendered manifests to"},
-			{Value: &opts.DigestSource, Name: "digest-source", DefValue: "local", Usage: "Set to 'local' to build images locally and use digests from built images; Set to 'remote' to resolve the digest of images by tag from the remote registry; Set to 'none' to use tags directly from the Kubernetes manifests. Set to 'tag' to use tags directly from the build.", IsEnum: true},
+			{Value: &opts.DigestSource, Name: "digest-source", DefValue: "remote", Usage: "Set to 'remote' to resolve the digest of images by tag from the remote registry. Set to 'local' to build images locally and use digests from built images. Set to 'tag' to use tags directly from the build. Set to 'none' to use tags directly from the Kubernetes manifests.", IsEnum: true},
 		}).
 		NoArgs(doRender)
 }
 
 func doRender(ctx context.Context, out io.Writer) error {
+	opts.RenderOnly = true
 	buildOut := ioutil.Discard
 	if showBuild {
 		buildOut = out

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -657,6 +657,7 @@ Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
+      --digest-source='remote': Set to 'remote' to skip builds and resolve the digest of images by tag from the remote registry. Set to 'local' to build images locally and use digests from built images. Set to 'tag' to use tags directly from the build. Set to 'none' to use tags directly from the Kubernetes manifests.
       --enable-rpc=true: Enable gRPC for exposing Skaffold events
       --event-log-file='': Save Skaffold events to the provided file after skaffold has finished executing, requires --enable-rpc=true
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
@@ -710,6 +711,7 @@ Env vars:
 * `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
+* `SKAFFOLD_DIGEST_SOURCE` (same as `--digest-source`)
 * `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_EVENT_LOG_FILE` (same as `--event-log-file`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
@@ -954,6 +956,7 @@ Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
+      --digest-source='remote': Set to 'remote' to skip builds and resolve the digest of images by tag from the remote registry. Set to 'local' to build images locally and use digests from built images. Set to 'tag' to use tags directly from the build. Set to 'none' to use tags directly from the Kubernetes manifests.
       --enable-rpc=false: Enable gRPC for exposing Skaffold events
       --event-log-file='': Save Skaffold events to the provided file after skaffold has finished executing, requires --enable-rpc=true
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
@@ -1002,6 +1005,7 @@ Env vars:
 * `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
+* `SKAFFOLD_DIGEST_SOURCE` (same as `--digest-source`)
 * `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_EVENT_LOG_FILE` (same as `--event-log-file`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -892,7 +892,7 @@ Options:
   -a, --build-artifacts=: File containing build result from a previous 'skaffold build --file-output'
       --cache-artifacts=true: Set to false to disable default caching of artifacts
   -d, --default-repo='': Default repository value (overrides global config)
-      --digest-source='local': Set to 'local' to build images locally and use digests from built images; Set to 'remote' to resolve the digest of images by tag from the remote registry; Set to 'none' to use tags directly from the Kubernetes manifests. Set to 'tag' to use tags directly from the build.
+      --digest-source='remote': Set to 'remote' to resolve the digest of images by tag from the remote registry. Set to 'local' to build images locally and use digests from built images. Set to 'tag' to use tags directly from the build. Set to 'none' to use tags directly from the Kubernetes manifests.
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
   -l, --label=[]: Add custom labels to deployed objects. Set multiple times for multiple labels
       --loud=false: Show the build logs and output

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -892,7 +892,7 @@ Options:
   -a, --build-artifacts=: File containing build result from a previous 'skaffold build --file-output'
       --cache-artifacts=true: Set to false to disable default caching of artifacts
   -d, --default-repo='': Default repository value (overrides global config)
-      --digest-source='remote': Set to 'remote' to resolve the digest of images by tag from the remote registry. Set to 'local' to build images locally and use digests from built images. Set to 'tag' to use tags directly from the build. Set to 'none' to use tags directly from the Kubernetes manifests.
+      --digest-source='remote': Set to 'remote' to skip builds and resolve the digest of images by tag from the remote registry. Set to 'local' to build images locally and use digests from built images. Set to 'tag' to use tags directly from the build. Set to 'none' to use tags directly from the Kubernetes manifests.
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
   -l, --label=[]: Add custom labels to deployed objects. Set multiple times for multiple labels
       --loud=false: Show the build logs and output

--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -41,7 +41,7 @@ func TestDiagnoseRenderApply(t *testing.T) {
 
 		tmpDir.Write("skaffold-diagnose.yaml", string(out))
 
-		out = skaffold.Render("--add-skaffold-labels=false", "-f", "skaffold-diagnose.yaml").InNs(ns.Name).RunOrFailOutput(t.T)
+		out = skaffold.Render("--digest-source=local", "--add-skaffold-labels=false", "-f", "skaffold-diagnose.yaml").InNs(ns.Name).RunOrFailOutput(t.T)
 		tmpDir.Write("render.yaml", string(out))
 
 		skaffold.Apply("render.yaml", "-f", "skaffold-diagnose.yaml").InNs(ns.Name).RunOrFail(t.T)

--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -114,7 +114,7 @@ func TestDebug(t *testing.T) {
 func TestFilterWithDebugging(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 	// `filter` currently expects to receive a digested yaml
-	renderedOutput := skaffold.Render().InDir("examples/getting-started").RunOrFailOutput(t)
+	renderedOutput := skaffold.Render("--digest-source=local").InDir("examples/getting-started").RunOrFailOutput(t)
 
 	testutil.Run(t, "no --build-artifacts should transform all images", func(t *testutil.T) {
 		transformedOutput := skaffold.Filter("--debugging").InDir("examples/getting-started").WithStdin(renderedOutput).RunOrFailOutput(t.T)

--- a/integration/filter_test.go
+++ b/integration/filter_test.go
@@ -28,7 +28,7 @@ import (
 func TestFilterPassthrough(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 	// `filter` currently expects to receive a digested yaml
-	renderedOutput := skaffold.Render().InDir("examples/getting-started").RunOrFailOutput(t)
+	renderedOutput := skaffold.Render("--digest-source=local").InDir("examples/getting-started").RunOrFailOutput(t)
 
 	testutil.Run(t, "no filters should just pass through", func(t *testutil.T) {
 		transformedOutput := skaffold.Filter().InDir("examples/getting-started").WithStdin(renderedOutput).RunOrFailOutput(t.T)

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -716,7 +716,7 @@ spec:
 
 			tmpDir.Chdir()
 
-			args := []string{"--build-artifacts=" + path.Join(testDir, test.buildOutputFilePath), "--add-skaffold-labels=" + strconv.FormatBool(test.addSkaffoldLabels), "--output", "rendered.yaml"}
+			args := []string{"--digest-source=local", "--build-artifacts=" + path.Join(testDir, test.buildOutputFilePath), "--add-skaffold-labels=" + strconv.FormatBool(test.addSkaffoldLabels), "--output", "rendered.yaml"}
 
 			if test.offline {
 				env := []string{"KUBECONFIG=not-supposed-to-be-used-in-offline-mode"}

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -171,7 +171,7 @@ func TestRunRenderOnly(t *testing.T) {
 			dir         string
 			pods        []string
 		}{
-			args: []string{"--render-only", "--render-output", renderPath},
+			args: []string{"--digest-source=local", "--render-only", "--render-output", renderPath},
 			dir:  "examples/getting-started",
 			pods: []string{"getting-started"},
 		}

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -89,7 +89,7 @@ func NewBuilder(bCtx BuilderContext, buildCfg *latest_v1.LocalBuild) (*Builder, 
 	var pushImages bool
 	if buildCfg.Push == nil {
 		pushImages = cluster.PushImages
-		logrus.Debugf("push value not present, defaulting to %t because cluster.PushImages is %t", pushImages, cluster.PushImages)
+		logrus.Debugf("push value not present in Newbuilder, defaulting to %t because cluster.PushImages is %t", pushImages, cluster.PushImages)
 	} else {
 		pushImages = *buildCfg.Push
 	}

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -89,7 +89,7 @@ func NewBuilder(bCtx BuilderContext, buildCfg *latest_v1.LocalBuild) (*Builder, 
 	var pushImages bool
 	if buildCfg.Push == nil {
 		pushImages = cluster.PushImages
-		logrus.Debugf("push value not present in Newbuilder, defaulting to %t because cluster.PushImages is %t", pushImages, cluster.PushImages)
+		logrus.Debugf("push value not present in NewBuilder, defaulting to %t because cluster.PushImages is %t", pushImages, cluster.PushImages)
 	} else {
 		pushImages = *buildCfg.Push
 	}

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -75,13 +75,13 @@ func (r *Builder) Build(ctx context.Context, out io.Writer, artifacts []*latest_
 	// In dry-run mode or with --digest-source set to 'remote' or 'tag' in render, we don't build anything, just return the tag for each artifact.
 	switch {
 	case r.runCtx.DryRun():
-		color.Yellow.Fprintln(out, "Skipping image build since --dry-run=true")
+		color.Yellow.Fprintln(out, "Skipping build phase since --dry-run=true")
 		return artifactsWithTags(tags, artifacts), nil
 	case r.runCtx.RenderOnly() && r.runCtx.DigestSource() == remoteDigestSource:
-		color.Yellow.Fprintln(out, "Skipping image build since --digest-source=remote")
+		color.Yellow.Fprintln(out, "Skipping build phase since --digest-source=remote")
 		return artifactsWithTags(tags, artifacts), nil
 	case r.runCtx.RenderOnly() && r.runCtx.DigestSource() == tagDigestSource:
-		color.Yellow.Fprintln(out, "Skipping image build since --digest-source=tag")
+		color.Yellow.Fprintln(out, "Skipping build phase since --digest-source=tag")
 		return artifactsWithTags(tags, artifacts), nil
 	default:
 	}

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -120,7 +120,7 @@ func (r *Builder) HasBuilt() bool {
 	return r.hasBuilt
 }
 
-func artifactsWithTags(tags tag.ImageTags, artifacts []*latest.Artifact) []graph.Artifact {
+func artifactsWithTags(tags tag.ImageTags, artifacts []*latest_v1.Artifact) []graph.Artifact {
 	var bRes []graph.Artifact
 	for _, artifact := range artifacts {
 		bRes = append(bRes, graph.Artifact{

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -72,18 +72,18 @@ func (r *Builder) Build(ctx context.Context, out io.Writer, artifacts []*latest_
 		return nil, err
 	}
 
-	// In dry-run mode or with --digest-source  set to 'remote' or with --digest-source set to 'tag' , we don't build anything, just return the tag for each artifact.
-	if r.runCtx.DryRun() || (r.runCtx.DigestSource() == remoteDigestSource) ||
-		(r.runCtx.DigestSource() == tagDigestSource) {
-		var bRes []graph.Artifact
-		for _, artifact := range artifacts {
-			bRes = append(bRes, graph.Artifact{
-				ImageName: artifact.ImageName,
-				Tag:       tags[artifact.ImageName],
-			})
-		}
-
-		return bRes, nil
+	// In dry-run mode or with --digest-source set to 'remote' or 'tag' in render, we don't build anything, just return the tag for each artifact.
+	switch {
+	case r.runCtx.DryRun():
+		color.Yellow.Fprintln(out, "Skipping image build since --dry-run=true")
+		return artifactsWithTags(tags, artifacts), nil
+	case r.runCtx.RenderOnly() && r.runCtx.DigestSource() == remoteDigestSource:
+		color.Yellow.Fprintln(out, "Skipping image build since --digest-source=remote")
+		return artifactsWithTags(tags, artifacts), nil
+	case r.runCtx.RenderOnly() && r.runCtx.DigestSource() == tagDigestSource:
+		color.Yellow.Fprintln(out, "Skipping image build since --digest-source=tag")
+		return artifactsWithTags(tags, artifacts), nil
+	default:
 	}
 
 	bRes, err := r.cache.Build(ctx, out, tags, artifacts, func(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest_v1.Artifact) ([]graph.Artifact, error) {
@@ -118,6 +118,18 @@ func (r *Builder) Build(ctx context.Context, out io.Writer, artifacts []*latest_
 // HasBuilt returns true if this runner has built something.
 func (r *Builder) HasBuilt() bool {
 	return r.hasBuilt
+}
+
+func artifactsWithTags(tags tag.ImageTags, artifacts []*latest.Artifact) []graph.Artifact {
+	var bRes []graph.Artifact
+	for _, artifact := range artifacts {
+		bRes = append(bRes, graph.Artifact{
+			ImageName: artifact.ImageName,
+			Tag:       tags[artifact.ImageName],
+		})
+	}
+
+	return bRes
 }
 
 // Update which images are logged.

--- a/pkg/skaffold/runner/build_deploy_test.go
+++ b/pkg/skaffold/runner/build_deploy_test.go
@@ -224,6 +224,7 @@ func TestDigestSources(t *testing.T) {
 			testBench := &TestBench{}
 			runner := createRunner(t, testBench, nil, artifacts, nil)
 			runner.runCtx.Opts.DigestSource = test.digestSource
+			runner.runCtx.Opts.RenderOnly = true
 
 			bRes, err := runner.Build(context.Background(), ioutil.Discard, artifacts)
 

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -206,7 +206,7 @@ func isImageLocal(runCtx *runcontext.RunContext, imageName string) (bool, error)
 		pushImages = *runCtx.Opts.PushImages.Value()
 	case pipeline.Build.LocalBuild.Push == nil:
 		pushImages = cl.PushImages
-		logrus.Debugf("push value not present, defaulting to %t because cluster.PushImages is %t", pushImages, cl.PushImages)
+		logrus.Debugf("push value not present in isImageLocal(), defaulting to %t because cluster.PushImages is %t", pushImages, cl.PushImages)
 	default:
 		pushImages = *pipeline.Build.LocalBuild.Push
 	}

--- a/pkg/skaffold/runner/render.go
+++ b/pkg/skaffold/runner/render.go
@@ -33,7 +33,7 @@ func (r *SkaffoldRunner) Render(ctx context.Context, out io.Writer, builds []gra
 		for i, a := range builds {
 			digest, err := docker.RemoteDigest(a.Tag, r.runCtx)
 			if err != nil {
-				return fmt.Errorf("failed to resolve the digest of %s, render aborted", a.Tag)
+				return fmt.Errorf("failed to resolve the digest of %s: does the image exist remotely?", a.Tag)
 			}
 			builds[i].Tag = build.TagWithDigest(a.Tag, digest)
 		}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5561  <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
this changes the default value for `--digest-source` in render to `remote`, meaning that `skaffold render` will attempt to retrieve the digests for all remote image references and use those digests to hydrate manifests. this seems to be a better default than `local`, as a local rendering isn't very useful since the ID for any images is exclusive to that host's docker daemon, and isn't usable by future deployments.
