### PR TITLE
add `skaffold inspect profiles` command

### DIFF
--- a/cmd/skaffold/app/cmd/inspect.go
+++ b/cmd/skaffold/app/cmd/inspect.go
@@ -24,6 +24,8 @@ import (
 var inspectFlags = struct {
 	fileName  string
 	outFormat string
+	modules   []string
+	buildEnv  string
 }{
 	fileName: "skaffold.yaml",
 }
@@ -33,7 +35,7 @@ func NewCmdInspect() *cobra.Command {
 		WithDescription("Helper commands for Cloud Code IDEs to interact with and modify skaffold configuration files.").
 		WithPersistentFlagAdder(cmdInspectFlags).
 		Hidden().
-		WithCommands(cmdModules())
+		WithCommands(cmdModules(), cmdProfiles())
 }
 
 func cmdInspectFlags(f *pflag.FlagSet) {

--- a/cmd/skaffold/app/cmd/inspect_modules.go
+++ b/cmd/skaffold/app/cmd/inspect_modules.go
@@ -33,7 +33,7 @@ func cmdModules() *cobra.Command {
 
 func cmdModulesList() *cobra.Command {
 	return NewCmd("list").
-		WithExample("Get list of modules", "skaffold inspect modules list --format json").
+		WithExample("Get list of modules", "inspect modules list --format json").
 		WithDescription("Print the list of module names that can be invoked with the --module flag in other skaffold commands.").
 		NoArgs(listModules)
 }

--- a/cmd/skaffold/app/cmd/inspect_profiles.go
+++ b/cmd/skaffold/app/cmd/inspect_profiles.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"io"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/inspect"
+)
+
+func cmdProfiles() *cobra.Command {
+	return NewCmd("profiles").
+		WithDescription("Interact with configuration profiles").
+		WithPersistentFlagAdder(cmdProfilesFlags).
+		WithCommands(cmdProfilesList())
+}
+
+func cmdProfilesList() *cobra.Command {
+	return NewCmd("list").
+		WithExample("Get list of profiles", "inspect profiles list --format json").
+		WithExample("Get list of profiles targeting GoogleCloudBuild environment", "inspect profiles list --build-env googleCloudBuild --format json").
+		WithDescription("Print the list of profile names that can be invoked with the --profile flag in other skaffold commands.").
+		WithFlagAdder(cmdProfilesListFlags).
+		NoArgs(listProfiles)
+}
+
+func listProfiles(ctx context.Context, out io.Writer) error {
+	return inspect.PrintProfilesList(ctx, out, inspect.Options{Filename: inspectFlags.fileName, OutFormat: inspectFlags.outFormat, Modules: inspectFlags.modules, ProfilesOptions: inspect.ProfilesOptions{BuildEnv: inspect.BuildEnv(inspectFlags.buildEnv)}})
+}
+
+func cmdProfilesFlags(f *pflag.FlagSet) {
+	f.StringSliceVarP(&inspectFlags.modules, "module", "m", nil, "Names of modules to filter target action by.")
+}
+
+func cmdProfilesListFlags(f *pflag.FlagSet) {
+	f.StringVar(&inspectFlags.buildEnv, "build-env", "", `If specified as one of "local", "googleCloudBuild" or "cluster", then filter the output profiles list to that build environment.`)
+}

--- a/pkg/skaffold/inspect/profiles.go
+++ b/pkg/skaffold/inspect/profiles.go
@@ -21,28 +21,36 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
-type moduleList struct {
-	Modules []moduleEntry `json:"modules"`
+type profileList struct {
+	Profiles []profileEntry `json:"profiles"`
 }
 
-type moduleEntry struct {
-	Name string `json:"name"`
-	Path string `json:"path"`
+type profileEntry struct {
+	Name   string `json:"name"`
+	Path   string `json:"path"`
+	Module string `json:"module"`
 }
 
-func PrintModulesList(ctx context.Context, out io.Writer, opts Options) error {
+func PrintProfilesList(ctx context.Context, out io.Writer, opts Options) error {
 	formatter := getOutputFormatter(out, opts.OutFormat)
 	cfgs, err := getConfigSetFunc(config.SkaffoldOptions{ConfigurationFile: opts.Filename})
 	if err != nil {
 		return formatter.WriteErr(err)
 	}
 
-	l := &moduleList{Modules: []moduleEntry{}}
+	l := &profileList{Profiles: []profileEntry{}}
 	for _, c := range cfgs {
-		if c.Metadata.Name != "" {
-			l.Modules = append(l.Modules, moduleEntry{Name: c.Metadata.Name, Path: c.SourceFile})
+		if len(opts.Modules) > 0 && !util.StrSliceContains(opts.Modules, c.Metadata.Name) {
+			continue
+		}
+		for _, p := range c.Profiles {
+			if !opts.BuildEnv.MatchesConfig(&p.Build.BuildType) {
+				continue
+			}
+			l.Profiles = append(l.Profiles, profileEntry{Name: p.Name, Path: c.SourceFile, Module: c.Metadata.Name})
 		}
 	}
 	return formatter.Write(l)

--- a/pkg/skaffold/inspect/profiles.go
+++ b/pkg/skaffold/inspect/profiles.go
@@ -31,7 +31,7 @@ type profileList struct {
 type profileEntry struct {
 	Name   string `json:"name"`
 	Path   string `json:"path"`
-	Module string `json:"module"`
+	Module string `json:"module,omitempty"`
 }
 
 func PrintProfilesList(ctx context.Context, out io.Writer, opts Options) error {

--- a/pkg/skaffold/inspect/profiles_test.go
+++ b/pkg/skaffold/inspect/profiles_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inspect
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser"
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/errors"
+	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestPrintProfilesList(t *testing.T) {
+	tests := []struct {
+		description string
+		configSet   parser.SkaffoldConfigSet
+		buildEnv    BuildEnv
+		module      []string
+		err         error
+		expected    string
+	}{
+		{
+			description: "print all profiles",
+			configSet: parser.SkaffoldConfigSet{
+				&parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{Metadata: v1.Metadata{Name: "cfg1"}, Profiles: []v1.Profile{
+					{Name: "p1", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
+					{Name: "p2", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{Cluster: &v1.ClusterDetails{}}}}},
+				}}, SourceFile: "path/to/cfg1"},
+				&parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{Metadata: v1.Metadata{Name: "cfg2"}, Profiles: []v1.Profile{
+					{Name: "p3", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
+					{Name: "p4", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{GoogleCloudBuild: &v1.GoogleCloudBuild{}}}}},
+				}}, SourceFile: "path/to/cfg2"},
+			},
+			expected: `{"profiles":[` +
+				`{"name":"p1","path":"path/to/cfg1","module":"cfg1"},` +
+				`{"name":"p2","path":"path/to/cfg1","module":"cfg1"},` +
+				`{"name":"p3","path":"path/to/cfg2","module":"cfg2"},` +
+				`{"name":"p4","path":"path/to/cfg2","module":"cfg2"}` +
+				"]}\n",
+		},
+		{
+			description: "print all profiles for one module",
+			configSet: parser.SkaffoldConfigSet{
+				&parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{Metadata: v1.Metadata{Name: "cfg1"}, Profiles: []v1.Profile{
+					{Name: "p1", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
+					{Name: "p2", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{Cluster: &v1.ClusterDetails{}}}}},
+				}}, SourceFile: "path/to/cfg1"},
+				&parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{Metadata: v1.Metadata{Name: "cfg2"}, Profiles: []v1.Profile{
+					{Name: "p3", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
+					{Name: "p4", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{GoogleCloudBuild: &v1.GoogleCloudBuild{}}}}},
+				}}, SourceFile: "path/to/cfg2"},
+			},
+			expected: `{"profiles":[` +
+				`{"name":"p3","path":"path/to/cfg2","module":"cfg2"},` +
+				`{"name":"p4","path":"path/to/cfg2","module":"cfg2"}` +
+				"]}\n",
+			module: []string{"cfg2"},
+		},
+		{
+			description: "print all profiles for one module and gcb build-env",
+			configSet: parser.SkaffoldConfigSet{
+				&parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{Metadata: v1.Metadata{Name: "cfg1"}, Profiles: []v1.Profile{
+					{Name: "p1", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
+					{Name: "p2", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{Cluster: &v1.ClusterDetails{}}}}},
+				}}, SourceFile: "path/to/cfg1"},
+				&parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{Metadata: v1.Metadata{Name: "cfg2"}, Profiles: []v1.Profile{
+					{Name: "p3", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
+					{Name: "p4", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{GoogleCloudBuild: &v1.GoogleCloudBuild{}}}}},
+				}}, SourceFile: "path/to/cfg2"},
+			},
+			expected: `{"profiles":[` +
+				`{"name":"p4","path":"path/to/cfg2","module":"cfg2"}` +
+				"]}\n",
+			module:   []string{"cfg2"},
+			buildEnv: BuildEnvs.GoogleCloudBuild,
+		},
+		{
+			description: "actionable error",
+			err:         sErrors.MainConfigFileNotFoundErr("path/to/skaffold.yaml", fmt.Errorf("failed to read file : %q", "skaffold.yaml")),
+			expected:    `{"errorCode":"CONFIG_FILE_NOT_FOUND_ERR","errorMessage":"unable to find configuration file \"path/to/skaffold.yaml\": failed to read file : \"skaffold.yaml\". Check that the specified configuration file exists at \"path/to/skaffold.yaml\"."}` + "\n",
+		},
+		{
+			description: "generic error",
+			err:         errors.New("some error occurred"),
+			expected:    `{"errorCode":"UNKNOWN_ERROR","errorMessage":"some error occurred"}` + "\n",
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&getConfigSetFunc, func(config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+				return test.configSet, test.err
+			})
+			var buf bytes.Buffer
+			err := PrintProfilesList(context.Background(), &buf, Options{OutFormat: "json", Modules: test.module, ProfilesOptions: ProfilesOptions{BuildEnv: test.buildEnv}})
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expected, buf.String())
+		})
+	}
+}

--- a/pkg/skaffold/inspect/profiles_test.go
+++ b/pkg/skaffold/inspect/profiles_test.go
@@ -50,12 +50,16 @@ func TestPrintProfilesList(t *testing.T) {
 					{Name: "p3", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
 					{Name: "p4", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{GoogleCloudBuild: &v1.GoogleCloudBuild{}}}}},
 				}}, SourceFile: "path/to/cfg2"},
+				&parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{Profiles: []v1.Profile{
+					{Name: "p5", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
+				}}, SourceFile: "path/to/cfg2"},
 			},
 			expected: `{"profiles":[` +
 				`{"name":"p1","path":"path/to/cfg1","module":"cfg1"},` +
 				`{"name":"p2","path":"path/to/cfg1","module":"cfg1"},` +
 				`{"name":"p3","path":"path/to/cfg2","module":"cfg2"},` +
-				`{"name":"p4","path":"path/to/cfg2","module":"cfg2"}` +
+				`{"name":"p4","path":"path/to/cfg2","module":"cfg2"},` +
+				`{"name":"p5","path":"path/to/cfg2"}` +
 				"]}\n",
 		},
 		{

--- a/pkg/skaffold/inspect/types.go
+++ b/pkg/skaffold/inspect/types.go
@@ -16,10 +16,54 @@ limitations under the License.
 
 package inspect
 
+import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+)
+
 // Options holds flag values for the various `skaffold inspect` commands
 type Options struct {
 	// Filename is the `skaffold.yaml` file path
 	Filename string
 	// OutFormat is the output format. One of: json
 	OutFormat string
+	// Modules is the module filter for specific commands
+	Modules []string
+
+	ProfilesOptions
+}
+
+// ProfilesOptions holds flag values for various `skaffold inspect profiles` commands
+type ProfilesOptions struct {
+	// BuildEnv is the build-env filter for command output. One of: local, googleCloudBuild, cluster.
+	BuildEnv BuildEnv
+}
+
+type BuildEnv string
+
+var (
+	getConfigSetFunc = parser.GetConfigSet
+	BuildEnvs        = struct {
+		Unspecified      BuildEnv
+		Local            BuildEnv
+		GoogleCloudBuild BuildEnv
+		Cluster          BuildEnv
+	}{
+		Local: "local", GoogleCloudBuild: "googleCloudBuild", Cluster: "cluster",
+	}
+)
+
+func (b BuildEnv) MatchesConfig(t *latest_v1.BuildType) bool {
+	switch b {
+	case BuildEnvs.Local:
+		return t.LocalBuild != nil
+	case BuildEnvs.GoogleCloudBuild:
+		return t.GoogleCloudBuild != nil
+	case BuildEnvs.Cluster:
+		return t.Cluster != nil
+	case BuildEnvs.Unspecified:
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
Related #5758
Add command `skaffold inspect profiles`

```
❯ skaffold inspect profiles                          
Interact with configuration profiles

Available Commands:
  list        Print the list of profile names that can be invoked with the
--profile flag in other skaffold commands.

Use "skaffold <command> --help" for more information about a given command.
```
```
❯ skaffold inspect profiles list --help
Print the list of profile names that can be invoked with the --profile flag in
other skaffold commands.

Examples:
  # Get list of profiles
  skaffold inspect profiles list --format json

  # Get list of profiles targeting GoogleCloudBuild environment
  skaffold inspect profiles list --build-env googleCloudBuild --format json

Options:
      --build-env='': If specified as one of "local", "googleCloudBuild" or
"cluster", then filter the output profiles list to that build environment.

Usage:
  skaffold inspect profiles list [flags] [options]

Use "skaffold options" for a list of global command-line options (applies to all
commands).


```