### PR TITLE
Emit `PortFowardEvent`s for API V2

### DIFF
--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	//nolint:golint,staticcheck
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes"
@@ -31,6 +30,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
 )
 
@@ -346,7 +346,7 @@ func TaskSucceeded(task constants.Phase) {
 // PortForwarded notifies that a remote port has been forwarded locally.
 func PortForwarded(localPort int32, remotePort util.IntOrString, podName, containerName, namespace string, portName string, resourceType, resourceName, address string) {
 	event := proto.PortForwardEvent{
-		TaskId: fmt.Sprintf("%s-%d", constants.PortForward, handler.iteration),
+		TaskId:        fmt.Sprintf("%s-%d", constants.PortForward, handler.iteration),
 		LocalPort:     localPort,
 		PodName:       podName,
 		ContainerName: containerName,

--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"sync"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	//nolint:golint,staticcheck
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes"
@@ -339,6 +340,31 @@ func TaskSucceeded(task constants.Phase) {
 		Task:      string(task),
 		Iteration: int32(handler.iteration),
 		Status:    Succeeded,
+	})
+}
+
+// PortForwarded notifies that a remote port has been forwarded locally.
+func PortForwarded(localPort int32, remotePort util.IntOrString, podName, containerName, namespace string, portName string, resourceType, resourceName, address string) {
+	event := proto.PortForwardEvent{
+		TaskId: fmt.Sprintf("%s-%d", constants.PortForward, handler.iteration),
+		LocalPort:     localPort,
+		PodName:       podName,
+		ContainerName: containerName,
+		Namespace:     namespace,
+		PortName:      portName,
+		ResourceType:  resourceType,
+		ResourceName:  resourceName,
+		Address:       address,
+		TargetPort: &proto.IntOrString{
+			Type:   int32(remotePort.Type),
+			IntVal: int32(remotePort.IntVal),
+			StrVal: remotePort.StrVal,
+		},
+	}
+	handler.handle(&proto.Event{
+		EventType: &proto.Event_PortEvent{
+			PortEvent: &event,
+		},
 	})
 }
 

--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -422,6 +422,9 @@ func (ev *eventHandler) handleExec(event *proto.Event) {
 	case *proto.Event_PortEvent:
 		pe := e.PortEvent
 		ev.stateLock.Lock()
+		if ev.state.ForwardedPorts == nil {
+			ev.state.ForwardedPorts = map[int32]*proto.PortForwardEvent{}
+		}
 		ev.state.ForwardedPorts[pe.LocalPort] = pe
 		ev.stateLock.Unlock()
 	case *proto.Event_StatusCheckSubtaskEvent:

--- a/pkg/skaffold/kubernetes/portforward/entry_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/entry_manager.go
@@ -30,7 +30,6 @@ import (
 
 var (
 	portForwardEvent = func(entry *portForwardEntry) {
-		// TODO priyawadhwa@, change event API to accept ports of type int
 		event.PortForwarded(
 			int32(entry.localPort),
 			entry.resource.Port,
@@ -43,7 +42,6 @@ var (
 			entry.resource.Address)
 	}
 	portForwardEventV2 = func(entry *portForwardEntry) {
-		// TODO priyawadhwa@, change event API to accept ports of type int
 		eventV2.PortForwarded(
 			int32(entry.localPort),
 			entry.resource.Port,

--- a/pkg/skaffold/kubernetes/portforward/entry_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/entry_manager.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -31,6 +32,19 @@ var (
 	portForwardEvent = func(entry *portForwardEntry) {
 		// TODO priyawadhwa@, change event API to accept ports of type int
 		event.PortForwarded(
+			int32(entry.localPort),
+			entry.resource.Port,
+			entry.podName,
+			entry.containerName,
+			entry.resource.Namespace,
+			entry.portName,
+			string(entry.resource.Type),
+			entry.resource.Name,
+			entry.resource.Address)
+	}
+	portForwardEventV2 = func(entry *portForwardEntry) {
+		// TODO priyawadhwa@, change event API to accept ports of type int
+		eventV2.PortForwarded(
 			int32(entry.localPort),
 			entry.resource.Port,
 			entry.podName,
@@ -124,6 +138,7 @@ func (b *EntryManager) forwardPortForwardEntry(ctx context.Context, entry *portF
 		output.Red.Fprintln(b.output, err)
 	}
 	portForwardEvent(entry)
+	portForwardEventV2(entry)
 }
 
 // Stop terminates all kubectl port-forward commands.


### PR DESCRIPTION
**Related**: #5368 

**Description**
This PR brings over the functionality from API V1 that emits events when a resource is forwarded. The event contains information about the forwarded resource.
