### PR TITLE
Emit deploy subtask events for API V2

### DIFF
--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -84,5 +84,5 @@ func (m DeployerMux) Render(ctx context.Context, w io.Writer, as []graph.Artifac
 	}
 
 	allResources := strings.Join(resources, "\n---\n")
-	return manifest.Write(allResources, filepath, w)
+	return manifest.Write(strings.TrimSpace(allResources), filepath, w)
 }

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -26,7 +26,9 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
+	testEvent "github.com/GoogleContainerTools/skaffold/testutil/event"
 )
 
 func NewMockDeployer() *MockDeployer { return &MockDeployer{labels: make(map[string]string)} }
@@ -141,6 +143,14 @@ func TestDeployerMux_Deploy(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			testEvent.InitializeState([]latest_v1.Pipeline{{
+				Deploy: latest_v1.DeployConfig{},
+				Build: latest_v1.BuildConfig{
+					BuildType: latest_v1.BuildType{
+						LocalBuild: &latest_v1.LocalBuild{},
+					},
+				}}})
+
 			deployerMux := DeployerMux([]Deployer{
 				NewMockDeployer().WithDeployNamespaces(test.namespaces1).WithDeployErr(test.err1),
 				NewMockDeployer().WithDeployNamespaces(test.namespaces2).WithDeployErr(test.err2),

--- a/pkg/skaffold/event/v2/deploy.go
+++ b/pkg/skaffold/event/v2/deploy.go
@@ -9,7 +9,7 @@ import (
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
 )
 
-func DeployInProgress(id int, artifact string) {
+func DeployInProgress(id int) {
 	handler.handleDeploySubtaskEvent(&proto.DeploySubtaskEvent{
 		Id:       strconv.Itoa(id),
 		TaskId:   fmt.Sprintf("%s-%d", constants.Deploy, handler.iteration),
@@ -17,7 +17,7 @@ func DeployInProgress(id int, artifact string) {
 	})
 }
 
-func DeployFailed(id int, artifact string, err error) {
+func DeployFailed(id int, err error) {
 	handler.handleDeploySubtaskEvent(&proto.DeploySubtaskEvent{
 		Id:            strconv.Itoa(id),
 		TaskId:        fmt.Sprintf("%s-%d", constants.Deploy, handler.iteration),
@@ -26,7 +26,7 @@ func DeployFailed(id int, artifact string, err error) {
 	})
 }
 
-func DeploySucceeded(id int, artifact string) {
+func DeploySucceeded(id int) {
 	handler.handleDeploySubtaskEvent(&proto.DeploySubtaskEvent{
 		Id:       strconv.Itoa(id),
 		TaskId:   fmt.Sprintf("%s-%d", constants.Deploy, handler.iteration),

--- a/pkg/skaffold/event/v2/deploy.go
+++ b/pkg/skaffold/event/v2/deploy.go
@@ -1,0 +1,43 @@
+package v2
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
+	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
+)
+
+func DeployInProgress(id int, artifact string) {
+	handler.handleDeploySubtaskEvent(&proto.DeploySubtaskEvent{
+		Id:       strconv.Itoa(id),
+		TaskId:   fmt.Sprintf("%s-%d", constants.Deploy, handler.iteration),
+		Status:   InProgress,
+	})
+}
+
+func DeployFailed(id int, artifact string, err error) {
+	handler.handleDeploySubtaskEvent(&proto.DeploySubtaskEvent{
+		Id:            strconv.Itoa(id),
+		TaskId:        fmt.Sprintf("%s-%d", constants.Deploy, handler.iteration),
+		Status:        Failed,
+		ActionableErr: sErrors.ActionableErrV2(handler.cfg, constants.Deploy, err),
+	})
+}
+
+func DeploySucceeded(id int, artifact string) {
+	handler.handleDeploySubtaskEvent(&proto.DeploySubtaskEvent{
+		Id:       strconv.Itoa(id),
+		TaskId:   fmt.Sprintf("%s-%d", constants.Deploy, handler.iteration),
+		Status:   Succeeded,
+	})
+}
+
+func (ev *eventHandler) handleDeploySubtaskEvent(e *proto.DeploySubtaskEvent) {
+	ev.handle(&proto.Event{
+		EventType: &proto.Event_DeploySubtaskEvent{
+			DeploySubtaskEvent: e,
+		},
+	})
+}

--- a/pkg/skaffold/event/v2/deploy.go
+++ b/pkg/skaffold/event/v2/deploy.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v2
 
 import (
@@ -11,9 +27,9 @@ import (
 
 func DeployInProgress(id int) {
 	handler.handleDeploySubtaskEvent(&proto.DeploySubtaskEvent{
-		Id:       strconv.Itoa(id),
-		TaskId:   fmt.Sprintf("%s-%d", constants.Deploy, handler.iteration),
-		Status:   InProgress,
+		Id:     strconv.Itoa(id),
+		TaskId: fmt.Sprintf("%s-%d", constants.Deploy, handler.iteration),
+		Status: InProgress,
 	})
 }
 
@@ -28,9 +44,9 @@ func DeployFailed(id int, err error) {
 
 func DeploySucceeded(id int) {
 	handler.handleDeploySubtaskEvent(&proto.DeploySubtaskEvent{
-		Id:       strconv.Itoa(id),
-		TaskId:   fmt.Sprintf("%s-%d", constants.Deploy, handler.iteration),
-		Status:   Succeeded,
+		Id:     strconv.Itoa(id),
+		TaskId: fmt.Sprintf("%s-%d", constants.Deploy, handler.iteration),
+		Status: Succeeded,
 	})
 }
 

--- a/pkg/skaffold/event/v2/deploy_test.go
+++ b/pkg/skaffold/event/v2/deploy_test.go
@@ -1,0 +1,51 @@
+package v2
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
+	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestHandleDeploySubtaskEvent(t *testing.T) {
+	tests := []struct{
+		name  string
+		event *proto.DeploySubtaskEvent
+	}{
+		{
+			name: "In Progress",
+			event: &proto.DeploySubtaskEvent{
+				Id:       "0",
+				TaskId:   fmt.Sprintf("%s-%d", constants.Deploy, 0),
+				Status:   InProgress,
+			},
+		},
+		{
+			name: "Failed",
+			event: &proto.DeploySubtaskEvent{
+				Id:            "23",
+				TaskId:        fmt.Sprintf("%s-%d", constants.Deploy, 0),
+				Status:        Failed,
+				ActionableErr: sErrors.ActionableErrV2(handler.cfg, constants.Deploy, errors.New("deploy failed")),
+			},
+		},
+		{
+			name: "Succeeded",
+			event: &proto.DeploySubtaskEvent{
+				Id:       "99",
+				TaskId:   fmt.Sprintf("%s-%d", constants.Deploy, 12),
+				Status:   Succeeded,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			handler.handleDeploySubtaskEvent(test.event)
+		})
+	}
+}

--- a/pkg/skaffold/event/v2/deploy_test.go
+++ b/pkg/skaffold/event/v2/deploy_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
+	latest_v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
-	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestHandleDeploySubtaskEvent(t *testing.T) {
@@ -43,9 +43,16 @@ func TestHandleDeploySubtaskEvent(t *testing.T) {
 		},
 	}
 
+	defer func() { handler = newHandler() }()
 	for _, test := range tests {
-		testutil.Run(t, test.name, func(t *testutil.T) {
+		t.Run(test.name, func(t *testing.T) {
+			handler = newHandler()
+			handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
+
+
+			wait(t, func() bool { return handler.getState().DeployState.Status == NotStarted })
 			handler.handleDeploySubtaskEvent(test.event)
+			wait(t, func() bool { return handler.getState().DeployState.Status == test.event.Status })
 		})
 	}
 }

--- a/pkg/skaffold/event/v2/deploy_test.go
+++ b/pkg/skaffold/event/v2/deploy_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package v2
 
 import (
@@ -12,16 +28,16 @@ import (
 )
 
 func TestHandleDeploySubtaskEvent(t *testing.T) {
-	tests := []struct{
+	tests := []struct {
 		name  string
 		event *proto.DeploySubtaskEvent
 	}{
 		{
 			name: "In Progress",
 			event: &proto.DeploySubtaskEvent{
-				Id:       "0",
-				TaskId:   fmt.Sprintf("%s-%d", constants.Deploy, 0),
-				Status:   InProgress,
+				Id:     "0",
+				TaskId: fmt.Sprintf("%s-%d", constants.Deploy, 0),
+				Status: InProgress,
 			},
 		},
 		{
@@ -36,9 +52,9 @@ func TestHandleDeploySubtaskEvent(t *testing.T) {
 		{
 			name: "Succeeded",
 			event: &proto.DeploySubtaskEvent{
-				Id:       "99",
-				TaskId:   fmt.Sprintf("%s-%d", constants.Deploy, 12),
-				Status:   Succeeded,
+				Id:     "99",
+				TaskId: fmt.Sprintf("%s-%d", constants.Deploy, 12),
+				Status: Succeeded,
 			},
 		},
 	}
@@ -48,7 +64,6 @@ func TestHandleDeploySubtaskEvent(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			handler = newHandler()
 			handler.state = emptyState(mockCfg([]latest_v1.Pipeline{{}}, "test"))
-
 
 			wait(t, func() bool { return handler.getState().DeployState.Status == NotStarted })
 			handler.handleDeploySubtaskEvent(test.event)

--- a/pkg/skaffold/runner/new.go
+++ b/pkg/skaffold/runner/new.go
@@ -360,10 +360,6 @@ func getDeployer(runCtx *runcontext.RunContext, labels map[string]string) (deplo
 			deployers = append(deployers, deployer)
 		}
 	}
-	// avoid muxing overhead when only a single deployer is configured
-	if len(deployers) == 1 {
-		return deployers[0], nil
-	}
 
 	return deployers, nil
 }

--- a/pkg/skaffold/runner/new_test.go
+++ b/pkg/skaffold/runner/new_test.go
@@ -49,7 +49,9 @@ func TestGetDeployer(tOuter *testing.T) {
 				description: "helm deployer with 3.0.0 version",
 				cfg:         latest_v1.DeployType{HelmDeploy: &latest_v1.HelmDeploy{}},
 				helmVersion: `version.BuildInfo{Version:"v3.0.0"}`,
-				expected:    &helm.Deployer{},
+				expected: deploy.DeployerMux{
+					&helm.Deployer{},
+				},
 			},
 			{
 				description: "helm deployer with less than 3.0.0 version",
@@ -60,25 +62,31 @@ func TestGetDeployer(tOuter *testing.T) {
 			{
 				description: "kubectl deployer",
 				cfg:         latest_v1.DeployType{KubectlDeploy: &latest_v1.KubectlDeploy{}},
-				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
-					Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{}}),
-				}, nil, &latest_v1.KubectlDeploy{
-					Flags: latest_v1.KubectlFlags{},
-				})).(deploy.Deployer),
+				expected: deploy.DeployerMux{
+					t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
+						Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{}}),
+					}, nil, &latest_v1.KubectlDeploy{
+						Flags: latest_v1.KubectlFlags{},
+					})).(deploy.Deployer),
+				},
 			},
 			{
 				description: "kustomize deployer",
 				cfg:         latest_v1.DeployType{KustomizeDeploy: &latest_v1.KustomizeDeploy{}},
-				expected: t.RequireNonNilResult(kustomize.NewDeployer(&runcontext.RunContext{
-					Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{}}),
-				}, nil, &latest_v1.KustomizeDeploy{
-					Flags: latest_v1.KubectlFlags{},
-				})).(deploy.Deployer),
+				expected: deploy.DeployerMux{
+					t.RequireNonNilResult(kustomize.NewDeployer(&runcontext.RunContext{
+						Pipelines: runcontext.NewPipelines([]latest_v1.Pipeline{{}}),
+					}, nil, &latest_v1.KustomizeDeploy{
+						Flags: latest_v1.KubectlFlags{},
+					})).(deploy.Deployer),
+				},
 			},
 			{
 				description: "kpt deployer",
 				cfg:         latest_v1.DeployType{KptDeploy: &latest_v1.KptDeploy{}},
-				expected:    kpt.NewDeployer(&runcontext.RunContext{}, nil, &latest_v1.KptDeploy{}),
+				expected: deploy.DeployerMux{
+					kpt.NewDeployer(&runcontext.RunContext{}, nil, &latest_v1.KptDeploy{}),
+				},
 			},
 			{
 				description: "multiple deployers",


### PR DESCRIPTION
Fixes: #5782 
**Related**: #5423 

**Description**
This PR changes some of the get deployer logic to always use the deployer mux, as it reduces the complexity/LoC needed for emitting deploy protos. It also makes the change to emit deploy protos.
