### PR TITLE
Resolve all filepaths to absolute in 'skaffold diagnose'

### DIFF
--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -52,6 +52,8 @@ func NewCmdDiagnose() *cobra.Command {
 }
 
 func doDiagnose(ctx context.Context, out io.Writer) error {
+	// force absolute path resolution during diagnose
+	opts.MakePathsAbsolute = true
 	configs, err := getCfgs(opts)
 	if err != nil {
 		return err

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -59,6 +59,7 @@ type SkaffoldOptions struct {
 	ProfileAutoActivation bool
 	DryRun                bool
 	SkipRender            bool
+	MakePathsAbsolute     bool
 
 	// Add Skaffold-specific labels including runID, deployer labels, etc.
 	// `CustomLabels` are still applied if this is false. Must only be used in

--- a/pkg/skaffold/diagnose/diagnose_test.go
+++ b/pkg/skaffold/diagnose/diagnose_test.go
@@ -86,7 +86,7 @@ func TestCheckArtifacts(t *testing.T) {
 				Workspace: tmpDir.Root(),
 				ArtifactType: latest_v1.ArtifactType{
 					DockerArtifact: &latest_v1.DockerArtifact{
-						DockerfilePath: "Dockerfile",
+						DockerfilePath: tmpDir.Path("Dockerfile"),
 					},
 				},
 			}},

--- a/pkg/skaffold/parser/config.go
+++ b/pkg/skaffold/parser/config.go
@@ -165,7 +165,7 @@ func processEachConfig(config *latest_v1.SkaffoldConfig, cfgOpts configOpts, opt
 		return nil, sErrors.ConfigSetDefaultValuesErr(config.Metadata.Name, cfgOpts.file, err)
 	}
 	// convert relative file paths to absolute for all configs that are not invoked explicitly. This avoids maintaining multiple root directory information since the dependency skaffold configs would have their own root directory.
-	if cfgOpts.isDependency {
+	if cfgOpts.isDependency || opts.MakePathsAbsolute {
 		if err := tags.MakeFilePathsAbsolute(config, filepath.Dir(cfgOpts.file)); err != nil {
 			return nil, sErrors.ConfigSetAbsFilePathsErr(config.Metadata.Name, cfgOpts.file, err)
 		}


### PR DESCRIPTION
**Description**
this change forces absolute path resolution for all paths provided in a `skaffold.yaml` when running `skaffold diagnose`.

**User facing changes (remove if N/A)**
paths provided in a `skaffold.yaml` will now always be resolved to absolute.

given our `getting-started` example:

Before:

```
➜ skaffold diagnose --yaml-only
apiVersion: skaffold/v2beta16
kind: Config
build:
  artifacts:
  - image: skaffold-example
    context: .
    docker:
      dockerfile: Dockerfile
  tagPolicy:
    gitCommit: {}
  local:
    concurrency: 1
deploy:
  kubectl:
    manifests:
    - k8s-*
  logs:
    prefix: container
```

After:

```
➜ skaffold diagnose --yaml-only
apiVersion: skaffold/v2beta16
kind: Config
build:
  artifacts:
  - image: skaffold-example
    context: /Users/nkubala/Development/skaffold/examples/getting-started
    docker:
      dockerfile: Dockerfile
  tagPolicy:
    gitCommit: {}
  local:
    concurrency: 1
deploy:
  kubectl:
    manifests:
    - /Users/nkubala/Development/skaffold/examples/getting-started/k8s-*
  logs:
    prefix: container
```

the purpose of `skaffold diagnose` is to inspect exactly what skaffold is doing at runtime - this change makes which files skaffold is using more clear. additionally, this makes the output of `skaffold diagnose --yaml-only` more useful in successive skaffold runs outside of the root directory (specifically, providing it to `skaffold render`).