### PR TITLE
fix `setup-secret.sh` script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/themes
 docs/package-lock.json
 pkg/skaffold/output/debug.test
 cmd/skaffold/app/cmd/statik/statik.go
+secrets/keys.json


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6013 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
The `setup-secret.sh` script has been running on every master build and very quickly exhausting the max service account keys allowed to be created. 

Also there's a bug with the same-day key creation check, since the key doesn't necessarily have to exist locally and as such these lines fail when we skip key creation:
https://github.com/GoogleContainerTools/skaffold/blob/59edbda57ae7d2f5d0b53c075497bca480f555f5/deploy/setup-secret.sh#L43-L44


This PR splits the script into `download_existing_key` and `upload_new_key` functions, where `upload_new_key` is the same as before, while `download_existing_key` tries to find valid keys created in the **past two weeks** and available in the GCS bucket, and downloads them locally to be used by `statik` in the binary build, and skips creating new ones.

By this process, all _bleeding edge_ and _release_ builds will share the latest key until a new one is created every two weeks.
We will still have to clean up the old ones manually. 
<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
