### PR TITLE
Make status-check flag nillable

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -280,6 +280,7 @@ var flagRegistry = []Flag{
 		FlagAddMethod: "Var",
 		DefinedOn:     []string{"dev", "debug", "deploy", "run", "apply"},
 		IsEnum:        true,
+		NoOptDefVal:   "true",
 	},
 	{
 		Name:          "render-only",

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -277,7 +277,7 @@ var flagRegistry = []Flag{
 		Usage:         "Wait for deployed resources to stabilize",
 		Value:         &opts.StatusCheck,
 		DefValue:      true,
-		FlagAddMethod: "BoolVar",
+		FlagAddMethod: "Var",
 		DefinedOn:     []string{"dev", "debug", "deploy", "run", "apply"},
 		IsEnum:        true,
 	},

--- a/cmd/skaffold/app/cmd/init_test.go
+++ b/cmd/skaffold/app/cmd/init_test.go
@@ -157,7 +157,7 @@ func TestFlagsToConfigVersion(t *testing.T) {
 
 			// we ignore Skaffold options
 			test.expectedConfig.Opts = capturedConfig.Opts
-			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedConfig, capturedConfig, cmp.AllowUnexported(cfg.StringOrUndefined{}))
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedConfig, capturedConfig, cmp.AllowUnexported(cfg.StringOrUndefined{}, cfg.BoolOrUndefined{}))
 		})
 	}
 }

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -49,7 +49,6 @@ type SkaffoldOptions struct {
 	Force                 bool
 	NoPrune               bool
 	NoPruneChildren       bool
-	StatusCheck           bool
 	AutoBuild             bool
 	AutoSync              bool
 	AutoDeploy            bool
@@ -68,6 +67,7 @@ type SkaffoldOptions struct {
 	DetectMinikube    bool
 	// Experimental is the entrypoint to run skaffold v3 before it's fully implemented.
 	Experimental bool
+	StatusCheck  BoolOrUndefined
 
 	PortForward        PortForwardOptions
 	CustomTag          string

--- a/pkg/skaffold/config/types.go
+++ b/pkg/skaffold/config/types.go
@@ -53,6 +53,57 @@ func (s *StringOrUndefined) String() string {
 	return *s.value
 }
 
+// BoolOrUndefined holds the value of a flag of type `bool`,
+// that's by default `undefined`.
+// We use this instead of just `bool` to differentiate `undefined`
+// and `false` values.
+type BoolOrUndefined struct {
+	value *bool
+}
+
+func (s *BoolOrUndefined) Type() string {
+	return "bool"
+}
+
+func (s *BoolOrUndefined) Value() *bool {
+	return s.value
+}
+
+func (s *BoolOrUndefined) Set(v string) error {
+	switch v {
+	case "true":
+		s.value = util.BoolPtr(true)
+	case "false":
+		s.value = util.BoolPtr(false)
+	default:
+		s.value = nil
+	}
+	return nil
+}
+
+func (s *BoolOrUndefined) SetNil() error {
+	s.value = nil
+	return nil
+}
+
+func (s *BoolOrUndefined) String() string {
+	b := s.value
+	if b == nil {
+		return ""
+	}
+	if *b {
+		return "true"
+	}
+	if !*b {
+		return "false"
+	}
+	return ""
+}
+
+func NewBoolOrUndefined(v *bool) BoolOrUndefined {
+	return BoolOrUndefined{value: v}
+}
+
 // Muted lists phases for which logs are muted.
 type Muted struct {
 	Phases []string

--- a/pkg/skaffold/config/types.go
+++ b/pkg/skaffold/config/types.go
@@ -94,10 +94,7 @@ func (s *BoolOrUndefined) String() string {
 	if *b {
 		return "true"
 	}
-	if !*b {
-		return "false"
-	}
-	return ""
+	return "false"
 }
 
 func NewBoolOrUndefined(v *bool) BoolOrUndefined {

--- a/pkg/skaffold/runner/deploy_test.go
+++ b/pkg/skaffold/runner/deploy_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -43,25 +44,32 @@ func TestDeploy(t *testing.T) {
 	tests := []struct {
 		description string
 		testBench   *TestBench
-		statusCheck bool
+		statusCheck config.BoolOrUndefined
 		shouldErr   bool
 		shouldWait  bool
 	}{
 		{
 			description: "deploy shd perform status check",
 			testBench:   &TestBench{},
-			statusCheck: true,
+			statusCheck: config.NewBoolOrUndefined(nil),
+			shouldWait:  true,
+		},
+		{
+			description: "deploy shd perform status check",
+			testBench:   &TestBench{},
+			statusCheck: config.NewBoolOrUndefined(util.BoolPtr(true)),
 			shouldWait:  true,
 		},
 		{
 			description: "deploy shd not perform status check",
 			testBench:   &TestBench{},
+			statusCheck: config.NewBoolOrUndefined(util.BoolPtr(false)),
 		},
 		{
 			description: "deploy shd not perform status check when deployer is in error",
 			testBench:   &TestBench{deployErrors: []error{errors.New("deploy error")}},
 			shouldErr:   true,
-			statusCheck: true,
+			statusCheck: config.NewBoolOrUndefined(util.BoolPtr(true)),
 		},
 	}
 

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -141,6 +141,14 @@ func (rc *RunContext) Deployers() []latest.DeployType { return rc.Pipelines.Depl
 
 func (rc *RunContext) TestCases() []*latest.TestCase { return rc.Pipelines.TestCases() }
 
+func (rc *RunContext) StatusCheck() bool {
+	sc := rc.Opts.StatusCheck.Value()
+	if sc == nil {
+		return true
+	}
+	return *sc
+}
+
 func (rc *RunContext) StatusCheckDeadlineSeconds() int {
 	return rc.Pipelines.StatusCheckDeadlineSeconds()
 }
@@ -180,7 +188,6 @@ func (rc *RunContext) RenderOnly() bool                          { return rc.Opt
 func (rc *RunContext) RenderOutput() string                      { return rc.Opts.RenderOutput }
 func (rc *RunContext) SkipRender() bool                          { return rc.Opts.SkipRender }
 func (rc *RunContext) SkipTests() bool                           { return rc.Opts.SkipTests }
-func (rc *RunContext) StatusCheck() bool                         { return rc.Opts.StatusCheck }
 func (rc *RunContext) Tail() bool                                { return rc.Opts.Tail }
 func (rc *RunContext) Trigger() string                           { return rc.Opts.Trigger }
 func (rc *RunContext) WaitForDeletions() config.WaitForDeletions { return rc.Opts.WaitForDeletions }


### PR DESCRIPTION

Fixes: N/A
**Related**: https://github.com/GoogleContainerTools/skaffold/issues/4904
**Merge before/after**: Merge before https://github.com/GoogleContainerTools/skaffold/pull/5706

**Description**
As [suggested](https://github.com/GoogleContainerTools/skaffold/pull/5706#issuecomment-822825728) by @gsquared94 and @MarlonGamez, make the `status-check` flag nullable in order to distinguish among true, false, and unset values. There is no user-facing impact of this change, but it will enable us to add a new `StatusCheck` field in the skaffold.yaml (https://github.com/GoogleContainerTools/skaffold/pull/5706) that, when set to false, will disable the healthcheck when the `status-check` flag is false or unset.


**Follow-up Work (remove if N/A)**
Update https://github.com/GoogleContainerTools/skaffold/pull/5706.
