### PR TITLE
Mute `ApplicationLogEvent`s when skaffold cli logger is muted

### DIFF
--- a/pkg/skaffold/kubernetes/logger/log.go
+++ b/pkg/skaffold/kubernetes/logger/log.go
@@ -25,10 +25,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 
+	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"

--- a/pkg/skaffold/kubernetes/logger/log_test.go
+++ b/pkg/skaffold/kubernetes/logger/log_test.go
@@ -112,7 +112,7 @@ func TestPrintLogLine(t *testing.T) {
 
 			go func() {
 				for i := 0; i < 100; i++ {
-					logger.printLogLine(output.Default.Sprintf("%s ", "PREFIX") + "TEXT\n")
+					logger.printLogLine(output.Default, "pod-name", "container-name", "PREFIX", "TEXT\n")
 				}
 				wg.Done()
 			}()


### PR DESCRIPTION
**Related**: https://github.com/GoogleContainerTools/skaffold/issues/6045

**Description**
This PR changes emission of `ApplicaitonLogEvent`s to happen only when the skaffold logger in unmuted, similar to how printing user application logs works with skaffold cli output.
