### PR TITLE
Add taskevents Test, StatusCheck, and fix duplicates for Deploy

### DIFF
--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -100,17 +100,18 @@ func (r *SkaffoldRunner) Build(ctx context.Context, out io.Writer, artifacts []*
 
 // Test tests a list of already built artifacts.
 func (r *SkaffoldRunner) Test(ctx context.Context, out io.Writer, artifacts []graph.Artifact) error {
+	eventV2.TaskInProgress(constants.Test, r.devIteration)
 	if err := r.tester.Test(ctx, out, artifacts); err != nil {
+		eventV2.TaskFailed(constants.Test, r.devIteration, err)
 		return err
 	}
 
+	eventV2.TaskSucceeded(constants.Test, r.devIteration)
 	return nil
 }
 
 // DeployAndLog deploys a list of already built artifacts and optionally show the logs.
 func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifacts []graph.Artifact) error {
-	eventV2.TaskInProgress(constants.Deploy, r.devIteration)
-
 	// Update which images are logged.
 	r.addTagsToPodSelector(artifacts)
 
@@ -121,7 +122,6 @@ func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifa
 	logger.SetSince(time.Now())
 	// First deploy
 	if err := r.Deploy(ctx, out, artifacts); err != nil {
-		eventV2.TaskFailed(constants.Deploy, r.devIteration, err)
 		return err
 	}
 
@@ -134,7 +134,6 @@ func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifa
 
 	// Start printing the logs after deploy is finished
 	if err := logger.Start(ctx, r.runCtx.GetNamespaces()); err != nil {
-		eventV2.TaskFailed(constants.Deploy, r.devIteration, err)
 		return fmt.Errorf("starting logger: %w", err)
 	}
 
@@ -143,7 +142,6 @@ func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifa
 		<-ctx.Done()
 	}
 
-	eventV2.TaskSucceeded(constants.Deploy, r.devIteration)
 	return nil
 }
 

--- a/pkg/skaffold/runner/deploy.go
+++ b/pkg/skaffold/runner/deploy.go
@@ -165,14 +165,17 @@ func (r *SkaffoldRunner) performStatusCheck(ctx context.Context, out io.Writer) 
 		return nil
 	}
 
+	eventV2.TaskInProgress(constants.StatusCheck, r.devIteration)
 	start := time.Now()
 	color.Default.Fprintln(out, "Waiting for deployments to stabilize...")
 
 	s := newStatusCheck(r.runCtx, r.labeller)
 	if err := s.Check(ctx, out); err != nil {
+		eventV2.TaskFailed(constants.StatusCheck, r.devIteration, err)
 		return err
 	}
 
 	color.Default.Fprintln(out, "Deployments stabilized in", util.ShowHumanizeTime(time.Since(start)))
+	eventV2.TaskSucceeded(constants.StatusCheck, r.devIteration)
 	return nil
 }


### PR DESCRIPTION
**Related**: #5368  #5422 

**Description**
Adds emission of TaskEvent protos for Test and StatusCheck phases. Also fixes duplicate emission of Deploy TaskEvents 

**User facing changes (remove if N/A)**
User will now see TaskEvents for phases mentioned

**Follow-up Work (remove if N/A)**
Add emission for PortForwarding