### PR TITLE
add command `skaffold inspect build-env add local`

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -284,14 +284,14 @@ func isHouseKeepingMessagesAllowed(cmd *cobra.Command) bool {
 	if cmd.Annotations == nil {
 		return false
 	}
-	return cmd.Annotations[HouseKeepingMessagesAllowedAnnotation] == "true"
+	return cmd.Annotations[HouseKeepingMessagesAllowedAnnotation] == fmt.Sprintf("%t", true)
 }
 
 func allowHouseKeepingMessages(cmd *cobra.Command) {
 	if cmd.Annotations == nil {
 		cmd.Annotations = make(map[string]string)
 	}
-	cmd.Annotations[HouseKeepingMessagesAllowedAnnotation] = "true"
+	cmd.Annotations[HouseKeepingMessagesAllowedAnnotation] = fmt.Sprintf("%t", true)
 }
 
 func preReleaseVersion(s string) bool {

--- a/pkg/skaffold/inspect/buildEnv/add_local.go
+++ b/pkg/skaffold/inspect/buildEnv/add_local.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inspect
+
+import (
+	"context"
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/inspect"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+func AddLocalBuildEnv(ctx context.Context, out io.Writer, opts inspect.Options) error {
+	formatter := inspect.OutputFormatter(out, opts.OutFormat)
+	cfgs, err := inspect.ConfigSetFunc(config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, SkipConfigDefaults: true, MakePathsAbsolute: util.BoolPtr(false)})
+	if err != nil {
+		return formatter.WriteErr(err)
+	}
+	if opts.Profile == "" {
+		// empty profile flag implies that the new build env needs to be added to the default pipeline.
+		// for these cases, don't add the new env definition to any configs imported as dependencies.
+		cfgs = cfgs.SelectRootConfigs()
+		for _, cfg := range cfgs {
+			if cfg.Build.LocalBuild != nil && (*cfg.Build.LocalBuild != latestV1.LocalBuild{}) {
+				return formatter.WriteErr(inspect.BuildEnvAlreadyExists(inspect.BuildEnvs.Local, cfg.SourceFile, ""))
+			}
+			cfg.Build.LocalBuild = constructLocalDefinition(cfg.Build.LocalBuild, opts.BuildEnvOptions)
+			cfg.Build.GoogleCloudBuild = nil
+			cfg.Build.Cluster = nil
+		}
+	} else {
+		for _, cfg := range cfgs {
+			index := -1
+			for i := range cfg.Profiles {
+				if cfg.Profiles[i].Name == opts.Profile {
+					index = i
+					break
+				}
+			}
+			if index < 0 {
+				index = len(cfg.Profiles)
+				cfg.Profiles = append(cfg.Profiles, latestV1.Profile{Name: opts.Profile})
+			}
+			if cfg.Profiles[index].Build.LocalBuild != nil && (*cfg.Profiles[index].Build.LocalBuild != latestV1.LocalBuild{}) {
+				return formatter.WriteErr(inspect.BuildEnvAlreadyExists(inspect.BuildEnvs.Local, cfg.SourceFile, opts.Profile))
+			}
+			cfg.Profiles[index].Build.LocalBuild = constructLocalDefinition(cfg.Profiles[index].Build.LocalBuild, opts.BuildEnvOptions)
+			cfg.Profiles[index].Build.GoogleCloudBuild = nil
+			cfg.Profiles[index].Build.Cluster = nil
+		}
+	}
+	return inspect.MarshalConfigSet(cfgs)
+}
+
+func constructLocalDefinition(existing *latestV1.LocalBuild, opts inspect.BuildEnvOptions) *latestV1.LocalBuild {
+	var b latestV1.LocalBuild
+	if existing != nil {
+		b = *existing
+	}
+	if opts.Concurrency >= 0 {
+		b.Concurrency = util.IntPtr(opts.Concurrency)
+	}
+	if opts.Push != nil {
+		b.Push = opts.Push
+	}
+	if opts.TryImportMissing != nil {
+		b.TryImportMissing = *opts.TryImportMissing
+	}
+	if opts.UseDockerCLI != nil {
+		b.UseDockerCLI = *opts.UseDockerCLI
+	}
+	if opts.UseBuildkit != nil {
+		b.UseBuildkit = *opts.UseBuildkit
+	}
+	return &b
+}

--- a/pkg/skaffold/inspect/buildEnv/add_local_test.go
+++ b/pkg/skaffold/inspect/buildEnv/add_local_test.go
@@ -1,0 +1,338 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inspect
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/inspect"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser"
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/errors"
+	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestAddLocalBuildEnv(t *testing.T) {
+	tests := []struct {
+		description     string
+		profile         string
+		modules         []string
+		buildEnvOpts    inspect.BuildEnvOptions
+		expectedConfigs []string
+		err             error
+		expectedErrMsg  string
+	}{
+		{
+			description:  "add to default pipeline",
+			buildEnvOpts: inspect.BuildEnvOptions{Push: util.BoolPtr(true), TryImportMissing: util.BoolPtr(false), UseDockerCLI: util.BoolPtr(false), UseBuildkit: nil, Concurrency: 2},
+			expectedConfigs: []string{
+				`apiVersion: ""
+kind: ""
+metadata:
+  name: cfg1_0
+build:
+  local:
+    push: true
+    concurrency: 2
+profiles:
+- name: p1
+  build:
+    cluster: {}
+---
+apiVersion: ""
+kind: ""
+metadata:
+  name: cfg1_1
+requires:
+- path: path/to/cfg2
+build:
+  local:
+    push: true
+    concurrency: 2
+profiles:
+- name: p1
+  build:
+    cluster: {}
+`, ``,
+			},
+		},
+		{
+			description:  "add to existing profile",
+			buildEnvOpts: inspect.BuildEnvOptions{Push: util.BoolPtr(true), TryImportMissing: util.BoolPtr(false), UseDockerCLI: util.BoolPtr(false), UseBuildkit: nil, Concurrency: 2, Profile: "p1"},
+			expectedConfigs: []string{
+				`apiVersion: ""
+kind: ""
+metadata:
+  name: cfg1_0
+build:
+  googleCloudBuild: {}
+profiles:
+- name: p1
+  build:
+    local:
+      push: true
+      concurrency: 2
+---
+apiVersion: ""
+kind: ""
+metadata:
+  name: cfg1_1
+requires:
+- path: path/to/cfg2
+build:
+  googleCloudBuild: {}
+profiles:
+- name: p1
+  build:
+    local:
+      push: true
+      concurrency: 2
+`, `apiVersion: ""
+kind: ""
+metadata:
+  name: cfg2
+build:
+  googleCloudBuild: {}
+profiles:
+- name: p1
+  build:
+    local:
+      push: true
+      concurrency: 2
+`,
+			},
+		},
+		{
+			description:  "add to new profile",
+			buildEnvOpts: inspect.BuildEnvOptions{Push: util.BoolPtr(true), TryImportMissing: util.BoolPtr(false), UseDockerCLI: util.BoolPtr(false), UseBuildkit: nil, Concurrency: 2, Profile: "p2"},
+			expectedConfigs: []string{
+				`apiVersion: ""
+kind: ""
+metadata:
+  name: cfg1_0
+build:
+  googleCloudBuild: {}
+profiles:
+- name: p1
+  build:
+    cluster: {}
+- name: p2
+  build:
+    local:
+      push: true
+      concurrency: 2
+---
+apiVersion: ""
+kind: ""
+metadata:
+  name: cfg1_1
+requires:
+- path: path/to/cfg2
+build:
+  googleCloudBuild: {}
+profiles:
+- name: p1
+  build:
+    cluster: {}
+- name: p2
+  build:
+    local:
+      push: true
+      concurrency: 2
+`, `apiVersion: ""
+kind: ""
+metadata:
+  name: cfg2
+build:
+  googleCloudBuild: {}
+profiles:
+- name: p1
+  build:
+    googleCloudBuild: {}
+- name: p2
+  build:
+    local:
+      push: true
+      concurrency: 2
+`,
+			},
+		},
+		{
+			description:  "add to new profile in selected modules",
+			modules:      []string{"cfg1_1"},
+			buildEnvOpts: inspect.BuildEnvOptions{Push: util.BoolPtr(true), TryImportMissing: util.BoolPtr(false), UseDockerCLI: util.BoolPtr(false), UseBuildkit: nil, Concurrency: 2, Profile: "p2"},
+			expectedConfigs: []string{
+				`apiVersion: ""
+kind: ""
+metadata:
+  name: cfg1_0
+build:
+  googleCloudBuild: {}
+profiles:
+- name: p1
+  build:
+    cluster: {}
+---
+apiVersion: ""
+kind: ""
+metadata:
+  name: cfg1_1
+requires:
+- path: path/to/cfg2
+build:
+  googleCloudBuild: {}
+profiles:
+- name: p1
+  build:
+    cluster: {}
+- name: p2
+  build:
+    local:
+      push: true
+      concurrency: 2
+`, `apiVersion: ""
+kind: ""
+metadata:
+  name: cfg2
+build:
+  googleCloudBuild: {}
+profiles:
+- name: p1
+  build:
+    googleCloudBuild: {}
+- name: p2
+  build:
+    local:
+      push: true
+      concurrency: 2
+`, "",
+			},
+		},
+		{
+			description:  "add to new profile in nested module",
+			modules:      []string{"cfg2"},
+			buildEnvOpts: inspect.BuildEnvOptions{Push: util.BoolPtr(true), TryImportMissing: util.BoolPtr(false), UseDockerCLI: util.BoolPtr(false), UseBuildkit: nil, Concurrency: 2, Profile: "p2"},
+			expectedConfigs: []string{"",
+				`apiVersion: ""
+kind: ""
+metadata:
+  name: cfg2
+build:
+  googleCloudBuild: {}
+profiles:
+- name: p1
+  build:
+    googleCloudBuild: {}
+- name: p2
+  build:
+    local:
+      push: true
+      concurrency: 2
+`,
+			},
+		},
+		{
+			description:    "actionable error",
+			err:            sErrors.MainConfigFileNotFoundErr("path/to/skaffold.yaml", fmt.Errorf("failed to read file : %q", "skaffold.yaml")),
+			expectedErrMsg: `{"errorCode":"CONFIG_FILE_NOT_FOUND_ERR","errorMessage":"unable to find configuration file \"path/to/skaffold.yaml\": failed to read file : \"skaffold.yaml\". Check that the specified configuration file exists at \"path/to/skaffold.yaml\"."}` + "\n",
+		},
+		{
+			description:    "generic error",
+			err:            errors.New("some error occurred"),
+			expectedErrMsg: `{"errorCode":"INSPECT_UNKNOWN_ERR","errorMessage":"some error occurred"}` + "\n",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			configSet := parser.SkaffoldConfigSet{
+				&parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{
+					Metadata: v1.Metadata{Name: "cfg1_0"},
+					Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{GoogleCloudBuild: &v1.GoogleCloudBuild{}}}},
+					Profiles: []v1.Profile{
+						{Name: "p1", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{Cluster: &v1.ClusterDetails{}}}}},
+					}}, SourceFile: pathToCfg1, IsRootConfig: true, SourceIndex: 0},
+				&parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{
+					Metadata:     v1.Metadata{Name: "cfg1_1"},
+					Dependencies: []v1.ConfigDependency{{Path: pathToCfg2}},
+					Pipeline:     v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{GoogleCloudBuild: &v1.GoogleCloudBuild{}}}},
+					Profiles: []v1.Profile{
+						{Name: "p1", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{Cluster: &v1.ClusterDetails{}}}}},
+					}}, SourceFile: pathToCfg1, IsRootConfig: true, SourceIndex: 1},
+				&parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{
+					Metadata: v1.Metadata{Name: "cfg2"},
+					Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{GoogleCloudBuild: &v1.GoogleCloudBuild{}}}},
+					Profiles: []v1.Profile{
+						{Name: "p1", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{GoogleCloudBuild: &v1.GoogleCloudBuild{}}}}},
+					}}, SourceFile: pathToCfg2, SourceIndex: 0},
+			}
+			t.Override(&inspect.ConfigSetFunc, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+				if test.err != nil {
+					return nil, test.err
+				}
+				var sets parser.SkaffoldConfigSet
+				if len(opts.ConfigurationFilter) == 0 || util.StrSliceContains(opts.ConfigurationFilter, "cfg2") || util.StrSliceContains(opts.ConfigurationFilter, "cfg1_1") {
+					sets = append(sets, configSet[2])
+				}
+				if len(opts.ConfigurationFilter) == 0 || util.StrSliceContains(opts.ConfigurationFilter, "cfg1_0") {
+					sets = append(sets, configSet[0])
+				}
+				if len(opts.ConfigurationFilter) == 0 || util.StrSliceContains(opts.ConfigurationFilter, "cfg1_1") {
+					sets = append(sets, configSet[1])
+				}
+				return sets, nil
+			})
+			t.Override(&inspect.ReadFileFunc, func(filename string) ([]byte, error) {
+				if filename == pathToCfg1 {
+					return yaml.MarshalWithSeparator([]*v1.SkaffoldConfig{configSet[0].SkaffoldConfig, configSet[1].SkaffoldConfig})
+				} else if filename == pathToCfg2 {
+					return yaml.MarshalWithSeparator([]*v1.SkaffoldConfig{configSet[2].SkaffoldConfig})
+				}
+				t.FailNow()
+				return nil, nil
+			})
+			var actualCfg1, actualCfg2 string
+			t.Override(&inspect.WriteFileFunc, func(filename string, data []byte) error {
+				switch filename {
+				case pathToCfg1:
+					actualCfg1 = string(data)
+				case pathToCfg2:
+					actualCfg2 = string(data)
+				default:
+					t.FailNow()
+				}
+				return nil
+			})
+
+			var buf bytes.Buffer
+			err := AddLocalBuildEnv(context.Background(), &buf, inspect.Options{OutFormat: "json", Modules: test.modules, BuildEnvOptions: test.buildEnvOpts})
+			t.CheckNoError(err)
+			if test.err == nil {
+				t.CheckDeepEqual(test.expectedConfigs[0], actualCfg1)
+				t.CheckDeepEqual(test.expectedConfigs[1], actualCfg2)
+			} else {
+				t.CheckDeepEqual(test.expectedErrMsg, buf.String())
+			}
+		})
+	}
+}

--- a/pkg/skaffold/inspect/types.go
+++ b/pkg/skaffold/inspect/types.go
@@ -46,6 +46,14 @@ type BuildEnvOptions struct {
 	Profiles []string
 	// Profile is a target profile to create or edit
 	Profile string
+	// Push specifies if images should be pushed to a registry.
+	Push *bool
+	// TryImportMissing specifies whether to attempt to import artifacts from Docker (either a local or remote registry) if not in the cache
+	TryImportMissing *bool
+	// UseDockerCLI specifies to use `docker` command-line interface instead of Docker Engine APIs
+	UseDockerCLI *bool
+	// UseBuildkit specifies to use Buildkit to build Docker images
+	UseBuildkit *bool
 	// ProjectID is the GCP project ID
 	ProjectID string
 	// DiskSizeGb is the disk size of the VM that runs the build


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Related: #5758 <!-- tracking issues that this PR will close -->
**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

**User facing changes (remove if N/A)**
```
❯ skaffold inspect build-env add local --help
Add a new local build environment definition.
Without the '--profile' flag the new environment definition is added to the default pipeline. With the '--profile' flag
it will create a new profile with this build env definition. 
In these respective scenarios, it will fail if the build env definition for the default pipeline or the named profile
already exists. To override an existing definition use 'skaffold inspect build-env modify' command instead. 
Use the '--module' filter to specify the individual module to target. Otherwise, it'll be applied to all modules defined
in the target file. Also, with the '--profile' flag if the target config imports other configs as dependencies, then the
new profile will be recursively created in all the imported configs also.

Examples:
  # Add a new profile named 'local' targeting the local build environment with option to push images and using buildkit
  skaffold inspect build-env add local --profile local --push true --useBuildkit true -f skaffold.yaml

Options:
      --concurrency=-1: number of artifacts to build concurrently. 0 means "no-limit"
      --push=: Set to true to push images to a registry
      --tryImportMissing=: Set to true to to attempt importing artifacts from Docker (either a local or remote registry)
if not in the build cache
      --useBuildkit=: Set to true to use BuildKit to build Docker images
      --useDockerCLI=: Set to true to use 'docker' command-line interface instead of Docker Engine APIs

Usage:
  skaffold inspect build-env add local [flags] [options]

Use "skaffold options" for a list of global command-line options (applies to all commands).
```
