### PR TITLE
add `skaffold inspect build-env` command

### DIFF
--- a/cmd/skaffold/app/cmd/inspect.go
+++ b/cmd/skaffold/app/cmd/inspect.go
@@ -26,6 +26,7 @@ var inspectFlags = struct {
 	outFormat string
 	modules   []string
 	buildEnv  string
+	profiles  []string
 }{
 	fileName: "skaffold.yaml",
 }
@@ -35,7 +36,7 @@ func NewCmdInspect() *cobra.Command {
 		WithDescription("Helper commands for Cloud Code IDEs to interact with and modify skaffold configuration files.").
 		WithPersistentFlagAdder(cmdInspectFlags).
 		Hidden().
-		WithCommands(cmdModules(), cmdProfiles())
+		WithCommands(cmdModules(), cmdProfiles(), cmdBuildEnv())
 }
 
 func cmdInspectFlags(f *pflag.FlagSet) {

--- a/cmd/skaffold/app/cmd/inspect_build_env.go
+++ b/cmd/skaffold/app/cmd/inspect_build_env.go
@@ -28,7 +28,7 @@ import (
 
 func cmdBuildEnv() *cobra.Command {
 	return NewCmd("build-env").
-		WithDescription("Interact with skaffold build environments definitions.").
+		WithDescription("Interact with skaffold build environment definitions.").
 		WithPersistentFlagAdder(cmdBuildEnvFlags).
 		WithCommands(cmdBuildEnvList())
 }

--- a/cmd/skaffold/app/cmd/inspect_build_env.go
+++ b/cmd/skaffold/app/cmd/inspect_build_env.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"io"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/inspect"
+)
+
+func cmdBuildEnv() *cobra.Command {
+	return NewCmd("build-env").
+		WithDescription("Interact with skaffold build environments definitions.").
+		WithPersistentFlagAdder(cmdBuildEnvFlags).
+		WithCommands(cmdBuildEnvList())
+}
+
+func cmdBuildEnvList() *cobra.Command {
+	return NewCmd("list").
+		WithExample("Get list of target build environments with activated profiles p1 and p2", "inspect build-env list -p p1,p2 --format json").
+		WithDescription("Print the list of active build environments.").
+		WithFlagAdder(cmdBuildEnvListFlags).
+		NoArgs(listBuildEnv)
+}
+
+func listBuildEnv(ctx context.Context, out io.Writer) error {
+	return inspect.PrintBuildEnvsList(ctx, out, inspect.Options{Filename: inspectFlags.fileName, OutFormat: inspectFlags.outFormat, Modules: inspectFlags.modules, BuildEnvOptions: inspect.BuildEnvOptions{Profiles: inspectFlags.profiles}})
+}
+
+func cmdBuildEnvFlags(f *pflag.FlagSet) {
+	f.StringSliceVarP(&inspectFlags.modules, "module", "m", nil, "Names of modules to filter target action by.")
+}
+
+func cmdBuildEnvListFlags(f *pflag.FlagSet) {
+	f.StringSliceVarP(&inspectFlags.profiles, "profile", "p", nil, `Profile names to activate`)
+}

--- a/pkg/skaffold/inspect/build_env_test.go
+++ b/pkg/skaffold/inspect/build_env_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inspect
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser"
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/errors"
+	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestPrintBuildEnvsList(t *testing.T) {
+	tests := []struct {
+		description string
+		profiles    []string
+		module      []string
+		err         error
+		expected    string
+	}{
+		{
+			description: "print all build environments",
+			expected: `{"build_envs":[` +
+				`{"type":"local","path":"path/to/cfg1","module":"cfg1"},` +
+				`{"type":"googleCloudBuild","path":"path/to/cfg2","module":"cfg2"}` +
+				"]}\n",
+		},
+		{
+			description: "print all build environments for one module",
+			expected: `{"build_envs":[` +
+				`{"type":"local","path":"path/to/cfg1","module":"cfg1"}` +
+				"]}\n",
+			module: []string{"cfg1"},
+		},
+		{
+			description: "print all build environments for two activated profiles",
+
+			expected: `{"build_envs":[` +
+				`{"type":"cluster","path":"path/to/cfg1","module":"cfg1"},` +
+				`{"type":"local","path":"path/to/cfg2","module":"cfg2"}` +
+				"]}\n",
+			profiles: []string{"local", "cluster"},
+		},
+		{
+			description: "print all build environments for one module and an activated profile",
+
+			expected: `{"build_envs":[` +
+				`{"type":"cluster","path":"path/to/cfg1","module":"cfg1"}` +
+				"]}\n",
+			module:   []string{"cfg1"},
+			profiles: []string{"cluster"},
+		},
+		{
+			description: "actionable error",
+			err:         sErrors.MainConfigFileNotFoundErr("path/to/skaffold.yaml", fmt.Errorf("failed to read file : %q", "skaffold.yaml")),
+			expected:    `{"errorCode":"CONFIG_FILE_NOT_FOUND_ERR","errorMessage":"unable to find configuration file \"path/to/skaffold.yaml\": failed to read file : \"skaffold.yaml\". Check that the specified configuration file exists at \"path/to/skaffold.yaml\"."}` + "\n",
+		},
+		{
+			description: "generic error",
+			err:         errors.New("some error occurred"),
+			expected:    `{"errorCode":"UNKNOWN_ERROR","errorMessage":"some error occurred"}` + "\n",
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			configSet := parser.SkaffoldConfigSet{
+				&parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{
+					Metadata: v1.Metadata{Name: "cfg1"},
+					Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}},
+					Profiles: []v1.Profile{
+						{Name: "cluster", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{Cluster: &v1.ClusterDetails{}}}}},
+					}}, SourceFile: "path/to/cfg1"},
+				&parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{
+					Metadata: v1.Metadata{Name: "cfg2"},
+					Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{GoogleCloudBuild: &v1.GoogleCloudBuild{}}}},
+					Profiles: []v1.Profile{
+						{Name: "local", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
+					}}, SourceFile: "path/to/cfg2"},
+			}
+			t.Override(&getConfigSetFunc, func(config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+				// mock profile activation
+				for _, c := range configSet {
+					for _, pName := range test.profiles {
+						for _, profile := range c.Profiles {
+							if profile.Name != pName {
+								continue
+							}
+							c.Build.BuildType = profile.Build.BuildType
+						}
+					}
+				}
+				return configSet, test.err
+			})
+			var buf bytes.Buffer
+			err := PrintBuildEnvsList(context.Background(), &buf, Options{OutFormat: "json", Modules: test.module, BuildEnvOptions: BuildEnvOptions{Profiles: test.profiles}})
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expected, buf.String())
+		})
+	}
+}

--- a/pkg/skaffold/inspect/types.go
+++ b/pkg/skaffold/inspect/types.go
@@ -31,12 +31,19 @@ type Options struct {
 	Modules []string
 
 	ProfilesOptions
+	BuildEnvOptions
 }
 
 // ProfilesOptions holds flag values for various `skaffold inspect profiles` commands
 type ProfilesOptions struct {
 	// BuildEnv is the build-env filter for command output. One of: local, googleCloudBuild, cluster.
 	BuildEnv BuildEnv
+}
+
+// BuildEnvOptions holds flag values for various `skaffold inspect build-env` commands
+type BuildEnvOptions struct {
+	// Profiles is the slice of profile names to activate.
+	Profiles []string
 }
 
 type BuildEnv string
@@ -53,17 +60,13 @@ var (
 	}
 )
 
-func (b BuildEnv) MatchesConfig(t *latest_v1.BuildType) bool {
-	switch b {
-	case BuildEnvs.Local:
-		return t.LocalBuild != nil
-	case BuildEnvs.GoogleCloudBuild:
-		return t.GoogleCloudBuild != nil
-	case BuildEnvs.Cluster:
-		return t.Cluster != nil
-	case BuildEnvs.Unspecified:
-		return true
+func GetBuildEnv(t *latest_v1.BuildType) BuildEnv {
+	switch {
+	case t.Cluster != nil:
+		return BuildEnvs.Cluster
+	case t.GoogleCloudBuild != nil:
+		return BuildEnvs.GoogleCloudBuild
 	default:
-		return false
+		return BuildEnvs.Local
 	}
 }


### PR DESCRIPTION
Add commands `skaffold inspect build-env` and `skaffold inspect build-env list`.

```
❯ skaffold inspect build-env          
Interact with skaffold build environment definitions.

Available Commands:
  list        Print the list of active build environments.

Use "skaffold <command> --help" for more information about a given command.
```
```
❯ skaffold inspect build-env list --help                    
Print the list of active build environments.

Examples:
  # Get list of target build environments with activated profiles p1 and p2
  skaffold inspect build-env list -p p1,p2 --format json

Options:
  -p, --profile=[]: Profile names to activate

Usage:
  skaffold inspect build-env list [flags] [options]

Use "skaffold options" for a list of global command-line options (applies to all
commands).
```
Run in `examples/buildpacks` directory:
```
❯ skaffold inspect build-env list | jq
{
  "build_envs": [
    {
      "type": "local",
      "path": "/Users/gaghosh/Code/Work/fork/skaffold/examples/buildpacks/skaffold.yaml"
    }
  ]
}
```