### PR TITLE
Use golang:1.15-alpine in proto gen

### DIFF
--- a/hack/proto/Dockerfile
+++ b/hack/proto/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.13.4-alpine3.10 AS generate-files
+FROM golang:1.15-alpine AS generate-files
 RUN apk add --no-cache protobuf=3.6.1-r1 unzip jq moreutils
 
 WORKDIR /protoc

--- a/hack/proto/Dockerfile
+++ b/hack/proto/Dockerfile
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 FROM golang:1.15-alpine AS generate-files
-RUN apk add --no-cache protobuf=3.6.1-r1 unzip jq moreutils
+RUN apk add --no-cache protobuf=3.13.0-r2 unzip jq moreutils
 
 WORKDIR /protoc
-ENV PROTOC_VERSION=3.11.0
+ENV PROTOC_VERSION=3.13.0
 RUN wget -O protoc.zip https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
 RUN unzip protoc.zip
 


### PR DESCRIPTION
Related to: #5231

**Description**
Update `golang` image and protoc/protobuf used in the proto check to be consistent with other images being used in our tests.  Take down another source of `toomanyrequests` errors 🤞 