### PR TITLE
Re-use key created for a release.

### DIFF
--- a/deploy/setup-secret.sh
+++ b/deploy/setup-secret.sh
@@ -30,12 +30,15 @@ done
 
 
 # create a new valid key
-gcloud iam service-accounts keys create ${KEY_FILE} --iam-account=metrics-writer@${PROJECT_ID}.iam.gserviceaccount.com --project=${PROJECT_ID}
-retVal=$?
-if [ $retVal -ne 0 ]; then
-  echo "No key created."
-  exit 1
-fi
 KEY_ID=$(gcloud iam service-accounts keys list --iam-account=metrics-writer@k8s-skaffold.iam.gserviceaccount.com --project=k8s-skaffold --managed-by=user --filter="validAfterTime.date('%Y-%m-%d', Z) = `date +%F`" --format="value(name)" --limit=1)
+if [ -z "$KEY_ID" ]; then
+  gcloud iam service-accounts keys create ${KEY_FILE} --iam-account=metrics-writer@${PROJECT_ID}.iam.gserviceaccount.com --project=${PROJECT_ID}
+  retVal=$?
+  if [ $retVal -ne 0 ]; then
+    echo "No key created."
+    exit 1
+  fi
+  KEY_ID=$(gcloud iam service-accounts keys list --iam-account=metrics-writer@k8s-skaffold.iam.gserviceaccount.com --project=k8s-skaffold --managed-by=user --filter="validAfterTime.date('%Y-%m-%d', Z) = `date +%F`" --format="value(name)" --limit=1)
+fi
 gsutil cp ${KEY_FILE} gs://${BUCKET_ID}/${KEY_ID}.json
 gsutil cp ${KEY_FILE} gs://${BUCKET_ID}/${LATEST_GCS_PATH}


### PR DESCRIPTION
In #5910, we changed the release workflow to always create a new key. 
however, this script could be called multiple times for the same release in github actions. 

In this PR, 
1) Check if a key exists for today and reuse the same key. This will ensure, we have a key with 3 months expiry date. 
2) Create a new key if key wasn't created today.

 