### PR TITLE
[V3] (Part 1) Refactor schema "latest" to "latest/v1"

### DIFF
--- a/cmd/skaffold/app/cmd/apply.go
+++ b/cmd/skaffold/app/cmd/apply.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // NewCmdApply describes the CLI command to apply manifests to a cluster.
@@ -53,7 +53,7 @@ func doApply(ctx context.Context, out io.Writer, args []string) error {
 	if err := validateManifests(args); err != nil {
 		return err
 	}
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []*latest_v1.SkaffoldConfig) error {
 		return r.Apply(ctx, out)
 	})
 }

--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 var (
@@ -67,7 +67,7 @@ func doBuild(ctx context.Context, out io.Writer) error {
 		buildOut = ioutil.Discard
 	}
 
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []*latest_v1.SkaffoldConfig) error {
 		bRes, err := r.Build(ctx, buildOut, targetArtifacts(opts, configs))
 
 		if quietFlag || buildOutputFlag != "" {
@@ -94,8 +94,8 @@ func doBuild(ctx context.Context, out io.Writer) error {
 	})
 }
 
-func targetArtifacts(opts config.SkaffoldOptions, configs []*latest.SkaffoldConfig) []*latest.Artifact {
-	var targetArtifacts []*latest.Artifact
+func targetArtifacts(opts config.SkaffoldOptions, configs []*latest_v1.SkaffoldConfig) []*latest_v1.Artifact {
+	var targetArtifacts []*latest_v1.Artifact
 	for _, cfg := range configs {
 		for _, artifact := range cfg.Build.Artifacts {
 			if opts.IsTargetImage(artifact) {

--- a/cmd/skaffold/app/cmd/build_test.go
+++ b/cmd/skaffold/app/cmd/build_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -37,7 +37,7 @@ type mockRunner struct {
 	runner.Runner
 }
 
-func (r *mockRunner) Build(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
+func (r *mockRunner) Build(ctx context.Context, out io.Writer, artifacts []*latest_v1.Artifact) ([]graph.Artifact, error) {
 	out.Write([]byte("Build Completed"))
 	return []graph.Artifact{{
 		ImageName: "gcr.io/skaffold/example",
@@ -50,8 +50,8 @@ func (r *mockRunner) Stop() error {
 }
 
 func TestTagFlag(t *testing.T) {
-	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest.SkaffoldConfig, *runcontext.RunContext, error) {
-		return &mockRunner{}, []*latest.SkaffoldConfig{{}}, nil, nil
+	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest_v1.SkaffoldConfig, *runcontext.RunContext, error) {
+		return &mockRunner{}, []*latest_v1.SkaffoldConfig{{}}, nil, nil
 	}
 
 	testutil.Run(t, "override tag with argument", func(t *testutil.T) {
@@ -69,8 +69,8 @@ func TestTagFlag(t *testing.T) {
 }
 
 func TestQuietFlag(t *testing.T) {
-	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest.SkaffoldConfig, *runcontext.RunContext, error) {
-		return &mockRunner{}, []*latest.SkaffoldConfig{{}}, nil, nil
+	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest_v1.SkaffoldConfig, *runcontext.RunContext, error) {
+		return &mockRunner{}, []*latest_v1.SkaffoldConfig{{}}, nil, nil
 	}
 
 	tests := []struct {
@@ -115,8 +115,8 @@ func TestQuietFlag(t *testing.T) {
 }
 
 func TestFileOutputFlag(t *testing.T) {
-	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest.SkaffoldConfig, *runcontext.RunContext, error) {
-		return &mockRunner{}, []*latest.SkaffoldConfig{{}}, nil, nil
+	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest_v1.SkaffoldConfig, *runcontext.RunContext, error) {
+		return &mockRunner{}, []*latest_v1.SkaffoldConfig{{}}, nil, nil
 	}
 
 	tests := []struct {
@@ -178,16 +178,16 @@ func TestFileOutputFlag(t *testing.T) {
 }
 
 func TestRunBuild(t *testing.T) {
-	errRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest.SkaffoldConfig, *runcontext.RunContext, error) {
+	errRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest_v1.SkaffoldConfig, *runcontext.RunContext, error) {
 		return nil, nil, nil, errors.New("some error")
 	}
-	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest.SkaffoldConfig, *runcontext.RunContext, error) {
-		return &mockRunner{}, []*latest.SkaffoldConfig{{}}, nil, nil
+	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest_v1.SkaffoldConfig, *runcontext.RunContext, error) {
+		return &mockRunner{}, []*latest_v1.SkaffoldConfig{{}}, nil, nil
 	}
 
 	tests := []struct {
 		description string
-		mock        func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest.SkaffoldConfig, *runcontext.RunContext, error)
+		mock        func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest_v1.SkaffoldConfig, *runcontext.RunContext, error)
 		shouldErr   bool
 	}{
 		{

--- a/cmd/skaffold/app/cmd/debug_test.go
+++ b/cmd/skaffold/app/cmd/debug_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -49,8 +49,8 @@ func TestNewCmdDebug(t *testing.T) {
 func TestDebugIndependentFromDev(t *testing.T) {
 	mockRunner := &mockDevRunner{}
 	testutil.Run(t, "DevDebug", func(t *testutil.T) {
-		t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest.SkaffoldConfig, *runcontext.RunContext, error) {
-			return mockRunner, []*latest.SkaffoldConfig{{}}, nil, nil
+		t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest_v1.SkaffoldConfig, *runcontext.RunContext, error) {
+			return mockRunner, []*latest_v1.SkaffoldConfig{{}}, nil, nil
 		})
 		t.Override(&opts, config.SkaffoldOptions{})
 		t.Override(&doDev, func(context.Context, io.Writer) error {

--- a/cmd/skaffold/app/cmd/delete.go
+++ b/cmd/skaffold/app/cmd/delete.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // NewCmdDelete describes the CLI command to delete deployed resources.
@@ -35,7 +35,7 @@ func NewCmdDelete() *cobra.Command {
 }
 
 func doDelete(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, _ []*latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, _ []*latest_v1.SkaffoldConfig) error {
 		return r.Cleanup(ctx, out)
 	})
 }

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 var (
@@ -51,11 +51,11 @@ func NewCmdDeploy() *cobra.Command {
 }
 
 func doDeploy(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []*latest_v1.SkaffoldConfig) error {
 		if opts.SkipRender {
 			return r.DeployAndLog(ctx, out, []graph.Artifact{})
 		}
-		var artifacts []*latest.Artifact
+		var artifacts []*latest_v1.Artifact
 		for _, cfg := range configs {
 			artifacts = append(artifacts, cfg.Build.Artifacts...)
 		}

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -25,7 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // for testing
@@ -60,8 +60,8 @@ func runDev(ctx context.Context, out io.Writer) error {
 		case <-ctx.Done():
 			return nil
 		default:
-			err := withRunner(ctx, out, func(r runner.Runner, configs []*latest.SkaffoldConfig) error {
-				var artifacts []*latest.Artifact
+			err := withRunner(ctx, out, func(r runner.Runner, configs []*latest_v1.SkaffoldConfig) error {
+				var artifacts []*latest_v1.Artifact
 				for _, cfg := range configs {
 					artifacts = append(artifacts, cfg.Build.Artifacts...)
 				}

--- a/cmd/skaffold/app/cmd/dev_test.go
+++ b/cmd/skaffold/app/cmd/dev_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -37,7 +37,7 @@ type mockDevRunner struct {
 	calls       []string
 }
 
-func (r *mockDevRunner) Dev(context.Context, io.Writer, []*latest.Artifact) error {
+func (r *mockDevRunner) Dev(context.Context, io.Writer, []*latest_v1.Artifact) error {
 	r.calls = append(r.calls, "Dev")
 	return r.errDev
 }
@@ -96,8 +96,8 @@ func TestDoDev(t *testing.T) {
 				hasDeployed: test.hasDeployed,
 				errDev:      context.Canceled,
 			}
-			t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest.SkaffoldConfig, *runcontext.RunContext, error) {
-				return mockRunner, []*latest.SkaffoldConfig{{}}, nil, nil
+			t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest_v1.SkaffoldConfig, *runcontext.RunContext, error) {
+				return mockRunner, []*latest_v1.SkaffoldConfig{{}}, nil, nil
 			})
 			t.Override(&opts, config.SkaffoldOptions{
 				Cleanup: true,
@@ -117,7 +117,7 @@ type mockConfigChangeRunner struct {
 	cycles int
 }
 
-func (m *mockConfigChangeRunner) Dev(context.Context, io.Writer, []*latest.Artifact) error {
+func (m *mockConfigChangeRunner) Dev(context.Context, io.Writer, []*latest_v1.Artifact) error {
 	m.cycles++
 	if m.cycles == 1 {
 		// pass through the first cycle with a config reload
@@ -146,8 +146,8 @@ func TestDevConfigChange(t *testing.T) {
 	testutil.Run(t, "test config change", func(t *testutil.T) {
 		mockRunner := &mockConfigChangeRunner{}
 
-		t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest.SkaffoldConfig, *runcontext.RunContext, error) {
-			return mockRunner, []*latest.SkaffoldConfig{{}}, nil, nil
+		t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest_v1.SkaffoldConfig, *runcontext.RunContext, error) {
+			return mockRunner, []*latest_v1.SkaffoldConfig{{}}, nil, nil
 		})
 		t.Override(&opts, config.SkaffoldOptions{
 			Cleanup: true,

--- a/cmd/skaffold/app/cmd/filter.go
+++ b/cmd/skaffold/app/cmd/filter.go
@@ -30,7 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // for tests
@@ -58,7 +58,7 @@ func NewCmdFilter() *cobra.Command {
 // runFilter loads the Kubernetes manifests from stdin and applies the debug transformations.
 // Unlike `skaffold debug`, this filtering affects all images and not just the built artifacts.
 func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildArtifacts []graph.Artifact) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []*latest_v1.SkaffoldConfig) error {
 		manifestList, err := manifest.Load(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("loading manifests: %w", err)
@@ -87,7 +87,7 @@ func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildA
 	})
 }
 
-func getInsecureRegistries(opts config.SkaffoldOptions, configs []*latest.SkaffoldConfig) (map[string]bool, error) {
+func getInsecureRegistries(opts config.SkaffoldOptions, configs []*latest_v1.SkaffoldConfig) (map[string]bool, error) {
 	cfgRegistries, err := config.GetInsecureRegistries(opts.GlobalConfig)
 	if err != nil {
 		return nil, err

--- a/cmd/skaffold/app/cmd/find_configs.go
+++ b/cmd/skaffold/app/cmd/find_configs.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
 )
 
@@ -66,7 +66,7 @@ func doFindConfigs(_ context.Context, out io.Writer) error {
 		pathOutLen, versionOutLen := 70, 30
 		for p, v := range pathToVersion {
 			c := color.Default
-			if v != latest.Version {
+			if v != latest_v1.Version {
 				c = color.Green
 			}
 			c.Fprintf(out, fmt.Sprintf("%%-%ds\t%%-%ds\n", pathOutLen, versionOutLen), p, v)

--- a/cmd/skaffold/app/cmd/find_configs_test.go
+++ b/cmd/skaffold/app/cmd/find_configs_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1beta7"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -32,22 +32,22 @@ func TestFindConfigs(t *testing.T) {
 	}{
 		{
 			files: map[string]string{
-				"valid.yml":        validYaml(latest.Version),
+				"valid.yml":        validYaml(latest_v1.Version),
 				"upgradeable.yaml": validYaml(v1beta7.Version),
 				"invalid.yaml":     invalidYaml(),
 			},
 			expected: map[string]string{
-				"valid.yml":        latest.Version,
+				"valid.yml":        latest_v1.Version,
 				"upgradeable.yaml": v1beta7.Version,
 			},
 		},
 		{
 			files: map[string]string{
-				"valid.yaml":   validYaml(latest.Version),
+				"valid.yaml":   validYaml(latest_v1.Version),
 				"invalid.yaml": invalidYaml(),
 			},
 			expected: map[string]string{
-				"valid.yaml": latest.Version,
+				"valid.yaml": latest_v1.Version,
 			},
 		},
 	}

--- a/cmd/skaffold/app/cmd/fix.go
+++ b/cmd/skaffold/app/cmd/fix.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/validation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 )
@@ -41,7 +41,7 @@ func NewCmdFix() *cobra.Command {
 		WithCommonFlags().
 		WithFlags([]*Flag{
 			{Value: &overwrite, Name: "overwrite", DefValue: false, Usage: "Overwrite original config with fixed config"},
-			{Value: &toVersion, Name: "version", DefValue: latest.Version, Usage: "Target schema version to upgrade to"},
+			{Value: &toVersion, Name: "version", DefValue: latest_v1.Version, Usage: "Target schema version to upgrade to"},
 		}).
 		NoArgs(doFix)
 }
@@ -74,10 +74,10 @@ func fix(out io.Writer, configFile string, toVersion string, overwrite bool) err
 
 	// TODO(dgageot): We should be able run validations on any schema version
 	// but that's not the case. They can only run on the latest version for now.
-	if toVersion == latest.Version {
-		var cfgs []*latest.SkaffoldConfig
+	if toVersion == latest_v1.Version {
+		var cfgs []*latest_v1.SkaffoldConfig
 		for _, cfg := range versionedCfgs {
-			cfgs = append(cfgs, cfg.(*latest.SkaffoldConfig))
+			cfgs = append(cfgs, cfg.(*latest_v1.SkaffoldConfig))
 		}
 		if err := validation.Process(cfgs); err != nil {
 			return fmt.Errorf("validating upgraded config: %w", err)

--- a/cmd/skaffold/app/cmd/fix_test.go
+++ b/cmd/skaffold/app/cmd/fix_test.go
@@ -22,7 +22,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -37,7 +37,7 @@ func TestFix(t *testing.T) {
 	}{
 		{
 			description:   "v1alpha4 to latest",
-			targetVersion: latest.Version,
+			targetVersion: latest_v1.Version,
 			inputYaml: `apiVersion: skaffold/v1alpha4
 kind: Config
 build:
@@ -69,11 +69,11 @@ deploy:
   kubectl:
     manifests:
     - k8s/deployment.yaml
-`, latest.Version),
+`, latest_v1.Version),
 		},
 		{
 			description:   "v1alpha1 to latest",
-			targetVersion: latest.Version,
+			targetVersion: latest_v1.Version,
 			inputYaml: `apiVersion: skaffold/v1alpha1
 kind: Config
 build:
@@ -97,7 +97,7 @@ deploy:
   kubectl:
     manifests:
     - k8s/deployment.yaml
-`, latest.Version),
+`, latest_v1.Version),
 		},
 		{
 			description:   "v1alpha1 to v1",
@@ -129,11 +129,11 @@ deploy:
 		},
 		{
 			description:   "already target version",
-			targetVersion: latest.Version,
+			targetVersion: latest_v1.Version,
 			inputYaml: fmt.Sprintf(`apiVersion: %s
 kind: Config
-`, latest.Version),
-			output: "config is already version " + latest.Version + "\n",
+`, latest_v1.Version),
+			output: "config is already version " + latest_v1.Version + "\n",
 		},
 		{
 			description: "invalid input",
@@ -142,7 +142,7 @@ kind: Config
 		},
 		{
 			description:   "validation fails",
-			targetVersion: latest.Version,
+			targetVersion: latest_v1.Version,
 			inputYaml: `apiVersion: skaffold/v1alpha1
 kind: Config
 build:
@@ -197,13 +197,13 @@ deploy:
   kubectl:
     manifests:
     - k8s/deployment.yaml
-`, latest.Version)
+`, latest_v1.Version)
 
 	testutil.Run(t, "", func(t *testutil.T) {
 		cfgFile := t.TempFile("config", []byte(inputYaml))
 
 		var b bytes.Buffer
-		err := fix(&b, cfgFile, latest.Version, true)
+		err := fix(&b, cfgFile, latest_v1.Version, true)
 
 		output, _ := ioutil.ReadFile(cfgFile)
 

--- a/cmd/skaffold/app/cmd/generate_pipeline.go
+++ b/cmd/skaffold/app/cmd/generate_pipeline.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 var (
@@ -44,7 +44,7 @@ func NewCmdGeneratePipeline() *cobra.Command {
 }
 
 func doGeneratePipeline(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []*latest_v1.SkaffoldConfig) error {
 		if err := r.GeneratePipeline(ctx, out, configs, configFiles, "pipeline.yaml"); err != nil {
 			return fmt.Errorf("generating : %w", err)
 		}

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 var (
@@ -60,7 +60,7 @@ func doRender(ctx context.Context, out io.Writer) error {
 		buildOut = out
 	}
 
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []*latest_v1.SkaffoldConfig) error {
 		var bRes []graph.Artifact
 
 		if renderFromBuildOutputFile.String() != "" {

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // NewCmdRun describes the CLI command to run a pipeline.
@@ -41,7 +41,7 @@ func NewCmdRun() *cobra.Command {
 }
 
 func doRun(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latest.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []*latest_v1.SkaffoldConfig) error {
 		bRes, err := r.Build(ctx, out, targetArtifacts(opts, configs))
 		if err != nil {
 			return fmt.Errorf("failed to build: %w", err)

--- a/cmd/skaffold/app/cmd/run_test.go
+++ b/cmd/skaffold/app/cmd/run_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -52,7 +52,7 @@ type mockRunRunner struct {
 	artifactImageNames []string
 }
 
-func (r *mockRunRunner) Build(_ context.Context, _ io.Writer, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
+func (r *mockRunRunner) Build(_ context.Context, _ io.Writer, artifacts []*latest_v1.Artifact) ([]graph.Artifact, error) {
 	var result []graph.Artifact
 	for _, artifact := range artifacts {
 		imageName := artifact.ImageName
@@ -92,11 +92,11 @@ func TestDoRun(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, "", func(t *testutil.T) {
 			mockRunner := &mockRunRunner{}
-			t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest.SkaffoldConfig, *runcontext.RunContext, error) {
-				return mockRunner, []*latest.SkaffoldConfig{{
-					Pipeline: latest.Pipeline{
-						Build: latest.BuildConfig{
-							Artifacts: []*latest.Artifact{
+			t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latest_v1.SkaffoldConfig, *runcontext.RunContext, error) {
+				return mockRunner, []*latest_v1.SkaffoldConfig{{
+					Pipeline: latest_v1.Pipeline{
+						Build: latest_v1.BuildConfig{
+							Artifacts: []*latest_v1.Artifact{
 								{ImageName: "first"},
 								{ImageName: "second-test"},
 								{ImageName: "test"},

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -36,7 +36,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/validation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
@@ -45,7 +45,7 @@ import (
 // For tests
 var createRunner = createNewRunner
 
-func withRunner(ctx context.Context, out io.Writer, action func(runner.Runner, []*latest.SkaffoldConfig) error) error {
+func withRunner(ctx context.Context, out io.Writer, action func(runner.Runner, []*latest_v1.SkaffoldConfig) error) error {
 	runner, config, runCtx, err := createRunner(out, opts)
 	if err != nil {
 		return err
@@ -57,7 +57,7 @@ func withRunner(ctx context.Context, out io.Writer, action func(runner.Runner, [
 }
 
 // createNewRunner creates a Runner and returns the SkaffoldConfig associated with it.
-func createNewRunner(out io.Writer, opts config.SkaffoldOptions) (runner.Runner, []*latest.SkaffoldConfig, *runcontext.RunContext, error) {
+func createNewRunner(out io.Writer, opts config.SkaffoldOptions) (runner.Runner, []*latest_v1.SkaffoldConfig, *runcontext.RunContext, error) {
 	runCtx, configs, err := runContext(out, opts)
 	if err != nil {
 		return nil, nil, nil, err
@@ -73,13 +73,13 @@ func createNewRunner(out io.Writer, opts config.SkaffoldOptions) (runner.Runner,
 	return runner, configs, runCtx, nil
 }
 
-func runContext(out io.Writer, opts config.SkaffoldOptions) (*runcontext.RunContext, []*latest.SkaffoldConfig, error) {
+func runContext(out io.Writer, opts config.SkaffoldOptions) (*runcontext.RunContext, []*latest_v1.SkaffoldConfig, error) {
 	configs, err := withFallbackConfig(out, opts, parser.GetAllConfigs)
 	if err != nil {
 		return nil, nil, err
 	}
 	setDefaultDeployer(configs)
-	var pipelines []latest.Pipeline
+	var pipelines []latest_v1.Pipeline
 	for _, cfg := range configs {
 		pipelines = append(pipelines, cfg.Pipeline)
 	}
@@ -104,7 +104,7 @@ func runContext(out io.Writer, opts config.SkaffoldOptions) (*runcontext.RunCont
 }
 
 // withFallbackConfig will try to automatically generate a config if root `skaffold.yaml` file does not exist.
-func withFallbackConfig(out io.Writer, opts config.SkaffoldOptions, getCfgs func(opts config.SkaffoldOptions) ([]*latest.SkaffoldConfig, error)) ([]*latest.SkaffoldConfig, error) {
+func withFallbackConfig(out io.Writer, opts config.SkaffoldOptions, getCfgs func(opts config.SkaffoldOptions) ([]*latest_v1.SkaffoldConfig, error)) ([]*latest_v1.SkaffoldConfig, error) {
 	configs, err := getCfgs(opts)
 	if err == nil {
 		return configs, nil
@@ -123,7 +123,7 @@ func withFallbackConfig(out io.Writer, opts config.SkaffoldOptions, getCfgs func
 
 			defaults.Set(config)
 
-			return []*latest.SkaffoldConfig{config}, nil
+			return []*latest_v1.SkaffoldConfig{config}, nil
 		}
 
 		return nil, fmt.Errorf("skaffold config file %s not found - check your current working directory, or try running `skaffold init`", opts.ConfigurationFile)
@@ -136,7 +136,7 @@ func withFallbackConfig(out io.Writer, opts config.SkaffoldOptions, getCfgs func
 	return nil, fmt.Errorf("parsing skaffold config: %w", err)
 }
 
-func setDefaultDeployer(configs []*latest.SkaffoldConfig) {
+func setDefaultDeployer(configs []*latest_v1.SkaffoldConfig) {
 	// do not set a default deployer in a multi-config application.
 	if len(configs) > 1 {
 		return

--- a/cmd/skaffold/app/cmd/runner_test.go
+++ b/cmd/skaffold/app/cmd/runner_test.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -96,7 +96,7 @@ func TestCreateNewRunner(t *testing.T) {
 				return semver.Version{}, semver.Version{}, nil
 			})
 			t.NewTempDir().
-				Write("skaffold.yaml", fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latest.Version, test.config)).
+				Write("skaffold.yaml", fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latest_v1.Version, test.config)).
 				Chdir()
 
 			_, _, _, err := createNewRunner(ioutil.Discard, test.options)

--- a/cmd/skaffold/app/cmd/schema/list_test.go
+++ b/cmd/skaffold/app/cmd/schema/list_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -34,7 +34,7 @@ func TestListPlain(t *testing.T) {
 		t.CheckNoError(err)
 
 		versions := out.String()
-		t.CheckTrue(strings.HasSuffix(versions, latest.Version+"\n"))
+		t.CheckTrue(strings.HasSuffix(versions, latest_v1.Version+"\n"))
 		t.CheckTrue(strings.HasPrefix(versions, `skaffold/v1alpha1
 skaffold/v1alpha2
 skaffold/v1alpha3
@@ -71,7 +71,7 @@ func TestListJson(t *testing.T) {
 
 		versions := out.String()
 		t.CheckTrue(strings.HasPrefix(versions, `{"versions":["skaffold/v1alpha1","skaffold/v1alpha2",`))
-		t.CheckTrue(strings.HasSuffix(versions, fmt.Sprintf(",\"%s\"]}\n", latest.Version)))
+		t.CheckTrue(strings.HasSuffix(versions, fmt.Sprintf(",\"%s\"]}\n", latest_v1.Version)))
 	})
 }
 

--- a/cmd/skaffold/app/cmd/test.go
+++ b/cmd/skaffold/app/cmd/test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // NewCmdTest describes the CLI command to test artifacts.
@@ -39,8 +39,8 @@ func NewCmdTest() *cobra.Command {
 }
 
 func doTest(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latest.SkaffoldConfig) error {
-		var artifacts []*latest.Artifact
+	return withRunner(ctx, out, func(r runner.Runner, configs []*latest_v1.SkaffoldConfig) error {
+		var artifacts []*latest_v1.Artifact
 		for _, c := range configs {
 			artifacts = append(artifacts, c.Build.Artifacts...)
 		}

--- a/cmd/skaffold/app/cmd/util.go
+++ b/cmd/skaffold/app/cmd/util.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 )
 
@@ -29,7 +29,7 @@ import (
 // no default repo is specified.
 type DefaultRepoFn func(string) (string, error)
 
-func getBuildArtifactsAndSetTags(artifacts []*latest.Artifact, defaulterFn DefaultRepoFn) ([]graph.Artifact, error) {
+func getBuildArtifactsAndSetTags(artifacts []*latest_v1.Artifact, defaulterFn DefaultRepoFn) ([]graph.Artifact, error) {
 	buildArtifacts, err := mergeBuildArtifacts(fromBuildOutputFile.BuildArtifacts(), preBuiltImages.Artifacts(), artifacts)
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func applyDefaultRepoToArtifacts(artifacts []graph.Artifact, defaulterFn Default
 	return artifacts, nil
 }
 
-func mergeBuildArtifacts(fromFile, fromCLI []graph.Artifact, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
+func mergeBuildArtifacts(fromFile, fromCLI []graph.Artifact, artifacts []*latest_v1.Artifact) ([]graph.Artifact, error) {
 	var buildArtifacts []graph.Artifact
 	for _, artifact := range artifacts {
 		buildArtifacts = append(buildArtifacts, graph.Artifact{

--- a/cmd/skaffold/app/cmd/util_test.go
+++ b/cmd/skaffold/app/cmd/util_test.go
@@ -22,14 +22,14 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestGetArtifacts(t *testing.T) {
 	tests := []struct {
 		description string
-		artifacts   []*latest.Artifact
+		artifacts   []*latest_v1.Artifact
 		fromFile    []graph.Artifact
 		fromCLI     []graph.Artifact
 		expected    []graph.Artifact
@@ -45,48 +45,48 @@ func TestGetArtifacts(t *testing.T) {
 		},
 		{
 			description: "from file",
-			artifacts:   []*latest.Artifact{{ImageName: "image"}},
+			artifacts:   []*latest_v1.Artifact{{ImageName: "image"}},
 			fromFile:    []graph.Artifact{{ImageName: "image", Tag: "image:tag"}},
 			fromCLI:     nil,
 			expected:    []graph.Artifact{{ImageName: "image", Tag: "image:tag"}},
 		},
 		{
 			description: "from CLI",
-			artifacts:   []*latest.Artifact{{ImageName: "image"}},
+			artifacts:   []*latest_v1.Artifact{{ImageName: "image"}},
 			fromFile:    nil,
 			fromCLI:     []graph.Artifact{{ImageName: "image", Tag: "image:tag"}},
 			expected:    []graph.Artifact{{ImageName: "image", Tag: "image:tag"}},
 		},
 		{
 			description: "one from file, one from CLI",
-			artifacts:   []*latest.Artifact{{ImageName: "image1"}, {ImageName: "image2"}},
+			artifacts:   []*latest_v1.Artifact{{ImageName: "image1"}, {ImageName: "image2"}},
 			fromFile:    []graph.Artifact{{ImageName: "image1", Tag: "image1:tag"}},
 			fromCLI:     []graph.Artifact{{ImageName: "image2", Tag: "image2:tag"}},
 			expected:    []graph.Artifact{{ImageName: "image1", Tag: "image1:tag"}, {ImageName: "image2", Tag: "image2:tag"}},
 		},
 		{
 			description: "file takes precedence on CLI",
-			artifacts:   []*latest.Artifact{{ImageName: "image1"}, {ImageName: "image2"}},
+			artifacts:   []*latest_v1.Artifact{{ImageName: "image1"}, {ImageName: "image2"}},
 			fromFile:    []graph.Artifact{{ImageName: "image1", Tag: "image1:tag"}, {ImageName: "image2", Tag: "image2:tag"}},
 			fromCLI:     []graph.Artifact{{ImageName: "image1", Tag: "image1:ignored"}},
 			expected:    []graph.Artifact{{ImageName: "image1", Tag: "image1:tag"}, {ImageName: "image2", Tag: "image2:tag"}},
 		},
 		{
 			description: "provide tag for non-artifact",
-			artifacts:   []*latest.Artifact{},
+			artifacts:   []*latest_v1.Artifact{},
 			fromCLI:     []graph.Artifact{{ImageName: "busybox", Tag: "busybox:v1"}},
 			expected:    []graph.Artifact{{ImageName: "busybox", Tag: "busybox:v1"}},
 		},
 		{
 			description: "missing tag",
-			artifacts:   []*latest.Artifact{{ImageName: "image1"}, {ImageName: "image2"}},
+			artifacts:   []*latest_v1.Artifact{{ImageName: "image1"}, {ImageName: "image2"}},
 			fromFile:    nil,
 			fromCLI:     nil,
 			shouldErr:   true,
 		},
 		{
 			description: "override tag",
-			artifacts:   []*latest.Artifact{{ImageName: "image1"}, {ImageName: "image2"}},
+			artifacts:   []*latest_v1.Artifact{{ImageName: "image1"}, {ImageName: "image2"}},
 			fromFile:    []graph.Artifact{{ImageName: "image1", Tag: "image1:tag"}},
 			fromCLI:     []graph.Artifact{{ImageName: "image2", Tag: "image2:tag"}},
 			expected:    []graph.Artifact{{ImageName: "image1", Tag: "image1:test"}, {ImageName: "image2", Tag: "image2:test"}},
@@ -94,7 +94,7 @@ func TestGetArtifacts(t *testing.T) {
 		},
 		{
 			description: "override missing tag",
-			artifacts:   []*latest.Artifact{{ImageName: "image1"}, {ImageName: "image2"}},
+			artifacts:   []*latest_v1.Artifact{{ImageName: "image1"}, {ImageName: "image2"}},
 			fromFile:    nil,
 			fromCLI:     nil,
 			expected:    []graph.Artifact{{ImageName: "image1", Tag: "image1:test"}, {ImageName: "image2", Tag: "image2:test"}},
@@ -102,7 +102,7 @@ func TestGetArtifacts(t *testing.T) {
 		},
 		{
 			description: "apply tags to no artifacts",
-			artifacts:   []*latest.Artifact{},
+			artifacts:   []*latest_v1.Artifact{},
 			fromFile:    nil,
 			fromCLI:     nil,
 			expected:    []graph.Artifact(nil),

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/buildpacks/lifecycle v0.10.2
 	github.com/buildpacks/pack v0.17.0
 	github.com/cenkalti/backoff/v4 v4.0.2
+	github.com/daixiang0/gci v0.2.8 // indirect
 	github.com/docker/cli v20.10.0-beta1.0.20201117192004-5cc239616494+incompatible
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v20.10.0-beta1.0.20201110211921-af34b94a78a1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -351,6 +351,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
+github.com/daixiang0/gci v0.2.8 h1:1mrIGMBQsBu0P7j7m1M8Lb+ZeZxsZL+jyGX4YoMJJpg=
+github.com/daixiang0/gci v0.2.8/go.mod h1:+4dZ7TISfSmqfAGv59ePaHfNzgGtIkHAhhdKggP1JAc=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -1708,6 +1710,7 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/tools v0.0.0-20200916195026-c9a70fc28ce3/go.mod h1:z6u4i615ZeAfBE4XtMziQW1fSVJXACjjbWkB/mvPzlU=
 golang.org/x/tools v0.0.0-20201110124207-079ba7bd75cd/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20201118003311-bd56c0adb394/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=

--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -18,7 +18,7 @@ files=$(find . -name "*.go" | grep -v vendor/ | xargs gofmt -l -s)
 if [[ $files ]]; then
     echo "Gofmt errors in files:"
     echo "$files"
-    diff=$(find . -name "*.go" | grep -v vendor/ | xargs gofmt -d -s)
+    diff=$(find . -name "*.go" | grep -v vendor/ | xargs gofmt -w -d)
     echo "$diff"
     exit 1
 fi

--- a/hack/schemas/main.go
+++ b/hack/schemas/main.go
@@ -132,7 +132,7 @@ func generateSchema(root string, dryRun bool, version schema.Version) (bool, err
 	folder := apiVersion
 	strict := false
 	if version.APIVersion == schema.SchemaVersions[len(schema.SchemaVersions)-1].APIVersion {
-		folder = "latest"
+		folder = "latest/v1"
 		strict = true
 	}
 

--- a/hack/versions/pkg/schema/version.go
+++ b/hack/versions/pkg/schema/version.go
@@ -25,15 +25,15 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
 )
 
 func GetLatestVersion() (string, bool) {
-	current := strings.TrimPrefix(latest.Version, "skaffold/")
+	current := strings.TrimPrefix(latest_v1.Version, "skaffold/")
 	logrus.Debugf("Current Skaffold version: %s", current)
 
-	config, err := ioutil.ReadFile("pkg/skaffold/schema/latest/config.go")
+	config, err := ioutil.ReadFile("pkg/skaffold/schema/latest/v1/config.go")
 	if err != nil {
 		logrus.Fatalf("failed to read latest config: %s", err)
 	}

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -79,16 +79,16 @@ spec:
 			Chdir()
 		deployer, err := kubectl.NewDeployer(&runcontext.RunContext{
 			WorkingDir: ".",
-			Pipelines: runcontext.NewPipelines([]latest.Pipeline{{
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KubectlDeploy: &latest.KubectlDeploy{
+			Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						KubectlDeploy: &latest_v1.KubectlDeploy{
 							Manifests: []string{"deployment.yaml"},
 						},
 					},
 				},
 			}}),
-		}, nil, &latest.KubectlDeploy{
+		}, nil, &latest_v1.KubectlDeploy{
 			Manifests: []string{"deployment.yaml"},
 		})
 		t.RequireNoError(err)
@@ -236,10 +236,10 @@ spec:
 
 			deployer, err := kubectl.NewDeployer(&runcontext.RunContext{
 				WorkingDir: ".",
-				Pipelines: runcontext.NewPipelines([]latest.Pipeline{{
-					Deploy: latest.DeployConfig{
-						DeployType: latest.DeployType{
-							KubectlDeploy: &latest.KubectlDeploy{
+				Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{
+					Deploy: latest_v1.DeployConfig{
+						DeployType: latest_v1.DeployType{
+							KubectlDeploy: &latest_v1.KubectlDeploy{
 								Manifests: []string{"deployment.yaml"},
 							},
 						},
@@ -248,7 +248,7 @@ spec:
 				Opts: config.SkaffoldOptions{
 					AddSkaffoldLabels: true,
 				},
-			}, nil, &latest.KubectlDeploy{
+			}, nil, &latest_v1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
 			})
 			t.RequireNoError(err)
@@ -267,7 +267,7 @@ func TestHelmRender(t *testing.T) {
 	tests := []struct {
 		description  string
 		builds       []graph.Artifact
-		helmReleases []latest.HelmRelease
+		helmReleases []latest_v1.HelmRelease
 		expectedOut  string
 	}{
 		{
@@ -278,7 +278,7 @@ func TestHelmRender(t *testing.T) {
 					Tag:       "gke-loadbalancer:test",
 				},
 			},
-			helmReleases: []latest.HelmRelease{{
+			helmReleases: []latest_v1.HelmRelease{{
 				Name:      "gke_loadbalancer",
 				ChartPath: "testdata/gke_loadbalancer/loadbalancer-helm",
 				ArtifactOverrides: map[string]string{
@@ -336,7 +336,7 @@ spec:
 					Tag:       "gcr.io/k8s-skaffold/skaffold-helm:sha256-nonsenslettersandnumbers",
 				},
 			},
-			helmReleases: []latest.HelmRelease{{
+			helmReleases: []latest_v1.HelmRelease{{
 				Name:      "skaffold-helm",
 				ChartPath: "testdata/helm/skaffold-helm",
 				ArtifactOverrides: map[string]string{
@@ -425,16 +425,16 @@ spec:
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			deployer, err := helm.NewDeployer(&runcontext.RunContext{
-				Pipelines: runcontext.NewPipelines([]latest.Pipeline{{
-					Deploy: latest.DeployConfig{
-						DeployType: latest.DeployType{
-							HelmDeploy: &latest.HelmDeploy{
+				Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{
+					Deploy: latest_v1.DeployConfig{
+						DeployType: latest_v1.DeployType{
+							HelmDeploy: &latest_v1.HelmDeploy{
 								Releases: test.helmReleases,
 							},
 						},
 					},
 				}}),
-			}, nil, &latest.HelmDeploy{
+			}, nil, &latest_v1.HelmDeploy{
 				Releases: test.helmReleases,
 			})
 			t.RequireNoError(err)

--- a/pkg/skaffold/build/bazel/build.go
+++ b/pkg/skaffold/build/bazel/build.go
@@ -28,12 +28,12 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // Build builds an artifact with Bazel.
-func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest_v1.Artifact, tag string) (string, error) {
 	a := artifact.ArtifactType.BazelArtifact
 
 	tarPath, err := b.buildTar(ctx, out, artifact.Workspace, a)
@@ -47,7 +47,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest.Art
 	return b.loadImage(ctx, out, tarPath, a, tag)
 }
 
-func (b *Builder) buildTar(ctx context.Context, out io.Writer, workspace string, a *latest.BazelArtifact) (string, error) {
+func (b *Builder) buildTar(ctx context.Context, out io.Writer, workspace string, a *latest_v1.BazelArtifact) (string, error) {
 	if !strings.HasSuffix(a.BuildTarget, ".tar") {
 		return "", errors.New("the bazel build target should end with .tar, see https://github.com/bazelbuild/rules_docker#using-with-docker-locally")
 	}
@@ -80,7 +80,7 @@ func (b *Builder) buildTar(ctx context.Context, out io.Writer, workspace string,
 	return tarPath, nil
 }
 
-func (b *Builder) loadImage(ctx context.Context, out io.Writer, tarPath string, a *latest.BazelArtifact, tag string) (string, error) {
+func (b *Builder) loadImage(ctx context.Context, out io.Writer, tarPath string, a *latest_v1.BazelArtifact, tag string) (string, error) {
 	imageTar, err := os.Open(tarPath)
 	if err != nil {
 		return "", fmt.Errorf("opening image tarball: %w", err)
@@ -100,7 +100,7 @@ func (b *Builder) loadImage(ctx context.Context, out io.Writer, tarPath string, 
 	return imageID, nil
 }
 
-func bazelBin(ctx context.Context, workspace string, a *latest.BazelArtifact) (string, error) {
+func bazelBin(ctx context.Context, workspace string, a *latest_v1.BazelArtifact) (string, error) {
 	args := []string{"info", "bazel-bin"}
 	args = append(args, a.BuildArgs...)
 

--- a/pkg/skaffold/build/bazel/build_test.go
+++ b/pkg/skaffold/build/bazel/build_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -33,10 +33,10 @@ func TestBuildBazel(t *testing.T) {
 		t.Override(&util.DefaultExecCommand, testutil.CmdRun("bazel build //:app.tar --color=no").AndRunOut("bazel info bazel-bin", "bin"))
 		testutil.CreateFakeImageTar("bazel:app", "bin/app.tar")
 
-		artifact := &latest.Artifact{
+		artifact := &latest_v1.Artifact{
 			Workspace: ".",
-			ArtifactType: latest.ArtifactType{
-				BazelArtifact: &latest.BazelArtifact{
+			ArtifactType: latest_v1.ArtifactType{
+				BazelArtifact: &latest_v1.BazelArtifact{
 					BuildTarget: "//:app.tar",
 				},
 			},
@@ -51,9 +51,9 @@ func TestBuildBazel(t *testing.T) {
 
 func TestBuildBazelFailInvalidTarget(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
-		artifact := &latest.Artifact{
-			ArtifactType: latest.ArtifactType{
-				BazelArtifact: &latest.BazelArtifact{
+		artifact := &latest_v1.Artifact{
+			ArtifactType: latest_v1.ArtifactType{
+				BazelArtifact: &latest_v1.BazelArtifact{
 					BuildTarget: "//:invalid-target",
 				},
 			},
@@ -73,7 +73,7 @@ func TestBazelBin(t *testing.T) {
 			"/absolute/path/bin\n",
 		))
 
-		bazelBin, err := bazelBin(context.Background(), ".", &latest.BazelArtifact{
+		bazelBin, err := bazelBin(context.Background(), ".", &latest_v1.BazelArtifact{
 			BuildArgs: []string{"--arg1", "--arg2"},
 		})
 

--- a/pkg/skaffold/build/bazel/dependencies.go
+++ b/pkg/skaffold/build/bazel/dependencies.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -43,7 +43,7 @@ var once sync.Once
 
 // GetDependencies finds the sources dependencies for the given bazel artifact.
 // All paths are relative to the workspace.
-func GetDependencies(ctx context.Context, dir string, a *latest.BazelArtifact) ([]string, error) {
+func GetDependencies(ctx context.Context, dir string, a *latest_v1.BazelArtifact) ([]string, error) {
 	timer := time.NewTimer(1 * time.Second)
 	defer timer.Stop()
 

--- a/pkg/skaffold/build/bazel/dependencies_test.go
+++ b/pkg/skaffold/build/bazel/dependencies_test.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -82,7 +82,7 @@ func TestGetDependencies(t *testing.T) {
 			))
 			t.NewTempDir().WriteFiles(test.files).Chdir()
 
-			deps, err := GetDependencies(context.Background(), test.workspace, &latest.BazelArtifact{
+			deps, err := GetDependencies(context.Background(), test.workspace, &latest_v1.BazelArtifact{
 				BuildTarget: test.target,
 			})
 

--- a/pkg/skaffold/build/build.go
+++ b/pkg/skaffold/build/build.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 )
 
@@ -30,7 +30,7 @@ import (
 // This could include pushing to a authorized repository or loading the nodes with the image.
 // If artifacts is supplied, the builder should only rebuild those artifacts.
 type Builder interface {
-	Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]graph.Artifact, error)
+	Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest_v1.Artifact) ([]graph.Artifact, error)
 
 	// Prune removes images built with Skaffold
 	Prune(context.Context, io.Writer) error
@@ -44,7 +44,7 @@ type PipelineBuilder interface {
 	PreBuild(ctx context.Context, out io.Writer) error
 
 	// Build returns the `ArtifactBuilder` based on this build pipeline type
-	Build(ctx context.Context, out io.Writer, artifact *latest.Artifact) ArtifactBuilder
+	Build(ctx context.Context, out io.Writer, artifact *latest_v1.Artifact) ArtifactBuilder
 
 	// PostBuild executes any one-time teardown required after all builds on this builder are complete
 	PostBuild(ctx context.Context, out io.Writer) error

--- a/pkg/skaffold/build/builder_mux.go
+++ b/pkg/skaffold/build/builder_mux.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 )
 
@@ -39,14 +39,14 @@ type BuilderMux struct {
 
 // Config represents an interface for getting all config pipelines.
 type Config interface {
-	GetPipelines() []latest.Pipeline
+	GetPipelines() []latest_v1.Pipeline
 	DefaultRepo() *string
 	GlobalConfig() string
 	BuildConcurrency() int
 }
 
 // NewBuilderMux returns an implementation of `build.BuilderMux`.
-func NewBuilderMux(cfg Config, store ArtifactStore, builder func(p latest.Pipeline) (PipelineBuilder, error)) (*BuilderMux, error) {
+func NewBuilderMux(cfg Config, store ArtifactStore, builder func(p latest_v1.Pipeline) (PipelineBuilder, error)) (*BuilderMux, error) {
 	pipelines := cfg.GetPipelines()
 	m := make(map[string]PipelineBuilder)
 	var pb []PipelineBuilder
@@ -84,7 +84,7 @@ func NewBuilderMux(cfg Config, store ArtifactStore, builder func(p latest.Pipeli
 }
 
 // Build executes the specific image builder for each artifact in the given artifact slice.
-func (b *BuilderMux) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
+func (b *BuilderMux) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest_v1.Artifact) ([]graph.Artifact, error) {
 	m := make(map[PipelineBuilder]bool)
 	for _, a := range artifacts {
 		m[b.byImageName[a.ImageName]] = true
@@ -96,7 +96,7 @@ func (b *BuilderMux) Build(ctx context.Context, out io.Writer, tags tag.ImageTag
 		}
 	}
 
-	builder := func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+	builder := func(ctx context.Context, out io.Writer, artifact *latest_v1.Artifact, tag string) (string, error) {
 		p := b.byImageName[artifact.ImageName]
 		artifactBuilder := p.Build(ctx, out, artifact)
 		return artifactBuilder(ctx, out, artifact, tag)

--- a/pkg/skaffold/build/builder_mux_test.go
+++ b/pkg/skaffold/build/builder_mux_test.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -30,16 +30,16 @@ import (
 func TestNewBuilderMux(t *testing.T) {
 	tests := []struct {
 		description         string
-		pipelines           []latest.Pipeline
-		pipeBuilder         func(latest.Pipeline) (PipelineBuilder, error)
+		pipelines           []latest_v1.Pipeline
+		pipeBuilder         func(latest_v1.Pipeline) (PipelineBuilder, error)
 		shouldErr           bool
 		expectedBuilders    []string
 		expectedConcurrency int
 	}{
 		{
 			description: "only local builder",
-			pipelines: []latest.Pipeline{
-				{Build: latest.BuildConfig{BuildType: latest.BuildType{LocalBuild: &latest.LocalBuild{Concurrency: util.IntPtr(1)}}}},
+			pipelines: []latest_v1.Pipeline{
+				{Build: latest_v1.BuildConfig{BuildType: latest_v1.BuildType{LocalBuild: &latest_v1.LocalBuild{Concurrency: util.IntPtr(1)}}}},
 			},
 			pipeBuilder:         newMockPipelineBuilder,
 			expectedBuilders:    []string{"local"},
@@ -47,26 +47,26 @@ func TestNewBuilderMux(t *testing.T) {
 		},
 		{
 			description: "only cluster builder",
-			pipelines: []latest.Pipeline{
-				{Build: latest.BuildConfig{BuildType: latest.BuildType{Cluster: &latest.ClusterDetails{}}}},
+			pipelines: []latest_v1.Pipeline{
+				{Build: latest_v1.BuildConfig{BuildType: latest_v1.BuildType{Cluster: &latest_v1.ClusterDetails{}}}},
 			},
 			pipeBuilder:      newMockPipelineBuilder,
 			expectedBuilders: []string{"cluster"},
 		},
 		{
 			description: "only gcb builder",
-			pipelines: []latest.Pipeline{
-				{Build: latest.BuildConfig{BuildType: latest.BuildType{GoogleCloudBuild: &latest.GoogleCloudBuild{}}}},
+			pipelines: []latest_v1.Pipeline{
+				{Build: latest_v1.BuildConfig{BuildType: latest_v1.BuildType{GoogleCloudBuild: &latest_v1.GoogleCloudBuild{}}}},
 			},
 			pipeBuilder:      newMockPipelineBuilder,
 			expectedBuilders: []string{"gcb"},
 		},
 		{
 			description: "min non-zero concurrency",
-			pipelines: []latest.Pipeline{
-				{Build: latest.BuildConfig{BuildType: latest.BuildType{LocalBuild: &latest.LocalBuild{Concurrency: util.IntPtr(0)}}}},
-				{Build: latest.BuildConfig{BuildType: latest.BuildType{LocalBuild: &latest.LocalBuild{Concurrency: util.IntPtr(3)}}}},
-				{Build: latest.BuildConfig{BuildType: latest.BuildType{Cluster: &latest.ClusterDetails{Concurrency: 2}}}},
+			pipelines: []latest_v1.Pipeline{
+				{Build: latest_v1.BuildConfig{BuildType: latest_v1.BuildType{LocalBuild: &latest_v1.LocalBuild{Concurrency: util.IntPtr(0)}}}},
+				{Build: latest_v1.BuildConfig{BuildType: latest_v1.BuildType{LocalBuild: &latest_v1.LocalBuild{Concurrency: util.IntPtr(3)}}}},
+				{Build: latest_v1.BuildConfig{BuildType: latest_v1.BuildType{Cluster: &latest_v1.ClusterDetails{Concurrency: 2}}}},
 			},
 			pipeBuilder:         newMockPipelineBuilder,
 			expectedBuilders:    []string{"local", "local", "cluster"},
@@ -92,12 +92,12 @@ func TestNewBuilderMux(t *testing.T) {
 }
 
 type mockConfig struct {
-	pipelines []latest.Pipeline
+	pipelines []latest_v1.Pipeline
 	optRepo   string
 }
 
-func (m *mockConfig) GetPipelines() []latest.Pipeline { return m.pipelines }
-func (m *mockConfig) GlobalConfig() string            { return "" }
+func (m *mockConfig) GetPipelines() []latest_v1.Pipeline { return m.pipelines }
+func (m *mockConfig) GlobalConfig() string               { return "" }
 func (m *mockConfig) DefaultRepo() *string {
 	if m.optRepo != "" {
 		return &m.optRepo
@@ -113,7 +113,7 @@ type mockPipelineBuilder struct {
 
 func (m *mockPipelineBuilder) PreBuild(ctx context.Context, out io.Writer) error { return nil }
 
-func (m *mockPipelineBuilder) Build(ctx context.Context, out io.Writer, artifact *latest.Artifact) ArtifactBuilder {
+func (m *mockPipelineBuilder) Build(ctx context.Context, out io.Writer, artifact *latest_v1.Artifact) ArtifactBuilder {
 	return nil
 }
 
@@ -123,7 +123,7 @@ func (m *mockPipelineBuilder) Concurrency() int { return m.concurrency }
 
 func (m *mockPipelineBuilder) Prune(context.Context, io.Writer) error { return nil }
 
-func newMockPipelineBuilder(p latest.Pipeline) (PipelineBuilder, error) {
+func newMockPipelineBuilder(p latest_v1.Pipeline) (PipelineBuilder, error) {
 	switch {
 	case p.Build.BuildType.LocalBuild != nil:
 		c := 0

--- a/pkg/skaffold/build/buildpacks/build.go
+++ b/pkg/skaffold/build/buildpacks/build.go
@@ -21,12 +21,12 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // Build builds an artifact with Cloud Native Buildpacks:
 // https://buildpacks.io/
-func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest_v1.Artifact, tag string) (string, error) {
 	built, err := b.build(ctx, out, artifact, tag)
 	if err != nil {
 		return "", err

--- a/pkg/skaffold/build/buildpacks/build_test.go
+++ b/pkg/skaffold/build/buildpacks/build_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -44,7 +44,7 @@ func (f *fakePack) runPack(_ context.Context, _ io.Writer, _ docker.LocalDaemon,
 func TestBuild(t *testing.T) {
 	tests := []struct {
 		description     string
-		artifact        *latest.Artifact
+		artifact        *latest_v1.Artifact
 		tag             string
 		api             *testutil.FakeAPIClient
 		files           map[string]string
@@ -196,7 +196,7 @@ value = "VALUE2"
 		},
 		{
 			description: "dev mode",
-			artifact:    withSync(&latest.Sync{Auto: util.BoolPtr(true)}, buildpacksArtifact("another/builder", "another/run")),
+			artifact:    withSync(&latest_v1.Sync{Auto: util.BoolPtr(true)}, buildpacksArtifact("another/builder", "another/run")),
 			tag:         "img:tag",
 			api:         &testutil.FakeAPIClient{},
 			resolver:    mockArtifactResolver{},
@@ -291,7 +291,7 @@ value = "VALUE2"
 func TestBuildWithArtifactDependencies(t *testing.T) {
 	tests := []struct {
 		description     string
-		artifact        *latest.Artifact
+		artifact        *latest_v1.Artifact
 		tag             string
 		api             *testutil.FakeAPIClient
 		files           map[string]string
@@ -303,7 +303,7 @@ func TestBuildWithArtifactDependencies(t *testing.T) {
 	}{
 		{
 			description: "custom builder image only with no push",
-			artifact:    withRequiredArtifacts([]*latest.ArtifactDependency{{ImageName: "builder-image", Alias: "BUILDER_IMAGE"}}, buildpacksArtifact("BUILDER_IMAGE", "my/run")),
+			artifact:    withRequiredArtifacts([]*latest_v1.ArtifactDependency{{ImageName: "builder-image", Alias: "BUILDER_IMAGE"}}, buildpacksArtifact("BUILDER_IMAGE", "my/run")),
 			tag:         "img:tag",
 			pushImages:  false,
 			mode:        config.RunModes.Build,
@@ -320,7 +320,7 @@ func TestBuildWithArtifactDependencies(t *testing.T) {
 		},
 		{
 			description: "custom run image only with no push",
-			artifact:    withRequiredArtifacts([]*latest.ArtifactDependency{{ImageName: "run-image", Alias: "RUN_IMAGE"}}, buildpacksArtifact("my/builder", "RUN_IMAGE")),
+			artifact:    withRequiredArtifacts([]*latest_v1.ArtifactDependency{{ImageName: "run-image", Alias: "RUN_IMAGE"}}, buildpacksArtifact("my/builder", "RUN_IMAGE")),
 			tag:         "img:tag",
 			pushImages:  false,
 			mode:        config.RunModes.Build,
@@ -337,7 +337,7 @@ func TestBuildWithArtifactDependencies(t *testing.T) {
 		},
 		{
 			description: "custom builder image only with push",
-			artifact:    withRequiredArtifacts([]*latest.ArtifactDependency{{ImageName: "builder-image", Alias: "BUILDER_IMAGE"}}, buildpacksArtifact("BUILDER_IMAGE", "my/run")),
+			artifact:    withRequiredArtifacts([]*latest_v1.ArtifactDependency{{ImageName: "builder-image", Alias: "BUILDER_IMAGE"}}, buildpacksArtifact("BUILDER_IMAGE", "my/run")),
 			tag:         "img:tag",
 			pushImages:  true,
 			mode:        config.RunModes.Build,
@@ -354,7 +354,7 @@ func TestBuildWithArtifactDependencies(t *testing.T) {
 		},
 		{
 			description: "custom run image only with push",
-			artifact:    withRequiredArtifacts([]*latest.ArtifactDependency{{ImageName: "run-image", Alias: "RUN_IMAGE"}}, buildpacksArtifact("my/builder", "RUN_IMAGE")),
+			artifact:    withRequiredArtifacts([]*latest_v1.ArtifactDependency{{ImageName: "run-image", Alias: "RUN_IMAGE"}}, buildpacksArtifact("my/builder", "RUN_IMAGE")),
 			tag:         "img:tag",
 			pushImages:  true,
 			mode:        config.RunModes.Build,
@@ -371,7 +371,7 @@ func TestBuildWithArtifactDependencies(t *testing.T) {
 		},
 		{
 			description: "custom run image and custom builder image with push",
-			artifact:    withRequiredArtifacts([]*latest.ArtifactDependency{{ImageName: "run-image", Alias: "RUN_IMAGE"}, {ImageName: "builder-image", Alias: "BUILDER_IMAGE"}}, buildpacksArtifact("BUILDER_IMAGE", "RUN_IMAGE")),
+			artifact:    withRequiredArtifacts([]*latest_v1.ArtifactDependency{{ImageName: "run-image", Alias: "RUN_IMAGE"}, {ImageName: "builder-image", Alias: "BUILDER_IMAGE"}}, buildpacksArtifact("BUILDER_IMAGE", "RUN_IMAGE")),
 			tag:         "img:tag",
 			pushImages:  true,
 			mode:        config.RunModes.Build,
@@ -388,7 +388,7 @@ func TestBuildWithArtifactDependencies(t *testing.T) {
 		},
 		{
 			description: "custom run image and custom builder image with no push",
-			artifact:    withRequiredArtifacts([]*latest.ArtifactDependency{{ImageName: "run-image", Alias: "RUN_IMAGE"}, {ImageName: "builder-image", Alias: "BUILDER_IMAGE"}}, buildpacksArtifact("BUILDER_IMAGE", "RUN_IMAGE")),
+			artifact:    withRequiredArtifacts([]*latest_v1.ArtifactDependency{{ImageName: "run-image", Alias: "RUN_IMAGE"}, {ImageName: "builder-image", Alias: "BUILDER_IMAGE"}}, buildpacksArtifact("BUILDER_IMAGE", "RUN_IMAGE")),
 			tag:         "img:tag",
 			pushImages:  false,
 			mode:        config.RunModes.Build,
@@ -426,15 +426,15 @@ func TestBuildWithArtifactDependencies(t *testing.T) {
 		})
 	}
 }
-func buildpacksArtifact(builder, runImage string) *latest.Artifact {
-	return &latest.Artifact{
+func buildpacksArtifact(builder, runImage string) *latest_v1.Artifact {
+	return &latest_v1.Artifact{
 		Workspace: ".",
-		ArtifactType: latest.ArtifactType{
-			BuildpackArtifact: &latest.BuildpackArtifact{
+		ArtifactType: latest_v1.ArtifactType{
+			BuildpackArtifact: &latest_v1.BuildpackArtifact{
 				Builder:           builder,
 				RunImage:          runImage,
 				ProjectDescriptor: "project.toml",
-				Dependencies: &latest.BuildpackDependencies{
+				Dependencies: &latest_v1.BuildpackDependencies{
 					Paths: []string{"."},
 				},
 			},
@@ -442,27 +442,27 @@ func buildpacksArtifact(builder, runImage string) *latest.Artifact {
 	}
 }
 
-func withEnv(env []string, artifact *latest.Artifact) *latest.Artifact {
+func withEnv(env []string, artifact *latest_v1.Artifact) *latest_v1.Artifact {
 	artifact.BuildpackArtifact.Env = env
 	return artifact
 }
 
-func withSync(sync *latest.Sync, artifact *latest.Artifact) *latest.Artifact {
+func withSync(sync *latest_v1.Sync, artifact *latest_v1.Artifact) *latest_v1.Artifact {
 	artifact.Sync = sync
 	return artifact
 }
 
-func withTrustedBuilder(artifact *latest.Artifact) *latest.Artifact {
+func withTrustedBuilder(artifact *latest_v1.Artifact) *latest_v1.Artifact {
 	artifact.BuildpackArtifact.TrustBuilder = true
 	return artifact
 }
 
-func withRequiredArtifacts(deps []*latest.ArtifactDependency, artifact *latest.Artifact) *latest.Artifact {
+func withRequiredArtifacts(deps []*latest_v1.ArtifactDependency, artifact *latest_v1.Artifact) *latest_v1.Artifact {
 	artifact.Dependencies = deps
 	return artifact
 }
 
-func withBuildpacks(buildpacks []string, artifact *latest.Artifact) *latest.Artifact {
+func withBuildpacks(buildpacks []string, artifact *latest_v1.Artifact) *latest_v1.Artifact {
 	artifact.BuildpackArtifact.Buildpacks = buildpacks
 	return artifact
 }

--- a/pkg/skaffold/build/buildpacks/dependencies.go
+++ b/pkg/skaffold/build/buildpacks/dependencies.go
@@ -20,11 +20,11 @@ import (
 	"context"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/list"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // GetDependencies returns dependencies listed for a buildpack artifact
-func GetDependencies(ctx context.Context, workspace string, a *latest.BuildpackArtifact) ([]string, error) {
+func GetDependencies(ctx context.Context, workspace string, a *latest_v1.BuildpackArtifact) ([]string, error) {
 	// TODO(dgageot): Support project.toml include/exclude.
 	return list.Files(workspace, a.Dependencies.Paths, a.Dependencies.Ignore)
 }

--- a/pkg/skaffold/build/buildpacks/dependencies_test.go
+++ b/pkg/skaffold/build/buildpacks/dependencies_test.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -68,8 +68,8 @@ func TestGetDependencies(t *testing.T) {
 			tmpDir := t.NewTempDir().
 				Touch("foo", "bar", "baz/file")
 
-			deps, err := GetDependencies(context.Background(), tmpDir.Root(), &latest.BuildpackArtifact{
-				Dependencies: &latest.BuildpackDependencies{
+			deps, err := GetDependencies(context.Background(), tmpDir.Root(), &latest_v1.BuildpackArtifact{
+				Dependencies: &latest_v1.BuildpackDependencies{
 					Paths:  test.paths,
 					Ignore: test.ignore,
 				},

--- a/pkg/skaffold/build/buildpacks/env.go
+++ b/pkg/skaffold/build/buildpacks/env.go
@@ -25,10 +25,10 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
-func GetEnv(a *latest.Artifact, mode config.RunMode) (map[string]string, error) {
+func GetEnv(a *latest_v1.Artifact, mode config.RunMode) (map[string]string, error) {
 	artifact := a.BuildpackArtifact
 	workspace := a.Workspace
 
@@ -40,7 +40,7 @@ func GetEnv(a *latest.Artifact, mode config.RunMode) (map[string]string, error) 
 	return env(a, mode, projectDescriptor)
 }
 
-func env(a *latest.Artifact, mode config.RunMode, projectDescriptor project.Descriptor) (map[string]string, error) {
+func env(a *latest_v1.Artifact, mode config.RunMode, projectDescriptor project.Descriptor) (map[string]string, error) {
 	envVars, err := misc.EvaluateEnv(a.BuildpackArtifact.Env)
 	if err != nil {
 		return nil, fmt.Errorf("unable to evaluate env variables: %w", err)

--- a/pkg/skaffold/build/buildpacks/init.go
+++ b/pkg/skaffold/build/buildpacks/init.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // For testing
@@ -49,9 +49,9 @@ func (c ArtifactConfig) Describe() string {
 }
 
 // ArtifactType returns the type of the artifact to be built.
-func (c ArtifactConfig) ArtifactType(_ string) latest.ArtifactType {
-	return latest.ArtifactType{
-		BuildpackArtifact: &latest.BuildpackArtifact{
+func (c ArtifactConfig) ArtifactType(_ string) latest_v1.ArtifactType {
+	return latest_v1.ArtifactType{
+		BuildpackArtifact: &latest_v1.BuildpackArtifact{
 			Builder: c.Builder,
 		},
 	}

--- a/pkg/skaffold/build/buildpacks/init_test.go
+++ b/pkg/skaffold/build/buildpacks/init_test.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -132,7 +132,7 @@ func TestArtifactType(t *testing.T) {
 	var tests = []struct {
 		description  string
 		config       ArtifactConfig
-		expectedType latest.ArtifactType
+		expectedType latest_v1.ArtifactType
 	}{
 		{
 			description: "buildpacks - NodeJS",
@@ -140,8 +140,8 @@ func TestArtifactType(t *testing.T) {
 				File:    filepath.Join("path", "to", "package.json"),
 				Builder: "some/builder",
 			},
-			expectedType: latest.ArtifactType{
-				BuildpackArtifact: &latest.BuildpackArtifact{
+			expectedType: latest_v1.ArtifactType{
+				BuildpackArtifact: &latest_v1.BuildpackArtifact{
 					Builder: "some/builder",
 				},
 			},

--- a/pkg/skaffold/build/buildpacks/lifecycle.go
+++ b/pkg/skaffold/build/buildpacks/lifecycle.go
@@ -34,7 +34,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // For testing
@@ -47,7 +47,7 @@ var (
 // to pull the images that are already pulled.
 var images pulledImages
 
-func (b *Builder) build(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
+func (b *Builder) build(ctx context.Context, out io.Writer, a *latest_v1.Artifact, tag string) (string, error) {
 	artifact := a.BuildpackArtifact
 	workspace := a.Workspace
 
@@ -180,7 +180,7 @@ func envMap(env []string) map[string]string {
 
 // resolveDependencyImages replaces the provided builder and run images with built images from the required artifacts if specified.
 // The return values are builder image, run image, and if remote pull is required.
-func resolveDependencyImages(artifact *latest.BuildpackArtifact, r ArtifactResolver, deps []*latest.ArtifactDependency, pushImages bool) (string, string, packcfg.PullPolicy) {
+func resolveDependencyImages(artifact *latest_v1.BuildpackArtifact, r ArtifactResolver, deps []*latest_v1.ArtifactDependency, pushImages bool) (string, string, packcfg.PullPolicy) {
 	builderImage, runImage := artifact.Builder, artifact.RunImage
 	builderImageLocal, runImageLocal := false, false
 
@@ -215,12 +215,12 @@ func resolveDependencyImages(artifact *latest.BuildpackArtifact, r ArtifactResol
 		// if only one of builder or run image is built locally, we can enable remote image pull only if that image is also pushed to remote.
 		pullPolicy = packcfg.PullIfNotPresent
 
-		// if remote image pull is disabled then the image that is not fetched from the required artifacts might not be latest.
+		// if remote image pull is disabled then the image that is not fetched from the required artifacts might not be latest_v1.
 		if !pushImages && builderImageLocal {
-			logrus.Warnln("Disabled remote image pull since builder image is built locally. Buildpacks run image may not be latest.")
+			logrus.Warnln("Disabled remote image pull since builder image is built locally. Buildpacks run image may not be latest_v1.")
 		}
 		if !pushImages && runImageLocal {
-			logrus.Warnln("Disabled remote image pull since run image is built locally. Buildpacks builder image may not be latest.")
+			logrus.Warnln("Disabled remote image pull since run image is built locally. Buildpacks builder image may not be latest_v1.")
 		}
 	}
 

--- a/pkg/skaffold/build/buildpacks/metadata.go
+++ b/pkg/skaffold/build/buildpacks/metadata.go
@@ -19,7 +19,7 @@ package buildpacks
 import (
 	"encoding/json"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 type buildMetadata struct {
@@ -40,7 +40,7 @@ type syncRule struct {
 }
 
 // $ docker inspect demo/buildpacks | jq -r '.[].Config.Labels["io.buildpacks.build.metadata"] | fromjson.bom[].metadata["devmode.sync"]'
-func SyncRules(labels map[string]string) ([]*latest.SyncRule, error) {
+func SyncRules(labels map[string]string) ([]*latest_v1.SyncRule, error) {
 	metadataJSON, present := labels["io.buildpacks.build.metadata"]
 	if !present {
 		return nil, nil
@@ -51,11 +51,11 @@ func SyncRules(labels map[string]string) ([]*latest.SyncRule, error) {
 		return nil, err
 	}
 
-	var rules []*latest.SyncRule
+	var rules []*latest_v1.SyncRule
 
 	for _, b := range m.Bom {
 		for _, sync := range b.Metadata.Sync {
-			rules = append(rules, &latest.SyncRule{
+			rules = append(rules, &latest_v1.SyncRule{
 				Src:  sync.Src,
 				Dest: sync.Dest,
 			})

--- a/pkg/skaffold/build/buildpacks/metadata_test.go
+++ b/pkg/skaffold/build/buildpacks/metadata_test.go
@@ -19,7 +19,7 @@ package buildpacks
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -27,7 +27,7 @@ func TestSyncRules(t *testing.T) {
 	tests := []struct {
 		description   string
 		labels        map[string]string
-		expectedRules []*latest.SyncRule
+		expectedRules []*latest_v1.SyncRule
 		shouldErr     bool
 	}{
 		{
@@ -55,7 +55,7 @@ func TestSyncRules(t *testing.T) {
 					}]
 				}`,
 			},
-			expectedRules: []*latest.SyncRule{
+			expectedRules: []*latest_v1.SyncRule{
 				{Src: "src-value1", Dest: "dest-value1"},
 				{Src: "src-value2", Dest: "dest-value2"},
 			},

--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -31,7 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 )
@@ -60,13 +60,13 @@ type cache struct {
 }
 
 // DependencyLister fetches a list of dependencies for an artifact
-type DependencyLister func(ctx context.Context, artifact *latest.Artifact) ([]string, error)
+type DependencyLister func(ctx context.Context, artifact *latest_v1.Artifact) ([]string, error)
 
 type Config interface {
 	docker.Config
-	PipelineForImage(imageName string) (latest.Pipeline, bool)
-	GetPipelines() []latest.Pipeline
-	DefaultPipeline() latest.Pipeline
+	PipelineForImage(imageName string) (latest_v1.Pipeline, bool)
+	GetPipelines() []latest_v1.Pipeline
+	DefaultPipeline() latest_v1.Pipeline
 	GetCluster() config.Cluster
 	CacheArtifacts() bool
 	CacheFile() string

--- a/pkg/skaffold/build/cache/hash.go
+++ b/pkg/skaffold/build/cache/hash.go
@@ -33,7 +33,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -45,7 +45,7 @@ var (
 )
 
 type artifactHasher interface {
-	hash(ctx context.Context, a *latest.Artifact) (string, error)
+	hash(ctx context.Context, a *latest_v1.Artifact) (string, error)
 }
 
 type artifactHasherImpl struct {
@@ -65,7 +65,7 @@ func newArtifactHasher(artifacts graph.ArtifactGraph, lister DependencyLister, m
 	}
 }
 
-func (h *artifactHasherImpl) hash(ctx context.Context, a *latest.Artifact) (string, error) {
+func (h *artifactHasherImpl) hash(ctx context.Context, a *latest_v1.Artifact) (string, error) {
 	hash, err := h.safeHash(ctx, a)
 	if err != nil {
 		return "", err
@@ -85,7 +85,7 @@ func (h *artifactHasherImpl) hash(ctx context.Context, a *latest.Artifact) (stri
 	return encode(hashes)
 }
 
-func (h *artifactHasherImpl) safeHash(ctx context.Context, a *latest.Artifact) (string, error) {
+func (h *artifactHasherImpl) safeHash(ctx context.Context, a *latest_v1.Artifact) (string, error) {
 	val := h.syncStore.Exec(a.ImageName,
 		func() interface{} {
 			hash, err := singleArtifactHash(ctx, h.lister, a, h.mode)
@@ -105,7 +105,7 @@ func (h *artifactHasherImpl) safeHash(ctx context.Context, a *latest.Artifact) (
 }
 
 // singleArtifactHash calculates the hash for a single artifact, and ignores its required artifacts.
-func singleArtifactHash(ctx context.Context, depLister DependencyLister, a *latest.Artifact, mode config.RunMode) (string, error) {
+func singleArtifactHash(ctx context.Context, depLister DependencyLister, a *latest_v1.Artifact, mode config.RunMode) (string, error) {
 	var inputs []string
 
 	// Append the artifact's configuration
@@ -157,7 +157,7 @@ func encode(inputs []string) (string, error) {
 }
 
 // TODO(dgageot): when the buildpacks builder image digest changes, we need to change the hash
-func artifactConfig(a *latest.Artifact) (string, error) {
+func artifactConfig(a *latest_v1.Artifact) (string, error) {
 	buf, err := json.Marshal(a.ArtifactType)
 	if err != nil {
 		return "", fmt.Errorf("marshalling the artifact's configuration for %q: %w", a.ImageName, err)
@@ -165,7 +165,7 @@ func artifactConfig(a *latest.Artifact) (string, error) {
 	return string(buf), nil
 }
 
-func hashBuildArgs(artifact *latest.Artifact, mode config.RunMode) ([]string, error) {
+func hashBuildArgs(artifact *latest_v1.Artifact, mode config.RunMode) ([]string, error) {
 	// only one of args or env is ever populated
 	var args map[string]*string
 	var env map[string]string
@@ -218,7 +218,7 @@ func fileHasher(p string) (string, error) {
 }
 
 // sortedDependencies returns the dependencies' corresponding Artifacts as sorted by their image name.
-func sortedDependencies(a *latest.Artifact, artifacts graph.ArtifactGraph) []*latest.Artifact {
+func sortedDependencies(a *latest_v1.Artifact, artifacts graph.ArtifactGraph) []*latest_v1.Artifact {
 	sl := artifacts.Dependencies(a)
 	sort.Slice(sl, func(i, j int) bool {
 		ia, ja := sl[i], sl[j]

--- a/pkg/skaffold/build/cache/hash_test.go
+++ b/pkg/skaffold/build/cache/hash_test.go
@@ -23,13 +23,13 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func stubDependencyLister(dependencies []string) DependencyLister {
-	return func(context.Context, *latest.Artifact) ([]string, error) {
+	return func(context.Context, *latest_v1.Artifact) ([]string, error) {
 		return dependencies, nil
 	}
 }
@@ -41,7 +41,7 @@ var mockCacheHasher = func(s string) (string, error) {
 	return s, nil
 }
 
-var fakeArtifactConfig = func(a *latest.Artifact) (string, error) {
+var fakeArtifactConfig = func(a *latest_v1.Artifact) (string, error) {
 	if a.ArtifactType.DockerArtifact != nil {
 		return "docker/target=" + a.ArtifactType.DockerArtifact.Target, nil
 	}
@@ -54,42 +54,42 @@ func TestGetHashForArtifact(t *testing.T) {
 	tests := []struct {
 		description  string
 		dependencies []string
-		artifact     *latest.Artifact
+		artifact     *latest_v1.Artifact
 		mode         config.RunMode
 		expected     string
 	}{
 		{
 			description:  "hash for artifact",
 			dependencies: []string{"a", "b"},
-			artifact:     &latest.Artifact{},
+			artifact:     &latest_v1.Artifact{},
 			mode:         config.RunModes.Dev,
 			expected:     "d99ab295a682897269b4db0fe7c136ea1ecd542150fa224ee03155b4e3e995d9",
 		},
 		{
 			description:  "ignore file not found",
 			dependencies: []string{"a", "b", "not-found"},
-			artifact:     &latest.Artifact{},
+			artifact:     &latest_v1.Artifact{},
 			mode:         config.RunModes.Dev,
 			expected:     "d99ab295a682897269b4db0fe7c136ea1ecd542150fa224ee03155b4e3e995d9",
 		},
 		{
 			description:  "dependencies in different orders",
 			dependencies: []string{"b", "a"},
-			artifact:     &latest.Artifact{},
+			artifact:     &latest_v1.Artifact{},
 			mode:         config.RunModes.Dev,
 			expected:     "d99ab295a682897269b4db0fe7c136ea1ecd542150fa224ee03155b4e3e995d9",
 		},
 		{
 			description: "no dependencies",
-			artifact:    &latest.Artifact{},
+			artifact:    &latest_v1.Artifact{},
 			mode:        config.RunModes.Dev,
 			expected:    "7c077ca2308714493d07163e1033c4282bd869ff6d477b3e77408587f95e2930",
 		},
 		{
 			description: "docker target",
-			artifact: &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+			artifact: &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						Target: "target",
 					},
 				},
@@ -99,9 +99,9 @@ func TestGetHashForArtifact(t *testing.T) {
 		},
 		{
 			description: "different docker target",
-			artifact: &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+			artifact: &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						Target: "other",
 					},
 				},
@@ -112,9 +112,9 @@ func TestGetHashForArtifact(t *testing.T) {
 		{
 			description:  "build args",
 			dependencies: []string{"a", "b"},
-			artifact: &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+			artifact: &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						BuildArgs: map[string]*string{
 							"key": util.StringPtr("value"),
 						},
@@ -127,9 +127,9 @@ func TestGetHashForArtifact(t *testing.T) {
 		{
 			description:  "buildpack in dev mode",
 			dependencies: []string{"a", "b"},
-			artifact: &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					BuildpackArtifact: &latest.BuildpackArtifact{},
+			artifact: &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					BuildpackArtifact: &latest_v1.BuildpackArtifact{},
 				},
 			},
 			mode:     config.RunModes.Dev,
@@ -138,9 +138,9 @@ func TestGetHashForArtifact(t *testing.T) {
 		{
 			description:  "buildpack in debug mode",
 			dependencies: []string{"a", "b"},
-			artifact: &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					BuildpackArtifact: &latest.BuildpackArtifact{},
+			artifact: &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					BuildpackArtifact: &latest_v1.BuildpackArtifact{},
 				},
 			},
 			mode:     config.RunModes.Debug,
@@ -170,18 +170,18 @@ func TestGetHashForArtifact(t *testing.T) {
 func TestGetHashForArtifactWithDependencies(t *testing.T) {
 	tests := []struct {
 		description string
-		artifacts   []*latest.Artifact
+		artifacts   []*latest_v1.Artifact
 		fileDeps    map[string][]string // keyed on artifact ImageName, returns a list of mock file dependencies.
 		mode        config.RunMode
 		expected    string
 	}{
 		{
 			description: "hash for artifact with two dependencies",
-			artifacts: []*latest.Artifact{
-				{ImageName: "img1", Dependencies: []*latest.ArtifactDependency{{ImageName: "img2"}, {ImageName: "img3"}}},
-				{ImageName: "img2", Dependencies: []*latest.ArtifactDependency{{ImageName: "img4"}}, ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{Target: "target2"}}},
-				{ImageName: "img3", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{Target: "target3"}}},
-				{ImageName: "img4", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{Target: "target4"}}},
+			artifacts: []*latest_v1.Artifact{
+				{ImageName: "img1", Dependencies: []*latest_v1.ArtifactDependency{{ImageName: "img2"}, {ImageName: "img3"}}},
+				{ImageName: "img2", Dependencies: []*latest_v1.ArtifactDependency{{ImageName: "img4"}}, ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{Target: "target2"}}},
+				{ImageName: "img3", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{Target: "target3"}}},
+				{ImageName: "img4", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{Target: "target4"}}},
 			},
 			fileDeps: map[string][]string{"img1": {"a"}, "img2": {"b"}, "img3": {"c"}, "img4": {"d"}},
 			mode:     config.RunModes.Dev,
@@ -189,11 +189,11 @@ func TestGetHashForArtifactWithDependencies(t *testing.T) {
 		},
 		{
 			description: "hash for artifact with two dependencies in different order",
-			artifacts: []*latest.Artifact{
-				{ImageName: "img1", Dependencies: []*latest.ArtifactDependency{{ImageName: "img3"}, {ImageName: "img2"}}},
-				{ImageName: "img2", Dependencies: []*latest.ArtifactDependency{{ImageName: "img4"}}, ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{Target: "target2"}}},
-				{ImageName: "img3", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{Target: "target3"}}},
-				{ImageName: "img4", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{Target: "target4"}}},
+			artifacts: []*latest_v1.Artifact{
+				{ImageName: "img1", Dependencies: []*latest_v1.ArtifactDependency{{ImageName: "img3"}, {ImageName: "img2"}}},
+				{ImageName: "img2", Dependencies: []*latest_v1.ArtifactDependency{{ImageName: "img4"}}, ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{Target: "target2"}}},
+				{ImageName: "img3", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{Target: "target3"}}},
+				{ImageName: "img4", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{Target: "target4"}}},
 			},
 			fileDeps: map[string][]string{"img1": {"a"}, "img2": {"b"}, "img3": {"c"}, "img4": {"d"}},
 			mode:     config.RunModes.Dev,
@@ -201,11 +201,11 @@ func TestGetHashForArtifactWithDependencies(t *testing.T) {
 		},
 		{
 			description: "hash for artifact with different dependencies (img4 builder changed)",
-			artifacts: []*latest.Artifact{
-				{ImageName: "img1", Dependencies: []*latest.ArtifactDependency{{ImageName: "img2"}, {ImageName: "img3"}}},
-				{ImageName: "img2", Dependencies: []*latest.ArtifactDependency{{ImageName: "img4"}}, ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{Target: "target2"}}},
-				{ImageName: "img3", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{Target: "target3"}}},
-				{ImageName: "img4", ArtifactType: latest.ArtifactType{BuildpackArtifact: &latest.BuildpackArtifact{Builder: "builder"}}},
+			artifacts: []*latest_v1.Artifact{
+				{ImageName: "img1", Dependencies: []*latest_v1.ArtifactDependency{{ImageName: "img2"}, {ImageName: "img3"}}},
+				{ImageName: "img2", Dependencies: []*latest_v1.ArtifactDependency{{ImageName: "img4"}}, ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{Target: "target2"}}},
+				{ImageName: "img3", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{Target: "target3"}}},
+				{ImageName: "img4", ArtifactType: latest_v1.ArtifactType{BuildpackArtifact: &latest_v1.BuildpackArtifact{Builder: "builder"}}},
 			},
 			fileDeps: map[string][]string{"img1": {"a"}, "img2": {"b"}, "img3": {"c"}, "img4": {"d"}},
 			mode:     config.RunModes.Dev,
@@ -213,11 +213,11 @@ func TestGetHashForArtifactWithDependencies(t *testing.T) {
 		},
 		{
 			description: "hash for artifact with different dependencies (img4 files changed)",
-			artifacts: []*latest.Artifact{
-				{ImageName: "img1", Dependencies: []*latest.ArtifactDependency{{ImageName: "img2"}, {ImageName: "img3"}}},
-				{ImageName: "img2", Dependencies: []*latest.ArtifactDependency{{ImageName: "img4"}}, ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{Target: "target2"}}},
-				{ImageName: "img3", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{Target: "target3"}}},
-				{ImageName: "img4", ArtifactType: latest.ArtifactType{BuildpackArtifact: &latest.BuildpackArtifact{}}},
+			artifacts: []*latest_v1.Artifact{
+				{ImageName: "img1", Dependencies: []*latest_v1.ArtifactDependency{{ImageName: "img2"}, {ImageName: "img3"}}},
+				{ImageName: "img2", Dependencies: []*latest_v1.ArtifactDependency{{ImageName: "img4"}}, ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{Target: "target2"}}},
+				{ImageName: "img3", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{Target: "target3"}}},
+				{ImageName: "img4", ArtifactType: latest_v1.ArtifactType{BuildpackArtifact: &latest_v1.BuildpackArtifact{}}},
 			},
 			fileDeps: map[string][]string{"img1": {"a"}, "img2": {"b"}, "img3": {"c"}, "img4": {"e"}},
 			mode:     config.RunModes.Dev,
@@ -239,7 +239,7 @@ func TestGetHashForArtifactWithDependencies(t *testing.T) {
 				}
 			}
 
-			depLister := func(_ context.Context, a *latest.Artifact) ([]string, error) {
+			depLister := func(_ context.Context, a *latest_v1.Artifact) ([]string, error) {
 				return test.fileDeps[a.ImageName], nil
 			}
 
@@ -253,18 +253,18 @@ func TestGetHashForArtifactWithDependencies(t *testing.T) {
 
 func TestArtifactConfig(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
-		config1, err := artifactConfig(&latest.Artifact{
-			ArtifactType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{
+		config1, err := artifactConfig(&latest_v1.Artifact{
+			ArtifactType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{
 					Target: "target",
 				},
 			},
 		})
 		t.CheckNoError(err)
 
-		config2, err := artifactConfig(&latest.Artifact{
-			ArtifactType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{
+		config2, err := artifactConfig(&latest_v1.Artifact{
+			ArtifactType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{
 					Target: "other",
 				},
 			},
@@ -295,10 +295,10 @@ func TestBuildArgs(t *testing.T) {
 		testutil.Run(t, "", func(t *testutil.T) {
 			tmpDir := t.NewTempDir()
 			tmpDir.Write("./Dockerfile", "ARG SKAFFOLD_GO_GCFLAGS\nFROM foo")
-			artifact := &latest.Artifact{
+			artifact := &latest_v1.Artifact{
 				Workspace: tmpDir.Path("."),
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						DockerfilePath: Dockerfile,
 						BuildArgs:      map[string]*string{"one": util.StringPtr("1"), "two": util.StringPtr("2")},
 					},
@@ -339,10 +339,10 @@ func TestBuildArgsEnvSubstitution(t *testing.T) {
 		}
 		tmpDir := t.NewTempDir()
 		tmpDir.Write("./Dockerfile", "ARG SKAFFOLD_GO_GCFLAGS\nFROM foo")
-		artifact := &latest.Artifact{
+		artifact := &latest_v1.Artifact{
 			Workspace: tmpDir.Path("."),
-			ArtifactType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{
+			ArtifactType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{
 					BuildArgs:      map[string]*string{"env": util.StringPtr("${{.FOO}}")},
 					DockerfilePath: Dockerfile,
 				},
@@ -420,7 +420,7 @@ func TestCacheHasher(t *testing.T) {
 			path := originalFile
 			depLister := stubDependencyLister([]string{tmpDir.Path(originalFile)})
 
-			oldHash, err := newArtifactHasher(nil, depLister, config.RunModes.Build).hash(context.Background(), &latest.Artifact{})
+			oldHash, err := newArtifactHasher(nil, depLister, config.RunModes.Build).hash(context.Background(), &latest_v1.Artifact{})
 			t.CheckNoError(err)
 
 			test.update(originalFile, tmpDir)
@@ -429,7 +429,7 @@ func TestCacheHasher(t *testing.T) {
 			}
 
 			depLister = stubDependencyLister([]string{tmpDir.Path(path)})
-			newHash, err := newArtifactHasher(nil, depLister, config.RunModes.Build).hash(context.Background(), &latest.Artifact{})
+			newHash, err := newArtifactHasher(nil, depLister, config.RunModes.Build).hash(context.Background(), &latest_v1.Artifact{})
 
 			t.CheckNoError(err)
 			t.CheckFalse(test.differentHash && oldHash == newHash)
@@ -441,14 +441,14 @@ func TestCacheHasher(t *testing.T) {
 func TestHashBuildArgs(t *testing.T) {
 	tests := []struct {
 		description  string
-		artifactType latest.ArtifactType
+		artifactType latest_v1.ArtifactType
 		expected     []string
 		mode         config.RunMode
 	}{
 		{
 			description: "docker artifact with build args for dev",
-			artifactType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{
+			artifactType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{
 					BuildArgs: map[string]*string{
 						"foo": util.StringPtr("bar"),
 					},
@@ -458,8 +458,8 @@ func TestHashBuildArgs(t *testing.T) {
 			expected: []string{"foo=bar"},
 		}, {
 			description: "docker artifact with build args for debug",
-			artifactType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{
+			artifactType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{
 					BuildArgs: map[string]*string{
 						"foo": util.StringPtr("bar"),
 					},
@@ -469,34 +469,34 @@ func TestHashBuildArgs(t *testing.T) {
 			expected: []string{"SKAFFOLD_GO_GCFLAGS=all=-N -l", "foo=bar"},
 		}, {
 			description: "docker artifact without build args for debug",
-			artifactType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{},
+			artifactType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{},
 			},
 			mode:     config.RunModes.Debug,
 			expected: []string{"SKAFFOLD_GO_GCFLAGS=all=-N -l"},
 		}, {
 			description: "docker artifact without build args for dev",
-			artifactType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{},
+			artifactType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{},
 			},
 			mode: config.RunModes.Dev,
 		}, {
 			description: "kaniko artifact with build args",
-			artifactType: latest.ArtifactType{
-				KanikoArtifact: &latest.KanikoArtifact{
+			artifactType: latest_v1.ArtifactType{
+				KanikoArtifact: &latest_v1.KanikoArtifact{
 					BuildArgs: map[string]*string{},
 				},
 			},
 			expected: nil,
 		}, {
 			description: "kaniko artifact without build args",
-			artifactType: latest.ArtifactType{
-				KanikoArtifact: &latest.KanikoArtifact{},
+			artifactType: latest_v1.ArtifactType{
+				KanikoArtifact: &latest_v1.KanikoArtifact{},
 			},
 		}, {
 			description: "buildpacks artifact with env for dev",
-			artifactType: latest.ArtifactType{
-				BuildpackArtifact: &latest.BuildpackArtifact{
+			artifactType: latest_v1.ArtifactType{
+				BuildpackArtifact: &latest_v1.BuildpackArtifact{
 					Env: []string{"foo=bar"},
 				},
 			},
@@ -504,14 +504,14 @@ func TestHashBuildArgs(t *testing.T) {
 			expected: []string{"foo=bar"},
 		}, {
 			description: "buildpacks artifact without env for dev",
-			artifactType: latest.ArtifactType{
-				BuildpackArtifact: &latest.BuildpackArtifact{},
+			artifactType: latest_v1.ArtifactType{
+				BuildpackArtifact: &latest_v1.BuildpackArtifact{},
 			},
 			mode: config.RunModes.Dev,
 		}, {
 			description: "buildpacks artifact with env for debug",
-			artifactType: latest.ArtifactType{
-				BuildpackArtifact: &latest.BuildpackArtifact{
+			artifactType: latest_v1.ArtifactType{
+				BuildpackArtifact: &latest_v1.BuildpackArtifact{
 					Env: []string{"foo=bar"},
 				},
 			},
@@ -519,17 +519,17 @@ func TestHashBuildArgs(t *testing.T) {
 			expected: []string{"GOOGLE_GOGCFLAGS=all=-N -l", "foo=bar"},
 		}, {
 			description: "buildpacks artifact without env for debug",
-			artifactType: latest.ArtifactType{
-				BuildpackArtifact: &latest.BuildpackArtifact{},
+			artifactType: latest_v1.ArtifactType{
+				BuildpackArtifact: &latest_v1.BuildpackArtifact{},
 			},
 			mode:     config.RunModes.Debug,
 			expected: []string{"GOOGLE_GOGCFLAGS=all=-N -l"},
 		}, {
 			description: "custom artifact, dockerfile dependency, with build args",
-			artifactType: latest.ArtifactType{
-				CustomArtifact: &latest.CustomArtifact{
-					Dependencies: &latest.CustomDependencies{
-						Dockerfile: &latest.DockerfileDependency{
+			artifactType: latest_v1.ArtifactType{
+				CustomArtifact: &latest_v1.CustomArtifact{
+					Dependencies: &latest_v1.CustomDependencies{
+						Dockerfile: &latest_v1.DockerfileDependency{
 							BuildArgs: map[string]*string{},
 						},
 					},
@@ -538,9 +538,9 @@ func TestHashBuildArgs(t *testing.T) {
 			expected: nil,
 		}, {
 			description: "custom artifact, no dockerfile dependency",
-			artifactType: latest.ArtifactType{
-				CustomArtifact: &latest.CustomArtifact{
-					Dependencies: &latest.CustomDependencies{},
+			artifactType: latest_v1.ArtifactType{
+				CustomArtifact: &latest_v1.CustomArtifact{
+					Dependencies: &latest_v1.CustomDependencies{},
 				},
 			},
 		},
@@ -548,7 +548,7 @@ func TestHashBuildArgs(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			a := &latest.Artifact{
+			a := &latest_v1.Artifact{
 				ArtifactType: test.artifactType,
 			}
 			if test.artifactType.DockerArtifact != nil {

--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -25,11 +25,11 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 )
 
-func (c *cache) lookupArtifacts(ctx context.Context, tags tag.ImageTags, artifacts []*latest.Artifact) []cacheDetails {
+func (c *cache) lookupArtifacts(ctx context.Context, tags tag.ImageTags, artifacts []*latest_v1.Artifact) []cacheDetails {
 	details := make([]cacheDetails, len(artifacts))
 	// Create a new `artifactHasher` on every new dev loop.
 	// This way every artifact hash is calculated at most once in a single dev loop, and recalculated on every dev loop.
@@ -49,7 +49,7 @@ func (c *cache) lookupArtifacts(ctx context.Context, tags tag.ImageTags, artifac
 	return details
 }
 
-func (c *cache) lookup(ctx context.Context, a *latest.Artifact, tag string, h artifactHasher) cacheDetails {
+func (c *cache) lookup(ctx context.Context, a *latest_v1.Artifact, tag string, h artifactHasher) cacheDetails {
 	hash, err := h.hash(ctx, a)
 	if err != nil {
 		return failed{err: fmt.Errorf("getting hash for artifact %q: %s", a.ImageName, err)}
@@ -122,7 +122,7 @@ func (c *cache) lookupRemote(ctx context.Context, hash, tag string, entry ImageD
 	return needsBuilding{hash: hash}
 }
 
-func (c *cache) tryImport(ctx context.Context, a *latest.Artifact, tag string, hash string) (ImageDetails, error) {
+func (c *cache) tryImport(ctx context.Context, a *latest_v1.Artifact, tag string, hash string) (ImageDetails, error) {
 	entry := ImageDetails{}
 
 	if importMissing, err := c.importMissingImage(a.ImageName); err != nil {

--- a/pkg/skaffold/build/cache/lookup_test.go
+++ b/pkg/skaffold/build/cache/lookup_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -126,7 +126,7 @@ func TestLookupLocal(t *testing.T) {
 			}
 
 			t.Override(&newArtifactHasherFunc, func(_ graph.ArtifactGraph, _ DependencyLister, _ config.RunMode) artifactHasher { return test.hasher })
-			details := cache.lookupArtifacts(context.Background(), map[string]string{"artifact": "tag"}, []*latest.Artifact{{
+			details := cache.lookupArtifacts(context.Background(), map[string]string{"artifact": "tag"}, []*latest_v1.Artifact{{
 				ImageName: "artifact",
 			}})
 
@@ -214,7 +214,7 @@ func TestLookupRemote(t *testing.T) {
 				cfg:                &mockConfig{mode: config.RunModes.Build},
 			}
 			t.Override(&newArtifactHasherFunc, func(_ graph.ArtifactGraph, _ DependencyLister, _ config.RunMode) artifactHasher { return test.hasher })
-			details := cache.lookupArtifacts(context.Background(), map[string]string{"artifact": "tag"}, []*latest.Artifact{{
+			details := cache.lookupArtifacts(context.Background(), map[string]string{"artifact": "tag"}, []*latest_v1.Artifact{{
 				ImageName: "artifact",
 			}})
 
@@ -230,7 +230,7 @@ type mockHasher struct {
 	val string
 }
 
-func (m mockHasher) hash(context.Context, *latest.Artifact) (string, error) {
+func (m mockHasher) hash(context.Context, *latest_v1.Artifact) (string, error) {
 	return m.val, nil
 }
 
@@ -238,7 +238,7 @@ type failingHasher struct {
 	err error
 }
 
-func (f failingHasher) hash(context.Context, *latest.Artifact) (string, error) {
+func (f failingHasher) hash(context.Context, *latest_v1.Artifact) (string, error) {
 	return "", f.err
 }
 

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -29,12 +29,12 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
-func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, buildAndTest BuildAndTestFn) ([]graph.Artifact, error) {
+func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest_v1.Artifact, buildAndTest BuildAndTestFn) ([]graph.Artifact, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -53,7 +53,7 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 	}
 
 	hashByName := make(map[string]string)
-	var needToBuild []*latest.Artifact
+	var needToBuild []*latest_v1.Artifact
 	var alreadyBuilt []graph.Artifact
 	for i, artifact := range artifacts {
 		color.Default.Fprintf(out, " - %s: ", artifact.ImageName)
@@ -141,7 +141,7 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 	return maintainArtifactOrder(append(bRes, alreadyBuilt...), artifacts), err
 }
 
-func maintainArtifactOrder(built []graph.Artifact, artifacts []*latest.Artifact) []graph.Artifact {
+func maintainArtifactOrder(built []graph.Artifact, artifacts []*latest_v1.Artifact) []graph.Artifact {
 	byName := make(map[string]graph.Artifact)
 	for _, build := range built {
 		byName[build.ImageName] = build

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -30,13 +30,13 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func depLister(files map[string][]string) DependencyLister {
-	return func(_ context.Context, artifact *latest.Artifact) ([]string, error) {
+	return func(_ context.Context, artifact *latest_v1.Artifact) ([]string, error) {
 		list, found := files[artifact.ImageName]
 		if !found {
 			return nil, errors.New("unknown artifact")
@@ -48,19 +48,19 @@ func depLister(files map[string][]string) DependencyLister {
 type mockArtifactStore map[string]string
 
 func (m mockArtifactStore) GetImageTag(imageName string) (string, bool) { return m[imageName], true }
-func (m mockArtifactStore) Record(a *latest.Artifact, tag string)       { m[a.ImageName] = tag }
-func (m mockArtifactStore) GetArtifacts([]*latest.Artifact) ([]graph.Artifact, error) {
+func (m mockArtifactStore) Record(a *latest_v1.Artifact, tag string)    { m[a.ImageName] = tag }
+func (m mockArtifactStore) GetArtifacts([]*latest_v1.Artifact) ([]graph.Artifact, error) {
 	return nil, nil
 }
 
 type mockBuilder struct {
-	built        []*latest.Artifact
+	built        []*latest_v1.Artifact
 	push         bool
 	dockerDaemon docker.LocalDaemon
 	store        build.ArtifactStore
 }
 
-func (b *mockBuilder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
+func (b *mockBuilder) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest_v1.Artifact) ([]graph.Artifact, error) {
 	var built []graph.Artifact
 
 	for _, artifact := range artifacts {
@@ -115,9 +115,9 @@ func TestCacheBuildLocal(t *testing.T) {
 			"artifact1": "artifact1:tag1",
 			"artifact2": "artifact2:tag2",
 		}
-		artifacts := []*latest.Artifact{
-			{ImageName: "artifact1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
-			{ImageName: "artifact2", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+		artifacts := []*latest_v1.Artifact{
+			{ImageName: "artifact1", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}},
+			{ImageName: "artifact2", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}},
 		}
 		deps := depLister(map[string][]string{
 			"artifact1": {"dep1", "dep2"},
@@ -138,7 +138,7 @@ func TestCacheBuildLocal(t *testing.T) {
 
 		// Create cache
 		cfg := &mockConfig{
-			pipeline:  latest.Pipeline{Build: latest.BuildConfig{BuildType: latest.BuildType{LocalBuild: &latest.LocalBuild{TryImportMissing: false}}}},
+			pipeline:  latest_v1.Pipeline{Build: latest_v1.BuildConfig{BuildType: latest_v1.BuildType{LocalBuild: &latest_v1.LocalBuild{TryImportMissing: false}}}},
 			cacheFile: tmpDir.Path("cache"),
 		}
 		store := make(mockArtifactStore)
@@ -202,9 +202,9 @@ func TestCacheBuildRemote(t *testing.T) {
 			"artifact1": "artifact1:tag1",
 			"artifact2": "artifact2:tag2",
 		}
-		artifacts := []*latest.Artifact{
-			{ImageName: "artifact1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
-			{ImageName: "artifact2", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+		artifacts := []*latest_v1.Artifact{
+			{ImageName: "artifact1", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}},
+			{ImageName: "artifact2", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}},
 		}
 		deps := depLister(map[string][]string{
 			"artifact1": {"dep1", "dep2"},
@@ -235,7 +235,7 @@ func TestCacheBuildRemote(t *testing.T) {
 
 		// Create cache
 		cfg := &mockConfig{
-			pipeline:  latest.Pipeline{Build: latest.BuildConfig{BuildType: latest.BuildType{LocalBuild: &latest.LocalBuild{TryImportMissing: false}}}},
+			pipeline:  latest_v1.Pipeline{Build: latest_v1.BuildConfig{BuildType: latest_v1.BuildType{LocalBuild: &latest_v1.LocalBuild{TryImportMissing: false}}}},
 			cacheFile: tmpDir.Path("cache"),
 		}
 		artifactCache, err := NewCache(cfg, func(imageName string) (bool, error) { return false, nil }, deps, graph.ToArtifactGraph(artifacts), make(mockArtifactStore))
@@ -287,9 +287,9 @@ func TestCacheFindMissing(t *testing.T) {
 			"artifact1": "artifact1:tag1",
 			"artifact2": "artifact2:tag2",
 		}
-		artifacts := []*latest.Artifact{
-			{ImageName: "artifact1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
-			{ImageName: "artifact2", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+		artifacts := []*latest_v1.Artifact{
+			{ImageName: "artifact1", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}},
+			{ImageName: "artifact2", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}},
 		}
 		deps := depLister(map[string][]string{
 			"artifact1": {"dep1", "dep2"},
@@ -320,7 +320,7 @@ func TestCacheFindMissing(t *testing.T) {
 
 		// Create cache
 		cfg := &mockConfig{
-			pipeline:  latest.Pipeline{Build: latest.BuildConfig{BuildType: latest.BuildType{LocalBuild: &latest.LocalBuild{TryImportMissing: true}}}},
+			pipeline:  latest_v1.Pipeline{Build: latest_v1.BuildConfig{BuildType: latest_v1.BuildType{LocalBuild: &latest_v1.LocalBuild{TryImportMissing: true}}}},
 			cacheFile: tmpDir.Path("cache"),
 		}
 		artifactCache, err := NewCache(cfg, func(imageName string) (bool, error) { return false, nil }, deps, graph.ToArtifactGraph(artifacts), make(mockArtifactStore))
@@ -343,10 +343,10 @@ type mockConfig struct {
 	runcontext.RunContext // Embedded to provide the default values.
 	cacheFile             string
 	mode                  config.RunMode
-	pipeline              latest.Pipeline
+	pipeline              latest_v1.Pipeline
 }
 
-func (c *mockConfig) CacheArtifacts() bool                            { return true }
-func (c *mockConfig) CacheFile() string                               { return c.cacheFile }
-func (c *mockConfig) Mode() config.RunMode                            { return c.mode }
-func (c *mockConfig) PipelineForImage(string) (latest.Pipeline, bool) { return c.pipeline, true }
+func (c *mockConfig) CacheArtifacts() bool                               { return true }
+func (c *mockConfig) CacheFile() string                                  { return c.cacheFile }
+func (c *mockConfig) Mode() config.RunMode                               { return c.mode }
+func (c *mockConfig) PipelineForImage(string) (latest_v1.Pipeline, bool) { return c.pipeline, true }

--- a/pkg/skaffold/build/cache/types.go
+++ b/pkg/skaffold/build/cache/types.go
@@ -21,18 +21,18 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 )
 
-type BuildAndTestFn func(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact) ([]graph.Artifact, error)
+type BuildAndTestFn func(context.Context, io.Writer, tag.ImageTags, []*latest_v1.Artifact) ([]graph.Artifact, error)
 
 type Cache interface {
-	Build(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact, BuildAndTestFn) ([]graph.Artifact, error)
+	Build(context.Context, io.Writer, tag.ImageTags, []*latest_v1.Artifact, BuildAndTestFn) ([]graph.Artifact, error)
 }
 
 type noCache struct{}
 
-func (n *noCache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, buildAndTest BuildAndTestFn) ([]graph.Artifact, error) {
+func (n *noCache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest_v1.Artifact, buildAndTest BuildAndTestFn) ([]graph.Artifact, error) {
 	return buildAndTest(ctx, out, tags, artifacts)
 }

--- a/pkg/skaffold/build/cluster/cluster.go
+++ b/pkg/skaffold/build/cluster/cluster.go
@@ -26,12 +26,12 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // Build builds a list of artifacts with Kaniko.
-func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest.Artifact) build.ArtifactBuilder {
+func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest_v1.Artifact) build.ArtifactBuilder {
 	builder := build.WithLogFile(b.buildArtifact, b.cfg.Muted())
 	return builder
 }
@@ -60,7 +60,7 @@ func (b *Builder) PostBuild(_ context.Context, _ io.Writer) error {
 	return nil
 }
 
-func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, artifact *latest_v1.Artifact, tag string) (string, error) {
 	// TODO: [#4922] Implement required artifact resolution from the `artifactStore`
 	digest, err := b.runBuildForArtifact(ctx, out, artifact, tag)
 	if err != nil {
@@ -74,7 +74,7 @@ func (b *Builder) Concurrency() int {
 	return b.ClusterDetails.Concurrency
 }
 
-func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
+func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *latest_v1.Artifact, tag string) (string, error) {
 	// required artifacts as build-args
 	requiredImages := docker.ResolveDependencyImages(a.Dependencies, b.artifactStore, true)
 	switch {

--- a/pkg/skaffold/build/cluster/cluster_test.go
+++ b/pkg/skaffold/build/cluster/cluster_test.go
@@ -19,7 +19,7 @@ package cluster
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -27,10 +27,10 @@ func TestRetrieveEnv(t *testing.T) {
 	builder, err := NewBuilder(&mockBuilderContext{
 		kubeContext: "kubecontext",
 		namespace:   "test-namespace",
-	}, &latest.ClusterDetails{
+	}, &latest_v1.ClusterDetails{
 		Namespace:      "namespace",
 		PullSecretName: "pullSecret",
-		DockerConfig: &latest.DockerConfig{
+		DockerConfig: &latest_v1.DockerConfig{
 			SecretName: "dockerconfig",
 		},
 		Timeout: "2m",
@@ -43,7 +43,7 @@ func TestRetrieveEnv(t *testing.T) {
 }
 
 func TestRetrieveEnvMinimal(t *testing.T) {
-	builder, err := NewBuilder(&mockBuilderContext{}, &latest.ClusterDetails{
+	builder, err := NewBuilder(&mockBuilderContext{}, &latest_v1.ClusterDetails{
 		Timeout: "20m",
 	})
 	testutil.CheckError(t, false, err)

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -31,13 +31,13 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 const initContainer = "kaniko-init-container"
 
-func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace string, artifactName string, artifact *latest.KanikoArtifact, tag string, requiredImages map[string]*string) (string, error) {
+func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace string, artifactName string, artifact *latest_v1.KanikoArtifact, tag string, requiredImages map[string]*string) (string, error) {
 	generatedEnvs, err := generateEnvFromImage(tag)
 	if err != nil {
 		return "", fmt.Errorf("error processing generated env variables from image uri: %w", err)
@@ -97,7 +97,7 @@ func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace 
 // first copy over the buildcontext tarball into the init container tmp dir via kubectl cp
 // Via kubectl exec, we extract the tarball to the empty dir
 // Then, via kubectl exec, create the /tmp/complete file via kubectl exec to complete the init container
-func (b *Builder) copyKanikoBuildContext(ctx context.Context, workspace string, artifactName string, artifact *latest.KanikoArtifact, pods corev1.PodInterface, podName string) error {
+func (b *Builder) copyKanikoBuildContext(ctx context.Context, workspace string, artifactName string, artifact *latest_v1.KanikoArtifact, pods corev1.PodInterface, podName string) error {
 	if err := kubernetes.WaitForPodInitialized(ctx, pods, podName); err != nil {
 		return fmt.Errorf("waiting for pod to initialize: %w", err)
 	}

--- a/pkg/skaffold/build/cluster/kaniko_test.go
+++ b/pkg/skaffold/build/cluster/kaniko_test.go
@@ -21,13 +21,13 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestEnvInterpolation(t *testing.T) {
 	imageStr := "why.com/is/this/such/a/long/repo/name/testimage:testtag"
-	artifact := &latest.KanikoArtifact{
+	artifact := &latest_v1.KanikoArtifact{
 		Env: []v1.EnvVar{{Name: "hui", Value: "buh"}},
 	}
 	generatedEnvs, err := generateEnvFromImage(imageStr)
@@ -51,7 +51,7 @@ func TestEnvInterpolation(t *testing.T) {
 
 func TestEnvInterpolation_IPPort(t *testing.T) {
 	imageStr := "10.10.10.10:1000/is/this/such/a/long/repo/name/testimage:testtag"
-	artifact := &latest.KanikoArtifact{
+	artifact := &latest_v1.KanikoArtifact{
 		Env: []v1.EnvVar{{Name: "hui", Value: "buh"}},
 	}
 	generatedEnvs, err := generateEnvFromImage(imageStr)
@@ -75,7 +75,7 @@ func TestEnvInterpolation_IPPort(t *testing.T) {
 
 func TestEnvInterpolation_Latest(t *testing.T) {
 	imageStr := "why.com/is/this/such/a/long/repo/name/testimage"
-	artifact := &latest.KanikoArtifact{
+	artifact := &latest_v1.KanikoArtifact{
 		Env: []v1.EnvVar{{Name: "hui", Value: "buh"}},
 	}
 	generatedEnvs, err := generateEnvFromImage(imageStr)

--- a/pkg/skaffold/build/cluster/pod.go
+++ b/pkg/skaffold/build/cluster/pod.go
@@ -26,11 +26,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
 
-func (b *Builder) kanikoPodSpec(artifact *latest.KanikoArtifact, tag string) (*v1.Pod, error) {
+func (b *Builder) kanikoPodSpec(artifact *latest_v1.KanikoArtifact, tag string) (*v1.Pod, error) {
 	args, err := kanikoArgs(artifact, tag, b.cfg.GetInsecureRegistries())
 	if err != nil {
 		return nil, fmt.Errorf("building args list: %w", err)
@@ -121,7 +121,7 @@ func (b *Builder) kanikoPodSpec(artifact *latest.KanikoArtifact, tag string) (*v
 	return pod, nil
 }
 
-func (b *Builder) env(artifact *latest.KanikoArtifact, httpProxy, httpsProxy string) []v1.EnvVar {
+func (b *Builder) env(artifact *latest_v1.KanikoArtifact, httpProxy, httpsProxy string) []v1.EnvVar {
 	pullSecretPath := strings.Join(
 		[]string{b.ClusterDetails.PullSecretMountPath, b.ClusterDetails.PullSecretPath},
 		"/", // linux filepath separator.
@@ -190,7 +190,7 @@ func addHostPathVolume(pod *v1.Pod, name, mountPath, path string) {
 	})
 }
 
-func resourceRequirements(rr *latest.ResourceRequirements) v1.ResourceRequirements {
+func resourceRequirements(rr *latest_v1.ResourceRequirements) v1.ResourceRequirements {
 	req := v1.ResourceRequirements{}
 
 	if rr != nil {
@@ -233,7 +233,7 @@ func resourceRequirements(rr *latest.ResourceRequirements) v1.ResourceRequiremen
 	return req
 }
 
-func kanikoArgs(artifact *latest.KanikoArtifact, tag string, insecureRegistries map[string]bool) ([]string, error) {
+func kanikoArgs(artifact *latest_v1.KanikoArtifact, tag string, insecureRegistries map[string]bool) ([]string, error) {
 	for reg := range insecureRegistries {
 		artifact.InsecureRegistry = append(artifact.InsecureRegistry, reg)
 	}

--- a/pkg/skaffold/build/cluster/pod_test.go
+++ b/pkg/skaffold/build/cluster/pod_test.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -32,7 +32,7 @@ import (
 func TestKanikoArgs(t *testing.T) {
 	tests := []struct {
 		description        string
-		artifact           *latest.KanikoArtifact
+		artifact           *latest_v1.KanikoArtifact
 		insecureRegistries map[string]bool
 		tag                string
 		shouldErr          bool
@@ -40,24 +40,24 @@ func TestKanikoArgs(t *testing.T) {
 	}{
 		{
 			description: "simple build",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 			},
 			expectedArgs: []string{},
 		},
 		{
 			description: "cache layers",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
-				Cache:          &latest.KanikoCache{},
+				Cache:          &latest_v1.KanikoCache{},
 			},
 			expectedArgs: []string{kaniko.CacheFlag},
 		},
 		{
 			description: "cache layers to specific repo",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
-				Cache: &latest.KanikoCache{
+				Cache: &latest_v1.KanikoCache{
 					Repo: "repo",
 				},
 			},
@@ -65,9 +65,9 @@ func TestKanikoArgs(t *testing.T) {
 		},
 		{
 			description: "cache path",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
-				Cache: &latest.KanikoCache{
+				Cache: &latest_v1.KanikoCache{
 					HostPath: "/cache",
 				},
 			},
@@ -77,7 +77,7 @@ func TestKanikoArgs(t *testing.T) {
 		},
 		{
 			description: "target",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Target:         "target",
 			},
@@ -85,7 +85,7 @@ func TestKanikoArgs(t *testing.T) {
 		},
 		{
 			description: "reproducible",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Reproducible:   true,
 			},
@@ -93,7 +93,7 @@ func TestKanikoArgs(t *testing.T) {
 		},
 		{
 			description: "build args",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				BuildArgs: map[string]*string{
 					"nil_key":   nil,
@@ -108,7 +108,7 @@ func TestKanikoArgs(t *testing.T) {
 		},
 		{
 			description: "invalid build args",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				BuildArgs: map[string]*string{
 					"invalid": util.StringPtr("{{Invalid"),
@@ -118,7 +118,7 @@ func TestKanikoArgs(t *testing.T) {
 		},
 		{
 			description: "insecure registries",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 			},
 			insecureRegistries: map[string]bool{"localhost:4000": true},
@@ -126,7 +126,7 @@ func TestKanikoArgs(t *testing.T) {
 		},
 		{
 			description: "skip tls",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				SkipTLS:        true,
 			},
@@ -137,7 +137,7 @@ func TestKanikoArgs(t *testing.T) {
 		},
 		{
 			description: "invalid registry",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				SkipTLS:        true,
 			},
@@ -164,7 +164,7 @@ func TestKanikoArgs(t *testing.T) {
 }
 
 func TestKanikoPodSpec(t *testing.T) {
-	artifact := &latest.KanikoArtifact{
+	artifact := &latest_v1.KanikoArtifact{
 		Image:          "image",
 		DockerfilePath: "Dockerfile",
 		InitImage:      "init/image",
@@ -192,7 +192,7 @@ func TestKanikoPodSpec(t *testing.T) {
 
 	builder := &Builder{
 		cfg: &mockBuilderContext{},
-		ClusterDetails: &latest.ClusterDetails{
+		ClusterDetails: &latest_v1.ClusterDetails{
 			Namespace:           "ns",
 			PullSecretName:      "secret",
 			PullSecretPath:      "kaniko-secret.json",
@@ -201,11 +201,11 @@ func TestKanikoPodSpec(t *testing.T) {
 			HTTPSProxy:          "https://proxy",
 			ServiceAccountName:  "aVerySpecialSA",
 			RunAsUser:           &runAsUser,
-			Resources: &latest.ResourceRequirements{
-				Requests: &latest.ResourceRequirement{
+			Resources: &latest_v1.ResourceRequirements{
+				Requests: &latest_v1.ResourceRequirement{
 					CPU: "0.1",
 				},
-				Limits: &latest.ResourceRequirement{
+				Limits: &latest_v1.ResourceRequirement{
 					CPU: "0.5",
 				},
 			},
@@ -386,24 +386,24 @@ func TestKanikoPodSpec(t *testing.T) {
 func TestResourceRequirements(t *testing.T) {
 	tests := []struct {
 		description string
-		initial     *latest.ResourceRequirements
+		initial     *latest_v1.ResourceRequirements
 		expected    v1.ResourceRequirements
 	}{
 		{
 			description: "no resource specified",
-			initial:     &latest.ResourceRequirements{},
+			initial:     &latest_v1.ResourceRequirements{},
 			expected:    v1.ResourceRequirements{},
 		},
 		{
 			description: "with resource specified",
-			initial: &latest.ResourceRequirements{
-				Requests: &latest.ResourceRequirement{
+			initial: &latest_v1.ResourceRequirements{
+				Requests: &latest_v1.ResourceRequirement{
 					CPU:              "0.5",
 					Memory:           "1000",
 					ResourceStorage:  "1000",
 					EphemeralStorage: "1000",
 				},
-				Limits: &latest.ResourceRequirement{
+				Limits: &latest_v1.ResourceRequirement{
 					CPU:              "1.0",
 					Memory:           "2000",
 					ResourceStorage:  "1000",

--- a/pkg/skaffold/build/cluster/secret_test.go
+++ b/pkg/skaffold/build/cluster/secret_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -39,7 +39,7 @@ func TestCreateSecret(t *testing.T) {
 			return fakeKubernetesclient, nil
 		})
 
-		builder, err := NewBuilder(&mockBuilderContext{}, &latest.ClusterDetails{
+		builder, err := NewBuilder(&mockBuilderContext{}, &latest_v1.ClusterDetails{
 			Timeout:        "20m",
 			PullSecretName: "kaniko-secret",
 			PullSecretPath: tmpDir.Path("secret.json"),
@@ -70,7 +70,7 @@ func TestExistingSecretNotFound(t *testing.T) {
 			return fake.NewSimpleClientset(), nil
 		})
 
-		builder, err := NewBuilder(&mockBuilderContext{}, &latest.ClusterDetails{
+		builder, err := NewBuilder(&mockBuilderContext{}, &latest_v1.ClusterDetails{
 			Timeout:        "20m",
 			PullSecretName: "kaniko-secret",
 		})
@@ -93,7 +93,7 @@ func TestExistingSecret(t *testing.T) {
 			}), nil
 		})
 
-		builder, err := NewBuilder(&mockBuilderContext{}, &latest.ClusterDetails{
+		builder, err := NewBuilder(&mockBuilderContext{}, &latest_v1.ClusterDetails{
 			Timeout:        "20m",
 			PullSecretName: "kaniko-secret",
 		})
@@ -113,7 +113,7 @@ func TestSkipSecretCreation(t *testing.T) {
 			return nil, nil
 		})
 
-		builder, err := NewBuilder(&mockBuilderContext{}, &latest.ClusterDetails{
+		builder, err := NewBuilder(&mockBuilderContext{}, &latest_v1.ClusterDetails{
 			Timeout: "20m",
 		})
 		t.CheckNoError(err)

--- a/pkg/skaffold/build/cluster/types.go
+++ b/pkg/skaffold/build/cluster/types.go
@@ -26,12 +26,12 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // Builder builds docker artifacts on Kubernetes.
 type Builder struct {
-	*latest.ClusterDetails
+	*latest_v1.ClusterDetails
 
 	cfg           Config
 	kubectlcli    *kubectl.CLI
@@ -56,7 +56,7 @@ type BuilderContext interface {
 }
 
 // NewBuilder creates a new Builder that builds artifacts on cluster.
-func NewBuilder(bCtx BuilderContext, buildCfg *latest.ClusterDetails) (*Builder, error) {
+func NewBuilder(bCtx BuilderContext, buildCfg *latest_v1.ClusterDetails) (*Builder, error) {
 	timeout, err := time.ParseDuration(buildCfg.Timeout)
 	if err != nil {
 		return nil, fmt.Errorf("parsing timeout: %w", err)

--- a/pkg/skaffold/build/cluster/types_test.go
+++ b/pkg/skaffold/build/cluster/types_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -37,12 +37,12 @@ func TestNewBuilder(t *testing.T) {
 		description string
 		shouldErr   bool
 		bCtx        BuilderContext
-		cluster     *latest.ClusterDetails
+		cluster     *latest_v1.ClusterDetails
 	}{
 		{
 			description: "failed to parse cluster build timeout",
 			bCtx:        &mockBuilderContext{},
-			cluster: &latest.ClusterDetails{
+			cluster: &latest_v1.ClusterDetails{
 				Timeout: "illegal",
 			},
 			shouldErr: true,
@@ -53,7 +53,7 @@ func TestNewBuilder(t *testing.T) {
 				kubeContext: kubeContext,
 				namespace:   namespace,
 			},
-			cluster: &latest.ClusterDetails{
+			cluster: &latest_v1.ClusterDetails{
 				Timeout:   "100s",
 				Namespace: "test-ns",
 			},
@@ -65,7 +65,7 @@ func TestNewBuilder(t *testing.T) {
 				namespace:          namespace,
 				insecureRegistries: map[string]bool{"insecure-reg1": true},
 			},
-			cluster: &latest.ClusterDetails{
+			cluster: &latest_v1.ClusterDetails{
 				Timeout:   "100s",
 				Namespace: "test-ns",
 			},

--- a/pkg/skaffold/build/custom/build.go
+++ b/pkg/skaffold/build/custom/build.go
@@ -22,11 +22,11 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // Build builds an artifact using a custom script
-func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest_v1.Artifact, tag string) (string, error) {
 	if err := b.runBuildScript(ctx, out, artifact, tag); err != nil {
 		return "", fmt.Errorf("building custom artifact: %w", err)
 	}

--- a/pkg/skaffold/build/custom/dependencies.go
+++ b/pkg/skaffold/build/custom/dependencies.go
@@ -25,12 +25,12 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/list"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // GetDependencies returns dependencies listed for a custom artifact
-func GetDependencies(ctx context.Context, workspace string, artifactName string, a *latest.CustomArtifact, cfg docker.Config) ([]string, error) {
+func GetDependencies(ctx context.Context, workspace string, artifactName string, a *latest_v1.CustomArtifact, cfg docker.Config) ([]string, error) {
 	switch {
 	case a.Dependencies.Dockerfile != nil:
 		return docker.GetDependencies(ctx, getDockerBuildConfig(workspace, artifactName, a), cfg)
@@ -53,7 +53,7 @@ func GetDependencies(ctx context.Context, workspace string, artifactName string,
 	}
 }
 
-func getDockerBuildConfig(ws string, artifact string, a *latest.CustomArtifact) docker.BuildConfig {
+func getDockerBuildConfig(ws string, artifact string, a *latest_v1.CustomArtifact) docker.BuildConfig {
 	dockerfile := a.Dependencies.Dockerfile
 	return docker.NewBuildConfig(ws, artifact, dockerfile.Path, dockerfile.BuildArgs)
 }

--- a/pkg/skaffold/build/custom/dependencies_test.go
+++ b/pkg/skaffold/build/custom/dependencies_test.go
@@ -21,7 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -38,9 +38,9 @@ func TestGetDependenciesDockerfile(t *testing.T) {
 	tmpDir.Touch("foo", "bar", "baz/file")
 	tmpDir.Write("Dockerfile", "FROM scratch \n ARG file \n COPY $file baz/file .")
 
-	customArtifact := &latest.CustomArtifact{
-		Dependencies: &latest.CustomDependencies{
-			Dockerfile: &latest.DockerfileDependency{
+	customArtifact := &latest_v1.CustomArtifact{
+		Dependencies: &latest_v1.CustomDependencies{
+			Dockerfile: &latest_v1.DockerfileDependency{
 				Path: "Dockerfile",
 				BuildArgs: map[string]*string{
 					"file": util.StringPtr("foo"),
@@ -62,8 +62,8 @@ func TestGetDependenciesCommand(t *testing.T) {
 			"[\"file1\",\"file2\",\"file3\"]",
 		))
 
-		customArtifact := &latest.CustomArtifact{
-			Dependencies: &latest.CustomDependencies{
+		customArtifact := &latest_v1.CustomArtifact{
+			Dependencies: &latest_v1.CustomDependencies{
 				Command: "echo [\"file1\",\"file2\",\"file3\"]",
 			},
 		}
@@ -119,8 +119,8 @@ func TestGetDependenciesPaths(t *testing.T) {
 			tmpDir := t.NewTempDir().
 				Touch("foo", "bar", "baz/file")
 
-			deps, err := GetDependencies(context.Background(), tmpDir.Root(), "test", &latest.CustomArtifact{
-				Dependencies: &latest.CustomDependencies{
+			deps, err := GetDependencies(context.Background(), tmpDir.Root(), "test", &latest_v1.CustomArtifact{
+				Dependencies: &latest_v1.CustomDependencies{
 					Paths:  test.paths,
 					Ignore: test.ignore,
 				},

--- a/pkg/skaffold/build/custom/script.go
+++ b/pkg/skaffold/build/custom/script.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -38,7 +38,7 @@ var (
 	buildContext = retrieveBuildContext
 )
 
-func (b *Builder) runBuildScript(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) error {
+func (b *Builder) runBuildScript(ctx context.Context, out io.Writer, a *latest_v1.Artifact, tag string) error {
 	cmd, err := b.retrieveCmd(ctx, out, a, tag)
 	if err != nil {
 		return fmt.Errorf("retrieving cmd: %w", err)
@@ -52,7 +52,7 @@ func (b *Builder) runBuildScript(ctx context.Context, out io.Writer, a *latest.A
 	return misc.HandleGracefulTermination(ctx, cmd)
 }
 
-func (b *Builder) retrieveCmd(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) (*exec.Cmd, error) {
+func (b *Builder) retrieveCmd(ctx context.Context, out io.Writer, a *latest_v1.Artifact, tag string) (*exec.Cmd, error) {
 	artifact := a.CustomArtifact
 
 	// Expand command
@@ -87,7 +87,7 @@ func (b *Builder) retrieveCmd(ctx context.Context, out io.Writer, a *latest.Arti
 	return cmd, nil
 }
 
-func (b *Builder) retrieveEnv(a *latest.Artifact, tag string) ([]string, error) {
+func (b *Builder) retrieveEnv(a *latest_v1.Artifact, tag string) ([]string, error) {
 	buildContext, err := buildContext(a.Workspace)
 	if err != nil {
 		return nil, fmt.Errorf("getting absolute path for artifact build context: %w", err)

--- a/pkg/skaffold/build/custom/script_test.go
+++ b/pkg/skaffold/build/custom/script_test.go
@@ -23,7 +23,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -70,7 +70,7 @@ func TestRetrieveEnv(t *testing.T) {
 			t.Override(&buildContext, func(string) (string, error) { return test.buildContext, nil })
 
 			builder := NewArtifactBuilder(nil, nil, test.pushImages, test.additionalEnv)
-			actual, err := builder.retrieveEnv(&latest.Artifact{}, test.tag)
+			actual, err := builder.retrieveEnv(&latest_v1.Artifact{}, test.tag)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)
@@ -81,7 +81,7 @@ func TestRetrieveEnv(t *testing.T) {
 func TestRetrieveCmd(t *testing.T) {
 	tests := []struct {
 		description       string
-		artifact          *latest.Artifact
+		artifact          *latest_v1.Artifact
 		tag               string
 		env               []string
 		expected          *exec.Cmd
@@ -89,10 +89,10 @@ func TestRetrieveCmd(t *testing.T) {
 	}{
 		{
 			description: "artifact with workspace set",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				Workspace: "workspace",
-				ArtifactType: latest.ArtifactType{
-					CustomArtifact: &latest.CustomArtifact{
+				ArtifactType: latest_v1.ArtifactType{
+					CustomArtifact: &latest_v1.CustomArtifact{
 						BuildCommand: "./build.sh",
 					},
 				},
@@ -103,9 +103,9 @@ func TestRetrieveCmd(t *testing.T) {
 		},
 		{
 			description: "buildcommand with multiple args",
-			artifact: &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					CustomArtifact: &latest.CustomArtifact{
+			artifact: &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					CustomArtifact: &latest_v1.CustomArtifact{
 						BuildCommand: "./build.sh --flag=$IMAGES --anotherflag",
 					},
 				},
@@ -116,9 +116,9 @@ func TestRetrieveCmd(t *testing.T) {
 		},
 		{
 			description: "buildcommand with go template",
-			artifact: &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					CustomArtifact: &latest.CustomArtifact{
+			artifact: &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					CustomArtifact: &latest_v1.CustomArtifact{
 						BuildCommand: "./build.sh --flag={{ .FLAG }}",
 					},
 				},

--- a/pkg/skaffold/build/docker/docker.go
+++ b/pkg/skaffold/build/docker/docker.go
@@ -25,12 +25,12 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
 
-func (b *Builder) Build(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
+func (b *Builder) Build(ctx context.Context, out io.Writer, a *latest_v1.Artifact, tag string) (string, error) {
 	// Fail fast if the Dockerfile can't be found.
 	dockerfile, err := docker.NormalizeDockerfilePath(a.Workspace, a.DockerArtifact.DockerfilePath)
 	if err != nil {
@@ -66,7 +66,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, a *latest.Artifact, 
 	return imageID, nil
 }
 
-func (b *Builder) dockerCLIBuild(ctx context.Context, out io.Writer, workspace string, dockerfilePath string, a *latest.DockerArtifact, opts docker.BuildOptions) (string, error) {
+func (b *Builder) dockerCLIBuild(ctx context.Context, out io.Writer, workspace string, dockerfilePath string, a *latest_v1.DockerArtifact, opts docker.BuildOptions) (string, error) {
 	args := []string{"build", workspace, "--file", dockerfilePath, "-t", opts.Tag}
 	ba, err := docker.EvalBuildArgs(b.mode, workspace, a.DockerfilePath, a.BuildArgs, opts.ExtraBuildArgs)
 	if err != nil {
@@ -97,7 +97,7 @@ func (b *Builder) dockerCLIBuild(ctx context.Context, out io.Writer, workspace s
 	return b.localDocker.ImageID(ctx, opts.Tag)
 }
 
-func (b *Builder) pullCacheFromImages(ctx context.Context, out io.Writer, a *latest.DockerArtifact) error {
+func (b *Builder) pullCacheFromImages(ctx context.Context, out io.Writer, a *latest_v1.DockerArtifact) error {
 	if len(a.CacheFrom) == 0 {
 		return nil
 	}

--- a/pkg/skaffold/build/docker/docker_test.go
+++ b/pkg/skaffold/build/docker/docker_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -36,7 +36,7 @@ import (
 func TestDockerCLIBuild(t *testing.T) {
 	tests := []struct {
 		description string
-		localBuild  latest.LocalBuild
+		localBuild  latest_v1.LocalBuild
 		mode        config.RunMode
 		extraEnv    []string
 		expectedEnv []string
@@ -45,37 +45,37 @@ func TestDockerCLIBuild(t *testing.T) {
 	}{
 		{
 			description: "docker build",
-			localBuild:  latest.LocalBuild{},
+			localBuild:  latest_v1.LocalBuild{},
 			mode:        config.RunModes.Dev,
 			expectedEnv: []string{"KEY=VALUE"},
 		},
 		{
 			description: "extra env",
-			localBuild:  latest.LocalBuild{},
+			localBuild:  latest_v1.LocalBuild{},
 			extraEnv:    []string{"OTHER=VALUE"},
 			expectedEnv: []string{"KEY=VALUE", "OTHER=VALUE"},
 		},
 		{
 			description: "buildkit",
-			localBuild:  latest.LocalBuild{UseBuildkit: true},
+			localBuild:  latest_v1.LocalBuild{UseBuildkit: true},
 			expectedEnv: []string{"KEY=VALUE", "DOCKER_BUILDKIT=1"},
 		},
 		{
 			description: "buildkit and extra env",
-			localBuild:  latest.LocalBuild{UseBuildkit: true},
+			localBuild:  latest_v1.LocalBuild{UseBuildkit: true},
 			extraEnv:    []string{"OTHER=VALUE"},
 			expectedEnv: []string{"KEY=VALUE", "OTHER=VALUE", "DOCKER_BUILDKIT=1"},
 		},
 		{
 			description: "env var collisions",
-			localBuild:  latest.LocalBuild{UseBuildkit: true},
+			localBuild:  latest_v1.LocalBuild{UseBuildkit: true},
 			extraEnv:    []string{"KEY=OTHER_VALUE", "DOCKER_BUILDKIT=0"},
 			// env var collisions are handled by cmd.Run(). Last one wins.
 			expectedEnv: []string{"KEY=VALUE", "KEY=OTHER_VALUE", "DOCKER_BUILDKIT=0", "DOCKER_BUILDKIT=1"},
 		},
 		{
 			description: "docker build internal error",
-			localBuild:  latest.LocalBuild{UseDockerCLI: true},
+			localBuild:  latest_v1.LocalBuild{UseDockerCLI: true},
 			err:         errdefs.Cancelled(fmt.Errorf("cancelled")),
 			expectedErr: newBuildError(errdefs.Cancelled(fmt.Errorf("cancelled"))),
 		},
@@ -108,10 +108,10 @@ func TestDockerCLIBuild(t *testing.T) {
 
 			builder := NewArtifactBuilder(fakeLocalDaemonWithExtraEnv(test.extraEnv), test.localBuild.UseDockerCLI, test.localBuild.UseBuildkit, false, false, test.mode, nil, mockArtifactResolver{make(map[string]string)}, nil)
 
-			artifact := &latest.Artifact{
+			artifact := &latest_v1.Artifact{
 				Workspace: ".",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						DockerfilePath: "Dockerfile",
 					},
 				},

--- a/pkg/skaffold/build/docker/errors_test.go
+++ b/pkg/skaffold/build/docker/errors_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -61,11 +61,11 @@ Refer https://skaffold.dev/docs/references/yaml/#build-artifacts-docker for deta
 			t.Override(&docker.DefaultAuthHelper, stubAuth{})
 			builder := NewArtifactBuilder(fakeLocalDaemonWithExtraEnv([]string{}), false, true, false, false, config.RunModes.Build, nil, mockArtifactResolver{make(map[string]string)}, nil)
 
-			artifact := &latest.Artifact{
+			artifact := &latest_v1.Artifact{
 				ImageName: "test-image",
 				Workspace: ".",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						DockerfilePath: test.dockerfilepath,
 					},
 				},

--- a/pkg/skaffold/build/docker/types.go
+++ b/pkg/skaffold/build/docker/types.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // Builder is an artifact builder that uses docker
@@ -44,7 +44,7 @@ type ArtifactResolver interface {
 
 // TransitiveSourceDependenciesResolver provides an interface to to evaluate the source dependencies for artifacts.
 type TransitiveSourceDependenciesResolver interface {
-	ResolveForArtifact(ctx context.Context, a *latest.Artifact) ([]string, error)
+	ResolveForArtifact(ctx context.Context, a *latest_v1.Artifact) ([]string, error)
 }
 
 // NewBuilder returns an new instance of a docker builder

--- a/pkg/skaffold/build/gcb/buildpacks.go
+++ b/pkg/skaffold/build/gcb/buildpacks.go
@@ -20,15 +20,15 @@ import (
 	"fmt"
 
 	"github.com/sirupsen/logrus"
-	cloudbuild "google.golang.org/api/cloudbuild/v1"
+	"google.golang.org/api/cloudbuild/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
-func (b *Builder) buildpackBuildSpec(artifact *latest.BuildpackArtifact, tag string, deps []*latest.ArtifactDependency) (cloudbuild.Build, error) {
+func (b *Builder) buildpackBuildSpec(artifact *latest_v1.BuildpackArtifact, tag string, deps []*latest_v1.ArtifactDependency) (cloudbuild.Build, error) {
 	args := []string{"pack", "build", tag, "--builder", fromRequiredArtifacts(artifact.Builder, b.artifactStore, deps)}
 
 	if artifact.ProjectDescriptor != constants.DefaultProjectDescriptor {
@@ -66,7 +66,7 @@ func (b *Builder) buildpackBuildSpec(artifact *latest.BuildpackArtifact, tag str
 }
 
 // fromRequiredArtifacts replaces the provided image name with image from the required artifacts if matched.
-func fromRequiredArtifacts(imageName string, r docker.ArtifactResolver, deps []*latest.ArtifactDependency) string {
+func fromRequiredArtifacts(imageName string, r docker.ArtifactResolver, deps []*latest_v1.ArtifactDependency) string {
 	for _, d := range deps {
 		if imageName == d.Alias {
 			image, found := r.GetImageTag(d.ImageName)

--- a/pkg/skaffold/build/gcb/buildpacks_test.go
+++ b/pkg/skaffold/build/gcb/buildpacks_test.go
@@ -19,9 +19,9 @@ package gcb
 import (
 	"testing"
 
-	cloudbuild "google.golang.org/api/cloudbuild/v1"
+	"google.golang.org/api/cloudbuild/v1"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -29,13 +29,13 @@ import (
 func TestBuildpackBuildSpec(t *testing.T) {
 	tests := []struct {
 		description string
-		artifact    *latest.BuildpackArtifact
+		artifact    *latest_v1.BuildpackArtifact
 		expected    cloudbuild.Build
 		shouldErr   bool
 	}{
 		{
 			description: "default run image",
-			artifact: &latest.BuildpackArtifact{
+			artifact: &latest_v1.BuildpackArtifact{
 				Builder:           "builder",
 				ProjectDescriptor: "project.toml",
 			},
@@ -49,7 +49,7 @@ func TestBuildpackBuildSpec(t *testing.T) {
 		},
 		{
 			description: "env variables",
-			artifact: &latest.BuildpackArtifact{
+			artifact: &latest_v1.BuildpackArtifact{
 				Builder:           "builder",
 				Env:               []string{"KEY=VALUE", "FOO={{.BAR}}"},
 				ProjectDescriptor: "project.toml",
@@ -64,7 +64,7 @@ func TestBuildpackBuildSpec(t *testing.T) {
 		},
 		{
 			description: "run image",
-			artifact: &latest.BuildpackArtifact{
+			artifact: &latest_v1.BuildpackArtifact{
 				Builder:           "otherbuilder",
 				RunImage:          "run/image",
 				ProjectDescriptor: "project.toml",
@@ -79,7 +79,7 @@ func TestBuildpackBuildSpec(t *testing.T) {
 		},
 		{
 			description: "custom build image",
-			artifact: &latest.BuildpackArtifact{
+			artifact: &latest_v1.BuildpackArtifact{
 				Builder:           "img2",
 				RunImage:          "run/image",
 				ProjectDescriptor: "project.toml",
@@ -94,7 +94,7 @@ func TestBuildpackBuildSpec(t *testing.T) {
 		},
 		{
 			description: "custom run image",
-			artifact: &latest.BuildpackArtifact{
+			artifact: &latest_v1.BuildpackArtifact{
 				Builder:           "otherbuilder",
 				RunImage:          "img3",
 				ProjectDescriptor: "project.toml",
@@ -109,7 +109,7 @@ func TestBuildpackBuildSpec(t *testing.T) {
 		},
 		{
 			description: "custom build and run image",
-			artifact: &latest.BuildpackArtifact{
+			artifact: &latest_v1.BuildpackArtifact{
 				Builder:           "img2",
 				RunImage:          "img3",
 				ProjectDescriptor: "project.toml",
@@ -124,7 +124,7 @@ func TestBuildpackBuildSpec(t *testing.T) {
 		},
 		{
 			description: "invalid env",
-			artifact: &latest.BuildpackArtifact{
+			artifact: &latest_v1.BuildpackArtifact{
 				Builder: "builder",
 				Env:     []string{"FOO={{INVALID}}"},
 			},
@@ -132,7 +132,7 @@ func TestBuildpackBuildSpec(t *testing.T) {
 		},
 		{
 			description: "buildpacks list",
-			artifact: &latest.BuildpackArtifact{
+			artifact: &latest_v1.BuildpackArtifact{
 				Builder:           "builder",
 				Buildpacks:        []string{"buildpack1", "buildpack2"},
 				ProjectDescriptor: "project.toml",
@@ -147,7 +147,7 @@ func TestBuildpackBuildSpec(t *testing.T) {
 		},
 		{
 			description: "trusted builder",
-			artifact: &latest.BuildpackArtifact{
+			artifact: &latest_v1.BuildpackArtifact{
 				Builder:           "builder",
 				ProjectDescriptor: "project.toml",
 				TrustBuilder:      true,
@@ -162,7 +162,7 @@ func TestBuildpackBuildSpec(t *testing.T) {
 		},
 		{
 			description: "project descriptor",
-			artifact: &latest.BuildpackArtifact{
+			artifact: &latest_v1.BuildpackArtifact{
 				Builder:           "builder",
 				ProjectDescriptor: "non-default.toml",
 			},
@@ -179,18 +179,18 @@ func TestBuildpackBuildSpec(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.OSEnviron, func() []string { return []string{"BAR=bar"} })
 
-			artifact := &latest.Artifact{
+			artifact := &latest_v1.Artifact{
 				ImageName: "img",
-				ArtifactType: latest.ArtifactType{
+				ArtifactType: latest_v1.ArtifactType{
 					BuildpackArtifact: test.artifact,
 				},
-				Dependencies: []*latest.ArtifactDependency{{ImageName: "img2", Alias: "img2"}, {ImageName: "img3", Alias: "img3"}},
+				Dependencies: []*latest_v1.ArtifactDependency{{ImageName: "img2", Alias: "img2"}, {ImageName: "img3", Alias: "img3"}},
 			}
 			store := mockArtifactStore{
 				"img2": "img2:tag",
 				"img3": "img3:tag",
 			}
-			builder := NewBuilder(&mockBuilderContext{artifactStore: store}, &latest.GoogleCloudBuild{
+			builder := NewBuilder(&mockBuilderContext{artifactStore: store}, &latest_v1.GoogleCloudBuild{
 				PackImage: "pack/image",
 			})
 			buildSpec, err := builder.buildSpec(artifact, "img", "bucket", "object")

--- a/pkg/skaffold/build/gcb/cloud_build.go
+++ b/pkg/skaffold/build/gcb/cloud_build.go
@@ -28,7 +28,7 @@ import (
 
 	cstorage "cloud.google.com/go/storage"
 	"github.com/sirupsen/logrus"
-	cloudbuild "google.golang.org/api/cloudbuild/v1"
+	"google.golang.org/api/cloudbuild/v1"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -38,13 +38,13 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/gcp"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sources"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // Build builds a list of artifacts with Google Cloud Build.
-func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest.Artifact) build.ArtifactBuilder {
+func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest_v1.Artifact) build.ArtifactBuilder {
 	builder := build.WithLogFile(b.buildArtifactWithCloudBuild, b.muted)
 	return builder
 }
@@ -61,7 +61,7 @@ func (b *Builder) Concurrency() int {
 	return b.GoogleCloudBuild.Concurrency
 }
 
-func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer, artifact *latest_v1.Artifact, tag string) (string, error) {
 	// TODO: [#4922] Implement required artifact resolution from the `artifactStore`
 	cbclient, err := cloudbuild.NewService(ctx, gcp.ClientOptions()...)
 	if err != nil {

--- a/pkg/skaffold/build/gcb/docker.go
+++ b/pkg/skaffold/build/gcb/docker.go
@@ -23,11 +23,11 @@ import (
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // dockerBuildSpec lists the build steps required to build a docker image.
-func (b *Builder) dockerBuildSpec(a *latest.Artifact, tag string) (cloudbuild.Build, error) {
+func (b *Builder) dockerBuildSpec(a *latest_v1.Artifact, tag string) (cloudbuild.Build, error) {
 	args, err := b.dockerBuildArgs(a, tag, a.Dependencies)
 	if err != nil {
 		return cloudbuild.Build{}, err
@@ -46,7 +46,7 @@ func (b *Builder) dockerBuildSpec(a *latest.Artifact, tag string) (cloudbuild.Bu
 }
 
 // cacheFromSteps pulls images used by `--cache-from`.
-func (b *Builder) cacheFromSteps(artifact *latest.DockerArtifact) []*cloudbuild.BuildStep {
+func (b *Builder) cacheFromSteps(artifact *latest_v1.DockerArtifact) []*cloudbuild.BuildStep {
 	var steps []*cloudbuild.BuildStep
 
 	for _, cacheFrom := range artifact.CacheFrom {
@@ -61,7 +61,7 @@ func (b *Builder) cacheFromSteps(artifact *latest.DockerArtifact) []*cloudbuild.
 }
 
 // dockerBuildArgs lists the arguments passed to `docker` to build a given image.
-func (b *Builder) dockerBuildArgs(a *latest.Artifact, tag string, deps []*latest.ArtifactDependency) ([]string, error) {
+func (b *Builder) dockerBuildArgs(a *latest_v1.Artifact, tag string, deps []*latest_v1.ArtifactDependency) ([]string, error) {
 	d := a.DockerArtifact
 	// TODO(nkubala): remove when buildkit is supported in GCB (#4773)
 	if d.Secret != nil || d.SSH != "" {

--- a/pkg/skaffold/build/gcb/docker_test.go
+++ b/pkg/skaffold/build/gcb/docker_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -31,15 +31,15 @@ import (
 func TestDockerBuildSpec(t *testing.T) {
 	tests := []struct {
 		description string
-		artifact    *latest.Artifact
+		artifact    *latest_v1.Artifact
 		expected    cloudbuild.Build
 		shouldErr   bool
 	}{
 		{
 			description: "normal docker build",
-			artifact: &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+			artifact: &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						DockerfilePath: "Dockerfile",
 						BuildArgs: map[string]*string{
 							"arg1": util.StringPtr("value1"),
@@ -70,10 +70,10 @@ func TestDockerBuildSpec(t *testing.T) {
 		},
 		{
 			description: "docker build with artifact dependencies",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "img1",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						DockerfilePath: "Dockerfile",
 						BuildArgs: map[string]*string{
 							"arg1": util.StringPtr("value1"),
@@ -81,7 +81,7 @@ func TestDockerBuildSpec(t *testing.T) {
 						},
 					},
 				},
-				Dependencies: []*latest.ArtifactDependency{{ImageName: "img2", Alias: "IMG2"}, {ImageName: "img3", Alias: "IMG3"}},
+				Dependencies: []*latest_v1.ArtifactDependency{{ImageName: "img2", Alias: "IMG2"}, {ImageName: "img3", Alias: "IMG3"}},
 			},
 			expected: cloudbuild.Build{
 				LogsBucket: "bucket",
@@ -105,11 +105,11 @@ func TestDockerBuildSpec(t *testing.T) {
 		},
 		{
 			description: "buildkit `secret` option not supported in GCB",
-			artifact: &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+			artifact: &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						DockerfilePath: "Dockerfile",
-						Secret: &latest.DockerSecret{
+						Secret: &latest_v1.DockerSecret{
 							ID: "secret",
 						},
 					},
@@ -119,9 +119,9 @@ func TestDockerBuildSpec(t *testing.T) {
 		},
 		{
 			description: "buildkit `ssh` option not supported in GCB",
-			artifact: &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+			artifact: &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						DockerfilePath: "Dockerfile",
 						SSH:            "default",
 					},
@@ -149,7 +149,7 @@ func TestDockerBuildSpec(t *testing.T) {
 				"img3": "img3:tag",
 			}
 
-			builder := NewBuilder(&mockBuilderContext{artifactStore: store}, &latest.GoogleCloudBuild{
+			builder := NewBuilder(&mockBuilderContext{artifactStore: store}, &latest_v1.GoogleCloudBuild{
 				DockerImage: "docker/docker",
 				DiskSizeGb:  100,
 				MachineType: "n1-standard-1",
@@ -167,15 +167,15 @@ func TestPullCacheFrom(t *testing.T) {
 		t.Override(&docker.EvalBuildArgs, func(_ config.RunMode, _ string, _ string, args map[string]*string, _ map[string]*string) (map[string]*string, error) {
 			return args, nil
 		})
-		artifact := &latest.Artifact{
-			ArtifactType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{
+		artifact := &latest_v1.Artifact{
+			ArtifactType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{
 					DockerfilePath: "Dockerfile",
 					CacheFrom:      []string{"from/image1", "from/image2"},
 				},
 			},
 		}
-		builder := NewBuilder(&mockBuilderContext{}, &latest.GoogleCloudBuild{
+		builder := NewBuilder(&mockBuilderContext{}, &latest_v1.GoogleCloudBuild{
 			DockerImage: "docker/docker",
 		})
 		desc, err := builder.dockerBuildSpec(artifact, "nginx2")

--- a/pkg/skaffold/build/gcb/jib.go
+++ b/pkg/skaffold/build/gcb/jib.go
@@ -25,11 +25,11 @@ import (
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
-func (b *Builder) jibBuildSpec(artifact *latest.Artifact, tag string) (cloudbuild.Build, error) {
+func (b *Builder) jibBuildSpec(artifact *latest_v1.Artifact, tag string) (cloudbuild.Build, error) {
 	t, err := jib.DeterminePluginType(artifact.Workspace, artifact.JibArtifact)
 	if err != nil {
 		return cloudbuild.Build{}, err

--- a/pkg/skaffold/build/gcb/jib_test.go
+++ b/pkg/skaffold/build/gcb/jib_test.go
@@ -23,7 +23,7 @@ import (
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -59,11 +59,11 @@ func TestJibMavenBuildSpec(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			artifact := &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					JibArtifact: &latest.JibArtifact{Type: string(jib.JibMaven), BaseImage: test.baseImage},
+			artifact := &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					JibArtifact: &latest_v1.JibArtifact{Type: string(jib.JibMaven), BaseImage: test.baseImage},
 				},
-				Dependencies: []*latest.ArtifactDependency{
+				Dependencies: []*latest_v1.ArtifactDependency{
 					{ImageName: "img2", Alias: "img2"},
 					{ImageName: "img3", Alias: "img3"},
 				},
@@ -73,7 +73,7 @@ func TestJibMavenBuildSpec(t *testing.T) {
 				"img2": "img2:tag",
 				"img3": "img3:tag",
 			}
-			builder := NewBuilder(&mockBuilderContext{artifactStore: store}, &latest.GoogleCloudBuild{
+			builder := NewBuilder(&mockBuilderContext{artifactStore: store}, &latest_v1.GoogleCloudBuild{
 				MavenImage: "maven:3.6.0",
 			})
 			builder.skipTests = test.skipTests
@@ -112,13 +112,13 @@ func TestJibGradleBuildSpec(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			artifact := &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					JibArtifact: &latest.JibArtifact{Type: string(jib.JibGradle)},
+			artifact := &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					JibArtifact: &latest_v1.JibArtifact{Type: string(jib.JibGradle)},
 				},
 			}
 
-			builder := NewBuilder(&mockBuilderContext{}, &latest.GoogleCloudBuild{
+			builder := NewBuilder(&mockBuilderContext{}, &latest_v1.GoogleCloudBuild{
 				GradleImage: "gradle:5.1.1",
 			})
 			builder.skipTests = test.skipTests

--- a/pkg/skaffold/build/gcb/kaniko.go
+++ b/pkg/skaffold/build/gcb/kaniko.go
@@ -23,10 +23,10 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
-func (b *Builder) kanikoBuildSpec(a *latest.Artifact, tag string) (cloudbuild.Build, error) {
+func (b *Builder) kanikoBuildSpec(a *latest_v1.Artifact, tag string) (cloudbuild.Build, error) {
 	k := a.KanikoArtifact
 	requiredImages := docker.ResolveDependencyImages(a.Dependencies, b.artifactStore, true)
 	// add required artifacts as build args

--- a/pkg/skaffold/build/gcb/kaniko_test.go
+++ b/pkg/skaffold/build/gcb/kaniko_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -33,19 +33,19 @@ import (
 func TestKanikoBuildSpec(t *testing.T) {
 	tests := []struct {
 		description  string
-		artifact     *latest.KanikoArtifact
+		artifact     *latest_v1.KanikoArtifact
 		expectedArgs []string
 	}{
 		{
 			description: "simple build",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 			},
 			expectedArgs: []string{},
 		},
 		{
 			description: "with BuildArgs",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				BuildArgs: map[string]*string{
 					"arg1": util.StringPtr("value1"),
@@ -59,9 +59,9 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with Cache",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
-				Cache:          &latest.KanikoCache{},
+				Cache:          &latest_v1.KanikoCache{},
 			},
 			expectedArgs: []string{
 				kaniko.CacheFlag,
@@ -69,7 +69,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with Cleanup",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Cleanup:        true,
 			},
@@ -79,7 +79,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with DigestFile",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				DigestFile:     "/tmp/digest",
 			},
@@ -89,7 +89,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with Force",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Force:          true,
 			},
@@ -99,7 +99,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with ImageNameWithDigestFile",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath:          "Dockerfile",
 				ImageNameWithDigestFile: "/tmp/imageName",
 			},
@@ -109,7 +109,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with Insecure",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Insecure:       true,
 			},
@@ -119,7 +119,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with InsecurePull",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				InsecurePull:   true,
 			},
@@ -129,7 +129,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with InsecureRegistry",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				InsecureRegistry: []string{
 					"s1.registry.url:5000",
@@ -143,7 +143,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with LogFormat",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				LogFormat:      "json",
 			},
@@ -153,7 +153,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with LogTimestamp",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				LogTimestamp:   true,
 			},
@@ -163,7 +163,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with NoPush",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				NoPush:         true,
 			},
@@ -173,7 +173,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with OCILayoutPath",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				OCILayoutPath:  "/tmp/builtImage",
 			},
@@ -183,7 +183,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with RegistryCertificate",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				RegistryCertificate: map[string]*string{
 					"s1.registry.url": util.StringPtr("/etc/certs/certificate1.cert"),
@@ -197,7 +197,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with RegistryMirror",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				RegistryMirror: "mirror.gcr.io",
 			},
@@ -207,7 +207,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with Reproducible",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Reproducible:   true,
 			},
@@ -217,7 +217,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with SingleSnapshot",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				SingleSnapshot: true,
 			},
@@ -227,7 +227,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with SkipTLS",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				SkipTLS:        true,
 			},
@@ -238,7 +238,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with SkipTLSVerifyPull",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath:    "Dockerfile",
 				SkipTLSVerifyPull: true,
 			},
@@ -248,7 +248,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with SkipTLSVerifyRegistry",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				SkipTLSVerifyRegistry: []string{
 					"s1.registry.url:5000",
@@ -262,7 +262,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with SkipUnusedStages",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath:   "Dockerfile",
 				SkipUnusedStages: true,
 			},
@@ -272,7 +272,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with Target",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Target:         "builder",
 			},
@@ -282,7 +282,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with SnapshotMode",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				SnapshotMode:   "redo",
 			},
@@ -292,7 +292,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with TarPath",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				TarPath:        "/workspace/tars",
 			},
@@ -302,7 +302,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with UseNewRun",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				UseNewRun:      true,
 			},
@@ -312,7 +312,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with Verbosity",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Verbosity:      "trace",
 			},
@@ -322,7 +322,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with WhitelistVarRun",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath:  "Dockerfile",
 				WhitelistVarRun: true,
 			},
@@ -332,7 +332,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with WhitelistVarRun",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath:  "Dockerfile",
 				WhitelistVarRun: true,
 			},
@@ -342,7 +342,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		},
 		{
 			description: "with Labels",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Label: map[string]*string{
 					"label1": util.StringPtr("value1"),
@@ -359,7 +359,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 		"img2": "img2:tag",
 		"img3": "img3:tag",
 	}
-	builder := NewBuilder(&mockBuilderContext{artifactStore: store}, &latest.GoogleCloudBuild{
+	builder := NewBuilder(&mockBuilderContext{artifactStore: store}, &latest_v1.GoogleCloudBuild{
 		KanikoImage: "gcr.io/kaniko-project/executor",
 		DiskSizeGb:  100,
 		MachineType: "n1-standard-1",
@@ -373,12 +373,12 @@ func TestKanikoBuildSpec(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			artifact := &latest.Artifact{
+			artifact := &latest_v1.Artifact{
 				ImageName: "img1",
-				ArtifactType: latest.ArtifactType{
+				ArtifactType: latest_v1.ArtifactType{
 					KanikoArtifact: test.artifact,
 				},
-				Dependencies: []*latest.ArtifactDependency{
+				Dependencies: []*latest_v1.ArtifactDependency{
 					{ImageName: "img2", Alias: "IMG2"},
 					{ImageName: "img3", Alias: "IMG3"},
 				},
@@ -426,7 +426,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 type mockArtifactStore map[string]string
 
 func (m mockArtifactStore) GetImageTag(imageName string) (string, bool) { return m[imageName], true }
-func (m mockArtifactStore) Record(a *latest.Artifact, tag string)       { m[a.ImageName] = tag }
-func (m mockArtifactStore) GetArtifacts([]*latest.Artifact) ([]graph.Artifact, error) {
+func (m mockArtifactStore) Record(a *latest_v1.Artifact, tag string)    { m[a.ImageName] = tag }
+func (m mockArtifactStore) GetArtifacts([]*latest_v1.Artifact) ([]graph.Artifact, error) {
 	return nil, nil
 }

--- a/pkg/skaffold/build/gcb/spec.go
+++ b/pkg/skaffold/build/gcb/spec.go
@@ -22,10 +22,10 @@ import (
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
-func (b *Builder) buildSpec(artifact *latest.Artifact, tag, bucket, object string) (cloudbuild.Build, error) {
+func (b *Builder) buildSpec(artifact *latest_v1.Artifact, tag, bucket, object string) (cloudbuild.Build, error) {
 	// Artifact specific build spec
 	buildSpec, err := b.buildSpecForArtifact(artifact, tag)
 	if err != nil {
@@ -53,7 +53,7 @@ func (b *Builder) buildSpec(artifact *latest.Artifact, tag, bucket, object strin
 	return buildSpec, nil
 }
 
-func (b *Builder) buildSpecForArtifact(a *latest.Artifact, tag string) (cloudbuild.Build, error) {
+func (b *Builder) buildSpecForArtifact(a *latest_v1.Artifact, tag string) (cloudbuild.Build, error) {
 	switch {
 	case a.KanikoArtifact != nil:
 		return b.kanikoBuildSpec(a, tag)

--- a/pkg/skaffold/build/gcb/spec_test.go
+++ b/pkg/skaffold/build/gcb/spec_test.go
@@ -22,31 +22,31 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestBuildSpecFail(t *testing.T) {
 	tests := []struct {
 		description string
-		artifact    *latest.Artifact
+		artifact    *latest_v1.Artifact
 	}{
 		{
 			description: "bazel",
-			artifact: &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					BazelArtifact: &latest.BazelArtifact{},
+			artifact: &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					BazelArtifact: &latest_v1.BazelArtifact{},
 				},
 			},
 		},
 		{
 			description: "unknown",
-			artifact:    &latest.Artifact{},
+			artifact:    &latest_v1.Artifact{},
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			builder := NewBuilder(&mockBuilderContext{}, &latest.GoogleCloudBuild{})
+			builder := NewBuilder(&mockBuilderContext{}, &latest_v1.GoogleCloudBuild{})
 
 			_, err := builder.buildSpec(test.artifact, "tag", "bucket", "object")
 

--- a/pkg/skaffold/build/gcb/types.go
+++ b/pkg/skaffold/build/gcb/types.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 const (
@@ -79,7 +79,7 @@ func NewStatusBackoff() *wait.Backoff {
 
 // Builder builds artifacts with Google Cloud Build.
 type Builder struct {
-	*latest.GoogleCloudBuild
+	*latest_v1.GoogleCloudBuild
 
 	cfg                Config
 	skipTests          bool
@@ -102,7 +102,7 @@ type BuilderContext interface {
 }
 
 // NewBuilder creates a new Builder that builds artifacts with Google Cloud Build.
-func NewBuilder(bCtx BuilderContext, buildCfg *latest.GoogleCloudBuild) *Builder {
+func NewBuilder(bCtx BuilderContext, buildCfg *latest_v1.GoogleCloudBuild) *Builder {
 	return &Builder{
 		GoogleCloudBuild:   buildCfg,
 		cfg:                bCtx,

--- a/pkg/skaffold/build/jib/build.go
+++ b/pkg/skaffold/build/jib/build.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // Build builds an artifact with Jib.
-func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest_v1.Artifact, tag string) (string, error) {
 	t, err := DeterminePluginType(artifact.Workspace, artifact.JibArtifact)
 	if err != nil {
 		return "", err

--- a/pkg/skaffold/build/jib/gradle.go
+++ b/pkg/skaffold/build/jib/gradle.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -43,7 +43,7 @@ const MinimumJibGradleVersionForSync = "2.0.0"
 // GradleCommand stores Gradle executable and wrapper name
 var GradleCommand = util.CommandWrapper{Executable: "gradle", Wrapper: "gradlew"}
 
-func (b *Builder) buildJibGradleToDocker(ctx context.Context, out io.Writer, workspace string, artifact *latest.JibArtifact, deps []*latest.ArtifactDependency, tag string) (string, error) {
+func (b *Builder) buildJibGradleToDocker(ctx context.Context, out io.Writer, workspace string, artifact *latest_v1.JibArtifact, deps []*latest_v1.ArtifactDependency, tag string) (string, error) {
 	args := GenerateGradleBuildArgs("jibDockerBuild", tag, artifact, b.skipTests, b.pushImages, deps, b.artifacts, b.cfg.GetInsecureRegistries(), color.IsColorable(out))
 	if err := b.runGradleCommand(ctx, out, workspace, args); err != nil {
 		return "", jibToolErr(err)
@@ -52,7 +52,7 @@ func (b *Builder) buildJibGradleToDocker(ctx context.Context, out io.Writer, wor
 	return b.localDocker.ImageID(ctx, tag)
 }
 
-func (b *Builder) buildJibGradleToRegistry(ctx context.Context, out io.Writer, workspace string, artifact *latest.JibArtifact, deps []*latest.ArtifactDependency, tag string) (string, error) {
+func (b *Builder) buildJibGradleToRegistry(ctx context.Context, out io.Writer, workspace string, artifact *latest_v1.JibArtifact, deps []*latest_v1.ArtifactDependency, tag string) (string, error) {
 	args := GenerateGradleBuildArgs("jib", tag, artifact, b.skipTests, b.pushImages, deps, b.artifacts, b.cfg.GetInsecureRegistries(), color.IsColorable(out))
 	if err := b.runGradleCommand(ctx, out, workspace, args); err != nil {
 		return "", jibToolErr(err)
@@ -77,7 +77,7 @@ func (b *Builder) runGradleCommand(ctx context.Context, out io.Writer, workspace
 
 // getDependenciesGradle finds the source dependencies for the given jib-gradle artifact.
 // All paths are absolute.
-func getDependenciesGradle(ctx context.Context, workspace string, a *latest.JibArtifact) ([]string, error) {
+func getDependenciesGradle(ctx context.Context, workspace string, a *latest_v1.JibArtifact) ([]string, error) {
 	cmd := getCommandGradle(ctx, workspace, a)
 	deps, err := getDependencies(workspace, cmd, a)
 	if err != nil {
@@ -87,18 +87,18 @@ func getDependenciesGradle(ctx context.Context, workspace string, a *latest.JibA
 	return deps, nil
 }
 
-func getCommandGradle(ctx context.Context, workspace string, a *latest.JibArtifact) exec.Cmd {
+func getCommandGradle(ctx context.Context, workspace string, a *latest_v1.JibArtifact) exec.Cmd {
 	args := append(gradleArgsFunc(a, "_jibSkaffoldFilesV2", MinimumJibGradleVersion), "-q", "--console=plain")
 	return GradleCommand.CreateCommand(ctx, workspace, args)
 }
 
-func getSyncMapCommandGradle(ctx context.Context, workspace string, a *latest.JibArtifact) *exec.Cmd {
+func getSyncMapCommandGradle(ctx context.Context, workspace string, a *latest_v1.JibArtifact) *exec.Cmd {
 	cmd := GradleCommand.CreateCommand(ctx, workspace, gradleBuildArgsFunc("_jibSkaffoldSyncMap", a, true, false, MinimumJibMavenVersionForSync))
 	return &cmd
 }
 
 // GenerateGradleBuildArgs generates the arguments to Gradle for building the project as an image.
-func GenerateGradleBuildArgs(task string, imageName string, a *latest.JibArtifact, skipTests, pushImages bool, deps []*latest.ArtifactDependency, r ArtifactResolver, insecureRegistries map[string]bool, showColors bool) []string {
+func GenerateGradleBuildArgs(task string, imageName string, a *latest_v1.JibArtifact, skipTests, pushImages bool, deps []*latest_v1.ArtifactDependency, r ArtifactResolver, insecureRegistries map[string]bool, showColors bool) []string {
 	args := gradleBuildArgsFunc(task, a, skipTests, showColors, MinimumJibGradleVersion)
 	if insecure, err := isOnInsecureRegistry(imageName, insecureRegistries); err == nil && insecure {
 		// jib doesn't support marking specific registries as insecure
@@ -112,7 +112,7 @@ func GenerateGradleBuildArgs(task string, imageName string, a *latest.JibArtifac
 }
 
 // Do not use directly, use gradleBuildArgsFunc
-func gradleBuildArgs(task string, a *latest.JibArtifact, skipTests, showColors bool, minimumVersion string) []string {
+func gradleBuildArgs(task string, a *latest_v1.JibArtifact, skipTests, showColors bool, minimumVersion string) []string {
 	// Disable jib's rich progress footer on builds. Show colors on normal builds for clearer information,
 	// but use --console=plain for internal goals to avoid formatting issues
 	var args []string
@@ -131,7 +131,7 @@ func gradleBuildArgs(task string, a *latest.JibArtifact, skipTests, showColors b
 }
 
 // Do not use directly, use gradleArgsFunc
-func gradleArgs(a *latest.JibArtifact, task string, minimumVersion string) []string {
+func gradleArgs(a *latest_v1.JibArtifact, task string, minimumVersion string) []string {
 	args := []string{"_skaffoldFailIfJibOutOfDate", "-Djib.requiredVersion=" + minimumVersion}
 	if a.Project == "" {
 		return append(args, ":"+task)

--- a/pkg/skaffold/build/jib/gradle_test.go
+++ b/pkg/skaffold/build/jib/gradle_test.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -36,35 +36,35 @@ import (
 func TestBuildJibGradleToDocker(t *testing.T) {
 	tests := []struct {
 		description   string
-		artifact      *latest.JibArtifact
+		artifact      *latest_v1.JibArtifact
 		commands      util.Command
 		shouldErr     bool
 		expectedError string
 	}{
 		{
 			description: "build",
-			artifact:    &latest.JibArtifact{},
+			artifact:    &latest_v1.JibArtifact{},
 			commands: testutil.CmdRun(
 				"gradle fake-gradleBuildArgs-for-jibDockerBuild --image=img:tag",
 			),
 		},
 		{
 			description: "build with project",
-			artifact:    &latest.JibArtifact{Project: "project"},
+			artifact:    &latest_v1.JibArtifact{Project: "project"},
 			commands: testutil.CmdRun(
 				"gradle fake-gradleBuildArgs-for-project-for-jibDockerBuild --image=img:tag",
 			),
 		},
 		{
 			description: "build with custom base image",
-			artifact:    &latest.JibArtifact{BaseImage: "docker://busybox"},
+			artifact:    &latest_v1.JibArtifact{BaseImage: "docker://busybox"},
 			commands: testutil.CmdRun(
 				"gradle fake-gradleBuildArgs-for-jibDockerBuild -Djib.from.image=docker://busybox --image=img:tag",
 			),
 		},
 		{
 			description: "fail build",
-			artifact:    &latest.JibArtifact{},
+			artifact:    &latest_v1.JibArtifact{},
 			commands: testutil.CmdRunErr(
 				"gradle fake-gradleBuildArgs-for-jibDockerBuild --image=img:tag",
 				errors.New("BUG"),
@@ -83,8 +83,8 @@ func TestBuildJibGradleToDocker(t *testing.T) {
 			localDocker := fakeLocalDaemon(api)
 
 			builder := NewArtifactBuilder(localDocker, &mockConfig{}, false, false, nil)
-			result, err := builder.Build(context.Background(), ioutil.Discard, &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
+			result, err := builder.Build(context.Background(), ioutil.Discard, &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
 					JibArtifact: test.artifact,
 				},
 			}, "img:tag")
@@ -102,35 +102,35 @@ func TestBuildJibGradleToDocker(t *testing.T) {
 func TestBuildJibGradleToRegistry(t *testing.T) {
 	tests := []struct {
 		description   string
-		artifact      *latest.JibArtifact
+		artifact      *latest_v1.JibArtifact
 		commands      util.Command
 		shouldErr     bool
 		expectedError string
 	}{
 		{
 			description: "remote build",
-			artifact:    &latest.JibArtifact{},
+			artifact:    &latest_v1.JibArtifact{},
 			commands: testutil.CmdRun(
 				"gradle fake-gradleBuildArgs-for-jib --image=img:tag",
 			),
 		},
 		{
 			description: "build with project",
-			artifact:    &latest.JibArtifact{Project: "project"},
+			artifact:    &latest_v1.JibArtifact{Project: "project"},
 			commands: testutil.CmdRun(
 				"gradle fake-gradleBuildArgs-for-project-for-jib --image=img:tag",
 			),
 		},
 		{
 			description: "build with custom base image",
-			artifact:    &latest.JibArtifact{BaseImage: "docker://busybox"},
+			artifact:    &latest_v1.JibArtifact{BaseImage: "docker://busybox"},
 			commands: testutil.CmdRun(
 				"gradle fake-gradleBuildArgs-for-jib -Djib.from.image=docker://busybox --image=img:tag",
 			),
 		},
 		{
 			description: "fail build",
-			artifact:    &latest.JibArtifact{},
+			artifact:    &latest_v1.JibArtifact{},
 			commands: testutil.CmdRunErr(
 				"gradle fake-gradleBuildArgs-for-jib --image=img:tag",
 				errors.New("BUG"),
@@ -154,8 +154,8 @@ func TestBuildJibGradleToRegistry(t *testing.T) {
 			localDocker := fakeLocalDaemon(&testutil.FakeAPIClient{})
 
 			builder := NewArtifactBuilder(localDocker, &mockConfig{}, true, false, nil)
-			result, err := builder.Build(context.Background(), ioutil.Discard, &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
+			result, err := builder.Build(context.Background(), ioutil.Discard, &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
 					JibArtifact: test.artifact,
 				},
 			}, "img:tag")
@@ -225,7 +225,7 @@ func TestGetDependenciesGradle(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunOutErr(
-				strings.Join(getCommandGradle(ctx, tmpDir.Root(), &latest.JibArtifact{Project: "gradle-test"}).Args, " "),
+				strings.Join(getCommandGradle(ctx, tmpDir.Root(), &latest_v1.JibArtifact{Project: "gradle-test"}).Args, " "),
 				test.stdout,
 				test.err,
 			))
@@ -236,7 +236,7 @@ func TestGetDependenciesGradle(t *testing.T) {
 			}
 
 			ws := tmpDir.Root()
-			deps, err := getDependenciesGradle(ctx, ws, &latest.JibArtifact{Project: "gradle-test"})
+			deps, err := getDependenciesGradle(ctx, ws, &latest_v1.JibArtifact{Project: "gradle-test"})
 			if test.err != nil {
 				prefix := fmt.Sprintf("could not fetch dependencies for workspace %s: initial Jib dependency refresh failed: failed to get Jib dependencies: ", ws)
 				t.CheckErrorAndDeepEqual(true, err, prefix+test.err.Error(), err.Error())
@@ -252,13 +252,13 @@ func TestGetCommandGradle(t *testing.T) {
 
 	tests := []struct {
 		description      string
-		jibArtifact      latest.JibArtifact
+		jibArtifact      latest_v1.JibArtifact
 		filesInWorkspace []string
 		expectedCmd      func(workspace string) exec.Cmd
 	}{
 		{
 			description:      "gradle default",
-			jibArtifact:      latest.JibArtifact{},
+			jibArtifact:      latest_v1.JibArtifact{},
 			filesInWorkspace: []string{},
 			expectedCmd: func(workspace string) exec.Cmd {
 				return GradleCommand.CreateCommand(ctx, workspace, []string{"_skaffoldFailIfJibOutOfDate", "-Djib.requiredVersion=" + MinimumJibGradleVersion, ":_jibSkaffoldFilesV2", "-q", "--console=plain"})
@@ -266,7 +266,7 @@ func TestGetCommandGradle(t *testing.T) {
 		},
 		{
 			description:      "gradle default with project",
-			jibArtifact:      latest.JibArtifact{Project: "project"},
+			jibArtifact:      latest_v1.JibArtifact{Project: "project"},
 			filesInWorkspace: []string{},
 			expectedCmd: func(workspace string) exec.Cmd {
 				return GradleCommand.CreateCommand(ctx, workspace, []string{"_skaffoldFailIfJibOutOfDate", "-Djib.requiredVersion=" + MinimumJibGradleVersion, ":project:_jibSkaffoldFilesV2", "-q", "--console=plain"})
@@ -274,7 +274,7 @@ func TestGetCommandGradle(t *testing.T) {
 		},
 		{
 			description:      "gradle with wrapper",
-			jibArtifact:      latest.JibArtifact{},
+			jibArtifact:      latest_v1.JibArtifact{},
 			filesInWorkspace: []string{"gradlew", "gradlew.cmd"},
 			expectedCmd: func(workspace string) exec.Cmd {
 				return GradleCommand.CreateCommand(ctx, workspace, []string{"_skaffoldFailIfJibOutOfDate", "-Djib.requiredVersion=" + MinimumJibGradleVersion, ":_jibSkaffoldFilesV2", "-q", "--console=plain"})
@@ -282,7 +282,7 @@ func TestGetCommandGradle(t *testing.T) {
 		},
 		{
 			description:      "gradle with wrapper and project",
-			jibArtifact:      latest.JibArtifact{Project: "project"},
+			jibArtifact:      latest_v1.JibArtifact{Project: "project"},
 			filesInWorkspace: []string{"gradlew", "gradlew.cmd"},
 			expectedCmd: func(workspace string) exec.Cmd {
 				return GradleCommand.CreateCommand(ctx, workspace, []string{"_skaffoldFailIfJibOutOfDate", "-Djib.requiredVersion=" + MinimumJibGradleVersion, ":project:_jibSkaffoldFilesV2", "-q", "--console=plain"})
@@ -309,19 +309,19 @@ func TestGetSyncMapCommandGradle(t *testing.T) {
 	tests := []struct {
 		description string
 		workspace   string
-		jibArtifact latest.JibArtifact
+		jibArtifact latest_v1.JibArtifact
 		expectedCmd func(workspace string) exec.Cmd
 	}{
 		{
 			description: "single module",
-			jibArtifact: latest.JibArtifact{},
+			jibArtifact: latest_v1.JibArtifact{},
 			expectedCmd: func(workspace string) exec.Cmd {
 				return GradleCommand.CreateCommand(ctx, workspace, []string{"fake-gradleBuildArgs-for-_jibSkaffoldSyncMap-skipTests"})
 			},
 		},
 		{
 			description: "multi module",
-			jibArtifact: latest.JibArtifact{Project: "project"},
+			jibArtifact: latest_v1.JibArtifact{Project: "project"},
 			expectedCmd: func(workspace string) exec.Cmd {
 				return GradleCommand.CreateCommand(ctx, workspace, []string{"fake-gradleBuildArgs-for-project-for-_jibSkaffoldSyncMap-skipTests"})
 			},
@@ -342,8 +342,8 @@ func TestGetSyncMapCommandGradle(t *testing.T) {
 func TestGenerateGradleBuildArgs(t *testing.T) {
 	tests := []struct {
 		description        string
-		in                 latest.JibArtifact
-		deps               []*latest.ArtifactDependency
+		in                 latest_v1.JibArtifact
+		deps               []*latest_v1.ArtifactDependency
 		image              string
 		skipTests          bool
 		pushImages         bool
@@ -353,41 +353,41 @@ func TestGenerateGradleBuildArgs(t *testing.T) {
 	}{
 		{description: "single module", image: "image", out: []string{"fake-gradleBuildArgs-for-testTask", "--image=image"}},
 		{description: "single module without tests", image: "image", skipTests: true, out: []string{"fake-gradleBuildArgs-for-testTask-skipTests", "--image=image"}},
-		{description: "multi module", in: latest.JibArtifact{Project: "project"}, image: "image", out: []string{"fake-gradleBuildArgs-for-project-for-testTask", "--image=image"}},
-		{description: "multi module without tests", in: latest.JibArtifact{Project: "project"}, image: "image", skipTests: true, out: []string{"fake-gradleBuildArgs-for-project-for-testTask-skipTests", "--image=image"}},
-		{description: "multi module without tests with insecure registries", in: latest.JibArtifact{Project: "project"}, image: "registry.tld/image", skipTests: true, insecureRegistries: map[string]bool{"registry.tld": true}, out: []string{"fake-gradleBuildArgs-for-project-for-testTask-skipTests", "-Djib.allowInsecureRegistries=true", "--image=registry.tld/image"}},
-		{description: "single module with custom base image", in: latest.JibArtifact{BaseImage: "docker://busybox"}, image: "image", out: []string{"fake-gradleBuildArgs-for-testTask", "-Djib.from.image=docker://busybox", "--image=image"}},
-		{description: "multi module with custom base image", in: latest.JibArtifact{Project: "project", BaseImage: "docker://busybox"}, image: "image", out: []string{"fake-gradleBuildArgs-for-project-for-testTask", "-Djib.from.image=docker://busybox", "--image=image"}},
+		{description: "multi module", in: latest_v1.JibArtifact{Project: "project"}, image: "image", out: []string{"fake-gradleBuildArgs-for-project-for-testTask", "--image=image"}},
+		{description: "multi module without tests", in: latest_v1.JibArtifact{Project: "project"}, image: "image", skipTests: true, out: []string{"fake-gradleBuildArgs-for-project-for-testTask-skipTests", "--image=image"}},
+		{description: "multi module without tests with insecure registries", in: latest_v1.JibArtifact{Project: "project"}, image: "registry.tld/image", skipTests: true, insecureRegistries: map[string]bool{"registry.tld": true}, out: []string{"fake-gradleBuildArgs-for-project-for-testTask-skipTests", "-Djib.allowInsecureRegistries=true", "--image=registry.tld/image"}},
+		{description: "single module with custom base image", in: latest_v1.JibArtifact{BaseImage: "docker://busybox"}, image: "image", out: []string{"fake-gradleBuildArgs-for-testTask", "-Djib.from.image=docker://busybox", "--image=image"}},
+		{description: "multi module with custom base image", in: latest_v1.JibArtifact{Project: "project", BaseImage: "docker://busybox"}, image: "image", out: []string{"fake-gradleBuildArgs-for-project-for-testTask", "-Djib.from.image=docker://busybox", "--image=image"}},
 		{
 			description: "single module with local base image from required artifacts",
-			in:          latest.JibArtifact{BaseImage: "alias"},
+			in:          latest_v1.JibArtifact{BaseImage: "alias"},
 			image:       "image",
-			deps:        []*latest.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
+			deps:        []*latest_v1.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
 			r:           mockArtifactResolver{m: map[string]string{"img": "img:tag"}},
 			out:         []string{"fake-gradleBuildArgs-for-testTask", "-Djib.from.image=docker://img:tag", "--image=image"},
 		},
 		{
 			description: "multi module with local base image from required artifacts",
-			in:          latest.JibArtifact{Project: "project", BaseImage: "alias"},
+			in:          latest_v1.JibArtifact{Project: "project", BaseImage: "alias"},
 			image:       "image",
-			deps:        []*latest.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
+			deps:        []*latest_v1.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
 			r:           mockArtifactResolver{m: map[string]string{"img": "img:tag"}},
 			out:         []string{"fake-gradleBuildArgs-for-project-for-testTask", "-Djib.from.image=docker://img:tag", "--image=image"},
 		}, {
 			description: "single module with remote base image from required artifacts",
-			in:          latest.JibArtifact{BaseImage: "alias"},
+			in:          latest_v1.JibArtifact{BaseImage: "alias"},
 			image:       "image",
 			pushImages:  true,
-			deps:        []*latest.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
+			deps:        []*latest_v1.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
 			r:           mockArtifactResolver{m: map[string]string{"img": "img:tag"}},
 			out:         []string{"fake-gradleBuildArgs-for-testTask", "-Djib.from.image=img:tag", "--image=image"},
 		},
 		{
 			description: "multi module with remote base image from required artifacts",
-			in:          latest.JibArtifact{Project: "project", BaseImage: "alias"},
+			in:          latest_v1.JibArtifact{Project: "project", BaseImage: "alias"},
 			image:       "image",
 			pushImages:  true,
-			deps:        []*latest.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
+			deps:        []*latest_v1.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
 			r:           mockArtifactResolver{m: map[string]string{"img": "img:tag"}},
 			out:         []string{"fake-gradleBuildArgs-for-project-for-testTask", "-Djib.from.image=img:tag", "--image=image"},
 		},
@@ -404,17 +404,17 @@ func TestGenerateGradleBuildArgs(t *testing.T) {
 func TestGradleArgs(t *testing.T) {
 	tests := []struct {
 		description string
-		jibArtifact latest.JibArtifact
+		jibArtifact latest_v1.JibArtifact
 		expected    []string
 	}{
 		{
 			description: "single module",
-			jibArtifact: latest.JibArtifact{},
+			jibArtifact: latest_v1.JibArtifact{},
 			expected:    []string{"_skaffoldFailIfJibOutOfDate", "-Djib.requiredVersion=test-version", ":testTask"},
 		},
 		{
 			description: "multi module",
-			jibArtifact: latest.JibArtifact{Project: "module"},
+			jibArtifact: latest_v1.JibArtifact{Project: "module"},
 			expected:    []string{"_skaffoldFailIfJibOutOfDate", "-Djib.requiredVersion=test-version", ":module:testTask"},
 		},
 	}
@@ -427,56 +427,56 @@ func TestGradleArgs(t *testing.T) {
 func TestGradleBuildArgs(t *testing.T) {
 	tests := []struct {
 		description string
-		jibArtifact latest.JibArtifact
+		jibArtifact latest_v1.JibArtifact
 		skipTests   bool
 		showColors  bool
 		expected    []string
 	}{
 		{
 			description: "single module",
-			jibArtifact: latest.JibArtifact{},
+			jibArtifact: latest_v1.JibArtifact{},
 			skipTests:   false,
 			showColors:  true,
 			expected:    []string{"-Djib.console=plain", "fake-gradleArgs-for-testTask"},
 		},
 		{
 			description: "single module skip tests",
-			jibArtifact: latest.JibArtifact{},
+			jibArtifact: latest_v1.JibArtifact{},
 			skipTests:   true,
 			showColors:  true,
 			expected:    []string{"-Djib.console=plain", "fake-gradleArgs-for-testTask", "-x", "test"},
 		},
 		{
 			description: "single module plain console",
-			jibArtifact: latest.JibArtifact{},
+			jibArtifact: latest_v1.JibArtifact{},
 			skipTests:   true,
 			showColors:  false,
 			expected:    []string{"--console=plain", "fake-gradleArgs-for-testTask", "-x", "test"},
 		},
 		{
 			description: "single module with extra flags",
-			jibArtifact: latest.JibArtifact{Flags: []string{"--flag1", "--flag2"}},
+			jibArtifact: latest_v1.JibArtifact{Flags: []string{"--flag1", "--flag2"}},
 			skipTests:   false,
 			showColors:  true,
 			expected:    []string{"-Djib.console=plain", "fake-gradleArgs-for-testTask", "--flag1", "--flag2"},
 		},
 		{
 			description: "multi module",
-			jibArtifact: latest.JibArtifact{Project: "module"},
+			jibArtifact: latest_v1.JibArtifact{Project: "module"},
 			skipTests:   false,
 			showColors:  true,
 			expected:    []string{"-Djib.console=plain", "fake-gradleArgs-for-module-for-testTask"},
 		},
 		{
 			description: "single module skip tests",
-			jibArtifact: latest.JibArtifact{Project: "module"},
+			jibArtifact: latest_v1.JibArtifact{Project: "module"},
 			skipTests:   true,
 			showColors:  true,
 			expected:    []string{"-Djib.console=plain", "fake-gradleArgs-for-module-for-testTask", "-x", "test"},
 		},
 		{
 			description: "multi module with extra flags",
-			jibArtifact: latest.JibArtifact{Project: "module", Flags: []string{"--flag1", "--flag2"}},
+			jibArtifact: latest_v1.JibArtifact{Project: "module", Flags: []string{"--flag1", "--flag2"}},
 			skipTests:   false,
 			showColors:  true,
 			expected:    []string{"-Djib.console=plain", "fake-gradleArgs-for-module-for-testTask", "--flag1", "--flag2"},
@@ -491,8 +491,8 @@ func TestGradleBuildArgs(t *testing.T) {
 	}
 }
 
-func getGradleArgsFuncFake(t *testutil.T, expectedMinimumVersion string) func(*latest.JibArtifact, string, string) []string {
-	return func(a *latest.JibArtifact, task string, minimumVersion string) []string {
+func getGradleArgsFuncFake(t *testutil.T, expectedMinimumVersion string) func(*latest_v1.JibArtifact, string, string) []string {
+	return func(a *latest_v1.JibArtifact, task string, minimumVersion string) []string {
 		t.CheckDeepEqual(expectedMinimumVersion, minimumVersion)
 		if a.Project == "" {
 			return []string{"fake-gradleArgs-for-" + task}
@@ -502,8 +502,8 @@ func getGradleArgsFuncFake(t *testutil.T, expectedMinimumVersion string) func(*l
 }
 
 // check that parameters are actually passed though
-func getGradleBuildArgsFuncFake(t *testutil.T, expectedMinimumVersion string) func(string, *latest.JibArtifact, bool, bool, string) []string {
-	return func(task string, a *latest.JibArtifact, skipTests, showColors bool, minimumVersion string) []string {
+func getGradleBuildArgsFuncFake(t *testutil.T, expectedMinimumVersion string) func(string, *latest_v1.JibArtifact, bool, bool, string) []string {
+	return func(task string, a *latest_v1.JibArtifact, skipTests, showColors bool, minimumVersion string) []string {
 		t.CheckDeepEqual(expectedMinimumVersion, minimumVersion)
 
 		testString := ""

--- a/pkg/skaffold/build/jib/init.go
+++ b/pkg/skaffold/build/jib/init.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -59,9 +59,9 @@ func (c ArtifactConfig) Describe() string {
 }
 
 // ArtifactType returns the type of the artifact to be built.
-func (c ArtifactConfig) ArtifactType(_ string) latest.ArtifactType {
-	return latest.ArtifactType{
-		JibArtifact: &latest.JibArtifact{
+func (c ArtifactConfig) ArtifactType(_ string) latest_v1.ArtifactType {
+	return latest_v1.ArtifactType{
+		JibArtifact: &latest_v1.JibArtifact{
 			Project: c.Project,
 		},
 	}

--- a/pkg/skaffold/build/jib/init_test.go
+++ b/pkg/skaffold/build/jib/init_test.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -217,27 +217,27 @@ func TestArtifactType(t *testing.T) {
 	var tests = []struct {
 		description  string
 		config       ArtifactConfig
-		expectedType latest.ArtifactType
+		expectedType latest_v1.ArtifactType
 	}{
 		{
 			description:  "jib gradle",
 			config:       ArtifactConfig{BuilderName: "Jib Gradle Plugin", File: filepath.Join("path", "to", "build.gradle"), Project: "project"},
-			expectedType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Project: "project"}},
+			expectedType: latest_v1.ArtifactType{JibArtifact: &latest_v1.JibArtifact{Project: "project"}},
 		},
 		{
 			description:  "jib gradle without project",
 			config:       ArtifactConfig{BuilderName: "Jib Gradle Plugin", File: filepath.Join("path", "to", "build.gradle")},
-			expectedType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{}},
+			expectedType: latest_v1.ArtifactType{JibArtifact: &latest_v1.JibArtifact{}},
 		},
 		{
 			description:  "jib maven",
 			config:       ArtifactConfig{BuilderName: "Jib Maven Plugin", File: filepath.Join("path", "to", "pom.xml"), Project: "project"},
-			expectedType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{Project: "project"}},
+			expectedType: latest_v1.ArtifactType{JibArtifact: &latest_v1.JibArtifact{Project: "project"}},
 		},
 		{
 			description:  "jib maven without project",
 			config:       ArtifactConfig{BuilderName: "Jib Maven Plugin", File: filepath.Join("path", "to", "pom.xml")},
-			expectedType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{}},
+			expectedType: latest_v1.ArtifactType{JibArtifact: &latest_v1.JibArtifact{}},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/build/jib/jib.go
+++ b/pkg/skaffold/build/jib/jib.go
@@ -34,7 +34,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
 )
@@ -91,16 +91,16 @@ var watchedFiles = map[projectKey]filesLists{}
 
 type projectKey string
 
-func getProjectKey(workspace string, a *latest.JibArtifact) projectKey {
+func getProjectKey(workspace string, a *latest_v1.JibArtifact) projectKey {
 	return projectKey(workspace + "+" + a.Project)
 }
 
-func GetBuildDefinitions(workspace string, a *latest.JibArtifact) []string {
+func GetBuildDefinitions(workspace string, a *latest_v1.JibArtifact) []string {
 	return watchedFiles[getProjectKey(workspace, a)].BuildDefinitions
 }
 
 // GetDependencies returns a list of files to watch for changes to rebuild
-func GetDependencies(ctx context.Context, workspace string, artifact *latest.JibArtifact) ([]string, error) {
+func GetDependencies(ctx context.Context, workspace string, artifact *latest_v1.JibArtifact) ([]string, error) {
 	t, err := DeterminePluginType(workspace, artifact)
 	if err != nil {
 		return nil, unableToDeterminePluginType(workspace, err)
@@ -116,7 +116,7 @@ func GetDependencies(ctx context.Context, workspace string, artifact *latest.Jib
 }
 
 // DeterminePluginType tries to determine the Jib plugin type for the given artifact.
-func DeterminePluginType(workspace string, artifact *latest.JibArtifact) (PluginType, error) {
+func DeterminePluginType(workspace string, artifact *latest_v1.JibArtifact) (PluginType, error) {
 	// check if explicitly specified
 	if artifact != nil {
 		if t := PluginType(artifact.Type); t.IsKnown() {
@@ -138,7 +138,7 @@ func DeterminePluginType(workspace string, artifact *latest.JibArtifact) (Plugin
 }
 
 // getDependencies returns a list of files to watch for changes to rebuild
-func getDependencies(workspace string, cmd exec.Cmd, a *latest.JibArtifact) ([]string, error) {
+func getDependencies(workspace string, cmd exec.Cmd, a *latest_v1.JibArtifact) ([]string, error) {
 	var dependencyList []string
 	files, ok := watchedFiles[getProjectKey(workspace, a)]
 	if !ok {
@@ -327,7 +327,7 @@ func isOnInsecureRegistry(image string, insecureRegistries map[string]bool) (boo
 }
 
 // baseImageArg formats the base image as a build argument. It also replaces the provided base image with an image from the required artifacts if specified.
-func baseImageArg(a *latest.JibArtifact, r ArtifactResolver, deps []*latest.ArtifactDependency, pushImages bool) (string, bool) {
+func baseImageArg(a *latest_v1.JibArtifact, r ArtifactResolver, deps []*latest_v1.ArtifactDependency, pushImages bool) (string, bool) {
 	if a.BaseImage == "" {
 		return "", false
 	}

--- a/pkg/skaffold/build/jib/jib_test.go
+++ b/pkg/skaffold/build/jib/jib_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/docker/docker/client"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -106,7 +106,7 @@ func TestGetDependencies(t *testing.T) {
 				test.stdout,
 			))
 
-			results, err := getDependencies(tmpDir.Root(), exec.Cmd{Args: []string{"ignored"}, Dir: tmpDir.Root()}, &latest.JibArtifact{Project: util.RandomID()})
+			results, err := getDependencies(tmpDir.Root(), exec.Cmd{Args: []string{"ignored"}, Dir: tmpDir.Root()}, &latest_v1.JibArtifact{Project: util.RandomID()})
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedDeps, results)
 		})
@@ -125,7 +125,7 @@ func TestGetUpdatedDependencies(t *testing.T) {
 		)
 
 		listCmd := exec.Cmd{Args: []string{"ignored"}, Dir: tmpDir.Root()}
-		artifact := &latest.JibArtifact{Project: util.RandomID()}
+		artifact := &latest_v1.JibArtifact{Project: util.RandomID()}
 
 		// List dependencies
 		_, err := getDependencies(tmpDir.Root(), listCmd, artifact)
@@ -169,7 +169,7 @@ func TestDeterminePluginType(t *testing.T) {
 	tests := []struct {
 		description string
 		files       []string
-		artifact    *latest.JibArtifact
+		artifact    *latest_v1.JibArtifact
 		shouldErr   bool
 		PluginType  PluginType
 	}{
@@ -183,8 +183,8 @@ func TestDeterminePluginType(t *testing.T) {
 		{"maven-1", []string{"pom.xml"}, nil, false, JibMaven},
 		{"maven-2", []string{".mvn/maven.config"}, nil, false, JibMaven},
 		{"maven-3", []string{".mvn/extensions.xml"}, nil, false, JibMaven},
-		{"gradle override", []string{"pom.xml"}, &latest.JibArtifact{Type: string(JibGradle)}, false, JibGradle},
-		{"maven override", []string{"build.gradle"}, &latest.JibArtifact{Type: string(JibMaven)}, false, JibMaven},
+		{"gradle override", []string{"pom.xml"}, &latest_v1.JibArtifact{Type: string(JibGradle)}, false, JibGradle},
+		{"maven override", []string{"build.gradle"}, &latest_v1.JibArtifact{Type: string(JibMaven)}, false, JibMaven},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
@@ -199,19 +199,19 @@ func TestDeterminePluginType(t *testing.T) {
 func TestGetProjectKey(t *testing.T) {
 	tests := []struct {
 		description string
-		artifact    *latest.JibArtifact
+		artifact    *latest_v1.JibArtifact
 		workspace   string
 		expected    projectKey
 	}{
 		{
 			"empty project",
-			&latest.JibArtifact{},
+			&latest_v1.JibArtifact{},
 			"dir",
 			projectKey("dir+"),
 		},
 		{
 			"non-empty project",
-			&latest.JibArtifact{Project: "project"},
+			&latest_v1.JibArtifact{Project: "project"},
 			"dir",
 			projectKey("dir+project"),
 		},

--- a/pkg/skaffold/build/jib/maven.go
+++ b/pkg/skaffold/build/jib/maven.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -43,7 +43,7 @@ const MinimumJibMavenVersionForSync = "2.0.0"
 // MavenCommand stores Maven executable and wrapper name
 var MavenCommand = util.CommandWrapper{Executable: "mvn", Wrapper: "mvnw"}
 
-func (b *Builder) buildJibMavenToDocker(ctx context.Context, out io.Writer, workspace string, artifact *latest.JibArtifact, deps []*latest.ArtifactDependency, tag string) (string, error) {
+func (b *Builder) buildJibMavenToDocker(ctx context.Context, out io.Writer, workspace string, artifact *latest_v1.JibArtifact, deps []*latest_v1.ArtifactDependency, tag string) (string, error) {
 	args := GenerateMavenBuildArgs("dockerBuild", tag, artifact, b.skipTests, b.pushImages, deps, b.artifacts, b.cfg.GetInsecureRegistries(), color.IsColorable(out))
 	if err := b.runMavenCommand(ctx, out, workspace, args); err != nil {
 		return "", jibToolErr(err)
@@ -52,7 +52,7 @@ func (b *Builder) buildJibMavenToDocker(ctx context.Context, out io.Writer, work
 	return b.localDocker.ImageID(ctx, tag)
 }
 
-func (b *Builder) buildJibMavenToRegistry(ctx context.Context, out io.Writer, workspace string, artifact *latest.JibArtifact, deps []*latest.ArtifactDependency, tag string) (string, error) {
+func (b *Builder) buildJibMavenToRegistry(ctx context.Context, out io.Writer, workspace string, artifact *latest_v1.JibArtifact, deps []*latest_v1.ArtifactDependency, tag string) (string, error) {
 	args := GenerateMavenBuildArgs("build", tag, artifact, b.skipTests, b.pushImages, deps, b.artifacts, b.cfg.GetInsecureRegistries(), color.IsColorable(out))
 	if err := b.runMavenCommand(ctx, out, workspace, args); err != nil {
 		return "", jibToolErr(err)
@@ -77,7 +77,7 @@ func (b *Builder) runMavenCommand(ctx context.Context, out io.Writer, workspace 
 
 // getDependenciesMaven finds the source dependencies for the given jib-maven artifact.
 // All paths are absolute.
-func getDependenciesMaven(ctx context.Context, workspace string, a *latest.JibArtifact) ([]string, error) {
+func getDependenciesMaven(ctx context.Context, workspace string, a *latest_v1.JibArtifact) ([]string, error) {
 	deps, err := getDependencies(workspace, getCommandMaven(ctx, workspace, a), a)
 	if err != nil {
 		return nil, dependencyErr(JibMaven, workspace, err)
@@ -86,20 +86,20 @@ func getDependenciesMaven(ctx context.Context, workspace string, a *latest.JibAr
 	return deps, nil
 }
 
-func getCommandMaven(ctx context.Context, workspace string, a *latest.JibArtifact) exec.Cmd {
+func getCommandMaven(ctx context.Context, workspace string, a *latest_v1.JibArtifact) exec.Cmd {
 	args := mavenArgsFunc(a, MinimumJibMavenVersion)
 	args = append(args, "jib:_skaffold-files-v2", "--quiet", "--batch-mode")
 
 	return MavenCommand.CreateCommand(ctx, workspace, args)
 }
 
-func getSyncMapCommandMaven(ctx context.Context, workspace string, a *latest.JibArtifact) *exec.Cmd {
+func getSyncMapCommandMaven(ctx context.Context, workspace string, a *latest_v1.JibArtifact) *exec.Cmd {
 	cmd := MavenCommand.CreateCommand(ctx, workspace, mavenBuildArgsFunc("_skaffold-sync-map", a, true, false, MinimumJibMavenVersionForSync))
 	return &cmd
 }
 
 // GenerateMavenBuildArgs generates the arguments to Maven for building the project as an image.
-func GenerateMavenBuildArgs(goal string, imageName string, a *latest.JibArtifact, skipTests, pushImages bool, deps []*latest.ArtifactDependency, r ArtifactResolver, insecureRegistries map[string]bool, showColors bool) []string {
+func GenerateMavenBuildArgs(goal string, imageName string, a *latest_v1.JibArtifact, skipTests, pushImages bool, deps []*latest_v1.ArtifactDependency, r ArtifactResolver, insecureRegistries map[string]bool, showColors bool) []string {
 	args := mavenBuildArgsFunc(goal, a, skipTests, showColors, MinimumJibMavenVersion)
 	if insecure, err := isOnInsecureRegistry(imageName, insecureRegistries); err == nil && insecure {
 		// jib doesn't support marking specific registries as insecure
@@ -114,7 +114,7 @@ func GenerateMavenBuildArgs(goal string, imageName string, a *latest.JibArtifact
 }
 
 // Do not use directly, use mavenBuildArgsFunc
-func mavenBuildArgs(goal string, a *latest.JibArtifact, skipTests, showColors bool, minimumVersion string) []string {
+func mavenBuildArgs(goal string, a *latest_v1.JibArtifact, skipTests, showColors bool, minimumVersion string) []string {
 	// Disable jib's rich progress footer on builds. Show colors on normal builds for clearer information,
 	// but use --batch-mode for internal goals to avoid formatting issues
 	var args []string
@@ -140,7 +140,7 @@ func mavenBuildArgs(goal string, a *latest.JibArtifact, skipTests, showColors bo
 }
 
 // Do not use directly, use mavenArgsFunc
-func mavenArgs(a *latest.JibArtifact, minimumVersion string) []string {
+func mavenArgs(a *latest_v1.JibArtifact, minimumVersion string) []string {
 	args := []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=" + minimumVersion}
 	args = append(args, a.Flags...)
 

--- a/pkg/skaffold/build/jib/maven_test.go
+++ b/pkg/skaffold/build/jib/maven_test.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -36,35 +36,35 @@ import (
 func TestBuildJibMavenToDocker(t *testing.T) {
 	tests := []struct {
 		description   string
-		artifact      *latest.JibArtifact
+		artifact      *latest_v1.JibArtifact
 		commands      util.Command
 		shouldErr     bool
 		expectedError string
 	}{
 		{
 			description: "build",
-			artifact:    &latest.JibArtifact{},
+			artifact:    &latest_v1.JibArtifact{},
 			commands: testutil.CmdRun(
 				"mvn fake-mavenBuildArgs-for-dockerBuild -Dimage=img:tag",
 			),
 		},
 		{
 			description: "build with module",
-			artifact:    &latest.JibArtifact{Project: "module"},
+			artifact:    &latest_v1.JibArtifact{Project: "module"},
 			commands: testutil.CmdRun(
 				"mvn fake-mavenBuildArgs-for-module-for-dockerBuild -Dimage=img:tag",
 			),
 		},
 		{
 			description: "build with custom base image",
-			artifact:    &latest.JibArtifact{BaseImage: "docker://busybox"},
+			artifact:    &latest_v1.JibArtifact{BaseImage: "docker://busybox"},
 			commands: testutil.CmdRun(
 				"mvn fake-mavenBuildArgs-for-dockerBuild -Djib.from.image=docker://busybox -Dimage=img:tag",
 			),
 		},
 		{
 			description: "fail build",
-			artifact:    &latest.JibArtifact{},
+			artifact:    &latest_v1.JibArtifact{},
 			commands: testutil.CmdRunErr(
 				"mvn fake-mavenBuildArgs-for-dockerBuild -Dimage=img:tag",
 				errors.New("BUG"),
@@ -83,8 +83,8 @@ func TestBuildJibMavenToDocker(t *testing.T) {
 			localDocker := fakeLocalDaemon(api)
 
 			builder := NewArtifactBuilder(localDocker, &mockConfig{}, false, false, mockArtifactResolver{})
-			result, err := builder.Build(context.Background(), ioutil.Discard, &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
+			result, err := builder.Build(context.Background(), ioutil.Discard, &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
 					JibArtifact: test.artifact,
 				},
 			}, "img:tag")
@@ -102,29 +102,29 @@ func TestBuildJibMavenToDocker(t *testing.T) {
 func TestBuildJibMavenToRegistry(t *testing.T) {
 	tests := []struct {
 		description   string
-		artifact      *latest.JibArtifact
+		artifact      *latest_v1.JibArtifact
 		commands      util.Command
 		shouldErr     bool
 		expectedError string
 	}{
 		{
 			description: "build",
-			artifact:    &latest.JibArtifact{},
+			artifact:    &latest_v1.JibArtifact{},
 			commands:    testutil.CmdRun("mvn fake-mavenBuildArgs-for-build -Dimage=img:tag"),
 		},
 		{
 			description: "build with module",
-			artifact:    &latest.JibArtifact{Project: "module"},
+			artifact:    &latest_v1.JibArtifact{Project: "module"},
 			commands:    testutil.CmdRun("mvn fake-mavenBuildArgs-for-module-for-build -Dimage=img:tag"),
 		},
 		{
 			description: "build with custom base image",
-			artifact:    &latest.JibArtifact{BaseImage: "docker://busybox"},
+			artifact:    &latest_v1.JibArtifact{BaseImage: "docker://busybox"},
 			commands:    testutil.CmdRun("mvn fake-mavenBuildArgs-for-build -Djib.from.image=docker://busybox -Dimage=img:tag"),
 		},
 		{
 			description: "fail build",
-			artifact:    &latest.JibArtifact{},
+			artifact:    &latest_v1.JibArtifact{},
 			commands: testutil.CmdRunErr(
 				"mvn fake-mavenBuildArgs-for-build -Dimage=img:tag",
 				errors.New("BUG"),
@@ -148,8 +148,8 @@ func TestBuildJibMavenToRegistry(t *testing.T) {
 			localDocker := fakeLocalDaemon(&testutil.FakeAPIClient{})
 
 			builder := NewArtifactBuilder(localDocker, &mockConfig{}, true, false, mockArtifactResolver{})
-			result, err := builder.Build(context.Background(), ioutil.Discard, &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
+			result, err := builder.Build(context.Background(), ioutil.Discard, &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
 					JibArtifact: test.artifact,
 				},
 			}, "img:tag")
@@ -219,7 +219,7 @@ func TestGetDependenciesMaven(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunOutErr(
-				strings.Join(getCommandMaven(ctx, tmpDir.Root(), &latest.JibArtifact{Project: "maven-test"}).Args, " "),
+				strings.Join(getCommandMaven(ctx, tmpDir.Root(), &latest_v1.JibArtifact{Project: "maven-test"}).Args, " "),
 				test.stdout,
 				test.err,
 			))
@@ -229,7 +229,7 @@ func TestGetDependenciesMaven(t *testing.T) {
 				t.Fatal(err)
 			}
 			ws := tmpDir.Root()
-			deps, err := getDependenciesMaven(ctx, ws, &latest.JibArtifact{Project: "maven-test"})
+			deps, err := getDependenciesMaven(ctx, ws, &latest_v1.JibArtifact{Project: "maven-test"})
 			if test.err != nil {
 				prefix := fmt.Sprintf("could not fetch dependencies for workspace %s: initial Jib dependency refresh failed: failed to get Jib dependencies: ", ws)
 				t.CheckErrorAndDeepEqual(true, err, prefix+test.err.Error(), err.Error())
@@ -244,13 +244,13 @@ func TestGetCommandMaven(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
 		description      string
-		jibArtifact      latest.JibArtifact
+		jibArtifact      latest_v1.JibArtifact
 		filesInWorkspace []string
 		expectedCmd      func(workspace string) exec.Cmd
 	}{
 		{
 			description:      "maven basic",
-			jibArtifact:      latest.JibArtifact{},
+			jibArtifact:      latest_v1.JibArtifact{},
 			filesInWorkspace: []string{},
 			expectedCmd: func(workspace string) exec.Cmd {
 				return MavenCommand.CreateCommand(ctx, workspace, []string{"fake-mavenArgs", "jib:_skaffold-files-v2", "--quiet", "--batch-mode"})
@@ -258,7 +258,7 @@ func TestGetCommandMaven(t *testing.T) {
 		},
 		{
 			description:      "maven with wrapper",
-			jibArtifact:      latest.JibArtifact{},
+			jibArtifact:      latest_v1.JibArtifact{},
 			filesInWorkspace: []string{"mvnw", "mvnw.bat"},
 			expectedCmd: func(workspace string) exec.Cmd {
 				return MavenCommand.CreateCommand(ctx, workspace, []string{"fake-mavenArgs", "jib:_skaffold-files-v2", "--quiet", "--batch-mode"})
@@ -266,7 +266,7 @@ func TestGetCommandMaven(t *testing.T) {
 		},
 		{
 			description:      "maven with multi-modules",
-			jibArtifact:      latest.JibArtifact{Project: "module"},
+			jibArtifact:      latest_v1.JibArtifact{Project: "module"},
 			filesInWorkspace: []string{"mvnw", "mvnw.bat"},
 			expectedCmd: func(workspace string) exec.Cmd {
 				return MavenCommand.CreateCommand(ctx, workspace, []string{"fake-mavenArgs-for-module", "jib:_skaffold-files-v2", "--quiet", "--batch-mode"})
@@ -294,19 +294,19 @@ func TestGetSyncMapCommandMaven(t *testing.T) {
 	tests := []struct {
 		description string
 		workspace   string
-		jibArtifact latest.JibArtifact
+		jibArtifact latest_v1.JibArtifact
 		expectedCmd func(workspace string) exec.Cmd
 	}{
 		{
 			description: "single module",
-			jibArtifact: latest.JibArtifact{},
+			jibArtifact: latest_v1.JibArtifact{},
 			expectedCmd: func(workspace string) exec.Cmd {
 				return MavenCommand.CreateCommand(ctx, workspace, []string{"fake-mavenBuildArgs-for-_skaffold-sync-map-skipTests"})
 			},
 		},
 		{
 			description: "multi module",
-			jibArtifact: latest.JibArtifact{Project: "module"},
+			jibArtifact: latest_v1.JibArtifact{Project: "module"},
 			expectedCmd: func(workspace string) exec.Cmd {
 				return MavenCommand.CreateCommand(ctx, workspace, []string{"fake-mavenBuildArgs-for-module-for-_skaffold-sync-map-skipTests"})
 			},
@@ -327,8 +327,8 @@ func TestGetSyncMapCommandMaven(t *testing.T) {
 func TestGenerateMavenBuildArgs(t *testing.T) {
 	tests := []struct {
 		description        string
-		a                  latest.JibArtifact
-		deps               []*latest.ArtifactDependency
+		a                  latest_v1.JibArtifact
+		deps               []*latest_v1.ArtifactDependency
 		image              string
 		r                  ArtifactResolver
 		skipTests          bool
@@ -338,31 +338,31 @@ func TestGenerateMavenBuildArgs(t *testing.T) {
 	}{
 		{description: "single module", image: "image", out: []string{"fake-mavenBuildArgs-for-test-goal", "-Dimage=image"}},
 		{description: "single module without tests", image: "image", skipTests: true, out: []string{"fake-mavenBuildArgs-for-test-goal-skipTests", "-Dimage=image"}},
-		{description: "multi module", a: latest.JibArtifact{Project: "module"}, image: "image", out: []string{"fake-mavenBuildArgs-for-module-for-test-goal", "-Dimage=image"}},
-		{description: "multi module without tests", a: latest.JibArtifact{Project: "module"}, image: "image", skipTests: true, out: []string{"fake-mavenBuildArgs-for-module-for-test-goal-skipTests", "-Dimage=image"}},
-		{description: "multi module without tests with insecure-registry", a: latest.JibArtifact{Project: "module"}, image: "registry.tld/image", skipTests: true, insecureRegistries: map[string]bool{"registry.tld": true}, out: []string{"fake-mavenBuildArgs-for-module-for-test-goal-skipTests", "-Djib.allowInsecureRegistries=true", "-Dimage=registry.tld/image"}},
-		{description: "single module with custom base image", a: latest.JibArtifact{BaseImage: "docker://busybox"}, image: "image", out: []string{"fake-mavenBuildArgs-for-test-goal", "-Djib.from.image=docker://busybox", "-Dimage=image"}},
-		{description: "multi module with custom base image", a: latest.JibArtifact{Project: "module", BaseImage: "docker://busybox"}, image: "image", out: []string{"fake-mavenBuildArgs-for-module-for-test-goal", "-Djib.from.image=docker://busybox", "-Dimage=image"}},
+		{description: "multi module", a: latest_v1.JibArtifact{Project: "module"}, image: "image", out: []string{"fake-mavenBuildArgs-for-module-for-test-goal", "-Dimage=image"}},
+		{description: "multi module without tests", a: latest_v1.JibArtifact{Project: "module"}, image: "image", skipTests: true, out: []string{"fake-mavenBuildArgs-for-module-for-test-goal-skipTests", "-Dimage=image"}},
+		{description: "multi module without tests with insecure-registry", a: latest_v1.JibArtifact{Project: "module"}, image: "registry.tld/image", skipTests: true, insecureRegistries: map[string]bool{"registry.tld": true}, out: []string{"fake-mavenBuildArgs-for-module-for-test-goal-skipTests", "-Djib.allowInsecureRegistries=true", "-Dimage=registry.tld/image"}},
+		{description: "single module with custom base image", a: latest_v1.JibArtifact{BaseImage: "docker://busybox"}, image: "image", out: []string{"fake-mavenBuildArgs-for-test-goal", "-Djib.from.image=docker://busybox", "-Dimage=image"}},
+		{description: "multi module with custom base image", a: latest_v1.JibArtifact{Project: "module", BaseImage: "docker://busybox"}, image: "image", out: []string{"fake-mavenBuildArgs-for-module-for-test-goal", "-Djib.from.image=docker://busybox", "-Dimage=image"}},
 		{
 			description: "single module with local base image from required artifacts",
-			a:           latest.JibArtifact{BaseImage: "alias"},
-			deps:        []*latest.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
+			a:           latest_v1.JibArtifact{BaseImage: "alias"},
+			deps:        []*latest_v1.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
 			image:       "image",
 			r:           mockArtifactResolver{m: map[string]string{"img": "img:tag"}},
 			out:         []string{"fake-mavenBuildArgs-for-test-goal", "-Djib.from.image=docker://img:tag", "-Dimage=image"},
 		},
 		{
 			description: "multi module with local base image from required artifacts",
-			a:           latest.JibArtifact{Project: "module", BaseImage: "alias"},
-			deps:        []*latest.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
+			a:           latest_v1.JibArtifact{Project: "module", BaseImage: "alias"},
+			deps:        []*latest_v1.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
 			image:       "image",
 			r:           mockArtifactResolver{m: map[string]string{"img": "img:tag"}},
 			out:         []string{"fake-mavenBuildArgs-for-module-for-test-goal", "-Djib.from.image=docker://img:tag", "-Dimage=image"},
 		},
 		{
 			description: "single module with remote base image from required artifacts",
-			a:           latest.JibArtifact{BaseImage: "alias"},
-			deps:        []*latest.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
+			a:           latest_v1.JibArtifact{BaseImage: "alias"},
+			deps:        []*latest_v1.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
 			image:       "image",
 			pushImages:  true,
 			r:           mockArtifactResolver{m: map[string]string{"img": "img:tag"}},
@@ -370,8 +370,8 @@ func TestGenerateMavenBuildArgs(t *testing.T) {
 		},
 		{
 			description: "multi module with remote base image from required artifacts",
-			a:           latest.JibArtifact{Project: "module", BaseImage: "alias"},
-			deps:        []*latest.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
+			a:           latest_v1.JibArtifact{Project: "module", BaseImage: "alias"},
+			deps:        []*latest_v1.ArtifactDependency{{ImageName: "img", Alias: "alias"}},
 			image:       "image",
 			pushImages:  true,
 			r:           mockArtifactResolver{m: map[string]string{"img": "img:tag"}},
@@ -390,42 +390,42 @@ func TestGenerateMavenBuildArgs(t *testing.T) {
 func TestMavenBuildArgs(t *testing.T) {
 	tests := []struct {
 		description string
-		jibArtifact latest.JibArtifact
+		jibArtifact latest_v1.JibArtifact
 		skipTests   bool
 		showColors  bool
 		expected    []string
 	}{
 		{
 			description: "single module",
-			jibArtifact: latest.JibArtifact{},
+			jibArtifact: latest_v1.JibArtifact{},
 			skipTests:   false,
 			showColors:  true,
 			expected:    []string{"-Dstyle.color=always", "-Djansi.passthrough=true", "-Djib.console=plain", "fake-mavenArgs", "prepare-package", "jib:test-goal"},
 		},
 		{
 			description: "single module skip tests",
-			jibArtifact: latest.JibArtifact{},
+			jibArtifact: latest_v1.JibArtifact{},
 			skipTests:   true,
 			showColors:  true,
 			expected:    []string{"-Dstyle.color=always", "-Djansi.passthrough=true", "-Djib.console=plain", "fake-mavenArgs", "-DskipTests=true", "prepare-package", "jib:test-goal"},
 		},
 		{
 			description: "single module plain console",
-			jibArtifact: latest.JibArtifact{},
+			jibArtifact: latest_v1.JibArtifact{},
 			skipTests:   true,
 			showColors:  false,
 			expected:    []string{"--batch-mode", "fake-mavenArgs", "-DskipTests=true", "prepare-package", "jib:test-goal"},
 		},
 		{
 			description: "multi module",
-			jibArtifact: latest.JibArtifact{Project: "module"},
+			jibArtifact: latest_v1.JibArtifact{Project: "module"},
 			skipTests:   false,
 			showColors:  true,
 			expected:    []string{"-Dstyle.color=always", "-Djansi.passthrough=true", "-Djib.console=plain", "fake-mavenArgs-for-module", "package", "jib:test-goal", "-Djib.containerize=module"},
 		},
 		{
 			description: "single module skip tests",
-			jibArtifact: latest.JibArtifact{Project: "module"},
+			jibArtifact: latest_v1.JibArtifact{Project: "module"},
 			skipTests:   true,
 			showColors:  true,
 			expected:    []string{"-Dstyle.color=always", "-Djansi.passthrough=true", "-Djib.console=plain", "fake-mavenArgs-for-module", "-DskipTests=true", "package", "jib:test-goal", "-Djib.containerize=module"},
@@ -443,29 +443,29 @@ func TestMavenBuildArgs(t *testing.T) {
 func TestMavenArgs(t *testing.T) {
 	tests := []struct {
 		description string
-		jibArtifact latest.JibArtifact
+		jibArtifact latest_v1.JibArtifact
 		expected    []string
 	}{
 		{
 			description: "single module",
-			jibArtifact: latest.JibArtifact{},
+			jibArtifact: latest_v1.JibArtifact{},
 			expected:    []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=test-version", "--non-recursive"},
 		},
 		{
 			description: "single module with extra flags",
-			jibArtifact: latest.JibArtifact{
+			jibArtifact: latest_v1.JibArtifact{
 				Flags: []string{"--flag1", "--flag2"},
 			},
 			expected: []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=test-version", "--flag1", "--flag2", "--non-recursive"},
 		},
 		{
 			description: "multi module",
-			jibArtifact: latest.JibArtifact{Project: "module"},
+			jibArtifact: latest_v1.JibArtifact{Project: "module"},
 			expected:    []string{"jib:_skaffold-fail-if-jib-out-of-date", "-Djib.requiredVersion=test-version", "--projects", "module", "--also-make"},
 		},
 		{
 			description: "multi module with extra falgs",
-			jibArtifact: latest.JibArtifact{
+			jibArtifact: latest_v1.JibArtifact{
 				Project: "module",
 				Flags:   []string{"--flag1", "--flag2"},
 			},
@@ -478,8 +478,8 @@ func TestMavenArgs(t *testing.T) {
 	}
 }
 
-func getMavenArgsFuncFake(t *testutil.T, expectedMinimumVersion string) func(*latest.JibArtifact, string) []string {
-	return func(a *latest.JibArtifact, minimumVersion string) []string {
+func getMavenArgsFuncFake(t *testutil.T, expectedMinimumVersion string) func(*latest_v1.JibArtifact, string) []string {
+	return func(a *latest_v1.JibArtifact, minimumVersion string) []string {
 		t.CheckDeepEqual(expectedMinimumVersion, minimumVersion)
 		if a.Project == "" {
 			return []string{"fake-mavenArgs"}
@@ -488,8 +488,8 @@ func getMavenArgsFuncFake(t *testutil.T, expectedMinimumVersion string) func(*la
 	}
 }
 
-func getMavenBuildArgsFuncFake(t *testutil.T, expectedMinimumVersion string) func(string, *latest.JibArtifact, bool, bool, string) []string {
-	return func(goal string, a *latest.JibArtifact, skipTests, showColors bool, minimumVersion string) []string {
+func getMavenBuildArgsFuncFake(t *testutil.T, expectedMinimumVersion string) func(string, *latest_v1.JibArtifact, bool, bool, string) []string {
+	return func(goal string, a *latest_v1.JibArtifact, skipTests, showColors bool, minimumVersion string) []string {
 		t.CheckDeepEqual(expectedMinimumVersion, minimumVersion)
 		testString := ""
 		if skipTests {

--- a/pkg/skaffold/build/jib/sync.go
+++ b/pkg/skaffold/build/jib/sync.go
@@ -30,7 +30,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -56,7 +56,7 @@ type JSONSyncEntry struct {
 
 var InitSync = initSync
 
-func initSync(ctx context.Context, workspace string, a *latest.JibArtifact) error {
+func initSync(ctx context.Context, workspace string, a *latest_v1.JibArtifact) error {
 	syncMap, err := getSyncMapFunc(ctx, workspace, a)
 	if err != nil {
 		return fmt.Errorf("failed to initialize sync state for %q: %w", workspace, err)
@@ -68,7 +68,7 @@ func initSync(ctx context.Context, workspace string, a *latest.JibArtifact) erro
 var GetSyncDiff = getSyncDiff
 
 // returns toCopy, toDelete, error
-func getSyncDiff(ctx context.Context, workspace string, a *latest.JibArtifact, e filemon.Events) (map[string][]string, map[string][]string, error) {
+func getSyncDiff(ctx context.Context, workspace string, a *latest_v1.JibArtifact, e filemon.Events) (map[string][]string, map[string][]string, error) {
 	// no deletions allowed
 	if len(e.Deleted) != 0 {
 		// change into logging
@@ -154,7 +154,7 @@ var (
 	getSyncMapFunc = getSyncMap
 )
 
-func getSyncMap(ctx context.Context, workspace string, artifact *latest.JibArtifact) (*SyncMap, error) {
+func getSyncMap(ctx context.Context, workspace string, artifact *latest_v1.JibArtifact) (*SyncMap, error) {
 	// cmd will hold context that identifies the project
 	cmd, err := getSyncMapCommand(ctx, workspace, artifact)
 	if err != nil {
@@ -168,7 +168,7 @@ func getSyncMap(ctx context.Context, workspace string, artifact *latest.JibArtif
 	return sm, nil
 }
 
-func getSyncMapCommand(ctx context.Context, workspace string, artifact *latest.JibArtifact) (*exec.Cmd, error) {
+func getSyncMapCommand(ctx context.Context, workspace string, artifact *latest_v1.JibArtifact) (*exec.Cmd, error) {
 	t, err := DeterminePluginType(workspace, artifact)
 	if err != nil {
 		return nil, err

--- a/pkg/skaffold/build/jib/sync_test.go
+++ b/pkg/skaffold/build/jib/sync_test.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -156,7 +156,7 @@ func TestGetSyncDiff(t *testing.T) {
 
 	tests := []struct {
 		description      string
-		artifact         *latest.JibArtifact
+		artifact         *latest_v1.JibArtifact
 		events           filemon.Events
 		buildDefinitions []string
 		nextSyncMap      SyncMap
@@ -165,7 +165,7 @@ func TestGetSyncDiff(t *testing.T) {
 	}{
 		{
 			description:      "build file changed (nil, nil, nil)",
-			artifact:         &latest.JibArtifact{},
+			artifact:         &latest_v1.JibArtifact{},
 			events:           filemon.Events{Modified: []string{buildFile}},
 			buildDefinitions: []string{buildFile},
 			expectedCopy:     nil,
@@ -173,7 +173,7 @@ func TestGetSyncDiff(t *testing.T) {
 		},
 		{
 			description:      "something is deleted (nil, nil, nil)",
-			artifact:         &latest.JibArtifact{},
+			artifact:         &latest_v1.JibArtifact{},
 			events:           filemon.Events{Deleted: []string{directFile}},
 			buildDefinitions: []string{},
 			expectedCopy:     nil,
@@ -181,7 +181,7 @@ func TestGetSyncDiff(t *testing.T) {
 		},
 		{
 			description:      "only direct sync entries changed",
-			artifact:         &latest.JibArtifact{},
+			artifact:         &latest_v1.JibArtifact{},
 			events:           filemon.Events{Modified: []string{directFile}},
 			buildDefinitions: []string{},
 			expectedCopy:     map[string][]string{directFile: directTarget},
@@ -189,7 +189,7 @@ func TestGetSyncDiff(t *testing.T) {
 		},
 		{
 			description:      "only generated sync entries changed",
-			artifact:         &latest.JibArtifact{},
+			artifact:         &latest_v1.JibArtifact{},
 			events:           filemon.Events{Modified: []string{generatedFile}},
 			buildDefinitions: []string{},
 			nextSyncMap: SyncMap{
@@ -201,7 +201,7 @@ func TestGetSyncDiff(t *testing.T) {
 		},
 		{
 			description:      "generated and direct sync entries changed",
-			artifact:         &latest.JibArtifact{},
+			artifact:         &latest_v1.JibArtifact{},
 			events:           filemon.Events{Modified: []string{directFile, generatedFile}},
 			buildDefinitions: []string{},
 			nextSyncMap: SyncMap{
@@ -213,7 +213,7 @@ func TestGetSyncDiff(t *testing.T) {
 		},
 		{
 			description:      "new file created",
-			artifact:         &latest.JibArtifact{},
+			artifact:         &latest_v1.JibArtifact{},
 			events:           filemon.Events{Added: []string{newFile}},
 			buildDefinitions: []string{},
 			nextSyncMap: SyncMap{
@@ -228,7 +228,7 @@ func TestGetSyncDiff(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&getSyncMapFunc, func(_ context.Context, _ string, _ *latest.JibArtifact) (*SyncMap, error) {
+			t.Override(&getSyncMapFunc, func(_ context.Context, _ string, _ *latest_v1.JibArtifact) (*SyncMap, error) {
 				return &test.nextSyncMap, nil
 			})
 			pk := getProjectKey(workspace, test.artifact)
@@ -253,7 +253,7 @@ func TestGetSyncDiff_directChecksUpdateFileTime(testing *testing.T) {
 
 	ctx := context.Background()
 	workspace := "testworkspace"
-	artifact := &latest.JibArtifact{}
+	artifact := &latest_v1.JibArtifact{}
 
 	tmpDir.Touch("direct")
 
@@ -267,7 +267,7 @@ func TestGetSyncDiff_directChecksUpdateFileTime(testing *testing.T) {
 
 	testutil.Run(testing, "Checks on direct files also update file times", func(t *testutil.T) {
 		pk := getProjectKey(workspace, artifact)
-		t.Override(&getSyncMapFunc, func(_ context.Context, _ string, _ *latest.JibArtifact) (*SyncMap, error) {
+		t.Override(&getSyncMapFunc, func(_ context.Context, _ string, _ *latest_v1.JibArtifact) (*SyncMap, error) {
 			t.Fatal("getSyncMapFunc should not have been called in this test")
 			return nil, nil
 		})

--- a/pkg/skaffold/build/kaniko/args.go
+++ b/pkg/skaffold/build/kaniko/args.go
@@ -21,12 +21,12 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // Args returns kaniko command arguments
-func Args(artifact *latest.KanikoArtifact, tag, context string) ([]string, error) {
+func Args(artifact *latest_v1.KanikoArtifact, tag, context string) ([]string, error) {
 	args := []string{
 		"--destination", tag,
 		"--dockerfile", artifact.DockerfilePath,

--- a/pkg/skaffold/build/kaniko/args_test.go
+++ b/pkg/skaffold/build/kaniko/args_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -27,13 +27,13 @@ import (
 func TestArgs(t *testing.T) {
 	tests := []struct {
 		description  string
-		artifact     *latest.KanikoArtifact
+		artifact     *latest_v1.KanikoArtifact
 		expectedArgs []string
 		wantErr      bool
 	}{
 		{
 			description: "simple build",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 			},
 			expectedArgs: []string{},
@@ -41,7 +41,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with BuildArgs",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				BuildArgs: map[string]*string{
 					"arg1": util.StringPtr("value1"),
@@ -56,9 +56,9 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with Cache",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
-				Cache:          &latest.KanikoCache{},
+				Cache:          &latest_v1.KanikoCache{},
 			},
 			expectedArgs: []string{
 				CacheFlag,
@@ -67,9 +67,9 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with Cache Options",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
-				Cache: &latest.KanikoCache{
+				Cache: &latest_v1.KanikoCache{
 					Repo:     "gcr.io/ngnix",
 					HostPath: "/cache",
 					TTL:      "2",
@@ -85,7 +85,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with Cleanup",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Cleanup:        true,
 			},
@@ -96,7 +96,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with DigestFile",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				DigestFile:     "/tmp/digest",
 			},
@@ -107,7 +107,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with Force",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Force:          true,
 			},
@@ -118,7 +118,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with ImageNameWithDigestFile",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath:          "Dockerfile",
 				ImageNameWithDigestFile: "/tmp/imageName",
 			},
@@ -129,7 +129,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with Insecure",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Insecure:       true,
 			},
@@ -140,7 +140,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with InsecurePull",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				InsecurePull:   true,
 			},
@@ -151,7 +151,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with InsecureRegistry",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				InsecureRegistry: []string{
 					"s1.registry.url:5000",
@@ -166,7 +166,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with LogFormat",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				LogFormat:      "json",
 			},
@@ -177,7 +177,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with LogTimestamp",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				LogTimestamp:   true,
 			},
@@ -188,7 +188,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with NoPush",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				NoPush:         true,
 			},
@@ -199,7 +199,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with OCILayoutPath",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				OCILayoutPath:  "/tmp/builtImage",
 			},
@@ -210,7 +210,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with RegistryCertificate",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				RegistryCertificate: map[string]*string{
 					"s1.registry.url": util.StringPtr("/etc/certs/certificate1.cert"),
@@ -225,7 +225,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with RegistryMirror",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				RegistryMirror: "mirror.gcr.io",
 			},
@@ -236,7 +236,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with Reproducible",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Reproducible:   true,
 			},
@@ -247,7 +247,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with SingleSnapshot",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				SingleSnapshot: true,
 			},
@@ -258,7 +258,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with SkipTLS",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				SkipTLS:        true,
 			},
@@ -270,7 +270,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with SkipTLSVerifyPull",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath:    "Dockerfile",
 				SkipTLSVerifyPull: true,
 			},
@@ -281,7 +281,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with SkipTLSVerifyRegistry",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				SkipTLSVerifyRegistry: []string{
 					"s1.registry.url:443",
@@ -296,7 +296,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with SkipUnusedStages",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath:   "Dockerfile",
 				SkipUnusedStages: true,
 			},
@@ -307,7 +307,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with Target",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Target:         "builder",
 			},
@@ -318,7 +318,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with SnapshotMode",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				SnapshotMode:   "redo",
 			},
@@ -329,7 +329,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with TarPath",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				TarPath:        "/workspace/tars",
 			},
@@ -340,7 +340,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with UseNewRun",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				UseNewRun:      true,
 			},
@@ -351,7 +351,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with Verbosity",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Verbosity:      "trace",
 			},
@@ -362,7 +362,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with WhitelistVarRun",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath:  "Dockerfile",
 				WhitelistVarRun: true,
 			},
@@ -373,7 +373,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with WhitelistVarRun",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath:  "Dockerfile",
 				WhitelistVarRun: true,
 			},
@@ -384,7 +384,7 @@ func TestArgs(t *testing.T) {
 		},
 		{
 			description: "with Labels",
-			artifact: &latest.KanikoArtifact{
+			artifact: &latest_v1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
 				Label: map[string]*string{
 					"label1": util.StringPtr("value1"),

--- a/pkg/skaffold/build/local/local.go
+++ b/pkg/skaffold/build/local/local.go
@@ -25,12 +25,12 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // Build runs a docker build on the host and tags the resulting image with
 // its checksum. It streams build progress to the writer argument.
-func (b *Builder) Build(ctx context.Context, out io.Writer, a *latest.Artifact) build.ArtifactBuilder {
+func (b *Builder) Build(ctx context.Context, out io.Writer, a *latest_v1.Artifact) build.ArtifactBuilder {
 	if b.prune {
 		b.localPruner.asynchronousCleanupOldImages(ctx, []string{a.ImageName})
 	}
@@ -64,7 +64,7 @@ func (b *Builder) Concurrency() int {
 	return *b.local.Concurrency
 }
 
-func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
+func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest_v1.Artifact, tag string) (string, error) {
 	digestOrImageID, err := b.runBuildForArtifact(ctx, out, a, tag)
 	if err != nil {
 		return "", err
@@ -92,7 +92,7 @@ func (b *Builder) buildArtifact(ctx context.Context, out io.Writer, a *latest.Ar
 	return build.TagWithImageID(ctx, tag, imageID, b.localDocker)
 }
 
-func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
+func (b *Builder) runBuildForArtifact(ctx context.Context, out io.Writer, a *latest_v1.Artifact, tag string) (string, error) {
 	if !b.pushImages {
 		// All of the builders will rely on a local Docker:
 		// + Either to build the image,

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -57,7 +57,7 @@ func TestLocalRun(t *testing.T) {
 		description      string
 		api              *testutil.FakeAPIClient
 		tag              string
-		artifact         *latest.Artifact
+		artifact         *latest_v1.Artifact
 		expected         string
 		expectedWarnings []string
 		expectedPushed   map[string]string
@@ -66,10 +66,10 @@ func TestLocalRun(t *testing.T) {
 	}{
 		{
 			description: "single build (local)",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{},
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{},
 				},
 			},
 			tag:        "gcr.io/test/image:tag",
@@ -79,10 +79,10 @@ func TestLocalRun(t *testing.T) {
 		},
 		{
 			description: "error getting image digest",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{},
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{},
 				},
 			},
 			tag: "gcr.io/test/image:tag",
@@ -93,10 +93,10 @@ func TestLocalRun(t *testing.T) {
 		},
 		{
 			description: "single build (remote)",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{},
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{},
 				},
 			},
 			tag:        "gcr.io/test/image:tag",
@@ -109,10 +109,10 @@ func TestLocalRun(t *testing.T) {
 		},
 		{
 			description: "error build",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{},
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{},
 				},
 			},
 			tag: "gcr.io/test/image:tag",
@@ -123,10 +123,10 @@ func TestLocalRun(t *testing.T) {
 		},
 		{
 			description: "Don't push on build error",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{},
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{},
 				},
 			},
 			tag:        "gcr.io/test/image:tag",
@@ -138,16 +138,16 @@ func TestLocalRun(t *testing.T) {
 		},
 		{
 			description: "unknown artifact type",
-			artifact:    &latest.Artifact{},
+			artifact:    &latest_v1.Artifact{},
 			api:         &testutil.FakeAPIClient{},
 			shouldErr:   true,
 		},
 		{
 			description: "cache-from images already pulled",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						CacheFrom: []string{"pull1", "pull2"},
 					},
 				},
@@ -158,10 +158,10 @@ func TestLocalRun(t *testing.T) {
 		},
 		{
 			description: "pull cache-from images",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						CacheFrom: []string{"pull1", "pull2"},
 					},
 				},
@@ -172,10 +172,10 @@ func TestLocalRun(t *testing.T) {
 		},
 		{
 			description: "ignore cache-from pull error",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						CacheFrom: []string{"pull1"},
 					},
 				},
@@ -189,10 +189,10 @@ func TestLocalRun(t *testing.T) {
 		},
 		{
 			description: "error checking cache-from image",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						CacheFrom: []string{"pull"},
 					},
 				},
@@ -205,10 +205,10 @@ func TestLocalRun(t *testing.T) {
 		},
 		{
 			description: "fail fast docker not found",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{},
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{},
 				},
 			},
 			tag: "gcr.io/test/image:tag",
@@ -230,16 +230,16 @@ func TestLocalRun(t *testing.T) {
 			t.Override(&docker.EvalBuildArgs, func(_ config.RunMode, _ string, _ string, args map[string]*string, _ map[string]*string) (map[string]*string, error) {
 				return args, nil
 			})
-			testEvent.InitializeState([]latest.Pipeline{{
-				Deploy: latest.DeployConfig{},
-				Build: latest.BuildConfig{
-					BuildType: latest.BuildType{
-						LocalBuild: &latest.LocalBuild{},
+			testEvent.InitializeState([]latest_v1.Pipeline{{
+				Deploy: latest_v1.DeployConfig{},
+				Build: latest_v1.BuildConfig{
+					BuildType: latest_v1.BuildType{
+						LocalBuild: &latest_v1.LocalBuild{},
 					},
 				}}})
 
 			builder, err := NewBuilder(&mockBuilderContext{artifactStore: build.NewArtifactStore()},
-				&latest.LocalBuild{
+				&latest_v1.LocalBuild{
 					Push:        util.BoolPtr(test.pushImages),
 					Concurrency: &constants.DefaultLocalConcurrency,
 				})
@@ -265,7 +265,7 @@ func TestNewBuilder(t *testing.T) {
 		shouldErr     bool
 		expectedPush  bool
 		cluster       config.Cluster
-		localBuild    latest.LocalBuild
+		localBuild    latest_v1.LocalBuild
 		localDockerFn func(docker.Config) (docker.LocalDaemon, error)
 	}{
 		{
@@ -289,7 +289,7 @@ func TestNewBuilder(t *testing.T) {
 				return dummyDaemon, nil
 			},
 			cluster: config.Cluster{PushImages: true},
-			localBuild: latest.LocalBuild{
+			localBuild: latest_v1.LocalBuild{
 				Push: util.BoolPtr(false),
 			},
 			shouldErr:    false,
@@ -318,56 +318,56 @@ func TestNewBuilder(t *testing.T) {
 func TestGetArtifactBuilder(t *testing.T) {
 	tests := []struct {
 		description string
-		artifact    *latest.Artifact
+		artifact    *latest_v1.Artifact
 		expected    string
 		shouldErr   bool
 	}{
 		{
 			description: "docker builder",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{},
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{},
 				},
 			},
 			expected: "docker",
 		},
 		{
 			description: "jib builder",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					JibArtifact: &latest.JibArtifact{},
+				ArtifactType: latest_v1.ArtifactType{
+					JibArtifact: &latest_v1.JibArtifact{},
 				},
 			},
 			expected: "jib",
 		},
 		{
 			description: "buildpacks builder",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					BuildpackArtifact: &latest.BuildpackArtifact{},
+				ArtifactType: latest_v1.ArtifactType{
+					BuildpackArtifact: &latest_v1.BuildpackArtifact{},
 				},
 			},
 			expected: "buildpacks",
 		},
 		{
 			description: "bazel builder",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					BazelArtifact: &latest.BazelArtifact{},
+				ArtifactType: latest_v1.ArtifactType{
+					BazelArtifact: &latest_v1.BazelArtifact{},
 				},
 			},
 			expected: "bazel",
 		},
 		{
 			description: "custom builder",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "gcr.io/test/image",
-				ArtifactType: latest.ArtifactType{
-					CustomArtifact: &latest.CustomArtifact{},
+				ArtifactType: latest_v1.ArtifactType{
+					CustomArtifact: &latest_v1.CustomArtifact{},
 				},
 			},
 			expected: "custom",
@@ -382,7 +382,7 @@ func TestGetArtifactBuilder(t *testing.T) {
 				return args, nil
 			})
 
-			b, err := NewBuilder(&mockBuilderContext{artifactStore: build.NewArtifactStore()}, &latest.LocalBuild{Concurrency: &constants.DefaultLocalConcurrency})
+			b, err := NewBuilder(&mockBuilderContext{artifactStore: build.NewArtifactStore()}, &latest_v1.LocalBuild{Concurrency: &constants.DefaultLocalConcurrency})
 			t.CheckNoError(err)
 
 			builder, err := newPerArtifactBuilder(b, test.artifact)
@@ -410,7 +410,7 @@ func fakeLocalDaemon(api client.CommonAPIClient) docker.LocalDaemon {
 
 type mockBuilderContext struct {
 	runcontext.RunContext // Embedded to provide the default values.
-	local                 latest.LocalBuild
+	local                 latest_v1.LocalBuild
 	mode                  config.RunMode
 	cluster               config.Cluster
 	artifactStore         build.ArtifactStore

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -33,13 +33,13 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // Builder uses the host docker daemon to build and tag the image.
 type Builder struct {
-	local latest.LocalBuild
+	local latest_v1.LocalBuild
 
 	cfg                docker.Config
 	localDocker        docker.LocalDaemon
@@ -78,7 +78,7 @@ type BuilderContext interface {
 }
 
 // NewBuilder returns an new instance of a local Builder.
-func NewBuilder(bCtx BuilderContext, buildCfg *latest.LocalBuild) (*Builder, error) {
+func NewBuilder(bCtx BuilderContext, buildCfg *latest_v1.LocalBuild) (*Builder, error) {
 	localDocker, err := docker.NewAPIClient(bCtx)
 	if err != nil {
 		return nil, fmt.Errorf("getting docker client: %w", err)
@@ -133,11 +133,11 @@ func (b *Builder) Prune(ctx context.Context, _ io.Writer) error {
 
 // artifactBuilder represents a per artifact builder interface
 type artifactBuilder interface {
-	Build(ctx context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error)
+	Build(ctx context.Context, out io.Writer, a *latest_v1.Artifact, tag string) (string, error)
 }
 
 // newPerArtifactBuilder returns an instance of `artifactBuilder`
-func newPerArtifactBuilder(b *Builder, a *latest.Artifact) (artifactBuilder, error) {
+func newPerArtifactBuilder(b *Builder, a *latest_v1.Artifact) (artifactBuilder, error) {
 	switch {
 	case a.DockerArtifact != nil:
 		return dockerbuilder.NewArtifactBuilder(b.localDocker, b.local.UseDockerCLI, b.local.UseBuildkit, b.pushImages, b.prune, b.cfg.Mode(), b.cfg.GetInsecureRegistries(), b.artifactStore, b.sourceDependencies), nil

--- a/pkg/skaffold/build/logfile.go
+++ b/pkg/skaffold/build/logfile.go
@@ -22,7 +22,7 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/logfile"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 type Muted interface {
@@ -35,7 +35,7 @@ func WithLogFile(builder ArtifactBuilder, muted Muted) ArtifactBuilder {
 		return builder
 	}
 
-	return func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error) {
+	return func(ctx context.Context, out io.Writer, artifact *latest_v1.Artifact, tag string) (string, error) {
 		file, err := logfile.Create("build", artifact.ImageName+".log")
 		if err != nil {
 			return "", fmt.Errorf("unable to create log file for %s: %w", artifact.ImageName, err)

--- a/pkg/skaffold/build/logfile_test.go
+++ b/pkg/skaffold/build/logfile_test.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -87,7 +87,7 @@ func TestWithLogFile(t *testing.T) {
 			var out bytes.Buffer
 
 			builder := WithLogFile(test.builder, test.muted)
-			digest, err := builder(context.Background(), &out, &latest.Artifact{ImageName: "img"}, "img:123")
+			digest, err := builder(context.Background(), &out, &latest_v1.Artifact{ImageName: "img"}, "img:123")
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedDigest, digest)
 			for _, found := range test.logsFound {
@@ -100,12 +100,12 @@ func TestWithLogFile(t *testing.T) {
 	}
 }
 
-func fakeBuilder(_ context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
+func fakeBuilder(_ context.Context, out io.Writer, a *latest_v1.Artifact, tag string) (string, error) {
 	fmt.Fprintln(out, "building", a.ImageName, "with tag", tag)
 	return "digest", nil
 }
 
-func fakeFailingBuilder(_ context.Context, out io.Writer, a *latest.Artifact, tag string) (string, error) {
+func fakeFailingBuilder(_ context.Context, out io.Writer, a *latest_v1.Artifact, tag string) (string, error) {
 	fmt.Fprintln(out, "failed to build", a.ImageName, "with tag", tag)
 	return "", errors.New("bug")
 }

--- a/pkg/skaffold/build/misc/artifact_type.go
+++ b/pkg/skaffold/build/misc/artifact_type.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 )
 
@@ -35,7 +35,7 @@ const (
 
 // ArtifactType returns a string representing the type found in an artifact. Used for error messages.
 // (this would normally be implemented as a String() method on the type, but types are versioned)
-func ArtifactType(a *latest.Artifact) string {
+func ArtifactType(a *latest_v1.Artifact) string {
 	switch {
 	case a.DockerArtifact != nil:
 		return Docker
@@ -55,7 +55,7 @@ func ArtifactType(a *latest.Artifact) string {
 }
 
 // FormatArtifact returns a string representation of an artifact for usage in error messages
-func FormatArtifact(a *latest.Artifact) string {
+func FormatArtifact(a *latest_v1.Artifact) string {
 	buf, err := yaml.Marshal(a)
 	if err != nil {
 		return fmt.Sprintf("%+v", a)

--- a/pkg/skaffold/build/misc/artifact_type_test.go
+++ b/pkg/skaffold/build/misc/artifact_type_test.go
@@ -19,7 +19,7 @@ package misc
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -27,22 +27,22 @@ func TestArtifactType(t *testing.T) {
 	tests := []struct {
 		description string
 		want        string
-		artifact    *latest.Artifact
+		artifact    *latest_v1.Artifact
 	}{
-		{"docker", "docker", &latest.Artifact{
-			ArtifactType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{},
+		{"docker", "docker", &latest_v1.Artifact{
+			ArtifactType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{},
 			},
 		}},
-		{"kaniko", "kaniko", &latest.Artifact{
-			ArtifactType: latest.ArtifactType{
-				KanikoArtifact: &latest.KanikoArtifact{},
+		{"kaniko", "kaniko", &latest_v1.Artifact{
+			ArtifactType: latest_v1.ArtifactType{
+				KanikoArtifact: &latest_v1.KanikoArtifact{},
 			},
 		}},
-		{"docker+kaniko", "docker", &latest.Artifact{
-			ArtifactType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{},
-				KanikoArtifact: &latest.KanikoArtifact{},
+		{"docker+kaniko", "docker", &latest_v1.Artifact{
+			ArtifactType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{},
+				KanikoArtifact: &latest_v1.KanikoArtifact{},
 			},
 		}},
 	}
@@ -60,16 +60,16 @@ func TestFormatArtifact(t *testing.T) {
 	tests := []struct {
 		description string
 		want        string
-		artifact    *latest.Artifact
+		artifact    *latest_v1.Artifact
 	}{
-		{"docker", "docker: {}", &latest.Artifact{
-			ArtifactType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{},
+		{"docker", "docker: {}", &latest_v1.Artifact{
+			ArtifactType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{},
 			},
 		}},
-		{"kaniko", "kaniko: {}", &latest.Artifact{
-			ArtifactType: latest.ArtifactType{
-				KanikoArtifact: &latest.KanikoArtifact{},
+		{"kaniko", "kaniko: {}", &latest_v1.Artifact{
+			ArtifactType: latest_v1.ArtifactType{
+				KanikoArtifact: &latest_v1.KanikoArtifact{},
 			},
 		}},
 	}

--- a/pkg/skaffold/build/model.go
+++ b/pkg/skaffold/build/model.go
@@ -19,7 +19,7 @@ package build
 import (
 	"context"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // node models the artifact dependency graph using a set of channels.
@@ -52,7 +52,7 @@ func (a *node) waitForDependencies(ctx context.Context) error {
 	return nil
 }
 
-func createNodes(artifacts []*latest.Artifact) []node {
+func createNodes(artifacts []*latest_v1.Artifact) []node {
 	nodeMap := make(map[string]node)
 	for _, a := range artifacts {
 		nodeMap[a.ImageName] = node{

--- a/pkg/skaffold/build/result.go
+++ b/pkg/skaffold/build/result.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 const bufferedLinesPerArtifact = 10000
@@ -134,9 +134,9 @@ func newLogAggregator(out io.Writer, capacity int, concurrency int) logAggregato
 
 // ArtifactStore stores the results of each artifact build.
 type ArtifactStore interface {
-	Record(a *latest.Artifact, tag string)
+	Record(a *latest_v1.Artifact, tag string)
 	GetImageTag(imageName string) (tag string, found bool)
-	GetArtifacts(s []*latest.Artifact) ([]graph.Artifact, error)
+	GetArtifacts(s []*latest_v1.Artifact) ([]graph.Artifact, error)
 }
 
 func NewArtifactStore() ArtifactStore {
@@ -147,7 +147,7 @@ type artifactStoreImpl struct {
 	m *sync.Map
 }
 
-func (ba *artifactStoreImpl) Record(a *latest.Artifact, tag string) {
+func (ba *artifactStoreImpl) Record(a *latest_v1.Artifact, tag string) {
 	ba.m.Store(a.ImageName, tag)
 }
 
@@ -163,7 +163,7 @@ func (ba *artifactStoreImpl) GetImageTag(imageName string) (string, bool) {
 	return t, true
 }
 
-func (ba *artifactStoreImpl) GetArtifacts(s []*latest.Artifact) ([]graph.Artifact, error) {
+func (ba *artifactStoreImpl) GetArtifacts(s []*latest_v1.Artifact) ([]graph.Artifact, error) {
 	var builds []graph.Artifact
 	for _, a := range s {
 		t, found := ba.GetImageTag(a.ImageName)

--- a/pkg/skaffold/build/scheduler.go
+++ b/pkg/skaffold/build/scheduler.go
@@ -27,14 +27,14 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 )
 
-type ArtifactBuilder func(ctx context.Context, out io.Writer, artifact *latest.Artifact, tag string) (string, error)
+type ArtifactBuilder func(ctx context.Context, out io.Writer, artifact *latest_v1.Artifact, tag string) (string, error)
 
 type scheduler struct {
-	artifacts       []*latest.Artifact
+	artifacts       []*latest_v1.Artifact
 	nodes           []node // size len(artifacts)
 	artifactBuilder ArtifactBuilder
 	logger          logAggregator
@@ -42,7 +42,7 @@ type scheduler struct {
 	concurrencySem  countingSemaphore
 }
 
-func newScheduler(artifacts []*latest.Artifact, artifactBuilder ArtifactBuilder, concurrency int, out io.Writer, store ArtifactStore) *scheduler {
+func newScheduler(artifacts []*latest_v1.Artifact, artifactBuilder ArtifactBuilder, concurrency int, out io.Writer, store ArtifactStore) *scheduler {
 	s := scheduler{
 		artifacts:       artifacts,
 		nodes:           createNodes(artifacts),
@@ -114,7 +114,7 @@ func (s *scheduler) build(ctx context.Context, tags tag.ImageTags, i int) error 
 }
 
 // InOrder builds a list of artifacts in dependency order.
-func InOrder(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact, artifactBuilder ArtifactBuilder, concurrency int, store ArtifactStore) ([]graph.Artifact, error) {
+func InOrder(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest_v1.Artifact, artifactBuilder ArtifactBuilder, concurrency int, store ArtifactStore) ([]graph.Artifact, error) {
 	// `concurrency` specifies the max number of builds that can run at any one time. If concurrency is 0, then all builds can run in parallel.
 	if concurrency == 0 {
 		concurrency = len(artifacts)
@@ -128,7 +128,7 @@ func InOrder(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts [
 	return s.run(ctx, tags)
 }
 
-func performBuild(ctx context.Context, cw io.Writer, tags tag.ImageTags, artifact *latest.Artifact, build ArtifactBuilder) (string, error) {
+func performBuild(ctx context.Context, cw io.Writer, tags tag.ImageTags, artifact *latest_v1.Artifact, build ArtifactBuilder) (string, error) {
 	color.Default.Fprintf(cw, "Building [%s]...\n", artifact.ImageName)
 	tag, present := tags[artifact.ImageName]
 	if !present {

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // WaitForDeletions configures the wait for pending deletions.
@@ -131,7 +131,7 @@ func (opts *SkaffoldOptions) Mode() RunMode {
 	return RunMode(opts.Command)
 }
 
-func (opts *SkaffoldOptions) IsTargetImage(artifact *latest.Artifact) bool {
+func (opts *SkaffoldOptions) IsTargetImage(artifact *latest_v1.Artifact) bool {
 	if len(opts.TargetImages) == 0 {
 		return true
 	}

--- a/pkg/skaffold/config/options_test.go
+++ b/pkg/skaffold/config/options_test.go
@@ -19,7 +19,7 @@ package config
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -61,7 +61,7 @@ func TestIsTargetImage(t *testing.T) {
 				TargetImages: test.targetImages,
 			}
 
-			match := opts.IsTargetImage(&latest.Artifact{
+			match := opts.IsTargetImage(&latest_v1.Artifact{
 				ImageName: "domain/image",
 			})
 

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -19,7 +19,7 @@ package constants
 import (
 	"github.com/sirupsen/logrus"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 const (
@@ -75,8 +75,8 @@ const (
 type Phase string
 
 var (
-	Pod     latest.ResourceType = "pod"
-	Service latest.ResourceType = "service"
+	Pod     latest_v1.ResourceType = "pod"
+	Service latest_v1.ResourceType = "service"
 
 	DefaultLocalConcurrency = 1
 )

--- a/pkg/skaffold/deploy/deploy_problems_test.go
+++ b/pkg/skaffold/deploy/deploy_problems_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -102,7 +102,7 @@ type mockConfig struct {
 }
 
 func (m mockConfig) MinikubeProfile() string                { return m.minikube }
-func (m mockConfig) GetPipelines() []latest.Pipeline        { return []latest.Pipeline{} }
+func (m mockConfig) GetPipelines() []latest_v1.Pipeline     { return []latest_v1.Pipeline{} }
 func (m mockConfig) GetWorkingDir() string                  { return "" }
 func (m mockConfig) GlobalConfig() string                   { return "" }
 func (m mockConfig) ConfigurationFile() string              { return "" }

--- a/pkg/skaffold/deploy/helm/args.go
+++ b/pkg/skaffold/deploy/helm/args.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -44,7 +44,7 @@ type installOpts struct {
 }
 
 // constructOverrideArgs creates the command line arguments for overrides
-func constructOverrideArgs(r *latest.HelmRelease, builds []graph.Artifact, args []string, record func(string)) ([]string, error) {
+func constructOverrideArgs(r *latest_v1.HelmRelease, builds []graph.Artifact, args []string, record func(string)) ([]string, error) {
 	for _, k := range sortKeys(r.SetValues) {
 		record(r.SetValues[k])
 		args = append(args, "--set", fmt.Sprintf("%s=%s", k, r.SetValues[k]))
@@ -112,7 +112,7 @@ func getArgs(releaseName string, namespace string) []string {
 }
 
 // installArgs calculates the correct arguments to "helm install"
-func (h *Deployer) installArgs(r latest.HelmRelease, builds []graph.Artifact, valuesSet map[string]bool, o installOpts) ([]string, error) {
+func (h *Deployer) installArgs(r latest_v1.HelmRelease, builds []graph.Artifact, valuesSet map[string]bool, o installOpts) ([]string, error) {
 	var args []string
 	if o.upgrade {
 		args = append(args, "upgrade", o.releaseName)

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -44,7 +44,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/types"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
@@ -71,7 +71,7 @@ var (
 
 // Deployer deploys workflows using the helm CLI
 type Deployer struct {
-	*latest.HelmDeploy
+	*latest_v1.HelmDeploy
 
 	kubeContext string
 	kubeConfig  string
@@ -96,7 +96,7 @@ type Config interface {
 }
 
 // NewDeployer returns a configured Deployer.  Returns an error if current version of helm is less than 3.0.0.
-func NewDeployer(cfg Config, labels map[string]string, h *latest.HelmDeploy) (*Deployer, error) {
+func NewDeployer(cfg Config, labels map[string]string, h *latest_v1.HelmDeploy) (*Deployer, error) {
 	hv, err := binVer()
 	if err != nil {
 		return nil, versionGetErr(err)
@@ -307,7 +307,7 @@ func (h *Deployer) Render(ctx context.Context, out io.Writer, builds []graph.Art
 }
 
 // deployRelease deploys a single release
-func (h *Deployer) deployRelease(ctx context.Context, out io.Writer, releaseName string, r latest.HelmRelease, builds []graph.Artifact, valuesSet map[string]bool, helmVersion semver.Version) ([]types.Artifact, error) {
+func (h *Deployer) deployRelease(ctx context.Context, out io.Writer, releaseName string, r latest_v1.HelmRelease, builds []graph.Artifact, valuesSet map[string]bool, helmVersion semver.Version) ([]types.Artifact, error) {
 	var err error
 	opts := installOpts{
 		releaseName: releaseName,
@@ -447,7 +447,7 @@ func (h *Deployer) getReleaseManifest(ctx context.Context, releaseName string, n
 }
 
 // packageChart packages the chart and returns the path to the resulting chart archive
-func (h *Deployer) packageChart(ctx context.Context, r latest.HelmRelease) (string, error) {
+func (h *Deployer) packageChart(ctx context.Context, r latest_v1.HelmRelease) (string, error) {
 	// Allow a test to sneak a predictable path in
 	tmpDir := h.pkgTmpDir
 
@@ -493,7 +493,7 @@ func (h *Deployer) packageChart(ctx context.Context, r latest.HelmRelease) (stri
 	return output[idx:], nil
 }
 
-func chartSource(r latest.HelmRelease) string {
+func chartSource(r latest_v1.HelmRelease) string {
 	if r.RemoteChart != "" {
 		return r.RemoteChart
 	}

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
@@ -45,8 +45,8 @@ var testBuildsFoo = []graph.Artifact{{
 	Tag:       "foo:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184",
 }}
 
-var testDeployConfig = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployConfig = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
 		ArtifactOverrides: map[string]string{
@@ -59,8 +59,8 @@ var testDeployConfig = latest.HelmDeploy{
 	}},
 }
 
-var testDeployNamespacedConfig = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployNamespacedConfig = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
 		ArtifactOverrides: map[string]string{
@@ -74,8 +74,8 @@ var testDeployNamespacedConfig = latest.HelmDeploy{
 	}},
 }
 
-var testDeployEnvTemplateNamespacedConfig = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployEnvTemplateNamespacedConfig = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
 		ArtifactOverrides: map[string]string{
@@ -89,8 +89,8 @@ var testDeployEnvTemplateNamespacedConfig = latest.HelmDeploy{
 	}},
 }
 
-var testDeployConfigRemoteRepo = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployConfigRemoteRepo = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
 		ArtifactOverrides: map[string]string{
@@ -104,8 +104,8 @@ var testDeployConfigRemoteRepo = latest.HelmDeploy{
 	}},
 }
 
-var testDeployConfigTemplated = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployConfigTemplated = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
 		ArtifactOverrides: map[string]string{
@@ -123,8 +123,8 @@ var testDeployConfigTemplated = latest.HelmDeploy{
 	}},
 }
 
-var testDeployConfigValuesFilesTemplated = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployConfigValuesFilesTemplated = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
 		ArtifactOverrides: map[string]string{
@@ -137,8 +137,8 @@ var testDeployConfigValuesFilesTemplated = latest.HelmDeploy{
 	}},
 }
 
-var testDeployConfigSetFiles = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployConfigSetFiles = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
 		ArtifactOverrides: map[string]string{
@@ -152,8 +152,8 @@ var testDeployConfigSetFiles = latest.HelmDeploy{
 	}},
 }
 
-var testDeployRecreatePodsConfig = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployRecreatePodsConfig = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
 		ArtifactOverrides: map[string]string{
@@ -167,8 +167,8 @@ var testDeployRecreatePodsConfig = latest.HelmDeploy{
 	}},
 }
 
-var testDeploySkipBuildDependenciesConfig = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeploySkipBuildDependenciesConfig = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
 		ArtifactOverrides: map[string]string{
@@ -182,8 +182,8 @@ var testDeploySkipBuildDependenciesConfig = latest.HelmDeploy{
 	}},
 }
 
-var testDeployHelmStyleConfig = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployHelmStyleConfig = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
 		ArtifactOverrides: map[string]string{
@@ -193,16 +193,16 @@ var testDeployHelmStyleConfig = latest.HelmDeploy{
 		SetValues: map[string]string{
 			"some.key": "somevalue",
 		},
-		ImageStrategy: latest.HelmImageStrategy{
-			HelmImageConfig: latest.HelmImageConfig{
-				HelmConventionConfig: &latest.HelmConventionConfig{},
+		ImageStrategy: latest_v1.HelmImageStrategy{
+			HelmImageConfig: latest_v1.HelmImageConfig{
+				HelmConventionConfig: &latest_v1.HelmConventionConfig{},
 			},
 		},
 	}},
 }
 
-var testDeployHelmExplicitRegistryStyleConfig = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployHelmExplicitRegistryStyleConfig = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
 		ArtifactOverrides: map[string]string{
@@ -212,9 +212,9 @@ var testDeployHelmExplicitRegistryStyleConfig = latest.HelmDeploy{
 		SetValues: map[string]string{
 			"some.key": "somevalue",
 		},
-		ImageStrategy: latest.HelmImageStrategy{
-			HelmImageConfig: latest.HelmImageConfig{
-				HelmConventionConfig: &latest.HelmConventionConfig{
+		ImageStrategy: latest_v1.HelmImageStrategy{
+			HelmImageConfig: latest_v1.HelmImageConfig{
+				HelmConventionConfig: &latest_v1.HelmConventionConfig{
 					ExplicitRegistry: true,
 				},
 			},
@@ -222,8 +222,8 @@ var testDeployHelmExplicitRegistryStyleConfig = latest.HelmDeploy{
 	}},
 }
 
-var testDeployConfigParameterUnmatched = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployConfigParameterUnmatched = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
 		ArtifactOverrides: map[string]string{
@@ -232,22 +232,22 @@ var testDeployConfigParameterUnmatched = latest.HelmDeploy{
 	},
 }
 
-var testDeployFooWithPackaged = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployFooWithPackaged = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "foo",
 		ChartPath: "testdata/foo",
 		ArtifactOverrides: map[string]string{
 			"image": "foo",
 		},
-		Packaged: &latest.HelmPackaged{
+		Packaged: &latest_v1.HelmPackaged{
 			Version:    "0.1.2",
 			AppVersion: "1.2.3",
 		},
 	}},
 }
 
-var testDeployWithTemplatedName = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployWithTemplatedName = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "{{.USER}}-skaffold-helm",
 		ChartPath: "examples/test",
 		ArtifactOverrides: map[string]string{
@@ -260,8 +260,8 @@ var testDeployWithTemplatedName = latest.HelmDeploy{
 	},
 }
 
-var testDeploySkipBuildDependencies = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeploySkipBuildDependencies = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "stable/chartmuseum",
 		ArtifactOverrides: map[string]string{
@@ -271,8 +271,8 @@ var testDeploySkipBuildDependencies = latest.HelmDeploy{
 	}},
 }
 
-var testDeployRemoteChart = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployRemoteChart = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:                  "skaffold-helm-remote",
 		ChartPath:             "stable/chartmuseum",
 		SkipBuildDependencies: false,
@@ -280,23 +280,23 @@ var testDeployRemoteChart = latest.HelmDeploy{
 }
 
 var upgradeOnChangeFalse = false
-var testDeployUpgradeOnChange = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployUpgradeOnChange = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:            "skaffold-helm-upgradeOnChange",
 		ChartPath:       "examples/test",
 		UpgradeOnChange: &upgradeOnChangeFalse,
 	}},
 }
 
-var testDeployWithoutTags = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployWithoutTags = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
 	}},
 }
 
-var testTwoReleases = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testTwoReleases = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "other",
 		ChartPath: "examples/test",
 	}, {
@@ -309,8 +309,8 @@ var testTwoReleases = latest.HelmDeploy{
 }
 
 var createNamespaceFlag = true
-var testDeployCreateNamespaceConfig = latest.HelmDeploy{
-	Releases: []latest.HelmRelease{{
+var testDeployCreateNamespaceConfig = latest_v1.HelmDeploy{
+	Releases: []latest_v1.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
 		ArtifactOverrides: map[string]string{
@@ -481,7 +481,7 @@ func TestHelmDeploy(t *testing.T) {
 		description        string
 		commands           util.Command
 		env                []string
-		helm               latest.HelmDeploy
+		helm               latest_v1.HelmDeploy
 		namespace          string
 		configure          func(*Deployer)
 		builds             []graph.Artifact
@@ -1004,7 +1004,7 @@ func TestHelmCleanup(t *testing.T) {
 	tests := []struct {
 		description      string
 		commands         util.Command
-		helm             latest.HelmDeploy
+		helm             latest_v1.HelmDeploy
 		namespace        string
 		builds           []graph.Artifact
 		expectedWarnings []string
@@ -1165,8 +1165,8 @@ func TestHelmDependencies(t *testing.T) {
 				local = tmpDir.Root()
 			}
 
-			deployer, err := NewDeployer(&helmConfig{}, nil, &latest.HelmDeploy{
-				Releases: []latest.HelmRelease{{
+			deployer, err := NewDeployer(&helmConfig{}, nil, &latest_v1.HelmDeploy{
+				Releases: []latest_v1.HelmRelease{{
 					Name:                  "skaffold-helm",
 					ChartPath:             local,
 					RemoteChart:           remote,
@@ -1192,7 +1192,7 @@ func TestImageSetFromConfig(t *testing.T) {
 		valueName   string
 		tag         string
 		expected    string
-		strategy    *latest.HelmConventionConfig
+		strategy    *latest_v1.HelmConventionConfig
 		shouldErr   bool
 	}{
 		{
@@ -1208,7 +1208,7 @@ func TestImageSetFromConfig(t *testing.T) {
 			valueName:   "image",
 			tag:         "skaffold-helm:1.0.0",
 			expected:    "image.repository=skaffold-helm,image.tag=1.0.0",
-			strategy:    &latest.HelmConventionConfig{},
+			strategy:    &latest_v1.HelmConventionConfig{},
 			shouldErr:   false,
 		},
 		{
@@ -1216,7 +1216,7 @@ func TestImageSetFromConfig(t *testing.T) {
 			valueName:   "image",
 			tag:         "docker.io/skaffold-helm:1.0.0",
 			expected:    "image.registry=docker.io,image.repository=skaffold-helm,image.tag=1.0.0",
-			strategy: &latest.HelmConventionConfig{
+			strategy: &latest_v1.HelmConventionConfig{
 				ExplicitRegistry: true,
 			},
 			shouldErr: false,
@@ -1226,7 +1226,7 @@ func TestImageSetFromConfig(t *testing.T) {
 			valueName:   "image",
 			tag:         "skaffold-helm:1.0.0,0",
 			expected:    "",
-			strategy:    &latest.HelmConventionConfig{},
+			strategy:    &latest_v1.HelmConventionConfig{},
 			shouldErr:   true,
 		},
 		{
@@ -1234,7 +1234,7 @@ func TestImageSetFromConfig(t *testing.T) {
 			valueName:   "image",
 			tag:         "skaffold-helm:1.0.0",
 			expected:    "",
-			strategy: &latest.HelmConventionConfig{
+			strategy: &latest_v1.HelmConventionConfig{
 				ExplicitRegistry: true,
 			},
 			shouldErr: true,
@@ -1244,7 +1244,7 @@ func TestImageSetFromConfig(t *testing.T) {
 			valueName:   "image",
 			tag:         "skaffold-helm:stable@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2",
 			expected:    "image.repository=skaffold-helm,image.tag=stable@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2",
-			strategy:    &latest.HelmConventionConfig{},
+			strategy:    &latest_v1.HelmConventionConfig{},
 			shouldErr:   false,
 		},
 	}
@@ -1262,7 +1262,7 @@ func TestHelmRender(t *testing.T) {
 		description string
 		shouldErr   bool
 		commands    util.Command
-		helm        latest.HelmDeploy
+		helm        latest_v1.HelmDeploy
 		outputFile  string
 		expected    string
 		builds      []graph.Artifact

--- a/pkg/skaffold/deploy/helm/util.go
+++ b/pkg/skaffold/deploy/helm/util.go
@@ -34,7 +34,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -92,7 +92,7 @@ func binVer() (semver.Version, error) {
 }
 
 // imageSetFromConfig calculates the --set-string value from the helm config
-func imageSetFromConfig(cfg *latest.HelmConventionConfig, valueName string, tag string) (string, error) {
+func imageSetFromConfig(cfg *latest_v1.HelmConventionConfig, valueName string, tag string) (string, error) {
 	if cfg == nil {
 		return fmt.Sprintf("%s=%s", valueName, tag), nil
 	}
@@ -153,7 +153,7 @@ func (h *Deployer) generateSkaffoldDebugFilter(buildsFile string) []string {
 	return args
 }
 
-func (h *Deployer) releaseNamespace(r latest.HelmRelease) (string, error) {
+func (h *Deployer) releaseNamespace(r latest_v1.HelmRelease) (string, error) {
 	if h.namespace != "" {
 		return h.namespace, nil
 	} else if r.Namespace != "" {

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -40,7 +40,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -61,7 +61,7 @@ const (
 
 // Deployer deploys workflows with kpt CLI
 type Deployer struct {
-	*latest.KptDeploy
+	*latest_v1.KptDeploy
 
 	insecureRegistries map[string]bool
 	labels             map[string]string
@@ -69,7 +69,7 @@ type Deployer struct {
 }
 
 // NewDeployer generates a new Deployer object contains the kptDeploy schema.
-func NewDeployer(cfg types.Config, labels map[string]string, d *latest.KptDeploy) *Deployer {
+func NewDeployer(cfg types.Config, labels map[string]string, d *latest_v1.KptDeploy) *Deployer {
 	return &Deployer{
 		KptDeploy:          d,
 		insecureRegistries: cfg.GetInsecureRegistries(),

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -58,7 +58,7 @@ func TestKpt_Deploy(t *testing.T) {
 	tests := []struct {
 		description    string
 		builds         []graph.Artifact
-		kpt            latest.KptDeploy
+		kpt            latest_v1.KptDeploy
 		kustomizations map[string]string
 		commands       util.Command
 		expected       []string
@@ -66,7 +66,7 @@ func TestKpt_Deploy(t *testing.T) {
 	}{
 		{
 			description: "no manifest",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			commands: testutil.
@@ -75,7 +75,7 @@ func TestKpt_Deploy(t *testing.T) {
 		},
 		{
 			description: "invalid manifest",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			commands: testutil.
@@ -86,10 +86,10 @@ func TestKpt_Deploy(t *testing.T) {
 		},
 		{
 			description: "invalid user specified applyDir",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
-				Live: latest.KptLive{
-					Apply: latest.KptApplyInventory{
+				Live: latest_v1.KptLive{
+					Apply: latest_v1.KptApplyInventory{
 						Dir: "invalid_path",
 					},
 				},
@@ -103,11 +103,11 @@ func TestKpt_Deploy(t *testing.T) {
 
 		{
 			description: "kustomization and specified kpt fn",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
-				Fn:  latest.KptFn{FnPath: "kpt-func.yaml"},
-				Live: latest.KptLive{
-					Apply: latest.KptApplyInventory{
+				Fn:  latest_v1.KptFn{FnPath: "kpt-func.yaml"},
+				Live: latest_v1.KptLive{
+					Apply: latest_v1.KptApplyInventory{
 						Dir: "valid_path",
 					},
 				},
@@ -125,7 +125,7 @@ func TestKpt_Deploy(t *testing.T) {
 		},
 		{
 			description: "kpt live apply fails",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			commands: testutil.
@@ -137,13 +137,13 @@ func TestKpt_Deploy(t *testing.T) {
 		},
 		{
 			description: "user specifies reconcile timeout and poll period",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
-				Live: latest.KptLive{
-					Apply: latest.KptApplyInventory{
+				Live: latest_v1.KptLive{
+					Apply: latest_v1.KptApplyInventory{
 						Dir: "valid_path",
 					},
-					Options: latest.KptApplyOptions{
+					Options: latest_v1.KptApplyOptions{
 						PollPeriod:       "5s",
 						ReconcileTimeout: "2m",
 					},
@@ -156,13 +156,13 @@ func TestKpt_Deploy(t *testing.T) {
 		},
 		{
 			description: "user specifies invalid reconcile timeout and poll period",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
-				Live: latest.KptLive{
-					Apply: latest.KptApplyInventory{
+				Live: latest_v1.KptLive{
+					Apply: latest_v1.KptApplyInventory{
 						Dir: "valid_path",
 					},
-					Options: latest.KptApplyOptions{
+					Options: latest_v1.KptApplyOptions{
 						PollPeriod:       "foo",
 						ReconcileTimeout: "bar",
 					},
@@ -175,13 +175,13 @@ func TestKpt_Deploy(t *testing.T) {
 		},
 		{
 			description: "user specifies prune propagation policy and prune timeout",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
-				Live: latest.KptLive{
-					Apply: latest.KptApplyInventory{
+				Live: latest_v1.KptLive{
+					Apply: latest_v1.KptApplyInventory{
 						Dir: "valid_path",
 					},
-					Options: latest.KptApplyOptions{
+					Options: latest_v1.KptApplyOptions{
 						PrunePropagationPolicy: "Orphan",
 						PruneTimeout:           "2m",
 					},
@@ -194,13 +194,13 @@ func TestKpt_Deploy(t *testing.T) {
 		},
 		{
 			description: "user specifies invalid prune propagation policy and prune timeout",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
-				Live: latest.KptLive{
-					Apply: latest.KptApplyInventory{
+				Live: latest_v1.KptLive{
+					Apply: latest_v1.KptApplyInventory{
 						Dir: "valid_path",
 					},
-					Options: latest.KptApplyOptions{
+					Options: latest_v1.KptApplyOptions{
 						PrunePropagationPolicy: "foo",
 						PruneTimeout:           "bar",
 					},
@@ -237,7 +237,7 @@ func TestKpt_Deploy(t *testing.T) {
 func TestKpt_Dependencies(t *testing.T) {
 	tests := []struct {
 		description    string
-		kpt            latest.KptDeploy
+		kpt            latest_v1.KptDeploy
 		createFiles    map[string]string
 		kustomizations map[string]string
 		expected       []string
@@ -245,20 +245,20 @@ func TestKpt_Dependencies(t *testing.T) {
 	}{
 		{
 			description: "bad dir",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: "invalid_path",
 			},
 			shouldErr: true,
 		},
 		{
 			description: "empty dir and unspecified fnPath",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 		},
 		{
 			description: "dir",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			createFiles: map[string]string{
@@ -269,7 +269,7 @@ func TestKpt_Dependencies(t *testing.T) {
 		},
 		{
 			description: "dir with subdirs and file path variants",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			createFiles: map[string]string{
@@ -282,9 +282,9 @@ func TestKpt_Dependencies(t *testing.T) {
 		},
 		{
 			description: "fnpath inside directory",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
-				Fn:  latest.KptFn{FnPath: "."},
+				Fn:  latest_v1.KptFn{FnPath: "."},
 			},
 			createFiles: map[string]string{
 				"./kpt-func.yaml": "",
@@ -293,9 +293,9 @@ func TestKpt_Dependencies(t *testing.T) {
 		},
 		{
 			description: "fnpath outside directory",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: "./config",
-				Fn:  latest.KptFn{FnPath: "./kpt-fn"},
+				Fn:  latest_v1.KptFn{FnPath: "./kpt-fn"},
 			},
 			createFiles: map[string]string{
 				"./config/deployment.yaml": "",
@@ -306,9 +306,9 @@ func TestKpt_Dependencies(t *testing.T) {
 
 		{
 			description: "fnpath and dir and kustomization",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
-				Fn:  latest.KptFn{FnPath: "./kpt-fn"},
+				Fn:  latest_v1.KptFn{FnPath: "./kpt-fn"},
 			},
 			createFiles: map[string]string{
 				"./kpt-fn/func.yaml": "",
@@ -319,7 +319,7 @@ func TestKpt_Dependencies(t *testing.T) {
 		},
 		{
 			description: "dependencies that can only be detected as a kustomization",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			kustomizations: map[string]string{"kustomization.yaml": `configMapGenerator:
@@ -328,7 +328,7 @@ func TestKpt_Dependencies(t *testing.T) {
 		},
 		{
 			description: "kustomization.yml variant",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			kustomizations: map[string]string{"kustomization.yml": `configMapGenerator:
@@ -337,7 +337,7 @@ func TestKpt_Dependencies(t *testing.T) {
 		},
 		{
 			description: "Kustomization variant",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			kustomizations: map[string]string{"Kustomization": `configMapGenerator:
@@ -346,7 +346,7 @@ func TestKpt_Dependencies(t *testing.T) {
 		},
 		{
 			description: "incorrectly named kustomization",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			kustomizations: map[string]string{"customization": `configMapGenerator:
@@ -413,9 +413,9 @@ func TestKpt_Cleanup(t *testing.T) {
 
 			k := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, nil, &latest.KptDeploy{
-				Live: latest.KptLive{
-					Apply: latest.KptApplyInventory{
+			}, nil, &latest_v1.KptDeploy{
+				Live: latest_v1.KptLive{
+					Apply: latest_v1.KptApplyInventory{
 						Dir: test.applyDir,
 					},
 				},
@@ -475,7 +475,7 @@ spec:
 		description    string
 		builds         []graph.Artifact
 		labels         map[string]string
-		kpt            latest.KptDeploy
+		kpt            latest_v1.KptDeploy
 		commands       util.Command
 		kustomizations map[string]string
 		expected       string
@@ -489,7 +489,7 @@ spec:
 					Tag:       "gcr.io/project/image1:tag1",
 				},
 			},
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			commands: testutil.
@@ -519,9 +519,9 @@ spec:
 				},
 			},
 			labels: map[string]string{"user/label": "test"},
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: "test",
-				Fn:  latest.KptFn{FnPath: "kpt-func.yaml"},
+				Fn:  latest_v1.KptFn{FnPath: "kpt-func.yaml"},
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source test", ``).
@@ -563,9 +563,9 @@ spec:
 					Tag:       "gcr.io/project/image2:tag2",
 				},
 			},
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
-				Fn:  latest.KptFn{Image: "gcr.io/example.com/my-fn:v1.0.0 -- foo=bar"},
+				Fn:  latest_v1.KptFn{Image: "gcr.io/example.com/my-fn:v1.0.0 -- foo=bar"},
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
@@ -592,7 +592,7 @@ spec:
 				},
 			},
 			labels: map[string]string{"user/label": "test"},
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			commands: testutil.
@@ -603,9 +603,9 @@ spec:
 		},
 		{
 			description: "both fnPath and image specified",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
-				Fn: latest.KptFn{
+				Fn: latest_v1.KptFn{
 					FnPath: "kpt-func.yaml",
 					Image:  "gcr.io/example.com/my-fn:v1.0.0 -- foo=bar"},
 			},
@@ -624,7 +624,7 @@ spec:
 					Tag:       "gcr.io/project/image1:tag1",
 				},
 			},
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			commands: testutil.
@@ -646,7 +646,7 @@ spec:
 		},
 		{
 			description: "reading configs from sourceDir fails",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			commands: testutil.
@@ -657,7 +657,7 @@ spec:
 		},
 		{
 			description: "outputting configs to sinkDir fails",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			commands: testutil.
@@ -674,7 +674,7 @@ spec:
 					Tag:       "gcr.io/project/image1:tag1",
 				},
 			},
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			commands: testutil.
@@ -689,7 +689,7 @@ spec:
 		},
 		{
 			description: "kpt fn run fails",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
 			},
 			commands: testutil.
@@ -700,9 +700,9 @@ spec:
 		},
 		{
 			description: "kpt fn run with --global-scope",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
-				Fn: latest.KptFn{
+				Fn: latest_v1.KptFn{
 					Image:       "gcr.io/example.com/my-fn:v1.0.0 -- foo=bar",
 					GlobalScope: true,
 				},
@@ -715,9 +715,9 @@ spec:
 		},
 		{
 			description: "kpt fn run with --mount arguments",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
-				Fn: latest.KptFn{
+				Fn: latest_v1.KptFn{
 					Image: "gcr.io/example.com/my-fn:v1.0.0 -- foo=bar",
 					Mount: []string{"type=bind", "src=$(pwd)", "dst=/source"},
 				},
@@ -730,9 +730,9 @@ spec:
 		},
 		{
 			description: "kpt fn run with invalid --mount arguments",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
-				Fn: latest.KptFn{
+				Fn: latest_v1.KptFn{
 					Image: "gcr.io/example.com/my-fn:v1.0.0 -- foo=bar",
 					Mount: []string{"foo", "", "bar"},
 				},
@@ -745,9 +745,9 @@ spec:
 		},
 		{
 			description: "kpt fn run flag with --network and --network-name arguments",
-			kpt: latest.KptDeploy{
+			kpt: latest_v1.KptDeploy{
 				Dir: ".",
-				Fn: latest.KptFn{
+				Fn: latest_v1.KptFn{
 					Image:       "gcr.io/example.com/my-fn:v1.0.0 -- foo=bar",
 					Network:     true,
 					NetworkName: "foo",
@@ -782,15 +782,15 @@ spec:
 func TestKpt_GetApplyDir(t *testing.T) {
 	tests := []struct {
 		description string
-		live        latest.KptLive
+		live        latest_v1.KptLive
 		expected    string
 		commands    util.Command
 		shouldErr   bool
 	}{
 		{
 			description: "specified an invalid applyDir",
-			live: latest.KptLive{
-				Apply: latest.KptApplyInventory{
+			live: latest_v1.KptLive{
+				Apply: latest_v1.KptApplyInventory{
 					Dir: "invalid_path",
 				},
 			},
@@ -798,8 +798,8 @@ func TestKpt_GetApplyDir(t *testing.T) {
 		},
 		{
 			description: "specified a valid applyDir",
-			live: latest.KptLive{
-				Apply: latest.KptApplyInventory{
+			live: latest_v1.KptLive{
+				Apply: latest_v1.KptApplyInventory{
 					Dir: "valid_path",
 				},
 			},
@@ -812,8 +812,8 @@ func TestKpt_GetApplyDir(t *testing.T) {
 		},
 		{
 			description: "unspecified applyDir with specified inventory-id and namespace",
-			live: latest.KptLive{
-				Apply: latest.KptApplyInventory{
+			live: latest_v1.KptLive{
+				Apply: latest_v1.KptApplyInventory{
 					InventoryID:        "1a23bcde-4f56-7891-a2bc-de34fabcde5f6",
 					InventoryNamespace: "foo",
 				},
@@ -843,7 +843,7 @@ func TestKpt_GetApplyDir(t *testing.T) {
 
 			k := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, nil, &latest.KptDeploy{
+			}, nil, &latest_v1.KptDeploy{
 				Live: test.live,
 			})
 

--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -29,15 +29,15 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	deployerr "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/error"
 	deploy "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/types"
-	kubectl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // CLI holds parameters to run kubectl.
 type CLI struct {
 	*kubectl.CLI
-	Flags latest.KubectlFlags
+	Flags latest_v1.KubectlFlags
 
 	forceDeploy      bool
 	waitForDeletions config.WaitForDeletions
@@ -53,7 +53,7 @@ type Config interface {
 	HydratedManifests() []string
 }
 
-func NewCLI(cfg Config, flags latest.KubectlFlags, defaultNameSpace string) CLI {
+func NewCLI(cfg Config, flags latest_v1.KubectlFlags, defaultNameSpace string) CLI {
 	return CLI{
 		CLI:              kubectl.NewCLI(cfg, defaultNameSpace),
 		Flags:            flags,

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -36,13 +36,13 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // Deployer deploys workflows using kubectl CLI.
 type Deployer struct {
-	*latest.KubectlDeploy
+	*latest_v1.KubectlDeploy
 
 	originalImages     []graph.Artifact
 	hydratedManifests  []string
@@ -58,7 +58,7 @@ type Deployer struct {
 
 // NewDeployer returns a new Deployer for a DeployConfig filled
 // with the needed configuration for `kubectl apply`
-func NewDeployer(cfg Config, labels map[string]string, d *latest.KubectlDeploy) (*Deployer, error) {
+func NewDeployer(cfg Config, labels map[string]string, d *latest_v1.KubectlDeploy) (*Deployer, error) {
 	defaultNamespace := ""
 	if d.DefaultNamespace != nil {
 		var err error

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -39,7 +39,7 @@ import (
 func TestKubectlDeploy(t *testing.T) {
 	tests := []struct {
 		description                 string
-		kubectl                     latest.KubectlDeploy
+		kubectl                     latest_v1.KubectlDeploy
 		builds                      []graph.Artifact
 		commands                    util.Command
 		shouldErr                   bool
@@ -50,15 +50,15 @@ func TestKubectlDeploy(t *testing.T) {
 	}{
 		{
 			description:      "no manifest",
-			kubectl:          latest.KubectlDeploy{},
+			kubectl:          latest_v1.KubectlDeploy{},
 			commands:         testutil.CmdRunOut("kubectl version --client -ojson", KubectlVersion112),
 			waitForDeletions: true,
 		},
 		{
 			description: "deploy success (disable validation)",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
-				Flags: latest.KubectlFlags{
+				Flags: latest_v1.KubectlFlags{
 					DisableValidation: true,
 				},
 			},
@@ -75,7 +75,7 @@ func TestKubectlDeploy(t *testing.T) {
 		},
 		{
 			description: "deploy success (forced)",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
 			},
 			commands: testutil.
@@ -92,7 +92,7 @@ func TestKubectlDeploy(t *testing.T) {
 		},
 		{
 			description: "deploy success",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
 			},
 			commands: testutil.
@@ -108,7 +108,7 @@ func TestKubectlDeploy(t *testing.T) {
 		},
 		{
 			description: "deploy success (kubectl v1.18)",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
 			},
 			commands: testutil.
@@ -124,7 +124,7 @@ func TestKubectlDeploy(t *testing.T) {
 		},
 		{
 			description: "deploy success (default namespace)",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				Manifests:        []string{"deployment.yaml"},
 				DefaultNamespace: &TestNamespace2,
 			},
@@ -142,7 +142,7 @@ func TestKubectlDeploy(t *testing.T) {
 		},
 		{
 			description: "deploy success (default namespace with env template)",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				Manifests:        []string{"deployment.yaml"},
 				DefaultNamespace: &TestNamespace2FromEnvTemplate,
 			},
@@ -163,7 +163,7 @@ func TestKubectlDeploy(t *testing.T) {
 		},
 		{
 			description: "http manifest",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml", "http://remote.yaml"},
 			},
 			commands: testutil.
@@ -179,7 +179,7 @@ func TestKubectlDeploy(t *testing.T) {
 		},
 		{
 			description: "deploy command error",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
 			},
 			commands: testutil.
@@ -196,9 +196,9 @@ func TestKubectlDeploy(t *testing.T) {
 		},
 		{
 			description: "additional flags",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
-				Flags: latest.KubectlFlags{
+				Flags: latest_v1.KubectlFlags{
 					Global: []string{"-v=0"},
 					Apply:  []string{"--overwrite=true"},
 					Delete: []string{"ignored"},
@@ -254,13 +254,13 @@ func TestKubectlDeploy(t *testing.T) {
 func TestKubectlCleanup(t *testing.T) {
 	tests := []struct {
 		description string
-		kubectl     latest.KubectlDeploy
+		kubectl     latest_v1.KubectlDeploy
 		commands    util.Command
 		shouldErr   bool
 	}{
 		{
 			description: "cleanup success",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
 			},
 			commands: testutil.
@@ -270,7 +270,7 @@ func TestKubectlCleanup(t *testing.T) {
 		},
 		{
 			description: "cleanup success (kubectl v1.18)",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
 			},
 			commands: testutil.
@@ -280,7 +280,7 @@ func TestKubectlCleanup(t *testing.T) {
 		},
 		{
 			description: "cleanup error",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
 			},
 			commands: testutil.
@@ -291,9 +291,9 @@ func TestKubectlCleanup(t *testing.T) {
 		},
 		{
 			description: "additional flags",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
-				Flags: latest.KubectlFlags{
+				Flags: latest_v1.KubectlFlags{
 					Global: []string{"-v=0"},
 					Apply:  []string{"ignored"},
 					Delete: []string{"--grace-period=1"},
@@ -328,12 +328,12 @@ func TestKubectlCleanup(t *testing.T) {
 func TestKubectlDeployerRemoteCleanup(t *testing.T) {
 	tests := []struct {
 		description string
-		kubectl     latest.KubectlDeploy
+		kubectl     latest_v1.KubectlDeploy
 		commands    util.Command
 	}{
 		{
 			description: "cleanup success",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				RemoteManifests: []string{"pod/leeroy-web"},
 			},
 			commands: testutil.
@@ -343,7 +343,7 @@ func TestKubectlDeployerRemoteCleanup(t *testing.T) {
 		},
 		{
 			description: "cleanup error",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				RemoteManifests: []string{"anotherNamespace:pod/leeroy-web"},
 			},
 			commands: testutil.
@@ -396,7 +396,7 @@ func TestKubectlRedeploy(t *testing.T) {
 				Enabled: true,
 				Delay:   0 * time.Millisecond,
 				Max:     10 * time.Second},
-		}, nil, &latest.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-app.yaml"), tmpDir.Path("deployment-web.yaml")}})
+		}, nil, &latest_v1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-app.yaml"), tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		// Deploy one manifest
@@ -460,7 +460,7 @@ func TestKubectlWaitForDeletions(t *testing.T) {
 				Delay:   0 * time.Millisecond,
 				Max:     10 * time.Second,
 			},
-		}, nil, &latest.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
+		}, nil, &latest_v1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		var out bytes.Buffer
@@ -497,7 +497,7 @@ func TestKubectlWaitForDeletionsFails(t *testing.T) {
 				Delay:   10 * time.Second,
 				Max:     100 * time.Millisecond,
 			},
-		}, nil, &latest.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
+		}, nil, &latest_v1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		_, err = deployer.Deploy(context.Background(), ioutil.Discard, []graph.Artifact{
@@ -558,7 +558,7 @@ func TestDependencies(t *testing.T) {
 				Touch("00/b.yaml", "00/a.yaml").
 				Chdir()
 
-			k, err := NewDeployer(&kubectlConfig{}, nil, &latest.KubectlDeploy{Manifests: test.manifests})
+			k, err := NewDeployer(&kubectlConfig{}, nil, &latest_v1.KubectlDeploy{Manifests: test.manifests})
 			t.RequireNoError(err)
 
 			dependencies, err := k.Dependencies()
@@ -674,7 +674,7 @@ spec:
 			deployer, err := NewDeployer(&kubectlConfig{
 				workingDir:  ".",
 				defaultRepo: "gcr.io/project",
-			}, nil, &latest.KubectlDeploy{
+			}, nil, &latest_v1.KubectlDeploy{
 				Manifests: []string{tmpDir.Path("deployment.yaml")},
 			})
 			t.RequireNoError(err)
@@ -689,14 +689,14 @@ spec:
 func TestGCSManifests(t *testing.T) {
 	tests := []struct {
 		description string
-		kubectl     latest.KubectlDeploy
+		kubectl     latest_v1.KubectlDeploy
 		commands    util.Command
 		shouldErr   bool
 		skipRender  bool
 	}{
 		{
 			description: "manifest from GCS",
-			kubectl: latest.KubectlDeploy{
+			kubectl: latest_v1.KubectlDeploy{
 				Manifests: []string{"gs://dev/deployment.yaml"},
 			},
 			commands: testutil.

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -34,7 +34,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
@@ -91,7 +91,7 @@ type secretGenerator struct {
 
 // Deployer deploys workflows using kustomize CLI.
 type Deployer struct {
-	*latest.KustomizeDeploy
+	*latest_v1.KustomizeDeploy
 
 	kubectl             kubectl.CLI
 	insecureRegistries  map[string]bool
@@ -100,7 +100,7 @@ type Deployer struct {
 	useKubectlKustomize bool
 }
 
-func NewDeployer(cfg kubectl.Config, labels map[string]string, d *latest.KustomizeDeploy) (*Deployer, error) {
+func NewDeployer(cfg kubectl.Config, labels map[string]string, d *latest_v1.KustomizeDeploy) (*Deployer, error) {
 	defaultNamespace := ""
 	if d.DefaultNamespace != nil {
 		var err error

--- a/pkg/skaffold/deploy/kustomize/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -37,7 +37,7 @@ import (
 func TestKustomizeDeploy(t *testing.T) {
 	tests := []struct {
 		description                 string
-		kustomize                   latest.KustomizeDeploy
+		kustomize                   latest_v1.KustomizeDeploy
 		builds                      []graph.Artifact
 		commands                    util.Command
 		shouldErr                   bool
@@ -48,7 +48,7 @@ func TestKustomizeDeploy(t *testing.T) {
 	}{
 		{
 			description: "no manifest",
-			kustomize: latest.KustomizeDeploy{
+			kustomize: latest_v1.KustomizeDeploy{
 				KustomizePaths: []string{"."},
 			},
 			commands: testutil.
@@ -58,7 +58,7 @@ func TestKustomizeDeploy(t *testing.T) {
 		},
 		{
 			description: "deploy success",
-			kustomize: latest.KustomizeDeploy{
+			kustomize: latest_v1.KustomizeDeploy{
 				KustomizePaths: []string{"."},
 			},
 			commands: testutil.
@@ -75,7 +75,7 @@ func TestKustomizeDeploy(t *testing.T) {
 		},
 		{
 			description: "deploy success (default namespace)",
-			kustomize: latest.KustomizeDeploy{
+			kustomize: latest_v1.KustomizeDeploy{
 				KustomizePaths:   []string{"."},
 				DefaultNamespace: &kubectl.TestNamespace2,
 			},
@@ -94,7 +94,7 @@ func TestKustomizeDeploy(t *testing.T) {
 		},
 		{
 			description: "deploy success (default namespace with env template)",
-			kustomize: latest.KustomizeDeploy{
+			kustomize: latest_v1.KustomizeDeploy{
 				KustomizePaths:   []string{"."},
 				DefaultNamespace: &kubectl.TestNamespace2FromEnvTemplate,
 			},
@@ -116,7 +116,7 @@ func TestKustomizeDeploy(t *testing.T) {
 		},
 		{
 			description: "deploy success with multiple kustomizations",
-			kustomize: latest.KustomizeDeploy{
+			kustomize: latest_v1.KustomizeDeploy{
 				KustomizePaths: []string{"a", "b"},
 			},
 			commands: testutil.
@@ -140,7 +140,7 @@ func TestKustomizeDeploy(t *testing.T) {
 		},
 		{
 			description: "built-in kubectl kustomize",
-			kustomize: latest.KustomizeDeploy{
+			kustomize: latest_v1.KustomizeDeploy{
 				KustomizePaths: []string{"a", "b"},
 			},
 			commands: testutil.
@@ -200,13 +200,13 @@ func TestKustomizeCleanup(t *testing.T) {
 
 	tests := []struct {
 		description string
-		kustomize   latest.KustomizeDeploy
+		kustomize   latest_v1.KustomizeDeploy
 		commands    util.Command
 		shouldErr   bool
 	}{
 		{
 			description: "cleanup success",
-			kustomize: latest.KustomizeDeploy{
+			kustomize: latest_v1.KustomizeDeploy{
 				KustomizePaths: []string{tmpDir.Root()},
 			},
 			commands: testutil.
@@ -215,7 +215,7 @@ func TestKustomizeCleanup(t *testing.T) {
 		},
 		{
 			description: "cleanup success with multiple kustomizations",
-			kustomize: latest.KustomizeDeploy{
+			kustomize: latest_v1.KustomizeDeploy{
 				KustomizePaths: tmpDir.Paths("a", "b"),
 			},
 			commands: testutil.
@@ -225,7 +225,7 @@ func TestKustomizeCleanup(t *testing.T) {
 		},
 		{
 			description: "cleanup error",
-			kustomize: latest.KustomizeDeploy{
+			kustomize: latest_v1.KustomizeDeploy{
 				KustomizePaths: []string{tmpDir.Root()},
 			},
 			commands: testutil.
@@ -235,7 +235,7 @@ func TestKustomizeCleanup(t *testing.T) {
 		},
 		{
 			description: "fail to read manifests",
-			kustomize: latest.KustomizeDeploy{
+			kustomize: latest_v1.KustomizeDeploy{
 				KustomizePaths: []string{tmpDir.Root()},
 			},
 			commands: testutil.
@@ -454,7 +454,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 				tmpDir.Write(path, contents)
 			}
 
-			k, err := NewDeployer(&kustomizeConfig{}, nil, &latest.KustomizeDeploy{KustomizePaths: kustomizePaths})
+			k, err := NewDeployer(&kustomizeConfig{}, nil, &latest_v1.KustomizeDeploy{KustomizePaths: kustomizePaths})
 			t.RequireNoError(err)
 
 			deps, err := k.Dependencies()
@@ -698,7 +698,7 @@ spec:
 			k, err := NewDeployer(&kustomizeConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: kubectl.TestNamespace}},
-			}, test.labels, &latest.KustomizeDeploy{
+			}, test.labels, &latest_v1.KustomizeDeploy{
 				KustomizePaths: kustomizationPaths,
 			})
 			t.RequireNoError(err)

--- a/pkg/skaffold/deploy/status/status_check_test.go
+++ b/pkg/skaffold/deploy/status/status_check_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/resource"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -293,7 +293,7 @@ func TestGetDeployStatus(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			testEvent.InitializeState([]latest.Pipeline{{}})
+			testEvent.InitializeState([]latest_v1.Pipeline{{}})
 			errCode, err := getSkaffoldDeployStatus(test.counter, test.deployments)
 			t.CheckError(test.shouldErr, err)
 			if test.shouldErr {
@@ -370,7 +370,7 @@ func TestPrintSummaryStatus(t *testing.T) {
 			out := new(bytes.Buffer)
 			rc := newCounter(10)
 			rc.pending = test.pending
-			testEvent.InitializeState([]latest.Pipeline{{}})
+			testEvent.InitializeState([]latest_v1.Pipeline{{}})
 			r := withStatus(resource.NewDeployment(test.deployment, test.namespace, 0), test.ae)
 			// report status once and set it changed to false.
 			r.ReportSinceLastUpdated(false)
@@ -460,7 +460,7 @@ func TestPrintStatus(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			out := new(bytes.Buffer)
-			testEvent.InitializeState([]latest.Pipeline{{}})
+			testEvent.InitializeState([]latest_v1.Pipeline{{}})
 			checker := statusChecker{labeller: labeller}
 			actual := checker.printStatus(test.rs, out)
 			t.CheckDeepEqual(test.expectedOut, out.String())
@@ -591,7 +591,7 @@ func TestPollDeployment(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, test.command)
 			t.Override(&defaultPollPeriodInMilliseconds, 100)
-			testEvent.InitializeState([]latest.Pipeline{{}})
+			testEvent.InitializeState([]latest_v1.Pipeline{{}})
 			mockVal := mockValidator{runs: test.runs}
 			dep := test.dep.WithValidator(mockVal)
 

--- a/pkg/skaffold/deploy/types/types.go
+++ b/pkg/skaffold/deploy/types/types.go
@@ -20,13 +20,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 type Config interface {
 	docker.Config
 
-	GetPipelines() []latest.Pipeline
+	GetPipelines() []latest_v1.Pipeline
 	GetWorkingDir() string
 	GlobalConfig() string
 	ConfigurationFile() string

--- a/pkg/skaffold/diagnose/diagnose.go
+++ b/pkg/skaffold/diagnose/diagnose.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -36,8 +36,8 @@ import (
 type Config interface {
 	docker.Config
 
-	GetPipelines() []latest.Pipeline
-	Artifacts() []*latest.Artifact
+	GetPipelines() []latest_v1.Pipeline
+	Artifacts() []*latest_v1.Artifact
 }
 
 func CheckArtifacts(ctx context.Context, cfg Config, out io.Writer) error {
@@ -96,7 +96,7 @@ func CheckArtifacts(ctx context.Context, cfg Config, out io.Writer) error {
 	return nil
 }
 
-func typeOfArtifact(a *latest.Artifact) string {
+func typeOfArtifact(a *latest_v1.Artifact) string {
 	switch {
 	case a.DockerArtifact != nil:
 		return "Docker artifact"
@@ -115,7 +115,7 @@ func typeOfArtifact(a *latest.Artifact) string {
 	}
 }
 
-func timeToListDependencies(ctx context.Context, a *latest.Artifact, cfg Config) (string, []string, error) {
+func timeToListDependencies(ctx context.Context, a *latest_v1.Artifact, cfg Config) (string, []string, error) {
 	start := time.Now()
 	g := graph.ToArtifactGraph(cfg.Artifacts())
 	sourceDependencies := graph.NewTransitiveSourceDependenciesCache(cfg, nil, g)
@@ -123,7 +123,7 @@ func timeToListDependencies(ctx context.Context, a *latest.Artifact, cfg Config)
 	return util.ShowHumanizeTime(time.Since(start)), paths, err
 }
 
-func timeToConstructSyncMap(a *latest.Artifact, cfg docker.Config) (string, error) {
+func timeToConstructSyncMap(a *latest_v1.Artifact, cfg docker.Config) (string, error) {
 	start := time.Now()
 	_, err := sync.SyncMap(a, cfg)
 	return util.ShowHumanizeTime(time.Since(start)), err
@@ -138,7 +138,7 @@ func timeToComputeMTimes(deps []string) (string, error) {
 	return util.ShowHumanizeTime(time.Since(start)), nil
 }
 
-func sizeOfDockerContext(ctx context.Context, a *latest.Artifact, cfg docker.Config) (int64, error) {
+func sizeOfDockerContext(ctx context.Context, a *latest_v1.Artifact, cfg docker.Config) (int64, error) {
 	buildCtx, buildCtxWriter := io.Pipe()
 	go func() {
 		err := docker.CreateDockerTarContext(ctx, buildCtxWriter, docker.NewBuildConfig(

--- a/pkg/skaffold/diagnose/diagnose_test.go
+++ b/pkg/skaffold/diagnose/diagnose_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -61,11 +61,11 @@ func TestSizeOfDockerContext(t *testing.T) {
 				Write("Dockerfile", test.DockerfileContents).
 				WriteFiles(test.files)
 
-			dummyArtifact := &latest.Artifact{
+			dummyArtifact := &latest_v1.Artifact{
 				Workspace: tmpDir.Root(),
 				ImageName: test.artifactName,
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						DockerfilePath: "Dockerfile",
 					},
 				},
@@ -82,10 +82,10 @@ func TestCheckArtifacts(t *testing.T) {
 		tmpDir := t.NewTempDir().Write("Dockerfile", "FROM busybox")
 
 		err := CheckArtifacts(context.Background(), &mockConfig{
-			artifacts: []*latest.Artifact{{
+			artifacts: []*latest_v1.Artifact{{
 				Workspace: tmpDir.Root(),
-				ArtifactType: latest.ArtifactType{
-					DockerArtifact: &latest.DockerArtifact{
+				ArtifactType: latest_v1.ArtifactType{
+					DockerArtifact: &latest_v1.DockerArtifact{
 						DockerfilePath: "Dockerfile",
 					},
 				},
@@ -98,15 +98,15 @@ func TestCheckArtifacts(t *testing.T) {
 
 type mockConfig struct {
 	runcontext.RunContext // Embedded to provide the default values.
-	artifacts             []*latest.Artifact
+	artifacts             []*latest_v1.Artifact
 }
 
-func (c *mockConfig) PipelineForImage() latest.Pipeline {
-	var pipeline latest.Pipeline
+func (c *mockConfig) PipelineForImage() latest_v1.Pipeline {
+	var pipeline latest_v1.Pipeline
 	pipeline.Build.Artifacts = c.artifacts
 	return pipeline
 }
 
-func (c *mockConfig) Artifacts() []*latest.Artifact {
+func (c *mockConfig) Artifacts() []*latest_v1.Artifact {
 	return c.artifacts
 }

--- a/pkg/skaffold/docker/build_args.go
+++ b/pkg/skaffold/docker/build_args.go
@@ -23,7 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -96,7 +96,7 @@ type ArtifactResolver interface {
 
 // ResolveDependencyImages creates a map of artifact aliases to their built image from a required artifacts slice.
 // If `missingIsFatal` is false then it is permissive of missing entries in the ArtifactResolver and returns nil for those entries.
-func ResolveDependencyImages(deps []*latest.ArtifactDependency, r ArtifactResolver, missingIsFatal bool) map[string]*string {
+func ResolveDependencyImages(deps []*latest_v1.ArtifactDependency, r ArtifactResolver, missingIsFatal bool) map[string]*string {
 	if r == nil {
 		// `diagnose` is called without an artifact resolver. Return an empty map in this case.
 		return nil

--- a/pkg/skaffold/docker/build_args_test.go
+++ b/pkg/skaffold/docker/build_args_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -201,7 +201,7 @@ FROM bar1`,
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			artifact := &latest.DockerArtifact{
+			artifact := &latest_v1.DockerArtifact{
 				DockerfilePath: "Dockerfile",
 				BuildArgs:      test.buildArgs,
 			}
@@ -221,20 +221,20 @@ func TestCreateBuildArgsFromArtifacts(t *testing.T) {
 	tests := []struct {
 		description string
 		r           ArtifactResolver
-		deps        []*latest.ArtifactDependency
+		deps        []*latest_v1.ArtifactDependency
 		args        map[string]*string
 	}{
 		{
 			description: "can resolve artifacts",
 			r:           mockArtifactResolver{m: map[string]string{"img1": "tag1", "img2": "tag2", "img3": "tag3", "img4": "tag4"}},
-			deps:        []*latest.ArtifactDependency{{ImageName: "img3", Alias: "alias3"}, {ImageName: "img4", Alias: "alias4"}},
+			deps:        []*latest_v1.ArtifactDependency{{ImageName: "img3", Alias: "alias3"}, {ImageName: "img4", Alias: "alias4"}},
 			args:        map[string]*string{"alias3": util.StringPtr("tag3"), "alias4": util.StringPtr("tag4")},
 		},
 		{
 			description: "cannot resolve artifacts",
 			r:           mockArtifactResolver{m: make(map[string]string)},
 			args:        map[string]*string{"alias3": nil, "alias4": nil},
-			deps:        []*latest.ArtifactDependency{{ImageName: "img3", Alias: "alias3"}, {ImageName: "img4", Alias: "alias4"}},
+			deps:        []*latest_v1.ArtifactDependency{{ImageName: "img3", Alias: "alias3"}, {ImageName: "img4", Alias: "alias4"}},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/docker/context_test.go
+++ b/pkg/skaffold/docker/context_test.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -40,7 +40,7 @@ func TestDockerContext(t *testing.T) {
 				Touch(dir + "/alsoignored.txt").
 				Chdir()
 
-			artifact := &latest.DockerArtifact{
+			artifact := &latest_v1.DockerArtifact{
 				DockerfilePath: "Dockerfile",
 			}
 

--- a/pkg/skaffold/docker/docker_init.go
+++ b/pkg/skaffold/docker/docker_init.go
@@ -25,7 +25,7 @@ import (
 	"github.com/moby/buildkit/frontend/dockerfile/parser"
 	"github.com/sirupsen/logrus"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // For testing
@@ -52,7 +52,7 @@ func (c ArtifactConfig) Describe() string {
 }
 
 // ArtifactType returns the type of the artifact to be built.
-func (c ArtifactConfig) ArtifactType(workspace string) latest.ArtifactType {
+func (c ArtifactConfig) ArtifactType(workspace string) latest_v1.ArtifactType {
 	dockerfile := filepath.Base(c.File)
 	if workspace != "" {
 		// attempt to relativize the path
@@ -61,8 +61,8 @@ func (c ArtifactConfig) ArtifactType(workspace string) latest.ArtifactType {
 		}
 	}
 
-	return latest.ArtifactType{
-		DockerArtifact: &latest.DockerArtifact{
+	return latest_v1.ArtifactType{
+		DockerArtifact: &latest_v1.DockerArtifact{
 			// to make skaffold.yaml more portable across OS-es we should always generate /-delimited filePaths
 			DockerfilePath: filepath.ToSlash(dockerfile),
 		},

--- a/pkg/skaffold/docker/docker_init_test.go
+++ b/pkg/skaffold/docker/docker_init_test.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -91,13 +91,13 @@ func TestArtifactType(t *testing.T) {
 		description  string
 		workspace    string
 		config       ArtifactConfig
-		expectedType latest.ArtifactType
+		expectedType latest_v1.ArtifactType
 	}{
 		{
 			description: "default filename",
 			config:      ArtifactConfig{File: filepath.Join("path", "to", "Dockerfile")},
-			expectedType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{
+			expectedType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{
 					DockerfilePath: "Dockerfile",
 				},
 			},
@@ -105,8 +105,8 @@ func TestArtifactType(t *testing.T) {
 		{
 			description: "non-default filename",
 			config:      ArtifactConfig{File: filepath.Join("path", "to", "Dockerfile1")},
-			expectedType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{
+			expectedType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{
 					DockerfilePath: "Dockerfile1",
 				},
 			},
@@ -115,8 +115,8 @@ func TestArtifactType(t *testing.T) {
 			description: "with workspace",
 			config:      ArtifactConfig{File: filepath.Join("path", "to", "Dockerfile")},
 			workspace:   "path",
-			expectedType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{
+			expectedType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{
 					DockerfilePath: "to/Dockerfile",
 				},
 			},

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -40,7 +40,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -64,7 +64,7 @@ type LocalDaemon interface {
 	ExtraEnv() []string
 	ServerVersion(ctx context.Context) (types.Version, error)
 	ConfigFile(ctx context.Context, image string) (*v1.ConfigFile, error)
-	Build(ctx context.Context, out io.Writer, workspace string, artifact string, a *latest.DockerArtifact, opts BuildOptions) (string, error)
+	Build(ctx context.Context, out io.Writer, workspace string, artifact string, a *latest_v1.DockerArtifact, opts BuildOptions) (string, error)
 	Push(ctx context.Context, out io.Writer, ref string) (string, error)
 	Pull(ctx context.Context, out io.Writer, ref string) error
 	Load(ctx context.Context, out io.Writer, input io.Reader, ref string) (string, error)
@@ -166,7 +166,7 @@ func (l *localDaemon) ConfigFile(ctx context.Context, image string) (*v1.ConfigF
 	return cfg, nil
 }
 
-func (l *localDaemon) CheckCompatible(a *latest.DockerArtifact) error {
+func (l *localDaemon) CheckCompatible(a *latest_v1.DockerArtifact) error {
 	if a.Secret != nil || a.SSH != "" {
 		return fmt.Errorf("docker build options, secrets and ssh, require BuildKit - set `useBuildkit: true` in your config, or run with `DOCKER_BUILDKIT=1`")
 	}
@@ -174,7 +174,7 @@ func (l *localDaemon) CheckCompatible(a *latest.DockerArtifact) error {
 }
 
 // Build performs a docker build and returns the imageID.
-func (l *localDaemon) Build(ctx context.Context, out io.Writer, workspace string, artifact string, a *latest.DockerArtifact, opts BuildOptions) (string, error) {
+func (l *localDaemon) Build(ctx context.Context, out io.Writer, workspace string, artifact string, a *latest_v1.DockerArtifact, opts BuildOptions) (string, error) {
 	logrus.Debugf("Running docker build: context: %s, dockerfile: %s", workspace, a.DockerfilePath)
 
 	if err := l.CheckCompatible(a); err != nil {
@@ -463,7 +463,7 @@ func (l *localDaemon) DiskUsage(ctx context.Context) (uint64, error) {
 	return uint64(usage.LayersSize), nil
 }
 
-func ToCLIBuildArgs(a *latest.DockerArtifact, evaluatedArgs map[string]*string) ([]string, error) {
+func ToCLIBuildArgs(a *latest_v1.DockerArtifact, evaluatedArgs map[string]*string) ([]string, error) {
 	var args []string
 	var keys []string
 	for k := range evaluatedArgs {

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -104,7 +104,7 @@ func TestBuild(t *testing.T) {
 		env           map[string]string
 		api           *testutil.FakeAPIClient
 		workspace     string
-		artifact      *latest.DockerArtifact
+		artifact      *latest_v1.DockerArtifact
 		expected      types.ImageBuildOptions
 		mode          config.RunMode
 		shouldErr     bool
@@ -114,7 +114,7 @@ func TestBuild(t *testing.T) {
 			description: "build",
 			api:         &testutil.FakeAPIClient{},
 			workspace:   ".",
-			artifact:    &latest.DockerArtifact{},
+			artifact:    &latest_v1.DockerArtifact{},
 			expected: types.ImageBuildOptions{
 				Tags:        []string{"finalimage"},
 				AuthConfigs: allAuthConfig,
@@ -128,7 +128,7 @@ func TestBuild(t *testing.T) {
 				"VALUE3": "value3",
 			},
 			workspace: ".",
-			artifact: &latest.DockerArtifact{
+			artifact: &latest_v1.DockerArtifact{
 				DockerfilePath: "Dockerfile",
 				BuildArgs: map[string]*string{
 					"k1": nil,
@@ -163,7 +163,7 @@ func TestBuild(t *testing.T) {
 			},
 			mode:          config.RunModes.Dev,
 			workspace:     ".",
-			artifact:      &latest.DockerArtifact{},
+			artifact:      &latest_v1.DockerArtifact{},
 			shouldErr:     true,
 			expectedError: "docker build",
 		},
@@ -174,13 +174,13 @@ func TestBuild(t *testing.T) {
 			},
 			workspace:     ".",
 			mode:          config.RunModes.Dev,
-			artifact:      &latest.DockerArtifact{},
+			artifact:      &latest_v1.DockerArtifact{},
 			shouldErr:     true,
 			expectedError: "unable to stream build output",
 		},
 		{
 			description: "bad build arg template",
-			artifact: &latest.DockerArtifact{
+			artifact: &latest_v1.DockerArtifact{
 				BuildArgs: map[string]*string{
 					"key": util.StringPtr("{{INVALID"),
 				},
@@ -268,14 +268,14 @@ func TestImageID(t *testing.T) {
 func TestGetBuildArgs(t *testing.T) {
 	tests := []struct {
 		description string
-		artifact    *latest.DockerArtifact
+		artifact    *latest_v1.DockerArtifact
 		env         []string
 		want        []string
 		shouldErr   bool
 	}{
 		{
 			description: "build args",
-			artifact: &latest.DockerArtifact{
+			artifact: &latest_v1.DockerArtifact{
 				BuildArgs: map[string]*string{
 					"key1": util.StringPtr("value1"),
 					"key2": nil,
@@ -287,7 +287,7 @@ func TestGetBuildArgs(t *testing.T) {
 		},
 		{
 			description: "invalid build arg",
-			artifact: &latest.DockerArtifact{
+			artifact: &latest_v1.DockerArtifact{
 				BuildArgs: map[string]*string{
 					"key": util.StringPtr("{{INVALID"),
 				},
@@ -296,50 +296,50 @@ func TestGetBuildArgs(t *testing.T) {
 		},
 		{
 			description: "add host",
-			artifact: &latest.DockerArtifact{
+			artifact: &latest_v1.DockerArtifact{
 				AddHost: []string{"1.gcr.io:127.0.0.1", "2.gcr.io:127.0.0.1"},
 			},
 			want: []string{"--add-host", "1.gcr.io:127.0.0.1", "--add-host", "2.gcr.io:127.0.0.1"},
 		},
 		{
 			description: "cache from",
-			artifact: &latest.DockerArtifact{
+			artifact: &latest_v1.DockerArtifact{
 				CacheFrom: []string{"gcr.io/foo/bar", "baz:latest"},
 			},
 			want: []string{"--cache-from", "gcr.io/foo/bar", "--cache-from", "baz:latest"},
 		},
 		{
 			description: "target",
-			artifact: &latest.DockerArtifact{
+			artifact: &latest_v1.DockerArtifact{
 				Target: "stage1",
 			},
 			want: []string{"--target", "stage1"},
 		},
 		{
 			description: "network mode",
-			artifact: &latest.DockerArtifact{
+			artifact: &latest_v1.DockerArtifact{
 				NetworkMode: "Bridge",
 			},
 			want: []string{"--network", "bridge"},
 		},
 		{
 			description: "no-cache",
-			artifact: &latest.DockerArtifact{
+			artifact: &latest_v1.DockerArtifact{
 				NoCache: true,
 			},
 			want: []string{"--no-cache"},
 		},
 		{
 			description: "squash",
-			artifact: &latest.DockerArtifact{
+			artifact: &latest_v1.DockerArtifact{
 				Squash: true,
 			},
 			want: []string{"--squash"},
 		},
 		{
 			description: "secret with no source",
-			artifact: &latest.DockerArtifact{
-				Secret: &latest.DockerSecret{
+			artifact: &latest_v1.DockerArtifact{
+				Secret: &latest_v1.DockerSecret{
 					ID: "mysecret",
 				},
 			},
@@ -347,8 +347,8 @@ func TestGetBuildArgs(t *testing.T) {
 		},
 		{
 			description: "secret with source",
-			artifact: &latest.DockerArtifact{
-				Secret: &latest.DockerSecret{
+			artifact: &latest_v1.DockerArtifact{
+				Secret: &latest_v1.DockerSecret{
 					ID:     "mysecret",
 					Source: "foo.src",
 				},
@@ -357,8 +357,8 @@ func TestGetBuildArgs(t *testing.T) {
 		},
 		{
 			description: "secret with destination",
-			artifact: &latest.DockerArtifact{
-				Secret: &latest.DockerSecret{
+			artifact: &latest_v1.DockerArtifact{
+				Secret: &latest_v1.DockerSecret{
 					ID:          "mysecret",
 					Destination: "foo.dst",
 				},
@@ -367,8 +367,8 @@ func TestGetBuildArgs(t *testing.T) {
 		},
 		{
 			description: "secret with source and destination",
-			artifact: &latest.DockerArtifact{
-				Secret: &latest.DockerSecret{
+			artifact: &latest_v1.DockerArtifact{
+				Secret: &latest_v1.DockerSecret{
 					ID:          "mysecret",
 					Source:      "foo.src",
 					Destination: "foo.dst",
@@ -378,14 +378,14 @@ func TestGetBuildArgs(t *testing.T) {
 		},
 		{
 			description: "ssh with no source",
-			artifact: &latest.DockerArtifact{
+			artifact: &latest_v1.DockerArtifact{
 				SSH: "default",
 			},
 			want: []string{"--ssh", "default"},
 		},
 		{
 			description: "all",
-			artifact: &latest.DockerArtifact{
+			artifact: &latest_v1.DockerArtifact{
 				BuildArgs: map[string]*string{
 					"key1": util.StringPtr("value1"),
 				},

--- a/pkg/skaffold/event/config.go
+++ b/pkg/skaffold/event/config.go
@@ -17,7 +17,7 @@ limitations under the License.
 package event
 
 import (
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 type Config interface {
@@ -25,5 +25,5 @@ type Config interface {
 	AutoBuild() bool
 	AutoDeploy() bool
 	AutoSync() bool
-	GetPipelines() []latest.Pipeline
+	GetPipelines() []latest_v1.Pipeline
 }

--- a/pkg/skaffold/event/event_test.go
+++ b/pkg/skaffold/event/event_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -68,7 +68,7 @@ func TestGetLogEvents(t *testing.T) {
 
 func TestGetState(t *testing.T) {
 	ev := newHandler()
-	ev.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	ev.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	ev.stateLock.Lock()
 	ev.state.BuildState.Artifacts["img"] = Complete
@@ -83,7 +83,7 @@ func TestDeployInProgress(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().DeployState.Status == NotStarted })
 	DeployInProgress()
@@ -94,7 +94,7 @@ func TestDeployFailed(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().DeployState.Status == NotStarted })
 	DeployFailed(errors.New("BUG"))
@@ -108,7 +108,7 @@ func TestDeployComplete(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().DeployState.Status == NotStarted })
 	DeployComplete()
@@ -122,7 +122,7 @@ func TestTestInProgress(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().TestState.Status == NotStarted })
 	TestInProgress()
@@ -133,7 +133,7 @@ func TestTestFailed(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().TestState.Status == NotStarted })
 	TestFailed("img", errors.New("BUG"))
@@ -148,7 +148,7 @@ func TestTestComplete(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().TestState.Status == NotStarted })
 	TestComplete()
@@ -159,8 +159,8 @@ func TestBuildInProgress(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{Build: latest.BuildConfig{
-		Artifacts: []*latest.Artifact{{
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{Build: latest_v1.BuildConfig{
+		Artifacts: []*latest_v1.Artifact{{
 			ImageName: "img",
 		}},
 	}}}, "test"))
@@ -174,8 +174,8 @@ func TestBuildFailed(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{Build: latest.BuildConfig{
-		Artifacts: []*latest.Artifact{{
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{Build: latest_v1.BuildConfig{
+		Artifacts: []*latest_v1.Artifact{{
 			ImageName: "img",
 		}},
 	}}}, "test"))
@@ -192,8 +192,8 @@ func TestBuildComplete(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{Build: latest.BuildConfig{
-		Artifacts: []*latest.Artifact{{
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{Build: latest_v1.BuildConfig{
+		Artifacts: []*latest_v1.Artifact{{
 			ImageName: "img",
 		}},
 	}}}, "test"))
@@ -207,7 +207,7 @@ func TestPortForwarded(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().ForwardedPorts[8080] == nil })
 	PortForwarded(8080, schemautil.FromInt(8888), "pod", "container", "ns", "portname", "resourceType", "resourceName", "127.0.0.1")
@@ -226,7 +226,7 @@ func TestPortForwarded_handleNil(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 	handler.setState(handler.getState())
 
 	if handler.getState().ForwardedPorts != nil {
@@ -240,7 +240,7 @@ func TestStatusCheckEventStarted(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
 	StatusCheckEventStarted()
@@ -251,7 +251,7 @@ func TestStatusCheckEventInProgress(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
 	StatusCheckEventInProgress("[2/5 deployment(s) are still pending]")
@@ -262,7 +262,7 @@ func TestStatusCheckEventSucceeded(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
 	statusCheckEventSucceeded()
@@ -273,7 +273,7 @@ func TestStatusCheckEventFailed(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
 	StatusCheckEventEnded(proto.StatusCode_STATUSCHECK_FAILED_SCHEDULING, errors.New("one or more deployments failed"))
@@ -287,7 +287,7 @@ func TestResourceStatusCheckEventUpdated(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
 	ResourceStatusCheckEventUpdated("ns:pod/foo", proto.ActionableErr{
@@ -301,7 +301,7 @@ func TestResourceStatusCheckEventSucceeded(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
 	resourceStatusCheckEventSucceeded("ns:pod/foo")
@@ -312,7 +312,7 @@ func TestResourceStatusCheckEventFailed(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
 	resourceStatusCheckEventFailed("ns:pod/foo", proto.ActionableErr{
@@ -326,7 +326,7 @@ func TestFileSyncInProgress(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().FileSyncState.Status == NotStarted })
 	FileSyncInProgress(5, "image")
@@ -337,7 +337,7 @@ func TestFileSyncFailed(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().FileSyncState.Status == NotStarted })
 	FileSyncFailed(5, "image", errors.New("BUG"))
@@ -348,7 +348,7 @@ func TestFileSyncSucceeded(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	wait(t, func() bool { return handler.getState().FileSyncState.Status == NotStarted })
 	FileSyncSucceeded(5, "image")
@@ -359,7 +359,7 @@ func TestDebuggingContainer(t *testing.T) {
 	defer func() { handler = newHandler() }()
 
 	handler = newHandler()
-	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	found := func() bool {
 		for _, dc := range handler.getState().DebuggingContainers {
@@ -670,17 +670,17 @@ func TestSaveEventsToFile(t *testing.T) {
 }
 
 type config struct {
-	pipes   []latest.Pipeline
+	pipes   []latest_v1.Pipeline
 	kubectx string
 }
 
-func (c config) GetKubeContext() string          { return c.kubectx }
-func (c config) AutoBuild() bool                 { return true }
-func (c config) AutoDeploy() bool                { return true }
-func (c config) AutoSync() bool                  { return true }
-func (c config) GetPipelines() []latest.Pipeline { return c.pipes }
+func (c config) GetKubeContext() string             { return c.kubectx }
+func (c config) AutoBuild() bool                    { return true }
+func (c config) AutoDeploy() bool                   { return true }
+func (c config) AutoSync() bool                     { return true }
+func (c config) GetPipelines() []latest_v1.Pipeline { return c.pipes }
 
-func mockCfg(pipes []latest.Pipeline, kubectx string) config {
+func mockCfg(pipes []latest_v1.Pipeline, kubectx string) config {
 	return config{
 		pipes:   pipes,
 		kubectx: kubectx,

--- a/pkg/skaffold/event/util.go
+++ b/pkg/skaffold/event/util.go
@@ -19,11 +19,11 @@ package event
 import (
 	"strings"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 )
 
-func initializeMetadata(pipelines []latest.Pipeline, kubeContext string) *proto.Metadata {
+func initializeMetadata(pipelines []latest_v1.Pipeline, kubeContext string) *proto.Metadata {
 	artifactCount := 0
 	for _, p := range pipelines {
 		artifactCount += len(p.Build.Artifacts)
@@ -67,7 +67,7 @@ func initializeMetadata(pipelines []latest.Pipeline, kubeContext string) *proto.
 	return m
 }
 
-func getBuilders(b latest.BuildConfig) []*proto.BuildMetadata_ImageBuilder {
+func getBuilders(b latest_v1.BuildConfig) []*proto.BuildMetadata_ImageBuilder {
 	m := map[proto.BuilderType]int{}
 	for _, a := range b.Artifacts {
 		switch {
@@ -96,7 +96,7 @@ func getBuilders(b latest.BuildConfig) []*proto.BuildMetadata_ImageBuilder {
 	return builders
 }
 
-func getDeploy(d latest.DeployConfig) []*proto.DeployMetadata_Deployer {
+func getDeploy(d latest_v1.DeployConfig) []*proto.DeployMetadata_Deployer {
 	var deployers []*proto.DeployMetadata_Deployer
 
 	if d.HelmDeploy != nil {

--- a/pkg/skaffold/event/util_test.go
+++ b/pkg/skaffold/event/util_test.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -28,21 +28,21 @@ import (
 func TestEmptyState(t *testing.T) {
 	tests := []struct {
 		description string
-		cfg         latest.Pipeline
+		cfg         latest_v1.Pipeline
 		cluster     string
 		expected    *proto.Metadata
 	}{
 		{
 			description: "one build artifact minikube cluster multiple deployers",
-			cfg: latest.Pipeline{
-				Build: latest.BuildConfig{
-					BuildType: latest.BuildType{LocalBuild: &latest.LocalBuild{}},
-					Artifacts: []*latest.Artifact{{ImageName: "img", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}}},
+			cfg: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					BuildType: latest_v1.BuildType{LocalBuild: &latest_v1.LocalBuild{}},
+					Artifacts: []*latest_v1.Artifact{{ImageName: "img", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}}},
 				},
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KubectlDeploy: &latest.KubectlDeploy{},
-						HelmDeploy:    &latest.HelmDeploy{Releases: []latest.HelmRelease{{Name: "first"}, {Name: "second"}}},
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						KubectlDeploy: &latest_v1.KubectlDeploy{},
+						HelmDeploy:    &latest_v1.HelmDeploy{Releases: []latest_v1.HelmRelease{{Name: "first"}, {Name: "second"}}},
 					},
 				},
 			},
@@ -63,18 +63,18 @@ func TestEmptyState(t *testing.T) {
 		},
 		{
 			description: "multiple artifacts of different types gke cluster 1 deployer ",
-			cfg: latest.Pipeline{
-				Build: latest.BuildConfig{
-					BuildType: latest.BuildType{Cluster: &latest.ClusterDetails{}},
-					Artifacts: []*latest.Artifact{
-						{ImageName: "img1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
-						{ImageName: "img2", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
-						{ImageName: "img3", ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{}}},
+			cfg: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					BuildType: latest_v1.BuildType{Cluster: &latest_v1.ClusterDetails{}},
+					Artifacts: []*latest_v1.Artifact{
+						{ImageName: "img1", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}},
+						{ImageName: "img2", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}},
+						{ImageName: "img3", ArtifactType: latest_v1.ArtifactType{JibArtifact: &latest_v1.JibArtifact{}}},
 					},
 				},
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KustomizeDeploy: &latest.KustomizeDeploy{},
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						KustomizeDeploy: &latest_v1.KustomizeDeploy{},
 					},
 				},
 			},
@@ -95,11 +95,11 @@ func TestEmptyState(t *testing.T) {
 		},
 		{
 			description: "no deployer, kaniko artifact, GCB build",
-			cfg: latest.Pipeline{
-				Build: latest.BuildConfig{
-					BuildType: latest.BuildType{GoogleCloudBuild: &latest.GoogleCloudBuild{}},
-					Artifacts: []*latest.Artifact{
-						{ImageName: "img1", ArtifactType: latest.ArtifactType{KanikoArtifact: &latest.KanikoArtifact{}}},
+			cfg: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					BuildType: latest_v1.BuildType{GoogleCloudBuild: &latest_v1.GoogleCloudBuild{}},
+					Artifacts: []*latest_v1.Artifact{
+						{ImageName: "img1", ArtifactType: latest_v1.ArtifactType{KanikoArtifact: &latest_v1.KanikoArtifact{}}},
 					},
 				},
 			},
@@ -115,10 +115,10 @@ func TestEmptyState(t *testing.T) {
 		},
 		{
 			description: "no build, kustomize deployer other cluster",
-			cfg: latest.Pipeline{
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KustomizeDeploy: &latest.KustomizeDeploy{},
+			cfg: latest_v1.Pipeline{
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						KustomizeDeploy: &latest_v1.KustomizeDeploy{},
 					},
 				},
 			},
@@ -135,7 +135,7 @@ func TestEmptyState(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			handler = &eventHandler{
-				state: emptyState(mockCfg([]latest.Pipeline{test.cfg}, test.cluster)),
+				state: emptyState(mockCfg([]latest_v1.Pipeline{test.cfg}, test.cluster)),
 			}
 			metadata := handler.state.Metadata
 			builders := metadata.Build.Builders

--- a/pkg/skaffold/event/v2/event_test.go
+++ b/pkg/skaffold/event/v2/event_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -77,7 +77,7 @@ func TestGetLogEvents(t *testing.T) {
 
 func TestGetState(t *testing.T) {
 	ev := newHandler()
-	ev.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	ev.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
 
 	ev.stateLock.Lock()
 	ev.state.BuildState.Artifacts["img"] = Complete
@@ -413,17 +413,17 @@ func TestSaveEventsToFile(t *testing.T) {
 }
 
 type config struct {
-	pipes   []latest.Pipeline
+	pipes   []latest_v1.Pipeline
 	kubectx string
 }
 
-func (c config) GetKubeContext() string          { return c.kubectx }
-func (c config) AutoBuild() bool                 { return true }
-func (c config) AutoDeploy() bool                { return true }
-func (c config) AutoSync() bool                  { return true }
-func (c config) GetPipelines() []latest.Pipeline { return c.pipes }
+func (c config) GetKubeContext() string             { return c.kubectx }
+func (c config) AutoBuild() bool                    { return true }
+func (c config) AutoDeploy() bool                   { return true }
+func (c config) AutoSync() bool                     { return true }
+func (c config) GetPipelines() []latest_v1.Pipeline { return c.pipes }
 
-func mockCfg(pipes []latest.Pipeline, kubectx string) config {
+func mockCfg(pipes []latest_v1.Pipeline, kubectx string) config {
 	return config{
 		pipes:   pipes,
 		kubectx: kubectx,

--- a/pkg/skaffold/event/v2/util.go
+++ b/pkg/skaffold/event/v2/util.go
@@ -19,11 +19,11 @@ package v2
 import (
 	"strings"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
 )
 
-func initializeMetadata(pipelines []latest.Pipeline, kubeContext string) *proto.Metadata {
+func initializeMetadata(pipelines []latest_v1.Pipeline, kubeContext string) *proto.Metadata {
 	artifactCount := 0
 	for _, p := range pipelines {
 		artifactCount += len(p.Build.Artifacts)
@@ -67,7 +67,7 @@ func initializeMetadata(pipelines []latest.Pipeline, kubeContext string) *proto.
 	return m
 }
 
-func getBuilders(b latest.BuildConfig) []*proto.BuildMetadata_ImageBuilder {
+func getBuilders(b latest_v1.BuildConfig) []*proto.BuildMetadata_ImageBuilder {
 	m := map[proto.BuilderType]int{}
 	for _, a := range b.Artifacts {
 		switch {
@@ -96,7 +96,7 @@ func getBuilders(b latest.BuildConfig) []*proto.BuildMetadata_ImageBuilder {
 	return builders
 }
 
-func getDeploy(d latest.DeployConfig) []*proto.DeployMetadata_Deployer {
+func getDeploy(d latest_v1.DeployConfig) []*proto.DeployMetadata_Deployer {
 	var deployers []*proto.DeployMetadata_Deployer
 
 	if d.HelmDeploy != nil {

--- a/pkg/skaffold/event/v2/util_test.go
+++ b/pkg/skaffold/event/v2/util_test.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -28,21 +28,21 @@ import (
 func TestEmptyState(t *testing.T) {
 	tests := []struct {
 		description string
-		cfg         latest.Pipeline
+		cfg         latest_v1.Pipeline
 		cluster     string
 		expected    *proto.Metadata
 	}{
 		{
 			description: "one build artifact minikube cluster multiple deployers",
-			cfg: latest.Pipeline{
-				Build: latest.BuildConfig{
-					BuildType: latest.BuildType{LocalBuild: &latest.LocalBuild{}},
-					Artifacts: []*latest.Artifact{{ImageName: "img", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}}},
+			cfg: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					BuildType: latest_v1.BuildType{LocalBuild: &latest_v1.LocalBuild{}},
+					Artifacts: []*latest_v1.Artifact{{ImageName: "img", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}}},
 				},
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KubectlDeploy: &latest.KubectlDeploy{},
-						HelmDeploy:    &latest.HelmDeploy{Releases: []latest.HelmRelease{{Name: "first"}, {Name: "second"}}},
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						KubectlDeploy: &latest_v1.KubectlDeploy{},
+						HelmDeploy:    &latest_v1.HelmDeploy{Releases: []latest_v1.HelmRelease{{Name: "first"}, {Name: "second"}}},
 					},
 				},
 			},
@@ -63,18 +63,18 @@ func TestEmptyState(t *testing.T) {
 		},
 		{
 			description: "multiple artifacts of different types gke cluster 1 deployer ",
-			cfg: latest.Pipeline{
-				Build: latest.BuildConfig{
-					BuildType: latest.BuildType{Cluster: &latest.ClusterDetails{}},
-					Artifacts: []*latest.Artifact{
-						{ImageName: "img1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
-						{ImageName: "img2", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
-						{ImageName: "img3", ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{}}},
+			cfg: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					BuildType: latest_v1.BuildType{Cluster: &latest_v1.ClusterDetails{}},
+					Artifacts: []*latest_v1.Artifact{
+						{ImageName: "img1", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}},
+						{ImageName: "img2", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}},
+						{ImageName: "img3", ArtifactType: latest_v1.ArtifactType{JibArtifact: &latest_v1.JibArtifact{}}},
 					},
 				},
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KustomizeDeploy: &latest.KustomizeDeploy{},
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						KustomizeDeploy: &latest_v1.KustomizeDeploy{},
 					},
 				},
 			},
@@ -95,11 +95,11 @@ func TestEmptyState(t *testing.T) {
 		},
 		{
 			description: "no deployer, kaniko artifact, GCB build",
-			cfg: latest.Pipeline{
-				Build: latest.BuildConfig{
-					BuildType: latest.BuildType{GoogleCloudBuild: &latest.GoogleCloudBuild{}},
-					Artifacts: []*latest.Artifact{
-						{ImageName: "img1", ArtifactType: latest.ArtifactType{KanikoArtifact: &latest.KanikoArtifact{}}},
+			cfg: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					BuildType: latest_v1.BuildType{GoogleCloudBuild: &latest_v1.GoogleCloudBuild{}},
+					Artifacts: []*latest_v1.Artifact{
+						{ImageName: "img1", ArtifactType: latest_v1.ArtifactType{KanikoArtifact: &latest_v1.KanikoArtifact{}}},
 					},
 				},
 			},
@@ -115,10 +115,10 @@ func TestEmptyState(t *testing.T) {
 		},
 		{
 			description: "no build, kustomize deployer other cluster",
-			cfg: latest.Pipeline{
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KustomizeDeploy: &latest.KustomizeDeploy{},
+			cfg: latest_v1.Pipeline{
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						KustomizeDeploy: &latest_v1.KustomizeDeploy{},
 					},
 				},
 			},
@@ -135,7 +135,7 @@ func TestEmptyState(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			handler = &eventHandler{
-				state: emptyState(mockCfg([]latest.Pipeline{test.cfg}, test.cluster)),
+				state: emptyState(mockCfg([]latest_v1.Pipeline{test.cfg}, test.cluster)),
 			}
 			metadata := handler.state.Metadata
 			builders := metadata.Build.Builders

--- a/pkg/skaffold/generate_pipeline/generate_pipeline.go
+++ b/pkg/skaffold/generate_pipeline/generate_pipeline.go
@@ -30,14 +30,14 @@ import (
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/pipeline"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // ConfigFile keeps track of config files and their corresponding SkaffoldConfigs and generated Profiles
 type ConfigFile struct {
 	Path    string
-	Config  *latest.SkaffoldConfig
-	Profile *latest.Profile
+	Config  *latest_v1.SkaffoldConfig
+	Profile *latest_v1.Profile
 }
 
 func Yaml(out io.Writer, namespace string, configFiles []*ConfigFile) (*bytes.Buffer, error) {

--- a/pkg/skaffold/generate_pipeline/profile.go
+++ b/pkg/skaffold/generate_pipeline/profile.go
@@ -28,7 +28,7 @@ import (
 	yamlv2 "gopkg.in/yaml.v2"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 func CreateSkaffoldProfile(out io.Writer, namespace string, configFile *ConfigFile) error {
@@ -67,7 +67,7 @@ confirmLoop:
 		return fmt.Errorf("generating profile \"oncluster\": %w", err)
 	}
 
-	bProfile, err := yamlv2.Marshal([]*latest.Profile{profile})
+	bProfile, err := yamlv2.Marshal([]*latest_v1.Profile{profile})
 	if err != nil {
 		return fmt.Errorf("marshaling new profile: %w", err)
 	}
@@ -105,16 +105,16 @@ confirmLoop:
 	return nil
 }
 
-func generateProfile(out io.Writer, namespace string, config *latest.SkaffoldConfig) (*latest.Profile, error) {
+func generateProfile(out io.Writer, namespace string, config *latest_v1.SkaffoldConfig) (*latest_v1.Profile, error) {
 	if len(config.Build.Artifacts) == 0 {
 		return nil, errors.New("no Artifacts to add to profile")
 	}
 
-	profile := &latest.Profile{
+	profile := &latest_v1.Profile{
 		Name: "oncluster",
-		Pipeline: latest.Pipeline{
+		Pipeline: latest_v1.Pipeline{
 			Build:  config.Pipeline.Build,
-			Deploy: latest.DeployConfig{},
+			Deploy: latest_v1.DeployConfig{},
 		},
 	}
 
@@ -125,20 +125,20 @@ func generateProfile(out io.Writer, namespace string, config *latest.SkaffoldCon
 		if artifact.DockerArtifact != nil {
 			color.Default.Fprintf(out, "Cannot use Docker to build %s on cluster. Adding config for building with Kaniko.\n", artifact.ImageName)
 			artifact.DockerArtifact = nil
-			artifact.KanikoArtifact = &latest.KanikoArtifact{}
+			artifact.KanikoArtifact = &latest_v1.KanikoArtifact{}
 			addKaniko = true
 		}
 	}
 	// Add kaniko config to build config if needed
 	if addKaniko {
-		profile.Build.Cluster = &latest.ClusterDetails{
+		profile.Build.Cluster = &latest_v1.ClusterDetails{
 			PullSecretName: "kaniko-secret",
 		}
 		profile.Build.LocalBuild = nil
 	}
 	if namespace != "" {
 		if profile.Build.Cluster == nil {
-			profile.Build.Cluster = &latest.ClusterDetails{}
+			profile.Build.Cluster = &latest_v1.ClusterDetails{}
 		}
 		profile.Build.Cluster.Namespace = namespace
 	}

--- a/pkg/skaffold/generate_pipeline/profile_test.go
+++ b/pkg/skaffold/generate_pipeline/profile_test.go
@@ -20,29 +20,29 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestGenerateProfile(t *testing.T) {
 	var tests = []struct {
 		description     string
-		skaffoldConfig  *latest.SkaffoldConfig
-		expectedProfile *latest.Profile
+		skaffoldConfig  *latest_v1.SkaffoldConfig
+		expectedProfile *latest_v1.Profile
 		responses       []string
 		namespace       string
 		shouldErr       bool
 	}{
 		{
 			description: "successful profile generation docker",
-			skaffoldConfig: &latest.SkaffoldConfig{
-				Pipeline: latest.Pipeline{
-					Build: latest.BuildConfig{
-						Artifacts: []*latest.Artifact{
+			skaffoldConfig: &latest_v1.SkaffoldConfig{
+				Pipeline: latest_v1.Pipeline{
+					Build: latest_v1.BuildConfig{
+						Artifacts: []*latest_v1.Artifact{
 							{
 								ImageName: "test",
-								ArtifactType: latest.ArtifactType{
-									DockerArtifact: &latest.DockerArtifact{},
+								ArtifactType: latest_v1.ArtifactType{
+									DockerArtifact: &latest_v1.DockerArtifact{},
 								},
 							},
 						},
@@ -50,20 +50,20 @@ func TestGenerateProfile(t *testing.T) {
 				},
 			},
 			namespace: "",
-			expectedProfile: &latest.Profile{
+			expectedProfile: &latest_v1.Profile{
 				Name: "oncluster",
-				Pipeline: latest.Pipeline{
-					Build: latest.BuildConfig{
-						Artifacts: []*latest.Artifact{
+				Pipeline: latest_v1.Pipeline{
+					Build: latest_v1.BuildConfig{
+						Artifacts: []*latest_v1.Artifact{
 							{
 								ImageName: "test-pipeline",
-								ArtifactType: latest.ArtifactType{
-									KanikoArtifact: &latest.KanikoArtifact{},
+								ArtifactType: latest_v1.ArtifactType{
+									KanikoArtifact: &latest_v1.KanikoArtifact{},
 								},
 							},
 						},
-						BuildType: latest.BuildType{
-							Cluster: &latest.ClusterDetails{
+						BuildType: latest_v1.BuildType{
+							Cluster: &latest_v1.ClusterDetails{
 								PullSecretName: "kaniko-secret",
 							},
 						},
@@ -74,14 +74,14 @@ func TestGenerateProfile(t *testing.T) {
 		},
 		{
 			description: "successful profile generation jib",
-			skaffoldConfig: &latest.SkaffoldConfig{
-				Pipeline: latest.Pipeline{
-					Build: latest.BuildConfig{
-						Artifacts: []*latest.Artifact{
+			skaffoldConfig: &latest_v1.SkaffoldConfig{
+				Pipeline: latest_v1.Pipeline{
+					Build: latest_v1.BuildConfig{
+						Artifacts: []*latest_v1.Artifact{
 							{
 								ImageName: "test",
-								ArtifactType: latest.ArtifactType{
-									JibArtifact: &latest.JibArtifact{
+								ArtifactType: latest_v1.ArtifactType{
+									JibArtifact: &latest_v1.JibArtifact{
 										Project: "test-module",
 									},
 									DockerArtifact: nil,
@@ -92,15 +92,15 @@ func TestGenerateProfile(t *testing.T) {
 				},
 			},
 			namespace: "",
-			expectedProfile: &latest.Profile{
+			expectedProfile: &latest_v1.Profile{
 				Name: "oncluster",
-				Pipeline: latest.Pipeline{
-					Build: latest.BuildConfig{
-						Artifacts: []*latest.Artifact{
+				Pipeline: latest_v1.Pipeline{
+					Build: latest_v1.BuildConfig{
+						Artifacts: []*latest_v1.Artifact{
 							{
 								ImageName: "test-pipeline",
-								ArtifactType: latest.ArtifactType{
-									JibArtifact: &latest.JibArtifact{
+								ArtifactType: latest_v1.ArtifactType{
+									JibArtifact: &latest_v1.JibArtifact{
 										Project: "test-module",
 									},
 								},
@@ -113,14 +113,14 @@ func TestGenerateProfile(t *testing.T) {
 		},
 		{
 			description: "kaniko artifact with namespace",
-			skaffoldConfig: &latest.SkaffoldConfig{
-				Pipeline: latest.Pipeline{
-					Build: latest.BuildConfig{
-						Artifacts: []*latest.Artifact{
+			skaffoldConfig: &latest_v1.SkaffoldConfig{
+				Pipeline: latest_v1.Pipeline{
+					Build: latest_v1.BuildConfig{
+						Artifacts: []*latest_v1.Artifact{
 							{
 								ImageName: "test",
-								ArtifactType: latest.ArtifactType{
-									DockerArtifact: &latest.DockerArtifact{},
+								ArtifactType: latest_v1.ArtifactType{
+									DockerArtifact: &latest_v1.DockerArtifact{},
 								},
 							},
 						},
@@ -128,20 +128,20 @@ func TestGenerateProfile(t *testing.T) {
 				},
 			},
 			namespace: "test-ns",
-			expectedProfile: &latest.Profile{
+			expectedProfile: &latest_v1.Profile{
 				Name: "oncluster",
-				Pipeline: latest.Pipeline{
-					Build: latest.BuildConfig{
-						Artifacts: []*latest.Artifact{
+				Pipeline: latest_v1.Pipeline{
+					Build: latest_v1.BuildConfig{
+						Artifacts: []*latest_v1.Artifact{
 							{
 								ImageName: "test-pipeline",
-								ArtifactType: latest.ArtifactType{
-									KanikoArtifact: &latest.KanikoArtifact{},
+								ArtifactType: latest_v1.ArtifactType{
+									KanikoArtifact: &latest_v1.KanikoArtifact{},
 								},
 							},
 						},
-						BuildType: latest.BuildType{
-							Cluster: &latest.ClusterDetails{
+						BuildType: latest_v1.BuildType{
+							Cluster: &latest_v1.ClusterDetails{
 								PullSecretName: "kaniko-secret",
 								Namespace:      "test-ns",
 							},
@@ -153,10 +153,10 @@ func TestGenerateProfile(t *testing.T) {
 		},
 		{
 			description: "failed profile generation",
-			skaffoldConfig: &latest.SkaffoldConfig{
-				Pipeline: latest.Pipeline{
-					Build: latest.BuildConfig{
-						Artifacts: []*latest.Artifact{},
+			skaffoldConfig: &latest_v1.SkaffoldConfig{
+				Pipeline: latest_v1.Pipeline{
+					Build: latest_v1.BuildConfig{
+						Artifacts: []*latest_v1.Artifact{},
 					},
 				},
 			},

--- a/pkg/skaffold/generate_pipeline/tasks_test.go
+++ b/pkg/skaffold/generate_pipeline/tasks_test.go
@@ -23,7 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -40,10 +40,10 @@ func TestGenerateBuildTasks(t *testing.T) {
 			configFiles: []*ConfigFile{
 				{
 					Path: "test1",
-					Profile: &latest.Profile{
-						Pipeline: latest.Pipeline{
-							Build: latest.BuildConfig{
-								Artifacts: []*latest.Artifact{
+					Profile: &latest_v1.Profile{
+						Pipeline: latest_v1.Pipeline{
+							Build: latest_v1.BuildConfig{
+								Artifacts: []*latest_v1.Artifact{
 									{
 										ImageName: "testArtifact1",
 									},
@@ -54,10 +54,10 @@ func TestGenerateBuildTasks(t *testing.T) {
 				},
 				{
 					Path: "test2",
-					Profile: &latest.Profile{
-						Pipeline: latest.Pipeline{
-							Build: latest.BuildConfig{
-								Artifacts: []*latest.Artifact{
+					Profile: &latest_v1.Profile{
+						Pipeline: latest_v1.Pipeline{
+							Build: latest_v1.BuildConfig{
+								Artifacts: []*latest_v1.Artifact{
 									{
 										ImageName: "testArtifact2",
 									},
@@ -111,10 +111,10 @@ func TestGenerateBuildTasks(t *testing.T) {
 			configFiles: []*ConfigFile{
 				{
 					Path: "test1",
-					Profile: &latest.Profile{
-						Pipeline: latest.Pipeline{
-							Build: latest.BuildConfig{
-								Artifacts: []*latest.Artifact{
+					Profile: &latest_v1.Profile{
+						Pipeline: latest_v1.Pipeline{
+							Build: latest_v1.BuildConfig{
+								Artifacts: []*latest_v1.Artifact{
 									{
 										ImageName: "testArtifact1",
 									},
@@ -168,13 +168,13 @@ func TestGenerateBuildTasks(t *testing.T) {
 func TestGenerateBuildTask(t *testing.T) {
 	var tests = []struct {
 		description string
-		buildConfig latest.BuildConfig
+		buildConfig latest_v1.BuildConfig
 		shouldErr   bool
 	}{
 		{
 			description: "successfully generate build task",
-			buildConfig: latest.BuildConfig{
-				Artifacts: []*latest.Artifact{
+			buildConfig: latest_v1.BuildConfig{
+				Artifacts: []*latest_v1.Artifact{
 					{
 						ImageName: "testArtifact",
 					},
@@ -184,8 +184,8 @@ func TestGenerateBuildTask(t *testing.T) {
 		},
 		{
 			description: "fail generating build task",
-			buildConfig: latest.BuildConfig{
-				Artifacts: []*latest.Artifact{},
+			buildConfig: latest_v1.BuildConfig{
+				Artifacts: []*latest_v1.Artifact{},
 			},
 			shouldErr: true,
 		},
@@ -195,8 +195,8 @@ func TestGenerateBuildTask(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			configFile := &ConfigFile{
 				Path: "test",
-				Profile: &latest.Profile{
-					Pipeline: latest.Pipeline{
+				Profile: &latest_v1.Profile{
+					Pipeline: latest_v1.Pipeline{
 						Build: test.buildConfig,
 					},
 				},
@@ -220,11 +220,11 @@ func TestGenerateDeployTasks(t *testing.T) {
 			configFiles: []*ConfigFile{
 				{
 					Path: "test1",
-					Config: &latest.SkaffoldConfig{
-						Pipeline: latest.Pipeline{
-							Deploy: latest.DeployConfig{
-								DeployType: latest.DeployType{
-									HelmDeploy: &latest.HelmDeploy{},
+					Config: &latest_v1.SkaffoldConfig{
+						Pipeline: latest_v1.Pipeline{
+							Deploy: latest_v1.DeployConfig{
+								DeployType: latest_v1.DeployType{
+									HelmDeploy: &latest_v1.HelmDeploy{},
 								},
 							},
 						},
@@ -232,11 +232,11 @@ func TestGenerateDeployTasks(t *testing.T) {
 				},
 				{
 					Path: "test2",
-					Config: &latest.SkaffoldConfig{
-						Pipeline: latest.Pipeline{
-							Deploy: latest.DeployConfig{
-								DeployType: latest.DeployType{
-									HelmDeploy: &latest.HelmDeploy{},
+					Config: &latest_v1.SkaffoldConfig{
+						Pipeline: latest_v1.Pipeline{
+							Deploy: latest_v1.DeployConfig{
+								DeployType: latest_v1.DeployType{
+									HelmDeploy: &latest_v1.HelmDeploy{},
 								},
 							},
 						},
@@ -285,11 +285,11 @@ func TestGenerateDeployTasks(t *testing.T) {
 			configFiles: []*ConfigFile{
 				{
 					Path: "test1",
-					Config: &latest.SkaffoldConfig{
-						Pipeline: latest.Pipeline{
-							Deploy: latest.DeployConfig{
-								DeployType: latest.DeployType{
-									HelmDeploy: &latest.HelmDeploy{},
+					Config: &latest_v1.SkaffoldConfig{
+						Pipeline: latest_v1.Pipeline{
+							Deploy: latest_v1.DeployConfig{
+								DeployType: latest_v1.DeployType{
+									HelmDeploy: &latest_v1.HelmDeploy{},
 								},
 							},
 						},
@@ -337,22 +337,22 @@ func TestGenerateDeployTasks(t *testing.T) {
 func TestGenerateDeployTask(t *testing.T) {
 	var tests = []struct {
 		description  string
-		deployConfig latest.DeployConfig
+		deployConfig latest_v1.DeployConfig
 		shouldErr    bool
 	}{
 		{
 			description: "successfully generate deploy task",
-			deployConfig: latest.DeployConfig{
-				DeployType: latest.DeployType{
-					HelmDeploy: &latest.HelmDeploy{},
+			deployConfig: latest_v1.DeployConfig{
+				DeployType: latest_v1.DeployType{
+					HelmDeploy: &latest_v1.HelmDeploy{},
 				},
 			},
 			shouldErr: false,
 		},
 		{
 			description: "fail generating deploy task",
-			deployConfig: latest.DeployConfig{
-				DeployType: latest.DeployType{
+			deployConfig: latest_v1.DeployConfig{
+				DeployType: latest_v1.DeployType{
 					HelmDeploy:      nil,
 					KubectlDeploy:   nil,
 					KustomizeDeploy: nil,
@@ -366,8 +366,8 @@ func TestGenerateDeployTask(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			configFile := &ConfigFile{
 				Path: "test",
-				Config: &latest.SkaffoldConfig{
-					Pipeline: latest.Pipeline{
+				Config: &latest_v1.SkaffoldConfig{
+					Pipeline: latest_v1.Pipeline{
 						Deploy: test.deployConfig,
 					},
 				},

--- a/pkg/skaffold/git/gitutil.go
+++ b/pkg/skaffold/git/gitutil.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -80,7 +80,7 @@ func branchExists(repo, branch string) (bool, error) {
 }
 
 // getRepoDir returns the cache directory name for a remote repo
-func getRepoDir(g latest.GitInfo) (string, error) {
+func getRepoDir(g latest_v1.GitInfo) (string, error) {
 	inputs := []string{g.Repo, g.Ref}
 	hasher := sha256.New()
 	enc := json.NewEncoder(hasher)
@@ -103,7 +103,7 @@ func getRepoCacheDir(opts config.SkaffoldOptions) (string, error) {
 	return filepath.Join(home, constants.DefaultSkaffoldDir, "repos"), nil
 }
 
-func syncRepo(g latest.GitInfo, opts config.SkaffoldOptions) (string, error) {
+func syncRepo(g latest_v1.GitInfo, opts config.SkaffoldOptions) (string, error) {
 	skaffoldCacheDir, err := getRepoCacheDir(opts)
 	r := gitCmd{Dir: skaffoldCacheDir}
 	if err != nil {

--- a/pkg/skaffold/git/gitutil_test.go
+++ b/pkg/skaffold/git/gitutil_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -75,7 +75,7 @@ func TestDefaultRef(t *testing.T) {
 func TestSyncRepo(t *testing.T) {
 	tests := []struct {
 		description string
-		g           latest.GitInfo
+		g           latest_v1.GitInfo
 		cmds        []cmdResponse
 		existing    bool
 		shouldErr   bool
@@ -83,7 +83,7 @@ func TestSyncRepo(t *testing.T) {
 	}{
 		{
 			description: "first time repo clone succeeds",
-			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
+			g:           latest_v1.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
 			cmds: []cmdResponse{
 				{cmd: "git clone http://github.com/foo.git iSEL5rQfK5EJ2yLhnW8tUgcVOvDC8Wjl --branch master --depth 1"},
 			},
@@ -91,7 +91,7 @@ func TestSyncRepo(t *testing.T) {
 		},
 		{
 			description: "first time repo clone fails",
-			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
+			g:           latest_v1.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
 			cmds: []cmdResponse{
 				{cmd: "git clone http://github.com/foo.git iSEL5rQfK5EJ2yLhnW8tUgcVOvDC8Wjl --branch master --depth 1", err: errors.New("error")},
 			},
@@ -99,7 +99,7 @@ func TestSyncRepo(t *testing.T) {
 		},
 		{
 			description: "existing repo update succeeds",
-			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
+			g:           latest_v1.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
 			existing:    true,
 			cmds: []cmdResponse{
 				{cmd: "git remote -v", out: "origin git@github.com/foo.git"},
@@ -112,7 +112,7 @@ func TestSyncRepo(t *testing.T) {
 		},
 		{
 			description: "existing repo update fails on remote check",
-			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
+			g:           latest_v1.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
 			existing:    true,
 			cmds: []cmdResponse{
 				{cmd: "git remote -v", err: errors.New("error")},
@@ -121,7 +121,7 @@ func TestSyncRepo(t *testing.T) {
 		},
 		{
 			description: "existing dirty repo with sync off succeeds",
-			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master", Sync: util.BoolPtr(false)},
+			g:           latest_v1.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master", Sync: util.BoolPtr(false)},
 			existing:    true,
 			cmds: []cmdResponse{
 				{cmd: "git remote -v", out: "origin git@github.com/foo.git"},
@@ -130,7 +130,7 @@ func TestSyncRepo(t *testing.T) {
 		},
 		{
 			description: "existing repo with uncommitted changes and sync on fails",
-			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master", Sync: util.BoolPtr(true)},
+			g:           latest_v1.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master", Sync: util.BoolPtr(true)},
 			existing:    true,
 			cmds: []cmdResponse{
 				{cmd: "git remote -v", out: "origin git@github.com/foo.git"},
@@ -141,7 +141,7 @@ func TestSyncRepo(t *testing.T) {
 		},
 		{
 			description: "existing repo with unpushed commits and sync on fails",
-			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master", Sync: util.BoolPtr(true)},
+			g:           latest_v1.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master", Sync: util.BoolPtr(true)},
 			existing:    true,
 			cmds: []cmdResponse{
 				{cmd: "git remote -v", out: "origin git@github.com/foo.git"},
@@ -154,7 +154,7 @@ func TestSyncRepo(t *testing.T) {
 		},
 		{
 			description: "existing repo update fails on fetch",
-			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
+			g:           latest_v1.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
 			existing:    true,
 			cmds: []cmdResponse{
 				{cmd: "git remote -v", out: "origin git@github.com/foo.git"},
@@ -164,7 +164,7 @@ func TestSyncRepo(t *testing.T) {
 		},
 		{
 			description: "existing repo update fails on diff remote",
-			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
+			g:           latest_v1.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
 			existing:    true,
 			cmds: []cmdResponse{
 				{cmd: "git remote -v", out: "origin git@github.com/foo.git"},
@@ -176,7 +176,7 @@ func TestSyncRepo(t *testing.T) {
 		},
 		{
 			description: "existing repo update fails on diff working dir",
-			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
+			g:           latest_v1.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
 			existing:    true,
 			cmds: []cmdResponse{
 				{cmd: "git remote -v", out: "origin git@github.com/foo.git"},
@@ -187,7 +187,7 @@ func TestSyncRepo(t *testing.T) {
 		},
 		{
 			description: "existing repo update fails on reset",
-			g:           latest.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
+			g:           latest_v1.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
 			existing:    true,
 			cmds: []cmdResponse{
 				{cmd: "git remote -v", out: "origin git@github.com/foo.git"},

--- a/pkg/skaffold/graph/artifact_graph.go
+++ b/pkg/skaffold/graph/artifact_graph.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package graph
 
-import "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+import latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 
 // Artifact is the result corresponding to each successful build.
 type Artifact struct {
@@ -25,11 +25,11 @@ type Artifact struct {
 }
 
 // ArtifactGraph is a map of [artifact image : artifact definition]
-type ArtifactGraph map[string]*latest.Artifact
+type ArtifactGraph map[string]*latest_v1.Artifact
 
-// ToArtifactGraph creates an instance of `ArtifactGraph` from `[]*latest.Artifact`
-func ToArtifactGraph(artifacts []*latest.Artifact) ArtifactGraph {
-	m := make(map[string]*latest.Artifact)
+// ToArtifactGraph creates an instance of `ArtifactGraph` from `[]*latest_v1.Artifact`
+func ToArtifactGraph(artifacts []*latest_v1.Artifact) ArtifactGraph {
+	m := make(map[string]*latest_v1.Artifact)
 	for _, a := range artifacts {
 		m[a.ImageName] = a
 	}
@@ -37,8 +37,8 @@ func ToArtifactGraph(artifacts []*latest.Artifact) ArtifactGraph {
 }
 
 // Dependencies returns the de-referenced slice of required artifacts for a given artifact
-func (g ArtifactGraph) Dependencies(a *latest.Artifact) []*latest.Artifact {
-	var sl []*latest.Artifact
+func (g ArtifactGraph) Dependencies(a *latest_v1.Artifact) []*latest_v1.Artifact {
+	var sl []*latest_v1.Artifact
 	for _, d := range a.Dependencies {
 		sl = append(sl, g[d.ImageName])
 	}

--- a/pkg/skaffold/graph/artifact_graph_test.go
+++ b/pkg/skaffold/graph/artifact_graph_test.go
@@ -19,13 +19,13 @@ package graph
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestToArtifactGraph_shouldGenerateArtifactGraph(t *testing.T) {
 	testutil.Run(t, "generate artifacts graph", func(t *testutil.T) {
-		artifacts := []*latest.Artifact{
+		artifacts := []*latest_v1.Artifact{
 			{
 				ImageName: "1",
 			},
@@ -43,10 +43,10 @@ func TestToArtifactGraph_shouldGenerateArtifactGraph(t *testing.T) {
 
 func TestToArtifactGraph_shouldReturnDependencies(t *testing.T) {
 	testutil.Run(t, "return artifact dependencies", func(t *testutil.T) {
-		artifacts := []*latest.Artifact{
+		artifacts := []*latest_v1.Artifact{
 			{
 				ImageName: "1",
-				Dependencies: []*latest.ArtifactDependency{
+				Dependencies: []*latest_v1.ArtifactDependency{
 					{
 						ImageName: "randomImageName",
 						Alias:     "alias",

--- a/pkg/skaffold/graph/dependencies.go
+++ b/pkg/skaffold/graph/dependencies.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -36,7 +36,7 @@ var getDependenciesFunc = sourceDependenciesForArtifact
 // TransitiveSourceDependenciesCache provides an interface to evaluate and cache the source dependencies for artifacts.
 // This additionally includes the source dependencies from all other artifacts that are in the transitive closure of its artifact dependencies.
 type TransitiveSourceDependenciesCache interface {
-	ResolveForArtifact(ctx context.Context, a *latest.Artifact) ([]string, error)
+	ResolveForArtifact(ctx context.Context, a *latest_v1.Artifact) ([]string, error)
 	Reset()
 }
 
@@ -53,7 +53,7 @@ type dependencyResolverImpl struct {
 
 // ResolveForArtifact returns the source dependencies for the target artifact. It includes the source dependencies from all other artifacts that are in the transitive closure of its artifact dependencies.
 // The result (even if an error) is cached so that the function is evaluated only once for every artifact. The cache is reset before the start of the next devloop.
-func (r *dependencyResolverImpl) ResolveForArtifact(ctx context.Context, a *latest.Artifact) ([]string, error) {
+func (r *dependencyResolverImpl) ResolveForArtifact(ctx context.Context, a *latest_v1.Artifact) ([]string, error) {
 	res := r.cache.Exec(a.ImageName, func() interface{} {
 		d, e := getDependenciesFunc(ctx, a, r.cfg, r.artifactResolver)
 		if e != nil {
@@ -82,7 +82,7 @@ func (r *dependencyResolverImpl) Reset() {
 }
 
 // sourceDependenciesForArtifact returns the build dependencies for the current artifact.
-func sourceDependenciesForArtifact(ctx context.Context, a *latest.Artifact, cfg docker.Config, r docker.ArtifactResolver) ([]string, error) {
+func sourceDependenciesForArtifact(ctx context.Context, a *latest_v1.Artifact, cfg docker.Config, r docker.ArtifactResolver) ([]string, error) {
 	var (
 		paths []string
 		err   error

--- a/pkg/skaffold/graph/dependencies_test.go
+++ b/pkg/skaffold/graph/dependencies_test.go
@@ -21,16 +21,16 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestTransitiveSourceDependenciesCache(t *testing.T) {
 	testutil.Run(t, "TestTransitiveSourceDependenciesCache", func(t *testutil.T) {
-		g := map[string]*latest.Artifact{
-			"img1": {ImageName: "img1", Dependencies: []*latest.ArtifactDependency{{ImageName: "img2"}}},
-			"img2": {ImageName: "img2", Dependencies: []*latest.ArtifactDependency{{ImageName: "img3"}, {ImageName: "img4"}}},
-			"img3": {ImageName: "img3", Dependencies: []*latest.ArtifactDependency{{ImageName: "img4"}}},
+		g := map[string]*latest_v1.Artifact{
+			"img1": {ImageName: "img1", Dependencies: []*latest_v1.ArtifactDependency{{ImageName: "img2"}}},
+			"img2": {ImageName: "img2", Dependencies: []*latest_v1.ArtifactDependency{{ImageName: "img3"}, {ImageName: "img4"}}},
+			"img3": {ImageName: "img3", Dependencies: []*latest_v1.ArtifactDependency{{ImageName: "img4"}}},
 			"img4": {ImageName: "img4"},
 		}
 		deps := map[string][]string{
@@ -40,7 +40,7 @@ func TestTransitiveSourceDependenciesCache(t *testing.T) {
 			"img4": {"file41", "file42"},
 		}
 		counts := map[string]int{"img1": 0, "img2": 0, "img3": 0, "img4": 0}
-		t.Override(&getDependenciesFunc, func(_ context.Context, a *latest.Artifact, _ docker.Config, _ docker.ArtifactResolver) ([]string, error) {
+		t.Override(&getDependenciesFunc, func(_ context.Context, a *latest_v1.Artifact, _ docker.Config, _ docker.ArtifactResolver) ([]string, error) {
 			counts[a.ImageName]++
 			return deps[a.ImageName], nil
 		})

--- a/pkg/skaffold/initializer/build/builders.go
+++ b/pkg/skaffold/initializer/build/builders.go
@@ -20,7 +20,7 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // NoBuilder allows users to specify they don't want to build
@@ -38,7 +38,7 @@ type InitBuilder interface {
 
 	// ArtifactType returns the type of the artifact to be built.  Paths should be relative to the workspace.
 	// To make skaffold.yaml more portable across OS-es we should always generate /-delimited filepaths.
-	ArtifactType(workspace string) latest.ArtifactType
+	ArtifactType(workspace string) latest_v1.ArtifactType
 
 	// ConfiguredImage returns the target image configured by the builder, or an empty string if no image is configured.
 	// This should be a cheap operation.
@@ -67,7 +67,7 @@ type Initializer interface {
 	// contained in the initializer with the provided images from the deploy initializer
 	ProcessImages([]string) error
 	// BuildConfig returns the processed build config to be written to the skaffold.yaml
-	BuildConfig() (latest.BuildConfig, []*latest.PortForwardResource)
+	BuildConfig() (latest_v1.BuildConfig, []*latest_v1.PortForwardResource)
 	// PrintAnalysis writes the project analysis to the provided out stream
 	PrintAnalysis(io.Writer) error
 	// GenerateManifests generates image names and manifests for all unresolved pairs
@@ -81,8 +81,8 @@ func (e *emptyBuildInitializer) ProcessImages([]string) error {
 	return nil
 }
 
-func (e *emptyBuildInitializer) BuildConfig() (latest.BuildConfig, []*latest.PortForwardResource) {
-	return latest.BuildConfig{}, nil
+func (e *emptyBuildInitializer) BuildConfig() (latest_v1.BuildConfig, []*latest_v1.PortForwardResource) {
+	return latest_v1.BuildConfig{}, nil
 }
 
 func (e *emptyBuildInitializer) PrintAnalysis(io.Writer) error {

--- a/pkg/skaffold/initializer/build/cli.go
+++ b/pkg/skaffold/initializer/build/cli.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 type cliBuildInitializer struct {
@@ -47,8 +47,8 @@ func (c *cliBuildInitializer) ProcessImages(images []string) error {
 	return nil
 }
 
-func (c *cliBuildInitializer) BuildConfig() (latest.BuildConfig, []*latest.PortForwardResource) {
-	return latest.BuildConfig{
+func (c *cliBuildInitializer) BuildConfig() (latest_v1.BuildConfig, []*latest_v1.PortForwardResource) {
+	return latest_v1.BuildConfig{
 		Artifacts: Artifacts(c.artifactInfos),
 	}, nil
 }

--- a/pkg/skaffold/initializer/build/init.go
+++ b/pkg/skaffold/initializer/build/init.go
@@ -23,7 +23,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/generator"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
@@ -55,13 +55,13 @@ func (d *defaultBuildInitializer) ProcessImages(images []string) error {
 	return nil
 }
 
-func (d *defaultBuildInitializer) BuildConfig() (latest.BuildConfig, []*latest.PortForwardResource) {
-	pf := []*latest.PortForwardResource{}
+func (d *defaultBuildInitializer) BuildConfig() (latest_v1.BuildConfig, []*latest_v1.PortForwardResource) {
+	pf := []*latest_v1.PortForwardResource{}
 
 	for _, manifestInfo := range d.manifests {
 		// Port value is set to 0 if user decides to not port forward service
 		if manifestInfo.Port != 0 {
-			pf = append(pf, &latest.PortForwardResource{
+			pf = append(pf, &latest_v1.PortForwardResource{
 				Type: "service",
 				Name: manifestInfo.Name,
 				Port: util.FromInt(manifestInfo.Port),
@@ -69,7 +69,7 @@ func (d *defaultBuildInitializer) BuildConfig() (latest.BuildConfig, []*latest.P
 		}
 	}
 
-	return latest.BuildConfig{
+	return latest_v1.BuildConfig{
 		Artifacts: Artifacts(d.artifactInfos),
 	}, pf
 }

--- a/pkg/skaffold/initializer/build/util.go
+++ b/pkg/skaffold/initializer/build/util.go
@@ -19,7 +19,7 @@ package build
 import (
 	"path/filepath"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 )
 
@@ -60,16 +60,16 @@ func findExactlyOneMatchingBuilder(builderConfigs []InitBuilder, image string) i
 	return matchingConfigIndex
 }
 
-// Artifacts takes builder image pairs and workspaces and creates a list of latest.Artifacts from the data.
-func Artifacts(artifactInfos []ArtifactInfo) []*latest.Artifact {
-	var artifacts []*latest.Artifact
+// Artifacts takes builder image pairs and workspaces and creates a list of latest_v1.Artifacts from the data.
+func Artifacts(artifactInfos []ArtifactInfo) []*latest_v1.Artifact {
+	var artifacts []*latest_v1.Artifact
 
 	for _, info := range artifactInfos {
 		workspace := info.Workspace
 		if workspace == "" {
 			workspace = filepath.Dir(info.Builder.Path())
 		}
-		artifact := &latest.Artifact{
+		artifact := &latest_v1.Artifact{
 			ImageName:    info.ImageName,
 			ArtifactType: info.Builder.ArtifactType(workspace),
 		}

--- a/pkg/skaffold/initializer/config.go
+++ b/pkg/skaffold/initializer/config.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/deploy"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
 
@@ -35,7 +35,7 @@ var (
 	getWd = os.Getwd
 )
 
-func generateSkaffoldConfig(b build.Initializer, d deploy.Initializer) *latest.SkaffoldConfig {
+func generateSkaffoldConfig(b build.Initializer, d deploy.Initializer) *latest_v1.SkaffoldConfig {
 	// if we're here, the user has no skaffold yaml so we need to generate one
 	// if the user doesn't have any k8s yamls, generate one for each dockerfile
 	logrus.Info("generating skaffold config")
@@ -48,13 +48,13 @@ func generateSkaffoldConfig(b build.Initializer, d deploy.Initializer) *latest.S
 	deploy, profiles := d.DeployConfig()
 	build, portForward := b.BuildConfig()
 
-	return &latest.SkaffoldConfig{
-		APIVersion: latest.Version,
+	return &latest_v1.SkaffoldConfig{
+		APIVersion: latest_v1.Version,
 		Kind:       "Config",
-		Metadata: latest.Metadata{
+		Metadata: latest_v1.Metadata{
 			Name: name,
 		},
-		Pipeline: latest.Pipeline{
+		Pipeline: latest_v1.Pipeline{
 			Build:       build,
 			Deploy:      deploy,
 			PortForward: portForward,

--- a/pkg/skaffold/initializer/config_test.go
+++ b/pkg/skaffold/initializer/config_test.go
@@ -24,16 +24,16 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/build"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 type stubDeploymentInitializer struct {
-	config   latest.DeployConfig
-	profiles []latest.Profile
+	config   latest_v1.DeployConfig
+	profiles []latest_v1.Profile
 }
 
-func (s stubDeploymentInitializer) DeployConfig() (latest.DeployConfig, []latest.Profile) {
+func (s stubDeploymentInitializer) DeployConfig() (latest_v1.DeployConfig, []latest_v1.Profile) {
 	return s.config, s.profiles
 }
 
@@ -61,8 +61,8 @@ func (s stubBuildInitializer) PrintAnalysis(io.Writer) error {
 	panic("no sir")
 }
 
-func (s stubBuildInitializer) BuildConfig() (latest.BuildConfig, []*latest.PortForwardResource) {
-	return latest.BuildConfig{
+func (s stubBuildInitializer) BuildConfig() (latest_v1.BuildConfig, []*latest_v1.PortForwardResource) {
+	return latest_v1.BuildConfig{
 		Artifacts: build.Artifacts(s.artifactInfos),
 	}, nil
 }
@@ -74,25 +74,25 @@ func (s stubBuildInitializer) GenerateManifests(io.Writer, bool) (map[build.Gene
 func TestGenerateSkaffoldConfig(t *testing.T) {
 	tests := []struct {
 		name                   string
-		expectedSkaffoldConfig *latest.SkaffoldConfig
-		deployConfig           latest.DeployConfig
-		profiles               []latest.Profile
+		expectedSkaffoldConfig *latest_v1.SkaffoldConfig
+		deployConfig           latest_v1.DeployConfig
+		profiles               []latest_v1.Profile
 		builderConfigInfos     []build.ArtifactInfo
 		getWd                  func() (string, error)
 	}{
 		{
 			name:               "empty",
 			builderConfigInfos: []build.ArtifactInfo{},
-			deployConfig:       latest.DeployConfig{},
+			deployConfig:       latest_v1.DeployConfig{},
 			getWd: func() (s string, err error) {
 				return filepath.Join("rootDir", "testConfig"), nil
 			},
-			expectedSkaffoldConfig: &latest.SkaffoldConfig{
-				APIVersion: latest.Version,
+			expectedSkaffoldConfig: &latest_v1.SkaffoldConfig{
+				APIVersion: latest_v1.Version,
 				Kind:       "Config",
-				Metadata:   latest.Metadata{Name: "testconfig"},
-				Pipeline: latest.Pipeline{
-					Deploy: latest.DeployConfig{},
+				Metadata:   latest_v1.Metadata{Name: "testconfig"},
+				Pipeline: latest_v1.Pipeline{
+					Deploy: latest_v1.DeployConfig{},
 				},
 			},
 		},
@@ -106,41 +106,41 @@ func TestGenerateSkaffoldConfig(t *testing.T) {
 					ImageName: "image1",
 				},
 			},
-			deployConfig: latest.DeployConfig{},
+			deployConfig: latest_v1.DeployConfig{},
 			getWd: func() (s string, err error) {
 				return string(filepath.Separator), nil
 			},
-			expectedSkaffoldConfig: &latest.SkaffoldConfig{
-				APIVersion: latest.Version,
+			expectedSkaffoldConfig: &latest_v1.SkaffoldConfig{
+				APIVersion: latest_v1.Version,
 				Kind:       "Config",
-				Metadata:   latest.Metadata{},
-				Pipeline: latest.Pipeline{
-					Build: latest.BuildConfig{
-						Artifacts: []*latest.Artifact{
+				Metadata:   latest_v1.Metadata{},
+				Pipeline: latest_v1.Pipeline{
+					Build: latest_v1.BuildConfig{
+						Artifacts: []*latest_v1.Artifact{
 							{
 								ImageName: "image1",
 								Workspace: "testDir",
-								ArtifactType: latest.ArtifactType{
-									DockerArtifact: &latest.DockerArtifact{DockerfilePath: "Dockerfile"},
+								ArtifactType: latest_v1.ArtifactType{
+									DockerArtifact: &latest_v1.DockerArtifact{DockerfilePath: "Dockerfile"},
 								},
 							},
 						},
 					},
-					Deploy: latest.DeployConfig{},
+					Deploy: latest_v1.DeployConfig{},
 				},
 			},
 		},
 		{
 			name:               "error working dir",
 			builderConfigInfos: []build.ArtifactInfo{},
-			deployConfig:       latest.DeployConfig{},
+			deployConfig:       latest_v1.DeployConfig{},
 			getWd: func() (s string, err error) {
 				return "", errors.New("testError")
 			},
-			expectedSkaffoldConfig: &latest.SkaffoldConfig{
-				APIVersion: latest.Version,
+			expectedSkaffoldConfig: &latest_v1.SkaffoldConfig{
+				APIVersion: latest_v1.Version,
 				Kind:       "Config",
-				Metadata:   latest.Metadata{},
+				Metadata:   latest_v1.Metadata{},
 			},
 		},
 	}

--- a/pkg/skaffold/initializer/deploy/init.go
+++ b/pkg/skaffold/initializer/deploy/init.go
@@ -19,13 +19,13 @@ package deploy
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // Initializer detects a deployment type and is able to extract image names from it
 type Initializer interface {
 	// deployConfig generates Deploy Config for skaffold configuration.
-	DeployConfig() (latest.DeployConfig, []latest.Profile)
+	DeployConfig() (latest_v1.DeployConfig, []latest_v1.Profile)
 	// GetImages fetches all the images defined in the manifest files.
 	GetImages() []string
 	// Validate ensures preconditions are met before generating a skaffold config
@@ -38,10 +38,10 @@ type cliDeployInit struct {
 	cliKubernetesManifests []string
 }
 
-func (c *cliDeployInit) DeployConfig() (latest.DeployConfig, []latest.Profile) {
-	return latest.DeployConfig{
-		DeployType: latest.DeployType{
-			KubectlDeploy: &latest.KubectlDeploy{
+func (c *cliDeployInit) DeployConfig() (latest_v1.DeployConfig, []latest_v1.Profile) {
+	return latest_v1.DeployConfig{
+		DeployType: latest_v1.DeployType{
+			KubectlDeploy: &latest_v1.KubectlDeploy{
 				Manifests: c.cliKubernetesManifests,
 			},
 		},
@@ -64,8 +64,8 @@ func (c *cliDeployInit) AddManifestForImage(string, string) {}
 type emptyDeployInit struct {
 }
 
-func (e *emptyDeployInit) DeployConfig() (latest.DeployConfig, []latest.Profile) {
-	return latest.DeployConfig{}, nil
+func (e *emptyDeployInit) DeployConfig() (latest_v1.DeployConfig, []latest_v1.Profile) {
+	return latest_v1.DeployConfig{}, nil
 }
 
 func (e *emptyDeployInit) GetImages() []string {

--- a/pkg/skaffold/initializer/deploy/kubectl.go
+++ b/pkg/skaffold/initializer/deploy/kubectl.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // kubectl implements deploymentInitializer for the kubectl deployer.
@@ -49,10 +49,10 @@ func newKubectlInitializer(potentialConfigs []string) *kubectl {
 
 // deployConfig implements the Initializer interface and generates
 // skaffold kubectl deployment config.
-func (k *kubectl) DeployConfig() (latest.DeployConfig, []latest.Profile) {
-	return latest.DeployConfig{
-		DeployType: latest.DeployType{
-			KubectlDeploy: &latest.KubectlDeploy{
+func (k *kubectl) DeployConfig() (latest_v1.DeployConfig, []latest_v1.Profile) {
+	return latest_v1.DeployConfig{
+		DeployType: latest_v1.DeployType{
+			KubectlDeploy: &latest_v1.KubectlDeploy{
 				Manifests: k.configs,
 			},
 		},

--- a/pkg/skaffold/initializer/deploy/kubectl_test.go
+++ b/pkg/skaffold/initializer/deploy/kubectl_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -40,9 +40,9 @@ spec:
 
 	k := newKubectlInitializer([]string{filename})
 
-	expectedConfig := latest.DeployConfig{
-		DeployType: latest.DeployType{
-			KubectlDeploy: &latest.KubectlDeploy{
+	expectedConfig := latest_v1.DeployConfig{
+		DeployType: latest_v1.DeployType{
+			KubectlDeploy: &latest_v1.KubectlDeploy{
 				Manifests: []string{filename},
 			},
 		},

--- a/pkg/skaffold/initializer/deploy/kustomize.go
+++ b/pkg/skaffold/initializer/deploy/kustomize.go
@@ -24,7 +24,7 @@ import (
 	pkgkustomize "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // kustomize implements deploymentInitializer for the kustomize deployer.
@@ -54,22 +54,22 @@ func newKustomizeInitializer(defaultKustomization string, bases, kustomizations,
 
 // deployConfig implements the Initializer interface and generates
 // a kustomize deployment config.
-func (k *kustomize) DeployConfig() (latest.DeployConfig, []latest.Profile) {
-	var kustomizeConfig *latest.KustomizeDeploy
-	var profiles []latest.Profile
+func (k *kustomize) DeployConfig() (latest_v1.DeployConfig, []latest_v1.Profile) {
+	var kustomizeConfig *latest_v1.KustomizeDeploy
+	var profiles []latest_v1.Profile
 
 	// if there's only one kustomize path, either leave it blank (if it's the default path),
 	// or generate a config with that single path and return it
 	if len(k.kustomizations) == 1 {
 		if k.kustomizations[0] == pkgkustomize.DefaultKustomizePath {
-			kustomizeConfig = &latest.KustomizeDeploy{}
+			kustomizeConfig = &latest_v1.KustomizeDeploy{}
 		} else {
-			kustomizeConfig = &latest.KustomizeDeploy{
+			kustomizeConfig = &latest_v1.KustomizeDeploy{
 				KustomizePaths: k.kustomizations,
 			}
 		}
-		return latest.DeployConfig{
-			DeployType: latest.DeployType{
+		return latest_v1.DeployConfig{
+			DeployType: latest_v1.DeployType{
 				KustomizeDeploy: kustomizeConfig,
 			},
 		}, nil
@@ -105,16 +105,16 @@ func (k *kustomize) DeployConfig() (latest.DeployConfig, []latest.Profile) {
 
 	for _, kustomization := range k.kustomizations {
 		if kustomization == defaultKustomization {
-			kustomizeConfig = &latest.KustomizeDeploy{
+			kustomizeConfig = &latest_v1.KustomizeDeploy{
 				KustomizePaths: []string{defaultKustomization},
 			}
 		} else {
-			profiles = append(profiles, latest.Profile{
+			profiles = append(profiles, latest_v1.Profile{
 				Name: filepath.Base(kustomization),
-				Pipeline: latest.Pipeline{
-					Deploy: latest.DeployConfig{
-						DeployType: latest.DeployType{
-							KustomizeDeploy: &latest.KustomizeDeploy{
+				Pipeline: latest_v1.Pipeline{
+					Deploy: latest_v1.DeployConfig{
+						DeployType: latest_v1.DeployType{
+							KustomizeDeploy: &latest_v1.KustomizeDeploy{
 								KustomizePaths: []string{kustomization},
 							},
 						},
@@ -124,8 +124,8 @@ func (k *kustomize) DeployConfig() (latest.DeployConfig, []latest.Profile) {
 		}
 	}
 
-	return latest.DeployConfig{
-		DeployType: latest.DeployType{
+	return latest_v1.DeployConfig{
+		DeployType: latest_v1.DeployType{
 			KustomizeDeploy: kustomizeConfig,
 		},
 	}, profiles

--- a/pkg/skaffold/initializer/deploy/kustomize_test.go
+++ b/pkg/skaffold/initializer/deploy/kustomize_test.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -71,18 +71,18 @@ func TestGenerateKustomizePipeline(t *testing.T) {
 		base              string
 		baseKustomization string
 		overlays          []overlay
-		expectedConfig    latest.SkaffoldConfig
+		expectedConfig    latest_v1.SkaffoldConfig
 	}{
 		{
 			description:       "single overlay",
 			base:              baseDeployment,
 			baseKustomization: baseKustomization,
 			overlays:          []overlay{{"dev", overlayDeployment, overlayKustomization}},
-			expectedConfig: latest.SkaffoldConfig{
-				Pipeline: latest.Pipeline{
-					Deploy: latest.DeployConfig{
-						DeployType: latest.DeployType{
-							KustomizeDeploy: &latest.KustomizeDeploy{
+			expectedConfig: latest_v1.SkaffoldConfig{
+				Pipeline: latest_v1.Pipeline{
+					Deploy: latest_v1.DeployConfig{
+						DeployType: latest_v1.DeployType{
+							KustomizeDeploy: &latest_v1.KustomizeDeploy{
 								KustomizePaths: []string{filepath.Join("overlays", "dev")},
 							},
 						},
@@ -99,23 +99,23 @@ func TestGenerateKustomizePipeline(t *testing.T) {
 				{"bar", overlayDeployment, overlayKustomization},
 				{"baz", overlayDeployment, overlayKustomization},
 			},
-			expectedConfig: latest.SkaffoldConfig{
-				Pipeline: latest.Pipeline{
-					Deploy: latest.DeployConfig{
-						DeployType: latest.DeployType{
-							KustomizeDeploy: &latest.KustomizeDeploy{
+			expectedConfig: latest_v1.SkaffoldConfig{
+				Pipeline: latest_v1.Pipeline{
+					Deploy: latest_v1.DeployConfig{
+						DeployType: latest_v1.DeployType{
+							KustomizeDeploy: &latest_v1.KustomizeDeploy{
 								KustomizePaths: []string{filepath.Join("overlays", "foo")},
 							},
 						},
 					},
 				},
-				Profiles: []latest.Profile{
+				Profiles: []latest_v1.Profile{
 					{
 						Name: "bar",
-						Pipeline: latest.Pipeline{
-							Deploy: latest.DeployConfig{
-								DeployType: latest.DeployType{
-									KustomizeDeploy: &latest.KustomizeDeploy{
+						Pipeline: latest_v1.Pipeline{
+							Deploy: latest_v1.DeployConfig{
+								DeployType: latest_v1.DeployType{
+									KustomizeDeploy: &latest_v1.KustomizeDeploy{
 										KustomizePaths: []string{filepath.Join("overlays", "bar")},
 									},
 								},
@@ -124,10 +124,10 @@ func TestGenerateKustomizePipeline(t *testing.T) {
 					},
 					{
 						Name: "baz",
-						Pipeline: latest.Pipeline{
-							Deploy: latest.DeployConfig{
-								DeployType: latest.DeployType{
-									KustomizeDeploy: &latest.KustomizeDeploy{
+						Pipeline: latest_v1.Pipeline{
+							Deploy: latest_v1.DeployConfig{
+								DeployType: latest_v1.DeployType{
+									KustomizeDeploy: &latest_v1.KustomizeDeploy{
 										KustomizePaths: []string{filepath.Join("overlays", "baz")},
 									},
 								},

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 )
 
@@ -76,7 +76,7 @@ See https://skaffold.dev/docs/pipeline-stages/deployers/helm/ for a detailed gui
 
 // Initialize uses the information gathered by the analyzer to create a skaffold config and generate kubernetes manifests.
 // The returned map[string][]byte represents a mapping from generated config name to its respective manifest data held in a []byte
-func Initialize(out io.Writer, c config.Config, a *analyze.ProjectAnalysis) (*latest.SkaffoldConfig, map[string][]byte, error) {
+func Initialize(out io.Writer, c config.Config, a *analyze.ProjectAnalysis) (*latest_v1.SkaffoldConfig, map[string][]byte, error) {
 	deployInitializer := deploy.NewInitializer(a.Manifests(), a.KustomizeBases(), a.KustomizePaths(), c)
 	images := deployInitializer.GetImages()
 
@@ -119,7 +119,7 @@ func generateManifests(out io.Writer, c config.Config, bInitializer build.Initia
 }
 
 // WriteData takes the given skaffold config and k8s manifests and writes them out to a file or the given io.Writer
-func WriteData(out io.Writer, c config.Config, newConfig *latest.SkaffoldConfig, newManifests map[string][]byte) error {
+func WriteData(out io.Writer, c config.Config, newConfig *latest_v1.SkaffoldConfig, newManifests map[string][]byte) error {
 	pipeline, err := yaml.Marshal(newConfig)
 	if err != nil {
 		return err

--- a/pkg/skaffold/initializer/prompt/prompt.go
+++ b/pkg/skaffold/initializer/prompt/prompt.go
@@ -26,7 +26,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/util"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // For testing
@@ -121,7 +121,7 @@ func portForwardResource(out io.Writer, imageName string) (int, error) {
 
 // ConfirmInitOptions prompts the user to confirm that they are okay with what skaffold will do if they
 // run with the current config
-func ConfirmInitOptions(out io.Writer, config *latest.SkaffoldConfig) (bool, error) {
+func ConfirmInitOptions(out io.Writer, config *latest_v1.SkaffoldConfig) (bool, error) {
 	builders := strings.Join(util.ListBuilders(&config.Build), ",")
 	deployers := strings.Join(util.ListDeployers(&config.Deploy), ",")
 

--- a/pkg/skaffold/initializer/prompt/prompt_test.go
+++ b/pkg/skaffold/initializer/prompt/prompt_test.go
@@ -23,35 +23,35 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestWriteSkaffoldConfig(t *testing.T) {
 	tests := []struct {
 		description    string
-		config         *latest.SkaffoldConfig
+		config         *latest_v1.SkaffoldConfig
 		promptResponse bool
 		expectedDone   bool
 		shouldErr      bool
 	}{
 		{
 			description:    "yes response",
-			config:         &latest.SkaffoldConfig{},
+			config:         &latest_v1.SkaffoldConfig{},
 			promptResponse: true,
 			expectedDone:   false,
 			shouldErr:      false,
 		},
 		{
 			description:    "no response",
-			config:         &latest.SkaffoldConfig{},
+			config:         &latest_v1.SkaffoldConfig{},
 			promptResponse: false,
 			expectedDone:   true,
 			shouldErr:      false,
 		},
 		{
 			description:    "error",
-			config:         &latest.SkaffoldConfig{},
+			config:         &latest_v1.SkaffoldConfig{},
 			promptResponse: false,
 			expectedDone:   true,
 			shouldErr:      true,
@@ -126,28 +126,28 @@ func TestChooseBuilders(t *testing.T) {
 func TestPortForwardResource(t *testing.T) {
 	tests := []struct {
 		description    string
-		config         *latest.SkaffoldConfig
+		config         *latest_v1.SkaffoldConfig
 		promptResponse string
 		expected       int
 		shouldErr      bool
 	}{
 		{
 			description:    "valid response",
-			config:         &latest.SkaffoldConfig{},
+			config:         &latest_v1.SkaffoldConfig{},
 			promptResponse: "8080",
 			expected:       8080,
 			shouldErr:      false,
 		},
 		{
 			description:    "empty response",
-			config:         &latest.SkaffoldConfig{},
+			config:         &latest_v1.SkaffoldConfig{},
 			promptResponse: "",
 			expected:       0,
 			shouldErr:      false,
 		},
 		{
 			description:    "error",
-			config:         &latest.SkaffoldConfig{},
+			config:         &latest_v1.SkaffoldConfig{},
 			promptResponse: "",
 			expected:       0,
 			shouldErr:      true,
@@ -174,28 +174,28 @@ func TestPortForwardResource(t *testing.T) {
 func TestConfirmInitOptions(t *testing.T) {
 	tests := []struct {
 		description    string
-		config         *latest.SkaffoldConfig
+		config         *latest_v1.SkaffoldConfig
 		promptResponse bool
 		expectedDone   bool
 		shouldErr      bool
 	}{
 		{
 			description:    "yes response",
-			config:         &latest.SkaffoldConfig{},
+			config:         &latest_v1.SkaffoldConfig{},
 			promptResponse: true,
 			expectedDone:   false,
 			shouldErr:      false,
 		},
 		{
 			description:    "no response",
-			config:         &latest.SkaffoldConfig{},
+			config:         &latest_v1.SkaffoldConfig{},
 			promptResponse: false,
 			expectedDone:   true,
 			shouldErr:      false,
 		},
 		{
 			description:    "error",
-			config:         &latest.SkaffoldConfig{},
+			config:         &latest_v1.SkaffoldConfig{},
 			promptResponse: false,
 			expectedDone:   true,
 			shouldErr:      true,

--- a/pkg/skaffold/initializer/transparent.go
+++ b/pkg/skaffold/initializer/transparent.go
@@ -23,7 +23,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	initConfig "github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/prompt"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 var (
@@ -32,7 +32,7 @@ var (
 
 // Transparent executes the `skaffold init` flow, but always enables the --force flag.
 // It will also always prompt the user to confirm at the end of the flow.
-func Transparent(ctx context.Context, out io.Writer, c initConfig.Config) (*latest.SkaffoldConfig, error) {
+func Transparent(ctx context.Context, out io.Writer, c initConfig.Config) (*latest_v1.SkaffoldConfig, error) {
 	// we set force to true because we want to have this happen invisibly to the user if possible
 	c.Force = true
 

--- a/pkg/skaffold/initializer/transparent_test.go
+++ b/pkg/skaffold/initializer/transparent_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	initconfig "github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -159,7 +159,7 @@ See https://skaffold.dev/docs/pipeline-stages/deployers/helm/ for a detailed gui
 		testutil.Run(t, test.name, func(t *testutil.T) {
 			t.Chdir(test.dir)
 
-			t.Override(&confirmInitOptions, func(_ io.Writer, _ *latest.SkaffoldConfig) (bool, error) {
+			t.Override(&confirmInitOptions, func(_ io.Writer, _ *latest_v1.SkaffoldConfig) (bool, error) {
 				return test.doneResponse, nil
 			})
 
@@ -170,7 +170,7 @@ See https://skaffold.dev/docs/pipeline-stages/deployers/helm/ for a detailed gui
 				t.CheckErrorContains(test.expectedError, err)
 				t.CheckDeepEqual(exitCode(err), test.expectedExitCode)
 			case test.doneResponse == true:
-				t.CheckErrorAndDeepEqual(false, err, (*latest.SkaffoldConfig)(nil), got)
+				t.CheckErrorAndDeepEqual(false, err, (*latest_v1.SkaffoldConfig)(nil), got)
 			default:
 				t.CheckNoError(err)
 				checkGeneratedConfig(t, ".")

--- a/pkg/skaffold/initializer/util/util.go
+++ b/pkg/skaffold/initializer/util/util.go
@@ -18,13 +18,13 @@ package util
 
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags"
 )
 
 // ListBuilders returns a list of builder names being used in the given build config.
-func ListBuilders(build *latest.BuildConfig) []string {
+func ListBuilders(build *latest_v1.BuildConfig) []string {
 	if build == nil {
 		return []string{}
 	}
@@ -38,7 +38,7 @@ func ListBuilders(build *latest.BuildConfig) []string {
 }
 
 // ListDeployers returns a list of deployer names being used in the given deploy config.
-func ListDeployers(deploy *latest.DeployConfig) []string {
+func ListDeployers(deploy *latest_v1.DeployConfig) []string {
 	if deploy == nil {
 		return []string{}
 	}

--- a/pkg/skaffold/initializer/util/util_test.go
+++ b/pkg/skaffold/initializer/util/util_test.go
@@ -19,14 +19,14 @@ package util
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestListBuilders(t *testing.T) {
 	tests := []struct {
 		description string
-		build       *latest.BuildConfig
+		build       *latest_v1.BuildConfig
 		expected    []string
 	}{
 		{
@@ -36,20 +36,20 @@ func TestListBuilders(t *testing.T) {
 		},
 		{
 			description: "multiple same builder config",
-			build: &latest.BuildConfig{
-				Artifacts: []*latest.Artifact{
-					{ImageName: "img1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
-					{ImageName: "img2", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
+			build: &latest_v1.BuildConfig{
+				Artifacts: []*latest_v1.Artifact{
+					{ImageName: "img1", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}},
+					{ImageName: "img2", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}},
 				},
 			},
 			expected: []string{"docker"},
 		},
 		{
 			description: "different builders config",
-			build: &latest.BuildConfig{
-				Artifacts: []*latest.Artifact{
-					{ImageName: "img1", ArtifactType: latest.ArtifactType{DockerArtifact: &latest.DockerArtifact{}}},
-					{ImageName: "img2", ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{}}},
+			build: &latest_v1.BuildConfig{
+				Artifacts: []*latest_v1.Artifact{
+					{ImageName: "img1", ArtifactType: latest_v1.ArtifactType{DockerArtifact: &latest_v1.DockerArtifact{}}},
+					{ImageName: "img2", ArtifactType: latest_v1.ArtifactType{JibArtifact: &latest_v1.JibArtifact{}}},
 				},
 			},
 			expected: []string{"docker", "jib"},
@@ -66,7 +66,7 @@ func TestListBuilders(t *testing.T) {
 func TestListDeployers(t *testing.T) {
 	tests := []struct {
 		description string
-		deploy      *latest.DeployConfig
+		deploy      *latest_v1.DeployConfig
 		expected    []string
 	}{
 		{
@@ -76,19 +76,19 @@ func TestListDeployers(t *testing.T) {
 		},
 		{
 			description: "single deployer config",
-			deploy: &latest.DeployConfig{
-				DeployType: latest.DeployType{
-					KubectlDeploy: &latest.KubectlDeploy{},
+			deploy: &latest_v1.DeployConfig{
+				DeployType: latest_v1.DeployType{
+					KubectlDeploy: &latest_v1.KubectlDeploy{},
 				},
 			},
 			expected: []string{"kubectl"},
 		},
 		{
 			description: "multiple deployers config",
-			deploy: &latest.DeployConfig{
-				DeployType: latest.DeployType{
-					HelmDeploy:    &latest.HelmDeploy{},
-					KubectlDeploy: &latest.KubectlDeploy{},
+			deploy: &latest_v1.DeployConfig{
+				DeployType: latest_v1.DeployType{
+					HelmDeploy:    &latest_v1.HelmDeploy{},
+					KubectlDeploy: &latest_v1.KubectlDeploy{},
 				},
 			},
 			expected: []string{"helm", "kubectl"},

--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -24,7 +24,7 @@ import (
 
 	flag "github.com/spf13/pflag"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags"
@@ -74,7 +74,7 @@ func SetOnlineStatus() {
 	}()
 }
 
-func InitMeterFromConfig(configs []*latest.SkaffoldConfig, user string) {
+func InitMeterFromConfig(configs []*latest_v1.SkaffoldConfig, user string) {
 	var platforms []string
 	for _, config := range configs {
 		pl := yamltags.GetYamlTag(config.Build.BuildType)

--- a/pkg/skaffold/kubernetes/log.go
+++ b/pkg/skaffold/kubernetes/log.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // LogAggregator aggregates the logs for all the deployed pods.
@@ -49,8 +49,8 @@ type LogAggregator struct {
 }
 
 type Config interface {
-	PipelineForImage(imageName string) (latest.Pipeline, bool)
-	DefaultPipeline() latest.Pipeline
+	PipelineForImage(imageName string) (latest_v1.Pipeline, bool)
+	DefaultPipeline() latest_v1.Pipeline
 }
 
 // NewLogAggregator creates a new LogAggregator for a given output.
@@ -180,7 +180,7 @@ func (a *LogAggregator) printLogLine(headerColor color.Color, prefix, text strin
 }
 
 func (a *LogAggregator) prefix(pod *v1.Pod, container v1.ContainerStatus) string {
-	var c latest.Pipeline
+	var c latest_v1.Pipeline
 	var present bool
 	for _, container := range pod.Spec.Containers {
 		if c, present = a.config.PipelineForImage(stripTag(container.Image)); present {

--- a/pkg/skaffold/kubernetes/log_test.go
+++ b/pkg/skaffold/kubernetes/log_test.go
@@ -28,7 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -187,7 +187,7 @@ func TestPrefix(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			logger := NewLogAggregator(nil, nil, nil, nil, &mockConfig{log: latest.LogsConfig{
+			logger := NewLogAggregator(nil, nil, nil, nil, &mockConfig{log: latest_v1.LogsConfig{
 				Prefix: test.prefix,
 			}})
 
@@ -213,17 +213,17 @@ func containerWithName(n string) v1.ContainerStatus {
 }
 
 type mockConfig struct {
-	log latest.LogsConfig
+	log latest_v1.LogsConfig
 }
 
-func (c *mockConfig) PipelineForImage(string) (latest.Pipeline, bool) {
-	var pipeline latest.Pipeline
+func (c *mockConfig) PipelineForImage(string) (latest_v1.Pipeline, bool) {
+	var pipeline latest_v1.Pipeline
 	pipeline.Deploy.Logs = c.log
 	return pipeline, true
 }
 
-func (c *mockConfig) DefaultPipeline() latest.Pipeline {
-	var pipeline latest.Pipeline
+func (c *mockConfig) DefaultPipeline() latest_v1.Pipeline {
+	var pipeline latest_v1.Pipeline
 	pipeline.Deploy.Logs = c.log
 	return pipeline
 }

--- a/pkg/skaffold/kubernetes/portforward/entry_manager_test.go
+++ b/pkg/skaffold/kubernetes/portforward/entry_manager_test.go
@@ -22,21 +22,21 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	testEvent "github.com/GoogleContainerTools/skaffold/testutil/event"
 )
 
 func TestStop(t *testing.T) {
-	testEvent.InitializeState([]latest.Pipeline{{}})
+	testEvent.InitializeState([]latest_v1.Pipeline{{}})
 
-	pfe1 := newPortForwardEntry(0, latest.PortForwardResource{
+	pfe1 := newPortForwardEntry(0, latest_v1.PortForwardResource{
 		Type:      constants.Pod,
 		Name:      "resource",
 		Namespace: "default",
 	}, "", "", "", "", 9000, false)
 
-	pfe2 := newPortForwardEntry(0, latest.PortForwardResource{
+	pfe2 := newPortForwardEntry(0, latest_v1.PortForwardResource{
 		Type:      constants.Pod,
 		Name:      "resource2",
 		Namespace: "default",

--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
@@ -30,7 +30,7 @@ import (
 	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // Forwarder is an interface that can modify and manage port-forward processes
@@ -45,7 +45,7 @@ type ForwarderManager struct {
 }
 
 // NewForwarderManager returns a new port manager which handles starting and stopping port forwarding
-func NewForwarderManager(out io.Writer, cli *kubectl.CLI, podSelector kubernetes.PodSelector, label string, runMode config.RunMode, options config.PortForwardOptions, userDefined []*latest.PortForwardResource) *ForwarderManager {
+func NewForwarderManager(out io.Writer, cli *kubectl.CLI, podSelector kubernetes.PodSelector, label string, runMode config.RunMode, options config.PortForwardOptions, userDefined []*latest_v1.PortForwardResource) *ForwarderManager {
 	if !options.Enabled() {
 		return nil
 	}

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -67,7 +67,7 @@ func TestUnavailablePort(t *testing.T) {
 		k := KubectlForwarder{
 			out: &buf,
 		}
-		pfe := newPortForwardEntry(0, latest.PortForwardResource{}, "", "", "", "", 8080, false)
+		pfe := newPortForwardEntry(0, latest_v1.PortForwardResource{}, "", "", "", "", 8080, false)
 
 		go k.Forward(context.Background(), pfe)
 
@@ -88,7 +88,7 @@ func TestUnavailablePort(t *testing.T) {
 func TestTerminate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	pfe := newPortForwardEntry(0, latest.PortForwardResource{}, "", "", "", "", 8080, false)
+	pfe := newPortForwardEntry(0, latest_v1.PortForwardResource{}, "", "", "", "", 8080, false)
 	pfe.cancel = cancel
 
 	k := &KubectlForwarder{}
@@ -200,29 +200,29 @@ func TestPortForwardArgs(t *testing.T) {
 	}{
 		{
 			description: "non-default address",
-			input:       newPortForwardEntry(0, latest.PortForwardResource{Type: "pod", Name: "p", Namespace: "ns", Port: schemautil.FromInt(9), Address: "0.0.0.0"}, "", "", "", "", 8080, false),
+			input:       newPortForwardEntry(0, latest_v1.PortForwardResource{Type: "pod", Name: "p", Namespace: "ns", Port: schemautil.FromInt(9), Address: "0.0.0.0"}, "", "", "", "", 8080, false),
 			result:      []string{"--pod-running-timeout", "1s", "--namespace", "ns", "pod/p", "8080:9", "--address", "0.0.0.0"},
 		},
 		{
 			description: "localhost is the default",
-			input:       newPortForwardEntry(0, latest.PortForwardResource{Type: "pod", Name: "p", Namespace: "ns", Port: schemautil.FromInt(9), Address: "127.0.0.1"}, "", "", "", "", 8080, false),
+			input:       newPortForwardEntry(0, latest_v1.PortForwardResource{Type: "pod", Name: "p", Namespace: "ns", Port: schemautil.FromInt(9), Address: "127.0.0.1"}, "", "", "", "", 8080, false),
 			result:      []string{"--pod-running-timeout", "1s", "--namespace", "ns", "pod/p", "8080:9"},
 		},
 		{
 			description: "no address",
-			input:       newPortForwardEntry(0, latest.PortForwardResource{Type: "pod", Name: "p", Namespace: "ns", Port: schemautil.FromInt(9)}, "", "", "", "", 8080, false),
+			input:       newPortForwardEntry(0, latest_v1.PortForwardResource{Type: "pod", Name: "p", Namespace: "ns", Port: schemautil.FromInt(9)}, "", "", "", "", 8080, false),
 			result:      []string{"--pod-running-timeout", "1s", "--namespace", "ns", "pod/p", "8080:9"},
 		},
 		{
 			description: "service to pod",
-			input:       newPortForwardEntry(0, latest.PortForwardResource{Type: "service", Name: "svc", Namespace: "ns", Port: schemautil.FromInt(9)}, "", "", "", "", 8080, false),
+			input:       newPortForwardEntry(0, latest_v1.PortForwardResource{Type: "service", Name: "svc", Namespace: "ns", Port: schemautil.FromInt(9)}, "", "", "", "", 8080, false),
 			servicePod:  "servicePod",
 			servicePort: 9999,
 			result:      []string{"--pod-running-timeout", "1s", "--namespace", "ns", "pod/servicePod", "8080:9999"},
 		},
 		{
 			description: "service could not be mapped to pod",
-			input:       newPortForwardEntry(0, latest.PortForwardResource{Type: "service", Name: "svc", Namespace: "ns", Port: schemautil.FromInt(9)}, "", "", "", "", 8080, false),
+			input:       newPortForwardEntry(0, latest_v1.PortForwardResource{Type: "service", Name: "svc", Namespace: "ns", Port: schemautil.FromInt(9)}, "", "", "", "", 8080, false),
 			serviceErr:  errors.New("error"),
 			result:      []string{"--pod-running-timeout", "1s", "--namespace", "ns", "service/svc", "8080:9"},
 		},

--- a/pkg/skaffold/kubernetes/portforward/pod_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/pod_forwarder.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
@@ -105,7 +105,7 @@ func (p *WatchingPodForwarder) portForwardPod(ctx context.Context, pod *v1.Pod) 
 	for _, c := range pod.Spec.Containers {
 		for _, port := range p.containerPorts(pod, c) {
 			// get current entry for this container
-			resource := latest.PortForwardResource{
+			resource := latest_v1.PortForwardResource{
 				Type:      constants.Pod,
 				Name:      pod.Name,
 				Namespace: pod.Namespace,
@@ -132,7 +132,7 @@ func (p *WatchingPodForwarder) portForwardPod(ctx context.Context, pod *v1.Pod) 
 	return nil
 }
 
-func (p *WatchingPodForwarder) podForwardingEntry(resourceVersion, containerName, portName, ownerReference string, resource latest.PortForwardResource) (*portForwardEntry, error) {
+func (p *WatchingPodForwarder) podForwardingEntry(resourceVersion, containerName, portName, ownerReference string, resource latest_v1.PortForwardResource) (*portForwardEntry, error) {
 	rv, err := strconv.Atoi(resourceVersion)
 	if err != nil {
 		return nil, fmt.Errorf("converting resource version to integer: %w", err)

--- a/pkg/skaffold/kubernetes/portforward/pod_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/pod_forwarder_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -55,7 +55,7 @@ func TestAutomaticPortForwardPod(t *testing.T) {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
-					resource: latest.PortForwardResource{
+					resource: latest_v1.PortForwardResource{
 						Type:      "pod",
 						Name:      "podname",
 						Namespace: "namespace",
@@ -100,7 +100,7 @@ func TestAutomaticPortForwardPod(t *testing.T) {
 				"owner-containername-namespace-portname-8080": {
 					resourceVersion: 1,
 					podName:         "podname",
-					resource: latest.PortForwardResource{
+					resource: latest_v1.PortForwardResource{
 						Type:      "pod",
 						Name:      "podname",
 						Namespace: "namespace",
@@ -176,7 +176,7 @@ func TestAutomaticPortForwardPod(t *testing.T) {
 					resourceVersion: 1,
 					podName:         "podname",
 					containerName:   "containername",
-					resource: latest.PortForwardResource{
+					resource: latest_v1.PortForwardResource{
 						Type:      "pod",
 						Name:      "podname",
 						Namespace: "namespace",
@@ -193,7 +193,7 @@ func TestAutomaticPortForwardPod(t *testing.T) {
 					resourceVersion: 1,
 					podName:         "podname2",
 					containerName:   "containername2",
-					resource: latest.PortForwardResource{
+					resource: latest_v1.PortForwardResource{
 						Type:      "pod",
 						Name:      "podname2",
 						Namespace: "namespace2",
@@ -260,7 +260,7 @@ func TestAutomaticPortForwardPod(t *testing.T) {
 					podName:         "podname",
 					containerName:   "containername",
 					portName:        "portname",
-					resource: latest.PortForwardResource{
+					resource: latest_v1.PortForwardResource{
 						Type:      "pod",
 						Name:      "podname",
 						Namespace: "namespace",
@@ -277,7 +277,7 @@ func TestAutomaticPortForwardPod(t *testing.T) {
 					podName:         "podname2",
 					containerName:   "containername2",
 					portName:        "portname2",
-					resource: latest.PortForwardResource{
+					resource: latest_v1.PortForwardResource{
 						Type:      "pod",
 						Name:      "podname2",
 						Namespace: "namespace2",
@@ -343,7 +343,7 @@ func TestAutomaticPortForwardPod(t *testing.T) {
 					podName:         "podname",
 					containerName:   "containername",
 					portName:        "portname",
-					resource: latest.PortForwardResource{
+					resource: latest_v1.PortForwardResource{
 						Type:      "pod",
 						Name:      "podname",
 						Namespace: "namespace",
@@ -402,7 +402,7 @@ func TestAutomaticPortForwardPod(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			testEvent.InitializeState([]latest.Pipeline{{}})
+			testEvent.InitializeState([]latest_v1.Pipeline{{}})
 			taken := map[int]struct{}{}
 			t.Override(&retrieveAvailablePort, mockRetrieveAvailablePort(util.Loopback, taken, test.availablePorts))
 			t.Override(&topLevelOwnerKey, func(context.Context, metav1.Object, string) string { return "owner" })
@@ -475,7 +475,7 @@ func TestStartPodForwarder(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			testEvent.InitializeState([]latest.Pipeline{{}})
+			testEvent.InitializeState([]latest_v1.Pipeline{{}})
 			t.Override(&topLevelOwnerKey, func(context.Context, metav1.Object, string) string { return "owner" })
 			t.Override(&newPodWatcher, func(kubernetes.PodSelector) kubernetes.PodWatcher {
 				return &fakePodWatcher{

--- a/pkg/skaffold/kubernetes/portforward/port_forward_entry.go
+++ b/pkg/skaffold/kubernetes/portforward/port_forward_entry.go
@@ -22,12 +22,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 type portForwardEntry struct {
 	resourceVersion        int
-	resource               latest.PortForwardResource
+	resource               latest_v1.PortForwardResource
 	podName                string
 	containerName          string
 	portName               string
@@ -40,7 +40,7 @@ type portForwardEntry struct {
 }
 
 // newPortForwardEntry returns a port forward entry.
-func newPortForwardEntry(resourceVersion int, resource latest.PortForwardResource, podName, containerName, portName, ownerReference string, localPort int, automaticPodForwarding bool) *portForwardEntry {
+func newPortForwardEntry(resourceVersion int, resource latest_v1.PortForwardResource, podName, containerName, portName, ownerReference string, localPort int, automaticPodForwarding bool) *portForwardEntry {
 	return &portForwardEntry{
 		resourceVersion:        resourceVersion,
 		resource:               resource,

--- a/pkg/skaffold/kubernetes/portforward/port_forward_entry_test.go
+++ b/pkg/skaffold/kubernetes/portforward/port_forward_entry_test.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -33,7 +33,7 @@ func TestPortForwardEntryKey(t *testing.T) {
 	}{
 		{
 			description: "entry for pod",
-			pfe: newPortForwardEntry(0, latest.PortForwardResource{
+			pfe: newPortForwardEntry(0, latest_v1.PortForwardResource{
 				Type:      "pod",
 				Name:      "podName",
 				Namespace: "default",
@@ -42,7 +42,7 @@ func TestPortForwardEntryKey(t *testing.T) {
 			expected: "pod-podName-default-8080",
 		}, {
 			description: "entry for deploy",
-			pfe: newPortForwardEntry(0, latest.PortForwardResource{
+			pfe: newPortForwardEntry(0, latest_v1.PortForwardResource{
 				Type:      "deployment",
 				Name:      "depName",
 				Namespace: "namespace",
@@ -51,7 +51,7 @@ func TestPortForwardEntryKey(t *testing.T) {
 			expected: "deployment-depName-namespace-9000",
 		}, {
 			description: "entry for deployment with capital normalization",
-			pfe: newPortForwardEntry(0, latest.PortForwardResource{
+			pfe: newPortForwardEntry(0, latest_v1.PortForwardResource{
 				Type:      "Deployment",
 				Name:      "depName",
 				Namespace: "namespace",
@@ -84,7 +84,7 @@ func TestAutomaticPodForwardingKey(t *testing.T) {
 	}{
 		{
 			description: "entry for automatically port forwarded pod",
-			pfe: newPortForwardEntry(0, latest.PortForwardResource{
+			pfe: newPortForwardEntry(0, latest_v1.PortForwardResource{
 				Type:      "pod",
 				Name:      "podName",
 				Namespace: "default",

--- a/pkg/skaffold/kubernetes/portforward/port_forward_integration.go
+++ b/pkg/skaffold/kubernetes/portforward/port_forward_integration.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -39,7 +39,7 @@ func SimulateDevCycle(t *testing.T, kubectlCLI *kubectl.CLI, namespace string) {
 	portForwardEvent = func(entry *portForwardEntry) {}
 	ctx := context.Background()
 	localPort := retrieveAvailablePort(util.Loopback, 9000, &em.forwardedPorts)
-	pfe := newPortForwardEntry(0, latest.PortForwardResource{
+	pfe := newPortForwardEntry(0, latest_v1.PortForwardResource{
 		Type:      "deployment",
 		Name:      "leeroy-web",
 		Namespace: namespace,

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -35,7 +35,7 @@ import (
 type ResourceForwarder struct {
 	entryManager         *EntryManager
 	label                string
-	userDefinedResources []*latest.PortForwardResource
+	userDefinedResources []*latest_v1.PortForwardResource
 	services             bool
 }
 
@@ -55,14 +55,14 @@ func NewServicesForwarder(entryManager *EntryManager, label string) *ResourceFor
 }
 
 // NewUserDefinedForwarder returns a struct that tracks and port-forwards services as they are created and modified
-func NewUserDefinedForwarder(entryManager *EntryManager, userDefinedResources []*latest.PortForwardResource) *ResourceForwarder {
+func NewUserDefinedForwarder(entryManager *EntryManager, userDefinedResources []*latest_v1.PortForwardResource) *ResourceForwarder {
 	return &ResourceForwarder{
 		entryManager:         entryManager,
 		userDefinedResources: userDefinedResources,
 	}
 }
 
-// Start gets a list of services deployed by skaffold as []latest.PortForwardResource and
+// Start gets a list of services deployed by skaffold as []latest_v1.PortForwardResource and
 // forwards them.
 func (p *ResourceForwarder) Start(ctx context.Context, namespaces []string) error {
 	if len(namespaces) == 1 {
@@ -72,7 +72,7 @@ func (p *ResourceForwarder) Start(ctx context.Context, namespaces []string) erro
 			}
 		}
 	} else {
-		var validResources []*latest.PortForwardResource
+		var validResources []*latest_v1.PortForwardResource
 		for _, pf := range p.userDefinedResources {
 			if pf.Namespace != "" {
 				validResources = append(validResources, pf)
@@ -83,7 +83,7 @@ func (p *ResourceForwarder) Start(ctx context.Context, namespaces []string) erro
 		p.userDefinedResources = validResources
 	}
 
-	var serviceResources []*latest.PortForwardResource
+	var serviceResources []*latest_v1.PortForwardResource
 	if p.services {
 		found, err := retrieveServices(ctx, p.label, namespaces)
 		if err != nil {
@@ -100,7 +100,7 @@ func (p *ResourceForwarder) Stop() {
 }
 
 // Port forward each resource individually in a goroutine
-func (p *ResourceForwarder) portForwardResources(ctx context.Context, resources []*latest.PortForwardResource) {
+func (p *ResourceForwarder) portForwardResources(ctx context.Context, resources []*latest_v1.PortForwardResource) {
 	go func() {
 		for _, r := range resources {
 			p.portForwardResource(ctx, *r)
@@ -108,14 +108,14 @@ func (p *ResourceForwarder) portForwardResources(ctx context.Context, resources 
 	}()
 }
 
-func (p *ResourceForwarder) portForwardResource(ctx context.Context, resource latest.PortForwardResource) {
+func (p *ResourceForwarder) portForwardResource(ctx context.Context, resource latest_v1.PortForwardResource) {
 	// Get port forward entry for this resource
 	entry := p.getCurrentEntry(resource)
 	// Forward the entry
 	p.entryManager.forwardPortForwardEntry(ctx, entry)
 }
 
-func (p *ResourceForwarder) getCurrentEntry(resource latest.PortForwardResource) *portForwardEntry {
+func (p *ResourceForwarder) getCurrentEntry(resource latest_v1.PortForwardResource) *portForwardEntry {
 	// determine if we have seen this before
 	entry := newPortForwardEntry(0, resource, "", "", "", "", 0, false)
 
@@ -138,13 +138,13 @@ func (p *ResourceForwarder) getCurrentEntry(resource latest.PortForwardResource)
 
 // retrieveServiceResources retrieves all services in the cluster matching the given label
 // as a list of PortForwardResources
-func retrieveServiceResources(ctx context.Context, label string, namespaces []string) ([]*latest.PortForwardResource, error) {
+func retrieveServiceResources(ctx context.Context, label string, namespaces []string) ([]*latest_v1.PortForwardResource, error) {
 	client, err := kubernetesclient.Client()
 	if err != nil {
 		return nil, fmt.Errorf("getting Kubernetes client: %w", err)
 	}
 
-	var resources []*latest.PortForwardResource
+	var resources []*latest_v1.PortForwardResource
 	for _, ns := range namespaces {
 		services, err := client.CoreV1().Services(ns).List(ctx, metav1.ListOptions{
 			LabelSelector: label,
@@ -154,7 +154,7 @@ func retrieveServiceResources(ctx context.Context, label string, namespaces []st
 		}
 		for _, s := range services.Items {
 			for _, p := range s.Spec.Ports {
-				resources = append(resources, &latest.PortForwardResource{
+				resources = append(resources, &latest_v1.PortForwardResource{
 					Type:      constants.Service,
 					Name:      s.Name,
 					Namespace: s.Namespace,

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
 	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -83,14 +83,14 @@ func mockRetrieveAvailablePort(_ string, taken map[int]struct{}, availablePorts 
 }
 
 func TestStart(t *testing.T) {
-	svc1 := &latest.PortForwardResource{
+	svc1 := &latest_v1.PortForwardResource{
 		Type:      constants.Service,
 		Name:      "svc1",
 		Namespace: "default",
 		Port:      schemautil.FromInt(8080),
 	}
 
-	svc2 := &latest.PortForwardResource{
+	svc2 := &latest_v1.PortForwardResource{
 		Type:      constants.Service,
 		Name:      "svc2",
 		Namespace: "default",
@@ -99,13 +99,13 @@ func TestStart(t *testing.T) {
 
 	tests := []struct {
 		description    string
-		resources      []*latest.PortForwardResource
+		resources      []*latest_v1.PortForwardResource
 		availablePorts []int
 		expected       map[string]*portForwardEntry
 	}{
 		{
 			description:    "forward two services",
-			resources:      []*latest.PortForwardResource{svc1, svc2},
+			resources:      []*latest_v1.PortForwardResource{svc1, svc2},
 			availablePorts: []int{8080, 9000},
 			expected: map[string]*portForwardEntry{
 				"service-svc1-default-8080": {
@@ -121,9 +121,9 @@ func TestStart(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			testEvent.InitializeState([]latest.Pipeline{{}})
+			testEvent.InitializeState([]latest_v1.Pipeline{{}})
 			t.Override(&retrieveAvailablePort, mockRetrieveAvailablePort(util.Loopback, map[int]struct{}{}, test.availablePorts))
-			t.Override(&retrieveServices, func(context.Context, string, []string) ([]*latest.PortForwardResource, error) {
+			t.Override(&retrieveServices, func(context.Context, string, []string) ([]*latest_v1.PortForwardResource, error) {
 				return test.resources, nil
 			})
 
@@ -151,33 +151,33 @@ func TestGetCurrentEntryFunc(t *testing.T) {
 		description        string
 		forwardedResources map[string]*portForwardEntry
 		availablePorts     []int
-		resource           latest.PortForwardResource
+		resource           latest_v1.PortForwardResource
 		expectedReq        int
 		expected           *portForwardEntry
 	}{
 		{
 			description: "port forward service",
-			resource: latest.PortForwardResource{
+			resource: latest_v1.PortForwardResource{
 				Type: "service",
 				Name: "serviceName",
 				Port: schemautil.FromInt(8080),
 			},
 			availablePorts: []int{8080},
 			expectedReq:    8080,
-			expected:       newPortForwardEntry(0, latest.PortForwardResource{}, "", "", "", "", 8080, false),
+			expected:       newPortForwardEntry(0, latest_v1.PortForwardResource{}, "", "", "", "", 8080, false),
 		}, {
 			description: "should not request system ports (1-1023)",
-			resource: latest.PortForwardResource{
+			resource: latest_v1.PortForwardResource{
 				Type: "service",
 				Name: "serviceName",
 				Port: schemautil.FromInt(80),
 			},
 			availablePorts: []int{8080},
 			expectedReq:    0, // no local port requested as port 80 is a system port
-			expected:       newPortForwardEntry(0, latest.PortForwardResource{}, "", "", "", "", 8080, false),
+			expected:       newPortForwardEntry(0, latest_v1.PortForwardResource{}, "", "", "", "", 8080, false),
 		}, {
 			description: "port forward existing deployment",
-			resource: latest.PortForwardResource{
+			resource: latest_v1.PortForwardResource{
 				Type:      "deployment",
 				Namespace: "default",
 				Name:      "depName",
@@ -185,7 +185,7 @@ func TestGetCurrentEntryFunc(t *testing.T) {
 			},
 			forwardedResources: map[string]*portForwardEntry{
 				"deployment-depName-default-8080": {
-					resource: latest.PortForwardResource{
+					resource: latest_v1.PortForwardResource{
 						Type:      "deployment",
 						Namespace: "default",
 						Name:      "depName",
@@ -195,7 +195,7 @@ func TestGetCurrentEntryFunc(t *testing.T) {
 				},
 			},
 			expectedReq: -1, // retrieveAvailablePort should not be called as there is an assigned localPort
-			expected:    newPortForwardEntry(0, latest.PortForwardResource{}, "", "", "", "", 9000, false),
+			expected:    newPortForwardEntry(0, latest_v1.PortForwardResource{}, "", "", "", "", 9000, false),
 		},
 	}
 
@@ -221,7 +221,7 @@ func TestGetCurrentEntryFunc(t *testing.T) {
 }
 
 func TestUserDefinedResources(t *testing.T) {
-	svc := &latest.PortForwardResource{
+	svc := &latest_v1.PortForwardResource{
 		Type:      constants.Service,
 		Name:      "svc1",
 		Namespace: "test",
@@ -230,13 +230,13 @@ func TestUserDefinedResources(t *testing.T) {
 
 	tests := []struct {
 		description       string
-		userResources     []*latest.PortForwardResource
+		userResources     []*latest_v1.PortForwardResource
 		namespaces        []string
 		expectedResources []string
 	}{
 		{
 			description: "pod should be found",
-			userResources: []*latest.PortForwardResource{
+			userResources: []*latest_v1.PortForwardResource{
 				{Type: constants.Pod, Name: "pod", Port: schemautil.FromInt(9000)},
 			},
 			namespaces: []string{"test"},
@@ -246,14 +246,14 @@ func TestUserDefinedResources(t *testing.T) {
 		},
 		{
 			description: "pod not available",
-			userResources: []*latest.PortForwardResource{
+			userResources: []*latest_v1.PortForwardResource{
 				{Type: constants.Pod, Name: "pod", Port: schemautil.FromInt(9000)},
 			},
 			namespaces:        []string{"test", "some"},
 			expectedResources: []string{},
 		},
 		{
-			userResources: []*latest.PortForwardResource{
+			userResources: []*latest_v1.PortForwardResource{
 				{Type: constants.Pod, Name: "pod", Port: schemautil.FromInt(9000)},
 				{Type: constants.Pod, Name: "pod", Namespace: "some", Port: schemautil.FromInt(9001)},
 			},
@@ -266,10 +266,10 @@ func TestUserDefinedResources(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			testEvent.InitializeState([]latest.Pipeline{{}})
+			testEvent.InitializeState([]latest_v1.Pipeline{{}})
 			t.Override(&retrieveAvailablePort, mockRetrieveAvailablePort(util.Loopback, map[int]struct{}{}, []int{8080, 9000}))
-			t.Override(&retrieveServices, func(context.Context, string, []string) ([]*latest.PortForwardResource, error) {
-				return []*latest.PortForwardResource{svc}, nil
+			t.Override(&retrieveServices, func(context.Context, string, []string) ([]*latest_v1.PortForwardResource, error) {
+				return []*latest_v1.PortForwardResource{svc}, nil
 			})
 
 			fakeForwarder := newTestForwarder()
@@ -305,7 +305,7 @@ func TestRetrieveServices(t *testing.T) {
 		description string
 		namespaces  []string
 		services    []*v1.Service
-		expected    []*latest.PortForwardResource
+		expected    []*latest_v1.PortForwardResource
 	}{
 		{
 			description: "multiple services in multiple namespaces",
@@ -331,7 +331,7 @@ func TestRetrieveServices(t *testing.T) {
 					Spec: v1.ServiceSpec{Ports: []v1.ServicePort{{Port: 8081}}},
 				},
 			},
-			expected: []*latest.PortForwardResource{{
+			expected: []*latest_v1.PortForwardResource{{
 				Type:      constants.Service,
 				Name:      "svc1",
 				Namespace: "test",

--- a/pkg/skaffold/parser/config_test.go
+++ b/pkg/skaffold/parser/config_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/git"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -54,18 +54,18 @@ profiles:
 `
 )
 
-func createCfg(name string, imageName string, workspace string, requires []latest.ConfigDependency) *latest.SkaffoldConfig {
-	return &latest.SkaffoldConfig{
-		APIVersion:   latest.Version,
+func createCfg(name string, imageName string, workspace string, requires []latest_v1.ConfigDependency) *latest_v1.SkaffoldConfig {
+	return &latest_v1.SkaffoldConfig{
+		APIVersion:   latest_v1.Version,
 		Kind:         "Config",
 		Dependencies: requires,
-		Metadata:     latest.Metadata{Name: name},
-		Pipeline: latest.Pipeline{Build: latest.BuildConfig{
-			Artifacts: []*latest.Artifact{{ImageName: imageName, ArtifactType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{DockerfilePath: "Dockerfile"}}, Workspace: workspace}}, TagPolicy: latest.TagPolicy{
-				GitTagger: &latest.GitTagger{}}, BuildType: latest.BuildType{
-				LocalBuild: &latest.LocalBuild{Concurrency: concurrency()},
-			}}, Deploy: latest.DeployConfig{Logs: latest.LogsConfig{Prefix: "container"}}},
+		Metadata:     latest_v1.Metadata{Name: name},
+		Pipeline: latest_v1.Pipeline{Build: latest_v1.BuildConfig{
+			Artifacts: []*latest_v1.Artifact{{ImageName: imageName, ArtifactType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{DockerfilePath: "Dockerfile"}}, Workspace: workspace}}, TagPolicy: latest_v1.TagPolicy{
+				GitTagger: &latest_v1.GitTagger{}}, BuildType: latest_v1.BuildType{
+				LocalBuild: &latest_v1.LocalBuild{Concurrency: concurrency()},
+			}}, Deploy: latest_v1.DeployConfig{Logs: latest_v1.LogsConfig{Prefix: "container"}}},
 	}
 }
 
@@ -91,23 +91,23 @@ func TestGetAllConfigs(t *testing.T) {
 		configFilter []string
 		profiles     []string
 		errCode      proto.StatusCode
-		expected     []*latest.SkaffoldConfig
+		expected     []*latest_v1.SkaffoldConfig
 	}{
 		{
 			description: "no dependencies",
 			documents:   []document{{path: "skaffold.yaml", configs: []mockCfg{{name: "cfg00", requiresStanza: ""}}}},
-			expected:    []*latest.SkaffoldConfig{createCfg("cfg00", "image00", ".", nil)},
+			expected:    []*latest_v1.SkaffoldConfig{createCfg("cfg00", "image00", ".", nil)},
 		},
 		{
 			description:  "no dependencies, config flag",
 			documents:    []document{{path: "skaffold.yaml", configs: []mockCfg{{name: "cfg00", requiresStanza: ""}, {name: "cfg01", requiresStanza: ""}}}},
-			expected:     []*latest.SkaffoldConfig{createCfg("cfg01", "image01", ".", nil)},
+			expected:     []*latest_v1.SkaffoldConfig{createCfg("cfg01", "image01", ".", nil)},
 			configFilter: []string{"cfg01"},
 		},
 		{
 			description:  "no dependencies, config flag, profiles flag",
 			documents:    []document{{path: "skaffold.yaml", configs: []mockCfg{{name: "cfg00", requiresStanza: ""}, {name: "cfg01", requiresStanza: ""}}}},
-			expected:     []*latest.SkaffoldConfig{createCfg("cfg01", "pf0image01", ".", nil)},
+			expected:     []*latest_v1.SkaffoldConfig{createCfg("cfg01", "pf0image01", ".", nil)},
 			configFilter: []string{"cfg01"},
 			profiles:     []string{"pf0"},
 		},
@@ -124,10 +124,10 @@ requires:
 				{path: "doc1/skaffold.yaml", configs: []mockCfg{{name: "cfg10", requiresStanza: ""}, {name: "cfg11", requiresStanza: ""}}},
 				{path: "doc2/skaffold.yaml", configs: []mockCfg{{name: "cfg20", requiresStanza: ""}, {name: "cfg21", requiresStanza: ""}}},
 			},
-			expected: []*latest.SkaffoldConfig{
+			expected: []*latest_v1.SkaffoldConfig{
 				createCfg("cfg10", "image10", "doc1", nil),
 				createCfg("cfg21", "image21", "doc2", nil),
-				createCfg("cfg00", "image00", ".", []latest.ConfigDependency{{Path: "doc1", Names: []string{"cfg10"}}, {Path: "doc2", Names: []string{"cfg21"}}}),
+				createCfg("cfg00", "image00", ".", []latest_v1.ConfigDependency{{Path: "doc1", Names: []string{"cfg10"}}, {Path: "doc2", Names: []string{"cfg21"}}}),
 				createCfg("cfg01", "image01", ".", nil),
 			},
 		},
@@ -146,10 +146,10 @@ requires:
 `}, {name: "cfg11", requiresStanza: ""}}},
 				{path: "doc2/skaffold.yaml", configs: []mockCfg{{name: "cfg20", requiresStanza: ""}, {name: "cfg21", requiresStanza: ""}}},
 			},
-			expected: []*latest.SkaffoldConfig{
+			expected: []*latest_v1.SkaffoldConfig{
 				createCfg("cfg21", "image21", "doc2", nil),
-				createCfg("cfg10", "image10", "doc1", []latest.ConfigDependency{{Path: "../doc2", Names: []string{"cfg21"}}}),
-				createCfg("cfg00", "image00", ".", []latest.ConfigDependency{{Path: "doc1", Names: []string{"cfg10"}}}),
+				createCfg("cfg10", "image10", "doc1", []latest_v1.ConfigDependency{{Path: "../doc2", Names: []string{"cfg21"}}}),
+				createCfg("cfg00", "image00", ".", []latest_v1.ConfigDependency{{Path: "doc1", Names: []string{"cfg10"}}}),
 				createCfg("cfg01", "image01", ".", nil),
 			},
 		},
@@ -165,10 +165,10 @@ requires:
 				{path: "doc1/skaffold.yaml", configs: []mockCfg{{name: "cfg10", requiresStanza: ""}, {name: "cfg11", requiresStanza: ""}}},
 				{path: "doc2/skaffold.yaml", configs: []mockCfg{{name: "cfg20", requiresStanza: ""}, {name: "cfg21", requiresStanza: ""}}},
 			},
-			expected: []*latest.SkaffoldConfig{
+			expected: []*latest_v1.SkaffoldConfig{
 				createCfg("cfg01", "image01", ".", nil),
 				createCfg("cfg21", "image21", "doc2", nil),
-				createCfg("cfg00", "image00", ".", []latest.ConfigDependency{{Names: []string{"cfg01"}}, {Path: "doc2", Names: []string{"cfg21"}}}),
+				createCfg("cfg00", "image00", ".", []latest_v1.ConfigDependency{{Names: []string{"cfg01"}}, {Path: "doc2", Names: []string{"cfg21"}}}),
 			},
 		},
 		{
@@ -183,10 +183,10 @@ requires:
   - configs: [cfg11]
 `}, {name: "cfg11", requiresStanza: ""}}},
 			},
-			expected: []*latest.SkaffoldConfig{
+			expected: []*latest_v1.SkaffoldConfig{
 				createCfg("cfg11", "image11", "doc1", nil),
-				createCfg("cfg10", "image10", "doc1", []latest.ConfigDependency{{Names: []string{"cfg11"}}}),
-				createCfg("cfg00", "image00", ".", []latest.ConfigDependency{{Path: "doc1"}}),
+				createCfg("cfg10", "image10", "doc1", []latest_v1.ConfigDependency{{Names: []string{"cfg11"}}}),
+				createCfg("cfg00", "image00", ".", []latest_v1.ConfigDependency{{Path: "doc1"}}),
 			},
 		},
 		{
@@ -208,10 +208,10 @@ requires:
     configs: [cfg00]
 `}}},
 			},
-			expected: []*latest.SkaffoldConfig{
-				createCfg("cfg21", "image21", "doc2", []latest.ConfigDependency{{Path: "../", Names: []string{"cfg00"}}}),
-				createCfg("cfg10", "image10", "doc1", []latest.ConfigDependency{{Path: "../doc2", Names: []string{"cfg21"}}}),
-				createCfg("cfg00", "image00", ".", []latest.ConfigDependency{{Path: "doc1", Names: []string{"cfg10"}}}),
+			expected: []*latest_v1.SkaffoldConfig{
+				createCfg("cfg21", "image21", "doc2", []latest_v1.ConfigDependency{{Path: "../", Names: []string{"cfg00"}}}),
+				createCfg("cfg10", "image10", "doc1", []latest_v1.ConfigDependency{{Path: "../doc2", Names: []string{"cfg21"}}}),
+				createCfg("cfg00", "image00", ".", []latest_v1.ConfigDependency{{Path: "doc1", Names: []string{"cfg10"}}}),
 				createCfg("cfg01", "image01", ".", nil),
 			},
 		},
@@ -231,10 +231,10 @@ requires:
 `}, {name: "cfg11", requiresStanza: ""}}},
 				{path: "doc2/skaffold.yaml", configs: []mockCfg{{name: "cfg20", requiresStanza: ""}, {name: "cfg21", requiresStanza: ""}}},
 			},
-			expected: []*latest.SkaffoldConfig{
+			expected: []*latest_v1.SkaffoldConfig{
 				createCfg("cfg21", "image21", "doc2", nil),
-				createCfg("cfg10", "image10", "doc1", []latest.ConfigDependency{{Path: "../doc2", Names: []string{"cfg21"}}}),
-				createCfg("cfg00", "pf0image00", ".", []latest.ConfigDependency{{Path: "doc1", Names: []string{"cfg10"}}}),
+				createCfg("cfg10", "image10", "doc1", []latest_v1.ConfigDependency{{Path: "../doc2", Names: []string{"cfg21"}}}),
+				createCfg("cfg00", "pf0image00", ".", []latest_v1.ConfigDependency{{Path: "doc1", Names: []string{"cfg10"}}}),
 				createCfg("cfg01", "pf0image01", ".", nil),
 			},
 		},
@@ -260,10 +260,10 @@ requires:
 `}, {name: "cfg11", requiresStanza: ""}}},
 				{path: "doc2/skaffold.yaml", configs: []mockCfg{{name: "cfg20", requiresStanza: ""}, {name: "cfg21", requiresStanza: ""}}},
 			},
-			expected: []*latest.SkaffoldConfig{
+			expected: []*latest_v1.SkaffoldConfig{
 				createCfg("cfg21", "pf0image21", "doc2", nil),
-				createCfg("cfg10", "pf0image10", "doc1", []latest.ConfigDependency{{Path: "../doc2", Names: []string{"cfg21"}, ActiveProfiles: []latest.ProfileDependency{{Name: "pf0", ActivatedBy: []string{"pf0"}}}}}),
-				createCfg("cfg00", "pf0image00", ".", []latest.ConfigDependency{{Path: "doc1", Names: []string{"cfg10"}, ActiveProfiles: []latest.ProfileDependency{{Name: "pf0", ActivatedBy: []string{"pf0"}}}}}),
+				createCfg("cfg10", "pf0image10", "doc1", []latest_v1.ConfigDependency{{Path: "../doc2", Names: []string{"cfg21"}, ActiveProfiles: []latest_v1.ProfileDependency{{Name: "pf0", ActivatedBy: []string{"pf0"}}}}}),
+				createCfg("cfg00", "pf0image00", ".", []latest_v1.ConfigDependency{{Path: "doc1", Names: []string{"cfg10"}, ActiveProfiles: []latest_v1.ProfileDependency{{Name: "pf0", ActivatedBy: []string{"pf0"}}}}}),
 				createCfg("cfg01", "pf0image01", ".", nil),
 			},
 		},
@@ -286,10 +286,10 @@ requires:
 `}, {name: "cfg11", requiresStanza: ""}}},
 				{path: "doc2/skaffold.yaml", configs: []mockCfg{{name: "cfg20", requiresStanza: ""}, {name: "cfg21", requiresStanza: ""}}},
 			},
-			expected: []*latest.SkaffoldConfig{
+			expected: []*latest_v1.SkaffoldConfig{
 				createCfg("cfg21", "pf1image21", "doc2", nil),
-				createCfg("cfg10", "pf0image10", "doc1", []latest.ConfigDependency{{Path: "../doc2", Names: []string{"cfg21"}, ActiveProfiles: []latest.ProfileDependency{{Name: "pf1"}}}}),
-				createCfg("cfg00", "image00", ".", []latest.ConfigDependency{{Path: "doc1", Names: []string{"cfg10"}, ActiveProfiles: []latest.ProfileDependency{{Name: "pf0"}}}}),
+				createCfg("cfg10", "pf0image10", "doc1", []latest_v1.ConfigDependency{{Path: "../doc2", Names: []string{"cfg21"}, ActiveProfiles: []latest_v1.ProfileDependency{{Name: "pf1"}}}}),
+				createCfg("cfg00", "image00", ".", []latest_v1.ConfigDependency{{Path: "doc1", Names: []string{"cfg10"}, ActiveProfiles: []latest_v1.ProfileDependency{{Name: "pf0"}}}}),
 				createCfg("cfg01", "image01", ".", nil),
 			},
 		},
@@ -317,9 +317,9 @@ requires:
 `}}},
 				{path: "doc2/skaffold.yaml", configs: []mockCfg{{name: "cfg20", requiresStanza: ""}, {name: "cfg21", requiresStanza: ""}}},
 			},
-			expected: []*latest.SkaffoldConfig{
+			expected: []*latest_v1.SkaffoldConfig{
 				createCfg("cfg21", "image21", "doc2", nil),
-				createCfg("cfg11", "image11", "doc1", []latest.ConfigDependency{{Path: "../doc2", Names: []string{"cfg21"}}}),
+				createCfg("cfg11", "image11", "doc1", []latest_v1.ConfigDependency{{Path: "../doc2", Names: []string{"cfg21"}}}),
 			},
 		},
 		{
@@ -394,11 +394,11 @@ requires:
 `}}},
 				{path: "doc2/skaffold.yaml", configs: []mockCfg{{name: "cfg20", requiresStanza: ""}, {name: "cfg21", requiresStanza: ""}}},
 			},
-			expected: []*latest.SkaffoldConfig{
+			expected: []*latest_v1.SkaffoldConfig{
 				createCfg("cfg21", "image21", "doc2", nil),
-				createCfg("cfg10", "image10", "doc1", []latest.ConfigDependency{{GitRepo: &latest.GitInfo{Repo: "doc2", Path: "skaffold.yaml", Ref: "main"}, Names: []string{"cfg21"}}}),
-				createCfg("cfg11", "image11", "doc1", []latest.ConfigDependency{{GitRepo: &latest.GitInfo{Repo: "doc2", Ref: "main"}, Names: []string{"cfg21"}}}),
-				createCfg("cfg00", "image00", ".", []latest.ConfigDependency{{Path: "doc1"}}),
+				createCfg("cfg10", "image10", "doc1", []latest_v1.ConfigDependency{{GitRepo: &latest_v1.GitInfo{Repo: "doc2", Path: "skaffold.yaml", Ref: "main"}, Names: []string{"cfg21"}}}),
+				createCfg("cfg11", "image11", "doc1", []latest_v1.ConfigDependency{{GitRepo: &latest_v1.GitInfo{Repo: "doc2", Ref: "main"}, Names: []string{"cfg21"}}}),
+				createCfg("cfg00", "image00", ".", []latest_v1.ConfigDependency{{Path: "doc1"}}),
 				createCfg("cfg01", "image01", ".", nil),
 			},
 		},
@@ -411,7 +411,7 @@ requires:
 				var cfgs []string
 				for j, c := range d.configs {
 					id := fmt.Sprintf("%d%d", i, j)
-					s := fmt.Sprintf(template, latest.Version, c.name, c.requiresStanza, id, id, id)
+					s := fmt.Sprintf(template, latest_v1.Version, c.name, c.requiresStanza, id, id, id)
 					cfgs = append(cfgs, s)
 				}
 				tmpDir.Write(d.path, strings.Join(cfgs, "\n---\n"))
@@ -433,7 +433,7 @@ requires:
 					c.Dependencies[i].Path = filepath.Join(wd, dir, c.Dependencies[i].Path)
 				}
 			}
-			t.Override(&git.SyncRepo, func(g latest.GitInfo, _ config.SkaffoldOptions) (string, error) { return g.Repo, nil })
+			t.Override(&git.SyncRepo, func(g latest_v1.GitInfo, _ config.SkaffoldOptions) (string, error) { return g.Repo, nil })
 			cfgs, err := GetAllConfigs(config.SkaffoldOptions{
 				Command:             "dev",
 				ConfigurationFile:   test.documents[0].path,

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -34,7 +34,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -53,7 +53,7 @@ type Builder struct {
 }
 
 // Build builds a list of artifacts.
-func (r *Builder) Build(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
+func (r *Builder) Build(ctx context.Context, out io.Writer, artifacts []*latest_v1.Artifact) ([]graph.Artifact, error) {
 	eventV2.TaskInProgress(constants.Build)
 
 	// Use tags directly from the Kubernetes manifests.
@@ -86,7 +86,7 @@ func (r *Builder) Build(ctx context.Context, out io.Writer, artifacts []*latest.
 		return bRes, nil
 	}
 
-	bRes, err := r.cache.Build(ctx, out, tags, artifacts, func(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
+	bRes, err := r.cache.Build(ctx, out, tags, artifacts, func(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest_v1.Artifact) ([]graph.Artifact, error) {
 		if len(artifacts) == 0 {
 			return nil, nil
 		}
@@ -138,7 +138,7 @@ func (r *Builder) ApplyDefaultRepo(tag string) (string, error) {
 }
 
 // imageTags generates tags for a list of artifacts
-func (r *Builder) imageTags(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) (tag.ImageTags, error) {
+func (r *Builder) imageTags(ctx context.Context, out io.Writer, artifacts []*latest_v1.Artifact) (tag.ImageTags, error) {
 	start := time.Now()
 	color.Default.Fprintln(out, "Generating tags...")
 
@@ -197,7 +197,7 @@ func (r *Builder) imageTags(ctx context.Context, out io.Writer, artifacts []*lat
 	return imageTags, nil
 }
 
-func checkWorkspaces(artifacts []*latest.Artifact) error {
+func checkWorkspaces(artifacts []*latest_v1.Artifact) error {
 	for _, a := range artifacts {
 		if a.Workspace != "" {
 			if info, err := os.Stat(a.Workspace); err != nil {

--- a/pkg/skaffold/runner/build_deploy_test.go
+++ b/pkg/skaffold/runner/build_deploy_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -36,7 +36,7 @@ func TestTest(t *testing.T) {
 	tests := []struct {
 		description     string
 		testBench       *TestBench
-		cfg             []*latest.Artifact
+		cfg             []*latest_v1.Artifact
 		artifacts       []graph.Artifact
 		expectedActions []Actions
 		shouldErr       bool
@@ -44,7 +44,7 @@ func TestTest(t *testing.T) {
 		{
 			description: "test no error",
 			testBench:   &TestBench{},
-			cfg:         []*latest.Artifact{{ImageName: "img1"}, {ImageName: "img2"}},
+			cfg:         []*latest_v1.Artifact{{ImageName: "img1"}, {ImageName: "img2"}},
 			artifacts: []graph.Artifact{
 				{ImageName: "img1", Tag: "img1:tag1"},
 				{ImageName: "img2", Tag: "img2:tag2"},
@@ -62,7 +62,7 @@ func TestTest(t *testing.T) {
 		{
 			description: "missing tag",
 			testBench:   &TestBench{},
-			cfg:         []*latest.Artifact{{ImageName: "image1"}},
+			cfg:         []*latest_v1.Artifact{{ImageName: "image1"}},
 			artifacts:   []graph.Artifact{{ImageName: "image1"}},
 			expectedActions: []Actions{{
 				Tested: []string{""},
@@ -134,7 +134,7 @@ func TestBuildTestDeploy(t *testing.T) {
 			t.Override(&client.Client, mockK8sClient)
 
 			ctx := context.Background()
-			artifacts := []*latest.Artifact{{
+			artifacts := []*latest_v1.Artifact{{
 				ImageName: "img",
 			}}
 
@@ -155,7 +155,7 @@ func TestBuildTestDeploy(t *testing.T) {
 func TestBuildDryRun(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		testBench := &TestBench{}
-		artifacts := []*latest.Artifact{
+		artifacts := []*latest_v1.Artifact{
 			{ImageName: "img1"},
 			{ImageName: "img2"},
 		}
@@ -176,7 +176,7 @@ func TestBuildDryRun(t *testing.T) {
 func TestBuildPushFlag(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		testBench := &TestBench{}
-		artifacts := []*latest.Artifact{
+		artifacts := []*latest_v1.Artifact{
 			{ImageName: "img1"},
 			{ImageName: "img2"},
 		}
@@ -190,7 +190,7 @@ func TestBuildPushFlag(t *testing.T) {
 }
 
 func TestDigestSources(t *testing.T) {
-	artifacts := []*latest.Artifact{
+	artifacts := []*latest_v1.Artifact{
 		{ImageName: "img1"},
 	}
 
@@ -240,12 +240,12 @@ func TestCheckWorkspaces(t *testing.T) {
 
 	tests := []struct {
 		description string
-		artifacts   []*latest.Artifact
+		artifacts   []*latest_v1.Artifact
 		shouldErr   bool
 	}{
 		{
 			description: "no workspace",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image",
 				},
@@ -253,7 +253,7 @@ func TestCheckWorkspaces(t *testing.T) {
 		},
 		{
 			description: "directory that exists",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image",
 					Workspace: tmpDir.Root(),
@@ -262,7 +262,7 @@ func TestCheckWorkspaces(t *testing.T) {
 		},
 		{
 			description: "error on non-existent location",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image",
 					Workspace: "doesnotexist",
@@ -272,7 +272,7 @@ func TestCheckWorkspaces(t *testing.T) {
 		},
 		{
 			description: "error on file",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image",
 					Workspace: tmpFile,

--- a/pkg/skaffold/runner/builder.go
+++ b/pkg/skaffold/runner/builder.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/local"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // builderCtx encapsulates a given skaffold run context along with additional builder constructs.
@@ -46,7 +46,7 @@ func (b *builderCtx) SourceDependenciesResolver() graph.TransitiveSourceDependen
 }
 
 // getBuilder creates a builder from a given RunContext and build pipeline type.
-func getBuilder(r *runcontext.RunContext, s build.ArtifactStore, d graph.TransitiveSourceDependenciesCache, p latest.Pipeline) (build.PipelineBuilder, error) {
+func getBuilder(r *runcontext.RunContext, s build.ArtifactStore, d graph.TransitiveSourceDependenciesCache, p latest_v1.Pipeline) (build.PipelineBuilder, error) {
 	bCtx := &builderCtx{artifactStore: s, sourceDependenciesCache: d, RunContext: r}
 	switch {
 	case p.Build.LocalBuild != nil:

--- a/pkg/skaffold/runner/changeset.go
+++ b/pkg/skaffold/runner/changeset.go
@@ -17,13 +17,13 @@ limitations under the License.
 package runner
 
 import (
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 )
 
 type ChangeSet struct {
-	needsRebuild   []*latest.Artifact
-	rebuildTracker map[string]*latest.Artifact
+	needsRebuild   []*latest_v1.Artifact
+	rebuildTracker map[string]*latest_v1.Artifact
 	needsResync    []*sync.Item
 	resyncTracker  map[string]*sync.Item
 	needsRetest    map[string]bool // keyed on artifact image name
@@ -31,19 +31,19 @@ type ChangeSet struct {
 	needsReload    bool
 }
 
-func (c *ChangeSet) AddRebuild(a *latest.Artifact) {
+func (c *ChangeSet) AddRebuild(a *latest_v1.Artifact) {
 	if _, ok := c.rebuildTracker[a.ImageName]; ok {
 		return
 	}
 
 	if c.rebuildTracker == nil {
-		c.rebuildTracker = map[string]*latest.Artifact{}
+		c.rebuildTracker = map[string]*latest_v1.Artifact{}
 	}
 	c.rebuildTracker[a.ImageName] = a
 	c.needsRebuild = append(c.needsRebuild, a)
 }
 
-func (c *ChangeSet) AddRetest(a *latest.Artifact) {
+func (c *ChangeSet) AddRetest(a *latest_v1.Artifact) {
 	if c.needsRetest == nil {
 		c.needsRetest = make(map[string]bool)
 	}
@@ -63,7 +63,7 @@ func (c *ChangeSet) AddResync(s *sync.Item) {
 }
 
 func (c *ChangeSet) resetBuild() {
-	c.rebuildTracker = make(map[string]*latest.Artifact)
+	c.rebuildTracker = make(map[string]*latest_v1.Artifact)
 	c.needsRebuild = nil
 }
 

--- a/pkg/skaffold/runner/deploy_test.go
+++ b/pkg/skaffold/runner/deploy_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -81,7 +81,7 @@ func TestDeploy(t *testing.T) {
 				return dummyStatusChecker{}
 			})
 
-			runner := createRunner(t, test.testBench, nil, []*latest.Artifact{{ImageName: "img1"}, {ImageName: "img2"}}, nil)
+			runner := createRunner(t, test.testBench, nil, []*latest_v1.Artifact{{ImageName: "img1"}, {ImageName: "img2"}}, nil)
 			runner.runCtx.Opts.StatusCheck = test.statusCheck
 			out := new(bytes.Buffer)
 
@@ -131,7 +131,7 @@ func TestDeployNamespace(t *testing.T) {
 				return dummyStatusChecker{}
 			})
 
-			runner := createRunner(t, test.testBench, nil, []*latest.Artifact{{ImageName: "img1"}, {ImageName: "img2"}}, nil)
+			runner := createRunner(t, test.testBench, nil, []*latest_v1.Artifact{{ImageName: "img1"}, {ImageName: "img2"}}, nil)
 			runner.runCtx.Namespaces = test.Namespaces
 
 			runner.Deploy(context.Background(), ioutil.Discard, []graph.Artifact{

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -34,7 +34,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
@@ -178,7 +178,7 @@ func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer, logger *kuber
 
 // Dev watches for changes and runs the skaffold build, test and deploy
 // config until interrupted by the user.
-func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) error {
+func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*latest_v1.Artifact) error {
 	event.DevLoopInProgress(r.devIteration)
 	eventV2.TaskInProgress(constants.DevLoop)
 	defer func() { r.devIteration++ }()
@@ -321,11 +321,11 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 }
 
 // graph represents the artifact graph
-type devGraph map[string][]*latest.Artifact
+type devGraph map[string][]*latest_v1.Artifact
 
 // getTransposeGraph builds the transpose of the graph represented by the artifacts slice, with edges directed from required artifact to the dependent artifact.
-func getTransposeGraph(artifacts []*latest.Artifact) devGraph {
-	g := make(map[string][]*latest.Artifact)
+func getTransposeGraph(artifacts []*latest_v1.Artifact) devGraph {
+	g := make(map[string][]*latest_v1.Artifact)
 	for _, a := range artifacts {
 		for _, d := range a.Dependencies {
 			g[d.ImageName] = append(g[d.ImageName], a)

--- a/pkg/skaffold/runner/dev_test.go
+++ b/pkg/skaffold/runner/dev_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -143,7 +143,7 @@ func TestDevFailFirstCycle(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
 			t.Override(&client.Client, mockK8sClient)
-			artifacts := []*latest.Artifact{{
+			artifacts := []*latest_v1.Artifact{{
 				ImageName: "img",
 			}}
 			runner := createRunner(t, test.testBench, test.monitor, artifacts, nil)
@@ -274,7 +274,7 @@ func TestDev(t *testing.T) {
 			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
 			t.Override(&client.Client, mockK8sClient)
 			test.testBench.cycles = len(test.watchEvents)
-			artifacts := []*latest.Artifact{
+			artifacts := []*latest_v1.Artifact{
 				{ImageName: "img1"},
 				{ImageName: "img2"},
 			}
@@ -418,11 +418,11 @@ func TestDevAutoTriggers(t *testing.T) {
 			testBench := &TestBench{}
 			testBench.cycles = len(test.watchEvents)
 			testBench.userIntents = test.userIntents
-			artifacts := []*latest.Artifact{
+			artifacts := []*latest_v1.Artifact{
 				{
 					ImageName: "img1",
-					Sync: &latest.Sync{
-						Manual: []*latest.SyncRule{{Src: "file1", Dest: "file1"}},
+					Sync: &latest_v1.Sync{
+						Manual: []*latest_v1.SyncRule{{Src: "file1", Dest: "file1"}},
 					},
 				},
 				{
@@ -524,11 +524,11 @@ func TestDevSync(t *testing.T) {
 			t.Override(&fileSyncSucceeded, func(int, string) { actualFileSyncEventCalls.Succeeded++ })
 			t.Override(&sync.WorkingDir, func(string, docker.Config) (string, error) { return "/", nil })
 			test.testBench.cycles = len(test.watchEvents)
-			artifacts := []*latest.Artifact{
+			artifacts := []*latest_v1.Artifact{
 				{
 					ImageName: "img1",
-					Sync: &latest.Sync{
-						Manual: []*latest.SyncRule{{Src: "file1", Dest: "file1"}},
+					Sync: &latest_v1.Sync{
+						Manual: []*latest_v1.SyncRule{{Src: "file1", Dest: "file1"}},
 					},
 				},
 				{

--- a/pkg/skaffold/runner/generate_pipeline.go
+++ b/pkg/skaffold/runner/generate_pipeline.go
@@ -26,10 +26,10 @@ import (
 	pipeline "github.com/GoogleContainerTools/skaffold/pkg/skaffold/generate_pipeline"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
-func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, configs []*latest.SkaffoldConfig, configPaths []string, fileOut string) error {
+func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, configs []*latest_v1.SkaffoldConfig, configPaths []string, fileOut string) error {
 	// Keep track of files, configs, and profiles. This will be used to know which files to write
 	// profiles to and what flags to add to task commands
 	var baseConfig []*pipeline.ConfigFile
@@ -74,12 +74,12 @@ func setupConfigFiles(configPaths []string) ([]*pipeline.ConfigFile, error) {
 	// Read all given config files to read contents into SkaffoldConfig
 	var configFiles []*pipeline.ConfigFile
 	for _, path := range configPaths {
-		parsedCfgs, err := schema.ParseConfigAndUpgrade(path, latest.Version)
+		parsedCfgs, err := schema.ParseConfigAndUpgrade(path, latest_v1.Version)
 		if err != nil {
 			return nil, fmt.Errorf("parsing config %q: %w", path, err)
 		}
 		for _, parsedCfg := range parsedCfgs {
-			config := parsedCfg.(*latest.SkaffoldConfig)
+			config := parsedCfg.(*latest_v1.SkaffoldConfig)
 
 			if err := defaults.Set(config); err != nil {
 				return nil, fmt.Errorf("setting default values for extra configs: %w", err)

--- a/pkg/skaffold/runner/listen_test.go
+++ b/pkg/skaffold/runner/listen_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/trigger"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -55,7 +55,7 @@ func (f *fakeTriggger) Debounce() bool {
 
 type fakeDepsResolver struct{}
 
-func (f *fakeDepsResolver) ResolveForArtifact(context.Context, *latest.Artifact) ([]string, error) {
+func (f *fakeDepsResolver) ResolveForArtifact(context.Context, *latest_v1.Artifact) ([]string, error) {
 	return nil, nil
 }
 

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -40,7 +40,7 @@ import (
 	pkgkubectl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/server"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
@@ -66,7 +66,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 	sourceDependencies := graph.NewTransitiveSourceDependenciesCache(runCtx, store, g)
 
 	var builder build.Builder
-	builder, err = build.NewBuilderMux(runCtx, store, func(p latest.Pipeline) (build.PipelineBuilder, error) {
+	builder, err = build.NewBuilderMux(runCtx, store, func(p latest_v1.Pipeline) (build.PipelineBuilder, error) {
 		return getBuilder(runCtx, store, sourceDependencies, p)
 	})
 	if err != nil {
@@ -87,7 +87,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		return nil, fmt.Errorf("creating deployer: %w", err)
 	}
 
-	depLister := func(ctx context.Context, artifact *latest.Artifact) ([]string, error) {
+	depLister := func(ctx context.Context, artifact *latest_v1.Artifact) ([]string, error) {
 		buildDependencies, err := sourceDependencies.ResolveForArtifact(ctx, artifact)
 		if err != nil {
 			return nil, err
@@ -242,7 +242,7 @@ Therefore, in this function we do implicit validation of the provided configurat
 func getDefaultDeployer(runCtx *runcontext.RunContext, labels map[string]string) (deploy.Deployer, error) {
 	deployCfgs := runCtx.DeployConfigs()
 
-	var kFlags *latest.KubectlFlags
+	var kFlags *latest_v1.KubectlFlags
 	var logPrefix string
 	var defaultNamespace *string
 	var kubeContext string
@@ -268,7 +268,7 @@ func getDefaultDeployer(runCtx *runcontext.RunContext, labels map[string]string)
 			logPrefix = d.Logs.Prefix
 		}
 		var currentDefaultNamespace *string
-		var currentKubectlFlags latest.KubectlFlags
+		var currentKubectlFlags latest_v1.KubectlFlags
 		if d.KubectlDeploy != nil {
 			currentDefaultNamespace = d.KubectlDeploy.DefaultNamespace
 			currentKubectlFlags = d.KubectlDeploy.Flags
@@ -291,9 +291,9 @@ func getDefaultDeployer(runCtx *runcontext.RunContext, labels map[string]string)
 		}
 	}
 	if kFlags == nil {
-		kFlags = &latest.KubectlFlags{}
+		kFlags = &latest_v1.KubectlFlags{}
 	}
-	k := &latest.KubectlDeploy{
+	k := &latest_v1.KubectlDeploy{
 		Flags:            *kFlags,
 		DefaultNamespace: defaultNamespace,
 	}
@@ -304,7 +304,7 @@ func getDefaultDeployer(runCtx *runcontext.RunContext, labels map[string]string)
 	return defaultDeployer, nil
 }
 
-func validateKubectlFlags(flags *latest.KubectlFlags, additional latest.KubectlFlags) error {
+func validateKubectlFlags(flags *latest_v1.KubectlFlags, additional latest_v1.KubectlFlags) error {
 	errStr := "conflicting sets of kubectl deploy flags not supported in `skaffold apply` (flag: %s)"
 	if additional.DisableValidation != flags.DisableValidation {
 		return fmt.Errorf(errStr, strconv.FormatBool(additional.DisableValidation))

--- a/pkg/skaffold/runner/new_test.go
+++ b/pkg/skaffold/runner/new_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -36,7 +36,7 @@ func TestGetDeployer(tOuter *testing.T) {
 	testutil.Run(tOuter, "TestGetDeployer", func(t *testutil.T) {
 		tests := []struct {
 			description string
-			cfg         latest.DeployType
+			cfg         latest_v1.DeployType
 			helmVersion string
 			expected    deploy.Deployer
 			shouldErr   bool
@@ -47,49 +47,49 @@ func TestGetDeployer(tOuter *testing.T) {
 			},
 			{
 				description: "helm deployer with 3.0.0 version",
-				cfg:         latest.DeployType{HelmDeploy: &latest.HelmDeploy{}},
+				cfg:         latest_v1.DeployType{HelmDeploy: &latest_v1.HelmDeploy{}},
 				helmVersion: `version.BuildInfo{Version:"v3.0.0"}`,
 				expected:    &helm.Deployer{},
 			},
 			{
 				description: "helm deployer with less than 3.0.0 version",
-				cfg:         latest.DeployType{HelmDeploy: &latest.HelmDeploy{}},
+				cfg:         latest_v1.DeployType{HelmDeploy: &latest_v1.HelmDeploy{}},
 				helmVersion: "2.0.0",
 				shouldErr:   true,
 			},
 			{
 				description: "kubectl deployer",
-				cfg:         latest.DeployType{KubectlDeploy: &latest.KubectlDeploy{}},
+				cfg:         latest_v1.DeployType{KubectlDeploy: &latest_v1.KubectlDeploy{}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
-					Pipelines: runcontext.NewPipelines([]latest.Pipeline{{}}),
-				}, nil, &latest.KubectlDeploy{
-					Flags: latest.KubectlFlags{},
+					Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{}}),
+				}, nil, &latest_v1.KubectlDeploy{
+					Flags: latest_v1.KubectlFlags{},
 				})).(deploy.Deployer),
 			},
 			{
 				description: "kustomize deployer",
-				cfg:         latest.DeployType{KustomizeDeploy: &latest.KustomizeDeploy{}},
+				cfg:         latest_v1.DeployType{KustomizeDeploy: &latest_v1.KustomizeDeploy{}},
 				expected: t.RequireNonNilResult(kustomize.NewDeployer(&runcontext.RunContext{
-					Pipelines: runcontext.NewPipelines([]latest.Pipeline{{}}),
-				}, nil, &latest.KustomizeDeploy{
-					Flags: latest.KubectlFlags{},
+					Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{}}),
+				}, nil, &latest_v1.KustomizeDeploy{
+					Flags: latest_v1.KubectlFlags{},
 				})).(deploy.Deployer),
 			},
 			{
 				description: "kpt deployer",
-				cfg:         latest.DeployType{KptDeploy: &latest.KptDeploy{}},
-				expected:    kpt.NewDeployer(&runcontext.RunContext{}, nil, &latest.KptDeploy{}),
+				cfg:         latest_v1.DeployType{KptDeploy: &latest_v1.KptDeploy{}},
+				expected:    kpt.NewDeployer(&runcontext.RunContext{}, nil, &latest_v1.KptDeploy{}),
 			},
 			{
 				description: "multiple deployers",
-				cfg: latest.DeployType{
-					HelmDeploy: &latest.HelmDeploy{},
-					KptDeploy:  &latest.KptDeploy{},
+				cfg: latest_v1.DeployType{
+					HelmDeploy: &latest_v1.HelmDeploy{},
+					KptDeploy:  &latest_v1.KptDeploy{},
 				},
 				helmVersion: `version.BuildInfo{Version:"v3.0.0"}`,
 				expected: deploy.DeployerMux{
 					&helm.Deployer{},
-					kpt.NewDeployer(&runcontext.RunContext{}, nil, &latest.KptDeploy{}),
+					kpt.NewDeployer(&runcontext.RunContext{}, nil, &latest_v1.KptDeploy{}),
 				},
 			},
 		}
@@ -103,8 +103,8 @@ func TestGetDeployer(tOuter *testing.T) {
 				}
 
 				deployer, err := getDeployer(&runcontext.RunContext{
-					Pipelines: runcontext.NewPipelines([]latest.Pipeline{{
-						Deploy: latest.DeployConfig{
+					Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{
+						Deploy: latest_v1.DeployConfig{
 							DeployType: test.cfg,
 						},
 					}}),
@@ -130,35 +130,35 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 	testutil.Run(tOuter, "TestGetDeployer", func(t *testutil.T) {
 		tests := []struct {
 			name      string
-			cfgs      []latest.DeployType
+			cfgs      []latest_v1.DeployType
 			expected  *kubectl.Deployer
 			shouldErr bool
 		}{
 			{
 				name: "one config with kubectl deploy",
-				cfgs: []latest.DeployType{{
-					KubectlDeploy: &latest.KubectlDeploy{},
+				cfgs: []latest_v1.DeployType{{
+					KubectlDeploy: &latest_v1.KubectlDeploy{},
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
-					Pipelines: runcontext.NewPipelines([]latest.Pipeline{{}}),
-				}, nil, &latest.KubectlDeploy{
-					Flags: latest.KubectlFlags{},
+					Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{}}),
+				}, nil, &latest_v1.KubectlDeploy{
+					Flags: latest_v1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
 			{
 				name: "one config with kubectl deploy, with flags",
-				cfgs: []latest.DeployType{{
-					KubectlDeploy: &latest.KubectlDeploy{
-						Flags: latest.KubectlFlags{
+				cfgs: []latest_v1.DeployType{{
+					KubectlDeploy: &latest_v1.KubectlDeploy{
+						Flags: latest_v1.KubectlFlags{
 							Apply:  []string{"--foo"},
 							Global: []string{"--bar"},
 						},
 					},
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
-					Pipelines: runcontext.NewPipelines([]latest.Pipeline{{}}),
-				}, nil, &latest.KubectlDeploy{
-					Flags: latest.KubectlFlags{
+					Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{}}),
+				}, nil, &latest_v1.KubectlDeploy{
+					Flags: latest_v1.KubectlFlags{
 						Apply:  []string{"--foo"},
 						Global: []string{"--bar"},
 					},
@@ -166,17 +166,17 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 			},
 			{
 				name: "two kubectl configs with mismatched flags should fail",
-				cfgs: []latest.DeployType{
+				cfgs: []latest_v1.DeployType{
 					{
-						KubectlDeploy: &latest.KubectlDeploy{
-							Flags: latest.KubectlFlags{
+						KubectlDeploy: &latest_v1.KubectlDeploy{
+							Flags: latest_v1.KubectlFlags{
 								Apply: []string{"--foo"},
 							},
 						},
 					},
 					{
-						KubectlDeploy: &latest.KubectlDeploy{
-							Flags: latest.KubectlFlags{
+						KubectlDeploy: &latest_v1.KubectlDeploy{
+							Flags: latest_v1.KubectlFlags{
 								Apply: []string{"--bar"},
 							},
 						},
@@ -186,34 +186,34 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 			},
 			{
 				name: "one config with helm deploy",
-				cfgs: []latest.DeployType{{
-					HelmDeploy: &latest.HelmDeploy{},
+				cfgs: []latest_v1.DeployType{{
+					HelmDeploy: &latest_v1.HelmDeploy{},
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
-					Pipelines: runcontext.NewPipelines([]latest.Pipeline{{}}),
-				}, nil, &latest.KubectlDeploy{
-					Flags: latest.KubectlFlags{},
+					Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{}}),
+				}, nil, &latest_v1.KubectlDeploy{
+					Flags: latest_v1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
 			{
 				name: "one config with kustomize deploy",
-				cfgs: []latest.DeployType{{
-					KustomizeDeploy: &latest.KustomizeDeploy{},
+				cfgs: []latest_v1.DeployType{{
+					KustomizeDeploy: &latest_v1.KustomizeDeploy{},
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
-					Pipelines: runcontext.NewPipelines([]latest.Pipeline{{}}),
-				}, nil, &latest.KubectlDeploy{
-					Flags: latest.KubectlFlags{},
+					Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{}}),
+				}, nil, &latest_v1.KubectlDeploy{
+					Flags: latest_v1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
 		}
 
 		for _, test := range tests {
 			testutil.Run(tOuter, test.name, func(t *testutil.T) {
-				pipelines := []latest.Pipeline{}
+				pipelines := []latest_v1.Pipeline{}
 				for _, cfg := range test.cfgs {
-					pipelines = append(pipelines, latest.Pipeline{
-						Deploy: latest.DeployConfig{
+					pipelines = append(pipelines, latest_v1.Pipeline{
+						Deploy: latest_v1.DeployConfig{
 							DeployType: cfg,
 						},
 					})
@@ -312,13 +312,13 @@ func TestIsImageLocal(t *testing.T) {
 				Opts: config.SkaffoldOptions{
 					PushImages: config.NewBoolOrUndefined(test.pushImagesFlagVal),
 				},
-				Pipelines: runcontext.NewPipelines([]latest.Pipeline{{
-					Build: latest.BuildConfig{
-						Artifacts: []*latest.Artifact{
+				Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{
+					Build: latest_v1.BuildConfig{
+						Artifacts: []*latest_v1.Artifact{
 							{ImageName: imageName},
 						},
-						BuildType: latest.BuildType{
-							LocalBuild: &latest.LocalBuild{
+						BuildType: latest_v1.BuildType{
+							LocalBuild: &latest_v1.LocalBuild{
 								Push: test.localBuildConfig,
 							},
 						},

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -25,7 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	runnerutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/util"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -45,22 +45,22 @@ type RunContext struct {
 
 // Pipelines encapsulates multiple config pipelines
 type Pipelines struct {
-	pipelines            []latest.Pipeline
-	pipelinesByImageName map[string]latest.Pipeline
+	pipelines            []latest_v1.Pipeline
+	pipelinesByImageName map[string]latest_v1.Pipeline
 }
 
 // All returns all config pipelines.
-func (ps Pipelines) All() []latest.Pipeline {
+func (ps Pipelines) All() []latest_v1.Pipeline {
 	return ps.pipelines
 }
 
-// Head returns the first `latest.Pipeline`.
-func (ps Pipelines) Head() latest.Pipeline {
+// Head returns the first `latest_v1.Pipeline`.
+func (ps Pipelines) Head() latest_v1.Pipeline {
 	return ps.pipelines[0] // there always exists atleast one pipeline.
 }
 
-// Select returns the first `latest.Pipeline` that matches the given artifact `imageName`.
-func (ps Pipelines) Select(imageName string) (latest.Pipeline, bool) {
+// Select returns the first `latest_v1.Pipeline` that matches the given artifact `imageName`.
+func (ps Pipelines) Select(imageName string) (latest_v1.Pipeline, bool) {
 	p, found := ps.pipelinesByImageName[imageName]
 	return p, found
 }
@@ -70,40 +70,40 @@ func (ps Pipelines) IsMultiPipeline() bool {
 	return len(ps.pipelines) > 1
 }
 
-func (ps Pipelines) PortForwardResources() []*latest.PortForwardResource {
-	var pf []*latest.PortForwardResource
+func (ps Pipelines) PortForwardResources() []*latest_v1.PortForwardResource {
+	var pf []*latest_v1.PortForwardResource
 	for _, p := range ps.pipelines {
 		pf = append(pf, p.PortForward...)
 	}
 	return pf
 }
 
-func (ps Pipelines) Artifacts() []*latest.Artifact {
-	var artifacts []*latest.Artifact
+func (ps Pipelines) Artifacts() []*latest_v1.Artifact {
+	var artifacts []*latest_v1.Artifact
 	for _, p := range ps.pipelines {
 		artifacts = append(artifacts, p.Build.Artifacts...)
 	}
 	return artifacts
 }
 
-func (ps Pipelines) DeployConfigs() []latest.DeployConfig {
-	var cfgs []latest.DeployConfig
+func (ps Pipelines) DeployConfigs() []latest_v1.DeployConfig {
+	var cfgs []latest_v1.DeployConfig
 	for _, p := range ps.pipelines {
 		cfgs = append(cfgs, p.Deploy)
 	}
 	return cfgs
 }
 
-func (ps Pipelines) Deployers() []latest.DeployType {
-	var deployers []latest.DeployType
+func (ps Pipelines) Deployers() []latest_v1.DeployType {
+	var deployers []latest_v1.DeployType
 	for _, p := range ps.pipelines {
 		deployers = append(deployers, p.Deploy.DeployType)
 	}
 	return deployers
 }
 
-func (ps Pipelines) TestCases() []*latest.TestCase {
-	var tests []*latest.TestCase
+func (ps Pipelines) TestCases() []*latest_v1.TestCase {
+	var tests []*latest_v1.TestCase
 	for _, p := range ps.pipelines {
 		tests = append(tests, p.Test...)
 	}
@@ -120,8 +120,8 @@ func (ps Pipelines) StatusCheckDeadlineSeconds() int {
 	}
 	return c
 }
-func NewPipelines(pipelines []latest.Pipeline) Pipelines {
-	m := make(map[string]latest.Pipeline)
+func NewPipelines(pipelines []latest_v1.Pipeline) Pipelines {
+	m := make(map[string]latest_v1.Pipeline)
 	for _, p := range pipelines {
 		for _, a := range p.Build.Artifacts {
 			m[a.ImageName] = p
@@ -130,21 +130,21 @@ func NewPipelines(pipelines []latest.Pipeline) Pipelines {
 	return Pipelines{pipelines: pipelines, pipelinesByImageName: m}
 }
 
-func (rc *RunContext) PipelineForImage(imageName string) (latest.Pipeline, bool) {
+func (rc *RunContext) PipelineForImage(imageName string) (latest_v1.Pipeline, bool) {
 	return rc.Pipelines.Select(imageName)
 }
 
-func (rc *RunContext) PortForwardResources() []*latest.PortForwardResource {
+func (rc *RunContext) PortForwardResources() []*latest_v1.PortForwardResource {
 	return rc.Pipelines.PortForwardResources()
 }
 
-func (rc *RunContext) Artifacts() []*latest.Artifact { return rc.Pipelines.Artifacts() }
+func (rc *RunContext) Artifacts() []*latest_v1.Artifact { return rc.Pipelines.Artifacts() }
 
-func (rc *RunContext) DeployConfigs() []latest.DeployConfig { return rc.Pipelines.DeployConfigs() }
+func (rc *RunContext) DeployConfigs() []latest_v1.DeployConfig { return rc.Pipelines.DeployConfigs() }
 
-func (rc *RunContext) Deployers() []latest.DeployType { return rc.Pipelines.Deployers() }
+func (rc *RunContext) Deployers() []latest_v1.DeployType { return rc.Pipelines.Deployers() }
 
-func (rc *RunContext) TestCases() []*latest.TestCase { return rc.Pipelines.TestCases() }
+func (rc *RunContext) TestCases() []*latest_v1.TestCase { return rc.Pipelines.TestCases() }
 
 func (rc *RunContext) StatusCheck() bool {
 	sc := rc.Opts.StatusCheck.Value()
@@ -158,10 +158,10 @@ func (rc *RunContext) StatusCheckDeadlineSeconds() int {
 	return rc.Pipelines.StatusCheckDeadlineSeconds()
 }
 
-func (rc *RunContext) DefaultPipeline() latest.Pipeline          { return rc.Pipelines.Head() }
+func (rc *RunContext) DefaultPipeline() latest_v1.Pipeline       { return rc.Pipelines.Head() }
 func (rc *RunContext) GetKubeContext() string                    { return rc.KubeContext }
 func (rc *RunContext) GetNamespaces() []string                   { return rc.Namespaces }
-func (rc *RunContext) GetPipelines() []latest.Pipeline           { return rc.Pipelines.All() }
+func (rc *RunContext) GetPipelines() []latest_v1.Pipeline        { return rc.Pipelines.All() }
 func (rc *RunContext) GetInsecureRegistries() map[string]bool    { return rc.InsecureRegistries }
 func (rc *RunContext) GetWorkingDir() string                     { return rc.WorkingDir }
 func (rc *RunContext) GetCluster() config.Cluster                { return rc.Cluster }
@@ -200,7 +200,7 @@ func (rc *RunContext) WatchPollInterval() int                    { return rc.Opt
 func (rc *RunContext) BuildConcurrency() int                     { return rc.Opts.BuildConcurrency }
 func (rc *RunContext) IsMultiConfig() bool                       { return rc.Pipelines.IsMultiPipeline() }
 
-func GetRunContext(opts config.SkaffoldOptions, pipelines []latest.Pipeline) (*RunContext, error) {
+func GetRunContext(opts config.SkaffoldOptions, pipelines []latest_v1.Pipeline) (*RunContext, error) {
 	kubeConfig, err := kubectx.CurrentConfig()
 	if err != nil {
 		return nil, fmt.Errorf("getting current cluster context: %w", err)

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -30,7 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 )
 
@@ -44,12 +44,12 @@ const (
 type Runner interface {
 	Apply(context.Context, io.Writer) error
 	ApplyDefaultRepo(tag string) (string, error)
-	Build(context.Context, io.Writer, []*latest.Artifact) ([]graph.Artifact, error)
+	Build(context.Context, io.Writer, []*latest_v1.Artifact) ([]graph.Artifact, error)
 	Cleanup(context.Context, io.Writer) error
-	Dev(context.Context, io.Writer, []*latest.Artifact) error
+	Dev(context.Context, io.Writer, []*latest_v1.Artifact) error
 	Deploy(context.Context, io.Writer, []graph.Artifact) error
 	DeployAndLog(context.Context, io.Writer, []graph.Artifact) error
-	GeneratePipeline(context.Context, io.Writer, []*latest.SkaffoldConfig, []string, string) error
+	GeneratePipeline(context.Context, io.Writer, []*latest_v1.SkaffoldConfig, []string, string) error
 	HasBuilt() bool
 	HasDeployed() bool
 	Prune(context.Context, io.Writer) error

--- a/pkg/skaffold/runner/runner_test.go
+++ b/pkg/skaffold/runner/runner_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/test"
@@ -100,17 +100,17 @@ func (t *TestBench) WithTestErrors(testErrors []error) *TestBench {
 	return t
 }
 
-func (t *TestBench) TestDependencies(*latest.Artifact) ([]string, error) { return nil, nil }
-func (t *TestBench) Dependencies() ([]string, error)                     { return nil, nil }
-func (t *TestBench) Cleanup(ctx context.Context, out io.Writer) error    { return nil }
-func (t *TestBench) Prune(ctx context.Context, out io.Writer) error      { return nil }
+func (t *TestBench) TestDependencies(*latest_v1.Artifact) ([]string, error) { return nil, nil }
+func (t *TestBench) Dependencies() ([]string, error)                        { return nil, nil }
+func (t *TestBench) Cleanup(ctx context.Context, out io.Writer) error       { return nil }
+func (t *TestBench) Prune(ctx context.Context, out io.Writer) error         { return nil }
 
 func (t *TestBench) enterNewCycle() {
 	t.actions = append(t.actions, t.currentActions)
 	t.currentActions = Actions{}
 }
 
-func (t *TestBench) Build(_ context.Context, _ io.Writer, _ tag.ImageTags, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
+func (t *TestBench) Build(_ context.Context, _ io.Writer, _ tag.ImageTags, artifacts []*latest_v1.Artifact) ([]graph.Artifact, error) {
 	if len(t.buildErrors) > 0 {
 		err := t.buildErrors[0]
 		t.buildErrors = t.buildErrors[1:]
@@ -226,26 +226,26 @@ type triggerState struct {
 	deploy bool
 }
 
-func createRunner(t *testutil.T, testBench *TestBench, monitor filemon.Monitor, artifacts []*latest.Artifact, autoTriggers *triggerState) *SkaffoldRunner {
+func createRunner(t *testutil.T, testBench *TestBench, monitor filemon.Monitor, artifacts []*latest_v1.Artifact, autoTriggers *triggerState) *SkaffoldRunner {
 	if autoTriggers == nil {
 		autoTriggers = &triggerState{true, true, true}
 	}
-	cfg := &latest.SkaffoldConfig{
-		Pipeline: latest.Pipeline{
-			Build: latest.BuildConfig{
-				TagPolicy: latest.TagPolicy{
+	cfg := &latest_v1.SkaffoldConfig{
+		Pipeline: latest_v1.Pipeline{
+			Build: latest_v1.BuildConfig{
+				TagPolicy: latest_v1.TagPolicy{
 					// Use the fastest tagger
-					ShaTagger: &latest.ShaTagger{},
+					ShaTagger: &latest_v1.ShaTagger{},
 				},
 				Artifacts: artifacts,
 			},
-			Deploy: latest.DeployConfig{StatusCheckDeadlineSeconds: 60},
+			Deploy: latest_v1.DeployConfig{StatusCheckDeadlineSeconds: 60},
 		},
 	}
 	defaults.Set(cfg)
 	defaults.SetDefaultDeployer(cfg)
 	runCtx := &runcontext.RunContext{
-		Pipelines: runcontext.NewPipelines([]latest.Pipeline{cfg.Pipeline}),
+		Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{cfg.Pipeline}),
 		Opts: config.SkaffoldOptions{
 			Trigger:           "polling",
 			WatchPollInterval: 100,
@@ -282,7 +282,7 @@ func createRunner(t *testutil.T, testBench *TestBench, monitor filemon.Monitor, 
 func TestNewForConfig(t *testing.T) {
 	tests := []struct {
 		description      string
-		pipeline         latest.Pipeline
+		pipeline         latest_v1.Pipeline
 		shouldErr        bool
 		cacheArtifacts   bool
 		expectedBuilder  build.BuilderMux
@@ -291,16 +291,16 @@ func TestNewForConfig(t *testing.T) {
 	}{
 		{
 			description: "local builder config",
-			pipeline: latest.Pipeline{
-				Build: latest.BuildConfig{
-					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
-					BuildType: latest.BuildType{
-						LocalBuild: &latest.LocalBuild{},
+			pipeline: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					TagPolicy: latest_v1.TagPolicy{ShaTagger: &latest_v1.ShaTagger{}},
+					BuildType: latest_v1.BuildType{
+						LocalBuild: &latest_v1.LocalBuild{},
 					},
 				},
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KubectlDeploy: &latest.KubectlDeploy{},
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						KubectlDeploy: &latest_v1.KubectlDeploy{},
 					},
 				},
 			},
@@ -309,16 +309,16 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "gcb config",
-			pipeline: latest.Pipeline{
-				Build: latest.BuildConfig{
-					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
-					BuildType: latest.BuildType{
-						GoogleCloudBuild: &latest.GoogleCloudBuild{},
+			pipeline: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					TagPolicy: latest_v1.TagPolicy{ShaTagger: &latest_v1.ShaTagger{}},
+					BuildType: latest_v1.BuildType{
+						GoogleCloudBuild: &latest_v1.GoogleCloudBuild{},
 					},
 				},
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KubectlDeploy: &latest.KubectlDeploy{},
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						KubectlDeploy: &latest_v1.KubectlDeploy{},
 					},
 				},
 			},
@@ -327,16 +327,16 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "cluster builder config",
-			pipeline: latest.Pipeline{
-				Build: latest.BuildConfig{
-					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
-					BuildType: latest.BuildType{
-						Cluster: &latest.ClusterDetails{Timeout: "100s"},
+			pipeline: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					TagPolicy: latest_v1.TagPolicy{ShaTagger: &latest_v1.ShaTagger{}},
+					BuildType: latest_v1.BuildType{
+						Cluster: &latest_v1.ClusterDetails{Timeout: "100s"},
 					},
 				},
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KubectlDeploy: &latest.KubectlDeploy{},
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						KubectlDeploy: &latest_v1.KubectlDeploy{},
 					},
 				},
 			},
@@ -345,16 +345,16 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "bad tagger config",
-			pipeline: latest.Pipeline{
-				Build: latest.BuildConfig{
-					TagPolicy: latest.TagPolicy{},
-					BuildType: latest.BuildType{
-						LocalBuild: &latest.LocalBuild{},
+			pipeline: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					TagPolicy: latest_v1.TagPolicy{},
+					BuildType: latest_v1.BuildType{
+						LocalBuild: &latest_v1.LocalBuild{},
 					},
 				},
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KubectlDeploy: &latest.KubectlDeploy{},
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						KubectlDeploy: &latest_v1.KubectlDeploy{},
 					},
 				},
 			},
@@ -362,23 +362,23 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description:      "unknown builder and tagger",
-			pipeline:         latest.Pipeline{},
+			pipeline:         latest_v1.Pipeline{},
 			shouldErr:        true,
 			expectedTester:   &test.FullTester{},
 			expectedDeployer: &kubectl.Deployer{},
 		},
 		{
 			description: "no artifacts, cache",
-			pipeline: latest.Pipeline{
-				Build: latest.BuildConfig{
-					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
-					BuildType: latest.BuildType{
-						LocalBuild: &latest.LocalBuild{},
+			pipeline: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					TagPolicy: latest_v1.TagPolicy{ShaTagger: &latest_v1.ShaTagger{}},
+					BuildType: latest_v1.BuildType{
+						LocalBuild: &latest_v1.LocalBuild{},
 					},
 				},
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KubectlDeploy: &latest.KubectlDeploy{},
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						KubectlDeploy: &latest_v1.KubectlDeploy{},
 					},
 				},
 			},
@@ -388,18 +388,18 @@ func TestNewForConfig(t *testing.T) {
 		},
 		{
 			description: "multiple deployers",
-			pipeline: latest.Pipeline{
-				Build: latest.BuildConfig{
-					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
-					BuildType: latest.BuildType{
-						LocalBuild: &latest.LocalBuild{},
+			pipeline: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					TagPolicy: latest_v1.TagPolicy{ShaTagger: &latest_v1.ShaTagger{}},
+					BuildType: latest_v1.BuildType{
+						LocalBuild: &latest_v1.LocalBuild{},
 					},
 				},
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KubectlDeploy:   &latest.KubectlDeploy{},
-						KustomizeDeploy: &latest.KustomizeDeploy{},
-						HelmDeploy:      &latest.HelmDeploy{},
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						KubectlDeploy:   &latest_v1.KubectlDeploy{},
+						KustomizeDeploy: &latest_v1.KustomizeDeploy{},
+						HelmDeploy:      &latest_v1.HelmDeploy{},
 					},
 				},
 			},
@@ -420,7 +420,7 @@ func TestNewForConfig(t *testing.T) {
 				AndRunWithOutput("kubectl version --client -ojson", "v1.5.6"))
 
 			runCtx := &runcontext.RunContext{
-				Pipelines: runcontext.NewPipelines([]latest.Pipeline{test.pipeline}),
+				Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{test.pipeline}),
 				Opts: config.SkaffoldOptions{
 					Trigger: "polling",
 				},
@@ -503,22 +503,22 @@ func TestTriggerCallbackAndIntents(t *testing.T) {
 				AutoSync:          test.autoSync,
 				AutoDeploy:        test.autoDeploy,
 			}
-			pipeline := latest.Pipeline{
-				Build: latest.BuildConfig{
-					TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
-					BuildType: latest.BuildType{
-						LocalBuild: &latest.LocalBuild{},
+			pipeline := latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					TagPolicy: latest_v1.TagPolicy{ShaTagger: &latest_v1.ShaTagger{}},
+					BuildType: latest_v1.BuildType{
+						LocalBuild: &latest_v1.LocalBuild{},
 					},
 				},
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						KubectlDeploy: &latest.KubectlDeploy{},
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						KubectlDeploy: &latest_v1.KubectlDeploy{},
 					},
 				},
 			}
 			r, _ := NewForConfig(&runcontext.RunContext{
 				Opts:      opts,
-				Pipelines: runcontext.NewPipelines([]latest.Pipeline{pipeline}),
+				Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{pipeline}),
 			})
 
 			r.intents.resetBuild()

--- a/pkg/skaffold/runner/timings.go
+++ b/pkg/skaffold/runner/timings.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/test"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -52,7 +52,7 @@ type withTimings struct {
 	cacheArtifacts bool
 }
 
-func (w withTimings) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest.Artifact) ([]graph.Artifact, error) {
+func (w withTimings) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, artifacts []*latest_v1.Artifact) ([]graph.Artifact, error) {
 	if len(artifacts) == 0 && w.cacheArtifacts {
 		return nil, nil
 	}

--- a/pkg/skaffold/runner/timings_test.go
+++ b/pkg/skaffold/runner/timings_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/test"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -40,7 +40,7 @@ type mockBuilder struct {
 	err bool
 }
 
-func (m *mockBuilder) Build(context.Context, io.Writer, tag.ImageTags, []*latest.Artifact) ([]graph.Artifact, error) {
+func (m *mockBuilder) Build(context.Context, io.Writer, tag.ImageTags, []*latest_v1.Artifact) ([]graph.Artifact, error) {
 	if m.err {
 		return nil, errors.New("Unable to build")
 	}

--- a/pkg/skaffold/runner/util/util.go
+++ b/pkg/skaffold/runner/util/util.go
@@ -21,14 +21,14 @@ import (
 	"sort"
 
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // GetAllPodNamespaces lists the namespaces that should be watched.
 // + The namespace passed on the command line
 // + Current kube context's namespace
 // + Namespaces referenced in Helm releases
-func GetAllPodNamespaces(configNamespace string, pipelines []latest.Pipeline) ([]string, error) {
+func GetAllPodNamespaces(configNamespace string, pipelines []latest_v1.Pipeline) ([]string, error) {
 	nsMap := make(map[string]bool)
 
 	if configNamespace == "" {
@@ -63,7 +63,7 @@ func GetAllPodNamespaces(configNamespace string, pipelines []latest.Pipeline) ([
 	return namespaces, nil
 }
 
-func collectHelmReleasesNamespaces(pipelines []latest.Pipeline) []string {
+func collectHelmReleasesNamespaces(pipelines []latest_v1.Pipeline) []string {
 	var namespaces []string
 	for _, cfg := range pipelines {
 		if cfg.Deploy.HelmDeploy != nil {

--- a/pkg/skaffold/runner/util/util_test.go
+++ b/pkg/skaffold/runner/util/util_test.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -31,7 +31,7 @@ func TestGetAllPodNamespaces(t *testing.T) {
 		description    string
 		argNamespace   string
 		currentContext string
-		cfg            latest.Pipeline
+		cfg            latest_v1.Pipeline
 		expected       []string
 	}{
 		{
@@ -52,11 +52,11 @@ func TestGetAllPodNamespaces(t *testing.T) {
 		{
 			description:  "add namespaces for helm",
 			argNamespace: "ns",
-			cfg: latest.Pipeline{
-				Deploy: latest.DeployConfig{
-					DeployType: latest.DeployType{
-						HelmDeploy: &latest.HelmDeploy{
-							Releases: []latest.HelmRelease{
+			cfg: latest_v1.Pipeline{
+				Deploy: latest_v1.DeployConfig{
+					DeployType: latest_v1.DeployType{
+						HelmDeploy: &latest_v1.HelmDeploy{
+							Releases: []latest_v1.HelmRelease{
 								{Namespace: "ns3"},
 								{Namespace: ""},
 								{Namespace: ""},
@@ -80,7 +80,7 @@ func TestGetAllPodNamespaces(t *testing.T) {
 				}, nil
 			})
 
-			namespaces, err := GetAllPodNamespaces(test.argNamespace, []latest.Pipeline{test.cfg})
+			namespaces, err := GetAllPodNamespaces(test.argNamespace, []latest_v1.Pipeline{test.cfg})
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, namespaces)

--- a/pkg/skaffold/runner/v3/dev.go
+++ b/pkg/skaffold/runner/v3/dev.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
-func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*latest.Artifact) error {
+func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*latest_v1.Artifact) error {
 	return fmt.Errorf("not implemented error: SkaffoldRunner(v3).Dev")
 }

--- a/pkg/skaffold/runner/v3/generate_pipeline.go
+++ b/pkg/skaffold/runner/v3/generate_pipeline.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
-func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, configs []*latest.SkaffoldConfig, configPaths []string, fileOut string) error {
+func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, configs []*latest_v1.SkaffoldConfig, configPaths []string, fileOut string) error {
 	return fmt.Errorf("not implemented error: SkaffoldRunner(v3).GeneratePipeline")
 }

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -20,13 +20,13 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -40,7 +40,7 @@ const (
 )
 
 // Set makes sure default values are set on a SkaffoldConfig.
-func Set(c *latest.SkaffoldConfig) error {
+func Set(c *latest_v1.SkaffoldConfig) error {
 	defaultToLocalBuild(c)
 	setDefaultTagger(c)
 	setDefaultKustomizePath(c)
@@ -75,7 +75,7 @@ func Set(c *latest.SkaffoldConfig) error {
 		}
 	}
 
-	withLocalBuild(c, func(lb *latest.LocalBuild) {
+	withLocalBuild(c, func(lb *latest_v1.LocalBuild) {
 		// don't set build concurrency if there are no artifacts in the current config
 		if len(c.Build.Artifacts) > 0 {
 			setDefaultConcurrency(lb)
@@ -112,30 +112,30 @@ func Set(c *latest.SkaffoldConfig) error {
 }
 
 // SetDefaultDeployer adds a default kubectl deploy configuration.
-func SetDefaultDeployer(c *latest.SkaffoldConfig) {
+func SetDefaultDeployer(c *latest_v1.SkaffoldConfig) {
 	defaultToKubectlDeploy(c)
 	setDefaultKubectlManifests(c)
 }
 
-func defaultToLocalBuild(c *latest.SkaffoldConfig) {
-	if c.Build.BuildType != (latest.BuildType{}) {
+func defaultToLocalBuild(c *latest_v1.SkaffoldConfig) {
+	if c.Build.BuildType != (latest_v1.BuildType{}) {
 		return
 	}
 
 	logrus.Debugf("Defaulting build type to local build")
-	c.Build.BuildType.LocalBuild = &latest.LocalBuild{}
+	c.Build.BuildType.LocalBuild = &latest_v1.LocalBuild{}
 }
 
-func defaultToKubectlDeploy(c *latest.SkaffoldConfig) {
-	if c.Deploy.DeployType != (latest.DeployType{}) {
+func defaultToKubectlDeploy(c *latest_v1.SkaffoldConfig) {
+	if c.Deploy.DeployType != (latest_v1.DeployType{}) {
 		return
 	}
 
 	logrus.Debugf("Defaulting deploy type to kubectl")
-	c.Deploy.DeployType.KubectlDeploy = &latest.KubectlDeploy{}
+	c.Deploy.DeployType.KubectlDeploy = &latest_v1.KubectlDeploy{}
 }
 
-func withLocalBuild(c *latest.SkaffoldConfig, operations ...func(*latest.LocalBuild)) {
+func withLocalBuild(c *latest_v1.SkaffoldConfig, operations ...func(*latest_v1.LocalBuild)) {
 	if local := c.Build.LocalBuild; local != nil {
 		for _, operation := range operations {
 			operation(local)
@@ -143,13 +143,13 @@ func withLocalBuild(c *latest.SkaffoldConfig, operations ...func(*latest.LocalBu
 	}
 }
 
-func setDefaultConcurrency(local *latest.LocalBuild) {
+func setDefaultConcurrency(local *latest_v1.LocalBuild) {
 	if local.Concurrency == nil {
 		local.Concurrency = &constants.DefaultLocalConcurrency
 	}
 }
 
-func withCloudBuildConfig(c *latest.SkaffoldConfig, operations ...func(*latest.GoogleCloudBuild)) {
+func withCloudBuildConfig(c *latest_v1.SkaffoldConfig, operations ...func(*latest_v1.GoogleCloudBuild)) {
 	if gcb := c.Build.GoogleCloudBuild; gcb != nil {
 		for _, operation := range operations {
 			operation(gcb)
@@ -157,35 +157,35 @@ func withCloudBuildConfig(c *latest.SkaffoldConfig, operations ...func(*latest.G
 	}
 }
 
-func setDefaultCloudBuildDockerImage(gcb *latest.GoogleCloudBuild) {
+func setDefaultCloudBuildDockerImage(gcb *latest_v1.GoogleCloudBuild) {
 	gcb.DockerImage = valueOrDefault(gcb.DockerImage, defaultCloudBuildDockerImage)
 }
 
-func setDefaultCloudBuildMavenImage(gcb *latest.GoogleCloudBuild) {
+func setDefaultCloudBuildMavenImage(gcb *latest_v1.GoogleCloudBuild) {
 	gcb.MavenImage = valueOrDefault(gcb.MavenImage, defaultCloudBuildMavenImage)
 }
 
-func setDefaultCloudBuildGradleImage(gcb *latest.GoogleCloudBuild) {
+func setDefaultCloudBuildGradleImage(gcb *latest_v1.GoogleCloudBuild) {
 	gcb.GradleImage = valueOrDefault(gcb.GradleImage, defaultCloudBuildGradleImage)
 }
 
-func setDefaultCloudBuildKanikoImage(gcb *latest.GoogleCloudBuild) {
+func setDefaultCloudBuildKanikoImage(gcb *latest_v1.GoogleCloudBuild) {
 	gcb.KanikoImage = valueOrDefault(gcb.KanikoImage, defaultCloudBuildKanikoImage)
 }
 
-func setDefaultCloudBuildPackImage(gcb *latest.GoogleCloudBuild) {
+func setDefaultCloudBuildPackImage(gcb *latest_v1.GoogleCloudBuild) {
 	gcb.PackImage = valueOrDefault(gcb.PackImage, defaultCloudBuildPackImage)
 }
 
-func setDefaultTagger(c *latest.SkaffoldConfig) {
-	if c.Build.TagPolicy != (latest.TagPolicy{}) {
+func setDefaultTagger(c *latest_v1.SkaffoldConfig) {
+	if c.Build.TagPolicy != (latest_v1.TagPolicy{}) {
 		return
 	}
 
-	c.Build.TagPolicy = latest.TagPolicy{GitTagger: &latest.GitTagger{}}
+	c.Build.TagPolicy = latest_v1.TagPolicy{GitTagger: &latest_v1.GitTagger{}}
 }
 
-func setDefaultKustomizePath(c *latest.SkaffoldConfig) {
+func setDefaultKustomizePath(c *latest_v1.SkaffoldConfig) {
 	kustomize := c.Deploy.KustomizeDeploy
 	if kustomize == nil {
 		return
@@ -195,54 +195,54 @@ func setDefaultKustomizePath(c *latest.SkaffoldConfig) {
 	}
 }
 
-func setDefaultKubectlManifests(c *latest.SkaffoldConfig) {
+func setDefaultKubectlManifests(c *latest_v1.SkaffoldConfig) {
 	if c.Deploy.KubectlDeploy != nil && len(c.Deploy.KubectlDeploy.Manifests) == 0 {
 		c.Deploy.KubectlDeploy.Manifests = constants.DefaultKubectlManifests
 	}
 }
 
-func setDefaultLogsConfig(c *latest.SkaffoldConfig) {
+func setDefaultLogsConfig(c *latest_v1.SkaffoldConfig) {
 	if c.Deploy.Logs.Prefix == "" {
 		c.Deploy.Logs.Prefix = "container"
 	}
 }
 
-func defaultToDockerArtifact(a *latest.Artifact) {
-	if a.ArtifactType == (latest.ArtifactType{}) {
-		a.ArtifactType = latest.ArtifactType{
-			DockerArtifact: &latest.DockerArtifact{},
+func defaultToDockerArtifact(a *latest_v1.Artifact) {
+	if a.ArtifactType == (latest_v1.ArtifactType{}) {
+		a.ArtifactType = latest_v1.ArtifactType{
+			DockerArtifact: &latest_v1.DockerArtifact{},
 		}
 	}
 }
 
-func setCustomArtifactDefaults(a *latest.CustomArtifact) {
+func setCustomArtifactDefaults(a *latest_v1.CustomArtifact) {
 	if a.Dependencies == nil {
-		a.Dependencies = &latest.CustomDependencies{
+		a.Dependencies = &latest_v1.CustomDependencies{
 			Paths: []string{"."},
 		}
 	}
 }
 
-func setBuildpackArtifactDefaults(a *latest.BuildpackArtifact) {
+func setBuildpackArtifactDefaults(a *latest_v1.BuildpackArtifact) {
 	if a.ProjectDescriptor == "" {
 		a.ProjectDescriptor = constants.DefaultProjectDescriptor
 	}
 	if a.Dependencies == nil {
-		a.Dependencies = &latest.BuildpackDependencies{
+		a.Dependencies = &latest_v1.BuildpackDependencies{
 			Paths: []string{"."},
 		}
 	}
 }
 
-func setDockerArtifactDefaults(a *latest.DockerArtifact) {
+func setDockerArtifactDefaults(a *latest_v1.DockerArtifact) {
 	a.DockerfilePath = valueOrDefault(a.DockerfilePath, constants.DefaultDockerfilePath)
 }
 
-func setDefaultWorkspace(a *latest.Artifact) {
+func setDefaultWorkspace(a *latest_v1.Artifact) {
 	a.Workspace = valueOrDefault(a.Workspace, ".")
 }
 
-func setDefaultSync(a *latest.Artifact) {
+func setDefaultSync(a *latest_v1.Artifact) {
 	if a.Sync != nil {
 		if len(a.Sync.Manual) == 0 && len(a.Sync.Infer) == 0 && a.Sync.Auto == nil {
 			switch {
@@ -253,11 +253,11 @@ func setDefaultSync(a *latest.Artifact) {
 			}
 		}
 	} else if a.BuildpackArtifact != nil {
-		a.Sync = &latest.Sync{Auto: util.BoolPtr(true)}
+		a.Sync = &latest_v1.Sync{Auto: util.BoolPtr(true)}
 	}
 }
 
-func withClusterConfig(c *latest.SkaffoldConfig, opts ...func(*latest.ClusterDetails) error) error {
+func withClusterConfig(c *latest_v1.SkaffoldConfig, opts ...func(*latest_v1.ClusterDetails) error) error {
 	clusterDetails := c.Build.BuildType.Cluster
 	if clusterDetails == nil {
 		return nil
@@ -270,7 +270,7 @@ func withClusterConfig(c *latest.SkaffoldConfig, opts ...func(*latest.ClusterDet
 	return nil
 }
 
-func setDefaultClusterNamespace(cluster *latest.ClusterDetails) error {
+func setDefaultClusterNamespace(cluster *latest_v1.ClusterDetails) error {
 	if cluster.Namespace == "" {
 		ns, err := currentNamespace()
 		if err != nil {
@@ -281,12 +281,12 @@ func setDefaultClusterNamespace(cluster *latest.ClusterDetails) error {
 	return nil
 }
 
-func setDefaultClusterTimeout(cluster *latest.ClusterDetails) error {
+func setDefaultClusterTimeout(cluster *latest_v1.ClusterDetails) error {
 	cluster.Timeout = valueOrDefault(cluster.Timeout, kaniko.DefaultTimeout)
 	return nil
 }
 
-func setDefaultClusterPullSecret(cluster *latest.ClusterDetails) error {
+func setDefaultClusterPullSecret(cluster *latest_v1.ClusterDetails) error {
 	cluster.PullSecretMountPath = valueOrDefault(cluster.PullSecretMountPath, kaniko.DefaultSecretMountPath)
 	if cluster.PullSecretPath != "" {
 		absPath, err := homedir.Expand(cluster.PullSecretPath)
@@ -305,7 +305,7 @@ func setDefaultClusterPullSecret(cluster *latest.ClusterDetails) error {
 	return nil
 }
 
-func setDefaultClusterDockerConfigSecret(cluster *latest.ClusterDetails) error {
+func setDefaultClusterDockerConfigSecret(cluster *latest_v1.ClusterDetails) error {
 	if cluster.DockerConfig == nil {
 		return nil
 	}
@@ -331,13 +331,13 @@ func setDefaultClusterDockerConfigSecret(cluster *latest.ClusterDetails) error {
 	return nil
 }
 
-func defaultToKanikoArtifact(artifact *latest.Artifact) {
+func defaultToKanikoArtifact(artifact *latest_v1.Artifact) {
 	if artifact.KanikoArtifact == nil {
-		artifact.KanikoArtifact = &latest.KanikoArtifact{}
+		artifact.KanikoArtifact = &latest_v1.KanikoArtifact{}
 	}
 }
 
-func setKanikoArtifactDefaults(a *latest.KanikoArtifact) {
+func setKanikoArtifactDefaults(a *latest_v1.KanikoArtifact) {
 	a.Image = valueOrDefault(a.Image, kaniko.DefaultImage)
 	a.DockerfilePath = valueOrDefault(a.DockerfilePath, constants.DefaultDockerfilePath)
 	a.InitImage = valueOrDefault(a.InitImage, constants.DefaultBusyboxImage)
@@ -366,7 +366,7 @@ func currentNamespace() (string, error) {
 	return "default", nil
 }
 
-func setDefaultLocalPort(pf *latest.PortForwardResource) {
+func setDefaultLocalPort(pf *latest_v1.PortForwardResource) {
 	if pf.LocalPort == 0 {
 		if pf.Port.Type == schemautil.Int {
 			pf.LocalPort = pf.Port.IntVal
@@ -374,19 +374,19 @@ func setDefaultLocalPort(pf *latest.PortForwardResource) {
 	}
 }
 
-func setDefaultAddress(pf *latest.PortForwardResource) {
+func setDefaultAddress(pf *latest_v1.PortForwardResource) {
 	if pf.Address == "" {
 		pf.Address = constants.DefaultPortForwardAddress
 	}
 }
 
-func setDefaultArtifactDependencyAlias(d *latest.ArtifactDependency) {
+func setDefaultArtifactDependencyAlias(d *latest_v1.ArtifactDependency) {
 	if d.Alias == "" {
 		d.Alias = d.ImageName
 	}
 }
 
-func setDefaultTestWorkspace(c *latest.SkaffoldConfig) {
+func setDefaultTestWorkspace(c *latest_v1.SkaffoldConfig) {
 	for _, tc := range c.Test {
 		if tc == nil {
 			continue

--- a/pkg/skaffold/schema/defaults/defaults_test.go
+++ b/pkg/skaffold/schema/defaults/defaults_test.go
@@ -23,20 +23,20 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestSetDefaults(t *testing.T) {
-	cfg := &latest.SkaffoldConfig{
-		Pipeline: latest.Pipeline{
-			Build: latest.BuildConfig{
-				Artifacts: []*latest.Artifact{
+	cfg := &latest_v1.SkaffoldConfig{
+		Pipeline: latest_v1.Pipeline{
+			Build: latest_v1.BuildConfig{
+				Artifacts: []*latest_v1.Artifact{
 					{
 						ImageName: "first",
-						Dependencies: []*latest.ArtifactDependency{
+						Dependencies: []*latest_v1.ArtifactDependency{
 							{ImageName: "second", Alias: "secondAlias"},
 							{ImageName: "third"},
 						},
@@ -44,44 +44,44 @@ func TestSetDefaults(t *testing.T) {
 					{
 						ImageName: "second",
 						Workspace: "folder",
-						ArtifactType: latest.ArtifactType{
-							DockerArtifact: &latest.DockerArtifact{
+						ArtifactType: latest_v1.ArtifactType{
+							DockerArtifact: &latest_v1.DockerArtifact{
 								DockerfilePath: "Dockerfile.second",
 							},
 						},
 					},
 					{
 						ImageName: "third",
-						ArtifactType: latest.ArtifactType{
-							CustomArtifact: &latest.CustomArtifact{},
+						ArtifactType: latest_v1.ArtifactType{
+							CustomArtifact: &latest_v1.CustomArtifact{},
 						},
 					},
 					{
 						ImageName: "fourth",
-						ArtifactType: latest.ArtifactType{
-							BuildpackArtifact: &latest.BuildpackArtifact{},
+						ArtifactType: latest_v1.ArtifactType{
+							BuildpackArtifact: &latest_v1.BuildpackArtifact{},
 						},
-						Sync: &latest.Sync{},
+						Sync: &latest_v1.Sync{},
 					},
 					{
 						ImageName: "fifth",
-						ArtifactType: latest.ArtifactType{
-							JibArtifact: &latest.JibArtifact{},
+						ArtifactType: latest_v1.ArtifactType{
+							JibArtifact: &latest_v1.JibArtifact{},
 						},
-						Sync: &latest.Sync{},
+						Sync: &latest_v1.Sync{},
 					},
 					{
 						ImageName: "sixth",
-						ArtifactType: latest.ArtifactType{
-							BuildpackArtifact: &latest.BuildpackArtifact{},
+						ArtifactType: latest_v1.ArtifactType{
+							BuildpackArtifact: &latest_v1.BuildpackArtifact{},
 						},
 					},
 					{
 						ImageName: "seventh",
-						ArtifactType: latest.ArtifactType{
-							BuildpackArtifact: &latest.BuildpackArtifact{},
+						ArtifactType: latest_v1.ArtifactType{
+							BuildpackArtifact: &latest_v1.BuildpackArtifact{},
 						},
-						Sync: &latest.Sync{Auto: util.BoolPtr(false)},
+						Sync: &latest_v1.Sync{Auto: util.BoolPtr(false)},
 					},
 				},
 			},
@@ -139,37 +139,37 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 		})
 
 		// no docker config
-		cfg := &latest.SkaffoldConfig{
-			Pipeline: latest.Pipeline{
-				Build: latest.BuildConfig{
-					Artifacts: []*latest.Artifact{
+		cfg := &latest_v1.SkaffoldConfig{
+			Pipeline: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					Artifacts: []*latest_v1.Artifact{
 						{
 							ImageName: "docker",
-							ArtifactType: latest.ArtifactType{
-								DockerArtifact: &latest.DockerArtifact{},
+							ArtifactType: latest_v1.ArtifactType{
+								DockerArtifact: &latest_v1.DockerArtifact{},
 							},
 						},
 						{
 							ImageName: "kaniko",
-							ArtifactType: latest.ArtifactType{
-								KanikoArtifact: &latest.KanikoArtifact{},
+							ArtifactType: latest_v1.ArtifactType{
+								KanikoArtifact: &latest_v1.KanikoArtifact{},
 							},
 						},
 						{
 							ImageName: "custom",
-							ArtifactType: latest.ArtifactType{
-								CustomArtifact: &latest.CustomArtifact{},
+							ArtifactType: latest_v1.ArtifactType{
+								CustomArtifact: &latest_v1.CustomArtifact{},
 							},
 						},
 						{
 							ImageName: "buildpacks",
-							ArtifactType: latest.ArtifactType{
-								BuildpackArtifact: &latest.BuildpackArtifact{},
+							ArtifactType: latest_v1.ArtifactType{
+								BuildpackArtifact: &latest_v1.BuildpackArtifact{},
 							},
 						},
 					},
-					BuildType: latest.BuildType{
-						Cluster: &latest.ClusterDetails{},
+					BuildType: latest_v1.BuildType{
+						Cluster: &latest_v1.ClusterDetails{},
 					},
 				},
 			},
@@ -188,11 +188,11 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 		t.CheckNil(cfg.Pipeline.Build.Artifacts[3].KanikoArtifact)
 
 		// pull secret set
-		cfg = &latest.SkaffoldConfig{
-			Pipeline: latest.Pipeline{
-				Build: latest.BuildConfig{
-					BuildType: latest.BuildType{
-						Cluster: &latest.ClusterDetails{
+		cfg = &latest_v1.SkaffoldConfig{
+			Pipeline: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					BuildType: latest_v1.BuildType{
+						Cluster: &latest_v1.ClusterDetails{
 							PullSecretPath: "path/to/pull/secret",
 						},
 					},
@@ -208,11 +208,11 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 
 		// pull secret mount path set
 		path := "/path"
-		cfg = &latest.SkaffoldConfig{
-			Pipeline: latest.Pipeline{
-				Build: latest.BuildConfig{
-					BuildType: latest.BuildType{
-						Cluster: &latest.ClusterDetails{
+		cfg = &latest_v1.SkaffoldConfig{
+			Pipeline: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					BuildType: latest_v1.BuildType{
+						Cluster: &latest_v1.ClusterDetails{
 							PullSecretPath:      "path/to/pull/secret",
 							PullSecretMountPath: path,
 						},
@@ -227,14 +227,14 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 		t.CheckDeepEqual(path, cfg.Build.Cluster.PullSecretMountPath)
 
 		// default docker config
-		cfg.Pipeline.Build.BuildType.Cluster.DockerConfig = &latest.DockerConfig{}
+		cfg.Pipeline.Build.BuildType.Cluster.DockerConfig = &latest_v1.DockerConfig{}
 		err = Set(cfg)
 		SetDefaultDeployer(cfg)
 
 		t.CheckNoError(err)
 
 		// docker config with path
-		cfg.Pipeline.Build.BuildType.Cluster.DockerConfig = &latest.DockerConfig{
+		cfg.Pipeline.Build.BuildType.Cluster.DockerConfig = &latest_v1.DockerConfig{
 			Path: "/path",
 		}
 		err = Set(cfg)
@@ -244,7 +244,7 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 		t.CheckDeepEqual("/path", cfg.Build.Cluster.DockerConfig.Path)
 
 		// docker config with secret name
-		cfg.Pipeline.Build.BuildType.Cluster.DockerConfig = &latest.DockerConfig{
+		cfg.Pipeline.Build.BuildType.Cluster.DockerConfig = &latest_v1.DockerConfig{
 			SecretName: "secret",
 		}
 		err = Set(cfg)
@@ -257,21 +257,21 @@ func TestSetDefaultsOnCluster(t *testing.T) {
 }
 
 func TestCustomBuildWithCluster(t *testing.T) {
-	cfg := &latest.SkaffoldConfig{
-		Pipeline: latest.Pipeline{
-			Build: latest.BuildConfig{
-				Artifacts: []*latest.Artifact{
+	cfg := &latest_v1.SkaffoldConfig{
+		Pipeline: latest_v1.Pipeline{
+			Build: latest_v1.BuildConfig{
+				Artifacts: []*latest_v1.Artifact{
 					{
 						ImageName: "image",
-						ArtifactType: latest.ArtifactType{
-							CustomArtifact: &latest.CustomArtifact{
+						ArtifactType: latest_v1.ArtifactType{
+							CustomArtifact: &latest_v1.CustomArtifact{
 								BuildCommand: "./build.sh",
 							},
 						},
 					},
 				},
-				BuildType: latest.BuildType{
-					Cluster: &latest.ClusterDetails{},
+				BuildType: latest_v1.BuildType{
+					Cluster: &latest_v1.ClusterDetails{},
 				},
 			},
 		},
@@ -281,18 +281,18 @@ func TestCustomBuildWithCluster(t *testing.T) {
 	SetDefaultDeployer(cfg)
 
 	testutil.CheckError(t, false, err)
-	testutil.CheckDeepEqual(t, (*latest.KanikoArtifact)(nil), cfg.Build.Artifacts[0].KanikoArtifact)
+	testutil.CheckDeepEqual(t, (*latest_v1.KanikoArtifact)(nil), cfg.Build.Artifacts[0].KanikoArtifact)
 }
 
 func TestSetDefaultsOnCloudBuild(t *testing.T) {
-	cfg := &latest.SkaffoldConfig{
-		Pipeline: latest.Pipeline{
-			Build: latest.BuildConfig{
-				Artifacts: []*latest.Artifact{
+	cfg := &latest_v1.SkaffoldConfig{
+		Pipeline: latest_v1.Pipeline{
+			Build: latest_v1.BuildConfig{
+				Artifacts: []*latest_v1.Artifact{
 					{ImageName: "image"},
 				},
-				BuildType: latest.BuildType{
-					GoogleCloudBuild: &latest.GoogleCloudBuild{},
+				BuildType: latest_v1.BuildType{
+					GoogleCloudBuild: &latest_v1.GoogleCloudBuild{},
 				},
 			},
 		},
@@ -309,13 +309,13 @@ func TestSetDefaultsOnCloudBuild(t *testing.T) {
 }
 
 func TestSetDefaultsOnLocalBuild(t *testing.T) {
-	cfg1 := &latest.SkaffoldConfig{Pipeline: latest.Pipeline{Build: latest.BuildConfig{}}}
-	cfg2 := &latest.SkaffoldConfig{Pipeline: latest.Pipeline{Build: latest.BuildConfig{Artifacts: []*latest.Artifact{{ImageName: "foo"}}}}}
+	cfg1 := &latest_v1.SkaffoldConfig{Pipeline: latest_v1.Pipeline{Build: latest_v1.BuildConfig{}}}
+	cfg2 := &latest_v1.SkaffoldConfig{Pipeline: latest_v1.Pipeline{Build: latest_v1.BuildConfig{Artifacts: []*latest_v1.Artifact{{ImageName: "foo"}}}}}
 
 	err := Set(cfg1)
 	testutil.CheckError(t, false, err)
 	SetDefaultDeployer(cfg1)
-	testutil.CheckDeepEqual(t, latest.LocalBuild{}, *cfg1.Build.LocalBuild)
+	testutil.CheckDeepEqual(t, latest_v1.LocalBuild{}, *cfg1.Build.LocalBuild)
 	err = Set(cfg2)
 	testutil.CheckError(t, false, err)
 	SetDefaultDeployer(cfg2)
@@ -323,10 +323,10 @@ func TestSetDefaultsOnLocalBuild(t *testing.T) {
 }
 
 func TestSetPortForwardLocalPort(t *testing.T) {
-	cfg := &latest.SkaffoldConfig{
-		Pipeline: latest.Pipeline{
-			Build: latest.BuildConfig{},
-			PortForward: []*latest.PortForwardResource{
+	cfg := &latest_v1.SkaffoldConfig{
+		Pipeline: latest_v1.Pipeline{
+			Build: latest_v1.BuildConfig{},
+			PortForward: []*latest_v1.PortForwardResource{
 				{
 					Type: constants.Service,
 					Port: schemautil.FromInt(8080),
@@ -346,10 +346,10 @@ func TestSetPortForwardLocalPort(t *testing.T) {
 }
 
 func TestSetPortForwardOnEmptyPortForwardResource(t *testing.T) {
-	cfg := &latest.SkaffoldConfig{
-		Pipeline: latest.Pipeline{
-			Build: latest.BuildConfig{},
-			PortForward: []*latest.PortForwardResource{
+	cfg := &latest_v1.SkaffoldConfig{
+		Pipeline: latest_v1.Pipeline{
+			Build: latest_v1.BuildConfig{},
+			PortForward: []*latest_v1.PortForwardResource{
 				nil,
 			},
 		},
@@ -359,10 +359,10 @@ func TestSetPortForwardOnEmptyPortForwardResource(t *testing.T) {
 }
 
 func TestSetDefaultPortForwardAddress(t *testing.T) {
-	cfg := &latest.SkaffoldConfig{
-		Pipeline: latest.Pipeline{
-			Build: latest.BuildConfig{},
-			PortForward: []*latest.PortForwardResource{
+	cfg := &latest_v1.SkaffoldConfig{
+		Pipeline: latest_v1.Pipeline{
+			Build: latest_v1.BuildConfig{},
+			PortForward: []*latest_v1.PortForwardResource{
 				{
 					Type:    constants.Service,
 					Address: "0.0.0.0",
@@ -382,31 +382,31 @@ func TestSetDefaultPortForwardAddress(t *testing.T) {
 func TestSetLogsConfig(t *testing.T) {
 	tests := []struct {
 		description string
-		input       latest.LogsConfig
-		expected    latest.LogsConfig
+		input       latest_v1.LogsConfig
+		expected    latest_v1.LogsConfig
 	}{
 		{
 			description: "prefix defaults to 'container'",
-			input:       latest.LogsConfig{},
-			expected: latest.LogsConfig{
+			input:       latest_v1.LogsConfig{},
+			expected: latest_v1.LogsConfig{
 				Prefix: "container",
 			},
 		},
 		{
 			description: "don't override existing prefix",
-			input: latest.LogsConfig{
+			input: latest_v1.LogsConfig{
 				Prefix: "none",
 			},
-			expected: latest.LogsConfig{
+			expected: latest_v1.LogsConfig{
 				Prefix: "none",
 			},
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			cfg := latest.SkaffoldConfig{
-				Pipeline: latest.Pipeline{
-					Deploy: latest.DeployConfig{
+			cfg := latest_v1.SkaffoldConfig{
+				Pipeline: latest_v1.Pipeline{
+					Deploy: latest_v1.DeployConfig{
 						Logs: test.input,
 					},
 				},

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2021 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package latest
+package v1
 
 import (
 	"encoding/json"

--- a/pkg/skaffold/schema/latest/v1/upgrade.go
+++ b/pkg/skaffold/schema/latest/v1/upgrade.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2021 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,8 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-package latest
+package v1
 
 import (
 	"errors"

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -27,7 +27,7 @@ import (
 
 	cfg "github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	skutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
@@ -36,7 +36,7 @@ import (
 
 // ApplyProfiles modifies the input skaffold configuration by the application
 // of a list of profiles, and returns the list of applied profiles.
-func ApplyProfiles(c *latest.SkaffoldConfig, opts cfg.SkaffoldOptions, namedProfiles []string) ([]string, error) {
+func ApplyProfiles(c *latest_v1.SkaffoldConfig, opts cfg.SkaffoldOptions, namedProfiles []string) ([]string, error) {
 	byName := profilesByName(c.Profiles)
 
 	profiles, contextSpecificProfiles, err := activatedProfiles(c.Profiles, opts, namedProfiles)
@@ -85,7 +85,7 @@ func checkKubeContextConsistency(contextSpecificProfiles []string, cliContext, e
 
 // activatedProfiles returns the activated profiles and activated profiles which are kube-context specific.
 // The latter matters for error reporting when the effective kube-context changes.
-func activatedProfiles(profiles []latest.Profile, opts cfg.SkaffoldOptions, namedProfiles []string) ([]string, []string, error) {
+func activatedProfiles(profiles []latest_v1.Profile, opts cfg.SkaffoldOptions, namedProfiles []string) ([]string, []string, error) {
 	var activated []string
 	var contextSpecificProfiles []string
 
@@ -189,7 +189,7 @@ func isKubeContext(kubeContext string, opts cfg.SkaffoldOptions) (bool, error) {
 	return skutil.RegexEqual(kubeContext, currentKubeConfig.CurrentContext), nil
 }
 
-func applyProfile(config *latest.SkaffoldConfig, profile latest.Profile) error {
+func applyProfile(config *latest_v1.SkaffoldConfig, profile latest_v1.Profile) error {
 	logrus.Infof("applying profile: %s", profile.Name)
 
 	// Apply profile, field by field
@@ -246,7 +246,7 @@ func applyProfile(config *latest.SkaffoldConfig, profile latest.Profile) error {
 		return err
 	}
 
-	*config = latest.SkaffoldConfig{}
+	*config = latest_v1.SkaffoldConfig{}
 	return yaml.Unmarshal(buf, config)
 }
 
@@ -264,8 +264,8 @@ func tryPatch(patch yamlpatch.Operation, buf []byte) (valid bool) {
 	return err == nil
 }
 
-func profilesByName(profiles []latest.Profile) map[string]latest.Profile {
-	byName := make(map[string]latest.Profile)
+func profilesByName(profiles []latest_v1.Profile) map[string]latest_v1.Profile {
+	byName := make(map[string]latest_v1.Profile)
 	for _, profile := range profiles {
 		byName[profile.Name] = profile
 	}

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	cfg "github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -67,14 +67,14 @@ profiles:
 		t.CheckNoError(err)
 		t.CheckTrue(len(parsed) > 0)
 
-		skaffoldConfig := parsed[0].(*latest.SkaffoldConfig)
+		skaffoldConfig := parsed[0].(*latest_v1.SkaffoldConfig)
 		activated, err := ApplyProfiles(skaffoldConfig, cfg.SkaffoldOptions{}, []string{"patches"})
 		t.CheckNoError(err)
 		t.CheckDeepEqual([]string{"patches"}, activated)
 		t.CheckDeepEqual("replacement", skaffoldConfig.Build.Artifacts[0].ImageName)
 		t.CheckDeepEqual("Dockerfile.DEV", skaffoldConfig.Build.Artifacts[0].DockerArtifact.DockerfilePath)
 		t.CheckDeepEqual("Dockerfile.second", skaffoldConfig.Build.Artifacts[1].DockerArtifact.DockerfilePath)
-		t.CheckDeepEqual(latest.DeployConfig{}, skaffoldConfig.Deploy)
+		t.CheckDeepEqual(latest_v1.DeployConfig{}, skaffoldConfig.Deploy)
 	})
 }
 
@@ -97,7 +97,7 @@ profiles:
 		t.CheckNoError(err)
 		t.CheckTrue(len(parsed) > 0)
 
-		skaffoldConfig := parsed[0].(*latest.SkaffoldConfig)
+		skaffoldConfig := parsed[0].(*latest_v1.SkaffoldConfig)
 		_, err = ApplyProfiles(skaffoldConfig, cfg.SkaffoldOptions{}, []string{"patches"})
 		t.CheckErrorAndDeepEqual(true, err, `applying profile "patches": invalid path: /build/artifacts/0/image/`, err.Error())
 	})
@@ -106,9 +106,9 @@ profiles:
 func TestApplyProfiles(t *testing.T) {
 	tests := []struct {
 		description              string
-		config                   *latest.SkaffoldConfig
+		config                   *latest_v1.SkaffoldConfig
 		profile                  string
-		expected                 *latest.SkaffoldConfig
+		expected                 *latest_v1.SkaffoldConfig
 		kubeContextCli           string
 		profileAutoActivationCli bool
 		shouldErr                bool
@@ -129,12 +129,12 @@ func TestApplyProfiles(t *testing.T) {
 					withDockerArtifact("image", ".", "Dockerfile"),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
-				withProfiles(latest.Profile{
+				withProfiles(latest_v1.Profile{
 					Name: "profile",
-					Pipeline: latest.Pipeline{
-						Build: latest.BuildConfig{
-							BuildType: latest.BuildType{
-								GoogleCloudBuild: &latest.GoogleCloudBuild{
+					Pipeline: latest_v1.Pipeline{
+						Build: latest_v1.BuildConfig{
+							BuildType: latest_v1.BuildType{
+								GoogleCloudBuild: &latest_v1.GoogleCloudBuild{
 									ProjectID:   "my-project",
 									DockerImage: "gcr.io/cloud-builders/docker",
 									MavenImage:  "gcr.io/cloud-builders/mvn",
@@ -165,11 +165,11 @@ func TestApplyProfiles(t *testing.T) {
 					withDockerArtifact("image", ".", "Dockerfile"),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
-				withProfiles(latest.Profile{
+				withProfiles(latest_v1.Profile{
 					Name: "dev",
-					Pipeline: latest.Pipeline{
-						Build: latest.BuildConfig{
-							TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
+					Pipeline: latest_v1.Pipeline{
+						Build: latest_v1.BuildConfig{
+							TagPolicy: latest_v1.TagPolicy{ShaTagger: &latest_v1.ShaTagger{}},
 						},
 					},
 				}),
@@ -192,18 +192,18 @@ func TestApplyProfiles(t *testing.T) {
 					withDockerArtifact("image", ".", "Dockerfile"),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
-				withProfiles(latest.Profile{
+				withProfiles(latest_v1.Profile{
 					Name: "profile",
-					Pipeline: latest.Pipeline{
-						Build: latest.BuildConfig{
-							Artifacts: []*latest.Artifact{
-								{ImageName: "image", Workspace: ".", ArtifactType: latest.ArtifactType{
-									DockerArtifact: &latest.DockerArtifact{
+					Pipeline: latest_v1.Pipeline{
+						Build: latest_v1.BuildConfig{
+							Artifacts: []*latest_v1.Artifact{
+								{ImageName: "image", Workspace: ".", ArtifactType: latest_v1.ArtifactType{
+									DockerArtifact: &latest_v1.DockerArtifact{
 										DockerfilePath: "Dockerfile.DEV",
 									},
 								}},
-								{ImageName: "imageProd", Workspace: ".", ArtifactType: latest.ArtifactType{
-									DockerArtifact: &latest.DockerArtifact{
+								{ImageName: "imageProd", Workspace: ".", ArtifactType: latest_v1.ArtifactType{
+									DockerArtifact: &latest_v1.DockerArtifact{
 										DockerfilePath: "Dockerfile.DEV",
 									},
 								}},
@@ -230,12 +230,12 @@ func TestApplyProfiles(t *testing.T) {
 					withGitTagger(),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
-				withProfiles(latest.Profile{
+				withProfiles(latest_v1.Profile{
 					Name: "profile",
-					Pipeline: latest.Pipeline{
-						Deploy: latest.DeployConfig{
-							DeployType: latest.DeployType{
-								HelmDeploy: &latest.HelmDeploy{},
+					Pipeline: latest_v1.Pipeline{
+						Deploy: latest_v1.DeployConfig{
+							DeployType: latest_v1.DeployType{
+								HelmDeploy: &latest_v1.HelmDeploy{},
 							},
 						},
 					},
@@ -259,9 +259,9 @@ func TestApplyProfiles(t *testing.T) {
 					withDockerArtifact("image", ".", "Dockerfile"),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
-				withProfiles(latest.Profile{
+				withProfiles(latest_v1.Profile{
 					Name: "profile",
-					Patches: []latest.JSONPatch{{
+					Patches: []latest_v1.JSONPatch{{
 						Path:  "/build/artifacts/0/docker/dockerfile",
 						Value: &util.YamlpatchNode{Node: *yamlpatch.NewNode(str("Dockerfile.DEV"))},
 					}},
@@ -285,9 +285,9 @@ func TestApplyProfiles(t *testing.T) {
 					withDockerArtifact("image", ".", "Dockerfile"),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
-				withProfiles(latest.Profile{
+				withProfiles(latest_v1.Profile{
 					Name: "profile",
-					Patches: []latest.JSONPatch{{
+					Patches: []latest_v1.JSONPatch{{
 						Path: "/unknown",
 						Op:   "replace",
 					}},
@@ -303,10 +303,10 @@ func TestApplyProfiles(t *testing.T) {
 				withLocalBuild(
 					withGitTagger(),
 				),
-				withProfiles(latest.Profile{
+				withProfiles(latest_v1.Profile{
 					Name: "profile",
-					Pipeline: latest.Pipeline{
-						Test: []*latest.TestCase{{
+					Pipeline: latest_v1.Pipeline{
+						Test: []*latest_v1.TestCase{{
 							ImageName:      "image",
 							StructureTests: []string{"test/*"},
 						}},
@@ -317,7 +317,7 @@ func TestApplyProfiles(t *testing.T) {
 				withLocalBuild(
 					withGitTagger(),
 				),
-				withTests(&latest.TestCase{
+				withTests(&latest_v1.TestCase{
 					ImageName:      "image",
 					StructureTests: []string{"test/*"},
 				}),
@@ -331,10 +331,10 @@ func TestApplyProfiles(t *testing.T) {
 				withLocalBuild(
 					withGitTagger(),
 				),
-				withProfiles(latest.Profile{
+				withProfiles(latest_v1.Profile{
 					Name: "profile",
-					Pipeline: latest.Pipeline{
-						PortForward: []*latest.PortForwardResource{{
+					Pipeline: latest_v1.Pipeline{
+						PortForward: []*latest_v1.PortForwardResource{{
 							Namespace: "ns",
 							Name:      "name",
 							Type:      "service",
@@ -348,7 +348,7 @@ func TestApplyProfiles(t *testing.T) {
 				withLocalBuild(
 					withGitTagger(),
 				),
-				withPortForward(&latest.PortForwardResource{
+				withPortForward(&latest_v1.PortForwardResource{
 					Namespace: "ns",
 					Name:      "name",
 					Type:      "service",
@@ -362,16 +362,16 @@ func TestApplyProfiles(t *testing.T) {
 			profile:                  "profile",
 			profileAutoActivationCli: true,
 			config: config(
-				withProfiles(latest.Profile{
+				withProfiles(latest_v1.Profile{
 					Name: "profile",
-					Pipeline: latest.Pipeline{
-						Deploy: latest.DeployConfig{
+					Pipeline: latest_v1.Pipeline{
+						Deploy: latest_v1.DeployConfig{
 							KubeContext: "staging",
 						},
 					}},
-					latest.Profile{
+					latest_v1.Profile{
 						Name:       "prod",
-						Activation: []latest.Activation{{KubeContext: "prod-context"}},
+						Activation: []latest_v1.Activation{{KubeContext: "prod-context"}},
 					},
 				),
 			),
@@ -382,10 +382,10 @@ func TestApplyProfiles(t *testing.T) {
 			profile:                  "profile",
 			profileAutoActivationCli: true,
 			config: config(
-				withProfiles(latest.Profile{
+				withProfiles(latest_v1.Profile{
 					Name: "profile",
-					Pipeline: latest.Pipeline{
-						Deploy: latest.DeployConfig{
+					Pipeline: latest_v1.Pipeline{
+						Deploy: latest_v1.DeployConfig{
 							KubeContext: "staging",
 						},
 					}},
@@ -401,14 +401,14 @@ func TestApplyProfiles(t *testing.T) {
 			profileAutoActivationCli: true,
 			config: config(
 				withProfiles(
-					latest.Profile{
+					latest_v1.Profile{
 						Name:       "prod",
-						Activation: []latest.Activation{{KubeContext: "prod-context"}},
+						Activation: []latest_v1.Activation{{KubeContext: "prod-context"}},
 					},
-					latest.Profile{
+					latest_v1.Profile{
 						Name: "profile",
-						Pipeline: latest.Pipeline{
-							Deploy: latest.DeployConfig{
+						Pipeline: latest_v1.Pipeline{
+							Deploy: latest_v1.DeployConfig{
 								KubeContext: "staging",
 							},
 						}},
@@ -429,15 +429,15 @@ func TestApplyProfiles(t *testing.T) {
 					withDockerArtifact("image", ".", "Dockerfile"),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
-				withProfiles(latest.Profile{
+				withProfiles(latest_v1.Profile{
 					Name: "dev",
 				},
-					latest.Profile{
+					latest_v1.Profile{
 						Name:       "prod",
-						Activation: []latest.Activation{{KubeContext: "prod-context"}},
-						Pipeline: latest.Pipeline{
-							Build: latest.BuildConfig{
-								TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
+						Activation: []latest_v1.Activation{{KubeContext: "prod-context"}},
+						Pipeline: latest_v1.Pipeline{
+							Build: latest_v1.BuildConfig{
+								TagPolicy: latest_v1.TagPolicy{ShaTagger: &latest_v1.ShaTagger{}},
 							},
 						},
 					}),
@@ -460,15 +460,15 @@ func TestApplyProfiles(t *testing.T) {
 					withDockerArtifact("image", ".", "Dockerfile"),
 				),
 				withKubectlDeploy("k8s/*.yaml"),
-				withProfiles(latest.Profile{
+				withProfiles(latest_v1.Profile{
 					Name: "dev",
 				},
-					latest.Profile{
+					latest_v1.Profile{
 						Name:       "prod",
-						Activation: []latest.Activation{{KubeContext: "prod-context"}},
-						Pipeline: latest.Pipeline{
-							Build: latest.BuildConfig{
-								TagPolicy: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}},
+						Activation: []latest_v1.Activation{{KubeContext: "prod-context"}},
+						Pipeline: latest_v1.Pipeline{
+							Build: latest_v1.BuildConfig{
+								TagPolicy: latest_v1.TagPolicy{ShaTagger: &latest_v1.ShaTagger{}},
 							},
 						},
 					}),
@@ -503,7 +503,7 @@ func TestApplyProfiles(t *testing.T) {
 func TestActivatedProfiles(t *testing.T) {
 	tests := []struct {
 		description string
-		profiles    []latest.Profile
+		profiles    []latest_v1.Profile
 		opts        cfg.SkaffoldOptions
 		envs        map[string]string
 		expected    []string
@@ -516,7 +516,7 @@ func TestActivatedProfiles(t *testing.T) {
 				Command:               "dev",
 				Profiles:              []string{"activated", "also-activated"},
 			},
-			profiles: []latest.Profile{
+			profiles: []latest_v1.Profile{
 				{Name: "activated"},
 				{Name: "not-activated"},
 				{Name: "also-activated"},
@@ -528,12 +528,12 @@ func TestActivatedProfiles(t *testing.T) {
 				ProfileAutoActivation: true,
 				Command:               "dev",
 			},
-			profiles: []latest.Profile{
-				{Name: "run-profile", Activation: []latest.Activation{{Command: "run"}}},
-				{Name: "dev-profile", Activation: []latest.Activation{{Command: "dev"}}},
-				{Name: "non-run-profile", Activation: []latest.Activation{{Command: "!run"}}},
-				{Name: "run-or-dev-profile", Activation: []latest.Activation{{Command: "(run)|(dev)"}}},
-				{Name: "other-profile", Activation: []latest.Activation{{Command: "!(run)|(dev)"}}},
+			profiles: []latest_v1.Profile{
+				{Name: "run-profile", Activation: []latest_v1.Activation{{Command: "run"}}},
+				{Name: "dev-profile", Activation: []latest_v1.Activation{{Command: "dev"}}},
+				{Name: "non-run-profile", Activation: []latest_v1.Activation{{Command: "!run"}}},
+				{Name: "run-or-dev-profile", Activation: []latest_v1.Activation{{Command: "(run)|(dev)"}}},
+				{Name: "other-profile", Activation: []latest_v1.Activation{{Command: "!(run)|(dev)"}}},
 			},
 			expected: []string{"dev-profile", "non-run-profile", "run-or-dev-profile"},
 		}, {
@@ -542,14 +542,14 @@ func TestActivatedProfiles(t *testing.T) {
 			opts: cfg.SkaffoldOptions{
 				ProfileAutoActivation: true,
 			},
-			profiles: []latest.Profile{
-				{Name: "activated", Activation: []latest.Activation{{Env: "KEY=VALUE"}}},
-				{Name: "not-activated", Activation: []latest.Activation{{Env: "KEY=OTHER"}}},
-				{Name: "also-activated", Activation: []latest.Activation{{Env: "KEY=!OTHER"}}},
-				{Name: "not-treated-as-regex", Activation: []latest.Activation{{Env: "KEY="}}},
-				{Name: "regex-activated", Activation: []latest.Activation{{Env: "KEY=V.*E"}}},
-				{Name: "regex-activated-two", Activation: []latest.Activation{{Env: "KEY=^V.*E$"}}},
-				{Name: "regex-activated-substring-match", Activation: []latest.Activation{{Env: "KEY=^VAL"}}},
+			profiles: []latest_v1.Profile{
+				{Name: "activated", Activation: []latest_v1.Activation{{Env: "KEY=VALUE"}}},
+				{Name: "not-activated", Activation: []latest_v1.Activation{{Env: "KEY=OTHER"}}},
+				{Name: "also-activated", Activation: []latest_v1.Activation{{Env: "KEY=!OTHER"}}},
+				{Name: "not-treated-as-regex", Activation: []latest_v1.Activation{{Env: "KEY="}}},
+				{Name: "regex-activated", Activation: []latest_v1.Activation{{Env: "KEY=V.*E"}}},
+				{Name: "regex-activated-two", Activation: []latest_v1.Activation{{Env: "KEY=^V.*E$"}}},
+				{Name: "regex-activated-substring-match", Activation: []latest_v1.Activation{{Env: "KEY=^VAL"}}},
 			},
 			expected: []string{"activated", "also-activated", "regex-activated", "regex-activated-two", "regex-activated-substring-match"},
 		}, {
@@ -560,10 +560,10 @@ func TestActivatedProfiles(t *testing.T) {
 				Command:               "dev",
 				Profiles:              []string{"activated", "also-activated"},
 			},
-			profiles: []latest.Profile{
-				{Name: "activated", Activation: []latest.Activation{{Env: "KEY=VALUE"}, {Command: "dev"}}},
-				{Name: "not-activated", Activation: []latest.Activation{{Env: "KEY=OTHER"}}},
-				{Name: "also-activated", Activation: []latest.Activation{{Env: "KEY=!OTHER"}}},
+			profiles: []latest_v1.Profile{
+				{Name: "activated", Activation: []latest_v1.Activation{{Env: "KEY=VALUE"}, {Command: "dev"}}},
+				{Name: "not-activated", Activation: []latest_v1.Activation{{Env: "KEY=OTHER"}}},
+				{Name: "also-activated", Activation: []latest_v1.Activation{{Env: "KEY=!OTHER"}}},
 			},
 			expected: []string{"activated", "also-activated"},
 		}, {
@@ -572,8 +572,8 @@ func TestActivatedProfiles(t *testing.T) {
 			opts: cfg.SkaffoldOptions{
 				ProfileAutoActivation: true,
 			},
-			profiles: []latest.Profile{
-				{Name: "activated", Activation: []latest.Activation{{Env: "KEY:VALUE"}}},
+			profiles: []latest_v1.Profile{
+				{Name: "activated", Activation: []latest_v1.Activation{{Env: "KEY:VALUE"}}},
 			},
 			shouldErr: true,
 		}, {
@@ -581,13 +581,13 @@ func TestActivatedProfiles(t *testing.T) {
 			opts: cfg.SkaffoldOptions{
 				ProfileAutoActivation: true,
 			},
-			profiles: []latest.Profile{
-				{Name: "activated", Activation: []latest.Activation{{KubeContext: "prod-context"}}},
-				{Name: "not-activated", Activation: []latest.Activation{{KubeContext: "dev-context"}}},
-				{Name: "also-activated", Activation: []latest.Activation{{KubeContext: "!dev-context"}}},
-				{Name: "activated-regexp", Activation: []latest.Activation{{KubeContext: "prod-.*"}}},
-				{Name: "not-activated-regexp", Activation: []latest.Activation{{KubeContext: "dev-.*"}}},
-				{Name: "invalid-regexp", Activation: []latest.Activation{{KubeContext: `\`}}},
+			profiles: []latest_v1.Profile{
+				{Name: "activated", Activation: []latest_v1.Activation{{KubeContext: "prod-context"}}},
+				{Name: "not-activated", Activation: []latest_v1.Activation{{KubeContext: "dev-context"}}},
+				{Name: "also-activated", Activation: []latest_v1.Activation{{KubeContext: "!dev-context"}}},
+				{Name: "activated-regexp", Activation: []latest_v1.Activation{{KubeContext: "prod-.*"}}},
+				{Name: "not-activated-regexp", Activation: []latest_v1.Activation{{KubeContext: "dev-.*"}}},
+				{Name: "invalid-regexp", Activation: []latest_v1.Activation{{KubeContext: `\`}}},
 			},
 			expected: []string{"activated", "also-activated", "activated-regexp"},
 		}, {
@@ -597,16 +597,16 @@ func TestActivatedProfiles(t *testing.T) {
 				ProfileAutoActivation: true,
 				Command:               "dev",
 			},
-			profiles: []latest.Profile{
+			profiles: []latest_v1.Profile{
 				{
-					Name: "activated", Activation: []latest.Activation{{
+					Name: "activated", Activation: []latest_v1.Activation{{
 						Env:         "KEY=VALUE",
 						KubeContext: "prod-context",
 						Command:     "dev",
 					}},
 				},
 				{
-					Name: "not-activated", Activation: []latest.Activation{{
+					Name: "not-activated", Activation: []latest_v1.Activation{{
 						Env:         "KEY=VALUE",
 						KubeContext: "prod-context",
 						Command:     "build",
@@ -620,9 +620,9 @@ func TestActivatedProfiles(t *testing.T) {
 				ProfileAutoActivation: true,
 				Command:               "dev",
 			},
-			profiles: []latest.Profile{
+			profiles: []latest_v1.Profile{
 				{
-					Name: "activated", Activation: []latest.Activation{{
+					Name: "activated", Activation: []latest_v1.Activation{{
 						Command: "run",
 					}, {
 						Command: "dev",
@@ -638,34 +638,34 @@ func TestActivatedProfiles(t *testing.T) {
 				ProfileAutoActivation: true,
 				Command:               "dev",
 			},
-			profiles: []latest.Profile{
+			profiles: []latest_v1.Profile{
 				{
-					Name: "empty", Activation: []latest.Activation{{
+					Name: "empty", Activation: []latest_v1.Activation{{
 						Env: "ABC=",
 					}},
 				},
 				{
-					Name: "empty-by-regex", Activation: []latest.Activation{{
+					Name: "empty-by-regex", Activation: []latest_v1.Activation{{
 						Env: "ABC=^$",
 					}},
 				},
 				{
-					Name: "not-empty", Activation: []latest.Activation{{
+					Name: "not-empty", Activation: []latest_v1.Activation{{
 						Env: "ABC=!",
 					}},
 				},
 				{
-					Name: "one", Activation: []latest.Activation{{
+					Name: "one", Activation: []latest_v1.Activation{{
 						Env: "ABC=1",
 					}},
 				},
 				{
-					Name: "not-one", Activation: []latest.Activation{{
+					Name: "not-one", Activation: []latest_v1.Activation{{
 						Env: "ABC=!1",
 					}},
 				},
 				{
-					Name: "two", Activation: []latest.Activation{{
+					Name: "two", Activation: []latest_v1.Activation{{
 						Env: "ABC=2",
 					}},
 				},
@@ -679,33 +679,33 @@ func TestActivatedProfiles(t *testing.T) {
 				ProfileAutoActivation: true,
 				Command:               "dev",
 			},
-			profiles: []latest.Profile{
+			profiles: []latest_v1.Profile{
 				{
-					Name: "empty", Activation: []latest.Activation{{
+					Name: "empty", Activation: []latest_v1.Activation{{
 						Env: "ABC=",
 					}},
 				},
 				{
-					Name: "one", Activation: []latest.Activation{{
+					Name: "one", Activation: []latest_v1.Activation{{
 						Env: "ABC=1",
 					}},
 				},
 				{
-					Name: "one-as-well", Activation: []latest.Activation{{
+					Name: "one-as-well", Activation: []latest_v1.Activation{{
 						Command: "not-triggered",
 					}, {
 						Env: "ABC=1",
 					}},
 				},
 				{
-					Name: "two", Activation: []latest.Activation{{
+					Name: "two", Activation: []latest_v1.Activation{{
 						Command: "build",
 					}, {
 						Env: "ABC=2",
 					}},
 				},
 				{
-					Name: "not-two", Activation: []latest.Activation{{
+					Name: "not-two", Activation: []latest_v1.Activation{{
 						Command: "build",
 					}, {
 						Env: "ABC=!2",
@@ -721,8 +721,8 @@ func TestActivatedProfiles(t *testing.T) {
 				Command:               "run",
 				Profiles:              []string{"activated", "also-activated"},
 			},
-			profiles: []latest.Profile{
-				{Name: "run-profile", Activation: []latest.Activation{{Command: "run"}}},
+			profiles: []latest_v1.Profile{
+				{Name: "run-profile", Activation: []latest_v1.Activation{{Command: "run"}}},
 			},
 			expected: []string{"run-profile", "activated", "also-activated"},
 		},
@@ -733,12 +733,12 @@ func TestActivatedProfiles(t *testing.T) {
 				Command:               "dev",
 				Profiles:              []string{"activated", "also-activated"},
 			},
-			profiles: []latest.Profile{
+			profiles: []latest_v1.Profile{
 				{Name: "activated"},
 				{Name: "not-activated"},
 				{Name: "also-activated"},
-				{Name: "not-activated-regexp", Activation: []latest.Activation{{KubeContext: "prod-.*"}}},
-				{Name: "not-activated-kubecontext", Activation: []latest.Activation{{KubeContext: "prod-context"}}},
+				{Name: "not-activated-regexp", Activation: []latest_v1.Activation{{KubeContext: "prod-.*"}}},
+				{Name: "not-activated-kubecontext", Activation: []latest_v1.Activation{{KubeContext: "prod-context"}}},
 			},
 			expected: []string{"activated", "also-activated"},
 		},
@@ -749,9 +749,9 @@ func TestActivatedProfiles(t *testing.T) {
 				Command:               "dev",
 				Profiles:              []string{"-dev-profile"},
 			},
-			profiles: []latest.Profile{
-				{Name: "dev-profile", Activation: []latest.Activation{{Command: "dev"}}},
-				{Name: "run-or-dev-profile", Activation: []latest.Activation{{Command: "(run)|(dev)"}}},
+			profiles: []latest_v1.Profile{
+				{Name: "dev-profile", Activation: []latest_v1.Activation{{Command: "dev"}}},
+				{Name: "run-or-dev-profile", Activation: []latest_v1.Activation{{Command: "(run)|(dev)"}}},
 			},
 			expected: []string{"run-or-dev-profile"},
 		},
@@ -801,19 +801,19 @@ profiles:
 		t.RequireNoError(err)
 		t.CheckTrue(len(parsed) > 0)
 
-		skaffoldConfig := parsed[0].(*latest.SkaffoldConfig)
+		skaffoldConfig := parsed[0].(*latest_v1.SkaffoldConfig)
 
 		t.CheckDeepEqual(2, len(skaffoldConfig.Profiles))
 		t.CheckDeepEqual("simple1", skaffoldConfig.Profiles[0].Name)
-		t.CheckDeepEqual([]latest.Activation{{Env: "ABC=common"}, {Env: "ABC=1"}}, skaffoldConfig.Profiles[0].Activation)
+		t.CheckDeepEqual([]latest_v1.Activation{{Env: "ABC=common"}, {Env: "ABC=1"}}, skaffoldConfig.Profiles[0].Activation)
 		t.CheckDeepEqual("simple2", skaffoldConfig.Profiles[1].Name)
-		t.CheckDeepEqual([]latest.Activation{{Env: "ABC=common"}, {Env: "ABC=2"}}, skaffoldConfig.Profiles[1].Activation)
+		t.CheckDeepEqual([]latest_v1.Activation{{Env: "ABC=common"}, {Env: "ABC=2"}}, skaffoldConfig.Profiles[1].Activation)
 
 		applied, err := ApplyProfiles(skaffoldConfig, cfg.SkaffoldOptions{}, []string{"simple1"})
 		t.CheckNoError(err)
 		t.CheckDeepEqual([]string{"simple1"}, applied)
 		t.CheckDeepEqual(1, len(skaffoldConfig.Build.Artifacts))
-		t.CheckDeepEqual(latest.Artifact{ImageName: "simpleimage1"}, *skaffoldConfig.Build.Artifacts[0])
+		t.CheckDeepEqual(latest_v1.Artifact{ImageName: "simpleimage1"}, *skaffoldConfig.Build.Artifacts[0])
 	})
 }
 
@@ -823,7 +823,7 @@ func str(value string) *interface{} {
 }
 
 func addVersion(yaml string) string {
-	return fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latest.Version, yaml)
+	return fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latest_v1.Version, yaml)
 }
 
 func setupFakeKubeConfig(t *testutil.T, config api.Config) {

--- a/pkg/skaffold/schema/samples_test.go
+++ b/pkg/skaffold/schema/samples_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/validation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
@@ -77,11 +77,11 @@ func TestParseSamples(t *testing.T) {
 
 func checkSkaffoldConfig(t *testutil.T, yaml []byte) {
 	configFile := t.TempFile("skaffold.yaml", yaml)
-	parsed, err := ParseConfigAndUpgrade(configFile, latest.Version)
+	parsed, err := ParseConfigAndUpgrade(configFile, latest_v1.Version)
 	t.CheckNoError(err)
-	var cfgs []*latest.SkaffoldConfig
+	var cfgs []*latest_v1.SkaffoldConfig
 	for _, p := range parsed {
-		cfg := p.(*latest.SkaffoldConfig)
+		cfg := p.(*latest_v1.SkaffoldConfig)
 		err = defaults.Set(cfg)
 		defaults.SetDefaultDeployer(cfg)
 		t.CheckNoError(err)
@@ -118,5 +118,5 @@ func addHeader(buf []byte) []byte {
 	if bytes.HasPrefix(buf, []byte("apiVersion:")) {
 		return buf
 	}
-	return []byte(fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latest.Version, buf))
+	return []byte(fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latest_v1.Version, buf))
 }

--- a/pkg/skaffold/schema/v2beta14/upgrade.go
+++ b/pkg/skaffold/schema/v2beta14/upgrade.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v2beta14
 
 import (
-	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	pkgutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )

--- a/pkg/skaffold/schema/v2beta14/upgrade_test.go
+++ b/pkg/skaffold/schema/v2beta14/upgrade_test.go
@@ -19,7 +19,7 @@ package v2beta14
 import (
 	"testing"
 
-	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -31,7 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
@@ -44,7 +44,7 @@ var (
 )
 
 // Process checks if the Skaffold pipeline is valid and returns all encountered errors as a concatenated string
-func Process(configs []*latest.SkaffoldConfig) error {
+func Process(configs []*latest_v1.SkaffoldConfig) error {
 	var errs = validateImageNames(configs)
 	for _, config := range configs {
 		errs = append(errs, visitStructs(config, validateYamltags)...)
@@ -88,7 +88,7 @@ func ProcessWithRunContext(runCtx *runcontext.RunContext) error {
 }
 
 // validateTaggingPolicy checks that the tagging policy is valid in combination with other options.
-func validateTaggingPolicy(bc latest.BuildConfig) (errs []error) {
+func validateTaggingPolicy(bc latest_v1.BuildConfig) (errs []error) {
 	if bc.LocalBuild != nil {
 		// sha256 just uses `latest` tag, so tryImportMissing will virtually always succeed (#4889)
 		if bc.LocalBuild.TryImportMissing && bc.TagPolicy.ShaTagger != nil {
@@ -100,7 +100,7 @@ func validateTaggingPolicy(bc latest.BuildConfig) (errs []error) {
 
 // validateImageNames makes sure the artifact image names are unique and valid base names,
 // without tags nor digests.
-func validateImageNames(configs []*latest.SkaffoldConfig) (errs []error) {
+func validateImageNames(configs []*latest_v1.SkaffoldConfig) (errs []error) {
 	seen := make(map[string]bool)
 	for _, c := range configs {
 		for _, a := range c.Build.Artifacts {
@@ -128,8 +128,8 @@ func validateImageNames(configs []*latest.SkaffoldConfig) (errs []error) {
 	return
 }
 
-func validateArtifactDependencies(configs []*latest.SkaffoldConfig) (errs []error) {
-	var artifacts []*latest.Artifact
+func validateArtifactDependencies(configs []*latest_v1.SkaffoldConfig) (errs []error) {
+	var artifacts []*latest_v1.Artifact
 	for _, c := range configs {
 		artifacts = append(artifacts, c.Build.Artifacts...)
 	}
@@ -140,8 +140,8 @@ func validateArtifactDependencies(configs []*latest.SkaffoldConfig) (errs []erro
 }
 
 // validateAcyclicDependencies makes sure all artifact dependencies are found and don't have cyclic references
-func validateAcyclicDependencies(artifacts []*latest.Artifact) (errs []error) {
-	m := make(map[string]*latest.Artifact)
+func validateAcyclicDependencies(artifacts []*latest_v1.Artifact) (errs []error) {
+	m := make(map[string]*latest_v1.Artifact)
 	for _, artifact := range artifacts {
 		m[artifact.ImageName] = artifact
 	}
@@ -156,7 +156,7 @@ func validateAcyclicDependencies(artifacts []*latest.Artifact) (errs []error) {
 }
 
 // dfs runs a Depth First Search algorithm for cycle detection in a directed graph
-func dfs(artifact *latest.Artifact, visited, marked map[string]bool, artifacts map[string]*latest.Artifact) error {
+func dfs(artifact *latest_v1.Artifact, visited, marked map[string]bool, artifacts map[string]*latest_v1.Artifact) error {
 	if marked[artifact.ImageName] {
 		return fmt.Errorf("cycle detected in build dependencies involving %q", artifact.ImageName)
 	}
@@ -183,7 +183,7 @@ func dfs(artifact *latest.Artifact, visited, marked map[string]bool, artifacts m
 
 // validateValidDependencyAliases makes sure that artifact dependency aliases are valid.
 // docker and custom builders require aliases match [a-zA-Z_][a-zA-Z0-9_]* pattern
-func validateValidDependencyAliases(artifacts []*latest.Artifact) (errs []error) {
+func validateValidDependencyAliases(artifacts []*latest_v1.Artifact) (errs []error) {
 	for _, a := range artifacts {
 		if a.DockerArtifact == nil && a.CustomArtifact == nil {
 			continue
@@ -198,7 +198,7 @@ func validateValidDependencyAliases(artifacts []*latest.Artifact) (errs []error)
 }
 
 // validateUniqueDependencyAliases makes sure that artifact dependency aliases are unique for each artifact
-func validateUniqueDependencyAliases(artifacts []*latest.Artifact) (errs []error) {
+func validateUniqueDependencyAliases(artifacts []*latest_v1.Artifact) (errs []error) {
 	type State int
 	var (
 		unseen   State = 0
@@ -286,7 +286,7 @@ func validateDockerContainerExpression(image string, id string) error {
 }
 
 // validateDockerNetworkMode makes sure that networkMode is one of `bridge`, `none`, `container:<name|id>`, or `host` if set.
-func validateDockerNetworkMode(artifacts []*latest.Artifact) (errs []error) {
+func validateDockerNetworkMode(artifacts []*latest_v1.Artifact) (errs []error) {
 	for _, a := range artifacts {
 		if a.DockerArtifact == nil || a.DockerArtifact.NetworkMode == "" {
 			continue
@@ -305,7 +305,7 @@ func validateDockerNetworkMode(artifacts []*latest.Artifact) (errs []error) {
 }
 
 // Validates that a Docker Container with a Network Mode "container:<id|name>" points to an actually running container
-func validateDockerNetworkContainerExists(artifacts []*latest.Artifact, runCtx docker.Config) []error {
+func validateDockerNetworkContainerExists(artifacts []*latest_v1.Artifact, runCtx docker.Config) []error {
 	var errs []error
 	apiClient, err := docker.NewAPIClient(runCtx)
 	if err != nil {
@@ -376,7 +376,7 @@ func validateDockerNetworkContainerExists(artifacts []*latest.Artifact, runCtx d
 }
 
 // validateCustomDependencies makes sure that dependencies.ignore is only used in conjunction with dependencies.paths
-func validateCustomDependencies(artifacts []*latest.Artifact) (errs []error) {
+func validateCustomDependencies(artifacts []*latest_v1.Artifact) (errs []error) {
 	for _, a := range artifacts {
 		if a.CustomArtifact == nil || a.CustomArtifact.Dependencies == nil || a.CustomArtifact.Dependencies.Ignore == nil {
 			continue
@@ -437,7 +437,7 @@ func visitStructs(s interface{}, visitor func(interface{}) error) []error {
 }
 
 // validateSyncRules checks that all manual sync rules have a valid strip prefix
-func validateSyncRules(artifacts []*latest.Artifact) []error {
+func validateSyncRules(artifacts []*latest_v1.Artifact) []error {
 	var errs []error
 	for _, a := range artifacts {
 		if a.Sync != nil {
@@ -454,7 +454,7 @@ func validateSyncRules(artifacts []*latest.Artifact) []error {
 
 // validatePortForwardResources checks that all user defined port forward resources
 // have a valid resourceType
-func validatePortForwardResources(pfrs []*latest.PortForwardResource) []error {
+func validatePortForwardResources(pfrs []*latest_v1.PortForwardResource) []error {
 	var errs []error
 	validResourceTypes := map[string]struct{}{
 		"pod":                   {},
@@ -477,7 +477,7 @@ func validatePortForwardResources(pfrs []*latest.PortForwardResource) []error {
 }
 
 // validateJibPluginTypes makes sure that jib type is one of `maven`, or `gradle` if set.
-func validateJibPluginTypes(artifacts []*latest.Artifact) (errs []error) {
+func validateJibPluginTypes(artifacts []*latest_v1.Artifact) (errs []error) {
 	for _, a := range artifacts {
 		if a.JibArtifact == nil || a.JibArtifact.Type == "" {
 			continue
@@ -492,7 +492,7 @@ func validateJibPluginTypes(artifacts []*latest.Artifact) (errs []error) {
 }
 
 // validateArtifactTypes checks that the artifact types are compatible with the specified builder.
-func validateArtifactTypes(bc latest.BuildConfig) (errs []error) {
+func validateArtifactTypes(bc latest_v1.BuildConfig) (errs []error) {
 	switch {
 	case bc.LocalBuild != nil:
 		for _, a := range bc.Artifacts {
@@ -518,7 +518,7 @@ func validateArtifactTypes(bc latest.BuildConfig) (errs []error) {
 }
 
 // validateLogPrefix checks that logs are configured with a valid prefix.
-func validateLogPrefix(lc latest.LogsConfig) []error {
+func validateLogPrefix(lc latest_v1.LogsConfig) []error {
 	validPrefixes := []string{"", "auto", "container", "podAndContainer", "none"}
 
 	if !util.StrSliceContains(validPrefixes, lc.Prefix) {
@@ -528,7 +528,7 @@ func validateLogPrefix(lc latest.LogsConfig) []error {
 	return nil
 }
 
-func validateSingleKubeContext(configs []*latest.SkaffoldConfig) []error {
+func validateSingleKubeContext(configs []*latest_v1.SkaffoldConfig) []error {
 	if len(configs) < 2 {
 		return nil
 	}
@@ -544,7 +544,7 @@ func validateSingleKubeContext(configs []*latest.SkaffoldConfig) []error {
 // validateCustomTest
 // - makes sure that command is not empty
 // - makes sure that dependencies.ignore is only used in conjunction with dependencies.paths
-func validateCustomTest(tcs []*latest.TestCase) (errs []error) {
+func validateCustomTest(tcs []*latest_v1.TestCase) (errs []error) {
 	for _, tc := range tcs {
 		for _, ct := range tc.CustomTests {
 			if ct.Command == "" {

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -28,34 +28,34 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 var (
-	cfgWithErrors = &latest.SkaffoldConfig{
-		Pipeline: latest.Pipeline{
-			Build: latest.BuildConfig{
-				Artifacts: []*latest.Artifact{
+	cfgWithErrors = &latest_v1.SkaffoldConfig{
+		Pipeline: latest_v1.Pipeline{
+			Build: latest_v1.BuildConfig{
+				Artifacts: []*latest_v1.Artifact{
 					{
-						ArtifactType: latest.ArtifactType{
-							DockerArtifact: &latest.DockerArtifact{},
-							BazelArtifact:  &latest.BazelArtifact{},
+						ArtifactType: latest_v1.ArtifactType{
+							DockerArtifact: &latest_v1.DockerArtifact{},
+							BazelArtifact:  &latest_v1.BazelArtifact{},
 						},
 					},
 					{
-						ArtifactType: latest.ArtifactType{
-							BazelArtifact:  &latest.BazelArtifact{},
-							KanikoArtifact: &latest.KanikoArtifact{},
+						ArtifactType: latest_v1.ArtifactType{
+							BazelArtifact:  &latest_v1.BazelArtifact{},
+							KanikoArtifact: &latest_v1.KanikoArtifact{},
 						},
 					},
 				},
 			},
-			Deploy: latest.DeployConfig{
-				DeployType: latest.DeployType{
-					HelmDeploy:    &latest.HelmDeploy{},
-					KubectlDeploy: &latest.KubectlDeploy{},
+			Deploy: latest_v1.DeployConfig{
+				DeployType: latest_v1.DeployType{
+					HelmDeploy:    &latest_v1.HelmDeploy{},
+					KubectlDeploy: &latest_v1.KubectlDeploy{},
 				},
 			},
 		},
@@ -65,7 +65,7 @@ var (
 func TestValidateSchema(t *testing.T) {
 	tests := []struct {
 		description string
-		cfg         *latest.SkaffoldConfig
+		cfg         *latest_v1.SkaffoldConfig
 		shouldErr   bool
 	}{
 		{
@@ -75,12 +75,12 @@ func TestValidateSchema(t *testing.T) {
 		},
 		{
 			description: "empty config",
-			cfg:         &latest.SkaffoldConfig{},
+			cfg:         &latest_v1.SkaffoldConfig{},
 			shouldErr:   true,
 		},
 		{
 			description: "minimal config",
-			cfg: &latest.SkaffoldConfig{
+			cfg: &latest_v1.SkaffoldConfig{
 				APIVersion: "foo",
 				Kind:       "bar",
 			},
@@ -89,7 +89,7 @@ func TestValidateSchema(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			err := Process([]*latest.SkaffoldConfig{test.cfg})
+			err := Process([]*latest_v1.SkaffoldConfig{test.cfg})
 
 			t.CheckError(test.shouldErr, err)
 		})
@@ -263,39 +263,39 @@ func TestVisitStructs(t *testing.T) {
 func TestValidateNetworkMode(t *testing.T) {
 	tests := []struct {
 		description string
-		artifacts   []*latest.Artifact
+		artifacts   []*latest_v1.Artifact
 		shouldErr   bool
 		env         []string
 	}{
 		{
 			description: "not a docker artifact",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/bazel",
-					ArtifactType: latest.ArtifactType{
-						BazelArtifact: &latest.BazelArtifact{},
+					ArtifactType: latest_v1.ArtifactType{
+						BazelArtifact: &latest_v1.BazelArtifact{},
 					},
 				},
 			},
 		},
 		{
 			description: "no networkmode",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/no-network",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{},
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{},
 					},
 				},
 			},
 		},
 		{
 			description: "bridge",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/bridge",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Bridge",
 						},
 					},
@@ -304,11 +304,11 @@ func TestValidateNetworkMode(t *testing.T) {
 		},
 		{
 			description: "empty container's network stack",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:",
 						},
 					},
@@ -318,11 +318,11 @@ func TestValidateNetworkMode(t *testing.T) {
 		},
 		{
 			description: "empty container's network stack in env var",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:{{.CONTAINER}}",
 						},
 					},
@@ -333,11 +333,11 @@ func TestValidateNetworkMode(t *testing.T) {
 		},
 		{
 			description: "wrong container's network stack '-not-valid'",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:-not-valid",
 						},
 					},
@@ -347,11 +347,11 @@ func TestValidateNetworkMode(t *testing.T) {
 		},
 		{
 			description: "wrong container's network stack '-not-valid' in env var",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:{{.CONTAINER}}",
 						},
 					},
@@ -362,11 +362,11 @@ func TestValidateNetworkMode(t *testing.T) {
 		},
 		{
 			description: "wrong container's network stack 'fussball'",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:fußball",
 						},
 					},
@@ -376,11 +376,11 @@ func TestValidateNetworkMode(t *testing.T) {
 		},
 		{
 			description: "wrong container's network stack 'fussball' in env var",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:{{.CONTAINER}}",
 						},
 					},
@@ -391,11 +391,11 @@ func TestValidateNetworkMode(t *testing.T) {
 		},
 		{
 			description: "container's network stack 'unique'",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:unique",
 						},
 					},
@@ -404,11 +404,11 @@ func TestValidateNetworkMode(t *testing.T) {
 		},
 		{
 			description: "container's network stack 'unique' in env var",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:{{.CONTAINER}}",
 						},
 					},
@@ -418,11 +418,11 @@ func TestValidateNetworkMode(t *testing.T) {
 		},
 		{
 			description: "container's network stack 'unique-id.123'",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:unique-id.123",
 						},
 					},
@@ -431,11 +431,11 @@ func TestValidateNetworkMode(t *testing.T) {
 		},
 		{
 			description: "container's network stack 'unique-id.123' in env var",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:{{.CONTAINER}}",
 						},
 					},
@@ -445,11 +445,11 @@ func TestValidateNetworkMode(t *testing.T) {
 		},
 		{
 			description: "none",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/none",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "None",
 						},
 					},
@@ -458,11 +458,11 @@ func TestValidateNetworkMode(t *testing.T) {
 		},
 		{
 			description: "host",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/host",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Host",
 						},
 					},
@@ -472,11 +472,11 @@ func TestValidateNetworkMode(t *testing.T) {
 		{
 			description: "invalid networkmode",
 			shouldErr:   true,
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/bad",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Bad",
 						},
 					},
@@ -485,11 +485,11 @@ func TestValidateNetworkMode(t *testing.T) {
 		},
 		{
 			description: "case insensitive",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/case-insensitive",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "bRiDgE",
 						},
 					},
@@ -504,9 +504,9 @@ func TestValidateNetworkMode(t *testing.T) {
 			t.Override(&util.OSEnviron, func() []string { return test.env })
 
 			err := Process(
-				[]*latest.SkaffoldConfig{{
-					Pipeline: latest.Pipeline{
-						Build: latest.BuildConfig{
+				[]*latest_v1.SkaffoldConfig{{
+					Pipeline: latest_v1.Pipeline{
+						Build: latest_v1.BuildConfig{
 							Artifacts: test.artifacts,
 						},
 					},
@@ -529,18 +529,18 @@ func (f fakeCommonAPIClient) ContainerList(ctx context.Context, options types.Co
 func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 	tests := []struct {
 		description    string
-		artifacts      []*latest.Artifact
+		artifacts      []*latest_v1.Artifact
 		clientResponse []types.Container
 		shouldErr      bool
 		env            []string
 	}{
 		{
 			description: "no running containers",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:foo",
 						},
 					},
@@ -551,11 +551,11 @@ func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 		},
 		{
 			description: "not matching running containers",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:foo",
 						},
 					},
@@ -571,11 +571,11 @@ func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 		},
 		{
 			description: "existing running container referenced by id",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:foo",
 						},
 					},
@@ -589,11 +589,11 @@ func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 		},
 		{
 			description: "existing running container referenced by first id chars",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:123",
 						},
 					},
@@ -607,11 +607,11 @@ func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 		},
 		{
 			description: "existing running container referenced by name",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:foo",
 						},
 					},
@@ -626,11 +626,11 @@ func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 		},
 		{
 			description: "non existing running container referenced by id in envvar",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:{{ .CONTAINER }}",
 						},
 					},
@@ -646,11 +646,11 @@ func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 		},
 		{
 			description: "existing running container referenced by id in envvar",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:{{ .CONTAINER }}",
 						},
 					},
@@ -665,11 +665,11 @@ func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 		},
 		{
 			description: "existing running container referenced by name in envvar",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/container",
-					ArtifactType: latest.ArtifactType{
-						DockerArtifact: &latest.DockerArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						DockerArtifact: &latest_v1.DockerArtifact{
 							NetworkMode: "Container:{{ .CONTAINER }}",
 						},
 					},
@@ -700,9 +700,9 @@ func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 			})
 
 			err := ProcessWithRunContext(&runcontext.RunContext{
-				Pipelines: runcontext.NewPipelines([]latest.Pipeline{
+				Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{
 					{
-						Build: latest.BuildConfig{
+						Build: latest_v1.BuildConfig{
 							Artifacts: test.artifacts,
 						},
 					},
@@ -717,7 +717,7 @@ func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 func TestValidateSyncRules(t *testing.T) {
 	tests := []struct {
 		description string
-		artifacts   []*latest.Artifact
+		artifacts   []*latest_v1.Artifact
 		shouldErr   bool
 	}{
 		{
@@ -726,16 +726,16 @@ func TestValidateSyncRules(t *testing.T) {
 		},
 		{
 			description: "no sync rules",
-			artifacts: []*latest.Artifact{{
+			artifacts: []*latest_v1.Artifact{{
 				ImageName: "img",
 				Sync:      nil,
 			}},
 		},
 		{
 			description: "two good rules",
-			artifacts: []*latest.Artifact{{
+			artifacts: []*latest_v1.Artifact{{
 				ImageName: "img",
-				Sync: &latest.Sync{Manual: []*latest.SyncRule{
+				Sync: &latest_v1.Sync{Manual: []*latest_v1.SyncRule{
 					{
 						Src:  "src/**/*.js",
 						Dest: ".",
@@ -750,9 +750,9 @@ func TestValidateSyncRules(t *testing.T) {
 		},
 		{
 			description: "one good one bad rule",
-			artifacts: []*latest.Artifact{{
+			artifacts: []*latest_v1.Artifact{{
 				ImageName: "img",
-				Sync: &latest.Sync{Manual: []*latest.SyncRule{
+				Sync: &latest_v1.Sync{Manual: []*latest_v1.SyncRule{
 					{
 						Src:   "src/**/*.js",
 						Dest:  ".",
@@ -769,9 +769,9 @@ func TestValidateSyncRules(t *testing.T) {
 		},
 		{
 			description: "two bad rules",
-			artifacts: []*latest.Artifact{{
+			artifacts: []*latest_v1.Artifact{{
 				ImageName: "img",
-				Sync: &latest.Sync{Manual: []*latest.SyncRule{
+				Sync: &latest_v1.Sync{Manual: []*latest_v1.SyncRule{
 					{
 						Dest:  ".",
 						Strip: "src",
@@ -787,10 +787,10 @@ func TestValidateSyncRules(t *testing.T) {
 		},
 		{
 			description: "stripping part of folder name is valid",
-			artifacts: []*latest.Artifact{{
+			artifacts: []*latest_v1.Artifact{{
 				ImageName: "img",
-				Sync: &latest.Sync{
-					Manual: []*latest.SyncRule{{
+				Sync: &latest_v1.Sync{
+					Manual: []*latest_v1.SyncRule{{
 						Src:   "srcsomeother/**/*.js",
 						Dest:  ".",
 						Strip: "src",
@@ -805,9 +805,9 @@ func TestValidateSyncRules(t *testing.T) {
 			t.Override(&validateYamltags, func(interface{}) error { return nil })
 
 			err := Process(
-				[]*latest.SkaffoldConfig{{
-					Pipeline: latest.Pipeline{
-						Build: latest.BuildConfig{
+				[]*latest_v1.SkaffoldConfig{{
+					Pipeline: latest_v1.Pipeline{
+						Build: latest_v1.BuildConfig{
 							Artifacts: test.artifacts,
 						},
 					},
@@ -821,19 +821,19 @@ func TestValidateSyncRules(t *testing.T) {
 func TestValidateCustomDependencies(t *testing.T) {
 	tests := []struct {
 		description    string
-		dependencies   *latest.CustomDependencies
+		dependencies   *latest_v1.CustomDependencies
 		expectedErrors int
 	}{
 		{
 			description: "no errors",
-			dependencies: &latest.CustomDependencies{
+			dependencies: &latest_v1.CustomDependencies{
 				Paths:  []string{"somepath"},
 				Ignore: []string{"anotherpath"},
 			},
 		}, {
 			description: "ignore in conjunction with dockerfile",
-			dependencies: &latest.CustomDependencies{
-				Dockerfile: &latest.DockerfileDependency{
+			dependencies: &latest_v1.CustomDependencies{
+				Dockerfile: &latest_v1.DockerfileDependency{
 					Path: "some/path",
 				},
 				Ignore: []string{"ignoreme"},
@@ -841,7 +841,7 @@ func TestValidateCustomDependencies(t *testing.T) {
 			expectedErrors: 1,
 		}, {
 			description: "ignore in conjunction with command",
-			dependencies: &latest.CustomDependencies{
+			dependencies: &latest_v1.CustomDependencies{
 				Command: "bazel query deps",
 				Ignore:  []string{"ignoreme"},
 			},
@@ -853,15 +853,15 @@ func TestValidateCustomDependencies(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			artifact := &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					CustomArtifact: &latest.CustomArtifact{
+			artifact := &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					CustomArtifact: &latest_v1.CustomArtifact{
 						Dependencies: test.dependencies,
 					},
 				},
 			}
 
-			errs := validateCustomDependencies([]*latest.Artifact{artifact})
+			errs := validateCustomDependencies([]*latest_v1.Artifact{artifact})
 
 			t.CheckDeepEqual(test.expectedErrors, len(errs))
 		})
@@ -886,9 +886,9 @@ func TestValidatePortForwardResources(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.resourceType, func(t *testutil.T) {
-			pfrs := []*latest.PortForwardResource{
+			pfrs := []*latest_v1.PortForwardResource{
 				{
-					Type: latest.ResourceType(test.resourceType),
+					Type: latest_v1.ResourceType(test.resourceType),
 				},
 			}
 			errs := validatePortForwardResources(pfrs)
@@ -905,26 +905,26 @@ func TestValidatePortForwardResources(t *testing.T) {
 func TestValidateImageNames(t *testing.T) {
 	tests := []struct {
 		description string
-		artifacts   []*latest.Artifact
+		artifacts   []*latest_v1.Artifact
 		shouldErr   bool
 	}{
 		{
 			description: "no name",
-			artifacts: []*latest.Artifact{{
+			artifacts: []*latest_v1.Artifact{{
 				ImageName: "",
 			}},
 			shouldErr: true,
 		},
 		{
 			description: "valid",
-			artifacts: []*latest.Artifact{{
+			artifacts: []*latest_v1.Artifact{{
 				ImageName: "img",
 			}},
 			shouldErr: false,
 		},
 		{
 			description: "duplicates",
-			artifacts: []*latest.Artifact{{
+			artifacts: []*latest_v1.Artifact{{
 				ImageName: "img",
 			}, {
 				ImageName: "img",
@@ -933,21 +933,21 @@ func TestValidateImageNames(t *testing.T) {
 		},
 		{
 			description: "shouldn't have a tag",
-			artifacts: []*latest.Artifact{{
+			artifacts: []*latest_v1.Artifact{{
 				ImageName: "img:tag",
 			}},
 			shouldErr: true,
 		},
 		{
 			description: "shouldn't have a digest",
-			artifacts: []*latest.Artifact{{
+			artifacts: []*latest_v1.Artifact{{
 				ImageName: "img@sha256:77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182",
 			}},
 			shouldErr: true,
 		},
 		{
 			description: "no tag nor digest",
-			artifacts: []*latest.Artifact{{
+			artifacts: []*latest_v1.Artifact{{
 				ImageName: "img:tag@sha256:77af4d6b9913e693e8d0b4b294fa62ade6054e6b2f1ffb617ac955dd63fb0182",
 			}},
 			shouldErr: true,
@@ -959,9 +959,9 @@ func TestValidateImageNames(t *testing.T) {
 			t.Override(&validateYamltags, func(interface{}) error { return nil })
 
 			err := Process(
-				[]*latest.SkaffoldConfig{{
-					Pipeline: latest.Pipeline{
-						Build: latest.BuildConfig{
+				[]*latest_v1.SkaffoldConfig{{
+					Pipeline: latest_v1.Pipeline{
+						Build: latest_v1.BuildConfig{
 							Artifacts: test.artifacts,
 						},
 					},
@@ -975,27 +975,27 @@ func TestValidateImageNames(t *testing.T) {
 func TestValidateJibPluginType(t *testing.T) {
 	tests := []struct {
 		description string
-		artifacts   []*latest.Artifact
+		artifacts   []*latest_v1.Artifact
 		shouldErr   bool
 	}{
 		{
 			description: "no type",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/jib",
-					ArtifactType: latest.ArtifactType{
-						JibArtifact: &latest.JibArtifact{},
+					ArtifactType: latest_v1.ArtifactType{
+						JibArtifact: &latest_v1.JibArtifact{},
 					},
 				},
 			},
 		},
 		{
 			description: "maven",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/jib",
-					ArtifactType: latest.ArtifactType{
-						JibArtifact: &latest.JibArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						JibArtifact: &latest_v1.JibArtifact{
 							Type: "maven",
 						},
 					},
@@ -1004,11 +1004,11 @@ func TestValidateJibPluginType(t *testing.T) {
 		},
 		{
 			description: "gradle",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/jib",
-					ArtifactType: latest.ArtifactType{
-						JibArtifact: &latest.JibArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						JibArtifact: &latest_v1.JibArtifact{
 							Type: "gradle",
 						},
 					},
@@ -1017,11 +1017,11 @@ func TestValidateJibPluginType(t *testing.T) {
 		},
 		{
 			description: "empty",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/jib",
-					ArtifactType: latest.ArtifactType{
-						JibArtifact: &latest.JibArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						JibArtifact: &latest_v1.JibArtifact{
 							Type: "",
 						},
 					},
@@ -1030,11 +1030,11 @@ func TestValidateJibPluginType(t *testing.T) {
 		},
 		{
 			description: "cAsE inSenSiTiVe",
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/jib",
-					ArtifactType: latest.ArtifactType{
-						JibArtifact: &latest.JibArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						JibArtifact: &latest_v1.JibArtifact{
 							Type: "gRaDlE",
 						},
 					},
@@ -1044,11 +1044,11 @@ func TestValidateJibPluginType(t *testing.T) {
 		{
 			description: "invalid type",
 			shouldErr:   true,
-			artifacts: []*latest.Artifact{
+			artifacts: []*latest_v1.Artifact{
 				{
 					ImageName: "image/jib",
-					ArtifactType: latest.ArtifactType{
-						JibArtifact: &latest.JibArtifact{
+					ArtifactType: latest_v1.ArtifactType{
+						JibArtifact: &latest_v1.JibArtifact{
 							Type: "invalid",
 						},
 					},
@@ -1062,9 +1062,9 @@ func TestValidateJibPluginType(t *testing.T) {
 			t.Override(&validateYamltags, func(interface{}) error { return nil })
 
 			err := Process(
-				[]*latest.SkaffoldConfig{{
-					Pipeline: latest.Pipeline{
-						Build: latest.BuildConfig{
+				[]*latest_v1.SkaffoldConfig{{
+					Pipeline: latest_v1.Pipeline{
+						Build: latest_v1.BuildConfig{
 							Artifacts: test.artifacts,
 						},
 					},
@@ -1078,7 +1078,7 @@ func TestValidateJibPluginType(t *testing.T) {
 func TestValidateLogsConfig(t *testing.T) {
 	tests := []struct {
 		prefix    string
-		cfg       latest.LogsConfig
+		cfg       latest_v1.LogsConfig
 		shouldErr bool
 	}{
 		{prefix: "auto", shouldErr: false},
@@ -1094,10 +1094,10 @@ func TestValidateLogsConfig(t *testing.T) {
 			t.Override(&validateYamltags, func(interface{}) error { return nil })
 
 			err := Process(
-				[]*latest.SkaffoldConfig{{
-					Pipeline: latest.Pipeline{
-						Deploy: latest.DeployConfig{
-							Logs: latest.LogsConfig{
+				[]*latest_v1.SkaffoldConfig{{
+					Pipeline: latest_v1.Pipeline{
+						Deploy: latest_v1.DeployConfig{
+							Logs: latest_v1.LogsConfig{
 								Prefix: test.prefix,
 							},
 						},
@@ -1167,10 +1167,10 @@ func TestValidateAcyclicDependencies(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			artifacts := make([]*latest.Artifact, test.artifactLen)
+			artifacts := make([]*latest_v1.Artifact, test.artifactLen)
 			for i := 0; i < test.artifactLen; i++ {
 				a := fmt.Sprintf("artifact%d", i+1)
-				artifacts[i] = &latest.Artifact{ImageName: a}
+				artifacts[i] = &latest_v1.Artifact{ImageName: a}
 			}
 
 			setDependencies(artifacts, test.dependency)
@@ -1194,10 +1194,10 @@ func TestValidateAcyclicDependencies(t *testing.T) {
 //    2 : {3},
 //}
 // implies that a[0] artifact depends on a[1] and a[2]; and a[2] depends on a[3].
-func setDependencies(a []*latest.Artifact, d map[int][]int) {
+func setDependencies(a []*latest_v1.Artifact, d map[int][]int) {
 	for k, dep := range d {
 		for i := range dep {
-			a[k].Dependencies = append(a[k].Dependencies, &latest.ArtifactDependency{
+			a[k].Dependencies = append(a[k].Dependencies, &latest_v1.ArtifactDependency{
 				ImageName: a[dep[i]].ImageName,
 			})
 		}
@@ -1205,21 +1205,21 @@ func setDependencies(a []*latest.Artifact, d map[int][]int) {
 }
 
 func TestValidateUniqueDependencyAliases(t *testing.T) {
-	cfgs := []*latest.SkaffoldConfig{
+	cfgs := []*latest_v1.SkaffoldConfig{
 		{
-			Pipeline: latest.Pipeline{
-				Build: latest.BuildConfig{
-					Artifacts: []*latest.Artifact{
+			Pipeline: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					Artifacts: []*latest_v1.Artifact{
 						{
 							ImageName: "artifact1",
-							Dependencies: []*latest.ArtifactDependency{
+							Dependencies: []*latest_v1.ArtifactDependency{
 								{Alias: "alias2", ImageName: "artifact2a"},
 								{Alias: "alias2", ImageName: "artifact2b"},
 							},
 						},
 						{
 							ImageName: "artifact2",
-							Dependencies: []*latest.ArtifactDependency{
+							Dependencies: []*latest_v1.ArtifactDependency{
 								{Alias: "alias1", ImageName: "artifact1"},
 								{Alias: "alias2", ImageName: "artifact1"},
 							},
@@ -1240,22 +1240,22 @@ func TestValidateUniqueDependencyAliases(t *testing.T) {
 func TestValidateSingleKubeContext(t *testing.T) {
 	tests := []struct {
 		description string
-		configs     []*latest.SkaffoldConfig
+		configs     []*latest_v1.SkaffoldConfig
 		err         []error
 	}{
 		{
 			description: "different kubeContext specified",
-			configs: []*latest.SkaffoldConfig{
+			configs: []*latest_v1.SkaffoldConfig{
 				{
-					Pipeline: latest.Pipeline{
-						Deploy: latest.DeployConfig{
+					Pipeline: latest_v1.Pipeline{
+						Deploy: latest_v1.DeployConfig{
 							KubeContext: "",
 						},
 					},
 				},
 				{
-					Pipeline: latest.Pipeline{
-						Deploy: latest.DeployConfig{
+					Pipeline: latest_v1.Pipeline{
+						Deploy: latest_v1.DeployConfig{
 							KubeContext: "foo",
 						},
 					},
@@ -1265,17 +1265,17 @@ func TestValidateSingleKubeContext(t *testing.T) {
 		},
 		{
 			description: "same kubeContext specified",
-			configs: []*latest.SkaffoldConfig{
+			configs: []*latest_v1.SkaffoldConfig{
 				{
-					Pipeline: latest.Pipeline{
-						Deploy: latest.DeployConfig{
+					Pipeline: latest_v1.Pipeline{
+						Deploy: latest_v1.DeployConfig{
 							KubeContext: "foo",
 						},
 					},
 				},
 				{
-					Pipeline: latest.Pipeline{
-						Deploy: latest.DeployConfig{
+					Pipeline: latest_v1.Pipeline{
+						Deploy: latest_v1.DeployConfig{
 							KubeContext: "foo",
 						},
 					},
@@ -1284,15 +1284,15 @@ func TestValidateSingleKubeContext(t *testing.T) {
 		},
 		{
 			description: "no kubeContext specified",
-			configs: []*latest.SkaffoldConfig{
+			configs: []*latest_v1.SkaffoldConfig{
 				{
-					Pipeline: latest.Pipeline{
-						Deploy: latest.DeployConfig{},
+					Pipeline: latest_v1.Pipeline{
+						Deploy: latest_v1.DeployConfig{},
 					},
 				},
 				{
-					Pipeline: latest.Pipeline{
-						Deploy: latest.DeployConfig{},
+					Pipeline: latest_v1.Pipeline{
+						Deploy: latest_v1.DeployConfig{},
 					},
 				},
 			},
@@ -1308,50 +1308,50 @@ func TestValidateSingleKubeContext(t *testing.T) {
 }
 
 func TestValidateValidDependencyAliases(t *testing.T) {
-	cfgs := []*latest.SkaffoldConfig{
+	cfgs := []*latest_v1.SkaffoldConfig{
 		{
-			Pipeline: latest.Pipeline{
-				Build: latest.BuildConfig{
-					Artifacts: []*latest.Artifact{
+			Pipeline: latest_v1.Pipeline{
+				Build: latest_v1.BuildConfig{
+					Artifacts: []*latest_v1.Artifact{
 						{
 							ImageName: "artifact1",
 						},
 						{
 							ImageName: "artifact2",
-							ArtifactType: latest.ArtifactType{
-								DockerArtifact: &latest.DockerArtifact{},
+							ArtifactType: latest_v1.ArtifactType{
+								DockerArtifact: &latest_v1.DockerArtifact{},
 							},
-							Dependencies: []*latest.ArtifactDependency{
+							Dependencies: []*latest_v1.ArtifactDependency{
 								{Alias: "ARTIFACT_1", ImageName: "artifact1"},
 								{Alias: "1_ARTIFACT", ImageName: "artifact1"},
 							},
 						},
 						{
 							ImageName: "artifact3",
-							ArtifactType: latest.ArtifactType{
-								DockerArtifact: &latest.DockerArtifact{},
+							ArtifactType: latest_v1.ArtifactType{
+								DockerArtifact: &latest_v1.DockerArtifact{},
 							},
-							Dependencies: []*latest.ArtifactDependency{
+							Dependencies: []*latest_v1.ArtifactDependency{
 								{Alias: "artifact!", ImageName: "artifact1"},
 								{Alias: "artifact#1", ImageName: "artifact1"},
 							},
 						},
 						{
 							ImageName: "artifact4",
-							ArtifactType: latest.ArtifactType{
-								CustomArtifact: &latest.CustomArtifact{},
+							ArtifactType: latest_v1.ArtifactType{
+								CustomArtifact: &latest_v1.CustomArtifact{},
 							},
-							Dependencies: []*latest.ArtifactDependency{
+							Dependencies: []*latest_v1.ArtifactDependency{
 								{Alias: "alias1", ImageName: "artifact1"},
 								{Alias: "alias2", ImageName: "artifact2"},
 							},
 						},
 						{
 							ImageName: "artifact5",
-							ArtifactType: latest.ArtifactType{
-								BuildpackArtifact: &latest.BuildpackArtifact{},
+							ArtifactType: latest_v1.ArtifactType{
+								BuildpackArtifact: &latest_v1.BuildpackArtifact{},
 							},
-							Dependencies: []*latest.ArtifactDependency{
+							Dependencies: []*latest_v1.ArtifactDependency{
 								{Alias: "artifact!", ImageName: "artifact1"},
 								{Alias: "artifact#1", ImageName: "artifact1"},
 							},
@@ -1383,34 +1383,34 @@ func errorsComparer(a, b error) bool {
 func TestValidateTaggingPolicy(t *testing.T) {
 	tests := []struct {
 		description string
-		cfg         latest.BuildConfig
+		cfg         latest_v1.BuildConfig
 		shouldErr   bool
 	}{
 		{
 			description: "ShaTagger can be used when tryImportMissing is disabled",
 			shouldErr:   false,
-			cfg: latest.BuildConfig{
-				BuildType: latest.BuildType{
-					LocalBuild: &latest.LocalBuild{
+			cfg: latest_v1.BuildConfig{
+				BuildType: latest_v1.BuildType{
+					LocalBuild: &latest_v1.LocalBuild{
 						TryImportMissing: false,
 					},
 				},
-				TagPolicy: latest.TagPolicy{
-					ShaTagger: &latest.ShaTagger{},
+				TagPolicy: latest_v1.TagPolicy{
+					ShaTagger: &latest_v1.ShaTagger{},
 				},
 			},
 		},
 		{
 			description: "ShaTagger can not be used when tryImportMissing is enabled",
 			shouldErr:   true,
-			cfg: latest.BuildConfig{
-				BuildType: latest.BuildType{
-					LocalBuild: &latest.LocalBuild{
+			cfg: latest_v1.BuildConfig{
+				BuildType: latest_v1.BuildType{
+					LocalBuild: &latest_v1.LocalBuild{
 						TryImportMissing: true,
 					},
 				},
-				TagPolicy: latest.TagPolicy{
-					ShaTagger: &latest.ShaTagger{},
+				TagPolicy: latest_v1.TagPolicy{
+					ShaTagger: &latest_v1.ShaTagger{},
 				},
 			},
 		},
@@ -1421,8 +1421,8 @@ func TestValidateTaggingPolicy(t *testing.T) {
 			t.Override(&validateYamltags, func(interface{}) error { return nil })
 
 			err := Process(
-				[]*latest.SkaffoldConfig{{
-					Pipeline: latest.Pipeline{
+				[]*latest_v1.SkaffoldConfig{{
+					Pipeline: latest_v1.Pipeline{
 						Build: test.cfg,
 					},
 				}})
@@ -1436,20 +1436,20 @@ func TestValidateCustomTest(t *testing.T) {
 	tests := []struct {
 		description    string
 		command        string
-		dependencies   *latest.CustomTestDependencies
+		dependencies   *latest_v1.CustomTestDependencies
 		expectedErrors int
 	}{
 		{
 			description: "no errors",
 			command:     "echo Hello!",
-			dependencies: &latest.CustomTestDependencies{
+			dependencies: &latest_v1.CustomTestDependencies{
 				Paths:  []string{"somepath"},
 				Ignore: []string{"anotherpath"},
 			},
 		}, {
 			description: "empty command",
 			command:     "",
-			dependencies: &latest.CustomTestDependencies{
+			dependencies: &latest_v1.CustomTestDependencies{
 				Paths:  []string{"somepath"},
 				Ignore: []string{"anotherpath"},
 			},
@@ -1457,7 +1457,7 @@ func TestValidateCustomTest(t *testing.T) {
 		}, {
 			description: "use both path and command",
 			command:     "echo Hello!",
-			dependencies: &latest.CustomTestDependencies{
+			dependencies: &latest_v1.CustomTestDependencies{
 				Command: "bazel query deps",
 				Paths:   []string{"somepath"},
 			},
@@ -1465,7 +1465,7 @@ func TestValidateCustomTest(t *testing.T) {
 		}, {
 			description: "ignore in conjunction with command",
 			command:     "echo Hello!",
-			dependencies: &latest.CustomTestDependencies{
+			dependencies: &latest_v1.CustomTestDependencies{
 				Command: "bazel query deps",
 				Ignore:  []string{"ignoreme"},
 			},
@@ -1478,15 +1478,15 @@ func TestValidateCustomTest(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			testCase := &latest.TestCase{
+			testCase := &latest_v1.TestCase{
 				ImageName: "image",
-				CustomTests: []latest.CustomTest{{
+				CustomTests: []latest_v1.CustomTest{{
 					Command:      test.command,
 					Dependencies: test.dependencies,
 				}},
 			}
 
-			errs := validateCustomTest([]*latest.TestCase{testCase})
+			errs := validateCustomTest([]*latest_v1.TestCase{testCase})
 			t.CheckDeepEqual(test.expectedErrors, len(errs))
 		})
 	}

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/apiversion"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v1alpha1"
@@ -120,7 +120,7 @@ var SchemaVersions = Versions{
 	{v2beta12.Version, v2beta12.NewSkaffoldConfig},
 	{v2beta13.Version, v2beta13.NewSkaffoldConfig},
 	{v2beta14.Version, v2beta14.NewSkaffoldConfig},
-	{latest.Version, latest.NewSkaffoldConfig},
+	{latest_v1.Version, latest_v1.NewSkaffoldConfig},
 }
 
 type Version struct {

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/v2beta8"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -187,7 +187,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 		shouldErr   bool
 	}{
 		{
-			apiVersion:  []string{latest.Version},
+			apiVersion:  []string{latest_v1.Version},
 			description: "Kaniko Volume Mount - ConfigMap",
 			config:      []string{kanikoConfigMap},
 			expected: []util.VersionedConfig{config(
@@ -210,7 +210,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 			)},
 		},
 		{
-			apiVersion:  []string{latest.Version},
+			apiVersion:  []string{latest_v1.Version},
 			description: "Minimal config",
 			config:      []string{minimalConfig},
 			expected: []util.VersionedConfig{config(
@@ -234,7 +234,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 			)},
 		},
 		{
-			apiVersion:  []string{latest.Version},
+			apiVersion:  []string{latest_v1.Version},
 			description: "Simple config",
 			config:      []string{simpleConfig},
 			expected: []util.VersionedConfig{config(
@@ -247,7 +247,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 			)},
 		},
 		{
-			apiVersion:  []string{latest.Version},
+			apiVersion:  []string{latest_v1.Version},
 			description: "Complete config",
 			config:      []string{completeConfig},
 			expected: []util.VersionedConfig{config(
@@ -275,7 +275,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 			)},
 		},
 		{
-			apiVersion:  []string{latest.Version, latest.Version},
+			apiVersion:  []string{latest_v1.Version, latest_v1.Version},
 			description: "Multiple complete config with same API versions",
 			config:      []string{completeConfig, completeClusterConfig},
 			expected: []util.VersionedConfig{config(
@@ -297,7 +297,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 			)},
 		},
 		{
-			apiVersion:  []string{latest.Version, v2beta8.Version},
+			apiVersion:  []string{latest_v1.Version, v2beta8.Version},
 			description: "Multiple complete config with different API versions",
 			config:      []string{completeConfig, completeClusterConfig},
 			expected: []util.VersionedConfig{config(
@@ -319,7 +319,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 			)},
 		},
 		{
-			apiVersion:  []string{latest.Version},
+			apiVersion:  []string{latest_v1.Version},
 			description: "Minimal Cluster config",
 			config:      []string{minimalClusterConfig},
 			expected: []util.VersionedConfig{config(
@@ -332,7 +332,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 			)},
 		},
 		{
-			apiVersion:  []string{latest.Version},
+			apiVersion:  []string{latest_v1.Version},
 			description: "Complete Cluster config",
 			config:      []string{completeClusterConfig},
 			expected: []util.VersionedConfig{config(
@@ -346,13 +346,13 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 			)},
 		},
 		{
-			apiVersion:  []string{latest.Version},
+			apiVersion:  []string{latest_v1.Version},
 			description: "Bad config",
 			config:      []string{badConfig},
 			shouldErr:   true,
 		},
 		{
-			apiVersion:  []string{latest.Version},
+			apiVersion:  []string{latest_v1.Version},
 			description: "two taggers defined",
 			config:      []string{invalidConfig},
 			shouldErr:   true,
@@ -364,13 +364,13 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 			shouldErr:   true,
 		},
 		{
-			apiVersion:  []string{latest.Version},
+			apiVersion:  []string{latest_v1.Version},
 			description: "invalid statusCheckDeadline",
 			config:      []string{invalidStatusCheckConfig},
 			shouldErr:   true,
 		},
 		{
-			apiVersion:  []string{latest.Version},
+			apiVersion:  []string{latest_v1.Version},
 			description: "valid statusCheckDeadline",
 			config:      []string{validStatusCheckConfig},
 			expected: []util.VersionedConfig{config(
@@ -383,7 +383,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 			)},
 		},
 		{
-			apiVersion:  []string{latest.Version},
+			apiVersion:  []string{latest_v1.Version},
 			description: "custom log prefix",
 			config:      []string{customLogPrefix},
 			expected: []util.VersionedConfig{config(
@@ -402,10 +402,10 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 			tmpDir := t.NewTempDir().
 				Write("skaffold.yaml", format(t, test.config, test.apiVersion))
 
-			cfgs, err := ParseConfigAndUpgrade(tmpDir.Path("skaffold.yaml"), latest.Version)
+			cfgs, err := ParseConfigAndUpgrade(tmpDir.Path("skaffold.yaml"), latest_v1.Version)
 			for _, cfg := range cfgs {
-				err := defaults.Set(cfg.(*latest.SkaffoldConfig))
-				defaults.SetDefaultDeployer(cfg.(*latest.SkaffoldConfig))
+				err := defaults.Set(cfg.(*latest_v1.SkaffoldConfig))
+				defaults.SetDefaultDeployer(cfg.(*latest_v1.SkaffoldConfig))
 				t.CheckNoError(err)
 			}
 
@@ -417,7 +417,7 @@ func TestParseConfigAndUpgrade(t *testing.T) {
 func TestMarshalConfig(t *testing.T) {
 	tests := []struct {
 		description string
-		config      *latest.SkaffoldConfig
+		config      *latest_v1.SkaffoldConfig
 		shouldErr   bool
 	}{
 		{
@@ -454,7 +454,7 @@ func TestMarshalConfig(t *testing.T) {
 			// TestParseConfigAndUpgrade verifies that YAML -> Go works correctly.
 			// This test verifies Go -> YAML -> Go returns the original structure. Since we know
 			// YAML -> Go is working this ensures Go -> YAML is correct.
-			recovered := &latest.SkaffoldConfig{}
+			recovered := &latest_v1.SkaffoldConfig{}
 
 			err = yaml.Unmarshal(actual, recovered)
 
@@ -463,8 +463,8 @@ func TestMarshalConfig(t *testing.T) {
 	}
 }
 
-func config(ops ...func(*latest.SkaffoldConfig)) *latest.SkaffoldConfig {
-	cfg := &latest.SkaffoldConfig{APIVersion: latest.Version, Kind: "Config"}
+func config(ops ...func(*latest_v1.SkaffoldConfig)) *latest_v1.SkaffoldConfig {
+	cfg := &latest_v1.SkaffoldConfig{APIVersion: latest_v1.Version, Kind: "Config"}
 	for _, op := range ops {
 		op(cfg)
 	}
@@ -480,9 +480,9 @@ func format(t *testutil.T, configs []string, apiVersions []string) string {
 	return strings.Join(str, "\n---\n")
 }
 
-func withLocalBuild(ops ...func(*latest.BuildConfig)) func(*latest.SkaffoldConfig) {
-	return func(cfg *latest.SkaffoldConfig) {
-		b := latest.BuildConfig{BuildType: latest.BuildType{LocalBuild: &latest.LocalBuild{}}}
+func withLocalBuild(ops ...func(*latest_v1.BuildConfig)) func(*latest_v1.SkaffoldConfig) {
+	return func(cfg *latest_v1.SkaffoldConfig) {
+		b := latest_v1.BuildConfig{BuildType: latest_v1.BuildType{LocalBuild: &latest_v1.LocalBuild{}}}
 		for _, op := range ops {
 			op(&b)
 		}
@@ -493,9 +493,9 @@ func withLocalBuild(ops ...func(*latest.BuildConfig)) func(*latest.SkaffoldConfi
 	}
 }
 
-func withGoogleCloudBuild(id string, ops ...func(*latest.BuildConfig)) func(*latest.SkaffoldConfig) {
-	return func(cfg *latest.SkaffoldConfig) {
-		b := latest.BuildConfig{BuildType: latest.BuildType{GoogleCloudBuild: &latest.GoogleCloudBuild{
+func withGoogleCloudBuild(id string, ops ...func(*latest_v1.BuildConfig)) func(*latest_v1.SkaffoldConfig) {
+	return func(cfg *latest_v1.SkaffoldConfig) {
+		b := latest_v1.BuildConfig{BuildType: latest_v1.BuildType{GoogleCloudBuild: &latest_v1.GoogleCloudBuild{
 			ProjectID:   id,
 			DockerImage: "gcr.io/cloud-builders/docker",
 			MavenImage:  "gcr.io/cloud-builders/mvn",
@@ -510,9 +510,9 @@ func withGoogleCloudBuild(id string, ops ...func(*latest.BuildConfig)) func(*lat
 	}
 }
 
-func withClusterBuild(secretName, mountPath, namespace, secret string, timeout string, ops ...func(*latest.BuildConfig)) func(*latest.SkaffoldConfig) {
-	return func(cfg *latest.SkaffoldConfig) {
-		b := latest.BuildConfig{BuildType: latest.BuildType{Cluster: &latest.ClusterDetails{
+func withClusterBuild(secretName, mountPath, namespace, secret string, timeout string, ops ...func(*latest_v1.BuildConfig)) func(*latest_v1.SkaffoldConfig) {
+	return func(cfg *latest_v1.SkaffoldConfig) {
+		b := latest_v1.BuildConfig{BuildType: latest_v1.BuildType{Cluster: &latest_v1.ClusterDetails{
 			PullSecretName:      secretName,
 			Namespace:           namespace,
 			PullSecretPath:      secret,
@@ -526,44 +526,44 @@ func withClusterBuild(secretName, mountPath, namespace, secret string, timeout s
 	}
 }
 
-func withDockerConfig(secretName string, path string) func(*latest.BuildConfig) {
-	return func(cfg *latest.BuildConfig) {
-		cfg.Cluster.DockerConfig = &latest.DockerConfig{
+func withDockerConfig(secretName string, path string) func(*latest_v1.BuildConfig) {
+	return func(cfg *latest_v1.BuildConfig) {
+		cfg.Cluster.DockerConfig = &latest_v1.DockerConfig{
 			SecretName: secretName,
 			Path:       path,
 		}
 	}
 }
 
-func withKubectlDeploy(manifests ...string) func(*latest.SkaffoldConfig) {
-	return func(cfg *latest.SkaffoldConfig) {
-		cfg.Deploy.DeployType.KubectlDeploy = &latest.KubectlDeploy{
+func withKubectlDeploy(manifests ...string) func(*latest_v1.SkaffoldConfig) {
+	return func(cfg *latest_v1.SkaffoldConfig) {
+		cfg.Deploy.DeployType.KubectlDeploy = &latest_v1.KubectlDeploy{
 			Manifests: manifests,
 		}
 	}
 }
 
-func withKubeContext(kubeContext string) func(*latest.SkaffoldConfig) {
-	return func(cfg *latest.SkaffoldConfig) {
-		cfg.Deploy = latest.DeployConfig{
+func withKubeContext(kubeContext string) func(*latest_v1.SkaffoldConfig) {
+	return func(cfg *latest_v1.SkaffoldConfig) {
+		cfg.Deploy = latest_v1.DeployConfig{
 			KubeContext: kubeContext,
 		}
 	}
 }
 
-func withHelmDeploy() func(*latest.SkaffoldConfig) {
-	return func(cfg *latest.SkaffoldConfig) {
-		cfg.Deploy.DeployType.HelmDeploy = &latest.HelmDeploy{}
+func withHelmDeploy() func(*latest_v1.SkaffoldConfig) {
+	return func(cfg *latest_v1.SkaffoldConfig) {
+		cfg.Deploy.DeployType.HelmDeploy = &latest_v1.HelmDeploy{}
 	}
 }
 
-func withDockerArtifact(image, workspace, dockerfile string) func(*latest.BuildConfig) {
-	return func(cfg *latest.BuildConfig) {
-		cfg.Artifacts = append(cfg.Artifacts, &latest.Artifact{
+func withDockerArtifact(image, workspace, dockerfile string) func(*latest_v1.BuildConfig) {
+	return func(cfg *latest_v1.BuildConfig) {
+		cfg.Artifacts = append(cfg.Artifacts, &latest_v1.Artifact{
 			ImageName: image,
 			Workspace: workspace,
-			ArtifactType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{
+			ArtifactType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{
 					DockerfilePath: dockerfile,
 				},
 			},
@@ -571,13 +571,13 @@ func withDockerArtifact(image, workspace, dockerfile string) func(*latest.BuildC
 	}
 }
 
-func withBazelArtifact() func(*latest.BuildConfig) {
-	return func(cfg *latest.BuildConfig) {
-		cfg.Artifacts = append(cfg.Artifacts, &latest.Artifact{
+func withBazelArtifact() func(*latest_v1.BuildConfig) {
+	return func(cfg *latest_v1.BuildConfig) {
+		cfg.Artifacts = append(cfg.Artifacts, &latest_v1.Artifact{
 			ImageName: "image2",
 			Workspace: "./examples/app2",
-			ArtifactType: latest.ArtifactType{
-				BazelArtifact: &latest.BazelArtifact{
+			ArtifactType: latest_v1.ArtifactType{
+				BazelArtifact: &latest_v1.BazelArtifact{
 					BuildTarget: "//:example.tar",
 				},
 			},
@@ -585,13 +585,13 @@ func withBazelArtifact() func(*latest.BuildConfig) {
 	}
 }
 
-func withKanikoArtifact() func(*latest.BuildConfig) {
-	return func(cfg *latest.BuildConfig) {
-		cfg.Artifacts = append(cfg.Artifacts, &latest.Artifact{
+func withKanikoArtifact() func(*latest_v1.BuildConfig) {
+	return func(cfg *latest_v1.BuildConfig) {
+		cfg.Artifacts = append(cfg.Artifacts, &latest_v1.Artifact{
 			ImageName: "image1",
 			Workspace: "./examples/app1",
-			ArtifactType: latest.ArtifactType{
-				KanikoArtifact: &latest.KanikoArtifact{
+			ArtifactType: latest_v1.ArtifactType{
+				KanikoArtifact: &latest_v1.KanikoArtifact{
 					DockerfilePath: "Dockerfile",
 					InitImage:      constants.DefaultBusyboxImage,
 					Image:          kaniko.DefaultImage,
@@ -602,8 +602,8 @@ func withKanikoArtifact() func(*latest.BuildConfig) {
 }
 
 // withKanikoVolumeMount appends a volume mount to the latest Kaniko artifact
-func withKanikoVolumeMount(name, mountPath string) func(*latest.BuildConfig) {
-	return func(cfg *latest.BuildConfig) {
+func withKanikoVolumeMount(name, mountPath string) func(*latest_v1.BuildConfig) {
+	return func(cfg *latest_v1.BuildConfig) {
 		if cfg.Artifacts[len(cfg.Artifacts)-1].KanikoArtifact.VolumeMounts == nil {
 			cfg.Artifacts[len(cfg.Artifacts)-1].KanikoArtifact.VolumeMounts = []v1.VolumeMount{}
 		}
@@ -619,50 +619,50 @@ func withKanikoVolumeMount(name, mountPath string) func(*latest.BuildConfig) {
 }
 
 // withVolume appends a volume to the cluster
-func withVolume(v v1.Volume) func(*latest.BuildConfig) {
-	return func(cfg *latest.BuildConfig) {
+func withVolume(v v1.Volume) func(*latest_v1.BuildConfig) {
+	return func(cfg *latest_v1.BuildConfig) {
 		cfg.Cluster.Volumes = append(cfg.Cluster.Volumes, v)
 	}
 }
 
-func withTagPolicy(tagPolicy latest.TagPolicy) func(*latest.BuildConfig) {
-	return func(cfg *latest.BuildConfig) { cfg.TagPolicy = tagPolicy }
+func withTagPolicy(tagPolicy latest_v1.TagPolicy) func(*latest_v1.BuildConfig) {
+	return func(cfg *latest_v1.BuildConfig) { cfg.TagPolicy = tagPolicy }
 }
 
-func withGitTagger() func(*latest.BuildConfig) {
-	return withTagPolicy(latest.TagPolicy{GitTagger: &latest.GitTagger{}})
+func withGitTagger() func(*latest_v1.BuildConfig) {
+	return withTagPolicy(latest_v1.TagPolicy{GitTagger: &latest_v1.GitTagger{}})
 }
 
-func withShaTagger() func(*latest.BuildConfig) {
-	return withTagPolicy(latest.TagPolicy{ShaTagger: &latest.ShaTagger{}})
+func withShaTagger() func(*latest_v1.BuildConfig) {
+	return withTagPolicy(latest_v1.TagPolicy{ShaTagger: &latest_v1.ShaTagger{}})
 }
 
-func withProfiles(profiles ...latest.Profile) func(*latest.SkaffoldConfig) {
-	return func(cfg *latest.SkaffoldConfig) {
+func withProfiles(profiles ...latest_v1.Profile) func(*latest_v1.SkaffoldConfig) {
+	return func(cfg *latest_v1.SkaffoldConfig) {
 		cfg.Profiles = profiles
 	}
 }
 
-func withTests(testCases ...*latest.TestCase) func(*latest.SkaffoldConfig) {
-	return func(cfg *latest.SkaffoldConfig) {
+func withTests(testCases ...*latest_v1.TestCase) func(*latest_v1.SkaffoldConfig) {
+	return func(cfg *latest_v1.SkaffoldConfig) {
 		cfg.Test = testCases
 	}
 }
 
-func withPortForward(portForward ...*latest.PortForwardResource) func(*latest.SkaffoldConfig) {
-	return func(cfg *latest.SkaffoldConfig) {
+func withPortForward(portForward ...*latest_v1.PortForwardResource) func(*latest_v1.SkaffoldConfig) {
+	return func(cfg *latest_v1.SkaffoldConfig) {
 		cfg.PortForward = portForward
 	}
 }
 
-func withStatusCheckDeadline(deadline int) func(*latest.SkaffoldConfig) {
-	return func(cfg *latest.SkaffoldConfig) {
+func withStatusCheckDeadline(deadline int) func(*latest_v1.SkaffoldConfig) {
+	return func(cfg *latest_v1.SkaffoldConfig) {
 		cfg.Deploy.StatusCheckDeadlineSeconds = deadline
 	}
 }
 
-func withLogsPrefix(prefix string) func(*latest.SkaffoldConfig) {
-	return func(cfg *latest.SkaffoldConfig) {
+func withLogsPrefix(prefix string) func(*latest_v1.SkaffoldConfig) {
+	return func(cfg *latest_v1.SkaffoldConfig) {
 		cfg.Deploy.Logs.Prefix = prefix
 	}
 }
@@ -685,7 +685,7 @@ func TestUpgradeToNextVersion(t *testing.T) {
 }
 
 func TestCantUpgradeFromLatestVersion(t *testing.T) {
-	factory, present := SchemaVersions.Find(latest.Version)
+	factory, present := SchemaVersions.Find(latest_v1.Version)
 	testutil.CheckDeepEqual(t, true, present)
 
 	_, err := factory().Upgrade()
@@ -695,7 +695,7 @@ func TestCantUpgradeFromLatestVersion(t *testing.T) {
 func TestParseConfigAndUpgradeToUnknownVersion(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		t.NewTempDir().
-			Write("skaffold.yaml", fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latest.Version, minimalConfig)).
+			Write("skaffold.yaml", fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latest_v1.Version, minimalConfig)).
 			Chdir()
 
 		_, err := ParseConfigAndUpgrade("skaffold.yaml", "unknown")
@@ -707,7 +707,7 @@ func TestParseConfigAndUpgradeToUnknownVersion(t *testing.T) {
 func TestParseConfigAndUpgradeToOlderVersion(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		t.NewTempDir().
-			Write("skaffold.yaml", fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latest.Version, minimalConfig)).
+			Write("skaffold.yaml", fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latest_v1.Version, minimalConfig)).
 			Chdir()
 
 		_, err := ParseConfigAndUpgrade("skaffold.yaml", "skaffold/v1alpha1")

--- a/pkg/skaffold/sources/upload.go
+++ b/pkg/skaffold/sources/upload.go
@@ -22,12 +22,12 @@ import (
 
 	cstorage "cloud.google.com/go/storage"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // UploadToGCS uploads the artifact's sources to a GCS bucket.
-func UploadToGCS(ctx context.Context, c *cstorage.Client, a *latest.Artifact, bucket, objectName string, dependencies []string) error {
+func UploadToGCS(ctx context.Context, c *cstorage.Client, a *latest_v1.Artifact, bucket, objectName string, dependencies []string) error {
 	w := c.Bucket(bucket).Object(objectName).NewWriter(ctx)
 
 	if err := util.CreateTarGz(w, a.Workspace, dependencies); err != nil {

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -38,7 +38,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -49,7 +49,7 @@ var (
 	SyncMap    = syncMapForArtifact
 )
 
-func NewItem(ctx context.Context, a *latest.Artifact, e filemon.Events, builds []graph.Artifact, cfg docker.Config, dependentArtifactsCount int) (*Item, error) {
+func NewItem(ctx context.Context, a *latest_v1.Artifact, e filemon.Events, builds []graph.Artifact, cfg docker.Config, dependentArtifactsCount int) (*Item, error) {
 	if !e.HasChanged() || a.Sync == nil {
 		return nil, nil
 	}
@@ -79,7 +79,7 @@ func NewItem(ctx context.Context, a *latest.Artifact, e filemon.Events, builds [
 	}
 }
 
-func syncItem(a *latest.Artifact, tag string, e filemon.Events, syncRules []*latest.SyncRule, cfg docker.Config) (*Item, error) {
+func syncItem(a *latest_v1.Artifact, tag string, e filemon.Events, syncRules []*latest_v1.SyncRule, cfg docker.Config) (*Item, error) {
 	containerWd, err := WorkingDir(tag, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving working dir for %q: %w", tag, err)
@@ -103,7 +103,7 @@ func syncItem(a *latest.Artifact, tag string, e filemon.Events, syncRules []*lat
 	return &Item{Image: tag, Copy: toCopy, Delete: toDelete}, nil
 }
 
-func inferredSyncItem(a *latest.Artifact, tag string, e filemon.Events, cfg docker.Config) (*Item, error) {
+func inferredSyncItem(a *latest_v1.Artifact, tag string, e filemon.Events, cfg docker.Config) (*Item, error) {
 	// deleted files are no longer contained in the syncMap, so we need to rebuild
 	if len(e.Deleted) > 0 {
 		return nil, nil
@@ -147,7 +147,7 @@ func inferredSyncItem(a *latest.Artifact, tag string, e filemon.Events, cfg dock
 	return &Item{Image: tag, Copy: toCopy}, nil
 }
 
-func syncMapForArtifact(a *latest.Artifact, cfg docker.Config) (map[string][]string, error) {
+func syncMapForArtifact(a *latest_v1.Artifact, cfg docker.Config) (map[string][]string, error) {
 	switch {
 	case a.DockerArtifact != nil:
 		return docker.SyncMap(a.Workspace, a.DockerArtifact.DockerfilePath, a.DockerArtifact.BuildArgs, cfg)
@@ -163,7 +163,7 @@ func syncMapForArtifact(a *latest.Artifact, cfg docker.Config) (map[string][]str
 	}
 }
 
-func autoSyncItem(ctx context.Context, a *latest.Artifact, tag string, e filemon.Events, cfg docker.Config) (*Item, error) {
+func autoSyncItem(ctx context.Context, a *latest_v1.Artifact, tag string, e filemon.Events, cfg docker.Config) (*Item, error) {
 	switch {
 	case a.BuildpackArtifact != nil:
 		labels, err := Labels(tag, cfg)
@@ -204,7 +204,7 @@ func latestTag(image string, builds []graph.Artifact) string {
 	return ""
 }
 
-func intersect(contextWd, containerWd string, syncRules []*latest.SyncRule, files []string) (syncMap, error) {
+func intersect(contextWd, containerWd string, syncRules []*latest_v1.SyncRule, files []string) (syncMap, error) {
 	ret := make(syncMap)
 	for _, f := range files {
 		relPath, err := filepath.Rel(contextWd, f)
@@ -227,7 +227,7 @@ func intersect(contextWd, containerWd string, syncRules []*latest.SyncRule, file
 	return ret, nil
 }
 
-func matchSyncRules(syncRules []*latest.SyncRule, relPath, containerWd string) ([]string, error) {
+func matchSyncRules(syncRules []*latest_v1.SyncRule, relPath, containerWd string) ([]string, error) {
 	dsts := make([]string, 0, 1)
 	for _, r := range syncRules {
 		matches, err := doublestar.PathMatch(filepath.FromSlash(r.Src), relPath)
@@ -321,7 +321,7 @@ func Perform(ctx context.Context, image string, files syncMap, cmdFn func(contex
 	return nil
 }
 
-func Init(ctx context.Context, artifacts []*latest.Artifact) error {
+func Init(ctx context.Context, artifacts []*latest_v1.Artifact) error {
 	for _, a := range artifacts {
 		if a.Sync == nil {
 			continue

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -44,7 +44,7 @@ func TestNewSyncItem(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
 		description  string
-		artifact     *latest.Artifact
+		artifact     *latest_v1.Artifact
 		dependencies map[string][]string
 		labels       map[string]string
 		evt          filemon.Events
@@ -56,10 +56,10 @@ func TestNewSyncItem(t *testing.T) {
 		// manual sync cases
 		{
 			description: "manual: match copy",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
-					Manual: []*latest.SyncRule{{Src: "*.html", Dest: "."}},
+				Sync: &latest_v1.Sync{
+					Manual: []*latest_v1.SyncRule{{Src: "*.html", Dest: "."}},
 				},
 				Workspace: ".",
 			},
@@ -82,10 +82,10 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "manual: no tag for image",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "notbuildyet",
-				Sync: &latest.Sync{
-					Manual: []*latest.SyncRule{{Src: "*.html", Dest: "."}},
+				Sync: &latest_v1.Sync{
+					Manual: []*latest_v1.SyncRule{{Src: "*.html", Dest: "."}},
 				},
 				Workspace: ".",
 			},
@@ -102,10 +102,10 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "manual: multiple sync patterns",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
-					Manual: []*latest.SyncRule{
+				Sync: &latest_v1.Sync{
+					Manual: []*latest_v1.SyncRule{
 						{Src: "*.js", Dest: "."},
 						{Src: "*.html", Dest: "."},
 						{Src: "*.json", Dest: "."},
@@ -137,10 +137,10 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "manual: recursive glob patterns",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
-					Manual: []*latest.SyncRule{
+				Sync: &latest_v1.Sync{
+					Manual: []*latest_v1.SyncRule{
 						{Src: "src/**/*.js", Dest: "src/", Strip: "src/"},
 					},
 				},
@@ -166,10 +166,10 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "manual: sync all",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
-					Manual: []*latest.SyncRule{
+				Sync: &latest_v1.Sync{
+					Manual: []*latest_v1.SyncRule{
 						{Src: "*", Dest: "."},
 					},
 				},
@@ -199,9 +199,9 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "manual: not copy syncable",
-			artifact: &latest.Artifact{
-				Sync: &latest.Sync{
-					Manual: []*latest.SyncRule{
+			artifact: &latest_v1.Artifact{
+				Sync: &latest_v1.Sync{
+					Manual: []*latest_v1.SyncRule{
 						{Src: "*.html", Dest: "."},
 					},
 				},
@@ -219,9 +219,9 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "manual: not delete syncable",
-			artifact: &latest.Artifact{
-				Sync: &latest.Sync{
-					Manual: []*latest.SyncRule{
+			artifact: &latest_v1.Artifact{
+				Sync: &latest_v1.Sync{
+					Manual: []*latest_v1.SyncRule{
 						{Src: "*.html", Dest: "/static"},
 					},
 				},
@@ -239,9 +239,9 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "manual: err bad pattern",
-			artifact: &latest.Artifact{
-				Sync: &latest.Sync{
-					Manual: []*latest.SyncRule{
+			artifact: &latest_v1.Artifact{
+				Sync: &latest_v1.Sync{
+					Manual: []*latest_v1.SyncRule{
 						{Src: "[*.html", Dest: "*"},
 					},
 				},
@@ -255,9 +255,9 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "manual: no change no sync",
-			artifact: &latest.Artifact{
-				Sync: &latest.Sync{
-					Manual: []*latest.SyncRule{
+			artifact: &latest_v1.Artifact{
+				Sync: &latest_v1.Sync{
+					Manual: []*latest_v1.SyncRule{
 						{Src: "*.html", Dest: "*"},
 					},
 				},
@@ -272,10 +272,10 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "manual: slashes in glob pattern",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
-					Manual: []*latest.SyncRule{
+				Sync: &latest_v1.Sync{
+					Manual: []*latest_v1.SyncRule{
 						{Src: "**/**/*.js", Dest: "."},
 					},
 				},
@@ -301,10 +301,10 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "manual: sync subtrees",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
-					Manual: []*latest.SyncRule{
+				Sync: &latest_v1.Sync{
+					Manual: []*latest_v1.SyncRule{
 						{Src: "dir1/**/*.js", Dest: ".", Strip: "dir1/"},
 					},
 				},
@@ -330,10 +330,10 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "manual: multiple matches",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
-					Manual: []*latest.SyncRule{
+				Sync: &latest_v1.Sync{
+					Manual: []*latest_v1.SyncRule{
 						{Src: "dir1/**/*.js", Dest: ".", Strip: "dir1/"},
 						{Src: "dir1/**/**/*.js", Dest: "."},
 					},
@@ -360,10 +360,10 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "manual: stars work with absolute paths",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
-					Manual: []*latest.SyncRule{
+				Sync: &latest_v1.Sync{
+					Manual: []*latest_v1.SyncRule{
 						{Src: "dir1a/**/*.js", Dest: "/tstar", Strip: "dir1a/"},
 						{Src: "dir1b/**/*.js", Dest: "/dstar"},
 					},
@@ -396,9 +396,9 @@ func TestNewSyncItem(t *testing.T) {
 		// auto-sync cases
 		{
 			description: "infer: match copy",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
+				Sync: &latest_v1.Sync{
 					Infer: []string{"*.html"},
 				},
 				Workspace: ".",
@@ -422,9 +422,9 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "infer: not auto-syncable",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
+				Sync: &latest_v1.Sync{
 					Infer: []string{"*.html"},
 				},
 				Workspace: ".",
@@ -442,9 +442,9 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "infer: file not specified for syncing",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
+				Sync: &latest_v1.Sync{
 					Infer: []string{"*.js"},
 				},
 				Workspace: ".",
@@ -462,9 +462,9 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "infer: no tag for image",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "notbuildyet",
-				Sync: &latest.Sync{
+				Sync: &latest_v1.Sync{
 					Infer: []string{"*.html"},
 				},
 				Workspace: ".",
@@ -483,9 +483,9 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "infer: multiple sync patterns",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
+				Sync: &latest_v1.Sync{
 					Infer: []string{"*.js", "*.html", "*.json"},
 				},
 				Workspace: "node",
@@ -511,9 +511,9 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "infer: recursive glob patterns",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
+				Sync: &latest_v1.Sync{
 					Infer: []string{"src/**/*.js"},
 				},
 				Workspace: "node",
@@ -538,9 +538,9 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "infer: sync all",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
+				Sync: &latest_v1.Sync{
 					Infer: []string{"*"},
 				},
 				Workspace: "node",
@@ -566,8 +566,8 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "infer: delete not syncable",
-			artifact: &latest.Artifact{
-				Sync: &latest.Sync{
+			artifact: &latest_v1.Artifact{
+				Sync: &latest_v1.Sync{
 					Infer: []string{"*"},
 				},
 				Workspace: ".",
@@ -585,8 +585,8 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "infer: err bad pattern",
-			artifact: &latest.Artifact{
-				Sync: &latest.Sync{
+			artifact: &latest_v1.Artifact{
+				Sync: &latest_v1.Sync{
 					Infer: []string{"[*.html"},
 				},
 				Workspace: ".",
@@ -599,8 +599,8 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "infer: no change no sync",
-			artifact: &latest.Artifact{
-				Sync: &latest.Sync{
+			artifact: &latest_v1.Artifact{
+				Sync: &latest_v1.Sync{
 					Infer: []string{"*.html"},
 				},
 				Workspace: ".",
@@ -615,9 +615,9 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "infer: slashes in glob pattern",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
-				Sync: &latest.Sync{
+				Sync: &latest_v1.Sync{
 					Infer: []string{"**/**/*.js"},
 				},
 				Workspace: ".",
@@ -644,12 +644,12 @@ func TestNewSyncItem(t *testing.T) {
 		// Buildpacks
 		{
 			description: "auto with buildpacks",
-			artifact: &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					BuildpackArtifact: &latest.BuildpackArtifact{},
+			artifact: &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					BuildpackArtifact: &latest_v1.BuildpackArtifact{},
 				},
 				ImageName: "test",
-				Sync: &latest.Sync{
+				Sync: &latest_v1.Sync{
 					Auto: util.BoolPtr(true),
 				},
 				Workspace: ".",
@@ -684,12 +684,12 @@ func TestNewSyncItem(t *testing.T) {
 		},
 		{
 			description: "unknown change with buildpacks",
-			artifact: &latest.Artifact{
-				ArtifactType: latest.ArtifactType{
-					BuildpackArtifact: &latest.BuildpackArtifact{},
+			artifact: &latest_v1.Artifact{
+				ArtifactType: latest_v1.ArtifactType{
+					BuildpackArtifact: &latest_v1.BuildpackArtifact{},
 				},
 				ImageName: "test",
-				Sync: &latest.Sync{
+				Sync: &latest_v1.Sync{
 					Auto: util.BoolPtr(true),
 				},
 				Workspace: ".",
@@ -720,14 +720,14 @@ func TestNewSyncItem(t *testing.T) {
 		// Auto with Jib
 		{
 			description: "auto with jib",
-			artifact: &latest.Artifact{
+			artifact: &latest_v1.Artifact{
 				ImageName: "test",
 				Workspace: ".",
-				Sync: &latest.Sync{
+				Sync: &latest_v1.Sync{
 					Auto: util.BoolPtr(true),
 				},
-				ArtifactType: latest.ArtifactType{
-					JibArtifact: &latest.JibArtifact{},
+				ArtifactType: latest_v1.ArtifactType{
+					JibArtifact: &latest_v1.JibArtifact{},
 				},
 			},
 			evt: filemon.Events{
@@ -751,9 +751,9 @@ func TestNewSyncItem(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&WorkingDir, func(string, docker.Config) (string, error) { return test.workingDir, nil })
-			t.Override(&SyncMap, func(*latest.Artifact, docker.Config) (map[string][]string, error) { return test.dependencies, nil })
+			t.Override(&SyncMap, func(*latest_v1.Artifact, docker.Config) (map[string][]string, error) { return test.dependencies, nil })
 			t.Override(&Labels, func(string, docker.Config) (map[string]string, error) { return test.labels, nil })
-			t.Override(&jib.GetSyncDiff, func(context.Context, string, *latest.JibArtifact, filemon.Events) (map[string][]string, map[string][]string, error) {
+			t.Override(&jib.GetSyncDiff, func(context.Context, string, *latest_v1.JibArtifact, filemon.Events) (map[string][]string, map[string][]string, error) {
 				return map[string][]string{"file.class": {"/some/file.class"}}, nil, nil
 			})
 
@@ -767,7 +767,7 @@ func TestNewSyncItem(t *testing.T) {
 func TestIntersect(t *testing.T) {
 	tests := []struct {
 		description string
-		syncRules   []*latest.SyncRule
+		syncRules   []*latest_v1.SyncRule
 		files       []string
 		context     string
 		workingDir  string
@@ -781,7 +781,7 @@ func TestIntersect(t *testing.T) {
 		{
 			description: "copy nested file to correct destination",
 			files:       []string{filepath.Join("static", "index.html"), filepath.Join("static", "test.html")},
-			syncRules: []*latest.SyncRule{
+			syncRules: []*latest_v1.SyncRule{
 				{Src: filepath.Join("static", "*.html"), Dest: "/html", Strip: "static/"},
 			},
 			expected: map[string][]string{
@@ -792,7 +792,7 @@ func TestIntersect(t *testing.T) {
 		{
 			description: "double-star matches depth zero",
 			files:       []string{"index.html"},
-			syncRules: []*latest.SyncRule{
+			syncRules: []*latest_v1.SyncRule{
 				{Src: filepath.Join("**", "*.html"), Dest: "/html"},
 			},
 			expected: map[string][]string{
@@ -803,7 +803,7 @@ func TestIntersect(t *testing.T) {
 			description: "file not in . copies to correct destination",
 			files:       []string{filepath.Join("node", "server.js")},
 			context:     "node",
-			syncRules: []*latest.SyncRule{
+			syncRules: []*latest_v1.SyncRule{
 				{Src: "*.js", Dest: "/"},
 			},
 			expected: map[string][]string{
@@ -814,7 +814,7 @@ func TestIntersect(t *testing.T) {
 			description: "file change not relative to context throws error",
 			files:       []string{filepath.Join("node", "server.js"), filepath.Join("/", "something", "test.js")},
 			context:     "node",
-			syncRules: []*latest.SyncRule{
+			syncRules: []*latest_v1.SyncRule{
 				{Src: "*.js", Dest: "/"},
 			},
 			shouldErr: true,
@@ -972,15 +972,15 @@ func TestPerform(t *testing.T) {
 func TestSyncMap(t *testing.T) {
 	tests := []struct {
 		description  string
-		artifactType latest.ArtifactType
+		artifactType latest_v1.ArtifactType
 		files        map[string]string
 		shouldErr    bool
 		expectedMap  map[string][]string
 	}{
 		{
 			description: "docker - supported",
-			artifactType: latest.ArtifactType{
-				DockerArtifact: &latest.DockerArtifact{
+			artifactType: latest_v1.ArtifactType{
+				DockerArtifact: &latest_v1.DockerArtifact{
 					DockerfilePath: "Dockerfile",
 				},
 			},
@@ -992,8 +992,8 @@ func TestSyncMap(t *testing.T) {
 		},
 		{
 			description: "kaniko - supported",
-			artifactType: latest.ArtifactType{
-				KanikoArtifact: &latest.KanikoArtifact{
+			artifactType: latest_v1.ArtifactType{
+				KanikoArtifact: &latest_v1.KanikoArtifact{
 					DockerfilePath: "Dockerfile",
 				},
 			},
@@ -1005,10 +1005,10 @@ func TestSyncMap(t *testing.T) {
 		},
 		{
 			description: "custom - supported",
-			artifactType: latest.ArtifactType{
-				CustomArtifact: &latest.CustomArtifact{
-					Dependencies: &latest.CustomDependencies{
-						Dockerfile: &latest.DockerfileDependency{
+			artifactType: latest_v1.ArtifactType{
+				CustomArtifact: &latest_v1.CustomArtifact{
+					Dependencies: &latest_v1.CustomDependencies{
+						Dockerfile: &latest_v1.DockerfileDependency{
 							Path: "Dockerfile",
 						},
 					},
@@ -1022,14 +1022,14 @@ func TestSyncMap(t *testing.T) {
 		},
 		{
 			description: "custom, no dockerfile - not supported",
-			artifactType: latest.ArtifactType{
-				CustomArtifact: &latest.CustomArtifact{},
+			artifactType: latest_v1.ArtifactType{
+				CustomArtifact: &latest_v1.CustomArtifact{},
 			},
 			shouldErr: true,
 		},
 		{
 			description:  "not supported",
-			artifactType: latest.ArtifactType{},
+			artifactType: latest_v1.ArtifactType{},
 			shouldErr:    true,
 		},
 	}
@@ -1039,7 +1039,7 @@ func TestSyncMap(t *testing.T) {
 			t.Override(&docker.RetrieveImage, imageFetcher.fetch)
 			t.NewTempDir().WriteFiles(test.files).Chdir()
 
-			syncMap, err := SyncMap(&latest.Artifact{ArtifactType: test.artifactType}, nil)
+			syncMap, err := SyncMap(&latest_v1.Artifact{ArtifactType: test.artifactType}, nil)
 
 			t.CheckError(test.shouldErr, err)
 			t.CheckDeepEqual(test.expectedMap, syncMap)
@@ -1057,34 +1057,34 @@ func TestInit(t *testing.T) {
 	ctx := context.Background()
 	tests := []struct {
 		description string
-		artifact    *latest.Artifact
+		artifact    *latest_v1.Artifact
 		shouldInit  bool
 		initErrors  bool
 	}{
 		{
 			description: "sync off",
-			artifact:    &latest.Artifact{},
+			artifact:    &latest_v1.Artifact{},
 			shouldInit:  false,
 		},
 		{
 			description: "sync on, auto off",
-			artifact:    &latest.Artifact{Sync: &latest.Sync{}},
+			artifact:    &latest_v1.Artifact{Sync: &latest_v1.Sync{}},
 			shouldInit:  false,
 		},
 		{
 			description: "sync on, auto on, non-jib",
-			artifact:    &latest.Artifact{Sync: &latest.Sync{Auto: util.BoolPtr(true)}},
+			artifact:    &latest_v1.Artifact{Sync: &latest_v1.Sync{Auto: util.BoolPtr(true)}},
 			shouldInit:  false,
 		},
 		{
 			description: "sync on, auto on, jib",
-			artifact:    &latest.Artifact{ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{}}, Sync: &latest.Sync{Auto: util.BoolPtr(true)}},
+			artifact:    &latest_v1.Artifact{ArtifactType: latest_v1.ArtifactType{JibArtifact: &latest_v1.JibArtifact{}}, Sync: &latest_v1.Sync{Auto: util.BoolPtr(true)}},
 			shouldInit:  true,
 			initErrors:  false,
 		},
 		{
 			description: "sync on, auto on, jib, init fails",
-			artifact:    &latest.Artifact{ArtifactType: latest.ArtifactType{JibArtifact: &latest.JibArtifact{}}, Sync: &latest.Sync{Auto: util.BoolPtr(true)}},
+			artifact:    &latest_v1.Artifact{ArtifactType: latest_v1.ArtifactType{JibArtifact: &latest_v1.JibArtifact{}}, Sync: &latest_v1.Sync{Auto: util.BoolPtr(true)}},
 			shouldInit:  true,
 			initErrors:  true,
 		},
@@ -1092,7 +1092,7 @@ func TestInit(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			isCalled := false
-			t.Override(&jib.InitSync, func(ctx context.Context, workspace string, a *latest.JibArtifact) error {
+			t.Override(&jib.InitSync, func(ctx context.Context, workspace string, a *latest_v1.JibArtifact) error {
 				isCalled = true
 				if test.initErrors {
 					return errors.New("intentional test failure")
@@ -1100,7 +1100,7 @@ func TestInit(t *testing.T) {
 				return nil
 			})
 
-			artifacts := []*latest.Artifact{test.artifact}
+			artifacts := []*latest_v1.Artifact{test.artifact}
 			err := Init(ctx, artifacts)
 			t.CheckDeepEqual(test.shouldInit, isCalled)
 			t.CheckError(test.initErrors, err)

--- a/pkg/skaffold/tag/custom.go
+++ b/pkg/skaffold/tag/custom.go
@@ -19,7 +19,7 @@ package tag
 import (
 	"errors"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 type CustomTag struct {
@@ -27,7 +27,7 @@ type CustomTag struct {
 }
 
 // GenerateTag generates a tag using the custom tag.
-func (t *CustomTag) GenerateTag(_ latest.Artifact) (string, error) {
+func (t *CustomTag) GenerateTag(_ latest_v1.Artifact) (string, error) {
 	tag := t.Tag
 	if tag == "" {
 		return "", errors.New("custom tag not provided")

--- a/pkg/skaffold/tag/custom_template.go
+++ b/pkg/skaffold/tag/custom_template.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // customTemplateTagger implements Tagger
@@ -46,7 +46,7 @@ func NewCustomTemplateTagger(t string, components map[string]Tagger) (Tagger, er
 }
 
 // GenerateTag generates a tag from a template referencing tagging strategies.
-func (t *customTemplateTagger) GenerateTag(image latest.Artifact) (string, error) {
+func (t *customTemplateTagger) GenerateTag(image latest_v1.Artifact) (string, error) {
 	customMap, err := t.EvaluateComponents(image)
 	if err != nil {
 		return "", err
@@ -62,7 +62,7 @@ func (t *customTemplateTagger) GenerateTag(image latest.Artifact) (string, error
 }
 
 // EvaluateComponents creates a custom mapping of component names to their tagger string representation.
-func (t *customTemplateTagger) EvaluateComponents(image latest.Artifact) (map[string]string, error) {
+func (t *customTemplateTagger) EvaluateComponents(image latest_v1.Artifact) (map[string]string, error) {
 	customMap := map[string]string{}
 
 	gitTagger, _ := NewGitCommit("", "", false)

--- a/pkg/skaffold/tag/custom_template_test.go
+++ b/pkg/skaffold/tag/custom_template_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -104,7 +104,7 @@ func TestTagTemplate_GenerateTag(t *testing.T) {
 
 			t.CheckNoError(err)
 
-			image := latest.Artifact{
+			image := latest_v1.Artifact{
 				ImageName: "test",
 			}
 			tag, err := c.GenerateTag(image)

--- a/pkg/skaffold/tag/custom_test.go
+++ b/pkg/skaffold/tag/custom_test.go
@@ -19,7 +19,7 @@ package tag
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -44,7 +44,7 @@ func TestCustomTag_GenerateTag(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		image := latest.Artifact{
+		image := latest_v1.Artifact{
 			ImageName: "test",
 		}
 		tag, err := test.c.GenerateTag(image)

--- a/pkg/skaffold/tag/date_time.go
+++ b/pkg/skaffold/tag/date_time.go
@@ -22,7 +22,7 @@ import (
 
 	"4d63.com/tz"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 const tagTime = "2006-01-02_15-04-05.999_MST"
@@ -45,7 +45,7 @@ func NewDateTimeTagger(format, timezone string) Tagger {
 }
 
 // GenerateTag generates a tag using the current timestamp.
-func (t *dateTimeTagger) GenerateTag(_ latest.Artifact) (string, error) {
+func (t *dateTimeTagger) GenerateTag(_ latest_v1.Artifact) (string, error) {
 	format := tagTime
 	if len(t.Format) > 0 {
 		format = t.Format

--- a/pkg/skaffold/tag/date_time_test.go
+++ b/pkg/skaffold/tag/date_time_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -69,7 +69,7 @@ func TestDateTime_GenerateTag(t *testing.T) {
 				timeFn:   func() time.Time { return test.buildTime },
 			}
 
-			image := latest.Artifact{
+			image := latest_v1.Artifact{
 				ImageName: "test",
 			}
 

--- a/pkg/skaffold/tag/env_template.go
+++ b/pkg/skaffold/tag/env_template.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"text/template"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -42,7 +42,7 @@ func NewEnvTemplateTagger(t string) (Tagger, error) {
 }
 
 // GenerateTag generates a tag from a template referencing environment variables.
-func (t *envTemplateTagger) GenerateTag(image latest.Artifact) (string, error) {
+func (t *envTemplateTagger) GenerateTag(image latest_v1.Artifact) (string, error) {
 	// missingkey=error throws error when map is indexed with an undefined key
 	tag, err := util.ExecuteEnvTemplate(t.Template.Option("missingkey=error"), map[string]string{
 		"IMAGE_NAME": image.ImageName,

--- a/pkg/skaffold/tag/env_template_test.go
+++ b/pkg/skaffold/tag/env_template_test.go
@@ -19,7 +19,7 @@ package tag
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -100,7 +100,7 @@ func TestEnvTemplateTagger_GenerateTag(t *testing.T) {
 			c, err := NewEnvTemplateTagger(test.template)
 			t.CheckNoError(err)
 
-			image := latest.Artifact{
+			image := latest_v1.Artifact{
 				ImageName: test.imageName,
 			}
 

--- a/pkg/skaffold/tag/git_commit.go
+++ b/pkg/skaffold/tag/git_commit.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -61,7 +61,7 @@ func NewGitCommit(prefix, variant string, ignoreChanges bool) (*GitCommit, error
 }
 
 // GenerateTag generates a tag from the git commit.
-func (t *GitCommit) GenerateTag(image latest.Artifact) (string, error) {
+func (t *GitCommit) GenerateTag(image latest_v1.Artifact) (string, error) {
 	ref, err := t.runGitFn(image.Workspace)
 	if err != nil {
 		return "", fmt.Errorf("unable to find git commit: %w", err)

--- a/pkg/skaffold/tag/git_commit_test.go
+++ b/pkg/skaffold/tag/git_commit_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -384,7 +384,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			tmpDir := t.NewTempDir()
 			test.createGitRepo(tmpDir.Root())
 
-			image := latest.Artifact{
+			image := latest_v1.Artifact{
 				ImageName: "test",
 				Workspace: tmpDir.Path(test.subDir),
 			}
@@ -446,7 +446,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			tmpDir := t.NewTempDir()
 			test.createGitRepo(tmpDir.Root())
-			image := latest.Artifact{
+			image := latest_v1.Artifact{
 				ImageName: "test",
 				Workspace: tmpDir.Path(test.subDir),
 			}
@@ -508,7 +508,7 @@ func TestGitCommit_CustomTemplate(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			tmpDir := t.NewTempDir()
 			test.createGitRepo(tmpDir.Root())
-			image := latest.Artifact{
+			image := latest_v1.Artifact{
 				ImageName: "test",
 				Workspace: tmpDir.Path(test.subDir),
 			}
@@ -529,7 +529,7 @@ func TestGitCommitSubDirectory(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		tmpDir := t.NewTempDir()
 		gitInit(t.T, tmpDir.Root()).mkdir("sub/sub").commit("initial")
-		image := latest.Artifact{
+		image := latest_v1.Artifact{
 			ImageName: "test",
 			Workspace: tmpDir.Path("sub/sub"),
 		}
@@ -568,7 +568,7 @@ func TestPrefix(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		tmpDir := t.NewTempDir()
 		gitInit(t.T, tmpDir.Root()).commit("initial")
-		image := latest.Artifact{
+		image := latest_v1.Artifact{
 			ImageName: "test",
 			Workspace: tmpDir.Path("."),
 		}

--- a/pkg/skaffold/tag/input_digest.go
+++ b/pkg/skaffold/tag/input_digest.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 type inputDigestTagger struct {
@@ -49,7 +49,7 @@ func NewInputDigestTagger(cfg docker.Config, ag graph.ArtifactGraph) (Tagger, er
 	}, nil
 }
 
-func (t *inputDigestTagger) GenerateTag(image latest.Artifact) (string, error) {
+func (t *inputDigestTagger) GenerateTag(image latest_v1.Artifact) (string, error) {
 	var inputs []string
 	// TODO(nkubala): plumb through context into Tagger interface
 	ctx := context.TODO()

--- a/pkg/skaffold/tag/sha256.go
+++ b/pkg/skaffold/tag/sha256.go
@@ -18,14 +18,14 @@ package tag
 
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // ChecksumTagger tags an image by the sha256 of the image tarball
 type ChecksumTagger struct{}
 
 // GenerateTag returns either the current tag or `latest`.
-func (t *ChecksumTagger) GenerateTag(image latest.Artifact) (string, error) {
+func (t *ChecksumTagger) GenerateTag(image latest_v1.Artifact) (string, error) {
 	parsed, err := docker.ParseReference(image.ImageName)
 	if err != nil {
 		return "", err

--- a/pkg/skaffold/tag/sha256_test.go
+++ b/pkg/skaffold/tag/sha256_test.go
@@ -19,14 +19,14 @@ package tag
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestSha256_GenerateTag(t *testing.T) {
 	c := &ChecksumTagger{}
 
-	image := latest.Artifact{
+	image := latest_v1.Artifact{
 		ImageName: "img:tag",
 	}
 

--- a/pkg/skaffold/tag/tag.go
+++ b/pkg/skaffold/tag/tag.go
@@ -19,7 +19,7 @@ package tag
 import (
 	"fmt"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // ImageTags maps image names to tags
@@ -28,13 +28,13 @@ type ImageTags map[string]string
 // Tagger is an interface for tag strategies to be implemented against
 type Tagger interface {
 	// GenerateTag generates a tag for an artifact.
-	GenerateTag(image latest.Artifact) (string, error)
+	GenerateTag(image latest_v1.Artifact) (string, error)
 }
 
 // GenerateFullyQualifiedImageName resolves the fully qualified image name for an artifact.
 // The workingDir is the root directory of the artifact with respect to the Skaffold root,
 // and imageName is the base name of the image.
-func GenerateFullyQualifiedImageName(t Tagger, image latest.Artifact) (string, error) {
+func GenerateFullyQualifiedImageName(t Tagger, image latest_v1.Artifact) (string, error) {
 	tag, err := t.GenerateTag(image)
 	if err != nil {
 		return "", fmt.Errorf("generating tag: %w", err)

--- a/pkg/skaffold/tag/tag_test.go
+++ b/pkg/skaffold/tag/tag_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -104,7 +104,7 @@ func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 			t.Override(&warnings.Printf, fakeWarner.Warnf)
 			t.Override(&util.OSEnviron, func() []string { return env })
 
-			image := latest.Artifact{
+			image := latest_v1.Artifact{
 				ImageName: test.imageName,
 			}
 

--- a/pkg/skaffold/tag/tagger_mux.go
+++ b/pkg/skaffold/tag/tagger_mux.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 type TaggerMux struct {
@@ -29,7 +29,7 @@ type TaggerMux struct {
 	byImageName map[string]Tagger
 }
 
-func (t *TaggerMux) GenerateTag(image latest.Artifact) (string, error) {
+func (t *TaggerMux) GenerateTag(image latest_v1.Artifact) (string, error) {
 	tagger, found := t.byImageName[image.ImageName]
 	if !found {
 		return "", fmt.Errorf("no valid tagger found for artifact: %q", image.ImageName)
@@ -54,7 +54,7 @@ func NewTaggerMux(runCtx *runcontext.RunContext) (Tagger, error) {
 	return &TaggerMux{taggers: sl, byImageName: m}, nil
 }
 
-func getTagger(runCtx *runcontext.RunContext, t *latest.TagPolicy) (Tagger, error) {
+func getTagger(runCtx *runcontext.RunContext, t *latest_v1.TagPolicy) (Tagger, error) {
 	switch {
 	case runCtx.CustomTag() != "":
 		return &CustomTag{
@@ -92,7 +92,7 @@ func getTagger(runCtx *runcontext.RunContext, t *latest.TagPolicy) (Tagger, erro
 }
 
 // CreateComponents creates a map of taggers for CustomTemplateTagger
-func CreateComponents(runCtx *runcontext.RunContext, t *latest.CustomTemplateTagger) (map[string]Tagger, error) {
+func CreateComponents(runCtx *runcontext.RunContext, t *latest_v1.CustomTemplateTagger) (map[string]Tagger, error) {
 	components := map[string]Tagger{}
 
 	for _, taggerComponent := range t.Components {

--- a/pkg/skaffold/tag/tagger_mux_test.go
+++ b/pkg/skaffold/tag/tagger_mux_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -34,19 +34,19 @@ func TestCreateComponents(t *testing.T) {
 
 	tests := []struct {
 		description          string
-		customTemplateTagger *latest.CustomTemplateTagger
+		customTemplateTagger *latest_v1.CustomTemplateTagger
 		expected             map[string]Tagger
 		shouldErr            bool
 	}{
 		{
 			description: "correct component types",
-			customTemplateTagger: &latest.CustomTemplateTagger{
-				Components: []latest.TaggerComponent{
-					{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
-					{Name: "FOE", Component: latest.TagPolicy{ShaTagger: &latest.ShaTagger{}}},
-					{Name: "BAR", Component: latest.TagPolicy{EnvTemplateTagger: &latest.EnvTemplateTagger{Template: "test"}}},
-					{Name: "BAT", Component: latest.TagPolicy{DateTimeTagger: &latest.DateTimeTagger{}}},
-					{Name: "BAS", Component: latest.TagPolicy{InputDigest: &latest.InputDigest{}}},
+			customTemplateTagger: &latest_v1.CustomTemplateTagger{
+				Components: []latest_v1.TaggerComponent{
+					{Name: "FOO", Component: latest_v1.TagPolicy{GitTagger: &latest_v1.GitTagger{}}},
+					{Name: "FOE", Component: latest_v1.TagPolicy{ShaTagger: &latest_v1.ShaTagger{}}},
+					{Name: "BAR", Component: latest_v1.TagPolicy{EnvTemplateTagger: &latest_v1.EnvTemplateTagger{Template: "test"}}},
+					{Name: "BAT", Component: latest_v1.TagPolicy{DateTimeTagger: &latest_v1.DateTimeTagger{}}},
+					{Name: "BAS", Component: latest_v1.TagPolicy{InputDigest: &latest_v1.InputDigest{}}},
 				},
 			},
 			expected: map[string]Tagger{
@@ -59,28 +59,28 @@ func TestCreateComponents(t *testing.T) {
 		},
 		{
 			description: "customTemplate is an invalid component",
-			customTemplateTagger: &latest.CustomTemplateTagger{
-				Components: []latest.TaggerComponent{
-					{Name: "FOO", Component: latest.TagPolicy{CustomTemplateTagger: &latest.CustomTemplateTagger{Template: "test"}}},
+			customTemplateTagger: &latest_v1.CustomTemplateTagger{
+				Components: []latest_v1.TaggerComponent{
+					{Name: "FOO", Component: latest_v1.TagPolicy{CustomTemplateTagger: &latest_v1.CustomTemplateTagger{Template: "test"}}},
 				},
 			},
 			shouldErr: true,
 		},
 		{
 			description: "recurring names",
-			customTemplateTagger: &latest.CustomTemplateTagger{
-				Components: []latest.TaggerComponent{
-					{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
-					{Name: "FOO", Component: latest.TagPolicy{GitTagger: &latest.GitTagger{}}},
+			customTemplateTagger: &latest_v1.CustomTemplateTagger{
+				Components: []latest_v1.TaggerComponent{
+					{Name: "FOO", Component: latest_v1.TagPolicy{GitTagger: &latest_v1.GitTagger{}}},
+					{Name: "FOO", Component: latest_v1.TagPolicy{GitTagger: &latest_v1.GitTagger{}}},
 				},
 			},
 			shouldErr: true,
 		},
 		{
 			description: "unknown component",
-			customTemplateTagger: &latest.CustomTemplateTagger{
-				Components: []latest.TaggerComponent{
-					{Name: "FOO", Component: latest.TagPolicy{}},
+			customTemplateTagger: &latest_v1.CustomTemplateTagger{
+				Components: []latest_v1.TaggerComponent{
+					{Name: "FOO", Component: latest_v1.TagPolicy{}},
 				},
 			},
 			shouldErr: true,

--- a/pkg/skaffold/tags/paths_test.go
+++ b/pkg/skaffold/tags/paths_test.go
@@ -21,32 +21,32 @@ package tags
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestSetAbsFilePaths(t *testing.T) {
 	tests := []struct {
 		description string
-		config      *latest.SkaffoldConfig
+		config      *latest_v1.SkaffoldConfig
 		base        string
-		expected    *latest.SkaffoldConfig
+		expected    *latest_v1.SkaffoldConfig
 	}{
 		{
 			description: "relative path",
-			config: &latest.SkaffoldConfig{
-				Pipeline: latest.Pipeline{
-					Build: latest.BuildConfig{
-						Artifacts: []*latest.Artifact{
+			config: &latest_v1.SkaffoldConfig{
+				Pipeline: latest_v1.Pipeline{
+					Build: latest_v1.BuildConfig{
+						Artifacts: []*latest_v1.Artifact{
 							{ImageName: "foo1", Workspace: "./foo"},
 							{ImageName: "foo2", Workspace: "/a/foo"},
 						},
 					},
-					Deploy: latest.DeployConfig{
-						DeployType: latest.DeployType{
-							KptDeploy:     &latest.KptDeploy{Dir: "."},
-							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{"foo/*", "/a/foo/*"}},
-							HelmDeploy: &latest.HelmDeploy{Releases: []latest.HelmRelease{
+					Deploy: latest_v1.DeployConfig{
+						DeployType: latest_v1.DeployType{
+							KptDeploy:     &latest_v1.KptDeploy{Dir: "."},
+							KubectlDeploy: &latest_v1.KubectlDeploy{Manifests: []string{"foo/*", "/a/foo/*"}},
+							HelmDeploy: &latest_v1.HelmDeploy{Releases: []latest_v1.HelmRelease{
 								{ChartPath: "../charts", ValuesFiles: []string{"./values1.yaml", "./values2.yaml"}, SetFiles: map[string]string{"envFile": "./values3.yaml", "configFile": "./values4.yaml", "anotherFile": "/c/values5.yaml"}},
 								{RemoteChart: "foo/bar", ValuesFiles: []string{"./values1.yaml", "./values2.yaml"}, SetFiles: map[string]string{"envFile": "./values3.yaml", "configFile": "./values4.yaml", "anotherFile": "/c/values5.yaml"}},
 							}},
@@ -55,19 +55,19 @@ func TestSetAbsFilePaths(t *testing.T) {
 				},
 			},
 			base: "/a/b",
-			expected: &latest.SkaffoldConfig{
-				Pipeline: latest.Pipeline{
-					Build: latest.BuildConfig{
-						Artifacts: []*latest.Artifact{
+			expected: &latest_v1.SkaffoldConfig{
+				Pipeline: latest_v1.Pipeline{
+					Build: latest_v1.BuildConfig{
+						Artifacts: []*latest_v1.Artifact{
 							{ImageName: "foo1", Workspace: "/a/b/foo"},
 							{ImageName: "foo2", Workspace: "/a/foo"},
 						},
 					},
-					Deploy: latest.DeployConfig{
-						DeployType: latest.DeployType{
-							KptDeploy:     &latest.KptDeploy{Dir: "/a/b"},
-							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{"/a/b/foo/*", "/a/foo/*"}},
-							HelmDeploy: &latest.HelmDeploy{Releases: []latest.HelmRelease{
+					Deploy: latest_v1.DeployConfig{
+						DeployType: latest_v1.DeployType{
+							KptDeploy:     &latest_v1.KptDeploy{Dir: "/a/b"},
+							KubectlDeploy: &latest_v1.KubectlDeploy{Manifests: []string{"/a/b/foo/*", "/a/foo/*"}},
+							HelmDeploy: &latest_v1.HelmDeploy{Releases: []latest_v1.HelmRelease{
 								{ChartPath: "/a/charts", ValuesFiles: []string{"/a/b/values1.yaml", "/a/b/values2.yaml"}, SetFiles: map[string]string{"envFile": "/a/b/values3.yaml", "configFile": "/a/b/values4.yaml", "anotherFile": "/c/values5.yaml"}},
 								{RemoteChart: "foo/bar", ValuesFiles: []string{"/a/b/values1.yaml", "/a/b/values2.yaml"}, SetFiles: map[string]string{"envFile": "/a/b/values3.yaml", "configFile": "/a/b/values4.yaml", "anotherFile": "/c/values5.yaml"}},
 							}},

--- a/pkg/skaffold/tags/paths_windows_test.go
+++ b/pkg/skaffold/tags/paths_windows_test.go
@@ -19,32 +19,32 @@ package tags
 import (
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestSetAbsFilePaths(t *testing.T) {
 	tests := []struct {
 		description string
-		config      *latest.SkaffoldConfig
+		config      *latest_v1.SkaffoldConfig
 		base        string
-		expected    *latest.SkaffoldConfig
+		expected    *latest_v1.SkaffoldConfig
 	}{
 		{
 			description: "relative path",
-			config: &latest.SkaffoldConfig{
-				Pipeline: latest.Pipeline{
-					Build: latest.BuildConfig{
-						Artifacts: []*latest.Artifact{
+			config: &latest_v1.SkaffoldConfig{
+				Pipeline: latest_v1.Pipeline{
+					Build: latest_v1.BuildConfig{
+						Artifacts: []*latest_v1.Artifact{
 							{ImageName: "foo1", Workspace: "foo"},
 							{ImageName: "foo2", Workspace: `C:\a\foo`},
 						},
 					},
-					Deploy: latest.DeployConfig{
-						DeployType: latest.DeployType{
-							KptDeploy:     &latest.KptDeploy{Dir: "."},
-							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{`foo\*`, `C:\a\foo\*`}},
-							HelmDeploy: &latest.HelmDeploy{Releases: []latest.HelmRelease{
+					Deploy: latest_v1.DeployConfig{
+						DeployType: latest_v1.DeployType{
+							KptDeploy:     &latest_v1.KptDeploy{Dir: "."},
+							KubectlDeploy: &latest_v1.KubectlDeploy{Manifests: []string{`foo\*`, `C:\a\foo\*`}},
+							HelmDeploy: &latest_v1.HelmDeploy{Releases: []latest_v1.HelmRelease{
 								{ChartPath: `..\charts`, ValuesFiles: []string{"values1.yaml", "values2.yaml"}, SetFiles: map[string]string{"envFile": "values3.yaml", "configFile": "values4.yaml", "anotherFile": `C:\c\values5.yaml`}},
 								{RemoteChart: "foo/bar", ValuesFiles: []string{"values1.yaml", "values2.yaml"}, SetFiles: map[string]string{"envFile": "values3.yaml", "configFile": "values4.yaml", "anotherFile": `C:\c\values5.yaml`}},
 							}},
@@ -53,19 +53,19 @@ func TestSetAbsFilePaths(t *testing.T) {
 				},
 			},
 			base: `C:\a\b`,
-			expected: &latest.SkaffoldConfig{
-				Pipeline: latest.Pipeline{
-					Build: latest.BuildConfig{
-						Artifacts: []*latest.Artifact{
+			expected: &latest_v1.SkaffoldConfig{
+				Pipeline: latest_v1.Pipeline{
+					Build: latest_v1.BuildConfig{
+						Artifacts: []*latest_v1.Artifact{
 							{ImageName: "foo1", Workspace: `C:\a\b\foo`},
 							{ImageName: "foo2", Workspace: `C:\a\foo`},
 						},
 					},
-					Deploy: latest.DeployConfig{
-						DeployType: latest.DeployType{
-							KptDeploy:     &latest.KptDeploy{Dir: `C:\a\b`},
-							KubectlDeploy: &latest.KubectlDeploy{Manifests: []string{`C:\a\b\foo\*`, `C:\a\foo\*`}},
-							HelmDeploy: &latest.HelmDeploy{Releases: []latest.HelmRelease{
+					Deploy: latest_v1.DeployConfig{
+						DeployType: latest_v1.DeployType{
+							KptDeploy:     &latest_v1.KptDeploy{Dir: `C:\a\b`},
+							KubectlDeploy: &latest_v1.KubectlDeploy{Manifests: []string{`C:\a\b\foo\*`, `C:\a\foo\*`}},
+							HelmDeploy: &latest_v1.HelmDeploy{Releases: []latest_v1.HelmRelease{
 								{ChartPath: `C:\a\charts`, ValuesFiles: []string{`C:\a\b\values1.yaml`, `C:\a\b\values2.yaml`}, SetFiles: map[string]string{"envFile": `C:\a\b\values3.yaml`, "configFile": `C:\a\b\values4.yaml`, "anotherFile": `C:\c\values5.yaml`}},
 								{RemoteChart: "foo/bar", ValuesFiles: []string{`C:\a\b\values1.yaml`, `C:\a\b\values2.yaml`}, SetFiles: map[string]string{"envFile": `C:\a\b\values3.yaml`, "configFile": `C:\a\b\values4.yaml`, "anotherFile": `C:\c\values5.yaml`}},
 							}},

--- a/pkg/skaffold/test/custom/custom.go
+++ b/pkg/skaffold/test/custom/custom.go
@@ -30,7 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -42,13 +42,13 @@ var (
 const Windows string = "windows"
 
 type Runner struct {
-	customTest latest.CustomTest
+	customTest latest_v1.CustomTest
 	imageName  string
 	workspace  string
 }
 
 // New creates a new custom.Runner.
-func New(cfg docker.Config, imageName string, ws string, ct latest.CustomTest) (*Runner, error) {
+func New(cfg docker.Config, imageName string, ws string, ct latest_v1.CustomTest) (*Runner, error) {
 	return &Runner{
 		imageName:  imageName,
 		customTest: ct,

--- a/pkg/skaffold/test/custom/custom_test.go
+++ b/pkg/skaffold/test/custom/custom_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	testEvent "github.com/GoogleContainerTools/skaffold/testutil/event"
@@ -40,25 +40,25 @@ func TestNewCustomTestRunner(t *testing.T) {
 		}
 		tmpDir := t.NewTempDir().Touch("test.yaml")
 
-		custom := latest.CustomTest{
+		custom := latest_v1.CustomTest{
 			Command:        "echo Running Custom Test command.",
 			TimeoutSeconds: 10,
-			Dependencies: &latest.CustomTestDependencies{
+			Dependencies: &latest_v1.CustomTestDependencies{
 				Paths:  []string{"**"},
 				Ignore: []string{"b*"},
 			},
 		}
 
-		testCase := &latest.TestCase{
+		testCase := &latest_v1.TestCase{
 			ImageName:   "image",
 			Workspace:   tmpDir.Root(),
-			CustomTests: []latest.CustomTest{custom},
+			CustomTests: []latest_v1.CustomTest{custom},
 		}
 
 		cfg := &mockConfig{
-			tests: []*latest.TestCase{testCase},
+			tests: []*latest_v1.TestCase{testCase},
 		}
-		testEvent.InitializeState([]latest.Pipeline{{}})
+		testEvent.InitializeState([]latest_v1.Pipeline{{}})
 
 		testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, custom)
 		t.CheckNoError(err)
@@ -71,7 +71,7 @@ func TestNewCustomTestRunner(t *testing.T) {
 func TestCustomCommandError(t *testing.T) {
 	tests := []struct {
 		description        string
-		custom             latest.CustomTest
+		custom             latest_v1.CustomTest
 		shouldErr          bool
 		expectedCmd        string
 		expectedWindowsCmd string
@@ -79,7 +79,7 @@ func TestCustomCommandError(t *testing.T) {
 	}{
 		{
 			description: "Non zero exit",
-			custom: latest.CustomTest{
+			custom: latest_v1.CustomTest{
 				Command: "exit 20",
 			},
 			shouldErr:          true,
@@ -89,7 +89,7 @@ func TestCustomCommandError(t *testing.T) {
 		},
 		{
 			description: "Command timed out",
-			custom: latest.CustomTest{
+			custom: latest_v1.CustomTest{
 				Command:        "sleep 20",
 				TimeoutSeconds: 2,
 			},
@@ -108,16 +108,16 @@ func TestCustomCommandError(t *testing.T) {
 			}
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunErr(command, fmt.Errorf(test.expectedError)))
 
-			testCase := &latest.TestCase{
+			testCase := &latest_v1.TestCase{
 				ImageName:   "image",
 				Workspace:   tmpDir.Root(),
-				CustomTests: []latest.CustomTest{test.custom},
+				CustomTests: []latest_v1.CustomTest{test.custom},
 			}
 
 			cfg := &mockConfig{
-				tests: []*latest.TestCase{testCase},
+				tests: []*latest_v1.TestCase{testCase},
 			}
-			testEvent.InitializeState([]latest.Pipeline{{}})
+			testEvent.InitializeState([]latest_v1.Pipeline{{}})
 
 			testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, test.custom)
 			t.CheckNoError(err)
@@ -136,23 +136,23 @@ func TestTestDependenciesCommand(t *testing.T) {
 	testutil.Run(t, "Testing new custom test runner", func(t *testutil.T) {
 		tmpDir := t.NewTempDir().Touch("test.yaml")
 
-		custom := latest.CustomTest{
+		custom := latest_v1.CustomTest{
 			Command: "echo Hello!",
-			Dependencies: &latest.CustomTestDependencies{
+			Dependencies: &latest_v1.CustomTestDependencies{
 				Command: "echo [\"file1\",\"file2\",\"file3\"]",
 			},
 		}
 
-		testCase := &latest.TestCase{
+		testCase := &latest_v1.TestCase{
 			ImageName:   "image",
 			Workspace:   tmpDir.Root(),
-			CustomTests: []latest.CustomTest{custom},
+			CustomTests: []latest_v1.CustomTest{custom},
 		}
 
 		cfg := &mockConfig{
-			tests: []*latest.TestCase{testCase},
+			tests: []*latest_v1.TestCase{testCase},
 		}
-		testEvent.InitializeState([]latest.Pipeline{{}})
+		testEvent.InitializeState([]latest_v1.Pipeline{{}})
 
 		if runtime.GOOS == Windows {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunOut(
@@ -219,24 +219,24 @@ func TestTestDependenciesPaths(t *testing.T) {
 			tmpDir := t.NewTempDir().
 				Touch("foo", "bar", "baz/file")
 
-			custom := latest.CustomTest{
+			custom := latest_v1.CustomTest{
 				Command: "echo Hello!",
-				Dependencies: &latest.CustomTestDependencies{
+				Dependencies: &latest_v1.CustomTestDependencies{
 					Paths:  test.paths,
 					Ignore: test.ignore,
 				},
 			}
 
-			testCase := &latest.TestCase{
+			testCase := &latest_v1.TestCase{
 				ImageName:   "image",
 				Workspace:   tmpDir.Root(),
-				CustomTests: []latest.CustomTest{custom},
+				CustomTests: []latest_v1.CustomTest{custom},
 			}
 
 			cfg := &mockConfig{
-				tests: []*latest.TestCase{testCase},
+				tests: []*latest_v1.TestCase{testCase},
 			}
-			testEvent.InitializeState([]latest.Pipeline{{}})
+			testEvent.InitializeState([]latest_v1.Pipeline{{}})
 
 			testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, custom)
 			t.CheckNoError(err)
@@ -276,20 +276,20 @@ func TestGetEnv(t *testing.T) {
 			t.Override(&testContext, func(string) (string, error) { return test.testContext, nil })
 			tmpDir := t.NewTempDir().Touch("test.yaml")
 
-			custom := latest.CustomTest{
+			custom := latest_v1.CustomTest{
 				Command: "echo Running Custom Test command.",
 			}
 
-			testCase := &latest.TestCase{
+			testCase := &latest_v1.TestCase{
 				ImageName:   "image",
 				Workspace:   tmpDir.Root(),
-				CustomTests: []latest.CustomTest{custom},
+				CustomTests: []latest_v1.CustomTest{custom},
 			}
 
 			cfg := &mockConfig{
-				tests: []*latest.TestCase{testCase},
+				tests: []*latest_v1.TestCase{testCase},
 			}
-			testEvent.InitializeState([]latest.Pipeline{{}})
+			testEvent.InitializeState([]latest_v1.Pipeline{{}})
 
 			testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, custom)
 			t.CheckNoError(err)
@@ -303,5 +303,5 @@ func TestGetEnv(t *testing.T) {
 
 type mockConfig struct {
 	runcontext.RunContext // Embedded to provide the default values.
-	tests                 []*latest.TestCase
+	tests                 []*latest_v1.TestCase
 }

--- a/pkg/skaffold/test/structure/structure.go
+++ b/pkg/skaffold/test/structure/structure.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -40,7 +40,7 @@ type Runner struct {
 }
 
 // New creates a new structure.Runner.
-func New(cfg docker.Config, tc *latest.TestCase, imageIsLocal bool) (*Runner, error) {
+func New(cfg docker.Config, tc *latest_v1.TestCase, imageIsLocal bool) (*Runner, error) {
 	localDaemon, err := docker.NewAPIClient(cfg)
 	if err != nil {
 		return nil, err

--- a/pkg/skaffold/test/structure/structure_test.go
+++ b/pkg/skaffold/test/structure/structure_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	testEvent "github.com/GoogleContainerTools/skaffold/testutil/event"
@@ -46,19 +46,19 @@ func TestNewRunner(t *testing.T) {
 		t.Override(&util.DefaultExecCommand, testutil.CmdRun("container-structure-test test -v warn --image "+imageName+" --config "+tmpDir.Path("test.yaml")))
 
 		cfg := &mockConfig{
-			tests: []*latest.TestCase{{
+			tests: []*latest_v1.TestCase{{
 				ImageName:      "image",
 				Workspace:      tmpDir.Root(),
 				StructureTests: []string{"test.yaml"},
 			}},
 		}
 
-		testCase := &latest.TestCase{
+		testCase := &latest_v1.TestCase{
 			ImageName:      "image",
 			Workspace:      tmpDir.Root(),
 			StructureTests: []string{"test.yaml"},
 		}
-		testEvent.InitializeState([]latest.Pipeline{{}})
+		testEvent.InitializeState([]latest_v1.Pipeline{{}})
 
 		testRunner, err := New(cfg, testCase, true)
 		t.CheckNoError(err)
@@ -75,14 +75,14 @@ func TestIgnoreDockerNotFound(t *testing.T) {
 		})
 
 		cfg := &mockConfig{
-			tests: []*latest.TestCase{{
+			tests: []*latest_v1.TestCase{{
 				ImageName:      "image",
 				Workspace:      tmpDir.Root(),
 				StructureTests: []string{"test.yaml"},
 			}},
 		}
 
-		testCase := &latest.TestCase{
+		testCase := &latest_v1.TestCase{
 			ImageName:      "image",
 			Workspace:      tmpDir.Root(),
 			StructureTests: []string{"test.yaml"},
@@ -96,10 +96,10 @@ func TestIgnoreDockerNotFound(t *testing.T) {
 
 type mockConfig struct {
 	runcontext.RunContext // Embedded to provide the default values.
-	tests                 []*latest.TestCase
+	tests                 []*latest_v1.TestCase
 	muted                 config.Muted
 }
 
 func (c *mockConfig) Muted() config.Muted { return c.muted }
 
-func (c *mockConfig) TestCases() []*latest.TestCase { return c.tests }
+func (c *mockConfig) TestCases() []*latest_v1.TestCase { return c.tests }

--- a/pkg/skaffold/test/test_factory.go
+++ b/pkg/skaffold/test/test_factory.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/logfile"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/test/custom"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/test/structure"
 )
@@ -35,7 +35,7 @@ import (
 type Config interface {
 	docker.Config
 
-	TestCases() []*latest.TestCase
+	TestCases() []*latest_v1.TestCase
 	Muted() config.Muted
 }
 
@@ -55,7 +55,7 @@ func NewTester(cfg Config, imagesAreLocal func(imageName string) (bool, error)) 
 }
 
 // TestDependencies returns the watch dependencies for the target artifact to the runner.
-func (t FullTester) TestDependencies(artifact *latest.Artifact) ([]string, error) {
+func (t FullTester) TestDependencies(artifact *latest_v1.Artifact) ([]string, error) {
 	var deps []string
 	for _, tester := range t.Testers[artifact.ImageName] {
 		result, err := tester.TestDependencies()
@@ -113,7 +113,7 @@ func (t FullTester) runTests(ctx context.Context, out io.Writer, bRes []graph.Ar
 	return nil
 }
 
-func getImageTesters(cfg docker.Config, imagesAreLocal func(imageName string) (bool, error), tcs []*latest.TestCase) (ImageTesters, error) {
+func getImageTesters(cfg docker.Config, imagesAreLocal func(imageName string) (bool, error), tcs []*latest_v1.TestCase) (ImageTesters, error) {
 	runners := make(map[string][]ImageTester)
 	for _, tc := range tcs {
 		isLocal, err := imagesAreLocal(tc.ImageName)

--- a/pkg/skaffold/test/test_factory_test.go
+++ b/pkg/skaffold/test/test_factory_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	testEvent "github.com/GoogleContainerTools/skaffold/testutil/event"
@@ -44,7 +44,7 @@ func TestNoTestDependencies(t *testing.T) {
 		cfg := &mockConfig{}
 		tester, err := NewTester(cfg, func(imageName string) (bool, error) { return true, nil })
 		t.CheckNoError(err)
-		deps, err := tester.TestDependencies(&latest.Artifact{ImageName: "foo"})
+		deps, err := tester.TestDependencies(&latest_v1.Artifact{ImageName: "foo"})
 		t.CheckNoError(err)
 		t.CheckEmpty(deps)
 	})
@@ -55,7 +55,7 @@ func TestTestDependencies(t *testing.T) {
 		tmpDir := t.NewTempDir().Touch("tests/test1.yaml", "tests/test2.yaml", "test3.yaml")
 
 		cfg := &mockConfig{
-			tests: []*latest.TestCase{
+			tests: []*latest_v1.TestCase{
 				{StructureTests: []string{"./tests/*"}, Workspace: tmpDir.Root(), ImageName: "foo"},
 				{},
 				{StructureTests: []string{"test3.yaml"}, Workspace: tmpDir.Root(), ImageName: "foo"},
@@ -64,7 +64,7 @@ func TestTestDependencies(t *testing.T) {
 
 		tester, err := NewTester(cfg, func(imageName string) (bool, error) { return true, nil })
 		t.CheckNoError(err)
-		deps, err := tester.TestDependencies(&latest.Artifact{ImageName: "foo"})
+		deps, err := tester.TestDependencies(&latest_v1.Artifact{ImageName: "foo"})
 
 		expectedDeps := tmpDir.Paths("tests/test1.yaml", "tests/test2.yaml", "test3.yaml")
 		t.CheckNoError(err)
@@ -75,7 +75,7 @@ func TestTestDependencies(t *testing.T) {
 func TestWrongPattern(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		cfg := &mockConfig{
-			tests: []*latest.TestCase{{
+			tests: []*latest_v1.TestCase{{
 				ImageName:      "image",
 				StructureTests: []string{"[]"},
 			}},
@@ -84,9 +84,9 @@ func TestWrongPattern(t *testing.T) {
 		tester, err := NewTester(cfg, func(imageName string) (bool, error) { return true, nil })
 		t.CheckNoError(err)
 
-		_, err = tester.TestDependencies(&latest.Artifact{ImageName: "image"})
+		_, err = tester.TestDependencies(&latest_v1.Artifact{ImageName: "image"})
 		t.CheckError(true, err)
-		testEvent.InitializeState([]latest.Pipeline{{}})
+		testEvent.InitializeState([]latest_v1.Pipeline{{}})
 
 		err = tester.Test(context.Background(), ioutil.Discard, []graph.Artifact{{
 			ImageName: "image",
@@ -118,7 +118,7 @@ func TestTestSuccess(t *testing.T) {
 			AndRun("container-structure-test test -v warn --image image:tag --config "+tmpDir.Path("test3.yaml")))
 
 		cfg := &mockConfig{
-			tests: []*latest.TestCase{
+			tests: []*latest_v1.TestCase{
 				{
 					ImageName:      "image",
 					Workspace:      tmpDir.Root(),
@@ -158,7 +158,7 @@ func TestTestSuccessRemoteImage(t *testing.T) {
 		})
 
 		cfg := &mockConfig{
-			tests: []*latest.TestCase{{
+			tests: []*latest_v1.TestCase{{
 				ImageName:      "image",
 				StructureTests: []string{"test.yaml"},
 			}},
@@ -186,7 +186,7 @@ func TestTestFailureRemoteImage(t *testing.T) {
 		})
 
 		cfg := &mockConfig{
-			tests: []*latest.TestCase{{
+			tests: []*latest_v1.TestCase{{
 				ImageName:      "image",
 				StructureTests: []string{"test.yaml"},
 			}},
@@ -215,7 +215,7 @@ func TestTestFailure(t *testing.T) {
 		))
 
 		cfg := &mockConfig{
-			tests: []*latest.TestCase{
+			tests: []*latest_v1.TestCase{
 				{
 					ImageName:      "broken-image",
 					StructureTests: []string{"test.yaml"},
@@ -240,7 +240,7 @@ func TestTestMuted(t *testing.T) {
 		t.Override(&util.DefaultExecCommand, testutil.CmdRun("container-structure-test test -v warn --image image:tag --config "+tmpDir.Path("test.yaml")))
 
 		cfg := &mockConfig{
-			tests: []*latest.TestCase{{
+			tests: []*latest_v1.TestCase{{
 				ImageName:      "image",
 				Workspace:      tmpDir.Root(),
 				StructureTests: []string{"test.yaml"},
@@ -270,10 +270,10 @@ func fakeLocalDaemon(api client.CommonAPIClient) docker.LocalDaemon {
 
 type mockConfig struct {
 	runcontext.RunContext // Embedded to provide the default values.
-	tests                 []*latest.TestCase
+	tests                 []*latest_v1.TestCase
 	muted                 config.Muted
 }
 
 func (c *mockConfig) Muted() config.Muted { return c.muted }
 
-func (c *mockConfig) TestCases() []*latest.TestCase { return c.tests }
+func (c *mockConfig) TestCases() []*latest_v1.TestCase { return c.tests }

--- a/pkg/skaffold/test/types.go
+++ b/pkg/skaffold/test/types.go
@@ -21,7 +21,7 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // Tester is the top level test executor in Skaffold.
@@ -30,7 +30,7 @@ import (
 // a single test run.
 type Tester interface {
 	Test(context.Context, io.Writer, []graph.Artifact) error
-	TestDependencies(*latest.Artifact) ([]string, error)
+	TestDependencies(*latest_v1.Artifact) ([]string, error)
 }
 
 type Muted interface {

--- a/pkg/skaffold/trigger/triggers.go
+++ b/pkg/skaffold/trigger/triggers.go
@@ -29,7 +29,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	fsNotify "github.com/GoogleContainerTools/skaffold/pkg/skaffold/trigger/fsnotify"
 )
 
@@ -42,7 +42,7 @@ type Trigger interface {
 
 type Config interface {
 	Trigger() string
-	Artifacts() []*latest.Artifact
+	Artifacts() []*latest_v1.Artifact
 	WatchPollInterval() int
 }
 

--- a/pkg/skaffold/trigger/triggers_test.go
+++ b/pkg/skaffold/trigger/triggers_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/rjeczalik/notify"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	fsNotify "github.com/GoogleContainerTools/skaffold/pkg/skaffold/trigger/fsnotify"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -71,7 +71,7 @@ func TestNewTrigger(t *testing.T) {
 			cfg := &mockConfig{
 				trigger:           test.trigger,
 				watchPollInterval: test.watchPollInterval,
-				artifacts: []*latest.Artifact{
+				artifacts: []*latest_v1.Artifact{
 					{Workspace: "../workspace"},
 					{Workspace: "../workspace"},
 					{Workspace: "../some/other/workspace"},
@@ -208,9 +208,9 @@ func TestStartTrigger(t *testing.T) {
 type mockConfig struct {
 	trigger           string
 	watchPollInterval int
-	artifacts         []*latest.Artifact
+	artifacts         []*latest_v1.Artifact
 }
 
-func (c *mockConfig) Trigger() string               { return c.trigger }
-func (c *mockConfig) WatchPollInterval() int        { return c.watchPollInterval }
-func (c *mockConfig) Artifacts() []*latest.Artifact { return c.artifacts }
+func (c *mockConfig) Trigger() string                  { return c.trigger }
+func (c *mockConfig) WatchPollInterval() int           { return c.watchPollInterval }
+func (c *mockConfig) Artifacts() []*latest_v1.Artifact { return c.artifacts }

--- a/pkg/skaffold/util/util_test.go
+++ b/pkg/skaffold/util/util_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -183,8 +183,8 @@ func TestCloneThroughJSON(t *testing.T) {
 			old: map[string]string{
 				"projectId": "unit-test",
 			},
-			new: &latest.GoogleCloudBuild{},
-			expected: &latest.GoogleCloudBuild{
+			new: &latest_v1.GoogleCloudBuild{},
+			expected: &latest_v1.GoogleCloudBuild{
 				ProjectID: "unit-test",
 			},
 		},
@@ -210,8 +210,8 @@ func TestCloneThroughYAML(t *testing.T) {
 			old: map[string]string{
 				"projectId": "unit-test",
 			},
-			new: &latest.GoogleCloudBuild{},
-			expected: &latest.GoogleCloudBuild{
+			new: &latest_v1.GoogleCloudBuild{},
+			expected: &latest_v1.GoogleCloudBuild{
 				ProjectID: "unit-test",
 			},
 		},

--- a/pkg/skaffold/version/version.go
+++ b/pkg/skaffold/version/version.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/blang/semver"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 var version, gitCommit, buildDate string
@@ -46,7 +46,7 @@ var Get = func() *Info {
 	// These variables typically come from -ldflags settings to `go build`
 	return &Info{
 		Version:       version,
-		ConfigVersion: latest.Version,
+		ConfigVersion: latest_v1.Version,
 		GitCommit:     gitCommit,
 		BuildDate:     buildDate,
 		GoVersion:     runtime.Version(),

--- a/pkg/skaffold/yamltags/tags.go
+++ b/pkg/skaffold/yamltags/tags.go
@@ -76,7 +76,7 @@ func GetYamlTag(value interface{}) string {
 }
 
 // GetYamlKeys returns the yaml key for each non-nested field of the given non-nil config parameter
-// For example if config is `latest.DeployType{HelmDeploy: &HelmDeploy{...}, KustomizeDeploy: &KustomizeDeploy{...}}`
+// For example if config is `latest_v1.DeployType{HelmDeploy: &HelmDeploy{...}, KustomizeDeploy: &KustomizeDeploy{...}}`
 // then it returns `["helm", "kustomize"]`
 func GetYamlKeys(config interface{}) []string {
 	var tags []string

--- a/testutil/event/config.go
+++ b/testutil/event/config.go
@@ -19,10 +19,10 @@ package event
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
-func InitializeState(pipes []latest.Pipeline) {
+func InitializeState(pipes []latest_v1.Pipeline) {
 	cfg := config{
 		pipes: pipes,
 	}
@@ -31,11 +31,11 @@ func InitializeState(pipes []latest.Pipeline) {
 }
 
 type config struct {
-	pipes []latest.Pipeline
+	pipes []latest_v1.Pipeline
 }
 
-func (c config) AutoBuild() bool                 { return true }
-func (c config) AutoDeploy() bool                { return true }
-func (c config) AutoSync() bool                  { return true }
-func (c config) GetPipelines() []latest.Pipeline { return c.pipes }
-func (c config) GetKubeContext() string          { return "temp" }
+func (c config) AutoBuild() bool                    { return true }
+func (c config) AutoDeploy() bool                   { return true }
+func (c config) AutoSync() bool                     { return true }
+func (c config) GetPipelines() []latest_v1.Pipeline { return c.pipes }
+func (c config) GetKubeContext() string             { return "temp" }


### PR DESCRIPTION
**Related**: #5727

**Description**
- In pkg/skaffold/schema, move ./latest/* to ./latest/v1/* (so as later on once we add v2, v1 and v2 can both be imported as latest)
- Update the reference of "latest" to "latest_v1" (pkg/ cmd/ integration/)
- Fix build.ArtifactDependencies reference in pkg/build/maven.

Note: We use alias `latest_v1` instead of `v1` to import package pkg/skaffold/schema/latest/v1.
The "latest" prefix is to distinguish another "v1" package which is also under pkg/skaffold/schema

**Follow-up Work**
- add v3alpha*
- create latest/v2 to track v3 API schema
- bisect the latest_v1 reference to accept v2 packages.

## To reviewers 
the main change is about the new directory `pkg/skaffold/schema/latest/v1`, whose `config.go` and `upgrade.go` are from `pkg/skaffold/schema/latest`. The other 240+ files are just updating the package import to "latest/v1".  
