### PR TITLE
Fix couldn't start notify trigger in multi-config projects

### DIFF
--- a/pkg/skaffold/trigger/fsnotify/trigger.go
+++ b/pkg/skaffold/trigger/fsnotify/trigger.go
@@ -91,7 +91,15 @@ func (t *Trigger) Start(ctx context.Context) (<-chan bool, error) {
 			continue
 		}
 
-		if err := t.watchFunc(filepath.Join(wd, w, "..."), c, notify.All); err != nil {
+		// Workspace paths may already have been converted to absolute paths (e.g. in a multi-config project).
+		var path string
+		if filepath.IsAbs(w) {
+			path = w
+		} else {
+			path = filepath.Join(wd, w)
+		}
+
+		if err := t.watchFunc(filepath.Join(path, "..."), c, notify.All); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
**Description**
This PR fixes the problem that notify trigger does not start in multi-config projects.

Here is how to reproduce the problem.

```console
$ cd examples/multi-config-microservices
$ skaffold dev -vdebug
...
DEBU[0043] Couldn't start notify trigger. Falling back to a polling trigger
Watching for changes...
```

The current code expects the workspace path is an relative path.
However, in multi-config projects, the workspace path seems to have already been converted to an absolute path.

**User facing changes**
The notify trigger will also work in multi-config projects.
This will reduce CPU usage in multi-config projects with a large number of files.
