### PR TITLE
Fix and cleanup Kpt fn integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 GOPATH ?= $(shell go env GOPATH)
+GOBIN ?= $(or $(shell go env GOBIN),$(GOPATH)/bin)
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 BUILD_DIR ?= ./out
@@ -73,7 +74,7 @@ $(BUILD_DIR)/$(PROJECT): $(STATIK_FILES) $(GO_FILES) $(BUILD_DIR)
 .PHONY: install
 install: $(BUILD_DIR)/$(PROJECT)
 	mkdir -p $(GOPATH)/bin
-	cp $(BUILD_DIR)/$(PROJECT) $(GOPATH)/bin/$(PROJECT)
+	cp $(BUILD_DIR)/$(PROJECT) $(GOBIN)/$(PROJECT)
 
 .PRECIOUS: $(foreach platform, $(SUPPORTED_PLATFORMS), $(BUILD_DIR)/$(PROJECT)-$(platform))
 

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -51,8 +51,9 @@ const (
 	kptFnAnnotation   = "config.kubernetes.io/function"
 	kptFnLocalConfig  = "config.kubernetes.io/local-config"
 
-	kptDownloadLink = "https://googlecontainertools.github.io/kpt/installation/"
-	kptMinVersion   = "0.38.1"
+	kptDownloadLink        = "https://googlecontainertools.github.io/kpt/installation/"
+	kptMinVersionInclusive = "v0.38.1"
+	kptMaxVersionExclusive = "v1.0.0"
 
 	kustomizeDownloadLink  = "https://kubernetes-sigs.github.io/kustomize/installation/"
 	kustomizeMinVersion    = "v3.2.3"
@@ -100,16 +101,18 @@ func versionCheck(dir string, stdout io.Writer) error {
 		return fmt.Errorf("kpt is not installed yet\nSee kpt installation: %v",
 			kptDownloadLink)
 	}
-	version := strings.TrimSuffix(string(out), "\n")
 	// kpt follows semver but does not have "v" prefix.
-	if !semver.IsValid("v" + version) {
-		return fmt.Errorf("unknown kpt version %v\nPlease upgrade your "+
-			"local kpt CLI to a version >= %v\nSee kpt installation: %v",
-			string(out), kptMinVersion, kptDownloadLink)
+	version := "v" + strings.TrimSuffix(string(out), "\n")
+	if !semver.IsValid(version) {
+		return fmt.Errorf("unknown kpt version %v\nPlease install "+
+			"kpt %v <= version < %v\nSee kpt installation: %v",
+			string(out), kptMinVersionInclusive, kptMaxVersionExclusive, kptDownloadLink)
 	}
-	if semver.Compare("v"+version, "v"+kptMinVersion) < 0 {
-		return fmt.Errorf("you are using kpt %q\nPlease update your kpt version to"+
-			" >= %v\nSee kpt installation: %v", version[0], kptMinVersion, kptDownloadLink)
+	if semver.Compare(version, kptMinVersionInclusive) < 0 ||
+		semver.Compare(version, kptMaxVersionExclusive) >= 0 {
+		return fmt.Errorf("you are using kpt %q\nPlease install "+
+			"kpt %v <= version < %v\nSee kpt installation: %v",
+			version, kptMinVersionInclusive, kptMaxVersionExclusive, kptDownloadLink)
 	}
 
 	// Users can choose not to use kustomize in kpt deployer mode. We only check the kustomize

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -51,18 +51,20 @@ spec:
 // Test that kpt deployer manipulate manifests in the given order and no intermediate data is
 // stored after each step:
 //	Step 1. `kp fn source` (read in the manifest as stdin),
-//  Step 2. `kustomize build` (hydrate the manifest),
-//  Step 3. `kpt fn run` (validate, transform or generate the manifests via kpt functions),
-//  Step 4. `kpt fn sink` (store the stdout in a given dir).
+//  Step 2. `kpt fn run` (validate, transform or generate the manifests via kpt functions),
+//  Step 3. `kpt fn sink` (to temp dir to run kuustomize build on),
+//  Step 4. `kustomize build` (if the temp dir from step 3 has a Kustomization hydrate the manifest),
+//  Step 5. `kpt fn sink` (store the stdout in a given dir).
 func TestKpt_Deploy(t *testing.T) {
+	sanityCheck = func(dir string, buf io.Writer) error { return nil }
 	tests := []struct {
-		description    string
-		builds         []graph.Artifact
-		kpt            latestV1.KptDeploy
-		kustomizations map[string]string
-		commands       util.Command
-		expected       []string
-		shouldErr      bool
+		description      string
+		builds           []graph.Artifact
+		kpt              latestV1.KptDeploy
+		hasKustomization func(string) bool
+		commands         util.Command
+		expected         []string
+		shouldErr        bool
 	}{
 		{
 			description: "no manifest",
@@ -71,7 +73,8 @@ func TestKpt_Deploy(t *testing.T) {
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run", ``),
+				AndRunOut("kpt fn run", ``).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``),
 		},
 		{
 			description: "invalid manifest",
@@ -80,7 +83,8 @@ func TestKpt_Deploy(t *testing.T) {
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run", `foo`).
+				AndRunOut("kpt fn run", `foo`).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOut("kpt fn sink .tmp-sink-dir", ``),
 			shouldErr: true,
 		},
@@ -96,7 +100,8 @@ func TestKpt_Deploy(t *testing.T) {
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run", testPod).
+				AndRunOut("kpt fn run", testPod).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOut("kpt fn sink .tmp-sink-dir", ``),
 			shouldErr: true,
 		},
@@ -112,14 +117,12 @@ func TestKpt_Deploy(t *testing.T) {
 					},
 				},
 			},
-			kustomizations: map[string]string{"Kustomization": `resources:
-				- foo.yaml`},
+			hasKustomization: func(dir string) bool { return dir == tmpKustomizeDir },
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn source kpt-func.yaml", ``).
+				AndRunOut("kpt fn run --fn-path kpt-func.yaml", testPod).
 				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOut(fmt.Sprintf("kustomize build %v", tmpKustomizeDir), ``).
-				AndRunOut("kpt fn run --dry-run", testPod).
 				AndRun("kpt live apply valid_path --context kubecontext --namespace testNamespace"),
 			expected: []string{"default"},
 		},
@@ -130,8 +133,10 @@ func TestKpt_Deploy(t *testing.T) {
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run", testPod).
+				AndRunOut("kpt fn run", testPod).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOut("kpt live init .kpt-hydrated --context kubecontext --namespace testNamespace", ``).
+				AndRunOut("kpt fn sink .kpt-hydrated", ``).
 				AndRunErr("kpt live apply .kpt-hydrated --context kubecontext --namespace testNamespace", errors.New("BUG")),
 			shouldErr: true,
 		},
@@ -151,7 +156,9 @@ func TestKpt_Deploy(t *testing.T) {
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run", testPod).
+				AndRunOut("kpt fn run", testPod).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
+				AndRunOut("kpt fn sink valid_path", ``).
 				AndRun("kpt live apply valid_path --poll-period 5s --reconcile-timeout 2m --context kubecontext --namespace testNamespace"),
 		},
 		{
@@ -170,7 +177,9 @@ func TestKpt_Deploy(t *testing.T) {
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run", testPod).
+				AndRunOut("kpt fn run", testPod).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
+				AndRunOut("kpt fn sink valid_path", ``).
 				AndRun("kpt live apply valid_path --poll-period foo --reconcile-timeout bar --context kubecontext --namespace testNamespace"),
 		},
 		{
@@ -189,7 +198,9 @@ func TestKpt_Deploy(t *testing.T) {
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run", testPod).
+				AndRunOut("kpt fn run", testPod).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
+				AndRunOut("kpt fn sink valid_path", ``).
 				AndRun("kpt live apply valid_path --prune-propagation-policy Orphan --prune-timeout 2m --context kubecontext --namespace testNamespace"),
 		},
 		{
@@ -208,24 +219,26 @@ func TestKpt_Deploy(t *testing.T) {
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run", testPod).
+				AndRunOut("kpt fn run", testPod).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
+				AndRunOut("kpt fn sink valid_path", ``).
 				AndRun("kpt live apply valid_path --prune-propagation-policy foo --prune-timeout bar --context kubecontext --namespace testNamespace"),
 		},
 	}
 	for _, test := range tests {
-		sanityCheck = func(dir string, buf io.Writer) error { return nil }
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
-			tmpDir := t.NewTempDir().Chdir()
-
-			tmpDir.WriteFiles(test.kustomizations)
+			t.NewTempDir().Chdir()
 
 			k := NewDeployer(&kptConfig{}, nil, &test.kpt)
+			if test.hasKustomization != nil {
+				k.hasKustomization = test.hasKustomization
+			}
 
 			if k.Live.Apply.Dir == "valid_path" {
 				// 0755 is a permission setting where the owner can read, write, and execute.
 				// Others can read and execute but not modify the directory.
-				os.Mkdir(k.Live.Apply.Dir, 0755)
+				t.CheckNoError(os.Mkdir(k.Live.Apply.Dir, 0755))
 			}
 
 			_, err := k.Deploy(context.Background(), ioutil.Discard, test.builds)
@@ -408,7 +421,7 @@ func TestKpt_Cleanup(t *testing.T) {
 			if test.applyDir == "valid_path" {
 				// 0755 is a permission setting where the owner can read, write, and execute.
 				// Others can read and execute but not modify the directory.
-				os.Mkdir(test.applyDir, 0755)
+				t.CheckNoError(os.Mkdir(test.applyDir, 0755))
 			}
 
 			k := NewDeployer(&kptConfig{
@@ -429,6 +442,7 @@ func TestKpt_Cleanup(t *testing.T) {
 }
 
 func TestKpt_Render(t *testing.T) {
+	sanityCheck = func(dir string, buf io.Writer) error { return nil }
 	// The follow are outputs to `kpt fn run` commands.
 	output1 := `apiVersion: v1
 kind: Pod
@@ -472,14 +486,14 @@ spec:
 `
 
 	tests := []struct {
-		description    string
-		builds         []graph.Artifact
-		labels         map[string]string
-		kpt            latestV1.KptDeploy
-		commands       util.Command
-		kustomizations map[string]string
-		expected       string
-		shouldErr      bool
+		description      string
+		builds           []graph.Artifact
+		labels           map[string]string
+		kpt              latestV1.KptDeploy
+		commands         util.Command
+		hasKustomization func(string) bool
+		expected         string
+		shouldErr        bool
 	}{
 		{
 			description: "no fnPath or image specified",
@@ -494,7 +508,8 @@ spec:
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run", output1).
+				AndRunOut("kpt fn run", output1).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOut("kpt fn sink .tmp-sink-dir", ``),
 			expected: `apiVersion: v1
 kind: Pod
@@ -525,8 +540,8 @@ spec:
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source test", ``).
-				AndRunOut("kpt fn source kpt-func.yaml", ``).
-				AndRunOut("kpt fn run --dry-run", output3).
+				AndRunOut("kpt fn run --fn-path kpt-func.yaml", output3).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOut("kpt fn sink .tmp-sink-dir/test", ``),
 			expected: `apiVersion: v1
 kind: Pod
@@ -569,7 +584,8 @@ spec:
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", output2).
+				AndRunOut("kpt fn run --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", output2).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOut("kpt fn sink .tmp-sink-dir", ``),
 			expected: `apiVersion: v1
 kind: Pod
@@ -597,7 +613,8 @@ spec:
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run", ``).
+				AndRunOut("kpt fn run", ``).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOut("kpt fn sink .tmp-sink-dir", ``),
 			expected: "\n",
 		},
@@ -612,7 +629,8 @@ spec:
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
 				AndRunOut("kpt fn source kpt-func.yaml", ``).
-				AndRunOut("kpt fn run --dry-run --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``).
+				AndRunOut("kpt fn run --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOut("kpt fn sink .tmp-sink-dir", ``),
 			shouldErr: true,
 		},
@@ -629,11 +647,10 @@ spec:
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
+				AndRunOut("kpt fn run", ``).
 				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
-				AndRunOut(fmt.Sprintf("kustomize build %v", tmpKustomizeDir), ``).
-				AndRunOut("kpt fn run --dry-run", output1),
-			kustomizations: map[string]string{"kustomization.yaml": `resources:
-- foo.yaml`},
+				AndRunOut(fmt.Sprintf("kustomize build %v", tmpKustomizeDir), output1),
+			hasKustomization: func(dir string) bool { return dir == tmpKustomizeDir },
 			expected: `apiVersion: v1
 kind: Pod
 metadata:
@@ -651,7 +668,8 @@ spec:
 			},
 			commands: testutil.
 				CmdRunOutErr("kpt fn source .", ``, errors.New("BUG")).
-				AndRunOut("kpt fn run --dry-run", "invalid pipeline").
+				AndRunOut("kpt fn run", "invalid pipeline").
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOut("kpt fn sink .tmp-sink-dir", ``),
 			shouldErr: true,
 		},
@@ -662,7 +680,8 @@ spec:
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run", "invalid pipeline").
+				AndRunOut("kpt fn run", "invalid pipeline").
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOutErr("kpt fn sink .tmp-sink-dir", ``, errors.New("BUG")),
 			shouldErr: true,
 		},
@@ -679,13 +698,11 @@ spec:
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
+				AndRunOut("kpt fn run", output1).
 				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
-				AndRunOutErr(fmt.Sprintf("kustomize build %v", tmpKustomizeDir), ``, errors.New("BUG")).
-				AndRunOut("kpt fn run --dry-run", output1).
-				AndRunOut("kpt fn sink .tmp-sink-dir", ``),
-			kustomizations: map[string]string{"kustomization.yaml": `resources:
-- foo.yaml`},
-			shouldErr: true,
+				AndRunOutErr(fmt.Sprintf("kustomize build %v", tmpKustomizeDir), ``, errors.New("BUG")),
+			hasKustomization: func(dir string) bool { return dir == tmpKustomizeDir },
+			shouldErr:        true,
 		},
 		{
 			description: "kpt fn run fails",
@@ -694,7 +711,7 @@ spec:
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOutErr("kpt fn run --dry-run", "invalid pipeline", errors.New("BUG")).
+				AndRunOutErr("kpt fn run", "invalid pipeline", errors.New("BUG")).
 				AndRunOut("kpt fn sink .tmp-sink-dir", ``),
 			shouldErr: true,
 		},
@@ -709,7 +726,8 @@ spec:
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run --global-scope --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``).
+				AndRunOut("kpt fn run --global-scope --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOut("kpt fn sink .tmp-sink-dir", ``),
 			expected: "\n",
 		},
@@ -724,7 +742,8 @@ spec:
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run --mount type=bind,src=$(pwd),dst=/source --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``).
+				AndRunOut("kpt fn run --mount type=bind,src=$(pwd),dst=/source --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOut("kpt fn sink .tmp-sink-dir", ``),
 			expected: "\n",
 		},
@@ -739,7 +758,8 @@ spec:
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run --mount foo,,bar --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``).
+				AndRunOut("kpt fn run --mount foo,,bar --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOut("kpt fn sink .tmp-sink-dir", ``),
 			expected: "\n",
 		},
@@ -755,7 +775,8 @@ spec:
 			},
 			commands: testutil.
 				CmdRunOut("kpt fn source .", ``).
-				AndRunOut("kpt fn run --dry-run --network --network-name foo --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``).
+				AndRunOut("kpt fn run --network --network-name foo --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar", ``).
+				AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
 				AndRunOut("kpt fn sink .tmp-sink-dir", ``),
 			expected: "\n",
 		},
@@ -763,13 +784,12 @@ spec:
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
-			tmpDir := t.NewTempDir().Chdir()
+			t.NewTempDir().Chdir()
 
-			tmpDir.WriteFiles(test.kustomizations)
-
-			k := NewDeployer(&kptConfig{
-				workingDir: ".",
-			}, test.labels, &test.kpt)
+			k := NewDeployer(&kptConfig{workingDir: "."}, test.labels, &test.kpt)
+			if test.hasKustomization != nil {
+				k.hasKustomization = test.hasKustomization
+			}
 
 			var b bytes.Buffer
 			err := k.Render(context.Background(), &b, test.builds, true, "")
@@ -834,7 +854,7 @@ func TestKpt_GetApplyDir(t *testing.T) {
 			if test.live.Apply.Dir == test.expected {
 				// 0755 is a permission setting where the owner can read, write, and execute.
 				// Others can read and execute but not modify the directory.
-				os.Mkdir(test.live.Apply.Dir, 0755)
+				t.CheckNoError(os.Mkdir(test.live.Apply.Dir, 0755))
 			}
 
 			if test.description == "existing template resource in .kpt-hydrated" {
@@ -1021,7 +1041,7 @@ func TestVersionCheck(t *testing.T) {
 		{
 			description: "Both kpt and kustomize versions are good",
 			commands: testutil.
-				CmdRunOut("kpt version", `0.34.0`).
+				CmdRunOut("kpt version", `0.38.1`).
 				AndRunOut("kustomize version", `{Version:v3.6.1 GitCommit:a0072a2cf92bf5399565e84c621e1e7c5c1f1094 BuildDate:2020-06-15T20:19:07Z GoOs:darwin GoArch:amd64}`),
 			kustomizations: map[string]string{"Kustomization": `resources:
 				- foo.yaml`},
@@ -1038,14 +1058,14 @@ func TestVersionCheck(t *testing.T) {
 		{
 			description: "kustomize is not used, kpt version is good",
 			commands: testutil.
-				CmdRunOut("kpt version", `0.34.0`),
+				CmdRunOut("kpt version", `0.38.1`),
 			shouldErr: false,
 			error:     nil,
 		},
 		{
 			description: "kustomize is used but not installed",
 			commands: testutil.
-				CmdRunOut("kpt version", `0.34.0`).
+				CmdRunOut("kpt version", `0.38.1`).
 				AndRunOutErr("kustomize version", "", errors.New("BUG")),
 			kustomizations: map[string]string{"Kustomization": `resources:
 					- foo.yaml`},
@@ -1078,7 +1098,7 @@ func TestVersionCheck(t *testing.T) {
 		{
 			description: "kustomize versions is too old (< v3.2.3)",
 			commands: testutil.
-				CmdRunOut("kpt version", `0.34.0`).
+				CmdRunOut("kpt version", `0.38.1`).
 				AndRunOut("kustomize version", `{Version:v0.0.1 GitCommit:a0072a2cf92bf5399565e84c621e1e7c5c1f1094 BuildDate:2020-06-15T20:19:07Z GoOs:darwin GoArch:amd64}`),
 			kustomizations: map[string]string{"Kustomization": `resources:
 					- foo.yaml`},
@@ -1090,7 +1110,7 @@ func TestVersionCheck(t *testing.T) {
 		{
 			description: "kustomize version is unknown",
 			commands: testutil.
-				CmdRunOut("kpt version", `0.34.0`).
+				CmdRunOut("kpt version", `0.38.1`).
 				AndRunOut("kustomize version", `{Version:unknown GitCommit:a0072a2cf92bf5399565e84c621e1e7c5c1f1094 BuildDate:2020-06-15T20:19:07Z GoOs:darwin GoArch:amd64}`),
 			kustomizations: map[string]string{"Kustomization": `resources:
 					- foo.yaml`},
@@ -1102,7 +1122,7 @@ func TestVersionCheck(t *testing.T) {
 		{
 			description: "kustomize version is non-official",
 			commands: testutil.
-				CmdRunOut("kpt version", `0.34.0`).
+				CmdRunOut("kpt version", `0.38.1`).
 				AndRunOut("kustomize version", `UNKNOWN`),
 			kustomizations: map[string]string{"Kustomization": `resources:
 					- foo.yaml`},
@@ -1128,7 +1148,9 @@ func TestVersionCheck(t *testing.T) {
 
 func TestNonEmptyKubeconfig(t *testing.T) {
 	commands := testutil.CmdRunOut("kpt fn source .", ``).
-		AndRunOut("kpt fn run --dry-run", testPod).
+		AndRunOut("kpt fn run", testPod).
+		AndRunOut(fmt.Sprintf("kpt fn sink %v", tmpKustomizeDir), ``).
+		AndRunOut("kpt fn sink valid_path", ``).
 		AndRun("kpt live apply valid_path --context kubecontext --kubeconfig testConfigPath --namespace testNamespace")
 
 	testutil.Run(t, "", func(t *testutil.T) {
@@ -1141,7 +1163,7 @@ func TestNonEmptyKubeconfig(t *testing.T) {
 				},
 			},
 		})
-		os.Mkdir(k.Live.Apply.Dir, 0755)
+		t.CheckNoError(os.Mkdir(k.Live.Apply.Dir, 0755))
 		defer os.RemoveAll(k.Live.Apply.Dir)
 		_, err := k.Deploy(context.Background(), ioutil.Discard, []graph.Artifact{})
 		t.CheckNoError(err)


### PR DESCRIPTION
**Description**

This PR attempts to fix and clean up Kpt hydration.

1. It removes a workaround for a [Kpt issue](https://github.com/GoogleContainerTools/kpt/issues/1149) that is no longer relevant. The Kpt version shipped with gcloud and several version before does not have this issue. So instead this PR bumps the required Kpt version. The workaround was problematic because:
    1. In some cases it was completely broken. In my case I had no Kustomization and was using `kpt.fn.fnPath` and the input
       Skaffold gave to my function was just the first resource in `kpt.dir` and the function config.
    1. It didn't match the behavior of using `kpt fn run --fn-path` which will cause function configs to be used only from the
        specified path whereas the workaround added those to whatever was in `kpt.dir`
1. The order in which `kpt fn run` and `kustomize build` are executed has been reversed. I have outlined my reasoning 
    in code comments.
1. Some general cleanup to get rid of duplicated logic. The only visible difference from these changes should be that dumping
    to `kpt.live.apply.dir` is now using the same mechanism as when writing to `kpt.fn.sinkDir` and the kustomize temp dir
    (`kpt fn sink` instead of `manifest.Write`) so this directory will contain one file per resource instead of a single file.

**User facing changes (remove if N/A)**

The order in which `kpt fn run` and `kustomize build` are executed has changed from Kustomize first to Kpt first. I don't believe there is any user facing documentation for this.

**Follow-up Work (remove if N/A)**

I have not updated any tests yet because I want to first see if these changes have a chance of being accepted, which is also why I'm publishing it as a draft.

Also after cleaning stuff up I wonder if there is any point to `kpt.fn.sinkDir` or if should be deprecated? If you do `skaffold render` you get the same stuff on on stdout and if you do `skaffold deploy` you get the same plus the inventory template in `kpt.live.apply.dir`
