### PR TITLE
add custom parameters to structured tests

### DIFF
--- a/docs/content/en/docs/pipeline-stages/testers/structure.md
+++ b/docs/content/en/docs/pipeline-stages/testers/structure.md
@@ -34,4 +34,8 @@ In order to restrict the executed structure tests, a `profile` section can overr
 
 {{% readfile file="samples/testers/structure/testProfile.yaml" %}}
 
+User can customize `container-structure-test` behavior by passing a list of configuration flags as a value of `structureTestsArgs` yaml property in `skaffold.yaml`, e.g.:
+
+{{% readfile file="samples/testers/structure/structureTestArgs.yaml" %}}
+
 To execute the tests once, run `skaffold test --profile quickcheck`.

--- a/docs/content/en/samples/testers/structure/structureTestArgs.yaml
+++ b/docs/content/en/samples/testers/structure/structureTestArgs.yaml
@@ -3,7 +3,7 @@ test:
     structureTests:
       - './structure-test/*'
     structureTestsArgs:
-      - --driver tar
+      - --driver=tar
       - -q
       - --no-color
-      -  --test-report TEST_REPORT_NAME
+      -  --test-report=TEST_REPORT_NAME

--- a/docs/content/en/samples/testers/structure/structureTestArgs.yaml
+++ b/docs/content/en/samples/testers/structure/structureTestArgs.yaml
@@ -1,0 +1,9 @@
+test:
+  - image: gcr.io/k8s-skaffold/skaffold-example
+    structureTests:
+      - './structure-test/*'
+    structureTestsArgs:
+      - --driver tar
+      - -q
+      - --no-color
+      -  --test-report TEST_REPORT_NAME

--- a/docs/content/en/schemas/v2beta18.json
+++ b/docs/content/en/schemas/v2beta18.json
@@ -3156,7 +3156,7 @@
           "x-intellij-html-description": "additional configuration arguments passed to <code>container-structure-test</code> binary.",
           "default": "[]",
           "examples": [
-            "[\"--driver tar\", \"--no-color\", \"-q\"]"
+            "[\"--driver=tar\", \"--no-color\", \"-q\"]"
           ]
         }
       },

--- a/docs/content/en/schemas/v2beta18.json
+++ b/docs/content/en/schemas/v2beta18.json
@@ -3146,13 +3146,26 @@
           "examples": [
             "[\"./test/*\"]"
           ]
+        },
+        "structureTestsArgs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "additional configuration arguments passed to `container-structure-test` binary.",
+          "x-intellij-html-description": "additional configuration arguments passed to <code>container-structure-test</code> binary.",
+          "default": "[]",
+          "examples": [
+            "[\"--driver tar\", \"--no-color\", \"-q\"]"
+          ]
         }
       },
       "preferredOrder": [
         "image",
         "context",
         "custom",
-        "structureTests"
+        "structureTests",
+        "structureTestsArgs"
       ],
       "additionalProperties": false,
       "type": "object",

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -493,7 +493,7 @@ type TestCase struct {
 	StructureTests []string `yaml:"structureTests,omitempty" skaffold:"filepath"`
 
 	// StructureTestArgs lists additional configuration arguments passed to `container-structure-test` binary.
-	// For example: `["--driver tar", "--no-color", "-q"]`.
+	// For example: `["--driver=tar", "--no-color", "-q"]`.
 	StructureTestArgs []string `yaml:"structureTestsArgs,omitempty"`
 }
 

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -491,6 +491,10 @@ type TestCase struct {
 	// to run on that artifact.
 	// For example: `["./test/*"]`.
 	StructureTests []string `yaml:"structureTests,omitempty" skaffold:"filepath"`
+
+	// StructureTestArgs lists additional configuration arguments passed to `container-structure-test` binary.
+	// For example: `["--driver tar", "--no-color", "-q"]`.
+	StructureTestArgs []string `yaml:"structureTestsArgs,omitempty"`
 }
 
 // DeployConfig contains all the configuration needed by the deploy steps.

--- a/pkg/skaffold/test/structure/structure.go
+++ b/pkg/skaffold/test/structure/structure.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -49,11 +48,11 @@ func New(cfg docker.Config, tc *latestV1.TestCase, imageIsLocal bool) (*Runner, 
 	}
 	return &Runner{
 		structureTests:    tc.StructureTests,
+		structureTestArgs: tc.StructureTestArgs,
 		imageName:         tc.ImageName,
 		workspace:         tc.Workspace,
 		localDaemon:       localDaemon,
 		imageIsLocal:      imageIsLocal,
-		structureTestArgs: tc.StructureTestArgs,
 	}, nil
 }
 
@@ -89,10 +88,7 @@ func (cst *Runner) runStructureTests(ctx context.Context, out io.Writer, imageTa
 	for _, f := range files {
 		args = append(args, "--config", f)
 	}
-	for _, customArg := range cst.structureTestArgs {
-		splittedCustomArg := strings.Fields(customArg)
-		args = append(args, splittedCustomArg...)
-	}
+	args = append(args, cst.structureTestArgs...)
 	cmd := exec.CommandContext(ctx, "container-structure-test", args...)
 	cmd.Stdout = out
 	cmd.Stderr = out

--- a/pkg/skaffold/test/structure/structure.go
+++ b/pkg/skaffold/test/structure/structure.go
@@ -33,11 +33,11 @@ import (
 
 type Runner struct {
 	structureTests    []string
+	structureTestArgs []string
 	imageName         string
 	imageIsLocal      bool
 	workspace         string
 	localDaemon       docker.LocalDaemon
-	structureTestArgs []string
 }
 
 // New creates a new structure.Runner.


### PR DESCRIPTION
Fixes: #5817

**Description**
Custom parameters can now be added to structured tests in form of yaml config list.