### PR TITLE
Embed Logger inside Deployer

### DIFF
--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/helm"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -88,7 +89,7 @@ spec:
 					},
 				},
 			}}),
-		}, nil, &latestV1.KubectlDeploy{
+		}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
 			Manifests: []string{"deployment.yaml"},
 		})
 		t.RequireNoError(err)
@@ -248,7 +249,7 @@ spec:
 				Opts: config.SkaffoldOptions{
 					AddSkaffoldLabels: true,
 				},
-			}, nil, &latestV1.KubectlDeploy{
+			}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
 			})
 			t.RequireNoError(err)
@@ -434,7 +435,7 @@ spec:
 						},
 					},
 				}}),
-			}, nil, &latestV1.HelmDeploy{
+			}, nil, &log.NoopLogger{}, &latestV1.HelmDeploy{
 				Releases: test.helmReleases,
 			})
 			t.RequireNoError(err)

--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -21,11 +21,14 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 )
 
 // Deployer is the Deploy API of skaffold and responsible for deploying
 // the build results to a Kubernetes cluster
 type Deployer interface {
+	log.Logger
+
 	// Deploy should ensure that the build results are deployed to the Kubernetes
 	// cluster. Returns the list of impacted namespaces.
 	Deploy(context.Context, io.Writer, []graph.Artifact) ([]string, error)

--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"io"
 	"strings"
+	"time"
 
 	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
@@ -85,4 +86,43 @@ func (m DeployerMux) Render(ctx context.Context, w io.Writer, as []graph.Artifac
 
 	allResources := strings.Join(resources, "\n---\n")
 	return manifest.Write(strings.TrimSpace(allResources), filepath, w)
+}
+
+func (m DeployerMux) StartLogger(ctx context.Context, out io.Writer, namespaces []string) error {
+	for _, deployer := range m {
+		if err := deployer.StartLogger(ctx, out, namespaces); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m DeployerMux) StopLogger() {
+	for _, deployer := range m {
+		deployer.StopLogger()
+	}
+}
+
+func (m DeployerMux) Mute() {
+	for _, deployer := range m {
+		deployer.Mute()
+	}
+}
+
+func (m DeployerMux) Unmute() {
+	for _, deployer := range m {
+		deployer.Unmute()
+	}
+}
+
+func (m DeployerMux) SetSince(t time.Time) {
+	for _, deployer := range m {
+		deployer.SetSince(t)
+	}
+}
+
+func (m DeployerMux) RegisterBuildArtifacts(artifacts []graph.Artifact) {
+	for _, deployer := range m {
+		deployer.RegisterBuildArtifacts(artifacts)
+	}
 }

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	testEvent "github.com/GoogleContainerTools/skaffold/testutil/event"
@@ -34,6 +35,8 @@ import (
 func NewMockDeployer() *MockDeployer { return &MockDeployer{labels: make(map[string]string)} }
 
 type MockDeployer struct {
+	log.NoopLogger
+
 	labels           map[string]string
 	deployNamespaces []string
 	deployErr        error

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -44,6 +44,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/types"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
@@ -73,6 +74,8 @@ var (
 type Deployer struct {
 	*latestV1.HelmDeploy
 
+	log.Logger
+
 	kubeContext string
 	kubeConfig  string
 	namespace   string
@@ -96,7 +99,7 @@ type Config interface {
 }
 
 // NewDeployer returns a configured Deployer.  Returns an error if current version of helm is less than 3.0.0.
-func NewDeployer(cfg Config, labels map[string]string, h *latestV1.HelmDeploy) (*Deployer, error) {
+func NewDeployer(cfg Config, labels map[string]string, logger log.Logger, h *latestV1.HelmDeploy) (*Deployer, error) {
 	hv, err := binVer()
 	if err != nil {
 		return nil, versionGetErr(err)
@@ -107,6 +110,7 @@ func NewDeployer(cfg Config, labels map[string]string, h *latestV1.HelmDeploy) (
 	}
 
 	return &Deployer{
+		Logger:        logger,
 		HelmDeploy:    h,
 		kubeContext:   cfg.GetKubeContext(),
 		kubeConfig:    cfg.GetKubeConfig(),

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
@@ -462,7 +463,7 @@ func TestNewDeployer(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", test.helmVersion))
 
-			_, err := NewDeployer(&helmConfig{}, nil, &testDeployConfig)
+			_, err := NewDeployer(&helmConfig{}, nil, &log.NoopLogger{}, &testDeployConfig)
 			t.CheckError(test.shouldErr, err)
 		})
 	}
@@ -984,7 +985,7 @@ func TestHelmDeploy(t *testing.T) {
 				namespace:  test.namespace,
 				force:      test.force,
 				configFile: "test.yaml",
-			}, nil, &test.helm)
+			}, nil, &log.NoopLogger{}, &test.helm)
 			t.RequireNoError(err)
 
 			if test.configure != nil {
@@ -1061,7 +1062,7 @@ func TestHelmCleanup(t *testing.T) {
 
 			deployer, err := NewDeployer(&helmConfig{
 				namespace: test.namespace,
-			}, nil, &test.helm)
+			}, nil, &log.NoopLogger{}, &test.helm)
 			t.RequireNoError(err)
 
 			deployer.Cleanup(context.Background(), ioutil.Discard)
@@ -1164,7 +1165,7 @@ func TestHelmDependencies(t *testing.T) {
 				local = tmpDir.Root()
 			}
 
-			deployer, err := NewDeployer(&helmConfig{}, nil, &latestV1.HelmDeploy{
+			deployer, err := NewDeployer(&helmConfig{}, nil, &log.NoopLogger{}, &latestV1.HelmDeploy{
 				Releases: []latestV1.HelmRelease{{
 					Name:                  "skaffold-helm",
 					ChartPath:             local,
@@ -1415,7 +1416,7 @@ func TestHelmRender(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			deployer, err := NewDeployer(&helmConfig{
 				namespace: test.namespace,
-			}, nil, &test.helm)
+			}, nil, &log.NoopLogger{}, &test.helm)
 			t.RequireNoError(err)
 			err = deployer.Render(context.Background(), ioutil.Discard, test.builds, true, file)
 			t.CheckError(test.shouldErr, err)
@@ -1484,7 +1485,7 @@ func TestGenerateSkaffoldDebugFilter(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", version31))
-			h, err := NewDeployer(&helmConfig{}, nil, &testDeployConfig)
+			h, err := NewDeployer(&helmConfig{}, nil, &log.NoopLogger{}, &testDeployConfig)
 			t.RequireNoError(err)
 			result := h.generateSkaffoldDebugFilter(test.buildFile)
 			t.CheckDeepEqual(test.result, result)

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -40,6 +40,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -63,14 +64,17 @@ const (
 type Deployer struct {
 	*latestV1.KptDeploy
 
+	log.Logger
+
 	insecureRegistries map[string]bool
 	labels             map[string]string
 	globalConfig       string
 }
 
 // NewDeployer generates a new Deployer object contains the kptDeploy schema.
-func NewDeployer(cfg types.Config, labels map[string]string, d *latestV1.KptDeploy) *Deployer {
+func NewDeployer(cfg types.Config, labels map[string]string, logger log.Logger, d *latestV1.KptDeploy) *Deployer {
 	return &Deployer{
+		Logger:             logger,
 		KptDeploy:          d,
 		insecureRegistries: cfg.GetInsecureRegistries(),
 		labels:             labels,

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -220,7 +221,7 @@ func TestKpt_Deploy(t *testing.T) {
 
 			tmpDir.WriteFiles(test.kustomizations)
 
-			k := NewDeployer(&kptConfig{}, nil, &test.kpt)
+			k := NewDeployer(&kptConfig{}, nil, &log.NoopLogger{}, &test.kpt)
 
 			if k.Live.Apply.Dir == "valid_path" {
 				// 0755 is a permission setting where the owner can read, write, and execute.
@@ -360,7 +361,7 @@ func TestKpt_Dependencies(t *testing.T) {
 			tmpDir.WriteFiles(test.createFiles)
 			tmpDir.WriteFiles(test.kustomizations)
 
-			k := NewDeployer(&kptConfig{}, nil, &test.kpt)
+			k := NewDeployer(&kptConfig{}, nil, &log.NoopLogger{}, &test.kpt)
 
 			res, err := k.Dependencies()
 
@@ -413,7 +414,7 @@ func TestKpt_Cleanup(t *testing.T) {
 
 			k := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, nil, &latestV1.KptDeploy{
+			}, nil, &log.NoopLogger{}, &latestV1.KptDeploy{
 				Live: latestV1.KptLive{
 					Apply: latestV1.KptApplyInventory{
 						Dir: test.applyDir,
@@ -769,7 +770,7 @@ spec:
 
 			k := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, test.labels, &test.kpt)
+			}, test.labels, &log.NoopLogger{}, &test.kpt)
 
 			var b bytes.Buffer
 			err := k.Render(context.Background(), &b, test.builds, true, "")
@@ -843,7 +844,7 @@ func TestKpt_GetApplyDir(t *testing.T) {
 
 			k := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, nil, &latestV1.KptDeploy{
+			}, nil, &log.NoopLogger{}, &latestV1.KptDeploy{
 				Live: test.live,
 			})
 
@@ -1002,7 +1003,7 @@ spec:
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			k := NewDeployer(&kptConfig{}, nil, nil)
+			k := NewDeployer(&kptConfig{}, nil, &log.NoopLogger{}, nil)
 			actualManifest, err := k.excludeKptFn(test.manifests)
 			t.CheckErrorAndDeepEqual(false, err, test.expected.String(), actualManifest.String())
 		})

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -36,6 +36,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -43,6 +44,8 @@ import (
 // Deployer deploys workflows using kubectl CLI.
 type Deployer struct {
 	*latestV1.KubectlDeploy
+
+	log.Logger
 
 	originalImages     []graph.Artifact
 	hydratedManifests  []string
@@ -58,7 +61,7 @@ type Deployer struct {
 
 // NewDeployer returns a new Deployer for a DeployConfig filled
 // with the needed configuration for `kubectl apply`
-func NewDeployer(cfg Config, labels map[string]string, d *latestV1.KubectlDeploy) (*Deployer, error) {
+func NewDeployer(cfg Config, labels map[string]string, logger log.Logger, d *latestV1.KubectlDeploy) (*Deployer, error) {
 	defaultNamespace := ""
 	if d.DefaultNamespace != nil {
 		var err error
@@ -69,6 +72,7 @@ func NewDeployer(cfg Config, labels map[string]string, d *latestV1.KubectlDeploy
 	}
 
 	return &Deployer{
+		Logger:             logger,
 		KubectlDeploy:      d,
 		workingDir:         cfg.GetWorkingDir(),
 		globalConfig:       cfg.GlobalConfig(),

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -241,7 +242,7 @@ func TestKubectlDeploy(t *testing.T) {
 				},
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: skaffoldNamespaceOption}},
-			}, nil, &test.kubectl)
+			}, nil, &log.NoopLogger{}, &test.kubectl)
 			t.RequireNoError(err)
 
 			_, err = k.Deploy(context.Background(), ioutil.Discard, test.builds)
@@ -315,7 +316,7 @@ func TestKubectlCleanup(t *testing.T) {
 			k, err := NewDeployer(&kubectlConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
-			}, nil, &test.kubectl)
+			}, nil, &log.NoopLogger{}, &test.kubectl)
 			t.RequireNoError(err)
 
 			err = k.Cleanup(context.Background(), ioutil.Discard)
@@ -362,7 +363,7 @@ func TestKubectlDeployerRemoteCleanup(t *testing.T) {
 			k, err := NewDeployer(&kubectlConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
-			}, nil, &test.kubectl)
+			}, nil, &log.NoopLogger{}, &test.kubectl)
 			t.RequireNoError(err)
 
 			err = k.Cleanup(context.Background(), ioutil.Discard)
@@ -396,7 +397,7 @@ func TestKubectlRedeploy(t *testing.T) {
 				Enabled: true,
 				Delay:   0 * time.Millisecond,
 				Max:     10 * time.Second},
-		}, nil, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-app.yaml"), tmpDir.Path("deployment-web.yaml")}})
+		}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-app.yaml"), tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		// Deploy one manifest
@@ -460,7 +461,7 @@ func TestKubectlWaitForDeletions(t *testing.T) {
 				Delay:   0 * time.Millisecond,
 				Max:     10 * time.Second,
 			},
-		}, nil, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
+		}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		var out bytes.Buffer
@@ -497,7 +498,7 @@ func TestKubectlWaitForDeletionsFails(t *testing.T) {
 				Delay:   10 * time.Second,
 				Max:     100 * time.Millisecond,
 			},
-		}, nil, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
+		}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		_, err = deployer.Deploy(context.Background(), ioutil.Discard, []graph.Artifact{
@@ -558,7 +559,7 @@ func TestDependencies(t *testing.T) {
 				Touch("00/b.yaml", "00/a.yaml").
 				Chdir()
 
-			k, err := NewDeployer(&kubectlConfig{}, nil, &latestV1.KubectlDeploy{Manifests: test.manifests})
+			k, err := NewDeployer(&kubectlConfig{}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{Manifests: test.manifests})
 			t.RequireNoError(err)
 
 			dependencies, err := k.Dependencies()
@@ -674,7 +675,7 @@ spec:
 			deployer, err := NewDeployer(&kubectlConfig{
 				workingDir:  ".",
 				defaultRepo: "gcr.io/project",
-			}, nil, &latestV1.KubectlDeploy{
+			}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
 				Manifests: []string{tmpDir.Path("deployment.yaml")},
 			})
 			t.RequireNoError(err)
@@ -719,7 +720,7 @@ func TestGCSManifests(t *testing.T) {
 				workingDir: ".",
 				skipRender: test.skipRender,
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
-			}, nil, &test.kubectl)
+			}, nil, &log.NoopLogger{}, &test.kubectl)
 			t.RequireNoError(err)
 
 			_, err = k.Deploy(context.Background(), ioutil.Discard, nil)

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -34,6 +34,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
@@ -93,6 +94,8 @@ type secretGenerator struct {
 type Deployer struct {
 	*latestV1.KustomizeDeploy
 
+	log.Logger
+
 	kubectl             kubectl.CLI
 	insecureRegistries  map[string]bool
 	labels              map[string]string
@@ -100,7 +103,7 @@ type Deployer struct {
 	useKubectlKustomize bool
 }
 
-func NewDeployer(cfg kubectl.Config, labels map[string]string, d *latestV1.KustomizeDeploy) (*Deployer, error) {
+func NewDeployer(cfg kubectl.Config, labels map[string]string, logger log.Logger, d *latestV1.KustomizeDeploy) (*Deployer, error) {
 	defaultNamespace := ""
 	if d.DefaultNamespace != nil {
 		var err error
@@ -115,6 +118,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, d *latestV1.Kusto
 	useKubectlKustomize := !kustomizeBinaryCheck() && kubectlVersionCheck(kubectl)
 
 	return &Deployer{
+		Logger:              logger,
 		KustomizeDeploy:     d,
 		kubectl:             kubectl,
 		insecureRegistries:  cfg.GetInsecureRegistries(),

--- a/pkg/skaffold/deploy/kustomize/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -186,7 +187,7 @@ func TestKustomizeDeploy(t *testing.T) {
 				},
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: skaffoldNamespaceOption,
-				}}}, nil, &test.kustomize)
+				}}}, nil, &log.NoopLogger{}, &test.kustomize)
 			t.RequireNoError(err)
 			_, err = k.Deploy(context.Background(), ioutil.Discard, test.builds)
 
@@ -252,7 +253,7 @@ func TestKustomizeCleanup(t *testing.T) {
 				workingDir: tmpDir.Root(),
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: kubectl.TestNamespace}},
-			}, nil, &test.kustomize)
+			}, nil, &log.NoopLogger{}, &test.kustomize)
 			t.RequireNoError(err)
 			err = k.Cleanup(context.Background(), ioutil.Discard)
 
@@ -454,7 +455,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 				tmpDir.Write(path, contents)
 			}
 
-			k, err := NewDeployer(&kustomizeConfig{}, nil, &latestV1.KustomizeDeploy{KustomizePaths: kustomizePaths})
+			k, err := NewDeployer(&kustomizeConfig{}, nil, &log.NoopLogger{}, &latestV1.KustomizeDeploy{KustomizePaths: kustomizePaths})
 			t.RequireNoError(err)
 
 			deps, err := k.Dependencies()
@@ -698,7 +699,7 @@ spec:
 			k, err := NewDeployer(&kustomizeConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: kubectl.TestNamespace}},
-			}, test.labels, &latestV1.KustomizeDeploy{
+			}, test.labels, &log.NoopLogger{}, &latestV1.KustomizeDeploy{
 				KustomizePaths: kustomizationPaths,
 			})
 			t.RequireNoError(err)

--- a/pkg/skaffold/kubernetes/colorpicker.go
+++ b/pkg/skaffold/kubernetes/colorpicker.go
@@ -42,6 +42,7 @@ var colorCodes = []color.Color{
 // from each pod.
 type ColorPicker interface {
 	Pick(pod *v1.Pod) color.Color
+	AddImage(image string)
 }
 
 type colorPicker struct {
@@ -52,16 +53,20 @@ type colorPicker struct {
 // sequentially from `colorCodes`. If all colors are used, the first color will be used
 // again. The formatter for the associated color will then be returned by `Pick` each
 // time it is called for the artifact and can be used to write to out in that color.
-func NewColorPicker(imageNames []string) ColorPicker {
+func NewColorPicker() ColorPicker {
 	imageColors := make(map[string]color.Color)
-
-	for i, imageName := range imageNames {
-		imageColors[tag.StripTag(imageName)] = colorCodes[i%len(colorCodes)]
-	}
 
 	return &colorPicker{
 		imageColors: imageColors,
 	}
+}
+
+func (p *colorPicker) AddImage(image string) {
+	imageName := tag.StripTag(image)
+	if _, ok := p.imageColors[imageName]; ok {
+		return
+	}
+	p.imageColors[imageName] = colorCodes[len(p.imageColors)%len(colorCodes)]
 }
 
 // Pick will return the color that was associated with pod when `NewColorPicker` was called.

--- a/pkg/skaffold/kubernetes/colorpicker_test.go
+++ b/pkg/skaffold/kubernetes/colorpicker_test.go
@@ -71,7 +71,9 @@ func TestColorPicker(t *testing.T) {
 		},
 	}
 
-	picker := NewColorPicker([]string{"image:ignored", "second"})
+	picker := NewColorPicker()
+	picker.AddImage("image:ignored")
+	picker.AddImage("second")
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {

--- a/pkg/skaffold/kubernetes/logger/log_test.go
+++ b/pkg/skaffold/kubernetes/logger/log_test.go
@@ -129,10 +129,10 @@ func TestLogAggregatorZeroValue(t *testing.T) {
 	var m *LogAggregator
 
 	// Should not raise a nil dereference
-	m.Start(context.Background(), []string{})
+	m.StartLogger(context.Background(), nil, []string{})
 	m.Mute()
 	m.Unmute()
-	m.Stop()
+	m.StopLogger()
 }
 
 func TestPrefix(t *testing.T) {
@@ -188,7 +188,7 @@ func TestPrefix(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			logger := NewLogAggregator(nil, nil, nil, nil, &mockConfig{log: latestV1.LogsConfig{
+			logger := NewLogAggregator(nil, nil, &mockConfig{log: latestV1.LogsConfig{
 				Prefix: test.prefix,
 			}})
 

--- a/pkg/skaffold/log/log.go
+++ b/pkg/skaffold/log/log.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2021 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,24 +14,40 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1
+package log
 
 import (
+	"context"
 	"io"
+	"time"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/logger"
 )
 
-func (r *SkaffoldRunner) createLogger(out io.Writer, artifacts []graph.Artifact) *logger.LogAggregator {
-	if !r.runCtx.Tail() {
-		return nil
-	}
+type Logger interface {
+	StartLogger(context.Context, io.Writer, []string) error
 
-	var imageNames []string
-	for _, artifact := range artifacts {
-		imageNames = append(imageNames, artifact.Tag)
-	}
+	StopLogger()
 
-	return logger.NewLogAggregator(out, r.kubectlCLI, imageNames, r.podSelector, r.runCtx)
+	Mute()
+
+	Unmute()
+
+	SetSince(time.Time)
+
+	RegisterBuildArtifacts([]graph.Artifact)
 }
+
+type NoopLogger struct{}
+
+func (n *NoopLogger) StartLogger(context.Context, io.Writer, []string) error { return nil }
+
+func (n *NoopLogger) StopLogger() {}
+
+func (n *NoopLogger) Mute() {}
+
+func (n *NoopLogger) Unmute() {}
+
+func (n *NoopLogger) SetSince(time.Time) {}
+
+func (n *NoopLogger) RegisterBuildArtifacts(_ []graph.Artifact) {}

--- a/pkg/skaffold/runner/v1/deploy.go
+++ b/pkg/skaffold/runner/v1/deploy.go
@@ -45,11 +45,10 @@ func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifa
 	// Update which images are logged.
 	r.AddTagsToPodSelector(artifacts)
 
-	logger := r.createLogger(out, artifacts)
-	defer logger.Stop()
+	defer r.deployer.StopLogger()
 
 	// Logs should be retrieved up to just before the deploy
-	logger.SetSince(time.Now())
+	r.deployer.SetSince(time.Now())
 	// First deploy
 	if err := r.Deploy(ctx, out, artifacts); err != nil {
 		eventV2.TaskFailed(constants.Deploy, err)
@@ -64,7 +63,7 @@ func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifa
 	}
 
 	// Start printing the logs after deploy is finished
-	if err := logger.Start(ctx, r.runCtx.GetNamespaces()); err != nil {
+	if err := r.deployer.StartLogger(ctx, out, r.runCtx.GetNamespaces()); err != nil {
 		eventV2.TaskFailed(constants.Deploy, err)
 		return fmt.Errorf("starting logger: %w", err)
 	}

--- a/pkg/skaffold/runner/v1/deploy_test.go
+++ b/pkg/skaffold/runner/v1/deploy_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -193,7 +194,7 @@ func TestSkaffoldDeployRenderOnly(t *testing.T) {
 			KubeContext: "does-not-exist",
 		}
 
-		deployer, err := getDeployer(runCtx, nil)
+		deployer, err := getDeployer(runCtx, nil, &log.NoopLogger{})
 		t.RequireNoError(err)
 		r := SkaffoldRunner{
 			runCtx:     runCtx,

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -363,7 +363,7 @@ func getDeployer(runCtx *runcontext.RunContext, labels map[string]string, logger
 
 func getLogger(runCtx *runcontext.RunContext, cli *pkgkubectl.CLI, podSelector kubernetes.PodSelector) log.Logger {
 	if !runCtx.Tail() {
-		return nil
+		return &log.NoopLogger{}
 	}
 
 	return logger.NewLogAggregator(cli, podSelector, runCtx)

--- a/pkg/skaffold/runner/v1/new_test.go
+++ b/pkg/skaffold/runner/v1/new_test.go
@@ -96,7 +96,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				apply:       true,
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(deploy.Deployer),
 			},
@@ -107,7 +107,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				apply:       true,
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(deploy.Deployer),
 			},

--- a/pkg/skaffold/runner/v1/new_test.go
+++ b/pkg/skaffold/runner/v1/new_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kpt"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -66,7 +67,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				expected: deploy.DeployerMux{
 					t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 						Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-					}, nil, &latestV1.KubectlDeploy{
+					}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
 						Flags: latestV1.KubectlFlags{},
 					})).(deploy.Deployer),
 				},
@@ -77,7 +78,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				expected: deploy.DeployerMux{
 					t.RequireNonNilResult(kustomize.NewDeployer(&runcontext.RunContext{
 						Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-					}, nil, &latestV1.KustomizeDeploy{
+					}, nil, &log.NoopLogger{}, &latestV1.KustomizeDeploy{
 						Flags: latestV1.KubectlFlags{},
 					})).(deploy.Deployer),
 				},
@@ -86,7 +87,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				description: "kpt deployer",
 				cfg:         latestV1.DeployType{KptDeploy: &latestV1.KptDeploy{}},
 				expected: deploy.DeployerMux{
-					kpt.NewDeployer(&runcontext.RunContext{}, nil, &latestV1.KptDeploy{}),
+					kpt.NewDeployer(&runcontext.RunContext{}, nil, &log.NoopLogger{}, &latestV1.KptDeploy{}),
 				},
 			},
 			{
@@ -119,7 +120,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				helmVersion: `version.BuildInfo{Version:"v3.0.0"}`,
 				expected: deploy.DeployerMux{
 					&helm.Deployer{},
-					kpt.NewDeployer(&runcontext.RunContext{}, nil, &latestV1.KptDeploy{}),
+					kpt.NewDeployer(&runcontext.RunContext{}, nil, &log.NoopLogger{}, &latestV1.KptDeploy{}),
 				},
 			},
 		}
@@ -141,7 +142,7 @@ func TestGetDeployer(tOuter *testing.T) {
 							DeployType: test.cfg,
 						},
 					}}),
-				}, nil)
+				}, nil, &log.NoopLogger{})
 
 				t.CheckError(test.shouldErr, err)
 				t.CheckTypeEquality(test.expected, deployer)
@@ -174,7 +175,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -190,7 +191,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{
 						Apply:  []string{"--foo"},
 						Global: []string{"--bar"},
@@ -224,7 +225,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -235,7 +236,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -253,7 +254,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}
 				deployer, err := getDefaultDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines(pipelines),
-				}, nil)
+				}, nil, &log.NoopLogger{})
 
 				t.CheckErrorAndFailNow(test.shouldErr, err)
 

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
@@ -54,6 +55,8 @@ type Actions struct {
 }
 
 type TestBench struct {
+	log.NoopLogger
+
 	buildErrors   []error
 	syncErrors    []error
 	testErrors    []error


### PR DESCRIPTION
This change embeds the `Logger` object's responsibilities inside of the `Deployer`. As "logging" can really be interpreted as "retrieving information from deployed resources", any implementation of a `Logger` is implicitly tied to an implementation of a `Deployer` in Skaffold. To pave the way for future implementations of a `Deployer` that are not centered around Kubernetes, we need to delegate logging responsibilities to the `Deployer`.

A slightly modified interface for `Logger` is introduced:

```golang
type Logger interface {
	StartLogger(context.Context, io.Writer, []string) error

	StopLogger()

	Mute()

	Unmute()

	SetSince(time.Time)

	RegisterBuildArtifacts([]graph.Artifact)
}
```

such that the logging-specific actions are more clearly identified when present on the `Deployer`. One additional method is added, `RegisterBuildArtifacts`, which allows newly-built artifacts to be added to a pre-existing `Logger`.

This interface is then embedded into the `Deployer` interface:

```golang
type Deployer interface {
	log.Logger

       ...
}
```

to ensure that every implementation of `Deployer` in Skaffold also provides an implementation for `Logger`.

All existing implementations of `Deployer` in Skaffold are Kubernetes-centric, and have been retrofitted to use the `kubernetes.LogAggregator` as their implementation of `Logger`. in the future, any new Kubernetes-centric `Deployer` implementations can reuse this `Logger`, but any new `Deployer` implementations that use a non-Kubernetes platform (e.g. `docker`) will need to implement a new `Logger`.

cc #5813 