### PR TITLE
[V3] add renderer basic struct.

### DIFF
--- a/pkg/skaffold/render/renderer/renderer.go
+++ b/pkg/skaffold/render/renderer/renderer.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package renderer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/generate"
+	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+const (
+	DefaultHydrationDir = ".kpt-pipeline"
+	dryFileName         = "manifests.yaml"
+	KptFileName         = "Kptfile"
+)
+
+type Renderer interface {
+	Render(context.Context, io.Writer, []graph.Artifact) error
+}
+
+func NewSkaffoldRenderer(config *latestV2.RenderConfig, workingDir string) Renderer {
+	// TODO(yuwenma): return instance of kpt-managed mode or skaffold-managed mode defer to the config.Path fields.
+	// The alpha implementation only has skaffold-managed mode.
+	generator := generate.NewGenerator(workingDir, *config.Generate)
+	return &SkaffoldRenderer{Generator: *generator, workingDir: workingDir}
+}
+
+type SkaffoldRenderer struct {
+	generate.Generator
+	workingDir string
+	labels     map[string]string
+}
+
+// prepareHydrationDir guarantees the existence of a kpt-initialized temporary directory.
+// This directory is used to cache DRY config and hydrates the DRY config to WET config in-place.
+// This is needed because kpt v1 only supports in-place config while users may not want to have their config be
+// hydrated in place.
+func (r *SkaffoldRenderer) prepareHydrationDir(ctx context.Context) error {
+	// TODO(yuwenma): The current work directory may not be accurate if users use --filepath flag.
+	outputPath := filepath.Join(r.workingDir, DefaultHydrationDir)
+	logrus.Debugf("creating render directory: %v", outputPath)
+
+	if err := os.MkdirAll(outputPath, os.ModePerm); err != nil {
+		return fmt.Errorf("creating cache directory for hydration: %w", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputPath, KptFileName)); os.IsNotExist(err) {
+		cmd := exec.CommandContext(ctx, "kpt", "pkg", "init", outputPath)
+		if _, err := util.RunCmdOut(cmd); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *SkaffoldRenderer) Render(ctx context.Context, out io.Writer, builds []graph.Artifact) error {
+	if err := r.prepareHydrationDir(ctx); err != nil {
+		return err
+	}
+
+	manifests, err := r.Generate(ctx)
+	if err != nil {
+		return err
+	}
+	manifests, err = manifests.ReplaceImages(builds)
+	if err != nil {
+		return err
+	}
+	manifests.SetLabels(r.labels)
+
+	// cache the dry manifests to the temp directory. manifests.yaml will be truncated if already exists.
+	dryConfigPath := filepath.Join(r.workingDir, DefaultHydrationDir, dryFileName)
+	if err := manifest.Write(manifests.String(), dryConfigPath, out); err != nil {
+		return err
+	}
+
+	// TODO: mutate and validate
+	return nil
+}

--- a/pkg/skaffold/render/renderer/renderer_test.go
+++ b/pkg/skaffold/render/renderer/renderer_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package renderer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+const (
+	// Raw manifests
+	podYaml = `apiVersion: v1
+kind: Pod
+metadata:
+  name: leeroy-web
+spec:
+  containers:
+  - image: leeroy-web
+    name: leeroy-web
+`
+	// manifests with image labels
+	labeledPodYaml = `apiVersion: v1
+kind: Pod
+metadata:
+  name: leeroy-web
+spec:
+  containers:
+  - image: leeroy-web:v1
+    name: leeroy-web
+`
+)
+
+func TestRender_StoredInCache(t *testing.T) {
+	testutil.Run(t, "", func(t *testutil.T) {
+		r := NewSkaffoldRenderer(&latestV2.RenderConfig{Generate: &latestV2.Generate{
+			Manifests: []string{"pod.yaml"}}}, "")
+		fakeCmd := testutil.CmdRunOut(fmt.Sprintf("kpt pkg init %v", DefaultHydrationDir), "")
+		t.Override(&util.DefaultExecCommand, fakeCmd)
+
+		t.NewTempDir().
+			Write("pod.yaml", podYaml).
+			Touch("empty.ignored").
+			Chdir()
+
+		var b bytes.Buffer
+		err := r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}})
+		t.CheckNoError(err)
+		t.CheckFileExistAndContent(filepath.Join(DefaultHydrationDir, dryFileName), []byte(labeledPodYaml))
+	})
+}

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -19,6 +19,7 @@ package testutil
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -147,6 +148,12 @@ func (t *T) CheckError(shouldErr bool, err error) {
 func (t *T) CheckErrorAndFailNow(shouldErr bool, err error) {
 	t.Helper()
 	CheckErrorAndFailNow(t.T, shouldErr, err)
+}
+
+// CheckFileExistAndContent checks if the given file path exists and the content is expected.
+func (t *T) CheckFileExistAndContent(filePath string, expectedContent []byte) {
+	t.Helper()
+	CheckFileExistAndContent(t.T, filePath, expectedContent)
 }
 
 // CheckErrorContains checks that an error is not nil and contains
@@ -311,6 +318,21 @@ func CheckErrorAndFailNow(t *testing.T, shouldErr bool, err error) {
 	if err := checkErr(shouldErr, err); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func CheckFileExistAndContent(t *testing.T, path string, expectedContent []byte) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatalf("abs path %v: %v", path, err)
+	}
+	if _, err := os.Stat(absPath); os.IsNotExist(err) {
+		t.Fatalf("file %v does not exist", path)
+	}
+	actualContent, err := ioutil.ReadFile(absPath)
+	if err != nil {
+		t.Error(err)
+	}
+	CheckDeepEqual(t, expectedContent, actualContent)
 }
 
 func EnsureTestPanicked(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: #5673 
**Merge after**: #5865

**Description**
The renderer struct initialize generator which parses the DRY config and stores the dry config in a tmp directory.

To reviewers:
this PR is diff-based from #5865, to review the renderer specific code change, please see this  [`4867900` (#5793)](https://github.com/GoogleContainerTools/skaffold/pull/5793/commits/4867900a6969e85cf4531083aa2309166f1db895)