### PR TITLE
Update Jib to 3.0 and set base images

### DIFF
--- a/integration/examples/jib-gradle/build.gradle
+++ b/integration/examples/jib-gradle/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'groovy'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
     id 'net.ltgt.apt-idea' version '0.18'
-    id 'com.google.cloud.tools.jib' version '2.8.0'
+    id 'com.google.cloud.tools.jib' version '3.0.0'
 }
 
 version '0.1'
@@ -35,3 +35,5 @@ dependencies {
 compileJava.options.compilerArgs += '-parameters'
 compileTestJava.options.compilerArgs += '-parameters'
 mainClassName = 'example.micronaut.Application'
+
+jib.from.image = 'gcr.io/google-appengine/openjdk:8'

--- a/integration/examples/jib-gradle/build.gradle
+++ b/integration/examples/jib-gradle/build.gradle
@@ -6,6 +6,9 @@ plugins {
     id 'com.google.cloud.tools.jib' version '3.0.0'
 }
 
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
 version '0.1'
 group 'example.jib-gradle'
 

--- a/integration/examples/jib-multimodule/pom.xml
+++ b/integration/examples/jib-multimodule/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <jib.maven-plugin-version>2.8.0</jib.maven-plugin-version>
+    <jib.maven-plugin-version>3.0.0</jib.maven-plugin-version>
   </properties>
 
   <dependencies>
@@ -40,6 +40,11 @@
           <groupId>com.google.cloud.tools</groupId>
           <artifactId>jib-maven-plugin</artifactId>
           <version>${jib.maven-plugin-version}</version>
+          <configuration>
+            <from>
+              <image>gcr.io/google-appengine/openjdk:8</image>
+            </from>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/integration/examples/jib-sync/build.gradle
+++ b/integration/examples/jib-sync/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '2.0.5.RELEASE'
     id 'io.spring.dependency-management' version '1.0.7.RELEASE'
-    id 'com.google.cloud.tools.jib' version '2.8.0'
+    id 'com.google.cloud.tools.jib' version '3.0.0'
 }
 
 repositories {
@@ -21,3 +21,5 @@ dependencies {
 
   testImplementation "org.springframework.boot:spring-boot-starter-test"
 }
+
+jib.from.image = 'gcr.io/google-appengine/openjdk:8'

--- a/integration/examples/jib-sync/pom.xml
+++ b/integration/examples/jib-sync/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <java.version>1.8</java.version>
-    <jib.maven-plugin-version>2.8.0</jib.maven-plugin-version>
+    <jib.maven-plugin-version>3.0.0</jib.maven-plugin-version>
   </properties>
 
   <parent>
@@ -37,6 +37,9 @@
         <artifactId>jib-maven-plugin</artifactId>
         <version>${jib.maven-plugin-version}</version>
         <configuration>
+          <from>
+            <image>gcr.io/google-appengine/openjdk:8</image>
+          </from>
           <container>
             <jvmFlags>
               <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>

--- a/integration/examples/jib/pom.xml
+++ b/integration/examples/jib/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <jib.maven-plugin-version>2.8.0</jib.maven-plugin-version>
+        <jib.maven-plugin-version>3.0.0</jib.maven-plugin-version>
     </properties>
 
     <parent>
@@ -37,6 +37,9 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>${jib.maven-plugin-version}</version>
                 <configuration>
+                    <from>
+                        <image>gcr.io/google-appengine/openjdk:8</image>
+                    </from>
                     <container>
                         <jvmFlags>
                             <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>

--- a/integration/testdata/debug/java/pom.xml
+++ b/integration/testdata/debug/java/pom.xml
@@ -8,7 +8,7 @@
   <description>Simple Java server with Skaffold and Jib</description>
 
   <properties>
-    <jib.maven-plugin-version>2.8.0</jib.maven-plugin-version>
+    <jib.maven-plugin-version>3.0.0</jib.maven-plugin-version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>

--- a/integration/testdata/jib/pom.xml
+++ b/integration/testdata/jib/pom.xml
@@ -8,7 +8,7 @@
     <description>Simple Java server with Skaffold and Jib</description>
 
     <properties>
-        <jib.maven-plugin-version>2.8.0</jib.maven-plugin-version>
+        <jib.maven-plugin-version>3.0.0</jib.maven-plugin-version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
@@ -21,6 +21,9 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>${jib.maven-plugin-version}</version>
                 <configuration>
+                    <from>
+                        <image>gcr.io/google-appengine/openjdk:8</image>
+                    </from>
                     <container>
                         <jvmFlags>
                             <jvmFlag>-Djava.security.egd=file:/dev/./urandom</jvmFlag>


### PR DESCRIPTION
Put up a new PR. (Supersedes #5650. #5650 has a weird check failure, so I did a fresh clone. Hopefully this resolves the failure.)

Also explicitly sets base images to avoid Docker Hub rate limiting.