### PR TITLE
only explicitly set flag defaults for flags that have command specific defaults

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -558,11 +558,12 @@ func ResetFlagDefaults(cmd *cobra.Command, flags []*Flag) {
 				if d, present := fl.DefValuePerCommand[cmd.Use]; present {
 					defValue = d
 				}
-			}
-			if sv, ok := flag.Value.(pflag.SliceValue); ok {
-				reflect.ValueOf(sv).MethodByName("Replace").Call(reflectValueOf([]interface{}{defValue}))
-			} else {
-				flag.Value.Set(fmt.Sprintf("%v", defValue))
+
+				if sv, ok := flag.Value.(pflag.SliceValue); ok {
+					reflect.ValueOf(sv).MethodByName("Replace").Call(reflectValueOf([]interface{}{defValue}))
+				} else {
+					flag.Value.Set(fmt.Sprintf("%v", defValue))
+				}
 			}
 		}
 		if fl.IsEnum {


### PR DESCRIPTION
Fixes: #5588  <!-- tracking issues that this PR will close -->

**Description**
Changes our flag parsing logic to only explicitly update the defaults of flags who have different defaults defined for different commands, since the pflag library should already nicely handle setting defaults for those with a universal default.

Calling `flag.Value.Set()` for the `--default-repo` flag was causing the underlying value to be represented as an empty string, when we really want it to be a nil pointer. This fixes that issue, however if there ever were a case where we defined defaults for this flag based on the user's command, I believe this could arise again for this flag.
