### PR TITLE
Add `BuilderContext` interface to encapsulate `RunContext` and provide additional builder constructor requirements.

### DIFF
--- a/pkg/skaffold/build/cluster/cluster_test.go
+++ b/pkg/skaffold/build/cluster/cluster_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestRetrieveEnv(t *testing.T) {
-	builder, err := NewBuilder(&mockConfig{
+	builder, err := NewBuilder(&mockBuilderContext{
 		kubeContext: "kubecontext",
 		namespace:   "test-namespace",
 	}, &latest.ClusterDetails{
@@ -43,7 +43,7 @@ func TestRetrieveEnv(t *testing.T) {
 }
 
 func TestRetrieveEnvMinimal(t *testing.T) {
-	builder, err := NewBuilder(&mockConfig{}, &latest.ClusterDetails{
+	builder, err := NewBuilder(&mockBuilderContext{}, &latest.ClusterDetails{
 		Timeout: "20m",
 	})
 	testutil.CheckError(t, false, err)

--- a/pkg/skaffold/build/cluster/pod_test.go
+++ b/pkg/skaffold/build/cluster/pod_test.go
@@ -191,7 +191,7 @@ func TestKanikoPodSpec(t *testing.T) {
 	var runAsUser int64 = 0
 
 	builder := &Builder{
-		cfg: &mockConfig{},
+		cfg: &mockBuilderContext{},
 		ClusterDetails: &latest.ClusterDetails{
 			Namespace:           "ns",
 			PullSecretName:      "secret",

--- a/pkg/skaffold/build/cluster/secret_test.go
+++ b/pkg/skaffold/build/cluster/secret_test.go
@@ -39,7 +39,7 @@ func TestCreateSecret(t *testing.T) {
 			return fakeKubernetesclient, nil
 		})
 
-		builder, err := NewBuilder(&mockConfig{}, &latest.ClusterDetails{
+		builder, err := NewBuilder(&mockBuilderContext{}, &latest.ClusterDetails{
 			Timeout:        "20m",
 			PullSecretName: "kaniko-secret",
 			PullSecretPath: tmpDir.Path("secret.json"),
@@ -70,7 +70,7 @@ func TestExistingSecretNotFound(t *testing.T) {
 			return fake.NewSimpleClientset(), nil
 		})
 
-		builder, err := NewBuilder(&mockConfig{}, &latest.ClusterDetails{
+		builder, err := NewBuilder(&mockBuilderContext{}, &latest.ClusterDetails{
 			Timeout:        "20m",
 			PullSecretName: "kaniko-secret",
 		})
@@ -93,7 +93,7 @@ func TestExistingSecret(t *testing.T) {
 			}), nil
 		})
 
-		builder, err := NewBuilder(&mockConfig{}, &latest.ClusterDetails{
+		builder, err := NewBuilder(&mockBuilderContext{}, &latest.ClusterDetails{
 			Timeout:        "20m",
 			PullSecretName: "kaniko-secret",
 		})
@@ -113,7 +113,7 @@ func TestSkipSecretCreation(t *testing.T) {
 			return nil, nil
 		})
 
-		builder, err := NewBuilder(&mockConfig{}, &latest.ClusterDetails{
+		builder, err := NewBuilder(&mockBuilderContext{}, &latest.ClusterDetails{
 			Timeout: "20m",
 		})
 		t.CheckNoError(err)

--- a/pkg/skaffold/build/gcb/buildpacks_test.go
+++ b/pkg/skaffold/build/gcb/buildpacks_test.go
@@ -190,10 +190,9 @@ func TestBuildpackBuildSpec(t *testing.T) {
 				"img2": "img2:tag",
 				"img3": "img3:tag",
 			}
-			builder := NewBuilder(&mockConfig{}, &latest.GoogleCloudBuild{
+			builder := NewBuilder(&mockBuilderContext{artifactStore: store}, &latest.GoogleCloudBuild{
 				PackImage: "pack/image",
 			})
-			builder.ArtifactStore(store)
 			buildSpec, err := builder.buildSpec(artifact, "img", "bucket", "object")
 			t.CheckError(test.shouldErr, err)
 

--- a/pkg/skaffold/build/gcb/docker_test.go
+++ b/pkg/skaffold/build/gcb/docker_test.go
@@ -143,17 +143,19 @@ func TestDockerBuildSpec(t *testing.T) {
 				}
 				return m, nil
 			})
-			builder := NewBuilder(&mockConfig{}, &latest.GoogleCloudBuild{
+
+			store := mockArtifactStore{
+				"img2": "img2:tag",
+				"img3": "img3:tag",
+			}
+
+			builder := NewBuilder(&mockBuilderContext{artifactStore: store}, &latest.GoogleCloudBuild{
 				DockerImage: "docker/docker",
 				DiskSizeGb:  100,
 				MachineType: "n1-standard-1",
 				Timeout:     "10m",
 			})
-			store := mockArtifactStore{
-				"img2": "img2:tag",
-				"img3": "img3:tag",
-			}
-			builder.ArtifactStore(store)
+
 			desc, err := builder.buildSpec(test.artifact, "nginx", "bucket", "object")
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, desc)
 		})
@@ -173,7 +175,7 @@ func TestPullCacheFrom(t *testing.T) {
 				},
 			},
 		}
-		builder := NewBuilder(&mockConfig{}, &latest.GoogleCloudBuild{
+		builder := NewBuilder(&mockBuilderContext{}, &latest.GoogleCloudBuild{
 			DockerImage: "docker/docker",
 		})
 		desc, err := builder.dockerBuildSpec(artifact, "nginx2")

--- a/pkg/skaffold/build/gcb/jib_test.go
+++ b/pkg/skaffold/build/gcb/jib_test.go
@@ -69,15 +69,15 @@ func TestJibMavenBuildSpec(t *testing.T) {
 				},
 			}
 
-			builder := NewBuilder(&mockConfig{}, &latest.GoogleCloudBuild{
-				MavenImage: "maven:3.6.0",
-			})
-			builder.skipTests = test.skipTests
 			store := mockArtifactStore{
 				"img2": "img2:tag",
 				"img3": "img3:tag",
 			}
-			builder.ArtifactStore(store)
+			builder := NewBuilder(&mockBuilderContext{artifactStore: store}, &latest.GoogleCloudBuild{
+				MavenImage: "maven:3.6.0",
+			})
+			builder.skipTests = test.skipTests
+
 			buildSpec, err := builder.buildSpec(artifact, "img", "bucket", "object")
 			t.CheckNoError(err)
 
@@ -118,7 +118,7 @@ func TestJibGradleBuildSpec(t *testing.T) {
 				},
 			}
 
-			builder := NewBuilder(&mockConfig{}, &latest.GoogleCloudBuild{
+			builder := NewBuilder(&mockBuilderContext{}, &latest.GoogleCloudBuild{
 				GradleImage: "gradle:5.1.1",
 			})
 			builder.skipTests = test.skipTests

--- a/pkg/skaffold/build/gcb/kaniko_test.go
+++ b/pkg/skaffold/build/gcb/kaniko_test.go
@@ -355,8 +355,11 @@ func TestKanikoBuildSpec(t *testing.T) {
 			},
 		},
 	}
-
-	builder := NewBuilder(&mockConfig{}, &latest.GoogleCloudBuild{
+	store := mockArtifactStore{
+		"img2": "img2:tag",
+		"img3": "img3:tag",
+	}
+	builder := NewBuilder(&mockBuilderContext{artifactStore: store}, &latest.GoogleCloudBuild{
 		KanikoImage: "gcr.io/kaniko-project/executor",
 		DiskSizeGb:  100,
 		MachineType: "n1-standard-1",
@@ -380,11 +383,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 					{ImageName: "img3", Alias: "IMG3"},
 				},
 			}
-			store := mockArtifactStore{
-				"img2": "img2:tag",
-				"img3": "img3:tag",
-			}
-			builder.ArtifactStore(store)
+
 			imageArgs := []string{kaniko.BuildArgsFlag, "IMG2=img2:tag", kaniko.BuildArgsFlag, "IMG3=img3:tag"}
 
 			t.Override(&docker.EvalBuildArgs, func(_ config.RunMode, _ string, _ string, args map[string]*string, extra map[string]*string) (map[string]*string, error) {

--- a/pkg/skaffold/build/gcb/spec_test.go
+++ b/pkg/skaffold/build/gcb/spec_test.go
@@ -19,6 +19,7 @@ package gcb
 import (
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -44,7 +45,7 @@ func TestBuildSpecFail(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			builder := NewBuilder(&mockConfig{}, &latest.GoogleCloudBuild{})
+			builder := NewBuilder(&mockBuilderContext{}, &latest.GoogleCloudBuild{})
 
 			_, err := builder.buildSpec(test.artifact, "tag", "bucket", "object")
 
@@ -53,6 +54,9 @@ func TestBuildSpecFail(t *testing.T) {
 	}
 }
 
-type mockConfig struct {
+type mockBuilderContext struct {
 	runcontext.RunContext // Embedded to provide the default values.
+	artifactStore         build.ArtifactStore
 }
+
+func (c *mockBuilderContext) ArtifactStore() build.ArtifactStore { return c.artifactStore }

--- a/pkg/skaffold/build/gcb/types.go
+++ b/pkg/skaffold/build/gcb/types.go
@@ -93,18 +93,20 @@ type Config interface {
 	Muted() config.Muted
 }
 
-// NewBuilder creates a new Builder that builds artifacts with Google Cloud Build.
-func NewBuilder(cfg Config, buildCfg *latest.GoogleCloudBuild) *Builder {
-	return &Builder{
-		GoogleCloudBuild: buildCfg,
-		cfg:              cfg,
-		skipTests:        cfg.SkipTests(),
-		muted:            cfg.Muted(),
-	}
+type BuilderContext interface {
+	Config
+	ArtifactStore() build.ArtifactStore
 }
 
-func (b *Builder) ArtifactStore(store build.ArtifactStore) {
-	b.artifactStore = store
+// NewBuilder creates a new Builder that builds artifacts with Google Cloud Build.
+func NewBuilder(bCtx BuilderContext, buildCfg *latest.GoogleCloudBuild) *Builder {
+	return &Builder{
+		GoogleCloudBuild: buildCfg,
+		cfg:              bCtx,
+		skipTests:        bCtx.SkipTests(),
+		muted:            bCtx.Muted(),
+		artifactStore:    bCtx.ArtifactStore(),
+	}
 }
 
 func (b *Builder) Prune(ctx context.Context, out io.Writer) error {

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -237,13 +237,12 @@ func TestLocalRun(t *testing.T) {
 					},
 				}}})
 
-			builder, err := NewBuilder(&mockConfig{},
+			builder, err := NewBuilder(&mockBuilderContext{artifactStore: build.NewArtifactStore()},
 				&latest.LocalBuild{
 					Push:        util.BoolPtr(test.pushImages),
 					Concurrency: &constants.DefaultLocalConcurrency,
 				})
 			t.CheckNoError(err)
-			builder.ArtifactStore(build.NewArtifactStore())
 			ab := builder.Build(context.Background(), ioutil.Discard, test.artifact)
 			res, err := ab(context.Background(), ioutil.Discard, test.artifact, test.tag)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, res)
@@ -302,7 +301,7 @@ func TestNewBuilder(t *testing.T) {
 				t.Override(&docker.NewAPIClient, test.localDockerFn)
 			}
 
-			builder, err := NewBuilder(&mockConfig{
+			builder, err := NewBuilder(&mockBuilderContext{
 				local:   test.localBuild,
 				cluster: test.cluster,
 			}, &test.localBuild)
@@ -382,9 +381,8 @@ func TestGetArtifactBuilder(t *testing.T) {
 				return args, nil
 			})
 
-			b, err := NewBuilder(&mockConfig{}, &latest.LocalBuild{Concurrency: &constants.DefaultLocalConcurrency})
+			b, err := NewBuilder(&mockBuilderContext{artifactStore: build.NewArtifactStore()}, &latest.LocalBuild{Concurrency: &constants.DefaultLocalConcurrency})
 			t.CheckNoError(err)
-			b.ArtifactStore(build.NewArtifactStore())
 
 			builder, err := newPerArtifactBuilder(b, test.artifact)
 			t.CheckNoError(err)
@@ -409,17 +407,22 @@ func fakeLocalDaemon(api client.CommonAPIClient) docker.LocalDaemon {
 	return docker.NewLocalDaemon(api, nil, false, nil)
 }
 
-type mockConfig struct {
+type mockBuilderContext struct {
 	runcontext.RunContext // Embedded to provide the default values.
 	local                 latest.LocalBuild
 	mode                  config.RunMode
 	cluster               config.Cluster
+	artifactStore         build.ArtifactStore
 }
 
-func (c *mockConfig) Mode() config.RunMode {
+func (c *mockBuilderContext) Mode() config.RunMode {
 	return c.mode
 }
 
-func (c *mockConfig) GetCluster() config.Cluster {
+func (c *mockBuilderContext) GetCluster() config.Cluster {
 	return c.cluster
+}
+
+func (c *mockBuilderContext) ArtifactStore() build.ArtifactStore {
+	return c.artifactStore
 }

--- a/pkg/skaffold/runner/builder.go
+++ b/pkg/skaffold/runner/builder.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runner
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cluster"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/gcb"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/local"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+)
+
+// builderCtx encapsulates a given skaffold run context along with additional builder constructs.
+type builderCtx struct {
+	*runcontext.RunContext
+	artifactStore build.ArtifactStore
+}
+
+func (b *builderCtx) ArtifactStore() build.ArtifactStore {
+	return b.artifactStore
+}
+
+// getBuilder creates a builder from a given RunContext and build pipeline type.
+func getBuilder(runCtx *runcontext.RunContext, store build.ArtifactStore, p latest.Pipeline) (build.PipelineBuilder, error) {
+	bCtx := &builderCtx{artifactStore: store, RunContext: runCtx}
+	switch {
+	case p.Build.LocalBuild != nil:
+		logrus.Debugln("Using builder: local")
+		builder, err := local.NewBuilder(bCtx, p.Build.LocalBuild)
+		if err != nil {
+			return nil, err
+		}
+		return builder, nil
+
+	case p.Build.GoogleCloudBuild != nil:
+		logrus.Debugln("Using builder: google cloud")
+		builder := gcb.NewBuilder(bCtx, p.Build.GoogleCloudBuild)
+		return builder, nil
+
+	case p.Build.Cluster != nil:
+		logrus.Debugln("Using builder: cluster")
+		builder, err := cluster.NewBuilder(bCtx, p.Build.Cluster)
+		if err != nil {
+			return nil, err
+		}
+		return builder, err
+
+	default:
+		return nil, fmt.Errorf("unknown builder for config %+v", p.Build)
+	}
+}

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -26,9 +26,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cluster"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/gcb"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/local"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/helm"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kpt"
@@ -190,38 +187,6 @@ func isImageLocal(runCtx *runcontext.RunContext, imageName string) (bool, error)
 		pushImages = *pipeline.Build.LocalBuild.Push
 	}
 	return !pushImages, nil
-}
-
-// getBuilder creates a builder from a given RunContext and build pipeline type.
-func getBuilder(runCtx *runcontext.RunContext, store build.ArtifactStore, p latest.Pipeline) (build.PipelineBuilder, error) {
-	switch {
-	case p.Build.LocalBuild != nil:
-		logrus.Debugln("Using builder: local")
-		builder, err := local.NewBuilder(runCtx, p.Build.LocalBuild)
-		if err != nil {
-			return nil, err
-		}
-		builder.ArtifactStore(store)
-		return builder, nil
-
-	case p.Build.GoogleCloudBuild != nil:
-		logrus.Debugln("Using builder: google cloud")
-		builder := gcb.NewBuilder(runCtx, p.Build.GoogleCloudBuild)
-		builder.ArtifactStore(store)
-		return builder, nil
-
-	case p.Build.Cluster != nil:
-		logrus.Debugln("Using builder: cluster")
-		builder, err := cluster.NewBuilder(runCtx, p.Build.Cluster)
-		if err != nil {
-			return nil, err
-		}
-		builder.ArtifactStore(store)
-		return builder, err
-
-	default:
-		return nil, fmt.Errorf("unknown builder for config %+v", p.Build)
-	}
 }
 
 func getTester(cfg test.Config, isLocalImage func(imageName string) (bool, error)) (test.Tester, error) {


### PR DESCRIPTION
Refactor builder constructor to take a `BuilderContext` instead of only the `RunContext` to provide additional builder requirements.

This will simplify https://github.com/GoogleContainerTools/skaffold/pull/5614

This PR doesn't change any existing behavior.