### PR TITLE
disable housekeeping messages for render

### DIFF
--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -50,7 +50,6 @@ func NewCmdRender() *cobra.Command {
 			{Value: &renderOutputPath, Name: "output", Shorthand: "o", DefValue: "", Usage: "file to write rendered manifests to"},
 			{Value: &opts.DigestSource, Name: "digest-source", DefValue: "local", Usage: "Set to 'local' to build images locally and use digests from built images; Set to 'remote' to resolve the digest of images by tag from the remote registry; Set to 'none' to use tags directly from the Kubernetes manifests. Set to 'tag' to use tags directly from the build.", IsEnum: true},
 		}).
-		WithHouseKeepingMessages().
 		NoArgs(doRender)
 }
 


### PR DESCRIPTION
Relates to #5711 , 

With the new changes to "update check" (#5741)  and metrics, 
1) update check and metrics prompt will happen on every run unless they are disabled. 

This might break `skaffold render` if it's being used for the first time. This is true for CI usecase. 
Since `skaffold render` spits out yaml, we should be disallowing any house keeping messages similar to `skaffold diagnose`
