### PR TITLE
[v2 refactoring proposal] Decouple the runner creation from v1 schema

### DIFF
--- a/cmd/skaffold/app/cmd/apply.go
+++ b/cmd/skaffold/app/cmd/apply.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 // NewCmdApply describes the CLI command to apply manifests to a cluster.
@@ -53,7 +53,7 @@ func doApply(ctx context.Context, out io.Writer, args []string) error {
 	if err := validateManifests(args); err != nil {
 		return err
 	}
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []util.VersionedConfig) error {
 		return r.Apply(ctx, out)
 	})
 }

--- a/cmd/skaffold/app/cmd/build.go
+++ b/cmd/skaffold/app/cmd/build.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 var (
@@ -67,7 +68,7 @@ func doBuild(ctx context.Context, out io.Writer) error {
 		buildOut = ioutil.Discard
 	}
 
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []util.VersionedConfig) error {
 		bRes, err := r.Build(ctx, buildOut, targetArtifacts(opts, configs))
 
 		if quietFlag || buildOutputFlag != "" {
@@ -94,10 +95,10 @@ func doBuild(ctx context.Context, out io.Writer) error {
 	})
 }
 
-func targetArtifacts(opts config.SkaffoldOptions, configs []*latestV1.SkaffoldConfig) []*latestV1.Artifact {
+func targetArtifacts(opts config.SkaffoldOptions, configs []util.VersionedConfig) []*latestV1.Artifact {
 	var targetArtifacts []*latestV1.Artifact
 	for _, cfg := range configs {
-		for _, artifact := range cfg.Build.Artifacts {
+		for _, artifact := range cfg.(*latestV1.SkaffoldConfig).Build.Artifacts {
 			if opts.IsTargetImage(artifact) {
 				targetArtifacts = append(targetArtifacts, artifact)
 			}

--- a/cmd/skaffold/app/cmd/build_test.go
+++ b/cmd/skaffold/app/cmd/build_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -50,8 +51,8 @@ func (r *mockRunner) Stop() error {
 }
 
 func TestTagFlag(t *testing.T) {
-	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latestV1.SkaffoldConfig, *runcontext.RunContext, error) {
-		return &mockRunner{}, []*latestV1.SkaffoldConfig{{}}, nil, nil
+	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+		return &mockRunner{}, []util.VersionedConfig{&latestV1.SkaffoldConfig{}}, nil, nil
 	}
 
 	testutil.Run(t, "override tag with argument", func(t *testutil.T) {
@@ -69,8 +70,8 @@ func TestTagFlag(t *testing.T) {
 }
 
 func TestQuietFlag(t *testing.T) {
-	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latestV1.SkaffoldConfig, *runcontext.RunContext, error) {
-		return &mockRunner{}, []*latestV1.SkaffoldConfig{{}}, nil, nil
+	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+		return &mockRunner{}, []util.VersionedConfig{&latestV1.SkaffoldConfig{}}, nil, nil
 	}
 
 	tests := []struct {
@@ -115,8 +116,8 @@ func TestQuietFlag(t *testing.T) {
 }
 
 func TestFileOutputFlag(t *testing.T) {
-	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latestV1.SkaffoldConfig, *runcontext.RunContext, error) {
-		return &mockRunner{}, []*latestV1.SkaffoldConfig{{}}, nil, nil
+	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+		return &mockRunner{}, []util.VersionedConfig{&latestV1.SkaffoldConfig{}}, nil, nil
 	}
 
 	tests := []struct {
@@ -178,16 +179,16 @@ func TestFileOutputFlag(t *testing.T) {
 }
 
 func TestRunBuild(t *testing.T) {
-	errRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latestV1.SkaffoldConfig, *runcontext.RunContext, error) {
+	errRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
 		return nil, nil, nil, errors.New("some error")
 	}
-	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latestV1.SkaffoldConfig, *runcontext.RunContext, error) {
-		return &mockRunner{}, []*latestV1.SkaffoldConfig{{}}, nil, nil
+	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+		return &mockRunner{}, []util.VersionedConfig{&latestV1.SkaffoldConfig{}}, nil, nil
 	}
 
 	tests := []struct {
 		description string
-		mock        func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latestV1.SkaffoldConfig, *runcontext.RunContext, error)
+		mock        func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error)
 		shouldErr   bool
 	}{
 		{

--- a/cmd/skaffold/app/cmd/debug_test.go
+++ b/cmd/skaffold/app/cmd/debug_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -49,8 +50,8 @@ func TestNewCmdDebug(t *testing.T) {
 func TestDebugIndependentFromDev(t *testing.T) {
 	mockRunner := &mockDevRunner{}
 	testutil.Run(t, "DevDebug", func(t *testutil.T) {
-		t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latestV1.SkaffoldConfig, *runcontext.RunContext, error) {
-			return mockRunner, []*latestV1.SkaffoldConfig{{}}, nil, nil
+		t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+			return mockRunner, []util.VersionedConfig{&latestV1.SkaffoldConfig{}}, nil, nil
 		})
 		t.Override(&opts, config.SkaffoldOptions{})
 		t.Override(&doDev, func(context.Context, io.Writer) error {

--- a/cmd/skaffold/app/cmd/delete.go
+++ b/cmd/skaffold/app/cmd/delete.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 // NewCmdDelete describes the CLI command to delete deployed resources.
@@ -35,7 +35,7 @@ func NewCmdDelete() *cobra.Command {
 }
 
 func doDelete(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, _ []*latestV1.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, _ []util.VersionedConfig) error {
 		return r.Cleanup(ctx, out)
 	})
 }

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 var (
@@ -51,13 +52,13 @@ func NewCmdDeploy() *cobra.Command {
 }
 
 func doDeploy(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []util.VersionedConfig) error {
 		if opts.SkipRender {
 			return r.DeployAndLog(ctx, out, []graph.Artifact{})
 		}
 		var artifacts []*latestV1.Artifact
 		for _, cfg := range configs {
-			artifacts = append(artifacts, cfg.Build.Artifacts...)
+			artifacts = append(artifacts, cfg.(*latestV1.SkaffoldConfig).Build.Artifacts...)
 		}
 		buildArtifacts, err := getBuildArtifactsAndSetTags(artifacts, r.ApplyDefaultRepo)
 		if err != nil {

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 // for testing
@@ -60,10 +61,12 @@ func runDev(ctx context.Context, out io.Writer) error {
 		case <-ctx.Done():
 			return nil
 		default:
-			err := withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
+			// Note: The latestV1.SkaffoldConfig is used for both latestV1 schema and latestV2 schema because
+			// the latestV1 and latestV2 use the same Build struct. Ideally they should be separated.
+			err := withRunner(ctx, out, func(r runner.Runner, configs []util.VersionedConfig) error {
 				var artifacts []*latestV1.Artifact
 				for _, cfg := range configs {
-					artifacts = append(artifacts, cfg.Build.Artifacts...)
+					artifacts = append(artifacts, cfg.(*latestV1.SkaffoldConfig).Build.Artifacts...)
 				}
 				err := r.Dev(ctx, out, artifacts)
 

--- a/cmd/skaffold/app/cmd/dev_test.go
+++ b/cmd/skaffold/app/cmd/dev_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -96,8 +97,8 @@ func TestDoDev(t *testing.T) {
 				hasDeployed: test.hasDeployed,
 				errDev:      context.Canceled,
 			}
-			t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latestV1.SkaffoldConfig, *runcontext.RunContext, error) {
-				return mockRunner, []*latestV1.SkaffoldConfig{{}}, nil, nil
+			t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+				return mockRunner, []util.VersionedConfig{&latestV1.SkaffoldConfig{}}, nil, nil
 			})
 			t.Override(&opts, config.SkaffoldOptions{
 				Cleanup: true,
@@ -146,8 +147,8 @@ func TestDevConfigChange(t *testing.T) {
 	testutil.Run(t, "test config change", func(t *testutil.T) {
 		mockRunner := &mockConfigChangeRunner{}
 
-		t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latestV1.SkaffoldConfig, *runcontext.RunContext, error) {
-			return mockRunner, []*latestV1.SkaffoldConfig{{}}, nil, nil
+		t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+			return mockRunner, []util.VersionedConfig{&latestV1.SkaffoldConfig{}}, nil, nil
 		})
 		t.Override(&opts, config.SkaffoldOptions{
 			Cleanup: true,

--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	schemaUtil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
@@ -66,7 +67,7 @@ func doDiagnose(ctx context.Context, out io.Writer) error {
 	}
 	// remove the dependency config references since they have already been imported and will be marshalled together.
 	for i := range configs {
-		configs[i].Dependencies = nil
+		configs[i].(*latestV1.SkaffoldConfig).Dependencies = nil
 	}
 	buf, err := yaml.MarshalWithSeparator(configs)
 	if err != nil {
@@ -77,12 +78,13 @@ func doDiagnose(ctx context.Context, out io.Writer) error {
 	return nil
 }
 
-func printArtifactDiagnostics(ctx context.Context, out io.Writer, configs []*latestV1.SkaffoldConfig) error {
+func printArtifactDiagnostics(ctx context.Context, out io.Writer, configs []schemaUtil.VersionedConfig) error {
 	runCtx, err := getRunContext(opts, configs)
 	if err != nil {
 		return fmt.Errorf("getting run context: %w", err)
 	}
-	for _, config := range configs {
+	for _, c := range configs {
+		config := c.(*latestV1.SkaffoldConfig)
 		fmt.Fprintln(out, "Skaffold version:", version.Get().GitCommit)
 		fmt.Fprintln(out, "Configuration version:", config.APIVersion)
 		fmt.Fprintln(out, "Number of artifacts:", len(config.Build.Artifacts))

--- a/cmd/skaffold/app/cmd/diagnose_test.go
+++ b/cmd/skaffold/app/cmd/diagnose_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -57,20 +58,20 @@ metadata:
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&getRunContext, func(config.SkaffoldOptions, []*latestV1.SkaffoldConfig) (*runcontext.RunContext, error) {
+			t.Override(&getRunContext, func(config.SkaffoldOptions, []util.VersionedConfig) (*runcontext.RunContext, error) {
 				return nil, fmt.Errorf("cannot get the runtime context")
 			})
 			t.Override(&yamlOnly, test.yamlOnly)
-			t.Override(&getCfgs, func(opts config.SkaffoldOptions) ([]*latestV1.SkaffoldConfig, error) {
-				return []*latestV1.SkaffoldConfig{
-					{
+			t.Override(&getCfgs, func(opts config.SkaffoldOptions) ([]util.VersionedConfig, error) {
+				return []util.VersionedConfig{
+					&latestV1.SkaffoldConfig{
 						APIVersion: "testVersion",
 						Kind:       "Config",
 						Metadata: latestV1.Metadata{
 							Name: "config1",
 						},
 					},
-					{
+					&latestV1.SkaffoldConfig{
 						APIVersion: "testVersion",
 						Kind:       "Config",
 						Metadata: latestV1.Metadata{

--- a/cmd/skaffold/app/cmd/filter.go
+++ b/cmd/skaffold/app/cmd/filter.go
@@ -31,6 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 // for tests
@@ -58,7 +59,7 @@ func NewCmdFilter() *cobra.Command {
 // runFilter loads the Kubernetes manifests from stdin and applies the debug transformations.
 // Unlike `skaffold debug`, this filtering affects all images and not just the built artifacts.
 func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildArtifacts []graph.Artifact) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []util.VersionedConfig) error {
 		manifestList, err := manifest.Load(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("loading manifests: %w", err)
@@ -87,7 +88,7 @@ func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildA
 	})
 }
 
-func getInsecureRegistries(opts config.SkaffoldOptions, configs []*latestV1.SkaffoldConfig) (map[string]bool, error) {
+func getInsecureRegistries(opts config.SkaffoldOptions, configs []util.VersionedConfig) (map[string]bool, error) {
 	cfgRegistries, err := config.GetInsecureRegistries(opts.GlobalConfig)
 	if err != nil {
 		return nil, err
@@ -96,7 +97,7 @@ func getInsecureRegistries(opts config.SkaffoldOptions, configs []*latestV1.Skaf
 
 	regList = append(regList, opts.InsecureRegistries...)
 	for _, cfg := range configs {
-		regList = append(regList, cfg.Build.InsecureRegistries...)
+		regList = append(regList, cfg.(*latestV1.SkaffoldConfig).Build.InsecureRegistries...)
 	}
 	regList = append(regList, cfgRegistries...)
 	insecureRegistries := make(map[string]bool, len(regList))

--- a/cmd/skaffold/app/cmd/generate_pipeline.go
+++ b/cmd/skaffold/app/cmd/generate_pipeline.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 var (
@@ -44,7 +44,7 @@ func NewCmdGeneratePipeline() *cobra.Command {
 }
 
 func doGeneratePipeline(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []util.VersionedConfig) error {
 		if err := r.GeneratePipeline(ctx, out, configs, configFiles, "pipeline.yaml"); err != nil {
 			return fmt.Errorf("generating : %w", err)
 		}

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 var (
@@ -60,7 +60,7 @@ func doRender(ctx context.Context, out io.Writer) error {
 		buildOut = out
 	}
 
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []util.VersionedConfig) error {
 		var bRes []graph.Artifact
 
 		if renderFromBuildOutputFile.String() != "" {

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 // NewCmdRun describes the CLI command to run a pipeline.
@@ -41,7 +41,7 @@ func NewCmdRun() *cobra.Command {
 }
 
 func doRun(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []util.VersionedConfig) error {
 		bRes, err := r.Build(ctx, out, targetArtifacts(opts, configs))
 		if err != nil {
 			return fmt.Errorf("failed to build: %w", err)

--- a/cmd/skaffold/app/cmd/run_test.go
+++ b/cmd/skaffold/app/cmd/run_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -92,19 +93,21 @@ func TestDoRun(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, "", func(t *testutil.T) {
 			mockRunner := &mockRunRunner{}
-			t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latestV1.SkaffoldConfig, *runcontext.RunContext, error) {
-				return mockRunner, []*latestV1.SkaffoldConfig{{
-					Pipeline: latestV1.Pipeline{
-						Build: latestV1.BuildConfig{
-							Artifacts: []*latestV1.Artifact{
-								{ImageName: "first"},
-								{ImageName: "second-test"},
-								{ImageName: "test"},
-								{ImageName: "aaabbbccc"},
+			t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+				return mockRunner, []util.VersionedConfig{
+					&latestV1.SkaffoldConfig{
+						Pipeline: latestV1.Pipeline{
+							Build: latestV1.BuildConfig{
+								Artifacts: []*latestV1.Artifact{
+									{ImageName: "first"},
+									{ImageName: "second-test"},
+									{ImageName: "test"},
+									{ImageName: "aaabbbccc"},
+								},
 							},
 						},
 					},
-				}}, nil, nil
+				}, nil, nil
 			})
 			t.Override(&opts, config.SkaffoldOptions{
 				TargetImages: []string{"test"},

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -64,7 +64,6 @@ func createNewRunner(out io.Writer, opts config.SkaffoldOptions) (runner.Runner,
 		return nil, nil, nil, err
 	}
 
-	// TODO yuwen Check v1 or v2.
 	var v1Configs []*latestV1.SkaffoldConfig
 	for _, c := range configs {
 		v1Configs = append(v1Configs, c.(*latestV1.SkaffoldConfig))

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -37,6 +37,7 @@ import (
 	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/validation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
@@ -45,7 +46,7 @@ import (
 // For tests
 var createRunner = createNewRunner
 
-func withRunner(ctx context.Context, out io.Writer, action func(runner.Runner, []*latestV1.SkaffoldConfig) error) error {
+func withRunner(ctx context.Context, out io.Writer, action func(runner.Runner, []util.VersionedConfig) error) error {
 	runner, config, runCtx, err := createRunner(out, opts)
 	if err != nil {
 		return err
@@ -57,13 +58,18 @@ func withRunner(ctx context.Context, out io.Writer, action func(runner.Runner, [
 }
 
 // createNewRunner creates a Runner and returns the SkaffoldConfig associated with it.
-func createNewRunner(out io.Writer, opts config.SkaffoldOptions) (runner.Runner, []*latestV1.SkaffoldConfig, *runcontext.RunContext, error) {
+func createNewRunner(out io.Writer, opts config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
 	runCtx, configs, err := runContext(out, opts)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	instrumentation.Init(configs, opts.User)
+	// TODO yuwen Check v1 or v2.
+	var v1Configs []*latestV1.SkaffoldConfig
+	for _, c := range configs {
+		v1Configs = append(v1Configs, c.(*latestV1.SkaffoldConfig))
+	}
+	instrumentation.Init(v1Configs, opts.User)
 	runner, err := v1.NewForConfig(runCtx)
 	if err != nil {
 		event.InititializationFailed(err)
@@ -72,7 +78,7 @@ func createNewRunner(out io.Writer, opts config.SkaffoldOptions) (runner.Runner,
 	return runner, configs, runCtx, nil
 }
 
-func runContext(out io.Writer, opts config.SkaffoldOptions) (*runcontext.RunContext, []*latestV1.SkaffoldConfig, error) {
+func runContext(out io.Writer, opts config.SkaffoldOptions) (*runcontext.RunContext, []util.VersionedConfig, error) {
 	cfgSet, err := withFallbackConfig(out, opts, parser.GetConfigSet)
 	if err != nil {
 		return nil, nil, err
@@ -82,7 +88,7 @@ func runContext(out io.Writer, opts config.SkaffoldOptions) (*runcontext.RunCont
 	if err := validation.Process(cfgSet, validation.GetValidationOpts(opts)); err != nil {
 		return nil, nil, fmt.Errorf("invalid skaffold config: %w", err)
 	}
-	var configs []*latestV1.SkaffoldConfig
+	var configs []util.VersionedConfig
 	for _, cfg := range cfgSet {
 		configs = append(configs, cfg.SkaffoldConfig)
 	}

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -92,6 +92,7 @@ func runContext(out io.Writer, opts config.SkaffoldOptions) (*runcontext.RunCont
 	for _, cfg := range cfgSet {
 		configs = append(configs, cfg.SkaffoldConfig)
 	}
+
 	runCtx, err := runcontext.GetRunContext(opts, configs)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting run context: %w", err)

--- a/cmd/skaffold/app/cmd/test.go
+++ b/cmd/skaffold/app/cmd/test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 // NewCmdTest describes the CLI command to test artifacts.
@@ -39,10 +40,10 @@ func NewCmdTest() *cobra.Command {
 }
 
 func doTest(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner, configs []util.VersionedConfig) error {
 		var artifacts []*latestV1.Artifact
 		for _, c := range configs {
-			artifacts = append(artifacts, c.Build.Artifacts...)
+			artifacts = append(artifacts, c.(*latestV1.SkaffoldConfig).Build.Artifacts...)
 		}
 		buildArtifacts, err := getBuildArtifactsAndSetTags(artifacts, r.ApplyDefaultRepo)
 		if err != nil {

--- a/pkg/skaffold/parser/config.go
+++ b/pkg/skaffold/parser/config.go
@@ -33,7 +33,6 @@ import (
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/errors"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemaUtil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
-
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )

--- a/pkg/skaffold/parser/config.go
+++ b/pkg/skaffold/parser/config.go
@@ -32,6 +32,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/errors"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	schemaUtil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -61,12 +63,12 @@ func newRecord() *record {
 }
 
 // GetAllConfigs returns the list of all skaffold configurations parsed from the target config file in addition to all resolved dependency configs.
-func GetAllConfigs(opts config.SkaffoldOptions) ([]*latestV1.SkaffoldConfig, error) {
+func GetAllConfigs(opts config.SkaffoldOptions) ([]schemaUtil.VersionedConfig, error) {
 	set, err := GetConfigSet(opts)
 	if err != nil {
 		return nil, err
 	}
-	var cfgs []*latestV1.SkaffoldConfig
+	var cfgs []schemaUtil.VersionedConfig
 	for _, cfg := range set {
 		cfgs = append(cfgs, cfg.SkaffoldConfig)
 	}

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -27,6 +27,7 @@ import (
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	runnerutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/util"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	schemaUtil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -199,11 +200,11 @@ func (rc *RunContext) BuildConcurrency() int                         { return rc
 func (rc *RunContext) IsMultiConfig() bool                           { return rc.Pipelines.IsMultiPipeline() }
 func (rc *RunContext) GetRunID() string                              { return rc.RunID }
 
-func GetRunContext(opts config.SkaffoldOptions, configs []*latestV1.SkaffoldConfig) (*RunContext, error) {
+func GetRunContext(opts config.SkaffoldOptions, configs []schemaUtil.VersionedConfig) (*RunContext, error) {
 	var pipelines []latestV1.Pipeline
 	for _, cfg := range configs {
 		if cfg != nil {
-			pipelines = append(pipelines, cfg.Pipeline)
+			pipelines = append(pipelines, cfg.(*latestV1.SkaffoldConfig).Pipeline)
 		}
 	}
 	kubeConfig, err := kubectx.CurrentConfig()

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 const (
@@ -43,7 +44,7 @@ type Runner interface {
 	Dev(context.Context, io.Writer, []*latestV1.Artifact) error
 	Deploy(context.Context, io.Writer, []graph.Artifact) error
 	DeployAndLog(context.Context, io.Writer, []graph.Artifact) error
-	GeneratePipeline(context.Context, io.Writer, []*latestV1.SkaffoldConfig, []string, string) error
+	GeneratePipeline(context.Context, io.Writer, []util.VersionedConfig, []string, string) error
 	HasBuilt() bool
 	HasDeployed() bool
 	Prune(context.Context, io.Writer) error

--- a/pkg/skaffold/runner/v1/generate_pipeline.go
+++ b/pkg/skaffold/runner/v1/generate_pipeline.go
@@ -27,16 +27,17 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
-func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, configs []*latestV1.SkaffoldConfig, configPaths []string, fileOut string) error {
+func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, configs []util.VersionedConfig, configPaths []string, fileOut string) error {
 	// Keep track of files, configs, and profiles. This will be used to know which files to write
 	// profiles to and what flags to add to task commands
 	var baseConfig []*pipeline.ConfigFile
 	for _, config := range configs {
 		cfgFile := &pipeline.ConfigFile{
 			Path:    r.runCtx.ConfigurationFile(),
-			Config:  config,
+			Config:  config.(*latestV1.SkaffoldConfig),
 			Profile: nil,
 		}
 		baseConfig = append(baseConfig, cfgFile)

--- a/pkg/skaffold/runner/v2/generate_pipeline.go
+++ b/pkg/skaffold/runner/v2/generate_pipeline.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"io"
 
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
-func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, configs []*latestV1.SkaffoldConfig, configPaths []string, fileOut string) error {
+func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, configs []util.VersionedConfig, configPaths []string, fileOut string) error {
 	return fmt.Errorf("not implemented error: SkaffoldRunner(v2).GeneratePipeline")
 }


### PR DESCRIPTION
<!-- Include if applicable: -->
**Related**: #5673 

Fixes #5797 

**Description**
In runner creation, the schema is no longer bundled with v1 schema (latestV1.skaffoldConfig) but used the interface util.VersionedConfig. 

All v1 commands are manually tested to make sure this PR does not break existing commands.

**Follow-up Work (remove if N/A)**
Distinguish v1 and v2 schema based on the in-use apiVersion in skaffold.yaml.


