### PR TITLE
add gh actions early success if change is docs only

### DIFF
--- a/.github/workflows/integration-darwin.yml
+++ b/.github/workflows/integration-darwin.yml
@@ -18,12 +18,25 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    # Skip integration tests for `docs`-only changes (only works for PR-based dev workflows like Skaffold's).
+    # NOTE: grep output is stored in env var with `|| true` as the run command cannot fail or action will fail
+    - name: Check if only docs changes were made in this PR
+      run: |
+        echo ${{ github.event.before }}
+        echo ${{ github.event.after }}
+        NON_DOCS_FILES_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.sha }}| grep -v '^docs/' || true) 
+        echo "NON_DOCS_FILES_CHANGED=${#NON_DOCS_FILES_CHANGED}" >> $GITHUB_ENV  # get the char len of diff output (used later)
 
     - name: Make and install Skaffold binary from current PR
+      if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}
       run: |
         make
         sudo install "${HOME}/work/skaffold/skaffold/out/skaffold" /usr/local/bin/skaffold
 
     - name: Run integration tests
+      if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}
       run: |
          make quicktest

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -17,7 +17,6 @@ jobs:
         container_structure_tests_version: [1.8.0]
         integration_test_partitions: [0, 1, 2, 3]
     steps:
-
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
@@ -26,23 +25,38 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    # Skip integration tests for `docs`-only changes (only works for PR-based dev workflows like Skaffold's).
+    # NOTE: grep output is stored in env var with `|| true` as the run command cannot fail or action will fail
+    - name: Check if only docs changes were made in this PR
+      run: |
+        echo ${{ github.event.before }}
+        echo ${{ github.event.after }}
+        NON_DOCS_FILES_CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.sha }}| grep -v '^docs/' || true) 
+        echo "NON_DOCS_FILES_CHANGED=${#NON_DOCS_FILES_CHANGED}" >> $GITHUB_ENV  # get the char len of diff output (used later)
 
     - name: Install Kustomize
+      if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}
       run: |
         wget -O kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${{ matrix.kustomize_version }}/kustomize_v${{ matrix.kustomize_version }}_linux_amd64.tar.gz
         sudo tar -xvf kustomize.tar.gz -C /usr/local/bin/
 
     - name: Install Ko
+      if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}
       run: |
         wget -O ko.tar.gz https://github.com/google/ko/releases/download/v${{ matrix.ko_version }}/ko_${{ matrix.ko_version }}_Linux_x86_64.tar.gz
         sudo tar -xvf ko.tar.gz -C /usr/local/bin/
 
     - name: Install Kompose
+      if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}
       run: |
         wget -O kompose https://github.com/kubernetes/kompose/releases/download/v${{ matrix.kompose_version }}/kompose-linux-amd64 && chmod +x kompose
         sudo mv kompose /usr/local/bin/
 
     - name: Install GCloud
+      if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}
       run: |
         wget -O gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${{ matrix.gcloud_sdk_version }}-linux-x86_64.tar.gz
         tar -xvf gcloud.tar.gz -C ${HOME}/
@@ -50,14 +64,17 @@ jobs:
         echo "${HOME}/google-cloud-sdk/bin" >> $GITHUB_PATH
 
     - name: Configure GCloud with Docker
+      if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}
       run:  gcloud auth configure-docker
 
     - name: Install Container Structure Test
+      if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}
       run: |
         wget -O container-structure-test https://storage.googleapis.com/container-structure-test/v${{ matrix.container_structure_tests_version }}/container-structure-test-linux-amd64 && chmod +x container-structure-test
         sudo mv container-structure-test /usr/local/bin/
 
     - name: Setup other files and permissions
+      if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}
       run: |
         sudo chown $(whoami):docker ${HOME}/.docker -R
         sudo chmod g+rw ${HOME}/.docker -R
@@ -65,17 +82,20 @@ jobs:
         mkdir -p ${HOME}/.m2/ && cp ./hack/maven/settings.xml ${HOME}/.m2/settings.xml
         
     - name: Install Minikube from minikube master branch @HEAD and start cluster
+      if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}
       run: |
         curl -Lo minikube https://storage.googleapis.com/minikube-builds/master/minikube-linux-amd64
         sudo install minikube /usr/local/bin/minikube
         minikube start --profile=minikube --driver=docker
 
     - name: Make and install Skaffold binary from current PR
+      if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }} # non docs files were changed, skaffold build needed
       run: |
         make
         sudo install "${HOME}/work/skaffold/skaffold/out/skaffold" /usr/local/bin/skaffold
 
     - name: Run integration tests
+      if: ${{ env.NON_DOCS_FILES_CHANGED != 0 }}
       run: |
         skaffold config set --global collect-metrics false
         IT_PARTITION=${{ matrix.integration_test_partitions }} make integration-tests


### PR DESCRIPTION
### What is the problem being solved?
Fixes #6032, add code to not run Github Actions on docs-only changes. This PR:
    - Updates linux and osx github actions to check if the PR only changes docs/* files and if so, pass the test w/o running the full test suite

Github actions does not have support for exiting the job from a step easily. See:
    - https://stackoverflow.com/questions/60589373/how-to-force-to-exit-in-github-actions-step
    - https://github.com/actions/runner/issues/662

### Why is this the best approach?
The approach here uses an env var and checks this env var in all subsequent steps, this way no single command fails and tests are skipped as desired.  The downside is that all subsequent steps need to have this check but there is no better solution at the moment from my investigation

### What other approaches did you consider?
I considered directly using the the 'conclusion' value github actions provides, eg:
  - "if: steps.s1.conclusion == 'failure'"
  but I believe that if a step fails then the test fails which is not what we want.

### What side effects will this approach have?
There shouldn't be any side effects w/ this approach, all steps have a conditional on the docs-only check and should work correctly as before in the non-docs file are updated case

### What future work remains to be done?
N/A.  Future work generally might include a tag that also skips testing but is not directly related
