### PR TITLE
Add node selector option for building image on k8s cluster with Kaniko.

### DIFF
--- a/docs/content/en/schemas/v2beta18.json
+++ b/docs/content/en/schemas/v2beta18.json
@@ -748,6 +748,15 @@
           "description": "Kubernetes namespace. Defaults to current namespace in Kubernetes configuration.",
           "x-intellij-html-description": "Kubernetes namespace. Defaults to current namespace in Kubernetes configuration."
         },
+        "nodeSelector": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object",
+          "description": "describes the Kubernetes node selector for the pod.",
+          "x-intellij-html-description": "describes the Kubernetes node selector for the pod.",
+          "default": "{}"
+        },
         "pullSecretMountPath": {
           "type": "string",
           "description": "path the pull secret will be mounted at within the running container.",
@@ -822,6 +831,7 @@
         "dockerConfig",
         "serviceAccount",
         "tolerations",
+        "nodeSelector",
         "annotations",
         "runAsUser",
         "resources",

--- a/pkg/skaffold/build/cluster/pod.go
+++ b/pkg/skaffold/build/cluster/pod.go
@@ -109,6 +109,11 @@ func (b *Builder) kanikoPodSpec(artifact *latestV1.KanikoArtifact, tag string) (
 		pod.Spec.Tolerations = b.ClusterDetails.Tolerations
 	}
 
+	// Add nodeSelector for kaniko pod setup
+	if b.ClusterDetails.NodeSelector != nil {
+	    pod.Spec.NodeSelector = b.ClusterDetails.NodeSelector
+	}
+
 	// Add used-defines Volumes
 	pod.Spec.Volumes = append(pod.Spec.Volumes, b.Volumes...)
 

--- a/pkg/skaffold/build/cluster/pod.go
+++ b/pkg/skaffold/build/cluster/pod.go
@@ -111,7 +111,7 @@ func (b *Builder) kanikoPodSpec(artifact *latestV1.KanikoArtifact, tag string) (
 
 	// Add nodeSelector for kaniko pod setup
 	if b.ClusterDetails.NodeSelector != nil {
-	    pod.Spec.NodeSelector = b.ClusterDetails.NodeSelector
+		pod.Spec.NodeSelector = b.ClusterDetails.NodeSelector
 	}
 
 	// Add used-defines Volumes

--- a/pkg/skaffold/build/cluster/pod_test.go
+++ b/pkg/skaffold/build/cluster/pod_test.go
@@ -238,7 +238,7 @@ func TestKanikoPodSpec(t *testing.T) {
 					TolerationSeconds: nil,
 				},
 			},
-			NodeSelector:  map[string]string{"kubernetes.io/os": "linux"},
+			NodeSelector: map[string]string{"kubernetes.io/os": "linux"},
 		},
 	}
 	pod, _ := builder.kanikoPodSpec(artifact, "tag")
@@ -378,7 +378,7 @@ func TestKanikoPodSpec(t *testing.T) {
 					TolerationSeconds: nil,
 				},
 			},
-			NodeSelector:  map[string]string{"kubernetes.io/os": "linux"},
+			NodeSelector: map[string]string{"kubernetes.io/os": "linux"},
 		},
 	}
 

--- a/pkg/skaffold/build/cluster/pod_test.go
+++ b/pkg/skaffold/build/cluster/pod_test.go
@@ -238,6 +238,7 @@ func TestKanikoPodSpec(t *testing.T) {
 					TolerationSeconds: nil,
 				},
 			},
+			NodeSelector:  map[string]string{"kubernetes.io/os": "linux"},
 		},
 	}
 	pod, _ := builder.kanikoPodSpec(artifact, "tag")
@@ -377,6 +378,7 @@ func TestKanikoPodSpec(t *testing.T) {
 					TolerationSeconds: nil,
 				},
 			},
+			NodeSelector:  map[string]string{"kubernetes.io/os": "linux"},
 		},
 	}
 

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -411,6 +411,9 @@ type ClusterDetails struct {
 	// Tolerations describes the Kubernetes tolerations for the pod.
 	Tolerations []v1.Toleration `yaml:"tolerations,omitempty"`
 
+	// NodeSelector describes the Kubernetes node selector for the pod.
+	NodeSelector map[string]string `yaml:"nodeSelector,omitempty"`
+
 	// Annotations describes the Kubernetes annotations for the pod.
 	Annotations map[string]string `yaml:"annotations,omitempty"`
 


### PR DESCRIPTION
**Description**
When building an image on a Kubernetes Cluster the Kaniko pod cannot be schedules, if we use node selectors to differentiate between Linux and Windows nodes. With the `nodeSelector` I can specify the os for example. This patch makes it possible to specify the `nodeSelector` option.

**User facing changes**
With this patch the user is able to schedule the Kaniko pod for building an image on a specific node in a Kubernetes cluster.
