### PR TITLE
Improve documentation of docker buildArgs (#5871)

### DIFF
--- a/docs/content/en/schemas/v2beta16.json
+++ b/docs/content/en/schemas/v2beta16.json
@@ -1111,7 +1111,7 @@
           "x-intellij-html-description": "arguments passed to the docker build.",
           "default": "{}",
           "examples": [
-            "{\"key1\": \"value1\", \"key2\": \"value2\"}"
+            "{\"key1\": \"value1\", \"key2\": \"{{ .ENV_VAR }}\"}"
           ]
         },
         "cacheFrom": {

--- a/pkg/skaffold/build/gcb/docker.go
+++ b/pkg/skaffold/build/gcb/docker.go
@@ -68,7 +68,6 @@ func (b *Builder) dockerBuildArgs(a *latestV1.Artifact, tag string, deps []*late
 		return nil, errors.New("docker build options, secrets and ssh, are not currently supported in GCB builds")
 	}
 	requiredImages := docker.ResolveDependencyImages(deps, b.artifactStore, true)
-
 	buildArgs, err := docker.EvalBuildArgs(b.cfg.Mode(), a.Workspace, d.DockerfilePath, d.BuildArgs, requiredImages)
 	if err != nil {
 		return nil, fmt.Errorf("unable to evaluate build args: %w", err)

--- a/pkg/skaffold/build/gcb/docker.go
+++ b/pkg/skaffold/build/gcb/docker.go
@@ -68,6 +68,7 @@ func (b *Builder) dockerBuildArgs(a *latestV1.Artifact, tag string, deps []*late
 		return nil, errors.New("docker build options, secrets and ssh, are not currently supported in GCB builds")
 	}
 	requiredImages := docker.ResolveDependencyImages(deps, b.artifactStore, true)
+
 	buildArgs, err := docker.EvalBuildArgs(b.cfg.Mode(), a.Workspace, d.DockerfilePath, d.BuildArgs, requiredImages)
 	if err != nil {
 		return nil, fmt.Errorf("unable to evaluate build args: %w", err)

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -1205,7 +1205,7 @@ type DockerArtifact struct {
 	Target string `yaml:"target,omitempty"`
 
 	// BuildArgs are arguments passed to the docker build.
-	// For example: `{"key1": "value1", "key2": "value2"}`.
+	// For example: `{"key1": "value1", "key2": "{{ .ENV_VAR }}"}`.
 	BuildArgs map[string]*string `yaml:"buildArgs,omitempty"`
 
 	// NetworkMode is passed through to docker and overrides the


### PR DESCRIPTION
- Fixes documentation issue where yaml syntax was not described and templating not mentioned.
- Adds a unit test to verify that docker buildArgs support golang templating from the environment.

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5871 <!-- tracking issues that this PR will close -->
**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR replaces PR-5884, which took a meandering path to get to the results you see here.

PR includes:

- A doc change for docker buildArgs showing YAML syntax for their use, and reminding users that the feature supports templating from the environment.
- A unit test to verify that this actually works.

**User facing changes (remove if N/A)**
Only a change in documentation. 

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
Change to [pkg/skaffold/docker/build_args_test.go](./pkg/skaffold/docker/build_args_test.go) to exercise the templating code.