### PR TITLE
Mark structureTests as filepaths

### DIFF
--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -486,7 +486,7 @@ type TestCase struct {
 	// StructureTests lists the [Container Structure Tests](https://github.com/GoogleContainerTools/container-structure-test)
 	// to run on that artifact.
 	// For example: `["./test/*"]`.
-	StructureTests []string `yaml:"structureTests,omitempty"`
+	StructureTests []string `yaml:"structureTests,omitempty" skaffold:"filepath"`
 }
 
 // DeployConfig contains all the configuration needed by the deploy steps.


### PR DESCRIPTION
**Description**
In refactoring effort of [`container-debug-support`](https://github.com/GoogleContainerTools/container-debug-support) to use multi-config to simplify iterating on per-language support, I discovered that the `structureTests` field isn't marked as a `filepath`:
```
Checking cache...
WARN[0001] structure-tests.yaml did not match any file  
WARN[0001] structure-tests.yaml did not match any file  
WARN[0001] structure-tests.yaml did not match any file  
WARN[0001] structure-tests.yaml did not match any file  
WARN[0001] structure-tests.yaml did not match any file  
```
