### PR TITLE
Add support for Port forwarding with resourceName with Templated Fields

### DIFF
--- a/docs/content/en/docs/environment/templating.md
+++ b/docs/content/en/docs/environment/templating.md
@@ -23,6 +23,7 @@ List of fields that support templating:
 * `deploy.kubectl.defaultNamespace`
 * `deploy.kustomize.defaultNamespace`
 * `portForward.namespace`
+* `portForward.resourceName`
 
 _Please note, this list is not exhaustive._
 

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -282,6 +282,26 @@ func TestUserDefinedResources(t *testing.T) {
 				"pod-pod-some-with-template-bar-9000",
 			},
 		},
+		{
+			description: "pod should be found with name with template",
+			userResources: []*latestV1.PortForwardResource{
+				{Type: constants.Pod, Name: "pod-{{ .FOO }}", Port: schemautil.FromInt(9000)},
+			},
+			namespaces: []string{"test"},
+			expectedResources: []string{
+				"pod-pod-bar-test-9000",
+			},
+		},
+		{
+			description: "pod should be found with name with template",
+			userResources: []*latestV1.PortForwardResource{
+				{Type: constants.Pod, Name: "pod-{{ .FOO }}", Namespace: "some-ns", Port: schemautil.FromInt(9000)},
+			},
+			namespaces: []string{"test", "another"},
+			expectedResources: []string{
+				"pod-pod-bar-some-ns-9000",
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION

**Related**:  #5808 

**Description**
it is similar to namespace in port-forward, as user can customize helm namespace and release name using environment variables, it will impact both namespace and resource name in portForward section

```
deploy:
  helm:
    releases:
     - name: my-deployment-{{ .FOO }}
       chartPath: helm
       artifactOverrides:
          image: my-image
       namespace: "my-namespace-{{ .FOO }}"

portForward:
  resourceType: StatefulSet
  resourceName: resourceName-{{ .FOO }}
  namespace: "my-namespace-{{ .FOO }}"
  port: 22
  localPort: 5022

```

