### PR TITLE
Deprecate --render-only and --render-output flags

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -53,6 +53,7 @@ type Flag struct {
 	DefValuePerCommand map[string]interface{}
 	NoOptDefVal        string
 	FlagAddMethod      string
+	Deprecated         string
 	DefinedOn          []string
 	Hidden             bool
 	IsEnum             bool
@@ -287,6 +288,7 @@ var flagRegistry = []Flag{
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"dev", "run"},
+		Deprecated:    "please use the `skaffold render` command instead.",
 		IsEnum:        true,
 	},
 	{
@@ -296,6 +298,7 @@ var flagRegistry = []Flag{
 		DefValue:      "",
 		FlagAddMethod: "StringVar",
 		DefinedOn:     []string{"run"},
+		Deprecated:    "please use the `skaffold render` command instead.",
 	},
 	{
 		Name:          "config",
@@ -557,7 +560,8 @@ func (fl *Flag) flag(cmdName string) *pflag.Flag {
 		f.NoOptDefVal = fl.NoOptDefVal
 	}
 	f.Shorthand = fl.Shorthand
-	f.Hidden = fl.Hidden
+	f.Hidden = fl.Hidden || (fl.Deprecated != "")
+	f.Deprecated = fl.Deprecated
 	return f
 }
 

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -659,7 +659,6 @@ Options:
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
-      --render-only=false: Print rendered Kubernetes manifests instead of deploying them
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
@@ -711,7 +710,6 @@ Env vars:
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
-* `SKAFFOLD_RENDER_ONLY` (same as `--render-only`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
@@ -954,8 +952,6 @@ Options:
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
-      --render-only=false: Print rendered Kubernetes manifests instead of deploying them
-      --render-output='': Writes '--render-only' output to the specified file
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
       --skip-tests=false: Whether to skip the tests after building
@@ -1002,8 +998,6 @@ Env vars:
 * `SKAFFOLD_PROFILE` (same as `--profile`)
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
-* `SKAFFOLD_RENDER_ONLY` (same as `--render-only`)
-* `SKAFFOLD_RENDER_OUTPUT` (same as `--render-output`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)

--- a/docs/content/en/docs/references/deprecation.md
+++ b/docs/content/en/docs/references/deprecation.md
@@ -70,6 +70,8 @@ Exceptions will always be announced in all relevant release notes.
 
 ## Current deprecation notices
 
+04/07/2021: Release v1.22.0 deprecates the `--render-only` and `--render-output` flags from `skaffold run` and `skaffold dev`, in favor of simply using the `skaffold render` command directly.
+
 ## Past deprecation notices
 
 10/21/2019: With release v0.41.0 we mark for deprecation the `$IMAGES` environment variable passed to custom builders. Variable `$IMAGE` should be used instead.
@@ -80,7 +82,7 @@ Exceptions will always be announced in all relevant release notes.
 
 **This field was removed in version 1.0.0.**
 
-02/15/2019: With  release v0.23.0 we mark for deprecation the following env variables in the `envTemplate` tagger:
+02/15/2019: With release v0.23.0 we mark for deprecation the following env variables in the `envTemplate` tagger:
 - `DIGEST`
 - `DIGEST_ALGO`
 - `DIGEST_HEX`


### PR DESCRIPTION
This change deprecates the `--render-only` and `--render-output` flags from `skaffold run`, in favor of using the `skaffold render` command directly.