### PR TITLE
Avoid adding image digest twice to tag on render

### DIFF
--- a/pkg/skaffold/build/util.go
+++ b/pkg/skaffold/build/util.go
@@ -18,6 +18,7 @@ package build
 
 import (
 	"context"
+	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
@@ -54,7 +55,11 @@ func MergeWithPreviousBuilds(builds, previous []graph.Artifact) []graph.Artifact
 }
 
 func TagWithDigest(tag, digest string) string {
-	return tag + "@" + digest
+	digestSuffix := "@" + digest
+	if strings.HasSuffix(tag, digestSuffix) {
+		return tag
+	}
+	return tag + digestSuffix
 }
 
 func TagWithImageID(ctx context.Context, tag string, imageID string, localDocker docker.LocalDaemon) (string, error) {

--- a/pkg/skaffold/build/util_test.go
+++ b/pkg/skaffold/build/util_test.go
@@ -39,6 +39,13 @@ func TestMergeWithPreviousBuilds(t *testing.T) {
 	testutil.CheckDeepEqual(t, "img1:tag1_3,img2:tag2_3", tags(builds))
 }
 
+func TestTagWithDigest(t *testing.T) {
+	tag := TagWithDigest("some-tag", "sha256:abcd1234")
+	testutil.CheckDeepEqual(t, "some-tag@sha256:abcd1234", tag)
+	tag = TagWithDigest("some-tag@sha256:abcd1234", "sha256:abcd1234")
+	testutil.CheckDeepEqual(t, "some-tag@sha256:abcd1234", tag)
+}
+
 func artifact(image, tag string) graph.Artifact {
 	return graph.Artifact{
 		ImageName: image,


### PR DESCRIPTION
**Description**

Avoid adding image digest twice to tag on render. This can happen when reading tags from file (`--build-artifacts`) where the tag already has a digest.
