### PR TITLE
add `--all` flag to `inspect modules list` command; other refactors

### DIFF
--- a/cmd/skaffold/app/cmd/inspect.go
+++ b/cmd/skaffold/app/cmd/inspect.go
@@ -22,12 +22,13 @@ import (
 )
 
 var inspectFlags = struct {
-	filename  string
-	outFormat string
-	modules   []string
-	buildEnv  string
-	profiles  []string
-	strict    bool
+	filename     string
+	outFormat    string
+	modules      []string
+	repoCacheDir string
+	buildEnv     string
+	profiles     []string
+	strict       bool
 }{
 	filename: "skaffold.yaml",
 	strict:   true,
@@ -44,4 +45,5 @@ func NewCmdInspect() *cobra.Command {
 func cmdInspectFlags(f *pflag.FlagSet) {
 	f.StringVarP(&inspectFlags.filename, "filename", "f", "skaffold.yaml", "Path to the local Skaffold config file. Defaults to `skaffold.yaml`")
 	f.StringVarP(&inspectFlags.outFormat, "format", "o", "json", "Output format. One of: json(default)")
+	f.StringVar(&inspectFlags.repoCacheDir, "remote-cache-dir", "", "Specify the location of the remote git repositories cache (defaults to $HOME/.skaffold/repos)")
 }

--- a/cmd/skaffold/app/cmd/inspect_build_env.go
+++ b/cmd/skaffold/app/cmd/inspect_build_env.go
@@ -225,9 +225,10 @@ func cmdBuildEnvListFlags(f *pflag.FlagSet) {
 
 func printBuildEnvsListOptions() inspect.Options {
 	return inspect.Options{
-		Filename:  inspectFlags.filename,
-		OutFormat: inspectFlags.outFormat,
-		Modules:   inspectFlags.modules,
+		Filename:     inspectFlags.filename,
+		RepoCacheDir: inspectFlags.repoCacheDir,
+		OutFormat:    inspectFlags.outFormat,
+		Modules:      inspectFlags.modules,
 		BuildEnvOptions: inspect.BuildEnvOptions{
 			Profiles: inspectFlags.profiles,
 		},
@@ -236,9 +237,10 @@ func printBuildEnvsListOptions() inspect.Options {
 
 func localBuildEnvOptions() inspect.Options {
 	return inspect.Options{
-		Filename:  inspectFlags.filename,
-		OutFormat: inspectFlags.outFormat,
-		Modules:   inspectFlags.modules,
+		Filename:     inspectFlags.filename,
+		RepoCacheDir: inspectFlags.repoCacheDir,
+		OutFormat:    inspectFlags.outFormat,
+		Modules:      inspectFlags.modules,
 		BuildEnvOptions: inspect.BuildEnvOptions{
 			Profile:          buildEnvFlags.profile,
 			Push:             buildEnvFlags.push.Value(),
@@ -272,9 +274,10 @@ func gcbBuildEnvOptions() inspect.Options {
 
 func addClusterBuildEnvOptions() inspect.Options {
 	return inspect.Options{
-		Filename:  inspectFlags.filename,
-		OutFormat: inspectFlags.outFormat,
-		Modules:   inspectFlags.modules,
+		Filename:     inspectFlags.filename,
+		RepoCacheDir: inspectFlags.repoCacheDir,
+		OutFormat:    inspectFlags.outFormat,
+		Modules:      inspectFlags.modules,
 		BuildEnvOptions: inspect.BuildEnvOptions{
 			PullSecretPath:           buildEnvFlags.pullSecretPath,
 			PullSecretName:           buildEnvFlags.pullSecretName,

--- a/cmd/skaffold/app/cmd/inspect_modules.go
+++ b/cmd/skaffold/app/cmd/inspect_modules.go
@@ -21,10 +21,15 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/inspect"
 	modules "github.com/GoogleContainerTools/skaffold/pkg/skaffold/inspect/modules"
 )
+
+var modulesFlags = struct {
+	includeAll bool
+}{}
 
 func cmdModules() *cobra.Command {
 	return NewCmd("modules").
@@ -35,10 +40,21 @@ func cmdModules() *cobra.Command {
 func cmdModulesList() *cobra.Command {
 	return NewCmd("list").
 		WithExample("Get list of modules", "inspect modules list --format json").
+		WithExample("Get list of all configs (including unnamed modules)", "inspect modules list -a --format json").
 		WithDescription("Print the list of module names that can be invoked with the --module flag in other skaffold commands.").
+		WithFlagAdder(cmdModulesListFlags).
 		NoArgs(listModules)
 }
 
 func listModules(ctx context.Context, out io.Writer) error {
-	return modules.PrintModulesList(ctx, out, inspect.Options{Filename: inspectFlags.filename, OutFormat: inspectFlags.outFormat})
+	return modules.PrintModulesList(ctx, out, inspect.Options{
+		Filename:       inspectFlags.filename,
+		RepoCacheDir:   inspectFlags.repoCacheDir,
+		OutFormat:      inspectFlags.outFormat,
+		ModulesOptions: inspect.ModulesOptions{IncludeAll: modulesFlags.includeAll},
+	})
+}
+
+func cmdModulesListFlags(f *pflag.FlagSet) {
+	f.BoolVarP(&modulesFlags.includeAll, "all", "a", false, "Include unnamed modules in the result.")
 }

--- a/cmd/skaffold/app/cmd/inspect_profiles.go
+++ b/cmd/skaffold/app/cmd/inspect_profiles.go
@@ -44,7 +44,13 @@ func cmdProfilesList() *cobra.Command {
 }
 
 func listProfiles(ctx context.Context, out io.Writer) error {
-	return profiles.PrintProfilesList(ctx, out, inspect.Options{Filename: inspectFlags.filename, OutFormat: inspectFlags.outFormat, Modules: inspectFlags.modules, ProfilesOptions: inspect.ProfilesOptions{BuildEnv: inspect.BuildEnv(inspectFlags.buildEnv)}})
+	return profiles.PrintProfilesList(ctx, out, inspect.Options{
+		Filename:        inspectFlags.filename,
+		RepoCacheDir:    inspectFlags.repoCacheDir,
+		OutFormat:       inspectFlags.outFormat,
+		Modules:         inspectFlags.modules,
+		ProfilesOptions: inspect.ProfilesOptions{BuildEnv: inspect.BuildEnv(inspectFlags.buildEnv)},
+	})
 }
 
 func cmdProfilesFlags(f *pflag.FlagSet) {

--- a/pkg/skaffold/git/gitutil.go
+++ b/pkg/skaffold/git/gitutil.go
@@ -90,7 +90,8 @@ func getRepoDir(g latestV1.GitInfo) (string, error) {
 	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))[:32], nil
 }
 
-func getRepoCacheDir(opts config.SkaffoldOptions) (string, error) {
+// GetRepoCacheDir returns the directory for the remote git repo cache
+func GetRepoCacheDir(opts config.SkaffoldOptions) (string, error) {
 	if opts.RepoCacheDir != "" {
 		return opts.RepoCacheDir, nil
 	}
@@ -104,7 +105,7 @@ func getRepoCacheDir(opts config.SkaffoldOptions) (string, error) {
 }
 
 func syncRepo(g latestV1.GitInfo, opts config.SkaffoldOptions) (string, error) {
-	skaffoldCacheDir, err := getRepoCacheDir(opts)
+	skaffoldCacheDir, err := GetRepoCacheDir(opts)
 	r := gitCmd{Dir: skaffoldCacheDir}
 	if err != nil {
 		return "", fmt.Errorf("failed to clone repo %s: %w", g.Repo, err)

--- a/pkg/skaffold/inspect/buildEnv/add_cluster.go
+++ b/pkg/skaffold/inspect/buildEnv/add_cluster.go
@@ -29,7 +29,13 @@ import (
 
 func AddClusterBuildEnv(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.ConfigSetFunc(config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, SkipConfigDefaults: true, MakePathsAbsolute: util.BoolPtr(false)})
+	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{
+		ConfigurationFile:   opts.Filename,
+		RepoCacheDir:        opts.RepoCacheDir,
+		ConfigurationFilter: opts.Modules,
+		SkipConfigDefaults:  true,
+		MakePathsAbsolute:   util.BoolPtr(false),
+	})
 	if err != nil {
 		return formatter.WriteErr(err)
 	}

--- a/pkg/skaffold/inspect/buildEnv/add_cluster_test.go
+++ b/pkg/skaffold/inspect/buildEnv/add_cluster_test.go
@@ -331,7 +331,7 @@ profiles:
 						{Name: "p1", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
 					}}, SourceFile: pathToCfg2, SourceIndex: 0},
 			}
-			t.Override(&inspect.ConfigSetFunc, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
 				if test.err != nil {
 					return nil, test.err
 				}

--- a/pkg/skaffold/inspect/buildEnv/add_gcb.go
+++ b/pkg/skaffold/inspect/buildEnv/add_gcb.go
@@ -29,7 +29,12 @@ import (
 
 func AddGcbBuildEnv(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.ConfigSetFunc(config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, SkipConfigDefaults: true, MakePathsAbsolute: util.BoolPtr(false)})
+	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{
+		ConfigurationFile:   opts.Filename,
+		RepoCacheDir:        opts.RepoCacheDir,
+		ConfigurationFilter: opts.Modules,
+		SkipConfigDefaults:  true,
+		MakePathsAbsolute:   util.BoolPtr(false)})
 	if err != nil {
 		return formatter.WriteErr(err)
 	}

--- a/pkg/skaffold/inspect/buildEnv/add_gcb_test.go
+++ b/pkg/skaffold/inspect/buildEnv/add_gcb_test.go
@@ -336,7 +336,7 @@ profiles:
 						{Name: "p1", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
 					}}, SourceFile: pathToCfg2, SourceIndex: 0},
 			}
-			t.Override(&inspect.ConfigSetFunc, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
 				if test.err != nil {
 					return nil, test.err
 				}

--- a/pkg/skaffold/inspect/buildEnv/add_local.go
+++ b/pkg/skaffold/inspect/buildEnv/add_local.go
@@ -28,7 +28,7 @@ import (
 
 func AddLocalBuildEnv(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.ConfigSetFunc(config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, SkipConfigDefaults: true, MakePathsAbsolute: util.BoolPtr(false)})
+	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, SkipConfigDefaults: true, MakePathsAbsolute: util.BoolPtr(false)})
 	if err != nil {
 		return formatter.WriteErr(err)
 	}

--- a/pkg/skaffold/inspect/buildEnv/add_local_test.go
+++ b/pkg/skaffold/inspect/buildEnv/add_local_test.go
@@ -286,7 +286,7 @@ profiles:
 						{Name: "p1", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{GoogleCloudBuild: &v1.GoogleCloudBuild{}}}}},
 					}}, SourceFile: pathToCfg2, SourceIndex: 0},
 			}
-			t.Override(&inspect.ConfigSetFunc, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
 				if test.err != nil {
 					return nil, test.err
 				}

--- a/pkg/skaffold/inspect/buildEnv/list.go
+++ b/pkg/skaffold/inspect/buildEnv/list.go
@@ -36,7 +36,12 @@ type buildEnvEntry struct {
 
 func PrintBuildEnvsList(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.ConfigSetFunc(config.SkaffoldOptions{ConfigurationFile: opts.Filename, Profiles: opts.Profiles, ConfigurationFilter: opts.Modules})
+	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{
+		ConfigurationFile:   opts.Filename,
+		RepoCacheDir:        opts.RepoCacheDir,
+		Profiles:            opts.Profiles,
+		ConfigurationFilter: opts.Modules,
+	})
 	if err != nil {
 		return formatter.WriteErr(err)
 	}

--- a/pkg/skaffold/inspect/buildEnv/list_test.go
+++ b/pkg/skaffold/inspect/buildEnv/list_test.go
@@ -100,7 +100,7 @@ func TestPrintBuildEnvsList(t *testing.T) {
 						{Name: "local", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
 					}}, SourceFile: "path/to/cfg2"},
 			}
-			t.Override(&inspect.ConfigSetFunc, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
 				// mock profile activation
 				var set parser.SkaffoldConfigSet
 				for _, c := range configSet {

--- a/pkg/skaffold/inspect/buildEnv/modify_gcb.go
+++ b/pkg/skaffold/inspect/buildEnv/modify_gcb.go
@@ -27,7 +27,7 @@ import (
 
 func ModifyGcbBuildEnv(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.ConfigSetFunc(config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, SkipConfigDefaults: true, MakePathsAbsolute: util.BoolPtr(false)})
+	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, SkipConfigDefaults: true, MakePathsAbsolute: util.BoolPtr(false)})
 	if err != nil {
 		return formatter.WriteErr(err)
 	}

--- a/pkg/skaffold/inspect/buildEnv/modify_gcb_test.go
+++ b/pkg/skaffold/inspect/buildEnv/modify_gcb_test.go
@@ -236,7 +236,7 @@ profiles:
 						{Name: "p1", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{GoogleCloudBuild: &v1.GoogleCloudBuild{ProjectID: "project1"}}}}},
 					}}, SourceFile: pathToCfg2, SourceIndex: 0},
 			}
-			t.Override(&inspect.ConfigSetFunc, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
 				if len(opts.ConfigurationFilter) == 0 || util.StrSliceContains(opts.ConfigurationFilter, "cfg1") {
 					return configSet, nil
 				}

--- a/pkg/skaffold/inspect/profiles/list.go
+++ b/pkg/skaffold/inspect/profiles/list.go
@@ -36,7 +36,7 @@ type profileEntry struct {
 
 func PrintProfilesList(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.ConfigSetFunc(config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules})
+	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, RepoCacheDir: opts.RepoCacheDir})
 	if err != nil {
 		return formatter.WriteErr(err)
 	}

--- a/pkg/skaffold/inspect/profiles/list_test.go
+++ b/pkg/skaffold/inspect/profiles/list_test.go
@@ -114,7 +114,7 @@ func TestPrintProfilesList(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&inspect.ConfigSetFunc, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
 				if len(opts.ConfigurationFilter) == 0 {
 					return test.configSet, test.err
 				}

--- a/pkg/skaffold/inspect/types.go
+++ b/pkg/skaffold/inspect/types.go
@@ -25,14 +25,24 @@ import (
 type Options struct {
 	// Filename is the `skaffold.yaml` file path
 	Filename string
+	// RepoCacheDir is the directory for the remote git repository cache
+	RepoCacheDir string
 	// OutFormat is the output format. One of: json
 	OutFormat string
 	// Modules is the module filter for specific commands
 	Modules []string
 	// Strict specifies the error-tolerance for specific commands
 	Strict bool
+
+	ModulesOptions
 	ProfilesOptions
 	BuildEnvOptions
+}
+
+// ModulesOptions holds flag values for various `skaffold inspect modules` commands
+type ModulesOptions struct {
+	// IncludeAll specifies if unnamed modules should be included in the output list
+	IncludeAll bool
 }
 
 // ProfilesOptions holds flag values for various `skaffold inspect profiles` commands
@@ -97,8 +107,8 @@ type BuildEnvOptions struct {
 type BuildEnv string
 
 var (
-	ConfigSetFunc = parser.GetConfigSet
-	BuildEnvs     = struct {
+	GetConfigSet = parser.GetConfigSet
+	BuildEnvs    = struct {
 		Unspecified      BuildEnv
 		Local            BuildEnv
 		GoogleCloudBuild BuildEnv

--- a/pkg/skaffold/parser/types.go
+++ b/pkg/skaffold/parser/types.go
@@ -27,6 +27,7 @@ type SkaffoldConfigEntry struct {
 	SourceFile   string
 	SourceIndex  int
 	IsRootConfig bool
+	IsRemote     bool
 }
 
 // SelectRootConfigs filters SkaffoldConfigSet to only configs read from the root skaffold.yaml file


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

This PR modifies the `skaffold inspect modules list` command to also output whether the config is `remote` or if it is from the `root` skaffold.yaml file. The flag `--all` or `-a` also includes unnamed configs (these cannot be passed to the `--module` flag in other commands).
For example, for the project `examples/remote-multi-config-microservices`, we get:

```
❯ skaffold inspect modules list -a | jq  
{
  "modules": [
    {
      "name": "__config_0",
      "path": "/Users/gaghosh/.skaffold/repos/euw2xNJipHV7cZ9CraIE8t5SYEhMAt9x/examples/multi-config-microservices/base/skaffold.yaml",
      "isRemote": true
    },
    {
      "name": "app-config",
      "path": "/Users/gaghosh/.skaffold/repos/euw2xNJipHV7cZ9CraIE8t5SYEhMAt9x/examples/multi-config-microservices/leeroy-app/skaffold.yaml",
      "isRemote": true
    },
    {
      "name": "web-config",
      "path": "/Users/gaghosh/.skaffold/repos/euw2xNJipHV7cZ9CraIE8t5SYEhMAt9x/examples/multi-config-microservices/leeroy-web/skaffold.yaml",
      "isRemote": true
    },
    {
      "name": "__config_0",
      "path": "/Users/gaghosh/Code/Work/fork/skaffold/integration/examples/remote-multi-config-microservices/skaffold.yaml",
      "isRoot": true
    }
  ]
}
```

The motivation for this change is the Cloud Code IDE integration for Modules. They need to be able to get a list of all resolved modules in addition to only named modules. Also they need to be able to identify which modules are from remote git repos