### PR TITLE
log metrics upload failure and write to file instead.

### DIFF
--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -94,7 +94,12 @@ func exportMetrics(ctx context.Context, filename string, meter skaffoldMeter) er
 	for _, m := range meters {
 		createMetrics(ctx, m)
 	}
-	p.Stop(ctx)
+	if err := p.Stop(ctx); err != nil {
+		logrus.Debugf("error uploading metrics: %s", err)
+		logrus.Debugf("writing to file %s instead", filename)
+		b, _ = json.Marshal(meters)
+		return ioutil.WriteFile(filename, b, 0666)
+	}
 	logrus.Debugf("metrics uploading complete in %s", time.Since(start).String())
 
 	if fileExists {


### PR DESCRIPTION
While debugging new secret set up, realized we were swallowing the error message when uploads fail