### PR TITLE
Add service config to leeroy-web deployment.yaml

### DIFF
--- a/examples/microservices/leeroy-web/kubernetes/deployment.yaml
+++ b/examples/microservices/leeroy-web/kubernetes/deployment.yaml
@@ -1,3 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: leeroy-web
+  labels:
+    app: leeroy-web
+spec:
+  type: NodePort
+  ports:
+    - port: 8080
+      name: leeroy-web
+  selector:
+    app: leeroy-web
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Fixes: #5629

**Description**
Adds a `leeroy-web` service of type NodePort to conform with the intent and instructions of the example README.md

**User facing changes**
Users will now see both a `leeroy-web` and a `leeroy-app` service when running the "microservices" example.
