### PR TITLE
Fix up missed remote -> remotePath changes

### DIFF
--- a/docs/content/en/schemas/v2beta17.json
+++ b/docs/content/en/schemas/v2beta17.json
@@ -1689,14 +1689,14 @@
         },
         "skipBuildDependencies": {
           "type": "boolean",
-          "description": "should build dependencies be skipped. Ignored when `remote: true`.",
-          "x-intellij-html-description": "should build dependencies be skipped. Ignored when <code>remote: true</code>.",
+          "description": "should build dependencies be skipped. Ignored for `remoteChart`.",
+          "x-intellij-html-description": "should build dependencies be skipped. Ignored for <code>remoteChart</code>.",
           "default": "false"
         },
         "upgradeOnChange": {
           "type": "boolean",
-          "description": "specifies whether to upgrade helm chart on code changes. Default is `true` when helm chart is local (`remote: false`). Default is `false` if `remote: true`.",
-          "x-intellij-html-description": "specifies whether to upgrade helm chart on code changes. Default is <code>true</code> when helm chart is local (<code>remote: false</code>). Default is <code>false</code> if <code>remote: true</code>."
+          "description": "specifies whether to upgrade helm chart on code changes. Default is `true` when helm chart is local (has `chartPath`). Default is `false` when helm chart is remote (has `remoteChart`).",
+          "x-intellij-html-description": "specifies whether to upgrade helm chart on code changes. Default is <code>true</code> when helm chart is local (has <code>chartPath</code>). Default is <code>false</code> when helm chart is remote (has <code>remoteChart</code>)."
         },
         "useHelmSecrets": {
           "type": "boolean",

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -741,7 +741,7 @@ type HelmRelease struct {
 	RecreatePods bool `yaml:"recreatePods,omitempty"`
 
 	// SkipBuildDependencies should build dependencies be skipped.
-	// Ignored when `remote: true`.
+	// Ignored for `remoteChart`.
 	SkipBuildDependencies bool `yaml:"skipBuildDependencies,omitempty"`
 
 	// UseHelmSecrets instructs skaffold to use secrets plugin on deployment.
@@ -752,8 +752,8 @@ type HelmRelease struct {
 	Repo string `yaml:"repo,omitempty"`
 
 	// UpgradeOnChange specifies whether to upgrade helm chart on code changes.
-	// Default is `true` when helm chart is local (`remote: false`).
-	// Default is `false` if `remote: true`.
+	// Default is `true` when helm chart is local (has `chartPath`).
+	// Default is `false` when helm chart is remote (has `remoteChart`).
 	UpgradeOnChange *bool `yaml:"upgradeOnChange,omitempty"`
 
 	// Overrides are key-value pairs.


### PR DESCRIPTION
**Related**: #5482

**Description**
#5482 changes `remote` to `remoteChart`, but there were some dangling doc comments referring to `remote`.