### PR TITLE
Ignore first user cancelled and get actual error as final error

### DIFF
--- a/pkg/skaffold/deploy/status/status_check_test.go
+++ b/pkg/skaffold/deploy/status/status_check_test.go
@@ -289,6 +289,26 @@ func TestGetDeployStatus(t *testing.T) {
 			shouldErr:    true,
 			expectedCode: proto.StatusCode_STATUSCHECK_DEPLOYMENT_FETCH_ERR,
 		},
+		{
+			description: "one deployment failed and others cancelled and or succeeded",
+			counter:     &counter{total: 3, failed: 2},
+			deployments: []*resource.Deployment{
+				withStatus(
+					resource.NewDeployment("deployment-cancelled", "test", 1),
+					proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_USER_CANCELLED},
+				),
+				withStatus(
+					resource.NewDeployment("deployment-success", "test", 1),
+					proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_SUCCESS},
+				),
+				withStatus(
+					resource.NewDeployment("deployment", "test", 1),
+					proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_DEPLOYMENT_FETCH_ERR},
+				),
+			},
+			shouldErr:    true,
+			expectedCode: proto.StatusCode_STATUSCHECK_DEPLOYMENT_FETCH_ERR,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #5424

In status check phase, when skaffold encounters the first non recoverable error, skaffold cancels the status check for all other resources and exits immediately.
We had checks in place to make sure the final error code for status check phase is the actual error that happened. 
However, we did not handle the cancelled error code. 

In this PR, don't return on first user cancelled error code and keep looking for the actual error code.
