### PR TITLE
use os.Lookup instead of os.Get

### DIFF
--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -142,7 +142,7 @@ func initCloudMonitoringExporterMetrics() (*push.Controller, error) {
 
 func devStdOutExporter() (*push.Controller, error) {
 	// export metrics to std out if local env is set.
-	if isLocal := os.Getenv("SKAFFOLD_EXPORT_TO_STDOUT"); isLocal != "" {
+	if _, ok := os.LookupEnv("SKAFFOLD_EXPORT_TO_STDOUT"); ok {
 		return stdout.InstallNewPipeline([]stdout.Option{
 			stdout.WithQuantiles([]float64{0.5}),
 			stdout.WithPrettyPrint(),


### PR DESCRIPTION
In #5731, I used the `os.Get` function to see if a `SKAFFOLD_EXPORT_TO_STDOUT` is defined. 

`os.Get` returns an empty string, if environment vairable is not present.  However, i just wanted to check for the presence.
 `os.Lookup` does that.