### PR TITLE
Metric labels need to be string type

### DIFF
--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -139,6 +139,8 @@ func createMetrics(ctx context.Context, meter skaffoldMeter) {
 	randLabel := label.String("randomizer", strconv.Itoa(rand.Intn(75000)))
 
 	m := global.Meter("skaffold")
+
+	// cloud monitoring only supports string type labels
 	labels := []label.KeyValue{
 		label.String("version", meter.Version),
 		label.String("os", meter.OS),
@@ -146,7 +148,7 @@ func createMetrics(ctx context.Context, meter skaffoldMeter) {
 		label.String("command", meter.Command),
 		label.String("error", meter.ErrorCode.String()),
 		label.String("platform_type", meter.PlatformType),
-		label.Int("config_count", meter.ConfigCount),
+		label.String("config_count", strconv.Itoa(meter.ConfigCount)),
 		randLabel,
 	}
 


### PR DESCRIPTION
Cloud monitoring doesn't support non-string type values in `labels`.

Labels parsed [here](https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/blob/402033a575703385b81fee3bdf703b0dd61ff9f8/exporter/metric/metric.go#L490). Their [`AsString`](https://github.com/open-telemetry/opentelemetry-go/blob/ecf65d7968225482a4d50e4955d6bc826119b49c/attribute/value.go#L149) method returns `""` for all non-string type labels.