### PR TITLE
Refactor runID usage, populate runID field in metadata event

### DIFF
--- a/pkg/skaffold/deploy/label/labeller.go
+++ b/pkg/skaffold/deploy/label/labeller.go
@@ -19,16 +19,12 @@ package label
 import (
 	"fmt"
 	"strings"
-
-	"github.com/google/uuid"
 )
 
 const (
 	K8sManagedByLabelKey = "app.kubernetes.io/managed-by"
 	RunIDLabel           = "skaffold.dev/run-id"
 )
-
-var RunID = uuid.New().String()
 
 // DefaultLabeller adds K8s style managed-by label and a run-specific UUID label
 type DefaultLabeller struct {
@@ -37,11 +33,11 @@ type DefaultLabeller struct {
 	runID             string
 }
 
-func NewLabeller(addSkaffoldLabels bool, customLabels []string) *DefaultLabeller {
+func NewLabeller(addSkaffoldLabels bool, customLabels []string, runID string) *DefaultLabeller {
 	return &DefaultLabeller{
 		addSkaffoldLabels: addSkaffoldLabels,
 		customLabels:      customLabels,
-		runID:             RunID,
+		runID:             runID,
 	}
 }
 

--- a/pkg/skaffold/deploy/label/labeller.go
+++ b/pkg/skaffold/deploy/label/labeller.go
@@ -28,7 +28,7 @@ const (
 	RunIDLabel           = "skaffold.dev/run-id"
 )
 
-var runID = uuid.New().String()
+var RunID = uuid.New().String()
 
 // DefaultLabeller adds K8s style managed-by label and a run-specific UUID label
 type DefaultLabeller struct {
@@ -41,7 +41,7 @@ func NewLabeller(addSkaffoldLabels bool, customLabels []string) *DefaultLabeller
 	return &DefaultLabeller{
 		addSkaffoldLabels: addSkaffoldLabels,
 		customLabels:      customLabels,
-		runID:             runID,
+		runID:             RunID,
 	}
 }
 

--- a/pkg/skaffold/deploy/status/status_check_test.go
+++ b/pkg/skaffold/deploy/status/status_check_test.go
@@ -45,7 +45,7 @@ import (
 )
 
 func TestGetDeployments(t *testing.T) {
-	labeller := label.NewLabeller(true, nil)
+	labeller := label.NewLabeller(true, nil, "run-id")
 	tests := []struct {
 		description string
 		deps        []*appsv1.Deployment
@@ -325,7 +325,7 @@ func TestGetDeployStatus(t *testing.T) {
 }
 
 func TestPrintSummaryStatus(t *testing.T) {
-	labeller := label.NewLabeller(true, nil)
+	labeller := label.NewLabeller(true, nil, "run-id")
 	tests := []struct {
 		description string
 		namespace   string
@@ -402,7 +402,7 @@ func TestPrintSummaryStatus(t *testing.T) {
 }
 
 func TestPrintStatus(t *testing.T) {
-	labeller := label.NewLabeller(true, nil)
+	labeller := label.NewLabeller(true, nil, "run-id")
 	tests := []struct {
 		description string
 		rs          []*resource.Deployment

--- a/pkg/skaffold/event/v2/config.go
+++ b/pkg/skaffold/event/v2/config.go
@@ -26,4 +26,5 @@ type Config interface {
 	AutoDeploy() bool
 	AutoSync() bool
 	GetPipelines() []latestV1.Pipeline
+	GetRunID() string
 }

--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -203,7 +203,7 @@ func emptyState(cfg Config) proto.State {
 			builds[a.ImageName] = NotStarted
 		}
 	}
-	metadata := initializeMetadata(cfg.GetPipelines(), cfg.GetKubeContext())
+	metadata := initializeMetadata(cfg.GetPipelines(), cfg.GetKubeContext(), cfg.GetRunID())
 	return emptyStateWithArtifacts(builds, metadata, cfg.AutoBuild(), cfg.AutoDeploy(), cfg.AutoSync())
 }
 

--- a/pkg/skaffold/event/v2/event_test.go
+++ b/pkg/skaffold/event/v2/event_test.go
@@ -422,6 +422,7 @@ func (c config) AutoBuild() bool                   { return true }
 func (c config) AutoDeploy() bool                  { return true }
 func (c config) AutoSync() bool                    { return true }
 func (c config) GetPipelines() []latestV1.Pipeline { return c.pipes }
+func (c config) GetRunID() string                  { return "run-id" }
 
 func mockCfg(pipes []latestV1.Pipeline, kubectx string) config {
 	return config{

--- a/pkg/skaffold/event/v2/metadata.go
+++ b/pkg/skaffold/event/v2/metadata.go
@@ -44,7 +44,7 @@ func initializeMetadata(pipelines []latestV1.Pipeline, kubeContext string) *prot
 	m := &proto.Metadata{
 		Build:  &proto.BuildMetadata{},
 		Deploy: &proto.DeployMetadata{},
-		RunID: label.RunID,
+		RunID:  label.RunID,
 	}
 
 	// TODO: Event metadata should support multiple build types.

--- a/pkg/skaffold/event/v2/metadata.go
+++ b/pkg/skaffold/event/v2/metadata.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
@@ -40,11 +39,11 @@ func LogMetaEvent() {
 	)
 }
 
-func initializeMetadata(pipelines []latestV1.Pipeline, kubeContext string) *proto.Metadata {
+func initializeMetadata(pipelines []latestV1.Pipeline, kubeContext string, runID string) *proto.Metadata {
 	m := &proto.Metadata{
 		Build:  &proto.BuildMetadata{},
 		Deploy: &proto.DeployMetadata{},
-		RunID:  label.RunID,
+		RunID:  runID,
 	}
 
 	// TODO: Event metadata should support multiple build types.

--- a/pkg/skaffold/event/v2/metadata.go
+++ b/pkg/skaffold/event/v2/metadata.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
@@ -43,6 +44,7 @@ func initializeMetadata(pipelines []latestV1.Pipeline, kubeContext string) *prot
 	m := &proto.Metadata{
 		Build:  &proto.BuildMetadata{},
 		Deploy: &proto.DeployMetadata{},
+		RunID: label.RunID,
 	}
 
 	// TODO: Event metadata should support multiple build types.

--- a/pkg/skaffold/event/v2/metadata_test.go
+++ b/pkg/skaffold/event/v2/metadata_test.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -60,7 +59,7 @@ func TestEmptyState(t *testing.T) {
 						{Type: proto.DeployerType_KUBECTL, Count: 1},
 					},
 				},
-				RunID: label.RunID,
+				RunID: "run-id",
 			},
 		},
 		{
@@ -94,7 +93,7 @@ func TestEmptyState(t *testing.T) {
 					Cluster:   proto.ClusterType_GKE,
 					Deployers: []*proto.DeployMetadata_Deployer{{Type: proto.DeployerType_KUSTOMIZE, Count: 1}},
 				},
-				RunID: label.RunID,
+				RunID: "run-id",
 			},
 		},
 		{
@@ -114,7 +113,7 @@ func TestEmptyState(t *testing.T) {
 					Artifacts: []*proto.BuildMetadata_Artifact{{Type: proto.BuilderType_KANIKO, Name: "artifact-1"}},
 				},
 				Deploy: &proto.DeployMetadata{},
-				RunID:  label.RunID,
+				RunID:  "run-id",
 			},
 		},
 		{
@@ -133,7 +132,7 @@ func TestEmptyState(t *testing.T) {
 					Cluster:   proto.ClusterType_OTHER,
 					Deployers: []*proto.DeployMetadata_Deployer{{Type: proto.DeployerType_KUSTOMIZE, Count: 1}},
 				},
-				RunID: label.RunID,
+				RunID: "run-id",
 			},
 		},
 	}

--- a/pkg/skaffold/event/v2/metadata_test.go
+++ b/pkg/skaffold/event/v2/metadata_test.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -57,7 +58,9 @@ func TestEmptyState(t *testing.T) {
 					Deployers: []*proto.DeployMetadata_Deployer{
 						{Type: proto.DeployerType_HELM, Count: 2},
 						{Type: proto.DeployerType_KUBECTL, Count: 1},
-					}},
+					},
+				},
+				RunID: label.RunID,
 			},
 		},
 		{
@@ -89,7 +92,9 @@ func TestEmptyState(t *testing.T) {
 				},
 				Deploy: &proto.DeployMetadata{
 					Cluster:   proto.ClusterType_GKE,
-					Deployers: []*proto.DeployMetadata_Deployer{{Type: proto.DeployerType_KUSTOMIZE, Count: 1}}},
+					Deployers: []*proto.DeployMetadata_Deployer{{Type: proto.DeployerType_KUSTOMIZE, Count: 1}},
+				},
+				RunID: label.RunID,
 			},
 		},
 		{
@@ -109,6 +114,7 @@ func TestEmptyState(t *testing.T) {
 					Artifacts: []*proto.BuildMetadata_Artifact{{Type: proto.BuilderType_KANIKO, Name: "artifact-1"}},
 				},
 				Deploy: &proto.DeployMetadata{},
+				RunID:  label.RunID,
 			},
 		},
 		{
@@ -127,6 +133,7 @@ func TestEmptyState(t *testing.T) {
 					Cluster:   proto.ClusterType_OTHER,
 					Deployers: []*proto.DeployMetadata_Deployer{{Type: proto.DeployerType_KUSTOMIZE, Count: 1}},
 				},
+				RunID: label.RunID,
 			},
 		},
 	}

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
@@ -41,6 +42,7 @@ type RunContext struct {
 	WorkingDir         string
 	InsecureRegistries map[string]bool
 	Cluster            config.Cluster
+	RunID              string
 }
 
 // Pipelines encapsulates multiple config pipelines
@@ -229,6 +231,7 @@ func (rc *RunContext) WaitForDeletions() config.WaitForDeletions { return rc.Opt
 func (rc *RunContext) WatchPollInterval() int                    { return rc.Opts.WatchPollInterval }
 func (rc *RunContext) BuildConcurrency() int                     { return rc.Opts.BuildConcurrency }
 func (rc *RunContext) IsMultiConfig() bool                       { return rc.Pipelines.IsMultiPipeline() }
+func (rc *RunContext) GetRunID() string                          { return rc.RunID }
 
 func GetRunContext(opts config.SkaffoldOptions, configs []*latestV1.SkaffoldConfig) (*RunContext, error) {
 	var pipelines []latestV1.Pipeline
@@ -280,6 +283,8 @@ func GetRunContext(opts config.SkaffoldOptions, configs []*latestV1.SkaffoldConf
 		return nil, fmt.Errorf("getting cluster: %w", err)
 	}
 
+	runID := uuid.New().String()
+
 	return &RunContext{
 		Opts:               opts,
 		Pipelines:          ps,
@@ -288,6 +293,7 @@ func GetRunContext(opts config.SkaffoldOptions, configs []*latestV1.SkaffoldConf
 		Namespaces:         namespaces,
 		InsecureRegistries: insecureRegistries,
 		Cluster:            cluster,
+		RunID:              runID,
 	}, nil
 }
 

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -83,7 +83,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 	isLocalImage := func(imageName string) (bool, error) {
 		return isImageLocal(runCtx, imageName)
 	}
-	labeller := label.NewLabeller(runCtx.AddSkaffoldLabels(), runCtx.CustomLabels())
+	labeller := label.NewLabeller(runCtx.AddSkaffoldLabels(), runCtx.CustomLabels(), runCtx.GetRunID())
 	tester, err := getTester(runCtx, isLocalImage)
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(err))

--- a/testutil/event/config.go
+++ b/testutil/event/config.go
@@ -39,3 +39,4 @@ func (c config) AutoDeploy() bool                  { return true }
 func (c config) AutoSync() bool                    { return true }
 func (c config) GetPipelines() []latestV1.Pipeline { return c.pipes }
 func (c config) GetKubeContext() string            { return "temp" }
+func (c config) GetRunID() string                  { return "run-id" }


### PR DESCRIPTION
**Related**: #5843 

**Description**
This PR refactors the runID variable to be passed through the main RunContext of skaffold, rather than used through a package variable. It also populates the runID field in the metadata event that gets sent through the event API.