### PR TITLE
Bring survey prompt back to 10 days and every 90 days.

### DIFF
--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -38,6 +38,8 @@ import (
 const (
 	defaultConfigDir  = ".skaffold"
 	defaultConfigFile = "config"
+	tenDays           = time.Hour * 24 * 10
+	threeMonths       = time.Hour * 24 * 90
 )
 
 var (
@@ -321,7 +323,7 @@ func recentlyPromptedOrTaken(cfg *ContextConfig) bool {
 	if cfg == nil || cfg.Survey == nil {
 		return false
 	}
-	return lessThan(cfg.Survey.LastTaken, 365*24*time.Hour) || lessThan(cfg.Survey.LastPrompted, 60*24*time.Hour)
+	return lessThan(cfg.Survey.LastTaken, threeMonths) || lessThan(cfg.Survey.LastPrompted, tenDays)
 }
 
 func lessThan(date string, duration time.Duration) bool {

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -38,8 +38,6 @@ import (
 const (
 	defaultConfigDir  = ".skaffold"
 	defaultConfigFile = "config"
-	tenDays           = time.Hour * 24 * 10
-	threeMonths       = time.Hour * 24 * 90
 )
 
 var (
@@ -323,7 +321,7 @@ func recentlyPromptedOrTaken(cfg *ContextConfig) bool {
 	if cfg == nil || cfg.Survey == nil {
 		return false
 	}
-	return lessThan(cfg.Survey.LastTaken, threeMonths) || lessThan(cfg.Survey.LastPrompted, tenDays)
+	return lessThan(cfg.Survey.LastTaken, 90*24*time.Hour) || lessThan(cfg.Survey.LastPrompted, 10*24*time.Hour)
 }
 
 func lessThan(date string, duration time.Duration) bool {

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -558,11 +558,11 @@ func TestShouldDisplayPrompt(t *testing.T) {
 			},
 		},
 		{
-			description: "should display prompt when last prompted is older than 3 months",
+			description: "should display prompt when last prompted is before 2 weeks",
 			cfg: &ContextConfig{
 				Survey: &SurveyConfig{
 					DisablePrompt: util.BoolPtr(false),
-					LastPrompted:  "2018-09-10T00:00:00Z",
+					LastPrompted:  "2019-01-10T00:00:00Z",
 				},
 			},
 			expected: true,


### PR DESCRIPTION
Revert #4626 and bring back survey prompts to normal cadency 
1) Show one every 90 days
2) Keep prompting after every 10 days until a user fills.