### PR TITLE
Support templated release names in helm render

### DIFF
--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -256,9 +256,13 @@ func (h *Deployer) Render(ctx context.Context, out io.Writer, builds []graph.Art
 	renderedManifests := new(bytes.Buffer)
 
 	for _, r := range h.Releases {
-		args := []string{"template", chartSource(r)}
+		releaseName, err := util.ExpandEnvTemplateOrFail(r.Name, nil)
+		if err != nil {
+			return userErr(fmt.Sprintf("cannot expand release name %q", r.Name), err)
+		}
 
-		args = append(args[:1], append([]string{r.Name}, args[1:]...)...)
+		args := []string{"template", chartSource(r)}
+		args = append(args[:1], append([]string{releaseName}, args[1:]...)...)
 
 		params, err := pairParamsToArtifacts(builds, r.ArtifactOverrides)
 		if err != nil {


### PR DESCRIPTION
Fixes: #5671 

**Description**
This PR causes the Helm deployer's `Render()` needs to expand the release name.  It cleans up the unused `envs` field in the tests.

**User facing changes (remove if N/A)**
- `render` for Helm now supports templated release names
