### PR TITLE
Log when unable to retrieve access token

### DIFF
--- a/pkg/skaffold/gcp/auth.go
+++ b/pkg/skaffold/gcp/auth.go
@@ -64,6 +64,8 @@ func activeUserCredentials() (*google.Credentials, error) {
 		cmd := exec.Command("gcloud", "auth", "print-access-token", "--format=json")
 		body, err := util.RunCmdOut(cmd)
 		if err != nil {
+			logrus.Infof("unable to retrieve gcloud access token: %v", err)
+			logrus.Infof("falling back to application default credentials")
 			credsErr = fmt.Errorf("retrieving gcloud access token: %w", err)
 			return
 		}


### PR DESCRIPTION
There have been a couple of users having issues with the GCB builder.  From working with one user, I believe they're encountering an error where we attempt to retrieve the access token with `gcloud auth print-access-token`.  If there is an error, we currently silently fail.  This PR logs the error similar to how we log subsequent errors.