### PR TITLE
fix: port-forward for multi-config projects

### DIFF
--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -49,6 +49,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
 	kstatus "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
@@ -112,6 +113,7 @@ type Deployer struct {
 type Config interface {
 	kubectl.Config
 	kstatus.Config
+	portforward.Config
 	IsMultiConfig() bool
 }
 
@@ -140,7 +142,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 	return &Deployer{
 		HelmDeploy:     h,
 		podSelector:    podSelector,
-		accessor:       provider.Accessor.GetKubernetesAccessor(podSelector),
+		accessor:       provider.Accessor.GetKubernetesAccessor(cfg, podSelector),
 		debugger:       provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:         provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:  provider.Monitor.GetKubernetesMonitor(cfg),

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -1539,11 +1539,12 @@ type helmConfig struct {
 	configFile            string
 }
 
-func (c *helmConfig) ForceDeploy() bool         { return c.force }
-func (c *helmConfig) GetKubeConfig() string     { return kubectl.TestKubeConfig }
-func (c *helmConfig) GetKubeContext() string    { return kubectl.TestKubeContext }
-func (c *helmConfig) GetKubeNamespace() string  { return c.namespace }
-func (c *helmConfig) ConfigurationFile() string { return c.configFile }
+func (c *helmConfig) ForceDeploy() bool                                     { return c.force }
+func (c *helmConfig) GetKubeConfig() string                                 { return kubectl.TestKubeConfig }
+func (c *helmConfig) GetKubeContext() string                                { return kubectl.TestKubeContext }
+func (c *helmConfig) GetKubeNamespace() string                              { return c.namespace }
+func (c *helmConfig) ConfigurationFile() string                             { return c.configFile }
+func (c *helmConfig) PortForwardResources() []*latestV1.PortForwardResource { return nil }
 
 // helmReleaseInfo returns the result of `helm --namespace <namespace> get all <name>` with the given KRM manifest.
 func helmReleaseInfo(namespace, manifest string) string {

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -44,6 +44,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
 	kstatus "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
@@ -94,6 +95,7 @@ type Deployer struct {
 type Config interface {
 	kubectl.Config
 	kstatus.Config
+	portforward.Config
 }
 
 // NewDeployer generates a new Deployer object contains the kptDeploy schema.
@@ -102,7 +104,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 	return &Deployer{
 		KptDeploy:          d,
 		podSelector:        podSelector,
-		accessor:           provider.Accessor.GetKubernetesAccessor(podSelector),
+		accessor:           provider.Accessor.GetKubernetesAccessor(cfg, podSelector),
 		debugger:           provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:             provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:      provider.Monitor.GetKubernetesMonitor(cfg),

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -1190,7 +1190,8 @@ type kptConfig struct {
 	config                string
 }
 
-func (c *kptConfig) WorkingDir() string       { return c.workingDir }
-func (c *kptConfig) GetKubeContext() string   { return kubectl.TestKubeContext }
-func (c *kptConfig) GetKubeNamespace() string { return kubectl.TestNamespace }
-func (c *kptConfig) GetKubeConfig() string    { return c.config }
+func (c *kptConfig) WorkingDir() string                                    { return c.workingDir }
+func (c *kptConfig) GetKubeContext() string                                { return kubectl.TestKubeContext }
+func (c *kptConfig) GetKubeNamespace() string                              { return kubectl.TestNamespace }
+func (c *kptConfig) GetKubeConfig() string                                 { return c.config }
+func (c *kptConfig) PortForwardResources() []*latestV1.PortForwardResource { return nil }

--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -32,6 +32,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
 	kstatus "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/status"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
@@ -49,6 +50,7 @@ type CLI struct {
 type Config interface {
 	kubectl.Config
 	kstatus.Config
+	portforward.Config
 	deploy.Config
 	ForceDeploy() bool
 	WaitForDeletions() config.WaitForDeletions

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -87,7 +87,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 	return &Deployer{
 		KubectlDeploy:      d,
 		podSelector:        podSelector,
-		accessor:           provider.Accessor.GetKubernetesAccessor(podSelector),
+		accessor:           provider.Accessor.GetKubernetesAccessor(cfg, podSelector),
 		debugger:           provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:             provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:      provider.Monitor.GetKubernetesMonitor(cfg),

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -739,10 +739,11 @@ type kubectlConfig struct {
 	waitForDeletions      config.WaitForDeletions
 }
 
-func (c *kubectlConfig) GetKubeContext() string                    { return "kubecontext" }
-func (c *kubectlConfig) GetKubeNamespace() string                  { return c.Opts.Namespace }
-func (c *kubectlConfig) WorkingDir() string                        { return c.workingDir }
-func (c *kubectlConfig) SkipRender() bool                          { return c.skipRender }
-func (c *kubectlConfig) ForceDeploy() bool                         { return c.force }
-func (c *kubectlConfig) DefaultRepo() *string                      { return &c.defaultRepo }
-func (c *kubectlConfig) WaitForDeletions() config.WaitForDeletions { return c.waitForDeletions }
+func (c *kubectlConfig) GetKubeContext() string                                { return "kubecontext" }
+func (c *kubectlConfig) GetKubeNamespace() string                              { return c.Opts.Namespace }
+func (c *kubectlConfig) WorkingDir() string                                    { return c.workingDir }
+func (c *kubectlConfig) SkipRender() bool                                      { return c.skipRender }
+func (c *kubectlConfig) ForceDeploy() bool                                     { return c.force }
+func (c *kubectlConfig) DefaultRepo() *string                                  { return &c.defaultRepo }
+func (c *kubectlConfig) WaitForDeletions() config.WaitForDeletions             { return c.waitForDeletions }
+func (c *kubectlConfig) PortForwardResources() []*latestV1.PortForwardResource { return nil }

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -136,7 +136,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, provider deploy.C
 	return &Deployer{
 		KustomizeDeploy:     d,
 		podSelector:         podSelector,
-		accessor:            provider.Accessor.GetKubernetesAccessor(podSelector),
+		accessor:            provider.Accessor.GetKubernetesAccessor(cfg, podSelector),
 		debugger:            provider.Debugger.GetKubernetesDebugger(podSelector),
 		logger:              provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:       provider.Monitor.GetKubernetesMonitor(cfg),

--- a/pkg/skaffold/deploy/kustomize/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize_test.go
@@ -719,8 +719,9 @@ type kustomizeConfig struct {
 	waitForDeletions      config.WaitForDeletions
 }
 
-func (c *kustomizeConfig) ForceDeploy() bool                         { return c.force }
-func (c *kustomizeConfig) WaitForDeletions() config.WaitForDeletions { return c.waitForDeletions }
-func (c *kustomizeConfig) WorkingDir() string                        { return c.workingDir }
-func (c *kustomizeConfig) GetKubeContext() string                    { return kubectl.TestKubeContext }
-func (c *kustomizeConfig) GetKubeNamespace() string                  { return c.Opts.Namespace }
+func (c *kustomizeConfig) ForceDeploy() bool                                     { return c.force }
+func (c *kustomizeConfig) WaitForDeletions() config.WaitForDeletions             { return c.waitForDeletions }
+func (c *kustomizeConfig) WorkingDir() string                                    { return c.workingDir }
+func (c *kustomizeConfig) GetKubeContext() string                                { return kubectl.TestKubeContext }
+func (c *kustomizeConfig) GetKubeNamespace() string                              { return c.Opts.Namespace }
+func (c *kustomizeConfig) PortForwardResources() []*latestV1.PortForwardResource { return nil }

--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
@@ -35,6 +35,8 @@ import (
 )
 
 type Config interface {
+	kubectl.Config
+
 	Mode() config.RunMode
 	PortForwardResources() []*latestV1.PortForwardResource
 	PortForwardOptions() config.PortForwardOptions

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -86,7 +86,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 
 	var deployer deploy.Deployer
 	provider := deploy.ComponentProvider{
-		Accessor: access.NewAccessorProvider(runCtx, labeller, kubectlCLI),
+		Accessor: access.NewAccessorProvider(labeller),
 		Debugger: debug.NewDebugProvider(runCtx),
 		Logger:   log.NewLogProvider(runCtx, kubectlCLI),
 		Monitor:  status.NewMonitorProvider(labeller),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6074  <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
The issue described in #6074 happens for multi-config projects or even a single config project defining multiple deployers (say `kubectl` and `helm`). This was caused by instantiating multiple `PortForwardManager` structs on every call to `GetKubernetesAccessor` method. These multiple structs each tried to port-forward all user defined ports and only one of them succeeded while the others reported failures.

This PR replaces that with a `map` keyed on the `kubecontext`. This way the same `PortForwardManager` is returned for all kubernetes deployments against the same cluster.
<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
