### PR TITLE
fix status-check to return success only on exact success criteria match

### DIFF
--- a/pkg/diag/validator/pod.go
+++ b/pkg/diag/validator/pod.go
@@ -120,37 +120,80 @@ func (p *PodValidator) getPodStatus(pod *v1.Pod) *podStatus {
 
 func getPodStatus(pod *v1.Pod) (proto.StatusCode, []string, error) {
 	// See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions
-	for _, c := range pod.Status.Conditions {
-		if c.Type == v1.PodScheduled {
-			switch c.Status {
-			case v1.ConditionFalse:
-				logrus.Debugf("Pod %q not scheduled: checking tolerations", pod.Name)
-				sc, err := getUntoleratedTaints(c.Reason, c.Message)
-				return sc, nil, err
-			case v1.ConditionTrue:
-				logrus.Debugf("Pod %q scheduled: checking container statuses", pod.Name)
-				// TODO(dgageot): Add EphemeralContainerStatuses
-				cs := append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...)
-				// See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-states
-				statusCode, logs, err := getContainerStatus(pod, cs)
-				if statusCode == proto.StatusCode_STATUSCHECK_POD_INITIALIZING {
-					// Determine if an init container is still running and fetch the init logs.
-					for _, c := range pod.Status.InitContainerStatuses {
-						if c.State.Waiting != nil {
-							return statusCode, []string{}, fmt.Errorf("waiting for init container %s to start", c.Name)
-						} else if c.State.Running != nil {
-							return statusCode, getPodLogs(pod, c.Name), fmt.Errorf("waiting for init container %s to complete", c.Name)
-						}
-					}
+	if isPodReady(pod) {
+		return proto.StatusCode_STATUSCHECK_SUCCESS, nil, nil
+	}
+	if c, ok := isPodNotScheduled(pod); ok {
+		logrus.Debugf("Pod %q not scheduled: checking tolerations", pod.Name)
+		sc, err := getUntoleratedTaints(c.Reason, c.Message)
+		return sc, nil, err
+	}
+
+	if isPodScheduledButNotReady(pod) {
+		logrus.Debugf("Pod %q scheduled but not ready: checking container statuses", pod.Name)
+		// TODO(dgageot): Add EphemeralContainerStatuses
+		cs := append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...)
+		// See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-states
+		statusCode, logs, err := getContainerStatus(pod, cs)
+		if statusCode == proto.StatusCode_STATUSCHECK_POD_INITIALIZING {
+			// Determine if an init container is still running and fetch the init logs.
+			for _, c := range pod.Status.InitContainerStatuses {
+				if c.State.Waiting != nil {
+					return statusCode, []string{}, fmt.Errorf("waiting for init container %s to start", c.Name)
+				} else if c.State.Running != nil {
+					return statusCode, getPodLogs(pod, c.Name), fmt.Errorf("waiting for init container %s to complete", c.Name)
 				}
-				return statusCode, logs, err
-			case v1.ConditionUnknown:
-				logrus.Debugf("Pod %q scheduling condition is unknown", pod.Name)
-				return proto.StatusCode_STATUSCHECK_UNKNOWN, nil, fmt.Errorf(c.Message)
 			}
 		}
+		return statusCode, logs, err
 	}
-	return proto.StatusCode_STATUSCHECK_SUCCESS, nil, nil
+
+	if c, ok := isPodStatusUnknown(pod); ok {
+		logrus.Debugf("Pod %q condition status of type %s is unknown", pod.Name, c.Type)
+		return proto.StatusCode_STATUSCHECK_UNKNOWN, nil, fmt.Errorf(c.Message)
+	}
+
+	logrus.Debugf("Unable to determine current service state of pod %q", pod.Name)
+	return proto.StatusCode_STATUSCHECK_UNKNOWN, nil, fmt.Errorf("unable to determine current service state of pod %q", pod.Name)
+}
+
+func isPodReady(pod *v1.Pod) bool {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == v1.ContainersReady && c.Status == v1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}
+
+func isPodNotScheduled(pod *v1.Pod) (v1.PodCondition, bool) {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == v1.PodScheduled && c.Status == v1.ConditionFalse {
+			return c, true
+		}
+	}
+	return v1.PodCondition{}, false
+}
+
+func isPodScheduledButNotReady(pod *v1.Pod) bool {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == v1.PodScheduled && c.Status == v1.ConditionTrue {
+			return true
+		}
+		if c.Type == v1.PodReady && c.Status == v1.ConditionFalse {
+			return true
+		}
+	}
+	return false
+}
+
+func isPodStatusUnknown(pod *v1.Pod) (v1.PodCondition, bool) {
+	for _, c := range pod.Status.Conditions {
+		if c.Status == v1.ConditionUnknown {
+			return c, true
+		}
+	}
+	return v1.PodCondition{}, false
 }
 
 func getContainerStatus(po *v1.Pod, cs []v1.ContainerStatus) (proto.StatusCode, []string, error) {

--- a/pkg/diag/validator/pod_test.go
+++ b/pkg/diag/validator/pod_test.go
@@ -356,17 +356,26 @@ func TestRun(t *testing.T) {
 				Status: v1.PodStatus{
 					Phase: v1.PodPending,
 					Conditions: []v1.PodCondition{{
-						Type:    v1.PodScheduled,
-						Status:  v1.ConditionFalse,
-						Reason:  v1.PodReasonUnschedulable,
-						Message: "0/2 nodes are available: 1 node(s) had taint {node.kubernetes.io/disk-pressure: }, that the pod didn't tolerate, 1 node(s) had taint {node.kubernetes.io/unreachable: }, that the pod didn't tolerate",
+						Type:   v1.PodScheduled,
+						Status: v1.ConditionFalse,
+						Reason: v1.PodReasonUnschedulable,
+						Message: "0/7 nodes are available: " +
+							"1 node(s) had taint {node.kubernetes.io/memory-pressure: }, that the pod didn't tolerate, " +
+							"1 node(s) had taint {node.kubernetes.io/disk-pressure: }, that the pod didn't tolerate, " +
+							"1 node(s) had taint {node.kubernetes.io/pid-pressure: }, that the pod didn't tolerate, " +
+							"1 node(s) had taint {node.kubernetes.io/not-ready: }, that the pod didn't tolerate, " +
+							"1 node(s) had taint {node.kubernetes.io/unreachable: }, that the pod didn't tolerate, " +
+							"1 node(s) had taint {node.kubernetes.io/unschedulable: }, that the pod didn't tolerate, " +
+							"1 node(s) had taint {node.kubernetes.io/network-unavailable: }, that the pod didn't tolerate, ",
 					}},
 				},
 			}},
 			expected: []Resource{NewResource("test", "Pod", "foo", "Pending",
 				proto.ActionableErr{
-					Message: "Unschedulable: 0/2 nodes available: 1 node has disk pressure, 1 node is unreachable",
-					ErrCode: proto.StatusCode_STATUSCHECK_NODE_DISK_PRESSURE,
+					Message: "Unschedulable: 0/7 nodes available: 1 node has memory pressure, " +
+						"1 node has disk pressure, 1 node has PID pressure, 1 node is not ready, " +
+						"1 node is unreachable, 1 node is unschedulable, 1 node's network not available",
+					ErrCode: proto.StatusCode_STATUSCHECK_NODE_PID_PRESSURE,
 				}, nil)},
 		},
 		{

--- a/pkg/diag/validator/pod_test.go
+++ b/pkg/diag/validator/pod_test.go
@@ -191,6 +191,25 @@ func TestRun(t *testing.T) {
 				}, nil)},
 		},
 		{
+			description: "all pod containers are ready",
+			pods: []*v1.Pod{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test",
+				},
+				TypeMeta: metav1.TypeMeta{Kind: "Pod"},
+				Status: v1.PodStatus{
+					Phase:      v1.PodSucceeded,
+					Conditions: []v1.PodCondition{{Type: v1.ContainersReady, Status: v1.ConditionTrue}},
+				},
+			}},
+			expected: []Resource{NewResource("test", "Pod", "foo", "Succeeded",
+				proto.ActionableErr{
+					Message: "",
+					ErrCode: proto.StatusCode_STATUSCHECK_SUCCESS,
+				}, nil)},
+		},
+		{
 			description: "One of the pod containers is in Terminated State",
 			pods: []*v1.Pod{{
 				ObjectMeta: metav1.ObjectMeta{
@@ -217,6 +236,36 @@ func TestRun(t *testing.T) {
 					Message: "",
 					ErrCode: proto.StatusCode_STATUSCHECK_SUCCESS,
 				}, nil)},
+		},
+		{
+			description: "one of the pod containers is in Terminated State with non zero exit code but pod condition is Ready",
+			pods: []*v1.Pod{{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "test",
+				},
+				TypeMeta: metav1.TypeMeta{Kind: "Pod"},
+				Status: v1.PodStatus{
+					Phase:      v1.PodRunning,
+					Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}},
+					ContainerStatuses: []v1.ContainerStatus{
+						{
+							Name:  "foo-container",
+							Image: "foo-image",
+							State: v1.ContainerState{
+								Terminated: &v1.ContainerStateTerminated{ExitCode: 1, Message: "panic caused"},
+							},
+						},
+					}},
+			}},
+			expected: []Resource{NewResource("test", "Pod", "foo", "Running",
+				proto.ActionableErr{
+					Message: "container foo-container terminated with exit code 1",
+					ErrCode: proto.StatusCode_STATUSCHECK_CONTAINER_TERMINATED,
+					Suggestions: []*proto.Suggestion{
+						{SuggestionCode: proto.SuggestionCode_CHECK_CONTAINER_LOGS,
+							Action: "Try checking container logs"},
+					}}, []string{})},
 		},
 		{
 			description: "one of the pod containers is in Terminated State with non zero exit code",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5427  <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR changes the logic that deals with deciding when to declare that a pod is _successfully_ deployed in Skaffold's `status check` phase.

Previously, we returned `success` if none of the pod condition type was `PodScheduled`. This didn't work for cases when the event transitions do not have a `PodScheduled` type event but a `PodReady` type event with `Status="False"`.
https://github.com/GoogleContainerTools/skaffold/blob/815984c068f232a548d2b8ba002207530af8004e/pkg/diag/validator/pod.go#L121-L154

This refactor returns `success` only when we detect the last condition transition (`PodReady` type with status `True`). The behavior for `PodScheduled` type event is extended for `PodReady` and `ContainersReady` type with status `False`.

This fixes the original repro in #5427 against https://github.com/VeerMuchandi/nodejs-todo-cloudshell where we get the correct status check events when run from VSCode Cloud Code IDE:

```
Status check started
Resource pod/mongodb-deployment-7d7c46b57-b9pzj status updated to In Progress
Resource pod/nodetodo-deployment-7f49f845b-429t5 status completed successfully
Resource pod/mongodb-deployment-7d7c46b57-b9pzj status completed successfully
Resource deployment/mongodb-deployment status completed successfully
Resource deployment/nodetodo-deployment status updated to In Progress
Resource pod/nodetodo-deployment-7f49f845b-429t5 status failed with Readiness probe failed: Get http://10.244.0.26:3000/todo: net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Resource deployment/nodetodo-deployment status completed successfully
Status check succeeded
```

