### PR TITLE
Refactor `skaffold test` implementation

### DIFF
--- a/pkg/skaffold/test/custom/custom.go
+++ b/pkg/skaffold/test/custom/custom.go
@@ -26,13 +26,10 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/list"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -60,9 +57,9 @@ func New(cfg docker.Config, imageName string, wd string, ct latest.CustomTest) (
 }
 
 // Test is the entrypoint for running custom tests
-func (ct *Runner) Test(ctx context.Context, out io.Writer, artifacts []graph.Artifact) error {
+func (ct *Runner) Test(ctx context.Context, out io.Writer, imageTag string) error {
 	event.TestInProgress()
-	if err := ct.runCustomTest(ctx, out, artifacts); err != nil {
+	if err := ct.runCustomTest(ctx, out, imageTag); err != nil {
 		event.TestFailed(ct.imageName, err)
 		return err
 	}
@@ -70,7 +67,7 @@ func (ct *Runner) Test(ctx context.Context, out io.Writer, artifacts []graph.Art
 	return nil
 }
 
-func (ct *Runner) runCustomTest(ctx context.Context, out io.Writer, artifacts []graph.Artifact) error {
+func (ct *Runner) runCustomTest(ctx context.Context, out io.Writer, imageTag string) error {
 	test := ct.customTest
 
 	// Expand command
@@ -89,7 +86,7 @@ func (ct *Runner) runCustomTest(ctx context.Context, out io.Writer, artifacts []
 		ctx = newCtx
 	}
 
-	cmd, err := ct.retrieveCmd(ctx, out, command, artifacts)
+	cmd, err := ct.retrieveCmd(ctx, out, command, imageTag)
 	if err != nil {
 		return cmdRunRetrieveErr(command, ct.imageName, err)
 	}
@@ -155,7 +152,7 @@ func (ct *Runner) TestDependencies() ([]string, error) {
 	return nil, nil
 }
 
-func (ct *Runner) retrieveCmd(ctx context.Context, out io.Writer, command string, artifacts []graph.Artifact) (*exec.Cmd, error) {
+func (ct *Runner) retrieveCmd(ctx context.Context, out io.Writer, command string, imageTag string) (*exec.Cmd, error) {
 	var cmd *exec.Cmd
 	// We evaluate the command with a shell so that it can contain env variables.
 	if runtime.GOOS == Windows {
@@ -166,7 +163,7 @@ func (ct *Runner) retrieveCmd(ctx context.Context, out io.Writer, command string
 	cmd.Stdout = out
 	cmd.Stderr = out
 
-	env, err := ct.getEnv(artifacts)
+	env, err := ct.getEnv(imageTag)
 	if err != nil {
 		return nil, fmt.Errorf("setting env variables: %w", err)
 	}
@@ -181,35 +178,19 @@ func (ct *Runner) retrieveCmd(ctx context.Context, out io.Writer, command string
 	return cmd, nil
 }
 
-func (ct *Runner) getEnv(artifacts []graph.Artifact) ([]string, error) {
+func (ct *Runner) getEnv(imageTag string) ([]string, error) {
 	testContext, err := testContext(ct.testWorkingDir)
 	if err != nil {
 		return nil, fmt.Errorf("getting absolute path for test context: %w", err)
 	}
 
-	fqn, found := resolveArtifactImageTag(ct.imageName, artifacts)
-	if !found {
-		logrus.Debugln("Skipping tests for", ct.imageName, "since it wasn't built")
-		return nil, nil
-	}
-
 	envs := []string{
-		fmt.Sprintf("%s=%s", "IMAGE", fqn),
+		fmt.Sprintf("%s=%s", "IMAGE", imageTag),
 		fmt.Sprintf("%s=%s", "TEST_CONTEXT", testContext),
 	}
 
 	envs = append(envs, util.OSEnviron()...)
 	return envs, nil
-}
-
-func resolveArtifactImageTag(imageName string, artifacts []graph.Artifact) (string, bool) {
-	for _, res := range artifacts {
-		if imageName == res.ImageName {
-			return res.Tag, true
-		}
-	}
-
-	return "", false
 }
 
 func retrieveTestContext(workspace string) (string, error) {

--- a/pkg/skaffold/test/custom/custom_test.go
+++ b/pkg/skaffold/test/custom/custom_test.go
@@ -24,7 +24,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -63,10 +62,7 @@ func TestNewCustomTestRunner(t *testing.T) {
 
 		testRunner, err := New(cfg, testCase.ImageName, cfg.workingDir, custom)
 		t.CheckNoError(err)
-		err = testRunner.Test(context.Background(), ioutil.Discard, []graph.Artifact{{
-			ImageName: "image",
-			Tag:       "image:tag",
-		}})
+		err = testRunner.Test(context.Background(), ioutil.Discard, "image:tag")
 
 		t.CheckNoError(err)
 	})
@@ -125,10 +121,7 @@ func TestCustomCommandError(t *testing.T) {
 
 			testRunner, err := New(cfg, testCase.ImageName, cfg.workingDir, test.custom)
 			t.CheckNoError(err)
-			err = testRunner.Test(context.Background(), ioutil.Discard, []graph.Artifact{{
-				ImageName: "image",
-				Tag:       "image:tag",
-			}})
+			err = testRunner.Test(context.Background(), ioutil.Discard, "image:tag")
 
 			// TODO(modali): Update the logic to check for error code instead of error string.
 			t.CheckError(test.shouldErr, err)
@@ -300,10 +293,7 @@ func TestGetEnv(t *testing.T) {
 
 			testRunner, err := New(cfg, testCase.ImageName, cfg.workingDir, custom)
 			t.CheckNoError(err)
-			actual, err := testRunner.getEnv([]graph.Artifact{{
-				ImageName: "image",
-				Tag:       test.tag,
-			}})
+			actual, err := testRunner.getEnv(test.tag)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)

--- a/pkg/skaffold/test/structure/error.go
+++ b/pkg/skaffold/test/structure/error.go
@@ -41,8 +41,8 @@ func expandingFilePathsErr(err error) error {
 	)
 }
 
-func dockerPullImageErr(fqn string, err error) (string, error) {
-	return "", sErrors.NewError(err,
+func dockerPullImageErr(fqn string, err error) error {
+	return sErrors.NewError(err,
 		proto.ActionableErr{
 			Message: fmt.Sprintf("unable to docker pull image %s: %s", fqn, err),
 			ErrCode: proto.StatusCode_TEST_IMG_PULL_ERR,

--- a/pkg/skaffold/test/structure/structure.go
+++ b/pkg/skaffold/test/structure/structure.go
@@ -27,52 +27,52 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 type Runner struct {
 	structureTests []string
-	image          string
+	imageName      string
+	imageIsLocal   bool
 	testWorkingDir string
 	localDaemon    docker.LocalDaemon
-	imagesAreLocal func(imageName string) (bool, error)
 }
 
 // New creates a new structure.Runner.
-func New(cfg docker.Config, wd string, tc *latest.TestCase, imagesAreLocal func(imageName string) (bool, error)) (*Runner, error) {
+func New(cfg docker.Config, wd string, tc *latest.TestCase, imageIsLocal bool) (*Runner, error) {
 	localDaemon, err := docker.NewAPIClient(cfg)
 	if err != nil {
 		return nil, err
 	}
 	return &Runner{
 		structureTests: tc.StructureTests,
-		image:          tc.ImageName,
+		imageName:      tc.ImageName,
 		testWorkingDir: wd,
 		localDaemon:    localDaemon,
-		imagesAreLocal: imagesAreLocal,
+		imageIsLocal:   imageIsLocal,
 	}, nil
 }
 
 // Test is the entrypoint for running structure tests
-func (cst *Runner) Test(ctx context.Context, out io.Writer, bRes []graph.Artifact) error {
+func (cst *Runner) Test(ctx context.Context, out io.Writer, imageTag string) error {
 	event.TestInProgress()
-	if err := cst.runStructureTests(ctx, out, bRes); err != nil {
-		event.TestFailed(cst.image, err)
+	if err := cst.runStructureTests(ctx, out, imageTag); err != nil {
+		event.TestFailed(cst.imageName, err)
 		return containerStructureTestErr(err)
 	}
 	event.TestComplete()
 	return nil
 }
 
-func (cst *Runner) runStructureTests(ctx context.Context, out io.Writer, bRes []graph.Artifact) error {
-	fqn, err := cst.getImage(ctx, out, cst.image, bRes, cst.imagesAreLocal)
-	if err != nil {
-		return err
-	}
-	if fqn == "" {
-		return nil
+func (cst *Runner) runStructureTests(ctx context.Context, out io.Writer, imageTag string) error {
+	if !cst.imageIsLocal {
+		// The image is remote so we have to pull it locally.
+		// `container-structure-test` currently can't do it:
+		// https://github.com/GoogleContainerTools/container-structure-test/issues/253.
+		if err := cst.localDaemon.Pull(ctx, out, imageTag); err != nil {
+			return dockerPullImageErr(imageTag, err)
+		}
 	}
 
 	files, err := cst.TestDependencies()
@@ -82,7 +82,7 @@ func (cst *Runner) runStructureTests(ctx context.Context, out io.Writer, bRes []
 
 	logrus.Infof("Running structure tests for files %v", files)
 
-	args := []string{"test", "-v", "warn", "--image", fqn}
+	args := []string{"test", "-v", "warn", "--image", imageTag}
 	for _, f := range files {
 		args = append(args, "--config", f)
 	}
@@ -122,36 +122,4 @@ func (cst *Runner) env() []string {
 	mergedEnv := make([]string, len(parentEnv), len(parentEnv)+len(extraEnv))
 	copy(mergedEnv, parentEnv)
 	return append(mergedEnv, extraEnv...)
-}
-
-func (cst *Runner) getImage(ctx context.Context, out io.Writer, imageName string, bRes []graph.Artifact,
-	imagesAreLocal func(imageName string) (bool, error)) (string, error) {
-	fqn, found := resolveArtifactImageTag(imageName, bRes)
-	if !found {
-		logrus.Debugln("Skipping tests for", imageName, "since it wasn't built")
-		return "", nil
-	}
-
-	if imageIsLocal, err := imagesAreLocal(imageName); err != nil {
-		return "", err
-	} else if !imageIsLocal {
-		// The image is remote so we have to pull it locally.
-		// `container-structure-test` currently can't do it:
-		// https://github.com/GoogleContainerTools/container-structure-test/issues/253.
-		if err := cst.localDaemon.Pull(ctx, out, fqn); err != nil {
-			return dockerPullImageErr(fqn, err)
-		}
-	}
-
-	return fqn, nil
-}
-
-func resolveArtifactImageTag(imageName string, bRes []graph.Artifact) (string, bool) {
-	for _, res := range bRes {
-		if imageName == res.ImageName {
-			return res.Tag, true
-		}
-	}
-
-	return "", false
 }

--- a/pkg/skaffold/test/structure/structure_test.go
+++ b/pkg/skaffold/test/structure/structure_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -55,12 +54,9 @@ func TestNewRunner(t *testing.T) {
 		}
 		testEvent.InitializeState([]latest.Pipeline{{}})
 
-		testRunner, err := New(cfg, cfg.workingDir, testCase, func(imageName string) (bool, error) { return true, nil })
+		testRunner, err := New(cfg, cfg.workingDir, testCase, true)
 		t.CheckNoError(err)
-		err = testRunner.Test(context.Background(), ioutil.Discard, []graph.Artifact{{
-			ImageName: "image",
-			Tag:       "image:tag",
-		}})
+		err = testRunner.Test(context.Background(), ioutil.Discard, "image:tag")
 		t.CheckNoError(err)
 	})
 }
@@ -85,7 +81,7 @@ func TestIgnoreDockerNotFound(t *testing.T) {
 			StructureTests: []string{"test.yaml"},
 		}
 
-		testRunner, err := New(cfg, cfg.workingDir, testCase, func(imageName string) (bool, error) { return true, nil })
+		testRunner, err := New(cfg, cfg.workingDir, testCase, true)
 		t.CheckError(true, err)
 		t.CheckNil(testRunner)
 	})

--- a/pkg/skaffold/test/types.go
+++ b/pkg/skaffold/test/types.go
@@ -43,18 +43,21 @@ type Muted interface {
 // the FullTester actually handles the work.
 
 // FullTester should always be the ONLY implementation of the Tester interface;
-// newly added testing implementations should implement the runner interface.
+// newly added testing implementations should implement the imageTester interface.
 type FullTester struct {
-	runners []runner
+	Testers ImageTesters
 	muted   Muted
 	// imagesAreLocal func(imageName string) (bool, error)
 }
 
-// runner is the lowest-level test executor in Skaffold, responsible for
+// ImageTester is the lowest-level test executor in Skaffold, responsible for
 // running a single test on a single artifact image and returning its result.
 // Any new test type should implement this interface.
-type runner interface {
-	Test(ctx context.Context, out io.Writer, bRes []graph.Artifact) error
+type ImageTester interface {
+	Test(ctx context.Context, out io.Writer, tag string) error
 
 	TestDependencies() ([]string, error)
 }
+
+// ImageTesters is a collection of imageTester interfaces grouped by the target image name
+type ImageTesters map[string][]ImageTester


### PR DESCRIPTION
This PR makes following changes to the `skaffold test` implementation:
- rename `runner` interface to `ImageTester` and change the signature from accepting a slice of artifacts to just taking the image tag that needs to be tested.
- Change `FullTester` from running all the known testers and later skip for images that are not rebuilt, to only iterate on the newly build slice of images.

This removes redundant tester invocations which are getting skipped anyways. Also will simplify fixing https://github.com/GoogleContainerTools/skaffold/issues/5530