### PR TITLE
Buildpacks builder supports mounting read/write volumes (experimental)

### DIFF
--- a/docs/content/en/schemas/v2beta17.json
+++ b/docs/content/en/schemas/v2beta17.json
@@ -628,6 +628,10 @@
           "description": "indicates that the builder should be trusted.",
           "x-intellij-html-description": "indicates that the builder should be trusted.",
           "default": "false"
+        },
+        "volumes": {
+          "description": "support mounting host volumes into the container.",
+          "x-intellij-html-description": "support mounting host volumes into the container."
         }
       },
       "preferredOrder": [
@@ -637,7 +641,8 @@
         "buildpacks",
         "trustBuilder",
         "projectDescriptor",
-        "dependencies"
+        "dependencies",
+        "volumes"
       ],
       "additionalProperties": false,
       "type": "object",
@@ -673,6 +678,38 @@
       "type": "object",
       "description": "*alpha* used to specify dependencies for an artifact built by buildpacks.",
       "x-intellij-html-description": "<em>alpha</em> used to specify dependencies for an artifact built by buildpacks."
+    },
+    "BuildpackVolume": {
+      "required": [
+        "host",
+        "target"
+      ],
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "local volume or absolute directory of the path to mount.",
+          "x-intellij-html-description": "local volume or absolute directory of the path to mount."
+        },
+        "options": {
+          "type": "string",
+          "description": "specify a list of comma-separated mount options. Valid options are: `ro` (default): volume contents are read-only. `rw`: volume contents are readable and writable. `volume-opt=<key>=<value>`: can be specified more than once, takes a key-value pair.",
+          "x-intellij-html-description": "specify a list of comma-separated mount options. Valid options are: <code>ro</code> (default): volume contents are read-only. <code>rw</code>: volume contents are readable and writable. <code>volume-opt=&lt;key&gt;=&lt;value&gt;</code>: can be specified more than once, takes a key-value pair."
+        },
+        "target": {
+          "type": "string",
+          "description": "path where the file or directory is available in the container. It is strongly recommended to not specify locations under `/cnb` or `/layers`.",
+          "x-intellij-html-description": "path where the file or directory is available in the container. It is strongly recommended to not specify locations under <code>/cnb</code> or <code>/layers</code>."
+        }
+      },
+      "preferredOrder": [
+        "host",
+        "target",
+        "options"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "*alpha* used to mount host volumes or directories in the build container.",
+      "x-intellij-html-description": "<em>alpha</em> used to mount host volumes or directories in the build container."
     },
     "ClusterDetails": {
       "properties": {

--- a/pkg/skaffold/build/buildpacks/lifecycle_test.go
+++ b/pkg/skaffold/build/buildpacks/lifecycle_test.go
@@ -21,10 +21,11 @@ import (
 	"fmt"
 	"testing"
 
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
-	"github.com/GoogleContainerTools/skaffold/testutil"
 	lifecycle "github.com/buildpacks/lifecycle/cmd"
 	"github.com/buildpacks/pack"
+
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestLifecycleStatusCode(t *testing.T) {
@@ -69,18 +70,18 @@ func TestContainerConfig(t *testing.T) {
 	tests := []struct {
 		description string
 		volumes     []latestV1.BuildpackVolume
-		shouldErr bool
+		shouldErr   bool
 		expected    pack.ContainerConfig
 	}{
 		{
 			description: "single volume with no options",
-			volumes:     []latestV1.BuildpackVolume{{Host: "/foo",  Target: "/bar"}},
-			expected:    pack.ContainerConfig{Volumes:[]string{"/foo:/bar"}},
+			volumes:     []latestV1.BuildpackVolume{{Host: "/foo", Target: "/bar"}},
+			expected:    pack.ContainerConfig{Volumes: []string{"/foo:/bar"}},
 		},
 		{
 			description: "single volume with  options",
 			volumes:     []latestV1.BuildpackVolume{{Host: "/foo", Target: "/bar", Options: "rw"}},
-			expected:    pack.ContainerConfig{Volumes:[]string{"/foo:/bar:rw"}},
+			expected:    pack.ContainerConfig{Volumes: []string{"/foo:/bar:rw"}},
 		},
 		{
 			description: "multiple volumes",
@@ -88,21 +89,21 @@ func TestContainerConfig(t *testing.T) {
 				{Host: "/foo", Target: "/bar", Options: "rw"},
 				{Host: "/bat", Target: "/baz", Options: "ro"},
 			},
-			expected: pack.ContainerConfig{Volumes:[]string{"/foo:/bar:rw","/bat:/baz:ro"}},
+			expected: pack.ContainerConfig{Volumes: []string{"/foo:/bar:rw", "/bat:/baz:ro"}},
 		},
 		{
 			description: "missing host is skipped",
 			volumes:     []latestV1.BuildpackVolume{{Host: "", Target: "/bar"}},
-			shouldErr: true,
+			shouldErr:   true,
 		},
 		{
 			description: "missing target is skipped",
 			volumes:     []latestV1.BuildpackVolume{{Host: "/foo", Target: ""}},
-			shouldErr: true,
+			shouldErr:   true,
 		},
 	}
 
-		for _, test := range tests {
+	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			artifact := latestV1.BuildpackArtifact{
 				Volumes: &test.volumes,

--- a/pkg/skaffold/build/buildpacks/lifecycle_test.go
+++ b/pkg/skaffold/build/buildpacks/lifecycle_test.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 	"testing"
 
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/testutil"
 	lifecycle "github.com/buildpacks/lifecycle/cmd"
+	"github.com/buildpacks/pack"
 )
 
 func TestLifecycleStatusCode(t *testing.T) {
@@ -59,5 +62,53 @@ func TestLifecycleStatusCode(t *testing.T) {
 		if result.Error() != test.expected {
 			t.Errorf("got %q, wanted %q", result.Error(), test.expected)
 		}
+	}
+}
+
+func TestContainerConfig(t *testing.T) {
+	tests := []struct {
+		description string
+		volumes     []latestV1.BuildpackVolume
+		shouldErr bool
+		expected    pack.ContainerConfig
+	}{
+		{
+			description: "single volume with no options",
+			volumes:     []latestV1.BuildpackVolume{{Host: "/foo",  Target: "/bar"}},
+			expected:    pack.ContainerConfig{Volumes:[]string{"/foo:/bar"}},
+		},
+		{
+			description: "single volume with  options",
+			volumes:     []latestV1.BuildpackVolume{{Host: "/foo", Target: "/bar", Options: "rw"}},
+			expected:    pack.ContainerConfig{Volumes:[]string{"/foo:/bar:rw"}},
+		},
+		{
+			description: "multiple volumes",
+			volumes: []latestV1.BuildpackVolume{
+				{Host: "/foo", Target: "/bar", Options: "rw"},
+				{Host: "/bat", Target: "/baz", Options: "ro"},
+			},
+			expected: pack.ContainerConfig{Volumes:[]string{"/foo:/bar:rw","/bat:/baz:ro"}},
+		},
+		{
+			description: "missing host is skipped",
+			volumes:     []latestV1.BuildpackVolume{{Host: "", Target: "/bar"}},
+			shouldErr: true,
+		},
+		{
+			description: "missing target is skipped",
+			volumes:     []latestV1.BuildpackVolume{{Host: "/foo", Target: ""}},
+			shouldErr: true,
+		},
+	}
+
+		for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			artifact := latestV1.BuildpackArtifact{
+				Volumes: &test.volumes,
+			}
+			result, err := containerConfig(&artifact)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, result)
+		})
 	}
 }

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -994,6 +994,9 @@ type BuildpackArtifact struct {
 
 	// Dependencies are the file dependencies that skaffold should watch for both rebuilding and file syncing for this artifact.
 	Dependencies *BuildpackDependencies `yaml:"dependencies,omitempty"`
+	
+	// Volumes support mounting host volumes into the container.
+	Volumes *[]BuildpackVolume `yaml:"volumes,omitempty"`
 }
 
 // BuildpackDependencies *alpha* is used to specify dependencies for an artifact built by buildpacks.
@@ -1004,6 +1007,23 @@ type BuildpackDependencies struct {
 	// Ignore specifies the paths that should be ignored by skaffold's file watcher. If a file exists in both `paths` and in `ignore`, it will be ignored, and will be excluded from both rebuilds and file synchronization.
 	// Will only work in conjunction with `paths`.
 	Ignore []string `yaml:"ignore,omitempty"`
+}
+
+// BuildpackVolume *alpha* is used to mount host volumes or directories in the build container.
+type BuildpackVolume struct {
+	// Host is the local volume or absolute directory of the path to mount.
+	Host string `yaml:"host" skaffold:"filepath" yamltags:"required"`
+
+	// Target is the path where the file or directory is available in the container.
+	// It is strongly recommended to not specify locations under `/cnb` or `/layers`.
+	Target string `yaml:"target" yamltags:"required"`
+
+	// Options specify a list of comma-separated mount options.
+	// Valid options are:
+	// `ro` (default): volume contents are read-only.
+	// `rw`: volume contents are readable and writable.
+	// `volume-opt=<key>=<value>`: can be specified more than once, takes a key-value pair.
+	Options string `yaml:"options,omitempty"`
 }
 
 // CustomArtifact *beta* describes an artifact built from a custom build script

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -994,7 +994,7 @@ type BuildpackArtifact struct {
 
 	// Dependencies are the file dependencies that skaffold should watch for both rebuilding and file syncing for this artifact.
 	Dependencies *BuildpackDependencies `yaml:"dependencies,omitempty"`
-	
+
 	// Volumes support mounting host volumes into the container.
 	Volumes *[]BuildpackVolume `yaml:"volumes,omitempty"`
 }


### PR DESCRIPTION
Fixes: #5407 

**Description**
This PR adds support for mounting volumes in buildpacks artifacts, as per `pack build --volume`.  This functionality allows mounting both volumes and local files/directories during the build process. 


#### Possible Uses

This feature, with with a few key environment variables, can allow developers to perform more aggressive caching *between* buildpacks builds using language-specific settings:

- The Golang _module cache_ can be set with [`GOMODCACHE`](https://golang.org/ref/mod#module-cache)
- The Pip wheel cache can be set with `PIP_CACHE_DIR` (pip uses a skaffold-like [mapping of command-like flags to environment variables](https://pip.pypa.io/en/stable/user_guide/#environment-variables)); there's a similar [`PIPENV_CACHE_DIR`](https://github.com/pypa/pipenv/blob/66713a7bcf25fa4d31344df0e1e484a99e562d70/pipenv/environments.py#L87) for `pipenv`
- The npm download location can be set with the [`npm_config_cache`](https://docs.npmjs.com/cli/v7/using-npm/config#cache) [environment variable](https://docs.npmjs.com/cli/v7/using-npm/config#environment-variables)
- The yarn cache directory can be set with the [`YARN_CACHE_FOLDER`](https://classic.yarnpkg.com/en/docs/cli/cache/) environment variable.
- The Maven local repository can be set via the [`MAVEN_OPTS=-Dmaven.repo.local=xxx`](https://maven.apache.org/guides/mini/guide-configuring-maven.html#configuring-your-local-repository) (the property is not actually documented officially)
- Gradle doesn't have a single setting for controlling where downloads are cached, but the Gradle User Home (`~/.gradle`) can be set via the [`GRADLE_USER_HOME`](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_environment_variables) environment variable

Using these mounts is somewhat complicated as Docker normally configures volume- and bind-mounts as owned by root (https://github.com/moby/moby/issues/2259):
  -  _bind mounts_, for local files and directories, generally work for root containers, but can have mixed results with permission problems with non-root containers such as CNB builder images.  And the behaviour seems to vary on the platform (linux vs macOS/Windows).
  - _volume mounts_ retain the ownership defined in the volume.

So the volume needs some preparation for use in a non-root container like the following (assuming the user:group is 1000:1000):
```
docker volume create skaffold-buildpacks-cache
docker run --rm -v skaffold-buildpacks-cache:/skbpcache busybox chown 1000:1000 /skbpcache
```

CNB builder images, like `gcr.io/buildpacks/builder:v1`, define environment variables `CNB_USER` and `CNB_GROUP` to encode the UID and GID used for the build.

So for example, we can enable caching for a Java image with the GCP Buildpacks builder like:
```diff
--- examples/buildpacks-java/skaffold.yaml
+++ examples/buildpacks-java/skaffold.yaml
   - image: skaffold-buildpacks
     buildpacks:
       builder: "gcr.io/buildpacks/builder:v1"
+      trustBuilder: true
+      volumes:
+      - host: skaffold-buildpacks-cache
+        target: /skbpcache
+        options: "rw"
       env:
       - GOOGLE_RUNTIME_VERSION=8
+      - GOOGLE_BUILD_ARGS=-Dmaven.repo.local=/skbpcache
```

This seems like a good candidate for automating with Skaffold.

**User facing changes (remove if N/A)**

- Buildpacks builder supports mounting read/write volumes (experimental)