### PR TITLE
Move PodSelector into Deployer

### DIFF
--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -88,7 +88,7 @@ spec:
 					},
 				},
 			}}),
-		}, nil, &latestV1.KubectlDeploy{
+		}, nil, nil, &latestV1.KubectlDeploy{
 			Manifests: []string{"deployment.yaml"},
 		})
 		t.RequireNoError(err)
@@ -248,7 +248,7 @@ spec:
 				Opts: config.SkaffoldOptions{
 					AddSkaffoldLabels: true,
 				},
-			}, nil, &latestV1.KubectlDeploy{
+			}, nil, nil, &latestV1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
 			})
 			t.RequireNoError(err)
@@ -434,7 +434,7 @@ spec:
 						},
 					},
 				}}),
-			}, nil, &latestV1.HelmDeploy{
+			}, nil, nil, &latestV1.HelmDeploy{
 				Releases: test.helmReleases,
 			})
 			t.RequireNoError(err)

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -77,7 +77,7 @@ spec:
 		t.NewTempDir().
 			Write("deployment.yaml", test.input).
 			Chdir()
-		deployer, err := kubectl.NewDeployer(&runcontext.RunContext{
+		deployer, _, err := kubectl.NewDeployer(&runcontext.RunContext{
 			WorkingDir: ".",
 			Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{
 				Deploy: latestV1.DeployConfig{
@@ -88,7 +88,7 @@ spec:
 					},
 				},
 			}}),
-		}, nil, nil, &latestV1.KubectlDeploy{
+		}, nil, &latestV1.KubectlDeploy{
 			Manifests: []string{"deployment.yaml"},
 		})
 		t.RequireNoError(err)
@@ -234,7 +234,7 @@ spec:
 				Write("deployment.yaml", test.input).
 				Chdir()
 
-			deployer, err := kubectl.NewDeployer(&runcontext.RunContext{
+			deployer, _, err := kubectl.NewDeployer(&runcontext.RunContext{
 				WorkingDir: ".",
 				Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{
 					Deploy: latestV1.DeployConfig{
@@ -248,7 +248,7 @@ spec:
 				Opts: config.SkaffoldOptions{
 					AddSkaffoldLabels: true,
 				},
-			}, nil, nil, &latestV1.KubectlDeploy{
+			}, nil, &latestV1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
 			})
 			t.RequireNoError(err)
@@ -424,7 +424,7 @@ spec:
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			deployer, err := helm.NewDeployer(&runcontext.RunContext{
+			deployer, _, err := helm.NewDeployer(&runcontext.RunContext{
 				Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{
 					Deploy: latestV1.DeployConfig{
 						DeployType: latestV1.DeployType{
@@ -434,7 +434,7 @@ spec:
 						},
 					},
 				}}),
-			}, nil, nil, &latestV1.HelmDeploy{
+			}, nil, &latestV1.HelmDeploy{
 				Releases: test.helmReleases,
 			})
 			t.RequireNoError(err)

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
@@ -472,7 +471,7 @@ func TestNewDeployer(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", test.helmVersion))
 
-			_, err := NewDeployer(&helmConfig{}, nil, kubernetes.NewImageList(), &testDeployConfig)
+			_, _, err := NewDeployer(&helmConfig{}, nil, &testDeployConfig)
 			t.CheckError(test.shouldErr, err)
 		})
 	}
@@ -1006,11 +1005,11 @@ func TestHelmDeploy(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.Override(&osExecutable, func() (string, error) { return "SKAFFOLD-BINARY", nil })
 
-			deployer, err := NewDeployer(&helmConfig{
+			deployer, _, err := NewDeployer(&helmConfig{
 				namespace:  test.namespace,
 				force:      test.force,
 				configFile: "test.yaml",
-			}, nil, kubernetes.NewImageList(), &test.helm)
+			}, nil, &test.helm)
 			t.RequireNoError(err)
 
 			if test.configure != nil {
@@ -1085,9 +1084,9 @@ func TestHelmCleanup(t *testing.T) {
 			t.Override(&util.OSEnviron, func() []string { return []string{"FOO=FOOBAR"} })
 			t.Override(&util.DefaultExecCommand, test.commands)
 
-			deployer, err := NewDeployer(&helmConfig{
+			deployer, _, err := NewDeployer(&helmConfig{
 				namespace: test.namespace,
-			}, nil, kubernetes.NewImageList(), &test.helm)
+			}, nil, &test.helm)
 			t.RequireNoError(err)
 
 			deployer.Cleanup(context.Background(), ioutil.Discard)
@@ -1190,7 +1189,7 @@ func TestHelmDependencies(t *testing.T) {
 				local = tmpDir.Root()
 			}
 
-			deployer, err := NewDeployer(&helmConfig{}, nil, kubernetes.NewImageList(), &latestV1.HelmDeploy{
+			deployer, _, err := NewDeployer(&helmConfig{}, nil, &latestV1.HelmDeploy{
 				Releases: []latestV1.HelmRelease{{
 					Name:                  "skaffold-helm",
 					ChartPath:             local,
@@ -1453,9 +1452,9 @@ func TestHelmRender(t *testing.T) {
 
 			t.Override(&util.OSEnviron, func() []string { return append([]string{"FOO=FOOBAR"}, test.env...) })
 			t.Override(&util.DefaultExecCommand, test.commands)
-			deployer, err := NewDeployer(&helmConfig{
+			deployer, _, err := NewDeployer(&helmConfig{
 				namespace: test.namespace,
-			}, nil, kubernetes.NewImageList(), &test.helm)
+			}, nil, &test.helm)
 			t.RequireNoError(err)
 			err = deployer.Render(context.Background(), ioutil.Discard, test.builds, true, file)
 			t.CheckError(test.shouldErr, err)
@@ -1524,7 +1523,7 @@ func TestGenerateSkaffoldDebugFilter(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", version31))
-			h, err := NewDeployer(&helmConfig{}, nil, kubernetes.NewImageList(), &testDeployConfig)
+			h, _, err := NewDeployer(&helmConfig{}, nil, &testDeployConfig)
 			t.RequireNoError(err)
 			result := h.generateSkaffoldDebugFilter(test.buildFile)
 			t.CheckDeepEqual(test.result, result)

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
@@ -471,7 +472,7 @@ func TestNewDeployer(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", test.helmVersion))
 
-			_, err := NewDeployer(&helmConfig{}, nil, &testDeployConfig)
+			_, err := NewDeployer(&helmConfig{}, nil, kubernetes.NewImageList(), &testDeployConfig)
 			t.CheckError(test.shouldErr, err)
 		})
 	}
@@ -1009,7 +1010,7 @@ func TestHelmDeploy(t *testing.T) {
 				namespace:  test.namespace,
 				force:      test.force,
 				configFile: "test.yaml",
-			}, nil, &test.helm)
+			}, nil, kubernetes.NewImageList(), &test.helm)
 			t.RequireNoError(err)
 
 			if test.configure != nil {
@@ -1086,7 +1087,7 @@ func TestHelmCleanup(t *testing.T) {
 
 			deployer, err := NewDeployer(&helmConfig{
 				namespace: test.namespace,
-			}, nil, &test.helm)
+			}, nil, kubernetes.NewImageList(), &test.helm)
 			t.RequireNoError(err)
 
 			deployer.Cleanup(context.Background(), ioutil.Discard)
@@ -1189,7 +1190,7 @@ func TestHelmDependencies(t *testing.T) {
 				local = tmpDir.Root()
 			}
 
-			deployer, err := NewDeployer(&helmConfig{}, nil, &latestV1.HelmDeploy{
+			deployer, err := NewDeployer(&helmConfig{}, nil, kubernetes.NewImageList(), &latestV1.HelmDeploy{
 				Releases: []latestV1.HelmRelease{{
 					Name:                  "skaffold-helm",
 					ChartPath:             local,
@@ -1454,7 +1455,7 @@ func TestHelmRender(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			deployer, err := NewDeployer(&helmConfig{
 				namespace: test.namespace,
-			}, nil, &test.helm)
+			}, nil, kubernetes.NewImageList(), &test.helm)
 			t.RequireNoError(err)
 			err = deployer.Render(context.Background(), ioutil.Discard, test.builds, true, file)
 			t.CheckError(test.shouldErr, err)
@@ -1523,7 +1524,7 @@ func TestGenerateSkaffoldDebugFilter(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", version31))
-			h, err := NewDeployer(&helmConfig{}, nil, &testDeployConfig)
+			h, err := NewDeployer(&helmConfig{}, nil, kubernetes.NewImageList(), &testDeployConfig)
 			t.RequireNoError(err)
 			result := h.generateSkaffoldDebugFilter(test.buildFile)
 			t.CheckDeepEqual(test.result, result)

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -35,9 +35,11 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
+	deployutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -64,6 +66,9 @@ const (
 type Deployer struct {
 	*latestV1.KptDeploy
 
+	podSelector    *kubernetes.ImageList
+	originalImages []graph.Artifact
+
 	insecureRegistries map[string]bool
 	labels             map[string]string
 	globalConfig       string
@@ -78,9 +83,10 @@ type Config interface {
 }
 
 // NewDeployer generates a new Deployer object contains the kptDeploy schema.
-func NewDeployer(cfg Config, labels map[string]string, d *latestV1.KptDeploy) *Deployer {
+func NewDeployer(cfg Config, labels map[string]string, podSelector *kubernetes.ImageList, d *latestV1.KptDeploy) *Deployer {
 	return &Deployer{
 		KptDeploy:          d,
+		podSelector:        podSelector,
 		insecureRegistries: cfg.GetInsecureRegistries(),
 		labels:             labels,
 		globalConfig:       cfg.GlobalConfig(),
@@ -200,6 +206,7 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 		return nil, err
 	}
 
+	deployutil.AddTagsToPodSelector(builds, k.originalImages, k.podSelector)
 	endTrace()
 	return namespaces, nil
 }
@@ -376,6 +383,12 @@ func (k *Deployer) renderManifests(ctx context.Context, builds []graph.Artifact)
 	manifests, err = k.excludeKptFn(manifests)
 	if err != nil {
 		return nil, fmt.Errorf("excluding kpt functions from manifests: %w", err)
+	}
+	if k.originalImages == nil {
+		k.originalImages, err = manifests.GetImages()
+		if err != nil {
+			return nil, err
+		}
 	}
 	manifests, err = manifests.ReplaceImages(ctx, builds)
 	if err != nil {

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -83,7 +83,8 @@ type Config interface {
 }
 
 // NewDeployer generates a new Deployer object contains the kptDeploy schema.
-func NewDeployer(cfg Config, labels map[string]string, podSelector *kubernetes.ImageList, d *latestV1.KptDeploy) *Deployer {
+func NewDeployer(cfg Config, labels map[string]string, d *latestV1.KptDeploy) (*Deployer, *kubernetes.ImageList) {
+	podSelector := kubernetes.NewImageList()
 	return &Deployer{
 		KptDeploy:          d,
 		podSelector:        podSelector,
@@ -94,7 +95,7 @@ func NewDeployer(cfg Config, labels map[string]string, podSelector *kubernetes.I
 		kubeContext:        cfg.GetKubeContext(),
 		kubeConfig:         cfg.GetKubeConfig(),
 		namespace:          cfg.GetKubeNamespace(),
-	}
+	}, podSelector
 }
 
 var sanityCheck = versionCheck

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -230,7 +231,7 @@ func TestKpt_Deploy(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.NewTempDir().Chdir()
 
-			k := NewDeployer(&kptConfig{}, nil, &test.kpt)
+			k := NewDeployer(&kptConfig{}, nil, kubernetes.NewImageList(), &test.kpt)
 			if test.hasKustomization != nil {
 				k.hasKustomization = test.hasKustomization
 			}
@@ -373,7 +374,7 @@ func TestKpt_Dependencies(t *testing.T) {
 			tmpDir.WriteFiles(test.createFiles)
 			tmpDir.WriteFiles(test.kustomizations)
 
-			k := NewDeployer(&kptConfig{}, nil, &test.kpt)
+			k := NewDeployer(&kptConfig{}, nil, kubernetes.NewImageList(), &test.kpt)
 
 			res, err := k.Dependencies()
 
@@ -426,7 +427,7 @@ func TestKpt_Cleanup(t *testing.T) {
 
 			k := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, nil, &latestV1.KptDeploy{
+			}, nil, kubernetes.NewImageList(), &latestV1.KptDeploy{
 				Live: latestV1.KptLive{
 					Apply: latestV1.KptApplyInventory{
 						Dir: test.applyDir,
@@ -786,7 +787,7 @@ spec:
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.NewTempDir().Chdir()
 
-			k := NewDeployer(&kptConfig{workingDir: "."}, test.labels, &test.kpt)
+			k := NewDeployer(&kptConfig{workingDir: "."}, test.labels, kubernetes.NewImageList(), &test.kpt)
 			if test.hasKustomization != nil {
 				k.hasKustomization = test.hasKustomization
 			}
@@ -863,7 +864,7 @@ func TestKpt_GetApplyDir(t *testing.T) {
 
 			k := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, nil, &latestV1.KptDeploy{
+			}, nil, kubernetes.NewImageList(), &latestV1.KptDeploy{
 				Live: test.live,
 			})
 
@@ -1022,7 +1023,7 @@ spec:
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			k := NewDeployer(&kptConfig{}, nil, nil)
+			k := NewDeployer(&kptConfig{}, nil, nil, nil)
 			actualManifest, err := k.excludeKptFn(test.manifests)
 			t.CheckErrorAndDeepEqual(false, err, test.expected.String(), actualManifest.String())
 		})
@@ -1168,7 +1169,7 @@ func TestNonEmptyKubeconfig(t *testing.T) {
 
 	testutil.Run(t, "", func(t *testutil.T) {
 		t.Override(&util.DefaultExecCommand, commands)
-		k := NewDeployer(&kptConfig{config: "testConfigPath"}, nil, &latestV1.KptDeploy{
+		k := NewDeployer(&kptConfig{config: "testConfigPath"}, nil, kubernetes.NewImageList(), &latestV1.KptDeploy{
 			Dir: ".",
 			Live: latestV1.KptLive{
 				Apply: latestV1.KptApplyInventory{

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -231,7 +230,7 @@ func TestKpt_Deploy(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.NewTempDir().Chdir()
 
-			k := NewDeployer(&kptConfig{}, nil, kubernetes.NewImageList(), &test.kpt)
+			k, _ := NewDeployer(&kptConfig{}, nil, &test.kpt)
 			if test.hasKustomization != nil {
 				k.hasKustomization = test.hasKustomization
 			}
@@ -374,7 +373,7 @@ func TestKpt_Dependencies(t *testing.T) {
 			tmpDir.WriteFiles(test.createFiles)
 			tmpDir.WriteFiles(test.kustomizations)
 
-			k := NewDeployer(&kptConfig{}, nil, kubernetes.NewImageList(), &test.kpt)
+			k, _ := NewDeployer(&kptConfig{}, nil, &test.kpt)
 
 			res, err := k.Dependencies()
 
@@ -425,9 +424,9 @@ func TestKpt_Cleanup(t *testing.T) {
 				t.CheckNoError(os.Mkdir(test.applyDir, 0755))
 			}
 
-			k := NewDeployer(&kptConfig{
+			k, _ := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, nil, kubernetes.NewImageList(), &latestV1.KptDeploy{
+			}, nil, &latestV1.KptDeploy{
 				Live: latestV1.KptLive{
 					Apply: latestV1.KptApplyInventory{
 						Dir: test.applyDir,
@@ -787,7 +786,7 @@ spec:
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.NewTempDir().Chdir()
 
-			k := NewDeployer(&kptConfig{workingDir: "."}, test.labels, kubernetes.NewImageList(), &test.kpt)
+			k, _ := NewDeployer(&kptConfig{workingDir: "."}, test.labels, &test.kpt)
 			if test.hasKustomization != nil {
 				k.hasKustomization = test.hasKustomization
 			}
@@ -862,9 +861,9 @@ func TestKpt_GetApplyDir(t *testing.T) {
 				tmpDir.Touch(".kpt-hydrated/inventory-template.yaml")
 			}
 
-			k := NewDeployer(&kptConfig{
+			k, _ := NewDeployer(&kptConfig{
 				workingDir: ".",
-			}, nil, kubernetes.NewImageList(), &latestV1.KptDeploy{
+			}, nil, &latestV1.KptDeploy{
 				Live: test.live,
 			})
 
@@ -1023,7 +1022,7 @@ spec:
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			k := NewDeployer(&kptConfig{}, nil, nil, nil)
+			k, _ := NewDeployer(&kptConfig{}, nil, nil)
 			actualManifest, err := k.excludeKptFn(test.manifests)
 			t.CheckErrorAndDeepEqual(false, err, test.expected.String(), actualManifest.String())
 		})
@@ -1169,7 +1168,7 @@ func TestNonEmptyKubeconfig(t *testing.T) {
 
 	testutil.Run(t, "", func(t *testutil.T) {
 		t.Override(&util.DefaultExecCommand, commands)
-		k := NewDeployer(&kptConfig{config: "testConfigPath"}, nil, kubernetes.NewImageList(), &latestV1.KptDeploy{
+		k, _ := NewDeployer(&kptConfig{config: "testConfigPath"}, nil, &latestV1.KptDeploy{
 			Dir: ".",
 			Live: latestV1.KptLive{
 				Apply: latestV1.KptApplyInventory{

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -60,15 +60,17 @@ type Deployer struct {
 
 // NewDeployer returns a new Deployer for a DeployConfig filled
 // with the needed configuration for `kubectl apply`
-func NewDeployer(cfg Config, labels map[string]string, podSelector *kubernetes.ImageList, d *latestV1.KubectlDeploy) (*Deployer, error) {
+func NewDeployer(cfg Config, labels map[string]string, d *latestV1.KubectlDeploy) (*Deployer, *kubernetes.ImageList, error) {
 	defaultNamespace := ""
 	if d.DefaultNamespace != nil {
 		var err error
 		defaultNamespace, err = util.ExpandEnvTemplate(*d.DefaultNamespace, nil)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
+
+	podSelector := kubernetes.NewImageList()
 
 	return &Deployer{
 		KubectlDeploy:      d,
@@ -81,7 +83,7 @@ func NewDeployer(cfg Config, labels map[string]string, podSelector *kubernetes.I
 		skipRender:         cfg.SkipRender(),
 		labels:             labels,
 		hydratedManifests:  cfg.HydratedManifests(),
-	}, nil
+	}, podSelector, nil
 }
 
 // Deploy templates the provided manifests with a simple `find and replace` and

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -241,7 +242,7 @@ func TestKubectlDeploy(t *testing.T) {
 				},
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: skaffoldNamespaceOption}},
-			}, nil, &test.kubectl)
+			}, nil, kubernetes.NewImageList(), &test.kubectl)
 			t.RequireNoError(err)
 
 			_, err = k.Deploy(context.Background(), ioutil.Discard, test.builds)
@@ -315,7 +316,7 @@ func TestKubectlCleanup(t *testing.T) {
 			k, err := NewDeployer(&kubectlConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
-			}, nil, &test.kubectl)
+			}, nil, kubernetes.NewImageList(), &test.kubectl)
 			t.RequireNoError(err)
 
 			err = k.Cleanup(context.Background(), ioutil.Discard)
@@ -362,7 +363,7 @@ func TestKubectlDeployerRemoteCleanup(t *testing.T) {
 			k, err := NewDeployer(&kubectlConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
-			}, nil, &test.kubectl)
+			}, nil, kubernetes.NewImageList(), &test.kubectl)
 			t.RequireNoError(err)
 
 			err = k.Cleanup(context.Background(), ioutil.Discard)
@@ -396,7 +397,7 @@ func TestKubectlRedeploy(t *testing.T) {
 				Enabled: true,
 				Delay:   0 * time.Millisecond,
 				Max:     10 * time.Second},
-		}, nil, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-app.yaml"), tmpDir.Path("deployment-web.yaml")}})
+		}, nil, kubernetes.NewImageList(), &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-app.yaml"), tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		// Deploy one manifest
@@ -460,7 +461,7 @@ func TestKubectlWaitForDeletions(t *testing.T) {
 				Delay:   0 * time.Millisecond,
 				Max:     10 * time.Second,
 			},
-		}, nil, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
+		}, nil, kubernetes.NewImageList(), &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		var out bytes.Buffer
@@ -497,7 +498,7 @@ func TestKubectlWaitForDeletionsFails(t *testing.T) {
 				Delay:   10 * time.Second,
 				Max:     100 * time.Millisecond,
 			},
-		}, nil, &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
+		}, nil, kubernetes.NewImageList(), &latestV1.KubectlDeploy{Manifests: []string{tmpDir.Path("deployment-web.yaml")}})
 		t.RequireNoError(err)
 
 		_, err = deployer.Deploy(context.Background(), ioutil.Discard, []graph.Artifact{
@@ -558,7 +559,7 @@ func TestDependencies(t *testing.T) {
 				Touch("00/b.yaml", "00/a.yaml").
 				Chdir()
 
-			k, err := NewDeployer(&kubectlConfig{}, nil, &latestV1.KubectlDeploy{Manifests: test.manifests})
+			k, err := NewDeployer(&kubectlConfig{}, nil, kubernetes.NewImageList(), &latestV1.KubectlDeploy{Manifests: test.manifests})
 			t.RequireNoError(err)
 
 			dependencies, err := k.Dependencies()
@@ -674,7 +675,7 @@ spec:
 			deployer, err := NewDeployer(&kubectlConfig{
 				workingDir:  ".",
 				defaultRepo: "gcr.io/project",
-			}, nil, &latestV1.KubectlDeploy{
+			}, nil, kubernetes.NewImageList(), &latestV1.KubectlDeploy{
 				Manifests: []string{tmpDir.Path("deployment.yaml")},
 			})
 			t.RequireNoError(err)
@@ -719,7 +720,7 @@ func TestGCSManifests(t *testing.T) {
 				workingDir: ".",
 				skipRender: test.skipRender,
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
-			}, nil, &test.kubectl)
+			}, nil, kubernetes.NewImageList(), &test.kubectl)
 			t.RequireNoError(err)
 
 			_, err = k.Deploy(context.Background(), ioutil.Discard, nil)

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -30,9 +30,11 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	deployerr "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/error"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
+	deployutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -94,6 +96,9 @@ type secretGenerator struct {
 type Deployer struct {
 	*latestV1.KustomizeDeploy
 
+	podSelector    *kubernetes.ImageList
+	originalImages []graph.Artifact
+
 	kubectl             kubectl.CLI
 	insecureRegistries  map[string]bool
 	labels              map[string]string
@@ -101,7 +106,7 @@ type Deployer struct {
 	useKubectlKustomize bool
 }
 
-func NewDeployer(cfg kubectl.Config, labels map[string]string, d *latestV1.KustomizeDeploy) (*Deployer, error) {
+func NewDeployer(cfg kubectl.Config, labels map[string]string, podSelector *kubernetes.ImageList, d *latestV1.KustomizeDeploy) (*Deployer, error) {
 	defaultNamespace := ""
 	if d.DefaultNamespace != nil {
 		var err error
@@ -117,6 +122,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, d *latestV1.Kusto
 
 	return &Deployer{
 		KustomizeDeploy:     d,
+		podSelector:         podSelector,
 		kubectl:             kubectl,
 		insecureRegistries:  cfg.GetInsecureRegistries(),
 		globalConfig:        cfg.GlobalConfig(),
@@ -181,6 +187,8 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 		endTrace(instrumentation.TraceEndError(err))
 		return nil, err
 	}
+
+	deployutil.AddTagsToPodSelector(builds, k.originalImages, k.podSelector)
 	endTrace()
 
 	return namespaces, nil
@@ -204,6 +212,13 @@ func (k *Deployer) renderManifests(ctx context.Context, out io.Writer, builds []
 
 	if len(manifests) == 0 {
 		return nil, nil
+	}
+
+	if len(k.originalImages) == 0 {
+		k.originalImages, err = manifests.GetImages()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	manifests, err = manifests.ReplaceImages(ctx, builds)

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -106,13 +106,13 @@ type Deployer struct {
 	useKubectlKustomize bool
 }
 
-func NewDeployer(cfg kubectl.Config, labels map[string]string, podSelector *kubernetes.ImageList, d *latestV1.KustomizeDeploy) (*Deployer, error) {
+func NewDeployer(cfg kubectl.Config, labels map[string]string, d *latestV1.KustomizeDeploy) (*Deployer, *kubernetes.ImageList, error) {
 	defaultNamespace := ""
 	if d.DefaultNamespace != nil {
 		var err error
 		defaultNamespace, err = util.ExpandEnvTemplate(*d.DefaultNamespace, nil)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -120,6 +120,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, podSelector *kube
 	// if user has kustomize binary, prioritize that over kubectl kustomize
 	useKubectlKustomize := !KustomizeBinaryCheck() && kubectlVersionCheck(kubectl)
 
+	podSelector := kubernetes.NewImageList()
 	return &Deployer{
 		KustomizeDeploy:     d,
 		podSelector:         podSelector,
@@ -128,7 +129,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, podSelector *kube
 		globalConfig:        cfg.GlobalConfig(),
 		labels:              labels,
 		useKubectlKustomize: useKubectlKustomize,
-	}, nil
+	}, podSelector, nil
 }
 
 // Check for existence of kustomize binary in user's PATH

--- a/pkg/skaffold/deploy/kustomize/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -186,7 +187,7 @@ func TestKustomizeDeploy(t *testing.T) {
 				},
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: skaffoldNamespaceOption,
-				}}}, nil, &test.kustomize)
+				}}}, nil, kubernetes.NewImageList(), &test.kustomize)
 			t.RequireNoError(err)
 			_, err = k.Deploy(context.Background(), ioutil.Discard, test.builds)
 
@@ -252,7 +253,7 @@ func TestKustomizeCleanup(t *testing.T) {
 				workingDir: tmpDir.Root(),
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: kubectl.TestNamespace}},
-			}, nil, &test.kustomize)
+			}, nil, kubernetes.NewImageList(), &test.kustomize)
 			t.RequireNoError(err)
 			err = k.Cleanup(context.Background(), ioutil.Discard)
 
@@ -454,7 +455,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 				tmpDir.Write(path, contents)
 			}
 
-			k, err := NewDeployer(&kustomizeConfig{}, nil, &latestV1.KustomizeDeploy{KustomizePaths: kustomizePaths})
+			k, err := NewDeployer(&kustomizeConfig{}, nil, kubernetes.NewImageList(), &latestV1.KustomizeDeploy{KustomizePaths: kustomizePaths})
 			t.RequireNoError(err)
 
 			deps, err := k.Dependencies()
@@ -698,7 +699,7 @@ spec:
 			k, err := NewDeployer(&kustomizeConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: kubectl.TestNamespace}},
-			}, test.labels, &latestV1.KustomizeDeploy{
+			}, test.labels, kubernetes.NewImageList(), &latestV1.KustomizeDeploy{
 				KustomizePaths: kustomizationPaths,
 			})
 			t.RequireNoError(err)

--- a/pkg/skaffold/deploy/kustomize/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -177,7 +176,7 @@ func TestKustomizeDeploy(t *testing.T) {
 				skaffoldNamespaceOption = kubectl.TestNamespace
 			}
 
-			k, err := NewDeployer(&kustomizeConfig{
+			k, _, err := NewDeployer(&kustomizeConfig{
 				workingDir: ".",
 				force:      test.forceDeploy,
 				waitForDeletions: config.WaitForDeletions{
@@ -187,7 +186,7 @@ func TestKustomizeDeploy(t *testing.T) {
 				},
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: skaffoldNamespaceOption,
-				}}}, nil, kubernetes.NewImageList(), &test.kustomize)
+				}}}, nil, &test.kustomize)
 			t.RequireNoError(err)
 			_, err = k.Deploy(context.Background(), ioutil.Discard, test.builds)
 
@@ -249,11 +248,11 @@ func TestKustomizeCleanup(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.Override(&KustomizeBinaryCheck, func() bool { return true })
 
-			k, err := NewDeployer(&kustomizeConfig{
+			k, _, err := NewDeployer(&kustomizeConfig{
 				workingDir: tmpDir.Root(),
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: kubectl.TestNamespace}},
-			}, nil, kubernetes.NewImageList(), &test.kustomize)
+			}, nil, &test.kustomize)
 			t.RequireNoError(err)
 			err = k.Cleanup(context.Background(), ioutil.Discard)
 
@@ -455,7 +454,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 				tmpDir.Write(path, contents)
 			}
 
-			k, err := NewDeployer(&kustomizeConfig{}, nil, kubernetes.NewImageList(), &latestV1.KustomizeDeploy{KustomizePaths: kustomizePaths})
+			k, _, err := NewDeployer(&kustomizeConfig{}, nil, &latestV1.KustomizeDeploy{KustomizePaths: kustomizePaths})
 			t.RequireNoError(err)
 
 			deps, err := k.Dependencies()
@@ -696,10 +695,10 @@ spec:
 			t.Override(&util.DefaultExecCommand, fakeCmd)
 			t.NewTempDir().Chdir()
 
-			k, err := NewDeployer(&kustomizeConfig{
+			k, _, err := NewDeployer(&kustomizeConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: kubectl.TestNamespace}},
-			}, test.labels, kubernetes.NewImageList(), &latestV1.KustomizeDeploy{
+			}, test.labels, &latestV1.KustomizeDeploy{
 				KustomizePaths: kustomizationPaths,
 			})
 			t.RequireNoError(err)

--- a/pkg/skaffold/deploy/util/util.go
+++ b/pkg/skaffold/deploy/util/util.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 )
 
 // ApplyDefaultRepo applies the default repo to a given image tag.
@@ -36,4 +38,17 @@ func ApplyDefaultRepo(globalConfig string, defaultRepo *string, tag string) (str
 	}
 
 	return newTag, nil
+}
+
+// Update which images are logged, if the image is present in the provided deployer's artifacts.
+func AddTagsToPodSelector(artifacts []graph.Artifact, deployerArtifacts []graph.Artifact, podSelector *kubernetes.ImageList) {
+	m := map[string]bool{}
+	for _, a := range deployerArtifacts {
+		m[a.ImageName] = true
+	}
+	for _, artifact := range artifacts {
+		if _, ok := m[artifact.ImageName]; ok {
+			podSelector.Add(artifact.Tag)
+		}
+	}
 }

--- a/pkg/skaffold/kubernetes/image_list.go
+++ b/pkg/skaffold/kubernetes/image_list.go
@@ -60,3 +60,15 @@ func (l *ImageList) Select(pod *v1.Pod) bool {
 
 	return false
 }
+
+// TODO(nkubala): remove this when podSelector is moved entirely into Deployer
+type ImageListMux []*ImageList
+
+func (l ImageListMux) Select(pod *v1.Pod) bool {
+	for _, selector := range l {
+		if selector.Select(pod) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -122,9 +122,6 @@ func (r *Builder) Build(ctx context.Context, out io.Writer, artifacts []*latestV
 		return nil, err
 	}
 
-	// Update which images are logged.
-	r.AddTagsToPodSelector(bRes)
-
 	// Make sure all artifacts are redeployed. Not only those that were just built.
 	r.Builds = build.MergeWithPreviousBuilds(bRes, r.Builds)
 
@@ -147,13 +144,6 @@ func artifactsWithTags(tags tag.ImageTags, artifacts []*latestV1.Artifact) []gra
 	}
 
 	return bRes
-}
-
-// Update which images are logged.
-func (r *Builder) AddTagsToPodSelector(artifacts []graph.Artifact) {
-	for _, artifact := range artifacts {
-		r.podSelector.Add(artifact.Tag)
-	}
 }
 
 type tagErr struct {

--- a/pkg/skaffold/runner/build_deploy.go
+++ b/pkg/skaffold/runner/build_deploy.go
@@ -31,7 +31,6 @@ import (
 	deployutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/util"
 	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -39,14 +38,12 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
-func NewBuilder(builder build.Builder, tagger tag.Tagger, cache cache.Cache, podSelector *kubernetes.ImageList,
-	runCtx *runcontext.RunContext) *Builder {
+func NewBuilder(builder build.Builder, tagger tag.Tagger, cache cache.Cache, runCtx *runcontext.RunContext) *Builder {
 	return &Builder{
-		Builder:     builder,
-		tagger:      tagger,
-		cache:       cache,
-		podSelector: podSelector,
-		runCtx:      runCtx,
+		Builder: builder,
+		tagger:  tagger,
+		cache:   cache,
+		runCtx:  runCtx,
 	}
 }
 
@@ -55,9 +52,6 @@ type Builder struct {
 	tagger  tag.Tagger
 	cache   cache.Cache
 	Builds  []graph.Artifact
-
-	// podSelector is used to determine relevant pods for logging and portForwarding
-	podSelector *kubernetes.ImageList
 
 	hasBuilt bool
 	runCtx   *runcontext.RunContext

--- a/pkg/skaffold/runner/v1/deploy.go
+++ b/pkg/skaffold/runner/v1/deploy.go
@@ -41,9 +41,6 @@ import (
 
 // DeployAndLog deploys a list of already built artifacts and optionally show the logs.
 func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifacts []graph.Artifact) error {
-	// Update which images are logged.
-	r.AddTagsToPodSelector(artifacts)
-
 	logger := r.createLogger(out, artifacts)
 	defer logger.Stop()
 

--- a/pkg/skaffold/runner/v1/deploy_test.go
+++ b/pkg/skaffold/runner/v1/deploy_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
@@ -193,7 +194,7 @@ func TestSkaffoldDeployRenderOnly(t *testing.T) {
 			KubeContext: "does-not-exist",
 		}
 
-		deployer, err := getDeployer(runCtx, nil)
+		deployer, err := getDeployer(runCtx, kubernetes.NewImageList(), nil)
 		t.RequireNoError(err)
 		r := SkaffoldRunner{
 			runCtx:     runCtx,

--- a/pkg/skaffold/runner/v1/deploy_test.go
+++ b/pkg/skaffold/runner/v1/deploy_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
@@ -194,7 +193,7 @@ func TestSkaffoldDeployRenderOnly(t *testing.T) {
 			KubeContext: "does-not-exist",
 		}
 
-		deployer, err := getDeployer(runCtx, kubernetes.NewImageList(), nil)
+		deployer, _, err := getDeployer(runCtx, nil)
 		t.RequireNoError(err)
 		r := SkaffoldRunner{
 			runCtx:     runCtx,

--- a/pkg/skaffold/runner/v1/new_test.go
+++ b/pkg/skaffold/runner/v1/new_test.go
@@ -66,7 +66,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				expected: deploy.DeployerMux{
 					t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 						Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-					}, nil, &latestV1.KubectlDeploy{
+					}, nil, nil, &latestV1.KubectlDeploy{
 						Flags: latestV1.KubectlFlags{},
 					})).(deploy.Deployer),
 				},
@@ -77,7 +77,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				expected: deploy.DeployerMux{
 					t.RequireNonNilResult(kustomize.NewDeployer(&runcontext.RunContext{
 						Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-					}, nil, &latestV1.KustomizeDeploy{
+					}, nil, nil, &latestV1.KustomizeDeploy{
 						Flags: latestV1.KubectlFlags{},
 					})).(deploy.Deployer),
 				},
@@ -86,7 +86,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				description: "kpt deployer",
 				cfg:         latestV1.DeployType{KptDeploy: &latestV1.KptDeploy{}},
 				expected: deploy.DeployerMux{
-					kpt.NewDeployer(&runcontext.RunContext{}, nil, &latestV1.KptDeploy{}),
+					kpt.NewDeployer(&runcontext.RunContext{}, nil, nil, &latestV1.KptDeploy{}),
 				},
 			},
 			{
@@ -95,7 +95,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				apply:       true,
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &latestV1.KubectlDeploy{
+				}, nil, nil, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(deploy.Deployer),
 			},
@@ -106,7 +106,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				apply:       true,
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &latestV1.KubectlDeploy{
+				}, nil, nil, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(deploy.Deployer),
 			},
@@ -119,7 +119,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				helmVersion: `version.BuildInfo{Version:"v3.0.0"}`,
 				expected: deploy.DeployerMux{
 					&helm.Deployer{},
-					kpt.NewDeployer(&runcontext.RunContext{}, nil, &latestV1.KptDeploy{}),
+					kpt.NewDeployer(&runcontext.RunContext{}, nil, nil, &latestV1.KptDeploy{}),
 				},
 			},
 		}
@@ -141,7 +141,7 @@ func TestGetDeployer(tOuter *testing.T) {
 							DeployType: test.cfg,
 						},
 					}}),
-				}, nil)
+				}, nil, nil)
 
 				t.CheckError(test.shouldErr, err)
 				t.CheckTypeEquality(test.expected, deployer)
@@ -174,7 +174,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &latestV1.KubectlDeploy{
+				}, nil, nil, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -190,7 +190,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &latestV1.KubectlDeploy{
+				}, nil, nil, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{
 						Apply:  []string{"--foo"},
 						Global: []string{"--bar"},
@@ -224,7 +224,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &latestV1.KubectlDeploy{
+				}, nil, nil, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -235,7 +235,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, &latestV1.KubectlDeploy{
+				}, nil, nil, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -253,7 +253,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}
 				deployer, err := getDefaultDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines(pipelines),
-				}, nil)
+				}, nil, nil)
 
 				t.CheckErrorAndFailNow(test.shouldErr, err)
 

--- a/pkg/skaffold/runner/v1/new_test.go
+++ b/pkg/skaffold/runner/v1/new_test.go
@@ -66,7 +66,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				expected: deploy.DeployerMux{
 					t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 						Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-					}, nil, nil, &latestV1.KubectlDeploy{
+					}, nil, &latestV1.KubectlDeploy{
 						Flags: latestV1.KubectlFlags{},
 					})).(deploy.Deployer),
 				},
@@ -77,7 +77,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				expected: deploy.DeployerMux{
 					t.RequireNonNilResult(kustomize.NewDeployer(&runcontext.RunContext{
 						Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-					}, nil, nil, &latestV1.KustomizeDeploy{
+					}, nil, &latestV1.KustomizeDeploy{
 						Flags: latestV1.KubectlFlags{},
 					})).(deploy.Deployer),
 				},
@@ -86,7 +86,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				description: "kpt deployer",
 				cfg:         latestV1.DeployType{KptDeploy: &latestV1.KptDeploy{}},
 				expected: deploy.DeployerMux{
-					kpt.NewDeployer(&runcontext.RunContext{}, nil, nil, &latestV1.KptDeploy{}),
+					&kpt.Deployer{},
 				},
 			},
 			{
@@ -95,7 +95,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				apply:       true,
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, nil, &latestV1.KubectlDeploy{
+				}, nil, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(deploy.Deployer),
 			},
@@ -106,7 +106,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				apply:       true,
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, nil, &latestV1.KubectlDeploy{
+				}, nil, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(deploy.Deployer),
 			},
@@ -119,7 +119,7 @@ func TestGetDeployer(tOuter *testing.T) {
 				helmVersion: `version.BuildInfo{Version:"v3.0.0"}`,
 				expected: deploy.DeployerMux{
 					&helm.Deployer{},
-					kpt.NewDeployer(&runcontext.RunContext{}, nil, nil, &latestV1.KptDeploy{}),
+					&kpt.Deployer{},
 				},
 			},
 		}
@@ -132,7 +132,7 @@ func TestGetDeployer(tOuter *testing.T) {
 					))
 				}
 
-				deployer, err := getDeployer(&runcontext.RunContext{
+				deployer, _, err := getDeployer(&runcontext.RunContext{
 					Opts: config.SkaffoldOptions{
 						Apply: test.apply,
 					},
@@ -141,7 +141,7 @@ func TestGetDeployer(tOuter *testing.T) {
 							DeployType: test.cfg,
 						},
 					}}),
-				}, nil, nil)
+				}, nil)
 
 				t.CheckError(test.shouldErr, err)
 				t.CheckTypeEquality(test.expected, deployer)
@@ -174,7 +174,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, nil, &latestV1.KubectlDeploy{
+				}, nil, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -190,7 +190,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, nil, &latestV1.KubectlDeploy{
+				}, nil, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{
 						Apply:  []string{"--foo"},
 						Global: []string{"--bar"},
@@ -224,7 +224,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, nil, &latestV1.KubectlDeploy{
+				}, nil, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -235,7 +235,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{}}),
-				}, nil, nil, &latestV1.KubectlDeploy{
+				}, nil, &latestV1.KubectlDeploy{
 					Flags: latestV1.KubectlFlags{},
 				})).(*kubectl.Deployer),
 			},
@@ -251,9 +251,9 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 						},
 					})
 				}
-				deployer, err := getDefaultDeployer(&runcontext.RunContext{
+				deployer, _, err := getDefaultDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines(pipelines),
-				}, nil, nil)
+				}, nil)
 
 				t.CheckErrorAndFailNow(test.shouldErr, err)
 

--- a/pkg/skaffold/runner/v1/runner.go
+++ b/pkg/skaffold/runner/v1/runner.go
@@ -49,7 +49,7 @@ type SkaffoldRunner struct {
 	artifactStore      build.ArtifactStore
 	sourceDependencies graph.SourceDependenciesCache
 	// podSelector is used to determine relevant pods for logging and portForwarding
-	podSelector *kubernetes.ImageList
+	podSelector kubernetes.ImageListMux
 
 	devIteration int
 	isLocalImage func(imageName string) (bool, error)

--- a/testutil/checks.go
+++ b/testutil/checks.go
@@ -49,7 +49,7 @@ func (t *T) RequireNoError(err error) {
 	}
 }
 
-func (t *T) RequireNonNilResult(x interface{}, err error) interface{} {
+func (t *T) RequireNonNilResult(x interface{}, y interface{}, err error) interface{} {
 	t.Helper()
 
 	if err != nil {
@@ -57,6 +57,10 @@ func (t *T) RequireNonNilResult(x interface{}, err error) interface{} {
 		t.FailNow()
 	}
 	if x == nil {
+		t.Errorf("unexpected nil value (failing test now)")
+		t.FailNow()
+	}
+	if y == nil {
 		t.Errorf("unexpected nil value (failing test now)")
 		t.FailNow()
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: #5813, https://github.com/GoogleContainerTools/skaffold/pull/5936

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This change moves the `PodSelector` object inside of the `Deployer`. This is to enable future changes to embed all components that depend on the `PodSelector` (`Logger`, `ResourcePreviewer`, `Debugger`) in the `Deployer` as well.

Temporarily, the `PodSelector` will still be initialized by the `Runner`, which will also hold on to a reference to it so that it can be passed to the components that depend on it (e.g. the `Logger`). All `Deployer`s will share a reference to a single `PodSelector` for now.

The previous behavior was for the `Builder` to add all of its built images to the `PodSelector` (for flows where we build and then deploy), as well as the `Runner` to add all artifacts that it passed to the `Deployer`s once the actual deployment was finished. Now, each `Deployer` will be directly responsible for adding its deployed artifacts to the `PodSelector` by cross-referencing them against the list of images parsed out of the set of manifests they each deploy. This will ensure that every time skaffold deploys anything, the exact set of artifacts it deployed will be tracked for logging/debugging/etc.

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->
Move `PodSelector`-dependent components out of the `Runner` into the `Deployer`.


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
