### PR TITLE
Avoid aliasing in image configuration

### DIFF
--- a/pkg/skaffold/debug/debug.go
+++ b/pkg/skaffold/debug/debug.go
@@ -158,5 +158,4 @@ func dupMap(s map[string]string) map[string]string {
 		dup[k] = v
 	}
 	return dup
-
 }

--- a/pkg/skaffold/debug/debug.go
+++ b/pkg/skaffold/debug/debug.go
@@ -119,12 +119,13 @@ func retrieveImageConfiguration(ctx context.Context, artifact *graph.Artifact, i
 
 	config := manifest.Config
 	logrus.Debugf("Retrieved local image configuration for %v: %v", artifact.Tag, config)
+	// need to duplicate slices as apiClient caches requests
 	return imageConfiguration{
 		artifact:   artifact.ImageName,
 		env:        envAsMap(config.Env),
-		entrypoint: config.Entrypoint,
-		arguments:  config.Cmd,
-		labels:     config.Labels,
+		entrypoint: dupArray(config.Entrypoint),
+		arguments:  dupArray(config.Cmd),
+		labels:     dupMap(config.Labels),
 		workingDir: config.WorkingDir,
 	}, nil
 }
@@ -137,4 +138,25 @@ func envAsMap(env []string) map[string]string {
 		result[s[0]] = s[1]
 	}
 	return result
+}
+
+func dupArray(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	dup := make([]string, len(s))
+	copy(dup, s)
+	return dup
+}
+
+func dupMap(s map[string]string) map[string]string {
+	if len(s) == 0 {
+		return nil
+	}
+	dup := make(map[string]string, len(s))
+	for k, v := range s {
+		dup[k] = v
+	}
+	return dup
+
 }


### PR DESCRIPTION
Fixes: #5704

**Description**
In examining a debug trace, we discovered that the retrieved image configuration for the unchanged image was actually different:
- round 1:
  >    DEBU[0015] Retrieved local image configuration for gcr.io/gcloud-powershell-testing/nodejs-guestbook-frontend:latest@sha256:fdf561285af541e5db2483694966368287c1baced16f2c6180bcf06cfd328c06: {false false false [] <nil>  [node app.js] [PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin NODE_VERSION=12.22.1 YARN_VERSION=1.22.5 WRAPPER_VERBOSE=debug]  sha256:ce9a93883c04ba2b41e72a472b955dbaa171a00d7defe5c5b98ed280bd9d22cd map[] [] false false false  map[] /frontend map[] false false   []} 

- round 2 (notice the entrypoint now has an `--inspect=0.0.0.0:9229`)
  > DEBU[0131] Retrieved local image configuration for gcr.io/gcloud-powershell-testing/nodejs-guestbook-frontend:latest@sha256:fdf561285af541e5db2483694966368287c1baced16f2c6180bcf06cfd328c06: {false false false [] <nil>  [node --inspect=0.0.0.0:9229] [PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin NODE_VERSION=12.22.1 YARN_VERSION=1.22.5 WRAPPER_VERBOSE=debug]  sha256:ce9a93883c04ba2b41e72a472b955dbaa171a00d7defe5c5b98ed280bd9d22cd map[] [] false false false  map[] /frontend map[] false false   []} 

The problem is due to aliasing of underlying arrays when copying slices.  We retrieve the image manifest and configuration for the image from the local docker daemon:
https://github.com/GoogleContainerTools/skaffold/blob/01feff8c4dccaa6d76072abac1fe9ed6494da866/pkg/skaffold/debug/debug.go#L114

and then copy the values, but the slices and maps retain pointers to their underlying arrays:
https://github.com/GoogleContainerTools/skaffold/blob/01feff8c4dccaa6d76072abac1fe9ed6494da866/pkg/skaffold/debug/debug.go#L120-L129

This struct is then changed with new arguments values copied into the array:
https://github.com/GoogleContainerTools/skaffold/blob/01feff8c4dccaa6d76072abac1fe9ed6494da866/pkg/skaffold/debug/transform_nodejs.go#L196-L203

The solution here is to duplicate the arrays and maps taken from the image configuration.