### PR TITLE
Add event API v2 server handler

### DIFF
--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -167,6 +167,10 @@ func emptyStateWithArtifacts(builds map[string]string, metadata *proto.Metadata,
 			AutoTrigger: autoBuild,
 			StatusCode:  proto.StatusCode_OK,
 		},
+		TestState: &proto.TestState{
+			Status:     NotStarted,
+			StatusCode: proto.StatusCode_OK,
+		},
 		DeployState: &proto.DeployState{
 			Status:      NotStarted,
 			AutoTrigger: autoDeploy,

--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -182,11 +182,71 @@ func emptyStateWithArtifacts(builds map[string]string, metadata *proto.Metadata,
 	}
 }
 
+// ResetStateOnBuild resets the build, test, deploy and sync state
+func ResetStateOnBuild() {
+	builds := map[string]string{}
+	for k := range handler.getState().BuildState.Artifacts {
+		builds[k] = NotStarted
+	}
+	autoBuild, autoDeploy, autoSync := handler.getState().BuildState.AutoTrigger, handler.getState().DeployState.AutoTrigger, handler.getState().FileSyncState.AutoTrigger
+	newState := emptyStateWithArtifacts(builds, handler.getState().Metadata, autoBuild, autoDeploy, autoSync)
+	handler.setState(newState)
+}
+
+// ResetStateOnTest resets the test, deploy, sync and status check state
+func ResetStateOnTest() {
+	newState := handler.getState()
+	newState.TestState.Status = NotStarted
+	handler.setState(newState)
+}
+
+// ResetStateOnDeploy resets the deploy, sync and status check state
+func ResetStateOnDeploy() {
+	newState := handler.getState()
+	newState.DeployState.Status = NotStarted
+	newState.DeployState.StatusCode = proto.StatusCode_OK
+	newState.StatusCheckState = emptyStatusCheckState()
+	newState.ForwardedPorts = map[int32]*proto.PortForwardEvent{}
+	newState.DebuggingContainers = nil
+	handler.setState(newState)
+}
+
+func UpdateStateAutoBuildTrigger(t bool) {
+	newState := handler.getState()
+	newState.BuildState.AutoTrigger = t
+	handler.setState(newState)
+}
+
+func UpdateStateAutoDeployTrigger(t bool) {
+	newState := handler.getState()
+	newState.DeployState.AutoTrigger = t
+	handler.setState(newState)
+}
+
+func UpdateStateAutoSyncTrigger(t bool) {
+	newState := handler.getState()
+	newState.FileSyncState.AutoTrigger = t
+	handler.setState(newState)
+}
+
 func emptyStatusCheckState() *proto.StatusCheckState {
 	return &proto.StatusCheckState{
 		Status:     NotStarted,
 		Resources:  map[string]string{},
 		StatusCode: proto.StatusCode_OK,
+	}
+}
+
+func AutoTriggerDiff(name string, val bool) (bool, error) {
+	switch name {
+	case "build":
+		return val != handler.getState().BuildState.AutoTrigger, nil
+	case "sync":
+		return val != handler.getState().FileSyncState.AutoTrigger, nil
+	case "deploy":
+		return val != handler.getState().DeployState.AutoTrigger, nil
+	default:
+		return false, fmt.Errorf("unknown phase %v not found in handler state", name)
 	}
 }
 
@@ -208,6 +268,12 @@ func TaskFailed(taskName sErrors.Phase, iteration int, err error) {
 		Status:        Failed,
 		ActionableErr: ae,
 	})
+}
+
+func (ev *eventHandler) setState(state proto.State) {
+	ev.stateLock.Lock()
+	ev.state = state
+	ev.stateLock.Unlock()
 }
 
 func (ev *eventHandler) handle(event *proto.Event) {

--- a/pkg/skaffold/event/v2/event_test.go
+++ b/pkg/skaffold/event/v2/event_test.go
@@ -121,7 +121,6 @@ func TestResetStateOnBuild(t *testing.T) {
 		ForwardedPorts: map[int32]*proto.PortForwardEvent{
 			2001: {
 				LocalPort:  2000,
-				RemotePort: 2001,
 				PodName:    "test/pod",
 				TargetPort: &targetPort,
 			},
@@ -158,7 +157,6 @@ func TestResetStateOnDeploy(t *testing.T) {
 		ForwardedPorts: map[int32]*proto.PortForwardEvent{
 			2001: {
 				LocalPort:  2000,
-				RemotePort: 2001,
 				PodName:    "test/pod",
 				TargetPort: &targetPort,
 			},
@@ -202,7 +200,6 @@ func TestUpdateStateAutoTriggers(t *testing.T) {
 		ForwardedPorts: map[int32]*proto.PortForwardEvent{
 			2001: {
 				LocalPort:  2000,
-				RemotePort: 2001,
 				PodName:    "test/pod",
 				TargetPort: &targetPort,
 			},
@@ -228,7 +225,6 @@ func TestUpdateStateAutoTriggers(t *testing.T) {
 		ForwardedPorts: map[int32]*proto.PortForwardEvent{
 			2001: {
 				LocalPort:  2000,
-				RemotePort: 2001,
 				PodName:    "test/pod",
 				TargetPort: &targetPort,
 			},

--- a/pkg/skaffold/event/v2/event_test.go
+++ b/pkg/skaffold/event/v2/event_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
+var targetPort = proto.IntOrString{Type: 0, IntVal: 2001}
+
 func TestGetLogEvents(t *testing.T) {
 	for step := 0; step < 1000; step++ {
 		ev := newHandler()
@@ -106,12 +108,138 @@ func wait(t *testing.T, condition func() bool) {
 	}
 }
 
+func TestResetStateOnBuild(t *testing.T) {
+	defer func() { handler = newHandler() }()
+	handler = newHandler()
+	handler.state = proto.State{
+		BuildState: &proto.BuildState{
+			Artifacts: map[string]string{
+				"image1": Complete,
+			},
+		},
+		DeployState: &proto.DeployState{Status: Complete},
+		ForwardedPorts: map[int32]*proto.PortForwardEvent{
+			2001: {
+				LocalPort:  2000,
+				RemotePort: 2001,
+				PodName:    "test/pod",
+				TargetPort: &targetPort,
+			},
+		},
+		StatusCheckState: &proto.StatusCheckState{Status: Complete},
+		FileSyncState:    &proto.FileSyncState{Status: Succeeded},
+	}
+
+	ResetStateOnBuild()
+	expected := proto.State{
+		BuildState: &proto.BuildState{
+			Artifacts: map[string]string{
+				"image1": NotStarted,
+			},
+		},
+		TestState:        &proto.TestState{Status: NotStarted},
+		DeployState:      &proto.DeployState{Status: NotStarted},
+		StatusCheckState: &proto.StatusCheckState{Status: NotStarted, Resources: map[string]string{}},
+		FileSyncState:    &proto.FileSyncState{Status: NotStarted},
+	}
+	testutil.CheckDeepEqual(t, expected, handler.getState(), cmpopts.EquateEmpty())
+}
+
+func TestResetStateOnDeploy(t *testing.T) {
+	defer func() { handler = newHandler() }()
+	handler = newHandler()
+	handler.state = proto.State{
+		BuildState: &proto.BuildState{
+			Artifacts: map[string]string{
+				"image1": Complete,
+			},
+		},
+		DeployState: &proto.DeployState{Status: Complete},
+		ForwardedPorts: map[int32]*proto.PortForwardEvent{
+			2001: {
+				LocalPort:  2000,
+				RemotePort: 2001,
+				PodName:    "test/pod",
+				TargetPort: &targetPort,
+			},
+		},
+		StatusCheckState: &proto.StatusCheckState{Status: Complete},
+	}
+	ResetStateOnDeploy()
+	expected := proto.State{
+		BuildState: &proto.BuildState{
+			Artifacts: map[string]string{
+				"image1": Complete,
+			},
+		},
+		DeployState: &proto.DeployState{Status: NotStarted},
+		StatusCheckState: &proto.StatusCheckState{Status: NotStarted,
+			Resources: map[string]string{},
+		},
+	}
+	testutil.CheckDeepEqual(t, expected, handler.getState(), cmpopts.EquateEmpty())
+}
+
 func TestEmptyStateCheckState(t *testing.T) {
 	actual := emptyStatusCheckState()
 	expected := &proto.StatusCheckState{Status: NotStarted,
 		Resources: map[string]string{},
 	}
 	testutil.CheckDeepEqual(t, expected, actual, cmpopts.EquateEmpty())
+}
+
+func TestUpdateStateAutoTriggers(t *testing.T) {
+	defer func() { handler = newHandler() }()
+	handler = newHandler()
+	handler.state = proto.State{
+		BuildState: &proto.BuildState{
+			Artifacts: map[string]string{
+				"image1": Complete,
+			},
+			AutoTrigger: false,
+		},
+		DeployState: &proto.DeployState{Status: Complete, AutoTrigger: false},
+		ForwardedPorts: map[int32]*proto.PortForwardEvent{
+			2001: {
+				LocalPort:  2000,
+				RemotePort: 2001,
+				PodName:    "test/pod",
+				TargetPort: &targetPort,
+			},
+		},
+		StatusCheckState: &proto.StatusCheckState{Status: Complete},
+		FileSyncState: &proto.FileSyncState{
+			Status:      "Complete",
+			AutoTrigger: false,
+		},
+	}
+	UpdateStateAutoBuildTrigger(true)
+	UpdateStateAutoDeployTrigger(true)
+	UpdateStateAutoSyncTrigger(true)
+
+	expected := proto.State{
+		BuildState: &proto.BuildState{
+			Artifacts: map[string]string{
+				"image1": Complete,
+			},
+			AutoTrigger: true,
+		},
+		DeployState: &proto.DeployState{Status: Complete, AutoTrigger: true},
+		ForwardedPorts: map[int32]*proto.PortForwardEvent{
+			2001: {
+				LocalPort:  2000,
+				RemotePort: 2001,
+				PodName:    "test/pod",
+				TargetPort: &targetPort,
+			},
+		},
+		StatusCheckState: &proto.StatusCheckState{Status: Complete},
+		FileSyncState: &proto.FileSyncState{
+			Status:      "Complete",
+			AutoTrigger: true,
+		},
+	}
+	testutil.CheckDeepEqual(t, expected, handler.getState(), cmpopts.EquateEmpty())
 }
 
 func TestTaskFailed(t *testing.T) {

--- a/pkg/skaffold/server/server.go
+++ b/pkg/skaffold/server/server.go
@@ -25,7 +25,6 @@ import (
 	"net/http"
 	"time"
 
-	v2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/server/v2"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -33,6 +32,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	v2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/server/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	protoV2 "github.com/GoogleContainerTools/skaffold/proto/v2"

--- a/pkg/skaffold/server/server.go
+++ b/pkg/skaffold/server/server.go
@@ -198,7 +198,7 @@ func newHTTPServer(preferredPort, proxyPort int, usedPorts *util.PortSet) (func(
 	}
 	err = protoV2.RegisterSkaffoldV2ServiceHandlerFromEndpoint(context.Background(), mux, fmt.Sprintf("%s:%d", util.Loopback, proxyPort), opts)
 	if err != nil {
-		return func() error {return nil }, err
+		return func() error { return nil }, err
 	}
 
 	l, port, err := listenOnAvailablePort(preferredPort, usedPorts)

--- a/pkg/skaffold/server/v2/endpoints.go
+++ b/pkg/skaffold/server/v2/endpoints.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	// For Testing
-	resetStateOnBuild = event.ResetStateOnBuild
+	resetStateOnBuild  = event.ResetStateOnBuild
 	resetStateOnDeploy = event.ResetStateOnDeploy
 )
 

--- a/pkg/skaffold/server/v2/endpoints.go
+++ b/pkg/skaffold/server/v2/endpoints.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	event "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
+	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
+)
+
+func (s *Server) GetState(context.Context, *empty.Empty) (*proto.State, error) {
+	return event.GetState()
+}
+
+func (s *Server) Events(_ *empty.Empty, stream proto.SkaffoldV2Service_EventsServer) error {
+	return event.ForEachEvent(stream.Send)
+}
+
+func (s *Server) Handle(ctx context.Context, e *proto.Event) (*empty.Empty, error) {
+	event.Handle(e)
+	return &empty.Empty{}, nil
+}
+
+func (s *Server) Execute(ctx context.Context, intent *proto.UserIntentRequest) (*empty.Empty, error) {
+	if intent.GetIntent().GetBuild() {
+		event.ResetStateOnBuild()
+		go func() {
+			s.BuildIntentCallback()
+		}()
+	}
+
+	if intent.GetIntent().GetDeploy() {
+		event.ResetStateOnDeploy()
+		go func() {
+			s.DeployIntentCallback()
+		}()
+	}
+
+	if intent.GetIntent().GetSync() {
+		go func() {
+			s.SyncIntentCallback()
+		}()
+	}
+
+	return &empty.Empty{}, nil
+}
+
+func (s *Server) AutoBuild(ctx context.Context, request *proto.TriggerRequest) (res *empty.Empty, err error) {
+	return executeAutoTrigger("build", request, event.UpdateStateAutoBuildTrigger, event.ResetStateOnBuild, s.AutoBuildCallback)
+}
+
+func (s *Server) AutoDeploy(ctx context.Context, request *proto.TriggerRequest) (res *empty.Empty, err error) {
+	return executeAutoTrigger("deploy", request, event.UpdateStateAutoDeployTrigger, event.ResetStateOnDeploy, s.AutoDeployCallback)
+}
+
+func (s *Server) AutoSync(ctx context.Context, request *proto.TriggerRequest) (res *empty.Empty, err error) {
+	return executeAutoTrigger("sync", request, event.UpdateStateAutoSyncTrigger, func() {}, s.AutoSyncCallback)
+}
+
+func executeAutoTrigger(triggerName string, request *proto.TriggerRequest, updateTriggerStateFunc func(bool), resetPhaseStateFunc func(), serverCallback func(bool)) (res *empty.Empty, err error) {
+	res = &empty.Empty{}
+	v, ok := request.GetState().GetVal().(*proto.TriggerState_Enabled)
+	if !ok {
+		err = status.Error(codes.InvalidArgument, "missing required boolean parameter 'enabled'")
+		return
+	}
+	trigger := v.Enabled
+	update, err := event.AutoTriggerDiff(triggerName, trigger)
+	if err != nil {
+		return
+	}
+	if !update {
+		err = status.Errorf(codes.AlreadyExists, "auto %v is already set to %t", triggerName, trigger)
+		return
+	}
+	// update trigger state
+	updateTriggerStateFunc(trigger)
+	if trigger {
+		// reset phase state only when auto trigger is being set to true
+		resetPhaseStateFunc()
+	}
+	go func() {
+		serverCallback(trigger)
+	}()
+	return
+}

--- a/pkg/skaffold/server/v2/server.go
+++ b/pkg/skaffold/server/v2/server.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+var (
+	Srv *Server
+)
+
+type Server struct {
+	BuildIntentCallback  func()
+	SyncIntentCallback   func()
+	DeployIntentCallback func()
+	AutoBuildCallback    func(bool)
+	AutoSyncCallback     func(bool)
+	AutoDeployCallback   func(bool)
+}
+
+//TODO(marlongamez): Add Set*Callback() funcs once going for feature parity

--- a/pkg/skaffold/server/v2/server.go
+++ b/pkg/skaffold/server/v2/server.go
@@ -29,4 +29,4 @@ type Server struct {
 	AutoDeployCallback   func(bool)
 }
 
-//TODO(marlongamez): Add Set*Callback() funcs once going for v1 feature parity
+// TODO(marlongamez): Add Set*Callback() funcs once going for v1 feature parity

--- a/pkg/skaffold/server/v2/server.go
+++ b/pkg/skaffold/server/v2/server.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2021 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,4 +29,4 @@ type Server struct {
 	AutoDeployCallback   func(bool)
 }
 
-//TODO(marlongamez): Add Set*Callback() funcs once going for feature parity
+//TODO(marlongamez): Add Set*Callback() funcs once going for v1 feature parity

--- a/pkg/skaffold/server/v2/server_test.go
+++ b/pkg/skaffold/server/v2/server_test.go
@@ -10,12 +10,14 @@ import (
 
 // Mock structs and functions
 type mockData struct {
-	Build bool
-	Sync bool
+	Build  bool
+	Sync   bool
 	Deploy bool
 }
+
 var data mockData
 var done = make(chan bool)
+
 func mockBuildIntentCallback() {
 	data.Build = true
 	done <- true
@@ -30,11 +32,11 @@ func mockDeployIntentCallback() {
 }
 
 func TestServer_Execute(t *testing.T) {
-	tests := []struct{
-		description string
-		request *proto.UserIntentRequest
+	tests := []struct {
+		description  string
+		request      *proto.UserIntentRequest
 		numCallBacks int
-		expected mockData
+		expected     mockData
 	}{
 		{
 			description: "build intent",
@@ -45,7 +47,7 @@ func TestServer_Execute(t *testing.T) {
 			},
 			numCallBacks: 1,
 			expected: mockData{
-				Build:  true,
+				Build: true,
 			},
 		},
 		{
@@ -57,7 +59,7 @@ func TestServer_Execute(t *testing.T) {
 			},
 			numCallBacks: 1,
 			expected: mockData{
-				Sync:  true,
+				Sync: true,
 			},
 		},
 		{
@@ -69,51 +71,51 @@ func TestServer_Execute(t *testing.T) {
 			},
 			numCallBacks: 1,
 			expected: mockData{
-				Deploy:  true,
+				Deploy: true,
 			},
 		},
 		{
 			description: "build and deploy intent",
 			request: &proto.UserIntentRequest{
 				Intent: &proto.Intent{
-					Build: true,
+					Build:  true,
 					Deploy: true,
 				},
 			},
 			numCallBacks: 2,
 			expected: mockData{
-				Build: true,
-				Deploy:  true,
+				Build:  true,
+				Deploy: true,
 			},
 		},
 		{
 			description: "build, sync, and deploy intent",
 			request: &proto.UserIntentRequest{
 				Intent: &proto.Intent{
-					Build: true,
+					Build:  true,
 					Deploy: true,
-					Sync: true,
+					Sync:   true,
 				},
 			},
 			numCallBacks: 3,
 			expected: mockData{
-				Build: true,
-				Sync: true,
-				Deploy:  true,
+				Build:  true,
+				Sync:   true,
+				Deploy: true,
 			},
 		},
 	}
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&resetStateOnBuild, func(){})
-			t.Override(&resetStateOnDeploy, func(){})
+			t.Override(&resetStateOnBuild, func() {})
+			t.Override(&resetStateOnDeploy, func() {})
 			data = mockData{}
 
 			// Setup server with mock callback functions and run Execute()
 			Srv = &Server{
-				BuildIntentCallback: mockBuildIntentCallback,
-				SyncIntentCallback: mockSyncIntentCallback,
+				BuildIntentCallback:  mockBuildIntentCallback,
+				SyncIntentCallback:   mockSyncIntentCallback,
 				DeployIntentCallback: mockDeployIntentCallback,
 			}
 			_, err := Srv.Execute(context.Background(), test.request)
@@ -123,7 +125,7 @@ func TestServer_Execute(t *testing.T) {
 
 			// Ensure callbacks finish updating data
 			for i := 0; i < test.numCallBacks; i++ {
-				<- done
+				<-done
 			}
 
 			t.CheckDeepEqual(test.expected, data)

--- a/pkg/skaffold/server/v2/server_test.go
+++ b/pkg/skaffold/server/v2/server_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v2
 
 import (

--- a/pkg/skaffold/server/v2/server_test.go
+++ b/pkg/skaffold/server/v2/server_test.go
@@ -1,0 +1,132 @@
+package v2
+
+import (
+	"context"
+	"testing"
+
+	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+// Mock structs and functions
+type mockData struct {
+	Build bool
+	Sync bool
+	Deploy bool
+}
+var data mockData
+var done = make(chan bool)
+func mockBuildIntentCallback() {
+	data.Build = true
+	done <- true
+}
+func mockSyncIntentCallback() {
+	data.Sync = true
+	done <- true
+}
+func mockDeployIntentCallback() {
+	data.Deploy = true
+	done <- true
+}
+
+func TestServer_Execute(t *testing.T) {
+	tests := []struct{
+		description string
+		request *proto.UserIntentRequest
+		numCallBacks int
+		expected mockData
+	}{
+		{
+			description: "build intent",
+			request: &proto.UserIntentRequest{
+				Intent: &proto.Intent{
+					Build: true,
+				},
+			},
+			numCallBacks: 1,
+			expected: mockData{
+				Build:  true,
+			},
+		},
+		{
+			description: "sync intent",
+			request: &proto.UserIntentRequest{
+				Intent: &proto.Intent{
+					Sync: true,
+				},
+			},
+			numCallBacks: 1,
+			expected: mockData{
+				Sync:  true,
+			},
+		},
+		{
+			description: "deploy intent",
+			request: &proto.UserIntentRequest{
+				Intent: &proto.Intent{
+					Deploy: true,
+				},
+			},
+			numCallBacks: 1,
+			expected: mockData{
+				Deploy:  true,
+			},
+		},
+		{
+			description: "build and deploy intent",
+			request: &proto.UserIntentRequest{
+				Intent: &proto.Intent{
+					Build: true,
+					Deploy: true,
+				},
+			},
+			numCallBacks: 2,
+			expected: mockData{
+				Build: true,
+				Deploy:  true,
+			},
+		},
+		{
+			description: "build, sync, and deploy intent",
+			request: &proto.UserIntentRequest{
+				Intent: &proto.Intent{
+					Build: true,
+					Deploy: true,
+					Sync: true,
+				},
+			},
+			numCallBacks: 3,
+			expected: mockData{
+				Build: true,
+				Sync: true,
+				Deploy:  true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&resetStateOnBuild, func(){})
+			t.Override(&resetStateOnDeploy, func(){})
+			data = mockData{}
+
+			// Setup server with mock callback functions and run Execute()
+			Srv = &Server{
+				BuildIntentCallback: mockBuildIntentCallback,
+				SyncIntentCallback: mockSyncIntentCallback,
+				DeployIntentCallback: mockDeployIntentCallback,
+			}
+			_, err := Srv.Execute(context.Background(), test.request)
+			if err != nil {
+				t.Fail()
+			}
+
+			// Ensure callbacks finish updating data
+			for i := 0; i < test.numCallBacks; i++ {
+				<- done
+			}
+
+			t.CheckDeepEqual(test.expected, data)
+		})
+	}
+}


### PR DESCRIPTION
**Related**: #5422 , #5368 

**Description**
Adds `pkg/skaffold/server/v2` package which contains a new struct that handles the endpoints for the v2 API. Users will now be able to hit both the v1 and v2 endpoints through the running gRPC server.

Most of the server definition is copied from `pkg/skaffold/server` files, and the functions added to `pkg/skaffold/event/v2/event.go` are straight from `pkg/skaffold/event/event.go`

**Follow-up Work (remove if N/A)**
Emit protos on this server
