### PR TITLE
fix file sync comment in examples/hot-reload/skaffold.yaml

### DIFF
--- a/examples/hot-reload/skaffold.yaml
+++ b/examples/hot-reload/skaffold.yaml
@@ -32,7 +32,7 @@ profiles:
             DEBUG: 1
         sync:
           manual:
-          # Sync all the javascript files that are in the src folder
+          # Sync all the python files that are in the src folder
           # with the container src folder
           - src: 'src/**/*.py'
             dest: .

--- a/integration/examples/hot-reload/skaffold.yaml
+++ b/integration/examples/hot-reload/skaffold.yaml
@@ -32,7 +32,7 @@ profiles:
             DEBUG: 1
         sync:
           manual:
-          # Sync all the javascript files that are in the src folder
+          # Sync all the python files that are in the src folder
           # with the container src folder
           - src: 'src/**/*.py'
             dest: .


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->

**Description**
The comment in the python manual sync section of the skaffold.yaml erroneously refers to 'javascript'; this changes it to 'python'.


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
