### PR TITLE
Always create a secret during release

### DIFF
--- a/deploy/setup-secret.sh
+++ b/deploy/setup-secret.sh
@@ -28,25 +28,14 @@ while getopts "p:" opt; do
 esac
 done
 
-VALID_KEYS=$(gcloud iam service-accounts keys list --iam-account=metrics-writer@${PROJECT_ID}.iam.gserviceaccount.com --project=${PROJECT_ID} --managed-by=user --filter="validBeforeTime.date('%Y-%m-%d', Z)>`date +%F`" --format="value(name)")
+
+# create a new valid key
+gcloud iam service-accounts keys create ${KEY_FILE} --iam-account=metrics-writer@${PROJECT_ID}.iam.gserviceaccount.com --project=${PROJECT_ID}
 retVal=$?
 if [ $retVal -ne 0 ]; then
-    echo "No permissions to list keys."
-    exit 1
+  echo "No key created."
+  exit 1
 fi
-
-if [ -z "$VALID_KEYS" ]; then
-    # create a new valid key
-    gcloud iam service-accounts keys create ${KEY_FILE} --iam-account=metrics-writer@${PROJECT_ID}.iam.gserviceaccount.com --project=${PROJECT_ID}
-    retVal=$?
-    if [ $retVal -ne 0 ]; then
-      echo "No key created."
-      exit 1
-    fi
-    KEY_ID=$(gcloud iam service-accounts keys list --iam-account=metrics-writer@${PROJECT_ID}.iam.gserviceaccount.com --project=${PROJECT_ID} --managed-by=user --filter="validBeforeTime.date('%Y-%m-%d', Z)>`date +%F`" --format="value(name)")
-    gsutil cp ${KEY_FILE} gs://${BUCKET_ID}/${KEY_ID}.json
-    gsutil cp ${KEY_FILE} gs://${BUCKET_ID}/${LATEST_GCS_PATH}
-else
-    # download the valid key from gcs
-    gsutil cp gs://${BUCKET_ID}/${LATEST_GCS_PATH} ${KEY_FILE}
-fi
+KEY_ID=$(gcloud iam service-accounts keys list --iam-account=metrics-writer@k8s-skaffold.iam.gserviceaccount.com --project=k8s-skaffold --managed-by=user --filter="validAfterTime.date('%Y-%m-%d', Z) = `date +%F`" --format="value(name)")
+gsutil cp ${KEY_FILE} gs://${BUCKET_ID}/${KEY_ID}.json
+gsutil cp ${KEY_FILE} gs://${BUCKET_ID}/${LATEST_GCS_PATH}

--- a/deploy/setup-secret.sh
+++ b/deploy/setup-secret.sh
@@ -36,6 +36,6 @@ if [ $retVal -ne 0 ]; then
   echo "No key created."
   exit 1
 fi
-KEY_ID=$(gcloud iam service-accounts keys list --iam-account=metrics-writer@k8s-skaffold.iam.gserviceaccount.com --project=k8s-skaffold --managed-by=user --filter="validAfterTime.date('%Y-%m-%d', Z) = `date +%F`" --format="value(name)")
+KEY_ID=$(gcloud iam service-accounts keys list --iam-account=metrics-writer@k8s-skaffold.iam.gserviceaccount.com --project=k8s-skaffold --managed-by=user --filter="validAfterTime.date('%Y-%m-%d', Z) = `date +%F`" --format="value(name)" --limit=1)
 gsutil cp ${KEY_FILE} gs://${BUCKET_ID}/${KEY_ID}.json
 gsutil cp ${KEY_FILE} gs://${BUCKET_ID}/${LATEST_GCS_PATH}


### PR DESCRIPTION
Change the flow to always create a secret until we figure out project permissions

I could not find a way to get the `KeyId` during creation
```
gcloud iam service-accounts keys create key.ky --iam-account=metrics-writer@k8s-skaffold.iam.gserviceaccount.com --project=k8s-skaffold --format=json
created key [faf54d349c7d164cd807147a3fca4ece37ff25d1] of type [json] as [key.ky] for [metrics-writer@k8s-skaffold.iam.gserviceaccount.com]
[]
```

The json returned is empty. 

Hence using the `validAfterTime` as creationTime to fetch the keyid of the keyid of the key we just crated.

Using `limit=1` to make sure only key is returned in case we do multiple releases on the same day.  
```
gcloud iam service-accounts keys list --iam-account=metrics-writer@k8s-skaffold.iam.gserviceaccount.com --project=k8s-skaffold --managed-by=user --filter="validAfterTime.date('%Y-%m-%d', Z) = `date +%F`" --format="value(name)" --limit=1   
f7914fe6a46760071076e07bf7dc558590c9c169


```