### PR TITLE
Fix `default-repo` by supporting nil as default value for flags

### DIFF
--- a/pkg/skaffold/config/types.go
+++ b/pkg/skaffold/config/types.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package config
 
-import "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
 
 // StringOrUndefined holds the value of a flag of type `string`,
 // that's by default `undefined`.
@@ -36,6 +38,11 @@ func (s *StringOrUndefined) Value() *string {
 
 func (s *StringOrUndefined) Set(v string) error {
 	s.value = &v
+	return nil
+}
+
+func (s *StringOrUndefined) SetNil() error {
+	s.value = nil
 	return nil
 }
 

--- a/pkg/skaffold/config/types_test.go
+++ b/pkg/skaffold/config/types_test.go
@@ -38,6 +38,16 @@ func TestStringOrUndefinedUsage(t *testing.T) {
 	testutil.CheckDeepEqual(t, "Usage:\n\nFlags:\n      --flag string   use it like this\n", output.String())
 }
 
+func TestStringOrUndefined_SetNil(t *testing.T) {
+	var s StringOrUndefined
+	s.Set("hello")
+	testutil.CheckDeepEqual(t, "hello", s.String())
+	s.SetNil()
+	testutil.CheckDeepEqual(t, "", s.String())
+	testutil.CheckDeepEqual(t, (*string)(nil), s.value)
+	testutil.CheckDeepEqual(t, (*string)(nil), s.Value())
+}
+
 func TestStringOrUndefined(t *testing.T) {
 	tests := []struct {
 		description string


### PR DESCRIPTION
Fixes: #5588
**Related**: #5632, #5548

**Description**
Adds support for "nillable" values like the use of `StringOrUndefined` used for `--default-repo`.  

Prior to #5632, we never initialized struct values (called `Var` in pflag).  But with the new `--port-forward` implementation (#5554), we now needed to initialize struct values with possibly different values depending on the command (#5548).

With #5548 we now reset `Var` type values to their default value, but it turns out that `--default-repo` had an incorrect default value of the empty string:
https://github.com/GoogleContainerTools/skaffold/blob/bcb2eaac8a642e71a8dcd2da1864b93295bd84aa/cmd/skaffold/app/cmd/flags.go#L99-L105

This default value should have been `nil`: the default repo support differentiates between `nil` and the empty string "".  When `nil`, Skaffold will look to see if there is a value set in the global config; whereas the empty string indicates that no default-repo should be used.

**User facing changes (remove if N/A)**
- the `default-repo` is able to be used from the global config again