### PR TITLE
[Refactor] Move log stream utility out of pkg/skaffold/kubernetes

### DIFF
--- a/pkg/skaffold/kubernetes/logger/log_test.go
+++ b/pkg/skaffold/kubernetes/logger/log_test.go
@@ -17,11 +17,8 @@ limitations under the License.
 package logger
 
 import (
-	"bytes"
 	"context"
 	"io/ioutil"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -29,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -96,34 +92,6 @@ func TestSelect(t *testing.T) {
 			t.CheckDeepEqual(test.expectedMatch, selected)
 		})
 	}
-}
-
-func TestPrintLogLine(t *testing.T) {
-	testutil.Run(t, "verify lines are not intermixed", func(t *testutil.T) {
-		var buf bytes.Buffer
-
-		logger := &LogAggregator{
-			output: &buf,
-		}
-
-		var wg sync.WaitGroup
-		for i := 0; i < 5; i++ {
-			wg.Add(1)
-
-			go func() {
-				for i := 0; i < 100; i++ {
-					logger.printLogLine(output.Default.Sprintf("%s ", "PREFIX") + "TEXT\n")
-				}
-				wg.Done()
-			}()
-		}
-		wg.Wait()
-
-		lines := strings.Split(buf.String(), "\n")
-		for i := 0; i < 5*100; i++ {
-			t.CheckDeepEqual("PREFIX TEXT", lines[i])
-		}
-	})
 }
 
 func TestLogAggregatorZeroValue(t *testing.T) {

--- a/pkg/skaffold/log/stream/stream.go
+++ b/pkg/skaffold/log/stream/stream.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stream
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+
+	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+)
+
+//nolint:golint
+func StreamRequest(ctx context.Context, out io.Writer, headerColor output.Color, prefix, podName, containerName string, stopper chan bool, lock sync.Locker, isMuted func() bool, rc io.Reader) error {
+	r := bufio.NewReader(rc)
+	for {
+		select {
+		case <-ctx.Done():
+			logrus.Infof("%s interrupted", prefix)
+			return nil
+		case <-stopper:
+			return nil
+		default:
+			// Read up to newline
+			line, err := r.ReadString('\n')
+			if err == io.EOF {
+				return nil
+			}
+			if err != nil {
+				return fmt.Errorf("reading bytes from log stream: %w", err)
+			}
+
+			formattedLine := headerColor.Sprintf("%s ", prefix) + line
+			printLogLine(headerColor, out, isMuted, lock, prefix, line)
+			eventV2.ApplicationLog(podName, containerName, line, formattedLine)
+		}
+	}
+}
+
+func printLogLine(headerColor output.Color, out io.Writer, isMuted func() bool, lock sync.Locker, prefix, text string) {
+	if !isMuted() {
+		lock.Lock()
+
+		headerColor.Fprintf(out, "%s ", prefix)
+		fmt.Fprint(out, text)
+
+		lock.Unlock()
+	}
+}

--- a/pkg/skaffold/log/stream/stream_test.go
+++ b/pkg/skaffold/log/stream/stream_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stream
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestPrintLogLine(t *testing.T) {
+	testutil.Run(t, "verify lines are not intermixed", func(t *testutil.T) {
+		var (
+			buf  bytes.Buffer
+			wg   sync.WaitGroup
+			lock sync.Mutex
+
+			linesPerGroup = 100
+			groups        = 5
+		)
+
+		for i := 0; i < groups; i++ {
+			wg.Add(1)
+
+			go func() {
+				for i := 0; i < linesPerGroup; i++ {
+					printLogLine(output.Default, &buf, func() bool { return false }, &lock, "PREFIX", "TEXT\n")
+				}
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+
+		lines := strings.Split(buf.String(), "\n")
+		for i := 0; i < groups*linesPerGroup; i++ {
+			t.CheckDeepEqual("PREFIX TEXT", lines[i])
+		}
+	})
+}


### PR DESCRIPTION
Related: #6107

This moves the `StreamRequest` method out of `pkg/skaffold/kubernetes` so it can be used by other `Logger` implementations.