### PR TITLE
Refactor to use new SkaffoldWriter type

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -79,7 +79,7 @@ func NewSkaffoldCommand(out, errOut io.Writer) *cobra.Command {
 
 			opts.Command = cmd.Use
 			instrumentation.SetCommand(cmd.Use)
-			out := output.SetupColors(out, defaultColor, forceColors)
+			out := output.SetupOutput(out, defaultColor, forceColors)
 			if timestamps {
 				l := logrus.New()
 				l.SetOutput(out)

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -79,7 +79,7 @@ func NewSkaffoldCommand(out, errOut io.Writer) *cobra.Command {
 
 			opts.Command = cmd.Use
 			instrumentation.SetCommand(cmd.Use)
-			out := output.SetupOutput(out, defaultColor, forceColors)
+			out := output.GetWriter(out, defaultColor, forceColors)
 			if timestamps {
 				l := logrus.New()
 				l.SetOutput(out)

--- a/cmd/skaffold/skaffold.go
+++ b/cmd/skaffold/skaffold.go
@@ -41,7 +41,7 @@ func main() {
 			// As we allow some color setup using CLI flags for the main run, we can't run SetupColors()
 			// for the entire skaffold run here. It's possible SetupColors() was never called, so call it again
 			// before we print an error to get the right coloring.
-			errOut := output.SetupColors(os.Stderr, output.DefaultColorCode, false)
+			errOut := output.SetupOutput(os.Stderr, output.DefaultColorCode, false)
 			output.Red.Fprintln(errOut, err)
 			code = exitCode(err)
 		}

--- a/cmd/skaffold/skaffold.go
+++ b/cmd/skaffold/skaffold.go
@@ -41,7 +41,7 @@ func main() {
 			// As we allow some color setup using CLI flags for the main run, we can't run SetupColors()
 			// for the entire skaffold run here. It's possible SetupColors() was never called, so call it again
 			// before we print an error to get the right coloring.
-			errOut := output.SetupOutput(os.Stderr, output.DefaultColorCode, false)
+			errOut := output.GetWriter(os.Stderr, output.DefaultColorCode, false)
 			output.Red.Fprintln(errOut, err)
 			code = exitCode(err)
 		}

--- a/pkg/skaffold/build/buildpacks/lifecycle.go
+++ b/pkg/skaffold/build/buildpacks/lifecycle.go
@@ -91,7 +91,7 @@ func (b *Builder) build(ctx context.Context, out io.Writer, a *latestV1.Artifact
 
 	builderImage, runImage, pullPolicy := resolveDependencyImages(artifact, b.artifacts, a.Dependencies, b.pushImages)
 
-	if err := runPackBuildFunc(ctx, output.GetWriter(out), b.localDocker, pack.BuildOptions{
+	if err := runPackBuildFunc(ctx, output.GetUnderlyingWriter(out), b.localDocker, pack.BuildOptions{
 		AppPath:      workspace,
 		Builder:      builderImage,
 		RunImage:     runImage,

--- a/pkg/skaffold/build/docker/docker.go
+++ b/pkg/skaffold/build/docker/docker.go
@@ -48,7 +48,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, a *latestV1.Artifact
 	var imageID string
 
 	if b.useCLI || b.useBuildKit {
-		imageID, err = b.dockerCLIBuild(ctx, output.GetWriter(out), a.Workspace, dockerfile, a.ArtifactType.DockerArtifact, opts)
+		imageID, err = b.dockerCLIBuild(ctx, output.GetUnderlyingWriter(out), a.Workspace, dockerfile, a.ArtifactType.DockerArtifact, opts)
 	} else {
 		imageID, err = b.localDocker.Build(ctx, out, a.Workspace, a.ImageName, a.ArtifactType.DockerArtifact, opts)
 	}

--- a/pkg/skaffold/build/result.go
+++ b/pkg/skaffold/build/result.go
@@ -63,7 +63,7 @@ func (l *logAggregatorImpl) GetWriter() (io.Writer, func(), error) {
 
 	writer := io.Writer(w)
 	if output.IsColorable(l.out) {
-		writer = output.NewWriter(writer)
+		writer = output.NewColorWriter(writer)
 	}
 	ch := make(chan string, buffSize)
 	l.messages <- ch

--- a/pkg/skaffold/output/color.go
+++ b/pkg/skaffold/output/color.go
@@ -144,7 +144,7 @@ func IsColorable(out io.Writer) bool {
 	switch w := out.(type) {
 	case colorableWriter:
 		return true
-	case SkaffoldWriter:
+	case skaffoldWriter:
 		return IsColorable(w.MainWriter)
 	default:
 		return false

--- a/pkg/skaffold/output/color.go
+++ b/pkg/skaffold/output/color.go
@@ -19,7 +19,6 @@ package output
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	colors "github.com/heroku/color"
@@ -71,7 +70,7 @@ func SetupColors(out io.Writer, defaultColor int, forceColors bool) io.Writer {
 	}[defaultColor]
 
 	if useColors {
-		return NewWriter(out)
+		return NewColorWriter(out)
 	}
 	return out
 }
@@ -137,32 +136,17 @@ func (c Color) Fprintf(out io.Writer, format string, a ...interface{}) {
 	fmt.Fprint(out, c.color.Sprintf(format, a...))
 }
 
-func NewWriter(out io.Writer) io.Writer {
+func NewColorWriter(out io.Writer) io.Writer {
 	return colorableWriter{out}
 }
 
 func IsColorable(out io.Writer) bool {
-	switch out.(type) {
+	switch w := out.(type) {
 	case colorableWriter:
 		return true
+	case SkaffoldWriter:
+		return IsColorable(w.MainWriter)
 	default:
 		return false
 	}
-}
-
-func IsStdout(out io.Writer) bool {
-	o, ok := out.(colorableWriter)
-	if ok {
-		return o.Writer == os.Stdout
-	}
-	return out == os.Stdout
-}
-
-// GetWriter returns the underlying writer if out is a colorableWriter
-func GetWriter(out io.Writer) io.Writer {
-	o, ok := out.(colorableWriter)
-	if ok {
-		return o.Writer
-	}
-	return out
 }

--- a/pkg/skaffold/output/color_test.go
+++ b/pkg/skaffold/output/color_test.go
@@ -18,11 +18,7 @@ package output
 
 import (
 	"bytes"
-	"io"
-	"os"
 	"testing"
-
-	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func compareText(t *testing.T, expected, actual string) {
@@ -92,60 +88,4 @@ func TestFprintlnChangeDefaultToUnknown(t *testing.T) {
 	cw := SetupColors(&b, -1, true)
 	Default.Fprintln(cw, "2", "less", "chars!")
 	compareText(t, "2 less chars!\n", b.String())
-}
-
-func TestIsStdOut(t *testing.T) {
-	tests := []struct {
-		description string
-		out         io.Writer
-		expected    bool
-	}{
-		{
-			description: "std out passed",
-			out:         os.Stdout,
-			expected:    true,
-		},
-		{
-			description: "out nil",
-			out:         nil,
-		},
-		{
-			description: "out bytes buffer",
-			out:         new(bytes.Buffer),
-		},
-		{
-			description: "colorable std out passed",
-			out:         NewWriter(os.Stdout),
-			expected:    true,
-		},
-	}
-	for _, test := range tests {
-		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.CheckDeepEqual(test.expected, IsStdout(test.out))
-		})
-	}
-}
-
-func TestGetWriter(t *testing.T) {
-	tests := []struct {
-		description string
-		out         io.Writer
-		expected    io.Writer
-	}{
-		{
-			description: "colorable os.Stdout returns os.Stdout",
-			out:         colorableWriter{os.Stdout},
-			expected:    os.Stdout,
-		},
-		{
-			description: "GetWriter returns original writer if not colorable",
-			out:         os.Stdout,
-			expected:    os.Stdout,
-		},
-	}
-	for _, test := range tests {
-		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.CheckDeepEqual(true, test.expected == GetWriter(test.out))
-		})
-	}
 }

--- a/pkg/skaffold/output/output.go
+++ b/pkg/skaffold/output/output.go
@@ -18,6 +18,7 @@ package output
 
 import (
 	"io"
+	"io/ioutil"
 	"os"
 )
 
@@ -44,7 +45,7 @@ func SetupOutput(out io.Writer, defaultColor int, forceColors bool) io.Writer {
 	return SkaffoldWriter{
 		MainWriter: SetupColors(out, defaultColor, forceColors),
 		// TODO(marlongamez): Replace this once event writer is implemented
-		EventWriter: io.Discard,
+		EventWriter: ioutil.Discard,
 	}
 }
 

--- a/pkg/skaffold/output/output.go
+++ b/pkg/skaffold/output/output.go
@@ -42,6 +42,10 @@ func (s skaffoldWriter) Write(p []byte) (int, error) {
 }
 
 func GetWriter(out io.Writer, defaultColor int, forceColors bool) io.Writer {
+	if _, isSW := out.(skaffoldWriter); isSW {
+		return out
+	}
+
 	return skaffoldWriter{
 		MainWriter: SetupColors(out, defaultColor, forceColors),
 		// TODO(marlongamez): Replace this once event writer is implemented

--- a/pkg/skaffold/output/output.go
+++ b/pkg/skaffold/output/output.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"io"
+	"os"
+)
+
+type SkaffoldWriter struct {
+	MainWriter  io.Writer
+	EventWriter io.Writer
+}
+
+func (s SkaffoldWriter) Write(p []byte) (int, error) {
+	for _, w := range []io.Writer{s.MainWriter, s.EventWriter} {
+		n, err := w.Write(p)
+		if err != nil {
+			return n, err
+		}
+		if n < len(p) {
+			return n, io.ErrShortWrite
+		}
+	}
+
+	return len(p), nil
+}
+
+func SetupOutput(out io.Writer, defaultColor int, forceColors bool) io.Writer {
+	return SkaffoldWriter{
+		MainWriter: SetupColors(out, defaultColor, forceColors),
+		// TODO(marlongamez): Replace this once event writer is implemented
+		EventWriter: io.Discard,
+	}
+}
+
+func IsStdout(out io.Writer) bool {
+	sw, isSW := out.(SkaffoldWriter)
+	if isSW {
+		cw, isCW := sw.MainWriter.(colorableWriter)
+		if isCW {
+			return cw.Writer == os.Stdout
+		}
+		return sw.MainWriter == os.Stdout
+	}
+	return out == os.Stdout
+}
+
+// GetWriter returns the underlying writer if out is a colorableWriter
+func GetWriter(out io.Writer) io.Writer {
+	sw, isSW := out.(SkaffoldWriter)
+	if isSW {
+		cw, isCW := sw.MainWriter.(colorableWriter)
+		if isCW {
+			return cw.Writer
+		}
+		return sw.MainWriter
+	}
+	return out
+}

--- a/pkg/skaffold/output/output.go
+++ b/pkg/skaffold/output/output.go
@@ -22,12 +22,12 @@ import (
 	"os"
 )
 
-type SkaffoldWriter struct {
+type skaffoldWriter struct {
 	MainWriter  io.Writer
 	EventWriter io.Writer
 }
 
-func (s SkaffoldWriter) Write(p []byte) (int, error) {
+func (s skaffoldWriter) Write(p []byte) (int, error) {
 	n, err := s.MainWriter.Write(p)
 	if err != nil {
 		return n, err
@@ -41,8 +41,8 @@ func (s SkaffoldWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
-func SetupOutput(out io.Writer, defaultColor int, forceColors bool) io.Writer {
-	return SkaffoldWriter{
+func GetWriter(out io.Writer, defaultColor int, forceColors bool) io.Writer {
+	return skaffoldWriter{
 		MainWriter: SetupColors(out, defaultColor, forceColors),
 		// TODO(marlongamez): Replace this once event writer is implemented
 		EventWriter: ioutil.Discard,
@@ -50,7 +50,7 @@ func SetupOutput(out io.Writer, defaultColor int, forceColors bool) io.Writer {
 }
 
 func IsStdout(out io.Writer) bool {
-	sw, isSW := out.(SkaffoldWriter)
+	sw, isSW := out.(skaffoldWriter)
 	if isSW {
 		out = sw.MainWriter
 	}
@@ -61,9 +61,9 @@ func IsStdout(out io.Writer) bool {
 	return out == os.Stdout
 }
 
-// GetWriter returns the underlying writer if out is a colorableWriter
-func GetWriter(out io.Writer) io.Writer {
-	sw, isSW := out.(SkaffoldWriter)
+// GetUnderlyingWriter returns the underlying writer if out is a colorableWriter
+func GetUnderlyingWriter(out io.Writer) io.Writer {
+	sw, isSW := out.(skaffoldWriter)
 	if isSW {
 		out = sw.MainWriter
 	}

--- a/pkg/skaffold/output/output_test.go
+++ b/pkg/skaffold/output/output_test.go
@@ -19,6 +19,7 @@ package output
 import (
 	"bytes"
 	"io"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -51,6 +52,18 @@ func TestIsStdOut(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			description: "colorableWriter passed",
+			out:         NewColorWriter(os.Stdout),
+			expected:    true,
+		},
+		{
+			description: "invalid colorableWriter passed",
+			out: SkaffoldWriter{
+				MainWriter: NewColorWriter(ioutil.Discard),
+			},
+			expected: false,
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
@@ -71,6 +84,25 @@ func TestGetWriter(t *testing.T) {
 				MainWriter: colorableWriter{os.Stdout},
 			},
 			expected: os.Stdout,
+		},
+		{
+			description: "skaffold writer returns os.Stdout without colorableWriter",
+			out: SkaffoldWriter{
+				MainWriter: os.Stdout,
+			},
+			expected: os.Stdout,
+		},
+		{
+			description: "return ioutil.Discard from SkaffoldWriter",
+			out: SkaffoldWriter{
+				MainWriter: NewColorWriter(ioutil.Discard),
+			},
+			expected: ioutil.Discard,
+		},
+		{
+			description: "os.Stdout returned from colorableWriter",
+			out:         NewColorWriter(os.Stdout),
+			expected:    os.Stdout,
 		},
 		{
 			description: "GetWriter returns original writer if not colorable",

--- a/pkg/skaffold/output/output_test.go
+++ b/pkg/skaffold/output/output_test.go
@@ -47,7 +47,7 @@ func TestIsStdOut(t *testing.T) {
 		},
 		{
 			description: "colorable std out passed",
-			out: SkaffoldWriter{
+			out: skaffoldWriter{
 				MainWriter: NewColorWriter(os.Stdout),
 			},
 			expected: true,
@@ -59,7 +59,7 @@ func TestIsStdOut(t *testing.T) {
 		},
 		{
 			description: "invalid colorableWriter passed",
-			out: SkaffoldWriter{
+			out: skaffoldWriter{
 				MainWriter: NewColorWriter(ioutil.Discard),
 			},
 			expected: false,
@@ -72,7 +72,7 @@ func TestIsStdOut(t *testing.T) {
 	}
 }
 
-func TestGetWriter(t *testing.T) {
+func TestGetUnderlyingWriter(t *testing.T) {
 	tests := []struct {
 		description string
 		out         io.Writer
@@ -80,21 +80,21 @@ func TestGetWriter(t *testing.T) {
 	}{
 		{
 			description: "colorable os.Stdout returns os.Stdout",
-			out: SkaffoldWriter{
+			out: skaffoldWriter{
 				MainWriter: colorableWriter{os.Stdout},
 			},
 			expected: os.Stdout,
 		},
 		{
 			description: "skaffold writer returns os.Stdout without colorableWriter",
-			out: SkaffoldWriter{
+			out: skaffoldWriter{
 				MainWriter: os.Stdout,
 			},
 			expected: os.Stdout,
 		},
 		{
-			description: "return ioutil.Discard from SkaffoldWriter",
-			out: SkaffoldWriter{
+			description: "return ioutil.Discard from skaffoldWriter",
+			out: skaffoldWriter{
 				MainWriter: NewColorWriter(ioutil.Discard),
 			},
 			expected: ioutil.Discard,
@@ -112,7 +112,7 @@ func TestGetWriter(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.CheckDeepEqual(true, test.expected == GetWriter(test.out))
+			t.CheckDeepEqual(true, test.expected == GetUnderlyingWriter(test.out))
 		})
 	}
 }

--- a/pkg/skaffold/output/output_test.go
+++ b/pkg/skaffold/output/output_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestIsStdOut(t *testing.T) {
+	tests := []struct {
+		description string
+		out         io.Writer
+		expected    bool
+	}{
+		{
+			description: "std out passed",
+			out:         os.Stdout,
+			expected:    true,
+		},
+		{
+			description: "out nil",
+			out:         nil,
+		},
+		{
+			description: "out bytes buffer",
+			out:         new(bytes.Buffer),
+		},
+		{
+			description: "colorable std out passed",
+			out: SkaffoldWriter{
+				MainWriter: NewColorWriter(os.Stdout),
+			},
+			expected: true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expected, IsStdout(test.out))
+		})
+	}
+}
+
+func TestGetWriter(t *testing.T) {
+	tests := []struct {
+		description string
+		out         io.Writer
+		expected    io.Writer
+	}{
+		{
+			description: "colorable os.Stdout returns os.Stdout",
+			out: SkaffoldWriter{
+				MainWriter: colorableWriter{os.Stdout},
+			},
+			expected: os.Stdout,
+		},
+		{
+			description: "GetWriter returns original writer if not colorable",
+			out:         os.Stdout,
+			expected:    os.Stdout,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(true, test.expected == GetWriter(test.out))
+		})
+	}
+}


### PR DESCRIPTION
**Related**: #5370 

**Description**
Introduces a new type, `SkaffoldWriter`. This replaces `colorableWriter` as the top level `io.Writer` type used by skaffold. It holds one main writer, which will most commonly be a `colorableWriter`, and a secondary writer, which will be used to write output out as events through skaffold API V2. The case for using this over `io.MultiWriter` is that this will allow us to implement functions that perform manipulations on the underlying writers that will be necessary for future implementation of API V2.

**Follow-up Work (remove if N/A)**
Implement event writer type and use in this struct.
