### PR TITLE
[WIP][V3] Add the new schema v3alpha1.

### DIFF
--- a/docs/content/en/schemas/v3alpha1.json
+++ b/docs/content/en/schemas/v3alpha1.json
@@ -1,0 +1,2533 @@
+{
+  "type": "object",
+  "anyOf": [
+    {
+      "$ref": "#/definitions/SkaffoldConfig"
+    }
+  ],
+  "$schema": "http://json-schema-org/draft-07/schema#",
+  "definitions": {
+    "Activation": {
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "a Skaffold command for which the profile is auto-activated.",
+          "x-intellij-html-description": "a Skaffold command for which the profile is auto-activated.",
+          "examples": [
+            "dev"
+          ]
+        },
+        "env": {
+          "type": "string",
+          "description": "a `key=pattern` pair. The profile is auto-activated if an Environment Variable `key` matches the pattern. If the pattern starts with `!`, activation happens if the remaining pattern is _not_ matched. The pattern matches if the Environment Variable value is exactly `pattern`, or the regex `pattern` is found in it. An empty `pattern` (e.g. `env: \"key=\"`) always only matches if the Environment Variable is undefined or empty.",
+          "x-intellij-html-description": "a <code>key=pattern</code> pair. The profile is auto-activated if an Environment Variable <code>key</code> matches the pattern. If the pattern starts with <code>!</code>, activation happens if the remaining pattern is <em>not</em> matched. The pattern matches if the Environment Variable value is exactly <code>pattern</code>, or the regex <code>pattern</code> is found in it. An empty <code>pattern</code> (e.g. <code>env: &quot;key=&quot;</code>) always only matches if the Environment Variable is undefined or empty.",
+          "examples": [
+            "ENV=production"
+          ]
+        },
+        "kubeContext": {
+          "type": "string",
+          "description": "a Kubernetes context for which the profile is auto-activated.",
+          "x-intellij-html-description": "a Kubernetes context for which the profile is auto-activated.",
+          "examples": [
+            "minikube"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "env",
+        "kubeContext",
+        "command"
+      ],
+      "additionalProperties": false,
+      "description": "criteria by which a profile is auto-activated.",
+      "x-intellij-html-description": "criteria by which a profile is auto-activated."
+    },
+    "Artifact": {
+      "required": [
+        "image"
+      ],
+      "anyOf": [
+        {
+          "properties": {
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "docker": {
+              "$ref": "#/definitions/DockerArtifact",
+              "description": "*beta* describes an artifact built from a Dockerfile.",
+              "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires",
+            "docker"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "bazel": {
+              "$ref": "#/definitions/BazelArtifact",
+              "description": "*beta* requires bazel CLI to be installed and the sources to contain [Bazel](https://bazel.build/) configuration files.",
+              "x-intellij-html-description": "<em>beta</em> requires bazel CLI to be installed and the sources to contain <a href=\"https://bazel.build/\">Bazel</a> configuration files."
+            },
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires",
+            "bazel"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "jib": {
+              "$ref": "#/definitions/JibArtifact",
+              "description": "builds images using the [Jib plugins for Maven or Gradle](https://github.com/GoogleContainerTools/jib/).",
+              "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven or Gradle</a>."
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires",
+            "jib"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "kaniko": {
+              "$ref": "#/definitions/KanikoArtifact",
+              "description": "builds images using [kaniko](https://github.com/GoogleContainerTools/kaniko).",
+              "x-intellij-html-description": "builds images using <a href=\"https://github.com/GoogleContainerTools/kaniko\">kaniko</a>."
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires",
+            "kaniko"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "buildpacks": {
+              "$ref": "#/definitions/BuildpackArtifact",
+              "description": "builds images using [Cloud Native Buildpacks](https://buildpacks.io/).",
+              "x-intellij-html-description": "builds images using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>."
+            },
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires",
+            "buildpacks"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "context": {
+              "type": "string",
+              "description": "directory containing the artifact's sources.",
+              "x-intellij-html-description": "directory containing the artifact's sources.",
+              "default": "."
+            },
+            "custom": {
+              "$ref": "#/definitions/CustomArtifact",
+              "description": "*beta* builds images using a custom build script written by the user.",
+              "x-intellij-html-description": "<em>beta</em> builds images using a custom build script written by the user."
+            },
+            "image": {
+              "type": "string",
+              "description": "name of the image to be built.",
+              "x-intellij-html-description": "name of the image to be built.",
+              "examples": [
+                "gcr.io/k8s-skaffold/example"
+              ]
+            },
+            "requires": {
+              "items": {
+                "$ref": "#/definitions/ArtifactDependency"
+              },
+              "type": "array",
+              "description": "describes build artifacts that this artifact depends on.",
+              "x-intellij-html-description": "describes build artifacts that this artifact depends on."
+            },
+            "sync": {
+              "$ref": "#/definitions/Sync",
+              "description": "*beta* local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "x-intellij-html-description": "<em>beta</em> local files synced to pods instead of triggering an image build when modified. If no files are listed, sync all the files and infer the destination.",
+              "default": "infer: [\"**/*\"]"
+            }
+          },
+          "preferredOrder": [
+            "image",
+            "context",
+            "sync",
+            "requires",
+            "custom"
+          ],
+          "additionalProperties": false
+        }
+      ],
+      "description": "items that need to be built, along with the context in which they should be built.",
+      "x-intellij-html-description": "items that need to be built, along with the context in which they should be built."
+    },
+    "ArtifactDependency": {
+      "required": [
+        "image"
+      ],
+      "properties": {
+        "alias": {
+          "type": "string",
+          "description": "a token that is replaced with the image reference in the builder definition files. For example, the `docker` builder will use the alias as a build-arg key. Defaults to the value of `image`.",
+          "x-intellij-html-description": "a token that is replaced with the image reference in the builder definition files. For example, the <code>docker</code> builder will use the alias as a build-arg key. Defaults to the value of <code>image</code>."
+        },
+        "image": {
+          "type": "string",
+          "description": "a reference to an artifact's image name.",
+          "x-intellij-html-description": "a reference to an artifact's image name."
+        }
+      },
+      "preferredOrder": [
+        "image",
+        "alias"
+      ],
+      "additionalProperties": false,
+      "description": "describes a specific build dependency for an artifact.",
+      "x-intellij-html-description": "describes a specific build dependency for an artifact."
+    },
+    "BazelArtifact": {
+      "required": [
+        "target"
+      ],
+      "properties": {
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional args to pass to `bazel build`.",
+          "x-intellij-html-description": "additional args to pass to <code>bazel build</code>.",
+          "default": "[]",
+          "examples": [
+            "[\"-flag\", \"--otherflag\"]"
+          ]
+        },
+        "target": {
+          "type": "string",
+          "description": "`bazel build` target to run.",
+          "x-intellij-html-description": "<code>bazel build</code> target to run.",
+          "examples": [
+            "//:skaffold_example.tar"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "target",
+        "args"
+      ],
+      "additionalProperties": false,
+      "description": "describes an artifact built with [Bazel](https://bazel.build/).",
+      "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
+    },
+    "BuildConfig": {
+      "anyOf": [
+        {
+          "properties": {
+            "artifacts": {
+              "items": {
+                "$ref": "#/definitions/Artifact"
+              },
+              "type": "array",
+              "description": "the images you're going to be building.",
+              "x-intellij-html-description": "the images you're going to be building."
+            },
+            "insecureRegistries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "x-intellij-html-description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "default": "[]"
+            },
+            "tagPolicy": {
+              "$ref": "#/definitions/TagPolicy",
+              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {variant: Tags}`.",
+              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {variant: Tags}</code>."
+            }
+          },
+          "preferredOrder": [
+            "artifacts",
+            "insecureRegistries",
+            "tagPolicy"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "artifacts": {
+              "items": {
+                "$ref": "#/definitions/Artifact"
+              },
+              "type": "array",
+              "description": "the images you're going to be building.",
+              "x-intellij-html-description": "the images you're going to be building."
+            },
+            "insecureRegistries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "x-intellij-html-description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "default": "[]"
+            },
+            "local": {
+              "$ref": "#/definitions/LocalBuild",
+              "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
+              "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
+            },
+            "tagPolicy": {
+              "$ref": "#/definitions/TagPolicy",
+              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {variant: Tags}`.",
+              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {variant: Tags}</code>."
+            }
+          },
+          "preferredOrder": [
+            "artifacts",
+            "insecureRegistries",
+            "tagPolicy",
+            "local"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "artifacts": {
+              "items": {
+                "$ref": "#/definitions/Artifact"
+              },
+              "type": "array",
+              "description": "the images you're going to be building.",
+              "x-intellij-html-description": "the images you're going to be building."
+            },
+            "googleCloudBuild": {
+              "$ref": "#/definitions/GoogleCloudBuild",
+              "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/).",
+              "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/\">Google Cloud Build</a>."
+            },
+            "insecureRegistries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "x-intellij-html-description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "default": "[]"
+            },
+            "tagPolicy": {
+              "$ref": "#/definitions/TagPolicy",
+              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {variant: Tags}`.",
+              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {variant: Tags}</code>."
+            }
+          },
+          "preferredOrder": [
+            "artifacts",
+            "insecureRegistries",
+            "tagPolicy",
+            "googleCloudBuild"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "artifacts": {
+              "items": {
+                "$ref": "#/definitions/Artifact"
+              },
+              "type": "array",
+              "description": "the images you're going to be building.",
+              "x-intellij-html-description": "the images you're going to be building."
+            },
+            "cluster": {
+              "$ref": "#/definitions/ClusterDetails",
+              "description": "*beta* describes how to do an on-cluster build.",
+              "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
+            },
+            "insecureRegistries": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "x-intellij-html-description": "a list of registries declared by the user to be insecure. These registries will be connected to via HTTP instead of HTTPS.",
+              "default": "[]"
+            },
+            "tagPolicy": {
+              "$ref": "#/definitions/TagPolicy",
+              "description": "*beta* determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to `gitCommit: {variant: Tags}`.",
+              "x-intellij-html-description": "<em>beta</em> determines how images are tagged. A few strategies are provided here, although you most likely won't need to care! If not specified, it defaults to <code>gitCommit: {variant: Tags}</code>."
+            }
+          },
+          "preferredOrder": [
+            "artifacts",
+            "insecureRegistries",
+            "tagPolicy",
+            "cluster"
+          ],
+          "additionalProperties": false
+        }
+      ],
+      "description": "contains all the configuration for the build steps.",
+      "x-intellij-html-description": "contains all the configuration for the build steps."
+    },
+    "BuildpackArtifact": {
+      "required": [
+        "builder"
+      ],
+      "properties": {
+        "builder": {
+          "type": "string",
+          "description": "builder image used.",
+          "x-intellij-html-description": "builder image used."
+        },
+        "buildpacks": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "a list of strings, where each string is a specific buildpack to use with the builder. If you specify buildpacks the builder image automatic detection will be ignored. These buildpacks will be used to build the Image from your source code. Order matters.",
+          "x-intellij-html-description": "a list of strings, where each string is a specific buildpack to use with the builder. If you specify buildpacks the builder image automatic detection will be ignored. These buildpacks will be used to build the Image from your source code. Order matters.",
+          "default": "[]"
+        },
+        "dependencies": {
+          "$ref": "#/definitions/BuildpackDependencies",
+          "description": "file dependencies that skaffold should watch for both rebuilding and file syncing for this artifact.",
+          "x-intellij-html-description": "file dependencies that skaffold should watch for both rebuilding and file syncing for this artifact."
+        },
+        "env": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "environment variables, in the `key=value` form,  passed to the build. Values can use the go template syntax.",
+          "x-intellij-html-description": "environment variables, in the <code>key=value</code> form,  passed to the build. Values can use the go template syntax.",
+          "default": "[]",
+          "examples": [
+            "[\"key1=value1\", \"key2=value2\", \"key3={{.ENV_VARIABLE}}\"]"
+          ]
+        },
+        "projectDescriptor": {
+          "type": "string",
+          "description": "path to the project descriptor file.",
+          "x-intellij-html-description": "path to the project descriptor file.",
+          "default": "project.toml"
+        },
+        "runImage": {
+          "type": "string",
+          "description": "overrides the stack's default run image.",
+          "x-intellij-html-description": "overrides the stack's default run image."
+        },
+        "trustBuilder": {
+          "type": "boolean",
+          "description": "indicates that the builder should be trusted.",
+          "x-intellij-html-description": "indicates that the builder should be trusted.",
+          "default": "false"
+        }
+      },
+      "preferredOrder": [
+        "builder",
+        "runImage",
+        "env",
+        "buildpacks",
+        "trustBuilder",
+        "projectDescriptor",
+        "dependencies"
+      ],
+      "additionalProperties": false,
+      "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
+      "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
+    },
+    "BuildpackDependencies": {
+      "properties": {
+        "ignore": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both `paths` and in `ignore`, it will be ignored, and will be excluded from both rebuilds and file synchronization. Will only work in conjunction with `paths`.",
+          "x-intellij-html-description": "specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both <code>paths</code> and in <code>ignore</code>, it will be ignored, and will be excluded from both rebuilds and file synchronization. Will only work in conjunction with <code>paths</code>.",
+          "default": "[]"
+        },
+        "paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "should be set to the file dependencies for this artifact, so that the skaffold file watcher knows when to rebuild and perform file synchronization.",
+          "x-intellij-html-description": "should be set to the file dependencies for this artifact, so that the skaffold file watcher knows when to rebuild and perform file synchronization.",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "paths",
+        "ignore"
+      ],
+      "additionalProperties": false,
+      "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
+      "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
+    },
+    "ClusterDetails": {
+      "properties": {
+        "HTTPS_PROXY": {
+          "type": "string",
+          "description": "for kaniko pod.",
+          "x-intellij-html-description": "for kaniko pod."
+        },
+        "HTTP_PROXY": {
+          "type": "string",
+          "description": "for kaniko pod.",
+          "x-intellij-html-description": "for kaniko pod."
+        },
+        "annotations": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "describes the Kubernetes annotations for the pod.",
+          "x-intellij-html-description": "describes the Kubernetes annotations for the pod.",
+          "default": "{}"
+        },
+        "concurrency": {
+          "type": "integer",
+          "description": "how many artifacts can be built concurrently. 0 means \"no-limit\".",
+          "x-intellij-html-description": "how many artifacts can be built concurrently. 0 means &quot;no-limit&quot;.",
+          "default": "0"
+        },
+        "dockerConfig": {
+          "$ref": "#/definitions/DockerConfig",
+          "description": "describes how to mount the local Docker configuration into a pod.",
+          "x-intellij-html-description": "describes how to mount the local Docker configuration into a pod."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Kubernetes namespace. Defaults to current namespace in Kubernetes configuration.",
+          "x-intellij-html-description": "Kubernetes namespace. Defaults to current namespace in Kubernetes configuration."
+        },
+        "pullSecretMountPath": {
+          "type": "string",
+          "description": "path the pull secret will be mounted at within the running container.",
+          "x-intellij-html-description": "path the pull secret will be mounted at within the running container."
+        },
+        "pullSecretName": {
+          "type": "string",
+          "description": "name of the Kubernetes secret for pulling base images and pushing the final image. If given, the secret needs to contain the Google Cloud service account secret key under the key `kaniko-secret`.",
+          "x-intellij-html-description": "name of the Kubernetes secret for pulling base images and pushing the final image. If given, the secret needs to contain the Google Cloud service account secret key under the key <code>kaniko-secret</code>.",
+          "default": "kaniko-secret"
+        },
+        "pullSecretPath": {
+          "type": "string",
+          "description": "path to the Google Cloud service account secret key file.",
+          "x-intellij-html-description": "path to the Google Cloud service account secret key file."
+        },
+        "randomDockerConfigSecret": {
+          "type": "boolean",
+          "description": "adds a random UUID postfix to the default name of the docker secret to facilitate parallel builds, e.g. docker-cfgfd154022-c761-416f-8eb3-cf8258450b85.",
+          "x-intellij-html-description": "adds a random UUID postfix to the default name of the docker secret to facilitate parallel builds, e.g. docker-cfgfd154022-c761-416f-8eb3-cf8258450b85.",
+          "default": "false"
+        },
+        "randomPullSecret": {
+          "type": "boolean",
+          "description": "adds a random UUID postfix to the default name of the pull secret to facilitate parallel builds, e.g. kaniko-secretdocker-cfgfd154022-c761-416f-8eb3-cf8258450b85.",
+          "x-intellij-html-description": "adds a random UUID postfix to the default name of the pull secret to facilitate parallel builds, e.g. kaniko-secretdocker-cfgfd154022-c761-416f-8eb3-cf8258450b85.",
+          "default": "false"
+        },
+        "resources": {
+          "$ref": "#/definitions/ResourceRequirements",
+          "description": "define the resource requirements for the kaniko pod.",
+          "x-intellij-html-description": "define the resource requirements for the kaniko pod."
+        },
+        "runAsUser": {
+          "type": "integer",
+          "description": "defines the UID to request for running the container. If omitted, no SeurityContext will be specified for the pod and will therefore be inherited from the service account.",
+          "x-intellij-html-description": "defines the UID to request for running the container. If omitted, no SeurityContext will be specified for the pod and will therefore be inherited from the service account."
+        },
+        "serviceAccount": {
+          "type": "string",
+          "description": "describes the Kubernetes service account to use for the pod. Defaults to 'default'.",
+          "x-intellij-html-description": "describes the Kubernetes service account to use for the pod. Defaults to 'default'."
+        },
+        "timeout": {
+          "type": "string",
+          "description": "amount of time (in seconds) that this build is allowed to run. Defaults to 20 minutes (`20m`).",
+          "x-intellij-html-description": "amount of time (in seconds) that this build is allowed to run. Defaults to 20 minutes (<code>20m</code>)."
+        },
+        "tolerations": {
+          "items": {},
+          "type": "array",
+          "description": "describes the Kubernetes tolerations for the pod.",
+          "x-intellij-html-description": "describes the Kubernetes tolerations for the pod.",
+          "default": "[]"
+        },
+        "volumes": {
+          "items": {},
+          "type": "array",
+          "description": "defines container mounts for ConfigMap and Secret resources.",
+          "x-intellij-html-description": "defines container mounts for ConfigMap and Secret resources.",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "pullSecretPath",
+        "pullSecretName",
+        "pullSecretMountPath",
+        "namespace",
+        "timeout",
+        "dockerConfig",
+        "serviceAccount",
+        "tolerations",
+        "annotations",
+        "runAsUser",
+        "resources",
+        "concurrency",
+        "volumes",
+        "randomPullSecret",
+        "randomDockerConfigSecret"
+      ],
+      "additionalProperties": false,
+      "description": "*beta* describes how to do an on-cluster build.",
+      "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
+    },
+    "ConfigDependency": {
+      "properties": {
+        "activeProfiles": {
+          "items": {
+            "$ref": "#/definitions/ProfileDependency"
+          },
+          "type": "array",
+          "description": "describes the list of profiles to activate when resolving the required configs. These profiles must exist in the imported config.",
+          "x-intellij-html-description": "describes the list of profiles to activate when resolving the required configs. These profiles must exist in the imported config."
+        },
+        "configs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "includes specific named configs within the file path. If empty, then all configs in the file are included.",
+          "x-intellij-html-description": "includes specific named configs within the file path. If empty, then all configs in the file are included.",
+          "default": "[]"
+        },
+        "git": {
+          "$ref": "#/definitions/GitInfo",
+          "description": "describes a remote git repository containing the required configs.",
+          "x-intellij-html-description": "describes a remote git repository containing the required configs."
+        },
+        "path": {
+          "type": "string",
+          "description": "describes the path to the file containing the required configs.",
+          "x-intellij-html-description": "describes the path to the file containing the required configs."
+        }
+      },
+      "preferredOrder": [
+        "configs",
+        "path",
+        "git",
+        "activeProfiles"
+      ],
+      "additionalProperties": false,
+      "description": "describes a dependency on another skaffold configuration.",
+      "x-intellij-html-description": "describes a dependency on another skaffold configuration."
+    },
+    "CustomArtifact": {
+      "properties": {
+        "buildCommand": {
+          "type": "string",
+          "description": "command executed to build the image.",
+          "x-intellij-html-description": "command executed to build the image."
+        },
+        "dependencies": {
+          "$ref": "#/definitions/CustomDependencies",
+          "description": "file dependencies that skaffold should watch for both rebuilding and file syncing for this artifact.",
+          "x-intellij-html-description": "file dependencies that skaffold should watch for both rebuilding and file syncing for this artifact."
+        }
+      },
+      "preferredOrder": [
+        "buildCommand",
+        "dependencies"
+      ],
+      "additionalProperties": false,
+      "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
+      "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
+    },
+    "CustomDependencies": {
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "represents a custom command that skaffold executes to obtain dependencies. The output of this command *must* be a valid JSON array.",
+          "x-intellij-html-description": "represents a custom command that skaffold executes to obtain dependencies. The output of this command <em>must</em> be a valid JSON array."
+        },
+        "dockerfile": {
+          "$ref": "#/definitions/DockerfileDependency",
+          "description": "should be set if the artifact is built from a Dockerfile, from which skaffold can determine dependencies.",
+          "x-intellij-html-description": "should be set if the artifact is built from a Dockerfile, from which skaffold can determine dependencies."
+        },
+        "ignore": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both `paths` and in `ignore`, it will be ignored, and will be excluded from both rebuilds and file synchronization. Will only work in conjunction with `paths`.",
+          "x-intellij-html-description": "specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both <code>paths</code> and in <code>ignore</code>, it will be ignored, and will be excluded from both rebuilds and file synchronization. Will only work in conjunction with <code>paths</code>.",
+          "default": "[]"
+        },
+        "paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "should be set to the file dependencies for this artifact, so that the skaffold file watcher knows when to rebuild and perform file synchronization.",
+          "x-intellij-html-description": "should be set to the file dependencies for this artifact, so that the skaffold file watcher knows when to rebuild and perform file synchronization.",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "dockerfile",
+        "command",
+        "paths",
+        "ignore"
+      ],
+      "additionalProperties": false,
+      "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
+      "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
+    },
+    "CustomTemplateTagger": {
+      "required": [
+        "template"
+      ],
+      "properties": {
+        "components": {
+          "items": {
+            "$ref": "#/definitions/TaggerComponent"
+          },
+          "type": "array",
+          "description": "TaggerComponents that the template (see field above) can be executed against.",
+          "x-intellij-html-description": "TaggerComponents that the template (see field above) can be executed against."
+        },
+        "template": {
+          "type": "string",
+          "description": "used to produce the image name and tag. See golang [text/template](https://golang.org/pkg/text/template/). The template is executed against the provided components with those variables injected.",
+          "x-intellij-html-description": "used to produce the image name and tag. See golang <a href=\"https://golang.org/pkg/text/template/\">text/template</a>. The template is executed against the provided components with those variables injected.",
+          "examples": [
+            "{{.DATE}}"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "template",
+        "components"
+      ],
+      "additionalProperties": false,
+      "description": "*beta* tags images with a configurable template string.",
+      "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
+    },
+    "CustomTest": {
+      "required": [
+        "command"
+      ],
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "custom command to be executed.  If the command exits with a non-zero return code, the test will be considered to have failed.",
+          "x-intellij-html-description": "custom command to be executed.  If the command exits with a non-zero return code, the test will be considered to have failed."
+        },
+        "dependencies": {
+          "$ref": "#/definitions/CustomTestDependencies",
+          "description": "additional test-specific file dependencies; changes to these files will re-run this test.",
+          "x-intellij-html-description": "additional test-specific file dependencies; changes to these files will re-run this test."
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "description": "sets the wait time for skaffold for the command to complete. If unset or 0, Skaffold will wait until the command completes.",
+          "x-intellij-html-description": "sets the wait time for skaffold for the command to complete. If unset or 0, Skaffold will wait until the command completes."
+        }
+      },
+      "preferredOrder": [
+        "command",
+        "timeoutSeconds",
+        "dependencies"
+      ],
+      "additionalProperties": false,
+      "description": "describes the custom test command provided by the user. Custom tests are run after an image build whenever build or test dependencies are changed.",
+      "x-intellij-html-description": "describes the custom test command provided by the user. Custom tests are run after an image build whenever build or test dependencies are changed."
+    },
+    "CustomTestDependencies": {
+      "properties": {
+        "command": {
+          "type": "string",
+          "description": "represents a command that skaffold executes to obtain dependencies. The output of this command *must* be a valid JSON array.",
+          "x-intellij-html-description": "represents a command that skaffold executes to obtain dependencies. The output of this command <em>must</em> be a valid JSON array."
+        },
+        "ignore": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both `paths` and in `ignore`, it will be ignored, and will be excluded from both retest and file synchronization. Will only work in conjunction with `paths`.",
+          "x-intellij-html-description": "specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both <code>paths</code> and in <code>ignore</code>, it will be ignored, and will be excluded from both retest and file synchronization. Will only work in conjunction with <code>paths</code>.",
+          "default": "[]"
+        },
+        "paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "should be set to the file dependencies for this command, so that the skaffold file watcher knows when to retest and perform file synchronization.",
+          "x-intellij-html-description": "should be set to the file dependencies for this command, so that the skaffold file watcher knows when to retest and perform file synchronization.",
+          "default": "[]",
+          "examples": [
+            "[\"src/test/**\"]"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "command",
+        "paths",
+        "ignore"
+      ],
+      "additionalProperties": false,
+      "description": "used to specify dependencies for custom test command. `paths` should be specified for file watching to work as expected.",
+      "x-intellij-html-description": "used to specify dependencies for custom test command. <code>paths</code> should be specified for file watching to work as expected."
+    },
+    "DateTimeTagger": {
+      "properties": {
+        "format": {
+          "type": "string",
+          "description": "formats the date and time. See [#Time.Format](https://golang.org/pkg/time/#Time.Format).",
+          "x-intellij-html-description": "formats the date and time. See <a href=\"https://golang.org/pkg/time/#Time.Format\">#Time.Format</a>.",
+          "default": "2006-01-02_15-04-05.999_MST"
+        },
+        "timezone": {
+          "type": "string",
+          "description": "sets the timezone for the date and time. See [Time.LoadLocation](https://golang.org/pkg/time/#Time.LoadLocation). Defaults to the local timezone.",
+          "x-intellij-html-description": "sets the timezone for the date and time. See <a href=\"https://golang.org/pkg/time/#Time.LoadLocation\">Time.LoadLocation</a>. Defaults to the local timezone."
+        }
+      },
+      "preferredOrder": [
+        "format",
+        "timezone"
+      ],
+      "additionalProperties": false,
+      "description": "*beta* tags images with the build timestamp.",
+      "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
+    },
+    "DeployConfig": {
+      "properties": {
+        "dir": {
+          "type": "string",
+          "description": "equivalent to the dir in `kpt live apply <dir>`. If not provided, skaffold renders the raw manifests and store them to a a hidden directory `.kpt-hydrated`, and deploys the hidden directory.",
+          "x-intellij-html-description": "equivalent to the dir in <code>kpt live apply &lt;dir&gt;</code>. If not provided, skaffold renders the raw manifests and store them to a a hidden directory <code>.kpt-hydrated</code>, and deploys the hidden directory."
+        },
+        "inventoryID": {
+          "type": "string",
+          "description": "**************** kpt live Inventory ************* InventoryID *alpha* is the identifier for a group of applied resources. This value is only needed when the `kpt live` is working on a pre-applied cluster resources.",
+          "x-intellij-html-description": "**************** kpt live Inventory ************* InventoryID <em>alpha</em> is the identifier for a group of applied resources. This value is only needed when the <code>kpt live</code> is working on a pre-applied cluster resources."
+        },
+        "inventoryNamespace": {
+          "type": "string",
+          "description": "*alpha* sets the inventory namespace.",
+          "x-intellij-html-description": "<em>alpha</em> sets the inventory namespace."
+        },
+        "kubeContext": {
+          "type": "string",
+          "description": "Kubernetes context that Skaffold should deploy to.",
+          "x-intellij-html-description": "Kubernetes context that Skaffold should deploy to.",
+          "examples": [
+            "minikube"
+          ]
+        },
+        "logs": {
+          "$ref": "#/definitions/LogsConfig",
+          "description": "configures how container logs are printed as a result of a deployment.",
+          "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
+        },
+        "prunePropagationPolicy": {
+          "type": "string",
+          "description": "sets the propagation policy for pruning. Possible settings are Background, Foreground, Orphan. Default to \"Background\".",
+          "x-intellij-html-description": "sets the propagation policy for pruning. Possible settings are Background, Foreground, Orphan. Default to &quot;Background&quot;."
+        },
+        "pruneTimeout": {
+          "type": "string",
+          "description": "sets the time threshold to wait for all pruned resources to be deleted.",
+          "x-intellij-html-description": "sets the time threshold to wait for all pruned resources to be deleted."
+        },
+        "reconcileTimeout": {
+          "type": "string",
+          "description": "sets the time threshold to wait for all resources to reach the current status.",
+          "x-intellij-html-description": "sets the time threshold to wait for all resources to reach the current status."
+        }
+      },
+      "preferredOrder": [
+        "dir",
+        "inventoryID",
+        "inventoryNamespace",
+        "prunePropagationPolicy",
+        "pruneTimeout",
+        "reconcileTimeout",
+        "kubeContext",
+        "logs"
+      ],
+      "additionalProperties": false,
+      "description": "contains all the configuration needed by the deploy steps.",
+      "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
+    },
+    "DockerArtifact": {
+      "properties": {
+        "buildArgs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "arguments passed to the docker build.",
+          "x-intellij-html-description": "arguments passed to the docker build.",
+          "default": "{}",
+          "examples": [
+            "{\"key1\": \"value1\", \"key2\": \"value2\"}"
+          ]
+        },
+        "cacheFrom": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "the Docker images used as cache sources.",
+          "x-intellij-html-description": "the Docker images used as cache sources.",
+          "default": "[]",
+          "examples": [
+            "[\"golang:1.10.1-alpine3.7\", \"alpine:3.7\"]"
+          ]
+        },
+        "dockerfile": {
+          "type": "string",
+          "description": "locates the Dockerfile relative to workspace.",
+          "x-intellij-html-description": "locates the Dockerfile relative to workspace.",
+          "default": "Dockerfile"
+        },
+        "network": {
+          "type": "string",
+          "description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Valid modes are `host`: use the host's networking stack. `bridge`: use the bridged network configuration. `container:<name|id>`: reuse another container's network stack. `none`: no networking in the container.",
+          "x-intellij-html-description": "passed through to docker and overrides the network configuration of docker builder. If unset, use whatever is configured in the underlying docker daemon. Valid modes are <code>host</code>: use the host's networking stack. <code>bridge</code>: use the bridged network configuration. <code>container:&lt;name|id&gt;</code>: reuse another container's network stack. <code>none</code>: no networking in the container.",
+          "enum": [
+            "host",
+            "bridge",
+            "container:<name|id>",
+            "none"
+          ]
+        },
+        "noCache": {
+          "type": "boolean",
+          "description": "used to pass in --no-cache to docker build to prevent caching.",
+          "x-intellij-html-description": "used to pass in --no-cache to docker build to prevent caching.",
+          "default": "false"
+        },
+        "secret": {
+          "$ref": "#/definitions/DockerSecret",
+          "description": "contains information about a local secret passed to `docker build`, along with optional destination information.",
+          "x-intellij-html-description": "contains information about a local secret passed to <code>docker build</code>, along with optional destination information."
+        },
+        "squash": {
+          "type": "boolean",
+          "description": "used to pass in --squash to docker build to squash docker image layers into single layer.",
+          "x-intellij-html-description": "used to pass in --squash to docker build to squash docker image layers into single layer.",
+          "default": "false"
+        },
+        "ssh": {
+          "type": "string",
+          "description": "used to pass in --ssh to docker build to use SSH agent. Format is \"default|<id>[=<socket>|<key>[,<key>]]\".",
+          "x-intellij-html-description": "used to pass in --ssh to docker build to use SSH agent. Format is &quot;default|<id>[=<socket>|<key>[,<key>]]&quot;."
+        },
+        "target": {
+          "type": "string",
+          "description": "Dockerfile target name to build.",
+          "x-intellij-html-description": "Dockerfile target name to build."
+        }
+      },
+      "preferredOrder": [
+        "dockerfile",
+        "target",
+        "buildArgs",
+        "network",
+        "cacheFrom",
+        "noCache",
+        "squash",
+        "secret",
+        "ssh"
+      ],
+      "additionalProperties": false,
+      "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
+      "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
+    },
+    "DockerConfig": {
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "path to the docker `config.json`.",
+          "x-intellij-html-description": "path to the docker <code>config.json</code>."
+        },
+        "secretName": {
+          "type": "string",
+          "description": "Kubernetes secret that contains the `config.json` Docker configuration. Note that the expected secret type is not 'kubernetes.io/dockerconfigjson' but 'Opaque'.",
+          "x-intellij-html-description": "Kubernetes secret that contains the <code>config.json</code> Docker configuration. Note that the expected secret type is not 'kubernetes.io/dockerconfigjson' but 'Opaque'."
+        }
+      },
+      "preferredOrder": [
+        "path",
+        "secretName"
+      ],
+      "additionalProperties": false,
+      "description": "contains information about the docker `config.json` to mount.",
+      "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
+    },
+    "DockerSecret": {
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "dst": {
+          "type": "string",
+          "description": "path in the container to mount the secret.",
+          "x-intellij-html-description": "path in the container to mount the secret."
+        },
+        "id": {
+          "type": "string",
+          "description": "id of the secret.",
+          "x-intellij-html-description": "id of the secret."
+        },
+        "src": {
+          "type": "string",
+          "description": "path to the secret on the host machine.",
+          "x-intellij-html-description": "path to the secret on the host machine."
+        }
+      },
+      "preferredOrder": [
+        "id",
+        "src",
+        "dst"
+      ],
+      "additionalProperties": false,
+      "description": "contains information about a local secret passed to `docker build`, along with optional destination information.",
+      "x-intellij-html-description": "contains information about a local secret passed to <code>docker build</code>, along with optional destination information."
+    },
+    "DockerfileDependency": {
+      "properties": {
+        "buildArgs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "key/value pairs used to resolve values of `ARG` instructions in a Dockerfile. Values can be constants or environment variables via the go template syntax.",
+          "x-intellij-html-description": "key/value pairs used to resolve values of <code>ARG</code> instructions in a Dockerfile. Values can be constants or environment variables via the go template syntax.",
+          "default": "{}",
+          "examples": [
+            "{\"key1\": \"value1\", \"key2\": \"value2\", \"key3\": \"'{{.ENV_VARIABLE}}'\"}"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "description": "locates the Dockerfile relative to workspace.",
+          "x-intellij-html-description": "locates the Dockerfile relative to workspace."
+        }
+      },
+      "preferredOrder": [
+        "path",
+        "buildArgs"
+      ],
+      "additionalProperties": false,
+      "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
+      "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
+    },
+    "EnvTemplateTagger": {
+      "required": [
+        "template"
+      ],
+      "properties": {
+        "template": {
+          "type": "string",
+          "description": "used to produce the image name and tag. See golang [text/template](https://golang.org/pkg/text/template/). The template is executed against the current environment, with those variables injected.",
+          "x-intellij-html-description": "used to produce the image name and tag. See golang <a href=\"https://golang.org/pkg/text/template/\">text/template</a>. The template is executed against the current environment, with those variables injected.",
+          "examples": [
+            "{{.RELEASE}}"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "template"
+      ],
+      "additionalProperties": false,
+      "description": "*beta* tags images with a configurable template string.",
+      "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
+    },
+    "Generate": {
+      "properties": {
+        "Manifests": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "contains the raw kubernetes manifest paths and kustomize paths.",
+          "x-intellij-html-description": "contains the raw kubernetes manifest paths and kustomize paths.",
+          "default": "[]"
+        }
+      },
+      "preferredOrder": [
+        "Manifests"
+      ],
+      "additionalProperties": false,
+      "description": "defines the dry manifests from a variety of sources.",
+      "x-intellij-html-description": "defines the dry manifests from a variety of sources."
+    },
+    "GitInfo": {
+      "required": [
+        "repo"
+      ],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "relative path from the repo root to the skaffold configuration file. eg. `getting-started/skaffold.yaml`.",
+          "x-intellij-html-description": "relative path from the repo root to the skaffold configuration file. eg. <code>getting-started/skaffold.yaml</code>."
+        },
+        "ref": {
+          "type": "string",
+          "description": "git ref the package should be cloned from. eg. `master` or `main`.",
+          "x-intellij-html-description": "git ref the package should be cloned from. eg. <code>master</code> or <code>main</code>."
+        },
+        "repo": {
+          "type": "string",
+          "description": "git repository the package should be cloned from.  e.g. `https://github.com/GoogleContainerTools/skaffold.git`.",
+          "x-intellij-html-description": "git repository the package should be cloned from.  e.g. <code>https://github.com/GoogleContainerTools/skaffold.git</code>."
+        },
+        "sync": {
+          "type": "boolean",
+          "description": "when set to `true` will reset the cached repository to the latest commit from remote on every run. To use the cached repository with uncommitted changes or unpushed commits, it needs to be set to `false`.",
+          "x-intellij-html-description": "when set to <code>true</code> will reset the cached repository to the latest commit from remote on every run. To use the cached repository with uncommitted changes or unpushed commits, it needs to be set to <code>false</code>."
+        }
+      },
+      "preferredOrder": [
+        "repo",
+        "path",
+        "ref",
+        "sync"
+      ],
+      "additionalProperties": false,
+      "description": "contains information on the origin of skaffold configurations cloned from a git repository.",
+      "x-intellij-html-description": "contains information on the origin of skaffold configurations cloned from a git repository."
+    },
+    "GitTagger": {
+      "properties": {
+        "ignoreChanges": {
+          "type": "boolean",
+          "description": "specifies whether to omit the `-dirty` postfix if there are uncommitted changes.",
+          "x-intellij-html-description": "specifies whether to omit the <code>-dirty</code> postfix if there are uncommitted changes.",
+          "default": "false"
+        },
+        "prefix": {
+          "type": "string",
+          "description": "adds a fixed prefix to the tag.",
+          "x-intellij-html-description": "adds a fixed prefix to the tag."
+        },
+        "variant": {
+          "type": "string",
+          "description": "determines the behavior of the git tagger. Valid variants are: `Tags` (default): use git tags or fall back to abbreviated commit hash. `CommitSha`: use the full git commit sha. `AbbrevCommitSha`: use the abbreviated git commit sha. `TreeSha`: use the full tree hash of the artifact workingdir. `AbbrevTreeSha`: use the abbreviated tree hash of the artifact workingdir.",
+          "x-intellij-html-description": "determines the behavior of the git tagger. Valid variants are: <code>Tags</code> (default): use git tags or fall back to abbreviated commit hash. <code>CommitSha</code>: use the full git commit sha. <code>AbbrevCommitSha</code>: use the abbreviated git commit sha. <code>TreeSha</code>: use the full tree hash of the artifact workingdir. <code>AbbrevTreeSha</code>: use the abbreviated tree hash of the artifact workingdir."
+        }
+      },
+      "preferredOrder": [
+        "variant",
+        "prefix",
+        "ignoreChanges"
+      ],
+      "additionalProperties": false,
+      "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
+      "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
+    },
+    "GoogleCloudBuild": {
+      "properties": {
+        "concurrency": {
+          "type": "integer",
+          "description": "how many artifacts can be built concurrently. 0 means \"no-limit\".",
+          "x-intellij-html-description": "how many artifacts can be built concurrently. 0 means &quot;no-limit&quot;.",
+          "default": "0"
+        },
+        "diskSizeGb": {
+          "type": "integer",
+          "description": "disk size of the VM that runs the build. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions).",
+          "x-intellij-html-description": "disk size of the VM that runs the build. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions\">Cloud Build Reference</a>."
+        },
+        "dockerImage": {
+          "type": "string",
+          "description": "image that runs a Docker build. See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).",
+          "x-intellij-html-description": "image that runs a Docker build. See <a href=\"https://cloud.google.com/cloud-build/docs/cloud-builders\">Cloud Builders</a>.",
+          "default": "gcr.io/cloud-builders/docker"
+        },
+        "gradleImage": {
+          "type": "string",
+          "description": "image that runs a Gradle build. See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).",
+          "x-intellij-html-description": "image that runs a Gradle build. See <a href=\"https://cloud.google.com/cloud-build/docs/cloud-builders\">Cloud Builders</a>.",
+          "default": "gcr.io/cloud-builders/gradle"
+        },
+        "kanikoImage": {
+          "type": "string",
+          "description": "image that runs a Kaniko build. See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).",
+          "x-intellij-html-description": "image that runs a Kaniko build. See <a href=\"https://cloud.google.com/cloud-build/docs/cloud-builders\">Cloud Builders</a>.",
+          "default": "gcr.io/kaniko-project/executor"
+        },
+        "logStreamingOption": {
+          "type": "string",
+          "description": "specifies the behavior when writing build logs to Google Cloud Storage. Valid options are: `STREAM_DEFAULT`: Service may automatically determine build log streaming behavior. `STREAM_ON`:  Build logs should be streamed to Google Cloud Storage. `STREAM_OFF`: Build logs should not be streamed to Google Cloud Storage; they will be written when the build is completed. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#logstreamingoption).",
+          "x-intellij-html-description": "specifies the behavior when writing build logs to Google Cloud Storage. Valid options are: <code>STREAM_DEFAULT</code>: Service may automatically determine build log streaming behavior. <code>STREAM_ON</code>:  Build logs should be streamed to Google Cloud Storage. <code>STREAM_OFF</code>: Build logs should not be streamed to Google Cloud Storage; they will be written when the build is completed. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#logstreamingoption\">Cloud Build Reference</a>."
+        },
+        "logging": {
+          "type": "string",
+          "description": "specifies the logging mode. Valid modes are: `LOGGING_UNSPECIFIED`: The service determines the logging mode. `LEGACY`: Stackdriver logging and Cloud Storage logging are enabled (default). `GCS_ONLY`: Only Cloud Storage logging is enabled. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#loggingmode).",
+          "x-intellij-html-description": "specifies the logging mode. Valid modes are: <code>LOGGING_UNSPECIFIED</code>: The service determines the logging mode. <code>LEGACY</code>: Stackdriver logging and Cloud Storage logging are enabled (default). <code>GCS_ONLY</code>: Only Cloud Storage logging is enabled. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#loggingmode\">Cloud Build Reference</a>."
+        },
+        "machineType": {
+          "type": "string",
+          "description": "type of the VM that runs the build. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions).",
+          "x-intellij-html-description": "type of the VM that runs the build. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions\">Cloud Build Reference</a>."
+        },
+        "mavenImage": {
+          "type": "string",
+          "description": "image that runs a Maven build. See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).",
+          "x-intellij-html-description": "image that runs a Maven build. See <a href=\"https://cloud.google.com/cloud-build/docs/cloud-builders\">Cloud Builders</a>.",
+          "default": "gcr.io/cloud-builders/mvn"
+        },
+        "packImage": {
+          "type": "string",
+          "description": "image that runs a Cloud Native Buildpacks build. See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).",
+          "x-intellij-html-description": "image that runs a Cloud Native Buildpacks build. See <a href=\"https://cloud.google.com/cloud-build/docs/cloud-builders\">Cloud Builders</a>.",
+          "default": "gcr.io/k8s-skaffold/pack"
+        },
+        "projectId": {
+          "type": "string",
+          "description": "ID of your Cloud Platform Project. If it is not provided, Skaffold will guess it from the image name. For example, given the artifact image name `gcr.io/myproject/image`, Skaffold will use the `myproject` GCP project.",
+          "x-intellij-html-description": "ID of your Cloud Platform Project. If it is not provided, Skaffold will guess it from the image name. For example, given the artifact image name <code>gcr.io/myproject/image</code>, Skaffold will use the <code>myproject</code> GCP project."
+        },
+        "timeout": {
+          "type": "string",
+          "description": "amount of time (in seconds) that this build should be allowed to run. See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#resource-build).",
+          "x-intellij-html-description": "amount of time (in seconds) that this build should be allowed to run. See <a href=\"https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#resource-build\">Cloud Build Reference</a>."
+        },
+        "workerPool": {
+          "type": "string",
+          "description": "configures a pool of workers to run the build.",
+          "x-intellij-html-description": "configures a pool of workers to run the build."
+        }
+      },
+      "preferredOrder": [
+        "projectId",
+        "diskSizeGb",
+        "machineType",
+        "timeout",
+        "logging",
+        "logStreamingOption",
+        "dockerImage",
+        "kanikoImage",
+        "mavenImage",
+        "gradleImage",
+        "packImage",
+        "concurrency",
+        "workerPool"
+      ],
+      "additionalProperties": false,
+      "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
+      "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
+    },
+    "JSONPatch": {
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "from": {
+          "type": "string",
+          "description": "source position in the yaml, used for `copy` or `move` operations.",
+          "x-intellij-html-description": "source position in the yaml, used for <code>copy</code> or <code>move</code> operations."
+        },
+        "op": {
+          "type": "string",
+          "description": "operation carried by the patch: `add`, `remove`, `replace`, `move`, `copy` or `test`.",
+          "x-intellij-html-description": "operation carried by the patch: <code>add</code>, <code>remove</code>, <code>replace</code>, <code>move</code>, <code>copy</code> or <code>test</code>.",
+          "default": "replace"
+        },
+        "path": {
+          "type": "string",
+          "description": "position in the yaml where the operation takes place. For example, this targets the `dockerfile` of the first artifact built.",
+          "x-intellij-html-description": "position in the yaml where the operation takes place. For example, this targets the <code>dockerfile</code> of the first artifact built.",
+          "examples": [
+            "/build/artifacts/0/docker/dockerfile"
+          ]
+        },
+        "value": {
+          "description": "value to apply. Can be any portion of yaml.",
+          "x-intellij-html-description": "value to apply. Can be any portion of yaml."
+        }
+      },
+      "preferredOrder": [
+        "op",
+        "path",
+        "from",
+        "value"
+      ],
+      "additionalProperties": false,
+      "description": "patch to be applied by a profile.",
+      "x-intellij-html-description": "patch to be applied by a profile."
+    },
+    "JibArtifact": {
+      "properties": {
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional build flags passed to the builder.",
+          "x-intellij-html-description": "additional build flags passed to the builder.",
+          "default": "[]",
+          "examples": [
+            "[\"--no-build-cache\"]"
+          ]
+        },
+        "fromImage": {
+          "type": "string",
+          "description": "overrides the configured jib base image.",
+          "x-intellij-html-description": "overrides the configured jib base image."
+        },
+        "project": {
+          "type": "string",
+          "description": "selects which sub-project to build for multi-module builds.",
+          "x-intellij-html-description": "selects which sub-project to build for multi-module builds."
+        },
+        "type": {
+          "type": "string",
+          "description": "the Jib builder type; normally determined automatically. Valid types are `maven`: for Maven. `gradle`: for Gradle.",
+          "x-intellij-html-description": "the Jib builder type; normally determined automatically. Valid types are <code>maven</code>: for Maven. <code>gradle</code>: for Gradle.",
+          "enum": [
+            "maven",
+            "gradle"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "project",
+        "args",
+        "type",
+        "fromImage"
+      ],
+      "additionalProperties": false,
+      "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
+      "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
+    },
+    "KanikoArtifact": {
+      "properties": {
+        "buildArgs": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "arguments passed to the docker build. It also accepts environment variables and generated values via the go template syntax. Exposed generated values: IMAGE_REPO, IMAGE_NAME, IMAGE_TAG.",
+          "x-intellij-html-description": "arguments passed to the docker build. It also accepts environment variables and generated values via the go template syntax. Exposed generated values: IMAGE<em>REPO, IMAGE</em>NAME, IMAGE_TAG.",
+          "default": "{}",
+          "examples": [
+            "{\"key1\": \"value1\", \"key2\": \"value2\", \"key3\": \"'{{.ENV_VARIABLE}}'\"}"
+          ]
+        },
+        "cache": {
+          "$ref": "#/definitions/KanikoCache",
+          "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
+          "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
+        },
+        "cleanup": {
+          "type": "boolean",
+          "description": "to clean the filesystem at the end of the build.",
+          "x-intellij-html-description": "to clean the filesystem at the end of the build.",
+          "default": "false"
+        },
+        "digestFile": {
+          "type": "string",
+          "description": "to specify a file in the container. This file will receive the digest of a built image. This can be used to automatically track the exact image built by kaniko.",
+          "x-intellij-html-description": "to specify a file in the container. This file will receive the digest of a built image. This can be used to automatically track the exact image built by kaniko."
+        },
+        "dockerfile": {
+          "type": "string",
+          "description": "locates the Dockerfile relative to workspace.",
+          "x-intellij-html-description": "locates the Dockerfile relative to workspace.",
+          "default": "Dockerfile"
+        },
+        "env": {
+          "items": {},
+          "type": "array",
+          "description": "environment variables passed to the kaniko pod. It also accepts environment variables via the go template syntax.",
+          "x-intellij-html-description": "environment variables passed to the kaniko pod. It also accepts environment variables via the go template syntax.",
+          "default": "[]",
+          "examples": [
+            "[{\"name\": \"key1\", \"value\": \"value1\"}, {\"name\": \"key2\", \"value\": \"value2\"}, {\"name\": \"key3\", \"value\": \"'{{.ENV_VARIABLE}}'\"}]"
+          ]
+        },
+        "force": {
+          "type": "boolean",
+          "description": "building outside of a container.",
+          "x-intellij-html-description": "building outside of a container.",
+          "default": "false"
+        },
+        "image": {
+          "type": "string",
+          "description": "Docker image used by the Kaniko pod. Defaults to the latest released version of `gcr.io/kaniko-project/executor`.",
+          "x-intellij-html-description": "Docker image used by the Kaniko pod. Defaults to the latest released version of <code>gcr.io/kaniko-project/executor</code>."
+        },
+        "imageNameWithDigestFile": {
+          "type": "string",
+          "description": "specify a file to save the image name with digest of the built image to.",
+          "x-intellij-html-description": "specify a file to save the image name with digest of the built image to."
+        },
+        "initImage": {
+          "type": "string",
+          "description": "image used to run init container which mounts kaniko context.",
+          "x-intellij-html-description": "image used to run init container which mounts kaniko context."
+        },
+        "insecure": {
+          "type": "boolean",
+          "description": "if you want to push images to a plain HTTP registry.",
+          "x-intellij-html-description": "if you want to push images to a plain HTTP registry.",
+          "default": "false"
+        },
+        "insecurePull": {
+          "type": "boolean",
+          "description": "if you want to pull images from a plain HTTP registry.",
+          "x-intellij-html-description": "if you want to pull images from a plain HTTP registry.",
+          "default": "false"
+        },
+        "insecureRegistry": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "to use plain HTTP requests when accessing a registry.",
+          "x-intellij-html-description": "to use plain HTTP requests when accessing a registry.",
+          "default": "[]"
+        },
+        "label": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "key: value to set some metadata to the final image. This is equivalent as using the LABEL within the Dockerfile.",
+          "x-intellij-html-description": "key: value to set some metadata to the final image. This is equivalent as using the LABEL within the Dockerfile.",
+          "default": "{}"
+        },
+        "logFormat": {
+          "type": "string",
+          "description": "<text|color|json> to set the log format.",
+          "x-intellij-html-description": "<text|color|json> to set the log format."
+        },
+        "logTimestamp": {
+          "type": "boolean",
+          "description": "to add timestamps to log format.",
+          "x-intellij-html-description": "to add timestamps to log format.",
+          "default": "false"
+        },
+        "noPush": {
+          "type": "boolean",
+          "description": "if you only want to build the image, without pushing to a registry.",
+          "x-intellij-html-description": "if you only want to build the image, without pushing to a registry.",
+          "default": "false"
+        },
+        "ociLayoutPath": {
+          "type": "string",
+          "description": "to specify a directory in the container where the OCI image layout of a built image will be placed. This can be used to automatically track the exact image built by kaniko.",
+          "x-intellij-html-description": "to specify a directory in the container where the OCI image layout of a built image will be placed. This can be used to automatically track the exact image built by kaniko."
+        },
+        "registryCertificate": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "to provide a certificate for TLS communication with a given registry. my.registry.url: /path/to/the/certificate.cert is the expected format.",
+          "x-intellij-html-description": "to provide a certificate for TLS communication with a given registry. my.registry.url: /path/to/the/certificate.cert is the expected format.",
+          "default": "{}"
+        },
+        "registryMirror": {
+          "type": "string",
+          "description": "if you want to use a registry mirror instead of default `index.docker.io`.",
+          "x-intellij-html-description": "if you want to use a registry mirror instead of default <code>index.docker.io</code>."
+        },
+        "reproducible": {
+          "type": "boolean",
+          "description": "used to strip timestamps out of the built image.",
+          "x-intellij-html-description": "used to strip timestamps out of the built image.",
+          "default": "false"
+        },
+        "singleSnapshot": {
+          "type": "boolean",
+          "description": "takes a single snapshot of the filesystem at the end of the build. So only one layer will be appended to the base image.",
+          "x-intellij-html-description": "takes a single snapshot of the filesystem at the end of the build. So only one layer will be appended to the base image.",
+          "default": "false"
+        },
+        "skipTLS": {
+          "type": "boolean",
+          "description": "skips TLS certificate validation when pushing to a registry.",
+          "x-intellij-html-description": "skips TLS certificate validation when pushing to a registry.",
+          "default": "false"
+        },
+        "skipTLSVerifyPull": {
+          "type": "boolean",
+          "description": "skips TLS certificate validation when pulling from a registry.",
+          "x-intellij-html-description": "skips TLS certificate validation when pulling from a registry.",
+          "default": "false"
+        },
+        "skipTLSVerifyRegistry": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "skips TLS certificate validation when accessing a registry.",
+          "x-intellij-html-description": "skips TLS certificate validation when accessing a registry.",
+          "default": "[]"
+        },
+        "skipUnusedStages": {
+          "type": "boolean",
+          "description": "builds only used stages if defined to true. Otherwise it builds by default all stages, even the unnecessaries ones until it reaches the target stage / end of Dockerfile.",
+          "x-intellij-html-description": "builds only used stages if defined to true. Otherwise it builds by default all stages, even the unnecessaries ones until it reaches the target stage / end of Dockerfile.",
+          "default": "false"
+        },
+        "snapshotMode": {
+          "type": "string",
+          "description": "how Kaniko will snapshot the filesystem.",
+          "x-intellij-html-description": "how Kaniko will snapshot the filesystem."
+        },
+        "tarPath": {
+          "type": "string",
+          "description": "path to save the image as a tarball at path instead of pushing the image.",
+          "x-intellij-html-description": "path to save the image as a tarball at path instead of pushing the image."
+        },
+        "target": {
+          "type": "string",
+          "description": "to indicate which build stage is the target build stage.",
+          "x-intellij-html-description": "to indicate which build stage is the target build stage."
+        },
+        "useNewRun": {
+          "type": "boolean",
+          "description": "to Use the experimental run implementation for detecting changes without requiring file system snapshots. In some cases, this may improve build performance by 75%.",
+          "x-intellij-html-description": "to Use the experimental run implementation for detecting changes without requiring file system snapshots. In some cases, this may improve build performance by 75%.",
+          "default": "false"
+        },
+        "verbosity": {
+          "type": "string",
+          "description": "<panic|fatal|error|warn|info|debug|trace> to set the logging level.",
+          "x-intellij-html-description": "<panic|fatal|error|warn|info|debug|trace> to set the logging level."
+        },
+        "volumeMounts": {
+          "items": {},
+          "type": "array",
+          "description": "volume mounts passed to kaniko pod.",
+          "x-intellij-html-description": "volume mounts passed to kaniko pod.",
+          "default": "[]"
+        },
+        "whitelistVarRun": {
+          "type": "boolean",
+          "description": "used to ignore `/var/run` when taking image snapshot. Set it to false to preserve /var/run/* in destination image.",
+          "x-intellij-html-description": "used to ignore <code>/var/run</code> when taking image snapshot. Set it to false to preserve /var/run/* in destination image.",
+          "default": "false"
+        }
+      },
+      "preferredOrder": [
+        "cleanup",
+        "insecure",
+        "insecurePull",
+        "noPush",
+        "force",
+        "logTimestamp",
+        "reproducible",
+        "singleSnapshot",
+        "skipTLS",
+        "skipTLSVerifyPull",
+        "skipUnusedStages",
+        "useNewRun",
+        "whitelistVarRun",
+        "dockerfile",
+        "target",
+        "initImage",
+        "image",
+        "digestFile",
+        "imageNameWithDigestFile",
+        "logFormat",
+        "ociLayoutPath",
+        "registryMirror",
+        "snapshotMode",
+        "tarPath",
+        "verbosity",
+        "insecureRegistry",
+        "skipTLSVerifyRegistry",
+        "env",
+        "cache",
+        "registryCertificate",
+        "label",
+        "buildArgs",
+        "volumeMounts"
+      ],
+      "additionalProperties": false,
+      "description": "describes an artifact built from a Dockerfile, with kaniko.",
+      "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
+    },
+    "KanikoCache": {
+      "properties": {
+        "hostPath": {
+          "type": "string",
+          "description": "specifies a path on the host that is mounted to each pod as read only cache volume containing base images. If set, must exist on each node and prepopulated with kaniko-warmer.",
+          "x-intellij-html-description": "specifies a path on the host that is mounted to each pod as read only cache volume containing base images. If set, must exist on each node and prepopulated with kaniko-warmer."
+        },
+        "repo": {
+          "type": "string",
+          "description": "a remote repository to store cached layers. If none is specified, one will be inferred from the image name. See [Kaniko Caching](https://github.com/GoogleContainerTools/kaniko#caching).",
+          "x-intellij-html-description": "a remote repository to store cached layers. If none is specified, one will be inferred from the image name. See <a href=\"https://github.com/GoogleContainerTools/kaniko#caching\">Kaniko Caching</a>."
+        },
+        "ttl": {
+          "type": "string",
+          "description": "Cache timeout in hours.",
+          "x-intellij-html-description": "Cache timeout in hours."
+        }
+      },
+      "preferredOrder": [
+        "repo",
+        "hostPath",
+        "ttl"
+      ],
+      "additionalProperties": false,
+      "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
+      "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
+    },
+    "LocalBuild": {
+      "properties": {
+        "concurrency": {
+          "type": "integer",
+          "description": "how many artifacts can be built concurrently. 0 means \"no-limit\".",
+          "x-intellij-html-description": "how many artifacts can be built concurrently. 0 means &quot;no-limit&quot;.",
+          "default": "1"
+        },
+        "push": {
+          "type": "boolean",
+          "description": "should images be pushed to a registry. If not specified, images are pushed only if the current Kubernetes context connects to a remote cluster.",
+          "x-intellij-html-description": "should images be pushed to a registry. If not specified, images are pushed only if the current Kubernetes context connects to a remote cluster."
+        },
+        "tryImportMissing": {
+          "type": "boolean",
+          "description": "whether to attempt to import artifacts from Docker (either a local or remote registry) if not in the cache.",
+          "x-intellij-html-description": "whether to attempt to import artifacts from Docker (either a local or remote registry) if not in the cache.",
+          "default": "false"
+        },
+        "useBuildkit": {
+          "type": "boolean",
+          "description": "use BuildKit to build Docker images.",
+          "x-intellij-html-description": "use BuildKit to build Docker images.",
+          "default": "false"
+        },
+        "useDockerCLI": {
+          "type": "boolean",
+          "description": "use `docker` command-line interface instead of Docker Engine APIs.",
+          "x-intellij-html-description": "use <code>docker</code> command-line interface instead of Docker Engine APIs.",
+          "default": "false"
+        }
+      },
+      "preferredOrder": [
+        "push",
+        "tryImportMissing",
+        "useDockerCLI",
+        "useBuildkit",
+        "concurrency"
+      ],
+      "additionalProperties": false,
+      "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
+      "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
+    },
+    "LogsConfig": {
+      "properties": {
+        "prefix": {
+          "type": "string",
+          "description": "defines the prefix shown on each log line. Valid values are `container`: prefix logs lines with the name of the container. `podAndContainer`: prefix logs lines with the names of the pod and of the container. `auto`: same as `podAndContainer` except that the pod name is skipped if it's the same as the container name. `none`: don't add a prefix.",
+          "x-intellij-html-description": "defines the prefix shown on each log line. Valid values are <code>container</code>: prefix logs lines with the name of the container. <code>podAndContainer</code>: prefix logs lines with the names of the pod and of the container. <code>auto</code>: same as <code>podAndContainer</code> except that the pod name is skipped if it's the same as the container name. <code>none</code>: don't add a prefix.",
+          "default": "auto",
+          "enum": [
+            "container",
+            "podAndContainer",
+            "auto",
+            "none"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "prefix"
+      ],
+      "additionalProperties": false,
+      "description": "configures how container logs are printed as a result of a deployment.",
+      "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
+    },
+    "Metadata": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "an identifier for the project.",
+          "x-intellij-html-description": "an identifier for the project."
+        }
+      },
+      "preferredOrder": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "description": "holds an optional name of the project.",
+      "x-intellij-html-description": "holds an optional name of the project."
+    },
+    "PortForwardResource": {
+      "properties": {
+        "address": {
+          "type": "string",
+          "description": "local address to bind to. Defaults to the loopback address 127.0.0.1.",
+          "x-intellij-html-description": "local address to bind to. Defaults to the loopback address 127.0.0.1."
+        },
+        "localPort": {
+          "type": "integer",
+          "description": "local port to forward to. If the port is unavailable, Skaffold will choose a random open port to forward to. *Optional*.",
+          "x-intellij-html-description": "local port to forward to. If the port is unavailable, Skaffold will choose a random open port to forward to. <em>Optional</em>."
+        },
+        "namespace": {
+          "type": "string",
+          "description": "namespace of the resource to port forward.",
+          "x-intellij-html-description": "namespace of the resource to port forward."
+        },
+        "port": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "integer"
+            }
+          ],
+          "description": "resource port that will be forwarded.",
+          "x-intellij-html-description": "resource port that will be forwarded."
+        },
+        "resourceName": {
+          "type": "string",
+          "description": "name of the Kubernetes resource to port forward.",
+          "x-intellij-html-description": "name of the Kubernetes resource to port forward."
+        },
+        "resourceType": {
+          "type": "string",
+          "description": "Kubernetes type that should be port forwarded. Acceptable resource types include: `Service`, `Pod` and Controller resource type that has a pod spec: `ReplicaSet`, `ReplicationController`, `Deployment`, `StatefulSet`, `DaemonSet`, `Job`, `CronJob`.",
+          "x-intellij-html-description": "Kubernetes type that should be port forwarded. Acceptable resource types include: <code>Service</code>, <code>Pod</code> and Controller resource type that has a pod spec: <code>ReplicaSet</code>, <code>ReplicationController</code>, <code>Deployment</code>, <code>StatefulSet</code>, <code>DaemonSet</code>, <code>Job</code>, <code>CronJob</code>."
+        }
+      },
+      "preferredOrder": [
+        "resourceType",
+        "resourceName",
+        "namespace",
+        "port",
+        "address",
+        "localPort"
+      ],
+      "additionalProperties": false,
+      "description": "describes a resource to port forward.",
+      "x-intellij-html-description": "describes a resource to port forward."
+    },
+    "Profile": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "activation": {
+          "items": {
+            "$ref": "#/definitions/Activation"
+          },
+          "type": "array",
+          "description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.",
+          "x-intellij-html-description": "criteria by which a profile can be auto-activated. The profile is auto-activated if any one of the activations are triggered. An activation is triggered if all of the criteria (env, kubeContext, command) are triggered."
+        },
+        "build": {
+          "$ref": "#/definitions/BuildConfig",
+          "description": "describes how images are built.",
+          "x-intellij-html-description": "describes how images are built."
+        },
+        "deploy": {
+          "$ref": "#/definitions/DeployConfig",
+          "description": "describes how the manifests are deployed.",
+          "x-intellij-html-description": "describes how the manifests are deployed."
+        },
+        "name": {
+          "type": "string",
+          "description": "a unique profile name.",
+          "x-intellij-html-description": "a unique profile name.",
+          "examples": [
+            "profile-prod"
+          ]
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/definitions/JSONPatch"
+          },
+          "type": "array",
+          "description": "patches applied to the configuration. Patches use the JSON patch notation.",
+          "x-intellij-html-description": "patches applied to the configuration. Patches use the JSON patch notation."
+        },
+        "portForward": {
+          "items": {
+            "$ref": "#/definitions/PortForwardResource"
+          },
+          "type": "array",
+          "description": "describes user defined resources to port-forward.",
+          "x-intellij-html-description": "describes user defined resources to port-forward."
+        },
+        "render": {
+          "$ref": "#/definitions/RenderConfig",
+          "description": "describes how the original manifests are hydrated, validated and transformed.",
+          "x-intellij-html-description": "describes how the original manifests are hydrated, validated and transformed."
+        },
+        "test": {
+          "items": {
+            "$ref": "#/definitions/TestCase"
+          },
+          "type": "array",
+          "description": "describes how images are tested.",
+          "x-intellij-html-description": "describes how images are tested."
+        }
+      },
+      "preferredOrder": [
+        "name",
+        "activation",
+        "patches",
+        "build",
+        "test",
+        "render",
+        "deploy",
+        "portForward"
+      ],
+      "additionalProperties": false,
+      "description": "used to override any `build`, `test` or `deploy` configuration.",
+      "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
+    },
+    "ProfileDependency": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "activatedBy": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "describes a list of profiles in the current config that when activated will also activate the named profile in the dependency config. If empty then the named profile is always activated.",
+          "x-intellij-html-description": "describes a list of profiles in the current config that when activated will also activate the named profile in the dependency config. If empty then the named profile is always activated.",
+          "default": "[]"
+        },
+        "name": {
+          "type": "string",
+          "description": "describes name of the profile to activate in the dependency config. It should exist in the dependency config.",
+          "x-intellij-html-description": "describes name of the profile to activate in the dependency config. It should exist in the dependency config."
+        }
+      },
+      "preferredOrder": [
+        "name",
+        "activatedBy"
+      ],
+      "additionalProperties": false,
+      "description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles.",
+      "x-intellij-html-description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles."
+    },
+    "RenderConfig": {
+      "properties": {
+        "generate": {
+          "$ref": "#/definitions/Generate",
+          "description": "defines the dry manifests from a variety of sources.",
+          "x-intellij-html-description": "defines the dry manifests from a variety of sources."
+        },
+        "output": {
+          "type": "string",
+          "description": "path to the hydrated directory.",
+          "x-intellij-html-description": "path to the hydrated directory."
+        },
+        "transform": {
+          "description": "defines a set of transformation operations to run in series",
+          "x-intellij-html-description": "defines a set of transformation operations to run in series"
+        },
+        "validate": {
+          "description": "defines a set of validator operations to run in series.",
+          "x-intellij-html-description": "defines a set of validator operations to run in series."
+        }
+      },
+      "preferredOrder": [
+        "generate",
+        "transform",
+        "validate",
+        "output"
+      ],
+      "additionalProperties": false,
+      "description": "contains all the configuration needed by the render steps.",
+      "x-intellij-html-description": "contains all the configuration needed by the render steps."
+    },
+    "ResourceRequirement": {
+      "properties": {
+        "cpu": {
+          "type": "string",
+          "description": "the number cores to be used.",
+          "x-intellij-html-description": "the number cores to be used.",
+          "examples": [
+            "2`, `2.0` or `200m"
+          ]
+        },
+        "ephemeralStorage": {
+          "type": "string",
+          "description": "the amount of Ephemeral storage to allocate to the pod.",
+          "x-intellij-html-description": "the amount of Ephemeral storage to allocate to the pod.",
+          "examples": [
+            "1Gi` or `1000Mi"
+          ]
+        },
+        "memory": {
+          "type": "string",
+          "description": "the amount of memory to allocate to the pod.",
+          "x-intellij-html-description": "the amount of memory to allocate to the pod.",
+          "examples": [
+            "1Gi` or `1000Mi"
+          ]
+        },
+        "resourceStorage": {
+          "type": "string",
+          "description": "the amount of resource storage to allocate to the pod.",
+          "x-intellij-html-description": "the amount of resource storage to allocate to the pod.",
+          "examples": [
+            "1Gi` or `1000Mi"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "cpu",
+        "memory",
+        "ephemeralStorage",
+        "resourceStorage"
+      ],
+      "additionalProperties": false,
+      "description": "stores the CPU/Memory requirements for the pod.",
+      "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
+    },
+    "ResourceRequirements": {
+      "properties": {
+        "limits": {
+          "$ref": "#/definitions/ResourceRequirement",
+          "description": "[resource limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container) for the Kaniko pod.",
+          "x-intellij-html-description": "<a href=\"https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container\">resource limits</a> for the Kaniko pod."
+        },
+        "requests": {
+          "$ref": "#/definitions/ResourceRequirement",
+          "description": "[resource requests](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container) for the Kaniko pod.",
+          "x-intellij-html-description": "<a href=\"https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container\">resource requests</a> for the Kaniko pod."
+        }
+      },
+      "preferredOrder": [
+        "requests",
+        "limits"
+      ],
+      "additionalProperties": false,
+      "description": "describes the resource requirements for the kaniko pod.",
+      "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
+    },
+    "ResourceType": {
+      "type": "string",
+      "description": "describes the Kubernetes resource types used for port forwarding.",
+      "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
+    },
+    "ShaTagger": {
+      "description": "*beta* tags images with their sha256 digest.",
+      "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
+    },
+    "SkaffoldConfig": {
+      "required": [
+        "apiVersion",
+        "kind"
+      ],
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "version of the configuration.",
+          "x-intellij-html-description": "version of the configuration."
+        },
+        "build": {
+          "$ref": "#/definitions/BuildConfig",
+          "description": "describes how images are built.",
+          "x-intellij-html-description": "describes how images are built."
+        },
+        "deploy": {
+          "$ref": "#/definitions/DeployConfig",
+          "description": "describes how the manifests are deployed.",
+          "x-intellij-html-description": "describes how the manifests are deployed."
+        },
+        "kind": {
+          "type": "string",
+          "description": "always `Config`.",
+          "x-intellij-html-description": "always <code>Config</code>.",
+          "default": "Config"
+        },
+        "metadata": {
+          "$ref": "#/definitions/Metadata",
+          "description": "holds additional information about the config.",
+          "x-intellij-html-description": "holds additional information about the config."
+        },
+        "portForward": {
+          "items": {
+            "$ref": "#/definitions/PortForwardResource"
+          },
+          "type": "array",
+          "description": "describes user defined resources to port-forward.",
+          "x-intellij-html-description": "describes user defined resources to port-forward."
+        },
+        "profiles": {
+          "items": {
+            "$ref": "#/definitions/Profile"
+          },
+          "type": "array",
+          "description": "*beta* can override be used to `build`, `test` or `deploy` configuration.",
+          "x-intellij-html-description": "<em>beta</em> can override be used to <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
+        },
+        "render": {
+          "$ref": "#/definitions/RenderConfig",
+          "description": "describes how the original manifests are hydrated, validated and transformed.",
+          "x-intellij-html-description": "describes how the original manifests are hydrated, validated and transformed."
+        },
+        "requires": {
+          "items": {
+            "$ref": "#/definitions/ConfigDependency"
+          },
+          "type": "array",
+          "description": "describes a list of other required configs for the current config.",
+          "x-intellij-html-description": "describes a list of other required configs for the current config."
+        },
+        "test": {
+          "items": {
+            "$ref": "#/definitions/TestCase"
+          },
+          "type": "array",
+          "description": "describes how images are tested.",
+          "x-intellij-html-description": "describes how images are tested."
+        }
+      },
+      "preferredOrder": [
+        "apiVersion",
+        "kind",
+        "metadata",
+        "requires",
+        "build",
+        "test",
+        "render",
+        "deploy",
+        "portForward",
+        "profiles"
+      ],
+      "additionalProperties": false,
+      "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
+      "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
+    },
+    "Sync": {
+      "properties": {
+        "auto": {
+          "type": "boolean",
+          "description": "delegates discovery of sync rules to the build system. Only available for jib and buildpacks.",
+          "x-intellij-html-description": "delegates discovery of sync rules to the build system. Only available for jib and buildpacks."
+        },
+        "infer": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "file patterns which may be synced into the container The container destination is inferred by the builder based on the instructions of a Dockerfile. Available for docker and kaniko artifacts and custom artifacts that declare dependencies on a dockerfile.",
+          "x-intellij-html-description": "file patterns which may be synced into the container The container destination is inferred by the builder based on the instructions of a Dockerfile. Available for docker and kaniko artifacts and custom artifacts that declare dependencies on a dockerfile.",
+          "default": "[]"
+        },
+        "manual": {
+          "items": {
+            "$ref": "#/definitions/SyncRule"
+          },
+          "type": "array",
+          "description": "manual sync rules indicating the source and destination.",
+          "x-intellij-html-description": "manual sync rules indicating the source and destination."
+        }
+      },
+      "preferredOrder": [
+        "manual",
+        "infer",
+        "auto"
+      ],
+      "additionalProperties": false,
+      "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
+      "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
+      "default": "infer: [\"**/*\"]"
+    },
+    "SyncRule": {
+      "required": [
+        "src",
+        "dest"
+      ],
+      "properties": {
+        "dest": {
+          "type": "string",
+          "description": "destination path in the container where the files should be synced to.",
+          "x-intellij-html-description": "destination path in the container where the files should be synced to.",
+          "examples": [
+            "\"app/\""
+          ]
+        },
+        "src": {
+          "type": "string",
+          "description": "a glob pattern to match local paths against. Directories should be delimited by `/` on all platforms.",
+          "x-intellij-html-description": "a glob pattern to match local paths against. Directories should be delimited by <code>/</code> on all platforms.",
+          "examples": [
+            "\"css/**/*.css\""
+          ]
+        },
+        "strip": {
+          "type": "string",
+          "description": "specifies the path prefix to remove from the source path when transplanting the files into the destination folder.",
+          "x-intellij-html-description": "specifies the path prefix to remove from the source path when transplanting the files into the destination folder.",
+          "examples": [
+            "\"css/\""
+          ]
+        }
+      },
+      "preferredOrder": [
+        "src",
+        "dest",
+        "strip"
+      ],
+      "additionalProperties": false,
+      "description": "specifies which local files to sync to remote folders.",
+      "x-intellij-html-description": "specifies which local files to sync to remote folders."
+    },
+    "TagPolicy": {
+      "properties": {
+        "customTemplate": {
+          "$ref": "#/definitions/CustomTemplateTagger",
+          "description": "*beta* tags images with a configurable template string *composed of other taggers*.",
+          "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string <em>composed of other taggers</em>."
+        },
+        "dateTime": {
+          "$ref": "#/definitions/DateTimeTagger",
+          "description": "*beta* tags images with the build timestamp.",
+          "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
+        },
+        "envTemplate": {
+          "$ref": "#/definitions/EnvTemplateTagger",
+          "description": "*beta* tags images with a configurable template string.",
+          "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
+        },
+        "gitCommit": {
+          "$ref": "#/definitions/GitTagger",
+          "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
+          "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
+        },
+        "sha256": {
+          "$ref": "#/definitions/ShaTagger",
+          "description": "*beta* tags images with their sha256 digest.",
+          "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
+        }
+      },
+      "preferredOrder": [
+        "gitCommit",
+        "sha256",
+        "envTemplate",
+        "dateTime",
+        "customTemplate"
+      ],
+      "additionalProperties": false,
+      "description": "contains all the configuration for the tagging step.",
+      "x-intellij-html-description": "contains all the configuration for the tagging step."
+    },
+    "TaggerComponent": {
+      "anyOf": [
+        {
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "gitCommit": {
+              "$ref": "#/definitions/GitTagger",
+              "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
+              "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
+            },
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "gitCommit"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            },
+            "sha256": {
+              "$ref": "#/definitions/ShaTagger",
+              "description": "*beta* tags images with their sha256 digest.",
+              "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "sha256"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "envTemplate": {
+              "$ref": "#/definitions/EnvTemplateTagger",
+              "description": "*beta* tags images with a configurable template string.",
+              "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
+            },
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "envTemplate"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "dateTime": {
+              "$ref": "#/definitions/DateTimeTagger",
+              "description": "*beta* tags images with the build timestamp.",
+              "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
+            },
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "dateTime"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "properties": {
+            "customTemplate": {
+              "$ref": "#/definitions/CustomTemplateTagger",
+              "description": "*beta* tags images with a configurable template string *composed of other taggers*.",
+              "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string <em>composed of other taggers</em>."
+            },
+            "name": {
+              "type": "string",
+              "description": "an identifier for the component.",
+              "x-intellij-html-description": "an identifier for the component."
+            }
+          },
+          "preferredOrder": [
+            "name",
+            "customTemplate"
+          ],
+          "additionalProperties": false
+        }
+      ],
+      "description": "*beta* a component of CustomTemplateTagger.",
+      "x-intellij-html-description": "<em>beta</em> a component of CustomTemplateTagger."
+    },
+    "TestCase": {
+      "required": [
+        "image"
+      ],
+      "properties": {
+        "custom": {
+          "items": {
+            "$ref": "#/definitions/CustomTest"
+          },
+          "type": "array",
+          "description": "the set of custom tests to run after an artifact is built.",
+          "x-intellij-html-description": "the set of custom tests to run after an artifact is built."
+        },
+        "image": {
+          "type": "string",
+          "description": "artifact on which to run those tests.",
+          "x-intellij-html-description": "artifact on which to run those tests.",
+          "examples": [
+            "gcr.io/k8s-skaffold/example"
+          ]
+        },
+        "structureTests": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "the [Container Structure Tests](https://github.com/GoogleContainerTools/container-structure-test) to run on that artifact.",
+          "x-intellij-html-description": "the <a href=\"https://github.com/GoogleContainerTools/container-structure-test\">Container Structure Tests</a> to run on that artifact.",
+          "default": "[]",
+          "examples": [
+            "[\"./test/*\"]"
+          ]
+        }
+      },
+      "preferredOrder": [
+        "image",
+        "custom",
+        "structureTests"
+      ],
+      "additionalProperties": false,
+      "description": "a list of tests to run on images that Skaffold builds.",
+      "x-intellij-html-description": "a list of tests to run on images that Skaffold builds."
+    },
+    "Transformer": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "transformer name. Can only accept skaffold whitelisted tools.",
+          "x-intellij-html-description": "transformer name. Can only accept skaffold whitelisted tools."
+        }
+      },
+      "preferredOrder": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "description": "describes the supported kpt transformers.",
+      "x-intellij-html-description": "describes the supported kpt transformers."
+    },
+    "Validator": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Validator name. Can only accept skaffold whitelisted tools.",
+          "x-intellij-html-description": "Validator name. Can only accept skaffold whitelisted tools."
+        }
+      },
+      "preferredOrder": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "description": "Transformer describes the supported kpt transformers.",
+      "x-intellij-html-description": "Transformer describes the supported kpt transformers."
+    }
+  }
+}

--- a/pkg/skaffold/schema/v3alpha1/config.go
+++ b/pkg/skaffold/schema/v3alpha1/config.go
@@ -1,0 +1,1405 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v3alpha1
+
+import (
+	"encoding/json"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
+)
+
+const Version string = "skaffold/v3alpha1"
+
+// NewSkaffoldConfig creates a SkaffoldConfig
+func NewSkaffoldConfig() util.VersionedConfig {
+	return new(SkaffoldConfig)
+}
+
+// SkaffoldConfig holds the fields parsed from the Skaffold configuration file (skaffold.yaml).
+type SkaffoldConfig struct {
+	// APIVersion is the version of the configuration.
+	APIVersion string `yaml:"apiVersion" yamltags:"required"`
+
+	// Kind is always `Config`. Defaults to `Config`.
+	Kind string `yaml:"kind" yamltags:"required"`
+
+	// Metadata holds additional information about the config.
+	Metadata Metadata `yaml:"metadata,omitempty"`
+
+	// Dependencies describes a list of other required configs for the current config.
+	Dependencies []ConfigDependency `yaml:"requires,omitempty"`
+
+	// Pipeline defines the Build/Test/Deploy phases.
+	Pipeline `yaml:",inline"`
+
+	// Profiles *beta* can override be used to `build`, `test` or `deploy` configuration.
+	Profiles []Profile `yaml:"profiles,omitempty"`
+}
+
+// Metadata holds an optional name of the project.
+type Metadata struct {
+	// Name is an identifier for the project.
+	Name string `yaml:"name,omitempty"`
+}
+
+// Pipeline describes a Skaffold pipeline.
+type Pipeline struct {
+	// Build describes how images are built.
+	Build BuildConfig `yaml:"build,omitempty"`
+
+	// Test describes how images are tested.
+	Test []*TestCase `yaml:"test,omitempty"`
+
+	// Render describes how the original manifests are hydrated, validated and transformed.
+	Render RenderConfig `yaml:"render,omitempty"`
+
+	// Deploy describes how the manifests are deployed.
+	Deploy DeployConfig `yaml:"deploy,omitempty"`
+
+	// PortForward describes user defined resources to port-forward.
+	PortForward []*PortForwardResource `yaml:"portForward,omitempty"`
+}
+
+// GitInfo contains information on the origin of skaffold configurations cloned from a git repository.
+type GitInfo struct {
+	// Repo is the git repository the package should be cloned from.  e.g. `https://github.com/GoogleContainerTools/skaffold.git`.
+	Repo string `yaml:"repo" yamltags:"required"`
+
+	// Path is the relative path from the repo root to the skaffold configuration file. eg. `getting-started/skaffold.yaml`.
+	Path string `yaml:"path,omitempty"`
+
+	// Ref is the git ref the package should be cloned from. eg. `master` or `main`.
+	Ref string `yaml:"ref,omitempty"`
+
+	// Sync when set to `true` will reset the cached repository to the latest commit from remote on every run. To use the cached repository with uncommitted changes or unpushed commits, it needs to be set to `false`.
+	Sync *bool `yaml:"sync,omitempty"`
+}
+
+// ConfigDependency describes a dependency on another skaffold configuration.
+type ConfigDependency struct {
+	// Names includes specific named configs within the file path. If empty, then all configs in the file are included.
+	Names []string `yaml:"configs,omitempty"`
+
+	// Path describes the path to the file containing the required configs.
+	Path string `yaml:"path,omitempty" skaffold:"filepath" yamltags:"oneOf=paths"`
+
+	// GitRepo describes a remote git repository containing the required configs.
+	GitRepo *GitInfo `yaml:"git,omitempty" yamltags:"oneOf=paths"`
+
+	// ActiveProfiles describes the list of profiles to activate when resolving the required configs. These profiles must exist in the imported config.
+	ActiveProfiles []ProfileDependency `yaml:"activeProfiles,omitempty"`
+}
+
+// ProfileDependency describes a mapping from referenced config profiles to the current config profiles.
+// If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles.
+type ProfileDependency struct {
+	// Name describes name of the profile to activate in the dependency config. It should exist in the dependency config.
+	Name string `yaml:"name" yamltags:"required"`
+
+	// ActivatedBy describes a list of profiles in the current config that when activated will also activate the named profile in the dependency config. If empty then the named profile is always activated.
+	ActivatedBy []string `yaml:"activatedBy,omitempty"`
+}
+
+func (c *SkaffoldConfig) GetVersion() string {
+	return c.APIVersion
+}
+
+// ResourceType describes the Kubernetes resource types used for port forwarding.
+type ResourceType string
+
+// PortForwardResource describes a resource to port forward.
+type PortForwardResource struct {
+	// Type is the Kubernetes type that should be port forwarded.
+	// Acceptable resource types include: `Service`, `Pod` and Controller resource type that has a pod spec: `ReplicaSet`, `ReplicationController`, `Deployment`, `StatefulSet`, `DaemonSet`, `Job`, `CronJob`.
+	Type ResourceType `yaml:"resourceType,omitempty"`
+
+	// Name is the name of the Kubernetes resource to port forward.
+	Name string `yaml:"resourceName,omitempty"`
+
+	// Namespace is the namespace of the resource to port forward.
+	Namespace string `yaml:"namespace,omitempty"`
+
+	// Port is the resource port that will be forwarded.
+	Port util.IntOrString `yaml:"port,omitempty"`
+
+	// Address is the local address to bind to. Defaults to the loopback address 127.0.0.1.
+	Address string `yaml:"address,omitempty"`
+
+	// LocalPort is the local port to forward to. If the port is unavailable, Skaffold will choose a random open port to forward to. *Optional*.
+	LocalPort int `yaml:"localPort,omitempty"`
+}
+
+// BuildConfig contains all the configuration for the build steps.
+type BuildConfig struct {
+	// Artifacts lists the images you're going to be building.
+	Artifacts []*Artifact `yaml:"artifacts,omitempty"`
+
+	// InsecureRegistries is a list of registries declared by the user to be insecure.
+	// These registries will be connected to via HTTP instead of HTTPS.
+	InsecureRegistries []string `yaml:"insecureRegistries,omitempty"`
+
+	// TagPolicy *beta* determines how images are tagged.
+	// A few strategies are provided here, although you most likely won't need to care!
+	// If not specified, it defaults to `gitCommit: {variant: Tags}`.
+	TagPolicy TagPolicy `yaml:"tagPolicy,omitempty"`
+
+	BuildType `yaml:",inline"`
+}
+
+// TagPolicy contains all the configuration for the tagging step.
+type TagPolicy struct {
+	// GitTagger *beta* tags images with the git tag or commit of the artifact's workspace.
+	GitTagger *GitTagger `yaml:"gitCommit,omitempty" yamltags:"oneOf=tag"`
+
+	// ShaTagger *beta* tags images with their sha256 digest.
+	ShaTagger *ShaTagger `yaml:"sha256,omitempty" yamltags:"oneOf=tag"`
+
+	// EnvTemplateTagger *beta* tags images with a configurable template string.
+	EnvTemplateTagger *EnvTemplateTagger `yaml:"envTemplate,omitempty" yamltags:"oneOf=tag"`
+
+	// DateTimeTagger *beta* tags images with the build timestamp.
+	DateTimeTagger *DateTimeTagger `yaml:"dateTime,omitempty" yamltags:"oneOf=tag"`
+
+	// CustomTemplateTagger *beta* tags images with a configurable template string *composed of other taggers*.
+	CustomTemplateTagger *CustomTemplateTagger `yaml:"customTemplate,omitempty" yamltags:"oneOf=tag"`
+}
+
+// ShaTagger *beta* tags images with their sha256 digest.
+type ShaTagger struct{}
+
+// GitTagger *beta* tags images with the git tag or commit of the artifact's workspace.
+type GitTagger struct {
+	// Variant determines the behavior of the git tagger. Valid variants are:
+	// `Tags` (default): use git tags or fall back to abbreviated commit hash.
+	// `CommitSha`: use the full git commit sha.
+	// `AbbrevCommitSha`: use the abbreviated git commit sha.
+	// `TreeSha`: use the full tree hash of the artifact workingdir.
+	// `AbbrevTreeSha`: use the abbreviated tree hash of the artifact workingdir.
+	Variant string `yaml:"variant,omitempty"`
+
+	// Prefix adds a fixed prefix to the tag.
+	Prefix string `yaml:"prefix,omitempty"`
+
+	// IgnoreChanges specifies whether to omit the `-dirty` postfix if there are uncommitted changes.
+	IgnoreChanges bool `yaml:"ignoreChanges,omitempty"`
+}
+
+// EnvTemplateTagger *beta* tags images with a configurable template string.
+type EnvTemplateTagger struct {
+	// Template used to produce the image name and tag.
+	// See golang [text/template](https://golang.org/pkg/text/template/).
+	// The template is executed against the current environment,
+	// with those variables injected.
+	// For example: `{{.RELEASE}}`.
+	Template string `yaml:"template,omitempty" yamltags:"required"`
+}
+
+// DateTimeTagger *beta* tags images with the build timestamp.
+type DateTimeTagger struct {
+	// Format formats the date and time.
+	// See [#Time.Format](https://golang.org/pkg/time/#Time.Format).
+	// Defaults to `2006-01-02_15-04-05.999_MST`.
+	Format string `yaml:"format,omitempty"`
+
+	// TimeZone sets the timezone for the date and time.
+	// See [Time.LoadLocation](https://golang.org/pkg/time/#Time.LoadLocation).
+	// Defaults to the local timezone.
+	TimeZone string `yaml:"timezone,omitempty"`
+}
+
+// CustomTemplateTagger *beta* tags images with a configurable template string.
+type CustomTemplateTagger struct {
+	// Template used to produce the image name and tag.
+	// See golang [text/template](https://golang.org/pkg/text/template/).
+	// The template is executed against the provided components with those variables injected.
+	// For example: `{{.DATE}}` where DATE references a TaggerComponent.
+	Template string `yaml:"template,omitempty" yamltags:"required"`
+
+	// Components lists TaggerComponents that the template (see field above) can be executed against.
+	Components []TaggerComponent `yaml:"components,omitempty"`
+}
+
+// TaggerComponent *beta* is a component of CustomTemplateTagger.
+type TaggerComponent struct {
+	// Name is an identifier for the component.
+	Name string `yaml:"name,omitempty"`
+
+	// Component is a tagging strategy to be used in CustomTemplateTagger.
+	Component TagPolicy `yaml:",inline" yamltags:"skipTrim"`
+}
+
+// BuildType contains the specific implementation and parameters needed
+// for the build step. Only one field should be populated.
+type BuildType struct {
+	// LocalBuild *beta* describes how to do a build on the local docker daemon
+	// and optionally push to a repository.
+	LocalBuild *LocalBuild `yaml:"local,omitempty" yamltags:"oneOf=build"`
+
+	// GoogleCloudBuild *beta* describes how to do a remote build on
+	// [Google Cloud Build](https://cloud.google.com/cloud-build/).
+	GoogleCloudBuild *GoogleCloudBuild `yaml:"googleCloudBuild,omitempty" yamltags:"oneOf=build"`
+
+	// Cluster *beta* describes how to do an on-cluster build.
+	Cluster *ClusterDetails `yaml:"cluster,omitempty" yamltags:"oneOf=build"`
+}
+
+// LocalBuild *beta* describes how to do a build on the local docker daemon
+// and optionally push to a repository.
+type LocalBuild struct {
+	// Push should images be pushed to a registry.
+	// If not specified, images are pushed only if the current Kubernetes context
+	// connects to a remote cluster.
+	Push *bool `yaml:"push,omitempty"`
+
+	// TryImportMissing whether to attempt to import artifacts from
+	// Docker (either a local or remote registry) if not in the cache.
+	TryImportMissing bool `yaml:"tryImportMissing,omitempty"`
+
+	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
+	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
+
+	// UseBuildkit use BuildKit to build Docker images.
+	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+
+	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
+	// Defaults to `1`.
+	Concurrency *int `yaml:"concurrency,omitempty"`
+}
+
+// GoogleCloudBuild *beta* describes how to do a remote build on
+// [Google Cloud Build](https://cloud.google.com/cloud-build/docs/).
+// Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs
+// to be provided and the currently logged in user should be given permissions to trigger
+// new builds.
+type GoogleCloudBuild struct {
+	// ProjectID is the ID of your Cloud Platform Project.
+	// If it is not provided, Skaffold will guess it from the image name.
+	// For example, given the artifact image name `gcr.io/myproject/image`, Skaffold
+	// will use the `myproject` GCP project.
+	ProjectID string `yaml:"projectId,omitempty"`
+
+	// DiskSizeGb is the disk size of the VM that runs the build.
+	// See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions).
+	DiskSizeGb int64 `yaml:"diskSizeGb,omitempty"`
+
+	// MachineType is the type of the VM that runs the build.
+	// See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#buildoptions).
+	MachineType string `yaml:"machineType,omitempty"`
+
+	// Timeout is the amount of time (in seconds) that this build should be allowed to run.
+	// See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#resource-build).
+	Timeout string `yaml:"timeout,omitempty"`
+
+	// Logging specifies the logging mode.
+	// Valid modes are:
+	// `LOGGING_UNSPECIFIED`: The service determines the logging mode.
+	// `LEGACY`: Stackdriver logging and Cloud Storage logging are enabled (default).
+	// `GCS_ONLY`: Only Cloud Storage logging is enabled.
+	// See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#loggingmode).
+	Logging string `yaml:"logging,omitempty"`
+
+	// LogStreamingOption specifies the behavior when writing build logs to Google Cloud Storage.
+	// Valid options are:
+	// `STREAM_DEFAULT`: Service may automatically determine build log streaming behavior.
+	// `STREAM_ON`:  Build logs should be streamed to Google Cloud Storage.
+	// `STREAM_OFF`: Build logs should not be streamed to Google Cloud Storage; they will be written when the build is completed.
+	// See [Cloud Build Reference](https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.builds#logstreamingoption).
+	LogStreamingOption string `yaml:"logStreamingOption,omitempty"`
+
+	// DockerImage is the image that runs a Docker build.
+	// See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).
+	// Defaults to `gcr.io/cloud-builders/docker`.
+	DockerImage string `yaml:"dockerImage,omitempty"`
+
+	// KanikoImage is the image that runs a Kaniko build.
+	// See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).
+	// Defaults to `gcr.io/kaniko-project/executor`.
+	KanikoImage string `yaml:"kanikoImage,omitempty"`
+
+	// MavenImage is the image that runs a Maven build.
+	// See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).
+	// Defaults to `gcr.io/cloud-builders/mvn`.
+	MavenImage string `yaml:"mavenImage,omitempty"`
+
+	// GradleImage is the image that runs a Gradle build.
+	// See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).
+	// Defaults to `gcr.io/cloud-builders/gradle`.
+	GradleImage string `yaml:"gradleImage,omitempty"`
+
+	// PackImage is the image that runs a Cloud Native Buildpacks build.
+	// See [Cloud Builders](https://cloud.google.com/cloud-build/docs/cloud-builders).
+	// Defaults to `gcr.io/k8s-skaffold/pack`.
+	PackImage string `yaml:"packImage,omitempty"`
+
+	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
+	// Defaults to `0`.
+	Concurrency int `yaml:"concurrency,omitempty"`
+
+	// WorkerPool configures a pool of workers to run the build.
+	WorkerPool string `yaml:"workerPool,omitempty"`
+}
+
+// KanikoCache configures Kaniko caching. If a cache is specified, Kaniko will
+// use a remote cache which will speed up builds.
+type KanikoCache struct {
+	// Repo is a remote repository to store cached layers. If none is specified, one will be
+	// inferred from the image name. See [Kaniko Caching](https://github.com/GoogleContainerTools/kaniko#caching).
+	Repo string `yaml:"repo,omitempty"`
+	// HostPath specifies a path on the host that is mounted to each pod as read only cache volume containing base images.
+	// If set, must exist on each node and prepopulated with kaniko-warmer.
+	HostPath string `yaml:"hostPath,omitempty"`
+	// TTL Cache timeout in hours.
+	TTL string `yaml:"ttl,omitempty"`
+}
+
+// ClusterDetails *beta* describes how to do an on-cluster build.
+type ClusterDetails struct {
+	// HTTPProxy for kaniko pod.
+	HTTPProxy string `yaml:"HTTP_PROXY,omitempty"`
+
+	// HTTPSProxy for kaniko pod.
+	HTTPSProxy string `yaml:"HTTPS_PROXY,omitempty"`
+
+	// PullSecretPath is the path to the Google Cloud service account secret key file.
+	PullSecretPath string `yaml:"pullSecretPath,omitempty"`
+
+	// PullSecretName is the name of the Kubernetes secret for pulling base images
+	// and pushing the final image. If given, the secret needs to contain the Google Cloud
+	// service account secret key under the key `kaniko-secret`.
+	// Defaults to `kaniko-secret`.
+	PullSecretName string `yaml:"pullSecretName,omitempty"`
+
+	// PullSecretMountPath is the path the pull secret will be mounted at within the running container.
+	PullSecretMountPath string `yaml:"pullSecretMountPath,omitempty"`
+
+	// Namespace is the Kubernetes namespace.
+	// Defaults to current namespace in Kubernetes configuration.
+	Namespace string `yaml:"namespace,omitempty"`
+
+	// Timeout is the amount of time (in seconds) that this build is allowed to run.
+	// Defaults to 20 minutes (`20m`).
+	Timeout string `yaml:"timeout,omitempty"`
+
+	// DockerConfig describes how to mount the local Docker configuration into a pod.
+	DockerConfig *DockerConfig `yaml:"dockerConfig,omitempty"`
+
+	// ServiceAccountName describes the Kubernetes service account to use for the pod.
+	// Defaults to 'default'.
+	ServiceAccountName string `yaml:"serviceAccount,omitempty"`
+
+	// Tolerations describes the Kubernetes tolerations for the pod.
+	Tolerations []v1.Toleration `yaml:"tolerations,omitempty"`
+
+	// Annotations describes the Kubernetes annotations for the pod.
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+
+	// RunAsUser defines the UID to request for running the container.
+	// If omitted, no SeurityContext will be specified for the pod and will therefore be inherited
+	// from the service account.
+	RunAsUser *int64 `yaml:"runAsUser,omitempty"`
+
+	// Resources define the resource requirements for the kaniko pod.
+	Resources *ResourceRequirements `yaml:"resources,omitempty"`
+
+	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
+	// Defaults to `0`.
+	Concurrency int `yaml:"concurrency,omitempty"`
+
+	// Volumes defines container mounts for ConfigMap and Secret resources.
+	Volumes []v1.Volume `yaml:"volumes,omitempty"`
+
+	// RandomPullSecret adds a random UUID postfix to the default name of the pull secret to facilitate parallel builds, e.g. kaniko-secretdocker-cfgfd154022-c761-416f-8eb3-cf8258450b85.
+	RandomPullSecret bool `yaml:"randomPullSecret,omitempty"`
+
+	// RandomDockerConfigSecret adds a random UUID postfix to the default name of the docker secret to facilitate parallel builds, e.g. docker-cfgfd154022-c761-416f-8eb3-cf8258450b85.
+	RandomDockerConfigSecret bool `yaml:"randomDockerConfigSecret,omitempty"`
+}
+
+// DockerConfig contains information about the docker `config.json` to mount.
+type DockerConfig struct {
+	// Path is the path to the docker `config.json`.
+	Path string `yaml:"path,omitempty"`
+
+	// SecretName is the Kubernetes secret that contains the `config.json` Docker configuration.
+	// Note that the expected secret type is not 'kubernetes.io/dockerconfigjson' but 'Opaque'.
+	SecretName string `yaml:"secretName,omitempty"`
+}
+
+// ResourceRequirements describes the resource requirements for the kaniko pod.
+type ResourceRequirements struct {
+	// Requests [resource requests](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container) for the Kaniko pod.
+	Requests *ResourceRequirement `yaml:"requests,omitempty"`
+
+	// Limits [resource limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container) for the Kaniko pod.
+	Limits *ResourceRequirement `yaml:"limits,omitempty"`
+}
+
+// ResourceRequirement stores the CPU/Memory requirements for the pod.
+type ResourceRequirement struct {
+	// CPU the number cores to be used.
+	// For example: `2`, `2.0` or `200m`.
+	CPU string `yaml:"cpu,omitempty"`
+
+	// Memory the amount of memory to allocate to the pod.
+	// For example: `1Gi` or `1000Mi`.
+	Memory string `yaml:"memory,omitempty"`
+
+	// EphemeralStorage the amount of Ephemeral storage to allocate to the pod.
+	// For example: `1Gi` or `1000Mi`.
+	EphemeralStorage string `yaml:"ephemeralStorage,omitempty"`
+
+	// ResourceStorage the amount of resource storage to allocate to the pod.
+	// For example: `1Gi` or `1000Mi`.
+	ResourceStorage string `yaml:"resourceStorage,omitempty"`
+}
+
+// TestCase is a list of tests to run on images that Skaffold builds.
+type TestCase struct {
+	// ImageName is the artifact on which to run those tests.
+	// For example: `gcr.io/k8s-skaffold/example`.
+	ImageName string `yaml:"image" yamltags:"required"`
+
+	// CustomTests lists the set of custom tests to run after an artifact is built.
+	CustomTests []CustomTest `yaml:"custom,omitempty"`
+
+	// StructureTests lists the [Container Structure Tests](https://github.com/GoogleContainerTools/container-structure-test)
+	// to run on that artifact.
+	// For example: `["./test/*"]`.
+	StructureTests []string `yaml:"structureTests,omitempty"`
+}
+
+// RenderConfig contains all the configuration needed by the render steps.
+type RenderConfig struct {
+
+	// Generate defines the dry manifests from a variety of sources.
+	Generate *Generate `yaml:"generate,omitempty"`
+
+	// Transform defines a set of transformation operations to run in series
+	Transform *[]Transformer `yaml:"transform,omitempty"`
+
+	// Validate defines a set of validator operations to run in series.
+	Validate *[]Validator `yaml:"validate,omitempty"`
+
+	// Output is the path to the hydrated directory.
+	Output string `yaml:"output,omitempty"`
+}
+
+// Generate defines the dry manifests from a variety of sources.
+type Generate struct {
+
+	// Manifests contains the raw kubernetes manifest paths and kustomize paths.
+	Manifests []string `yaml:"Manifests,omitempty"`
+
+	// TODO: Implement the "HelmCharts" and "RemoteResoruces" fields.
+}
+
+// Transformer describes the supported kpt transformers.
+type Transformer struct {
+	// Name is the transformer name. Can only accept skaffold whitelisted tools.
+	Name string `yaml:"name" yamltags:"required"`
+}
+
+// Transformer describes the supported kpt transformers.
+type Validator struct {
+	// Name is the Validator name. Can only accept skaffold whitelisted tools.
+	Name string `yaml:"name" yamltags:"required"`
+}
+
+// DeployConfig contains all the configuration needed by the deploy steps.
+type DeployConfig struct {
+
+	// Dir is equivalent to the dir in `kpt live apply <dir>`. If not provided, skaffold renders the raw manifests
+	// and store them to a a hidden directory `.kpt-hydrated`, and deploys the hidden directory.
+	Dir string `yaml:"dir,omitempty"`
+
+	// **************** kpt live Inventory *************
+	// InventoryID *alpha* is the identifier for a group of applied resources.
+	// This value is only needed when the `kpt live` is working on a pre-applied cluster resources.
+	InventoryID string `yaml:"inventoryID,omitempty"`
+	// InventoryNamespace *alpha* sets the inventory namespace.
+	InventoryNamespace string `yaml:"inventoryNamespace,omitempty"`
+	// ********************** END ***********************
+
+	// **************** kpt live Options ****************
+	// PollPeriod sets for the polling period for resource statuses. Default to 2s. Values can be "2s", "1min", "3h", etc
+	PollPeriod string `statusCheckDeadlineSeconds:"pollPeriod,omitempty"`
+	// PrunePropagationPolicy sets the propagation policy for pruning.
+	// Possible settings are Background, Foreground, Orphan.
+	// Default to "Background".
+	PrunePropagationPolicy string `yaml:"prunePropagationPolicy,omitempty"`
+	// PruneTimeout sets the time threshold to wait for all pruned resources to be deleted.
+	PruneTimeout string `yaml:"pruneTimeout,omitempty"`
+	// ReconcileTimeout sets the time threshold to wait for all resources to reach the current status.
+	ReconcileTimeout string `yaml:"reconcileTimeout,omitempty"`
+	// ********************** END ***********************
+
+	// KubeContext is the Kubernetes context that Skaffold should deploy to.
+	// For example: `minikube`.
+	KubeContext string `yaml:"kubeContext,omitempty"`
+
+	// Logs configures how container logs are printed as a result of a deployment.
+	Logs LogsConfig `yaml:"logs,omitempty"`
+}
+
+/*  DO NOT REMOVE. This comment tracks the unimplemented deployer features. Implemented features have been removed
+from each deployer.
+
+************** DEPRECATED: KubectlDeploy ******************
+
+// KubectlDeploy *beta* uses a client side `kubectl apply` to deploy manifests.
+// You'll need a `kubectl` CLI version installed that's compatible with your cluster.
+type KubectlDeploy struct {
+
+	// TODO: Not implemented yet. Support this feature (may not be this field)
+	// RemoteManifests lists Kubernetes manifests in remote clusters.
+	RemoteManifests []string `yaml:"remoteManifests,omitempty"`
+
+	// TODO: Not implemented yet. Support this feature (may not be this field)
+	// Flags are additional flags passed to `kubectl`.
+	Flags KubectlFlags `yaml:"flags,omitempty"`
+
+
+	// TODO: Not implemented yet. Support this feature (may not be this field)
+	// DefaultNamespace is the default namespace passed to kubectl on deployment if no other override is given.
+	DefaultNamespace *string `yaml:"defaultNamespace,omitempty"`
+}
+
+// KubectlFlags are additional flags passed on the command
+// line to kubectl either on every command (Global), on creations (Apply)
+// or deletions (Delete).
+type KubectlFlags struct {
+	// Global are additional flags passed on every command.
+	Global []string `yaml:"global,omitempty"`
+
+    // TODO: Deprecated. Need to udpate the skaffold documents.
+	// Delete are additional flags passed on deletions (`kubectl delete`).
+	Delete []string `yaml:"delete,omitempty"`
+
+	// TODO: Not implemented yet. Support this feature (may not be this field)
+	// DisableValidation passes the `--validate=false` flag to supported
+	// `kubectl` commands when enabled.
+	DisableValidation bool `yaml:"disableValidation,omitempty"`
+}
+
+// TODO: Not implemented yet. Support this feature (may not be this field)
+// HelmDeploy *beta* uses the `helm` CLI to apply the charts to the cluster.
+type HelmDeploy struct {
+	// Releases is a list of Helm releases.
+	Releases []HelmRelease `yaml:"releases,omitempty" yamltags:"required"`
+
+	// Flags are additional option flags that are passed on the command
+	// line to `helm`.
+	Flags HelmDeployFlags `yaml:"flags,omitempty"`
+}
+
+// TODO: Not implemented yet. Support this feature (may not be this field)
+// HelmDeployFlags are additional option flags that are passed on the command
+// line to `helm`.
+type HelmDeployFlags struct {
+	// Global are additional flags passed on every command.
+	Global []string `yaml:"global,omitempty"`
+
+	// Install are additional flags passed to (`helm install`).
+	Install []string `yaml:"install,omitempty"`
+
+	// Upgrade are additional flags passed to (`helm upgrade`).
+	Upgrade []string `yaml:"upgrade,omitempty"`
+}
+
+// KustomizeDeploy *beta* uses the `kustomize` CLI to "patch" a deployment for a target environment.
+type KustomizeDeploy struct {
+
+     // TODO: Not implemented yet. Support this feature (may not be this field)
+	// BuildArgs are additional args passed to `kustomize build`.
+	BuildArgs []string `yaml:"buildArgs,omitempty"`
+
+     // TODO: Not implemented yet. Support this feature (may not be this field)
+	// DefaultNamespace is the default namespace passed to kubectl on deployment if no other override is given.
+	DefaultNamespace *string `yaml:"defaultNamespace,omitempty"`
+}
+
+// TODO: Not implemented yet. Support this feature (may not be this field)
+// HelmRelease describes a helm release to be deployed.
+type HelmRelease struct {
+	// Name is the name of the Helm release.
+	// It accepts environment variables via the go template syntax.
+	Name string `yaml:"name,omitempty" yamltags:"required"`
+
+	// ChartPath is the local path to a packaged Helm chart or an unpacked Helm chart directory.
+	ChartPath string `yaml:"chartPath,omitempty" yamltags:"oneOf=chartSource" skaffold:"filepath"`
+
+	// RemoteChart refers to a remote Helm chart reference or URL.
+	RemoteChart string `yaml:"remoteChart,omitempty" yamltags:"oneOf=chartSource"`
+
+	// ValuesFiles are the paths to the Helm `values` files.
+	ValuesFiles []string `yaml:"valuesFiles,omitempty" skaffold:"filepath"`
+
+	// ArtifactOverrides are key value pairs where the
+	// key represents the parameter used in the `--set-string` Helm CLI flag to define a container
+	// image and the value corresponds to artifact i.e. `ImageName` defined in `Build.Artifacts` section.
+	// The resulting command-line is controlled by `ImageStrategy`.
+	ArtifactOverrides util.FlatMap `yaml:"artifactOverrides,omitempty"`
+
+	// Namespace is the Kubernetes namespace.
+	Namespace string `yaml:"namespace,omitempty"`
+
+	// Version is the version of the chart.
+	Version string `yaml:"version,omitempty"`
+
+	// SetValues are key-value pairs.
+	// If present, Skaffold will send `--set` flag to Helm CLI and append all pairs after the flag.
+	SetValues util.FlatMap `yaml:"setValues,omitempty"`
+
+	// SetValueTemplates are key-value pairs.
+	// If present, Skaffold will try to parse the value part of each key-value pair using
+	// environment variables in the system, then send `--set` flag to Helm CLI and append
+	// all parsed pairs after the flag.
+	SetValueTemplates util.FlatMap `yaml:"setValueTemplates,omitempty"`
+
+	// SetFiles are key-value pairs.
+	// If present, Skaffold will send `--set-file` flag to Helm CLI and append all pairs after the flag.
+	SetFiles map[string]string `yaml:"setFiles,omitempty" skaffold:"filepath"`
+
+	// CreateNamespace if `true`, Skaffold will send `--create-namespace` flag to Helm CLI.
+	// `--create-namespace` flag is available in Helm since version 3.2.
+	// Defaults is `false`.
+	CreateNamespace *bool `yaml:"createNamespace,omitempty"`
+
+	// Wait if `true`, Skaffold will send `--wait` flag to Helm CLI.
+	// Defaults to `false`.
+	Wait bool `yaml:"wait,omitempty"`
+
+	// RecreatePods if `true`, Skaffold will send `--recreate-pods` flag to Helm CLI
+	// when upgrading a new version of a chart in subsequent dev loop deploy.
+	// Defaults to `false`.
+	RecreatePods bool `yaml:"recreatePods,omitempty"`
+
+	// SkipBuildDependencies should build dependencies be skipped.
+	// Ignored when `remote: true`.
+	SkipBuildDependencies bool `yaml:"skipBuildDependencies,omitempty"`
+
+	// UseHelmSecrets instructs skaffold to use secrets plugin on deployment.
+	UseHelmSecrets bool `yaml:"useHelmSecrets,omitempty"`
+
+	// Repo specifies the helm repository for remote charts.
+	// If present, Skaffold will send `--repo` Helm CLI flag or flags.
+	Repo string `yaml:"repo,omitempty"`
+
+	// UpgradeOnChange specifies whether to upgrade helm chart on code changes.
+	// Default is `true` when helm chart is local (`remote: false`).
+	// Default is `false` if `remote: true`.
+	UpgradeOnChange *bool `yaml:"upgradeOnChange,omitempty"`
+
+	// Overrides are key-value pairs.
+	// If present, Skaffold will build a Helm `values` file that overrides
+	// the original and use it to call Helm CLI (`--f` flag).
+	Overrides util.HelmOverrides `yaml:"overrides,omitempty"`
+
+	// Packaged parameters for packaging helm chart (`helm package`).
+	Packaged *HelmPackaged `yaml:"packaged,omitempty"`
+
+	// ImageStrategy controls how an `ArtifactOverrides` entry is
+	// turned into `--set-string` Helm CLI flag or flags.
+	ImageStrategy HelmImageStrategy `yaml:"imageStrategy,omitempty"`
+}
+
+// HelmPackaged parameters for packaging helm chart (`helm package`).
+type HelmPackaged struct {
+	// Version sets the `version` on the chart to this semver version.
+	Version string `yaml:"version,omitempty"`
+
+	// AppVersion sets the `appVersion` on the chart to this version.
+	AppVersion string `yaml:"appVersion,omitempty"`
+}
+
+// HelmImageStrategy adds image configurations to the Helm `values` file.
+type HelmImageStrategy struct {
+	HelmImageConfig `yaml:",inline"`
+}
+
+// HelmImageConfig describes an image configuration.
+type HelmImageConfig struct {
+	// HelmFQNConfig is the image configuration uses the syntax `IMAGE-NAME=IMAGE-REPOSITORY:IMAGE-TAG`.
+	HelmFQNConfig *HelmFQNConfig `yaml:"fqn,omitempty" yamltags:"oneOf=helmImageStrategy"`
+
+	// HelmConventionConfig is the image configuration uses the syntax `IMAGE-NAME.repository=IMAGE-REPOSITORY, IMAGE-NAME.tag=IMAGE-TAG`.
+	HelmConventionConfig *HelmConventionConfig `yaml:"helm,omitempty" yamltags:"oneOf=helmImageStrategy"`
+}
+
+// HelmFQNConfig is the image config to use the FullyQualifiedImageName as param to set.
+type HelmFQNConfig struct {
+	// Property defines the image config.
+	Property string `yaml:"property,omitempty"`
+}
+
+// HelmConventionConfig is the image config in the syntax of image.repository and image.tag.
+type HelmConventionConfig struct {
+	// ExplicitRegistry separates `image.registry` to the image config syntax. Useful for some charts e.g. `postgresql`.
+	ExplicitRegistry bool `yaml:"explicitRegistry,omitempty"`
+}
+*/
+
+// LogsConfig configures how container logs are printed as a result of a deployment.
+type LogsConfig struct {
+	// Prefix defines the prefix shown on each log line. Valid values are
+	// `container`: prefix logs lines with the name of the container.
+	// `podAndContainer`: prefix logs lines with the names of the pod and of the container.
+	// `auto`: same as `podAndContainer` except that the pod name is skipped if it's the same as the container name.
+	// `none`: don't add a prefix.
+	// Defaults to `auto`.
+	Prefix string `yaml:"prefix,omitempty"`
+}
+
+// Artifact are the items that need to be built, along with the context in which
+// they should be built.
+type Artifact struct {
+	// ImageName is the name of the image to be built.
+	// For example: `gcr.io/k8s-skaffold/example`.
+	ImageName string `yaml:"image,omitempty" yamltags:"required"`
+
+	// Workspace is the directory containing the artifact's sources.
+	// Defaults to `.`.
+	Workspace string `yaml:"context,omitempty" skaffold:"filepath"`
+
+	// Sync *beta* lists local files synced to pods instead
+	// of triggering an image build when modified.
+	// If no files are listed, sync all the files and infer the destination.
+	// Defaults to `infer: ["**/*"]`.
+	Sync *Sync `yaml:"sync,omitempty"`
+
+	// ArtifactType describes how to build an artifact.
+	ArtifactType `yaml:",inline"`
+
+	// Dependencies describes build artifacts that this artifact depends on.
+	Dependencies []*ArtifactDependency `yaml:"requires,omitempty"`
+}
+
+// Sync *beta* specifies what files to sync into the container.
+// This is a list of sync rules indicating the intent to sync for source files.
+// If no files are listed, sync all the files and infer the destination.
+// Defaults to `infer: ["**/*"]`.
+type Sync struct {
+	// Manual lists manual sync rules indicating the source and destination.
+	Manual []*SyncRule `yaml:"manual,omitempty" yamltags:"oneOf=sync"`
+
+	// Infer lists file patterns which may be synced into the container
+	// The container destination is inferred by the builder
+	// based on the instructions of a Dockerfile.
+	// Available for docker and kaniko artifacts and custom
+	// artifacts that declare dependencies on a dockerfile.
+	Infer []string `yaml:"infer,omitempty" yamltags:"oneOf=sync"`
+
+	// Auto delegates discovery of sync rules to the build system.
+	// Only available for jib and buildpacks.
+	Auto *bool `yaml:"auto,omitempty" yamltags:"oneOf=sync"`
+}
+
+// SyncRule specifies which local files to sync to remote folders.
+type SyncRule struct {
+	// Src is a glob pattern to match local paths against.
+	// Directories should be delimited by `/` on all platforms.
+	// For example: `"css/**/*.css"`.
+	Src string `yaml:"src,omitempty" yamltags:"required"`
+
+	// Dest is the destination path in the container where the files should be synced to.
+	// For example: `"app/"`
+	Dest string `yaml:"dest,omitempty" yamltags:"required"`
+
+	// Strip specifies the path prefix to remove from the source path when
+	// transplanting the files into the destination folder.
+	// For example: `"css/"`
+	Strip string `yaml:"strip,omitempty"`
+}
+
+// Profile is used to override any `build`, `test` or `deploy` configuration.
+type Profile struct {
+	// Name is a unique profile name.
+	// For example: `profile-prod`.
+	Name string `yaml:"name,omitempty" yamltags:"required"`
+
+	// Activation criteria by which a profile can be auto-activated.
+	// The profile is auto-activated if any one of the activations are triggered.
+	// An activation is triggered if all of the criteria (env, kubeContext, command) are triggered.
+	Activation []Activation `yaml:"activation,omitempty"`
+
+	// Patches lists patches applied to the configuration.
+	// Patches use the JSON patch notation.
+	Patches []JSONPatch `yaml:"patches,omitempty"`
+
+	// Pipeline contains the definitions to replace the default skaffold pipeline.
+	Pipeline `yaml:",inline"`
+}
+
+// JSONPatch patch to be applied by a profile.
+type JSONPatch struct {
+	// Op is the operation carried by the patch: `add`, `remove`, `replace`, `move`, `copy` or `test`.
+	// Defaults to `replace`.
+	Op string `yaml:"op,omitempty"`
+
+	// Path is the position in the yaml where the operation takes place.
+	// For example, this targets the `dockerfile` of the first artifact built.
+	// For example: `/build/artifacts/0/docker/dockerfile`.
+	Path string `yaml:"path,omitempty" yamltags:"required"`
+
+	// From is the source position in the yaml, used for `copy` or `move` operations.
+	From string `yaml:"from,omitempty"`
+
+	// Value is the value to apply. Can be any portion of yaml.
+	Value *util.YamlpatchNode `yaml:"value,omitempty"`
+}
+
+// Activation criteria by which a profile is auto-activated.
+type Activation struct {
+	// Env is a `key=pattern` pair. The profile is auto-activated if an Environment
+	// Variable `key` matches the pattern. If the pattern starts with `!`, activation
+	// happens if the remaining pattern is _not_ matched. The pattern matches if the
+	// Environment Variable value is exactly `pattern`, or the regex `pattern` is
+	// found in it. An empty `pattern` (e.g. `env: "key="`) always only matches if
+	// the Environment Variable is undefined or empty.
+	// For example: `ENV=production`
+	Env string `yaml:"env,omitempty"`
+
+	// KubeContext is a Kubernetes context for which the profile is auto-activated.
+	// For example: `minikube`.
+	KubeContext string `yaml:"kubeContext,omitempty"`
+
+	// Command is a Skaffold command for which the profile is auto-activated.
+	// For example: `dev`.
+	Command string `yaml:"command,omitempty"`
+}
+
+// ArtifactType describes how to build an artifact.
+type ArtifactType struct {
+	// DockerArtifact *beta* describes an artifact built from a Dockerfile.
+	DockerArtifact *DockerArtifact `yaml:"docker,omitempty" yamltags:"oneOf=artifact"`
+
+	// BazelArtifact *beta* requires bazel CLI to be installed and the sources to
+	// contain [Bazel](https://bazel.build/) configuration files.
+	BazelArtifact *BazelArtifact `yaml:"bazel,omitempty" yamltags:"oneOf=artifact"`
+
+	// JibArtifact builds images using the
+	// [Jib plugins for Maven or Gradle](https://github.com/GoogleContainerTools/jib/).
+	JibArtifact *JibArtifact `yaml:"jib,omitempty" yamltags:"oneOf=artifact"`
+
+	// KanikoArtifact builds images using [kaniko](https://github.com/GoogleContainerTools/kaniko).
+	KanikoArtifact *KanikoArtifact `yaml:"kaniko,omitempty" yamltags:"oneOf=artifact"`
+
+	// BuildpackArtifact builds images using [Cloud Native Buildpacks](https://buildpacks.io/).
+	BuildpackArtifact *BuildpackArtifact `yaml:"buildpacks,omitempty" yamltags:"oneOf=artifact"`
+
+	// CustomArtifact *beta* builds images using a custom build script written by the user.
+	CustomArtifact *CustomArtifact `yaml:"custom,omitempty" yamltags:"oneOf=artifact"`
+}
+
+// ArtifactDependency describes a specific build dependency for an artifact.
+type ArtifactDependency struct {
+	// ImageName is a reference to an artifact's image name.
+	ImageName string `yaml:"image" yamltags:"required"`
+	// Alias is a token that is replaced with the image reference in the builder definition files.
+	// For example, the `docker` builder will use the alias as a build-arg key.
+	// Defaults to the value of `image`.
+	Alias string `yaml:"alias,omitempty"`
+}
+
+// BuildpackArtifact *alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/).
+// It can be used to build images out of project's sources without any additional configuration.
+type BuildpackArtifact struct {
+	// Builder is the builder image used.
+	Builder string `yaml:"builder" yamltags:"required"`
+
+	// RunImage overrides the stack's default run image.
+	RunImage string `yaml:"runImage,omitempty"`
+
+	// Env are environment variables, in the `key=value` form,  passed to the build.
+	// Values can use the go template syntax.
+	// For example: `["key1=value1", "key2=value2", "key3={{.ENV_VARIABLE}}"]`.
+	Env []string `yaml:"env,omitempty"`
+
+	// Buildpacks is a list of strings, where each string is a specific buildpack to use with the builder.
+	// If you specify buildpacks the builder image automatic detection will be ignored. These buildpacks will be used to build the Image from your source code.
+	// Order matters.
+	Buildpacks []string `yaml:"buildpacks,omitempty"`
+
+	// TrustBuilder indicates that the builder should be trusted.
+	TrustBuilder bool `yaml:"trustBuilder,omitempty"`
+
+	// ProjectDescriptor is the path to the project descriptor file.
+	// Defaults to `project.toml` if it exists.
+	ProjectDescriptor string `yaml:"projectDescriptor,omitempty"`
+
+	// Dependencies are the file dependencies that skaffold should watch for both rebuilding and file syncing for this artifact.
+	Dependencies *BuildpackDependencies `yaml:"dependencies,omitempty"`
+}
+
+// BuildpackDependencies *alpha* is used to specify dependencies for an artifact built by buildpacks.
+type BuildpackDependencies struct {
+	// Paths should be set to the file dependencies for this artifact, so that the skaffold file watcher knows when to rebuild and perform file synchronization.
+	Paths []string `yaml:"paths,omitempty" yamltags:"oneOf=dependency"`
+
+	// Ignore specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both `paths` and in `ignore`, it will be ignored, and will be excluded from both rebuilds and file synchronization.
+	// Will only work in conjunction with `paths`.
+	Ignore []string `yaml:"ignore,omitempty"`
+}
+
+// CustomArtifact *beta* describes an artifact built from a custom build script
+// written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.
+type CustomArtifact struct {
+	// BuildCommand is the command executed to build the image.
+	BuildCommand string `yaml:"buildCommand,omitempty"`
+	// Dependencies are the file dependencies that skaffold should watch for both rebuilding and file syncing for this artifact.
+	Dependencies *CustomDependencies `yaml:"dependencies,omitempty"`
+}
+
+// CustomDependencies *beta* is used to specify dependencies for an artifact built by a custom build script.
+// Either `dockerfile` or `paths` should be specified for file watching to work as expected.
+type CustomDependencies struct {
+	// Dockerfile should be set if the artifact is built from a Dockerfile, from which skaffold can determine dependencies.
+	Dockerfile *DockerfileDependency `yaml:"dockerfile,omitempty" yamltags:"oneOf=dependency"`
+
+	// Command represents a custom command that skaffold executes to obtain dependencies. The output of this command *must* be a valid JSON array.
+	Command string `yaml:"command,omitempty" yamltags:"oneOf=dependency"`
+
+	// Paths should be set to the file dependencies for this artifact, so that the skaffold file watcher knows when to rebuild and perform file synchronization.
+	Paths []string `yaml:"paths,omitempty" yamltags:"oneOf=dependency"`
+
+	// Ignore specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both `paths` and in `ignore`, it will be ignored, and will be excluded from both rebuilds and file synchronization.
+	// Will only work in conjunction with `paths`.
+	Ignore []string `yaml:"ignore,omitempty"`
+}
+
+// CustomTest describes the custom test command provided by the user.
+// Custom tests are run after an image build whenever build or test dependencies are changed.
+type CustomTest struct {
+	// Command is the custom command to be executed.  If the command exits with a non-zero return
+	// code, the test will be considered to have failed.
+	Command string `yaml:"command" yamltags:"required"`
+
+	// TimeoutSeconds sets the wait time for skaffold for the command to complete.
+	// If unset or 0, Skaffold will wait until the command completes.
+	TimeoutSeconds int `yaml:"timeoutSeconds,omitempty"`
+
+	// Dependencies are additional test-specific file dependencies; changes to these files will re-run this test.
+	Dependencies *CustomTestDependencies `yaml:"dependencies,omitempty"`
+}
+
+// CustomTestDependencies is used to specify dependencies for custom test command.
+// `paths` should be specified for file watching to work as expected.
+type CustomTestDependencies struct {
+	// Command represents a command that skaffold executes to obtain dependencies. The output of this command *must* be a valid JSON array.
+	Command string `yaml:"command,omitempty" yamltags:"oneOf=dependency"`
+
+	// Paths should be set to the file dependencies for this command, so that the skaffold file watcher knows when to retest and perform file synchronization.
+	// For example: `["src/test/**"]`
+	Paths []string `yaml:"paths,omitempty" yamltags:"oneOf=dependency" skaffold:"filepath"`
+
+	// Ignore specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both `paths` and in `ignore`, it will be ignored, and will be excluded from both retest and file synchronization.
+	// Will only work in conjunction with `paths`.
+	Ignore []string `yaml:"ignore,omitempty" skaffold:"filepath"`
+}
+
+// DockerfileDependency *beta* is used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.
+type DockerfileDependency struct {
+	// Path locates the Dockerfile relative to workspace.
+	Path string `yaml:"path,omitempty"`
+
+	// BuildArgs are key/value pairs used to resolve values of `ARG` instructions in a Dockerfile.
+	// Values can be constants or environment variables via the go template syntax.
+	// For example: `{"key1": "value1", "key2": "value2", "key3": "'{{.ENV_VARIABLE}}'"}`.
+	BuildArgs map[string]*string `yaml:"buildArgs,omitempty"`
+}
+
+// KanikoArtifact describes an artifact built from a Dockerfile,
+// with kaniko.
+type KanikoArtifact struct {
+
+	// Cleanup to clean the filesystem at the end of the build.
+	Cleanup bool `yaml:"cleanup,omitempty"`
+
+	// Insecure if you want to push images to a plain HTTP registry.
+	Insecure bool `yaml:"insecure,omitempty"`
+
+	// InsecurePull if you want to pull images from a plain HTTP registry.
+	InsecurePull bool `yaml:"insecurePull,omitempty"`
+
+	// NoPush if you only want to build the image, without pushing to a registry.
+	NoPush bool `yaml:"noPush,omitempty"`
+
+	// Force building outside of a container.
+	Force bool `yaml:"force,omitempty"`
+
+	// LogTimestamp to add timestamps to log format.
+	LogTimestamp bool `yaml:"logTimestamp,omitempty"`
+
+	// Reproducible is used to strip timestamps out of the built image.
+	Reproducible bool `yaml:"reproducible,omitempty"`
+
+	// SingleSnapshot is takes a single snapshot of the filesystem at the end of the build.
+	// So only one layer will be appended to the base image.
+	SingleSnapshot bool `yaml:"singleSnapshot,omitempty"`
+
+	// SkipTLS skips TLS certificate validation when pushing to a registry.
+	SkipTLS bool `yaml:"skipTLS,omitempty"`
+
+	// SkipTLSVerifyPull skips TLS certificate validation when pulling from a registry.
+	SkipTLSVerifyPull bool `yaml:"skipTLSVerifyPull,omitempty"`
+
+	// SkipUnusedStages builds only used stages if defined to true.
+	// Otherwise it builds by default all stages, even the unnecessaries ones until it reaches the target stage / end of Dockerfile.
+	SkipUnusedStages bool `yaml:"skipUnusedStages,omitempty"`
+
+	// UseNewRun to Use the experimental run implementation for detecting changes without requiring file system snapshots.
+	// In some cases, this may improve build performance by 75%.
+	UseNewRun bool `yaml:"useNewRun,omitempty"`
+
+	// WhitelistVarRun is used to ignore `/var/run` when taking image snapshot.
+	// Set it to false to preserve /var/run/* in destination image.
+	WhitelistVarRun bool `yaml:"whitelistVarRun,omitempty"`
+
+	// DockerfilePath locates the Dockerfile relative to workspace.
+	// Defaults to `Dockerfile`.
+	DockerfilePath string `yaml:"dockerfile,omitempty"`
+
+	// Target is to indicate which build stage is the target build stage.
+	Target string `yaml:"target,omitempty"`
+
+	// InitImage is the image used to run init container which mounts kaniko context.
+	InitImage string `yaml:"initImage,omitempty"`
+
+	// Image is the Docker image used by the Kaniko pod.
+	// Defaults to the latest released version of `gcr.io/kaniko-project/executor`.
+	Image string `yaml:"image,omitempty"`
+
+	// DigestFile to specify a file in the container. This file will receive the digest of a built image.
+	// This can be used to automatically track the exact image built by kaniko.
+	DigestFile string `yaml:"digestFile,omitempty"`
+
+	// ImageNameWithDigestFile specify a file to save the image name with digest of the built image to.
+	ImageNameWithDigestFile string `yaml:"imageNameWithDigestFile,omitempty"`
+
+	// LogFormat <text|color|json> to set the log format.
+	LogFormat string `yaml:"logFormat,omitempty"`
+
+	// OCILayoutPath is to specify a directory in the container where the OCI image layout of a built image will be placed.
+	// This can be used to automatically track the exact image built by kaniko.
+	OCILayoutPath string `yaml:"ociLayoutPath,omitempty"`
+
+	// RegistryMirror if you want to use a registry mirror instead of default `index.docker.io`.
+	RegistryMirror string `yaml:"registryMirror,omitempty"`
+
+	// SnapshotMode is how Kaniko will snapshot the filesystem.
+	SnapshotMode string `yaml:"snapshotMode,omitempty"`
+
+	// TarPath is path to save the image as a tarball at path instead of pushing the image.
+	TarPath string `yaml:"tarPath,omitempty"`
+
+	// Verbosity <panic|fatal|error|warn|info|debug|trace> to set the logging level.
+	Verbosity string `yaml:"verbosity,omitempty"`
+
+	// InsecureRegistry is to use plain HTTP requests when accessing a registry.
+	InsecureRegistry []string `yaml:"insecureRegistry,omitempty"`
+
+	// SkipTLSVerifyRegistry skips TLS certificate validation when accessing a registry.
+	SkipTLSVerifyRegistry []string `yaml:"skipTLSVerifyRegistry,omitempty"`
+
+	// Env are environment variables passed to the kaniko pod.
+	// It also accepts environment variables via the go template syntax.
+	// For example: `[{"name": "key1", "value": "value1"}, {"name": "key2", "value": "value2"}, {"name": "key3", "value": "'{{.ENV_VARIABLE}}'"}]`.
+	Env []v1.EnvVar `yaml:"env,omitempty"`
+
+	// Cache configures Kaniko caching. If a cache is specified, Kaniko will
+	// use a remote cache which will speed up builds.
+	Cache *KanikoCache `yaml:"cache,omitempty"`
+
+	// RegistryCertificate is to provide a certificate for TLS communication with a given registry.
+	// my.registry.url: /path/to/the/certificate.cert is the expected format.
+	RegistryCertificate map[string]*string `yaml:"registryCertificate,omitempty"`
+
+	// Label key: value to set some metadata to the final image.
+	// This is equivalent as using the LABEL within the Dockerfile.
+	Label map[string]*string `yaml:"label,omitempty"`
+
+	// BuildArgs are arguments passed to the docker build.
+	// It also accepts environment variables and generated values via the go template syntax.
+	// Exposed generated values: IMAGE_REPO, IMAGE_NAME, IMAGE_TAG.
+	// For example: `{"key1": "value1", "key2": "value2", "key3": "'{{.ENV_VARIABLE}}'"}`.
+	BuildArgs map[string]*string `yaml:"buildArgs,omitempty"`
+
+	// VolumeMounts are volume mounts passed to kaniko pod.
+	VolumeMounts []v1.VolumeMount `yaml:"volumeMounts,omitempty"`
+}
+
+// DockerArtifact describes an artifact built from a Dockerfile,
+// usually using `docker build`.
+type DockerArtifact struct {
+	// DockerfilePath locates the Dockerfile relative to workspace.
+	// Defaults to `Dockerfile`.
+	DockerfilePath string `yaml:"dockerfile,omitempty"`
+
+	// Target is the Dockerfile target name to build.
+	Target string `yaml:"target,omitempty"`
+
+	// BuildArgs are arguments passed to the docker build.
+	// For example: `{"key1": "value1", "key2": "value2"}`.
+	BuildArgs map[string]*string `yaml:"buildArgs,omitempty"`
+
+	// NetworkMode is passed through to docker and overrides the
+	// network configuration of docker builder. If unset, use whatever
+	// is configured in the underlying docker daemon. Valid modes are
+	// `host`: use the host's networking stack.
+	// `bridge`: use the bridged network configuration.
+	// `container:<name|id>`: reuse another container's network stack.
+	// `none`: no networking in the container.
+	NetworkMode string `yaml:"network,omitempty"`
+
+	// CacheFrom lists the Docker images used as cache sources.
+	// For example: `["golang:1.10.1-alpine3.7", "alpine:3.7"]`.
+	CacheFrom []string `yaml:"cacheFrom,omitempty"`
+
+	// NoCache used to pass in --no-cache to docker build to prevent caching.
+	NoCache bool `yaml:"noCache,omitempty"`
+
+	// Squash is used to pass in --squash to docker build to squash docker image layers into single layer.
+	Squash bool `yaml:"squash,omitempty"`
+
+	// Secret contains information about a local secret passed to `docker build`,
+	// along with optional destination information.
+	Secret *DockerSecret `yaml:"secret,omitempty"`
+
+	// SSH is used to pass in --ssh to docker build to use SSH agent. Format is "default|<id>[=<socket>|<key>[,<key>]]".
+	SSH string `yaml:"ssh,omitempty"`
+}
+
+// DockerSecret contains information about a local secret passed to `docker build`,
+// along with optional destination information.
+type DockerSecret struct {
+	// ID is the id of the secret.
+	ID string `yaml:"id,omitempty" yamltags:"required"`
+
+	// Source is the path to the secret on the host machine.
+	Source string `yaml:"src,omitempty"`
+
+	// Destination is the path in the container to mount the secret.
+	Destination string `yaml:"dst,omitempty"`
+}
+
+// BazelArtifact describes an artifact built with [Bazel](https://bazel.build/).
+type BazelArtifact struct {
+	// BuildTarget is the `bazel build` target to run.
+	// For example: `//:skaffold_example.tar`.
+	BuildTarget string `yaml:"target,omitempty" yamltags:"required"`
+
+	// BuildArgs are additional args to pass to `bazel build`.
+	// For example: `["-flag", "--otherflag"]`.
+	BuildArgs []string `yaml:"args,omitempty"`
+}
+
+// JibArtifact builds images using the
+// [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).
+type JibArtifact struct {
+	// Project selects which sub-project to build for multi-module builds.
+	Project string `yaml:"project,omitempty"`
+
+	// Flags are additional build flags passed to the builder.
+	// For example: `["--no-build-cache"]`.
+	Flags []string `yaml:"args,omitempty"`
+
+	// Type the Jib builder type; normally determined automatically. Valid types are
+	// `maven`: for Maven.
+	// `gradle`: for Gradle.
+	Type string `yaml:"type,omitempty"`
+
+	// BaseImage overrides the configured jib base image.
+	BaseImage string `yaml:"fromImage,omitempty"`
+}
+
+// UnmarshalYAML provides a custom unmarshaller to deal with
+// https://github.com/GoogleContainerTools/skaffold/issues/4175
+func (clusterDetails *ClusterDetails) UnmarshalYAML(value *yaml.Node) error {
+	// We do this as follows
+	// 1. We zero out the fields in the node that require custom processing
+	// 2. We unmarshal all the non special fields using the aliased type resource
+	//    we use an alias type to avoid recursion caused by invoking this function infinitely
+	// 3. We deserialize the special fields as required.
+	type ClusterDetailsForUnmarshaling ClusterDetails
+
+	volumes, remaining, err := util.UnmarshalClusterVolumes(value)
+
+	if err != nil {
+		return err
+	}
+
+	// Unmarshal the remaining values
+	aux := (*ClusterDetailsForUnmarshaling)(clusterDetails)
+	err = yaml.Unmarshal(remaining, aux)
+
+	if err != nil {
+		return err
+	}
+
+	clusterDetails.Volumes = volumes
+	return nil
+}
+
+// UnmarshalYAML provides a custom unmarshaller to deal with
+// https://github.com/GoogleContainerTools/skaffold/issues/4175
+func (ka *KanikoArtifact) UnmarshalYAML(value *yaml.Node) error {
+	// We do this as follows
+	// 1. We zero out the fields in the node that require custom processing
+	// 2. We unmarshal all the non special fields using the aliased type resource
+	//    we use an alias type to avoid recursion caused by invoking this function infinitely
+	// 3. We deserialize the special fields as required.
+	type KanikoArtifactForUnmarshaling KanikoArtifact
+
+	mounts, remaining, err := util.UnmarshalKanikoArtifact(value)
+
+	if err != nil {
+		return err
+	}
+
+	// Unmarshal the remaining values
+	aux := (*KanikoArtifactForUnmarshaling)(ka)
+	err = yaml.Unmarshal(remaining, aux)
+
+	if err != nil {
+		return err
+	}
+
+	ka.VolumeMounts = mounts
+	return nil
+}
+
+// MarshalYAML provides a custom marshaller to deal with
+// https://github.com/GoogleContainerTools/skaffold/issues/4175
+func (clusterDetails *ClusterDetails) MarshalYAML() (interface{}, error) {
+	// We do this as follows
+	// 1. We zero out the fields in the node that require custom processing
+	// 2. We marshall all the non special fields using the aliased type resource
+	//    we use an alias type to avoid recursion caused by invoking this function infinitely
+	// 3. We unmarshal to a map
+	// 4. We marshal the special fields to json and unmarshal to a map
+	//    * This leverages the json struct annotations to marshal as expected
+	// 5. We combine the two maps and return
+	type ClusterDetailsForUnmarshaling ClusterDetails
+
+	// Marshal volumes to a list. Use json because the Kubernetes resources have json annotations.
+	volumes := clusterDetails.Volumes
+
+	j, err := json.Marshal(volumes)
+
+	if err != nil {
+		return err, nil
+	}
+
+	vList := []interface{}{}
+
+	if err := json.Unmarshal(j, &vList); err != nil {
+		return nil, err
+	}
+
+	// Make a deep copy of clusterDetails because we need to zero out volumes and we don't want to modify the
+	// current object.
+	aux := &ClusterDetailsForUnmarshaling{}
+
+	b, err := json.Marshal(clusterDetails)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(b, aux); err != nil {
+		return nil, err
+	}
+
+	aux.Volumes = nil
+
+	marshaled, err := yaml.Marshal(aux)
+
+	if err != nil {
+		return nil, err
+	}
+
+	m := map[string]interface{}{}
+
+	err = yaml.Unmarshal(marshaled, m)
+
+	if len(vList) > 0 {
+		m["volumes"] = vList
+	}
+	return m, err
+}
+
+// MarshalYAML provides a custom marshaller to deal with
+// https://github.com/GoogleContainerTools/skaffold/issues/4175
+func (ka *KanikoArtifact) MarshalYAML() (interface{}, error) {
+	// We do this as follows
+	// 1. We zero out the fields in the node that require custom processing
+	// 2. We marshal all the non special fields using the aliased type resource
+	//    we use an alias type to avoid recursion caused by invoking this function infinitely
+	// 3. We unmarshal to a map
+	// 4. We marshal the special fields to json and unmarshal to a map
+	//    * This leverages the json struct annotations to marshal as expected
+	// 5. We combine the two maps and return
+	type KanikoArtifactForUnmarshaling KanikoArtifact
+
+	// Marshal volumes to a map. User json because the Kubernetes resources have json annotations.
+	volumeMounts := ka.VolumeMounts
+
+	j, err := json.Marshal(volumeMounts)
+
+	if err != nil {
+		return err, nil
+	}
+
+	vList := []interface{}{}
+
+	if err := json.Unmarshal(j, &vList); err != nil {
+		return nil, err
+	}
+
+	// Make a deep copy of kanikoArtifact because we need to zero out volumeMounts and we don't want to modify the
+	// current object.
+	aux := &KanikoArtifactForUnmarshaling{}
+
+	b, err := json.Marshal(ka)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(b, aux); err != nil {
+		return nil, err
+	}
+	aux.VolumeMounts = nil
+
+	marshaled, err := yaml.Marshal(aux)
+
+	if err != nil {
+		return nil, err
+	}
+
+	m := map[string]interface{}{}
+
+	err = yaml.Unmarshal(marshaled, m)
+
+	if len(vList) > 0 {
+		m["volumeMounts"] = vList
+	}
+	return m, err
+}

--- a/pkg/skaffold/schema/v3alpha1/upgrade.go
+++ b/pkg/skaffold/schema/v3alpha1/upgrade.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v3alpha1
+
+import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
+)
+
+// Upgrade upgrades a configuration to the next version.
+// Config changes from v3alpha1 to v3alpha2
+func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
+	return c, nil
+}

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -70,6 +70,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta7"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta8"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta9"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v3alpha1"
 	misc "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -78,52 +79,54 @@ type APIVersion struct {
 }
 
 var SchemaVersions = Versions{
-	{v1alpha1.Version, v1alpha1.NewSkaffoldConfig},
-	{v1alpha2.Version, v1alpha2.NewSkaffoldConfig},
-	{v1alpha3.Version, v1alpha3.NewSkaffoldConfig},
-	{v1alpha4.Version, v1alpha4.NewSkaffoldConfig},
-	{v1alpha5.Version, v1alpha5.NewSkaffoldConfig},
-	{v1beta1.Version, v1beta1.NewSkaffoldConfig},
-	{v1beta2.Version, v1beta2.NewSkaffoldConfig},
-	{v1beta3.Version, v1beta3.NewSkaffoldConfig},
-	{v1beta4.Version, v1beta4.NewSkaffoldConfig},
-	{v1beta5.Version, v1beta5.NewSkaffoldConfig},
-	{v1beta6.Version, v1beta6.NewSkaffoldConfig},
-	{v1beta7.Version, v1beta7.NewSkaffoldConfig},
-	{v1beta8.Version, v1beta8.NewSkaffoldConfig},
-	{v1beta9.Version, v1beta9.NewSkaffoldConfig},
-	{v1beta10.Version, v1beta10.NewSkaffoldConfig},
-	{v1beta11.Version, v1beta11.NewSkaffoldConfig},
-	{v1beta12.Version, v1beta12.NewSkaffoldConfig},
-	{v1beta13.Version, v1beta13.NewSkaffoldConfig},
-	{v1beta14.Version, v1beta14.NewSkaffoldConfig},
-	{v1beta15.Version, v1beta15.NewSkaffoldConfig},
-	{v1beta16.Version, v1beta16.NewSkaffoldConfig},
-	{v1beta17.Version, v1beta17.NewSkaffoldConfig},
-	{v1.Version, v1.NewSkaffoldConfig},
-	{v2alpha1.Version, v2alpha1.NewSkaffoldConfig},
-	{v2alpha2.Version, v2alpha2.NewSkaffoldConfig},
-	{v2alpha3.Version, v2alpha3.NewSkaffoldConfig},
-	{v2alpha4.Version, v2alpha4.NewSkaffoldConfig},
-	{v2beta1.Version, v2beta1.NewSkaffoldConfig},
-	{v2beta2.Version, v2beta2.NewSkaffoldConfig},
-	{v2beta3.Version, v2beta3.NewSkaffoldConfig},
-	{v2beta4.Version, v2beta4.NewSkaffoldConfig},
-	{v2beta5.Version, v2beta5.NewSkaffoldConfig},
-	{v2beta6.Version, v2beta6.NewSkaffoldConfig},
-	{v2beta7.Version, v2beta7.NewSkaffoldConfig},
-	{v2beta8.Version, v2beta8.NewSkaffoldConfig},
-	{v2beta9.Version, v2beta9.NewSkaffoldConfig},
-	{v2beta10.Version, v2beta10.NewSkaffoldConfig},
-	{v2beta11.Version, v2beta11.NewSkaffoldConfig},
-	{v2beta12.Version, v2beta12.NewSkaffoldConfig},
-	{v2beta13.Version, v2beta13.NewSkaffoldConfig},
-	{latest.Version, latest.NewSkaffoldConfig},
+	{v1alpha1.Version, v1alpha1.NewSkaffoldConfig, true},
+	{v1alpha2.Version, v1alpha2.NewSkaffoldConfig, true},
+	{v1alpha3.Version, v1alpha3.NewSkaffoldConfig, true},
+	{v1alpha4.Version, v1alpha4.NewSkaffoldConfig, true},
+	{v1alpha5.Version, v1alpha5.NewSkaffoldConfig, true},
+	{v1beta1.Version, v1beta1.NewSkaffoldConfig, true},
+	{v1beta2.Version, v1beta2.NewSkaffoldConfig, true},
+	{v1beta3.Version, v1beta3.NewSkaffoldConfig, true},
+	{v1beta4.Version, v1beta4.NewSkaffoldConfig, true},
+	{v1beta5.Version, v1beta5.NewSkaffoldConfig, true},
+	{v1beta6.Version, v1beta6.NewSkaffoldConfig, true},
+	{v1beta7.Version, v1beta7.NewSkaffoldConfig, true},
+	{v1beta8.Version, v1beta8.NewSkaffoldConfig, true},
+	{v1beta9.Version, v1beta9.NewSkaffoldConfig, true},
+	{v1beta10.Version, v1beta10.NewSkaffoldConfig, true},
+	{v1beta11.Version, v1beta11.NewSkaffoldConfig, true},
+	{v1beta12.Version, v1beta12.NewSkaffoldConfig, true},
+	{v1beta13.Version, v1beta13.NewSkaffoldConfig, true},
+	{v1beta14.Version, v1beta14.NewSkaffoldConfig, true},
+	{v1beta15.Version, v1beta15.NewSkaffoldConfig, true},
+	{v1beta16.Version, v1beta16.NewSkaffoldConfig, true},
+	{v1beta17.Version, v1beta17.NewSkaffoldConfig, true},
+	{v1.Version, v1.NewSkaffoldConfig, true},
+	{v2alpha1.Version, v2alpha1.NewSkaffoldConfig, true},
+	{v2alpha2.Version, v2alpha2.NewSkaffoldConfig, true},
+	{v2alpha3.Version, v2alpha3.NewSkaffoldConfig, true},
+	{v2alpha4.Version, v2alpha4.NewSkaffoldConfig, true},
+	{v2beta1.Version, v2beta1.NewSkaffoldConfig, true},
+	{v2beta2.Version, v2beta2.NewSkaffoldConfig, true},
+	{v2beta3.Version, v2beta3.NewSkaffoldConfig, true},
+	{v2beta4.Version, v2beta4.NewSkaffoldConfig, true},
+	{v2beta5.Version, v2beta5.NewSkaffoldConfig, true},
+	{v2beta6.Version, v2beta6.NewSkaffoldConfig, true},
+	{v2beta7.Version, v2beta7.NewSkaffoldConfig, true},
+	{v2beta8.Version, v2beta8.NewSkaffoldConfig, true},
+	{v2beta9.Version, v2beta9.NewSkaffoldConfig, true},
+	{v2beta10.Version, v2beta10.NewSkaffoldConfig, true},
+	{v2beta11.Version, v2beta11.NewSkaffoldConfig, true},
+	{v2beta12.Version, v2beta12.NewSkaffoldConfig, true},
+	{v2beta13.Version, v2beta13.NewSkaffoldConfig, true},
+	{v3alpha1.Version, v3alpha1.NewSkaffoldConfig, false},
+	{latest.Version, latest.NewSkaffoldConfig, true},
 }
 
 type Version struct {
-	APIVersion string
-	Factory    func() util.VersionedConfig
+	APIVersion           string
+	Factory              func() util.VersionedConfig
+	IsBackwardCompatible bool
 }
 
 type Versions []Version

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -672,7 +672,9 @@ func TestUpgradeToNextVersion(t *testing.T) {
 		from := schemaVersion
 		to := SchemaVersions[i+1]
 		description := fmt.Sprintf("Upgrade from %s to %s", from.APIVersion, to.APIVersion)
-
+		if !to.IsBackwardCompatible {
+			continue
+		}
 		testutil.Run(t, description, func(t *testutil.T) {
 			factory, _ := SchemaVersions.Find(from.APIVersion)
 


### PR DESCRIPTION
**Related**: #5673

**Description**
his schema contains the main fields to support the new skaffold render and deployment, powered by kpt. Some config names may change based on the the user survey results.

For reviewers:
 - `Render`: Top tier section. It contains the basic render functions `generate`, `validate` and `trasform`. It does not include the helmcharts (generate) and kpt package magement yet, which will be added on following CLs.
 - `Deploy`: Simplified. The deployers (helm, kubectl, kpt, kustomize) are removed. Some helm and kubectl features, and flags are not covered in the `deploy` section yet. Will be added in following CLs.
 -  v2 and v3 versions are not compatible. So the `upgrade` functions do not need to change. But we will add more checks on other codes to guarantee the v2 and v3 are not mixed (especially in multi-config mode).
 -  Generated doc via "go run hack/schemas/main.go".
