### PR TITLE
Default to empty secret path for Kaniko to use Workload Identity credentials

### DIFF
--- a/pkg/skaffold/build/cluster/pod.go
+++ b/pkg/skaffold/build/cluster/pod.go
@@ -122,14 +122,7 @@ func (b *Builder) kanikoPodSpec(artifact *latest_v1.KanikoArtifact, tag string) 
 }
 
 func (b *Builder) env(artifact *latest_v1.KanikoArtifact, httpProxy, httpsProxy string) []v1.EnvVar {
-	pullSecretPath := strings.Join(
-		[]string{b.ClusterDetails.PullSecretMountPath, b.ClusterDetails.PullSecretPath},
-		"/", // linux filepath separator.
-	)
 	env := []v1.EnvVar{{
-		Name:  "GOOGLE_APPLICATION_CREDENTIALS",
-		Value: pullSecretPath,
-	}, {
 		// This should be same https://github.com/GoogleContainerTools/kaniko/blob/77cfb912f3483c204bfd09e1ada44fd200b15a78/pkg/executor/push.go#L49
 		Name:  "UPSTREAM_CLIENT_TYPE",
 		Value: fmt.Sprintf("UpstreamClient(skaffold-%s)", version.Get().Version),
@@ -155,6 +148,18 @@ func (b *Builder) env(artifact *latest_v1.KanikoArtifact, httpProxy, httpsProxy 
 		})
 	}
 
+	// if cluster.PullSecretName  is non-empty populate secret path and use as GOOGLE_APPLICATION_CREDENTIALS
+	// by default it is not empty, so need to
+	if b.ClusterDetails.PullSecretName != "" {
+		pullSecretPath := strings.Join(
+			[]string{b.ClusterDetails.PullSecretMountPath, b.ClusterDetails.PullSecretPath},
+			"/", // linux filepath separator.
+		)
+		env = append(env, v1.EnvVar{
+			Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+			Value: pullSecretPath,
+		})
+	}
 	return env
 }
 

--- a/pkg/skaffold/build/cluster/pod_test.go
+++ b/pkg/skaffold/build/cluster/pod_test.go
@@ -283,9 +283,6 @@ func TestKanikoPodSpec(t *testing.T) {
 				Args:            []string{"--dockerfile", "Dockerfile", "--context", "dir:///kaniko/buildcontext", "--destination", "tag", "-v", "info"},
 				ImagePullPolicy: v1.PullIfNotPresent,
 				Env: []v1.EnvVar{{
-					Name:  "GOOGLE_APPLICATION_CREDENTIALS",
-					Value: "/secret/kaniko-secret.json",
-				}, {
 					Name:  "UPSTREAM_CLIENT_TYPE",
 					Value: "UpstreamClient(skaffold-)",
 				}, {
@@ -297,6 +294,9 @@ func TestKanikoPodSpec(t *testing.T) {
 				}, {
 					Name:  "HTTPS_PROXY",
 					Value: "https://proxy",
+				}, {
+					Name:  "GOOGLE_APPLICATION_CREDENTIALS",
+					Value: "/secret/kaniko-secret.json",
 				}},
 				VolumeMounts: []v1.VolumeMount{
 					{


### PR DESCRIPTION
Fixes: #3468


**Description**
If `GOOGLE_APPLICATION_CREDENTIALS` is set, Kaniko doesn't opt for using Workload Identity. Current setup always forces non-empty `GOOGLE_APPLICATION_CREDENTIALS` value. Proposed change make empty value default for `pullSecretPath`, unless MountPath is specified in the config. This in turn prevents `GOOGLE_APPLICATION_CREDENTIALS` from being set.
