### PR TITLE
Add support for Port forwarding with namespaces with Templated Fields

### DIFF
--- a/docs/content/en/docs/environment/templating.md
+++ b/docs/content/en/docs/environment/templating.md
@@ -22,6 +22,7 @@ List of fields that support templating:
 * `deploy.helm.releases.namespace` (see [Deploying with helm]({{< relref "/docs/pipeline-stages/deployers#deploying-with-helm)" >}}))
 * `deploy.kubectl.defaultNamespace`
 * `deploy.kustomize.defaultNamespace`
+* `portForward.namespace`
 
 _Please note, this list is not exhaustive._
 

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder.go
@@ -68,8 +68,7 @@ func (p *ResourceForwarder) Start(ctx context.Context, namespaces []string) erro
 	if len(namespaces) == 1 {
 		for _, pf := range p.userDefinedResources {
 			if pf.Namespace != "" {
-				err := applyNamespaceWithTemplate(pf)
-				if err != nil {
+				if err := applyNamespaceWithTemplate(pf); err != nil {
 					return err
 				}
 			} else {
@@ -80,8 +79,7 @@ func (p *ResourceForwarder) Start(ctx context.Context, namespaces []string) erro
 		var validResources []*latestV1.PortForwardResource
 		for _, pf := range p.userDefinedResources {
 			if pf.Namespace != "" {
-				err := applyNamespaceWithTemplate(pf)
-				if err != nil {
+				if err := applyNamespaceWithTemplate(pf); err != nil {
 					return err
 				}
 				validResources = append(validResources, pf)

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder.go
@@ -67,13 +67,13 @@ func NewUserDefinedForwarder(entryManager *EntryManager, userDefinedResources []
 func (p *ResourceForwarder) Start(ctx context.Context, namespaces []string) error {
 	if len(namespaces) == 1 {
 		for _, pf := range p.userDefinedResources {
-			if pf.Namespace == "" {
-				pf.Namespace = namespaces[0]
-			} else {
+			if pf.Namespace != "" {
 				err := applyNamespaceWithTemplate(pf)
 				if err != nil {
 					return err
 				}
+			} else {
+				pf.Namespace = namespaces[0]
 			}
 		}
 	} else {

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -262,6 +262,26 @@ func TestUserDefinedResources(t *testing.T) {
 				"pod-pod-some-9001",
 			},
 		},
+		{
+			description: "pod should be found with namespace with template",
+			userResources: []*latestV1.PortForwardResource{
+				{Type: constants.Pod, Name: "pod", Namespace: "some-with-template-{{ .FOO }}", Port: schemautil.FromInt(9000)},
+			},
+			namespaces: []string{"test"},
+			expectedResources: []string{
+				"pod-pod-some-with-template-bar-9000",
+			},
+		},
+		{
+			description: "pod should be found with namespace with template",
+			userResources: []*latestV1.PortForwardResource{
+				{Type: constants.Pod, Name: "pod", Namespace: "some-with-template-{{ .FOO }}", Port: schemautil.FromInt(9000)},
+			},
+			namespaces: []string{"test", "another"},
+			expectedResources: []string{
+				"pod-pod-some-with-template-bar-9000",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -274,6 +294,10 @@ func TestUserDefinedResources(t *testing.T) {
 
 			fakeForwarder := newTestForwarder()
 			entryManager := NewEntryManager(ioutil.Discard, fakeForwarder)
+
+			util.OSEnviron = func() []string {
+				return []string{"FOO=bar"}
+			}
 
 			rf := NewUserDefinedForwarder(entryManager, test.userResources)
 			if err := rf.Start(context.Background(), test.namespaces); err != nil {


### PR DESCRIPTION
Fixes: #5802 

**Description**
As described in #5802 user defined PortForward wasn't supporting a namespace with templated fields.
I added the support to allow users to add in their skaffold.yaml port forwarding with a templated field namespace.
So they can match a namespace in the port forward to a  namespace in the deploy section.
Since the deply.helm.releases.namespace was already supported that brought some inconsistency and not allowing to port forward deployment with a namespace with templated fields in it

> deploy:  
  helm:
    releases:
      - name: my-deployment
        chartPath: helm
        version: v2        
        valuesFiles:
          - helm/values/values.yaml
        artifactOverrides:
          image: my-image
        **namespace: "my-namespace-{{ .FOO }}"**

> portForward:
   resourceType: StatefulSet
      resourceName: resourceName
    **namespace: "my-namespace-{{ .FOO }}"**
    port: 22
    localPort: 5022

I also added the new field support to the documentation under the templated field section.

