### PR TITLE
Move Syncer into Deployer

### DIFF
--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -25,10 +25,17 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 )
 
 // NoopComponentProvider is for tests
-var NoopComponentProvider = ComponentProvider{Accessor: &access.NoopProvider{}, Logger: &log.NoopProvider{}, Debugger: &debug.NoopProvider{}, Monitor: &status.NoopProvider{}}
+var NoopComponentProvider = ComponentProvider{
+	Accessor: &access.NoopProvider{},
+	Debugger: &debug.NoopProvider{},
+	Logger:   &log.NoopProvider{},
+	Monitor:  &status.NoopProvider{},
+	Syncer:   &sync.NoopProvider{},
+}
 
 // Deployer is the Deploy API of skaffold and responsible for deploying
 // the build results to a Kubernetes cluster
@@ -48,7 +55,7 @@ type Deployer interface {
 	// writes them to the given file path
 	Render(context.Context, io.Writer, []graph.Artifact, bool, string) error
 
-	// GetDebugger returns a Deployer's implementation of a Logger
+	// GetDebugger returns a Deployer's implementation of a Debugger
 	GetDebugger() debug.Debugger
 
 	// GetLogger returns a Deployer's implementation of a Logger
@@ -56,6 +63,9 @@ type Deployer interface {
 
 	// GetAccessor returns a Deployer's implementation of an Accessor
 	GetAccessor() access.Accessor
+
+	// GetSyncer returns a Deployer's implementation of a Syncer
+	GetSyncer() sync.Syncer
 
 	// TrackBuildArtifacts registers build artifacts to be tracked by a Deployer
 	TrackBuildArtifacts([]graph.Artifact)
@@ -71,4 +81,5 @@ type ComponentProvider struct {
 	Debugger debug.Provider
 	Logger   log.Provider
 	Monitor  status.Provider
+	Syncer   sync.Provider
 }

--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -71,6 +72,14 @@ func (m DeployerMux) GetStatusMonitor() status.Monitor {
 		monitors = append(monitors, deployer.GetStatusMonitor())
 	}
 	return monitors
+}
+
+func (m DeployerMux) GetSyncer() sync.Syncer {
+	var syncers sync.SyncerMux
+	for _, deployer := range m {
+		syncers = append(syncers, deployer.GetSyncer())
+	}
+	return syncers
 }
 
 func (m DeployerMux) Deploy(ctx context.Context, w io.Writer, as []graph.Artifact) ([]string, error) {

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 	testEvent "github.com/GoogleContainerTools/skaffold/testutil/event"
 )
@@ -62,6 +63,10 @@ func (m *MockDeployer) GetLogger() log.Logger {
 
 func (m *MockDeployer) GetStatusMonitor() status.Monitor {
 	return &status.NoopMonitor{}
+}
+
+func (m *MockDeployer) GetSyncer() sync.Syncer {
+	return &sync.NoopSyncer{}
 }
 
 func (m *MockDeployer) TrackBuildArtifacts(_ []graph.Artifact) {}

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -53,6 +53,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/walk"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
@@ -85,6 +86,7 @@ type Deployer struct {
 	debugger      debug.Debugger
 	logger        log.Logger
 	statusMonitor status.Monitor
+	syncer        sync.Syncer
 
 	podSelector    *kubernetes.ImageList
 	originalImages []graph.Artifact
@@ -140,6 +142,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		debugger:       provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:         provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:  provider.Monitor.GetKubernetesMonitor(),
+		syncer:         provider.Syncer.GetKubernetesSyncer(podSelector),
 		originalImages: originalImages,
 		kubeContext:    cfg.GetKubeContext(),
 		kubeConfig:     cfg.GetKubeConfig(),
@@ -167,6 +170,10 @@ func (h *Deployer) GetLogger() log.Logger {
 
 func (h *Deployer) GetStatusMonitor() status.Monitor {
 	return h.statusMonitor
+}
+
+func (h *Deployer) GetSyncer() sync.Syncer {
+	return h.syncer
 }
 
 func (h *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -48,6 +48,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -75,6 +76,7 @@ type Deployer struct {
 	logger        log.Logger
 	debugger      debug.Debugger
 	statusMonitor status.Monitor
+	syncer        sync.Syncer
 
 	podSelector    *kubernetes.ImageList
 	originalImages []graph.Artifact
@@ -102,6 +104,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		debugger:           provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:             provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:      provider.Monitor.GetKubernetesMonitor(),
+		syncer:             provider.Syncer.GetKubernetesSyncer(podSelector),
 		insecureRegistries: cfg.GetInsecureRegistries(),
 		labels:             labels,
 		globalConfig:       cfg.GlobalConfig(),
@@ -126,6 +129,10 @@ func (k *Deployer) GetLogger() log.Logger {
 
 func (k *Deployer) GetStatusMonitor() status.Monitor {
 	return k.statusMonitor
+}
+
+func (k *Deployer) GetSyncer() sync.Syncer {
+	return k.syncer
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -43,6 +43,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -54,6 +55,7 @@ type Deployer struct {
 	logger        log.Logger
 	debugger      debug.Debugger
 	statusMonitor status.Monitor
+	syncer        sync.Syncer
 
 	originalImages     []graph.Artifact
 	podSelector        *kubernetes.ImageList
@@ -89,6 +91,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		debugger:           provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:             provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:      provider.Monitor.GetKubernetesMonitor(),
+		syncer:             provider.Syncer.GetKubernetesSyncer(podSelector),
 		workingDir:         cfg.GetWorkingDir(),
 		globalConfig:       cfg.GlobalConfig(),
 		defaultRepo:        cfg.DefaultRepo(),
@@ -114,6 +117,10 @@ func (k *Deployer) GetLogger() log.Logger {
 
 func (k *Deployer) GetStatusMonitor() status.Monitor {
 	return k.statusMonitor
+}
+
+func (k *Deployer) GetSyncer() sync.Syncer {
+	return k.syncer
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -43,6 +43,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
 )
@@ -105,6 +106,7 @@ type Deployer struct {
 	logger        log.Logger
 	debugger      debug.Debugger
 	statusMonitor status.Monitor
+	syncer        sync.Syncer
 
 	podSelector    *kubernetes.ImageList
 	originalImages []graph.Artifact
@@ -138,6 +140,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, provider deploy.C
 		debugger:            provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:              provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:       provider.Monitor.GetKubernetesMonitor(),
+		syncer:              provider.Syncer.GetKubernetesSyncer(podSelector),
 		kubectl:             kubectl,
 		insecureRegistries:  cfg.GetInsecureRegistries(),
 		globalConfig:        cfg.GlobalConfig(),
@@ -160,6 +163,10 @@ func (k *Deployer) GetLogger() log.Logger {
 
 func (k *Deployer) GetStatusMonitor() status.Monitor {
 	return k.statusMonitor
+}
+
+func (k *Deployer) GetSyncer() sync.Syncer {
+	return k.syncer
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/runner/v1/dev.go
+++ b/pkg/skaffold/runner/v1/dev.go
@@ -92,7 +92,7 @@ func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer) error {
 			output.Default.Fprintf(out, "Syncing %d files for %s\n", fileCount, s.Image)
 			fileSyncInProgress(fileCount, s.Image)
 
-			if err := r.syncer.Sync(childCtx, s); err != nil {
+			if err := r.deployer.GetSyncer().Sync(childCtx, s); err != nil {
 				logrus.Warnln("Skipping deploy due to sync error:", err)
 				fileSyncFailed(fileCount, s.Image, err)
 				event.DevLoopFailedInPhase(r.devIteration, constants.Sync, err)

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -92,7 +92,6 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		endTrace(instrumentation.TraceEndError(err))
 		return nil, fmt.Errorf("creating tester: %w", err)
 	}
-	syncer := getSyncer(runCtx)
 
 	var podSelectors kubernetes.ImageListMux
 	var deployer deploy.Deployer
@@ -101,6 +100,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		Debugger: debug.NewDebugProvider(runCtx),
 		Logger:   log.NewLogProvider(runCtx, kubectlCLI),
 		Monitor:  status.NewMonitorProvider(runCtx, labeller),
+		Syncer:   sync.NewSyncProvider(runCtx, kubectlCLI),
 	}
 
 	deployer, podSelectors, err = getDeployer(runCtx, provider, labeller.Labels())
@@ -152,7 +152,6 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		Pruner:             runner.Pruner{Builder: builder},
 		Tester:             tester,
 		deployer:           deployer,
-		syncer:             syncer,
 		monitor:            monitor,
 		listener:           runner.NewSkaffoldListener(monitor, rtrigger, sourceDependencies, intentChan),
 		artifactStore:      store,
@@ -233,10 +232,6 @@ func getTester(cfg test.Config, isLocalImage func(imageName string) (bool, error
 	}
 
 	return tester, nil
-}
-
-func getSyncer(cfg sync.Config) sync.Syncer {
-	return sync.NewSyncer(cfg)
 }
 
 /*

--- a/pkg/skaffold/runner/v1/runner.go
+++ b/pkg/skaffold/runner/v1/runner.go
@@ -26,7 +26,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/test"
 )
 
@@ -37,7 +36,6 @@ type SkaffoldRunner struct {
 	test.Tester
 
 	deployer deploy.Deployer
-	syncer   sync.Syncer
 	monitor  filemon.Monitor
 	listener runner.Listener
 

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -120,6 +120,11 @@ func (t *TestBench) GetLogger() log.Logger {
 func (t *TestBench) GetStatusMonitor() status.Monitor {
 	return &status.NoopMonitor{}
 }
+
+func (t *TestBench) GetSyncer() sync.Syncer {
+	return t
+}
+
 func (t *TestBench) TrackBuildArtifacts(_ []graph.Artifact) {}
 
 func (t *TestBench) TestDependencies(*latestV1.Artifact) ([]string, error) { return nil, nil }
@@ -281,7 +286,6 @@ func createRunner(t *testutil.T, testBench *TestBench, monitor filemon.Monitor, 
 
 	// TODO(yuwenma):builder.builder looks weird. Avoid the nested struct.
 	runner.Builder.Builder = testBench
-	runner.syncer = testBench
 	runner.Tester = testBench
 	runner.deployer = testBench
 	runner.listener = testBench

--- a/pkg/skaffold/sync/provider.go
+++ b/pkg/skaffold/sync/provider.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	gosync "sync"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+)
+
+type Provider interface {
+	GetKubernetesSyncer(*kubernetes.ImageList) Syncer
+	GetNoopSyncer() Syncer
+}
+
+type fullProvider struct {
+	kubernetesSyncer func(*kubernetes.ImageList) Syncer
+	noopSyncer       func() Syncer
+}
+
+var (
+	provider *fullProvider
+	once     gosync.Once
+)
+
+func NewSyncProvider(config Config, cli *kubectl.CLI) Provider {
+	once.Do(func() {
+		provider = &fullProvider{
+			kubernetesSyncer: func(podSelector *kubernetes.ImageList) Syncer {
+				return &podSyncer{
+					kubectl:    cli,
+					namespaces: config.GetNamespaces(),
+				}
+			},
+			noopSyncer: func() Syncer {
+				return nil
+			},
+		}
+	})
+	return provider
+}
+
+func (p *fullProvider) GetKubernetesSyncer(s *kubernetes.ImageList) Syncer {
+	return p.kubernetesSyncer(s)
+}
+
+func (p *fullProvider) GetNoopSyncer() Syncer {
+	return p.noopSyncer()
+}
+
+type NoopProvider struct{}
+
+func (p *NoopProvider) GetKubernetesSyncer(_ *kubernetes.ImageList) Syncer {
+	return &NoopSyncer{}
+}
+
+func (p *NoopProvider) GetNoopSyncer() Syncer {
+	return &NoopSyncer{}
+}

--- a/pkg/skaffold/sync/syncer_mux.go
+++ b/pkg/skaffold/sync/syncer_mux.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2021 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,35 +16,15 @@ limitations under the License.
 
 package sync
 
-import (
-	"context"
+import "context"
 
-	pkgkubectl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
-)
+type SyncerMux []Syncer
 
-type syncMap map[string][]string
-
-type Item struct {
-	Image  string
-	Copy   map[string][]string
-	Delete map[string][]string
-}
-
-type Syncer interface {
-	Sync(context.Context, *Item) error
-}
-
-type podSyncer struct {
-	kubectl    *pkgkubectl.CLI
-	namespaces []string
-}
-
-type Config interface {
-	GetNamespaces() []string
-}
-
-type NoopSyncer struct{}
-
-func (s *NoopSyncer) Sync(context.Context, *Item) error {
+func (s SyncerMux) Sync(ctx context.Context, item *Item) error {
+	for _, syncer := range s {
+		if err := syncer.Sync(ctx, item); err != nil {
+			return err
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

Related: #5813

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

This change moves the `Syncer` object from the `Runner` into the `Deployer`, since the syncing behavior is implicitly tied to the underlying `Deployer` implementation. See #5809 for a more detailed description of why we need to do this.

This change adds one method to the `Deployer` interface:

```golang
type Deployer interface {
  ...

  GetSyncer() sync.Syncer
}

```

The `GetSyncer()` method is used by the `Runner` to retrieve the`Syncer` implementation and actually orchestrate that behavior in the dev loop.