### PR TITLE
Remove unsupported `docker.secret.dst` field

### DIFF
--- a/docs/content/en/schemas/v2beta17.json
+++ b/docs/content/en/schemas/v2beta17.json
@@ -1215,11 +1215,6 @@
         "id"
       ],
       "properties": {
-        "dst": {
-          "type": "string",
-          "description": "path in the container to mount the secret.",
-          "x-intellij-html-description": "path in the container to mount the secret."
-        },
         "id": {
           "type": "string",
           "description": "id of the secret.",
@@ -1233,8 +1228,7 @@
       },
       "preferredOrder": [
         "id",
-        "src",
-        "dst"
+        "src"
       ],
       "additionalProperties": false,
       "type": "object",

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -511,9 +511,6 @@ func ToCLIBuildArgs(a *latestV1.DockerArtifact, evaluatedArgs map[string]*string
 		if a.Secret.Source != "" {
 			secretString += ",src=" + a.Secret.Source
 		}
-		if a.Secret.Destination != "" {
-			secretString += ",dst=" + a.Secret.Destination
-		}
 		args = append(args, "--secret", secretString)
 	}
 

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -356,27 +356,6 @@ func TestGetBuildArgs(t *testing.T) {
 			want: []string{"--secret", "id=mysecret,src=foo.src"},
 		},
 		{
-			description: "secret with destination",
-			artifact: &latestV1.DockerArtifact{
-				Secret: &latestV1.DockerSecret{
-					ID:          "mysecret",
-					Destination: "foo.dst",
-				},
-			},
-			want: []string{"--secret", "id=mysecret,dst=foo.dst"},
-		},
-		{
-			description: "secret with source and destination",
-			artifact: &latestV1.DockerArtifact{
-				Secret: &latestV1.DockerSecret{
-					ID:          "mysecret",
-					Source:      "foo.src",
-					Destination: "foo.dst",
-				},
-			},
-			want: []string{"--secret", "id=mysecret,src=foo.src,dst=foo.dst"},
-		},
-		{
 			description: "ssh with no source",
 			artifact: &latestV1.DockerArtifact{
 				SSH: "default",

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -1247,9 +1247,6 @@ type DockerSecret struct {
 
 	// Source is the path to the secret on the host machine.
 	Source string `yaml:"src,omitempty"`
-
-	// Destination is the path in the container to mount the secret.
-	Destination string `yaml:"dst,omitempty"`
 }
 
 // BazelArtifact describes an artifact built with [Bazel](https://bazel.build/).

--- a/pkg/skaffold/schema/v2beta16/upgrade.go
+++ b/pkg/skaffold/schema/v2beta16/upgrade.go
@@ -17,11 +17,11 @@ limitations under the License.
 package v2beta16
 
 import (
+	"github.com/sirupsen/logrus"
+
 	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	pkgutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-
-	"github.com/sirupsen/logrus"
 )
 
 // Upgrade upgrades a configuration to the next version.

--- a/pkg/skaffold/schema/v2beta16/upgrade.go
+++ b/pkg/skaffold/schema/v2beta16/upgrade.go
@@ -20,6 +20,8 @@ import (
 	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	pkgutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Upgrade upgrades a configuration to the next version.
@@ -34,5 +36,10 @@ func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
 }
 
 func upgradeOnePipeline(oldPipeline, newPipeline interface{}) error {
+	for _, a := range oldPipeline.(*Pipeline).Build.Artifacts {
+		if a.DockerArtifact != nil && a.DockerArtifact.Secret != nil && a.DockerArtifact.Secret.Destination != "" {
+			logrus.Warnf("Artifact %q: Docker secret destination is no longer supported: %q", a.ImageName, a.DockerArtifact.Secret.Destination)
+		}
+	}
 	return nil
 }

--- a/pkg/skaffold/schema/v2beta16/upgrade_test.go
+++ b/pkg/skaffold/schema/v2beta16/upgrade_test.go
@@ -32,6 +32,10 @@ build:
   - image: gcr.io/k8s-skaffold/skaffold-example
     docker:
       dockerfile: path/to/Dockerfile
+      secret:
+        id: id
+        src: /file.txt
+        dst: /etc/passwd
   - image: gcr.io/k8s-skaffold/bazel
     bazel:
       target: //mytarget
@@ -108,6 +112,9 @@ build:
   - image: gcr.io/k8s-skaffold/skaffold-example
     docker:
       dockerfile: path/to/Dockerfile
+      secret:
+        id: id
+        src: /file.txt
   - image: gcr.io/k8s-skaffold/bazel
     bazel:
       target: //mytarget


### PR DESCRIPTION
Fixes: #5925
Merge after: #5926

**Description**
`docker build --secret` does not actually support a `dst`.  SIlently remove the field since its use causes errors.

**User facing changes (remove if N/A)**
The `docker` builder's `secret` object supported an optional `dst` field which was not supported by Buildkit.
