### PR TITLE
Escape parentheses in shJoin

### DIFF
--- a/pkg/skaffold/debug/transform.go
+++ b/pkg/skaffold/debug/transform.go
@@ -527,7 +527,7 @@ func shJoin(args []string) string {
 		if i > 0 {
 			result += " "
 		}
-		if strings.ContainsAny(arg, " \t\r\n\"") {
+		if strings.ContainsAny(arg, " \t\r\n\"'()[]{}") {
 			arg := strings.ReplaceAll(arg, `"`, `\"`)
 			result += `"` + arg + `"`
 		} else {

--- a/pkg/skaffold/debug/transform_test.go
+++ b/pkg/skaffold/debug/transform_test.go
@@ -202,6 +202,11 @@ func TestShJoin(t *testing.T) {
 		{[]string{`a"b`}, `"a\"b"`},
 		{[]string{`a"b`}, `"a\"b"`},
 		{[]string{"a", `a"b`, "b c"}, `a "a\"b" "b c"`},
+		{[]string{"a", "b'c'd"}, `a "b'c'd"`},
+		{[]string{"a", "b()"}, `a "b()"`},
+		{[]string{"a", "b[]"}, `a "b[]"`},
+		{[]string{"a", "b{}"}, `a "b{}"`},
+		{[]string{"a", "$PORT", "${PORT}", "a ${PORT} and $PORT"}, `a $PORT "${PORT}" "a ${PORT} and $PORT"`},
 	}
 	for _, test := range tests {
 		testutil.Run(t, strings.Join(test.in, " "), func(t *testutil.T) {


### PR DESCRIPTION
Fixes: #6100

**Description**
In `skaffold debug`, we rewrite container command-lines to run under the applicable language runtime debugger.  We support "sh -c"-style command-lines that result from Dockerfile `RUN command args` by splitting and then re-joining the command-lines.  Our [re-joining helper](https://github.com/GoogleContainerTools/skaffold/blob/044c65fddcd0dcaaacca35c08391d1a8beb4dd1e/pkg/skaffold/debug/transform.go#L522-L538) tries to do minimal escaping, escaping only whitespace and a double-quote.  But command-lines such as [Bank of Anthos's `contacts`] container then fail as they include parentheses, which are interpreted by the shell:

    gunicorn -b :$PORT --threads 4 --log-config /logging.conf --log-level=$LOG_LEVEL "contacts:create_app()"

This PR causes our re-join to quote parentheses, brackets, and braces, and single-quotes too.

This quoting is imperfect as we don't track information such as the `contacts:create_app()` being quoted.