### PR TITLE
Use Helm chart version in render

### DIFF
--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -261,8 +261,10 @@ func (h *Deployer) Render(ctx context.Context, out io.Writer, builds []graph.Art
 			return userErr(fmt.Sprintf("cannot expand release name %q", r.Name), err)
 		}
 
-		args := []string{"template", chartSource(r)}
-		args = append(args[:1], append([]string{releaseName}, args[1:]...)...)
+		args := []string{"template", releaseName, chartSource(r)}
+		if r.Packaged == nil && r.Version != "" {
+			args = append(args, "--version", r.Version)
+		}
 
 		params, err := pairParamsToArtifacts(builds, r.ArtifactOverrides)
 		if err != nil {

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -1401,6 +1401,20 @@ func TestHelmRender(t *testing.T) {
 				}},
 		},
 		{
+			description: "render with remote chart",
+			shouldErr:   false,
+			commands: testutil.CmdRunWithOutput("helm version --client", version31).
+				AndRun("helm --kube-context kubecontext template skaffold-helm-remote stable/chartmuseum --repo https://charts.helm.sh/stable --kubeconfig kubeconfig"),
+			helm: testDeployRemoteChart,
+		},
+		{
+			description: "render with remote chart with version",
+			shouldErr:   false,
+			commands: testutil.CmdRunWithOutput("helm version --client", version31).
+				AndRun("helm --kube-context kubecontext template skaffold-helm-remote stable/chartmuseum --version 1.0.0 --repo https://charts.helm.sh/stable --kubeconfig kubeconfig"),
+			helm: testDeployRemoteChartVersion,
+		},
+		{
 			description: "render with cli namespace",
 			shouldErr:   false,
 			namespace:   "clinamespace",


### PR DESCRIPTION
Fixes: #5887
Merge after: #5921

**Description**
Use release `version` when rendering a remote chart.

**User facing changes (remove if N/A)**
- `skaffold render` uses remote Helm chart version when specified