### PR TITLE
Update examples/typescript w/ recommended ENV=production info

### DIFF
--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -17,3 +17,6 @@ skaffold dev
     * `tsc-watch` will restart the application
 * Make some changes to `package.json`:
     * The full build/push/deploy process will be triggered, fetching dependencies from `npm`
+* NOTE: Currently in this example, `tsc-watch` is not configured when `ENV=production`.  To configure it, update the [package.json](./backend/src/package.json) file `scripts.production"` field to be:
+  * `"production": "tsc && node ./src/index.js"` instead of the default `"production": "node src/index.js",`
+  

--- a/integration/examples/typescript/README.md
+++ b/integration/examples/typescript/README.md
@@ -17,3 +17,6 @@ skaffold dev
     * `tsc-watch` will restart the application
 * Make some changes to `package.json`:
     * The full build/push/deploy process will be triggered, fetching dependencies from `npm`
+* NOTE: Currently in this example, `tsc-watch` is not configured when `ENV=production`.  To configure it, update the [package.json](./backend/src/package.json) file `scripts.production"` field to be:
+  * `"production": "tsc && node ./src/index.js"` instead of the default `"production": "node src/index.js",`
+  


### PR DESCRIPTION
Fixes #5771

Updates `examples/typescript` README.md mentioning that that the `tsc-watch` compile step is missing when `ENV=production` as well as how a user might change the code if desired to have the update work for `ENV=production`