### PR TITLE
Ensure output stream is set before port forwarding

### DIFF
--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -306,7 +306,7 @@ func getLocalPortFromPortForwardEvent(t *testing.T, entries chan *proto.LogEntry
 		case e := <-entries:
 			switch e.Event.GetEventType().(type) {
 			case *proto.Event_PortEvent:
-				t.Logf("event received %v", e)
+				t.Logf("port event received: %v", e)
 				if e.Event.GetPortEvent().ResourceName == resourceName &&
 					e.Event.GetPortEvent().ResourceType == resourceType &&
 					e.Event.GetPortEvent().Namespace == namespace {
@@ -316,7 +316,7 @@ func getLocalPortFromPortForwardEvent(t *testing.T, entries chan *proto.LogEntry
 					return address, int(port)
 				}
 			default:
-				t.Logf("event received %v", e)
+				t.Logf("event received: %v", e)
 			}
 		}
 	}

--- a/pkg/skaffold/kubernetes/portforward/entry_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/entry_manager.go
@@ -137,6 +137,11 @@ func (b *EntryManager) forwardPortForwardEntry(ctx context.Context, out io.Write
 	portForwardEventV2(entry)
 }
 
+// Start ensures the underlying entryForwarder is ready to forward.
+func (b *EntryManager) Start(out io.Writer) {
+	b.entryForwarder.Start(out)
+}
+
 // Stop terminates all kubectl port-forward commands.
 func (b *EntryManager) Stop() {
 	for _, pfe := range b.forwardedResources.resources {

--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
@@ -48,7 +48,8 @@ type Forwarder interface {
 
 // ForwarderManager manages all forwarders
 type ForwarderManager struct {
-	forwarders []Forwarder
+	forwarders   []Forwarder
+	entryManager *EntryManager
 }
 
 // NewForwarderManager returns a new port manager which handles starting and stopping port forwarding
@@ -73,7 +74,8 @@ func NewForwarderManager(cli *kubectl.CLI, podSelector kubernetes.PodSelector, l
 	}
 
 	return &ForwarderManager{
-		forwarders: forwarders,
+		forwarders:   forwarders,
+		entryManager: entryManager,
 	}
 }
 
@@ -120,6 +122,7 @@ func (p *ForwarderManager) Start(ctx context.Context, out io.Writer, namespaces 
 	ctx, endTrace := instrumentation.StartTrace(ctx, "Start")
 	defer endTrace()
 
+	p.entryManager.Start(out)
 	for _, f := range p.forwarders {
 		if err := f.Start(ctx, out, namespaces); err != nil {
 			eventV2.TaskFailed(constants.PortForward, err)

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
@@ -70,6 +70,7 @@ func TestUnavailablePort(t *testing.T) {
 		}
 		pfe := newPortForwardEntry(0, latestV1.PortForwardResource{}, "", "", "", "", 8080, false)
 
+		k.Start(&buf)
 		go k.Forward(context.Background(), pfe)
 
 		// wait for isPortFree to be called

--- a/pkg/skaffold/kubernetes/portforward/pod_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/pod_forwarder.go
@@ -67,6 +67,7 @@ func NewWatchingPodForwarder(entryManager *EntryManager, podSelector kubernetes.
 func (p *WatchingPodForwarder) Start(ctx context.Context, out io.Writer, namespaces []string) error {
 	p.podWatcher.Register(p.events)
 	p.output = out
+	p.entryManager.Start(out)
 	stopWatcher, err := p.podWatcher.Start(namespaces)
 	if err != nil {
 		return err

--- a/pkg/skaffold/kubernetes/portforward/pod_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/pod_forwarder.go
@@ -67,7 +67,6 @@ func NewWatchingPodForwarder(entryManager *EntryManager, podSelector kubernetes.
 func (p *WatchingPodForwarder) Start(ctx context.Context, out io.Writer, namespaces []string) error {
 	p.podWatcher.Register(p.events)
 	p.output = out
-	p.entryManager.Start(out)
 	stopWatcher, err := p.podWatcher.Start(namespaces)
 	if err != nil {
 		return err

--- a/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/resource_forwarder_test.go
@@ -19,6 +19,7 @@ package portforward
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"sync"
 	"testing"
@@ -59,6 +60,8 @@ func (f *testForwarder) Terminate(pfe *portForwardEntry) {
 	f.forwardedResources.Delete(pfe.key())
 	f.forwardedPorts.Delete(pfe.localPort)
 }
+
+func (f *testForwarder) Start(io.Writer) {}
 
 func newTestForwarder() *testForwarder {
 	return &testForwarder{}

--- a/pkg/skaffold/runner/v1/dev.go
+++ b/pkg/skaffold/runner/v1/dev.go
@@ -336,11 +336,8 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 
 	defer r.deployer.GetAccessor().Stop()
 
-	// forwarderManager := r.createForwarder(out)
-	// defer forwarderManager.Stop()
-
 	if err := r.deployer.GetAccessor().Start(ctx, out, r.runCtx.GetNamespaces()); err != nil {
-		logrus.Warnln("Error starting port forwarding:", err)
+		logrus.Warnln("Error starting resource accessor:", err)
 	}
 	if err := r.deployer.GetDebugger().Start(ctx, r.runCtx.GetNamespaces()); err != nil {
 		logrus.Warnln("Error starting debug container notification:", err)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**:  https://github.com/GoogleCloudPlatform/cloud-code-vscode-internal/issues/4896

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This change ensures that the `output` stream is set on the `KubectlForwarder` before `Forward()` is called on it. This should fix an NPE being seen during successive forwards.

