### PR TITLE
Updating skaffold test command to accept a list of prebuilt images as input

### DIFF
--- a/cmd/skaffold/app/cmd/test.go
+++ b/cmd/skaffold/app/cmd/test.go
@@ -33,7 +33,12 @@ func NewCmdTest() *cobra.Command {
 		WithDescription("Run tests against your built application images").
 		WithExample("Build the artifacts and collect the tags into a file", "build --file-output=tags.json").
 		WithExample("Run test against images previously built by Skaffold into a 'tags.json' file", "test --build-artifacts=tags.json").
+		WithExample("Build the artifacts and then deploy them", "build -q | skaffold test --build-artifacts -").
+		WithExample("Test the pre-build image", "test --image='<image-name>'").
 		WithCommonFlags().
+		WithFlags([]*Flag{
+			{Value: &preBuiltImages, Name: "image", Shorthand: "i", Usage: "A pre-built image to test"},
+		}).
 		WithHouseKeepingMessages().
 		NoArgs(doTest)
 }

--- a/cmd/skaffold/app/tips/tips.go
+++ b/cmd/skaffold/app/tips/tips.go
@@ -41,6 +41,8 @@ func PrintForInit(out io.Writer, opts config.SkaffoldOptions) {
 func PrintForTest(out io.Writer) {
 	printTip(out, "You need to:")
 	printTip(out, "run [skaffold test] with [--build-artifacts <file-output>] for running tests on artifacts from a given file.")
+	printTip(out, "or build the artifacts and then test them with `build -q | skaffold test --build-artifacts -`.")
+	printTip(out, "or run [skaffold test] with [--image TAG] for each pre-built artifact.")
 }
 
 // PrintUseRunVsDeploy prints tips on when to use skaffold run vs deploy.

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -1105,9 +1105,16 @@ Examples:
   # Run test against images previously built by Skaffold into a 'tags.json' file
   skaffold test --build-artifacts=tags.json
 
+  # Build the artifacts and then deploy them
+  skaffold build -q | skaffold test --build-artifacts -
+
+  # Test the pre-build image
+  skaffold test --image='<image-name>'
+
 Options:
   -a, --build-artifacts=: File containing build result from a previous 'skaffold build --file-output'
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
+  -i, --image=: A pre-built image to test
   -m, --module=[]: Filter Skaffold configs to only the provided named modules
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
 
@@ -1122,6 +1129,7 @@ Env vars:
 
 * `SKAFFOLD_BUILD_ARTIFACTS` (same as `--build-artifacts`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
+* `SKAFFOLD_IMAGE` (same as `--image`)
 * `SKAFFOLD_MODULE` (same as `--module`)
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 


### PR DESCRIPTION
Fixes: #5599 

**Description**
Updating skaffold test command to accept a list of prebuilt images as input for testing

Updated skaffold test cmd to
 - accept skaffold build output as input
 - accept a list of prebuilt images as input



**Use facing changes & usage:**

> `skaffold test --help`
```
Run tests against your built application images

Examples:
  # Build the artifacts and collect the tags into a file
  skaffold build --file-output=tags.json

  # Run test against images previously built by Skaffold into a 'tags.json' file
  skaffold test --build-artifacts=tags.json

  # Build the artifacts and then deploy them
  skaffold build -q | skaffold test --build-artifacts -

  # Test the pre-build image
  skaffold test --image='<image-name>'

Options:
  -a, --build-artifacts=: File containing build result from a previous 'skaffold build --file-output'
  -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
  -i, --image=: A pre-built image to test
  -m, --module=[]: Filter Skaffold configs to only the provided named modules
      --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)

Usage:
  skaffold test [flags] [options]

Use "skaffold options" for a list of global command-line options (applies to all commands).
```

### Testing notes
Here are some sample outputs:

> `skaffold test`
```
You need to:
run [skaffold test] with [--build-artifacts <file-output>] for running tests on artifacts from a given file.
or build the artifacts and then test them with `build -q | skaffold test --build-artifacts -`.
or run [skaffold test] with [--image TAG] for each pre-built artifact.
```

> `skaffold test --image='custom-test-example'`
```
Starting test...
Testing images...
Running custom test command: "./test.sh" with timeout 60 s
go custom test 
ok      github.com/GoogleContainerTools/skaffold/integration/examples/custom-tests      (cached)
Command finished successfully.
Running custom test command: "echo Hello world!!"
Hello world!!
Command finished successfully.
```

> `skaffold test -i custom-test-example'
```
Starting test...
Testing images...
Running custom test command: "./test.sh" with timeout 60 s
go custom test 
ok      github.com/GoogleContainerTools/skaffold/integration/examples/custom-tests      (cached)
Command finished successfully.
Running custom test command: "echo Hello world!!"
Hello world!!
Command finished successfully.
```
