### PR TITLE
Flag defaults should support pflag SliceValue

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -568,7 +568,7 @@ func setDefaultValues(v interface{}, fl *Flag, cmdName string) {
 	if sv, ok := v.(pflag.SliceValue); ok {
 		sv.Replace(asStringSlice(d))
 	} else if v, ok := fl.Value.(pflag.Value); ok {
-		v.Set(fmt.Sprintf("%s", d))
+		v.Set(fmt.Sprintf("%v", d))
 	}
 }
 

--- a/cmd/skaffold/app/cmd/flags_test.go
+++ b/cmd/skaffold/app/cmd/flags_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -171,6 +172,25 @@ func TestResetFlagDefaults(t *testing.T) {
 
 			t.CheckDeepEqual(v, test.expectedValue)
 			t.CheckDeepEqual(sl, test.expectedSlice)
+		})
+	}
+}
+
+func TestAsStringSlice(t *testing.T) {
+	tests := []struct {
+		input    interface{}
+		expected []string
+	}{
+		{"string", []string{"string"}},
+		{0, []string{"0"}},
+		{[]string{"a", "b"}, []string{"a", "b"}},
+		{[]int{0, 1}, []string{"0", "1"}},
+	}
+	for _, test := range tests {
+		testutil.Run(t, fmt.Sprintf("%v", test.expected), func(t *testutil.T) {
+			result := asStringSlice(test.input)
+
+			t.CheckDeepEqual(test.expected, result)
 		})
 	}
 }


### PR DESCRIPTION
Unblocks #5575 and #5554

**Description**
This PR brings in support to our [flag-defaults handling](http://github.com/GoogleContainerTools/skaffold/blob/master/cmd/skaffold/app/cmd/flags.go) add-on to [`spl13/pflag`](https://github.com/spf13/pflag) to handle value objects that implement [pflag' SliceValue](https://github.com/spf13/pflag/blob/master/flag.go#L193).  

One thing to note is that pflag's `Var*` methods, which are used to provide a value object, does not take a default value and instead assumes the value object is already set to its default value.  This assumption doesn't hold with our flags defaults, and so we must explicitly set the defaults.
