### PR TITLE
Try reducing ttl to 30 seconds

### DIFF
--- a/examples/buildpacks-java/.mvn/jvm.config
+++ b/examples/buildpacks-java/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true

--- a/examples/jib-multimodule/.mvn/jvm.config
+++ b/examples/jib-multimodule/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true

--- a/examples/jib-sync/.mvn/jvm.config
+++ b/examples/jib-sync/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true

--- a/integration/examples/buildpacks-java/.mvn/jvm.config
+++ b/integration/examples/buildpacks-java/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true

--- a/integration/examples/jib-multimodule/.mvn/jvm.config
+++ b/integration/examples/jib-multimodule/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true

--- a/integration/examples/jib-sync/.mvn/jvm.config
+++ b/integration/examples/jib-sync/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true

--- a/integration/testdata/debug/java/.mvn/jvm.config
+++ b/integration/testdata/debug/java/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true 
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true

--- a/integration/testdata/jib/.mvn/jvm.config
+++ b/integration/testdata/jib/.mvn/jvm.config
@@ -1,1 +1,1 @@
--Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true
+-Dmaven.wagon.httpconnectionManager.ttlSeconds=30 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true


### PR DESCRIPTION
Re: #5248

**Description**
Try reducing the TTL for Maven Wagon pooled connections to 30s in the hopes that it may prevent connection resets during tests.