### PR TITLE
Use non alpine image and protoc 3.17.3 in proto generation

### DIFF
--- a/hack/proto/Dockerfile
+++ b/hack/proto/Dockerfile
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-alpine AS generate-files
-RUN apk add --no-cache protobuf=3.13.0-r2 unzip jq moreutils
+FROM golang:1.15 AS generate-files
+RUN apt-get update && apt-get install -y unzip moreutils
 
 WORKDIR /protoc
-ENV PROTOC_VERSION=3.13.0
+ENV PROTOC_VERSION=3.17.3
 RUN wget -O protoc.zip https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
 RUN unzip protoc.zip
+ENV PATH="/protoc/bin:${PATH}"
 
 WORKDIR /grpc-gateway
 RUN wget -q -O- https://github.com/grpc-ecosystem/grpc-gateway/tarball/v1.16.0 | tar --strip-components 1 -zx
@@ -75,8 +76,9 @@ RUN protoc \
   v2/*.proto
 
 # this is a hack - seemingly grpc-gateway-swagger-gen is sometimes generating titles when they should be descriptions
-RUN jq 'walk(if type == "object" and has("title") then .description = ([.title, .description] | map(values) | join ("\n")) | del(.title) else .  end)' v1/skaffold.swagger.json | sponge v1/skaffold.swagger.json
-RUN jq 'walk(if type == "object" and has("title") then .description = ([.title, .description] | map(values) | join ("\n")) | del(.title) else .  end)' v2/skaffold.swagger.json | sponge v2/skaffold.swagger.json
+RUN wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x ./jq
+RUN ./jq 'walk(if type == "object" and has("title") then .description = ([.title, .description] | map(values) | join ("\n")) | del(.title) else .  end)' v1/skaffold.swagger.json | sponge v1/skaffold.swagger.json
+RUN ./jq 'walk(if type == "object" and has("title") then .description = ([.title, .description] | map(values) | join ("\n")) | del(.title) else .  end)' v2/skaffold.swagger.json | sponge v2/skaffold.swagger.json
 
 # Append enum docs content to main docs content
 RUN cat enums/enums.md >> v1/index.md

--- a/proto/v1/skaffold.pb.go
+++ b/proto/v1/skaffold.pb.go
@@ -8,12 +8,12 @@ import (
 	fmt "fmt"
 	enums "github.com/GoogleContainerTools/skaffold/proto/enums"
 	proto "github.com/golang/protobuf/proto"
-	empty "github.com/golang/protobuf/ptypes/empty"
-	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	math "math"
 )
 
@@ -2232,12 +2232,12 @@ func (m *DebuggingContainerEvent) GetDebugPorts() map[string]uint32 {
 
 // LogEntry describes an event and a string description of the event.
 type LogEntry struct {
-	Timestamp            *timestamp.Timestamp `protobuf:"bytes,1,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	Event                *Event               `protobuf:"bytes,2,opt,name=event,proto3" json:"event,omitempty"`
-	Entry                string               `protobuf:"bytes,3,opt,name=entry,proto3" json:"entry,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
-	XXX_unrecognized     []byte               `json:"-"`
-	XXX_sizecache        int32                `json:"-"`
+	Timestamp            *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Event                *Event                 `protobuf:"bytes,2,opt,name=event,proto3" json:"event,omitempty"`
+	Entry                string                 `protobuf:"bytes,3,opt,name=entry,proto3" json:"entry,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}               `json:"-"`
+	XXX_unrecognized     []byte                 `json:"-"`
+	XXX_sizecache        int32                  `json:"-"`
 }
 
 func (m *LogEntry) Reset()         { *m = LogEntry{} }
@@ -2265,7 +2265,7 @@ func (m *LogEntry) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_LogEntry proto.InternalMessageInfo
 
-func (m *LogEntry) GetTimestamp() *timestamp.Timestamp {
+func (m *LogEntry) GetTimestamp() *timestamppb.Timestamp {
 	if m != nil {
 		return m.Timestamp
 	}
@@ -2784,22 +2784,22 @@ const _ = grpc.SupportPackageIsVersion6
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type SkaffoldServiceClient interface {
 	// Returns the state of the current Skaffold execution
-	GetState(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*State, error)
+	GetState(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*State, error)
 	// DEPRECATED. Events should be used instead.
 	// TODO remove (https://github.com/GoogleContainerTools/skaffold/issues/3168)
 	EventLog(ctx context.Context, opts ...grpc.CallOption) (SkaffoldService_EventLogClient, error)
 	// Returns all the events of the current Skaffold execution from the start
-	Events(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (SkaffoldService_EventsClient, error)
+	Events(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (SkaffoldService_EventsClient, error)
 	// Allows for a single execution of some or all of the phases (build, sync, deploy) in case autoBuild, autoDeploy or autoSync are disabled.
-	Execute(ctx context.Context, in *UserIntentRequest, opts ...grpc.CallOption) (*empty.Empty, error)
+	Execute(ctx context.Context, in *UserIntentRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Allows for enabling or disabling automatic build trigger
-	AutoBuild(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*empty.Empty, error)
+	AutoBuild(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Allows for enabling or disabling automatic sync trigger
-	AutoSync(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*empty.Empty, error)
+	AutoSync(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Allows for enabling or disabling automatic deploy trigger
-	AutoDeploy(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*empty.Empty, error)
+	AutoDeploy(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// EXPERIMENTAL. It allows for custom events to be implemented in custom builders for example.
-	Handle(ctx context.Context, in *Event, opts ...grpc.CallOption) (*empty.Empty, error)
+	Handle(ctx context.Context, in *Event, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
 type skaffoldServiceClient struct {
@@ -2810,7 +2810,7 @@ func NewSkaffoldServiceClient(cc grpc.ClientConnInterface) SkaffoldServiceClient
 	return &skaffoldServiceClient{cc}
 }
 
-func (c *skaffoldServiceClient) GetState(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*State, error) {
+func (c *skaffoldServiceClient) GetState(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*State, error) {
 	out := new(State)
 	err := c.cc.Invoke(ctx, "/proto.SkaffoldService/GetState", in, out, opts...)
 	if err != nil {
@@ -2850,7 +2850,7 @@ func (x *skaffoldServiceEventLogClient) Recv() (*LogEntry, error) {
 	return m, nil
 }
 
-func (c *skaffoldServiceClient) Events(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (SkaffoldService_EventsClient, error) {
+func (c *skaffoldServiceClient) Events(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (SkaffoldService_EventsClient, error) {
 	stream, err := c.cc.NewStream(ctx, &_SkaffoldService_serviceDesc.Streams[1], "/proto.SkaffoldService/Events", opts...)
 	if err != nil {
 		return nil, err
@@ -2882,8 +2882,8 @@ func (x *skaffoldServiceEventsClient) Recv() (*LogEntry, error) {
 	return m, nil
 }
 
-func (c *skaffoldServiceClient) Execute(ctx context.Context, in *UserIntentRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
-	out := new(empty.Empty)
+func (c *skaffoldServiceClient) Execute(ctx context.Context, in *UserIntentRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	out := new(emptypb.Empty)
 	err := c.cc.Invoke(ctx, "/proto.SkaffoldService/Execute", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -2891,8 +2891,8 @@ func (c *skaffoldServiceClient) Execute(ctx context.Context, in *UserIntentReque
 	return out, nil
 }
 
-func (c *skaffoldServiceClient) AutoBuild(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
-	out := new(empty.Empty)
+func (c *skaffoldServiceClient) AutoBuild(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	out := new(emptypb.Empty)
 	err := c.cc.Invoke(ctx, "/proto.SkaffoldService/AutoBuild", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -2900,8 +2900,8 @@ func (c *skaffoldServiceClient) AutoBuild(ctx context.Context, in *TriggerReques
 	return out, nil
 }
 
-func (c *skaffoldServiceClient) AutoSync(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
-	out := new(empty.Empty)
+func (c *skaffoldServiceClient) AutoSync(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	out := new(emptypb.Empty)
 	err := c.cc.Invoke(ctx, "/proto.SkaffoldService/AutoSync", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -2909,8 +2909,8 @@ func (c *skaffoldServiceClient) AutoSync(ctx context.Context, in *TriggerRequest
 	return out, nil
 }
 
-func (c *skaffoldServiceClient) AutoDeploy(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
-	out := new(empty.Empty)
+func (c *skaffoldServiceClient) AutoDeploy(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	out := new(emptypb.Empty)
 	err := c.cc.Invoke(ctx, "/proto.SkaffoldService/AutoDeploy", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -2918,8 +2918,8 @@ func (c *skaffoldServiceClient) AutoDeploy(ctx context.Context, in *TriggerReque
 	return out, nil
 }
 
-func (c *skaffoldServiceClient) Handle(ctx context.Context, in *Event, opts ...grpc.CallOption) (*empty.Empty, error) {
-	out := new(empty.Empty)
+func (c *skaffoldServiceClient) Handle(ctx context.Context, in *Event, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	out := new(emptypb.Empty)
 	err := c.cc.Invoke(ctx, "/proto.SkaffoldService/Handle", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -2930,50 +2930,50 @@ func (c *skaffoldServiceClient) Handle(ctx context.Context, in *Event, opts ...g
 // SkaffoldServiceServer is the server API for SkaffoldService service.
 type SkaffoldServiceServer interface {
 	// Returns the state of the current Skaffold execution
-	GetState(context.Context, *empty.Empty) (*State, error)
+	GetState(context.Context, *emptypb.Empty) (*State, error)
 	// DEPRECATED. Events should be used instead.
 	// TODO remove (https://github.com/GoogleContainerTools/skaffold/issues/3168)
 	EventLog(SkaffoldService_EventLogServer) error
 	// Returns all the events of the current Skaffold execution from the start
-	Events(*empty.Empty, SkaffoldService_EventsServer) error
+	Events(*emptypb.Empty, SkaffoldService_EventsServer) error
 	// Allows for a single execution of some or all of the phases (build, sync, deploy) in case autoBuild, autoDeploy or autoSync are disabled.
-	Execute(context.Context, *UserIntentRequest) (*empty.Empty, error)
+	Execute(context.Context, *UserIntentRequest) (*emptypb.Empty, error)
 	// Allows for enabling or disabling automatic build trigger
-	AutoBuild(context.Context, *TriggerRequest) (*empty.Empty, error)
+	AutoBuild(context.Context, *TriggerRequest) (*emptypb.Empty, error)
 	// Allows for enabling or disabling automatic sync trigger
-	AutoSync(context.Context, *TriggerRequest) (*empty.Empty, error)
+	AutoSync(context.Context, *TriggerRequest) (*emptypb.Empty, error)
 	// Allows for enabling or disabling automatic deploy trigger
-	AutoDeploy(context.Context, *TriggerRequest) (*empty.Empty, error)
+	AutoDeploy(context.Context, *TriggerRequest) (*emptypb.Empty, error)
 	// EXPERIMENTAL. It allows for custom events to be implemented in custom builders for example.
-	Handle(context.Context, *Event) (*empty.Empty, error)
+	Handle(context.Context, *Event) (*emptypb.Empty, error)
 }
 
 // UnimplementedSkaffoldServiceServer can be embedded to have forward compatible implementations.
 type UnimplementedSkaffoldServiceServer struct {
 }
 
-func (*UnimplementedSkaffoldServiceServer) GetState(ctx context.Context, req *empty.Empty) (*State, error) {
+func (*UnimplementedSkaffoldServiceServer) GetState(ctx context.Context, req *emptypb.Empty) (*State, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetState not implemented")
 }
 func (*UnimplementedSkaffoldServiceServer) EventLog(srv SkaffoldService_EventLogServer) error {
 	return status.Errorf(codes.Unimplemented, "method EventLog not implemented")
 }
-func (*UnimplementedSkaffoldServiceServer) Events(req *empty.Empty, srv SkaffoldService_EventsServer) error {
+func (*UnimplementedSkaffoldServiceServer) Events(req *emptypb.Empty, srv SkaffoldService_EventsServer) error {
 	return status.Errorf(codes.Unimplemented, "method Events not implemented")
 }
-func (*UnimplementedSkaffoldServiceServer) Execute(ctx context.Context, req *UserIntentRequest) (*empty.Empty, error) {
+func (*UnimplementedSkaffoldServiceServer) Execute(ctx context.Context, req *UserIntentRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Execute not implemented")
 }
-func (*UnimplementedSkaffoldServiceServer) AutoBuild(ctx context.Context, req *TriggerRequest) (*empty.Empty, error) {
+func (*UnimplementedSkaffoldServiceServer) AutoBuild(ctx context.Context, req *TriggerRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AutoBuild not implemented")
 }
-func (*UnimplementedSkaffoldServiceServer) AutoSync(ctx context.Context, req *TriggerRequest) (*empty.Empty, error) {
+func (*UnimplementedSkaffoldServiceServer) AutoSync(ctx context.Context, req *TriggerRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AutoSync not implemented")
 }
-func (*UnimplementedSkaffoldServiceServer) AutoDeploy(ctx context.Context, req *TriggerRequest) (*empty.Empty, error) {
+func (*UnimplementedSkaffoldServiceServer) AutoDeploy(ctx context.Context, req *TriggerRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AutoDeploy not implemented")
 }
-func (*UnimplementedSkaffoldServiceServer) Handle(ctx context.Context, req *Event) (*empty.Empty, error) {
+func (*UnimplementedSkaffoldServiceServer) Handle(ctx context.Context, req *Event) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Handle not implemented")
 }
 
@@ -2982,7 +2982,7 @@ func RegisterSkaffoldServiceServer(s *grpc.Server, srv SkaffoldServiceServer) {
 }
 
 func _SkaffoldService_GetState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(empty.Empty)
+	in := new(emptypb.Empty)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -2994,7 +2994,7 @@ func _SkaffoldService_GetState_Handler(srv interface{}, ctx context.Context, dec
 		FullMethod: "/proto.SkaffoldService/GetState",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(SkaffoldServiceServer).GetState(ctx, req.(*empty.Empty))
+		return srv.(SkaffoldServiceServer).GetState(ctx, req.(*emptypb.Empty))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -3026,7 +3026,7 @@ func (x *skaffoldServiceEventLogServer) Recv() (*LogEntry, error) {
 }
 
 func _SkaffoldService_Events_Handler(srv interface{}, stream grpc.ServerStream) error {
-	m := new(empty.Empty)
+	m := new(emptypb.Empty)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}

--- a/proto/v1/skaffold.pb.gw.go
+++ b/proto/v1/skaffold.pb.gw.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/golang/protobuf/descriptor"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
 	"google.golang.org/grpc"
@@ -23,6 +22,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // Suppress "imported and not used" errors
@@ -35,7 +35,7 @@ var _ = descriptor.ForMessage
 var _ = metadata.Join
 
 func request_SkaffoldService_GetState_0(ctx context.Context, marshaler runtime.Marshaler, client SkaffoldServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq empty.Empty
+	var protoReq emptypb.Empty
 	var metadata runtime.ServerMetadata
 
 	msg, err := client.GetState(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -44,7 +44,7 @@ func request_SkaffoldService_GetState_0(ctx context.Context, marshaler runtime.M
 }
 
 func local_request_SkaffoldService_GetState_0(ctx context.Context, marshaler runtime.Marshaler, server SkaffoldServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq empty.Empty
+	var protoReq emptypb.Empty
 	var metadata runtime.ServerMetadata
 
 	msg, err := server.GetState(ctx, &protoReq)
@@ -105,7 +105,7 @@ func request_SkaffoldService_EventLog_0(ctx context.Context, marshaler runtime.M
 }
 
 func request_SkaffoldService_Events_0(ctx context.Context, marshaler runtime.Marshaler, client SkaffoldServiceClient, req *http.Request, pathParams map[string]string) (SkaffoldService_EventsClient, runtime.ServerMetadata, error) {
-	var protoReq empty.Empty
+	var protoReq emptypb.Empty
 	var metadata runtime.ServerMetadata
 
 	stream, err := client.Events(ctx, &protoReq)

--- a/proto/v2/skaffold.pb.go
+++ b/proto/v2/skaffold.pb.go
@@ -8,12 +8,12 @@ import (
 	fmt "fmt"
 	enums "github.com/GoogleContainerTools/skaffold/proto/enums"
 	proto "github.com/golang/protobuf/proto"
-	empty "github.com/golang/protobuf/ptypes/empty"
-	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	_ "google.golang.org/genproto/googleapis/api/annotations"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
+	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	math "math"
 )
 
@@ -1175,7 +1175,7 @@ func (m *FileSyncState) GetAutoTrigger() bool {
 // `Event` describes an event in the Skaffold process.
 // It is one of MetaEvent, BuildEvent, TestEvent, DeployEvent, PortEvent, StatusCheckEvent, ResourceStatusCheckEvent, FileSyncEvent, or DebuggingContainerEvent.
 type Event struct {
-	Timestamp *timestamp.Timestamp `protobuf:"bytes,1,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	Timestamp *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	// Types that are valid to be assigned to EventType:
 	//	*Event_MetaEvent
 	//	*Event_SkaffoldLogEvent
@@ -1220,7 +1220,7 @@ func (m *Event) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_Event proto.InternalMessageInfo
 
-func (m *Event) GetTimestamp() *timestamp.Timestamp {
+func (m *Event) GetTimestamp() *timestamppb.Timestamp {
 	if m != nil {
 		return m.Timestamp
 	}
@@ -2904,23 +2904,23 @@ const _ = grpc.SupportPackageIsVersion6
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type SkaffoldV2ServiceClient interface {
 	// Returns the state of the current Skaffold execution
-	GetState(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*State, error)
+	GetState(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*State, error)
 	// Returns all the events of the current Skaffold execution from the start
-	Events(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (SkaffoldV2Service_EventsClient, error)
+	Events(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (SkaffoldV2Service_EventsClient, error)
 	// Returns all the user application logs of the current Skaffold execution
-	ApplicationLogs(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (SkaffoldV2Service_ApplicationLogsClient, error)
+	ApplicationLogs(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (SkaffoldV2Service_ApplicationLogsClient, error)
 	// Returns all the skaffold output of the current Skaffold execution
-	SkaffoldLogs(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (SkaffoldV2Service_SkaffoldLogsClient, error)
+	SkaffoldLogs(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (SkaffoldV2Service_SkaffoldLogsClient, error)
 	// Allows for a single execution of some or all of the phases (build, sync, deploy) in case autoBuild, autoDeploy or autoSync are disabled.
-	Execute(ctx context.Context, in *UserIntentRequest, opts ...grpc.CallOption) (*empty.Empty, error)
+	Execute(ctx context.Context, in *UserIntentRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Allows for enabling or disabling automatic build trigger
-	AutoBuild(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*empty.Empty, error)
+	AutoBuild(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Allows for enabling or disabling automatic sync trigger
-	AutoSync(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*empty.Empty, error)
+	AutoSync(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// Allows for enabling or disabling automatic deploy trigger
-	AutoDeploy(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*empty.Empty, error)
+	AutoDeploy(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// EXPERIMENTAL. It allows for custom events to be implemented in custom builders for example.
-	Handle(ctx context.Context, in *Event, opts ...grpc.CallOption) (*empty.Empty, error)
+	Handle(ctx context.Context, in *Event, opts ...grpc.CallOption) (*emptypb.Empty, error)
 }
 
 type skaffoldV2ServiceClient struct {
@@ -2931,7 +2931,7 @@ func NewSkaffoldV2ServiceClient(cc grpc.ClientConnInterface) SkaffoldV2ServiceCl
 	return &skaffoldV2ServiceClient{cc}
 }
 
-func (c *skaffoldV2ServiceClient) GetState(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (*State, error) {
+func (c *skaffoldV2ServiceClient) GetState(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*State, error) {
 	out := new(State)
 	err := c.cc.Invoke(ctx, "/proto.v2.SkaffoldV2Service/GetState", in, out, opts...)
 	if err != nil {
@@ -2940,7 +2940,7 @@ func (c *skaffoldV2ServiceClient) GetState(ctx context.Context, in *empty.Empty,
 	return out, nil
 }
 
-func (c *skaffoldV2ServiceClient) Events(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (SkaffoldV2Service_EventsClient, error) {
+func (c *skaffoldV2ServiceClient) Events(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (SkaffoldV2Service_EventsClient, error) {
 	stream, err := c.cc.NewStream(ctx, &_SkaffoldV2Service_serviceDesc.Streams[0], "/proto.v2.SkaffoldV2Service/Events", opts...)
 	if err != nil {
 		return nil, err
@@ -2972,7 +2972,7 @@ func (x *skaffoldV2ServiceEventsClient) Recv() (*Event, error) {
 	return m, nil
 }
 
-func (c *skaffoldV2ServiceClient) ApplicationLogs(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (SkaffoldV2Service_ApplicationLogsClient, error) {
+func (c *skaffoldV2ServiceClient) ApplicationLogs(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (SkaffoldV2Service_ApplicationLogsClient, error) {
 	stream, err := c.cc.NewStream(ctx, &_SkaffoldV2Service_serviceDesc.Streams[1], "/proto.v2.SkaffoldV2Service/ApplicationLogs", opts...)
 	if err != nil {
 		return nil, err
@@ -3004,7 +3004,7 @@ func (x *skaffoldV2ServiceApplicationLogsClient) Recv() (*Event, error) {
 	return m, nil
 }
 
-func (c *skaffoldV2ServiceClient) SkaffoldLogs(ctx context.Context, in *empty.Empty, opts ...grpc.CallOption) (SkaffoldV2Service_SkaffoldLogsClient, error) {
+func (c *skaffoldV2ServiceClient) SkaffoldLogs(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (SkaffoldV2Service_SkaffoldLogsClient, error) {
 	stream, err := c.cc.NewStream(ctx, &_SkaffoldV2Service_serviceDesc.Streams[2], "/proto.v2.SkaffoldV2Service/SkaffoldLogs", opts...)
 	if err != nil {
 		return nil, err
@@ -3036,8 +3036,8 @@ func (x *skaffoldV2ServiceSkaffoldLogsClient) Recv() (*Event, error) {
 	return m, nil
 }
 
-func (c *skaffoldV2ServiceClient) Execute(ctx context.Context, in *UserIntentRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
-	out := new(empty.Empty)
+func (c *skaffoldV2ServiceClient) Execute(ctx context.Context, in *UserIntentRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	out := new(emptypb.Empty)
 	err := c.cc.Invoke(ctx, "/proto.v2.SkaffoldV2Service/Execute", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -3045,8 +3045,8 @@ func (c *skaffoldV2ServiceClient) Execute(ctx context.Context, in *UserIntentReq
 	return out, nil
 }
 
-func (c *skaffoldV2ServiceClient) AutoBuild(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
-	out := new(empty.Empty)
+func (c *skaffoldV2ServiceClient) AutoBuild(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	out := new(emptypb.Empty)
 	err := c.cc.Invoke(ctx, "/proto.v2.SkaffoldV2Service/AutoBuild", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -3054,8 +3054,8 @@ func (c *skaffoldV2ServiceClient) AutoBuild(ctx context.Context, in *TriggerRequ
 	return out, nil
 }
 
-func (c *skaffoldV2ServiceClient) AutoSync(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
-	out := new(empty.Empty)
+func (c *skaffoldV2ServiceClient) AutoSync(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	out := new(emptypb.Empty)
 	err := c.cc.Invoke(ctx, "/proto.v2.SkaffoldV2Service/AutoSync", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -3063,8 +3063,8 @@ func (c *skaffoldV2ServiceClient) AutoSync(ctx context.Context, in *TriggerReque
 	return out, nil
 }
 
-func (c *skaffoldV2ServiceClient) AutoDeploy(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*empty.Empty, error) {
-	out := new(empty.Empty)
+func (c *skaffoldV2ServiceClient) AutoDeploy(ctx context.Context, in *TriggerRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	out := new(emptypb.Empty)
 	err := c.cc.Invoke(ctx, "/proto.v2.SkaffoldV2Service/AutoDeploy", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -3072,8 +3072,8 @@ func (c *skaffoldV2ServiceClient) AutoDeploy(ctx context.Context, in *TriggerReq
 	return out, nil
 }
 
-func (c *skaffoldV2ServiceClient) Handle(ctx context.Context, in *Event, opts ...grpc.CallOption) (*empty.Empty, error) {
-	out := new(empty.Empty)
+func (c *skaffoldV2ServiceClient) Handle(ctx context.Context, in *Event, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	out := new(emptypb.Empty)
 	err := c.cc.Invoke(ctx, "/proto.v2.SkaffoldV2Service/Handle", in, out, opts...)
 	if err != nil {
 		return nil, err
@@ -3084,54 +3084,54 @@ func (c *skaffoldV2ServiceClient) Handle(ctx context.Context, in *Event, opts ..
 // SkaffoldV2ServiceServer is the server API for SkaffoldV2Service service.
 type SkaffoldV2ServiceServer interface {
 	// Returns the state of the current Skaffold execution
-	GetState(context.Context, *empty.Empty) (*State, error)
+	GetState(context.Context, *emptypb.Empty) (*State, error)
 	// Returns all the events of the current Skaffold execution from the start
-	Events(*empty.Empty, SkaffoldV2Service_EventsServer) error
+	Events(*emptypb.Empty, SkaffoldV2Service_EventsServer) error
 	// Returns all the user application logs of the current Skaffold execution
-	ApplicationLogs(*empty.Empty, SkaffoldV2Service_ApplicationLogsServer) error
+	ApplicationLogs(*emptypb.Empty, SkaffoldV2Service_ApplicationLogsServer) error
 	// Returns all the skaffold output of the current Skaffold execution
-	SkaffoldLogs(*empty.Empty, SkaffoldV2Service_SkaffoldLogsServer) error
+	SkaffoldLogs(*emptypb.Empty, SkaffoldV2Service_SkaffoldLogsServer) error
 	// Allows for a single execution of some or all of the phases (build, sync, deploy) in case autoBuild, autoDeploy or autoSync are disabled.
-	Execute(context.Context, *UserIntentRequest) (*empty.Empty, error)
+	Execute(context.Context, *UserIntentRequest) (*emptypb.Empty, error)
 	// Allows for enabling or disabling automatic build trigger
-	AutoBuild(context.Context, *TriggerRequest) (*empty.Empty, error)
+	AutoBuild(context.Context, *TriggerRequest) (*emptypb.Empty, error)
 	// Allows for enabling or disabling automatic sync trigger
-	AutoSync(context.Context, *TriggerRequest) (*empty.Empty, error)
+	AutoSync(context.Context, *TriggerRequest) (*emptypb.Empty, error)
 	// Allows for enabling or disabling automatic deploy trigger
-	AutoDeploy(context.Context, *TriggerRequest) (*empty.Empty, error)
+	AutoDeploy(context.Context, *TriggerRequest) (*emptypb.Empty, error)
 	// EXPERIMENTAL. It allows for custom events to be implemented in custom builders for example.
-	Handle(context.Context, *Event) (*empty.Empty, error)
+	Handle(context.Context, *Event) (*emptypb.Empty, error)
 }
 
 // UnimplementedSkaffoldV2ServiceServer can be embedded to have forward compatible implementations.
 type UnimplementedSkaffoldV2ServiceServer struct {
 }
 
-func (*UnimplementedSkaffoldV2ServiceServer) GetState(ctx context.Context, req *empty.Empty) (*State, error) {
+func (*UnimplementedSkaffoldV2ServiceServer) GetState(ctx context.Context, req *emptypb.Empty) (*State, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetState not implemented")
 }
-func (*UnimplementedSkaffoldV2ServiceServer) Events(req *empty.Empty, srv SkaffoldV2Service_EventsServer) error {
+func (*UnimplementedSkaffoldV2ServiceServer) Events(req *emptypb.Empty, srv SkaffoldV2Service_EventsServer) error {
 	return status.Errorf(codes.Unimplemented, "method Events not implemented")
 }
-func (*UnimplementedSkaffoldV2ServiceServer) ApplicationLogs(req *empty.Empty, srv SkaffoldV2Service_ApplicationLogsServer) error {
+func (*UnimplementedSkaffoldV2ServiceServer) ApplicationLogs(req *emptypb.Empty, srv SkaffoldV2Service_ApplicationLogsServer) error {
 	return status.Errorf(codes.Unimplemented, "method ApplicationLogs not implemented")
 }
-func (*UnimplementedSkaffoldV2ServiceServer) SkaffoldLogs(req *empty.Empty, srv SkaffoldV2Service_SkaffoldLogsServer) error {
+func (*UnimplementedSkaffoldV2ServiceServer) SkaffoldLogs(req *emptypb.Empty, srv SkaffoldV2Service_SkaffoldLogsServer) error {
 	return status.Errorf(codes.Unimplemented, "method SkaffoldLogs not implemented")
 }
-func (*UnimplementedSkaffoldV2ServiceServer) Execute(ctx context.Context, req *UserIntentRequest) (*empty.Empty, error) {
+func (*UnimplementedSkaffoldV2ServiceServer) Execute(ctx context.Context, req *UserIntentRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Execute not implemented")
 }
-func (*UnimplementedSkaffoldV2ServiceServer) AutoBuild(ctx context.Context, req *TriggerRequest) (*empty.Empty, error) {
+func (*UnimplementedSkaffoldV2ServiceServer) AutoBuild(ctx context.Context, req *TriggerRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AutoBuild not implemented")
 }
-func (*UnimplementedSkaffoldV2ServiceServer) AutoSync(ctx context.Context, req *TriggerRequest) (*empty.Empty, error) {
+func (*UnimplementedSkaffoldV2ServiceServer) AutoSync(ctx context.Context, req *TriggerRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AutoSync not implemented")
 }
-func (*UnimplementedSkaffoldV2ServiceServer) AutoDeploy(ctx context.Context, req *TriggerRequest) (*empty.Empty, error) {
+func (*UnimplementedSkaffoldV2ServiceServer) AutoDeploy(ctx context.Context, req *TriggerRequest) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AutoDeploy not implemented")
 }
-func (*UnimplementedSkaffoldV2ServiceServer) Handle(ctx context.Context, req *Event) (*empty.Empty, error) {
+func (*UnimplementedSkaffoldV2ServiceServer) Handle(ctx context.Context, req *Event) (*emptypb.Empty, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Handle not implemented")
 }
 
@@ -3140,7 +3140,7 @@ func RegisterSkaffoldV2ServiceServer(s *grpc.Server, srv SkaffoldV2ServiceServer
 }
 
 func _SkaffoldV2Service_GetState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(empty.Empty)
+	in := new(emptypb.Empty)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -3152,13 +3152,13 @@ func _SkaffoldV2Service_GetState_Handler(srv interface{}, ctx context.Context, d
 		FullMethod: "/proto.v2.SkaffoldV2Service/GetState",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(SkaffoldV2ServiceServer).GetState(ctx, req.(*empty.Empty))
+		return srv.(SkaffoldV2ServiceServer).GetState(ctx, req.(*emptypb.Empty))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _SkaffoldV2Service_Events_Handler(srv interface{}, stream grpc.ServerStream) error {
-	m := new(empty.Empty)
+	m := new(emptypb.Empty)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}
@@ -3179,7 +3179,7 @@ func (x *skaffoldV2ServiceEventsServer) Send(m *Event) error {
 }
 
 func _SkaffoldV2Service_ApplicationLogs_Handler(srv interface{}, stream grpc.ServerStream) error {
-	m := new(empty.Empty)
+	m := new(emptypb.Empty)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}
@@ -3200,7 +3200,7 @@ func (x *skaffoldV2ServiceApplicationLogsServer) Send(m *Event) error {
 }
 
 func _SkaffoldV2Service_SkaffoldLogs_Handler(srv interface{}, stream grpc.ServerStream) error {
-	m := new(empty.Empty)
+	m := new(emptypb.Empty)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}

--- a/proto/v2/skaffold.pb.gw.go
+++ b/proto/v2/skaffold.pb.gw.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/golang/protobuf/descriptor"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/grpc-ecosystem/grpc-gateway/utilities"
 	"google.golang.org/grpc"
@@ -23,6 +22,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // Suppress "imported and not used" errors
@@ -35,7 +35,7 @@ var _ = descriptor.ForMessage
 var _ = metadata.Join
 
 func request_SkaffoldV2Service_GetState_0(ctx context.Context, marshaler runtime.Marshaler, client SkaffoldV2ServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq empty.Empty
+	var protoReq emptypb.Empty
 	var metadata runtime.ServerMetadata
 
 	msg, err := client.GetState(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -44,7 +44,7 @@ func request_SkaffoldV2Service_GetState_0(ctx context.Context, marshaler runtime
 }
 
 func local_request_SkaffoldV2Service_GetState_0(ctx context.Context, marshaler runtime.Marshaler, server SkaffoldV2ServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq empty.Empty
+	var protoReq emptypb.Empty
 	var metadata runtime.ServerMetadata
 
 	msg, err := server.GetState(ctx, &protoReq)
@@ -53,7 +53,7 @@ func local_request_SkaffoldV2Service_GetState_0(ctx context.Context, marshaler r
 }
 
 func request_SkaffoldV2Service_Events_0(ctx context.Context, marshaler runtime.Marshaler, client SkaffoldV2ServiceClient, req *http.Request, pathParams map[string]string) (SkaffoldV2Service_EventsClient, runtime.ServerMetadata, error) {
-	var protoReq empty.Empty
+	var protoReq emptypb.Empty
 	var metadata runtime.ServerMetadata
 
 	stream, err := client.Events(ctx, &protoReq)
@@ -70,7 +70,7 @@ func request_SkaffoldV2Service_Events_0(ctx context.Context, marshaler runtime.M
 }
 
 func request_SkaffoldV2Service_ApplicationLogs_0(ctx context.Context, marshaler runtime.Marshaler, client SkaffoldV2ServiceClient, req *http.Request, pathParams map[string]string) (SkaffoldV2Service_ApplicationLogsClient, runtime.ServerMetadata, error) {
-	var protoReq empty.Empty
+	var protoReq emptypb.Empty
 	var metadata runtime.ServerMetadata
 
 	stream, err := client.ApplicationLogs(ctx, &protoReq)
@@ -87,7 +87,7 @@ func request_SkaffoldV2Service_ApplicationLogs_0(ctx context.Context, marshaler 
 }
 
 func request_SkaffoldV2Service_SkaffoldLogs_0(ctx context.Context, marshaler runtime.Marshaler, client SkaffoldV2ServiceClient, req *http.Request, pathParams map[string]string) (SkaffoldV2Service_SkaffoldLogsClient, runtime.ServerMetadata, error) {
-	var protoReq empty.Empty
+	var protoReq emptypb.Empty
 	var metadata runtime.ServerMetadata
 
 	stream, err := client.SkaffoldLogs(ctx, &protoReq)


### PR DESCRIPTION
**Related**: #5986 

**Description**
This PR makes changes to `/hack/proto/Dockerfile` to have it use a non alpine image, in order to be able to use the downloaded `protoc` binary. Also updates `protoc` version to `3.17.3`

**Follow-up Work (remove if N/A)**
Update to use newer version of `protoc-gen-grpc-gateway` and `protoc-gen-openapiv2`


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
