### PR TITLE
Add missing flags to `skaffold test`

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -102,7 +102,7 @@ var flagRegistry = []Flag{
 		Value:         &opts.Profiles,
 		DefValue:      []string{},
 		FlagAddMethod: "StringSliceVar",
-		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "build", "delete", "diagnose", "apply"},
+		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "build", "delete", "diagnose", "apply", "test"},
 	},
 	{
 		Name:          "namespace",
@@ -183,7 +183,7 @@ var flagRegistry = []Flag{
 		Value:         &opts.RPCPort,
 		DefValue:      constants.DefaultRPCPort,
 		FlagAddMethod: "IntVar",
-		DefinedOn:     []string{"dev", "build", "run", "debug", "deploy"},
+		DefinedOn:     []string{"dev", "build", "run", "debug", "deploy", "test"},
 	},
 	{
 		Name:          "rpc-http-port",
@@ -191,7 +191,7 @@ var flagRegistry = []Flag{
 		Value:         &opts.RPCHTTPPort,
 		DefValue:      constants.DefaultRPCHTTPPort,
 		FlagAddMethod: "IntVar",
-		DefinedOn:     []string{"dev", "build", "run", "debug", "deploy"},
+		DefinedOn:     []string{"dev", "build", "run", "debug", "deploy", "test"},
 	},
 	{
 		Name:          "label",
@@ -319,7 +319,7 @@ var flagRegistry = []Flag{
 		Value:         &opts.GlobalConfig,
 		DefValue:      "",
 		FlagAddMethod: "StringVar",
-		DefinedOn:     []string{"run", "dev", "debug", "build", "deploy", "delete", "diagnose", "apply"},
+		DefinedOn:     []string{"run", "dev", "debug", "build", "deploy", "delete", "diagnose", "apply", "test"},
 	},
 	{
 		Name:          "kube-context",
@@ -364,7 +364,7 @@ var flagRegistry = []Flag{
 		Value:         &opts.ProfileAutoActivation,
 		DefValue:      true,
 		FlagAddMethod: "BoolVar",
-		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "build", "delete", "diagnose"},
+		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "build", "delete", "diagnose", "test"},
 		IsEnum:        true,
 	},
 	{
@@ -373,7 +373,7 @@ var flagRegistry = []Flag{
 		Value:         &opts.PropagateProfiles,
 		DefValue:      true,
 		FlagAddMethod: "BoolVar",
-		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "build", "delete", "diagnose"},
+		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "build", "delete", "diagnose", "test"},
 		IsEnum:        true,
 	},
 	{

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -1139,10 +1139,16 @@ Examples:
 
 Options:
   -a, --build-artifacts=: File containing build result from a previous 'skaffold build --file-output'
+  -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
       --enable-rpc=false: Enable gRPC for exposing Skaffold events
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
   -m, --module=[]: Filter Skaffold configs to only the provided named modules
+  -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
+      --profile-auto-activation=true: Set to false to disable profile auto activation
+      --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
+      --rpc-http-port=50052: tcp port to expose event REST API over HTTP
+      --rpc-port=50051: tcp port to expose event API
 
 Usage:
   skaffold test [options]
@@ -1154,10 +1160,16 @@ Use "skaffold options" for a list of global command-line options (applies to all
 Env vars:
 
 * `SKAFFOLD_BUILD_ARTIFACTS` (same as `--build-artifacts`)
+* `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_MODULE` (same as `--module`)
+* `SKAFFOLD_PROFILE` (same as `--profile`)
+* `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
+* `SKAFFOLD_PROPAGATE_PROFILES` (same as `--propagate-profiles`)
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
+* `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
+* `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 
 ### skaffold version
 


### PR DESCRIPTION
Fixes: #5904

**Description**
`skaffold test` is missing some key flags like `--profile` and `--filename`:
```
$ skaffold help test
...
Options:
  -a, --build-artifacts=: File containing build result from a previous 'skaffold build --file-output'
      --enable-rpc=false: Enable gRPC for exposing Skaffold events
  -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
  -m, --module=[]: Filter Skaffold configs to only the provided named modules
      --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
```

We support `--event-log-file` but don't support any RPC-related flags.

This PR adds `--profile`, `--propagate-profiles`, `--profile-auto-activation`, `--rpc-port`, `--rpc-http-port`, `--config`.
It wasn't clear if we should include `--kube-context` or `--kubeconfig`.