### PR TITLE
Remove deprecated {{.IMAGES}} and {{.DIGEST_}} env vars

### DIFF
--- a/docs/content/en/docs/references/deprecation.md
+++ b/docs/content/en/docs/references/deprecation.md
@@ -70,17 +70,21 @@ Exceptions will always be announced in all relevant release notes.
 
 ## Current deprecation notices
 
-10/21/2019: With release v0.41.0 we mark for deprecation the `$IMAGES` environment variable passed to custom builders. Variable `$IMAGE` should be used instead.
-This environment variable flag will be removed no earlier than 01/21/2020.
-
 ## Past deprecation notices
 
-03/15/2019: With release v0.25.0 we mark for deprecation the `flags` field in kaniko (`KanikoArtifact.AdditionalFlags`) , instead Kaniko's additional flags will now be represented as unique fields under `kaniko` per artifact (`KanikoArtifact` type).
-This flag will will be removed earliest 06/15/2019.
+10/21/2019: With release v0.41.0 we mark for deprecation the `$IMAGES` environment variable passed to custom builders. Variable `$IMAGE` should be used instead.
+
+**This environment variable flag was removed in version v1.22.0.**
+
+03/15/2019: With release v0.25.0 we mark for deprecation the `flags` field in kaniko (`KanikoArtifact.AdditionalFlags`), instead Kaniko's additional flags will now be represented as unique fields under `kaniko` per artifact (`KanikoArtifact` type).
+
+**This field was removed in version 1.0.0.**
 
 02/15/2019: With  release v0.23.0 we mark for deprecation the following env variables in the `envTemplate` tagger:
 - `DIGEST`
 - `DIGEST_ALGO`
 - `DIGEST_HEX`
+
 Currently these variables resolve to `_DEPRECATED_<envvar>_`, and the new tagging mechanism adds a digest to the image name thus it shouldn't break existing configurations.
-This backward compatibility behavior will be removed earliest 05/14/2019.
+
+**This compatibility behavior was removed in version v1.22.0.**

--- a/pkg/skaffold/build/custom/script.go
+++ b/pkg/skaffold/build/custom/script.go
@@ -95,7 +95,6 @@ func (b *Builder) retrieveEnv(a *latest.Artifact, tag string) ([]string, error) 
 
 	envs := []string{
 		fmt.Sprintf("%s=%s", constants.Image, tag),
-		fmt.Sprintf("%s=%s", constants.DeprecatedImages, tag),
 		fmt.Sprintf("%s=%t", constants.PushImage, b.pushImages),
 		fmt.Sprintf("%s=%s", constants.BuildContext, buildContext),
 	}

--- a/pkg/skaffold/build/custom/script_test.go
+++ b/pkg/skaffold/build/custom/script_test.go
@@ -44,24 +44,24 @@ func TestRetrieveEnv(t *testing.T) {
 			tag:          "gcr.io/image/tag:mytag",
 			environ:      nil,
 			buildContext: "/some/path",
-			expected:     []string{"IMAGE=gcr.io/image/tag:mytag", "IMAGES=gcr.io/image/tag:mytag", "PUSH_IMAGE=false", "BUILD_CONTEXT=/some/path", "IMAGE_REPO=gcr.io/image/tag", "IMAGE_TAG=mytag"},
+			expected:     []string{"IMAGE=gcr.io/image/tag:mytag", "PUSH_IMAGE=false", "BUILD_CONTEXT=/some/path", "IMAGE_REPO=gcr.io/image/tag", "IMAGE_TAG=mytag"},
 		}, {
 			description:  "make sure environ is correctly applied",
 			tag:          "gcr.io/image/tag:anothertag",
 			environ:      []string{"PATH=/path", "HOME=/root"},
 			buildContext: "/some/path",
-			expected:     []string{"IMAGE=gcr.io/image/tag:anothertag", "IMAGES=gcr.io/image/tag:anothertag", "PUSH_IMAGE=false", "BUILD_CONTEXT=/some/path", "IMAGE_REPO=gcr.io/image/tag", "IMAGE_TAG=anothertag", "PATH=/path", "HOME=/root"},
+			expected:     []string{"IMAGE=gcr.io/image/tag:anothertag", "PUSH_IMAGE=false", "BUILD_CONTEXT=/some/path", "IMAGE_REPO=gcr.io/image/tag", "IMAGE_TAG=anothertag", "PATH=/path", "HOME=/root"},
 		}, {
 			description: "push image is true",
 			tag:         "gcr.io/image/push:tag",
 			pushImages:  true,
-			expected:    []string{"IMAGE=gcr.io/image/push:tag", "IMAGES=gcr.io/image/push:tag", "PUSH_IMAGE=true", "BUILD_CONTEXT=", "IMAGE_REPO=gcr.io/image/push", "IMAGE_TAG=tag"},
+			expected:    []string{"IMAGE=gcr.io/image/push:tag", "PUSH_IMAGE=true", "BUILD_CONTEXT=", "IMAGE_REPO=gcr.io/image/push", "IMAGE_TAG=tag"},
 		}, {
 			description:   "add additional env",
 			tag:           "gcr.io/image/push:tag",
 			pushImages:    true,
 			additionalEnv: []string{"KUBECONTEXT=mycluster"},
-			expected:      []string{"IMAGE=gcr.io/image/push:tag", "IMAGES=gcr.io/image/push:tag", "PUSH_IMAGE=true", "BUILD_CONTEXT=", "IMAGE_REPO=gcr.io/image/push", "IMAGE_TAG=tag", "KUBECONTEXT=mycluster"},
+			expected:      []string{"IMAGE=gcr.io/image/push:tag", "PUSH_IMAGE=true", "BUILD_CONTEXT=", "IMAGE_REPO=gcr.io/image/push", "IMAGE_TAG=tag", "KUBECONTEXT=mycluster"},
 		},
 	}
 	for _, test := range tests {
@@ -98,8 +98,8 @@ func TestRetrieveCmd(t *testing.T) {
 				},
 			},
 			tag:               "image:tag",
-			expected:          expectedCmd("workspace", "sh", []string{"-c", "./build.sh"}, []string{"IMAGE=image:tag", "IMAGES=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT=workspace", "IMAGE_REPO=image", "IMAGE_TAG=tag"}),
-			expectedOnWindows: expectedCmd("workspace", "cmd.exe", []string{"/C", "./build.sh"}, []string{"IMAGE=image:tag", "IMAGES=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT=workspace", "IMAGE_REPO=image", "IMAGE_TAG=tag"}),
+			expected:          expectedCmd("workspace", "sh", []string{"-c", "./build.sh"}, []string{"IMAGE=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT=workspace", "IMAGE_REPO=image", "IMAGE_TAG=tag"}),
+			expectedOnWindows: expectedCmd("workspace", "cmd.exe", []string{"/C", "./build.sh"}, []string{"IMAGE=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT=workspace", "IMAGE_REPO=image", "IMAGE_TAG=tag"}),
 		},
 		{
 			description: "buildcommand with multiple args",
@@ -111,8 +111,8 @@ func TestRetrieveCmd(t *testing.T) {
 				},
 			},
 			tag:               "image:tag",
-			expected:          expectedCmd("", "sh", []string{"-c", "./build.sh --flag=$IMAGES --anotherflag"}, []string{"IMAGE=image:tag", "IMAGES=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT=", "IMAGE_REPO=image", "IMAGE_TAG=tag"}),
-			expectedOnWindows: expectedCmd("", "cmd.exe", []string{"/C", "./build.sh --flag=$IMAGES --anotherflag"}, []string{"IMAGE=image:tag", "IMAGES=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT=", "IMAGE_REPO=image", "IMAGE_TAG=tag"}),
+			expected:          expectedCmd("", "sh", []string{"-c", "./build.sh --flag=$IMAGES --anotherflag"}, []string{"IMAGE=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT=", "IMAGE_REPO=image", "IMAGE_TAG=tag"}),
+			expectedOnWindows: expectedCmd("", "cmd.exe", []string{"/C", "./build.sh --flag=$IMAGES --anotherflag"}, []string{"IMAGE=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT=", "IMAGE_REPO=image", "IMAGE_TAG=tag"}),
 		},
 		{
 			description: "buildcommand with go template",
@@ -125,8 +125,8 @@ func TestRetrieveCmd(t *testing.T) {
 			},
 			tag:               "image:tag",
 			env:               []string{"FLAG=some-flag"},
-			expected:          expectedCmd("", "sh", []string{"-c", "./build.sh --flag=some-flag"}, []string{"IMAGE=image:tag", "IMAGES=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT=", "IMAGE_REPO=image", "IMAGE_TAG=tag", "FLAG=some-flag"}),
-			expectedOnWindows: expectedCmd("", "cmd.exe", []string{"/C", "./build.sh --flag=some-flag"}, []string{"IMAGE=image:tag", "IMAGES=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT=", "IMAGE_REPO=image", "IMAGE_TAG=tag", "FLAG=some-flag"}),
+			expected:          expectedCmd("", "sh", []string{"-c", "./build.sh --flag=some-flag"}, []string{"IMAGE=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT=", "IMAGE_REPO=image", "IMAGE_TAG=tag", "FLAG=some-flag"}),
+			expectedOnWindows: expectedCmd("", "cmd.exe", []string{"/C", "./build.sh --flag=some-flag"}, []string{"IMAGE=image:tag", "PUSH_IMAGE=false", "BUILD_CONTEXT=", "IMAGE_REPO=image", "IMAGE_TAG=tag", "FLAG=some-flag"}),
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -68,9 +68,6 @@ var (
 )
 
 var (
-	// DeprecatedImages is an environment variable key, whose value is an array of fully qualified image names passed in to a custom build script.
-	DeprecatedImages = "IMAGES"
-
 	// Image is an environment variable key, whose value is the fully qualified image name passed in to a custom build script.
 	Image = "IMAGE"
 

--- a/pkg/skaffold/tag/env_template.go
+++ b/pkg/skaffold/tag/env_template.go
@@ -17,9 +17,7 @@ limitations under the License.
 package tag
 
 import (
-	"errors"
 	"fmt"
-	"strings"
 	"text/template"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -46,19 +44,10 @@ func NewEnvTemplateTagger(t string) (Tagger, error) {
 func (t *envTemplateTagger) GenerateTag(_, imageName string) (string, error) {
 	// missingkey=error throws error when map is indexed with an undefined key
 	tag, err := util.ExecuteEnvTemplate(t.Template.Option("missingkey=error"), map[string]string{
-		"IMAGE_NAME":  imageName,
-		"DIGEST":      "_DEPRECATED_DIGEST_",
-		"DIGEST_ALGO": "_DEPRECATED_DIGEST_ALGO_",
-		"DIGEST_HEX":  "_DEPRECATED_DIGEST_HEX_",
+		"IMAGE_NAME": imageName,
 	})
 	if err != nil {
 		return "", err
-	}
-
-	if strings.Contains(tag, "_DEPRECATED_DIGEST_") ||
-		strings.Contains(tag, "_DEPRECATED_DIGEST_ALGO_") ||
-		strings.Contains(tag, "_DEPRECATED_DIGEST_HEX_") {
-		return "", errors.New("{{.DIGEST}}, {{.DIGEST_ALGO}} and {{.DIGEST_HEX}} are deprecated, image digest will now automatically be appended to image tags")
 	}
 
 	return tag, nil

--- a/pkg/skaffold/tag/tag.go
+++ b/pkg/skaffold/tag/tag.go
@@ -18,9 +18,6 @@ package tag
 
 import (
 	"fmt"
-	"strings"
-
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
 
 // ImageTags maps image names to tags
@@ -32,29 +29,10 @@ type Tagger interface {
 	GenerateTag(workingDir, imageName string) (string, error)
 }
 
-const DeprecatedImageName = "_DEPRECATED_IMAGE_NAME_"
-
 // GenerateFullyQualifiedImageName resolves the fully qualified image name for an artifact.
 // The workingDir is the root directory of the artifact with respect to the Skaffold root,
 // and imageName is the base name of the image.
 func GenerateFullyQualifiedImageName(t Tagger, workingDir, imageName string) (string, error) {
-	// Supporting the use of the deprecated {{.IMAGE_NAME}} in envTemplate
-	if v, ok := t.(*envTemplateTagger); ok {
-		tag, err := v.GenerateTag(workingDir, DeprecatedImageName)
-
-		if err != nil {
-			return "", fmt.Errorf("generating envTemplate tag: %w", err)
-		}
-
-		if strings.Contains(tag, DeprecatedImageName) {
-			warnings.Printf("{{.IMAGE_NAME}} is deprecated, envTemplate's template should only specify the tag value. See https://skaffold.dev/docs/pipeline-stages/taggers/")
-
-			return strings.ReplaceAll(tag, DeprecatedImageName, imageName), nil
-		}
-
-		return fmt.Sprintf("%s:%s", imageName, tag), nil
-	}
-
 	tag, err := t.GenerateTag(workingDir, imageName)
 	if err != nil {
 		return "", fmt.Errorf("generating tag: %w", err)

--- a/pkg/skaffold/tag/tag_test.go
+++ b/pkg/skaffold/tag/tag_test.go
@@ -28,7 +28,6 @@ import (
 func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 	// This is for testing envTemplate
 	envTemplateExample, _ := NewEnvTemplateTagger("{{.FOO}}")
-	envTemplateDeprecatedExample, _ := NewEnvTemplateTagger("{{.IMAGE_NAME}}:{{.FOO}}")
 	invalidEnvTemplate, _ := NewEnvTemplateTagger("{{.BAR}}")
 	env := []string{"FOO=BAR"}
 
@@ -68,13 +67,6 @@ func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 			imageName:   "test",
 			tagger:      envTemplateExample,
 			expected:    "test:BAR",
-		},
-		{
-			description:      "deprecated envTemplate",
-			imageName:        "test",
-			tagger:           envTemplateDeprecatedExample,
-			expected:         "test:BAR",
-			expectedWarnings: []string{"{{.IMAGE_NAME}} is deprecated, envTemplate's template should only specify the tag value. See https://skaffold.dev/docs/pipeline-stages/taggers/"},
 		},
 		{
 			description: "undefined env variable",


### PR DESCRIPTION
These variables were marked for deprecation well over a year ago - it's time they were removed.