### PR TITLE
Fix `skaffold diagnose` to work when skaffold.yaml is outside of source root dir

### DIFF
--- a/integration/diagnose_test.go
+++ b/integration/diagnose_test.go
@@ -101,11 +101,10 @@ func TestMultiConfigDiagnose(t *testing.T) {
 				tmpDir.Write("skaffold.yaml", string(configContents))
 				args = append(args, fmt.Sprintf("-f=%s", tmpDir.Path("skaffold.yaml")))
 			}
-			out := skaffold.Diagnose(append(args, "--yaml-only")...).
-				InDir(test.dir).RunOrFailOutput(t.T)
+			out := skaffold.Diagnose(append(args, "--yaml-only")...).InDir(test.dir).RunOrFailOutput(t.T)
 			templ, err := ioutil.ReadFile(filepath.Join(test.dir, "diagnose.tmpl"))
-			outTemplate := template.Must(template.New("tmpl").Parse(string(templ)))
 			t.CheckNoError(err)
+			outTemplate := template.Must(template.New("tmpl").Parse(string(templ)))
 			cwd, err := filepath.Abs(test.dir)
 			t.CheckNoError(err)
 			expected := &bytes.Buffer{}

--- a/integration/testdata/diagnose/multi-config/diagnose.tmpl
+++ b/integration/testdata/diagnose/multi-config/diagnose.tmpl
@@ -5,7 +5,7 @@ metadata:
 build:
   artifacts:
   - image: app2
-    context: /foo
+    context: {{.Root}}/foo2
     docker:
       dockerfile: Dockerfile
   tagPolicy:
@@ -26,7 +26,7 @@ metadata:
 build:
   artifacts:
   - image: app3
-    context: /foo
+    context: {{.Root}}/foo3
     docker:
       dockerfile: Dockerfile
   tagPolicy:
@@ -45,7 +45,7 @@ kind: Config
 build:
   artifacts:
   - image: app1
-    context: /foo
+    context: {{.Root}}/foo
     docker:
       dockerfile: Dockerfile
   tagPolicy:

--- a/integration/testdata/diagnose/multi-config/skaffold.yaml
+++ b/integration/testdata/diagnose/multi-config/skaffold.yaml
@@ -6,7 +6,7 @@ requires:
 build:
   artifacts:
   - image: app1
-    context: /foo
+    context: foo
 deploy:
   kubectl:
     manifests:

--- a/integration/testdata/diagnose/multi-config/skaffold3.yaml
+++ b/integration/testdata/diagnose/multi-config/skaffold3.yaml
@@ -5,7 +5,7 @@ metadata:
 build:
   artifacts:
   - image: app3
-    context: /foo
+    context: foo3
 deploy:
   kubectl:
     manifests:

--- a/integration/testdata/diagnose/temp-config/diagnose.tmpl
+++ b/integration/testdata/diagnose/temp-config/diagnose.tmpl
@@ -1,0 +1,18 @@
+apiVersion: skaffold/v2beta16
+kind: Config
+build:
+  artifacts:
+  - image: skaffold-example
+    context: {{.Root}}
+    docker:
+      dockerfile: Dockerfile
+  tagPolicy:
+    gitCommit: {}
+  local:
+    concurrency: 1
+deploy:
+  kubectl:
+    manifests:
+    - {{.Root}}/k8s-*
+  logs:
+    prefix: container

--- a/integration/testdata/diagnose/temp-config/skaffold.yaml
+++ b/integration/testdata/diagnose/temp-config/skaffold.yaml
@@ -1,12 +1,9 @@
 apiVersion: skaffold/v2beta16
 kind: Config
-metadata:
-  name: cfg2
 build:
   artifacts:
-  - image: app2
-    context: foo2
+  - image: skaffold-example
 deploy:
   kubectl:
     manifests:
-    - /k8s/*
+    - k8s-*

--- a/pkg/skaffold/parser/config.go
+++ b/pkg/skaffold/parser/config.go
@@ -351,9 +351,9 @@ func isMakePathsAbsoluteSet(opts config.SkaffoldOptions) bool {
 
 func getBase(cfgOpts configOpts) (string, error) {
 	if cfgOpts.isDependency {
-		logrus.Tracef("returning %q as base for absolute path substitution for dependent skaffold config %s", filepath.Dir(cfgOpts.file), cfgOpts.file)
+		logrus.Tracef("found %s base dir for absolute path substitution within skaffold config %s", filepath.Dir(cfgOpts.file), cfgOpts.file)
 		return filepath.Dir(cfgOpts.file), nil
 	}
-	logrus.Tracef("returning current work dir as base for absolute path substitution for top-level skaffold config %s", cfgOpts.file)
+	logrus.Tracef("found cwd as base for absolute path substitution within skaffold config %s", cfgOpts.file)
 	return util.RealWorkDir()
 }

--- a/pkg/skaffold/tags/paths.go
+++ b/pkg/skaffold/tags/paths.go
@@ -62,7 +62,7 @@ func makeFilePathsAbsolute(config interface{}, base string) []error {
 						continue
 					}
 					v.SetString(filepath.Join(base, path))
-					logrus.Tracef("setting absolute path for config field %q", f.Name)
+					logrus.Tracef("setting absolute path %q for config field %q", filepath.Join(base, path), f.Name)
 				case []string:
 					for j := 0; j < v.Len(); j++ {
 						elem := v.Index(j)


### PR DESCRIPTION
Fixes #5898 

Added integration tests. 

There are 40 unit tests for the current logic which cover all scenarios when skaffold.yaml is root of the source code.
 