### PR TITLE
Emit status check subtask events for V2 API

### DIFF
--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -277,10 +277,10 @@ func (d *Deployment) fetchPods(ctx context.Context) error {
 			case proto.StatusCode_STATUSCHECK_CONTAINER_CREATING,
 				proto.StatusCode_STATUSCHECK_POD_INITIALIZING:
 				event.ResourceStatusCheckEventUpdated(p.String(), p.ActionableError())
-				eventV2.ResourceStatusCheckEventUpdated(p.String(), *sErrors.V2fromV1(p.ActionableError()))
+				eventV2.ResourceStatusCheckEventUpdated(p.String(), sErrors.V2fromV1(p.ActionableError()))
 			default:
 				event.ResourceStatusCheckEventCompleted(p.String(), p.ActionableError())
-				eventV2.ResourceStatusCheckEventCompleted(p.String(), *sErrors.V2fromV1(p.ActionableError()))
+				eventV2.ResourceStatusCheckEventCompleted(p.String(), sErrors.V2fromV1(p.ActionableError()))
 			}
 		}
 		newPods[p.String()] = p

--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -26,7 +26,9 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/diag"
 	"github.com/GoogleContainerTools/skaffold/pkg/diag/validator"
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 )
@@ -275,8 +277,10 @@ func (d *Deployment) fetchPods(ctx context.Context) error {
 			case proto.StatusCode_STATUSCHECK_CONTAINER_CREATING,
 				proto.StatusCode_STATUSCHECK_POD_INITIALIZING:
 				event.ResourceStatusCheckEventUpdated(p.String(), p.ActionableError())
+				eventV2.ResourceStatusCheckEventUpdated(p.String(), *sErrors.V2fromV1(p.ActionableError()))
 			default:
 				event.ResourceStatusCheckEventCompleted(p.String(), p.ActionableError())
+				eventV2.ResourceStatusCheckEventCompleted(p.String(), *sErrors.V2fromV1(p.ActionableError()))
 			}
 		}
 		newPods[p.String()] = p

--- a/pkg/skaffold/deploy/status/status_check.go
+++ b/pkg/skaffold/deploy/status/status_check.go
@@ -249,7 +249,7 @@ func (s statusChecker) printStatusCheckSummary(out io.Writer, r *resource.Deploy
 		return
 	}
 	event.ResourceStatusCheckEventCompleted(r.String(), ae)
-	eventV2.ResourceStatusCheckEventCompleted(r.String(), *sErrors.V2fromV1(ae))
+	eventV2.ResourceStatusCheckEventCompleted(r.String(), sErrors.V2fromV1(ae))
 	status := fmt.Sprintf("%s %s", tabHeader, r)
 	if ae.ErrCode != proto.StatusCode_STATUSCHECK_SUCCESS {
 		if str := r.ReportSinceLastUpdated(s.muteLogs); str != "" {
@@ -292,7 +292,7 @@ func (s statusChecker) printStatus(deployments []*resource.Deployment, out io.Wr
 		if str := r.ReportSinceLastUpdated(s.muteLogs); str != "" {
 			ae := r.Status().ActionableError()
 			event.ResourceStatusCheckEventUpdated(r.String(), ae)
-			eventV2.ResourceStatusCheckEventUpdated(r.String(), *sErrors.V2fromV1(ae))
+			eventV2.ResourceStatusCheckEventUpdated(r.String(), sErrors.V2fromV1(ae))
 			fmt.Fprintln(out, trimNewLine(str))
 		}
 	}

--- a/pkg/skaffold/deploy/status/status_check.go
+++ b/pkg/skaffold/deploy/status/status_check.go
@@ -35,7 +35,9 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/resource"
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	pkgkubectl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
@@ -247,6 +249,7 @@ func (s statusChecker) printStatusCheckSummary(out io.Writer, r *resource.Deploy
 		return
 	}
 	event.ResourceStatusCheckEventCompleted(r.String(), ae)
+	eventV2.ResourceStatusCheckEventCompleted(r.String(), *sErrors.V2fromV1(ae))
 	status := fmt.Sprintf("%s %s", tabHeader, r)
 	if ae.ErrCode != proto.StatusCode_STATUSCHECK_SUCCESS {
 		if str := r.ReportSinceLastUpdated(s.muteLogs); str != "" {
@@ -287,7 +290,9 @@ func (s statusChecker) printStatus(deployments []*resource.Deployment, out io.Wr
 		}
 		allDone = false
 		if str := r.ReportSinceLastUpdated(s.muteLogs); str != "" {
-			event.ResourceStatusCheckEventUpdated(r.String(), r.Status().ActionableError())
+			ae := r.Status().ActionableError()
+			event.ResourceStatusCheckEventUpdated(r.String(), ae)
+			eventV2.ResourceStatusCheckEventUpdated(r.String(), *sErrors.V2fromV1(ae))
 			fmt.Fprintln(out, trimNewLine(str))
 		}
 	}

--- a/pkg/skaffold/errors/errors.go
+++ b/pkg/skaffold/errors/errors.go
@@ -68,13 +68,13 @@ func ActionableErrV2(cfg interface{}, phase constants.Phase, err error) *protoV2
 	}
 }
 
-func V2fromV1(ae proto.ActionableErr) *protoV2.ActionableErr {
+func V2fromV1(ae proto.ActionableErr) protoV2.ActionableErr {
 	suggestionsV2 := make([]*protoV2.Suggestion, len(ae.Suggestions))
 	for i, suggestion := range ae.Suggestions {
 		converted := protoV2.Suggestion(*suggestion)
 		suggestionsV2[i] = &converted
 	}
-	return &protoV2.ActionableErr{
+	return protoV2.ActionableErr{
 		ErrCode:     ae.ErrCode,
 		Message:     ae.Message,
 		Suggestions: suggestionsV2,

--- a/pkg/skaffold/errors/errors.go
+++ b/pkg/skaffold/errors/errors.go
@@ -68,6 +68,19 @@ func ActionableErrV2(cfg interface{}, phase constants.Phase, err error) *protoV2
 	}
 }
 
+func V2fromV1(ae proto.ActionableErr) *protoV2.ActionableErr {
+	suggestionsV2 := make([]*protoV2.Suggestion, len(ae.Suggestions))
+	for i, suggestion := range ae.Suggestions {
+		converted := protoV2.Suggestion(*suggestion)
+		suggestionsV2[i] = &converted
+	}
+	return &protoV2.ActionableErr{
+		ErrCode:     ae.ErrCode,
+		Message:     ae.Message,
+		Suggestions: suggestionsV2,
+	}
+}
+
 func ShowAIError(cfg interface{}, err error) error {
 	if uErr := errors.Unwrap(err); uErr != nil {
 		err = uErr

--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -390,7 +390,7 @@ func (ev *eventHandler) handleExec(event *proto.Event) {
 	case *proto.Event_StatusCheckSubtaskEvent:
 		se := e.StatusCheckSubtaskEvent
 		ev.stateLock.Lock()
-		ev.state.StatusCheckState.Status = se.Status
+		ev.state.StatusCheckState.Resources[se.Resource] = se.Status
 		ev.stateLock.Unlock()
 	case *proto.Event_FileSyncEvent:
 		fse := e.FileSyncEvent

--- a/pkg/skaffold/event/v2/status_check.go
+++ b/pkg/skaffold/event/v2/status_check.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"fmt"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
+)
+
+func ResourceStatusCheckEventCompleted(r string, ae proto.ActionableErr) {
+	if ae.ErrCode != proto.StatusCode_STATUSCHECK_SUCCESS {
+		resourceStatusCheckEventFailed(r, ae)
+		return
+	}
+	resourceStatusCheckEventSucceeded(r)
+}
+
+func resourceStatusCheckEventSucceeded(r string) {
+	handler.handleStatusCheckSubtaskEvent(&proto.StatusCheckSubtaskEvent{
+		TaskId:     fmt.Sprintf("%s-%d", constants.StatusCheck, handler.iteration),
+		Resource:   r,
+		Status:     Succeeded,
+		Message:    Succeeded,
+		StatusCode: proto.StatusCode_STATUSCHECK_SUCCESS,
+	})
+}
+
+func resourceStatusCheckEventFailed(r string, ae proto.ActionableErr) {
+	handler.handleStatusCheckSubtaskEvent(&proto.StatusCheckSubtaskEvent{
+		TaskId:        fmt.Sprintf("%s-%d", constants.StatusCheck, handler.iteration),
+		Resource:      r,
+		Status:        Failed,
+		StatusCode:    ae.ErrCode,
+		ActionableErr: &ae,
+	})
+}
+
+func ResourceStatusCheckEventUpdated(r string, ae proto.ActionableErr) {
+	handler.handleStatusCheckSubtaskEvent(&proto.StatusCheckSubtaskEvent{
+		TaskId:        fmt.Sprintf("%s-%d", constants.StatusCheck, handler.iteration),
+		Resource:      r,
+		Status:        InProgress,
+		Message:       ae.Message,
+		StatusCode:    ae.ErrCode,
+		ActionableErr: &ae,
+	})
+}
+
+func (ev *eventHandler) handleStatusCheckSubtaskEvent(e *proto.StatusCheckSubtaskEvent) {
+	ev.handle(&proto.Event{
+		EventType: &proto.Event_StatusCheckSubtaskEvent{
+			StatusCheckSubtaskEvent: e,
+		},
+	})
+}

--- a/pkg/skaffold/event/v2/status_check_test.go
+++ b/pkg/skaffold/event/v2/status_check_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"testing"
+
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
+)
+
+func TestResourceStatusCheckEventUpdated(t *testing.T) {
+	defer func() { handler = newHandler() }()
+
+	handler = newHandler()
+	handler.state = emptyState(mockCfg([]latestV1.Pipeline{{}}, "test"))
+
+	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
+	ResourceStatusCheckEventUpdated("ns:pod/foo", proto.ActionableErr{
+		ErrCode: 509,
+		Message: "image pull error",
+	})
+	wait(t, func() bool { return handler.getState().StatusCheckState.Resources["ns:pod/foo"] == InProgress })
+}
+
+func TestResourceStatusCheckEventSucceeded(t *testing.T) {
+	defer func() { handler = newHandler() }()
+
+	handler = newHandler()
+	handler.state = emptyState(mockCfg([]latestV1.Pipeline{{}}, "test"))
+
+	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
+	resourceStatusCheckEventSucceeded("ns:pod/foo")
+	wait(t, func() bool { return handler.getState().StatusCheckState.Resources["ns:pod/foo"] == Succeeded })
+}
+
+func TestResourceStatusCheckEventFailed(t *testing.T) {
+	defer func() { handler = newHandler() }()
+
+	handler = newHandler()
+	handler.state = emptyState(mockCfg([]latestV1.Pipeline{{}}, "test"))
+
+	wait(t, func() bool { return handler.getState().StatusCheckState.Status == NotStarted })
+	resourceStatusCheckEventFailed("ns:pod/foo", proto.ActionableErr{
+		ErrCode: 309,
+		Message: "one or more deployments failed",
+	})
+	wait(t, func() bool { return handler.getState().StatusCheckState.Resources["ns:pod/foo"] == Failed })
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5785 
Related: #5368 

**Description**
Event API V2 now emits `StatusCheckSubtaskEvents`, which give information about resources being updated during their deployment to a cluster.

Most of this functionality is taken from V1

**User facing changes (remove if N/A)**
Users will not see `StatusCheckSubtaskEvents` emitted through the API. 
