### PR TITLE
GCB project guessing should support Artifact Registry images

### DIFF
--- a/pkg/skaffold/gcp/projectid.go
+++ b/pkg/skaffold/gcp/projectid.go
@@ -32,7 +32,7 @@ func ExtractProjectID(imageName string) (string, error) {
 	}
 
 	registry := ref.Context().Registry.Name()
-	if registry == "gcr.io" || strings.HasSuffix(registry, ".gcr.io") {
+	if registry == "gcr.io" || strings.HasSuffix(registry, ".gcr.io") || strings.HasSuffix(registry, "-docker.pkg.dev") {
 		parts := strings.Split(imageName, "/")
 		if len(parts) >= 2 {
 			return parts[1], nil

--- a/pkg/skaffold/gcp/projectid_test.go
+++ b/pkg/skaffold/gcp/projectid_test.go
@@ -40,6 +40,11 @@ func TestExtractProjectID(t *testing.T) {
 			expected:    "project",
 		},
 		{
+			description: "us-east1-docker.pkg.dev",
+			imageName:   "us-east1-docker.pkg.dev/project/yyy/go-hello-world:latest",
+			expected:    "project",
+		},
+		{
 			description: "docker hub",
 			imageName:   "project/image",
 			shouldErr:   true,


### PR DESCRIPTION
Fixes: #6092
Related: #5053

**Description**
GCB has support for guessing GCP Project IDs from a GCR image reference (gcr.io).  We need similar support for Artifact Registry.
