### PR TITLE
refactor: move status-checker under deployer

### DIFF
--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -24,10 +24,11 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 )
 
 // NoopComponentProvider is for tests
-var NoopComponentProvider = ComponentProvider{Accessor: &access.NoopProvider{}, Debugger: &debug.NoopProvider{}, Logger: &log.NoopProvider{}}
+var NoopComponentProvider = ComponentProvider{Accessor: &access.NoopProvider{}, Logger: &log.NoopProvider{}, Debugger: &debug.NoopProvider{}, Checker: &status.NoopProvider{}}
 
 // Deployer is the Deploy API of skaffold and responsible for deploying
 // the build results to a Kubernetes cluster
@@ -58,6 +59,9 @@ type Deployer interface {
 
 	// TrackBuildArtifacts registers build artifacts to be tracked by a Deployer
 	TrackBuildArtifacts([]graph.Artifact)
+
+	// GetStatusChecker returns a Deployer's implementation of a StatusChecker
+	GetStatusChecker() status.Checker
 }
 
 // ComponentProvider serves as a clean way to send three providers
@@ -66,4 +70,5 @@ type ComponentProvider struct {
 	Accessor access.Provider
 	Debugger debug.Provider
 	Logger   log.Provider
+	Checker  status.Provider
 }

--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -28,7 +28,7 @@ import (
 )
 
 // NoopComponentProvider is for tests
-var NoopComponentProvider = ComponentProvider{Accessor: &access.NoopProvider{}, Logger: &log.NoopProvider{}, Debugger: &debug.NoopProvider{}, Checker: &status.NoopProvider{}}
+var NoopComponentProvider = ComponentProvider{Accessor: &access.NoopProvider{}, Logger: &log.NoopProvider{}, Debugger: &debug.NoopProvider{}, Monitor: &status.NoopProvider{}}
 
 // Deployer is the Deploy API of skaffold and responsible for deploying
 // the build results to a Kubernetes cluster
@@ -60,8 +60,8 @@ type Deployer interface {
 	// TrackBuildArtifacts registers build artifacts to be tracked by a Deployer
 	TrackBuildArtifacts([]graph.Artifact)
 
-	// GetStatusChecker returns a Deployer's implementation of a StatusChecker
-	GetStatusChecker() status.Checker
+	// GetStatusMonitor returns a Deployer's implementation of a StatusMonitor
+	GetStatusMonitor() status.Monitor
 }
 
 // ComponentProvider serves as a clean way to send three providers
@@ -70,5 +70,5 @@ type ComponentProvider struct {
 	Accessor access.Provider
 	Debugger debug.Provider
 	Logger   log.Provider
-	Checker  status.Provider
+	Monitor  status.Provider
 }

--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -32,6 +32,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -62,6 +63,14 @@ func (m DeployerMux) GetLogger() log.Logger {
 		loggers = append(loggers, deployer.GetLogger())
 	}
 	return loggers
+}
+
+func (m DeployerMux) GetStatusChecker() status.Checker {
+	var checkers status.CheckerMux
+	for _, deployer := range m {
+		checkers = append(checkers, deployer.GetStatusChecker())
+	}
+	return checkers
 }
 
 func (m DeployerMux) Deploy(ctx context.Context, w io.Writer, as []graph.Artifact) ([]string, error) {

--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -65,12 +65,12 @@ func (m DeployerMux) GetLogger() log.Logger {
 	return loggers
 }
 
-func (m DeployerMux) GetStatusChecker() status.Checker {
-	var checkers status.CheckerMux
+func (m DeployerMux) GetStatusMonitor() status.Monitor {
+	var monitors status.MonitorMux
 	for _, deployer := range m {
-		checkers = append(checkers, deployer.GetStatusChecker())
+		monitors = append(monitors, deployer.GetStatusMonitor())
 	}
-	return checkers
+	return monitors
 }
 
 func (m DeployerMux) Deploy(ctx context.Context, w io.Writer, as []graph.Artifact) ([]string, error) {

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -60,8 +60,8 @@ func (m *MockDeployer) GetLogger() log.Logger {
 	return &log.NoopLogger{}
 }
 
-func (m *MockDeployer) GetStatusChecker() status.Checker {
-	return &status.NoopChecker{}
+func (m *MockDeployer) GetStatusMonitor() status.Monitor {
+	return &status.NoopMonitor{}
 }
 
 func (m *MockDeployer) TrackBuildArtifacts(_ []graph.Artifact) {}

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	testEvent "github.com/GoogleContainerTools/skaffold/testutil/event"
 )
@@ -57,6 +58,10 @@ func (m *MockDeployer) GetDebugger() debug.Debugger {
 
 func (m *MockDeployer) GetLogger() log.Logger {
 	return &log.NoopLogger{}
+}
+
+func (m *MockDeployer) GetStatusChecker() status.Checker {
+	return &status.NoopChecker{}
 }
 
 func (m *MockDeployer) TrackBuildArtifacts(_ []graph.Artifact) {}

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -84,7 +84,7 @@ type Deployer struct {
 	accessor      access.Accessor
 	debugger      debug.Debugger
 	logger        log.Logger
-	statusChecker status.Checker
+	statusMonitor status.Monitor
 
 	podSelector    *kubernetes.ImageList
 	originalImages []graph.Artifact
@@ -139,7 +139,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		accessor:       provider.Accessor.GetKubernetesAccessor(podSelector),
 		debugger:       provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:         provider.Logger.GetKubernetesLogger(podSelector),
-		statusChecker:  provider.Checker.GetKubernetesChecker(),
+		statusMonitor:  provider.Monitor.GetKubernetesMonitor(),
 		originalImages: originalImages,
 		kubeContext:    cfg.GetKubeContext(),
 		kubeConfig:     cfg.GetKubeConfig(),
@@ -165,8 +165,8 @@ func (h *Deployer) GetLogger() log.Logger {
 	return h.logger
 }
 
-func (h *Deployer) GetStatusChecker() status.Checker {
-	return h.statusChecker
+func (h *Deployer) GetStatusMonitor() status.Monitor {
+	return h.statusMonitor
 }
 
 func (h *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -168,6 +168,7 @@ func (h *Deployer) GetLogger() log.Logger {
 func (h *Deployer) GetStatusChecker() status.Checker {
 	return h.statusChecker
 }
+
 func (h *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {
 	deployutil.AddTagsToPodSelector(artifacts, h.originalImages, h.podSelector)
 	h.logger.RegisterArtifacts(artifacts)

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -74,7 +74,7 @@ type Deployer struct {
 	accessor      access.Accessor
 	logger        log.Logger
 	debugger      debug.Debugger
-	statusChecker status.Checker
+	statusMonitor status.Monitor
 
 	podSelector    *kubernetes.ImageList
 	originalImages []graph.Artifact
@@ -101,7 +101,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		accessor:           provider.Accessor.GetKubernetesAccessor(podSelector),
 		debugger:           provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:             provider.Logger.GetKubernetesLogger(podSelector),
-		statusChecker:      provider.Checker.GetKubernetesChecker(),
+		statusMonitor:      provider.Monitor.GetKubernetesMonitor(),
 		insecureRegistries: cfg.GetInsecureRegistries(),
 		labels:             labels,
 		globalConfig:       cfg.GlobalConfig(),
@@ -124,8 +124,8 @@ func (k *Deployer) GetLogger() log.Logger {
 	return k.logger
 }
 
-func (k *Deployer) GetStatusChecker() status.Checker {
-	return k.statusChecker
+func (k *Deployer) GetStatusMonitor() status.Monitor {
+	return k.statusMonitor
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -47,6 +47,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -70,9 +71,10 @@ const (
 type Deployer struct {
 	*latestV1.KptDeploy
 
-	accessor access.Accessor
-	debugger debug.Debugger
-	logger   log.Logger
+	accessor      access.Accessor
+	logger        log.Logger
+	debugger      debug.Debugger
+	statusChecker status.Checker
 
 	podSelector    *kubernetes.ImageList
 	originalImages []graph.Artifact
@@ -99,6 +101,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		accessor:           provider.Accessor.GetKubernetesAccessor(podSelector),
 		debugger:           provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:             provider.Logger.GetKubernetesLogger(podSelector),
+		statusChecker:      provider.Checker.GetKubernetesChecker(),
 		insecureRegistries: cfg.GetInsecureRegistries(),
 		labels:             labels,
 		globalConfig:       cfg.GlobalConfig(),
@@ -119,6 +122,10 @@ func (k *Deployer) GetDebugger() debug.Debugger {
 
 func (k *Deployer) GetLogger() log.Logger {
 	return k.logger
+}
+
+func (k *Deployer) GetStatusChecker() status.Checker {
+	return k.statusChecker
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -42,6 +42,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -49,9 +50,10 @@ import (
 type Deployer struct {
 	*latestV1.KubectlDeploy
 
-	accessor access.Accessor
-	debugger debug.Debugger
-	logger   log.Logger
+	accessor      access.Accessor
+	logger        log.Logger
+	debugger      debug.Debugger
+	statusChecker status.Checker
 
 	originalImages     []graph.Artifact
 	podSelector        *kubernetes.ImageList
@@ -86,6 +88,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		accessor:           provider.Accessor.GetKubernetesAccessor(podSelector),
 		debugger:           provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:             provider.Logger.GetKubernetesLogger(podSelector),
+		statusChecker:      provider.Checker.GetKubernetesChecker(),
 		workingDir:         cfg.GetWorkingDir(),
 		globalConfig:       cfg.GlobalConfig(),
 		defaultRepo:        cfg.DefaultRepo(),
@@ -107,6 +110,10 @@ func (k *Deployer) GetDebugger() debug.Debugger {
 
 func (k *Deployer) GetLogger() log.Logger {
 	return k.logger
+}
+
+func (k *Deployer) GetStatusChecker() status.Checker {
+	return k.statusChecker
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -53,7 +53,7 @@ type Deployer struct {
 	accessor      access.Accessor
 	logger        log.Logger
 	debugger      debug.Debugger
-	statusChecker status.Checker
+	statusMonitor status.Monitor
 
 	originalImages     []graph.Artifact
 	podSelector        *kubernetes.ImageList
@@ -88,7 +88,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		accessor:           provider.Accessor.GetKubernetesAccessor(podSelector),
 		debugger:           provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:             provider.Logger.GetKubernetesLogger(podSelector),
-		statusChecker:      provider.Checker.GetKubernetesChecker(),
+		statusMonitor:      provider.Monitor.GetKubernetesMonitor(),
 		workingDir:         cfg.GetWorkingDir(),
 		globalConfig:       cfg.GlobalConfig(),
 		defaultRepo:        cfg.DefaultRepo(),
@@ -112,8 +112,8 @@ func (k *Deployer) GetLogger() log.Logger {
 	return k.logger
 }
 
-func (k *Deployer) GetStatusChecker() status.Checker {
-	return k.statusChecker
+func (k *Deployer) GetStatusMonitor() status.Monitor {
+	return k.statusMonitor
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -104,7 +104,7 @@ type Deployer struct {
 	accessor      access.Accessor
 	logger        log.Logger
 	debugger      debug.Debugger
-	statusChecker status.Checker
+	statusMonitor status.Monitor
 
 	podSelector    *kubernetes.ImageList
 	originalImages []graph.Artifact
@@ -137,7 +137,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, provider deploy.C
 		accessor:            provider.Accessor.GetKubernetesAccessor(podSelector),
 		debugger:            provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:              provider.Logger.GetKubernetesLogger(podSelector),
-		statusChecker:       provider.Checker.GetKubernetesChecker(),
+		statusMonitor:       provider.Monitor.GetKubernetesMonitor(),
 		kubectl:             kubectl,
 		insecureRegistries:  cfg.GetInsecureRegistries(),
 		globalConfig:        cfg.GlobalConfig(),
@@ -158,8 +158,8 @@ func (k *Deployer) GetLogger() log.Logger {
 	return k.logger
 }
 
-func (k *Deployer) GetStatusChecker() status.Checker {
-	return k.statusChecker
+func (k *Deployer) GetStatusMonitor() status.Monitor {
+	return k.statusMonitor
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -42,6 +42,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
@@ -100,9 +101,10 @@ type secretGenerator struct {
 type Deployer struct {
 	*latestV1.KustomizeDeploy
 
-	accessor access.Accessor
-	debugger debug.Debugger
-	logger   log.Logger
+	accessor      access.Accessor
+	logger        log.Logger
+	debugger      debug.Debugger
+	statusChecker status.Checker
 
 	podSelector    *kubernetes.ImageList
 	originalImages []graph.Artifact
@@ -135,6 +137,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, provider deploy.C
 		accessor:            provider.Accessor.GetKubernetesAccessor(podSelector),
 		debugger:            provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:              provider.Logger.GetKubernetesLogger(podSelector),
+		statusChecker:       provider.Checker.GetKubernetesChecker(),
 		kubectl:             kubectl,
 		insecureRegistries:  cfg.GetInsecureRegistries(),
 		globalConfig:        cfg.GlobalConfig(),
@@ -153,6 +156,10 @@ func (k *Deployer) GetDebugger() debug.Debugger {
 
 func (k *Deployer) GetLogger() log.Logger {
 	return k.logger
+}
+
+func (k *Deployer) GetStatusChecker() status.Checker {
+	return k.statusChecker
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -56,6 +56,23 @@ var (
 	}
 )
 
+type Group map[string]*Deployment
+
+func (r Group) Add(d *Deployment) {
+	r[d.ID()] = d
+}
+
+func (r Group) Contains(d *Deployment) bool {
+	_, found := r[d.ID()]
+	return found
+}
+
+func (r Group) Reset() {
+	for k := range r {
+		delete(r, k)
+	}
+}
+
 type Deployment struct {
 	name         string
 	namespace    string
@@ -66,6 +83,10 @@ type Deployment struct {
 	deadline     time.Duration
 	pods         map[string]validator.Resource
 	podValidator diag.Diagnose
+}
+
+func (d *Deployment) ID() string {
+	return fmt.Sprintf("%s:%s:%s", d.name, d.namespace, d.rType)
 }
 
 func (d *Deployment) Deadline() time.Duration {

--- a/pkg/skaffold/deploy/util/logfile_test.go
+++ b/pkg/skaffold/deploy/util/logfile_test.go
@@ -151,7 +151,7 @@ func TestWithStatusCheckLogFile(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			var mockOut bytes.Buffer
 
-			var deployer = mockStatusChecker{
+			var deployer = mockStatusMonitor{
 				muted:     test.muted,
 				shouldErr: test.shouldErr,
 			}
@@ -188,12 +188,12 @@ func (fd *mockDeployer) Deploy(ctx context.Context, out io.Writer, _ []graph.Art
 }
 
 // Used just to show how output gets routed to different writers with the log file
-type mockStatusChecker struct {
+type mockStatusMonitor struct {
 	muted     Muted
 	shouldErr bool
 }
 
-func (fd *mockStatusChecker) Deploy(ctx context.Context, out io.Writer, _ []graph.Artifact) ([]string, error) {
+func (fd *mockStatusMonitor) Deploy(ctx context.Context, out io.Writer, _ []graph.Artifact) ([]string, error) {
 	if fd.shouldErr {
 		fmt.Fprintln(out, " - deployment/leeroy-app failed. could not pull image")
 		return nil, errors.New("- deployment/leeroy-app failed. could not pull image")

--- a/pkg/skaffold/kubernetes/status/status_check.go
+++ b/pkg/skaffold/kubernetes/status/status_check.go
@@ -26,20 +26,24 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/singleflight"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/diag"
 	"github.com/GoogleContainerTools/skaffold/pkg/diag/validator"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/resource"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
-	pkgkubectl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 )
 
@@ -71,40 +75,65 @@ type Config interface {
 	GetNamespaces() []string
 	StatusCheckDeadlineSeconds() int
 	Muted() config.Muted
-}
-
-// Checker waits for the application to be totally deployed.
-type Checker interface {
-	Check(context.Context, io.Writer) error
+	StatusCheck() (*bool, error)
 }
 
 // statusChecker runs status checks for pods and deployments
-type statusChecker struct {
+type Checker struct {
 	cfg             Config
 	labeller        *label.DefaultLabeller
 	deadlineSeconds int
 	muteLogs        bool
+	seenResources   resource.Group
+	singleRun       singleflight.Group
 }
 
 // NewStatusChecker returns a status checker which runs checks on deployments and pods.
-func NewStatusChecker(cfg Config, labeller *label.DefaultLabeller) Checker {
-	return statusChecker{
+func NewStatusChecker(cfg Config, labeller *label.DefaultLabeller) *Checker {
+	return &Checker{
 		muteLogs:        cfg.Muted().MuteStatusCheck(),
 		cfg:             cfg,
 		labeller:        labeller,
 		deadlineSeconds: cfg.StatusCheckDeadlineSeconds(),
+		seenResources:   make(resource.Group),
+		singleRun:       singleflight.Group{},
 	}
 }
 
-// Run runs the status checks on deployments and pods deployed in current skaffold dev iteration.
-func (s statusChecker) Check(ctx context.Context, out io.Writer) error {
-	event.StatusCheckEventStarted()
-	errCode, err := s.statusCheck(ctx, out)
-	event.StatusCheckEventEnded(errCode, err)
+// Check runs the status checks on deployments and pods deployed in current skaffold dev iteration.
+func (s *Checker) Check(ctx context.Context, out io.Writer) error {
+	_, err, _ := s.singleRun.Do(s.labeller.GetRunID(), func() (interface{}, error) {
+		return struct{}{}, s.check(ctx, out)
+	})
 	return err
 }
 
-func (s statusChecker) statusCheck(ctx context.Context, out io.Writer) (proto.StatusCode, error) {
+func (s *Checker) check(ctx context.Context, out io.Writer) error {
+	event.StatusCheckEventStarted()
+	eventV2.TaskInProgress(constants.StatusCheck, "Verifying service availability")
+	ctx, endTrace := instrumentation.StartTrace(ctx, "performStatusCheck_WaitForDeploymentToStabilize")
+	defer endTrace()
+
+	start := time.Now()
+	output.Default.Fprintln(out, "Waiting for deployments to stabilize...")
+
+	errCode, err := s.statusCheck(ctx, out)
+	event.StatusCheckEventEnded(errCode, err)
+	if err != nil {
+		eventV2.TaskFailed(constants.StatusCheck, err)
+		return err
+	}
+
+	output.Default.Fprintln(out, "Deployments stabilized in", util.ShowHumanizeTime(time.Since(start)))
+	eventV2.TaskSucceeded(constants.StatusCheck)
+	return nil
+}
+
+func (s *Checker) Reset() {
+	s.seenResources.Reset()
+}
+
+func (s *Checker) statusCheck(ctx context.Context, out io.Writer) (proto.StatusCode, error) {
 	client, err := kubernetesclient.Client()
 	if err != nil {
 		return proto.StatusCode_STATUSCHECK_KUBECTL_CLIENT_FETCH_ERR, fmt.Errorf("getting Kubernetes client: %w", err)
@@ -117,7 +146,13 @@ func (s statusChecker) statusCheck(ctx context.Context, out io.Writer) (proto.St
 		if err != nil {
 			return proto.StatusCode_STATUSCHECK_DEPLOYMENT_FETCH_ERR, fmt.Errorf("could not fetch deployments: %w", err)
 		}
-		deployments = append(deployments, newDeployments...)
+		for _, d := range newDeployments {
+			if s.seenResources.Contains(d) {
+				continue
+			}
+			deployments = append(deployments, d)
+			s.seenResources.Add(d)
+		}
 	}
 
 	var wg sync.WaitGroup
@@ -182,7 +217,7 @@ func getDeployments(ctx context.Context, client kubernetes.Interface, ns string,
 	return deployments, nil
 }
 
-func pollDeploymentStatus(ctx context.Context, cfg pkgkubectl.Config, r *resource.Deployment) {
+func pollDeploymentStatus(ctx context.Context, cfg kubectl.Config, r *resource.Deployment) {
 	pollDuration := time.Duration(defaultPollPeriodInMilliseconds) * time.Millisecond
 	ticker := time.NewTicker(pollDuration)
 	defer ticker.Stop()
@@ -245,7 +280,7 @@ func getDeadline(d int) time.Duration {
 	return DefaultStatusCheckDeadline
 }
 
-func (s statusChecker) printStatusCheckSummary(out io.Writer, r *resource.Deployment, c counter) {
+func (s *Checker) printStatusCheckSummary(out io.Writer, r *resource.Deployment, c counter) {
 	ae := r.Status().ActionableError()
 	if r.StatusCode() == proto.StatusCode_STATUSCHECK_USER_CANCELLED {
 		// Don't print the status summary if the user ctrl-C or
@@ -271,7 +306,7 @@ func (s statusChecker) printStatusCheckSummary(out io.Writer, r *resource.Deploy
 }
 
 // printDeploymentStatus prints resource statuses until all status check are completed or context is cancelled.
-func (s statusChecker) printDeploymentStatus(ctx context.Context, out io.Writer, deployments []*resource.Deployment) {
+func (s *Checker) printDeploymentStatus(ctx context.Context, out io.Writer, deployments []*resource.Deployment) {
 	ticker := time.NewTicker(reportStatusTime)
 	defer ticker.Stop()
 	for {
@@ -288,7 +323,7 @@ func (s statusChecker) printDeploymentStatus(ctx context.Context, out io.Writer,
 	}
 }
 
-func (s statusChecker) printStatus(deployments []*resource.Deployment, out io.Writer) bool {
+func (s *Checker) printStatus(deployments []*resource.Deployment, out io.Writer) bool {
 	allDone := true
 	for _, r := range deployments {
 		if r.IsStatusCheckCompleteOrCancelled() {

--- a/pkg/skaffold/kubernetes/status/status_check_test.go
+++ b/pkg/skaffold/kubernetes/status/status_check_test.go
@@ -387,7 +387,7 @@ func TestPrintSummaryStatus(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			checker := Checker{labeller: labeller}
+			monitor := Monitor{labeller: labeller}
 			out := new(bytes.Buffer)
 			rc := newCounter(10)
 			rc.pending = test.pending
@@ -396,7 +396,7 @@ func TestPrintSummaryStatus(t *testing.T) {
 			// report status once and set it changed to false.
 			r.ReportSinceLastUpdated(false)
 			r.UpdateStatus(test.ae)
-			checker.printStatusCheckSummary(out, r, *rc)
+			monitor.printStatusCheckSummary(out, r, *rc)
 			t.CheckDeepEqual(test.expected, out.String())
 		})
 	}
@@ -482,8 +482,8 @@ func TestPrintStatus(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			out := new(bytes.Buffer)
 			testEvent.InitializeState([]latestV1.Pipeline{{}})
-			checker := Checker{labeller: labeller}
-			actual := checker.printStatus(test.rs, out)
+			monitor := Monitor{labeller: labeller}
+			actual := monitor.printStatus(test.rs, out)
 			t.CheckDeepEqual(test.expectedOut, out.String())
 			t.CheckDeepEqual(test.expected, actual)
 		})

--- a/pkg/skaffold/kubernetes/status/status_check_test.go
+++ b/pkg/skaffold/kubernetes/status/status_check_test.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/diag"
 	"github.com/GoogleContainerTools/skaffold/pkg/diag/validator"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/resource"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
@@ -43,6 +42,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	testEvent "github.com/GoogleContainerTools/skaffold/testutil/event"
 )
+
+var TestKubeContext = "kubecontext"
 
 func TestGetDeployments(t *testing.T) {
 	labeller := label.NewLabeller(true, nil, "run-id")
@@ -386,7 +387,7 @@ func TestPrintSummaryStatus(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			checker := statusChecker{labeller: labeller}
+			checker := Checker{labeller: labeller}
 			out := new(bytes.Buffer)
 			rc := newCounter(10)
 			rc.pending = test.pending
@@ -481,7 +482,7 @@ func TestPrintStatus(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			out := new(bytes.Buffer)
 			testEvent.InitializeState([]latestV1.Pipeline{{}})
-			checker := statusChecker{labeller: labeller}
+			checker := Checker{labeller: labeller}
 			actual := checker.printStatus(test.rs, out)
 			t.CheckDeepEqual(test.expectedOut, out.String())
 			t.CheckDeepEqual(test.expected, actual)
@@ -647,4 +648,4 @@ type statusConfig struct {
 	runcontext.RunContext // Embedded to provide the default values.
 }
 
-func (c *statusConfig) GetKubeContext() string { return kubectl.TestKubeContext }
+func (c *statusConfig) GetKubeContext() string { return TestKubeContext }

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"io"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
@@ -51,8 +50,3 @@ type Runner interface {
 	Render(context.Context, io.Writer, []graph.Artifact, bool, string) error
 	Test(context.Context, io.Writer, []graph.Artifact) error
 }
-
-// for testing
-var (
-	NewStatusCheck = status.NewStatusChecker
-)

--- a/pkg/skaffold/runner/v1/apply.go
+++ b/pkg/skaffold/runner/v1/apply.go
@@ -39,7 +39,7 @@ func (r *SkaffoldRunner) Apply(ctx context.Context, out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	sErr := r.performStatusCheck(ctx, statusCheckOut)
+	sErr := r.deployer.GetStatusChecker().Check(ctx, statusCheckOut)
 	return sErr
 }
 

--- a/pkg/skaffold/runner/v1/apply.go
+++ b/pkg/skaffold/runner/v1/apply.go
@@ -39,7 +39,7 @@ func (r *SkaffoldRunner) Apply(ctx context.Context, out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	sErr := r.deployer.GetStatusChecker().Check(ctx, statusCheckOut)
+	sErr := r.deployer.GetStatusMonitor().Check(ctx, statusCheckOut)
 	return sErr
 }
 

--- a/pkg/skaffold/runner/v1/deploy.go
+++ b/pkg/skaffold/runner/v1/deploy.go
@@ -141,7 +141,7 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 	event.DeployComplete()
 	eventV2.TaskSucceeded(constants.Deploy)
 	r.runCtx.UpdateNamespaces(namespaces)
-	sErr := r.deployer.GetStatusChecker().Check(ctx, statusCheckOut)
+	sErr := r.deployer.GetStatusMonitor().Check(ctx, statusCheckOut)
 	return sErr
 }
 

--- a/pkg/skaffold/runner/v1/deploy.go
+++ b/pkg/skaffold/runner/v1/deploy.go
@@ -35,8 +35,6 @@ import (
 	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // DeployAndLog deploys a list of already built artifacts and optionally show the logs.
@@ -143,7 +141,7 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 	event.DeployComplete()
 	eventV2.TaskSucceeded(constants.Deploy)
 	r.runCtx.UpdateNamespaces(namespaces)
-	sErr := r.performStatusCheck(ctx, statusCheckOut)
+	sErr := r.deployer.GetStatusChecker().Check(ctx, statusCheckOut)
 	return sErr
 }
 
@@ -197,32 +195,4 @@ func failIfClusterIsNotReachable() error {
 
 	_, err = client.Discovery().ServerVersion()
 	return err
-}
-
-func (r *SkaffoldRunner) performStatusCheck(ctx context.Context, out io.Writer) error {
-	// Check if we need to perform deploy status
-	enabled, err := r.runCtx.StatusCheck()
-	if err != nil {
-		return err
-	}
-	if enabled != nil && !*enabled {
-		return nil
-	}
-
-	eventV2.TaskInProgress(constants.StatusCheck, "Verifying service availability")
-	ctx, endTrace := instrumentation.StartTrace(ctx, "performStatusCheck_WaitForDeploymentToStabilize")
-	defer endTrace()
-
-	start := time.Now()
-	output.Default.Fprintln(out, "Waiting for deployments to stabilize...")
-
-	s := runner.NewStatusCheck(r.runCtx, r.labeller)
-	if err := s.Check(ctx, out); err != nil {
-		eventV2.TaskFailed(constants.StatusCheck, err)
-		return err
-	}
-
-	output.Default.Fprintln(out, "Deployments stabilized in", util.ShowHumanizeTime(time.Since(start)))
-	eventV2.TaskSucceeded(constants.StatusCheck)
-	return nil
 }

--- a/pkg/skaffold/runner/v1/deploy_test.go
+++ b/pkg/skaffold/runner/v1/deploy_test.go
@@ -20,95 +20,35 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"io"
 	"io/ioutil"
-	"strings"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestDeploy(t *testing.T) {
-	expectedOutput := "Waiting for deployments to stabilize..."
 	tests := []struct {
-		description       string
-		testBench         *TestBench
-		statusCheckFlag   *bool // --status-check CLI flag
-		statusCheckConfig *bool // skaffold.yaml Deploy.StatusCheck field
-		shouldErr         bool
-		shouldWait        bool
+		description string
+		testBench   *TestBench
+		shouldErr   bool
 	}{
 		{
-			description: "deploy shd perform status check when statusCheck flag is unspecified, in-config value is unspecified",
+			description: "deploy succeeds",
 			testBench:   &TestBench{},
-			shouldWait:  true,
 		},
 		{
-			description:       "deploy shd not perform status check when statusCheck flag is unspecified, in-config value is false",
-			testBench:         &TestBench{},
-			statusCheckConfig: util.BoolPtr(false),
-		},
-		{
-			description:       "deploy shd perform status check when statusCheck flag is unspecified, in-config value is true",
-			testBench:         &TestBench{},
-			statusCheckConfig: util.BoolPtr(true),
-			shouldWait:        true,
-		},
-		{
-			description:     "deploy shd not perform status check when statusCheck flag is false, in-config value is unspecified",
-			testBench:       &TestBench{},
-			statusCheckFlag: util.BoolPtr(false),
-		},
-		{
-			description:       "deploy shd not perform status check when statusCheck flag is false, in-config value is false",
-			testBench:         &TestBench{},
-			statusCheckFlag:   util.BoolPtr(false),
-			statusCheckConfig: util.BoolPtr(false),
-		},
-		{
-			description:       "deploy shd not perform status check when statusCheck flag is false, in-config value is true",
-			testBench:         &TestBench{},
-			statusCheckFlag:   util.BoolPtr(false),
-			statusCheckConfig: util.BoolPtr(true),
-		},
-		{
-			description:     "deploy shd perform status check when statusCheck flag is true, in-config value is unspecified",
-			testBench:       &TestBench{},
-			statusCheckFlag: util.BoolPtr(true),
-			shouldWait:      true,
-		},
-		{
-			description:       "deploy shd perform status check when statusCheck flag is true, in-config value is false",
-			testBench:         &TestBench{},
-			statusCheckFlag:   util.BoolPtr(true),
-			statusCheckConfig: util.BoolPtr(false),
-			shouldWait:        true,
-		},
-		{
-			description:       "deploy shd perform status check when statusCheck flag is true, in-config value is true",
-			testBench:         &TestBench{},
-			statusCheckFlag:   util.BoolPtr(true),
-			statusCheckConfig: util.BoolPtr(true),
-			shouldWait:        true,
-		},
-		{
-			description:     "deploy shd not perform status check when deployer is in error",
-			testBench:       &TestBench{deployErrors: []error{errors.New("deploy error")}},
-			shouldErr:       true,
-			statusCheckFlag: util.BoolPtr(true),
+			description: "deploy fails",
+			testBench:   &TestBench{deployErrors: []error{errors.New("deploy error")}},
+			shouldErr:   true,
 		},
 	}
 
@@ -116,13 +56,8 @@ func TestDeploy(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
 			t.Override(&client.Client, mockK8sClient)
-			t.Override(&runner.NewStatusCheck, func(status.Config, *label.DefaultLabeller) status.Checker {
-				return dummyStatusChecker{}
-			})
 
 			r := createRunner(t, test.testBench, nil, []*latestV1.Artifact{{ImageName: "img1"}, {ImageName: "img2"}}, nil)
-			r.runCtx.Opts.StatusCheck = config.NewBoolOrUndefined(test.statusCheckFlag)
-			r.runCtx.Pipelines.All()[0].Deploy.StatusCheck = test.statusCheckConfig
 			out := new(bytes.Buffer)
 
 			err := r.Deploy(context.Background(), out, []graph.Artifact{
@@ -130,9 +65,6 @@ func TestDeploy(t *testing.T) {
 				{ImageName: "img2", Tag: "img2:tag2"},
 			})
 			t.CheckError(test.shouldErr, err)
-			if strings.Contains(out.String(), expectedOutput) != test.shouldWait {
-				t.Errorf("expected %s to contain %s %t. But found %t", out.String(), expectedOutput, test.shouldWait, !test.shouldWait)
-			}
 		})
 	}
 }
@@ -167,9 +99,6 @@ func TestDeployNamespace(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
 			t.Override(&client.Client, mockK8sClient)
-			t.Override(&runner.NewStatusCheck, func(status.Config, *label.DefaultLabeller) status.Checker {
-				return dummyStatusChecker{}
-			})
 
 			r := createRunner(t, test.testBench, nil, []*latestV1.Artifact{{ImageName: "img1"}, {ImageName: "img2"}}, nil)
 			r.runCtx.Namespaces = test.Namespaces
@@ -207,10 +136,4 @@ func TestSkaffoldDeployRenderOnly(t *testing.T) {
 
 		t.CheckNoError(err)
 	})
-}
-
-type dummyStatusChecker struct{}
-
-func (d dummyStatusChecker) Check(_ context.Context, _ io.Writer) error {
-	return nil
 }

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -34,7 +34,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
@@ -42,11 +41,13 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	pkgkubectl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	kstatus "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/server"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/test"
@@ -99,6 +100,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		Accessor: access.NewAccessorProvider(runCtx, labeller, kubectlCLI),
 		Debugger: debug.NewDebugProvider(runCtx),
 		Logger:   log.NewLogProvider(runCtx, kubectlCLI),
+		Checker:  status.NewCheckerProvider(runCtx, labeller),
 	}
 
 	deployer, podSelectors, err = getDeployer(runCtx, provider, labeller.Labels())
@@ -266,7 +268,7 @@ func getDefaultDeployer(runCtx *runcontext.RunContext, provider deploy.Component
 			}
 			kubeContext = d.KubeContext
 		}
-		if d.StatusCheckDeadlineSeconds != 0 && d.StatusCheckDeadlineSeconds != int(status.DefaultStatusCheckDeadline.Seconds()) {
+		if d.StatusCheckDeadlineSeconds != 0 && d.StatusCheckDeadlineSeconds != int(kstatus.DefaultStatusCheckDeadline.Seconds()) {
 			if statusCheckTimeout != -1 && statusCheckTimeout != d.StatusCheckDeadlineSeconds {
 				return nil, nil, fmt.Errorf("found multiple status check timeouts in skaffold.yaml (not supported in `skaffold apply`): %d, %d", statusCheckTimeout, d.StatusCheckDeadlineSeconds)
 			}

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -100,7 +100,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		Accessor: access.NewAccessorProvider(runCtx, labeller, kubectlCLI),
 		Debugger: debug.NewDebugProvider(runCtx),
 		Logger:   log.NewLogProvider(runCtx, kubectlCLI),
-		Checker:  status.NewCheckerProvider(runCtx, labeller),
+		Monitor:  status.NewMonitorProvider(runCtx, labeller),
 	}
 
 	deployer, podSelectors, err = getDeployer(runCtx, provider, labeller.Labels())

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/test"
@@ -116,6 +117,9 @@ func (t *TestBench) GetLogger() log.Logger {
 	return &log.NoopLogger{}
 }
 
+func (t *TestBench) GetStatusChecker() status.Checker {
+	return &status.NoopChecker{}
+}
 func (t *TestBench) TrackBuildArtifacts(_ []graph.Artifact) {}
 
 func (t *TestBench) TestDependencies(*latestV1.Artifact) ([]string, error) { return nil, nil }

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -117,8 +117,8 @@ func (t *TestBench) GetLogger() log.Logger {
 	return &log.NoopLogger{}
 }
 
-func (t *TestBench) GetStatusChecker() status.Checker {
-	return &status.NoopChecker{}
+func (t *TestBench) GetStatusMonitor() status.Monitor {
+	return &status.NoopMonitor{}
 }
 func (t *TestBench) TrackBuildArtifacts(_ []graph.Artifact) {}
 

--- a/pkg/skaffold/status/provider.go
+++ b/pkg/skaffold/status/provider.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"sync"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/status"
+)
+
+type Provider interface {
+	GetKubernetesChecker() Checker
+	GetNoopChecker() Checker
+}
+
+type fullProvider struct {
+	kubernetesChecker Checker
+}
+
+var (
+	provider *fullProvider
+	once     sync.Once
+)
+
+func NewCheckerProvider(config status.Config, l *label.DefaultLabeller) Provider {
+	once.Do(func() {
+		var c Checker
+		enabled, _ := config.StatusCheck()
+		if enabled != nil && !*enabled { // assume enabled if value unspecified
+			c = &NoopChecker{}
+		} else {
+			c = status.NewStatusChecker(config, l)
+		}
+		provider = &fullProvider{
+			kubernetesChecker: c,
+		}
+	})
+	return provider
+}
+
+func (p *fullProvider) GetKubernetesChecker() Checker {
+	return p.kubernetesChecker
+}
+
+func (p *fullProvider) GetNoopChecker() Checker {
+	return &NoopChecker{}
+}
+
+// NoopProvider is used in tests
+type NoopProvider struct{}
+
+func (p *NoopProvider) GetKubernetesChecker() Checker {
+	return &NoopChecker{}
+}
+
+func (p *NoopProvider) GetNoopChecker() Checker {
+	return &NoopChecker{}
+}

--- a/pkg/skaffold/status/provider.go
+++ b/pkg/skaffold/status/provider.go
@@ -39,15 +39,13 @@ var (
 
 func NewMonitorProvider(config status.Config, l *label.DefaultLabeller) Provider {
 	once.Do(func() {
-		var c Monitor
+		var m Monitor = &NoopMonitor{}
 		enabled, _ := config.StatusCheck()
-		if enabled != nil && !*enabled { // assume enabled if value unspecified
-			c = &NoopMonitor{}
-		} else {
-			c = status.NewStatusMonitor(config, l)
+		if enabled == nil || *enabled { // assume enabled if value is nil
+			m = status.NewStatusMonitor(config, l)
 		}
 		provider = &fullProvider{
-			kubernetesMonitor: c,
+			kubernetesMonitor: m,
 		}
 	})
 	return provider

--- a/pkg/skaffold/status/provider.go
+++ b/pkg/skaffold/status/provider.go
@@ -24,12 +24,12 @@ import (
 )
 
 type Provider interface {
-	GetKubernetesChecker() Checker
-	GetNoopChecker() Checker
+	GetKubernetesMonitor() Monitor
+	GetNoopMonitor() Monitor
 }
 
 type fullProvider struct {
-	kubernetesChecker Checker
+	kubernetesMonitor Monitor
 }
 
 var (
@@ -37,37 +37,37 @@ var (
 	once     sync.Once
 )
 
-func NewCheckerProvider(config status.Config, l *label.DefaultLabeller) Provider {
+func NewMonitorProvider(config status.Config, l *label.DefaultLabeller) Provider {
 	once.Do(func() {
-		var c Checker
+		var c Monitor
 		enabled, _ := config.StatusCheck()
 		if enabled != nil && !*enabled { // assume enabled if value unspecified
-			c = &NoopChecker{}
+			c = &NoopMonitor{}
 		} else {
-			c = status.NewStatusChecker(config, l)
+			c = status.NewStatusMonitor(config, l)
 		}
 		provider = &fullProvider{
-			kubernetesChecker: c,
+			kubernetesMonitor: c,
 		}
 	})
 	return provider
 }
 
-func (p *fullProvider) GetKubernetesChecker() Checker {
-	return p.kubernetesChecker
+func (p *fullProvider) GetKubernetesMonitor() Monitor {
+	return p.kubernetesMonitor
 }
 
-func (p *fullProvider) GetNoopChecker() Checker {
-	return &NoopChecker{}
+func (p *fullProvider) GetNoopMonitor() Monitor {
+	return &NoopMonitor{}
 }
 
 // NoopProvider is used in tests
 type NoopProvider struct{}
 
-func (p *NoopProvider) GetKubernetesChecker() Checker {
-	return &NoopChecker{}
+func (p *NoopProvider) GetKubernetesMonitor() Monitor {
+	return &NoopMonitor{}
 }
 
-func (p *NoopProvider) GetNoopChecker() Checker {
-	return &NoopChecker{}
+func (p *NoopProvider) GetNoopMonitor() Monitor {
+	return &NoopMonitor{}
 }

--- a/pkg/skaffold/status/provider_test.go
+++ b/pkg/skaffold/status/provider_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/status"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestMonitorProvider(t *testing.T) {
+	tests := []struct {
+		description string
+		statusCheck *bool
+		isNoop      bool
+	}{
+		{
+			description: "unspecified statusCheck parameter",
+		},
+		{
+			description: "statusCheck parameter set to true",
+			statusCheck: util.BoolPtr(true),
+		},
+		{
+			description: "statusCheck parameter set to false",
+			statusCheck: util.BoolPtr(false),
+			isNoop:      true,
+		},
+	}
+
+	for _, test := range tests {
+		once = sync.Once{} // reset once for tests
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			m := NewMonitorProvider(mockConfig{statusCheck: test.statusCheck}, nil).GetKubernetesMonitor()
+			t.CheckDeepEqual(test.isNoop, reflect.Indirect(reflect.ValueOf(m)).Type() == reflect.TypeOf(NoopMonitor{}))
+		})
+	}
+}
+
+type mockConfig struct {
+	status.Config
+	statusCheck *bool
+}
+
+func (m mockConfig) StatusCheck() (*bool, error) { return m.statusCheck, nil }
+
+func (m mockConfig) StatusCheckDeadlineSeconds() int { return 0 }
+
+func (m mockConfig) Muted() config.Muted { return config.Muted{} }

--- a/pkg/skaffold/status/status.go
+++ b/pkg/skaffold/status/status.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"io"
+)
+
+// Checker is an interface for checking a resource deployment status.
+type Checker interface {
+	Check(context.Context, io.Writer) error
+	Reset()
+}
+
+type NoopChecker struct{}
+
+func (n *NoopChecker) Check(context.Context, io.Writer) error { return nil }
+
+func (n *NoopChecker) Reset() {}

--- a/pkg/skaffold/status/status.go
+++ b/pkg/skaffold/status/status.go
@@ -21,9 +21,11 @@ import (
 	"io"
 )
 
-// Monitor is an interface for checking a resource deployment status.
+// Monitor is an interface for checking resource deployment status.
 type Monitor interface {
+	// Check runs the status check monitor for a deployment
 	Check(context.Context, io.Writer) error
+	// Reset executes any reset behavior required by the status monitor between dev loops.
 	Reset()
 }
 

--- a/pkg/skaffold/status/status.go
+++ b/pkg/skaffold/status/status.go
@@ -21,14 +21,14 @@ import (
 	"io"
 )
 
-// Checker is an interface for checking a resource deployment status.
-type Checker interface {
+// Monitor is an interface for checking a resource deployment status.
+type Monitor interface {
 	Check(context.Context, io.Writer) error
 	Reset()
 }
 
-type NoopChecker struct{}
+type NoopMonitor struct{}
 
-func (n *NoopChecker) Check(context.Context, io.Writer) error { return nil }
+func (n *NoopMonitor) Check(context.Context, io.Writer) error { return nil }
 
-func (n *NoopChecker) Reset() {}
+func (n *NoopMonitor) Reset() {}

--- a/pkg/skaffold/status/status_mux.go
+++ b/pkg/skaffold/status/status_mux.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"io"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type CheckerMux []Checker
+
+func (c CheckerMux) Check(ctx context.Context, out io.Writer) error {
+	g, gCtx := errgroup.WithContext(ctx)
+
+	// run all status checkers in parallel.
+	// the kubernetes status checker is a singleton for all deployers of that type, and runs only one concurrent check at a time across all deployed resources.
+	for _, checker := range c {
+		checker := checker // https://golang.org/doc/faq#closures_and_goroutines
+		g.Go(func() error {
+			return checker.Check(gCtx, out)
+		})
+	}
+	return g.Wait()
+}
+
+func (c CheckerMux) Reset() {
+	for _, checker := range c {
+		checker.Reset()
+	}
+}

--- a/pkg/skaffold/status/status_mux.go
+++ b/pkg/skaffold/status/status_mux.go
@@ -23,24 +23,24 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type CheckerMux []Checker
+type MonitorMux []Monitor
 
-func (c CheckerMux) Check(ctx context.Context, out io.Writer) error {
+func (c MonitorMux) Check(ctx context.Context, out io.Writer) error {
 	g, gCtx := errgroup.WithContext(ctx)
 
-	// run all status checkers in parallel.
-	// the kubernetes status checker is a singleton for all deployers of that type, and runs only one concurrent check at a time across all deployed resources.
-	for _, checker := range c {
-		checker := checker // https://golang.org/doc/faq#closures_and_goroutines
+	// run all status monitors in parallel.
+	// the kubernetes status monitor is a singleton for all deployers of that type, and runs only one concurrent check at a time across all deployed resources.
+	for _, monitor := range c {
+		monitor := monitor // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {
-			return checker.Check(gCtx, out)
+			return monitor.Check(gCtx, out)
 		})
 	}
 	return g.Wait()
 }
 
-func (c CheckerMux) Reset() {
-	for _, checker := range c {
-		checker.Reset()
+func (c MonitorMux) Reset() {
+	for _, monitor := range c {
+		monitor.Reset()
 	}
 }

--- a/pkg/skaffold/status/status_mux_test.go
+++ b/pkg/skaffold/status/status_mux_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"errors"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestMonitorMux(t *testing.T) {
+	tests := []struct {
+		description string
+		monitor     func(context.Context, io.Writer) error
+		shouldErr   bool
+	}{
+		{
+			description: "passing",
+			monitor: func(c context.Context, w io.Writer) error {
+				return nil
+			},
+		},
+		{
+			description: "failing",
+			monitor: func(c context.Context, w io.Writer) error {
+				return errors.New("error")
+			},
+			shouldErr: true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			var m MonitorMux
+			for i := 0; i < 3; i++ {
+				m = append(m, &MockMonitor{monitor: test.monitor})
+			}
+			err := m.Check(context.Background(), ioutil.Discard)
+			if test.shouldErr {
+				t.CheckError(true, err)
+			} else {
+				t.CheckNoError(err)
+				for _, mi := range m {
+					t.CheckTrue(mi.(*MockMonitor).run)
+				}
+				m.Reset()
+				for _, mi := range m {
+					t.CheckFalse(mi.(*MockMonitor).run)
+				}
+			}
+		})
+	}
+}
+
+type MockMonitor struct {
+	run     bool
+	monitor func(context.Context, io.Writer) error
+}
+
+func (m *MockMonitor) Check(ctx context.Context, out io.Writer) error {
+	m.run = true
+	return m.monitor(ctx, out)
+}
+
+func (m *MockMonitor) Reset() { m.run = false }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

Related: #5813

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

This change moves the `StatusChecker` object from the `Runner` into the `Deployer` and renames it as `Monitor`, since the status-checking behavior is implicitly tied to the underlying `Deployer` implementation. See #5809 for a more detailed description of why we need to do this.

This change adds one method to the `Deployer` interface:

```golang
type Deployer interface {
  ...

  GetStatusMonitor() status.Monitor
}

```

The `GetStatusMonitor()` method is used by the `Runner` to retrieve the`status.Monitor` implementation and actually orchestrate that behavior in the dev loop.

Additionally the Kubernetes status checker is implemented as a singleton since a single `Check()` can report for all resources deployed by kubernetes for that run.

Followup: This PR is also a prerequisite for #6024 and  #5774