### PR TITLE
make `test[i].imageName` optional in the skaffold config

### DIFF
--- a/cmd/skaffold/app/cmd/fix_test.go
+++ b/cmd/skaffold/app/cmd/fix_test.go
@@ -62,9 +62,9 @@ build:
     docker:
       dockerfile: dockerfile.test
 test:
-- image: docker/image
-  structureTests:
+- structureTests:
   - ./test/*
+  image: docker/image
 deploy:
   kubectl:
     manifests:
@@ -190,9 +190,9 @@ build:
     docker:
       dockerfile: dockerfile.test
 test:
-- image: docker/image
-  structureTests:
+- structureTests:
   - ./test/*
+  image: docker/image
 deploy:
   kubectl:
     manifests:

--- a/docs/content/en/schemas/v2beta18.json
+++ b/docs/content/en/schemas/v2beta18.json
@@ -3109,9 +3109,6 @@
       "x-intellij-html-description": "<em>beta</em> a component of CustomTemplateTagger."
     },
     "TestCase": {
-      "required": [
-        "image"
-      ],
       "properties": {
         "context": {
           "type": "string",
@@ -3129,8 +3126,8 @@
         },
         "image": {
           "type": "string",
-          "description": "artifact on which to run those tests.",
-          "x-intellij-html-description": "artifact on which to run those tests.",
+          "description": "artifact on which to run those tests. If unspecified that these tests will run for all artifacts.",
+          "x-intellij-html-description": "artifact on which to run those tests. If unspecified that these tests will run for all artifacts.",
           "examples": [
             "gcr.io/k8s-skaffold/example"
           ]
@@ -3149,10 +3146,10 @@
         }
       },
       "preferredOrder": [
-        "image",
         "context",
         "custom",
-        "structureTests"
+        "structureTests",
+        "image"
       ],
       "additionalProperties": false,
       "type": "object",

--- a/integration/test_events_test.go
+++ b/integration/test_events_test.go
@@ -61,6 +61,14 @@ func TestTestEvents(t *testing.T) {
 			args:        []string{"--profile", "customandstructure"},
 			numOfTests:  2,
 		},
+		{
+			description: "test events for tests without explicit image names",
+			podName:     "test-events",
+			testDir:     "testdata/test-events",
+			config:      "skaffold.yaml",
+			args:        []string{"--profile", "noimagenames"},
+			numOfTests:  2,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {

--- a/integration/testdata/test-events/skaffold.yaml
+++ b/integration/testdata/test-events/skaffold.yaml
@@ -25,3 +25,9 @@ profiles:
           - command: echo Hello!
         structureTests:
           - ./test/*
+  - name: noimagenames
+    test:
+      - custom:
+          - command: echo Hello!
+        structureTests:
+          - ./test/*

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -203,7 +203,7 @@ func setupTrigger(triggerName string, setIntent func(bool), setAutoTrigger func(
 func isImageLocal(runCtx *runcontext.RunContext, imageName string) (bool, error) {
 	pipeline, found := runCtx.PipelineForImage(imageName)
 	if !found {
-		pipeline = runCtx.DefaultPipeline()
+		return false, nil // if image doesn't match any artifact definition then it's probably pulled from a registry
 	}
 	if pipeline.Build.GoogleCloudBuild != nil || pipeline.Build.Cluster != nil {
 		return false, nil

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -476,10 +476,6 @@ type ResourceRequirement struct {
 
 // TestCase is a list of tests to run on images that Skaffold builds.
 type TestCase struct {
-	// ImageName is the artifact on which to run those tests.
-	// For example: `gcr.io/k8s-skaffold/example`.
-	ImageName string `yaml:"image" yamltags:"required"`
-
 	// Workspace is the directory containing the test sources.
 	// Defaults to `.`.
 	Workspace string `yaml:"context,omitempty" skaffold:"filepath"`
@@ -491,6 +487,10 @@ type TestCase struct {
 	// to run on that artifact.
 	// For example: `["./test/*"]`.
 	StructureTests []string `yaml:"structureTests,omitempty" skaffold:"filepath"`
+
+	// ImageName is the artifact on which to run those tests. If unspecified that these tests will run for all artifacts.
+	// For example: `gcr.io/k8s-skaffold/example`.
+	ImageName string `yaml:"image,omitempty"`
 }
 
 // DeployConfig contains all the configuration needed by the deploy steps.

--- a/pkg/skaffold/test/custom/custom_test.go
+++ b/pkg/skaffold/test/custom/custom_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -69,9 +70,9 @@ func TestNewCustomTestRunner(t *testing.T) {
 		}
 		testEvent.InitializeState([]latestV1.Pipeline{{}})
 
-		testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, custom)
+		testRunner, err := New(cfg, testCase.Workspace, custom)
 		t.CheckNoError(err)
-		err = testRunner.Test(context.Background(), ioutil.Discard, "image:tag")
+		err = testRunner.Test(context.Background(), ioutil.Discard, graph.Artifact{ImageName: "image", Tag: "image:tag"})
 
 		t.CheckNoError(err)
 	})
@@ -131,9 +132,9 @@ func TestCustomCommandError(t *testing.T) {
 			}
 			testEvent.InitializeState([]latestV1.Pipeline{{}})
 
-			testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, test.custom)
+			testRunner, err := New(cfg, testCase.Workspace, test.custom)
 			t.CheckNoError(err)
-			err = testRunner.Test(context.Background(), ioutil.Discard, "image:tag")
+			err = testRunner.Test(context.Background(), ioutil.Discard, graph.Artifact{ImageName: "image", Tag: "image:tag"})
 
 			// TODO(modali): Update the logic to check for error code instead of error string.
 			t.CheckError(test.shouldErr, err)
@@ -179,7 +180,7 @@ func TestTestDependenciesCommand(t *testing.T) {
 		}
 
 		expected := []string{"file1", "file2", "file3"}
-		testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, custom)
+		testRunner, err := New(cfg, testCase.Workspace, custom)
 		t.CheckNoError(err)
 		deps, err := testRunner.TestDependencies()
 
@@ -250,7 +251,7 @@ func TestTestDependenciesPaths(t *testing.T) {
 			}
 			testEvent.InitializeState([]latestV1.Pipeline{{}})
 
-			testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, custom)
+			testRunner, err := New(cfg, testCase.Workspace, custom)
 			t.CheckNoError(err)
 			deps, err := testRunner.TestDependencies()
 
@@ -318,7 +319,7 @@ func TestGetEnv(t *testing.T) {
 			}
 			testEvent.InitializeState([]latestV1.Pipeline{{}})
 
-			testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, custom)
+			testRunner, err := New(cfg, testCase.Workspace, custom)
 			t.CheckNoError(err)
 			actual, err := testRunner.getEnv(test.tag)
 

--- a/pkg/skaffold/test/structure/structure_test.go
+++ b/pkg/skaffold/test/structure/structure_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/cluster"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -60,9 +61,9 @@ func TestNewRunner(t *testing.T) {
 		}
 		testEvent.InitializeState([]latestV1.Pipeline{{}})
 
-		testRunner, err := New(cfg, testCase, true)
+		testRunner, err := New(cfg, testCase, func(imageName string) (bool, error) { return true, nil })
 		t.CheckNoError(err)
-		err = testRunner.Test(context.Background(), ioutil.Discard, "image:tag")
+		err = testRunner.Test(context.Background(), ioutil.Discard, graph.Artifact{ImageName: "image", Tag: "image:tag"})
 		t.CheckNoError(err)
 	})
 }
@@ -88,7 +89,7 @@ func TestIgnoreDockerNotFound(t *testing.T) {
 			StructureTests: []string{"test.yaml"},
 		}
 
-		testRunner, err := New(cfg, testCase, true)
+		testRunner, err := New(cfg, testCase, func(imageName string) (bool, error) { return true, nil })
 		t.CheckError(true, err)
 		t.CheckNil(testRunner)
 	})

--- a/pkg/skaffold/test/types.go
+++ b/pkg/skaffold/test/types.go
@@ -54,7 +54,7 @@ type FullTester struct {
 // running a single test on a single artifact image and returning its result.
 // Any new test type should implement this interface.
 type ImageTester interface {
-	Test(ctx context.Context, out io.Writer, tag string) error
+	Test(ctx context.Context, out io.Writer, image graph.Artifact) error
 
 	TestDependencies() ([]string, error)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6067 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Make the `imageName` field under `test` optional. 

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
Users can skip specifying `imageName` if they intend for the test to run against all artifacts built in the current devloop.
