### PR TITLE
Add user flag with allowed user list to upload metrics

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -86,6 +86,15 @@ var flagRegistry = []Flag{
 		DefinedOn:     []string{"all"},
 	},
 	{
+		Name:          "user",
+		Shorthand:     "u",
+		Value:         &opts.User,
+		DefValue:      "",
+		FlagAddMethod: "StringVar",
+		Hidden:        true,
+		DefinedOn:     []string{"all"},
+	},
+	{
 		Name:          "profile",
 		Shorthand:     "p",
 		Usage:         "Activate profiles by name (prefixed with `-` to disable a profile)",

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -63,7 +63,7 @@ func createNewRunner(out io.Writer, opts config.SkaffoldOptions) (runner.Runner,
 		return nil, nil, nil, err
 	}
 
-	instrumentation.InitMeterFromConfig(configs)
+	instrumentation.InitMeterFromConfig(configs, opts.User)
 	runner, err := runner.NewForConfig(runCtx)
 	if err != nil {
 		event.InititializationFailed(err)

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -39,6 +39,7 @@ type SkaffoldOptions struct {
 	GlobalConfig          string
 	EventLogFile          string
 	RenderOutput          string
+	User                  string
 	Apply                 bool
 	Cleanup               bool
 	Notification          bool

--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -142,7 +142,7 @@ func initCloudMonitoringExporterMetrics() (*push.Controller, error) {
 
 func devStdOutExporter() (*push.Controller, error) {
 	// export metrics to std out if local env is set.
-	if isLocal := os.Getenv("EXPORT_TO_STDOUT"); isLocal != "" {
+	if isLocal := os.Getenv("SKAFFOLD_EXPORT_TO_STDOUT"); isLocal != "" {
 		return stdout.InstallNewPipeline([]stdout.Option{
 			stdout.WithQuantiles([]float64{0.5}),
 			stdout.WithPrettyPrint(),

--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -170,11 +170,14 @@ func createMetrics(ctx context.Context, meter skaffoldMeter) {
 		label.String("error", meter.ErrorCode.String()),
 		label.String("platform_type", meter.PlatformType),
 		label.String("config_count", strconv.Itoa(meter.ConfigCount)),
+	}
+	sharedLabels := []label.KeyValue{
 		randLabel,
 	}
 	if _, ok := allowedUsers[meter.User]; ok {
-		labels = append(labels, label.String("user", meter.User))
+		sharedLabels = append(sharedLabels, label.String("user", meter.User))
 	}
+	labels = append(labels, sharedLabels...)
 
 	runCounter := metric.Must(m).NewInt64ValueRecorder("launches", metric.WithDescription("Skaffold Invocations"))
 	runCounter.Record(ctx, 1, labels...)
@@ -183,18 +186,18 @@ func createMetrics(ctx context.Context, meter skaffoldMeter) {
 		metric.WithDescription("durations of skaffold commands in seconds"))
 	durationRecorder.Record(ctx, meter.Duration.Seconds(), labels...)
 	if meter.Command != "" {
-		commandMetrics(ctx, meter, m, randLabel)
+		commandMetrics(ctx, meter, m, sharedLabels...)
 		flagMetrics(ctx, meter, m, randLabel)
 		if doesBuild.Contains(meter.Command) {
-			builderMetrics(ctx, meter, m, randLabel)
+			builderMetrics(ctx, meter, m, sharedLabels...)
 		}
 		if doesDeploy.Contains(meter.Command) {
-			deployerMetrics(ctx, meter, m, randLabel)
+			deployerMetrics(ctx, meter, m, sharedLabels...)
 		}
 	}
 
 	if meter.ErrorCode != 0 {
-		errorMetrics(ctx, meter, m, randLabel)
+		errorMetrics(ctx, meter, m, sharedLabels...)
 	}
 }
 
@@ -212,13 +215,10 @@ func flagMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, randL
 	}
 }
 
-func commandMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, randLabel label.KeyValue) {
+func commandMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, labels ...label.KeyValue) {
 	commandCounter := metric.Must(m).NewInt64ValueRecorder(meter.Command,
 		metric.WithDescription(fmt.Sprintf("Number of times %s is used", meter.Command)))
-	labels := []label.KeyValue{
-		label.String("error", meter.ErrorCode.String()),
-		randLabel,
-	}
+	labels = append(labels, label.String("error", meter.ErrorCode.String()))
 	commandCounter.Record(ctx, 1, labels...)
 
 	if meter.Command == "dev" || meter.Command == "debug" {
@@ -237,55 +237,56 @@ func commandMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, ra
 		for intention, errorCounts := range counts {
 			for errorCode, count := range errorCounts {
 				iterationCounter.Record(ctx, int64(count),
-					label.String("intent", intention),
-					label.String("error", errorCode.String()),
-					randLabel)
+					append(labels,
+						label.String("intent", intention),
+						label.String("error", errorCode.String()),
+					)...)
 			}
 		}
 	}
 }
 
-func deployerMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, randLabel label.KeyValue) {
+func deployerMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, labels ...label.KeyValue) {
 	deployerCounter := metric.Must(m).NewInt64ValueRecorder("deployer", metric.WithDescription("Deployers used"))
 	for _, deployer := range meter.Deployers {
-		deployerCounter.Record(ctx, 1, randLabel, label.String("deployer", deployer))
+		deployerCounter.Record(ctx, 1, append(labels, label.String("deployer", deployer))...)
 	}
 	if meter.HelmReleasesCount > 0 {
 		multiReleasesCounter := metric.Must(m).NewInt64ValueRecorder("helmReleases", metric.WithDescription("Multiple helm releases used"))
-		multiReleasesCounter.Record(ctx, 1, randLabel, label.Int("count", meter.HelmReleasesCount))
+		multiReleasesCounter.Record(ctx, 1, append(labels, label.Int("count", meter.HelmReleasesCount))...)
 	}
 }
 
-func builderMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, randLabel label.KeyValue) {
+func builderMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, labels ...label.KeyValue) {
 	builderCounter := metric.Must(m).NewInt64ValueRecorder("builders", metric.WithDescription("Builders used"))
 	artifactCounter := metric.Must(m).NewInt64ValueRecorder("artifacts", metric.WithDescription("Number of artifacts used"))
 	dependenciesCounter := metric.Must(m).NewInt64ValueRecorder("artifact-dependencies", metric.WithDescription("Number of artifacts with dependencies"))
 	for builder, count := range meter.Builders {
 		bLabel := label.String("builder", builder)
-		builderCounter.Record(ctx, 1, bLabel, randLabel)
-		artifactCounter.Record(ctx, int64(count), bLabel, randLabel)
-		dependenciesCounter.Record(ctx, int64(meter.BuildDependencies[builder]), bLabel, randLabel)
+		builderCounter.Record(ctx, 1, append(labels, bLabel)...)
+		artifactCounter.Record(ctx, int64(count), append(labels, bLabel)...)
+		dependenciesCounter.Record(ctx, int64(meter.BuildDependencies[builder]), append(labels, bLabel)...)
 	}
 }
 
-func errorMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, randLabel label.KeyValue) {
+func errorMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, labels ...label.KeyValue) {
 	errCounter := metric.Must(m).NewInt64ValueRecorder("errors", metric.WithDescription("Skaffold errors"))
-	errCounter.Record(ctx, 1, label.String("error", meter.ErrorCode.String()), randLabel)
+	errCounter.Record(ctx, 1, append(labels, label.String("error", meter.ErrorCode.String()))...)
 
-	commandLabel := label.String("command", meter.Command)
+	labels = append(labels, label.String("command", meter.Command))
 
 	switch meter.ErrorCode {
 	case proto.StatusCode_UNKNOWN_ERROR:
 		unknownErrCounter := metric.Must(m).NewInt64ValueRecorder("errors/unknown", metric.WithDescription("Unknown Skaffold Errors"))
-		unknownErrCounter.Record(ctx, 1, randLabel)
+		unknownErrCounter.Record(ctx, 1, labels...)
 	case proto.StatusCode_TEST_UNKNOWN:
 		unknownCounter := metric.Must(m).NewInt64ValueRecorder("test/unknown", metric.WithDescription("Unknown test Skaffold Errors"))
-		unknownCounter.Record(ctx, 1, commandLabel, randLabel)
+		unknownCounter.Record(ctx, 1, labels...)
 	case proto.StatusCode_DEPLOY_UNKNOWN:
 		unknownCounter := metric.Must(m).NewInt64ValueRecorder("deploy/unknown", metric.WithDescription("Unknown deploy Skaffold Errors"))
-		unknownCounter.Record(ctx, 1, commandLabel, randLabel)
+		unknownCounter.Record(ctx, 1, labels...)
 	case proto.StatusCode_BUILD_UNKNOWN:
 		unknownCounter := metric.Must(m).NewInt64ValueRecorder("build/unknown", metric.WithDescription("Unknown build Skaffold Errors"))
-		unknownCounter.Record(ctx, 1, commandLabel, randLabel)
+		unknownCounter.Record(ctx, 1, labels...)
 	}
 }

--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -74,7 +74,7 @@ func SetOnlineStatus() {
 	}()
 }
 
-func InitMeterFromConfig(configs []*latest.SkaffoldConfig) {
+func InitMeterFromConfig(configs []*latest.SkaffoldConfig, user string) {
 	var platforms []string
 	for _, config := range configs {
 		pl := yamltags.GetYamlTag(config.Build.BuildType)
@@ -98,6 +98,7 @@ func InitMeterFromConfig(configs []*latest.SkaffoldConfig) {
 	}
 	meter.PlatformType = strings.Join(platforms, ":")
 	meter.ConfigCount = len(configs)
+	meter.User = strings.ToLower(user)
 }
 
 func SetCommand(cmd string) {

--- a/pkg/skaffold/instrumentation/types.go
+++ b/pkg/skaffold/instrumentation/types.go
@@ -51,6 +51,9 @@ type skaffoldMeter struct {
 	// PlatformType Where Skaffold is building artifacts (local, cluster, Google Cloud Build, or a combination of them).
 	PlatformType string
 
+	// User indicates the client invoking skaffold. Is one of allowedUser i.e. vsc, intellij, gcloud
+	User string
+
 	// Deployers All the deployers used in the Skaffold execution.
 	Deployers []string
 


### PR DESCRIPTION
Relates to #5711

In this PR, add a hidden `--user` flag to skaffold which IDEs and client can use to export metrics. 

This user label is added to all exported metrics. 

1) For now, only few values of `user` are recorded. `gcloud`, `vsc` and `intellij`
2) An easier way to see metrics exported while developing via `EXPORT_TO_LOCAL` env variable if the skaffold binary does not contain the secret to export metrics to cloud monitoring.


Testing Notes
```
LOCAL=true make

EXPORT_TO_STDOUT=true ../../out/skaffold run --user intellij

[
	{
		"Name": "artifact-dependencies{instrumentation.name=skaffold,builder=docker,randomizer=11151,user=intellij}",
		...
	},
	{
		"Name": "deployer{instrumentation.name=skaffold,deployer=kubectl,randomizer=11151,user=intellij}",
		...
	},
	{
		"Name": "launches{instrumentation.name=skaffold,arch=amd64,command=run,config_count=1,error=OK,os=darwin,platform_type=local,randomizer=11151,user=intellij,version=v1.21.0-68-gb96f66762-dirty}",
		...
	},
	{
		"Name": "launch/duration{instrumentation.name=skaffold,arch=amd64,command=run,config_count=1,error=OK,os=darwin,platform_type=local,randomizer=11151,user=intellij,version=v1.21.0-68-gb96f66762-dirty}",
		..
	},
	{
		"Name": "run{instrumentation.name=skaffold,error=OK,randomizer=11151,user=intellij}",
		...
	},
	{
		"Name": "builders{instrumentation.name=skaffold,builder=docker,randomizer=11151,user=intellij}",
		...
	},
	{
		"Name": "artifacts{instrumentation.name=skaffold,builder=docker,randomizer=11151,user=intellij}",
		...
	}
]

```
