### PR TITLE
Fix go module names to be unique

### DIFF
--- a/codelab/03_buildpacks-runimage-override/app/go.mod
+++ b/codelab/03_buildpacks-runimage-override/app/go.mod
@@ -1,3 +1,3 @@
-module github.com/GoogleContainerTools/skaffold/codelabs/buildpacks
+module github.com/GoogleContainerTools/skaffold/codelab/buildpacks
 
 go 1.13

--- a/codelab/03_buildpacks-runimage-override/app/go.mod
+++ b/codelab/03_buildpacks-runimage-override/app/go.mod
@@ -1,3 +1,3 @@
-module github.com/GoogleContainerTools/skaffold/examples/buildpacks
+module github.com/GoogleContainerTools/skaffold/codelabs/buildpacks
 
 go 1.13

--- a/integration/examples/custom-buildx/go.mod
+++ b/integration/examples/custom-buildx/go.mod
@@ -1,3 +1,3 @@
-module github.com/GoogleContainerTools/skaffold/examples/custom
+module github.com/GoogleContainerTools/skaffold/examples/custom-buildx
 
 go 1.13


### PR DESCRIPTION
**Description**
`gopls` doesn't like encountering multiple projects with the same module name and complains:
```
{"type":1,"message":"2021/04/26 08:58:21 diagnosing go.mod: found module \"github.com/GoogleContainerTools/skaffold/examples/buildpacks\" twice in the workspace\n"}
```

and refuses to continue on.  (It doesn't like the duplication of `examples` and `integrations/examples`, but I just delete `examples/`.)

This PR ensures we have unique module names, ignoring `examples/`.