### PR TITLE
Use LogProvider to instantiate Loggers

### DIFF
--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -90,7 +90,7 @@ spec:
 					},
 				},
 			}}),
-		}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
+		}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 			Manifests: []string{"deployment.yaml"},
 		})
 		t.RequireNoError(err)
@@ -250,7 +250,7 @@ spec:
 				Opts: config.SkaffoldOptions{
 					AddSkaffoldLabels: true,
 				},
-			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
+			}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
 			})
 			t.RequireNoError(err)
@@ -436,7 +436,7 @@ spec:
 						},
 					},
 				}}),
-			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.HelmDeploy{
+			}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.HelmDeploy{
 				Releases: test.helmReleases,
 			})
 			t.RequireNoError(err)

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -102,7 +102,7 @@ type Config interface {
 }
 
 // NewDeployer returns a configured Deployer.  Returns an error if current version of helm is less than 3.0.0.
-func NewDeployer(cfg Config, labels map[string]string, logger log.Logger, previewer preview.ResourcePreviewer, h *latestV1.HelmDeploy) (*Deployer, error) {
+func NewDeployer(cfg Config, labels map[string]string, logProvider log.Provider, previewer preview.ResourcePreviewer, h *latestV1.HelmDeploy) (*Deployer, error) {
 	hv, err := binVer()
 	if err != nil {
 		return nil, versionGetErr(err)
@@ -113,7 +113,7 @@ func NewDeployer(cfg Config, labels map[string]string, logger log.Logger, previe
 	}
 
 	return &Deployer{
-		Logger:            logger,
+		Logger:            logProvider.Do(),
 		ResourcePreviewer: previewer,
 		HelmDeploy:        h,
 		kubeContext:       cfg.GetKubeContext(),

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -464,7 +464,7 @@ func TestNewDeployer(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", test.helmVersion))
 
-			_, err := NewDeployer(&helmConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &testDeployConfig)
+			_, err := NewDeployer(&helmConfig{}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &testDeployConfig)
 			t.CheckError(test.shouldErr, err)
 		})
 	}
@@ -986,7 +986,7 @@ func TestHelmDeploy(t *testing.T) {
 				namespace:  test.namespace,
 				force:      test.force,
 				configFile: "test.yaml",
-			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.helm)
+			}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &test.helm)
 			t.RequireNoError(err)
 
 			if test.configure != nil {
@@ -1063,7 +1063,7 @@ func TestHelmCleanup(t *testing.T) {
 
 			deployer, err := NewDeployer(&helmConfig{
 				namespace: test.namespace,
-			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.helm)
+			}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &test.helm)
 			t.RequireNoError(err)
 
 			deployer.Cleanup(context.Background(), ioutil.Discard)
@@ -1166,7 +1166,7 @@ func TestHelmDependencies(t *testing.T) {
 				local = tmpDir.Root()
 			}
 
-			deployer, err := NewDeployer(&helmConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.HelmDeploy{
+			deployer, err := NewDeployer(&helmConfig{}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.HelmDeploy{
 				Releases: []latestV1.HelmRelease{{
 					Name:                  "skaffold-helm",
 					ChartPath:             local,
@@ -1417,7 +1417,7 @@ func TestHelmRender(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			deployer, err := NewDeployer(&helmConfig{
 				namespace: test.namespace,
-			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.helm)
+			}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &test.helm)
 			t.RequireNoError(err)
 			err = deployer.Render(context.Background(), ioutil.Discard, test.builds, true, file)
 			t.CheckError(test.shouldErr, err)
@@ -1486,7 +1486,7 @@ func TestGenerateSkaffoldDebugFilter(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", version31))
-			h, err := NewDeployer(&helmConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &testDeployConfig)
+			h, err := NewDeployer(&helmConfig{}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &testDeployConfig)
 			t.RequireNoError(err)
 			result := h.generateSkaffoldDebugFilter(test.buildFile)
 			t.CheckDeepEqual(test.result, result)

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -75,9 +75,9 @@ type Deployer struct {
 }
 
 // NewDeployer generates a new Deployer object contains the kptDeploy schema.
-func NewDeployer(cfg types.Config, labels map[string]string, logger log.Logger, previewer preview.ResourcePreviewer, d *latestV1.KptDeploy) *Deployer {
+func NewDeployer(cfg types.Config, labels map[string]string, logProvider log.Provider, previewer preview.ResourcePreviewer, d *latestV1.KptDeploy) *Deployer {
 	return &Deployer{
-		Logger:             logger,
+		Logger:             logProvider.Do(),
 		ResourcePreviewer:  previewer,
 		KptDeploy:          d,
 		insecureRegistries: cfg.GetInsecureRegistries(),

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -222,7 +222,7 @@ func TestKpt_Deploy(t *testing.T) {
 
 			tmpDir.WriteFiles(test.kustomizations)
 
-			k := NewDeployer(&kptConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kpt)
+			k := NewDeployer(&kptConfig{}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &test.kpt)
 
 			if k.Live.Apply.Dir == "valid_path" {
 				// 0755 is a permission setting where the owner can read, write, and execute.
@@ -362,7 +362,7 @@ func TestKpt_Dependencies(t *testing.T) {
 			tmpDir.WriteFiles(test.createFiles)
 			tmpDir.WriteFiles(test.kustomizations)
 
-			k := NewDeployer(&kptConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kpt)
+			k := NewDeployer(&kptConfig{}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &test.kpt)
 
 			res, err := k.Dependencies()
 
@@ -415,7 +415,7 @@ func TestKpt_Cleanup(t *testing.T) {
 
 			k := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KptDeploy{
+			}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KptDeploy{
 				Live: latestV1.KptLive{
 					Apply: latestV1.KptApplyInventory{
 						Dir: test.applyDir,
@@ -771,7 +771,7 @@ spec:
 
 			k := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, test.labels, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kpt)
+			}, test.labels, &log.NoopProvider{}, &preview.NoopPreviewer{}, &test.kpt)
 
 			var b bytes.Buffer
 			err := k.Render(context.Background(), &b, test.builds, true, "")
@@ -845,7 +845,7 @@ func TestKpt_GetApplyDir(t *testing.T) {
 
 			k := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KptDeploy{
+			}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KptDeploy{
 				Live: test.live,
 			})
 
@@ -1004,7 +1004,7 @@ spec:
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			k := NewDeployer(&kptConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, nil)
+			k := NewDeployer(&kptConfig{}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, nil)
 			actualManifest, err := k.excludeKptFn(test.manifests)
 			t.CheckErrorAndDeepEqual(false, err, test.expected.String(), actualManifest.String())
 		})

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -64,7 +64,7 @@ type Deployer struct {
 
 // NewDeployer returns a new Deployer for a DeployConfig filled
 // with the needed configuration for `kubectl apply`
-func NewDeployer(cfg Config, labels map[string]string, logger log.Logger, previewer preview.ResourcePreviewer, d *latestV1.KubectlDeploy) (*Deployer, error) {
+func NewDeployer(cfg Config, labels map[string]string, logProvider log.Provider, previewer preview.ResourcePreviewer, d *latestV1.KubectlDeploy) (*Deployer, error) {
 	defaultNamespace := ""
 	if d.DefaultNamespace != nil {
 		var err error
@@ -75,7 +75,7 @@ func NewDeployer(cfg Config, labels map[string]string, logger log.Logger, previe
 	}
 
 	return &Deployer{
-		Logger:             logger,
+		Logger:             logProvider.Do(),
 		ResourcePreviewer:  previewer,
 		KubectlDeploy:      d,
 		workingDir:         cfg.GetWorkingDir(),

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -243,7 +243,7 @@ func TestKubectlDeploy(t *testing.T) {
 				},
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: skaffoldNamespaceOption}},
-			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kubectl)
+			}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &test.kubectl)
 			t.RequireNoError(err)
 
 			_, err = k.Deploy(context.Background(), ioutil.Discard, test.builds)
@@ -317,7 +317,7 @@ func TestKubectlCleanup(t *testing.T) {
 			k, err := NewDeployer(&kubectlConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
-			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kubectl)
+			}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &test.kubectl)
 			t.RequireNoError(err)
 
 			err = k.Cleanup(context.Background(), ioutil.Discard)
@@ -364,7 +364,7 @@ func TestKubectlDeployerRemoteCleanup(t *testing.T) {
 			k, err := NewDeployer(&kubectlConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
-			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kubectl)
+			}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &test.kubectl)
 			t.RequireNoError(err)
 
 			err = k.Cleanup(context.Background(), ioutil.Discard)
@@ -398,7 +398,7 @@ func TestKubectlRedeploy(t *testing.T) {
 				Enabled: true,
 				Delay:   0 * time.Millisecond,
 				Max:     10 * time.Second},
-		}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-app.yaml"), tmpDir.Path("deployment-web.yaml")}})
+		}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-app.yaml"), tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		// Deploy one manifest
@@ -462,7 +462,7 @@ func TestKubectlWaitForDeletions(t *testing.T) {
 				Delay:   0 * time.Millisecond,
 				Max:     10 * time.Second,
 			},
-		}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
+		}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		var out bytes.Buffer
@@ -499,7 +499,7 @@ func TestKubectlWaitForDeletionsFails(t *testing.T) {
 				Delay:   10 * time.Second,
 				Max:     100 * time.Millisecond,
 			},
-		}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
+		}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		_, err = deployer.Deploy(context.Background(), ioutil.Discard, []graph.Artifact{
@@ -560,7 +560,7 @@ func TestDependencies(t *testing.T) {
 				Touch("00/b.yaml", "00/a.yaml").
 				Chdir()
 
-			k, err := NewDeployer(&kubectlConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{Manifests: test.manifests})
+			k, err := NewDeployer(&kubectlConfig{}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{Manifests: test.manifests})
 			t.RequireNoError(err)
 
 			dependencies, err := k.Dependencies()
@@ -676,7 +676,7 @@ spec:
 			deployer, err := NewDeployer(&kubectlConfig{
 				workingDir:  ".",
 				defaultRepo: "gcr.io/project",
-			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
+			}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 				Manifests: []string{tmpDir.Path("deployment.yaml")},
 			})
 			t.RequireNoError(err)
@@ -721,7 +721,7 @@ func TestGCSManifests(t *testing.T) {
 				workingDir: ".",
 				skipRender: test.skipRender,
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
-			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kubectl)
+			}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &test.kubectl)
 			t.RequireNoError(err)
 
 			_, err = k.Deploy(context.Background(), ioutil.Discard, nil)

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -106,7 +106,7 @@ type Deployer struct {
 	useKubectlKustomize bool
 }
 
-func NewDeployer(cfg kubectl.Config, labels map[string]string, logger log.Logger, previewer preview.ResourcePreviewer, d *latestV1.KustomizeDeploy) (*Deployer, error) {
+func NewDeployer(cfg kubectl.Config, labels map[string]string, logProvider log.Provider, previewer preview.ResourcePreviewer, d *latestV1.KustomizeDeploy) (*Deployer, error) {
 	defaultNamespace := ""
 	if d.DefaultNamespace != nil {
 		var err error
@@ -121,7 +121,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, logger log.Logger
 	useKubectlKustomize := !kustomizeBinaryCheck() && kubectlVersionCheck(kubectl)
 
 	return &Deployer{
-		Logger:              logger,
+		Logger:              logProvider.Do(),
 		ResourcePreviewer:   previewer,
 		KustomizeDeploy:     d,
 		kubectl:             kubectl,

--- a/pkg/skaffold/deploy/kustomize/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize_test.go
@@ -188,7 +188,7 @@ func TestKustomizeDeploy(t *testing.T) {
 				},
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: skaffoldNamespaceOption,
-				}}}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kustomize)
+				}}}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &test.kustomize)
 			t.RequireNoError(err)
 			_, err = k.Deploy(context.Background(), ioutil.Discard, test.builds)
 
@@ -254,7 +254,7 @@ func TestKustomizeCleanup(t *testing.T) {
 				workingDir: tmpDir.Root(),
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: kubectl.TestNamespace}},
-			}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &test.kustomize)
+			}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &test.kustomize)
 			t.RequireNoError(err)
 			err = k.Cleanup(context.Background(), ioutil.Discard)
 
@@ -456,7 +456,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 				tmpDir.Write(path, contents)
 			}
 
-			k, err := NewDeployer(&kustomizeConfig{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KustomizeDeploy{KustomizePaths: kustomizePaths})
+			k, err := NewDeployer(&kustomizeConfig{}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KustomizeDeploy{KustomizePaths: kustomizePaths})
 			t.RequireNoError(err)
 
 			deps, err := k.Dependencies()
@@ -700,7 +700,7 @@ spec:
 			k, err := NewDeployer(&kustomizeConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: kubectl.TestNamespace}},
-			}, test.labels, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KustomizeDeploy{
+			}, test.labels, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KustomizeDeploy{
 				KustomizePaths: kustomizationPaths,
 			})
 			t.RequireNoError(err)

--- a/pkg/skaffold/kubernetes/logger/log_test.go
+++ b/pkg/skaffold/kubernetes/logger/log_test.go
@@ -228,3 +228,7 @@ func (c *mockConfig) DefaultPipeline() latestV1.Pipeline {
 	pipeline.Deploy.Logs = c.log
 	return pipeline
 }
+
+func (c *mockConfig) Tail() bool {
+	return true
+}

--- a/pkg/skaffold/log/provider.go
+++ b/pkg/skaffold/log/provider.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package log
+
+import (
+	"sync"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/logger"
+)
+
+type Provider interface {
+	Do() Logger
+}
+
+type FullProvider struct {
+	tail bool
+
+	kubernetesLogger *logger.LogAggregator
+	noopLogger       *NoopLogger
+}
+
+var provider *FullProvider
+
+func NewLogProvider(cli *kubectl.CLI, podSelector kubernetes.PodSelector, config logger.Config) Provider {
+	once := sync.Once{}
+	once.Do(func() {
+		kLog := logger.NewLogAggregator(cli, podSelector, config)
+		provider = &FullProvider{
+			tail:             config.Tail(),
+			kubernetesLogger: kLog,
+			noopLogger:       &NoopLogger{},
+		}
+	})
+	return provider
+}
+
+func (p *FullProvider) Do() Logger {
+	if !p.tail {
+		return p.noopLogger
+	}
+	return p.kubernetesLogger
+}
+
+// NoopProvider is used in tests
+type NoopProvider struct{}
+
+func (p *NoopProvider) Do() Logger {
+	return &NoopLogger{}
+}

--- a/pkg/skaffold/runner/v1/deploy_test.go
+++ b/pkg/skaffold/runner/v1/deploy_test.go
@@ -195,7 +195,7 @@ func TestSkaffoldDeployRenderOnly(t *testing.T) {
 			KubeContext: "does-not-exist",
 		}
 
-		deployer, err := getDeployer(runCtx, nil, &log.NoopLogger{}, &preview.NoopPreviewer{})
+		deployer, err := getDeployer(runCtx, nil, &log.NoopProvider{}, &preview.NoopPreviewer{})
 		t.RequireNoError(err)
 		r := SkaffoldRunner{
 			runCtx:     runCtx,

--- a/pkg/skaffold/runner/v1/new_test.go
+++ b/pkg/skaffold/runner/v1/new_test.go
@@ -68,7 +68,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				expected: deploy.DeployerMux{
 					t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 						Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-					}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
+					}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 						Flags: latestV1.KubectlFlags{},
 					})).(deploy.Deployer),
 				},
@@ -79,7 +79,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				expected: deploy.DeployerMux{
 					t.RequireNonNilResult(kustomize.NewDeployer(&runcontext.RunContext{
 						Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-					}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KustomizeDeploy{
+					}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KustomizeDeploy{
 						Flags: latestV1.KubectlFlags{},
 					})).(deploy.Deployer),
 				},
@@ -88,7 +88,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				description: "kpt deployer",
 				cfg:         latestV1.DeployType{KptDeploy: &latestV1.KptDeploy{}},
 				expected: deploy.DeployerMux{
-					kpt.NewDeployer(&runcontext.RunContext{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KptDeploy{}),
+					kpt.NewDeployer(&runcontext.RunContext{}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KptDeploy{}),
 				},
 			},
 			{
@@ -97,7 +97,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				apply:       true,
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(deploy.Deployer),
 			},
@@ -108,7 +108,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				apply:       true,
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(deploy.Deployer),
 			},
@@ -121,7 +121,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				helmVersion: `version.BuildInfo{Version:"v3.0.0"}`,
 				expected: deploy.DeployerMux{
 					&helm.Deployer{},
-					kpt.NewDeployer(&runcontext.RunContext{}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KptDeploy{}),
+					kpt.NewDeployer(&runcontext.RunContext{}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KptDeploy{}),
 				},
 			},
 		}
@@ -143,7 +143,7 @@ func TestGetDeployer(tOuter *testing.T) {
 							DeployType: test.cfg,
 						},
 					}}),
-				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{})
+				}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{})
 
 				t.CheckError(test.shouldErr, err)
 				t.CheckTypeEquality(test.expected, deployer)
@@ -176,7 +176,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -192,7 +192,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{
 						Apply:  []string{"--foo"},
 						Global: []string{"--bar"},
@@ -226,7 +226,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -237,7 +237,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
+				}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{}, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -255,7 +255,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}
 				deployer, err := getDefaultDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines(pipelines),
-				}, nil, &log.NoopLogger{}, &preview.NoopPreviewer{})
+				}, nil, &log.NoopProvider{}, &preview.NoopPreviewer{})
 
 				t.CheckErrorAndFailNow(test.shouldErr, err)
 


### PR DESCRIPTION
This (partially) addresses follow-up work from https://github.com/GoogleContainerTools/skaffold/pull/5809#discussion_r629621227. This change transfers control of instantiating `Logger` objects to the `LogProvider`, which contains singleton instances of all types of `Logger`s. This will make it easier to add new `Logger`s in the future, and also helps deal with shared `Logger`s more cleanly.

This change also adds a bit of synchronization on the calls in the `kubernetes.LogAggregator`, which will allow it to be shared between deployers in a `DeployerMux` more safely.

Fixes https://github.com/GoogleContainerTools/skaffold/issues/5840