### PR TITLE
Container Structure Test page should use `skaffold test`

### DIFF
--- a/docs/content/en/docs/pipeline-stages/testers/structure.md
+++ b/docs/content/en/docs/pipeline-stages/testers/structure.md
@@ -34,4 +34,4 @@ In order to restrict the executed structure tests, a `profile` section can overr
 
 {{% readfile file="samples/testers/structure/testProfile.yaml" %}}
 
-To execute the tests once, run `skaffold build --profile quickcheck`.
+To execute the tests once, run `skaffold test --profile quickcheck`.


### PR DESCRIPTION
Merge after: #5912

**Description**

@tete17 [pointed out](https://github.com/GoogleContainerTools/skaffold/pull/5190#issuecomment-845132297) that the _Container Structure Test_ page uses `skaffold build` to run tests:

<img width="581" alt="Screen Shot 2021-05-26 at 3 48 05 PM" src="https://user-images.githubusercontent.com/202851/119722252-184cd080-be3a-11eb-8c6c-660597aa3122.png">
