### PR TITLE
make sure SkaffoldLogEvent types go through correct endpoint

### DIFF
--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -153,6 +153,10 @@ func (ev *eventHandler) logApplicationLog(event *proto.Event) {
 	ev.log(event, &ev.applicationLogListeners, &ev.applicationLogs, &ev.applicationLogsLock)
 }
 
+func (ev *eventHandler) logSkaffoldLog(event *proto.Event) {
+	ev.log(event, &ev.skaffoldLogListeners, &ev.skaffoldLogs, &ev.skaffoldLogsLock)
+}
+
 func (ev *eventHandler) forEach(listeners *[]*listener, log *[]proto.Event, lock sync.Locker, callback func(*proto.Event) error) error {
 	listener := &listener{
 		callback: callback,
@@ -364,6 +368,9 @@ func (ev *eventHandler) handleExec(event *proto.Event) {
 	switch e := event.GetEventType().(type) {
 	case *proto.Event_ApplicationLogEvent:
 		ev.logApplicationLog(event)
+		return
+	case *proto.Event_SkaffoldLogEvent:
+		ev.logSkaffoldLog(event)
 		return
 	case *proto.Event_BuildSubtaskEvent:
 		be := e.BuildSubtaskEvent

--- a/pkg/skaffold/event/v2/logger_test.go
+++ b/pkg/skaffold/event/v2/logger_test.go
@@ -46,9 +46,9 @@ func TestHandleSkaffoldLogEvent(t *testing.T) {
 		})
 	}
 	wait(t, func() bool {
-		testHandler.logLock.Lock()
-		logLen := len(testHandler.eventLog)
-		testHandler.logLock.Unlock()
+		testHandler.skaffoldLogsLock.Lock()
+		logLen := len(testHandler.skaffoldLogs)
+		testHandler.skaffoldLogsLock.Unlock()
 		return logLen == len(messages)
 	})
 }


### PR DESCRIPTION
**Related**: #5368 #5370 

**Description**
Ensures that `SkaffoldLogEvent`s are sent through the proper endpoint.
