### PR TITLE
Schemas should emit type=object for object

### DIFF
--- a/docs/content/en/schemas/v1.json
+++ b/docs/content/en/schemas/v1.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -322,10 +324,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -511,6 +515,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -540,6 +545,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a buildpack.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a buildpack."
     },
@@ -610,6 +616,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -631,6 +638,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -672,6 +680,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -694,10 +703,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -872,6 +883,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -893,6 +905,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -921,6 +934,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -942,6 +956,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -964,6 +979,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1031,6 +1047,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1047,6 +1064,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1074,6 +1092,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1113,6 +1132,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1128,10 +1148,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1184,6 +1206,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1323,6 +1346,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1362,6 +1386,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1400,6 +1425,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1477,6 +1503,7 @@
         "skipTLS"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1498,6 +1525,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1519,6 +1547,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1554,6 +1583,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1593,6 +1623,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1625,6 +1656,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1654,6 +1686,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1669,6 +1702,7 @@
         "initImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1684,6 +1718,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1723,6 +1758,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1792,6 +1828,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1837,6 +1874,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1858,6 +1896,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1867,6 +1906,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1938,6 +1978,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1966,6 +2007,7 @@
         "infer"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files."
     },
@@ -2006,6 +2048,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2039,6 +2082,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -2073,6 +2117,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v1alpha1.json
+++ b/docs/content/en/schemas/v1alpha1.json
@@ -33,10 +33,12 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents items that need should be built, along with the context in which they should be built.",
       "x-intellij-html-description": "represents items that need should be built, along with the context in which they should be built."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -105,6 +107,7 @@
       "x-intellij-html-description": "contains all the configuration for the build steps"
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -160,7 +163,8 @@
       "preferredOrder": [
         "projectId"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "HelmDeploy": {
       "properties": {
@@ -174,7 +178,8 @@
       "preferredOrder": [
         "releases"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "HelmRelease": {
       "properties": {
@@ -209,7 +214,8 @@
         "namespace",
         "version"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "KubectlDeploy": {
       "properties": {
@@ -224,6 +230,7 @@
         "manifests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with `kubectl apply`",
       "x-intellij-html-description": "contains the configuration needed for deploying with <code>kubectl apply</code>"
     },
@@ -237,6 +244,7 @@
         "skipPush"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -261,7 +269,8 @@
         "paths",
         "parameters"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "SkaffoldConfig": {
       "properties": {
@@ -285,6 +294,7 @@
         "deploy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "top level config object that is parsed from a skaffold.yaml",
       "x-intellij-html-description": "top level config object that is parsed from a skaffold.yaml"
     }

--- a/docs/content/en/schemas/v1alpha2.json
+++ b/docs/content/en/schemas/v1alpha2.json
@@ -8,6 +8,7 @@
   "$schema": "http://json-schema-org/draft-07/schema#",
   "definitions": {
     "Artifact": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -75,9 +76,11 @@
       "preferredOrder": [
         "target"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -181,10 +184,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the DateTime tagger.",
       "x-intellij-html-description": "contains the configuration for the DateTime tagger."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -255,7 +260,8 @@
         "cacheFrom",
         "target"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "EnvTemplateTagger": {
       "properties": {
@@ -267,10 +273,12 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the envTemplate tagger.",
       "x-intellij-html-description": "contains the configuration for the envTemplate tagger."
     },
     "GitTagger": {
+      "type": "object",
       "description": "contains the configuration for the git tagger.",
       "x-intellij-html-description": "contains the configuration for the git tagger."
     },
@@ -300,10 +308,12 @@
         "dockerImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a remote build on Google Cloud Build.",
       "x-intellij-html-description": "contains the fields needed to do a remote build on Google Cloud Build."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "represents image config in the syntax of image.repository and image.tag",
       "x-intellij-html-description": "represents image config in the syntax of image.repository and image.tag"
     },
@@ -320,6 +330,7 @@
         "releases"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with helm",
       "x-intellij-html-description": "contains the configuration needed for deploying with helm"
     },
@@ -333,10 +344,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents image config to use the FullyQualifiedImageName as param to set",
       "x-intellij-html-description": "represents image config to use the FullyQualifiedImageName as param to set"
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -383,6 +396,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents parameters for packaging helm chart.",
       "x-intellij-html-description": "represents parameters for packaging helm chart."
     },
@@ -455,7 +469,8 @@
         "packaged",
         "imageStrategy"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "KanikoBuild": {
       "properties": {
@@ -483,6 +498,7 @@
         "timeout"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a on-cluster build using the kaniko image",
       "x-intellij-html-description": "contains the fields needed to do a on-cluster build using the kaniko image"
     },
@@ -512,6 +528,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with `kubectl apply`",
       "x-intellij-html-description": "contains the configuration needed for deploying with <code>kubectl apply</code>"
     },
@@ -545,6 +562,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -561,7 +579,8 @@
         "kustomizePath",
         "flags"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "LocalBuild": {
       "properties": {
@@ -583,6 +602,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -604,10 +624,12 @@
         "deploy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional configuration that overrides default configuration when it is activated.",
       "x-intellij-html-description": "additional configuration that overrides default configuration when it is activated."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "contains the configuration for the SHA tagger.",
       "x-intellij-html-description": "contains the configuration for the SHA tagger."
     },
@@ -639,7 +661,8 @@
         "deploy",
         "profiles"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "TagPolicy": {
       "properties": {
@@ -663,6 +686,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step",
       "x-intellij-html-description": "contains all the configuration for the tagging step"
     }

--- a/docs/content/en/schemas/v1alpha3.json
+++ b/docs/content/en/schemas/v1alpha3.json
@@ -8,6 +8,7 @@
   "$schema": "http://json-schema-org/draft-07/schema#",
   "definitions": {
     "Artifact": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -75,9 +76,11 @@
       "preferredOrder": [
         "target"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -181,10 +184,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the DateTime tagger.",
       "x-intellij-html-description": "contains the configuration for the DateTime tagger."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -255,7 +260,8 @@
         "cacheFrom",
         "target"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "EnvTemplateTagger": {
       "properties": {
@@ -267,10 +273,12 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the envTemplate tagger.",
       "x-intellij-html-description": "contains the configuration for the envTemplate tagger."
     },
     "GitTagger": {
+      "type": "object",
       "description": "contains the configuration for the git tagger.",
       "x-intellij-html-description": "contains the configuration for the git tagger."
     },
@@ -300,10 +308,12 @@
         "dockerImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a remote build on Google Cloud Build.",
       "x-intellij-html-description": "contains the fields needed to do a remote build on Google Cloud Build."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "represents image config in the syntax of image.repository and image.tag",
       "x-intellij-html-description": "represents image config in the syntax of image.repository and image.tag"
     },
@@ -320,6 +330,7 @@
         "releases"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with helm",
       "x-intellij-html-description": "contains the configuration needed for deploying with helm"
     },
@@ -333,10 +344,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents image config to use the FullyQualifiedImageName as param to set",
       "x-intellij-html-description": "represents image config to use the FullyQualifiedImageName as param to set"
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -383,6 +396,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents parameters for packaging helm chart.",
       "x-intellij-html-description": "represents parameters for packaging helm chart."
     },
@@ -459,7 +473,8 @@
         "packaged",
         "imageStrategy"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "KanikoBuild": {
       "properties": {
@@ -487,6 +502,7 @@
         "timeout"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a on-cluster build using the kaniko image",
       "x-intellij-html-description": "contains the fields needed to do a on-cluster build using the kaniko image"
     },
@@ -500,6 +516,7 @@
         "gcsBucket"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a kaniko build context",
       "x-intellij-html-description": "contains the different fields available to specify a kaniko build context"
     },
@@ -529,6 +546,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with `kubectl apply`",
       "x-intellij-html-description": "contains the configuration needed for deploying with <code>kubectl apply</code>"
     },
@@ -562,6 +580,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -578,7 +597,8 @@
         "kustomizePath",
         "flags"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "LocalBuild": {
       "properties": {
@@ -600,6 +620,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -621,10 +642,12 @@
         "deploy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional configuration that overrides default configuration when it is activated.",
       "x-intellij-html-description": "additional configuration that overrides default configuration when it is activated."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "contains the configuration for the SHA tagger.",
       "x-intellij-html-description": "contains the configuration for the SHA tagger."
     },
@@ -656,7 +679,8 @@
         "deploy",
         "profiles"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "TagPolicy": {
       "properties": {
@@ -680,6 +704,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step",
       "x-intellij-html-description": "contains all the configuration for the tagging step"
     }

--- a/docs/content/en/schemas/v1alpha4.json
+++ b/docs/content/en/schemas/v1alpha4.json
@@ -8,6 +8,7 @@
   "$schema": "http://json-schema-org/draft-07/schema#",
   "definitions": {
     "Artifact": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -154,10 +155,12 @@
         "target"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with Bazel.",
       "x-intellij-html-description": "describes an artifact built with Bazel."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -261,10 +264,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the DateTime tagger.",
       "x-intellij-html-description": "contains the configuration for the DateTime tagger."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -336,6 +341,7 @@
         "target"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -349,10 +355,12 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the envTemplate tagger.",
       "x-intellij-html-description": "contains the configuration for the envTemplate tagger."
     },
     "GitTagger": {
+      "type": "object",
       "description": "contains the configuration for the git tagger.",
       "x-intellij-html-description": "contains the configuration for the git tagger."
     },
@@ -382,10 +390,12 @@
         "dockerImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a remote build on Google Cloud Build.",
       "x-intellij-html-description": "contains the fields needed to do a remote build on Google Cloud Build."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "represents image config in the syntax of image.repository and image.tag",
       "x-intellij-html-description": "represents image config in the syntax of image.repository and image.tag"
     },
@@ -402,6 +412,7 @@
         "releases"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with helm",
       "x-intellij-html-description": "contains the configuration needed for deploying with helm"
     },
@@ -415,10 +426,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents image config to use the FullyQualifiedImageName as param to set",
       "x-intellij-html-description": "represents image config to use the FullyQualifiedImageName as param to set"
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -465,6 +478,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents parameters for packaging helm chart.",
       "x-intellij-html-description": "represents parameters for packaging helm chart."
     },
@@ -541,7 +555,8 @@
         "packaged",
         "imageStrategy"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "JibGradleArtifact": {
       "properties": {
@@ -554,7 +569,8 @@
       "preferredOrder": [
         "project"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "JibMavenArtifact": {
       "properties": {
@@ -571,7 +587,8 @@
         "module",
         "profile"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "KanikoBuild": {
       "properties": {
@@ -603,6 +620,7 @@
         "image"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a on-cluster build using the kaniko image",
       "x-intellij-html-description": "contains the fields needed to do a on-cluster build using the kaniko image"
     },
@@ -620,6 +638,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a kaniko build context",
       "x-intellij-html-description": "contains the different fields available to specify a kaniko build context"
     },
@@ -649,6 +668,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with `kubectl apply`",
       "x-intellij-html-description": "contains the configuration needed for deploying with <code>kubectl apply</code>"
     },
@@ -682,6 +702,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -699,6 +720,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with kustomize.",
       "x-intellij-html-description": "contains the configuration needed for deploying with kustomize."
     },
@@ -722,10 +744,12 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository."
     },
     "LocalDir": {
+      "type": "object",
       "description": "represents the local directory kaniko build context",
       "x-intellij-html-description": "represents the local directory kaniko build context"
     },
@@ -754,10 +778,12 @@
         "deploy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional configuration that overrides default configuration when it is activated.",
       "x-intellij-html-description": "additional configuration that overrides default configuration when it is activated."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "contains the configuration for the SHA tagger.",
       "x-intellij-html-description": "contains the configuration for the SHA tagger."
     },
@@ -793,7 +819,8 @@
         "deploy",
         "profiles"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "TagPolicy": {
       "properties": {
@@ -817,6 +844,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step",
       "x-intellij-html-description": "contains all the configuration for the tagging step"
     },
@@ -838,6 +866,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a struct containing all the specified test configuration for an image.",
       "x-intellij-html-description": "a struct containing all the specified test configuration for an image."
     },

--- a/docs/content/en/schemas/v1alpha5.json
+++ b/docs/content/en/schemas/v1alpha5.json
@@ -8,6 +8,7 @@
   "$schema": "http://json-schema-org/draft-07/schema#",
   "definitions": {
     "Artifact": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -166,6 +167,7 @@
         "tenantId"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a build on Azure Container Registry",
       "x-intellij-html-description": "contains the fields needed to do a build on Azure Container Registry"
     },
@@ -179,10 +181,12 @@
         "target"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with Bazel.",
       "x-intellij-html-description": "describes an artifact built with Bazel."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -308,10 +312,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the DateTime tagger.",
       "x-intellij-html-description": "contains the configuration for the DateTime tagger."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -383,6 +389,7 @@
         "target"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -396,10 +403,12 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the envTemplate tagger.",
       "x-intellij-html-description": "contains the configuration for the envTemplate tagger."
     },
     "GitTagger": {
+      "type": "object",
       "description": "contains the configuration for the git tagger.",
       "x-intellij-html-description": "contains the configuration for the git tagger."
     },
@@ -429,10 +438,12 @@
         "dockerImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a remote build on Google Cloud Build.",
       "x-intellij-html-description": "contains the fields needed to do a remote build on Google Cloud Build."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "represents image config in the syntax of image.repository and image.tag",
       "x-intellij-html-description": "represents image config in the syntax of image.repository and image.tag"
     },
@@ -449,6 +460,7 @@
         "releases"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with helm",
       "x-intellij-html-description": "contains the configuration needed for deploying with helm"
     },
@@ -462,10 +474,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents image config to use the FullyQualifiedImageName as param to set",
       "x-intellij-html-description": "represents image config to use the FullyQualifiedImageName as param to set"
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -512,6 +526,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents parameters for packaging helm chart.",
       "x-intellij-html-description": "represents parameters for packaging helm chart."
     },
@@ -588,7 +603,8 @@
         "packaged",
         "imageStrategy"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "JibGradleArtifact": {
       "properties": {
@@ -601,7 +617,8 @@
       "preferredOrder": [
         "project"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "JibMavenArtifact": {
       "properties": {
@@ -618,7 +635,8 @@
         "module",
         "profile"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "KanikoBuild": {
       "properties": {
@@ -650,6 +668,7 @@
         "image"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a on-cluster build using the kaniko image",
       "x-intellij-html-description": "contains the fields needed to do a on-cluster build using the kaniko image"
     },
@@ -667,6 +686,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a kaniko build context",
       "x-intellij-html-description": "contains the different fields available to specify a kaniko build context"
     },
@@ -696,6 +716,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with `kubectl apply`",
       "x-intellij-html-description": "contains the configuration needed for deploying with <code>kubectl apply</code>"
     },
@@ -729,6 +750,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -746,6 +768,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with kustomize.",
       "x-intellij-html-description": "contains the configuration needed for deploying with kustomize."
     },
@@ -769,10 +792,12 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository."
     },
     "LocalDir": {
+      "type": "object",
       "description": "represents the local directory kaniko build context",
       "x-intellij-html-description": "represents the local directory kaniko build context"
     },
@@ -798,10 +823,12 @@
         "deploy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional configuration that overrides default configuration when it is activated.",
       "x-intellij-html-description": "additional configuration that overrides default configuration when it is activated."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "contains the configuration for the SHA tagger.",
       "x-intellij-html-description": "contains the configuration for the SHA tagger."
     },
@@ -837,7 +864,8 @@
         "deploy",
         "profiles"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "TagPolicy": {
       "properties": {
@@ -861,6 +889,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step",
       "x-intellij-html-description": "contains all the configuration for the tagging step"
     },
@@ -882,6 +911,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a struct containing all the specified test configuration for an image.",
       "x-intellij-html-description": "a struct containing all the specified test configuration for an image."
     },

--- a/docs/content/en/schemas/v1beta1.json
+++ b/docs/content/en/schemas/v1beta1.json
@@ -8,6 +8,7 @@
   "$schema": "http://json-schema-org/draft-07/schema#",
   "definitions": {
     "Artifact": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -162,10 +163,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with Bazel.",
       "x-intellij-html-description": "describes an artifact built with Bazel."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -269,10 +272,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the DateTime tagger.",
       "x-intellij-html-description": "contains the configuration for the DateTime tagger."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -344,6 +349,7 @@
         "target"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -357,10 +363,12 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the envTemplate tagger.",
       "x-intellij-html-description": "contains the configuration for the envTemplate tagger."
     },
     "GitTagger": {
+      "type": "object",
       "description": "contains the configuration for the git tagger.",
       "x-intellij-html-description": "contains the configuration for the git tagger."
     },
@@ -390,10 +398,12 @@
         "dockerImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a remote build on Google Cloud Build.",
       "x-intellij-html-description": "contains the fields needed to do a remote build on Google Cloud Build."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "represents image config in the syntax of image.repository and image.tag",
       "x-intellij-html-description": "represents image config in the syntax of image.repository and image.tag"
     },
@@ -410,6 +420,7 @@
         "releases"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with helm",
       "x-intellij-html-description": "contains the configuration needed for deploying with helm"
     },
@@ -423,10 +434,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents image config to use the FullyQualifiedImageName as param to set",
       "x-intellij-html-description": "represents image config to use the FullyQualifiedImageName as param to set"
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -473,6 +486,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents parameters for packaging helm chart.",
       "x-intellij-html-description": "represents parameters for packaging helm chart."
     },
@@ -549,7 +563,8 @@
         "packaged",
         "imageStrategy"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "JibGradleArtifact": {
       "properties": {
@@ -562,7 +577,8 @@
       "preferredOrder": [
         "project"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "JibMavenArtifact": {
       "properties": {
@@ -579,7 +595,8 @@
         "module",
         "profile"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "KanikoBuild": {
       "properties": {
@@ -615,6 +632,7 @@
         "image"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a on-cluster build using the kaniko image",
       "x-intellij-html-description": "contains the fields needed to do a on-cluster build using the kaniko image"
     },
@@ -632,6 +650,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a kaniko build context",
       "x-intellij-html-description": "contains the different fields available to specify a kaniko build context"
     },
@@ -645,6 +664,7 @@
         "repo"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains fields related to kaniko caching",
       "x-intellij-html-description": "contains fields related to kaniko caching"
     },
@@ -674,6 +694,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with `kubectl apply`",
       "x-intellij-html-description": "contains the configuration needed for deploying with <code>kubectl apply</code>"
     },
@@ -707,6 +728,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -724,6 +746,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with kustomize.",
       "x-intellij-html-description": "contains the configuration needed for deploying with kustomize."
     },
@@ -747,10 +770,12 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository."
     },
     "LocalDir": {
+      "type": "object",
       "description": "represents the local directory kaniko build context",
       "x-intellij-html-description": "represents the local directory kaniko build context"
     },
@@ -776,10 +801,12 @@
         "deploy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional configuration that overrides default configuration when it is activated.",
       "x-intellij-html-description": "additional configuration that overrides default configuration when it is activated."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "contains the configuration for the SHA tagger.",
       "x-intellij-html-description": "contains the configuration for the SHA tagger."
     },
@@ -815,7 +842,8 @@
         "deploy",
         "profiles"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "TagPolicy": {
       "properties": {
@@ -839,6 +867,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step",
       "x-intellij-html-description": "contains all the configuration for the tagging step"
     },
@@ -860,6 +889,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a struct containing all the specified test configuration for an image.",
       "x-intellij-html-description": "a struct containing all the specified test configuration for an image."
     },

--- a/docs/content/en/schemas/v1beta10.json
+++ b/docs/content/en/schemas/v1beta10.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -322,10 +324,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -520,6 +524,7 @@
         "resources"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -541,6 +546,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -582,6 +588,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -604,10 +611,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -718,6 +727,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -739,6 +749,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -767,6 +778,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>alpha</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -788,6 +800,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -808,6 +821,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -862,10 +876,12 @@
         "gradleImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -893,6 +909,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -932,6 +949,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -947,10 +965,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1003,6 +1023,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1125,6 +1146,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1164,6 +1186,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1192,6 +1215,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin\">Jib plugin for Gradle</a>."
     },
@@ -1226,6 +1250,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin\">Jib plugin for Maven</a>."
     },
@@ -1289,6 +1314,7 @@
         "cache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1310,6 +1336,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1325,6 +1352,7 @@
         "repo"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1360,6 +1388,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1399,6 +1428,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1421,6 +1451,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1450,6 +1481,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1465,6 +1497,7 @@
         "initImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1525,6 +1558,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1552,6 +1586,7 @@
         "memory"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1573,10 +1608,12 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1633,6 +1670,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1651,6 +1689,7 @@
         "manual"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files.",
       "x-intellij-html-description": "<em>alpha</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files."
     },
@@ -1691,6 +1730,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -1724,6 +1764,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -1758,6 +1799,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v1beta11.json
+++ b/docs/content/en/schemas/v1beta11.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -322,10 +324,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -520,6 +524,7 @@
         "resources"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -541,6 +546,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -582,6 +588,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -604,10 +611,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -718,6 +727,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -739,6 +749,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -767,6 +778,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>alpha</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -788,6 +800,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -810,6 +823,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -864,10 +878,12 @@
         "gradleImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -895,6 +911,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -934,6 +951,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -949,10 +967,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1005,6 +1025,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1134,6 +1155,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1173,6 +1195,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1201,6 +1224,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin\">Jib plugin for Gradle</a>."
     },
@@ -1235,6 +1259,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin\">Jib plugin for Maven</a>."
     },
@@ -1298,6 +1323,7 @@
         "cache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1319,6 +1345,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1340,6 +1367,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1375,6 +1403,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1414,6 +1443,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1436,6 +1466,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1465,6 +1496,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1480,6 +1512,7 @@
         "initImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1540,6 +1573,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1567,6 +1601,7 @@
         "memory"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1588,10 +1623,12 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1648,6 +1685,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1666,6 +1704,7 @@
         "manual"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files.",
       "x-intellij-html-description": "<em>alpha</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files."
     },
@@ -1706,6 +1745,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -1739,6 +1779,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -1773,6 +1814,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v1beta12.json
+++ b/docs/content/en/schemas/v1beta12.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -322,10 +324,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -520,6 +524,7 @@
         "resources"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -541,6 +546,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -582,6 +588,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -604,10 +611,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -718,6 +727,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -739,6 +749,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -767,6 +778,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>alpha</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -788,6 +800,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -810,6 +823,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -864,10 +878,12 @@
         "gradleImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -895,6 +911,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -934,6 +951,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -949,10 +967,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1005,6 +1025,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1134,6 +1155,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1173,6 +1195,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1201,6 +1224,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin\">Jib plugin for Gradle</a>."
     },
@@ -1235,6 +1259,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin\">Jib plugin for Maven</a>."
     },
@@ -1298,6 +1323,7 @@
         "cache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1319,6 +1345,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1340,6 +1367,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1375,6 +1403,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1414,6 +1443,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1436,6 +1466,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1465,6 +1496,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1480,6 +1512,7 @@
         "initImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1519,6 +1552,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1588,6 +1622,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1615,6 +1650,7 @@
         "memory"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1636,6 +1672,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1645,6 +1682,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1710,6 +1748,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1728,6 +1767,7 @@
         "manual"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files.",
       "x-intellij-html-description": "<em>alpha</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files."
     },
@@ -1768,6 +1808,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -1801,6 +1842,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -1835,6 +1877,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v1beta13.json
+++ b/docs/content/en/schemas/v1beta13.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -322,10 +324,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -532,6 +536,7 @@
         "resources"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -553,6 +558,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -594,6 +600,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -616,10 +623,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -758,6 +767,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -779,6 +789,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -807,6 +818,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>alpha</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -828,6 +840,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -850,6 +863,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -904,6 +918,7 @@
         "gradleImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -920,6 +935,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -947,6 +963,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -986,6 +1003,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1001,10 +1019,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1057,6 +1077,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1186,6 +1207,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1225,6 +1247,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1253,6 +1276,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin\">Jib plugin for Gradle</a>."
     },
@@ -1287,6 +1311,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin\">Jib plugin for Maven</a>."
     },
@@ -1357,6 +1382,7 @@
         "reproducible"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1378,6 +1404,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1399,6 +1426,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1434,6 +1462,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1473,6 +1502,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1495,6 +1525,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1524,6 +1555,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1539,6 +1571,7 @@
         "initImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1554,6 +1587,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1593,6 +1627,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1662,6 +1697,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1689,6 +1725,7 @@
         "memory"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1710,6 +1747,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1719,6 +1757,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1790,6 +1829,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1818,6 +1858,7 @@
         "infer"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files.",
       "x-intellij-html-description": "<em>alpha</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files."
     },
@@ -1858,6 +1899,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -1891,6 +1933,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -1925,6 +1968,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v1beta14.json
+++ b/docs/content/en/schemas/v1beta14.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -287,10 +289,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -503,6 +507,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -524,6 +529,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -565,6 +571,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -587,10 +594,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -729,6 +738,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -750,6 +760,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -778,6 +789,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>alpha</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -799,6 +811,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -821,6 +834,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -888,6 +902,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -904,6 +919,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -931,6 +947,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -970,6 +987,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -985,10 +1003,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1041,6 +1061,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1170,6 +1191,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1209,6 +1231,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1247,6 +1270,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1317,6 +1341,7 @@
         "reproducible"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1338,6 +1363,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1359,6 +1385,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1394,6 +1421,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1433,6 +1461,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1455,6 +1484,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1484,6 +1514,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1499,6 +1530,7 @@
         "initImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1514,6 +1546,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1553,6 +1586,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1622,6 +1656,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1649,6 +1684,7 @@
         "memory"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1670,6 +1706,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1679,6 +1716,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1750,6 +1788,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1778,6 +1817,7 @@
         "infer"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files.",
       "x-intellij-html-description": "<em>alpha</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files."
     },
@@ -1818,6 +1858,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -1851,6 +1892,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -1885,6 +1927,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v1beta15.json
+++ b/docs/content/en/schemas/v1beta15.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -287,10 +289,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -503,6 +507,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -524,6 +529,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -565,6 +571,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -587,10 +594,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -729,6 +738,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -750,6 +760,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -778,6 +789,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>alpha</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -799,6 +811,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -821,6 +834,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -888,6 +902,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -904,6 +919,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -931,6 +947,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -970,6 +987,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -985,10 +1003,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1041,6 +1061,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1180,6 +1201,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1219,6 +1241,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1257,6 +1280,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1327,6 +1351,7 @@
         "reproducible"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1348,6 +1373,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1369,6 +1395,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1404,6 +1431,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1443,6 +1471,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1475,6 +1504,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1504,6 +1534,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1519,6 +1550,7 @@
         "initImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1534,6 +1566,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1573,6 +1606,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1642,6 +1676,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1669,6 +1704,7 @@
         "memory"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1690,6 +1726,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1699,6 +1736,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1770,6 +1808,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1798,6 +1837,7 @@
         "infer"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files.",
       "x-intellij-html-description": "<em>alpha</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files."
     },
@@ -1838,6 +1878,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -1871,6 +1912,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -1905,6 +1947,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v1beta16.json
+++ b/docs/content/en/schemas/v1beta16.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -287,10 +289,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -509,6 +513,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -530,6 +535,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -571,6 +577,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -593,10 +600,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -771,6 +780,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -792,6 +802,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -820,6 +831,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>alpha</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -841,6 +853,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -863,6 +876,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -930,6 +944,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -946,6 +961,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -973,6 +989,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1012,6 +1029,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1027,10 +1045,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1083,6 +1103,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1222,6 +1243,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1261,6 +1283,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1299,6 +1322,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1376,6 +1400,7 @@
         "skipTLS"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1397,6 +1422,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1418,6 +1444,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1453,6 +1480,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1492,6 +1520,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1524,6 +1553,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1553,6 +1583,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1568,6 +1599,7 @@
         "initImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1583,6 +1615,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1622,6 +1655,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1691,6 +1725,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1718,6 +1753,7 @@
         "memory"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1739,6 +1775,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1748,6 +1785,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1819,6 +1857,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1847,6 +1886,7 @@
         "infer"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files.",
       "x-intellij-html-description": "<em>alpha</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files."
     },
@@ -1887,6 +1927,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -1920,6 +1961,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -1954,6 +1996,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v1beta17.json
+++ b/docs/content/en/schemas/v1beta17.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -287,10 +289,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -509,6 +513,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -530,6 +535,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -571,6 +577,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -593,10 +600,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -771,6 +780,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -792,6 +802,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -820,6 +831,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>alpha</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -841,6 +853,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -863,6 +876,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -930,6 +944,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -946,6 +961,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -973,6 +989,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1012,6 +1029,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1027,10 +1045,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1083,6 +1103,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1222,6 +1243,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1261,6 +1283,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1299,6 +1322,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1376,6 +1400,7 @@
         "skipTLS"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1397,6 +1422,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1418,6 +1444,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1453,6 +1480,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1492,6 +1520,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1524,6 +1553,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1553,6 +1583,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1568,6 +1599,7 @@
         "initImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1583,6 +1615,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1622,6 +1655,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1691,6 +1725,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1736,6 +1771,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1757,6 +1793,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1766,6 +1803,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1837,6 +1875,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1865,6 +1904,7 @@
         "infer"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files.",
       "x-intellij-html-description": "<em>alpha</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files."
     },
@@ -1905,6 +1945,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -1938,6 +1979,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -1972,6 +2014,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v1beta2.json
+++ b/docs/content/en/schemas/v1beta2.json
@@ -8,6 +8,7 @@
   "$schema": "http://json-schema-org/draft-07/schema#",
   "definitions": {
     "Artifact": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -162,10 +163,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with Bazel.",
       "x-intellij-html-description": "describes an artifact built with Bazel."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -269,10 +272,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the DateTime tagger.",
       "x-intellij-html-description": "contains the configuration for the DateTime tagger."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -344,6 +349,7 @@
         "target"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -357,10 +363,12 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the envTemplate tagger.",
       "x-intellij-html-description": "contains the configuration for the envTemplate tagger."
     },
     "GitTagger": {
+      "type": "object",
       "description": "contains the configuration for the git tagger.",
       "x-intellij-html-description": "contains the configuration for the git tagger."
     },
@@ -390,10 +398,12 @@
         "dockerImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a remote build on Google Cloud Build.",
       "x-intellij-html-description": "contains the fields needed to do a remote build on Google Cloud Build."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "represents image config in the syntax of image.repository and image.tag",
       "x-intellij-html-description": "represents image config in the syntax of image.repository and image.tag"
     },
@@ -410,6 +420,7 @@
         "releases"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with helm",
       "x-intellij-html-description": "contains the configuration needed for deploying with helm"
     },
@@ -423,10 +434,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents image config to use the FullyQualifiedImageName as param to set",
       "x-intellij-html-description": "represents image config to use the FullyQualifiedImageName as param to set"
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -473,6 +486,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents parameters for packaging helm chart.",
       "x-intellij-html-description": "represents parameters for packaging helm chart."
     },
@@ -549,7 +563,8 @@
         "packaged",
         "imageStrategy"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "JibGradleArtifact": {
       "properties": {
@@ -562,7 +577,8 @@
       "preferredOrder": [
         "project"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "JibMavenArtifact": {
       "properties": {
@@ -579,7 +595,8 @@
         "module",
         "profile"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "KanikoBuild": {
       "properties": {
@@ -623,6 +640,7 @@
         "image"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a on-cluster build using the kaniko image",
       "x-intellij-html-description": "contains the fields needed to do a on-cluster build using the kaniko image"
     },
@@ -640,6 +658,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a kaniko build context",
       "x-intellij-html-description": "contains the different fields available to specify a kaniko build context"
     },
@@ -653,6 +672,7 @@
         "repo"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains fields related to kaniko caching",
       "x-intellij-html-description": "contains fields related to kaniko caching"
     },
@@ -682,6 +702,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with `kubectl apply`",
       "x-intellij-html-description": "contains the configuration needed for deploying with <code>kubectl apply</code>"
     },
@@ -715,6 +736,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -732,6 +754,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with kustomize.",
       "x-intellij-html-description": "contains the configuration needed for deploying with kustomize."
     },
@@ -755,10 +778,12 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository."
     },
     "LocalDir": {
+      "type": "object",
       "description": "represents the local directory kaniko build context",
       "x-intellij-html-description": "represents the local directory kaniko build context"
     },
@@ -784,10 +809,12 @@
         "deploy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional configuration that overrides default configuration when it is activated.",
       "x-intellij-html-description": "additional configuration that overrides default configuration when it is activated."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "contains the configuration for the SHA tagger.",
       "x-intellij-html-description": "contains the configuration for the SHA tagger."
     },
@@ -823,7 +850,8 @@
         "deploy",
         "profiles"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "TagPolicy": {
       "properties": {
@@ -847,6 +875,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step",
       "x-intellij-html-description": "contains all the configuration for the tagging step"
     },
@@ -868,6 +897,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a struct containing all the specified test configuration for an image.",
       "x-intellij-html-description": "a struct containing all the specified test configuration for an image."
     },

--- a/docs/content/en/schemas/v1beta3.json
+++ b/docs/content/en/schemas/v1beta3.json
@@ -8,6 +8,7 @@
   "$schema": "http://json-schema-org/draft-07/schema#",
   "definitions": {
     "Artifact": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -162,10 +163,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with Bazel.",
       "x-intellij-html-description": "describes an artifact built with Bazel."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -269,10 +272,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the DateTime tagger.",
       "x-intellij-html-description": "contains the configuration for the DateTime tagger."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -344,6 +349,7 @@
         "target"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -361,6 +367,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker config.json to mount",
       "x-intellij-html-description": "contains information about the docker config.json to mount"
     },
@@ -374,10 +381,12 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the envTemplate tagger.",
       "x-intellij-html-description": "contains the configuration for the envTemplate tagger."
     },
     "GitTagger": {
+      "type": "object",
       "description": "contains the configuration for the git tagger.",
       "x-intellij-html-description": "contains the configuration for the git tagger."
     },
@@ -415,10 +424,12 @@
         "gradleImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a remote build on Google Cloud Build.",
       "x-intellij-html-description": "contains the fields needed to do a remote build on Google Cloud Build."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "represents image config in the syntax of image.repository and image.tag",
       "x-intellij-html-description": "represents image config in the syntax of image.repository and image.tag"
     },
@@ -435,6 +446,7 @@
         "releases"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with helm",
       "x-intellij-html-description": "contains the configuration needed for deploying with helm"
     },
@@ -448,10 +460,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents image config to use the FullyQualifiedImageName as param to set",
       "x-intellij-html-description": "represents image config to use the FullyQualifiedImageName as param to set"
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -498,6 +512,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents parameters for packaging helm chart.",
       "x-intellij-html-description": "represents parameters for packaging helm chart."
     },
@@ -574,7 +589,8 @@
         "packaged",
         "imageStrategy"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "JibGradleArtifact": {
       "properties": {
@@ -587,7 +603,8 @@
       "preferredOrder": [
         "project"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "JibMavenArtifact": {
       "properties": {
@@ -604,7 +621,8 @@
         "module",
         "profile"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "KanikoBuild": {
       "properties": {
@@ -652,6 +670,7 @@
         "dockerConfig"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a on-cluster build using the kaniko image",
       "x-intellij-html-description": "contains the fields needed to do a on-cluster build using the kaniko image"
     },
@@ -669,6 +688,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a kaniko build context",
       "x-intellij-html-description": "contains the different fields available to specify a kaniko build context"
     },
@@ -682,6 +702,7 @@
         "repo"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains fields related to kaniko caching",
       "x-intellij-html-description": "contains fields related to kaniko caching"
     },
@@ -711,6 +732,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with `kubectl apply`",
       "x-intellij-html-description": "contains the configuration needed for deploying with <code>kubectl apply</code>"
     },
@@ -744,6 +766,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -761,6 +784,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with kustomize.",
       "x-intellij-html-description": "contains the configuration needed for deploying with kustomize."
     },
@@ -784,10 +808,12 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository."
     },
     "LocalDir": {
+      "type": "object",
       "description": "represents the local directory kaniko build context",
       "x-intellij-html-description": "represents the local directory kaniko build context"
     },
@@ -813,10 +839,12 @@
         "deploy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional configuration that overrides default configuration when it is activated.",
       "x-intellij-html-description": "additional configuration that overrides default configuration when it is activated."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "contains the configuration for the SHA tagger.",
       "x-intellij-html-description": "contains the configuration for the SHA tagger."
     },
@@ -852,7 +880,8 @@
         "deploy",
         "profiles"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "TagPolicy": {
       "properties": {
@@ -876,6 +905,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step",
       "x-intellij-html-description": "contains all the configuration for the tagging step"
     },
@@ -897,6 +927,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a struct containing all the specified test configuration for an image.",
       "x-intellij-html-description": "a struct containing all the specified test configuration for an image."
     },

--- a/docs/content/en/schemas/v1beta4.json
+++ b/docs/content/en/schemas/v1beta4.json
@@ -25,10 +25,12 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "defines criteria to auto-activate a profile.",
       "x-intellij-html-description": "defines criteria to auto-activate a profile."
     },
     "Artifact": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -183,10 +185,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with Bazel.",
       "x-intellij-html-description": "describes an artifact built with Bazel."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -290,10 +294,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the DateTime tagger.",
       "x-intellij-html-description": "contains the configuration for the DateTime tagger."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -365,6 +371,7 @@
         "target"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -382,6 +389,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker config.json to mount",
       "x-intellij-html-description": "contains information about the docker config.json to mount"
     },
@@ -395,10 +403,12 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration for the envTemplate tagger.",
       "x-intellij-html-description": "contains the configuration for the envTemplate tagger."
     },
     "GitTagger": {
+      "type": "object",
       "description": "contains the configuration for the git tagger.",
       "x-intellij-html-description": "contains the configuration for the git tagger."
     },
@@ -436,10 +446,12 @@
         "gradleImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a remote build on Google Cloud Build.",
       "x-intellij-html-description": "contains the fields needed to do a remote build on Google Cloud Build."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "represents image config in the syntax of image.repository and image.tag",
       "x-intellij-html-description": "represents image config in the syntax of image.repository and image.tag"
     },
@@ -456,6 +468,7 @@
         "releases"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with helm",
       "x-intellij-html-description": "contains the configuration needed for deploying with helm"
     },
@@ -469,10 +482,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents image config to use the FullyQualifiedImageName as param to set",
       "x-intellij-html-description": "represents image config to use the FullyQualifiedImageName as param to set"
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -519,6 +534,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "represents parameters for packaging helm chart.",
       "x-intellij-html-description": "represents parameters for packaging helm chart."
     },
@@ -600,7 +616,8 @@
         "packaged",
         "imageStrategy"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "JibGradleArtifact": {
       "properties": {
@@ -613,7 +630,8 @@
       "preferredOrder": [
         "project"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "JibMavenArtifact": {
       "properties": {
@@ -630,7 +648,8 @@
         "module",
         "profile"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "KanikoBuild": {
       "properties": {
@@ -678,6 +697,7 @@
         "dockerConfig"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a on-cluster build using the kaniko image",
       "x-intellij-html-description": "contains the fields needed to do a on-cluster build using the kaniko image"
     },
@@ -695,6 +715,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a kaniko build context",
       "x-intellij-html-description": "contains the different fields available to specify a kaniko build context"
     },
@@ -708,6 +729,7 @@
         "repo"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains fields related to kaniko caching",
       "x-intellij-html-description": "contains fields related to kaniko caching"
     },
@@ -737,6 +759,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with `kubectl apply`",
       "x-intellij-html-description": "contains the configuration needed for deploying with <code>kubectl apply</code>"
     },
@@ -770,6 +793,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "describes additional options flags that are passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -787,6 +811,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the configuration needed for deploying with kustomize.",
       "x-intellij-html-description": "contains the configuration needed for deploying with kustomize."
     },
@@ -810,10 +835,12 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "contains the fields needed to do a build on the local docker daemon and optionally push to a repository."
     },
     "LocalDir": {
+      "type": "object",
       "description": "represents the local directory kaniko build context",
       "x-intellij-html-description": "represents the local directory kaniko build context"
     },
@@ -848,10 +875,12 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional configuration that overrides default configuration when it is activated.",
       "x-intellij-html-description": "additional configuration that overrides default configuration when it is activated."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "contains the configuration for the SHA tagger.",
       "x-intellij-html-description": "contains the configuration for the SHA tagger."
     },
@@ -887,7 +916,8 @@
         "deploy",
         "profiles"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "TagPolicy": {
       "properties": {
@@ -911,6 +941,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step",
       "x-intellij-html-description": "contains all the configuration for the tagging step"
     },
@@ -932,6 +963,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a struct containing all the specified test configuration for an image.",
       "x-intellij-html-description": "a struct containing all the specified test configuration for an image."
     },

--- a/docs/content/en/schemas/v1beta5.json
+++ b/docs/content/en/schemas/v1beta5.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -317,10 +319,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -476,6 +480,7 @@
         "properties"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all fields necessary for specifying a build plugin.",
       "x-intellij-html-description": "contains all fields necessary for specifying a build plugin."
     },
@@ -498,10 +503,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -594,6 +601,7 @@
         "cacheFrom"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -615,6 +623,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -636,6 +645,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -662,10 +672,12 @@
         "properties"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "environment in which the build should run (ex. local or in-cluster, etc.).",
       "x-intellij-html-description": "environment in which the build should run (ex. local or in-cluster, etc.)."
     },
     "GitTagger": {
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -720,10 +732,12 @@
         "gradleImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -745,6 +759,7 @@
         "releases"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -760,10 +775,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -816,6 +833,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -930,7 +948,8 @@
         "packaged",
         "imageStrategy"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "JSONPatch": {
       "required": [
@@ -968,6 +987,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -996,6 +1016,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin\">Jib plugin for Gradle</a>."
     },
@@ -1030,6 +1051,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin\">Jib plugin for Maven</a>."
     },
@@ -1098,6 +1120,7 @@
         "dockerConfig"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build using [Kaniko](https://github.com/GoogleContainerTools/kaniko).",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build using <a href=\"https://github.com/GoogleContainerTools/kaniko\">Kaniko</a>."
     },
@@ -1119,6 +1142,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1134,6 +1158,7 @@
         "repo"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1169,6 +1194,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1208,6 +1234,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1230,6 +1257,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1259,10 +1287,12 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
     "LocalDir": {
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1323,10 +1353,12 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1378,7 +1410,8 @@
         "deploy",
         "profiles"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "type": "object"
     },
     "TagPolicy": {
       "properties": {
@@ -1410,6 +1443,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -1444,6 +1478,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v1beta6.json
+++ b/docs/content/en/schemas/v1beta6.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -317,10 +319,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -476,6 +480,7 @@
         "properties"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all fields necessary for specifying a build plugin.",
       "x-intellij-html-description": "contains all fields necessary for specifying a build plugin."
     },
@@ -498,10 +503,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -594,6 +601,7 @@
         "cacheFrom"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -615,6 +623,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -636,6 +645,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -664,10 +674,12 @@
         "properties"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "environment in which the build should run (ex. local or in-cluster, etc.).",
       "x-intellij-html-description": "environment in which the build should run (ex. local or in-cluster, etc.)."
     },
     "GitTagger": {
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -722,10 +734,12 @@
         "gradleImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -753,6 +767,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -792,6 +807,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -807,10 +823,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -863,6 +881,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -978,6 +997,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1017,6 +1037,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1045,6 +1066,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin\">Jib plugin for Gradle</a>."
     },
@@ -1079,6 +1101,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin\">Jib plugin for Maven</a>."
     },
@@ -1147,6 +1170,7 @@
         "dockerConfig"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build using [Kaniko](https://github.com/GoogleContainerTools/kaniko).",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build using <a href=\"https://github.com/GoogleContainerTools/kaniko\">Kaniko</a>."
     },
@@ -1168,6 +1192,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1183,6 +1208,7 @@
         "repo"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1218,6 +1244,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1257,6 +1284,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1279,6 +1307,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1308,10 +1337,12 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
     "LocalDir": {
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1372,10 +1403,12 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1428,6 +1461,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a Skaffold pipeline.",
       "x-intellij-html-description": "describes a Skaffold pipeline."
     },
@@ -1461,6 +1495,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -1495,6 +1530,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v1beta7.json
+++ b/docs/content/en/schemas/v1beta7.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -365,10 +367,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -524,6 +528,7 @@
         "properties"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all fields necessary for specifying a build plugin.",
       "x-intellij-html-description": "contains all fields necessary for specifying a build plugin."
     },
@@ -564,6 +569,7 @@
         "dockerConfig"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -586,10 +592,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -682,6 +690,7 @@
         "cacheFrom"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -703,6 +712,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -724,6 +734,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -752,10 +763,12 @@
         "properties"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "environment in which the build should run (ex. local or in-cluster, etc.).",
       "x-intellij-html-description": "environment in which the build should run (ex. local or in-cluster, etc.)."
     },
     "GitTagger": {
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -810,10 +823,12 @@
         "gradleImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -841,6 +856,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -880,6 +896,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -895,10 +912,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -951,6 +970,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1073,6 +1093,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1112,6 +1133,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1140,6 +1162,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin\">Jib plugin for Gradle</a>."
     },
@@ -1174,6 +1197,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin\">Jib plugin for Maven</a>."
     },
@@ -1237,6 +1261,7 @@
         "cache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1258,6 +1283,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1273,6 +1299,7 @@
         "repo"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1308,6 +1335,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1347,6 +1375,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1369,6 +1398,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1398,6 +1428,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1413,6 +1444,7 @@
         "initImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1473,10 +1505,12 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1529,6 +1563,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a Skaffold pipeline.",
       "x-intellij-html-description": "describes a Skaffold pipeline."
     },
@@ -1562,6 +1597,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -1596,6 +1632,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v1beta8.json
+++ b/docs/content/en/schemas/v1beta8.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -365,10 +367,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -564,6 +568,7 @@
         "properties"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all fields necessary for specifying a build plugin.",
       "x-intellij-html-description": "contains all fields necessary for specifying a build plugin."
     },
@@ -610,6 +615,7 @@
         "resources"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -632,10 +638,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -728,6 +736,7 @@
         "cacheFrom"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -749,6 +758,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -770,6 +780,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -798,10 +809,12 @@
         "properties"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "environment in which the build should run (ex. local or in-cluster, etc.).",
       "x-intellij-html-description": "environment in which the build should run (ex. local or in-cluster, etc.)."
     },
     "GitTagger": {
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -856,10 +869,12 @@
         "gradleImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -887,6 +902,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -926,6 +942,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -941,10 +958,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -997,6 +1016,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1119,6 +1139,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1158,6 +1179,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1186,6 +1208,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin\">Jib plugin for Gradle</a>."
     },
@@ -1220,6 +1243,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin\">Jib plugin for Maven</a>."
     },
@@ -1283,6 +1307,7 @@
         "cache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1304,6 +1329,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1319,6 +1345,7 @@
         "repo"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1354,6 +1381,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1393,6 +1421,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1415,6 +1444,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1444,6 +1474,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1459,6 +1490,7 @@
         "initImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1519,6 +1551,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1546,6 +1579,7 @@
         "memory"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1567,10 +1601,12 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1627,6 +1663,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1660,6 +1697,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -1694,6 +1732,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v1beta9.json
+++ b/docs/content/en/schemas/v1beta9.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -329,10 +331,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -527,6 +531,7 @@
         "resources"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -549,10 +554,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -645,6 +652,7 @@
         "cacheFrom"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -666,6 +674,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -687,6 +696,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -707,6 +717,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -761,10 +772,12 @@
         "gradleImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
     "HelmConventionConfig": {
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -792,6 +805,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -831,6 +845,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -846,10 +861,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -902,6 +919,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1024,6 +1042,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1063,6 +1082,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1091,6 +1111,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Gradle](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin\">Jib plugin for Gradle</a>."
     },
@@ -1125,6 +1146,7 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* builds images using the [Jib plugin for Maven](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin).",
       "x-intellij-html-description": "<em>alpha</em> builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin\">Jib plugin for Maven</a>."
     },
@@ -1188,6 +1210,7 @@
         "cache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1209,6 +1232,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1224,6 +1248,7 @@
         "repo"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1259,6 +1284,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1298,6 +1324,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1320,6 +1347,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1349,6 +1377,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1364,6 +1393,7 @@
         "initImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1424,6 +1454,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* profiles are used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "<em>beta</em> profiles are used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1451,6 +1482,7 @@
         "memory"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1472,10 +1504,12 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1532,6 +1566,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1565,6 +1600,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -1599,6 +1635,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2alpha1.json
+++ b/docs/content/en/schemas/v2alpha1.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -322,10 +324,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -524,6 +528,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -553,6 +558,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a buildpack.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a buildpack."
     },
@@ -623,6 +629,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -644,6 +651,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -685,6 +693,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -707,10 +716,12 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
     "DeployConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -885,6 +896,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -906,6 +918,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -934,6 +947,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -955,6 +969,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -977,6 +992,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1044,6 +1060,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1060,6 +1077,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1087,6 +1105,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1126,6 +1145,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1141,10 +1161,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1197,6 +1219,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1336,6 +1359,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1375,6 +1399,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1413,6 +1438,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1498,6 +1524,7 @@
         "skipTLS"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1519,6 +1546,7 @@
         "localDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains the different fields available to specify a Kaniko build context.",
       "x-intellij-html-description": "contains the different fields available to specify a Kaniko build context."
     },
@@ -1540,6 +1568,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1575,6 +1604,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1614,6 +1644,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1646,6 +1677,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1675,6 +1707,7 @@
         "useBuildkit"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1690,6 +1723,7 @@
         "initImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how Kaniko mounts sources directly via an `emptyDir` volume.",
       "x-intellij-html-description": "configures how Kaniko mounts sources directly via an <code>emptyDir</code> volume."
     },
@@ -1705,6 +1739,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1750,6 +1785,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1819,6 +1855,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1864,6 +1901,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1885,6 +1923,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1894,6 +1933,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1965,6 +2005,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1993,6 +2034,7 @@
         "infer"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files."
     },
@@ -2033,6 +2075,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2066,6 +2109,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -2100,6 +2144,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2alpha2.json
+++ b/docs/content/en/schemas/v2alpha2.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -322,10 +324,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -524,6 +528,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -553,6 +558,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a buildpack.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a buildpack."
     },
@@ -624,6 +630,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -645,6 +652,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -686,6 +694,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -708,6 +717,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -750,6 +760,7 @@
         "kubeContext"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -816,6 +827,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -837,6 +849,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -865,6 +878,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -886,6 +900,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -908,6 +923,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -983,6 +999,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -999,6 +1016,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1026,6 +1044,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1065,6 +1084,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1080,10 +1100,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1136,6 +1158,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1275,6 +1298,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1314,6 +1338,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1352,6 +1377,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1437,6 +1463,7 @@
         "skipTLS"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1458,6 +1485,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1493,6 +1521,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1532,6 +1561,7 @@
         "delete"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1564,6 +1594,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1600,6 +1631,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1615,6 +1647,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1660,6 +1693,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1729,6 +1763,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1774,6 +1809,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1795,6 +1831,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1804,6 +1841,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1875,6 +1913,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1903,6 +1942,7 @@
         "infer"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files."
     },
@@ -1943,6 +1983,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -1976,6 +2017,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -2010,6 +2052,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2alpha3.json
+++ b/docs/content/en/schemas/v2alpha3.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -329,10 +331,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -534,6 +538,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -563,6 +568,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a buildpack.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a buildpack."
     },
@@ -656,6 +662,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -677,6 +684,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -718,6 +726,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -740,6 +749,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -782,6 +792,7 @@
         "kubeContext"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -848,6 +859,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -869,6 +881,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -897,6 +910,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -918,6 +932,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -940,6 +955,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1015,6 +1031,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1031,6 +1048,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1058,6 +1076,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1097,6 +1116,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1112,10 +1132,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1168,6 +1190,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1307,6 +1330,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1346,6 +1370,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1384,6 +1409,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1477,6 +1503,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1498,6 +1525,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1533,6 +1561,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1579,6 +1608,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1614,6 +1644,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1650,6 +1681,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1665,6 +1697,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1710,6 +1743,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1779,6 +1813,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1824,6 +1859,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1845,6 +1881,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1854,6 +1891,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1925,6 +1963,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1953,6 +1992,7 @@
         "infer"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -1994,6 +2034,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2027,6 +2068,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -2061,6 +2103,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2alpha4.json
+++ b/docs/content/en/schemas/v2alpha4.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -329,10 +331,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -534,6 +538,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -563,6 +568,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a buildpack.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a buildpack."
     },
@@ -656,6 +662,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -677,6 +684,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -718,6 +726,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -740,6 +749,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -782,6 +792,7 @@
         "kubeContext"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -848,6 +859,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -869,6 +881,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -897,6 +910,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -918,6 +932,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -940,6 +955,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1015,6 +1031,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1031,6 +1048,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1058,6 +1076,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1097,6 +1116,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1112,10 +1132,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1168,6 +1190,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1307,6 +1330,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1346,6 +1370,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1384,6 +1409,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1477,6 +1503,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1498,6 +1525,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1533,6 +1561,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1579,6 +1608,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1614,6 +1644,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1650,6 +1681,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1665,6 +1697,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1710,6 +1743,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1779,6 +1813,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1824,6 +1859,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1845,6 +1881,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1854,6 +1891,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1925,6 +1963,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1953,6 +1992,7 @@
         "infer"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -1994,6 +2034,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2027,6 +2068,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -2061,6 +2103,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta1.json
+++ b/docs/content/en/schemas/v2beta1.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -299,6 +301,7 @@
       "x-intellij-html-description": "items that need to be built, along with the context in which they should be built."
     },
     "Auto": {
+      "type": "object",
       "description": "cannot be customized.",
       "x-intellij-html-description": "cannot be customized."
     },
@@ -333,10 +336,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -538,6 +543,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -567,6 +573,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a buildpack.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a buildpack."
     },
@@ -660,6 +667,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -681,6 +689,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -722,6 +731,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -744,6 +754,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -786,6 +797,7 @@
         "kubeContext"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -852,6 +864,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -873,6 +886,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -901,6 +915,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -922,6 +937,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -944,6 +960,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1019,6 +1036,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1035,6 +1053,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1062,6 +1081,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1101,6 +1121,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1116,10 +1137,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1172,6 +1195,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1311,6 +1335,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1350,6 +1375,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1388,6 +1414,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1481,6 +1508,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1502,6 +1530,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1537,6 +1566,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1583,6 +1613,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1618,6 +1649,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1654,6 +1686,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1669,6 +1702,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1714,6 +1748,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1783,6 +1818,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1828,6 +1864,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1849,6 +1886,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1858,6 +1896,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1929,6 +1968,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1963,6 +2003,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2004,6 +2045,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2037,6 +2079,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -2071,6 +2114,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta10.json
+++ b/docs/content/en/schemas/v2beta10.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -382,6 +384,7 @@
         "alias"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a specific build dependency for an artifact.",
       "x-intellij-html-description": "describes a specific build dependency for an artifact."
     },
@@ -416,10 +419,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -635,6 +640,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -664,6 +670,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
     },
@@ -787,6 +794,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -808,6 +816,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -849,6 +858,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -879,6 +889,7 @@
         "components"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -901,6 +912,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -955,6 +967,7 @@
         "logs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -1033,6 +1046,7 @@
         "ssh"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -1054,6 +1068,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -1084,6 +1099,7 @@
         "dst"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about a local secret passed to `docker build`, along with optional destination information.",
       "x-intellij-html-description": "contains information about a local secret passed to <code>docker build</code>, along with optional destination information."
     },
@@ -1112,6 +1128,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -1133,6 +1150,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -1154,6 +1172,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1247,6 +1266,7 @@
         "workerPool"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1263,6 +1283,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1290,6 +1311,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1329,6 +1351,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1344,10 +1367,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1400,6 +1425,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1536,6 +1562,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1575,6 +1602,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1619,6 +1647,7 @@
         "fromImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1870,6 +1899,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1897,6 +1927,7 @@
         "ttl"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1924,6 +1955,7 @@
         "inventoryNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "sets the kpt inventory directory.",
       "x-intellij-html-description": "sets the kpt inventory directory."
     },
@@ -1957,6 +1989,7 @@
         "reconcileTimeout"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live apply`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live apply</code>."
     },
@@ -1987,6 +2020,7 @@
         "live"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* uses the `kpt` CLI to manage and deploy manifests.",
       "x-intellij-html-description": "<em>alpha</em> uses the <code>kpt</code> CLI to manage and deploy manifests."
     },
@@ -2044,6 +2078,7 @@
         "sinkDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt fn`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt fn</code>."
     },
@@ -2065,6 +2100,7 @@
         "options"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live</code>."
     },
@@ -2106,6 +2142,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -2152,6 +2189,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -2193,6 +2231,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -2236,6 +2275,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -2258,6 +2298,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how container logs are printed as a result of a deployment.",
       "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
     },
@@ -2273,6 +2314,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -2325,6 +2367,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -2394,6 +2437,7 @@
         "portForward"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -2439,6 +2483,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -2460,6 +2505,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -2469,6 +2515,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -2540,6 +2587,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -2574,6 +2622,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2615,6 +2664,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2654,10 +2704,12 @@
         "customTemplate"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
     "TaggerComponent": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -2802,6 +2854,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta11.json
+++ b/docs/content/en/schemas/v2beta11.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -382,6 +384,7 @@
         "alias"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a specific build dependency for an artifact.",
       "x-intellij-html-description": "describes a specific build dependency for an artifact."
     },
@@ -416,10 +419,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -635,6 +640,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -664,6 +670,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
     },
@@ -787,6 +794,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -821,6 +829,7 @@
         "activeProfiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a dependency on another skaffold configuration.",
       "x-intellij-html-description": "describes a dependency on another skaffold configuration."
     },
@@ -842,6 +851,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -883,6 +893,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -913,6 +924,7 @@
         "components"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -935,6 +947,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -989,6 +1002,7 @@
         "logs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -1075,6 +1089,7 @@
         "ssh"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -1096,6 +1111,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -1126,6 +1142,7 @@
         "dst"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about a local secret passed to `docker build`, along with optional destination information.",
       "x-intellij-html-description": "contains information about a local secret passed to <code>docker build</code>, along with optional destination information."
     },
@@ -1154,6 +1171,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -1175,6 +1193,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -1203,6 +1222,7 @@
         "ignoreChanges"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1296,6 +1316,7 @@
         "workerPool"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1312,6 +1333,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1339,6 +1361,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1378,6 +1401,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1393,10 +1417,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1449,6 +1475,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1585,6 +1612,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1624,6 +1652,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1668,6 +1697,7 @@
         "fromImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1919,6 +1949,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1946,6 +1977,7 @@
         "ttl"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1973,6 +2005,7 @@
         "inventoryNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "sets the kpt inventory directory.",
       "x-intellij-html-description": "sets the kpt inventory directory."
     },
@@ -2006,6 +2039,7 @@
         "reconcileTimeout"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live apply`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live apply</code>."
     },
@@ -2036,6 +2070,7 @@
         "live"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* uses the `kpt` CLI to manage and deploy manifests.",
       "x-intellij-html-description": "<em>alpha</em> uses the <code>kpt</code> CLI to manage and deploy manifests."
     },
@@ -2093,6 +2128,7 @@
         "sinkDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt fn`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt fn</code>."
     },
@@ -2114,6 +2150,7 @@
         "options"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live</code>."
     },
@@ -2155,6 +2192,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -2201,6 +2239,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -2242,6 +2281,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -2285,6 +2325,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -2307,6 +2348,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how container logs are printed as a result of a deployment.",
       "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
     },
@@ -2322,6 +2364,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -2374,6 +2417,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -2443,6 +2487,7 @@
         "portForward"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -2471,6 +2516,7 @@
         "activatedBy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles.",
       "x-intellij-html-description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles."
     },
@@ -2516,6 +2562,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -2537,6 +2584,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -2546,6 +2594,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -2626,6 +2675,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -2660,6 +2710,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2701,6 +2752,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2740,10 +2792,12 @@
         "customTemplate"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
     "TaggerComponent": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -2888,6 +2942,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta12.json
+++ b/docs/content/en/schemas/v2beta12.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -382,6 +384,7 @@
         "alias"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a specific build dependency for an artifact.",
       "x-intellij-html-description": "describes a specific build dependency for an artifact."
     },
@@ -416,10 +419,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -635,6 +640,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -664,6 +670,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
     },
@@ -787,6 +794,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -827,6 +835,7 @@
         "activeProfiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a dependency on another skaffold configuration.",
       "x-intellij-html-description": "describes a dependency on another skaffold configuration."
     },
@@ -848,6 +857,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -889,6 +899,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -919,6 +930,7 @@
         "components"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -941,6 +953,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -995,6 +1008,7 @@
         "logs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -1081,6 +1095,7 @@
         "ssh"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -1102,6 +1117,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -1132,6 +1148,7 @@
         "dst"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about a local secret passed to `docker build`, along with optional destination information.",
       "x-intellij-html-description": "contains information about a local secret passed to <code>docker build</code>, along with optional destination information."
     },
@@ -1160,6 +1177,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -1181,6 +1199,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -1217,6 +1236,7 @@
         "sync"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information on the origin of skaffold configurations cloned from a git repository.",
       "x-intellij-html-description": "contains information on the origin of skaffold configurations cloned from a git repository."
     },
@@ -1245,6 +1265,7 @@
         "ignoreChanges"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1338,6 +1359,7 @@
         "workerPool"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1354,6 +1376,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1381,6 +1404,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1420,6 +1444,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1435,10 +1460,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1491,6 +1518,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1627,6 +1655,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1666,6 +1695,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1710,6 +1740,7 @@
         "fromImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1961,6 +1992,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1988,6 +2020,7 @@
         "ttl"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -2015,6 +2048,7 @@
         "inventoryNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "sets the kpt inventory directory.",
       "x-intellij-html-description": "sets the kpt inventory directory."
     },
@@ -2048,6 +2082,7 @@
         "reconcileTimeout"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live apply`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live apply</code>."
     },
@@ -2078,6 +2113,7 @@
         "live"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* uses the `kpt` CLI to manage and deploy manifests.",
       "x-intellij-html-description": "<em>alpha</em> uses the <code>kpt</code> CLI to manage and deploy manifests."
     },
@@ -2135,6 +2171,7 @@
         "sinkDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt fn`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt fn</code>."
     },
@@ -2156,6 +2193,7 @@
         "options"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live</code>."
     },
@@ -2197,6 +2235,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -2243,6 +2282,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -2284,6 +2324,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -2327,6 +2368,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -2349,6 +2391,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how container logs are printed as a result of a deployment.",
       "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
     },
@@ -2364,6 +2407,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -2416,6 +2460,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -2485,6 +2530,7 @@
         "portForward"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -2513,6 +2559,7 @@
         "activatedBy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles.",
       "x-intellij-html-description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles."
     },
@@ -2558,6 +2605,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -2579,6 +2627,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -2588,6 +2637,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -2668,6 +2718,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -2702,6 +2753,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2743,6 +2795,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2782,10 +2835,12 @@
         "customTemplate"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
     "TaggerComponent": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -2930,6 +2985,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta13.json
+++ b/docs/content/en/schemas/v2beta13.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -382,6 +384,7 @@
         "alias"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a specific build dependency for an artifact.",
       "x-intellij-html-description": "describes a specific build dependency for an artifact."
     },
@@ -416,10 +419,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -635,6 +640,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -664,6 +670,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
     },
@@ -787,6 +794,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -827,6 +835,7 @@
         "activeProfiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a dependency on another skaffold configuration.",
       "x-intellij-html-description": "describes a dependency on another skaffold configuration."
     },
@@ -848,6 +857,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -889,6 +899,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -919,6 +930,7 @@
         "components"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -949,6 +961,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the custom test command provided by the user. Custom tests are run after an image build whenever build or test dependencies are changed.",
       "x-intellij-html-description": "describes the custom test command provided by the user. Custom tests are run after an image build whenever build or test dependencies are changed."
     },
@@ -987,6 +1000,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to specify dependencies for custom test command. `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "used to specify dependencies for custom test command. <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -1009,6 +1023,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -1063,6 +1078,7 @@
         "logs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -1149,6 +1165,7 @@
         "ssh"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -1170,6 +1187,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -1200,6 +1218,7 @@
         "dst"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about a local secret passed to `docker build`, along with optional destination information.",
       "x-intellij-html-description": "contains information about a local secret passed to <code>docker build</code>, along with optional destination information."
     },
@@ -1228,6 +1247,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -1249,6 +1269,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -1285,6 +1306,7 @@
         "sync"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information on the origin of skaffold configurations cloned from a git repository.",
       "x-intellij-html-description": "contains information on the origin of skaffold configurations cloned from a git repository."
     },
@@ -1313,6 +1335,7 @@
         "ignoreChanges"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1406,6 +1429,7 @@
         "workerPool"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1422,6 +1446,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1449,6 +1474,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1488,6 +1514,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1503,10 +1530,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1559,6 +1588,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1699,6 +1729,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1738,6 +1769,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1782,6 +1814,7 @@
         "fromImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -2033,6 +2066,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -2060,6 +2094,7 @@
         "ttl"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -2087,6 +2122,7 @@
         "inventoryNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "sets the kpt inventory directory.",
       "x-intellij-html-description": "sets the kpt inventory directory."
     },
@@ -2120,6 +2156,7 @@
         "reconcileTimeout"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live apply`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live apply</code>."
     },
@@ -2150,6 +2187,7 @@
         "live"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* uses the `kpt` CLI to manage and deploy manifests.",
       "x-intellij-html-description": "<em>alpha</em> uses the <code>kpt</code> CLI to manage and deploy manifests."
     },
@@ -2207,6 +2245,7 @@
         "sinkDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt fn`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt fn</code>."
     },
@@ -2228,6 +2267,7 @@
         "options"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live</code>."
     },
@@ -2269,6 +2309,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -2315,6 +2356,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -2356,6 +2398,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -2399,6 +2442,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -2421,6 +2465,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how container logs are printed as a result of a deployment.",
       "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
     },
@@ -2436,6 +2481,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -2488,6 +2534,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -2557,6 +2604,7 @@
         "portForward"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -2585,6 +2633,7 @@
         "activatedBy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles.",
       "x-intellij-html-description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles."
     },
@@ -2630,6 +2679,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -2651,6 +2701,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -2660,6 +2711,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -2740,6 +2792,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -2774,6 +2827,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2815,6 +2869,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2854,10 +2909,12 @@
         "customTemplate"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
     "TaggerComponent": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -3011,6 +3068,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta14.json
+++ b/docs/content/en/schemas/v2beta14.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -382,6 +384,7 @@
         "alias"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a specific build dependency for an artifact.",
       "x-intellij-html-description": "describes a specific build dependency for an artifact."
     },
@@ -416,10 +419,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -635,6 +640,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -664,6 +670,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
     },
@@ -787,6 +794,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -827,6 +835,7 @@
         "activeProfiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a dependency on another skaffold configuration.",
       "x-intellij-html-description": "describes a dependency on another skaffold configuration."
     },
@@ -848,6 +857,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -889,6 +899,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -919,6 +930,7 @@
         "components"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -949,6 +961,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the custom test command provided by the user. Custom tests are run after an image build whenever build or test dependencies are changed.",
       "x-intellij-html-description": "describes the custom test command provided by the user. Custom tests are run after an image build whenever build or test dependencies are changed."
     },
@@ -987,6 +1000,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to specify dependencies for custom test command. `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "used to specify dependencies for custom test command. <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -1009,6 +1023,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -1063,6 +1078,7 @@
         "logs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -1149,6 +1165,7 @@
         "ssh"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -1170,6 +1187,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -1200,6 +1218,7 @@
         "dst"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about a local secret passed to `docker build`, along with optional destination information.",
       "x-intellij-html-description": "contains information about a local secret passed to <code>docker build</code>, along with optional destination information."
     },
@@ -1228,6 +1247,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -1249,6 +1269,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -1285,6 +1306,7 @@
         "sync"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information on the origin of skaffold configurations cloned from a git repository.",
       "x-intellij-html-description": "contains information on the origin of skaffold configurations cloned from a git repository."
     },
@@ -1313,6 +1335,7 @@
         "ignoreChanges"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1406,6 +1429,7 @@
         "workerPool"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1422,6 +1446,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1449,6 +1474,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1488,6 +1514,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1503,10 +1530,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1559,6 +1588,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1699,10 +1729,12 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
     "InputDigest": {
+      "type": "object",
       "description": "*beta* tags hashes the image content.",
       "x-intellij-html-description": "<em>beta</em> tags hashes the image content."
     },
@@ -1742,6 +1774,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1786,6 +1819,7 @@
         "fromImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -2037,6 +2071,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -2064,6 +2099,7 @@
         "ttl"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -2091,6 +2127,7 @@
         "inventoryNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "sets the kpt inventory directory.",
       "x-intellij-html-description": "sets the kpt inventory directory."
     },
@@ -2124,6 +2161,7 @@
         "reconcileTimeout"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live apply`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live apply</code>."
     },
@@ -2154,6 +2192,7 @@
         "live"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* uses the `kpt` CLI to manage and deploy manifests.",
       "x-intellij-html-description": "<em>alpha</em> uses the <code>kpt</code> CLI to manage and deploy manifests."
     },
@@ -2211,6 +2250,7 @@
         "sinkDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt fn`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt fn</code>."
     },
@@ -2232,6 +2272,7 @@
         "options"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live</code>."
     },
@@ -2273,6 +2314,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -2319,6 +2361,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -2360,6 +2403,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -2403,6 +2447,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -2425,6 +2470,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how container logs are printed as a result of a deployment.",
       "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
     },
@@ -2440,6 +2486,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -2492,6 +2539,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -2561,6 +2609,7 @@
         "portForward"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -2589,6 +2638,7 @@
         "activatedBy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles.",
       "x-intellij-html-description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles."
     },
@@ -2634,6 +2684,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -2655,6 +2706,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -2664,6 +2716,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -2744,6 +2797,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -2778,6 +2832,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2819,6 +2874,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2864,10 +2920,12 @@
         "inputDigest"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
     "TaggerComponent": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -3047,6 +3105,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta15.json
+++ b/docs/content/en/schemas/v2beta15.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -382,6 +384,7 @@
         "alias"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a specific build dependency for an artifact.",
       "x-intellij-html-description": "describes a specific build dependency for an artifact."
     },
@@ -416,10 +419,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -635,6 +640,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -664,6 +670,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
     },
@@ -787,6 +794,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -827,6 +835,7 @@
         "activeProfiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a dependency on another skaffold configuration.",
       "x-intellij-html-description": "describes a dependency on another skaffold configuration."
     },
@@ -848,6 +857,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -889,6 +899,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -919,6 +930,7 @@
         "components"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -949,6 +961,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the custom test command provided by the user. Custom tests are run after an image build whenever build or test dependencies are changed.",
       "x-intellij-html-description": "describes the custom test command provided by the user. Custom tests are run after an image build whenever build or test dependencies are changed."
     },
@@ -987,6 +1000,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to specify dependencies for custom test command. `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "used to specify dependencies for custom test command. <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -1009,6 +1023,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -1063,6 +1078,7 @@
         "logs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -1162,6 +1178,7 @@
         "ssh"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -1183,6 +1200,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -1213,6 +1231,7 @@
         "dst"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about a local secret passed to `docker build`, along with optional destination information.",
       "x-intellij-html-description": "contains information about a local secret passed to <code>docker build</code>, along with optional destination information."
     },
@@ -1241,6 +1260,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -1262,6 +1282,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -1298,6 +1319,7 @@
         "sync"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information on the origin of skaffold configurations cloned from a git repository.",
       "x-intellij-html-description": "contains information on the origin of skaffold configurations cloned from a git repository."
     },
@@ -1326,6 +1348,7 @@
         "ignoreChanges"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1419,6 +1442,7 @@
         "workerPool"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1435,6 +1459,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1462,6 +1487,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1501,6 +1527,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1516,10 +1543,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1572,6 +1601,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1712,10 +1742,12 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
     "InputDigest": {
+      "type": "object",
       "description": "*beta* tags hashes the image content.",
       "x-intellij-html-description": "<em>beta</em> tags hashes the image content."
     },
@@ -1755,6 +1787,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1799,6 +1832,7 @@
         "fromImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -2050,6 +2084,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -2077,6 +2112,7 @@
         "ttl"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -2104,6 +2140,7 @@
         "inventoryNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "sets the kpt inventory directory.",
       "x-intellij-html-description": "sets the kpt inventory directory."
     },
@@ -2137,6 +2174,7 @@
         "reconcileTimeout"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live apply`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live apply</code>."
     },
@@ -2167,6 +2205,7 @@
         "live"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* uses the `kpt` CLI to manage and deploy manifests.",
       "x-intellij-html-description": "<em>alpha</em> uses the <code>kpt</code> CLI to manage and deploy manifests."
     },
@@ -2224,6 +2263,7 @@
         "sinkDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt fn`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt fn</code>."
     },
@@ -2245,6 +2285,7 @@
         "options"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live</code>."
     },
@@ -2286,6 +2327,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -2332,6 +2374,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -2373,6 +2416,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -2416,6 +2460,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -2438,6 +2483,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how container logs are printed as a result of a deployment.",
       "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
     },
@@ -2453,6 +2499,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -2505,6 +2552,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -2574,6 +2622,7 @@
         "portForward"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -2602,6 +2651,7 @@
         "activatedBy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles.",
       "x-intellij-html-description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles."
     },
@@ -2647,6 +2697,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -2668,6 +2719,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -2677,6 +2729,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -2757,6 +2810,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -2791,6 +2845,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2832,6 +2887,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2877,10 +2933,12 @@
         "inputDigest"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
     "TaggerComponent": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -3060,6 +3118,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta16.json
+++ b/docs/content/en/schemas/v2beta16.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -382,6 +384,7 @@
         "alias"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a specific build dependency for an artifact.",
       "x-intellij-html-description": "describes a specific build dependency for an artifact."
     },
@@ -416,10 +419,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -635,6 +640,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -664,6 +670,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
     },
@@ -787,6 +794,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -827,6 +835,7 @@
         "activeProfiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a dependency on another skaffold configuration.",
       "x-intellij-html-description": "describes a dependency on another skaffold configuration."
     },
@@ -848,6 +857,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -889,6 +899,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -919,6 +930,7 @@
         "components"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -949,6 +961,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the custom test command provided by the user. Custom tests are run after an image build whenever build or test dependencies are changed.",
       "x-intellij-html-description": "describes the custom test command provided by the user. Custom tests are run after an image build whenever build or test dependencies are changed."
     },
@@ -987,6 +1000,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to specify dependencies for custom test command. `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "used to specify dependencies for custom test command. <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -1009,6 +1023,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -1069,6 +1084,7 @@
         "logs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -1168,6 +1184,7 @@
         "ssh"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -1189,6 +1206,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -1219,6 +1237,7 @@
         "dst"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about a local secret passed to `docker build`, along with optional destination information.",
       "x-intellij-html-description": "contains information about a local secret passed to <code>docker build</code>, along with optional destination information."
     },
@@ -1247,6 +1266,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -1268,6 +1288,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -1304,6 +1325,7 @@
         "sync"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information on the origin of skaffold configurations cloned from a git repository.",
       "x-intellij-html-description": "contains information on the origin of skaffold configurations cloned from a git repository."
     },
@@ -1332,6 +1354,7 @@
         "ignoreChanges"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1425,6 +1448,7 @@
         "workerPool"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1441,6 +1465,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1468,6 +1493,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1507,6 +1533,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1522,10 +1549,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1578,6 +1607,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1718,10 +1748,12 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
     "InputDigest": {
+      "type": "object",
       "description": "*beta* tags hashes the image content.",
       "x-intellij-html-description": "<em>beta</em> tags hashes the image content."
     },
@@ -1761,6 +1793,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1805,6 +1838,7 @@
         "fromImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -2056,6 +2090,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -2083,6 +2118,7 @@
         "ttl"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -2110,6 +2146,7 @@
         "inventoryNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "sets the kpt inventory directory.",
       "x-intellij-html-description": "sets the kpt inventory directory."
     },
@@ -2143,6 +2180,7 @@
         "reconcileTimeout"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live apply`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live apply</code>."
     },
@@ -2173,6 +2211,7 @@
         "live"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* uses the `kpt` CLI to manage and deploy manifests.",
       "x-intellij-html-description": "<em>alpha</em> uses the <code>kpt</code> CLI to manage and deploy manifests."
     },
@@ -2230,6 +2269,7 @@
         "sinkDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt fn`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt fn</code>."
     },
@@ -2251,6 +2291,7 @@
         "options"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live</code>."
     },
@@ -2292,6 +2333,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -2338,6 +2380,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -2379,6 +2422,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -2422,6 +2466,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -2444,6 +2489,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how container logs are printed as a result of a deployment.",
       "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
     },
@@ -2459,6 +2505,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -2511,6 +2558,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -2580,6 +2628,7 @@
         "portForward"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -2608,6 +2657,7 @@
         "activatedBy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles.",
       "x-intellij-html-description": "describes a mapping from referenced config profiles to the current config profiles. If the current config is activated with a profile in this mapping then the dependency configs are also activated with the corresponding mapped profiles."
     },
@@ -2653,6 +2703,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -2674,6 +2725,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -2683,6 +2735,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -2763,6 +2816,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -2797,6 +2851,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2838,6 +2893,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2883,10 +2939,12 @@
         "inputDigest"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
     "TaggerComponent": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -3066,6 +3124,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta2.json
+++ b/docs/content/en/schemas/v2beta2.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -299,6 +301,7 @@
       "x-intellij-html-description": "items that need to be built, along with the context in which they should be built."
     },
     "Auto": {
+      "type": "object",
       "description": "cannot be customized.",
       "x-intellij-html-description": "cannot be customized."
     },
@@ -333,10 +336,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -538,6 +543,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -567,6 +573,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a buildpack.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a buildpack."
     },
@@ -660,6 +667,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -681,6 +689,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -722,6 +731,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -744,6 +754,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -786,6 +797,7 @@
         "kubeContext"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -852,6 +864,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -873,6 +886,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -901,6 +915,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -922,6 +937,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -944,6 +960,7 @@
         "variant"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1019,6 +1036,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1035,6 +1053,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1062,6 +1081,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1101,6 +1121,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1116,10 +1137,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1172,6 +1195,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1311,6 +1335,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1350,6 +1375,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1388,6 +1414,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1481,6 +1508,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1502,6 +1530,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1537,6 +1566,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1583,6 +1613,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1618,6 +1649,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1654,6 +1686,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1669,6 +1702,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1714,6 +1748,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1783,6 +1818,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1828,6 +1864,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1849,6 +1886,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1858,6 +1896,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1929,6 +1968,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1963,6 +2003,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2004,6 +2045,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2037,6 +2079,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -2071,6 +2114,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta3.json
+++ b/docs/content/en/schemas/v2beta3.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -299,6 +301,7 @@
       "x-intellij-html-description": "items that need to be built, along with the context in which they should be built."
     },
     "Auto": {
+      "type": "object",
       "description": "cannot be customized.",
       "x-intellij-html-description": "cannot be customized."
     },
@@ -333,10 +336,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -538,6 +543,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -567,6 +573,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a buildpack.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a buildpack."
     },
@@ -672,6 +679,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -693,6 +701,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -734,6 +743,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -756,6 +766,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -798,6 +809,7 @@
         "kubeContext"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -864,6 +876,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -885,6 +898,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -913,6 +927,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -934,6 +949,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -955,6 +971,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1042,6 +1059,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1058,6 +1076,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1085,6 +1104,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1124,6 +1144,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1139,10 +1160,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1195,6 +1218,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1334,6 +1358,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1373,6 +1398,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1411,6 +1437,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1504,6 +1531,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1525,6 +1553,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1560,6 +1589,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1606,6 +1636,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1641,6 +1672,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1677,6 +1709,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1692,6 +1725,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1737,6 +1771,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1806,6 +1841,7 @@
         "activation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1851,6 +1887,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1872,6 +1909,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1881,6 +1919,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1952,6 +1991,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1986,6 +2026,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2027,6 +2068,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2060,6 +2102,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -2094,6 +2137,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta4.json
+++ b/docs/content/en/schemas/v2beta4.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -299,6 +301,7 @@
       "x-intellij-html-description": "items that need to be built, along with the context in which they should be built."
     },
     "Auto": {
+      "type": "object",
       "description": "cannot be customized.",
       "x-intellij-html-description": "cannot be customized."
     },
@@ -333,10 +336,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -538,6 +543,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -567,6 +573,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by a buildpack.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by a buildpack."
     },
@@ -672,6 +679,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -693,6 +701,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -734,6 +743,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -756,6 +766,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -798,6 +809,7 @@
         "kubeContext"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -864,6 +876,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -885,6 +898,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -913,6 +927,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -934,6 +949,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -955,6 +971,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1042,6 +1059,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1058,6 +1076,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1085,6 +1104,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1124,6 +1144,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1139,10 +1160,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1195,6 +1218,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1334,6 +1358,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1373,6 +1398,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1411,6 +1437,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1504,6 +1531,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1525,6 +1553,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1560,6 +1589,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1606,6 +1636,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1641,6 +1672,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1677,6 +1709,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1692,6 +1725,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1737,6 +1771,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1806,6 +1841,7 @@
         "portForward"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1851,6 +1887,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1872,6 +1909,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1881,6 +1919,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1952,6 +1991,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -1986,6 +2026,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2027,6 +2068,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2060,6 +2102,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -2094,6 +2137,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta5.json
+++ b/docs/content/en/schemas/v2beta5.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -299,6 +301,7 @@
       "x-intellij-html-description": "items that need to be built, along with the context in which they should be built."
     },
     "Auto": {
+      "type": "object",
       "description": "cannot be customized.",
       "x-intellij-html-description": "cannot be customized."
     },
@@ -333,10 +336,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -552,6 +557,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -581,6 +587,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
     },
@@ -704,6 +711,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -725,6 +733,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -766,6 +775,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -788,6 +798,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -830,6 +841,7 @@
         "kubeContext"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -896,6 +908,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -917,6 +930,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -945,6 +959,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -966,6 +981,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -987,6 +1003,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1074,6 +1091,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1090,6 +1108,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1117,6 +1136,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1156,6 +1176,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1171,10 +1192,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1227,6 +1250,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1372,6 +1396,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1411,6 +1436,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1449,6 +1475,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1542,6 +1569,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1563,6 +1591,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1598,6 +1627,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1644,6 +1674,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1679,6 +1710,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1715,6 +1747,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1730,6 +1763,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1775,6 +1809,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1844,6 +1879,7 @@
         "portForward"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1889,6 +1925,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1910,6 +1947,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1919,6 +1957,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -1990,6 +2029,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -2024,6 +2064,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2065,6 +2106,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2098,6 +2140,7 @@
         "dateTime"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
@@ -2132,6 +2175,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta6.json
+++ b/docs/content/en/schemas/v2beta6.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -299,6 +301,7 @@
       "x-intellij-html-description": "items that need to be built, along with the context in which they should be built."
     },
     "Auto": {
+      "type": "object",
       "description": "cannot be customized.",
       "x-intellij-html-description": "cannot be customized."
     },
@@ -333,10 +336,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -552,6 +557,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -581,6 +587,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
     },
@@ -704,6 +711,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -725,6 +733,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -766,6 +775,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -796,6 +806,7 @@
         "components"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -818,6 +829,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -866,6 +878,7 @@
         "logs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -932,6 +945,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -953,6 +967,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -981,6 +996,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -1002,6 +1018,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -1023,6 +1040,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1116,6 +1134,7 @@
         "workerPool"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1132,6 +1151,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1159,6 +1179,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1198,6 +1219,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1213,10 +1235,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1269,6 +1293,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1399,6 +1424,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1438,6 +1464,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1476,6 +1503,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1569,6 +1597,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1590,6 +1619,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1625,6 +1655,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1671,6 +1702,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1706,6 +1738,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1742,6 +1775,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1764,6 +1798,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how container logs are printed as a result of a deployment.",
       "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
     },
@@ -1779,6 +1814,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1824,6 +1860,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -1893,6 +1930,7 @@
         "portForward"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -1938,6 +1976,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -1959,6 +1998,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -1968,6 +2008,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -2039,6 +2080,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -2073,6 +2115,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2114,6 +2157,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2153,10 +2197,12 @@
         "customTemplate"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
     "TaggerComponent": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -2301,6 +2347,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta7.json
+++ b/docs/content/en/schemas/v2beta7.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -299,6 +301,7 @@
       "x-intellij-html-description": "items that need to be built, along with the context in which they should be built."
     },
     "Auto": {
+      "type": "object",
       "description": "cannot be customized.",
       "x-intellij-html-description": "cannot be customized."
     },
@@ -333,10 +336,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -552,6 +557,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -581,6 +587,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
     },
@@ -704,6 +711,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -725,6 +733,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -766,6 +775,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -796,6 +806,7 @@
         "components"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -818,6 +829,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -872,6 +884,7 @@
         "logs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -938,6 +951,7 @@
         "noCache"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -959,6 +973,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -987,6 +1002,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -1008,6 +1024,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -1029,6 +1046,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1122,6 +1140,7 @@
         "workerPool"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1138,6 +1157,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1165,6 +1185,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1204,6 +1225,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1219,10 +1241,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1275,6 +1299,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1405,6 +1430,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1444,6 +1470,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1482,6 +1509,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1575,6 +1603,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1596,6 +1625,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1629,6 +1659,7 @@
         "live"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* uses the `kpt` CLI to manage and deploy manifests.",
       "x-intellij-html-description": "<em>alpha</em> uses the <code>kpt</code> CLI to manage and deploy manifests."
     },
@@ -1680,6 +1711,7 @@
         "mount"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt fn`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt fn</code>."
     },
@@ -1707,6 +1739,7 @@
         "inventoryNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live</code>."
     },
@@ -1740,6 +1773,7 @@
         "reconcileTimeout"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live apply`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live apply</code>."
     },
@@ -1775,6 +1809,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1821,6 +1856,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1856,6 +1892,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1892,6 +1929,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1914,6 +1952,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how container logs are printed as a result of a deployment.",
       "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
     },
@@ -1929,6 +1968,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -1974,6 +2014,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -2043,6 +2084,7 @@
         "portForward"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -2088,6 +2130,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -2109,6 +2152,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -2118,6 +2162,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -2189,6 +2234,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -2223,6 +2269,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2264,6 +2311,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2303,10 +2351,12 @@
         "customTemplate"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
     "TaggerComponent": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -2451,6 +2501,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta8.json
+++ b/docs/content/en/schemas/v2beta8.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -299,6 +301,7 @@
       "x-intellij-html-description": "items that need to be built, along with the context in which they should be built."
     },
     "Auto": {
+      "type": "object",
       "description": "cannot be customized.",
       "x-intellij-html-description": "cannot be customized."
     },
@@ -333,10 +336,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -552,6 +557,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -581,6 +587,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
     },
@@ -704,6 +711,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -725,6 +733,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -766,6 +775,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -796,6 +806,7 @@
         "components"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -818,6 +829,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -872,6 +884,7 @@
         "logs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -944,6 +957,7 @@
         "secret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -965,6 +979,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -995,6 +1010,7 @@
         "dst"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about a local secret passed to `docker build`, along with optional destination information.",
       "x-intellij-html-description": "contains information about a local secret passed to <code>docker build</code>, along with optional destination information."
     },
@@ -1023,6 +1039,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -1044,6 +1061,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -1065,6 +1083,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1158,6 +1177,7 @@
         "workerPool"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1174,6 +1194,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1201,6 +1222,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1240,6 +1262,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1255,10 +1278,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1311,6 +1336,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1447,6 +1473,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1486,6 +1513,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1524,6 +1552,7 @@
         "type"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1617,6 +1646,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1638,6 +1668,7 @@
         "hostPath"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1665,6 +1696,7 @@
         "inventoryNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "sets the kpt inventory directory.",
       "x-intellij-html-description": "sets the kpt inventory directory."
     },
@@ -1698,6 +1730,7 @@
         "reconcileTimeout"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live apply`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live apply</code>."
     },
@@ -1728,6 +1761,7 @@
         "live"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* uses the `kpt` CLI to manage and deploy manifests.",
       "x-intellij-html-description": "<em>alpha</em> uses the <code>kpt</code> CLI to manage and deploy manifests."
     },
@@ -1785,6 +1819,7 @@
         "sinkDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt fn`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt fn</code>."
     },
@@ -1806,6 +1841,7 @@
         "options"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live</code>."
     },
@@ -1847,6 +1883,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -1893,6 +1930,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -1934,6 +1972,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -1977,6 +2016,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -1999,6 +2039,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how container logs are printed as a result of a deployment.",
       "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
     },
@@ -2014,6 +2055,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -2059,6 +2101,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -2128,6 +2171,7 @@
         "portForward"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -2173,6 +2217,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -2194,6 +2239,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -2203,6 +2249,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -2274,6 +2321,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -2308,6 +2356,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2349,6 +2398,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2388,10 +2438,12 @@
         "customTemplate"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
     "TaggerComponent": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -2536,6 +2588,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/docs/content/en/schemas/v2beta9.json
+++ b/docs/content/en/schemas/v2beta9.json
@@ -40,6 +40,7 @@
         "command"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "criteria by which a profile is auto-activated.",
       "x-intellij-html-description": "criteria by which a profile is auto-activated."
     },
@@ -47,6 +48,7 @@
       "required": [
         "image"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -382,6 +384,7 @@
         "alias"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a specific build dependency for an artifact.",
       "x-intellij-html-description": "describes a specific build dependency for an artifact."
     },
@@ -416,10 +419,12 @@
         "args"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built with [Bazel](https://bazel.build/).",
       "x-intellij-html-description": "describes an artifact built with <a href=\"https://bazel.build/\">Bazel</a>."
     },
     "BuildConfig": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -635,6 +640,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* describes an artifact built using [Cloud Native Buildpacks](https://buildpacks.io/). It can be used to build images out of project's sources without any additional configuration.",
       "x-intellij-html-description": "<em>alpha</em> describes an artifact built using <a href=\"https://buildpacks.io/\">Cloud Native Buildpacks</a>. It can be used to build images out of project's sources without any additional configuration."
     },
@@ -664,6 +670,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
     },
@@ -787,6 +794,7 @@
         "randomDockerConfigSecret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do an on-cluster build.",
       "x-intellij-html-description": "<em>beta</em> describes how to do an on-cluster build."
     },
@@ -808,6 +816,7 @@
         "dependencies"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold.",
       "x-intellij-html-description": "<em>beta</em> describes an artifact built from a custom build script written by the user. It can be used to build images with builders that aren't directly integrated with skaffold."
     },
@@ -849,6 +858,7 @@
         "ignore"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify dependencies for an artifact built by a custom build script. Either `dockerfile` or `paths` should be specified for file watching to work as expected.",
       "x-intellij-html-description": "<em>beta</em> used to specify dependencies for an artifact built by a custom build script. Either <code>dockerfile</code> or <code>paths</code> should be specified for file watching to work as expected."
     },
@@ -879,6 +889,7 @@
         "components"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -901,6 +912,7 @@
         "timezone"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the build timestamp.",
       "x-intellij-html-description": "<em>beta</em> tags images with the build timestamp."
     },
@@ -955,6 +967,7 @@
         "logs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration needed by the deploy steps.",
       "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
     },
@@ -1027,6 +1040,7 @@
         "secret"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, usually using `docker build`.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, usually using <code>docker build</code>."
     },
@@ -1048,6 +1062,7 @@
         "secretName"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
@@ -1078,6 +1093,7 @@
         "dst"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains information about a local secret passed to `docker build`, along with optional destination information.",
       "x-intellij-html-description": "contains information about a local secret passed to <code>docker build</code>, along with optional destination information."
     },
@@ -1106,6 +1122,7 @@
         "buildArgs"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile.",
       "x-intellij-html-description": "<em>beta</em> used to specify a custom build artifact that is built from a Dockerfile. This allows skaffold to determine dependencies from the Dockerfile."
     },
@@ -1127,6 +1144,7 @@
         "template"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with a configurable template string.",
       "x-intellij-html-description": "<em>beta</em> tags images with a configurable template string."
     },
@@ -1148,6 +1166,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* tags images with the git tag or commit of the artifact's workspace.",
       "x-intellij-html-description": "<em>beta</em> tags images with the git tag or commit of the artifact's workspace."
     },
@@ -1241,6 +1260,7 @@
         "workerPool"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a remote build on [Google Cloud Build](https://cloud.google.com/cloud-build/docs/). Docker and Jib artifacts can be built on Cloud Build. The `projectId` needs to be provided and the currently logged in user should be given permissions to trigger new builds.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a remote build on <a href=\"https://cloud.google.com/cloud-build/docs/\">Google Cloud Build</a>. Docker and Jib artifacts can be built on Cloud Build. The <code>projectId</code> needs to be provided and the currently logged in user should be given permissions to trigger new builds."
     },
@@ -1257,6 +1277,7 @@
         "explicitRegistry"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config in the syntax of image.repository and image.tag.",
       "x-intellij-html-description": "image config in the syntax of image.repository and image.tag."
     },
@@ -1284,6 +1305,7 @@
         "flags"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>helm</code> CLI to apply the charts to the cluster."
     },
@@ -1323,6 +1345,7 @@
         "upgrade"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional option flags that are passed on the command line to `helm`.",
       "x-intellij-html-description": "additional option flags that are passed on the command line to <code>helm</code>."
     },
@@ -1338,10 +1361,12 @@
         "property"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "image config to use the FullyQualifiedImageName as param to set.",
       "x-intellij-html-description": "image config to use the FullyQualifiedImageName as param to set."
     },
     "HelmImageStrategy": {
+      "type": "object",
       "anyOf": [
         {
           "additionalProperties": false
@@ -1394,6 +1419,7 @@
         "appVersion"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "parameters for packaging helm chart (`helm package`).",
       "x-intellij-html-description": "parameters for packaging helm chart (<code>helm package</code>)."
     },
@@ -1530,6 +1556,7 @@
         "imageStrategy"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a helm release to be deployed.",
       "x-intellij-html-description": "describes a helm release to be deployed."
     },
@@ -1569,6 +1596,7 @@
         "value"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "patch to be applied by a profile.",
       "x-intellij-html-description": "patch to be applied by a profile."
     },
@@ -1613,6 +1641,7 @@
         "fromImage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "builds images using the [Jib plugins for Maven and Gradle](https://github.com/GoogleContainerTools/jib/).",
       "x-intellij-html-description": "builds images using the <a href=\"https://github.com/GoogleContainerTools/jib/\">Jib plugins for Maven and Gradle</a>."
     },
@@ -1864,6 +1893,7 @@
         "volumeMounts"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes an artifact built from a Dockerfile, with kaniko.",
       "x-intellij-html-description": "describes an artifact built from a Dockerfile, with kaniko."
     },
@@ -1891,6 +1921,7 @@
         "ttl"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds.",
       "x-intellij-html-description": "configures Kaniko caching. If a cache is specified, Kaniko will use a remote cache which will speed up builds."
     },
@@ -1918,6 +1949,7 @@
         "inventoryNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "sets the kpt inventory directory.",
       "x-intellij-html-description": "sets the kpt inventory directory."
     },
@@ -1951,6 +1983,7 @@
         "reconcileTimeout"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live apply`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live apply</code>."
     },
@@ -1981,6 +2014,7 @@
         "live"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*alpha* uses the `kpt` CLI to manage and deploy manifests.",
       "x-intellij-html-description": "<em>alpha</em> uses the <code>kpt</code> CLI to manage and deploy manifests."
     },
@@ -2038,6 +2072,7 @@
         "sinkDir"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt fn`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt fn</code>."
     },
@@ -2059,6 +2094,7 @@
         "options"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "adds additional configurations used when calling `kpt live`.",
       "x-intellij-html-description": "adds additional configurations used when calling <code>kpt live</code>."
     },
@@ -2100,6 +2136,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses a client side `kubectl apply` to deploy manifests. You'll need a `kubectl` CLI version installed that's compatible with your cluster.",
       "x-intellij-html-description": "<em>beta</em> uses a client side <code>kubectl apply</code> to deploy manifests. You'll need a <code>kubectl</code> CLI version installed that's compatible with your cluster."
     },
@@ -2146,6 +2183,7 @@
         "disableValidation"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete).",
       "x-intellij-html-description": "additional flags passed on the command line to kubectl either on every command (Global), on creations (Apply) or deletions (Delete)."
     },
@@ -2187,6 +2225,7 @@
         "defaultNamespace"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* uses the `kustomize` CLI to \"patch\" a deployment for a target environment.",
       "x-intellij-html-description": "<em>beta</em> uses the <code>kustomize</code> CLI to &quot;patch&quot; a deployment for a target environment."
     },
@@ -2230,6 +2269,7 @@
         "concurrency"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* describes how to do a build on the local docker daemon and optionally push to a repository.",
       "x-intellij-html-description": "<em>beta</em> describes how to do a build on the local docker daemon and optionally push to a repository."
     },
@@ -2252,6 +2292,7 @@
         "prefix"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "configures how container logs are printed as a result of a deployment.",
       "x-intellij-html-description": "configures how container logs are printed as a result of a deployment."
     },
@@ -2267,6 +2308,7 @@
         "name"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds an optional name of the project.",
       "x-intellij-html-description": "holds an optional name of the project."
     },
@@ -2312,6 +2354,7 @@
         "localPort"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes a resource to port forward.",
       "x-intellij-html-description": "describes a resource to port forward."
     },
@@ -2381,6 +2424,7 @@
         "portForward"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "used to override any `build`, `test` or `deploy` configuration.",
       "x-intellij-html-description": "used to override any <code>build</code>, <code>test</code> or <code>deploy</code> configuration."
     },
@@ -2426,6 +2470,7 @@
         "resourceStorage"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "stores the CPU/Memory requirements for the pod.",
       "x-intellij-html-description": "stores the CPU/Memory requirements for the pod."
     },
@@ -2447,6 +2492,7 @@
         "limits"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
@@ -2456,6 +2502,7 @@
       "x-intellij-html-description": "describes the Kubernetes resource types used for port forwarding."
     },
     "ShaTagger": {
+      "type": "object",
       "description": "*beta* tags images with their sha256 digest.",
       "x-intellij-html-description": "<em>beta</em> tags images with their sha256 digest."
     },
@@ -2527,6 +2574,7 @@
         "profiles"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml).",
       "x-intellij-html-description": "holds the fields parsed from the Skaffold configuration file (skaffold.yaml)."
     },
@@ -2561,6 +2609,7 @@
         "auto"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "*beta* specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "x-intellij-html-description": "<em>beta</em> specifies what files to sync into the container. This is a list of sync rules indicating the intent to sync for source files. If no files are listed, sync all the files and infer the destination.",
       "default": "infer: [\"**/*\"]"
@@ -2602,6 +2651,7 @@
         "strip"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "specifies which local files to sync to remote folders.",
       "x-intellij-html-description": "specifies which local files to sync to remote folders."
     },
@@ -2641,10 +2691,12 @@
         "customTemplate"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "contains all the configuration for the tagging step.",
       "x-intellij-html-description": "contains all the configuration for the tagging step."
     },
     "TaggerComponent": {
+      "type": "object",
       "anyOf": [
         {
           "properties": {
@@ -2789,6 +2841,7 @@
         "structureTests"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "a list of structure tests to run on images that Skaffold builds.",
       "x-intellij-html-description": "a list of structure tests to run on images that Skaffold builds."
     }

--- a/hack/schemas/main.go
+++ b/hack/schemas/main.go
@@ -234,6 +234,7 @@ func (g *schemaGenerator) newDefinition(name string, t ast.Expr, comment string,
 		def.AdditionalProperties = g.newDefinition("", tt.Value, "", "")
 
 	case *ast.StructType:
+		def.Type = "object"
 		for _, field := range tt.Fields.List {
 			yamlName := yamlFieldName(field)
 

--- a/hack/schemas/testdata/inline-anyof/output.json
+++ b/hack/schemas/testdata/inline-anyof/output.json
@@ -11,6 +11,7 @@
       "required": [
         "reqField"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {

--- a/hack/schemas/testdata/inline-hybrid/output.json
+++ b/hack/schemas/testdata/inline-hybrid/output.json
@@ -11,6 +11,7 @@
       "required": [
         "reqField"
       ],
+      "type": "object",
       "anyOf": [
         {
           "properties": {

--- a/hack/schemas/testdata/inline/output.json
+++ b/hack/schemas/testdata/inline/output.json
@@ -51,6 +51,7 @@
         "field4"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "for testing the schema generator.",
       "x-intellij-html-description": "for testing the schema generator."
     }

--- a/hack/schemas/testdata/integer/output.json
+++ b/hack/schemas/testdata/integer/output.json
@@ -31,6 +31,7 @@
         "intField"
       ],
       "additionalProperties": false,
+      "type": "object",
       "description": "for testing the schema generator.",
       "x-intellij-html-description": "for testing the schema generator."
     }


### PR DESCRIPTION
Fixes: #5421

**Description**
This PR causes the JSON schema generator to mark struct-types as `"type":"object"` in the resulting JSON scheme.  These `type` statements act as constraints.  Without this type, these definitions can be anything: objects, strings, numbers, null, etc.