### PR TITLE
Add emission of TestSubtaskEvents

### DIFF
--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -370,6 +370,11 @@ func (ev *eventHandler) handleExec(event *proto.Event) {
 		ev.stateLock.Lock()
 		ev.state.BuildState.Artifacts[be.Artifact] = be.Status
 		ev.stateLock.Unlock()
+	case *proto.Event_TestEvent:
+		te := e.TestEvent
+		ev.stateLock.Lock()
+		ev.state.TestState.Status = te.Status
+		ev.stateLock.Unlock()
 	case *proto.Event_DeploySubtaskEvent:
 		de := e.DeploySubtaskEvent
 		ev.stateLock.Lock()

--- a/pkg/skaffold/event/v2/tester.go
+++ b/pkg/skaffold/event/v2/tester.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
+	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
+)
+
+func TesterInProgress(id int) {
+	handler.handleTestSubtaskEvent(&proto.TestSubtaskEvent{
+		Id:     strconv.Itoa(id),
+		TaskId: fmt.Sprintf("%s-%d", constants.Test, handler.iteration),
+		Status: InProgress,
+	})
+}
+
+func TesterFailed(id int, err error) {
+	handler.handleTestSubtaskEvent(&proto.TestSubtaskEvent{
+		Id:            strconv.Itoa(id),
+		TaskId:        fmt.Sprintf("%s-%d", constants.Test, handler.iteration),
+		Status:        Failed,
+		ActionableErr: sErrors.ActionableErrV2(handler.cfg, constants.Test, err),
+	})
+}
+
+func TesterSucceeded(id int) {
+	handler.handleTestSubtaskEvent(&proto.TestSubtaskEvent{
+		Id:     strconv.Itoa(id),
+		TaskId: fmt.Sprintf("%s-%d", constants.Test, handler.iteration),
+		Status: Succeeded,
+	})
+}
+
+func (ev *eventHandler) handleTestSubtaskEvent(e *proto.TestSubtaskEvent) {
+	ev.handle(&proto.Event{
+		EventType: &proto.Event_TestEvent{
+			TestEvent: e,
+		},
+	})
+}

--- a/pkg/skaffold/event/v2/tester_test.go
+++ b/pkg/skaffold/event/v2/tester_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
+)
+
+func TestHandleTestSubtaskEvent(t *testing.T) {
+	tests := []struct {
+		name  string
+		event *proto.TestSubtaskEvent
+	}{
+		{
+			name: "In Progress",
+			event: &proto.TestSubtaskEvent{
+				Id:     "0",
+				TaskId: fmt.Sprintf("%s-%d", constants.Test, 0),
+				Status: InProgress,
+			},
+		},
+		{
+			name: "Failed",
+			event: &proto.TestSubtaskEvent{
+				Id:            "23",
+				TaskId:        fmt.Sprintf("%s-%d", constants.Test, 0),
+				Status:        Failed,
+				ActionableErr: sErrors.ActionableErrV2(handler.cfg, constants.Test, errors.New("deploy failed")),
+			},
+		},
+		{
+			name: "Succeeded",
+			event: &proto.TestSubtaskEvent{
+				Id:     "99",
+				TaskId: fmt.Sprintf("%s-%d", constants.Test, 12),
+				Status: Succeeded,
+			},
+		},
+	}
+
+	defer func() { handler = newHandler() }()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler = newHandler()
+			handler.state = emptyState(mockCfg([]latestV1.Pipeline{{}}, "test"))
+
+			wait(t, func() bool { return handler.getState().TestState.Status == NotStarted })
+			handler.handleTestSubtaskEvent(test.event)
+			wait(t, func() bool { return handler.getState().TestState.Status == test.event.Status })
+		})
+	}
+}

--- a/pkg/skaffold/test/test_factory.go
+++ b/pkg/skaffold/test/test_factory.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/color"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/logfile"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -103,11 +104,16 @@ func (t FullTester) Test(ctx context.Context, out io.Writer, bRes []graph.Artifa
 }
 
 func (t FullTester) runTests(ctx context.Context, out io.Writer, bRes []graph.Artifact) error {
+	testerID := 0
 	for _, b := range bRes {
 		for _, tester := range t.Testers[b.ImageName] {
+			eventV2.TesterInProgress(testerID)
 			if err := tester.Test(ctx, out, b.Tag); err != nil {
+				eventV2.TesterFailed(testerID, err)
 				return fmt.Errorf("running tests: %w", err)
 			}
+			eventV2.TesterSucceeded(testerID)
+			testerID++
 		}
 	}
 	return nil


### PR DESCRIPTION
<!-- Include if applicable: -->
Fixes: #5784 
**Related**: #5423 

**Description**
Adds emission of `TestSubtaskEvent`s when tests start, finish, or fail

**User facing changes (remove if N/A)**
Users can now see events that correlate to start, failure, and finish of tests in skaffold

**Follow-up Work (remove if N/A)**
Put more detail in these events. The initial definition doesn't have much meta info about the test running, but I'd like to update it with more information.