### PR TITLE
Associate `StatusCheckSubtaskEvent`s with `Deploy` phase

### DIFF
--- a/pkg/skaffold/event/v2/status_check.go
+++ b/pkg/skaffold/event/v2/status_check.go
@@ -34,7 +34,7 @@ func ResourceStatusCheckEventCompleted(r string, ae proto.ActionableErr) {
 func resourceStatusCheckEventSucceeded(r string) {
 	handler.handleStatusCheckSubtaskEvent(&proto.StatusCheckSubtaskEvent{
 		Id:         r,
-		TaskId:     fmt.Sprintf("%s-%d", constants.StatusCheck, handler.iteration),
+		TaskId:     fmt.Sprintf("%s-%d", constants.Deploy, handler.iteration),
 		Resource:   r,
 		Status:     Succeeded,
 		Message:    Succeeded,
@@ -45,7 +45,7 @@ func resourceStatusCheckEventSucceeded(r string) {
 func resourceStatusCheckEventFailed(r string, ae proto.ActionableErr) {
 	handler.handleStatusCheckSubtaskEvent(&proto.StatusCheckSubtaskEvent{
 		Id:            r,
-		TaskId:        fmt.Sprintf("%s-%d", constants.StatusCheck, handler.iteration),
+		TaskId:        fmt.Sprintf("%s-%d", constants.Deploy, handler.iteration),
 		Resource:      r,
 		Status:        Failed,
 		StatusCode:    ae.ErrCode,
@@ -56,7 +56,7 @@ func resourceStatusCheckEventFailed(r string, ae proto.ActionableErr) {
 func ResourceStatusCheckEventUpdated(r string, ae proto.ActionableErr) {
 	handler.handleStatusCheckSubtaskEvent(&proto.StatusCheckSubtaskEvent{
 		Id:            r,
-		TaskId:        fmt.Sprintf("%s-%d", constants.StatusCheck, handler.iteration),
+		TaskId:        fmt.Sprintf("%s-%d", constants.Deploy, handler.iteration),
 		Resource:      r,
 		Status:        InProgress,
 		Message:       ae.Message,


### PR DESCRIPTION
**Description**
This PR is being made at the request of the IDE folks to associate the status check events with the deploy phase, rather than a separate status check phase.

