### PR TITLE
add flag `apply-profiles-recursively`; change default behavior for multi-config projects

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -366,6 +366,15 @@ var flagRegistry = []Flag{
 		IsEnum:        true,
 	},
 	{
+		Name:          "apply-profiles-recursively",
+		Usage:         "Set to false to disable propagating profiles set by the '--profile' flag across config dependencies",
+		Value:         &opts.ApplyProfilesRecursively,
+		DefValue:      true,
+		FlagAddMethod: "BoolVar",
+		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "build", "delete", "diagnose"},
+		IsEnum:        true,
+	},
+	{
 		Name:          "trigger",
 		Usage:         "How is change detection triggered? (polling, notify, or manual)",
 		Value:         &opts.Trigger,

--- a/docs/content/en/docs/design/config.md
+++ b/docs/content/en/docs/design/config.md
@@ -156,7 +156,9 @@ The remote config gets treated like a local config after substituting the path w
 
 ### Profile Activation in required configs
 
-Additionally the `activeProfiles` stanza can define the profiles to be activated in the required configs, via:
+Skaffold will try to apply `profiles` specified by the `--profile` flag, recursively to all configurations imported as dependencies. This behavior can be disabled by setting the `--apply-profiles-recursively` flag to `false`.
+
+You can additionally set up more granular and conditional profile activations across dependencies through the `activeProfiles` stanza:
 
 ```yaml
 apiVersion: skaffold/v2beta11
@@ -172,6 +174,8 @@ requires:
 ```
 
 Here, `profile1` is a profile that needs to exist in both configs `cfg1` and `cfg2`; while `profile2` and `profile3` are profiles defined in the current config `cfg`. If the current config is activated with either `profile2` or `profile3` then the required configs `cfg1` and `cfg2` are imported with `profile1` applied. If the `activatedBy` clause is omitted then that `profile1` always gets applied for the imported configs.
+
+
 
 {{< alert title="Follow up" >}}
 Take a look at the [tutorial]({{< relref "/docs/tutorials/config-dependencies" >}}) section to see this in action.

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -182,6 +182,7 @@ Examples:
   skaffold build -q --dry-run
 
 Options:
+      --apply-profiles-recursively=true: Set to false to disable propagating profiles set by the '--profile' flag across config dependencies
       --build-concurrency=-1: Number of concurrently running builds. Set to 0 to run all builds in parallel. Doesn't violate build order among dependencies.
   -b, --build-image=[]: Only build artifacts with image names that contain the given substring. Default is to build sources for all artifacts
       --cache-artifacts=true: Set to false to disable default caching of artifacts
@@ -221,6 +222,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 ```
 Env vars:
 
+* `SKAFFOLD_APPLY_PROFILES_RECURSIVELY` (same as `--apply-profiles-recursively`)
 * `SKAFFOLD_BUILD_CONCURRENCY` (same as `--build-concurrency`)
 * `SKAFFOLD_BUILD_IMAGE` (same as `--build-image`)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
@@ -405,6 +407,7 @@ Examples:
   skaffold debug --port-forward
 
 Options:
+      --apply-profiles-recursively=true: Set to false to disable propagating profiles set by the '--profile' flag across config dependencies
       --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
       --auto-build=false: When set to false, builds wait for API request instead of running automatically
       --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
@@ -458,6 +461,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 ```
 Env vars:
 
+* `SKAFFOLD_APPLY_PROFILES_RECURSIVELY` (same as `--apply-profiles-recursively`)
 * `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
 * `SKAFFOLD_AUTO_BUILD` (same as `--auto-build`)
 * `SKAFFOLD_AUTO_CREATE_CONFIG` (same as `--auto-create-config`)
@@ -510,6 +514,7 @@ Delete the deployed application
 
 
 Options:
+      --apply-profiles-recursively=true: Set to false to disable propagating profiles set by the '--profile' flag across config dependencies
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
@@ -531,6 +536,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 ```
 Env vars:
 
+* `SKAFFOLD_APPLY_PROFILES_RECURSIVELY` (same as `--apply-profiles-recursively`)
 * `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
@@ -564,6 +570,7 @@ Examples:
   skaffold deploy --skip-render
 
 Options:
+      --apply-profiles-recursively=true: Set to false to disable propagating profiles set by the '--profile' flag across config dependencies
   -a, --build-artifacts=: File containing build result from a previous 'skaffold build --file-output'
       --build-concurrency=-1: Number of concurrently running builds. Set to 0 to run all builds in parallel. Doesn't violate build order among dependencies.
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
@@ -605,6 +612,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 ```
 Env vars:
 
+* `SKAFFOLD_APPLY_PROFILES_RECURSIVELY` (same as `--apply-profiles-recursively`)
 * `SKAFFOLD_BUILD_ARTIFACTS` (same as `--build-artifacts`)
 * `SKAFFOLD_BUILD_CONCURRENCY` (same as `--build-concurrency`)
 * `SKAFFOLD_CONFIG` (same as `--config`)
@@ -645,6 +653,7 @@ Run a pipeline in development mode
 
 
 Options:
+      --apply-profiles-recursively=true: Set to false to disable propagating profiles set by the '--profile' flag across config dependencies
       --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
       --auto-build=true: When set to false, builds wait for API request instead of running automatically
       --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
@@ -698,6 +707,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 ```
 Env vars:
 
+* `SKAFFOLD_APPLY_PROFILES_RECURSIVELY` (same as `--apply-profiles-recursively`)
 * `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
 * `SKAFFOLD_AUTO_BUILD` (same as `--auto-build`)
 * `SKAFFOLD_AUTO_CREATE_CONFIG` (same as `--auto-create-config`)
@@ -757,6 +767,7 @@ Examples:
   skaffold diagnose --yaml-only --profile PROFILE
 
 Options:
+      --apply-profiles-recursively=true: Set to false to disable propagating profiles set by the '--profile' flag across config dependencies
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
   -m, --module=[]: Filter Skaffold configs to only the provided named modules
@@ -774,6 +785,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 ```
 Env vars:
 
+* `SKAFFOLD_APPLY_PROFILES_RECURSIVELY` (same as `--apply-profiles-recursively`)
 * `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_MODULE` (same as `--module`)
@@ -889,6 +901,7 @@ Examples:
 
 Options:
       --add-skaffold-labels=true: Add Skaffold-specific labels to rendered manifest. If false, custom labels are still applied. Helpful for GitOps model where Skaffold is not the deployer.
+      --apply-profiles-recursively=true: Set to false to disable propagating profiles set by the '--profile' flag across config dependencies
   -a, --build-artifacts=: File containing build result from a previous 'skaffold build --file-output'
       --cache-artifacts=true: Set to false to disable default caching of artifacts
   -d, --default-repo='': Default repository value (overrides global config)
@@ -914,6 +927,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 Env vars:
 
 * `SKAFFOLD_ADD_SKAFFOLD_LABELS` (same as `--add-skaffold-labels`)
+* `SKAFFOLD_APPLY_PROFILES_RECURSIVELY` (same as `--apply-profiles-recursively`)
 * `SKAFFOLD_BUILD_ARTIFACTS` (same as `--build-artifacts`)
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
@@ -944,6 +958,7 @@ Examples:
   skaffold run -p <profile>
 
 Options:
+      --apply-profiles-recursively=true: Set to false to disable propagating profiles set by the '--profile' flag across config dependencies
       --assume-yes=false: If true, skaffold will skip yes/no confirmation from the user and default to yes
       --auto-create-config=true: If true, skaffold will try to create a config for the user's run if it doesn't find one
       --build-concurrency=-1: Number of concurrently running builds. Set to 0 to run all builds in parallel. Doesn't violate build order among dependencies.
@@ -992,6 +1007,7 @@ Use "skaffold options" for a list of global command-line options (applies to all
 ```
 Env vars:
 
+* `SKAFFOLD_APPLY_PROFILES_RECURSIVELY` (same as `--apply-profiles-recursively`)
 * `SKAFFOLD_ASSUME_YES` (same as `--assume-yes`)
 * `SKAFFOLD_AUTO_CREATE_CONFIG` (same as `--auto-create-config`)
 * `SKAFFOLD_BUILD_CONCURRENCY` (same as `--build-concurrency`)

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -33,32 +33,33 @@ type WaitForDeletions struct {
 // SkaffoldOptions are options that are set by command line arguments not included
 // in the config file itself
 type SkaffoldOptions struct {
-	ConfigurationFile     string
-	ConfigurationFilter   []string
-	HydratedManifests     []string
-	GlobalConfig          string
-	EventLogFile          string
-	RenderOutput          string
-	User                  string
-	Apply                 bool
-	Cleanup               bool
-	Notification          bool
-	Tail                  bool
-	SkipTests             bool
-	CacheArtifacts        bool
-	EnableRPC             bool
-	Force                 bool
-	NoPrune               bool
-	NoPruneChildren       bool
-	AutoBuild             bool
-	AutoSync              bool
-	AutoDeploy            bool
-	RenderOnly            bool
-	AutoCreateConfig      bool
-	AssumeYes             bool
-	ProfileAutoActivation bool
-	DryRun                bool
-	SkipRender            bool
+	ConfigurationFile        string
+	ConfigurationFilter      []string
+	HydratedManifests        []string
+	GlobalConfig             string
+	EventLogFile             string
+	RenderOutput             string
+	User                     string
+	Apply                    bool
+	Cleanup                  bool
+	Notification             bool
+	Tail                     bool
+	SkipTests                bool
+	CacheArtifacts           bool
+	EnableRPC                bool
+	Force                    bool
+	NoPrune                  bool
+	NoPruneChildren          bool
+	AutoBuild                bool
+	AutoSync                 bool
+	AutoDeploy               bool
+	RenderOnly               bool
+	AutoCreateConfig         bool
+	AssumeYes                bool
+	ProfileAutoActivation    bool
+	ApplyProfilesRecursively bool
+	DryRun                   bool
+	SkipRender               bool
 
 	// Add Skaffold-specific labels including runID, deployer labels, etc.
 	// `CustomLabels` are still applied if this is false. Must only be used in


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5707 <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Change the bahavior of `--profile` flag for multi-config projects:
 - Profiles specified by `--profile` are propagated across all imported configs recursively by default
 - This can be disabled by setting `apply-profiles-recursively` to `false` 
**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
  Before:
Users needed to defined this `activeProfiles` stanza for each and every config dependency in order to activate `profiles` with the same name (and behavior) across files.
```
    activeProfiles:                                     
     - name: p1                               
       activatedBy: [p1] 
```
  After:
Users no longer have to specify `activeProfiles` stanza if they want to activate the same named profile across configs.
**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->
`apply-profiles-recursively` can be changed from a bool to accept an allow and deny-list of profile names. This can be revisited if there is enough ask for that.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
