### PR TITLE
Ensure events are serialized

### DIFF
--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -567,17 +567,15 @@ func LogMetaEvent() {
 }
 
 func (ev *eventHandler) handle(event *proto.Event) {
-	go func(t *timestamp.Timestamp) {
-		ev.eventChan <- firedEvent{
-			event: event,
-			ts:    t,
-		}
-		if _, ok := event.GetEventType().(*proto.Event_TerminationEvent); ok {
-			// close the event channel indicating there are no more events to all the
-			// receivers
-			close(ev.eventChan)
-		}
-	}(ptypes.TimestampNow())
+	ev.eventChan <- firedEvent{
+		event: event,
+		ts:    ptypes.TimestampNow(),
+	}
+	if _, ok := event.GetEventType().(*proto.Event_TerminationEvent); ok {
+		// close the event channel indicating there are no more events to all the
+		// receivers
+		close(ev.eventChan)
+	}
 }
 
 func (ev *eventHandler) handleExec(f firedEvent) {

--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -26,7 +26,6 @@ import (
 	//nolint:golint,staticcheck
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/timestamp"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
@@ -377,15 +376,13 @@ func (ev *eventHandler) setState(state proto.State) {
 }
 
 func (ev *eventHandler) handle(event *proto.Event) {
-	go func(t *timestamp.Timestamp) {
-		event.Timestamp = t
-		ev.eventChan <- event
-		if _, ok := event.GetEventType().(*proto.Event_TerminationEvent); ok {
-			// close the event channel indicating there are no more events to all the
-			// receivers
-			close(ev.eventChan)
-		}
-	}(ptypes.TimestampNow())
+	event.Timestamp = ptypes.TimestampNow()
+	ev.eventChan <- event
+	if _, ok := event.GetEventType().(*proto.Event_TerminationEvent); ok {
+		// close the event channel indicating there are no more events to all the
+		// receivers
+		close(ev.eventChan)
+	}
 }
 
 func (ev *eventHandler) handleTaskEvent(e *proto.TaskEvent) {


### PR DESCRIPTION
@matthewmichihara reported seeing out-of-order events.  Our event code fires off a separate goroutine for each event which can lead to out-of-sequence delivery.  Change the event delivery to write directly to the event channel to ensure events are delivered in order.