### PR TITLE
Ensure tag stripping logic can optionally accept digests

### DIFF
--- a/pkg/skaffold/initializer/build/builders_test.go
+++ b/pkg/skaffold/initializer/build/builders_test.go
@@ -375,7 +375,7 @@ func TestStripImageTags(t *testing.T) {
 			fakeWarner := &warnings.Collect{}
 			t.Override(&warnings.Printf, fakeWarner.Warnf)
 
-			images := tag.StripTags(test.taggedImages)
+			images := tag.StripTags(test.taggedImages, true)
 
 			t.CheckDeepEqual(test.expectedImages, images)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)

--- a/pkg/skaffold/initializer/build/util.go
+++ b/pkg/skaffold/initializer/build/util.go
@@ -24,7 +24,7 @@ import (
 )
 
 func matchBuildersToImages(builders []InitBuilder, images []string) ([]ArtifactInfo, []InitBuilder, []string) {
-	images = tag.StripTags(images)
+	images = tag.StripTags(images, true)
 
 	var artifactInfos []ArtifactInfo
 	var unresolvedImages = make(sortedSet)

--- a/pkg/skaffold/kubernetes/colorpicker.go
+++ b/pkg/skaffold/kubernetes/colorpicker.go
@@ -56,7 +56,7 @@ func NewColorPicker(imageNames []string) ColorPicker {
 	imageColors := make(map[string]output.Color)
 
 	for i, imageName := range imageNames {
-		imageColors[tag.StripTag(imageName)] = colorCodes[i%len(colorCodes)]
+		imageColors[tag.StripTag(imageName, false)] = colorCodes[i%len(colorCodes)]
 	}
 
 	return &colorPicker{
@@ -69,7 +69,7 @@ func NewColorPicker(imageNames []string) ColorPicker {
 // write with no formatting.
 func (p *colorPicker) Pick(pod *v1.Pod) output.Color {
 	for _, container := range pod.Spec.Containers {
-		if c, present := p.imageColors[tag.StripTag(container.Image)]; present {
+		if c, present := p.imageColors[tag.StripTag(container.Image, false)]; present {
 			return c
 		}
 	}

--- a/pkg/skaffold/kubernetes/colorpicker_test.go
+++ b/pkg/skaffold/kubernetes/colorpicker_test.go
@@ -69,6 +69,17 @@ func TestColorPicker(t *testing.T) {
 			},
 			expectedColor: colorCodes[1],
 		},
+		{
+			description: "accept image with digest",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Image: "second:tag@sha256:d3f4dd1541ee34b96850efc46955bada1a415b0594dc9948607c0197d2d16749"},
+					},
+				},
+			},
+			expectedColor: colorCodes[1],
+		},
 	}
 
 	picker := NewColorPicker([]string{"image:ignored", "second"})

--- a/pkg/skaffold/kubernetes/logger/log.go
+++ b/pkg/skaffold/kubernetes/logger/log.go
@@ -186,7 +186,7 @@ func (a *LogAggregator) prefix(pod *v1.Pod, container v1.ContainerStatus) string
 	var c latestV1.Pipeline
 	var present bool
 	for _, container := range pod.Spec.Containers {
-		if c, present = a.config.PipelineForImage(tag.StripTag(container.Image)); present {
+		if c, present = a.config.PipelineForImage(tag.StripTag(container.Image, false)); present {
 			break
 		}
 	}

--- a/pkg/skaffold/tag/util.go
+++ b/pkg/skaffold/tag/util.go
@@ -21,11 +21,11 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
 
-func StripTags(taggedImages []string) []string {
+func StripTags(taggedImages []string, ignoreDigest bool) []string {
 	// Remove tags from image names
 	var images []string
 	for _, image := range taggedImages {
-		tag := StripTag(image)
+		tag := StripTag(image, ignoreDigest)
 		if tag != "" {
 			images = append(images, tag)
 		}
@@ -33,14 +33,14 @@ func StripTags(taggedImages []string) []string {
 	return images
 }
 
-func StripTag(image string) string {
+func StripTag(image string, ignoreDigest bool) string {
 	parsed, err := docker.ParseReference(image)
 	if err != nil {
 		// It's possible that it's a templatized name that can't be parsed as is.
 		warnings.Printf("Couldn't parse image [%s]: %s", image, err.Error())
 		return ""
 	}
-	if parsed.Digest != "" {
+	if ignoreDigest && parsed.Digest != "" {
 		warnings.Printf("Ignoring image referenced by digest: [%s]", image)
 		return ""
 	}

--- a/pkg/skaffold/tag/util_test.go
+++ b/pkg/skaffold/tag/util_test.go
@@ -27,6 +27,7 @@ func TestStripTags(t *testing.T) {
 		name           string
 		images         []string
 		expectedImages []string
+		ignoreDigest   bool
 	}{
 		{
 			name:           "latest",
@@ -47,6 +48,7 @@ func TestStripTags(t *testing.T) {
 			name:           "ignore digest",
 			images:         []string{"foo:sha256@deadbeef"},
 			expectedImages: nil,
+			ignoreDigest:   true,
 		},
 	}
 
@@ -54,7 +56,7 @@ func TestStripTags(t *testing.T) {
 		testutil.Run(t, test.name, func(t *testutil.T) {
 			t.Parallel()
 
-			i := StripTags(test.images)
+			i := StripTags(test.images, test.ignoreDigest)
 			t.CheckDeepEqual(test.expectedImages, i)
 		})
 	}


### PR DESCRIPTION
In https://github.com/GoogleContainerTools/skaffold/pull/5740, some redundant tag stripping logic was consolidated in to the `pkg/skaffold/tag` package. However, the `StripTags()` method is used in code paths that both do and do not accept images with digests on them, though an error is not thrown in either case (and a warning is issued instead). This caused many warning like 

`WARN[0012] Ignoring image referenced by digest: [gcr.io/nkubala-demo/leeroy-app:v1.24.0-41-g054953092@sha256:42d1b90337916fbedf61f8bd7046d52354e0dc39996538a2dae1fed7dfac44ca]`

to be issued in dev loop runs, and additionally caused issues with color selection for our logs from the `kubernetes.ColorPicker`. This change allows a boolean to be passed to `StripTags()` to enable ignoring the digest in this logic.