### PR TITLE
[Refactor] Move kubernetes log code to pkg/skaffold/kubernetes/logger

### DIFF
--- a/pkg/skaffold/kubernetes/image_list.go
+++ b/pkg/skaffold/kubernetes/image_list.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"sync"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// PodSelector is used to choose which pods to log.
+type PodSelector interface {
+	Select(pod *v1.Pod) bool
+}
+
+// ImageList implements PodSelector based on a list of images names.
+type ImageList struct {
+	sync.RWMutex
+	names map[string]bool
+}
+
+// NewImageList creates a new ImageList.
+func NewImageList() *ImageList {
+	return &ImageList{
+		names: make(map[string]bool),
+	}
+}
+
+// Add adds an image to the list.
+func (l *ImageList) Add(image string) {
+	l.Lock()
+	l.names[image] = true
+	l.Unlock()
+}
+
+// Select returns true if one of the pod's images is in the list.
+func (l *ImageList) Select(pod *v1.Pod) bool {
+	l.RLock()
+	defer l.RUnlock()
+
+	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+		if l.names[container.Image] {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/skaffold/kubernetes/logger/log.go
+++ b/pkg/skaffold/kubernetes/logger/log.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package logger
 
 import (
 	"bufio"
@@ -30,6 +30,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 )
@@ -39,12 +40,12 @@ type LogAggregator struct {
 	output      io.Writer
 	kubectlcli  *kubectl.CLI
 	config      Config
-	podWatcher  PodWatcher
-	colorPicker ColorPicker
+	podWatcher  kubernetes.PodWatcher
+	colorPicker kubernetes.ColorPicker
 
 	muted             int32
 	sinceTime         time.Time
-	events            chan PodEvent
+	events            chan kubernetes.PodEvent
 	trackedContainers trackedContainers
 	outputLock        sync.Mutex
 }
@@ -55,14 +56,14 @@ type Config interface {
 }
 
 // NewLogAggregator creates a new LogAggregator for a given output.
-func NewLogAggregator(out io.Writer, cli *kubectl.CLI, imageNames []string, podSelector PodSelector, config Config) *LogAggregator {
+func NewLogAggregator(out io.Writer, cli *kubectl.CLI, imageNames []string, podSelector kubernetes.PodSelector, config Config) *LogAggregator {
 	return &LogAggregator{
 		output:      out,
 		kubectlcli:  cli,
 		config:      config,
-		podWatcher:  NewPodWatcher(podSelector),
-		colorPicker: NewColorPicker(imageNames),
-		events:      make(chan PodEvent),
+		podWatcher:  kubernetes.NewPodWatcher(podSelector),
+		colorPicker: kubernetes.NewColorPicker(imageNames),
+		events:      make(chan kubernetes.PodEvent),
 	}
 }
 
@@ -287,43 +288,4 @@ func (t *trackedContainers) add(id string) bool {
 	t.Unlock()
 
 	return alreadyTracked
-}
-
-// PodSelector is used to choose which pods to log.
-type PodSelector interface {
-	Select(pod *v1.Pod) bool
-}
-
-// ImageList implements PodSelector based on a list of images names.
-type ImageList struct {
-	sync.RWMutex
-	names map[string]bool
-}
-
-// NewImageList creates a new ImageList.
-func NewImageList() *ImageList {
-	return &ImageList{
-		names: make(map[string]bool),
-	}
-}
-
-// Add adds an image to the list.
-func (l *ImageList) Add(image string) {
-	l.Lock()
-	l.names[image] = true
-	l.Unlock()
-}
-
-// Select returns true if one of the pod's images is in the list.
-func (l *ImageList) Select(pod *v1.Pod) bool {
-	l.RLock()
-	defer l.RUnlock()
-
-	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
-		if l.names[container.Image] {
-			return true
-		}
-	}
-
-	return false
 }

--- a/pkg/skaffold/kubernetes/logger/log_test.go
+++ b/pkg/skaffold/kubernetes/logger/log_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubernetes
+package logger
 
 import (
 	"bytes"
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -83,7 +84,7 @@ func TestSelect(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			list := NewImageList()
+			list := kubernetes.NewImageList()
 			list.Add("image1")
 			list.Add("image2")
 

--- a/pkg/skaffold/runner/dev.go
+++ b/pkg/skaffold/runner/dev.go
@@ -32,7 +32,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/logger"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
 	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
@@ -50,7 +50,7 @@ var (
 	fileSyncSucceeded  = event.FileSyncSucceeded
 )
 
-func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer, logger *kubernetes.LogAggregator, forwarderManager portforward.Forwarder) error {
+func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer, logger *logger.LogAggregator, forwarderManager portforward.Forwarder) error {
 	// never queue intents from user, even if they're not used
 	defer r.intents.reset()
 

--- a/pkg/skaffold/runner/logger.go
+++ b/pkg/skaffold/runner/logger.go
@@ -20,10 +20,10 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/logger"
 )
 
-func (r *SkaffoldRunner) createLogger(out io.Writer, artifacts []graph.Artifact) *kubernetes.LogAggregator {
+func (r *SkaffoldRunner) createLogger(out io.Writer, artifacts []graph.Artifact) *logger.LogAggregator {
 	if !r.runCtx.Tail() {
 		return nil
 	}
@@ -33,5 +33,5 @@ func (r *SkaffoldRunner) createLogger(out io.Writer, artifacts []graph.Artifact)
 		imageNames = append(imageNames, artifact.Tag)
 	}
 
-	return kubernetes.NewLogAggregator(out, r.kubectlCLI, imageNames, r.podSelector, r.runCtx)
+	return logger.NewLogAggregator(out, r.kubectlCLI, imageNames, r.podSelector, r.runCtx)
 }


### PR DESCRIPTION
this change moves the logging related code in the `kubernetes` package to its own `logger` package. this will make it easier to reuse later when we embed the logging functionality inside the deployer.

also, move some unrelated image tracking logic out from the logging code.

this change is non-functional.