### PR TITLE
[Paused] Add logic to ignore hidden files

### DIFF
--- a/pkg/skaffold/trigger/fsnotify/hidden_posix.go
+++ b/pkg/skaffold/trigger/fsnotify/hidden_posix.go
@@ -1,4 +1,5 @@
 // +build !windows
+
 /*
 Copyright 2021 The Skaffold Authors
 
@@ -18,6 +19,7 @@ limitations under the License.
 package fsnotify
 
 import (
+	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -28,7 +30,7 @@ import (
 func (t *Trigger) hidden(path string) bool {
 	for _, p := range strings.Split(path, string(filepath.Separator)) {
 		if strings.HasPrefix(p, ".") {
-			logrus.Debugf("ignoring hidden file or file in hidden dir %s", path)
+			logrus.Debugf("ignoring hidden file %s", path)
 			return true
 		}
 	}

--- a/pkg/skaffold/trigger/fsnotify/hidden_posix.go
+++ b/pkg/skaffold/trigger/fsnotify/hidden_posix.go
@@ -1,0 +1,36 @@
+// +build !windows
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fsnotify
+
+import (
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// hidden checks if the file is hidden or in hidden dir.
+// notify.EventInfo.Path always returns absolute paths.
+func (t *Trigger) hidden(path string) bool {
+	for _, p := range strings.Split(path, string(filepath.Separator)) {
+		if strings.HasPrefix(p, ".") {
+			logrus.Debugf("ignoring hidden file or file in hidden dir %s", path)
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/skaffold/trigger/fsnotify/hidden_posix_test.go
+++ b/pkg/skaffold/trigger/fsnotify/hidden_posix_test.go
@@ -1,4 +1,5 @@
 // +build !windows
+
 /*
 Copyright 2021 The Skaffold Authors
 
@@ -21,8 +22,6 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
-
-	"github.com/rjeczalik/notify"
 )
 
 func TestHidden(t *testing.T) {
@@ -60,20 +59,4 @@ func TestHidden(t *testing.T) {
 			t.CheckDeepEqual(test.expected, tr.hidden(test.filename))
 		})
 	}
-}
-
-type mockEvent struct {
-	file string
-}
-
-func (m mockEvent) Path() string {
-	return m.file
-}
-
-func (m mockEvent) Event() notify.Event {
-	return notify.FSEventsModified
-}
-
-func (m mockEvent) Sys() interface{} {
-	return m
 }

--- a/pkg/skaffold/trigger/fsnotify/hidden_posix_test.go
+++ b/pkg/skaffold/trigger/fsnotify/hidden_posix_test.go
@@ -1,0 +1,79 @@
+// +build !windows
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fsnotify
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+
+	"github.com/rjeczalik/notify"
+)
+
+func TestHidden(t *testing.T) {
+	tests := []struct {
+		description string
+		filename    string
+		expected    bool
+	}{
+		{
+			description: "ignore hidden files at some path",
+			filename:    "/some/.hidden.swp",
+			expected:    true,
+		},
+		{
+			description: "ignore hidden files at root",
+			filename:    "/.hidden.swp",
+			expected:    true,
+		},
+		{
+			description: "ignore files inside hidden dir",
+			filename:    "/.hidden/somefile.txt",
+			expected:    true,
+		},
+		{
+			description: "don't ignore abs files which are not hidden",
+			filename:    "/not-hidden/somefile.txt",
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			tr := &Trigger{
+				Interval: 10,
+			}
+			t.CheckDeepEqual(test.expected, tr.hidden(test.filename))
+		})
+	}
+}
+
+type mockEvent struct {
+	file string
+}
+
+func (m mockEvent) Path() string {
+	return m.file
+}
+
+func (m mockEvent) Event() notify.Event {
+	return notify.FSEventsModified
+}
+
+func (m mockEvent) Sys() interface{} {
+	return m
+}

--- a/pkg/skaffold/trigger/fsnotify/hidden_windows.go
+++ b/pkg/skaffold/trigger/fsnotify/hidden_windows.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"strings"
 	"syscall"
+
+	"github.com/sirupsen/logrus"
 )
 
 // For Testing

--- a/pkg/skaffold/trigger/fsnotify/hidden_windows.go
+++ b/pkg/skaffold/trigger/fsnotify/hidden_windows.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fsnotify
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// For Testing
+var (
+	fileAttributes = getFileAttributes
+)
+
+// Hidden checks if the change detected is to be ignored or not for windows
+func (t *Trigger) hidden(path string) bool {
+	for _, p := range strings.Split(path, string(os.PathSeparator)) {
+		attributes, err := fileAttributes(p)
+		if err != nil {
+			return false
+		} else if attributes&syscall.FILE_ATTRIBUTE_HIDDEN == 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func getFileAttributes(path string) (uint32, error) {
+	pointer, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		logrus.Debugf("could not determine if file %s was hidden due to %e", path, err)
+		return 0, err
+	}
+	attributes, err := syscall.GetFileAttributes(pointer)
+	if err != nil {
+		logrus.Debugf("could not determine if file %s was hidden due to %s", path, err)
+		return 0, err
+	}
+	return attributes, nil
+}

--- a/pkg/skaffold/trigger/fsnotify/hidden_windows_test.go
+++ b/pkg/skaffold/trigger/fsnotify/hidden_windows_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fsnotify
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestHiddenWindows(t *testing.T) {
+	tests := []struct {
+		description  string
+		path         string
+		mockFileAttr func(string) (uint32, error)
+		expected     bool
+	}{
+		{
+			description: "file attribute is hidden",
+			path:        "hidden.ast",
+			mockFileAttr: func(path string) (uint32, error) {
+				return syscall.FILE_ATTRIBUTE_HIDDEN, nil
+			},
+			expected: true,
+		},
+		{
+			description: "file is not hidden",
+			path:        "file.txt",
+			mockFileAttr: func(path string) (uint32, error) {
+				return syscall.FILE_ATTRIBUTE_READONLY, nil
+			},
+		},
+		{
+			description: "error reading attributes",
+			path:        "err",
+			mockFileAttr: func(path string) (uint32, error) {
+				return 0, fmt.Errorf("error reading")
+			},
+		},
+		{
+			description: "file in a hidden dir",
+			path:        filepath.Join([]string{"another", "hidden", "err.txt"}...),
+			mockFileAttr: func(path string) (uint32, error) {
+				if path == "hidden" {
+					return syscall.FILE_ATTRIBUTE_HIDDEN, nil
+				}
+				return syscall.FILE_ATTRIBUTE_READONLY, nil
+			},
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			trigger := &Trigger{
+				Interval: 10,
+			}
+			t.Override(&fileAttributes, test.mockFileAttr)
+			t.CheckDeepEqual(test.expected, trigger.hidden(test.path))
+		})
+	}
+}

--- a/pkg/skaffold/trigger/fsnotify/hidden_windows_test.go
+++ b/pkg/skaffold/trigger/fsnotify/hidden_windows_test.go
@@ -19,6 +19,7 @@ package fsnotify
 import (
 	"fmt"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"

--- a/pkg/skaffold/trigger/fsnotify/trigger.go
+++ b/pkg/skaffold/trigger/fsnotify/trigger.go
@@ -113,7 +113,7 @@ func (t *Trigger) Start(ctx context.Context) (<-chan bool, error) {
 				if !t.isActive() && t.Ignore(e) {
 					continue
 				}
-				logrus.Debugln("Change detected", e)
+				logrus.Debugln("Change detected", t.Ignore(e))
 
 				// Wait t.Ienterval before triggering.
 				// This way, rapid stream of events will be grouped.
@@ -131,7 +131,9 @@ func (t *Trigger) Start(ctx context.Context) (<-chan bool, error) {
 }
 
 // Ignore checks if the change detected is to be ignored or not.
-// Currently, returns false i.e Allows all files changed.
-func (t *Trigger) Ignore(_ notify.EventInfo) bool {
-	return false
+func (t *Trigger) Ignore(e notify.EventInfo) bool {
+	if e == nil {
+		return true
+	}
+	return !t.hidden(e.Path())
 }

--- a/pkg/skaffold/trigger/fsnotify/trigger.go
+++ b/pkg/skaffold/trigger/fsnotify/trigger.go
@@ -115,7 +115,7 @@ func (t *Trigger) Start(ctx context.Context) (<-chan bool, error) {
 				}
 				logrus.Debugln("Change detected", t.Ignore(e))
 
-				// Wait t.Ienterval before triggering.
+				// Wait t.Interval before triggering.
 				// This way, rapid stream of events will be grouped.
 				timer.Reset(t.Interval)
 			case <-timer.C:

--- a/pkg/skaffold/trigger/fsnotify/trigger_test.go
+++ b/pkg/skaffold/trigger/fsnotify/trigger_test.go
@@ -61,8 +61,3 @@ func Test_Debounce(t *testing.T) {
 	got, want := tr.Debounce(), false
 	testutil.CheckDeepEqual(t, want, got)
 }
-
-func Test_Ignore(t *testing.T) {
-	tr := &Trigger{}
-	testutil.CheckDeepEqual(t, false, tr.Ignore(nil))
-}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
Fixes #5140 to ignore hidden file changes. 

- [X] Verified on mac. 
- [ ] Not verified on window,

Sample output on mac
```
$ make 

$ cd examples/getting-started
$ mkdir .hidden
$ ../../out/skaffold dev -v=debug

DEBU[0026] ignoring hidden file /Users/tejaldesai/workspace/skaffold/examples/getting-started/.hidden/.t.tst.swx 
DEBU[0026] Change detected false                        
DEBU[0026] ignoring hidden file /Users/tejaldesai/workspace/skaffold/examples/getting-started/.hidden/.t.tst.swp 
DEBU[0026] Change detected false                        
DEBU[0026] ignoring hidden file /Users/tejaldesai/workspace/skaffold/examples/getting-started/.hidden/.t.tst.swp 
DEBU[0026] Change detected false                        
DEBU[0026] ignoring hidden file /Users/tejaldesai/workspace/skaffold/examples/getting-started/.hidden/.t.tst.swx 
DEBU[0026] Change detected false                        
DEBU[0026] ignoring hidden file /Users/tejaldesai/workspace/skaffold/examples/getting-started/.hidden/.t.tst.swp 
DEBU[0026] Change detected false                        
DEBU[0027] Found dependencies for dockerfile: [{main.go /go true}] 
DEBU[0028] ignoring hidden file /Users/tejaldesai/workspace/skaffold/examples/getting-started/.hidden/t.tst 
DEBU[0028] Change detected false             
```