### PR TITLE
[v3]  Add validator in render v2.

### DIFF
--- a/pkg/skaffold/render/renderer/renderer_test.go
+++ b/pkg/skaffold/render/renderer/renderer_test.go
@@ -16,13 +16,10 @@ limitations under the License.
 package renderer
 
 import (
-	"bytes"
-	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/kptfile"
 	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -68,10 +65,6 @@ func TestRender_StoredInCache(t *testing.T) {
 			Write(filepath.Join(DefaultHydrationDir, kptfile.KptFileName), initKptfile).
 			Touch("empty.ignored").
 			Chdir()
+	}
 
-		var b bytes.Buffer
-		err := r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}})
-		t.CheckNoError(err)
-		t.CheckFileExistAndContent(filepath.Join(DefaultHydrationDir, dryFileName), []byte(labeledPodYaml))
-	})
 }

--- a/pkg/skaffold/render/validate/validate.go
+++ b/pkg/skaffold/render/validate/validate.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package validate
+
+import (
+	"fmt"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/kptfile"
+	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
+)
+
+var validatorWhitelist = map[string]kptfile.Function{
+	"kubeval": {Image: "gcr.io/kpt-fn/kubeval:v0.1"},
+	// TODO: Add conftest validator in kpt catalog.
+}
+
+// NewValidator instantiates a Validator object.
+func NewValidator(config []latestV2.Validator) (*Validator, error) {
+	var fns []kptfile.Function
+	for _, c := range config {
+		fn, ok := validatorWhitelist[c.Name]
+		if !ok {
+			// TODO: kpt user error
+			return nil, fmt.Errorf("unsupported validator %v", c.Name)
+		}
+		fns = append(fns, fn)
+	}
+	return &Validator{kptFn: fns}, nil
+}
+
+type Validator struct {
+	kptFn []kptfile.Function
+}
+
+// GetDeclarativeValidators transforms and returns the skaffold validators defined in skaffold.yaml
+func (v *Validator) GetDeclarativeValidators() []kptfile.Function {
+	// TODO: guarantee the v.kptFn is updated once users changed skaffold.yaml file.
+	return v.kptFn
+}

--- a/pkg/skaffold/render/validate/validate_test.go
+++ b/pkg/skaffold/render/validate/validate_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package validate
+
+import (
+	"testing"
+
+	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestValidatorInit(t *testing.T) {
+	tests := []struct {
+		description string
+		config      []latestV2.Validator
+		shouldErr   bool
+	}{
+		{
+			description: "no validation",
+			config:      []latestV2.Validator{},
+			shouldErr:   false,
+		},
+		{
+			description: "kubeval validator",
+			config: []latestV2.Validator{
+				{Name: "kubeval"},
+			},
+			shouldErr: false,
+		},
+		{
+			description: "invalid validator",
+			config: []latestV2.Validator{
+				{Name: "bad-validator"},
+			},
+			shouldErr: true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			_, err := NewValidator(test.config)
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: #5673 
**Merge after**: #5940 

**Description**
- Add the render validator and write the skaffold validation rules to Kptfile pipeline.
- Fixed corner cases when `render.generate` is not given in skaffold.yaml
- More test coverage on Render configs.

To reviewers: 
This PR is diff-based from 5940. Please only review [the last commit](https://github.com/GoogleContainerTools/skaffold/commit/4c4890263ef430ee48538ef370c7cc03f8e61b70) 
