### PR TITLE
Construct ColorPicker without images

### DIFF
--- a/pkg/skaffold/kubernetes/colorpicker.go
+++ b/pkg/skaffold/kubernetes/colorpicker.go
@@ -42,6 +42,7 @@ var colorCodes = []output.Color{
 // from each pod.
 type ColorPicker interface {
 	Pick(pod *v1.Pod) output.Color
+	AddImage(image string)
 }
 
 type colorPicker struct {
@@ -52,16 +53,20 @@ type colorPicker struct {
 // sequentially from `colorCodes`. If all colors are used, the first color will be used
 // again. The formatter for the associated color will then be returned by `Pick` each
 // time it is called for the artifact and can be used to write to out in that color.
-func NewColorPicker(imageNames []string) ColorPicker {
+func NewColorPicker() ColorPicker {
 	imageColors := make(map[string]output.Color)
-
-	for i, imageName := range imageNames {
-		imageColors[tag.StripTag(imageName, false)] = colorCodes[i%len(colorCodes)]
-	}
 
 	return &colorPicker{
 		imageColors: imageColors,
 	}
+}
+
+func (p *colorPicker) AddImage(image string) {
+	imageName := tag.StripTag(image, false)
+	if _, ok := p.imageColors[imageName]; ok {
+		return
+	}
+	p.imageColors[imageName] = colorCodes[len(p.imageColors)%len(colorCodes)]
 }
 
 // Pick will return the color that was associated with pod when `NewColorPicker` was called.

--- a/pkg/skaffold/kubernetes/colorpicker_test.go
+++ b/pkg/skaffold/kubernetes/colorpicker_test.go
@@ -82,7 +82,9 @@ func TestColorPicker(t *testing.T) {
 		},
 	}
 
-	picker := NewColorPicker([]string{"image:ignored", "second"})
+	picker := NewColorPicker()
+	picker.AddImage("image:ignored")
+	picker.AddImage("second")
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {

--- a/pkg/skaffold/kubernetes/logger/log.go
+++ b/pkg/skaffold/kubernetes/logger/log.go
@@ -58,12 +58,16 @@ type Config interface {
 
 // NewLogAggregator creates a new LogAggregator for a given output.
 func NewLogAggregator(out io.Writer, cli *kubectl.CLI, imageNames []string, podSelector kubernetes.PodSelector, config Config) *LogAggregator {
+	colorPicker := kubernetes.NewColorPicker()
+	for _, image := range imageNames {
+		colorPicker.AddImage(image)
+	}
 	return &LogAggregator{
 		output:      out,
 		kubectlcli:  cli,
 		config:      config,
 		podWatcher:  kubernetes.NewPodWatcher(podSelector),
-		colorPicker: kubernetes.NewColorPicker(imageNames),
+		colorPicker: colorPicker,
 		events:      make(chan kubernetes.PodEvent),
 	}
 }


### PR DESCRIPTION
**Related**: #5813, #5936

This change alters the constructor for the `ColorPicker` to not accept images, and instead add them retroactively via `ColorPicker.AddImage()`. This will be it easier to move the `PodSelector`-dependent components inside of the `Deployer`.

This change is non-functional.