### PR TITLE
Add back 'tag' digest source

### DIFF
--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -57,7 +57,8 @@ func (r *SkaffoldRunner) Build(ctx context.Context, out io.Writer, artifacts []*
 	}
 
 	// In dry-run mode or with --digest-source  set to 'remote', we don't build anything, just return the tag for each artifact.
-	if r.runCtx.DryRun() || (r.runCtx.DigestSource() == remoteDigestSource) {
+	if r.runCtx.DryRun() || (r.runCtx.DigestSource() == remoteDigestSource) ||
+		(r.runCtx.DigestSource() == tagDigestSource) {
 		var bRes []graph.Artifact
 		for _, artifact := range artifacts {
 			bRes = append(bRes, graph.Artifact{

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -56,7 +56,7 @@ func (r *SkaffoldRunner) Build(ctx context.Context, out io.Writer, artifacts []*
 		return nil, err
 	}
 
-	// In dry-run mode or with --digest-source  set to 'remote', we don't build anything, just return the tag for each artifact.
+	// In dry-run mode or with --digest-source  set to 'remote' or with --digest-source set to 'tag' , we don't build anything, just return the tag for each artifact.
 	if r.runCtx.DryRun() || (r.runCtx.DigestSource() == remoteDigestSource) ||
 		(r.runCtx.DigestSource() == tagDigestSource) {
 		var bRes []graph.Artifact

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -39,6 +39,7 @@ import (
 const (
 	remoteDigestSource = "remote"
 	noneDigestSource   = "none"
+	tagDigestSource    = "tag"
 )
 
 // Runner is responsible for running the skaffold build, test and deploy config.


### PR DESCRIPTION
The `tag` digest source was accidentally removed in https://github.com/GoogleContainerTools/skaffold/pull/5192 due to a bad merge conflict resolution. This change adds it back and adds a test to make sure this doesn't happen again.