### PR TITLE
Fix for #5210

### DIFF
--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -47,10 +47,7 @@ var (
 	MsgKubectlConnection = "kubectl connection error\n"
 
 	nonRetryContainerErrors = map[proto.StatusCode]struct{}{
-		proto.StatusCode_STATUSCHECK_IMAGE_PULL_ERR:       {},
-		proto.StatusCode_STATUSCHECK_RUN_CONTAINER_ERR:    {},
-		proto.StatusCode_STATUSCHECK_CONTAINER_TERMINATED: {},
-		proto.StatusCode_STATUSCHECK_CONTAINER_RESTARTING: {},
+		proto.StatusCode_STATUSCHECK_IMAGE_PULL_ERR: {},
 	}
 )
 

--- a/pkg/skaffold/deploy/status/status_check_test.go
+++ b/pkg/skaffold/deploy/status/status_check_test.go
@@ -553,7 +553,7 @@ func TestPollDeployment(t *testing.T) {
 					"pod",
 					"dep-pod",
 					"Pending",
-					proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_CONTAINER_TERMINATED},
+					proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_IMAGE_PULL_ERR},
 					[]string{"err"})},
 			},
 			expected: proto.StatusCode_STATUSCHECK_DEPLOYMENT_ROLLOUT_PENDING,


### PR DESCRIPTION
Fixes: #5210 
**Description**

Remove these from the unrecoverable errors list.  Containers are
ephemeral in k8s, so errors in them may be recoverable at a system
level.  E.g. when they are waiting for another resource to stablelize.

**User facing changes (remove if N/A)**

The deploy status check will wait for the deployment to stabilize even if the container errors out.  This restores the 1.12 behaviour.