### PR TITLE
Protect errors.allErrors with mutex

### DIFF
--- a/pkg/skaffold/errors/errors.go
+++ b/pkg/skaffold/errors/errors.go
@@ -82,6 +82,8 @@ func ShowAIError(cfg interface{}, err error) error {
 		return p.AIError(cfg, err)
 	}
 
+	allErrorsLock.RLock()
+	defer allErrorsLock.RUnlock()
 	for _, problems := range allErrors {
 		for _, p := range problems {
 			if p.Regexp.MatchString(err.Error()) {

--- a/pkg/skaffold/errors/problem.go
+++ b/pkg/skaffold/errors/problem.go
@@ -20,13 +20,15 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 )
 
 var (
-	allErrors = map[constants.Phase][]Problem{}
+	allErrors     = map[constants.Phase][]Problem{}
+	allErrorsLock sync.RWMutex
 )
 
 type descriptionFunc func(error) string
@@ -78,8 +80,10 @@ func isProblem(err error) (Problem, bool) {
 }
 
 func AddPhaseProblems(phase constants.Phase, problems []Problem) {
+	allErrorsLock.Lock()
 	if ps, ok := allErrors[phase]; ok {
 		problems = append(ps, problems...)
 	}
 	allErrors[phase] = problems
+	allErrorsLock.Unlock()
 }


### PR DESCRIPTION
Fixes: #5733

**Description**
Ensure accesses to `errors.allErrors` are protected by mutex.