### PR TITLE
Remove podSelector from Runner

### DIFF
--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -78,7 +78,7 @@ spec:
 		t.NewTempDir().
 			Write("deployment.yaml", test.input).
 			Chdir()
-		deployer, _, err := kubectl.NewDeployer(&runcontext.RunContext{
+		deployer, err := kubectl.NewDeployer(&runcontext.RunContext{
 			WorkingDir: ".",
 			Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{
 				Deploy: latestV1.DeployConfig{
@@ -235,7 +235,7 @@ spec:
 				Write("deployment.yaml", test.input).
 				Chdir()
 
-			deployer, _, err := kubectl.NewDeployer(&runcontext.RunContext{
+			deployer, err := kubectl.NewDeployer(&runcontext.RunContext{
 				WorkingDir: ".",
 				Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{
 					Deploy: latestV1.DeployConfig{
@@ -425,7 +425,7 @@ spec:
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			deployer, _, err := helm.NewDeployer(&runcontext.RunContext{
+			deployer, err := helm.NewDeployer(&runcontext.RunContext{
 				Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{
 					Deploy: latestV1.DeployConfig{
 						DeployType: latestV1.DeployType{

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -116,14 +116,14 @@ type Config interface {
 }
 
 // NewDeployer returns a configured Deployer.  Returns an error if current version of helm is less than 3.0.0.
-func NewDeployer(cfg Config, labels map[string]string, provider deploy.ComponentProvider, h *latestV1.HelmDeploy) (*Deployer, *kubernetes.ImageList, error) {
+func NewDeployer(cfg Config, labels map[string]string, provider deploy.ComponentProvider, h *latestV1.HelmDeploy) (*Deployer, error) {
 	hv, err := binVer()
 	if err != nil {
-		return nil, nil, versionGetErr(err)
+		return nil, versionGetErr(err)
 	}
 
 	if hv.LT(helm3Version) {
-		return nil, nil, minVersionErr()
+		return nil, minVersionErr()
 	}
 
 	originalImages := []graph.Artifact{}
@@ -155,7 +155,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		bV:             hv,
 		enableDebug:    cfg.Mode() == config.RunModes.Debug,
 		isMultiConfig:  cfg.IsMultiConfig(),
-	}, podSelector, nil
+	}, nil
 }
 
 func (h *Deployer) GetAccessor() access.Accessor {

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -472,7 +472,7 @@ func TestNewDeployer(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", test.helmVersion))
 
-			_, _, err := NewDeployer(&helmConfig{}, nil, deploy.NoopComponentProvider, &testDeployConfig)
+			_, err := NewDeployer(&helmConfig{}, nil, deploy.NoopComponentProvider, &testDeployConfig)
 			t.CheckError(test.shouldErr, err)
 		})
 	}
@@ -1006,7 +1006,7 @@ func TestHelmDeploy(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.Override(&osExecutable, func() (string, error) { return "SKAFFOLD-BINARY", nil })
 
-			deployer, _, err := NewDeployer(&helmConfig{
+			deployer, err := NewDeployer(&helmConfig{
 				namespace:  test.namespace,
 				force:      test.force,
 				configFile: "test.yaml",
@@ -1085,7 +1085,7 @@ func TestHelmCleanup(t *testing.T) {
 			t.Override(&util.OSEnviron, func() []string { return []string{"FOO=FOOBAR"} })
 			t.Override(&util.DefaultExecCommand, test.commands)
 
-			deployer, _, err := NewDeployer(&helmConfig{
+			deployer, err := NewDeployer(&helmConfig{
 				namespace: test.namespace,
 			}, nil, deploy.NoopComponentProvider, &test.helm)
 			t.RequireNoError(err)
@@ -1190,7 +1190,7 @@ func TestHelmDependencies(t *testing.T) {
 				local = tmpDir.Root()
 			}
 
-			deployer, _, err := NewDeployer(&helmConfig{}, nil, deploy.NoopComponentProvider, &latestV1.HelmDeploy{
+			deployer, err := NewDeployer(&helmConfig{}, nil, deploy.NoopComponentProvider, &latestV1.HelmDeploy{
 				Releases: []latestV1.HelmRelease{{
 					Name:                  "skaffold-helm",
 					ChartPath:             local,
@@ -1453,7 +1453,7 @@ func TestHelmRender(t *testing.T) {
 
 			t.Override(&util.OSEnviron, func() []string { return append([]string{"FOO=FOOBAR"}, test.env...) })
 			t.Override(&util.DefaultExecCommand, test.commands)
-			deployer, _, err := NewDeployer(&helmConfig{
+			deployer, err := NewDeployer(&helmConfig{
 				namespace: test.namespace,
 			}, nil, deploy.NoopComponentProvider, &test.helm)
 			t.RequireNoError(err)
@@ -1524,7 +1524,7 @@ func TestGenerateSkaffoldDebugFilter(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", version31))
-			h, _, err := NewDeployer(&helmConfig{}, nil, deploy.NoopComponentProvider, &testDeployConfig)
+			h, err := NewDeployer(&helmConfig{}, nil, deploy.NoopComponentProvider, &testDeployConfig)
 			t.RequireNoError(err)
 			result := h.generateSkaffoldDebugFilter(test.buildFile)
 			t.CheckDeepEqual(test.result, result)

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -97,7 +97,7 @@ type Config interface {
 }
 
 // NewDeployer generates a new Deployer object contains the kptDeploy schema.
-func NewDeployer(cfg Config, labels map[string]string, provider deploy.ComponentProvider, d *latestV1.KptDeploy) (*Deployer, *kubernetes.ImageList) {
+func NewDeployer(cfg Config, labels map[string]string, provider deploy.ComponentProvider, d *latestV1.KptDeploy) *Deployer {
 	podSelector := kubernetes.NewImageList()
 	return &Deployer{
 		KptDeploy:          d,
@@ -114,7 +114,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		kubeContext:        cfg.GetKubeContext(),
 		kubeConfig:         cfg.GetKubeConfig(),
 		namespace:          cfg.GetKubeNamespace(),
-	}, podSelector
+	}
 }
 
 func (k *Deployer) GetAccessor() access.Accessor {

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -231,7 +231,7 @@ func TestKpt_Deploy(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.NewTempDir().Chdir()
 
-			k, _ := NewDeployer(&kptConfig{}, nil, deploy.NoopComponentProvider, &test.kpt)
+			k := NewDeployer(&kptConfig{}, nil, deploy.NoopComponentProvider, &test.kpt)
 			if test.hasKustomization != nil {
 				k.hasKustomization = test.hasKustomization
 			}
@@ -374,7 +374,7 @@ func TestKpt_Dependencies(t *testing.T) {
 			tmpDir.WriteFiles(test.createFiles)
 			tmpDir.WriteFiles(test.kustomizations)
 
-			k, _ := NewDeployer(&kptConfig{}, nil, deploy.NoopComponentProvider, &test.kpt)
+			k := NewDeployer(&kptConfig{}, nil, deploy.NoopComponentProvider, &test.kpt)
 
 			res, err := k.Dependencies()
 
@@ -425,7 +425,7 @@ func TestKpt_Cleanup(t *testing.T) {
 				t.CheckNoError(os.Mkdir(test.applyDir, 0755))
 			}
 
-			k, _ := NewDeployer(&kptConfig{
+			k := NewDeployer(&kptConfig{
 				workingDir: ".",
 			}, nil, deploy.NoopComponentProvider, &latestV1.KptDeploy{
 				Live: latestV1.KptLive{
@@ -787,7 +787,7 @@ spec:
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.NewTempDir().Chdir()
 
-			k, _ := NewDeployer(&kptConfig{workingDir: "."}, test.labels, deploy.NoopComponentProvider, &test.kpt)
+			k := NewDeployer(&kptConfig{workingDir: "."}, test.labels, deploy.NoopComponentProvider, &test.kpt)
 			if test.hasKustomization != nil {
 				k.hasKustomization = test.hasKustomization
 			}
@@ -862,7 +862,7 @@ func TestKpt_GetApplyDir(t *testing.T) {
 				tmpDir.Touch(".kpt-hydrated/inventory-template.yaml")
 			}
 
-			k, _ := NewDeployer(&kptConfig{
+			k := NewDeployer(&kptConfig{
 				workingDir: ".",
 			}, nil, deploy.NoopComponentProvider, &latestV1.KptDeploy{
 				Live: test.live,
@@ -1023,7 +1023,7 @@ spec:
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			k, _ := NewDeployer(&kptConfig{}, nil, deploy.NoopComponentProvider, nil)
+			k := NewDeployer(&kptConfig{}, nil, deploy.NoopComponentProvider, nil)
 			actualManifest, err := k.excludeKptFn(test.manifests)
 			t.CheckErrorAndDeepEqual(false, err, test.expected.String(), actualManifest.String())
 		})
@@ -1169,7 +1169,7 @@ func TestNonEmptyKubeconfig(t *testing.T) {
 
 	testutil.Run(t, "", func(t *testutil.T) {
 		t.Override(&util.DefaultExecCommand, commands)
-		k, _ := NewDeployer(&kptConfig{config: "testConfigPath"}, nil, deploy.NoopComponentProvider, &latestV1.KptDeploy{
+		k := NewDeployer(&kptConfig{config: "testConfigPath"}, nil, deploy.NoopComponentProvider, &latestV1.KptDeploy{
 			Dir: ".",
 			Live: latestV1.KptLive{
 				Apply: latestV1.KptApplyInventory{

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -72,13 +72,13 @@ type Deployer struct {
 
 // NewDeployer returns a new Deployer for a DeployConfig filled
 // with the needed configuration for `kubectl apply`
-func NewDeployer(cfg Config, labels map[string]string, provider deploy.ComponentProvider, d *latestV1.KubectlDeploy) (*Deployer, *kubernetes.ImageList, error) {
+func NewDeployer(cfg Config, labels map[string]string, provider deploy.ComponentProvider, d *latestV1.KubectlDeploy) (*Deployer, error) {
 	defaultNamespace := ""
 	if d.DefaultNamespace != nil {
 		var err error
 		defaultNamespace, err = util.ExpandEnvTemplate(*d.DefaultNamespace, nil)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
@@ -100,7 +100,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		skipRender:         cfg.SkipRender(),
 		labels:             labels,
 		hydratedManifests:  cfg.HydratedManifests(),
-	}, podSelector, nil
+	}, nil
 }
 
 func (k *Deployer) GetAccessor() access.Accessor {

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -232,7 +232,7 @@ func TestKubectlDeploy(t *testing.T) {
 				skaffoldNamespaceOption = TestNamespace
 			}
 
-			k, _, err := NewDeployer(&kubectlConfig{
+			k, err := NewDeployer(&kubectlConfig{
 				workingDir: ".",
 				force:      test.forceDeploy,
 				waitForDeletions: config.WaitForDeletions{
@@ -313,7 +313,7 @@ func TestKubectlCleanup(t *testing.T) {
 				Write("deployment.yaml", DeploymentWebYAML).
 				Chdir()
 
-			k, _, err := NewDeployer(&kubectlConfig{
+			k, err := NewDeployer(&kubectlConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
 			}, nil, deploy.NoopComponentProvider, &test.kubectl)
@@ -360,7 +360,7 @@ func TestKubectlDeployerRemoteCleanup(t *testing.T) {
 				Write("deployment.yaml", DeploymentWebYAML).
 				Chdir()
 
-			k, _, err := NewDeployer(&kubectlConfig{
+			k, err := NewDeployer(&kubectlConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},
 			}, nil, deploy.NoopComponentProvider, &test.kubectl)
@@ -391,7 +391,7 @@ func TestKubectlRedeploy(t *testing.T) {
 			AndRunInputOut("kubectl --context kubecontext get -f - --ignore-not-found -ojson", DeploymentAppYAMLv2+"\n---\n"+DeploymentWebYAMLv1, ""),
 		)
 
-		deployer, _, err := NewDeployer(&kubectlConfig{
+		deployer, err := NewDeployer(&kubectlConfig{
 			workingDir: ".",
 			waitForDeletions: config.WaitForDeletions{
 				Enabled: true,
@@ -454,7 +454,7 @@ func TestKubectlWaitForDeletions(t *testing.T) {
 			AndRunInput("kubectl --context kubecontext apply -f -", DeploymentWebYAMLv1),
 		)
 
-		deployer, _, err := NewDeployer(&kubectlConfig{
+		deployer, err := NewDeployer(&kubectlConfig{
 			workingDir: tmpDir.Root(),
 			waitForDeletions: config.WaitForDeletions{
 				Enabled: true,
@@ -491,7 +491,7 @@ func TestKubectlWaitForDeletionsFails(t *testing.T) {
 			}`),
 		)
 
-		deployer, _, err := NewDeployer(&kubectlConfig{
+		deployer, err := NewDeployer(&kubectlConfig{
 			workingDir: tmpDir.Root(),
 			waitForDeletions: config.WaitForDeletions{
 				Enabled: true,
@@ -559,7 +559,7 @@ func TestDependencies(t *testing.T) {
 				Touch("00/b.yaml", "00/a.yaml").
 				Chdir()
 
-			k, _, err := NewDeployer(&kubectlConfig{}, nil, deploy.NoopComponentProvider, &latestV1.KubectlDeploy{Manifests: test.manifests})
+			k, err := NewDeployer(&kubectlConfig{}, nil, deploy.NoopComponentProvider, &latestV1.KubectlDeploy{Manifests: test.manifests})
 			t.RequireNoError(err)
 
 			dependencies, err := k.Dependencies()
@@ -672,7 +672,7 @@ spec:
 			t.Override(&util.DefaultExecCommand, testutil.
 				CmdRunOut("kubectl version --client -ojson", KubectlVersion112).
 				AndRunOut("kubectl --context kubecontext create --dry-run -oyaml -f "+tmpDir.Path("deployment.yaml"), test.input))
-			deployer, _, err := NewDeployer(&kubectlConfig{
+			deployer, err := NewDeployer(&kubectlConfig{
 				workingDir:  ".",
 				defaultRepo: "gcr.io/project",
 			}, nil, deploy.NoopComponentProvider, &latestV1.KubectlDeploy{
@@ -716,7 +716,7 @@ func TestGCSManifests(t *testing.T) {
 			if err := ioutil.WriteFile(manifest.ManifestTmpDir+"/deployment.yaml", []byte(DeploymentWebYAML), os.ModePerm); err != nil {
 				t.Fatal(err)
 			}
-			k, _, err := NewDeployer(&kubectlConfig{
+			k, err := NewDeployer(&kubectlConfig{
 				workingDir: ".",
 				skipRender: test.skipRender,
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: TestNamespace}},

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -118,13 +118,13 @@ type Deployer struct {
 	useKubectlKustomize bool
 }
 
-func NewDeployer(cfg kubectl.Config, labels map[string]string, provider deploy.ComponentProvider, d *latestV1.KustomizeDeploy) (*Deployer, *kubernetes.ImageList, error) {
+func NewDeployer(cfg kubectl.Config, labels map[string]string, provider deploy.ComponentProvider, d *latestV1.KustomizeDeploy) (*Deployer, error) {
 	defaultNamespace := ""
 	if d.DefaultNamespace != nil {
 		var err error
 		defaultNamespace, err = util.ExpandEnvTemplate(*d.DefaultNamespace, nil)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
 
@@ -146,7 +146,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, provider deploy.C
 		globalConfig:        cfg.GlobalConfig(),
 		labels:              labels,
 		useKubectlKustomize: useKubectlKustomize,
-	}, podSelector, nil
+	}, nil
 }
 
 func (k *Deployer) GetAccessor() access.Accessor {

--- a/pkg/skaffold/deploy/kustomize/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize_test.go
@@ -177,7 +177,7 @@ func TestKustomizeDeploy(t *testing.T) {
 				skaffoldNamespaceOption = kubectl.TestNamespace
 			}
 
-			k, _, err := NewDeployer(&kustomizeConfig{
+			k, err := NewDeployer(&kustomizeConfig{
 				workingDir: ".",
 				force:      test.forceDeploy,
 				waitForDeletions: config.WaitForDeletions{
@@ -249,7 +249,7 @@ func TestKustomizeCleanup(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.Override(&KustomizeBinaryCheck, func() bool { return true })
 
-			k, _, err := NewDeployer(&kustomizeConfig{
+			k, err := NewDeployer(&kustomizeConfig{
 				workingDir: tmpDir.Root(),
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{
 					Namespace: kubectl.TestNamespace}},
@@ -455,7 +455,7 @@ func TestDependenciesForKustomization(t *testing.T) {
 				tmpDir.Write(path, contents)
 			}
 
-			k, _, err := NewDeployer(&kustomizeConfig{}, nil, deploy.NoopComponentProvider, &latestV1.KustomizeDeploy{KustomizePaths: kustomizePaths})
+			k, err := NewDeployer(&kustomizeConfig{}, nil, deploy.NoopComponentProvider, &latestV1.KustomizeDeploy{KustomizePaths: kustomizePaths})
 			t.RequireNoError(err)
 
 			deps, err := k.Dependencies()
@@ -696,7 +696,7 @@ spec:
 			t.Override(&util.DefaultExecCommand, fakeCmd)
 			t.NewTempDir().Chdir()
 
-			k, _, err := NewDeployer(&kustomizeConfig{
+			k, err := NewDeployer(&kustomizeConfig{
 				workingDir: ".",
 				RunContext: runcontext.RunContext{Opts: config.SkaffoldOptions{Namespace: kubectl.TestNamespace}},
 			}, test.labels, deploy.NoopComponentProvider, &latestV1.KustomizeDeploy{

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -26,7 +26,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kpt"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -56,8 +55,7 @@ func (d *deployerCtx) StatusCheck() *bool {
 }
 
 // GetDeployer creates a deployer from a given RunContext and deploy pipeline definitions.
-func GetDeployer(runCtx *runcontext.RunContext, provider deploy.ComponentProvider, labels map[string]string) (deploy.Deployer, kubernetes.ImageListMux, error) {
-	var podSelectors kubernetes.ImageListMux
+func GetDeployer(runCtx *runcontext.RunContext, provider deploy.ComponentProvider, labels map[string]string) (deploy.Deployer, error) {
 	if runCtx.Opts.Apply {
 		return getDefaultDeployer(runCtx, provider, labels)
 	}
@@ -68,40 +66,36 @@ func GetDeployer(runCtx *runcontext.RunContext, provider deploy.ComponentProvide
 	for _, d := range deployerCfg {
 		dCtx := &deployerCtx{runCtx, d}
 		if d.HelmDeploy != nil {
-			h, podSelector, err := helm.NewDeployer(dCtx, labels, provider, d.HelmDeploy)
+			h, err := helm.NewDeployer(dCtx, labels, provider, d.HelmDeploy)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
-			podSelectors = append(podSelectors, podSelector)
 			deployers = append(deployers, h)
 		}
 
 		if d.KptDeploy != nil {
-			deployer, podSelector := kpt.NewDeployer(dCtx, labels, provider, d.KptDeploy)
-			podSelectors = append(podSelectors, podSelector)
+			deployer := kpt.NewDeployer(dCtx, labels, provider, d.KptDeploy)
 			deployers = append(deployers, deployer)
 		}
 
 		if d.KubectlDeploy != nil {
-			deployer, podSelector, err := kubectl.NewDeployer(dCtx, labels, provider, d.KubectlDeploy)
+			deployer, err := kubectl.NewDeployer(dCtx, labels, provider, d.KubectlDeploy)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
-			podSelectors = append(podSelectors, podSelector)
 			deployers = append(deployers, deployer)
 		}
 
 		if d.KustomizeDeploy != nil {
-			deployer, podSelector, err := kustomize.NewDeployer(dCtx, labels, provider, d.KustomizeDeploy)
+			deployer, err := kustomize.NewDeployer(dCtx, labels, provider, d.KustomizeDeploy)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
-			podSelectors = append(podSelectors, podSelector)
 			deployers = append(deployers, deployer)
 		}
 	}
 
-	return deployers, podSelectors, nil
+	return deployers, nil
 }
 
 /*
@@ -117,7 +111,7 @@ The default deployer will honor a select set of deploy configuration from an exi
 For a multi-config project, we do not currently support resolving conflicts between differing sets of this deploy configuration.
 Therefore, in this function we do implicit validation of the provided configuration, and fail if any conflict cannot be resolved.
 */
-func getDefaultDeployer(runCtx *runcontext.RunContext, provider deploy.ComponentProvider, labels map[string]string) (deploy.Deployer, kubernetes.ImageListMux, error) {
+func getDefaultDeployer(runCtx *runcontext.RunContext, provider deploy.ComponentProvider, labels map[string]string) (deploy.Deployer, error) {
 	deployCfgs := runCtx.DeployConfigs()
 
 	var kFlags *v1.KubectlFlags
@@ -129,19 +123,19 @@ func getDefaultDeployer(runCtx *runcontext.RunContext, provider deploy.Component
 	for _, d := range deployCfgs {
 		if d.KubeContext != "" {
 			if kubeContext != "" && kubeContext != d.KubeContext {
-				return nil, nil, errors.New("cannot resolve active Kubernetes context - multiple contexts configured in skaffold.yaml")
+				return nil, errors.New("cannot resolve active Kubernetes context - multiple contexts configured in skaffold.yaml")
 			}
 			kubeContext = d.KubeContext
 		}
 		if d.StatusCheckDeadlineSeconds != 0 && d.StatusCheckDeadlineSeconds != int(status.DefaultStatusCheckDeadline.Seconds()) {
 			if statusCheckTimeout != -1 && statusCheckTimeout != d.StatusCheckDeadlineSeconds {
-				return nil, nil, fmt.Errorf("found multiple status check timeouts in skaffold.yaml (not supported in `skaffold apply`): %d, %d", statusCheckTimeout, d.StatusCheckDeadlineSeconds)
+				return nil, fmt.Errorf("found multiple status check timeouts in skaffold.yaml (not supported in `skaffold apply`): %d, %d", statusCheckTimeout, d.StatusCheckDeadlineSeconds)
 			}
 			statusCheckTimeout = d.StatusCheckDeadlineSeconds
 		}
 		if d.Logs.Prefix != "" {
 			if logPrefix != "" && logPrefix != d.Logs.Prefix {
-				return nil, nil, fmt.Errorf("found multiple log prefixes in skaffold.yaml (not supported in `skaffold apply`): %s, %s", logPrefix, d.Logs.Prefix)
+				return nil, fmt.Errorf("found multiple log prefixes in skaffold.yaml (not supported in `skaffold apply`): %s, %s", logPrefix, d.Logs.Prefix)
 			}
 			logPrefix = d.Logs.Prefix
 		}
@@ -159,11 +153,11 @@ func getDefaultDeployer(runCtx *runcontext.RunContext, provider deploy.Component
 			kFlags = &currentKubectlFlags
 		}
 		if err := validateKubectlFlags(kFlags, currentKubectlFlags); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if currentDefaultNamespace != nil {
 			if defaultNamespace != nil && *defaultNamespace != *currentDefaultNamespace {
-				return nil, nil, fmt.Errorf("found multiple namespaces in skaffold.yaml (not supported in `skaffold apply`): %s, %s", *defaultNamespace, *currentDefaultNamespace)
+				return nil, fmt.Errorf("found multiple namespaces in skaffold.yaml (not supported in `skaffold apply`): %s, %s", *defaultNamespace, *currentDefaultNamespace)
 			}
 			defaultNamespace = currentDefaultNamespace
 		}
@@ -175,11 +169,11 @@ func getDefaultDeployer(runCtx *runcontext.RunContext, provider deploy.Component
 		Flags:            *kFlags,
 		DefaultNamespace: defaultNamespace,
 	}
-	defaultDeployer, podSelector, err := kubectl.NewDeployer(runCtx, labels, provider, k)
+	defaultDeployer, err := kubectl.NewDeployer(runCtx, labels, provider, k)
 	if err != nil {
-		return nil, nil, fmt.Errorf("instantiating default kubectl deployer: %w", err)
+		return nil, fmt.Errorf("instantiating default kubectl deployer: %w", err)
 	}
-	return defaultDeployer, kubernetes.ImageListMux{podSelector}, nil
+	return defaultDeployer, nil
 }
 
 func validateKubectlFlags(flags *v1.KubectlFlags, additional v1.KubectlFlags) error {

--- a/pkg/skaffold/runner/deployer_test.go
+++ b/pkg/skaffold/runner/deployer_test.go
@@ -132,7 +132,7 @@ func TestGetDeployer(tOuter *testing.T) {
 					))
 				}
 
-				deployer, _, err := GetDeployer(&runcontext.RunContext{
+				deployer, err := GetDeployer(&runcontext.RunContext{
 					Opts: config.SkaffoldOptions{
 						Apply: test.apply,
 					},
@@ -251,7 +251,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 						},
 					})
 				}
-				deployer, _, err := getDefaultDeployer(&runcontext.RunContext{
+				deployer, err := getDefaultDeployer(&runcontext.RunContext{
 					Pipelines: runcontext.NewPipelines(pipelines),
 				}, deploy.NoopComponentProvider, nil)
 

--- a/pkg/skaffold/runner/v1/deploy_test.go
+++ b/pkg/skaffold/runner/v1/deploy_test.go
@@ -124,7 +124,7 @@ func TestSkaffoldDeployRenderOnly(t *testing.T) {
 			KubeContext: "does-not-exist",
 		}
 
-		deployer, _, err := runner.GetDeployer(runCtx, deploy.NoopComponentProvider, nil)
+		deployer, err := runner.GetDeployer(runCtx, deploy.NoopComponentProvider, nil)
 		t.RequireNoError(err)
 		r := SkaffoldRunner{
 			runCtx:     runCtx,

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -34,7 +34,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	pkgkubectl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
@@ -85,7 +84,6 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		return nil, fmt.Errorf("creating tester: %w", err)
 	}
 
-	var podSelectors kubernetes.ImageListMux
 	var deployer deploy.Deployer
 	provider := deploy.ComponentProvider{
 		Accessor: access.NewAccessorProvider(runCtx, labeller, kubectlCLI),
@@ -95,7 +93,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		Syncer:   sync.NewSyncProvider(runCtx, kubectlCLI),
 	}
 
-	deployer, podSelectors, err = runner.GetDeployer(runCtx, provider, labeller.Labels())
+	deployer, err = runner.GetDeployer(runCtx, provider, labeller.Labels())
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(err))
 		return nil, fmt.Errorf("creating deployer: %w", err)
@@ -150,7 +148,6 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		sourceDependencies: sourceDependencies,
 		kubectlCLI:         kubectlCLI,
 		labeller:           labeller,
-		podSelector:        podSelectors,
 		cache:              artifactCache,
 		runCtx:             runCtx,
 		intents:            intents,

--- a/pkg/skaffold/runner/v1/runner.go
+++ b/pkg/skaffold/runner/v1/runner.go
@@ -23,7 +23,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/test"
@@ -46,8 +45,6 @@ type SkaffoldRunner struct {
 	labeller           *label.DefaultLabeller
 	artifactStore      build.ArtifactStore
 	sourceDependencies graph.SourceDependenciesCache
-	// podSelector is used to determine relevant pods for logging and portForwarding
-	podSelector kubernetes.ImageListMux
 
 	devIteration int
 	isLocalImage func(imageName string) (bool, error)

--- a/testutil/checks.go
+++ b/testutil/checks.go
@@ -49,7 +49,7 @@ func (t *T) RequireNoError(err error) {
 	}
 }
 
-func (t *T) RequireNonNilResult(x interface{}, y interface{}, err error) interface{} {
+func (t *T) RequireNonNilResult(x interface{}, err error) interface{} {
 	t.Helper()
 
 	if err != nil {
@@ -57,10 +57,6 @@ func (t *T) RequireNonNilResult(x interface{}, y interface{}, err error) interfa
 		t.FailNow()
 	}
 	if x == nil {
-		t.Errorf("unexpected nil value (failing test now)")
-		t.FailNow()
-	}
-	if y == nil {
 		t.Errorf("unexpected nil value (failing test now)")
 		t.FailNow()
 	}


### PR DESCRIPTION
Now that all `podSelector`-dependent components have been moved inside the `Deployer`, the `podSelector` serves no purpose inside the `Runner`.