### PR TITLE
Handle State.ForwardedPorts == nil

### DIFF
--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -632,6 +632,9 @@ func (ev *eventHandler) handleExec(f firedEvent) {
 	case *proto.Event_PortEvent:
 		pe := e.PortEvent
 		ev.stateLock.Lock()
+		if ev.state.ForwardedPorts == nil {
+			ev.state.ForwardedPorts = map[int32]*proto.PortEvent{}
+		}
 		ev.state.ForwardedPorts[pe.LocalPort] = pe
 		ev.stateLock.Unlock()
 		logEntry.Entry = fmt.Sprintf("Forwarding container %s to local port %d", pe.ContainerName, pe.LocalPort)

--- a/pkg/skaffold/event/event_test.go
+++ b/pkg/skaffold/event/event_test.go
@@ -208,6 +208,8 @@ func TestPortForwarded(t *testing.T) {
 
 	handler = newHandler()
 	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	// explicitly re-set the state https://github.com/GoogleContainerTools/skaffold/issues/5612
+	handler.setState(handler.getState())
 
 	wait(t, func() bool { return handler.getState().ForwardedPorts[8080] == nil })
 	PortForwarded(8080, schemautil.FromInt(8888), "pod", "container", "ns", "portname", "resourceType", "resourceName", "127.0.0.1")


### PR DESCRIPTION
Fixes: #5612

**Description**
`pkg/skaffold/event.getState()` uses JSON marshalling and unmarshalling to create a deep copy of the event state object.  As `State.ForwardedPorts` is marked as `omitempty`:
https://github.com/GoogleContainerTools/skaffold/blob/834d5eaba317b24195f2cc09dc3a850890d1a1bc/proto/v1/skaffold.pb.go#L419
then `getState()` may return an object with a nil `ForwardPorts` map.

This change fixes the handling of `PortEvent`s to deal with a nil `State.ForwardPorts` map.  It also adds a test to trigger the panic seen in #5612.