### PR TITLE
emit applicationLogEvents on event endpoint

### DIFF
--- a/pkg/skaffold/event/v2/application_logs.go
+++ b/pkg/skaffold/event/v2/application_logs.go
@@ -20,12 +20,9 @@ import proto "github.com/GoogleContainerTools/skaffold/proto/v2"
 
 func ApplicationLog(podName, containerName, message string) {
 	handler.handleApplicationLogEvent(&proto.ApplicationLogEvent{
-		ContainerName:        podName,
-		PodName:              containerName,
-		Message:              message,
-		XXX_NoUnkeyedLiteral: struct{}{},
-		XXX_unrecognized:     nil,
-		XXX_sizecache:        0,
+		ContainerName: podName,
+		PodName:       containerName,
+		Message:       message,
 	})
 }
 

--- a/pkg/skaffold/event/v2/application_logs.go
+++ b/pkg/skaffold/event/v2/application_logs.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import proto "github.com/GoogleContainerTools/skaffold/proto/v2"
+
+func ApplicationLog(podName, containerName, message string) {
+	handler.handleApplicationLogEvent(&proto.ApplicationLogEvent{
+		ContainerName:        podName,
+		PodName:              containerName,
+		Message:              message,
+		XXX_NoUnkeyedLiteral: struct{}{},
+		XXX_unrecognized:     nil,
+		XXX_sizecache:        0,
+	})
+}
+
+func (ev *eventHandler) handleApplicationLogEvent(e *proto.ApplicationLogEvent) {
+	ev.handle(&proto.Event{
+		EventType: &proto.Event_ApplicationLogEvent{
+			ApplicationLogEvent: e,
+		},
+	})
+}

--- a/pkg/skaffold/event/v2/application_logs_test.go
+++ b/pkg/skaffold/event/v2/application_logs_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"testing"
+
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
+)
+
+func TestHandleApplicationLogEvent(t *testing.T) {
+	testHandler := newHandler()
+	testHandler.state = emptyState(mockCfg([]latestV1.Pipeline{{}}, "test"))
+
+	messages := []string{
+		"hi!",
+		"how's it going",
+		"hope you're well",
+	}
+
+	// ensure that messages sent through the ApplicationLog function are populating the event log
+	for _, message := range messages {
+		testHandler.handleApplicationLogEvent(&proto.ApplicationLogEvent{
+			ContainerName: "pod-0",
+			PodName:       "containerName-0",
+			Message:       message,
+		})
+	}
+	wait(t, func() bool {
+		testHandler.logLock.Lock()
+		logLen := len(testHandler.eventLog)
+		testHandler.logLock.Unlock()
+		return logLen == len(messages)
+	})
+}


### PR DESCRIPTION
**Related**: #5369 

**Description**
This PR adds emission of `applicationLogEvent`s through the event API V2.

**User facing changes (remove if N/A)**
User's will now be able to get logs from their application using the event API.

**Follow-up Work (remove if N/A)**
Following the original design doc, this functionality should exist on its own endpoint. I plan to do that in a follow up PR to keep the size of this one relatively small.
