### PR TITLE
skaffold inspect build-env googleCloudBuild fix to add missing flag o…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ ifeq ($(GCP_ONLY),true)
 		--zone $(GKE_ZONE) \
 		--project $(GCP_PROJECT)
 endif
-	@ GCP_ONLY=$(GCP_ONLY) ./hack/gotest.sh -v $(REPOPATH)/integration/binpack $(REPOPATH)/integration -timeout 20m $(INTEGRATION_TEST_ARGS)
+	@ GCP_ONLY=$(GCP_ONLY) ./hack/gotest.sh -v $(REPOPATH)/integration/binpack $(REPOPATH)/integration -timeout 45m $(INTEGRATION_TEST_ARGS)
 
 .PHONY: integration
 integration: install integration-tests

--- a/cmd/skaffold/app/cmd/inspect_build_env.go
+++ b/cmd/skaffold/app/cmd/inspect_build_env.go
@@ -42,9 +42,12 @@ var buildEnvFlags = struct {
 	useBuildkit      config.BoolOrUndefined
 
 	// Google Cloud Build
-	projectID   string
-	diskSizeGb  int64
-	machineType string
+	projectID          string
+	diskSizeGb         int64
+	machineType        string
+	logging            string
+	logStreamingOption string
+	workerPool         string
 
 	// Cluster (kaniko)
 	pullSecretPath      string
@@ -160,6 +163,9 @@ func cmdBuildEnvAddGcbFlags(f *pflag.FlagSet) {
 	f.StringVar(&buildEnvFlags.machineType, "machineType", "", `Type of VM that runs the build`)
 	f.StringVar(&buildEnvFlags.timeout, "timeout", "", `Build timeout (in seconds)`)
 	f.IntVar(&buildEnvFlags.concurrency, "concurrency", -1, `number of artifacts to build concurrently. 0 means "no-limit"`)
+	f.StringVar(&buildEnvFlags.logging, "logging", "", `Specifies the logging mode for GCB`)
+	f.StringVar(&buildEnvFlags.logStreamingOption, "logStreamingOption", "", `Specifies the log streaming specifies behavior when writing build logs to Google Cloud Storage for GCB`)
+	f.StringVar(&buildEnvFlags.workerPool, "workerPool", "", `Configures a pool of workers to run the build`)
 }
 
 func cmdBuildEnvAddClusterFlags(f *pflag.FlagSet) {
@@ -222,12 +228,15 @@ func addGcbBuildEnvOptions() inspect.Options {
 		OutFormat: inspectFlags.outFormat,
 		Modules:   inspectFlags.modules,
 		BuildEnvOptions: inspect.BuildEnvOptions{
-			Profile:     buildEnvFlags.profile,
-			ProjectID:   buildEnvFlags.projectID,
-			DiskSizeGb:  buildEnvFlags.diskSizeGb,
-			MachineType: buildEnvFlags.machineType,
-			Timeout:     buildEnvFlags.timeout,
-			Concurrency: buildEnvFlags.concurrency,
+			Profile:            buildEnvFlags.profile,
+			ProjectID:          buildEnvFlags.projectID,
+			DiskSizeGb:         buildEnvFlags.diskSizeGb,
+			MachineType:        buildEnvFlags.machineType,
+			Timeout:            buildEnvFlags.timeout,
+			Concurrency:        buildEnvFlags.concurrency,
+			Logging:            buildEnvFlags.logging,
+			LogStreamingOption: buildEnvFlags.logStreamingOption,
+			WorkerPool:         buildEnvFlags.workerPool,
 		},
 	}
 }

--- a/pkg/skaffold/inspect/buildEnv/add_gcb.go
+++ b/pkg/skaffold/inspect/buildEnv/add_gcb.go
@@ -91,6 +91,15 @@ func constructGcbDefinition(existing *latestV1.GoogleCloudBuild, opts inspect.Bu
 	if opts.Timeout != "" {
 		b.Timeout = opts.Timeout
 	}
+	if opts.Logging != "" {
+		b.Logging = opts.Logging
+	}
+	if opts.LogStreamingOption != "" {
+		b.LogStreamingOption = opts.LogStreamingOption
+	}
+	if opts.WorkerPool != "" {
+		b.WorkerPool = opts.WorkerPool
+	}
 	return &b
 }
 

--- a/pkg/skaffold/inspect/types.go
+++ b/pkg/skaffold/inspect/types.go
@@ -85,6 +85,12 @@ type BuildEnvOptions struct {
 	RandomPullSecret bool
 	// RandomDockerConfigSecret adds a random UUID postfix to the default name of the docker secret to facilitate parallel builds, e.g. docker-cfgfd154022-c761-416f-8eb3-cf8258450b85.
 	RandomDockerConfigSecret bool
+	// Logging specifies the logging mode.
+	Logging string
+	// LogStreamingOption specifies the behavior when writing build logs to Google Cloud Storage.
+	LogStreamingOption string
+	// WorkerPool configures a pool of workers to run the build.
+	WorkerPool string
 }
 
 type BuildEnv string


### PR DESCRIPTION
…ptions

Fixes #5947 by adding the missing flag options to googleCloudBuild for 'skaffold inspect build-env add googleCloudBuild' usage.