### PR TITLE
[v2] Major refactoring for v2 runner/runcontext

### DIFF
--- a/cmd/skaffold/app/cmd/apply.go
+++ b/cmd/skaffold/app/cmd/apply.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // NewCmdApply describes the CLI command to apply manifests to a cluster.
@@ -53,7 +52,7 @@ func doApply(ctx context.Context, out io.Writer, args []string) error {
 	if err := validateManifests(args); err != nil {
 		return err
 	}
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner) error {
 		return r.Apply(ctx, out)
 	})
 }

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -30,12 +29,10 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation/prompt"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/server"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/survey"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
@@ -264,24 +261,6 @@ func setUpLogs(stdErr io.Writer, level string, timestamp bool) error {
 		FullTimestamp: timestamp,
 	})
 	return nil
-}
-
-// alwaysSucceedWhenCancelled returns nil if the context was cancelled.
-// If the error is due to cancellation, return it as it gets swallowed
-// in skaffold main.
-// For all other errors, pass through known errors.
-// TODO: Return nil if error is `context.Cancelled` and remove check in main.
-func alwaysSucceedWhenCancelled(ctx context.Context, runCtx *runcontext.RunContext, err error) error {
-	if err == nil {
-		return err
-	}
-	// if the context was cancelled act as if all is well
-	if ctx.Err() == context.Canceled {
-		return nil
-	} else if err == context.Canceled {
-		return err
-	}
-	return sErrors.ShowAIError(runCtx, err)
 }
 
 func isHouseKeepingMessagesAllowed(cmd *cobra.Command) bool {

--- a/cmd/skaffold/app/cmd/debug_test.go
+++ b/cmd/skaffold/app/cmd/debug_test.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -49,8 +49,8 @@ func TestNewCmdDebug(t *testing.T) {
 func TestDebugIndependentFromDev(t *testing.T) {
 	mockRunner := &mockDevRunner{}
 	testutil.Run(t, "DevDebug", func(t *testutil.T) {
-		t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []*latestV1.SkaffoldConfig, *runcontext.RunContext, error) {
-			return mockRunner, []*latestV1.SkaffoldConfig{{}}, nil, nil
+		t.Override(&createRunner, func(config.SkaffoldOptions, []util.VersionedConfig) (runner.Runner, *runcontext.RunContext, error) {
+			return mockRunner, nil, nil
 		})
 		t.Override(&opts, config.SkaffoldOptions{})
 		t.Override(&doDev, func(context.Context, io.Writer) error {

--- a/cmd/skaffold/app/cmd/delete.go
+++ b/cmd/skaffold/app/cmd/delete.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // NewCmdDelete describes the CLI command to delete deployed resources.
@@ -35,7 +34,7 @@ func NewCmdDelete() *cobra.Command {
 }
 
 func doDelete(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, _ []*latestV1.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner) error {
 		return r.Cleanup(ctx, out)
 	})
 }

--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -26,7 +26,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 var (
@@ -51,15 +50,11 @@ func NewCmdDeploy() *cobra.Command {
 }
 
 func doDeploy(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner) error {
 		if opts.SkipRender {
 			return r.DeployAndLog(ctx, out, []graph.Artifact{})
 		}
-		var artifacts []*latestV1.Artifact
-		for _, cfg := range configs {
-			artifacts = append(artifacts, cfg.Build.Artifacts...)
-		}
-		buildArtifacts, err := getBuildArtifactsAndSetTags(artifacts, r.ApplyDefaultRepo)
+		buildArtifacts, err := getBuildArtifactsAndSetTags(r.GetArtifacts(), r.ApplyDefaultRepo)
 		if err != nil {
 			tips.PrintUseRunVsDeploy(out)
 			return err

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -25,7 +25,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // for testing
@@ -60,12 +59,8 @@ func runDev(ctx context.Context, out io.Writer) error {
 		case <-ctx.Done():
 			return nil
 		default:
-			err := withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
-				var artifacts []*latestV1.Artifact
-				for _, cfg := range configs {
-					artifacts = append(artifacts, cfg.Build.Artifacts...)
-				}
-				err := r.Dev(ctx, out, artifacts)
+			err := withRunner(ctx, out, func(r runner.Runner) error {
+				err := r.Dev(ctx, out, r.GetArtifacts())
 
 				if r.HasDeployed() {
 					cleanup = func() {

--- a/cmd/skaffold/app/cmd/diagnose_test.go
+++ b/cmd/skaffold/app/cmd/diagnose_test.go
@@ -23,8 +23,9 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -57,20 +58,20 @@ metadata:
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&getRunContext, func(config.SkaffoldOptions, []*latestV1.SkaffoldConfig) (*runcontext.RunContext, error) {
+			t.Override(&getRunContext, func(config.SkaffoldOptions, []util.VersionedConfig) (*runcontext.RunContext, error) {
 				return nil, fmt.Errorf("cannot get the runtime context")
 			})
 			t.Override(&yamlOnly, test.yamlOnly)
-			t.Override(&getCfgs, func(opts config.SkaffoldOptions) ([]*latestV1.SkaffoldConfig, error) {
-				return []*latestV1.SkaffoldConfig{
-					{
+			t.Override(&getCfgs, func(opts config.SkaffoldOptions) ([]util.VersionedConfig, error) {
+				return []util.VersionedConfig{
+					&latestV1.SkaffoldConfig{
 						APIVersion: "testVersion",
 						Kind:       "Config",
 						Metadata: latestV1.Metadata{
 							Name: "config1",
 						},
 					},
-					{
+					&latestV1.SkaffoldConfig{
 						APIVersion: "testVersion",
 						Kind:       "Config",
 						Metadata: latestV1.Metadata{

--- a/cmd/skaffold/app/cmd/filter.go
+++ b/cmd/skaffold/app/cmd/filter.go
@@ -30,7 +30,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // for tests
@@ -58,7 +57,7 @@ func NewCmdFilter() *cobra.Command {
 // runFilter loads the Kubernetes manifests from stdin and applies the debug transformations.
 // Unlike `skaffold debug`, this filtering affects all images and not just the built artifacts.
 func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildArtifacts []graph.Artifact) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner) error {
 		manifestList, err := manifest.Load(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("loading manifests: %w", err)
@@ -69,7 +68,7 @@ func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildA
 			if err != nil {
 				return fmt.Errorf("resolving debug helpers: %w", err)
 			}
-			insecureRegistries, err := getInsecureRegistries(opts, configs)
+			insecureRegistries, err := getInsecureRegistries(opts, r)
 			if err != nil {
 				return fmt.Errorf("retrieving insecure registries: %w", err)
 			}
@@ -87,7 +86,7 @@ func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildA
 	})
 }
 
-func getInsecureRegistries(opts config.SkaffoldOptions, configs []*latestV1.SkaffoldConfig) (map[string]bool, error) {
+func getInsecureRegistries(opts config.SkaffoldOptions, runner runner.Runner) (map[string]bool, error) {
 	cfgRegistries, err := config.GetInsecureRegistries(opts.GlobalConfig)
 	if err != nil {
 		return nil, err
@@ -95,9 +94,7 @@ func getInsecureRegistries(opts config.SkaffoldOptions, configs []*latestV1.Skaf
 	var regList []string
 
 	regList = append(regList, opts.InsecureRegistries...)
-	for _, cfg := range configs {
-		regList = append(regList, cfg.Build.InsecureRegistries...)
-	}
+	regList = append(regList, runner.GetInsecureRegistries()...)
 	regList = append(regList, cfgRegistries...)
 	insecureRegistries := make(map[string]bool, len(regList))
 	for _, r := range regList {

--- a/cmd/skaffold/app/cmd/generate_pipeline.go
+++ b/cmd/skaffold/app/cmd/generate_pipeline.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 var (
@@ -44,8 +43,8 @@ func NewCmdGeneratePipeline() *cobra.Command {
 }
 
 func doGeneratePipeline(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
-		if err := r.GeneratePipeline(ctx, out, configs, configFiles, "pipeline.yaml"); err != nil {
+	return withRunner(ctx, out, func(r runner.Runner) error {
+		if err := r.GeneratePipeline(ctx, out, configFiles, "pipeline.yaml"); err != nil {
 			return fmt.Errorf("generating : %w", err)
 		}
 		output.Default.Fprintln(out, "Pipeline config written to pipeline.yaml!")

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -27,7 +27,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 var (
@@ -60,14 +59,14 @@ func doRender(ctx context.Context, out io.Writer) error {
 		buildOut = out
 	}
 
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
+	return withRunner(ctx, out, func(r runner.Runner) error {
 		var bRes []graph.Artifact
 
 		if renderFromBuildOutputFile.String() != "" {
 			bRes = renderFromBuildOutputFile.BuildArtifacts()
 		} else {
 			var err error
-			bRes, err = r.Build(ctx, buildOut, targetArtifacts(opts, configs))
+			bRes, err = r.Build(ctx, buildOut, opts)
 			if err != nil {
 				return fmt.Errorf("executing build: %w", err)
 			}

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // NewCmdRun describes the CLI command to run a pipeline.
@@ -41,8 +40,8 @@ func NewCmdRun() *cobra.Command {
 }
 
 func doRun(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
-		bRes, err := r.Build(ctx, out, targetArtifacts(opts, configs))
+	return withRunner(ctx, out, func(r runner.Runner) error {
+		bRes, err := r.Build(ctx, out, opts)
 		if err != nil {
 			return fmt.Errorf("failed to build: %w", err)
 		}

--- a/cmd/skaffold/app/cmd/runner_test.go
+++ b/cmd/skaffold/app/cmd/runner_test.go
@@ -25,12 +25,14 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/update"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func TestCreateNewRunner(t *testing.T) {
+func TestParsingV1Config(t *testing.T) {
 	tests := []struct {
 		description   string
 		config        string
@@ -73,9 +75,62 @@ func TestCreateNewRunner(t *testing.T) {
 			shouldErr:     true,
 			expectedError: `profile selection ["unknown-profile"] did not match those defined in any configurations`,
 		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
+				return docker.NewLocalDaemon(&testutil.FakeAPIClient{
+					ErrVersion: true,
+				}, nil, false, nil), nil
+			})
+
+			t.Override(&update.GetLatestAndCurrentVersion, func() (semver.Version, semver.Version, error) {
+				return semver.Version{}, semver.Version{}, nil
+			})
+			t.NewTempDir().
+				Write("skaffold.yaml", fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latestV1.Version, test.config)).
+				Chdir()
+
+			_, err := withFallbackConfig(ioutil.Discard, test.options, parser.GetAllConfigs)
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}
+
+func TestCreateNewRunnerV1(t *testing.T) {
+	testConfig := &latestV1.SkaffoldConfig{
+		APIVersion: latestV1.Version,
+		Kind:       "Config",
+		Pipeline: latestV1.Pipeline{
+			Build: latestV1.BuildConfig{
+				TagPolicy: latestV1.TagPolicy{
+					GitTagger: &latestV1.GitTagger{},
+				},
+				BuildType: latestV1.BuildType{
+					LocalBuild: &latestV1.LocalBuild{},
+				},
+			},
+		},
+	}
+	tests := []struct {
+		description   string
+		config        *latestV1.SkaffoldConfig
+		options       config.SkaffoldOptions
+		shouldErr     bool
+		expectedError string
+	}{
+		{
+			description: "valid config",
+			config:      testConfig,
+			options: config.SkaffoldOptions{
+				ConfigurationFile: "skaffold.yaml",
+				Trigger:           "polling",
+			},
+			shouldErr: false,
+		},
 		{
 			description: "unsupported trigger",
-			config:      "",
+			config:      testConfig,
 			options: config.SkaffoldOptions{
 				ConfigurationFile: "skaffold.yaml",
 				Trigger:           "unknown trigger",
@@ -95,12 +150,7 @@ func TestCreateNewRunner(t *testing.T) {
 			t.Override(&update.GetLatestAndCurrentVersion, func() (semver.Version, semver.Version, error) {
 				return semver.Version{}, semver.Version{}, nil
 			})
-			t.NewTempDir().
-				Write("skaffold.yaml", fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latestV1.Version, test.config)).
-				Chdir()
-
-			_, _, _, err := createNewRunner(ioutil.Discard, test.options)
-
+			_, _, err := createNewRunnerV1(test.options, []util.VersionedConfig{test.config})
 			t.CheckError(test.shouldErr, err)
 			if test.expectedError != "" {
 				t.CheckErrorContains(test.expectedError, err)

--- a/cmd/skaffold/app/cmd/test.go
+++ b/cmd/skaffold/app/cmd/test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // NewCmdTest describes the CLI command to test artifacts.
@@ -39,12 +38,8 @@ func NewCmdTest() *cobra.Command {
 }
 
 func doTest(ctx context.Context, out io.Writer) error {
-	return withRunner(ctx, out, func(r runner.Runner, configs []*latestV1.SkaffoldConfig) error {
-		var artifacts []*latestV1.Artifact
-		for _, c := range configs {
-			artifacts = append(artifacts, c.Build.Artifacts...)
-		}
-		buildArtifacts, err := getBuildArtifactsAndSetTags(artifacts, r.ApplyDefaultRepo)
+	return withRunner(ctx, out, func(r runner.Runner) error {
+		buildArtifacts, err := getBuildArtifactsAndSetTags(r.GetArtifacts(), r.ApplyDefaultRepo)
 		if err != nil {
 			tips.PrintForTest(out)
 			return err

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 

--- a/integration/port_forward_test.go
+++ b/integration/port_forward_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 )
 
 func TestPortForward(t *testing.T) {

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/helm"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 	"github.com/GoogleContainerTools/skaffold/testutil"

--- a/pkg/skaffold/build/cluster/types_test.go
+++ b/pkg/skaffold/build/cluster/types_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )

--- a/pkg/skaffold/build/gcb/spec_test.go
+++ b/pkg/skaffold/build/gcb/spec_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"

--- a/pkg/skaffold/debug/apply_transforms.go
+++ b/pkg/skaffold/debug/apply_transforms.go
@@ -31,7 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 )
 
 var (

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"

--- a/pkg/skaffold/deploy/kustomize/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"

--- a/pkg/skaffold/deploy/resource/deployment_test.go
+++ b/pkg/skaffold/deploy/resource/deployment_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/diag/validator"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"

--- a/pkg/skaffold/diagnose/diagnose_test.go
+++ b/pkg/skaffold/diagnose/diagnose_test.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )

--- a/pkg/skaffold/errors/errors_test.go
+++ b/pkg/skaffold/errors/errors_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )

--- a/pkg/skaffold/kubernetes/status/status_check_test.go
+++ b/pkg/skaffold/kubernetes/status/status_check_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/diag/validator"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/resource"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"

--- a/pkg/skaffold/parser/config.go
+++ b/pkg/skaffold/parser/config.go
@@ -32,6 +32,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/errors"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	schemaUtil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
@@ -61,12 +62,12 @@ func newRecord() *record {
 }
 
 // GetAllConfigs returns the list of all skaffold configurations parsed from the target config file in addition to all resolved dependency configs.
-func GetAllConfigs(opts config.SkaffoldOptions) ([]*latestV1.SkaffoldConfig, error) {
+func GetAllConfigs(opts config.SkaffoldOptions) ([]schemaUtil.VersionedConfig, error) {
 	set, err := GetConfigSet(opts)
 	if err != nil {
 		return nil, err
 	}
-	var cfgs []*latestV1.SkaffoldConfig
+	var cfgs []schemaUtil.VersionedConfig
 	for _, cfg := range set {
 		cfgs = append(cfgs, cfg.SkaffoldConfig)
 	}

--- a/pkg/skaffold/render/renderer/renderer.go
+++ b/pkg/skaffold/render/renderer/renderer.go
@@ -45,7 +45,7 @@ const (
 )
 
 type Renderer interface {
-	Render(context.Context, io.Writer, []graph.Artifact) error
+	Render(context.Context, io.Writer, []graph.Artifact, bool, string) error
 }
 
 // NewSkaffoldRenderer creates a new Renderer object from the latestV2 API schema.
@@ -129,7 +129,7 @@ func (r *SkaffoldRenderer) prepareHydrationDir(ctx context.Context) error {
 	return nil
 }
 
-func (r *SkaffoldRenderer) Render(ctx context.Context, out io.Writer, builds []graph.Artifact) error {
+func (r *SkaffoldRenderer) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, offline bool, fpath string) error {
 	if err := r.prepareHydrationDir(ctx); err != nil {
 		return err
 	}

--- a/pkg/skaffold/render/renderer/renderer_test.go
+++ b/pkg/skaffold/render/renderer/renderer_test.go
@@ -143,7 +143,7 @@ pipeline:
 				Chdir()
 
 			var b bytes.Buffer
-			err = r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}})
+			err = r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}}, false, "")
 			t.CheckNoError(err)
 			t.CheckFileExistAndContent(filepath.Join(DefaultHydrationDir, dryFileName), []byte(labeledPodYaml))
 			t.CheckFileExistAndContent(filepath.Join(DefaultHydrationDir, kptfile.KptFileName), []byte(test.updatedKptfile))
@@ -161,7 +161,7 @@ func TestRender_UserErr(t *testing.T) {
 			errors.New("fake err"))
 		t.Override(&util.DefaultExecCommand, fakeCmd)
 		err = r.Render(context.Background(), &bytes.Buffer{}, []graph.Artifact{{ImageName: "leeroy-web",
-			Tag: "leeroy-web:v1"}})
+			Tag: "leeroy-web:v1"}}, false, "")
 		t.CheckContains("please manually run `kpt pkg init", err.Error())
 	})
 }

--- a/pkg/skaffold/runner/build.go
+++ b/pkg/skaffold/runner/build.go
@@ -32,7 +32,7 @@ import (
 	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"

--- a/pkg/skaffold/runner/builder.go
+++ b/pkg/skaffold/runner/builder.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/gcb"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/local"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
@@ -46,31 +46,31 @@ func (b *builderCtx) SourceDependenciesResolver() graph.SourceDependenciesCache 
 }
 
 // GetBuilder creates a builder from a given RunContext and build pipeline type.
-func GetBuilder(r *runcontext.RunContext, s build.ArtifactStore, d graph.SourceDependenciesCache, p latestV1.Pipeline) (build.PipelineBuilder, error) {
+func GetBuilder(r *runcontext.RunContext, s build.ArtifactStore, d graph.SourceDependenciesCache, build latestV1.BuildConfig) (build.PipelineBuilder, error) {
 	bCtx := &builderCtx{artifactStore: s, sourceDependenciesCache: d, RunContext: r}
 	switch {
-	case p.Build.LocalBuild != nil:
+	case build.LocalBuild != nil:
 		logrus.Debugln("Using builder: local")
-		builder, err := local.NewBuilder(bCtx, p.Build.LocalBuild)
+		builder, err := local.NewBuilder(bCtx, build.LocalBuild)
 		if err != nil {
 			return nil, err
 		}
 		return builder, nil
 
-	case p.Build.GoogleCloudBuild != nil:
+	case build.GoogleCloudBuild != nil:
 		logrus.Debugln("Using builder: google cloud")
-		builder := gcb.NewBuilder(bCtx, p.Build.GoogleCloudBuild)
+		builder := gcb.NewBuilder(bCtx, build.GoogleCloudBuild)
 		return builder, nil
 
-	case p.Build.Cluster != nil:
+	case build.Cluster != nil:
 		logrus.Debugln("Using builder: cluster")
-		builder, err := cluster.NewBuilder(bCtx, p.Build.Cluster)
+		builder, err := cluster.NewBuilder(bCtx, build.Cluster)
 		if err != nil {
 			return nil, err
 		}
 		return builder, err
 
 	default:
-		return nil, fmt.Errorf("unknown builder for config %+v", p.Build)
+		return nil, fmt.Errorf("unknown builder for config %+v", build)
 	}
 }

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/status"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )

--- a/pkg/skaffold/runner/deployer_test.go
+++ b/pkg/skaffold/runner/deployer_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kpt"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"

--- a/pkg/skaffold/runner/runcontext/v1/context.go
+++ b/pkg/skaffold/runner/runcontext/v1/context.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package runcontext
+package v1
 
 import (
 	"fmt"
@@ -27,6 +27,7 @@ import (
 	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	runnerutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/util"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	schemaUtil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -197,11 +198,11 @@ func (rc *RunContext) BuildConcurrency() int                         { return rc
 func (rc *RunContext) IsMultiConfig() bool                           { return rc.Pipelines.IsMultiPipeline() }
 func (rc *RunContext) GetRunID() string                              { return rc.RunID }
 
-func GetRunContext(opts config.SkaffoldOptions, configs []*latestV1.SkaffoldConfig) (*RunContext, error) {
+func GetRunContext(opts config.SkaffoldOptions, configs []schemaUtil.VersionedConfig) (*RunContext, error) {
 	var pipelines []latestV1.Pipeline
 	for _, cfg := range configs {
 		if cfg != nil {
-			pipelines = append(pipelines, cfg.Pipeline)
+			pipelines = append(pipelines, cfg.(*latestV1.SkaffoldConfig).Pipeline)
 		}
 	}
 	kubeConfig, err := kubectx.CurrentConfig()

--- a/pkg/skaffold/runner/runcontext/v1/context_test.go
+++ b/pkg/skaffold/runner/runcontext/v1/context_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package runcontext
+package v1
 
 import (
 	"testing"

--- a/pkg/skaffold/runner/runcontext/v2/context.go
+++ b/pkg/skaffold/runner/runcontext/v2/context.go
@@ -1,0 +1,316 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
+	schemaUtil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+const (
+	emptyNamespace = ""
+)
+
+type RunContext struct {
+	Opts               config.SkaffoldOptions
+	Pipelines          Pipelines
+	KubeContext        string
+	Namespaces         []string
+	WorkingDir         string
+	InsecureRegistries map[string]bool
+	Cluster            config.Cluster
+	RunID              string
+}
+
+// Pipelines encapsulates multiple config pipelines
+type Pipelines struct {
+	pipelines            []latestV2.Pipeline
+	pipelinesByImageName map[string]latestV2.Pipeline
+}
+
+// All returns all config pipelines.
+func (ps Pipelines) All() []latestV2.Pipeline {
+	return ps.pipelines
+}
+
+// Head returns the first `latestV2.Pipeline`.
+func (ps Pipelines) Head() latestV2.Pipeline {
+	return ps.pipelines[0] // there always exists atleast one pipeline.
+}
+
+// Select returns the first `latestV2.Pipeline` that matches the given artifact `imageName`.
+func (ps Pipelines) Select(imageName string) (latestV2.Pipeline, bool) {
+	p, found := ps.pipelinesByImageName[imageName]
+	return p, found
+}
+
+// IsMultiPipeline returns true if there are more than one constituent skaffold pipelines.
+func (ps Pipelines) IsMultiPipeline() bool {
+	return len(ps.pipelines) > 1
+}
+
+func (ps Pipelines) PortForwardResources() []*latestV1.PortForwardResource {
+	var pf []*latestV1.PortForwardResource
+	for _, p := range ps.pipelines {
+		pf = append(pf, p.PortForward...)
+	}
+	return pf
+}
+
+func (ps Pipelines) Artifacts() []*latestV1.Artifact {
+	var artifacts []*latestV1.Artifact
+	for _, p := range ps.pipelines {
+		artifacts = append(artifacts, p.Build.Artifacts...)
+	}
+	return artifacts
+}
+
+func (ps Pipelines) DeployConfigs() []latestV2.DeployConfig {
+	var cfgs []latestV2.DeployConfig
+	for _, p := range ps.pipelines {
+		cfgs = append(cfgs, p.Deploy)
+	}
+	return cfgs
+}
+
+/* TODO: need to update the new render v2 UX.
+func (ps Pipelines) Deployers() []latestV2.DeployType {
+	var deployers []latestV2.DeployType
+	for _, p := range ps.pipelines {
+		deployers = append(deployers, p.Deploy.DeployType)
+	}
+	return deployers
+}
+*/
+
+func (ps Pipelines) TestCases() []*latestV1.TestCase {
+	var tests []*latestV1.TestCase
+	for _, p := range ps.pipelines {
+		tests = append(tests, p.Test...)
+	}
+	return tests
+}
+
+func (ps Pipelines) StatusCheck() (*bool, error) {
+	var enabled, disabled bool
+	for _, p := range ps.pipelines {
+		if p.Deploy.StatusCheck != nil {
+			if *p.Deploy.StatusCheck {
+				enabled = true
+			} else {
+				disabled = true
+			}
+			if enabled && disabled {
+				return nil, fmt.Errorf("cannot explicitly enable StatusCheck in one pipeline and explicitly disable it in another pipeline, see https://skaffold.dev/docs/workflows/ci-cd/#waiting-for-skaffold-deployments-using-healthcheck")
+			}
+		}
+	}
+	// set the group status check to disabled if any pipeline has StatusCheck
+	// set to false.
+	if disabled {
+		return util.BoolPtr(false), nil
+	}
+	return util.BoolPtr(true), nil
+}
+
+func (ps Pipelines) StatusCheckDeadlineSeconds() int {
+	c := 0
+	// set the group status check deadline to maximum of any individually specified value
+	for _, p := range ps.pipelines {
+		// TODO: kpt supports more user friendly deadline operations like "1h", "30sec". we can update this arg to use
+		// kpt arg "request-timeout".
+		if p.Deploy.StatusCheckDeadlineSeconds > c {
+			c = p.Deploy.StatusCheckDeadlineSeconds
+		}
+	}
+	return c
+}
+
+func NewPipelines(pipelines []latestV2.Pipeline) Pipelines {
+	m := make(map[string]latestV2.Pipeline)
+	for _, p := range pipelines {
+		for _, a := range p.Build.Artifacts {
+			m[a.ImageName] = p
+		}
+	}
+	return Pipelines{pipelines: pipelines, pipelinesByImageName: m}
+}
+
+func (rc *RunContext) PipelineForImage(imageName string) (latestV2.Pipeline, bool) {
+	return rc.Pipelines.Select(imageName)
+}
+
+func (rc *RunContext) PortForwardResources() []*latestV1.PortForwardResource {
+	return rc.Pipelines.PortForwardResources()
+}
+
+func (rc *RunContext) Artifacts() []*latestV1.Artifact { return rc.Pipelines.Artifacts() }
+
+// func (rc *RunContext) DeployConfigs() []latestV2.DeployConfig { return rc.Pipelines.DeployConfigs() }
+
+// func (rc *RunContext) Deployers() []latestV1.DeployType { return rc.Pipelines.Deployers() }
+
+func (rc *RunContext) TestCases() []*latestV1.TestCase { return rc.Pipelines.TestCases() }
+
+func (rc *RunContext) StatusCheck() (*bool, error) {
+	scOpts := rc.Opts.StatusCheck.Value()
+	scConfig, err := rc.Pipelines.StatusCheck()
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case scOpts != nil:
+		return util.BoolPtr(*scOpts), nil
+	case scConfig != nil:
+		return util.BoolPtr(*scConfig), nil
+	default:
+		return util.BoolPtr(true), nil
+	}
+}
+
+func (rc *RunContext) StatusCheckDeadlineSeconds() int {
+	return rc.Pipelines.StatusCheckDeadlineSeconds()
+}
+
+func (rc *RunContext) DefaultPipeline() latestV2.Pipeline            { return rc.Pipelines.Head() }
+func (rc *RunContext) GetKubeContext() string                        { return rc.KubeContext }
+func (rc *RunContext) GetNamespaces() []string                       { return rc.Namespaces }
+func (rc *RunContext) GetPipelines() []latestV2.Pipeline             { return rc.Pipelines.All() }
+func (rc *RunContext) GetInsecureRegistries() map[string]bool        { return rc.InsecureRegistries }
+func (rc *RunContext) GetWorkingDir() string                         { return rc.WorkingDir }
+func (rc *RunContext) GetCluster() config.Cluster                    { return rc.Cluster }
+func (rc *RunContext) AddSkaffoldLabels() bool                       { return rc.Opts.AddSkaffoldLabels }
+func (rc *RunContext) AutoBuild() bool                               { return rc.Opts.AutoBuild }
+func (rc *RunContext) AutoDeploy() bool                              { return rc.Opts.AutoDeploy }
+func (rc *RunContext) AutoSync() bool                                { return rc.Opts.AutoSync }
+func (rc *RunContext) CacheArtifacts() bool                          { return rc.Opts.CacheArtifacts }
+func (rc *RunContext) CacheFile() string                             { return rc.Opts.CacheFile }
+func (rc *RunContext) ConfigurationFile() string                     { return rc.Opts.ConfigurationFile }
+func (rc *RunContext) CustomLabels() []string                        { return rc.Opts.CustomLabels }
+func (rc *RunContext) CustomTag() string                             { return rc.Opts.CustomTag }
+func (rc *RunContext) DefaultRepo() *string                          { return rc.Opts.DefaultRepo.Value() }
+func (rc *RunContext) Mode() config.RunMode                          { return rc.Opts.Mode() }
+func (rc *RunContext) DigestSource() string                          { return rc.Opts.DigestSource }
+func (rc *RunContext) DryRun() bool                                  { return rc.Opts.DryRun }
+func (rc *RunContext) ForceDeploy() bool                             { return rc.Opts.Force }
+func (rc *RunContext) GetKubeConfig() string                         { return rc.Opts.KubeConfig }
+func (rc *RunContext) GetKubeNamespace() string                      { return rc.Opts.Namespace }
+func (rc *RunContext) GlobalConfig() string                          { return rc.Opts.GlobalConfig }
+func (rc *RunContext) HydratedManifests() []string                   { return rc.Opts.HydratedManifests }
+func (rc *RunContext) MinikubeProfile() string                       { return rc.Opts.MinikubeProfile }
+func (rc *RunContext) Muted() config.Muted                           { return rc.Opts.Muted }
+func (rc *RunContext) NoPruneChildren() bool                         { return rc.Opts.NoPruneChildren }
+func (rc *RunContext) Notification() bool                            { return rc.Opts.Notification }
+func (rc *RunContext) PortForward() bool                             { return rc.Opts.PortForward.Enabled() }
+func (rc *RunContext) PortForwardOptions() config.PortForwardOptions { return rc.Opts.PortForward }
+func (rc *RunContext) Prune() bool                                   { return rc.Opts.Prune() }
+func (rc *RunContext) RenderOnly() bool                              { return rc.Opts.RenderOnly }
+func (rc *RunContext) RenderOutput() string                          { return rc.Opts.RenderOutput }
+func (rc *RunContext) SkipRender() bool                              { return rc.Opts.SkipRender }
+func (rc *RunContext) SkipTests() bool                               { return rc.Opts.SkipTests }
+func (rc *RunContext) Tail() bool                                    { return rc.Opts.Tail }
+func (rc *RunContext) Trigger() string                               { return rc.Opts.Trigger }
+func (rc *RunContext) WaitForDeletions() config.WaitForDeletions     { return rc.Opts.WaitForDeletions }
+func (rc *RunContext) WatchPollInterval() int                        { return rc.Opts.WatchPollInterval }
+func (rc *RunContext) BuildConcurrency() int                         { return rc.Opts.BuildConcurrency }
+func (rc *RunContext) IsMultiConfig() bool                           { return rc.Pipelines.IsMultiPipeline() }
+func (rc *RunContext) GetRunID() string                              { return rc.RunID }
+
+func GetRunContext(opts config.SkaffoldOptions, configs []schemaUtil.VersionedConfig) (*RunContext, error) {
+	var pipelines []latestV2.Pipeline
+	for _, cfg := range configs {
+		if cfg != nil {
+			pipelines = append(pipelines, cfg.(*latestV2.SkaffoldConfig).Pipeline)
+		}
+	}
+	kubeConfig, err := kubectx.CurrentConfig()
+	if err != nil {
+		return nil, fmt.Errorf("getting current cluster context: %w", err)
+	}
+	kubeContext := kubeConfig.CurrentContext
+	logrus.Infof("Using kubectl context: %s", kubeContext)
+
+	// TODO(dgageot): this should be the folder containing skaffold.yaml. Should also be moved elsewhere.
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("finding current directory: %w", err)
+	}
+
+	/* TODO (ywuenma): needs v2 version
+	namespaces, err := runnerutil.GetAllPodNamespaces(opts.Namespace, pipelines)
+	if err != nil {
+		return nil, fmt.Errorf("getting namespace list: %w", err)
+	}*/
+
+	// combine all provided lists of insecure registries into a map
+	cfgRegistries, err := config.GetInsecureRegistries(opts.GlobalConfig)
+	if err != nil {
+		logrus.Warnf("error retrieving insecure registries from global config: push/pull issues may exist...")
+	}
+	var regList []string
+	regList = append(regList, opts.InsecureRegistries...)
+	for _, cfg := range pipelines {
+		regList = append(regList, cfg.Build.InsecureRegistries...)
+	}
+	regList = append(regList, cfgRegistries...)
+	insecureRegistries := make(map[string]bool, len(regList))
+	for _, r := range regList {
+		insecureRegistries[r] = true
+	}
+	ps := NewPipelines(pipelines)
+
+	// TODO(https://github.com/GoogleContainerTools/skaffold/issues/3668):
+	// remove minikubeProfile from here and instead detect it by matching the
+	// kubecontext API Server to minikube profiles
+	cluster, err := config.GetCluster(opts.GlobalConfig, opts.MinikubeProfile, opts.DetectMinikube)
+	if err != nil {
+		return nil, fmt.Errorf("getting cluster: %w", err)
+	}
+
+	runID := uuid.New().String()
+
+	return &RunContext{
+		Opts:        opts,
+		Pipelines:   ps,
+		WorkingDir:  cwd,
+		KubeContext: kubeContext,
+		// Namespaces:         namespaces,
+		InsecureRegistries: insecureRegistries,
+		Cluster:            cluster,
+		RunID:              runID,
+	}, nil
+}
+
+func (rc *RunContext) UpdateNamespaces(ns []string) {
+	if len(ns) == 0 {
+		return
+	}
+	namespaces := util.NewStringSet()
+	namespaces.Insert(append(rc.Namespaces, ns...)...)
+	namespaces.Delete(emptyNamespace)
+	rc.Namespaces = namespaces.ToList()
+}

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -21,8 +21,10 @@ import (
 	"errors"
 	"io"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
 )
 
 const (
@@ -38,15 +40,20 @@ var ErrorConfigurationChanged = errors.New("configuration changed")
 type Runner interface {
 	Apply(context.Context, io.Writer) error
 	ApplyDefaultRepo(tag string) (string, error)
-	Build(context.Context, io.Writer, []*latestV1.Artifact) ([]graph.Artifact, error)
+	Build(context.Context, io.Writer, config.SkaffoldOptions) ([]graph.Artifact, error)
 	Cleanup(context.Context, io.Writer) error
 	Dev(context.Context, io.Writer, []*latestV1.Artifact) error
 	Deploy(context.Context, io.Writer, []graph.Artifact) error
 	DeployAndLog(context.Context, io.Writer, []graph.Artifact) error
-	GeneratePipeline(context.Context, io.Writer, []*latestV1.SkaffoldConfig, []string, string) error
+	GeneratePipeline(context.Context, io.Writer, []string, string) error
 	HasBuilt() bool
 	HasDeployed() bool
 	Prune(context.Context, io.Writer) error
 	Render(context.Context, io.Writer, []graph.Artifact, bool, string) error
 	Test(context.Context, io.Writer, []graph.Artifact) error
+
+	SetV1Config(config []*latestV1.SkaffoldConfig)
+	SetV2Config(config []*latestV2.SkaffoldConfig)
+	GetArtifacts() []*latestV1.Artifact
+	GetInsecureRegistries() []string
 }

--- a/pkg/skaffold/runner/timings_test.go
+++ b/pkg/skaffold/runner/timings_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/test"
@@ -62,6 +63,18 @@ type mockTester struct {
 func (m *mockTester) Test(context.Context, io.Writer, []graph.Artifact) error {
 	if m.err {
 		return errors.New("Unable to test")
+	}
+	return nil
+}
+
+type mockRenderer struct {
+	renderer.Renderer
+	err bool
+}
+
+func (m *mockRenderer) Render(context.Context, io.Writer, []graph.Artifact, bool, string) error {
+	if m.err {
+		return errors.New("Unable to render")
 	}
 	return nil
 }
@@ -109,7 +122,7 @@ func TestTimingsBuild(t *testing.T) {
 			hook := logrustest.NewGlobal()
 
 			b := &mockBuilder{err: test.shouldErr}
-			builder, _, _ := WithTimings(b, nil, nil, false)
+			builder, _, _, _ := WithTimings(b, nil, nil, nil, false)
 
 			var out bytes.Buffer
 			_, err := builder.Build(context.Background(), &out, nil, nil)
@@ -145,7 +158,7 @@ func TestTimingsPrune(t *testing.T) {
 			hook := logrustest.NewGlobal()
 
 			b := &mockBuilder{err: test.shouldErr}
-			builder, _, _ := WithTimings(b, nil, nil, false)
+			builder, _, _, _ := WithTimings(b, nil, nil, nil, false)
 
 			var out bytes.Buffer
 			err := builder.Prune(context.Background(), &out)
@@ -181,11 +194,46 @@ func TestTimingsTest(t *testing.T) {
 			hook := logrustest.NewGlobal()
 
 			tt := &mockTester{err: test.shouldErr}
-			_, tester, _ := WithTimings(nil, tt, nil, false)
+			_, tester, _, _ := WithTimings(nil, tt, nil, nil, false)
 
 			var out bytes.Buffer
 			err := tester.Test(context.Background(), &out, nil)
 
+			t.CheckError(test.shouldErr, err)
+			t.CheckMatches(test.shouldOutput, out.String())
+			t.CheckMatches(test.shouldLog, lastInfoEntry(hook))
+		})
+	}
+}
+
+func TestTimingsRender(t *testing.T) {
+	tests := []struct {
+		description  string
+		shouldOutput string
+		shouldLog    string
+		shouldErr    bool
+	}{
+		{
+			description:  "render success",
+			shouldOutput: "(?m)^Starting render...\n",
+			shouldLog:    "Render completed in .+$",
+			shouldErr:    false,
+		},
+		{
+			description:  "render failure",
+			shouldOutput: "^Starting render...\n$",
+			shouldErr:    true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			hook := logrustest.NewGlobal()
+
+			r := &mockRenderer{err: test.shouldErr}
+			_, _, renderer, _ := WithTimings(nil, nil, r, nil, false)
+
+			var out bytes.Buffer
+			err := renderer.Render(context.Background(), &out, nil, false, "")
 			t.CheckError(test.shouldErr, err)
 			t.CheckMatches(test.shouldOutput, out.String())
 			t.CheckMatches(test.shouldLog, lastInfoEntry(hook))
@@ -217,7 +265,7 @@ func TestTimingsDeploy(t *testing.T) {
 			hook := logrustest.NewGlobal()
 
 			d := &mockDeployer{err: test.shouldErr}
-			_, _, deployer := WithTimings(nil, nil, d, false)
+			_, _, _, deployer := WithTimings(nil, nil, nil, d, false)
 
 			var out bytes.Buffer
 			_, err := deployer.Deploy(context.Background(), &out, nil)
@@ -253,7 +301,7 @@ func TestTimingsCleanup(t *testing.T) {
 			hook := logrustest.NewGlobal()
 
 			d := &mockDeployer{err: test.shouldErr}
-			_, _, deployer := WithTimings(nil, nil, d, false)
+			_, _, _, deployer := WithTimings(nil, nil, nil, d, false)
 
 			var out bytes.Buffer
 			err := deployer.Cleanup(context.Background(), &out)

--- a/pkg/skaffold/runner/v1/build.go
+++ b/pkg/skaffold/runner/v1/build.go
@@ -13,14 +13,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package v2
+
+package v1
 
 import (
 	"context"
-	"fmt"
 	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 )
 
-func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, configPaths []string, fileOut string) error {
-	return fmt.Errorf("not implemented error: SkaffoldRunner(v2).GeneratePipeline")
+// Apply sends Kubernetes manifests to the cluster.
+func (r *SkaffoldRunner) Build(ctx context.Context, out io.Writer, ops config.SkaffoldOptions) ([]graph.Artifact, error) {
+	artifacts := TargetArtifacts(r.configs, ops)
+	return r.Builder.Build(ctx, out, artifacts)
 }

--- a/pkg/skaffold/runner/v1/build_test.go
+++ b/pkg/skaffold/runner/v1/build_test.go
@@ -140,7 +140,7 @@ func TestBuildTestDeploy(t *testing.T) {
 			}}
 
 			runner := createRunner(t, test.testBench, nil, artifacts, nil)
-			bRes, err := runner.Build(ctx, ioutil.Discard, artifacts)
+			bRes, err := runner.Build(ctx, ioutil.Discard, config.SkaffoldOptions{})
 			if err == nil {
 				err = runner.Test(ctx, ioutil.Discard, bRes)
 				if err == nil {
@@ -163,7 +163,7 @@ func TestBuildDryRun(t *testing.T) {
 		runner := createRunner(t, testBench, nil, artifacts, nil)
 		runner.runCtx.Opts.DryRun = true
 
-		bRes, err := runner.Build(context.Background(), ioutil.Discard, artifacts)
+		bRes, err := runner.Build(context.Background(), ioutil.Discard, config.SkaffoldOptions{})
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual([]graph.Artifact{
@@ -184,7 +184,7 @@ func TestBuildPushFlag(t *testing.T) {
 		runner := createRunner(t, testBench, nil, artifacts, nil)
 		runner.runCtx.Opts.PushImages = config.NewBoolOrUndefined(util.BoolPtr(true))
 
-		_, err := runner.Build(context.Background(), ioutil.Discard, artifacts)
+		_, err := runner.Build(context.Background(), ioutil.Discard, config.SkaffoldOptions{})
 
 		t.CheckNoError(err)
 	})
@@ -227,7 +227,7 @@ func TestDigestSources(t *testing.T) {
 			runner.runCtx.Opts.DigestSource = test.digestSource
 			runner.runCtx.Opts.RenderOnly = true
 
-			bRes, err := runner.Build(context.Background(), ioutil.Discard, artifacts)
+			bRes, err := runner.Build(context.Background(), ioutil.Discard, config.SkaffoldOptions{})
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, bRes)

--- a/pkg/skaffold/runner/v1/deploy_test.go
+++ b/pkg/skaffold/runner/v1/deploy_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )

--- a/pkg/skaffold/runner/v1/dev.go
+++ b/pkg/skaffold/runner/v1/dev.go
@@ -121,7 +121,7 @@ func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer) error {
 		}
 
 		var err error
-		bRes, err = r.Build(childCtx, out, r.changeSet.NeedsRebuild())
+		bRes, err = r.Builder.Build(childCtx, out, r.changeSet.NeedsRebuild())
 		if err != nil {
 			logrus.Warnln("Skipping test and deploy due to build error:", err)
 			event.DevLoopFailedInPhase(r.devIteration, constants.Build, err)
@@ -303,7 +303,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	}
 
 	// First build
-	bRes, err := r.Build(ctx, out, artifacts)
+	bRes, err := r.Builder.Build(ctx, out, artifacts)
 	if err != nil {
 		event.DevLoopFailedInPhase(r.devIteration, constants.Build, err)
 		eventV2.TaskFailed(constants.DevLoop, err)

--- a/pkg/skaffold/runner/v1/generate_pipeline.go
+++ b/pkg/skaffold/runner/v1/generate_pipeline.go
@@ -29,11 +29,11 @@ import (
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
-func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, configs []*latestV1.SkaffoldConfig, configPaths []string, fileOut string) error {
+func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, configPaths []string, fileOut string) error {
 	// Keep track of files, configs, and profiles. This will be used to know which files to write
 	// profiles to and what flags to add to task commands
 	var baseConfig []*pipeline.ConfigFile
-	for _, config := range configs {
+	for _, config := range r.configs {
 		cfgFile := &pipeline.ConfigFile{
 			Path:    r.runCtx.ConfigurationFile(),
 			Config:  config,

--- a/pkg/skaffold/runner/v1/load_images_test.go
+++ b/pkg/skaffold/runner/v1/load_images_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -37,7 +37,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/server"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
@@ -69,7 +69,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 
 	var builder build.Builder
 	builder, err = build.NewBuilderMux(runCtx, store, func(p latestV1.Pipeline) (build.PipelineBuilder, error) {
-		return runner.GetBuilder(runCtx, store, sourceDependencies, p)
+		return runner.GetBuilder(runCtx, store, sourceDependencies, p.Build)
 	})
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(err))
@@ -125,7 +125,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		return nil, fmt.Errorf("initializing cache: %w", err)
 	}
 
-	builder, tester, deployer = runner.WithTimings(builder, tester, deployer, runCtx.CacheArtifacts())
+	builder, tester, _, deployer = runner.WithTimings(builder, tester, nil, deployer, runCtx.CacheArtifacts())
 	if runCtx.Notification() {
 		deployer = runner.WithNotification(deployer)
 	}

--- a/pkg/skaffold/runner/v1/new_test.go
+++ b/pkg/skaffold/runner/v1/new_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
@@ -283,7 +283,7 @@ func createRunner(t *testutil.T, testBench *TestBench, monitor filemon.Monitor, 
 	}
 	runner, err := NewForConfig(runCtx)
 	t.CheckNoError(err)
-
+	runner.SetV1Config([]*latestV1.SkaffoldConfig{cfg})
 	// TODO(yuwenma):builder.builder looks weird. Avoid the nested struct.
 	runner.Builder.Builder = testBench
 	runner.Tester = testBench
@@ -456,7 +456,7 @@ func TestNewForConfig(t *testing.T) {
 			cfg, err := NewForConfig(runCtx)
 			t.CheckError(test.shouldErr, err)
 			if cfg != nil {
-				b, _t, d := runner.WithTimings(&test.expectedBuilder, test.expectedTester, test.expectedDeployer, test.cacheArtifacts)
+				b, _t, _, d := runner.WithTimings(&test.expectedBuilder, test.expectedTester, nil, test.expectedDeployer, test.cacheArtifacts)
 				if test.shouldErr {
 					t.CheckError(true, err)
 				} else {

--- a/pkg/skaffold/runner/v2/build.go
+++ b/pkg/skaffold/runner/v2/build.go
@@ -17,10 +17,14 @@ package v2
 
 import (
 	"context"
-	"fmt"
 	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 )
 
-func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, configPaths []string, fileOut string) error {
-	return fmt.Errorf("not implemented error: SkaffoldRunner(v2).GeneratePipeline")
+// Apply sends Kubernetes manifests to the cluster.
+func (r *SkaffoldRunner) Build(ctx context.Context, out io.Writer, ops config.SkaffoldOptions) ([]graph.Artifact, error) {
+	artifacts := TargetArtifacts(r.configs, ops)
+	return r.Builder.Build(ctx, out, artifacts)
 }

--- a/pkg/skaffold/runner/v2/deploy.go
+++ b/pkg/skaffold/runner/v2/deploy.go
@@ -26,3 +26,6 @@ import (
 func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []graph.Artifact) error {
 	return fmt.Errorf("not implemented error: SkaffoldRunner(v2).Deploy")
 }
+func (r *SkaffoldRunner) DeployAndLog(context.Context, io.Writer, []graph.Artifact) error {
+	return fmt.Errorf("not implemented error: SkaffoldRunner(v2).DeployAndLog")
+}

--- a/pkg/skaffold/runner/v2/new.go
+++ b/pkg/skaffold/runner/v2/new.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Skaffold Authors
+Copyright 2019 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,14 +13,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v2
 
 import (
-	"context"
-	"fmt"
-	"io"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v2"
 )
 
-func (r *SkaffoldRunner) GeneratePipeline(ctx context.Context, out io.Writer, configPaths []string, fileOut string) error {
-	return fmt.Errorf("not implemented error: SkaffoldRunner(v2).GeneratePipeline")
+// NewForConfig returns a new SkaffoldRunner for a SkaffoldConfig
+func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
+	return &SkaffoldRunner{}, nil
 }

--- a/pkg/skaffold/runner/v2/runner.go
+++ b/pkg/skaffold/runner/v2/runner.go
@@ -16,7 +16,10 @@ limitations under the License.
 package v2
 
 import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/test"
 )
 
@@ -24,6 +27,43 @@ type SkaffoldRunner struct {
 	runner.Builder
 	runner.Pruner
 	test.Tester
+	configs []*latestV2.SkaffoldConfig
 }
 
 func (r *SkaffoldRunner) HasDeployed() bool { return true }
+
+func (r *SkaffoldRunner) SetV1Config(config []*latestV1.SkaffoldConfig) {
+	panic("skaffold runner v2 shall not use V1 config.")
+}
+
+func (r *SkaffoldRunner) SetV2Config(config []*latestV2.SkaffoldConfig) {
+	r.configs = config
+}
+
+func TargetArtifacts(configs []*latestV2.SkaffoldConfig, opts config.SkaffoldOptions) []*latestV1.Artifact {
+	var targetArtifacts []*latestV1.Artifact
+	for _, cfg := range configs {
+		for _, artifact := range cfg.Build.Artifacts {
+			if opts.IsTargetImage(artifact) {
+				targetArtifacts = append(targetArtifacts, artifact)
+			}
+		}
+	}
+	return targetArtifacts
+}
+
+func (r *SkaffoldRunner) GetArtifacts() []*latestV1.Artifact {
+	var artifacts []*latestV1.Artifact
+	for _, cfg := range r.configs {
+		artifacts = append(artifacts, cfg.Build.Artifacts...)
+	}
+	return artifacts
+}
+
+func (r *SkaffoldRunner) GetInsecureRegistries() []string {
+	var regList []string
+	for _, cfg := range r.configs {
+		regList = append(regList, cfg.Build.InsecureRegistries...)
+	}
+	return regList
+}

--- a/pkg/skaffold/schema/latest/v2/config.go
+++ b/pkg/skaffold/schema/latest/v2/config.go
@@ -122,6 +122,9 @@ type Validator struct {
 // DeployConfig contains all the configuration needed by the deploy steps.
 type DeployConfig struct {
 
+	// StatusCheck enables waiting for deployments to stabilize.
+	StatusCheck *bool `yaml:"statusCheck,omitempty"`
+
 	// Dir is equivalent to the dir in `kpt live apply <dir>`. If not provided, skaffold renders the raw manifests
 	// and store them to a a hidden directory `.kpt-hydrated`, and deploys the hidden directory.
 	Dir string `yaml:"dir,omitempty"`
@@ -133,7 +136,7 @@ type DeployConfig struct {
 	InventoryNamespace string `yaml:"inventoryNamespace,omitempty"`
 
 	// StatusCheckDeadlineSeconds sets for the polling period for resource statuses. Default to 2s. Values can be "2s", "1min", "3h", etc
-	StatusCheckDeadlineSeconds string `statusCheckDeadlineSeconds:"pollPeriod,omitempty"`
+	StatusCheckDeadlineSeconds int `statusCheckDeadlineSeconds:"pollPeriod,omitempty"`
 	// PrunePropagationPolicy sets the propagation policy for pruning.
 	// Possible settings are Background, Foreground, Orphan.
 	// Default to "Background".

--- a/pkg/skaffold/schema/v3alpha1/config.go
+++ b/pkg/skaffold/schema/v3alpha1/config.go
@@ -121,6 +121,9 @@ type Validator struct {
 // DeployConfig contains all the configuration needed by the deploy steps.
 type DeployConfig struct {
 
+	// StatusCheck enables waiting for deployments to stabilize.
+	StatusCheck *bool `yaml:"statusCheck,omitempty"`
+
 	// Dir is equivalent to the dir in `kpt live apply <dir>`. If not provided, skaffold renders the raw manifests
 	// and store them to a a hidden directory `.kpt-hydrated`, and deploys the hidden directory.
 	Dir string `yaml:"dir,omitempty"`
@@ -132,7 +135,7 @@ type DeployConfig struct {
 	InventoryNamespace string `yaml:"inventoryNamespace,omitempty"`
 
 	// StatusCheckDeadlineSeconds sets for the polling period for resource statuses. Default to 2s. Values can be "2s", "1min", "3h", etc
-	StatusCheckDeadlineSeconds string `statusCheckDeadlineSeconds:"pollPeriod,omitempty"`
+	StatusCheckDeadlineSeconds int `statusCheckDeadlineSeconds:"pollPeriod,omitempty"`
 	// PrunePropagationPolicy sets the propagation policy for pruning.
 	// Possible settings are Background, Foreground, Orphan.
 	// Default to "Background".

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -30,7 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yamltags"

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"

--- a/pkg/skaffold/tag/tagger_mux.go
+++ b/pkg/skaffold/tag/tagger_mux.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 

--- a/pkg/skaffold/tag/tagger_mux_test.go
+++ b/pkg/skaffold/tag/tagger_mux_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )

--- a/pkg/skaffold/test/custom/custom_test.go
+++ b/pkg/skaffold/test/custom/custom_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"

--- a/pkg/skaffold/test/structure/structure_test.go
+++ b/pkg/skaffold/test/structure/structure_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/cluster"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"

--- a/pkg/skaffold/test/test_factory_test.go
+++ b/pkg/skaffold/test/test_factory_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"


### PR DESCRIPTION
**Related**: #5673 

**Description**    

- Seperate runcontext.Runcontext to V1 and V2, each runcontext holds its own v1 and v2 schema
- Store schema configs in their versioned runner. This decouple the versioned functions in cmd (where latestV1 is referred).
- Add Renderer to withTiming
