### PR TITLE
Use StdEncoding for git hash directory name

### DIFF
--- a/pkg/skaffold/git/gitutil.go
+++ b/pkg/skaffold/git/gitutil.go
@@ -87,7 +87,9 @@ func getRepoDir(g latestV1.GitInfo) (string, error) {
 	if err := enc.Encode(inputs); err != nil {
 		return "", err
 	}
-	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))[:32], nil
+
+	// UrlEncoding supports '-' as a 63rd character, which can cause dir name issues
+	return base64.StdEncoding.EncodeToString(hasher.Sum(nil))[:32], nil
 }
 
 // GetRepoCacheDir returns the directory for the remote git repo cache


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/6025


**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
`base64.UrlEncoding` uses the "alternative alphabet" from [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648), which supports the `-` characters. When this character is the leading character of a computed hash, using this as an argument to any `git` command causes an error because it's misinterpreted as a command switch.

`base64.StdEncoding` does not support the `-` character in its alphabet, so we should be able to use this encoder as a drop-in replacement with no issues.