### PR TITLE
Fix yaml reference rendering for object-type examples

### DIFF
--- a/docs/content/en/docs/references/yaml/main.js
+++ b/docs/content/en/docs/references/yaml/main.js
@@ -185,7 +185,7 @@ function* template(definitions, parentDefinition, ref, ident, parent) {
         yield html`
           <tr>
             <td>
-              <span class="key" style="margin-left: ${(ident + 1) * 20}px"><span class="${valueClass}">${anchor(k)}: ${v}</span></span>
+              <span class="key" style="margin-left: ${(ident + 1) * 20}px">${k}: <span class="${valueClass}">${v}</span></span>
             </td>
             <td class="comment">#&nbsp;</td>
           </tr>


### PR DESCRIPTION
Fixes: #5841

**Description**
Our JS rendering of the `skaffold.yaml` schemas was swallowing the key-part when walking the key-value pairs in an object-style example.  The only examples of this type are the `buildArgs` fields of our builders.

**Before**
<img width="293" alt="Screen Shot 2021-05-20 at 10 05 30 AM" src="https://user-images.githubusercontent.com/202851/118993041-2c349600-b953-11eb-82dc-b412df5db196.png">

**After**
<img width="242" alt="Screen Shot 2021-05-20 at 10 05 44 AM" src="https://user-images.githubusercontent.com/202851/118993068-32c30d80-b953-11eb-8878-983b5fcc5379.png">
