### PR TITLE
Embed PortForwarder in Deployer, rename to ResourcePreviewer

### DIFF
--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -89,7 +90,7 @@ spec:
 					},
 				},
 			}}),
-		}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
+		}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 			Manifests: []string{"deployment.yaml"},
 		})
 		t.RequireNoError(err)
@@ -249,7 +250,7 @@ spec:
 				Opts: config.SkaffoldOptions{
 					AddSkaffoldLabels: true,
 				},
-			}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
+			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
 			})
 			t.RequireNoError(err)
@@ -435,7 +436,7 @@ spec:
 						},
 					},
 				}}),
-			}, nil, &log.NoopLogger{}, &latestV1.HelmDeploy{
+			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.HelmDeploy{
 				Releases: test.helmReleases,
 			})
 			t.RequireNoError(err)

--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -22,12 +22,15 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 )
 
 // Deployer is the Deploy API of skaffold and responsible for deploying
 // the build results to a Kubernetes cluster
 type Deployer interface {
 	log.Logger
+
+	preview.ResourcePreviewer
 
 	// Deploy should ensure that the build results are deployed to the Kubernetes
 	// cluster. Returns the list of impacted namespaces.

--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -126,3 +126,19 @@ func (m DeployerMux) RegisterBuildArtifacts(artifacts []graph.Artifact) {
 		deployer.RegisterBuildArtifacts(artifacts)
 	}
 }
+
+func (m DeployerMux) StartResourcePreview(ctx context.Context, out io.Writer, namespaces []string) error {
+	for _, deployer := range m {
+		var err error
+		if err = deployer.StartResourcePreview(ctx, out, namespaces); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m DeployerMux) StopResourcePreview() {
+	for _, deployer := range m {
+		deployer.StopResourcePreview()
+	}
+}

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	testEvent "github.com/GoogleContainerTools/skaffold/testutil/event"
@@ -36,6 +37,7 @@ func NewMockDeployer() *MockDeployer { return &MockDeployer{labels: make(map[str
 
 type MockDeployer struct {
 	log.NoopLogger
+	preview.NoopPreviewer
 
 	labels           map[string]string
 	deployNamespaces []string

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -45,6 +45,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
@@ -76,6 +77,8 @@ type Deployer struct {
 
 	log.Logger
 
+	preview.ResourcePreviewer
+
 	kubeContext string
 	kubeConfig  string
 	namespace   string
@@ -99,7 +102,7 @@ type Config interface {
 }
 
 // NewDeployer returns a configured Deployer.  Returns an error if current version of helm is less than 3.0.0.
-func NewDeployer(cfg Config, labels map[string]string, logger log.Logger, h *latestV1.HelmDeploy) (*Deployer, error) {
+func NewDeployer(cfg Config, labels map[string]string, logger log.Logger, previewer preview.ResourcePreviewer, h *latestV1.HelmDeploy) (*Deployer, error) {
 	hv, err := binVer()
 	if err != nil {
 		return nil, versionGetErr(err)
@@ -110,17 +113,18 @@ func NewDeployer(cfg Config, labels map[string]string, logger log.Logger, h *lat
 	}
 
 	return &Deployer{
-		Logger:        logger,
-		HelmDeploy:    h,
-		kubeContext:   cfg.GetKubeContext(),
-		kubeConfig:    cfg.GetKubeConfig(),
-		namespace:     cfg.GetKubeNamespace(),
-		forceDeploy:   cfg.ForceDeploy(),
-		configFile:    cfg.ConfigurationFile(),
-		labels:        labels,
-		bV:            hv,
-		enableDebug:   cfg.Mode() == config.RunModes.Debug,
-		isMultiConfig: cfg.IsMultiConfig(),
+		Logger:            logger,
+		ResourcePreviewer: previewer,
+		HelmDeploy:        h,
+		kubeContext:       cfg.GetKubeContext(),
+		kubeConfig:        cfg.GetKubeConfig(),
+		namespace:         cfg.GetKubeNamespace(),
+		forceDeploy:       cfg.ForceDeploy(),
+		configFile:        cfg.ConfigurationFile(),
+		labels:            labels,
+		bV:                hv,
+		enableDebug:       cfg.Mode() == config.RunModes.Debug,
+		isMultiConfig:     cfg.IsMultiConfig(),
 	}, nil
 }
 

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
@@ -463,7 +464,7 @@ func TestNewDeployer(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", test.helmVersion))
 
-			_, err := NewDeployer(&helmConfig{}, nil, &log.NoopLogger{}, &testDeployConfig)
+			_, err := NewDeployer(&helmConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &testDeployConfig)
 			t.CheckError(test.shouldErr, err)
 		})
 	}
@@ -985,7 +986,7 @@ func TestHelmDeploy(t *testing.T) {
 				namespace:  test.namespace,
 				force:      test.force,
 				configFile: "test.yaml",
-			}, nil, &log.NoopLogger{}, &test.helm)
+			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.helm)
 			t.RequireNoError(err)
 
 			if test.configure != nil {
@@ -1062,7 +1063,7 @@ func TestHelmCleanup(t *testing.T) {
 
 			deployer, err := NewDeployer(&helmConfig{
 				namespace: test.namespace,
-			}, nil, &log.NoopLogger{}, &test.helm)
+			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.helm)
 			t.RequireNoError(err)
 
 			deployer.Cleanup(context.Background(), ioutil.Discard)
@@ -1165,7 +1166,7 @@ func TestHelmDependencies(t *testing.T) {
 				local = tmpDir.Root()
 			}
 
-			deployer, err := NewDeployer(&helmConfig{}, nil, &log.NoopLogger{}, &latestV1.HelmDeploy{
+			deployer, err := NewDeployer(&helmConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.HelmDeploy{
 				Releases: []latestV1.HelmRelease{{
 					Name:                  "skaffold-helm",
 					ChartPath:             local,
@@ -1416,7 +1417,7 @@ func TestHelmRender(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			deployer, err := NewDeployer(&helmConfig{
 				namespace: test.namespace,
-			}, nil, &log.NoopLogger{}, &test.helm)
+			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.helm)
 			t.RequireNoError(err)
 			err = deployer.Render(context.Background(), ioutil.Discard, test.builds, true, file)
 			t.CheckError(test.shouldErr, err)
@@ -1485,7 +1486,7 @@ func TestGenerateSkaffoldDebugFilter(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", version31))
-			h, err := NewDeployer(&helmConfig{}, nil, &log.NoopLogger{}, &testDeployConfig)
+			h, err := NewDeployer(&helmConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &testDeployConfig)
 			t.RequireNoError(err)
 			result := h.generateSkaffoldDebugFilter(test.buildFile)
 			t.CheckDeepEqual(test.result, result)

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -41,6 +41,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -66,15 +67,18 @@ type Deployer struct {
 
 	log.Logger
 
+	preview.ResourcePreviewer
+
 	insecureRegistries map[string]bool
 	labels             map[string]string
 	globalConfig       string
 }
 
 // NewDeployer generates a new Deployer object contains the kptDeploy schema.
-func NewDeployer(cfg types.Config, labels map[string]string, logger log.Logger, d *latestV1.KptDeploy) *Deployer {
+func NewDeployer(cfg types.Config, labels map[string]string, logger log.Logger, previewer preview.ResourcePreviewer, d *latestV1.KptDeploy) *Deployer {
 	return &Deployer{
 		Logger:             logger,
+		ResourcePreviewer:  previewer,
 		KptDeploy:          d,
 		insecureRegistries: cfg.GetInsecureRegistries(),
 		labels:             labels,

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -221,7 +222,7 @@ func TestKpt_Deploy(t *testing.T) {
 
 			tmpDir.WriteFiles(test.kustomizations)
 
-			k := NewDeployer(&kptConfig{}, nil, &log.NoopLogger{}, &test.kpt)
+			k := NewDeployer(&kptConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kpt)
 
 			if k.Live.Apply.Dir == "valid_path" {
 				// 0755 is a permission setting where the owner can read, write, and execute.
@@ -361,7 +362,7 @@ func TestKpt_Dependencies(t *testing.T) {
 			tmpDir.WriteFiles(test.createFiles)
 			tmpDir.WriteFiles(test.kustomizations)
 
-			k := NewDeployer(&kptConfig{}, nil, &log.NoopLogger{}, &test.kpt)
+			k := NewDeployer(&kptConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kpt)
 
 			res, err := k.Dependencies()
 
@@ -414,7 +415,7 @@ func TestKpt_Cleanup(t *testing.T) {
 
 			k := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, nil, &log.NoopLogger{}, &latestV1.KptDeploy{
+			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KptDeploy{
 				Live: latestV1.KptLive{
 					Apply: latestV1.KptApplyInventory{
 						Dir: test.applyDir,
@@ -770,7 +771,7 @@ spec:
 
 			k := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, test.labels, &log.NoopLogger{}, &test.kpt)
+			}, test.labels, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kpt)
 
 			var b bytes.Buffer
 			err := k.Render(context.Background(), &b, test.builds, true, "")
@@ -844,7 +845,7 @@ func TestKpt_GetApplyDir(t *testing.T) {
 
 			k := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, nil, &log.NoopLogger{}, &latestV1.KptDeploy{
+			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KptDeploy{
 				Live: test.live,
 			})
 
@@ -1003,7 +1004,7 @@ spec:
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			k := NewDeployer(&kptConfig{}, nil, &log.NoopLogger{}, nil)
+			k := NewDeployer(&kptConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, nil)
 			actualManifest, err := k.excludeKptFn(test.manifests)
 			t.CheckErrorAndDeepEqual(false, err, test.expected.String(), actualManifest.String())
 		})

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -37,6 +37,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -46,6 +47,8 @@ type Deployer struct {
 	*latestV1.KubectlDeploy
 
 	log.Logger
+
+	preview.ResourcePreviewer
 
 	originalImages     []graph.Artifact
 	hydratedManifests  []string
@@ -61,7 +64,7 @@ type Deployer struct {
 
 // NewDeployer returns a new Deployer for a DeployConfig filled
 // with the needed configuration for `kubectl apply`
-func NewDeployer(cfg Config, labels map[string]string, logger log.Logger, d *latestV1.KubectlDeploy) (*Deployer, error) {
+func NewDeployer(cfg Config, labels map[string]string, logger log.Logger, previewer preview.ResourcePreviewer, d *latestV1.KubectlDeploy) (*Deployer, error) {
 	defaultNamespace := ""
 	if d.DefaultNamespace != nil {
 		var err error
@@ -73,6 +76,7 @@ func NewDeployer(cfg Config, labels map[string]string, logger log.Logger, d *lat
 
 	return &Deployer{
 		Logger:             logger,
+		ResourcePreviewer:  previewer,
 		KubectlDeploy:      d,
 		workingDir:         cfg.GetWorkingDir(),
 		globalConfig:       cfg.GlobalConfig(),

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -242,7 +243,7 @@ func TestKubectlDeploy(t *testing.T) {
 				},
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: skaffoldNamespaceOption}},
-			}, nil, &log.NoopLogger{}, &test.kubectl)
+			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kubectl)
 			t.RequireNoError(err)
 
 			_, err = k.Deploy(context.Background(), ioutil.Discard, test.builds)
@@ -316,7 +317,7 @@ func TestKubectlCleanup(t *testing.T) {
 			k, err := NewDeployer(&kubectlConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
-			}, nil, &log.NoopLogger{}, &test.kubectl)
+			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kubectl)
 			t.RequireNoError(err)
 
 			err = k.Cleanup(context.Background(), ioutil.Discard)
@@ -363,7 +364,7 @@ func TestKubectlDeployerRemoteCleanup(t *testing.T) {
 			k, err := NewDeployer(&kubectlConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
-			}, nil, &log.NoopLogger{}, &test.kubectl)
+			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kubectl)
 			t.RequireNoError(err)
 
 			err = k.Cleanup(context.Background(), ioutil.Discard)
@@ -397,7 +398,7 @@ func TestKubectlRedeploy(t *testing.T) {
 				Enabled: true,
 				Delay:   0 * time.Millisecond,
 				Max:     10 * time.Second},
-		}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-app.yaml"), tmpDir.Path("deployment-web.yaml")}})
+		}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-app.yaml"), tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		// Deploy one manifest
@@ -461,7 +462,7 @@ func TestKubectlWaitForDeletions(t *testing.T) {
 				Delay:   0 * time.Millisecond,
 				Max:     10 * time.Second,
 			},
-		}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
+		}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		var out bytes.Buffer
@@ -498,7 +499,7 @@ func TestKubectlWaitForDeletionsFails(t *testing.T) {
 				Delay:   10 * time.Second,
 				Max:     100 * time.Millisecond,
 			},
-		}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
+		}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		_, err = deployer.Deploy(context.Background(), ioutil.Discard, []graph.Artifact{
@@ -559,7 +560,7 @@ func TestDependencies(t *testing.T) {
 				Touch("00/b.yaml", "00/a.yaml").
 				Chdir()
 
-			k, err := NewDeployer(&kubectlConfig{}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{Manifests: test.manifests})
+			k, err := NewDeployer(&kubectlConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{Manifests: test.manifests})
 			t.RequireNoError(err)
 
 			dependencies, err := k.Dependencies()
@@ -675,7 +676,7 @@ spec:
 			deployer, err := NewDeployer(&kubectlConfig{
 				workingDir:  ".",
 				defaultRepo: "gcr.io/project",
-			}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
+			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 				Manifests: []string{tmpDir.Path("deployment.yaml")},
 			})
 			t.RequireNoError(err)
@@ -720,7 +721,7 @@ func TestGCSManifests(t *testing.T) {
 				workingDir: ".",
 				skipRender: test.skipRender,
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
-			}, nil, &log.NoopLogger{}, &test.kubectl)
+			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kubectl)
 			t.RequireNoError(err)
 
 			_, err = k.Deploy(context.Background(), ioutil.Discard, nil)

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -35,6 +35,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
@@ -96,6 +97,8 @@ type Deployer struct {
 
 	log.Logger
 
+	preview.ResourcePreviewer
+
 	kubectl             kubectl.CLI
 	insecureRegistries  map[string]bool
 	labels              map[string]string
@@ -103,7 +106,7 @@ type Deployer struct {
 	useKubectlKustomize bool
 }
 
-func NewDeployer(cfg kubectl.Config, labels map[string]string, logger log.Logger, d *latestV1.KustomizeDeploy) (*Deployer, error) {
+func NewDeployer(cfg kubectl.Config, labels map[string]string, logger log.Logger, previewer preview.ResourcePreviewer, d *latestV1.KustomizeDeploy) (*Deployer, error) {
 	defaultNamespace := ""
 	if d.DefaultNamespace != nil {
 		var err error
@@ -119,6 +122,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, logger log.Logger
 
 	return &Deployer{
 		Logger:              logger,
+		ResourcePreviewer:   previewer,
 		KustomizeDeploy:     d,
 		kubectl:             kubectl,
 		insecureRegistries:  cfg.GetInsecureRegistries(),

--- a/pkg/skaffold/deploy/kustomize/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -187,7 +188,7 @@ func TestKustomizeDeploy(t *testing.T) {
 				},
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: skaffoldNamespaceOption,
-				}}}, nil, &log.NoopLogger{}, &test.kustomize)
+				}}}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kustomize)
 			t.RequireNoError(err)
 			_, err = k.Deploy(context.Background(), ioutil.Discard, test.builds)
 
@@ -253,7 +254,7 @@ func TestKustomizeCleanup(t *testing.T) {
 				workingDir: tmpDir.Root(),
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: kubectl.TestNamespace}},
-			}, nil, &log.NoopLogger{}, &test.kustomize)
+			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kustomize)
 			t.RequireNoError(err)
 			err = k.Cleanup(context.Background(), ioutil.Discard)
 
@@ -455,7 +456,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 				tmpDir.Write(path, contents)
 			}
 
-			k, err := NewDeployer(&kustomizeConfig{}, nil, &log.NoopLogger{}, &latestV1.KustomizeDeploy{KustomizePaths: kustomizePaths})
+			k, err := NewDeployer(&kustomizeConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KustomizeDeploy{KustomizePaths: kustomizePaths})
 			t.RequireNoError(err)
 
 			deps, err := k.Dependencies()
@@ -699,7 +700,7 @@ spec:
 			k, err := NewDeployer(&kustomizeConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: kubectl.TestNamespace}},
-			}, test.labels, &log.NoopLogger{}, &latestV1.KustomizeDeploy{
+			}, test.labels, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KustomizeDeploy{
 				KustomizePaths: kustomizationPaths,
 			})
 			t.RequireNoError(err)

--- a/pkg/skaffold/kubernetes/portforward/entry_manager_test.go
+++ b/pkg/skaffold/kubernetes/portforward/entry_manager_test.go
@@ -43,9 +43,9 @@ func TestStop(t *testing.T) {
 	}, "", "", "", "", 9001, false)
 
 	fakeForwarder := newTestForwarder()
-	em := NewEntryManager(ioutil.Discard, fakeForwarder)
-	em.forwardPortForwardEntry(context.Background(), pfe1)
-	em.forwardPortForwardEntry(context.Background(), pfe2)
+	em := NewEntryManager(fakeForwarder)
+	em.forwardPortForwardEntry(context.Background(), ioutil.Discard, pfe1)
+	em.forwardPortForwardEntry(context.Background(), ioutil.Discard, pfe2)
 
 	testutil.CheckDeepEqual(t, 2, fakeForwarder.forwardedResources.Length())
 	testutil.CheckDeepEqual(t, 2, fakeForwarder.forwardedPorts.Length())

--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager_test.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager_test.go
@@ -57,8 +57,7 @@ func TestNewForwarderManager(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			options := config.PortForwardOptions{}
 			options.Set(test.fmOptions)
-			fm := NewForwarderManager(ioutil.Discard,
-				&kubectl.CLI{},
+			fm := NewForwarderManager(&kubectl.CLI{},
 				&kubernetes.ImageList{},
 				"",
 				"",
@@ -76,7 +75,7 @@ func TestForwarderManagerZeroValue(t *testing.T) {
 	var m *ForwarderManager
 
 	// Should not raise a nil dereference
-	m.Start(context.Background(), nil)
+	m.Start(context.Background(), ioutil.Discard, nil)
 	m.Stop()
 }
 

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -51,9 +51,9 @@ type KubectlForwarder struct {
 }
 
 // NewKubectlForwarder returns a new KubectlForwarder
-func NewKubectlForwarder(out io.Writer, cli *kubectl.CLI) *KubectlForwarder {
+func NewKubectlForwarder(cli *kubectl.CLI) *KubectlForwarder {
 	return &KubectlForwarder{
-		out:     out,
+		// out:     out,
 		kubectl: cli,
 	}
 }

--- a/pkg/skaffold/kubernetes/portforward/pod_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/pod_forwarder.go
@@ -19,6 +19,7 @@ package portforward
 import (
 	"context"
 	"fmt"
+	"io"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
@@ -41,6 +42,7 @@ var (
 // WatchingPodForwarder is responsible for selecting pods satisfying a certain condition and port-forwarding the exposed
 // container ports within those pods. It also tracks and manages the port-forward connections.
 type WatchingPodForwarder struct {
+	output       io.Writer
 	entryManager *EntryManager
 	podWatcher   kubernetes.PodWatcher
 	events       chan kubernetes.PodEvent
@@ -62,8 +64,9 @@ func NewWatchingPodForwarder(entryManager *EntryManager, podSelector kubernetes.
 	}
 }
 
-func (p *WatchingPodForwarder) Start(ctx context.Context, namespaces []string) error {
+func (p *WatchingPodForwarder) Start(ctx context.Context, out io.Writer, namespaces []string) error {
 	p.podWatcher.Register(p.events)
+	p.output = out
 	stopWatcher, err := p.podWatcher.Start(namespaces)
 	if err != nil {
 		return err
@@ -118,7 +121,7 @@ func (p *WatchingPodForwarder) portForwardPod(ctx context.Context, pod *v1.Pod) 
 				return fmt.Errorf("getting pod forwarding entry: %w", err)
 			}
 			if entry.resource.Port.IntVal != entry.localPort {
-				color.Yellow.Fprintf(p.entryManager.output, "Forwarding container %s/%s to local port %d.\n", pod.Name, c.Name, entry.localPort)
+				color.Yellow.Fprintf(p.output, "Forwarding container %s/%s to local port %d.\n", pod.Name, c.Name, entry.localPort)
 			}
 			if prevEntry, ok := p.entryManager.forwardedResources.Load(entry.key()); ok {
 				// Check if this is a new generation of pod
@@ -126,7 +129,7 @@ func (p *WatchingPodForwarder) portForwardPod(ctx context.Context, pod *v1.Pod) 
 					p.entryManager.Terminate(prevEntry)
 				}
 			}
-			p.entryManager.forwardPortForwardEntry(ctx, entry)
+			p.entryManager.forwardPortForwardEntry(ctx, p.output, entry)
 		}
 	}
 	return nil

--- a/pkg/skaffold/kubernetes/portforward/pod_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/pod_forwarder_test.go
@@ -410,10 +410,11 @@ func TestAutomaticPortForwardPod(t *testing.T) {
 			if test.forwarder == nil {
 				test.forwarder = newTestForwarder()
 			}
-			entryManager := NewEntryManager(ioutil.Discard, nil)
+			entryManager := NewEntryManager(nil)
 			entryManager.entryForwarder = test.forwarder
 
 			p := NewWatchingPodForwarder(entryManager, kubernetes.NewImageList(), allPorts)
+			p.Start(context.Background(), ioutil.Discard, nil)
 			for _, pod := range test.pods {
 				err := p.portForwardPod(context.Background(), pod)
 				t.CheckError(test.shouldErr, err)
@@ -487,10 +488,10 @@ func TestStartPodForwarder(t *testing.T) {
 			imageList.Add("image")
 
 			fakeForwarder := newTestForwarder()
-			entryManager := NewEntryManager(ioutil.Discard, fakeForwarder)
+			entryManager := NewEntryManager(fakeForwarder)
 
 			p := NewWatchingPodForwarder(entryManager, imageList, allPorts)
-			p.Start(context.Background(), nil)
+			p.Start(context.Background(), ioutil.Discard, nil)
 
 			// wait for the pod resource to be forwarded
 			err := wait.PollImmediate(10*time.Millisecond, 100*time.Millisecond, func() (bool, error) {

--- a/pkg/skaffold/kubernetes/portforward/port_forward_integration.go
+++ b/pkg/skaffold/kubernetes/portforward/port_forward_integration.go
@@ -33,7 +33,7 @@ import (
 
 // SimulateDevCycle is used for testing a port forward + stop + restart in a simulated dev cycle
 func SimulateDevCycle(t *testing.T, kubectlCLI *kubectl.CLI, namespace string) {
-	em := NewEntryManager(os.Stdout, NewKubectlForwarder(os.Stdout, kubectlCLI))
+	em := NewEntryManager(NewKubectlForwarder(kubectlCLI))
 	portForwardEventHandler := portForwardEvent
 	defer func() { portForwardEvent = portForwardEventHandler }()
 	portForwardEvent = func(entry *portForwardEntry) {}
@@ -46,7 +46,7 @@ func SimulateDevCycle(t *testing.T, kubectlCLI *kubectl.CLI, namespace string) {
 		Port:      schemautil.FromInt(8080),
 	}, "", "dummy container", "", "", localPort, false)
 	defer em.Stop()
-	em.forwardPortForwardEntry(ctx, pfe)
+	em.forwardPortForwardEntry(ctx, os.Stdout, pfe)
 	em.Stop()
 
 	logrus.Info("waiting for the same port to become available...")
@@ -63,5 +63,5 @@ func SimulateDevCycle(t *testing.T, kubectlCLI *kubectl.CLI, namespace string) {
 		t.Fatalf("port is not released after portforwarding stopped: %d", localPort)
 	}
 
-	em.forwardPortForwardEntry(ctx, pfe)
+	em.forwardPortForwardEntry(ctx, os.Stdout, pfe)
 }

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder.go
@@ -19,6 +19,7 @@ package portforward
 import (
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +34,7 @@ import (
 // ResourceForwarder is responsible for forwarding user defined port forwarding resources and automatically forwarding
 // services deployed by skaffold.
 type ResourceForwarder struct {
+	output               io.Writer
 	entryManager         *EntryManager
 	label                string
 	userDefinedResources []*latestV1.PortForwardResource
@@ -64,7 +66,8 @@ func NewUserDefinedForwarder(entryManager *EntryManager, userDefinedResources []
 
 // Start gets a list of services deployed by skaffold as []latestV1.PortForwardResource and
 // forwards them.
-func (p *ResourceForwarder) Start(ctx context.Context, namespaces []string) error {
+func (p *ResourceForwarder) Start(ctx context.Context, out io.Writer, namespaces []string) error {
+	p.output = out
 	if len(namespaces) == 1 {
 		for _, pf := range p.userDefinedResources {
 			if pf.Namespace == "" {
@@ -112,7 +115,7 @@ func (p *ResourceForwarder) portForwardResource(ctx context.Context, resource la
 	// Get port forward entry for this resource
 	entry := p.getCurrentEntry(resource)
 	// Forward the entry
-	p.entryManager.forwardPortForwardEntry(ctx, entry)
+	p.entryManager.forwardPortForwardEntry(ctx, p.output, entry)
 }
 
 func (p *ResourceForwarder) getCurrentEntry(resource latestV1.PortForwardResource) *portForwardEntry {

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -128,10 +128,10 @@ func TestStart(t *testing.T) {
 			})
 
 			fakeForwarder := newTestForwarder()
-			entryManager := NewEntryManager(ioutil.Discard, fakeForwarder)
+			entryManager := NewEntryManager(fakeForwarder)
 
 			rf := NewServicesForwarder(entryManager, "")
-			if err := rf.Start(context.Background(), []string{"test"}); err != nil {
+			if err := rf.Start(context.Background(), ioutil.Discard, []string{"test"}); err != nil {
 				t.Fatalf("error starting resource forwarder: %v", err)
 			}
 
@@ -206,7 +206,7 @@ func TestGetCurrentEntryFunc(t *testing.T) {
 				return mockRetrieveAvailablePort(util.Loopback, map[int]struct{}{}, test.availablePorts)(addr, req, ps)
 			})
 
-			entryManager := NewEntryManager(ioutil.Discard, newTestForwarder())
+			entryManager := NewEntryManager(newTestForwarder())
 			entryManager.forwardedResources = forwardedResources{
 				resources: test.forwardedResources,
 			}
@@ -273,10 +273,10 @@ func TestUserDefinedResources(t *testing.T) {
 			})
 
 			fakeForwarder := newTestForwarder()
-			entryManager := NewEntryManager(ioutil.Discard, fakeForwarder)
+			entryManager := NewEntryManager(fakeForwarder)
 
 			rf := NewUserDefinedForwarder(entryManager, test.userResources)
-			if err := rf.Start(context.Background(), test.namespaces); err != nil {
+			if err := rf.Start(context.Background(), ioutil.Discard, test.namespaces); err != nil {
 				t.Fatalf("error starting resource forwarder: %v", err)
 			}
 

--- a/pkg/skaffold/preview/preview.go
+++ b/pkg/skaffold/preview/preview.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preview
+
+import (
+	"context"
+	"io"
+)
+
+type ResourcePreviewer interface {
+	StartResourcePreview(context.Context, io.Writer, []string) error
+
+	StopResourcePreview()
+}
+
+type NoopPreviewer struct{}
+
+func (n *NoopPreviewer) StartResourcePreview(context.Context, io.Writer, []string) error { return nil }
+
+func (n *NoopPreviewer) StopResourcePreview() {}

--- a/pkg/skaffold/runner/v1/deploy.go
+++ b/pkg/skaffold/runner/v1/deploy.go
@@ -55,10 +55,9 @@ func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifa
 		return err
 	}
 
-	forwarderManager := r.createForwarder(out)
-	defer forwarderManager.Stop()
+	defer r.deployer.StopResourcePreview()
 
-	if err := forwarderManager.Start(ctx, r.runCtx.GetNamespaces()); err != nil {
+	if err := r.deployer.StartResourcePreview(ctx, out, r.runCtx.GetNamespaces()); err != nil {
 		logrus.Warnln("Error starting port forwarding:", err)
 	}
 

--- a/pkg/skaffold/runner/v1/deploy_test.go
+++ b/pkg/skaffold/runner/v1/deploy_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -194,7 +195,7 @@ func TestSkaffoldDeployRenderOnly(t *testing.T) {
 			KubeContext: "does-not-exist",
 		}
 
-		deployer, err := getDeployer(runCtx, nil, &log.NoopLogger{})
+		deployer, err := getDeployer(runCtx, nil, &log.NoopLogger{}, &preview.NoopPreviewer{})
 		t.RequireNoError(err)
 		r := SkaffoldRunner{
 			runCtx:     runCtx,

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -41,6 +41,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/logger"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -88,9 +89,10 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 	podSelectors := kubernetes.NewImageList()
 
 	logger := getLogger(runCtx, kubectlCLI, podSelectors)
+	previewer := getResourcePreviewer(runCtx, kubectlCLI, podSelectors, labeller.RunIDSelector())
 
 	var deployer deploy.Deployer
-	deployer, err = getDeployer(runCtx, labeller.Labels(), logger)
+	deployer, err = getDeployer(runCtx, labeller.Labels(), logger, previewer)
 	if err != nil {
 		return nil, fmt.Errorf("creating deployer: %w", err)
 	}
@@ -232,7 +234,7 @@ The default deployer will honor a select set of deploy configuration from an exi
 For a multi-config project, we do not currently support resolving conflicts between differing sets of this deploy configuration.
 Therefore, in this function we do implicit validation of the provided configuration, and fail if any conflict cannot be resolved.
 */
-func getDefaultDeployer(runCtx *runcontext.RunContext, labels map[string]string, logger log.Logger) (deploy.Deployer, error) {
+func getDefaultDeployer(runCtx *runcontext.RunContext, labels map[string]string, logger log.Logger, previewer preview.ResourcePreviewer) (deploy.Deployer, error) {
 	deployCfgs := runCtx.DeployConfigs()
 
 	var kFlags *latestV1.KubectlFlags
@@ -290,7 +292,7 @@ func getDefaultDeployer(runCtx *runcontext.RunContext, labels map[string]string,
 		Flags:            *kFlags,
 		DefaultNamespace: defaultNamespace,
 	}
-	defaultDeployer, err := kubectl.NewDeployer(runCtx, labels, logger, k)
+	defaultDeployer, err := kubectl.NewDeployer(runCtx, labels, logger, previewer, k)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating default kubectl deployer: %w", err)
 	}
@@ -320,9 +322,9 @@ func validateKubectlFlags(flags *latestV1.KubectlFlags, additional latestV1.Kube
 	return nil
 }
 
-func getDeployer(runCtx *runcontext.RunContext, labels map[string]string, logger log.Logger) (deploy.Deployer, error) {
+func getDeployer(runCtx *runcontext.RunContext, labels map[string]string, logger log.Logger, previewer preview.ResourcePreviewer) (deploy.Deployer, error) {
 	if runCtx.Opts.Apply {
-		return getDefaultDeployer(runCtx, labels, logger)
+		return getDefaultDeployer(runCtx, labels, logger, previewer)
 	}
 
 	deployerCfg := runCtx.Deployers()
@@ -330,7 +332,7 @@ func getDeployer(runCtx *runcontext.RunContext, labels map[string]string, logger
 	var deployers deploy.DeployerMux
 	for _, d := range deployerCfg {
 		if d.HelmDeploy != nil {
-			h, err := helm.NewDeployer(runCtx, labels, logger, d.HelmDeploy)
+			h, err := helm.NewDeployer(runCtx, labels, logger, previewer, d.HelmDeploy)
 			if err != nil {
 				return nil, err
 			}
@@ -338,11 +340,11 @@ func getDeployer(runCtx *runcontext.RunContext, labels map[string]string, logger
 		}
 
 		if d.KptDeploy != nil {
-			deployers = append(deployers, kpt.NewDeployer(runCtx, labels, logger, d.KptDeploy))
+			deployers = append(deployers, kpt.NewDeployer(runCtx, labels, logger, previewer, d.KptDeploy))
 		}
 
 		if d.KubectlDeploy != nil {
-			deployer, err := kubectl.NewDeployer(runCtx, labels, logger, d.KubectlDeploy)
+			deployer, err := kubectl.NewDeployer(runCtx, labels, logger, previewer, d.KubectlDeploy)
 			if err != nil {
 				return nil, err
 			}
@@ -350,7 +352,7 @@ func getDeployer(runCtx *runcontext.RunContext, labels map[string]string, logger
 		}
 
 		if d.KustomizeDeploy != nil {
-			deployer, err := kustomize.NewDeployer(runCtx, labels, logger, d.KustomizeDeploy)
+			deployer, err := kustomize.NewDeployer(runCtx, labels, logger, previewer, d.KustomizeDeploy)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/skaffold/runner/v1/new_test.go
+++ b/pkg/skaffold/runner/v1/new_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -67,7 +68,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				expected: deploy.DeployerMux{
 					t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 						Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-					}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
+					}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 						Flags: latestV1.KubectlFlags{},
 					})).(deploy.Deployer),
 				},
@@ -78,7 +79,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				expected: deploy.DeployerMux{
 					t.RequireNonNilResult(kustomize.NewDeployer(&runcontext.RunContext{
 						Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-					}, nil, &log.NoopLogger{}, &latestV1.KustomizeDeploy{
+					}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KustomizeDeploy{
 						Flags: latestV1.KubectlFlags{},
 					})).(deploy.Deployer),
 				},
@@ -87,7 +88,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				description: "kpt deployer",
 				cfg:         latestV1.DeployType{KptDeploy: &latestV1.KptDeploy{}},
 				expected: deploy.DeployerMux{
-					kpt.NewDeployer(&runcontext.RunContext{}, nil, &log.NoopLogger{}, &latestV1.KptDeploy{}),
+					kpt.NewDeployer(&runcontext.RunContext{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KptDeploy{}),
 				},
 			},
 			{
@@ -96,7 +97,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				apply:       true,
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(deploy.Deployer),
 			},
@@ -107,7 +108,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				apply:       true,
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(deploy.Deployer),
 			},
@@ -120,7 +121,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				helmVersion: `version.BuildInfo{Version:"v3.0.0"}`,
 				expected: deploy.DeployerMux{
 					&helm.Deployer{},
-					kpt.NewDeployer(&runcontext.RunContext{}, nil, &log.NoopLogger{}, &latestV1.KptDeploy{}),
+					kpt.NewDeployer(&runcontext.RunContext{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KptDeploy{}),
 				},
 			},
 		}
@@ -142,7 +143,7 @@ func TestGetDeployer(tOuter *testing.T) {
 							DeployType: test.cfg,
 						},
 					}}),
-				}, nil, &log.NoopLogger{})
+				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{})
 
 				t.CheckError(test.shouldErr, err)
 				t.CheckTypeEquality(test.expected, deployer)
@@ -175,7 +176,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -191,7 +192,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{
 						Apply:  []string{"--foo"},
 						Global: []string{"--bar"},
@@ -225,7 +226,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -236,7 +237,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &log.NoopLogger{}, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -254,7 +255,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}
 				deployer, err := getDefaultDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines(pipelines),
-				}, nil, &log.NoopLogger{})
+				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{})
 
 				t.CheckErrorAndFailNow(test.shouldErr, err)
 

--- a/pkg/skaffold/runner/v1/portforwarder.go
+++ b/pkg/skaffold/runner/v1/portforwarder.go
@@ -17,21 +17,17 @@ limitations under the License.
 package v1
 
 import (
-	"io"
-
+	pkgkubectl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 )
 
-func (r *SkaffoldRunner) createForwarder(out io.Writer) *portforward.ForwarderManager {
-	if !r.runCtx.PortForward() {
-		return nil
+func getResourcePreviewer(runCtx *runcontext.RunContext, cli *pkgkubectl.CLI, podSelector kubernetes.PodSelector, runID string) preview.ResourcePreviewer {
+	if !runCtx.PortForward() {
+		return &preview.NoopPreviewer{}
 	}
 
-	return portforward.NewForwarderManager(out,
-		r.kubectlCLI,
-		r.podSelector,
-		r.labeller.RunIDSelector(),
-		r.runCtx.Mode(),
-		r.runCtx.Opts.PortForward,
-		r.runCtx.PortForwardResources())
+	return portforward.NewForwarderManager(cli, podSelector, runID, runCtx.Mode(), runCtx.Opts.PortForward, runCtx.PortForwardResources())
 }

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/preview"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
@@ -56,6 +57,7 @@ type Actions struct {
 
 type TestBench struct {
 	log.NoopLogger
+	preview.NoopPreviewer
 
 	buildErrors   []error
 	syncErrors    []error


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**:  https://github.com/GoogleContainerTools/skaffold/pull/5809, https://github.com/GoogleContainerTools/skaffold/issues/5813

This change embeds the `PortForward` object's responsibilities inside of the `Deployer`, and renames it to `ResourcePreviewer`.

A slightly modified interface for `Logger` is introduced:

```golang
type ResourcePreviewer interface {
	StartResourcePreview(context.Context, io.Writer, []string) error

	StopResourcePreview()
}
```

such that the actions taken to expose previews of created resources are more clearly identified when present on the `Deployer`.

This interface is then embedded into the `Deployer` interface:

```golang
type Deployer interface {
	preview.ResourcePreviewer

       ...
}
```

to ensure that every implementation of `Deployer` in Skaffold also provides an implementation for `ResourcePreviewer`.

**Follow-up work**:
* Remove the `namespaces` parameter from the `StartResourcePreviewer` method
* Abstract away creation of both `ResourcePreviewer` and `Logger` interfaces through providers, from https://github.com/GoogleContainerTools/skaffold/pull/5809#discussion_r629621227