### PR TITLE
Reset API intents on every dev cycle to avoid queueing

### DIFF
--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -50,11 +50,15 @@ var (
 )
 
 func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer, logger *kubernetes.LogAggregator, forwarderManager portforward.Forwarder) error {
+	// never queue intents from user, even if they're not used
+	defer r.intents.Reset()
+
 	if r.changeSet.needsReload {
 		return ErrorConfigurationChanged
 	}
 
 	buildIntent, syncIntent, deployIntent := r.intents.GetIntents()
+	logrus.Tracef("dev intents: build %t, sync %t, deploy %t\n", buildIntent, syncIntent, deployIntent)
 	needsSync := syncIntent && len(r.changeSet.needsResync) > 0
 	needsBuild := buildIntent && len(r.changeSet.needsRebuild) > 0
 	needsTest := r.changeSet.needsRetest

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -51,7 +51,7 @@ var (
 
 func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer, logger *kubernetes.LogAggregator, forwarderManager portforward.Forwarder) error {
 	// never queue intents from user, even if they're not used
-	defer r.intents.Reset()
+	defer r.intents.reset()
 
 	if r.changeSet.needsReload {
 		return ErrorConfigurationChanged

--- a/pkg/skaffold/runner/dev_test.go
+++ b/pkg/skaffold/runner/dev_test.go
@@ -71,6 +71,10 @@ func (t *TestMonitor) Register(deps func() ([]string, error), onChange func(file
 }
 
 func (t *TestMonitor) Run(bool) error {
+	if t.testBench.intentTrigger {
+		return nil
+	}
+
 	evt := t.events[t.testBench.currentCycle]
 
 	for _, file := range evt.Modified {
@@ -428,6 +432,7 @@ func TestDevAutoTriggers(t *testing.T) {
 		expectedActions []Actions
 		autoTriggers    triggerState // the state of auto triggers
 		singleTriggers  triggerState // the state of single intent triggers at the end of dev loop
+		userIntents     []func(i *intents)
 	}{
 		{
 			description: "build on; sync on; deploy on",
@@ -491,6 +496,46 @@ func TestDevAutoTriggers(t *testing.T) {
 			singleTriggers:  triggerState{false, false, true},
 			expectedActions: []Actions{{}, {}},
 		},
+		{
+			description:     "build off; sync off; deploy off; user requests build, but no change so intent is discarded",
+			watchEvents:     []filemon.Events{},
+			autoTriggers:    triggerState{false, false, false},
+			singleTriggers:  triggerState{false, false, false},
+			expectedActions: []Actions{},
+			userIntents: []func(i *intents){
+				func(i *intents) {
+					i.setBuild(true)
+				},
+			},
+		},
+		{
+			description:     "build off; sync off; deploy off; user requests build, and then sync, but no change so both intents are discarded",
+			watchEvents:     []filemon.Events{},
+			autoTriggers:    triggerState{false, false, false},
+			singleTriggers:  triggerState{false, false, false},
+			expectedActions: []Actions{},
+			userIntents: []func(i *intents){
+				func(i *intents) {
+					i.setBuild(true)
+					i.setSync(true)
+				},
+			},
+		},
+		{
+			description:     "build off; sync off; deploy off; user requests build, and then sync, but no change so both intents are discarded",
+			watchEvents:     []filemon.Events{},
+			autoTriggers:    triggerState{false, false, false},
+			singleTriggers:  triggerState{false, false, false},
+			expectedActions: []Actions{},
+			userIntents: []func(i *intents){
+				func(i *intents) {
+					i.setBuild(true)
+				},
+				func(i *intents) {
+					i.setSync(true)
+				},
+			},
+		},
 	}
 	// first build-test-deploy sequence always happens
 	firstAction := Actions{
@@ -506,6 +551,7 @@ func TestDevAutoTriggers(t *testing.T) {
 			t.Override(&sync.WorkingDir, func(string, docker.Config) (string, error) { return "/", nil })
 			testBench := &TestBench{}
 			testBench.cycles = len(test.watchEvents)
+			testBench.userIntents = test.userIntents
 			artifacts := []*latest.Artifact{
 				{
 					ImageName: "img1",
@@ -521,6 +567,8 @@ func TestDevAutoTriggers(t *testing.T) {
 				events:    test.watchEvents,
 				testBench: testBench,
 			}, artifacts, &test.autoTriggers)
+
+			testBench.intents = runner.intents
 
 			err := runner.Dev(context.Background(), ioutil.Discard, artifacts)
 

--- a/pkg/skaffold/runner/intent.go
+++ b/pkg/skaffold/runner/intent.go
@@ -39,7 +39,7 @@ func newIntents(autoBuild, autoSync, autoDeploy bool) *intents {
 	return i
 }
 
-func (i *intents) Reset() {
+func (i *intents) reset() {
 	i.lock.Lock()
 	i.build = i.autoBuild
 	i.sync = i.autoSync

--- a/pkg/skaffold/runner/intent.go
+++ b/pkg/skaffold/runner/intent.go
@@ -39,6 +39,14 @@ func newIntents(autoBuild, autoSync, autoDeploy bool) *intents {
 	return i
 }
 
+func (i *intents) Reset() {
+	i.lock.Lock()
+	i.build = i.autoBuild
+	i.sync = i.autoSync
+	i.deploy = i.autoDeploy
+	i.lock.Unlock()
+}
+
 func (i *intents) resetBuild() {
 	i.lock.Lock()
 	i.build = i.autoBuild


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: https://github.com/GoogleContainerTools/skaffold/issues/5551
**Merge after**: https://github.com/GoogleContainerTools/skaffold/pull/5553

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

Before this change, sending an execution intent to the Control API would queue up that intent, meaning that the next time Skaffold was able to execute on it it would, even if that ability came well after the intent was issued by the user. Now, we will stop queueing these intents and only process them ephemerally, meaning that they either trigger the associated action if it's eligible in the dev loop, or they are discarded.

Before:
```
$ skaffold dev --rpc-http-port=1234 --auto-build=false
    # normal build and deploy happens
$ curl http://localhost:12345/v1/execute -X POST -d '{"build": true}'
    # nothing happens, because no build files have changed

    # then, user changes an artifact source file, and.....
Generating tags...
 - skaffold-example -> skaffold-example:v1.19.0-99-ga976e5249-dirty
INFO[0082] Tags generated in 46.804306ms                
Checking cache...
 - skaffold-example: Not found. Building
INFO[0082] Cache check completed in 2.282136ms          
Starting build...
```

After:
```
$ skaffold dev --rpc-http-port=1234 --auto-build=false
    # normal build and deploy happens
$ curl http://localhost:12345/v1/execute -X POST -d '{"build": true}'
   # nothing happens, because no build files have changed
   
   # then, user changes an artifact source file, and.....

   # nothing happens again, because the intent has been discarded
$ curl http://localhost:12345/v1/execute -X POST -d '{"build": true}'
Generating tags...
 - skaffold-example -> skaffold-example:v1.19.0-99-ga976e5249-dirty
INFO[0082] Tags generated in 46.804306ms                
Checking cache...
 - skaffold-example: Not found. Building
INFO[0082] Cache check completed in 2.282136ms          
Starting build...
```