### PR TITLE
Clear `ApplicationLogEvent` and `SkaffoldLogEvent` buffers on new dev iteration

### DIFF
--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -305,8 +305,12 @@ func AutoTriggerDiff(phase constants.Phase, val bool) (bool, error) {
 }
 
 func TaskInProgress(task constants.Phase, description string) {
+	// Special casing to increment iteration and clear application and skaffold logs
 	if task == constants.DevLoop {
 		handler.iteration++
+
+		handler.applicationLogs = nil
+		handler.skaffoldLogs = nil
 	}
 
 	handler.handleTaskEvent(&proto.TaskEvent{

--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -309,8 +309,8 @@ func TaskInProgress(task constants.Phase, description string) {
 	if task == constants.DevLoop {
 		handler.iteration++
 
-		handler.applicationLogs = nil
-		handler.skaffoldLogs = nil
+		handler.applicationLogs = []proto.Event{}
+		handler.skaffoldLogs = []proto.Event{}
 	}
 
 	handler.handleTaskEvent(&proto.TaskEvent{


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
**Related**: #5368 #5370 

**Description**
This change resets the buffers containing `SkaffoldLogEvent`s and `ApplicationLogEvent`s on a new dev iteration, to prevent increased RAM usage over time. 