### PR TITLE
Minor cleanup to structure tests

### DIFF
--- a/pkg/skaffold/test/structure/structure_test.go
+++ b/pkg/skaffold/test/structure/structure_test.go
@@ -35,29 +35,19 @@ import (
 )
 
 func TestNewRunner(t *testing.T) {
-	const (
-		imageName = "image:tag"
-	)
-
 	testutil.Run(t, "", func(t *testutil.T) {
 		tmpDir := t.NewTempDir().Touch("test.yaml")
 		t.Override(&cluster.FindMinikubeBinary, func() (string, semver.Version, error) { return "", semver.Version{}, errors.New("not found") })
 
-		t.Override(&util.DefaultExecCommand, testutil.CmdRun("container-structure-test test -v warn --image "+imageName+" --config "+tmpDir.Path("test.yaml")))
-
-		cfg := &mockConfig{
-			tests: []*latestV1.TestCase{{
-				ImageName:      "image",
-				Workspace:      tmpDir.Root(),
-				StructureTests: []string{"test.yaml"},
-			}},
-		}
+		t.Override(&util.DefaultExecCommand, testutil.CmdRun("container-structure-test test -v warn --image image:tag --config "+tmpDir.Path("test.yaml")))
 
 		testCase := &latestV1.TestCase{
 			ImageName:      "image",
 			Workspace:      tmpDir.Root(),
 			StructureTests: []string{"test.yaml"},
 		}
+		cfg := &mockConfig{tests: []*latestV1.TestCase{testCase}}
+
 		testEvent.InitializeState([]latestV1.Pipeline{{}})
 
 		testRunner, err := New(cfg, testCase, true)
@@ -74,19 +64,12 @@ func TestIgnoreDockerNotFound(t *testing.T) {
 			return nil, errors.New("not found")
 		})
 
-		cfg := &mockConfig{
-			tests: []*latestV1.TestCase{{
-				ImageName:      "image",
-				Workspace:      tmpDir.Root(),
-				StructureTests: []string{"test.yaml"},
-			}},
-		}
-
 		testCase := &latestV1.TestCase{
 			ImageName:      "image",
 			Workspace:      tmpDir.Root(),
 			StructureTests: []string{"test.yaml"},
 		}
+		cfg := &mockConfig{tests: []*latestV1.TestCase{testCase}}
 
 		testRunner, err := New(cfg, testCase, true)
 		t.CheckError(true, err)
@@ -97,19 +80,19 @@ func TestIgnoreDockerNotFound(t *testing.T) {
 func TestCustomParams(t *testing.T) {
 	testCases := []struct {
 		structureTestArgs []string
-		expectedCmd       string
+		expectedExtras    string
 	}{
 		{
 			structureTestArgs: []string{"--driver=tar", "--force", "-q", "--save"},
-			expectedCmd:       " --driver=tar --force -q --save",
+			expectedExtras:    "--driver=tar --force -q --save",
 		},
 		{
 			structureTestArgs: []string{},
-			expectedCmd:       "",
+			expectedExtras:    "",
 		},
 		{
 			structureTestArgs: nil,
-			expectedCmd:       "",
+			expectedExtras:    "",
 		},
 	}
 
@@ -118,17 +101,11 @@ func TestCustomParams(t *testing.T) {
 			tmpDir := t.NewTempDir().Touch("test.yaml")
 			t.Override(&cluster.FindMinikubeBinary, func() (string, semver.Version, error) { return "", semver.Version{}, errors.New("not found") })
 
-			baseCmd := "container-structure-test test -v warn --image image:tag --config " + tmpDir.Path("test.yaml")
-			t.Override(&util.DefaultExecCommand, testutil.CmdRun(baseCmd+tc.expectedCmd))
-
-			cfg := &mockConfig{
-				tests: []*latestV1.TestCase{{
-					ImageName:         "image",
-					Workspace:         tmpDir.Root(),
-					StructureTests:    []string{"test.yaml"},
-					StructureTestArgs: tc.structureTestArgs,
-				}},
+			expected := "container-structure-test test -v warn --image image:tag --config " + tmpDir.Path("test.yaml")
+			if len(tc.expectedExtras) > 0 {
+				expected += " " + tc.expectedExtras
 			}
+			t.Override(&util.DefaultExecCommand, testutil.CmdRun(expected))
 
 			testCase := &latestV1.TestCase{
 				ImageName:         "image",
@@ -136,6 +113,8 @@ func TestCustomParams(t *testing.T) {
 				StructureTests:    []string{"test.yaml"},
 				StructureTestArgs: tc.structureTestArgs,
 			}
+			cfg := &mockConfig{tests: []*latestV1.TestCase{testCase}}
+
 			testEvent.InitializeState([]latestV1.Pipeline{{}})
 
 			testRunner, err := New(cfg, testCase, true)


### PR DESCRIPTION
Inline consts since values were inconsistently referenced, and avoid repetition.