### PR TITLE
Pause debug pod watchers before next iteration deploy

### DIFF
--- a/pkg/skaffold/kubernetes/debugging/container_manager.go
+++ b/pkg/skaffold/kubernetes/debugging/container_manager.go
@@ -65,7 +65,6 @@ func (d *ContainerManager) Start(ctx context.Context, namespaces []string) error
 	d.stopWatcher = stopWatcher
 
 	go func() {
-
 		for {
 			select {
 			case <-ctx.Done():

--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
@@ -137,3 +137,7 @@ func (p *ForwarderManager) Stop() {
 		f.Stop()
 	}
 }
+
+func (p *ForwarderManager) Name() string {
+	return "PortForwarding"
+}

--- a/pkg/skaffold/runner/v1/watcher.go
+++ b/pkg/skaffold/runner/v1/watcher.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import "context"
+
+type Watcher interface {
+	// Name returns the watcher name
+	Name() string
+	// Start starts the watcher
+	Start(ctx context.Context, namespaces []string) error
+	// Stop stops the watcher
+	Stop()
+}


### PR DESCRIPTION
Fixes #5914 


See https://github.com/GoogleContainerTools/skaffold/issues/5914#issuecomment-853423424 for more details on why we need to stop the debug manager between deploys.

Changes in this PR
1) Add a Watcher Interface for `PortforwardManager` and `DebugManager` with `Start` and `Stop` methods. 
2) Call `Stop` for DebugManager similar to what we do for `PortforwardManager`.
3) Remove `close` from   `DebugManager.Stop` since the doc mention `close` should only be called by sender. Changed the `DebugManager.Stop` to stop the pod watchers.

Verified locally, we don't see an `DebugContainerEvent` in StatusCheck phase. 
 