### PR TITLE
Move Debugger from Runner into Deployer

### DIFF
--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
+	debugannotations "github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -77,7 +77,7 @@ func TestDebug(t *testing.T) {
 			skaffold.Debug(test.args...).InDir(test.dir).InNs(ns.Name).RunBackground(t)
 
 			verifyDebugAnnotations := func(annotations map[string]string) {
-				var configs map[string]debug.ContainerDebugConfiguration
+				var configs map[string]debugannotations.ContainerDebugConfiguration
 				if anno, found := annotations["debug.cloud.google.com/config"]; !found {
 					t.Errorf("deployment missing debug annotation: %v", annotations)
 				} else if err := json.Unmarshal([]byte(anno), &configs); err != nil {

--- a/pkg/skaffold/debug/annotations/annotations.go
+++ b/pkg/skaffold/debug/annotations/annotations.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+// ContainerDebugConfiguration captures debugging information for a specific container.
+// This structure is serialized out and included in the pod metadata.
+type ContainerDebugConfiguration struct {
+	// Artifact is the corresponding artifact's image name used in the skaffold.yaml
+	Artifact string `json:"artifact,omitempty"`
+	// Runtime represents the underlying language runtime (`go`, `jvm`, `nodejs`, `python`, `netcore`)
+	Runtime string `json:"runtime,omitempty"`
+	// WorkingDir is the working directory in the image configuration; may be empty
+	WorkingDir string `json:"workingDir,omitempty"`
+	// Ports is the list of debugging ports, keyed by protocol type
+	Ports map[string]uint32 `json:"ports,omitempty"`
+}
+
+const (
+	// DebugConfig is the name of the podspec annotation that records debugging configuration information.
+	// The annotation should be a JSON-encoded map of container-name to a `ContainerDebugConfiguration` object.
+	DebugConfig = "debug.cloud.google.com/config"
+
+	// DebugProbesAnnotation is the name of the podspec annotation that disables rewriting of probe timeouts.
+	// The annotation value should be `skip`.
+	DebugProbeTimeouts = "debug.cloud.google.com/probe/timeouts"
+)

--- a/pkg/skaffold/debug/apply_transforms.go
+++ b/pkg/skaffold/debug/apply_transforms.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+)
+
+var (
+	decodeFromYaml = scheme.Codecs.UniversalDeserializer().Decode
+	encodeAsYaml   = func(o runtime.Object) ([]byte, error) {
+		s := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
+		var b bytes.Buffer
+		w := bufio.NewWriter(&b)
+		if err := s.Encode(o, w); err != nil {
+			return nil, err
+		}
+		w.Flush()
+		return b.Bytes(), nil
+	}
+)
+
+// ApplyDebuggingTransforms applies language-platform-specific transforms to a list of manifests.
+func ApplyDebuggingTransforms(l manifest.ManifestList, builds []graph.Artifact, registries manifest.Registries) (manifest.ManifestList, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	retriever := func(image string) (imageConfiguration, error) {
+		if artifact := findArtifact(image, builds); artifact != nil {
+			return retrieveImageConfiguration(ctx, artifact, registries.InsecureRegistries)
+		}
+		return imageConfiguration{}, fmt.Errorf("no build artifact for %q", image)
+	}
+	return applyDebuggingTransforms(l, retriever, registries.DebugHelpersRegistry)
+}
+
+func applyDebuggingTransforms(l manifest.ManifestList, retriever configurationRetriever, debugHelpersRegistry string) (manifest.ManifestList, error) {
+	var updated manifest.ManifestList
+	for _, manifest := range l {
+		obj, _, err := decodeFromYaml(manifest, nil, nil)
+		if err != nil {
+			logrus.Debugf("Unable to interpret manifest for debugging: %v\n", err)
+		} else if transformManifest(obj, retriever, debugHelpersRegistry) {
+			manifest, err = encodeAsYaml(obj)
+			if err != nil {
+				return nil, fmt.Errorf("marshalling yaml: %w", err)
+			}
+			if logrus.IsLevelEnabled(logrus.DebugLevel) {
+				logrus.Debugln("Applied debugging transform:\n", string(manifest))
+			}
+		}
+		updated = append(updated, manifest)
+	}
+
+	return updated, nil
+}
+
+// findArtifact finds the corresponding artifact for the given image.
+// If `builds` is empty, then treat all `image` images as a build artifact.
+func findArtifact(image string, builds []graph.Artifact) *graph.Artifact {
+	if len(builds) == 0 {
+		logrus.Debugf("No build artifacts specified: using image as-is %q", image)
+		return &graph.Artifact{ImageName: image, Tag: image}
+	}
+	for _, artifact := range builds {
+		if image == artifact.ImageName || image == artifact.Tag {
+			logrus.Debugf("Found artifact for image %q", image)
+			return &artifact
+		}
+	}
+	return nil
+}
+
+// retrieveImageConfiguration retrieves the image container configuration for
+// the given build artifact
+func retrieveImageConfiguration(ctx context.Context, artifact *graph.Artifact, insecureRegistries map[string]bool) (imageConfiguration, error) {
+	// TODO: use the proper RunContext
+	apiClient, err := docker.NewAPIClient(&runcontext.RunContext{
+		InsecureRegistries: insecureRegistries,
+	})
+	if err != nil {
+		return imageConfiguration{}, fmt.Errorf("could not connect to local docker daemon: %w", err)
+	}
+
+	// the apiClient will go to the remote registry if local docker daemon is not available
+	manifest, err := apiClient.ConfigFile(ctx, artifact.Tag)
+	if err != nil {
+		logrus.Debugf("Error retrieving image manifest for %v: %v", artifact.Tag, err)
+		return imageConfiguration{}, fmt.Errorf("retrieving image config for %q: %w", artifact.Tag, err)
+	}
+
+	config := manifest.Config
+	logrus.Debugf("Retrieved local image configuration for %v: %v", artifact.Tag, config)
+	// need to duplicate slices as apiClient caches requests
+	return imageConfiguration{
+		artifact:   artifact.ImageName,
+		env:        envAsMap(config.Env),
+		entrypoint: dupArray(config.Entrypoint),
+		arguments:  dupArray(config.Cmd),
+		labels:     dupMap(config.Labels),
+		workingDir: config.WorkingDir,
+	}, nil
+}
+
+// envAsMap turns an array of environment "NAME=value" strings into a map
+func envAsMap(env []string) map[string]string {
+	result := make(map[string]string)
+	for _, pair := range env {
+		s := strings.SplitN(pair, "=", 2)
+		result[s[0]] = s[1]
+	}
+	return result
+}
+
+func dupArray(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	dup := make([]string, len(s))
+	copy(dup, s)
+	return dup
+}
+
+func dupMap(s map[string]string) map[string]string {
+	if len(s) == 0 {
+		return nil
+	}
+	dup := make(map[string]string, len(s))
+	for k, v := range s {
+		dup[k] = v
+	}
+	return dup
+}

--- a/pkg/skaffold/debug/cnb.go
+++ b/pkg/skaffold/debug/cnb.go
@@ -21,12 +21,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	cnb "github.com/buildpacks/lifecycle"
 	cnbl "github.com/buildpacks/lifecycle/launch"
 	shell "github.com/kballard/go-shellquote"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 )
 
 const (

--- a/pkg/skaffold/debug/cnb.go
+++ b/pkg/skaffold/debug/cnb.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	cnb "github.com/buildpacks/lifecycle"
 	cnbl "github.com/buildpacks/lifecycle/launch"
 	shell "github.com/kballard/go-shellquote"
@@ -102,22 +103,22 @@ func hasCNBLauncherEntrypoint(ic imageConfiguration) bool {
 //     found in `/cnb/process/`, and the image entrypoint is set to the corresponding executable for
 //     the default process type.  `CNB_PROCESS_TYPE` is ignored in this situation.  A different process
 //     can be used by overriding the image entrypoint.  Direct and script launches are supported by
-//     setting the entrypoint to `/cnb/lifecycle/launcher` and providing the appropriate argments.
-func updateForCNBImage(container *v1.Container, ic imageConfiguration, transformer func(container *v1.Container, ic imageConfiguration) (ContainerDebugConfiguration, string, error)) (ContainerDebugConfiguration, string, error) {
+//     setting the entrypoint to `/cnb/lifecycle/launcher` and providing the appropriate arguments.
+func updateForCNBImage(container *v1.Container, ic imageConfiguration, transformer func(container *v1.Container, ic imageConfiguration) (annotations.ContainerDebugConfiguration, string, error)) (annotations.ContainerDebugConfiguration, string, error) {
 	// buildpacks/lifecycle 0.6.0 embeds the process definitions into a special image label.
 	// The build metadata isn't absolutely required as the image args could be
 	// a command line (e.g., `python xxx`) but it likely indicates the
 	// image was built with an older lifecycle.
 	metadataJSON, found := ic.labels["io.buildpacks.build.metadata"]
 	if !found {
-		return ContainerDebugConfiguration{}, "", fmt.Errorf("image is missing buildpacks metadata; perhaps built with older lifecycle?")
+		return annotations.ContainerDebugConfiguration{}, "", fmt.Errorf("image is missing buildpacks metadata; perhaps built with older lifecycle?")
 	}
 	m := cnb.BuildMetadata{}
 	if err := json.Unmarshal([]byte(metadataJSON), &m); err != nil {
-		return ContainerDebugConfiguration{}, "", fmt.Errorf("unable to parse image buildpacks metadata")
+		return annotations.ContainerDebugConfiguration{}, "", fmt.Errorf("unable to parse image buildpacks metadata")
 	}
 	if len(m.Processes) == 0 {
-		return ContainerDebugConfiguration{}, "", fmt.Errorf("buildpacks metadata has no processes")
+		return annotations.ContainerDebugConfiguration{}, "", fmt.Errorf("buildpacks metadata has no processes")
 	}
 
 	needsCnbLauncher := ic.entrypoint[0] != cnbLauncher

--- a/pkg/skaffold/debug/cnb_test.go
+++ b/pkg/skaffold/debug/cnb_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -227,7 +228,7 @@ func TestUpdateForCNBImage(t *testing.T) {
 		input       imageConfiguration
 		shouldErr   bool
 		expected    v1.Container
-		config      ContainerDebugConfiguration
+		config      annotations.ContainerDebugConfiguration
 	}{
 		{
 			description: "error when missing build.metadata",
@@ -244,84 +245,84 @@ func TestUpdateForCNBImage(t *testing.T) {
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, arguments: []string{"--", "web", "arg1", "arg2"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"--", "web", "arg1", "arg2"}},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "defaults to web process when no process type",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"webProcess arg1 arg2", "posArg1", "posArg2"}},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "resolves to default 'web' process",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, arguments: []string{"web"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"webProcess arg1 arg2", "posArg1", "posArg2"}},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "CNB_PROCESS_TYPE=web",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PROCESS_TYPE": "web"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"webProcess arg1 arg2", "posArg1", "posArg2"}},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "CNB_PROCESS_TYPE=diag",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PROCESS_TYPE": "diag"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"diagProcess"}},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "CNB_PROCESS_TYPE=direct",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PROCESS_TYPE": "direct"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"--", "command", "cmdArg1"}},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "script command-line",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, arguments: []string{"python main.py"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"python main.py"}},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "no process and no args",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, labels: map[string]string{"io.buildpacks.build.metadata": mdndJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "launcher ignores image's working dir",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, labels: map[string]string{"io.buildpacks.build.metadata": mdndJSON}, workingDir: "/workdir"},
 			shouldErr:   false,
 			expected:    v1.Container{},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "CNB_APP_DIR used if set",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, labels: map[string]string{"io.buildpacks.build.metadata": mdndJSON}, env: map[string]string{"CNB_APP_DIR": "/appDir"}, workingDir: "/workdir"},
 			shouldErr:   false,
 			expected:    v1.Container{},
-			config:      ContainerDebugConfiguration{WorkingDir: "/appDir"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/appDir"},
 		},
 		{
 			description: "CNB_PROCESS_TYPE=sh-c (Procfile-style)",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PROCESS_TYPE": "sh-c"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"command arg1 arg2"}},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "CNB_PROCESS_TYPE=bash-c (Procfile-style)",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PROCESS_TYPE": "sh-c"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"command arg1 arg2"}},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 
 		// Platform API 0.4
@@ -331,58 +332,58 @@ func TestUpdateForCNBImage(t *testing.T) {
 			input:     imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PLATFORM_API": "0.4"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr: false,
 			expected:  v1.Container{},
-			config:    ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:    annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "Platform API 0.4: direct command-lines are kept as direct command-lines",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, arguments: []string{"--", "web", "arg1", "arg2"}, env: map[string]string{"CNB_PLATFORM_API": "0.4"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"--", "web", "arg1", "arg2"}},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "Platform API 0.4: script command-line",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, arguments: []string{"python main.py"}, env: map[string]string{"CNB_PLATFORM_API": "0.4"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Args: []string{"python main.py"}},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "Platform API 0.4: launcher ignores image's working dir",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PLATFORM_API": "0.4"}, workingDir: "/workdir", labels: map[string]string{"io.buildpacks.build.metadata": mdndJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "Platform API 0.4: CNB_APP_DIR used if set",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/lifecycle/launcher"}, env: map[string]string{"CNB_PLATFORM_API": "0.4", "CNB_APP_DIR": "/appDir"}, workingDir: "/workdir", labels: map[string]string{"io.buildpacks.build.metadata": mdndJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{},
-			config:      ContainerDebugConfiguration{WorkingDir: "/appDir"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/appDir"},
 		},
 		{
 			description: "Platform API 0.4: /cnb/process/web",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/process/web"}, env: map[string]string{"CNB_PLATFORM_API": "0.4"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Command: []string{"/cnb/lifecycle/launcher"}, Args: []string{"webProcess arg1 arg2", "posArg1", "posArg2"}},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 		{
 			description: "Platform API 0.4: /cnb/process/web with arguments are appended",
 			input:       imageConfiguration{entrypoint: []string{"/cnb/process/web"}, arguments: []string{"altArg1", "altArg2"}, env: map[string]string{"CNB_PLATFORM_API": "0.4"}, labels: map[string]string{"io.buildpacks.build.metadata": mdJSON}},
 			shouldErr:   false,
 			expected:    v1.Container{Command: []string{"/cnb/lifecycle/launcher"}, Args: []string{"webProcess arg1 arg2", "posArg1", "posArg2", "altArg1", "altArg2"}},
-			config:      ContainerDebugConfiguration{WorkingDir: "/workspace"},
+			config:      annotations.ContainerDebugConfiguration{WorkingDir: "/workspace"},
 		},
 	}
 	for _, test := range tests {
 		// Test that when a transform modifies the command-line arguments, then
 		// the changes are reflected to the launcher command-line
 		testutil.Run(t, test.description+" (args changed)", func(t *testutil.T) {
-			argsChangedTransform := func(c *v1.Container, ic imageConfiguration) (ContainerDebugConfiguration, string, error) {
+			argsChangedTransform := func(c *v1.Container, ic imageConfiguration) (annotations.ContainerDebugConfiguration, string, error) {
 				c.Args = ic.arguments
-				return ContainerDebugConfiguration{}, "", nil
+				return annotations.ContainerDebugConfiguration{}, "", nil
 			}
 			copy := v1.Container{}
 			c, _, err := updateForCNBImage(&copy, test.input, argsChangedTransform)
@@ -392,8 +393,8 @@ func TestUpdateForCNBImage(t *testing.T) {
 
 		// Test that when the arguments are left unchanged, that the container is unchanged
 		testutil.Run(t, test.description+" (args unchanged)", func(t *testutil.T) {
-			argsUnchangedTransform := func(c *v1.Container, ic imageConfiguration) (ContainerDebugConfiguration, string, error) {
-				return ContainerDebugConfiguration{WorkingDir: ic.workingDir}, "", nil
+			argsUnchangedTransform := func(c *v1.Container, ic imageConfiguration) (annotations.ContainerDebugConfiguration, string, error) {
+				return annotations.ContainerDebugConfiguration{WorkingDir: ic.workingDir}, "", nil
 			}
 
 			copy := v1.Container{}

--- a/pkg/skaffold/debug/debug.go
+++ b/pkg/skaffold/debug/debug.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2021 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,145 +17,32 @@ limitations under the License.
 package debug
 
 import (
-	"bufio"
-	"bytes"
 	"context"
-	"fmt"
-	"strings"
 
-	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer/json"
-	"k8s.io/client-go/kubernetes/scheme"
-
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 )
 
-var (
-	decodeFromYaml = scheme.Codecs.UniversalDeserializer().Decode
-	encodeAsYaml   = func(o runtime.Object) ([]byte, error) {
-		s := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme.Scheme, scheme.Scheme)
-		var b bytes.Buffer
-		w := bufio.NewWriter(&b)
-		if err := s.Encode(o, w); err != nil {
-			return nil, err
-		}
-		w.Flush()
-		return b.Bytes(), nil
-	}
-)
-
-// ApplyDebuggingTransforms applies language-platform-specific transforms to a list of manifests.
-func ApplyDebuggingTransforms(l manifest.ManifestList, builds []graph.Artifact, registries manifest.Registries) (manifest.ManifestList, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	retriever := func(image string) (imageConfiguration, error) {
-		if artifact := findArtifact(image, builds); artifact != nil {
-			return retrieveImageConfiguration(ctx, artifact, registries.InsecureRegistries)
-		}
-		return imageConfiguration{}, fmt.Errorf("no build artifact for %q", image)
-	}
-	return applyDebuggingTransforms(l, retriever, registries.DebugHelpersRegistry)
+type Config interface {
+	Mode() config.RunMode
 }
 
-func applyDebuggingTransforms(l manifest.ManifestList, retriever configurationRetriever, debugHelpersRegistry string) (manifest.ManifestList, error) {
-	var updated manifest.ManifestList
-	for _, manifest := range l {
-		obj, _, err := decodeFromYaml(manifest, nil, nil)
-		if err != nil {
-			logrus.Debugf("Unable to interpret manifest for debugging: %v\n", err)
-		} else if transformManifest(obj, retriever, debugHelpersRegistry) {
-			manifest, err = encodeAsYaml(obj)
-			if err != nil {
-				return nil, fmt.Errorf("marshalling yaml: %w", err)
-			}
-			if logrus.IsLevelEnabled(logrus.DebugLevel) {
-				logrus.Debugln("Applied debugging transform:\n", string(manifest))
-			}
-		}
-		updated = append(updated, manifest)
-	}
+// Debugger defines the behavior for any implementation of a component
+// that attaches to and helps debug deployed resources from Skaffold.
+type Debugger interface {
+	// Start starts the debugger.
+	Start(context.Context, []string) error
 
-	return updated, nil
+	// Stop stops the debugger.
+	Stop()
+
+	// Name returns an identifier string for the debugger.
+	Name() string
 }
 
-// findArtifact finds the corresponding artifact for the given image.
-// If `builds` is empty, then treat all `image` images as a build artifact.
-func findArtifact(image string, builds []graph.Artifact) *graph.Artifact {
-	if len(builds) == 0 {
-		logrus.Debugf("No build artifacts specified: using image as-is %q", image)
-		return &graph.Artifact{ImageName: image, Tag: image}
-	}
-	for _, artifact := range builds {
-		if image == artifact.ImageName || image == artifact.Tag {
-			logrus.Debugf("Found artifact for image %q", image)
-			return &artifact
-		}
-	}
-	return nil
-}
+type NoopDebugger struct{}
 
-// retrieveImageConfiguration retrieves the image container configuration for
-// the given build artifact
-func retrieveImageConfiguration(ctx context.Context, artifact *graph.Artifact, insecureRegistries map[string]bool) (imageConfiguration, error) {
-	// TODO: use the proper RunContext
-	apiClient, err := docker.NewAPIClient(&runcontext.RunContext{
-		InsecureRegistries: insecureRegistries,
-	})
-	if err != nil {
-		return imageConfiguration{}, fmt.Errorf("could not connect to local docker daemon: %w", err)
-	}
+func (n *NoopDebugger) Start(context.Context, []string) error { return nil }
 
-	// the apiClient will go to the remote registry if local docker daemon is not available
-	manifest, err := apiClient.ConfigFile(ctx, artifact.Tag)
-	if err != nil {
-		logrus.Debugf("Error retrieving image manifest for %v: %v", artifact.Tag, err)
-		return imageConfiguration{}, fmt.Errorf("retrieving image config for %q: %w", artifact.Tag, err)
-	}
+func (n *NoopDebugger) Stop() {}
 
-	config := manifest.Config
-	logrus.Debugf("Retrieved local image configuration for %v: %v", artifact.Tag, config)
-	// need to duplicate slices as apiClient caches requests
-	return imageConfiguration{
-		artifact:   artifact.ImageName,
-		env:        envAsMap(config.Env),
-		entrypoint: dupArray(config.Entrypoint),
-		arguments:  dupArray(config.Cmd),
-		labels:     dupMap(config.Labels),
-		workingDir: config.WorkingDir,
-	}, nil
-}
-
-// envAsMap turns an array of environment "NAME=value" strings into a map
-func envAsMap(env []string) map[string]string {
-	result := make(map[string]string)
-	for _, pair := range env {
-		s := strings.SplitN(pair, "=", 2)
-		result[s[0]] = s[1]
-	}
-	return result
-}
-
-func dupArray(s []string) []string {
-	if len(s) == 0 {
-		return nil
-	}
-	dup := make([]string, len(s))
-	copy(dup, s)
-	return dup
-}
-
-func dupMap(s map[string]string) map[string]string {
-	if len(s) == 0 {
-		return nil
-	}
-	dup := make(map[string]string, len(s))
-	for k, v := range s {
-		dup[k] = v
-	}
-	return dup
-}
+func (n *NoopDebugger) Name() string { return "Noop Debugger" }

--- a/pkg/skaffold/debug/debug_test.go
+++ b/pkg/skaffold/debug/debug_test.go
@@ -24,6 +24,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -112,14 +113,14 @@ func (t testTransformer) IsApplicable(config imageConfiguration) bool {
 	return true
 }
 
-func (t testTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (ContainerDebugConfiguration, string, error) {
+func (t testTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (annotations.ContainerDebugConfiguration, string, error) {
 	port := portAlloc(9999)
 	container.Ports = append(container.Ports, v1.ContainerPort{Name: "test", ContainerPort: port})
 
 	testEnv := v1.EnvVar{Name: "KEY", Value: "value"}
 	container.Env = append(container.Env, testEnv)
 
-	return ContainerDebugConfiguration{Runtime: "test"}, "", nil
+	return annotations.ContainerDebugConfiguration{Runtime: "test"}, "", nil
 }
 
 func TestApplyDebuggingTransforms(t *testing.T) {

--- a/pkg/skaffold/debug/debugger_mux.go
+++ b/pkg/skaffold/debug/debugger_mux.go
@@ -36,9 +36,5 @@ func (d DebuggerMux) Stop() {
 }
 
 func (d DebuggerMux) Name() string {
-	var name string
-	for _, debugger := range d {
-		name += debugger.Name()
-	}
-	return name
+	return "Debugger Mux"
 }

--- a/pkg/skaffold/debug/debugger_mux.go
+++ b/pkg/skaffold/debug/debugger_mux.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2021 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,17 +14,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1
+package debug
 
-import (
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/debugging"
-)
+import "context"
 
-func (r *SkaffoldRunner) createContainerManager() *debugging.ContainerManager {
-	if r.runCtx.Mode() != config.RunModes.Debug {
-		return nil
+type DebuggerMux []Debugger
+
+func (d DebuggerMux) Start(ctx context.Context, namespaces []string) error {
+	for _, debugger := range d {
+		if err := debugger.Start(ctx, namespaces); err != nil {
+			return err
+		}
 	}
+	return nil
+}
 
-	return debugging.NewContainerManager(r.podSelector)
+func (d DebuggerMux) Stop() {
+	for _, debugger := range d {
+		debugger.Stop()
+	}
+}
+
+func (d DebuggerMux) Name() string {
+	var name string
+	for _, debugger := range d {
+		name += debugger.Name()
+	}
+	return name
 }

--- a/pkg/skaffold/debug/provider.go
+++ b/pkg/skaffold/debug/provider.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"sync"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/debugging"
+)
+
+// Provider is an object that distributes instances of all implementations of
+// Debugger in the Skaffold codebase.
+type Provider interface {
+	// GetKubernetesDebugger returns a new instance of the Kubernetes Debugger implementation
+	GetKubernetesDebugger(*kubernetes.ImageList) Debugger
+
+	// GetNoopDebugger returns a new instance of a Debugger that does nothing.
+	GetNoopDebugger() Debugger
+}
+
+type fullProvider struct {
+	kubernetesDebugger func(*kubernetes.ImageList) Debugger
+}
+
+var (
+	provider *fullProvider
+	once     sync.Once
+)
+
+// NewDebugProvider instantiates the Provider object that is used to retrieve instances of Debuggers.
+// This method is used by the Runner, which then passes it along to the Deployers it instantiates.
+func NewDebugProvider(debugConfig Config) Provider {
+	once.Do(func() {
+		provider = &fullProvider{
+			kubernetesDebugger: func(podSelector *kubernetes.ImageList) Debugger {
+				if debugConfig.Mode() != config.RunModes.Debug {
+					return &NoopDebugger{}
+				}
+
+				return debugging.NewContainerManager(podSelector)
+			},
+		}
+	})
+	return provider
+}
+
+func (p *fullProvider) GetKubernetesDebugger(podSelector *kubernetes.ImageList) Debugger {
+	return p.kubernetesDebugger(podSelector)
+}
+
+func (p *fullProvider) GetNoopDebugger() Debugger {
+	return &NoopDebugger{}
+}
+
+// NoopProvider is used in tests
+type NoopProvider struct{}
+
+func (p *NoopProvider) GetKubernetesDebugger(_ *kubernetes.ImageList) Debugger {
+	return &NoopDebugger{}
+}
+
+func (p *NoopProvider) GetNoopDebugger() Debugger {
+	return &NoopDebugger{}
+}

--- a/pkg/skaffold/debug/transform.go
+++ b/pkg/skaffold/debug/transform.go
@@ -57,7 +57,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	shell "github.com/kballard/go-shellquote"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -66,6 +65,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 )
 
 // portAllocator is a function that takes a desired port and returns an available port

--- a/pkg/skaffold/debug/transform_go.go
+++ b/pkg/skaffold/debug/transform_go.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -92,7 +93,7 @@ func (t dlvTransformer) IsApplicable(config imageConfiguration) bool {
 
 // Apply configures a container definition for Go with Delve.
 // Returns the debug configuration details, with the "go" support image
-func (t dlvTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (ContainerDebugConfiguration, string, error) {
+func (t dlvTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (annotations.ContainerDebugConfiguration, string, error) {
 	logrus.Infof("Configuring %q for Go/Delve debugging", container.Name)
 
 	// try to find existing `dlv` command
@@ -109,13 +110,13 @@ func (t dlvTransformer) Apply(container *v1.Container, config imageConfiguration
 			container.Args = rewriteDlvCommandLine(config.arguments, *spec, container.Args)
 
 		default:
-			return ContainerDebugConfiguration{}, "", fmt.Errorf("container %q has no command-line", container.Name)
+			return annotations.ContainerDebugConfiguration{}, "", fmt.Errorf("container %q has no command-line", container.Name)
 		}
 	}
 
 	container.Ports = exposePort(container.Ports, "dlv", int32(spec.port))
 
-	return ContainerDebugConfiguration{
+	return annotations.ContainerDebugConfiguration{
 		Runtime: "go",
 		Ports:   map[string]uint32{"dlv": uint32(spec.port)},
 	}, "go", nil

--- a/pkg/skaffold/debug/transform_go_test.go
+++ b/pkg/skaffold/debug/transform_go_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -131,7 +132,7 @@ func TestDlvTransformerApply(t *testing.T) {
 		configuration imageConfiguration
 		shouldErr     bool
 		result        v1.Container
-		debugConfig   ContainerDebugConfiguration
+		debugConfig   annotations.ContainerDebugConfiguration
 		image         string
 	}{
 		{
@@ -148,7 +149,7 @@ func TestDlvTransformerApply(t *testing.T) {
 				Command: []string{"/dbg/go/bin/dlv", "exec", "--headless", "--continue", "--accept-multiclient", "--listen=:56268", "--api-version=2", "app", "--", "arg"},
 				Ports:   []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "go", Ports: map[string]uint32{"dlv": 56268}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "go", Ports: map[string]uint32{"dlv": 56268}},
 			image:       "go",
 		},
 		{
@@ -161,7 +162,7 @@ func TestDlvTransformerApply(t *testing.T) {
 				Command: []string{"/dbg/go/bin/dlv", "exec", "--headless", "--continue", "--accept-multiclient", "--listen=:56268", "--api-version=2", "app", "--", "arg"},
 				Ports:   []v1.ContainerPort{{Name: "http-server", ContainerPort: 8080}, {Name: "dlv", ContainerPort: 56268}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "go", Ports: map[string]uint32{"dlv": 56268}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "go", Ports: map[string]uint32{"dlv": 56268}},
 			image:       "go",
 		},
 		{
@@ -174,7 +175,7 @@ func TestDlvTransformerApply(t *testing.T) {
 				Command: []string{"/dbg/go/bin/dlv", "exec", "--headless", "--continue", "--accept-multiclient", "--listen=:56268", "--api-version=2", "app", "--", "arg"},
 				Ports:   []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "go", Ports: map[string]uint32{"dlv": 56268}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "go", Ports: map[string]uint32{"dlv": 56268}},
 			image:       "go",
 		},
 		{
@@ -185,7 +186,7 @@ func TestDlvTransformerApply(t *testing.T) {
 				Args:  []string{"/dbg/go/bin/dlv", "exec", "--headless", "--continue", "--accept-multiclient", "--listen=:56268", "--api-version=2", "app", "--", "arg"},
 				Ports: []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "go", Ports: map[string]uint32{"dlv": 56268}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "go", Ports: map[string]uint32{"dlv": 56268}},
 			image:       "go",
 		},
 		{
@@ -199,7 +200,7 @@ func TestDlvTransformerApply(t *testing.T) {
 				Args:    []string{"arg1", "arg2"},
 				Ports:   []v1.ContainerPort{{Name: "dlv", ContainerPort: 56268}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "go", Ports: map[string]uint32{"dlv": 56268}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "go", Ports: map[string]uint32{"dlv": 56268}},
 			image:       "go",
 		},
 	}

--- a/pkg/skaffold/debug/transform_jvm.go
+++ b/pkg/skaffold/debug/transform_jvm.go
@@ -21,9 +21,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 )
 
 type jdwpTransformer struct{}

--- a/pkg/skaffold/debug/transform_jvm.go
+++ b/pkg/skaffold/debug/transform_jvm.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 )
@@ -63,7 +64,7 @@ type jdwpSpec struct {
 
 // Apply configures a container definition for JVM debugging.
 // Returns a simple map describing the debug configuration details.
-func (t jdwpTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (ContainerDebugConfiguration, string, error) {
+func (t jdwpTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (annotations.ContainerDebugConfiguration, string, error) {
 	logrus.Infof("Configuring %q for JVM debugging", container.Name)
 	// try to find existing JAVA_TOOL_OPTIONS or jdwp command argument
 	spec := retrieveJdwpSpec(config)
@@ -82,7 +83,7 @@ func (t jdwpTransformer) Apply(container *v1.Container, config imageConfiguratio
 
 	container.Ports = exposePort(container.Ports, "jdwp", port)
 
-	return ContainerDebugConfiguration{
+	return annotations.ContainerDebugConfiguration{
 		Runtime: "jvm",
 		Ports:   map[string]uint32{"jdwp": uint32(port)},
 	}, "", nil

--- a/pkg/skaffold/debug/transform_jvm_test.go
+++ b/pkg/skaffold/debug/transform_jvm_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -99,7 +100,7 @@ func TestJdwpTransformerApply(t *testing.T) {
 		containerSpec v1.Container
 		configuration imageConfiguration
 		result        v1.Container
-		debugConfig   ContainerDebugConfiguration
+		debugConfig   annotations.ContainerDebugConfiguration
 		image         string
 	}{
 		{
@@ -110,7 +111,7 @@ func TestJdwpTransformerApply(t *testing.T) {
 				Env:   []v1.EnvVar{{Name: "JAVA_TOOL_OPTIONS", Value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"}},
 				Ports: []v1.ContainerPort{{Name: "jdwp", ContainerPort: 5005}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "jvm", Ports: map[string]uint32{"jdwp": 5005}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "jvm", Ports: map[string]uint32{"jdwp": 5005}},
 		},
 		{
 			description: "existing port",
@@ -122,7 +123,7 @@ func TestJdwpTransformerApply(t *testing.T) {
 				Env:   []v1.EnvVar{{Name: "JAVA_TOOL_OPTIONS", Value: "-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"}},
 				Ports: []v1.ContainerPort{{Name: "http-server", ContainerPort: 8080}, {Name: "jdwp", ContainerPort: 5005}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "jvm", Ports: map[string]uint32{"jdwp": 5005}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "jvm", Ports: map[string]uint32{"jdwp": 5005}},
 		},
 		{
 			description: "existing jdwp spec",
@@ -135,7 +136,7 @@ func TestJdwpTransformerApply(t *testing.T) {
 				Env:   []v1.EnvVar{{Name: "JAVA_TOOL_OPTIONS", Value: "-agentlib:jdwp=transport=dt_socket,server=y,address=8000,suspend=n,quiet=y"}},
 				Ports: []v1.ContainerPort{{ContainerPort: 5005}, {Name: "jdwp", ContainerPort: 8000}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "jvm", Ports: map[string]uint32{"jdwp": 8000}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "jvm", Ports: map[string]uint32{"jdwp": 8000}},
 		},
 		{
 			description: "existing jdwp port and JAVA_TOOL_OPTIONS",
@@ -148,7 +149,7 @@ func TestJdwpTransformerApply(t *testing.T) {
 				Env:   []v1.EnvVar{{Name: "FOO", Value: "BAR"}, {Name: "JAVA_TOOL_OPTIONS", Value: "-Xms1g -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y"}},
 				Ports: []v1.ContainerPort{{Name: "jdwp", ContainerPort: 5005}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "jvm", Ports: map[string]uint32{"jdwp": 5005}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "jvm", Ports: map[string]uint32{"jdwp": 5005}},
 		},
 	}
 	var identity portAllocator = func(port int32) int32 {

--- a/pkg/skaffold/debug/transform_netcore.go
+++ b/pkg/skaffold/debug/transform_netcore.go
@@ -19,9 +19,10 @@ package debug
 import (
 	"strings"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 )
 
 type netcoreTransformer struct{}

--- a/pkg/skaffold/debug/transform_netcore.go
+++ b/pkg/skaffold/debug/transform_netcore.go
@@ -19,6 +19,7 @@ package debug
 import (
 	"strings"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 )
@@ -67,10 +68,10 @@ func (t netcoreTransformer) IsApplicable(config imageConfiguration) bool {
 
 // Apply configures a container definition for vsdbg.
 // Returns a simple map describing the debug configuration details.
-func (t netcoreTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (ContainerDebugConfiguration, string, error) {
+func (t netcoreTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (annotations.ContainerDebugConfiguration, string, error) {
 	logrus.Infof("Configuring %q for netcore debugging", container.Name)
 
-	return ContainerDebugConfiguration{
+	return annotations.ContainerDebugConfiguration{
 		Runtime: "netcore",
 	}, "netcore", nil
 }

--- a/pkg/skaffold/debug/transform_netcore_test.go
+++ b/pkg/skaffold/debug/transform_netcore_test.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -92,7 +93,7 @@ func TestNetcoreTransformerApply(t *testing.T) {
 		configuration imageConfiguration
 		shouldErr     bool
 		result        v1.Container
-		debugConfig   ContainerDebugConfiguration
+		debugConfig   annotations.ContainerDebugConfiguration
 		image         string
 	}{
 		{
@@ -100,7 +101,7 @@ func TestNetcoreTransformerApply(t *testing.T) {
 			containerSpec: v1.Container{},
 			configuration: imageConfiguration{},
 
-			debugConfig: ContainerDebugConfiguration{Runtime: "netcore"},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "netcore"},
 			image:       "netcore",
 			shouldErr:   false,
 		},
@@ -110,7 +111,7 @@ func TestNetcoreTransformerApply(t *testing.T) {
 			configuration: imageConfiguration{entrypoint: []string{"dotnet", "myapp.dll"}},
 
 			result:      v1.Container{},
-			debugConfig: ContainerDebugConfiguration{Runtime: "netcore"},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "netcore"},
 			image:       "netcore",
 			shouldErr:   false,
 		},

--- a/pkg/skaffold/debug/transform_nodejs.go
+++ b/pkg/skaffold/debug/transform_nodejs.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -75,7 +76,7 @@ func (t nodeTransformer) IsApplicable(config imageConfiguration) bool {
 
 // Apply configures a container definition for NodeJS Chrome V8 Inspector.
 // Returns a simple map describing the debug configuration details.
-func (t nodeTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (ContainerDebugConfiguration, string, error) {
+func (t nodeTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (annotations.ContainerDebugConfiguration, string, error) {
 	logrus.Infof("Configuring %q for node.js debugging", container.Name)
 
 	// try to find existing `--inspect` command
@@ -113,7 +114,7 @@ func (t nodeTransformer) Apply(container *v1.Container, config imageConfiguratio
 
 	container.Ports = exposePort(container.Ports, "devtools", spec.port)
 
-	return ContainerDebugConfiguration{
+	return annotations.ContainerDebugConfiguration{
 		Runtime: "nodejs",
 		Ports:   map[string]uint32{"devtools": uint32(spec.port)},
 	}, "nodejs", nil

--- a/pkg/skaffold/debug/transform_nodejs_test.go
+++ b/pkg/skaffold/debug/transform_nodejs_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -215,7 +216,7 @@ func TestNodeTransformer_Apply(t *testing.T) {
 		containerSpec v1.Container
 		configuration imageConfiguration
 		result        v1.Container
-		debugConfig   ContainerDebugConfiguration
+		debugConfig   annotations.ContainerDebugConfiguration
 	}{
 		{
 			description:   "empty",
@@ -225,7 +226,7 @@ func TestNodeTransformer_Apply(t *testing.T) {
 				Env:   []v1.EnvVar{{Name: "NODE_OPTIONS", Value: "--inspect=0.0.0.0:9229"}, {Name: "PATH", Value: "/dbg/nodejs/bin"}},
 				Ports: []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},
 		{
 			description:   "entrypoint",
@@ -236,7 +237,7 @@ func TestNodeTransformer_Apply(t *testing.T) {
 				Env:     []v1.EnvVar{{Name: "PATH", Value: "/dbg/nodejs/bin"}},
 				Ports:   []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},
 		{
 			description:   "entrypoint with PATH",
@@ -247,7 +248,7 @@ func TestNodeTransformer_Apply(t *testing.T) {
 				Env:     []v1.EnvVar{{Name: "PATH", Value: "/dbg/nodejs/bin:/usr/bin"}},
 				Ports:   []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},
 		{
 			description: "existing port",
@@ -260,7 +261,7 @@ func TestNodeTransformer_Apply(t *testing.T) {
 				Env:     []v1.EnvVar{{Name: "PATH", Value: "/dbg/nodejs/bin"}},
 				Ports:   []v1.ContainerPort{{Name: "http-server", ContainerPort: 8080}, {Name: "devtools", ContainerPort: 9229}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},
 		{
 			description: "existing devtools port",
@@ -273,7 +274,7 @@ func TestNodeTransformer_Apply(t *testing.T) {
 				Env:     []v1.EnvVar{{Name: "PATH", Value: "/dbg/nodejs/bin"}},
 				Ports:   []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},
 		{
 			description:   "command not entrypoint",
@@ -284,7 +285,7 @@ func TestNodeTransformer_Apply(t *testing.T) {
 				Env:   []v1.EnvVar{{Name: "PATH", Value: "/dbg/nodejs/bin"}},
 				Ports: []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},
 		{
 			description:   "docker-entrypoint (#3821)",
@@ -297,7 +298,7 @@ func TestNodeTransformer_Apply(t *testing.T) {
 				Env:   []v1.EnvVar{{Name: "NODE_OPTIONS", Value: "--inspect=0.0.0.0:9229"}, {Name: "PATH", Value: "/dbg/nodejs/bin"}},
 				Ports: []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},
 		{
 			description:   "image environment not copied",
@@ -308,7 +309,7 @@ func TestNodeTransformer_Apply(t *testing.T) {
 				Env:     []v1.EnvVar{{Name: "OTHER", Value: "VALUE"}, {Name: "PATH", Value: "/dbg/nodejs/bin"}},
 				Ports:   []v1.ContainerPort{{Name: "devtools", ContainerPort: 9229}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "nodejs", Ports: map[string]uint32{"devtools": 9229}},
 		},
 	}
 	var identity portAllocator = func(port int32) int32 {

--- a/pkg/skaffold/debug/transform_python.go
+++ b/pkg/skaffold/debug/transform_python.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -106,14 +107,14 @@ func (t pythonTransformer) IsApplicable(config imageConfiguration) bool {
 
 // Apply configures a container definition for Python with ptvsd/debugpy/pydevd.
 // Returns a simple map describing the debug configuration details.
-func (t pythonTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (ContainerDebugConfiguration, string, error) {
+func (t pythonTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (annotations.ContainerDebugConfiguration, string, error) {
 	logrus.Infof("Configuring %q for python debugging", container.Name)
 
 	// try to find existing `-mptvsd` or `-mdebugpy` command
 	if spec := retrievePythonDebugSpec(config); spec != nil {
 		protocol := spec.protocol()
 		container.Ports = exposePort(container.Ports, protocol, spec.port)
-		return ContainerDebugConfiguration{
+		return annotations.ContainerDebugConfiguration{
 			Runtime: "python",
 			Ports:   map[string]uint32{protocol: uint32(spec.port)},
 		}, "", nil
@@ -132,13 +133,13 @@ func (t pythonTransformer) Apply(container *v1.Container, config imageConfigurat
 		container.Command = rewritePythonCommandLine(config.entrypoint, *spec)
 
 	default:
-		return ContainerDebugConfiguration{}, "", fmt.Errorf("%q does not appear to invoke python", container.Name)
+		return annotations.ContainerDebugConfiguration{}, "", fmt.Errorf("%q does not appear to invoke python", container.Name)
 	}
 
 	protocol := spec.protocol()
 	container.Ports = exposePort(container.Ports, protocol, spec.port)
 
-	return ContainerDebugConfiguration{
+	return annotations.ContainerDebugConfiguration{
 		Runtime: "python",
 		Ports:   map[string]uint32{protocol: uint32(spec.port)},
 	}, "python", nil

--- a/pkg/skaffold/debug/transform_python_test.go
+++ b/pkg/skaffold/debug/transform_python_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -152,7 +153,7 @@ func TestPythonTransformer_Apply(t *testing.T) {
 		overrideProtocols []string
 		shouldErr         bool
 		result            v1.Container
-		debugConfig       ContainerDebugConfiguration
+		debugConfig       annotations.ContainerDebugConfiguration
 		image             string
 	}{
 		{
@@ -170,7 +171,7 @@ func TestPythonTransformer_Apply(t *testing.T) {
 				Command: []string{"/dbg/python/launcher", "--mode", "debugpy", "--port", "5678", "--", "python"},
 				Ports:   []v1.ContainerPort{{Name: "dap", ContainerPort: 5678}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
 			image:       "python",
 		},
 		{
@@ -182,7 +183,7 @@ func TestPythonTransformer_Apply(t *testing.T) {
 				Command: []string{"/dbg/python/launcher", "--mode", "pydevd", "--port", "5678", "--", "python"},
 				Ports:   []v1.ContainerPort{{Name: "pydevd", ContainerPort: 5678}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"pydevd": 5678}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"pydevd": 5678}},
 			image:       "python",
 		},
 		{
@@ -194,7 +195,7 @@ func TestPythonTransformer_Apply(t *testing.T) {
 				Command: []string{"/dbg/python/launcher", "--mode", "debugpy", "--port", "5678", "--", "python"},
 				Ports:   []v1.ContainerPort{{Name: "dap", ContainerPort: 5678}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
 			image:       "python",
 		},
 		{
@@ -207,7 +208,7 @@ func TestPythonTransformer_Apply(t *testing.T) {
 				Command: []string{"/dbg/python/launcher", "--mode", "debugpy", "--port", "5678", "--", "python"},
 				Ports:   []v1.ContainerPort{{Name: "http-server", ContainerPort: 8080}, {Name: "dap", ContainerPort: 5678}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
 			image:       "python",
 		},
 		{
@@ -218,7 +219,7 @@ func TestPythonTransformer_Apply(t *testing.T) {
 				Args:  []string{"/dbg/python/launcher", "--mode", "debugpy", "--port", "5678", "--", "python"},
 				Ports: []v1.ContainerPort{{Name: "dap", ContainerPort: 5678}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
 			image:       "python",
 		},
 		{
@@ -229,7 +230,7 @@ func TestPythonTransformer_Apply(t *testing.T) {
 				Command: []string{"/dbg/python/launcher", "--mode", "debugpy", "--port", "5678", "--", "foo"},
 				Ports:   []v1.ContainerPort{{Name: "dap", ContainerPort: 5678}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
 			image:       "python",
 		},
 		{
@@ -240,7 +241,7 @@ func TestPythonTransformer_Apply(t *testing.T) {
 				Command: []string{"/dbg/python/launcher", "--mode", "debugpy", "--port", "5678", "--"},
 				Ports:   []v1.ContainerPort{{Name: "dap", ContainerPort: 5678}},
 			},
-			debugConfig: ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
+			debugConfig: annotations.ContainerDebugConfiguration{Runtime: "python", Ports: map[string]uint32{"dap": 5678}},
 			image:       "python",
 		},
 	}

--- a/pkg/skaffold/debug/transform_test.go
+++ b/pkg/skaffold/debug/transform_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -320,7 +321,7 @@ func TestUpdateForShDashC(t *testing.T) {
 			container := v1.Container{}
 			// The transformer reverses the unwrapped entrypoint which should be reflected into the container.Entrypoint
 			updateForShDashC(&container, test.input,
-				func(c *v1.Container, result imageConfiguration) (ContainerDebugConfiguration, string, error) {
+				func(c *v1.Container, result imageConfiguration) (annotations.ContainerDebugConfiguration, string, error) {
 					t.CheckDeepEqual(test.unwrapped, result, cmp.AllowUnexported(imageConfiguration{}))
 					if len(result.entrypoint) > 0 {
 						c.Command = make([]string, len(result.entrypoint))
@@ -328,7 +329,7 @@ func TestUpdateForShDashC(t *testing.T) {
 							c.Command[len(result.entrypoint)-i-1] = s
 						}
 					}
-					return ContainerDebugConfiguration{}, "image", nil
+					return annotations.ContainerDebugConfiguration{}, "image", nil
 				})
 			t.CheckDeepEqual(test.expected, container)
 		})

--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"io"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 )
 
 // NoopComponentProvider is for tests
-var NoopComponentProvider = ComponentProvider{Logger: &log.NoopProvider{}}
+var NoopComponentProvider = ComponentProvider{Logger: &log.NoopProvider{}, Debugger: &debug.NoopProvider{}}
 
 // Deployer is the Deploy API of skaffold and responsible for deploying
 // the build results to a Kubernetes cluster
@@ -45,6 +46,9 @@ type Deployer interface {
 	// writes them to the given file path
 	Render(context.Context, io.Writer, []graph.Artifact, bool, string) error
 
+	// GetDebugger returns a Deployer's implementation of a Logger
+	GetDebugger() debug.Debugger
+
 	// GetLogger returns a Deployer's implementation of a Logger
 	GetLogger() log.Logger
 
@@ -55,5 +59,6 @@ type Deployer interface {
 // ComponentProvider serves as a clean way to send three providers
 // as params to the Deployer constructors
 type ComponentProvider struct {
-	Logger log.Provider
+	Logger   log.Provider
+	Debugger debug.Provider
 }

--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
@@ -44,6 +45,14 @@ func (m DeployerMux) GetLogger() log.Logger {
 		loggers = append(loggers, deployer.GetLogger())
 	}
 	return loggers
+}
+
+func (m DeployerMux) GetDebugger() debug.Debugger {
+	var debuggers debug.DebuggerMux
+	for _, deployer := range m {
+		debuggers = append(debuggers, deployer.GetDebugger())
+	}
+	return debuggers
 }
 
 func (m DeployerMux) Deploy(ctx context.Context, w io.Writer, as []graph.Artifact) ([]string, error) {

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -47,6 +48,10 @@ type MockDeployer struct {
 
 func (m *MockDeployer) GetLogger() log.Logger {
 	return &log.NoopLogger{}
+}
+
+func (m *MockDeployer) GetDebugger() debug.Debugger {
+	return &debug.NoopDebugger{}
 }
 
 func (m *MockDeployer) TrackBuildArtifacts(_ []graph.Artifact) {}

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -33,6 +33,7 @@ import (
 	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
@@ -69,6 +70,7 @@ type Deployer struct {
 	*latestV1.KptDeploy
 
 	logger         log.Logger
+	debugger       debug.Debugger
 	podSelector    *kubernetes.ImageList
 	originalImages []graph.Artifact
 
@@ -92,6 +94,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		KptDeploy:          d,
 		podSelector:        podSelector,
 		logger:             provider.Logger.GetKubernetesLogger(podSelector),
+		debugger:           provider.Debugger.GetKubernetesDebugger(podSelector),
 		insecureRegistries: cfg.GetInsecureRegistries(),
 		labels:             labels,
 		globalConfig:       cfg.GlobalConfig(),
@@ -104,6 +107,10 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 
 func (k *Deployer) GetLogger() log.Logger {
 	return k.logger
+}
+
+func (k *Deployer) GetDebugger() debug.Debugger {
+	return k.debugger
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	deployerr "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/error"
 	deployutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/util"
@@ -47,7 +48,8 @@ import (
 type Deployer struct {
 	*latestV1.KubectlDeploy
 
-	logger log.Logger
+	logger   log.Logger
+	debugger debug.Debugger
 
 	originalImages     []graph.Artifact
 	podSelector        *kubernetes.ImageList
@@ -80,6 +82,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		KubectlDeploy:      d,
 		podSelector:        podSelector,
 		logger:             provider.Logger.GetKubernetesLogger(podSelector),
+		debugger:           provider.Debugger.GetKubernetesDebugger(podSelector),
 		workingDir:         cfg.GetWorkingDir(),
 		globalConfig:       cfg.GlobalConfig(),
 		defaultRepo:        cfg.DefaultRepo(),
@@ -93,6 +96,10 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 
 func (k *Deployer) GetLogger() log.Logger {
 	return k.logger
+}
+
+func (k *Deployer) GetDebugger() debug.Debugger {
+	return k.debugger
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -28,6 +28,7 @@ import (
 	yamlv3 "gopkg.in/yaml.v3"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	deployerr "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/error"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
@@ -99,6 +100,7 @@ type Deployer struct {
 	*latestV1.KustomizeDeploy
 
 	logger         log.Logger
+	debugger       debug.Debugger
 	podSelector    *kubernetes.ImageList
 	originalImages []graph.Artifact
 
@@ -128,6 +130,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, provider deploy.C
 		KustomizeDeploy:     d,
 		podSelector:         podSelector,
 		logger:              provider.Logger.GetKubernetesLogger(podSelector),
+		debugger:            provider.Debugger.GetKubernetesDebugger(podSelector),
 		kubectl:             kubectl,
 		insecureRegistries:  cfg.GetInsecureRegistries(),
 		globalConfig:        cfg.GlobalConfig(),
@@ -138,6 +141,10 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, provider deploy.C
 
 func (k *Deployer) GetLogger() log.Logger {
 	return k.logger
+}
+
+func (k *Deployer) GetDebugger() debug.Debugger {
+	return k.debugger
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/kubernetes/debugging/container_manager.go
+++ b/pkg/skaffold/kubernetes/debugging/container_manager.go
@@ -23,7 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 )
@@ -98,11 +98,11 @@ func (d *ContainerManager) Name() string {
 }
 
 func (d *ContainerManager) checkPod(pod *v1.Pod) {
-	debugConfigString, found := pod.Annotations[debug.DebugConfigAnnotation]
+	debugConfigString, found := pod.Annotations[annotations.DebugConfig]
 	if !found {
 		return
 	}
-	var configurations map[string]debug.ContainerDebugConfiguration
+	var configurations map[string]annotations.ContainerDebugConfiguration
 	if err := json.Unmarshal([]byte(debugConfigString), &configurations); err != nil {
 		logrus.Warnf("Unable to parse debug-config for pod %s/%s: '%s'", pod.Namespace, pod.Name, debugConfigString)
 		return

--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-	debugging "github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
@@ -78,11 +78,11 @@ func allPorts(pod *v1.Pod, c v1.Container) []v1.ContainerPort {
 func debugPorts(pod *v1.Pod, c v1.Container) []v1.ContainerPort {
 	var ports []v1.ContainerPort
 
-	annot, found := pod.ObjectMeta.Annotations[debugging.DebugConfigAnnotation]
+	annot, found := pod.ObjectMeta.Annotations[annotations.DebugConfig]
 	if !found {
 		return nil
 	}
-	var configurations map[string]debugging.ContainerDebugConfiguration
+	var configurations map[string]annotations.ContainerDebugConfiguration
 	if err := json.Unmarshal([]byte(annot), &configurations); err != nil {
 		logrus.Warnf("could not decode debug annotation on pod/%s (%q): %v", pod.Name, annot, err)
 		return nil

--- a/pkg/skaffold/runner/v1/dev.go
+++ b/pkg/skaffold/runner/v1/dev.go
@@ -316,9 +316,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	}
 
 	defer r.deployer.GetLogger().Stop()
-
-	debugContainerManager := r.createContainerManager()
-	defer debugContainerManager.Stop()
+	defer r.deployer.GetDebugger().Stop()
 
 	// Logs should be retrieved up to just before the deploy
 	r.deployer.GetLogger().SetSince(time.Now())
@@ -337,7 +335,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	if err := forwarderManager.Start(ctx, r.runCtx.GetNamespaces()); err != nil {
 		logrus.Warnln("Error starting port forwarding:", err)
 	}
-	if err := debugContainerManager.Start(ctx, r.runCtx.GetNamespaces()); err != nil {
+	if err := r.deployer.GetDebugger().Start(ctx, r.runCtx.GetNamespaces()); err != nil {
 		logrus.Warnln("Error starting debug container notification:", err)
 	}
 	// Start printing the logs after deploy is finished
@@ -352,7 +350,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	endTrace()
 	r.devIteration++
 	return r.listener.WatchForChanges(ctx, out, func() error {
-		return r.doDev(ctx, out, forwarderManager, debugContainerManager)
+		return r.doDev(ctx, out, forwarderManager, r.deployer.GetDebugger())
 	})
 }
 

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/helm"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kpt"
@@ -94,7 +95,8 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 	var podSelectors kubernetes.ImageListMux
 	var deployer deploy.Deployer
 	provider := deploy.ComponentProvider{
-		Logger: log.NewLogProvider(runCtx, kubectlCLI),
+		Logger:   log.NewLogProvider(runCtx, kubectlCLI),
+		Debugger: debug.NewDebugProvider(runCtx),
 	}
 
 	deployer, podSelectors, err = getDeployer(runCtx, provider, labeller.Labels())

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/cluster"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/helm"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
@@ -104,6 +105,10 @@ func (t *TestBench) WithTestErrors(testErrors []error) *TestBench {
 
 func (t *TestBench) GetLogger() log.Logger {
 	return &log.NoopLogger{}
+}
+
+func (t *TestBench) GetDebugger() debug.Debugger {
+	return &debug.NoopDebugger{}
 }
 
 func (t *TestBench) TrackBuildArtifacts(_ []graph.Artifact) {}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

Related: #5813, #5936

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

This change moves the `Debugger` object from the `Runner` into the `Deployer`, since debugging-behavior is implicitly tied to the underlying `Deployer` implementation. See #5809 for a more detailed description of why we need to do this.

This change adds one method to the `Deployer` interface:

```golang
type Deployer interface {
  ...

  GetDebugger() debug.Debugger
}

```

The `GetDebugger()` method is used by the `Runner` to retrieve the`Debugger` implementation and actually orchestrate that behavior in the dev loop.