### PR TITLE
update hack/generate-kind-config.sh to handle multiple mirrors

### DIFF
--- a/hack/generate-kind-config.sh
+++ b/hack/generate-kind-config.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # Create a kind configuration to use the docker daemon's configured registry-mirrors.
-docker system info --format '{{printf "apiVersion: kind.x-k8s.io/v1alpha4\nkind: Cluster\ncontainerdConfigPatches:\n"}}{{range $reg, $config := .RegistryConfig.IndexConfigs}}{{if $config.Mirrors}}{{printf "- |-\n  [plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"%s\"]\n    endpoint = %q\n" $reg $config.Mirrors}}{{end}}{{end}}'
+docker system info --format '{{printf "apiVersion: kind.x-k8s.io/v1alpha4\nkind: Cluster\ncontainerdConfigPatches:\n"}}{{range $reg, $config := .RegistryConfig.IndexConfigs}}{{if $config.Mirrors}}{{printf "- |-\n  [plugins.\"io.containerd.grpc.v1.cri\".registry.mirrors.\"%s\"]\n    endpoint = [" $reg}}{{range $index, $mirror := $config.Mirrors}}{{if $index}},{{end}}{{printf "%q" $mirror}}{{end}}{{printf "]\n"}}{{end}}{{end}}'


### PR DESCRIPTION
**Description**

Related to: #5231

Update the `hack/generate-kind-config.sh` to handle multiple mirrors.  The [containerd docs](https://github.com/containerd/cri/blob/release/1.4/docs/registry.md) notes:
> The endpoint is a list that can contain multiple image registry URLs split by commas.

The resulting output:
```
apiVersion: kind.x-k8s.io/v1alpha4
kind: Cluster
containerdConfigPatches:
- |-
  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
    endpoint = ["https://mirror.gcr.io/","https://registry.travisci.com/"]
```
