### PR TITLE
skaffold diagnose to not initialize runconfig for yaml only flag

### DIFF
--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/spf13/cobra"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/diagnose"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
-	"github.com/spf13/cobra"
-
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 )
 
@@ -56,7 +57,7 @@ func doDiagnose(ctx context.Context, out io.Writer) error {
 		return err
 	}
 	if !yamlOnly {
-		if err := printDockerArtifact(ctx, out, configs); err != nil {
+		if err := printArtifactDiagnostics(ctx, out, configs); err != nil {
 			return err
 		}
 	}
@@ -73,7 +74,7 @@ func doDiagnose(ctx context.Context, out io.Writer) error {
 	return nil
 }
 
-func printDockerArtifact(ctx context.Context, out io.Writer, configs []*latest_v1.SkaffoldConfig) error {
+func printArtifactDiagnostics(ctx context.Context, out io.Writer, configs []*latest_v1.SkaffoldConfig) error {
 	var pipelines []latest_v1.Pipeline
 	for _, cfg := range configs {
 		pipelines = append(pipelines, cfg.Pipeline)
@@ -93,4 +94,5 @@ func printDockerArtifact(ctx context.Context, out io.Writer, configs []*latest_v
 
 		color.Blue.Fprintln(out, "\nConfiguration")
 	}
+	return nil
 }

--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -35,8 +35,8 @@ import (
 var (
 	yamlOnly bool
 	// for testing
-	getRunContext          = runcontext.GetRunContext
-	withFallbackConfigFunc = withFallbackConfig
+	getRunContext = runcontext.GetRunContext
+	getCfgs       = parser.GetAllConfigs
 )
 
 // NewCmdDiagnose describes the CLI command to diagnose skaffold.
@@ -52,7 +52,7 @@ func NewCmdDiagnose() *cobra.Command {
 }
 
 func doDiagnose(ctx context.Context, out io.Writer) error {
-	configs, err := withFallbackConfigFunc(out, opts, parser.GetAllConfigs)
+	configs, err := getCfgs(opts)
 	if err != nil {
 		return err
 	}

--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -75,11 +75,7 @@ func doDiagnose(ctx context.Context, out io.Writer) error {
 }
 
 func printArtifactDiagnostics(ctx context.Context, out io.Writer, configs []*latest_v1.SkaffoldConfig) error {
-	var pipelines []latest_v1.Pipeline
-	for _, cfg := range configs {
-		pipelines = append(pipelines, cfg.Pipeline)
-	}
-	runCtx, err := getRunContext(opts, pipelines)
+	runCtx, err := getRunContext(opts, configs)
 	if err != nil {
 		return fmt.Errorf("getting run context: %w", err)
 	}

--- a/cmd/skaffold/app/cmd/diagnose_test.go
+++ b/cmd/skaffold/app/cmd/diagnose_test.go
@@ -57,7 +57,7 @@ metadata:
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&getRunContext, func(config.SkaffoldOptions, []latest_v1.Pipeline) (*runcontext.RunContext, error) {
+			t.Override(&getRunContext, func(config.SkaffoldOptions, []*latest_v1.SkaffoldConfig) (*runcontext.RunContext, error) {
 				return nil, fmt.Errorf("cannot get the runtime context")
 			})
 			t.Override(&yamlOnly, test.yamlOnly)

--- a/cmd/skaffold/app/cmd/diagnose_test.go
+++ b/cmd/skaffold/app/cmd/diagnose_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDoDiagnose(t *testing.T) {
+	tests := []struct {
+		description string
+		yamlOnly    bool
+		shouldErr   bool
+		expected    string
+	}{
+		{
+			description: "yaml only set to true",
+			yamlOnly:    true,
+			expected: `apiVersion: testVersion
+kind: Config
+metadata:
+  name: config1
+---
+apiVersion: testVersion
+kind: Config
+metadata:
+  name: config2
+`,
+		},
+		{
+			description: "yaml only set to false",
+			shouldErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&getRunContext, func(config.SkaffoldOptions, []latest_v1.Pipeline) (*runcontext.RunContext, error) {
+				return nil, fmt.Errorf("cannot get the runtime context")
+			})
+			t.Override(&yamlOnly, test.yamlOnly)
+			t.Override(&withFallbackConfigFunc, func(io.Writer, config.SkaffoldOptions, func(opts config.SkaffoldOptions) ([]*latest_v1.SkaffoldConfig, error)) ([]*latest_v1.SkaffoldConfig, error) {
+				return []*latest_v1.SkaffoldConfig{
+					{
+						APIVersion: "testVersion",
+						Kind:       "Config",
+						Metadata: latest_v1.Metadata{
+							Name: "config1",
+						},
+					},
+					{
+						APIVersion: "testVersion",
+						Kind:       "Config",
+						Metadata: latest_v1.Metadata{
+							Name: "config2",
+						},
+					},
+				}, nil
+			})
+			var b bytes.Buffer
+			err := doDiagnose(context.Background(), &b)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, b.String())
+		})
+	}
+}

--- a/cmd/skaffold/app/cmd/diagnose_test.go
+++ b/cmd/skaffold/app/cmd/diagnose_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
@@ -62,7 +61,7 @@ metadata:
 				return nil, fmt.Errorf("cannot get the runtime context")
 			})
 			t.Override(&yamlOnly, test.yamlOnly)
-			t.Override(&withFallbackConfigFunc, func(io.Writer, config.SkaffoldOptions, func(opts config.SkaffoldOptions) ([]*latest_v1.SkaffoldConfig, error)) ([]*latest_v1.SkaffoldConfig, error) {
+			t.Override(&getCfgs, func(opts config.SkaffoldOptions) ([]*latest_v1.SkaffoldConfig, error) {
 				return []*latest_v1.SkaffoldConfig{
 					{
 						APIVersion: "testVersion",

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -79,10 +79,6 @@ func runContext(out io.Writer, opts config.SkaffoldOptions) (*runcontext.RunCont
 		return nil, nil, err
 	}
 	setDefaultDeployer(configs)
-	var pipelines []latest_v1.Pipeline
-	for _, cfg := range configs {
-		pipelines = append(pipelines, cfg.Pipeline)
-	}
 
 	// TODO: Should support per-config kubecontext. Right now we constrain all configs to define the same kubecontext.
 	kubectx.ConfigureKubeConfig(opts.KubeConfig, opts.KubeContext, configs[0].Deploy.KubeContext)
@@ -91,7 +87,7 @@ func runContext(out io.Writer, opts config.SkaffoldOptions) (*runcontext.RunCont
 		return nil, nil, fmt.Errorf("invalid skaffold config: %w", err)
 	}
 
-	runCtx, err := runcontext.GetRunContext(opts, pipelines)
+	runCtx, err := runcontext.GetRunContext(opts, configs)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting run context: %w", err)
 	}

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -200,7 +200,13 @@ func (rc *RunContext) WatchPollInterval() int                    { return rc.Opt
 func (rc *RunContext) BuildConcurrency() int                     { return rc.Opts.BuildConcurrency }
 func (rc *RunContext) IsMultiConfig() bool                       { return rc.Pipelines.IsMultiPipeline() }
 
-func GetRunContext(opts config.SkaffoldOptions, pipelines []latest_v1.Pipeline) (*RunContext, error) {
+func GetRunContext(opts config.SkaffoldOptions, configs []*latest_v1.SkaffoldConfig) (*RunContext, error) {
+	var pipelines []latest_v1.Pipeline
+	for _, cfg := range configs {
+		if cfg != nil {
+			pipelines = append(pipelines, cfg.Pipeline)
+		}
+	}
 	kubeConfig, err := kubectx.CurrentConfig()
 	if err != nil {
 		return nil, fmt.Errorf("getting current cluster context: %w", err)


### PR DESCRIPTION
Fixes #5701 

In this PR the code is refactored to make sure we don't create a skaffold RunContext object when skaffold diagnose is run with `--yaml-only` flag. 

