### PR TITLE
Add .NET .csproj detection to init for buildpacks

### DIFF
--- a/pkg/skaffold/build/buildpacks/init.go
+++ b/pkg/skaffold/build/buildpacks/init.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
@@ -94,6 +95,11 @@ func validate(path string) bool {
 		if _, err := os.Stat(filepath.Join(filepath.Dir(path), "Procfile")); err == nil {
 			return true
 		}
+	}
+
+	// .NET.
+	if strings.HasSuffix(filepath.Base(path), ".csproj") {
+		return true
 	}
 
 	return false

--- a/pkg/skaffold/build/buildpacks/init.go
+++ b/pkg/skaffold/build/buildpacks/init.go
@@ -97,10 +97,6 @@ func validate(path string) bool {
 		}
 	}
 
-	// .NET.
-	if strings.HasSuffix(filepath.Base(path), ".csproj") {
-		return true
-	}
-
-	return false
+	// .NET project
+	return strings.HasSuffix(filepath.Base(path), ".csproj")
 }

--- a/pkg/skaffold/build/buildpacks/init_test.go
+++ b/pkg/skaffold/build/buildpacks/init_test.go
@@ -88,6 +88,11 @@ func TestValidate(t *testing.T) {
 			expectedValid: true,
 		},
 		{
+			description:   ".NET project",
+			path:          "test.csproj",
+			expectedValid: true,
+		},
+		{
 			description:   "Buildpacks",
 			path:          "project.toml",
 			expectedValid: true,


### PR DESCRIPTION
**Description**
Reported by @viglesiasce: our buildpacks detection doesn't work for .NET projects.

No user doc since `init` for buildpacks is still behind a feature flag.
