### PR TITLE
Fix panic on nil dereference  in debugging.ContainerManager

### DIFF
--- a/pkg/skaffold/kubernetes/debugging/container_manager.go
+++ b/pkg/skaffold/kubernetes/debugging/container_manager.go
@@ -19,6 +19,7 @@ package debugging
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -52,7 +53,7 @@ func NewContainerManager(podSelector kubernetes.PodSelector) *ContainerManager {
 }
 
 func (d *ContainerManager) Start(ctx context.Context, namespaces []string) error {
-	if d == nil {
+	if d.isNil() {
 		// debug mode probably not enabled
 		return nil
 	}
@@ -84,9 +85,14 @@ func (d *ContainerManager) Start(ctx context.Context, namespaces []string) error
 
 func (d *ContainerManager) Stop() {
 	// if nil then debug mode probably not enabled
-	if d != nil {
+	if !d.isNil() {
 		d.stopWatcher()
 	}
+}
+
+func (d *ContainerManager) isNil() bool {
+	// This instance may be from an interface
+	return d == nil || (reflect.ValueOf(d).Kind() == reflect.Ptr && reflect.ValueOf(d).IsNil())
 }
 
 func (d *ContainerManager) Name() string {

--- a/pkg/skaffold/kubernetes/logger/log.go
+++ b/pkg/skaffold/kubernetes/logger/log.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -83,7 +84,7 @@ func (a *LogAggregator) RegisterArtifacts(artifacts []graph.Artifact) {
 }
 
 func (a *LogAggregator) SetSince(t time.Time) {
-	if a == nil {
+	if a.isNil() {
 		// Logs are not activated.
 		return
 	}
@@ -94,7 +95,7 @@ func (a *LogAggregator) SetSince(t time.Time) {
 // Start starts a logger that listens to pods and tail their logs
 // if they are matched by the `podSelector`.
 func (a *LogAggregator) Start(ctx context.Context, out io.Writer, namespaces []string) error {
-	if a == nil {
+	if a.isNil() {
 		// Logs are not activated.
 		return nil
 	}
@@ -143,13 +144,18 @@ func (a *LogAggregator) Start(ctx context.Context, out io.Writer, namespaces []s
 
 // Stop stops the logger.
 func (a *LogAggregator) Stop() {
-	if a == nil {
+	if a.isNil() {
 		// Logs are not activated.
 		return
 	}
 	a.stopWatcher()
 	a.podWatcher.Deregister(a.events)
 	close(a.events)
+}
+
+func (a *LogAggregator) isNil() bool {
+       // This instance may be from an interface
+       return a == nil || (reflect.ValueOf(a).Kind() == reflect.Ptr && reflect.ValueOf(a).IsNil())
 }
 
 func sinceSeconds(d time.Duration) int64 {
@@ -268,7 +274,7 @@ func (a *LogAggregator) streamRequest(ctx context.Context, headerColor output.Co
 
 // Mute mutes the logs.
 func (a *LogAggregator) Mute() {
-	if a == nil {
+	if a.isNil() {
 		// Logs are not activated.
 		return
 	}
@@ -278,7 +284,7 @@ func (a *LogAggregator) Mute() {
 
 // Unmute unmutes the logs.
 func (a *LogAggregator) Unmute() {
-	if a == nil {
+	if a.isNil() {
 		// Logs are not activated.
 		return
 	}

--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"reflect"
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -106,7 +107,7 @@ func debugPorts(pod *v1.Pod, c v1.Container) []v1.ContainerPort {
 // Start begins all forwarders managed by the ForwarderManager
 func (p *ForwarderManager) Start(ctx context.Context, namespaces []string) error {
 	// Port forwarding is not enabled.
-	if p == nil {
+	if p.isNil() {
 		return nil
 	}
 
@@ -129,13 +130,18 @@ func (p *ForwarderManager) Start(ctx context.Context, namespaces []string) error
 // Stop cleans up and terminates all forwarders managed by the ForwarderManager
 func (p *ForwarderManager) Stop() {
 	// Port forwarding is not enabled.
-	if p == nil {
+	if p.isNil() {
 		return
 	}
 
 	for _, f := range p.forwarders {
 		f.Stop()
 	}
+}
+
+func (p *ForwarderManager) isNil() bool {
+       // This instance may be from an interface
+       return p == nil || (reflect.ValueOf(p).Kind() == reflect.Ptr && reflect.ValueOf(p).IsNil())
 }
 
 func (p *ForwarderManager) Name() string {


### PR DESCRIPTION
I've encountered the following panic a couple of times when trying to dig into #5946.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x103b40054]

goroutine 1 [running]:
github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/debugging.(*ContainerManager).Stop(0x14000d7a390)
	/Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/kubernetes/debugging/container_manager.go:88 +0x34
github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/v1.(*SkaffoldRunner).Dev(0x140004a3500, 0x1045da458, 0x140004ba0c0, 0x1045939e8, 0x1400041ac40, 0x14000551f98, 0x1, 0x1, 0x10458c808, 0x140004791a0)
	/Users/bdealwis/Projects/Skaffold/repo-skaffold/pkg/skaffold/runner/v1/dev.go:333 +0x10c0
github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd.runDev.func5(0x1045fc1d8, 0x140004a3500, 0x14000551cd0, 0x1, 0x1, 0x0, 0x0)
	/Users/bdealwis/Projects/Skaffold/repo-skaffold/cmd/skaffold/app/cmd/dev.go:68 +0x1bc
github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd.withRunner(0x1045da458, 0x140004ba0c0, 0x1045939e8, 0x1400041ac40, 0x14000873b00, 0x105c7ca68, 0x8)
	/Users/bdealwis/Projects/Skaffold/repo-skaffold/cmd/skaffold/app/cmd/runner.go:55 +0xd0
github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/cmd.runDev(0x1045da458, 0x140004ba0c0, 0x1045939e8, 0x1400041ac40, 0x0, 0x0)
[...]
```
