### PR TITLE
Allow caching from previously built artifacts on GCB

### DIFF
--- a/docs/content/en/docs/pipeline-stages/builders/docker.md
+++ b/docs/content/en/docs/pipeline-stages/builders/docker.md
@@ -121,6 +121,10 @@ The following options can optionally be configured:
 
 {{< schema root="GoogleCloudBuild" >}}
 
+The `googleCloudBuild` builder replaces cache references to the
+artifact image with the tagged image to allow caching from the
+previously built image.
+
 **Example**
 
 The following `build` section, instructs Skaffold to build a

--- a/docs/content/en/samples/builders/gcb.yaml
+++ b/docs/content/en/samples/builders/gcb.yaml
@@ -1,5 +1,10 @@
 build:
   artifacts:
   - image: gcr.io/k8s-skaffold/example
+    docker:
+      cacheFrom:
+      # googleCloudBuild replaces cache references to the artifact image with
+      # the tagged image reference, useful for caching from the previous build.
+      - gcr.io/k8s-skaffold/example
   googleCloudBuild:
     projectId: YOUR-GCP-PROJECT

--- a/pkg/skaffold/build/gcb/docker_test.go
+++ b/pkg/skaffold/build/gcb/docker_test.go
@@ -163,36 +163,71 @@ func TestDockerBuildSpec(t *testing.T) {
 }
 
 func TestPullCacheFrom(t *testing.T) {
-	testutil.Run(t, "TestPullCacheFrom", func(t *testutil.T) {
-		t.Override(&docker.EvalBuildArgs, func(_ config.RunMode, _ string, _ string, args map[string]*string, _ map[string]*string) (map[string]*string, error) {
-			return args, nil
-		})
-		artifact := &latestV1.Artifact{
-			ArtifactType: latestV1.ArtifactType{
-				DockerArtifact: &latestV1.DockerArtifact{
-					DockerfilePath: "Dockerfile",
-					CacheFrom:      []string{"from/image1", "from/image2"},
+	tests := []struct {
+		description string
+		artifact    *latestV1.Artifact
+		tag string
+		expected    []*cloudbuild.BuildStep
+		shouldErr   bool
+	}{
+		{
+			description: "multiple cache-from images",
+			artifact: &latestV1.Artifact{
+				ArtifactType: latestV1.ArtifactType{
+					DockerArtifact: &latestV1.DockerArtifact{
+						DockerfilePath: "Dockerfile",
+						CacheFrom:      []string{"from/image1", "from/image2"},
+					},
 				},
 			},
-		}
-		builder := NewBuilder(&mockBuilderContext{}, &latestV1.GoogleCloudBuild{
-			DockerImage: "docker/docker",
+			tag: "nginx2",
+			expected: []*cloudbuild.BuildStep{{
+				Name:       "docker/docker",
+				Entrypoint: "sh",
+				Args:       []string{"-c", "docker pull from/image1 || true"},
+			}, {
+				Name:       "docker/docker",
+				Entrypoint: "sh",
+				Args:       []string{"-c", "docker pull from/image2 || true"},
+			}, {
+				Name: "docker/docker",
+				Args: []string{"build", "--tag", "nginx2", "-f", "Dockerfile", "--cache-from", "from/image1", "--cache-from", "from/image2", "."},
+			}},
+		},
+		{
+			description: "cache-from self uses tagged image",
+			artifact: &latestV1.Artifact{
+				ImageName: "gcr.io/k8s-skaffold/test",
+				ArtifactType: latestV1.ArtifactType{
+					DockerArtifact: &latestV1.DockerArtifact{
+						DockerfilePath: "Dockerfile",
+						CacheFrom:      []string{"gcr.io/k8s-skaffold/test"},
+					},
+				},
+			},
+			tag: "gcr.io/k8s-skaffold/test:tagged",
+			expected: []*cloudbuild.BuildStep{{
+				Name:       "docker/docker",
+				Entrypoint: "sh",
+				Args:       []string{"-c", "docker pull gcr.io/k8s-skaffold/test:tagged || true"},
+			}, {
+				Name: "docker/docker",
+				Args: []string{"build", "--tag", "gcr.io/k8s-skaffold/test:tagged", "-f", "Dockerfile", "--cache-from", "gcr.io/k8s-skaffold/test:tagged", "."},
+			}},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&docker.EvalBuildArgs, func(_ config.RunMode, _ string, _ string, args map[string]*string, _ map[string]*string) (map[string]*string, error) {
+				return args, nil
+			})
+			builder := NewBuilder(&mockBuilderContext{}, &latestV1.GoogleCloudBuild{
+				DockerImage: "docker/docker",
+			})
+			desc, err := builder.dockerBuildSpec(test.artifact, test.tag)
+
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, desc.Steps)
 		})
-		desc, err := builder.dockerBuildSpec(artifact, "nginx2")
-
-		expected := []*cloudbuild.BuildStep{{
-			Name:       "docker/docker",
-			Entrypoint: "sh",
-			Args:       []string{"-c", "docker pull from/image1 || true"},
-		}, {
-			Name:       "docker/docker",
-			Entrypoint: "sh",
-			Args:       []string{"-c", "docker pull from/image2 || true"},
-		}, {
-			Name: "docker/docker",
-			Args: []string{"build", "--tag", "nginx2", "-f", "Dockerfile", "--cache-from", "from/image1", "--cache-from", "from/image2", "."},
-		}}
-
-		t.CheckErrorAndDeepEqual(false, err, expected, desc.Steps)
-	})
+	}
 }


### PR DESCRIPTION
Fixes #5879

**Description**
Cause GCB Docker `cacheFrom` references to the artifact image (which is untagged) to be replaced with the tagged image (possibly affected by the default-repo).

For example:
```
build:
  googleCloudBuild:
    projectId: k8s-skaffold
  artifacts:
  - image: skaffold-example
    docker:
      cacheFrom:
      - skaffold-example
      - gcr.io/k8s-skaffold/skaffold-example:latest # used if the tagged image is not found
```

Allow disabling by setting `SKAFFOLD_DISABLE_GCB_CACHE_ADJUSTMENT` in the environment.

Note: Docker image caching is a bit complex, and this [StackOverflow answer](https://stackoverflow.com/q/54574821/600339) provides helpful details.

**User facing changes (remove if N/A)**
- Docker builds on GoogleCloudBuild can cache from the previous build by including the artifact `image` in the `cacheFrom`.

cc: @dhodun 