### PR TITLE
[refactor] move phase constants from `pkg/skaffold/errors` to `pkg/skaffold/constants`

### DIFF
--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -23,6 +23,17 @@ import (
 )
 
 const (
+	// These are phases in Skaffold
+	DevLoop     = Phase("DevLoop")
+	Init        = Phase("Init")
+	Build       = Phase("Build")
+	Test        = Phase("Test")
+	Deploy      = Phase("Deploy")
+	StatusCheck = Phase("StatusCheck")
+	Sync        = Phase("Sync")
+	DevInit     = Phase("DevInit")
+	Cleanup     = Phase("Cleanup")
+
 	// DefaultLogLevel is the default global verbosity
 	DefaultLogLevel = logrus.WarnLevel
 
@@ -59,6 +70,8 @@ const (
 
 	GithubIssueLink = "https://github.com/GoogleContainerTools/skaffold/issues/new"
 )
+
+type Phase string
 
 var (
 	Pod     latest.ResourceType = "pod"

--- a/pkg/skaffold/errors/errors.go
+++ b/pkg/skaffold/errors/errors.go
@@ -30,16 +30,6 @@ import (
 )
 
 const (
-	// These are phases in a Skaffolld
-	Init        = Phase("Init")
-	Build       = Phase("Build")
-	Test        = Phase("Test")
-	Deploy      = Phase("Deploy")
-	StatusCheck = Phase("StatusCheck")
-	Sync        = Phase("Sync")
-	DevInit     = Phase("DevInit")
-	Cleanup     = Phase("Cleanup")
-
 	// Report issue text
 	reportIssueText = "If above error is unexpected, please open an issue " + constants.GithubIssueLink + " to report this error"
 )
@@ -56,8 +46,6 @@ var (
 	}
 )
 
-type Phase string
-
 // SetRunContext set Skaffold runCtx  once. This run context is used later to
 // suggest actionable error messages based on skaffold command line options and run context
 func SetRunContext(rc runcontext.RunContext) {
@@ -67,7 +55,7 @@ func SetRunContext(rc runcontext.RunContext) {
 }
 
 // ActionableErr returns an actionable error message with suggestions
-func ActionableErr(phase Phase, err error) *proto.ActionableErr {
+func ActionableErr(phase constants.Phase, err error) *proto.ActionableErr {
 	errCode, suggestions := getErrorCodeFromError(phase, err)
 	return &proto.ActionableErr{
 		ErrCode:     errCode,
@@ -77,7 +65,7 @@ func ActionableErr(phase Phase, err error) *proto.ActionableErr {
 }
 
 // ActionableErrV2 returns an actionable error message with suggestions
-func ActionableErrV2(phase Phase, err error) *protoV2.ActionableErr {
+func ActionableErrV2(phase constants.Phase, err error) *protoV2.ActionableErr {
 	errCode, suggestions := getErrorCodeFromError(phase, err)
 	suggestionsV2 := make([]*protoV2.Suggestion, len(suggestions))
 	for i, suggestion := range suggestions {
@@ -125,7 +113,7 @@ func IsOldImageManifestProblem(err error) (string, bool) {
 	return "", false
 }
 
-func getErrorCodeFromError(phase Phase, err error) (proto.StatusCode, []*proto.Suggestion) {
+func getErrorCodeFromError(phase constants.Phase, err error) (proto.StatusCode, []*proto.Suggestion) {
 	var sErr Error
 	if errors.As(err, &sErr) {
 		return sErr.StatusCode(), sErr.Suggestions()
@@ -156,43 +144,43 @@ func concatSuggestions(suggestions []*proto.Suggestion) string {
 	return s.String()
 }
 
-var allErrors = map[Phase][]problem{
-	Build: append(knownBuildProblems, problem{
+var allErrors = map[constants.Phase][]problem{
+	constants.Build: append(knownBuildProblems, problem{
 		regexp:     re(".*"),
 		errCode:    proto.StatusCode_BUILD_UNKNOWN,
 		suggestion: reportIssueSuggestion,
 	}),
-	Init: append(knownInitProblems, problem{
+	constants.Init: append(knownInitProblems, problem{
 		regexp:     re(".*"),
 		errCode:    proto.StatusCode_INIT_UNKNOWN,
 		suggestion: reportIssueSuggestion,
 	}),
-	Test: {{
+	constants.Test: {{
 		regexp:     re(".*"),
 		errCode:    proto.StatusCode_TEST_UNKNOWN,
 		suggestion: reportIssueSuggestion,
 	}},
-	Deploy: append(knownDeployProblems, problem{
+	constants.Deploy: append(knownDeployProblems, problem{
 		regexp:     re(".*"),
 		errCode:    proto.StatusCode_DEPLOY_UNKNOWN,
 		suggestion: reportIssueSuggestion,
 	}),
-	StatusCheck: {{
+	constants.StatusCheck: {{
 		regexp:     re(".*"),
 		errCode:    proto.StatusCode_STATUSCHECK_UNKNOWN,
 		suggestion: reportIssueSuggestion,
 	}},
-	Sync: {{
+	constants.Sync: {{
 		regexp:     re(".*"),
 		errCode:    proto.StatusCode_SYNC_UNKNOWN,
 		suggestion: reportIssueSuggestion,
 	}},
-	DevInit: {oldImageManifest, {
+	constants.DevInit: {oldImageManifest, {
 		regexp:     re(".*"),
 		errCode:    proto.StatusCode_DEVINIT_UNKNOWN,
 		suggestion: reportIssueSuggestion,
 	}},
-	Cleanup: {{
+	constants.Cleanup: {{
 		regexp:     re(".*"),
 		errCode:    proto.StatusCode_CLEANUP_UNKNOWN,
 		suggestion: reportIssueSuggestion,

--- a/pkg/skaffold/errors/errors_test.go
+++ b/pkg/skaffold/errors/errors_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -34,7 +35,7 @@ func TestShowAIError(t *testing.T) {
 	tests := []struct {
 		description string
 		opts        config.SkaffoldOptions
-		phase       Phase
+		phase       constants.Phase
 		context     *config.ContextConfig
 		err         error
 		expected    string
@@ -43,7 +44,7 @@ func TestShowAIError(t *testing.T) {
 		{
 			description: "Push access denied when neither default repo or global config is defined",
 			context:     &config.ContextConfig{},
-			phase:       Build,
+			phase:       constants.Build,
 			err:         fmt.Errorf("skaffold build failed: could not push image: denied: push access to resource"),
 			expected:    "Build Failed. No push access to specified image repository. Trying running with `--default-repo` flag.",
 			expectedAE: &proto.ActionableErr{
@@ -58,7 +59,7 @@ func TestShowAIError(t *testing.T) {
 		{
 			description: "Push access denied when default repo is defined",
 			opts:        config.SkaffoldOptions{DefaultRepo: stringOrUndefined("gcr.io/test")},
-			phase:       Build,
+			phase:       constants.Build,
 			err:         fmt.Errorf("skaffold build failed: could not push image image1 : denied: push access to resource"),
 			expected:    "Build Failed. No push access to specified image repository. Check your `--default-repo` value or try `gcloud auth configure-docker`.",
 			expectedAE: &proto.ActionableErr{
@@ -77,7 +78,7 @@ func TestShowAIError(t *testing.T) {
 		{
 			description: "Push access denied when global repo is defined",
 			context:     &config.ContextConfig{DefaultRepo: "docker.io/global"},
-			phase:       Build,
+			phase:       constants.Build,
 			err:         fmt.Errorf("skaffold build failed: could not push image: denied: push access to resource"),
 			expected:    "Build Failed. No push access to specified image repository. Check your default-repo setting in skaffold config or try `docker login`.",
 			expectedAE: &proto.ActionableErr{
@@ -95,7 +96,7 @@ func TestShowAIError(t *testing.T) {
 		},
 		{
 			description: "unknown project error",
-			phase:       Build,
+			phase:       constants.Build,
 			err:         fmt.Errorf("build failed: could not push image: unknown: Project"),
 			expected:    "Build Failed. Check your GCR project.",
 			expectedAE: &proto.ActionableErr{
@@ -114,7 +115,7 @@ func TestShowAIError(t *testing.T) {
  - stdout: "\n\n"
  - stderr: "! Executing \"docker container inspect minikube --format={{.State.Status}}\" took an unusually long time: 7.36540945s\n* Restarting the docker service may improve performance.\nX Exiting due to GUEST_STATUS: state: unknown state \"minikube\": docker container inspect minikube --format=: exit status 1\nstdout:\n\n\nstderr:\nCannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?\n\n* \n* If the above advice does not help, please let us know: \n  - https://github.com/kubernetes/minikube/issues/new/choose\n"
  - cause: exit status 80`),
-			phase:    Build,
+			phase:    constants.Build,
 			expected: "Build Failed. Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Check if docker is running.",
 			expectedAE: &proto.ActionableErr{
 				ErrCode: proto.StatusCode_BUILD_DOCKER_DAEMON_NOT_RUNNING,
@@ -130,7 +131,7 @@ func TestShowAIError(t *testing.T) {
 			description: "build error when docker is not running and deploying to GKE",
 			err:         fmt.Errorf(`exiting dev mode because first build failed: docker build: Cannot connect to the Docker daemon at tcp://127.0.0.1:32770. Is the docker daemon running?`),
 			expected:    "Build Failed. Cannot connect to the Docker daemon at tcp://127.0.0.1:32770. Check if docker is running.",
-			phase:       Build,
+			phase:       constants.Build,
 			expectedAE: &proto.ActionableErr{
 				ErrCode: proto.StatusCode_BUILD_DOCKER_DAEMON_NOT_RUNNING,
 				Message: "exiting dev mode because first build failed: docker build: Cannot connect to the Docker daemon at tcp://127.0.0.1:32770. Is the docker daemon running?",
@@ -147,7 +148,7 @@ func TestShowAIError(t *testing.T) {
 			// See https://github.com/moby/moby/blob/master/client/errors.go#L20
 			err:      fmt.Errorf(`exiting dev mode because first build failed: docker build: Cannot connect to the Docker daemon. Is the docker daemon running on this host?`),
 			expected: "Build Failed. Cannot connect to the Docker daemon. Check if docker is running.",
-			phase:    Build,
+			phase:    constants.Build,
 			expectedAE: &proto.ActionableErr{
 				ErrCode: proto.StatusCode_BUILD_DOCKER_DAEMON_NOT_RUNNING,
 				Message: "exiting dev mode because first build failed: docker build: Cannot connect to the Docker daemon. Is the docker daemon running on this host?",
@@ -162,7 +163,7 @@ func TestShowAIError(t *testing.T) {
 			description: "build cancelled",
 			// See https://github.com/moby/moby/blob/master/client/errors.go#L20
 			err:      fmt.Errorf(`docker build: error during connect: Post \"https://127.0.0.1:32770/v1.24/build?buildargs=:  context canceled`),
-			phase:    Build,
+			phase:    constants.Build,
 			expected: "Build Cancelled.",
 			expectedAE: &proto.ActionableErr{
 				ErrCode: proto.StatusCode_BUILD_CANCELLED,
@@ -173,7 +174,7 @@ func TestShowAIError(t *testing.T) {
 		{
 			description: "build unknown error",
 			context:     &config.ContextConfig{DefaultRepo: "docker.io/global"},
-			phase:       Build,
+			phase:       constants.Build,
 			err:         fmt.Errorf("build failed: something went wrong"),
 			expected:    "build failed: something went wrong",
 			expectedAE: &proto.ActionableErr{
@@ -184,7 +185,7 @@ func TestShowAIError(t *testing.T) {
 		},
 		{
 			description: "deploy unknown error",
-			phase:       Deploy,
+			phase:       constants.Deploy,
 			err:         fmt.Errorf("deploy failed: something went wrong"),
 			expected:    "deploy failed: something went wrong",
 			expectedAE: &proto.ActionableErr{
@@ -195,7 +196,7 @@ func TestShowAIError(t *testing.T) {
 		},
 		{
 			description: "file sync unknown error",
-			phase:       Sync,
+			phase:       constants.Sync,
 			err:         fmt.Errorf("sync failed: something went wrong"),
 			expected:    "sync failed: something went wrong",
 			expectedAE: &proto.ActionableErr{
@@ -206,7 +207,7 @@ func TestShowAIError(t *testing.T) {
 		},
 		{
 			description: "init unknown error",
-			phase:       Init,
+			phase:       constants.Init,
 			err:         fmt.Errorf("init failed: something went wrong"),
 			expected:    "init failed: something went wrong",
 			expectedAE: &proto.ActionableErr{
@@ -217,7 +218,7 @@ func TestShowAIError(t *testing.T) {
 		},
 		{
 			description: "cleanup unknown error",
-			phase:       Cleanup,
+			phase:       constants.Cleanup,
 			err:         fmt.Errorf("failed: something went wrong"),
 			expected:    "failed: something went wrong",
 			expectedAE: &proto.ActionableErr{
@@ -228,7 +229,7 @@ func TestShowAIError(t *testing.T) {
 		},
 		{
 			description: "status check unknown error",
-			phase:       StatusCheck,
+			phase:       constants.StatusCheck,
 			err:         fmt.Errorf("failed: something went wrong"),
 			expected:    "failed: something went wrong",
 			expectedAE: &proto.ActionableErr{
@@ -239,7 +240,7 @@ func TestShowAIError(t *testing.T) {
 		},
 		{
 			description: "dev init unknown error",
-			phase:       DevInit,
+			phase:       constants.DevInit,
 			err:         fmt.Errorf("failed: something went wrong"),
 			expected:    "failed: something went wrong",
 			expectedAE: &proto.ActionableErr{
@@ -252,7 +253,7 @@ func TestShowAIError(t *testing.T) {
 			description: "deploy failed",
 			opts:        config.SkaffoldOptions{},
 			context:     &config.ContextConfig{},
-			phase:       Deploy,
+			phase:       constants.Deploy,
 			err:         fmt.Errorf(`exiting dev mode because first deploy failed: unable to connect to Kubernetes: Get "https://192.168.64.3:8443/version?timeout=32s": net/http: TLS handshake timeout`),
 			expected:    "Deploy Failed. Could not connect to cluster test_cluster due to \"https://192.168.64.3:8443/version?timeout=32s\": net/http: TLS handshake timeout. Check your connection for the cluster.",
 			expectedAE: &proto.ActionableErr{

--- a/pkg/skaffold/errors/init_problems_test.go
+++ b/pkg/skaffold/errors/init_problems_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 )
 
@@ -27,7 +28,7 @@ var (
 	initTestCases = []struct {
 		description string
 		opts        config.SkaffoldOptions
-		phase       Phase
+		phase       constants.Phase
 		context     *config.ContextConfig
 		err         error
 		expected    string
@@ -36,7 +37,7 @@ var (
 		{
 			description: "creating tagger error",
 			context:     &config.ContextConfig{},
-			phase:       Init,
+			phase:       constants.Init,
 			err:         fmt.Errorf("creating tagger: something went wrong"),
 			expected:    "creating tagger: something went wrong\n. If above error is unexpected, please open an issue https://github.com/GoogleContainerTools/skaffold/issues/new to report this error.",
 			expectedAE: &proto.ActionableErr{
@@ -48,7 +49,7 @@ var (
 		{
 			description: "minikube not started error",
 			context:     &config.ContextConfig{},
-			phase:       Init,
+			phase:       constants.Init,
 			err:         fmt.Errorf("creating runner: creating builder: getting docker client: getting minikube env: running [/Users/tejaldesai/Downloads/google-cloud-sdk2/bin/minikube docker-env --shell none -p minikube]\n - stdout: \"* The control plane node must be running for this command\\n  - To fix this, run: \\\"minikube start\\\"\\n\"\n - stderr: \"\"\n - cause: exit status 89"),
 			expected:    "minikube is probably not running. Try running \"minikube start\".",
 			expectedAE: &proto.ActionableErr{
@@ -63,7 +64,7 @@ var (
 		{
 			description: "create builder error",
 			context:     &config.ContextConfig{},
-			phase:       Init,
+			phase:       constants.Init,
 			err:         fmt.Errorf("creating runner: creating builder: something went wrong"),
 			expected:    "creating runner: creating builder: something went wrong\n. If above error is unexpected, please open an issue https://github.com/GoogleContainerTools/skaffold/issues/new to report this error.",
 			expectedAE: &proto.ActionableErr{
@@ -75,7 +76,7 @@ var (
 		{
 			description: "build dependency error",
 			context:     &config.ContextConfig{},
-			phase:       Init,
+			phase:       constants.Init,
 			err:         fmt.Errorf("creating runner: unexpected artifact type `DockerrArtifact`"),
 			expected:    "creating runner: unexpected artifact type `DockerrArtifact`\n. If above error is unexpected, please open an issue https://github.com/GoogleContainerTools/skaffold/issues/new to report this error.",
 			expectedAE: &proto.ActionableErr{
@@ -87,7 +88,7 @@ var (
 		{
 			description: "test dependency error",
 			context:     &config.ContextConfig{},
-			phase:       Init,
+			phase:       constants.Init,
 			err:         fmt.Errorf("creating runner: expanding test file paths: .src/test"),
 			expected:    "creating runner: expanding test file paths: .src/test\n. If above error is unexpected, please open an issue https://github.com/GoogleContainerTools/skaffold/issues/new to report this error.",
 			expectedAE: &proto.ActionableErr{
@@ -99,7 +100,7 @@ var (
 		{
 			description: "init cache error",
 			context:     &config.ContextConfig{},
-			phase:       Init,
+			phase:       constants.Init,
 			err:         fmt.Errorf("creating runner: initializing cache at some error"),
 			expected:    "creating runner: initializing cache at some error\n. If above error is unexpected, please open an issue https://github.com/GoogleContainerTools/skaffold/issues/new to report this error.",
 			expectedAE: &proto.ActionableErr{

--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -23,12 +23,12 @@ import (
 	"os"
 	"sync"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	//nolint:golint,staticcheck
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"

--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	//nolint:golint,staticcheck
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes"
@@ -205,7 +206,7 @@ func DeployInProgress() {
 
 // DeployFailed notifies that non-fatal errors were encountered during a deployment.
 func DeployFailed(err error) {
-	aiErr := sErrors.ActionableErr(sErrors.Deploy, err)
+	aiErr := sErrors.ActionableErr(constants.Deploy, err)
 	handler.stateLock.Lock()
 	handler.state.DeployState.StatusCode = aiErr.ErrCode
 	handler.stateLock.Unlock()
@@ -322,7 +323,7 @@ func BuildCanceled(imageName string) {
 
 // BuildFailed notifies that a build has failed.
 func BuildFailed(imageName string, err error) {
-	aiErr := sErrors.ActionableErr(sErrors.Build, err)
+	aiErr := sErrors.ActionableErr(constants.Build, err)
 	handler.handleBuildEvent(&proto.BuildEvent{
 		Artifact:      imageName,
 		Status:        Failed,
@@ -348,7 +349,7 @@ func TestCanceled() {
 
 // TestFailed notifies that a test has failed.
 func TestFailed(imageName string, err error) {
-	aiErr := sErrors.ActionableErr(sErrors.Test, err)
+	aiErr := sErrors.ActionableErr(constants.Test, err)
 	handler.stateLock.Lock()
 	handler.state.TestState.StatusCode = aiErr.ErrCode
 	handler.stateLock.Unlock()
@@ -380,20 +381,20 @@ func DevLoopFailedWithErrorCode(i int, statusCode proto.StatusCode, err error) {
 }
 
 // DevLoopFailed notifies that a dev loop has failed in a given phase
-func DevLoopFailedInPhase(iteration int, phase sErrors.Phase, err error) {
+func DevLoopFailedInPhase(iteration int, phase constants.Phase, err error) {
 	state := handler.getState()
 	switch phase {
-	case sErrors.Deploy:
+	case constants.Deploy:
 		if state.DeployState.StatusCode != proto.StatusCode_DEPLOY_SUCCESS {
 			DevLoopFailedWithErrorCode(iteration, state.DeployState.StatusCode, err)
 		} else {
 			DevLoopFailedWithErrorCode(iteration, state.StatusCheckState.StatusCode, err)
 		}
-	case sErrors.StatusCheck:
+	case constants.StatusCheck:
 		DevLoopFailedWithErrorCode(iteration, state.StatusCheckState.StatusCode, err)
-	case sErrors.Build:
+	case constants.Build:
 		DevLoopFailedWithErrorCode(iteration, state.BuildState.StatusCode, err)
-	case sErrors.Test:
+	case constants.Test:
 		DevLoopFailedWithErrorCode(iteration, state.TestState.StatusCode, err)
 	default:
 		ai := sErrors.ActionableErr(phase, err)
@@ -413,7 +414,7 @@ func FileSyncInProgress(fileCount int, image string) {
 
 // FileSyncFailed notifies that a file sync has failed.
 func FileSyncFailed(fileCount int, image string, err error) {
-	aiErr := sErrors.ActionableErr(sErrors.Sync, err)
+	aiErr := sErrors.ActionableErr(constants.Sync, err)
 	handler.handleFileSyncEvent(&proto.FileSyncEvent{FileCount: int32(fileCount), Image: image, Status: Failed,
 		Err: err.Error(), ErrCode: aiErr.ErrCode, ActionableErr: aiErr})
 }
@@ -792,7 +793,7 @@ func AutoTriggerDiff(name string, val bool) (bool, error) {
 
 // BuildSequenceFailed notifies that the build sequence has failed.
 func BuildSequenceFailed(err error) {
-	aiErr := sErrors.ActionableErr(sErrors.Build, err)
+	aiErr := sErrors.ActionableErr(constants.Build, err)
 	handler.stateLock.Lock()
 	handler.state.BuildState.StatusCode = aiErr.ErrCode
 	handler.stateLock.Unlock()
@@ -803,7 +804,7 @@ func InititializationFailed(err error) {
 		EventType: &proto.Event_TerminationEvent{
 			TerminationEvent: &proto.TerminationEvent{
 				Status: Failed,
-				Err:    sErrors.ActionableErr(sErrors.Init, err),
+				Err:    sErrors.ActionableErr(constants.Init, err),
 			},
 		},
 	})

--- a/pkg/skaffold/event/event_test.go
+++ b/pkg/skaffold/event/event_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
-	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
@@ -535,7 +535,7 @@ func TestDevLoopFailedInPhase(t *testing.T) {
 	tcs := []struct {
 		description string
 		state       proto.State
-		phase       sErrors.Phase
+		phase       constants.Phase
 		waitFn      func() bool
 	}{
 		{
@@ -543,7 +543,7 @@ func TestDevLoopFailedInPhase(t *testing.T) {
 			state: proto.State{
 				BuildState: &proto.BuildState{StatusCode: proto.StatusCode_BUILD_PUSH_ACCESS_DENIED},
 			},
-			phase: sErrors.Build,
+			phase: constants.Build,
 			waitFn: func() bool {
 				handler.logLock.Lock()
 				logEntry := handler.eventLog[len(handler.eventLog)-1]
@@ -557,7 +557,7 @@ func TestDevLoopFailedInPhase(t *testing.T) {
 				BuildState: &proto.BuildState{},
 				TestState:  &proto.TestState{StatusCode: proto.StatusCode_TEST_UNKNOWN},
 			},
-			phase: sErrors.Test,
+			phase: constants.Test,
 			waitFn: func() bool {
 				handler.logLock.Lock()
 				logEntry := handler.eventLog[len(handler.eventLog)-1]
@@ -571,7 +571,7 @@ func TestDevLoopFailedInPhase(t *testing.T) {
 				BuildState:  &proto.BuildState{},
 				DeployState: &proto.DeployState{StatusCode: proto.StatusCode_DEPLOY_UNKNOWN},
 			},
-			phase: sErrors.Deploy,
+			phase: constants.Deploy,
 			waitFn: func() bool {
 				handler.logLock.Lock()
 				logEntry := handler.eventLog[len(handler.eventLog)-1]
@@ -587,7 +587,7 @@ func TestDevLoopFailedInPhase(t *testing.T) {
 				DeployState:      &proto.DeployState{StatusCode: proto.StatusCode_DEPLOY_SUCCESS},
 				StatusCheckState: &proto.StatusCheckState{StatusCode: proto.StatusCode_STATUSCHECK_UNHEALTHY},
 			},
-			phase: sErrors.Deploy,
+			phase: constants.Deploy,
 			waitFn: func() bool {
 				handler.logLock.Lock()
 				logEntry := handler.eventLog[len(handler.eventLog)-1]

--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	//nolint:golint,staticcheck
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes"
@@ -241,20 +242,20 @@ func emptyStatusCheckState() *proto.StatusCheckState {
 	}
 }
 
-func AutoTriggerDiff(phase sErrors.Phase, val bool) (bool, error) {
+func AutoTriggerDiff(phase constants.Phase, val bool) (bool, error) {
 	switch phase {
-	case sErrors.Build:
+	case constants.Build:
 		return val != handler.getState().BuildState.AutoTrigger, nil
-	case sErrors.Sync:
+	case constants.Sync:
 		return val != handler.getState().FileSyncState.AutoTrigger, nil
-	case sErrors.Deploy:
+	case constants.Deploy:
 		return val != handler.getState().DeployState.AutoTrigger, nil
 	default:
 		return false, fmt.Errorf("unknown phase %v not found in handler state", phase)
 	}
 }
 
-func TaskInProgress(task sErrors.Phase, iteration int) {
+func TaskInProgress(task constants.Phase, iteration int) {
 	handler.handleTaskEvent(&proto.TaskEvent{
 		Id:        fmt.Sprintf("%s-%d", task, iteration),
 		Task:      string(task),
@@ -263,7 +264,7 @@ func TaskInProgress(task sErrors.Phase, iteration int) {
 	})
 }
 
-func TaskFailed(task sErrors.Phase, iteration int, err error) {
+func TaskFailed(task constants.Phase, iteration int, err error) {
 	ae := sErrors.ActionableErrV2(task, err)
 	handler.handleTaskEvent(&proto.TaskEvent{
 		Id:            fmt.Sprintf("%s-%d", task, iteration),
@@ -274,7 +275,7 @@ func TaskFailed(task sErrors.Phase, iteration int, err error) {
 	})
 }
 
-func TaskSucceeded(task sErrors.Phase, iteration int) {
+func TaskSucceeded(task constants.Phase, iteration int) {
 	handler.handleTaskEvent(&proto.TaskEvent{
 		Id:        fmt.Sprintf("%s-%d", task, iteration),
 		Task:      string(task),

--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -23,12 +23,12 @@ import (
 	"os"
 	"sync"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	//nolint:golint,staticcheck
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"

--- a/pkg/skaffold/event/v2/event_test.go
+++ b/pkg/skaffold/event/v2/event_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -242,13 +242,13 @@ func TestTaskFailed(t *testing.T) {
 	tcs := []struct {
 		description string
 		state       proto.State
-		phase       sErrors.Phase
+		phase       constants.Phase
 		iteration   int
 		waitFn      func() bool
 	}{
 		{
 			description: "build failed",
-			phase:       sErrors.Build,
+			phase:       constants.Build,
 			iteration:   0,
 			waitFn: func() bool {
 				handler.logLock.Lock()
@@ -260,7 +260,7 @@ func TestTaskFailed(t *testing.T) {
 		},
 		{
 			description: "deploy failed",
-			phase:       sErrors.Deploy,
+			phase:       constants.Deploy,
 			iteration:   1,
 			waitFn: func() bool {
 				handler.logLock.Lock()
@@ -272,7 +272,7 @@ func TestTaskFailed(t *testing.T) {
 		},
 		{
 			description: "status check failed",
-			phase:       sErrors.StatusCheck,
+			phase:       constants.StatusCheck,
 			iteration:   2,
 			waitFn: func() bool {
 				handler.logLock.Lock()
@@ -294,14 +294,14 @@ func TestTaskFailed(t *testing.T) {
 func TestAutoTriggerDiff(t *testing.T) {
 	tests := []struct {
 		description  string
-		phase        sErrors.Phase
+		phase        constants.Phase
 		handlerState proto.State
 		val          bool
 		expected     bool
 	}{
 		{
 			description: "build needs update",
-			phase:       sErrors.Build,
+			phase:       constants.Build,
 			val:         true,
 			handlerState: proto.State{
 				BuildState: &proto.BuildState{
@@ -312,7 +312,7 @@ func TestAutoTriggerDiff(t *testing.T) {
 		},
 		{
 			description: "deploy doesn't need update",
-			phase:       sErrors.Deploy,
+			phase:       constants.Deploy,
 			val:         true,
 			handlerState: proto.State{
 				BuildState: &proto.BuildState{
@@ -326,7 +326,7 @@ func TestAutoTriggerDiff(t *testing.T) {
 		},
 		{
 			description: "sync needs update",
-			phase:       sErrors.Sync,
+			phase:       constants.Sync,
 			val:         false,
 			handlerState: proto.State{
 				FileSyncState: &proto.FileSyncState{

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -23,11 +23,11 @@ import (
 	"io"
 	"time"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"

--- a/pkg/skaffold/server/v2/endpoints.go
+++ b/pkg/skaffold/server/v2/endpoints.go
@@ -19,11 +19,11 @@ package v2
 import (
 	"context"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	event "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
 )

--- a/pkg/skaffold/server/v2/endpoints.go
+++ b/pkg/skaffold/server/v2/endpoints.go
@@ -19,11 +19,11 @@ package v2
 import (
 	"context"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/golang/protobuf/ptypes/empty"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	event "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
 )
@@ -72,18 +72,18 @@ func (s *Server) Execute(ctx context.Context, request *proto.UserIntentRequest) 
 }
 
 func (s *Server) AutoBuild(ctx context.Context, request *proto.TriggerRequest) (res *empty.Empty, err error) {
-	return executeAutoTrigger(sErrors.Build, request, event.UpdateStateAutoBuildTrigger, event.ResetStateOnBuild, s.AutoBuildCallback)
+	return executeAutoTrigger(constants.Build, request, event.UpdateStateAutoBuildTrigger, event.ResetStateOnBuild, s.AutoBuildCallback)
 }
 
 func (s *Server) AutoDeploy(ctx context.Context, request *proto.TriggerRequest) (res *empty.Empty, err error) {
-	return executeAutoTrigger(sErrors.Deploy, request, event.UpdateStateAutoDeployTrigger, event.ResetStateOnDeploy, s.AutoDeployCallback)
+	return executeAutoTrigger(constants.Deploy, request, event.UpdateStateAutoDeployTrigger, event.ResetStateOnDeploy, s.AutoDeployCallback)
 }
 
 func (s *Server) AutoSync(ctx context.Context, request *proto.TriggerRequest) (res *empty.Empty, err error) {
-	return executeAutoTrigger(sErrors.Sync, request, event.UpdateStateAutoSyncTrigger, func() {}, s.AutoSyncCallback)
+	return executeAutoTrigger(constants.Sync, request, event.UpdateStateAutoSyncTrigger, func() {}, s.AutoSyncCallback)
 }
 
-func executeAutoTrigger(triggerName sErrors.Phase, request *proto.TriggerRequest, updateTriggerStateFunc func(bool), resetPhaseStateFunc func(), serverCallback func(bool)) (res *empty.Empty, err error) {
+func executeAutoTrigger(triggerName constants.Phase, request *proto.TriggerRequest, updateTriggerStateFunc func(bool), resetPhaseStateFunc func(), serverCallback func(bool)) (res *empty.Empty, err error) {
 	res = &empty.Empty{}
 
 	trigger := request.GetState().GetEnabled()


### PR DESCRIPTION
**Description**
This refactor moves the phase constants from `pkg/skaffold/errors` to `pkg/skaffold/constants`. @gsquared94 brought that referencing this values as errors.* was awkward and confusing, so we thought we should move them.

