### PR TITLE
Move cluster image loading logic into Deployer

### DIFF
--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/access"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
@@ -30,11 +31,12 @@ import (
 
 // NoopComponentProvider is for tests
 var NoopComponentProvider = ComponentProvider{
-	Accessor: &access.NoopProvider{},
-	Debugger: &debug.NoopProvider{},
-	Logger:   &log.NoopProvider{},
-	Monitor:  &status.NoopProvider{},
-	Syncer:   &sync.NoopProvider{},
+	Accessor:    &access.NoopProvider{},
+	Debugger:    &debug.NoopProvider{},
+	ImageLoader: &loader.NoopProvider{},
+	Logger:      &log.NoopProvider{},
+	Monitor:     &status.NoopProvider{},
+	Syncer:      &sync.NoopProvider{},
 }
 
 // Deployer is the Deploy API of skaffold and responsible for deploying
@@ -72,14 +74,18 @@ type Deployer interface {
 
 	// GetStatusMonitor returns a Deployer's implementation of a StatusMonitor
 	GetStatusMonitor() status.Monitor
+
+	// GetImageLoader returns a Deployer's implementation of an ImageLoader
+	GetImageLoader() loader.ImageLoader
 }
 
 // ComponentProvider serves as a clean way to send three providers
 // as params to the Deployer constructors
 type ComponentProvider struct {
-	Accessor access.Provider
-	Debugger debug.Provider
-	Logger   log.Provider
-	Monitor  status.Provider
-	Syncer   sync.Provider
+	Accessor    access.Provider
+	Debugger    debug.Provider
+	ImageLoader loader.Provider
+	Logger      log.Provider
+	Monitor     status.Provider
+	Syncer      sync.Provider
 }

--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -72,11 +72,11 @@ type Deployer interface {
 	// TrackBuildArtifacts registers build artifacts to be tracked by a Deployer
 	TrackBuildArtifacts([]graph.Artifact)
 
+	// RegisterLocalImages tracks all local images to be loaded by the Deployer
+	RegisterLocalImages([]graph.Artifact)
+
 	// GetStatusMonitor returns a Deployer's implementation of a StatusMonitor
 	GetStatusMonitor() status.Monitor
-
-	// GetImageLoader returns a Deployer's implementation of an ImageLoader
-	GetImageLoader() loader.ImageLoader
 }
 
 // ComponentProvider serves as a clean way to send three providers

--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -30,6 +30,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
@@ -91,6 +92,14 @@ func (m DeployerMux) GetSyncer() sync.Syncer {
 		syncers = append(syncers, deployer.GetSyncer())
 	}
 	return syncers
+}
+
+func (m DeployerMux) GetImageLoader() loader.ImageLoader {
+	var loaders loader.ImageLoaderMux
+	for _, deployer := range m.deployers {
+		loaders = append(loaders, deployer.GetImageLoader())
+	}
+	return loaders
 }
 
 func (m DeployerMux) Deploy(ctx context.Context, w io.Writer, as []graph.Artifact) ([]string, error) {

--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -30,7 +30,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
@@ -94,12 +93,10 @@ func (m DeployerMux) GetSyncer() sync.Syncer {
 	return syncers
 }
 
-func (m DeployerMux) GetImageLoader() loader.ImageLoader {
-	var loaders loader.ImageLoaderMux
+func (m DeployerMux) RegisterLocalImages(images []graph.Artifact) {
 	for _, deployer := range m.deployers {
-		loaders = append(loaders, deployer.GetImageLoader())
+		deployer.RegisterLocalImages(images)
 	}
-	return loaders
 }
 
 func (m DeployerMux) Deploy(ctx context.Context, w io.Writer, as []graph.Artifact) ([]string, error) {

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/access"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
@@ -70,9 +69,7 @@ func (m *MockDeployer) GetSyncer() sync.Syncer {
 	return &sync.NoopSyncer{}
 }
 
-func (m *MockDeployer) GetImageLoader() loader.ImageLoader {
-	return &loader.NoopImageLoader{}
-}
+func (m *MockDeployer) RegisterLocalImages(_ []graph.Artifact) {}
 
 func (m *MockDeployer) TrackBuildArtifacts(_ []graph.Artifact) {}
 

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/access"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
@@ -67,6 +68,10 @@ func (m *MockDeployer) GetStatusMonitor() status.Monitor {
 
 func (m *MockDeployer) GetSyncer() sync.Syncer {
 	return &sync.NoopSyncer{}
+}
+
+func (m *MockDeployer) GetImageLoader() loader.ImageLoader {
+	return &loader.NoopImageLoader{}
 }
 
 func (m *MockDeployer) TrackBuildArtifacts(_ []graph.Artifact) {}

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -51,6 +51,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
 	kstatus "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/status"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -86,6 +87,7 @@ type Deployer struct {
 
 	accessor      access.Accessor
 	debugger      debug.Debugger
+	imageLoader   loader.ImageLoader
 	logger        log.Logger
 	statusMonitor status.Monitor
 	syncer        sync.Syncer
@@ -144,6 +146,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		podSelector:    podSelector,
 		accessor:       provider.Accessor.GetKubernetesAccessor(cfg, podSelector),
 		debugger:       provider.Debugger.GetKubernetesDebugger(podSelector),
+		imageLoader:    provider.ImageLoader.GetKubernetesImageLoader(),
 		logger:         provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:  provider.Monitor.GetKubernetesMonitor(cfg),
 		syncer:         provider.Syncer.GetKubernetesSyncer(podSelector),
@@ -178,6 +181,10 @@ func (h *Deployer) GetStatusMonitor() status.Monitor {
 
 func (h *Deployer) GetSyncer() sync.Syncer {
 	return h.syncer
+}
+
+func (h *Deployer) GetImageLoader() loader.ImageLoader {
+	return h.imageLoader
 }
 
 func (h *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -94,8 +94,8 @@ type Deployer struct {
 	syncer        sync.Syncer
 
 	podSelector    *kubernetes.ImageList
-	originalImages []graph.Artifact
-	localImages    []graph.Artifact
+	originalImages []graph.Artifact // the set of images defined in ArtifactOverrides
+	localImages    []graph.Artifact // the set of images marked as "local" by the Runner
 
 	kubeContext string
 	kubeConfig  string

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -48,6 +48,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	kloader "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
 	kstatus "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/status"
@@ -116,6 +117,7 @@ type Deployer struct {
 type Config interface {
 	kubectl.Config
 	kstatus.Config
+	kloader.Config
 	portforward.Config
 	IsMultiConfig() bool
 }
@@ -147,7 +149,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		podSelector:    podSelector,
 		accessor:       provider.Accessor.GetKubernetesAccessor(cfg, podSelector),
 		debugger:       provider.Debugger.GetKubernetesDebugger(podSelector),
-		imageLoader:    provider.ImageLoader.GetKubernetesImageLoader(),
+		imageLoader:    provider.ImageLoader.GetKubernetesImageLoader(cfg),
 		logger:         provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:  provider.Monitor.GetKubernetesMonitor(cfg),
 		syncer:         provider.Syncer.GetKubernetesSyncer(podSelector),

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -46,6 +46,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
 	kstatus "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/status"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -77,6 +78,7 @@ type Deployer struct {
 	accessor      access.Accessor
 	logger        log.Logger
 	debugger      debug.Debugger
+	imageLoader   loader.ImageLoader
 	statusMonitor status.Monitor
 	syncer        sync.Syncer
 
@@ -106,6 +108,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		podSelector:        podSelector,
 		accessor:           provider.Accessor.GetKubernetesAccessor(cfg, podSelector),
 		debugger:           provider.Debugger.GetKubernetesDebugger(podSelector),
+		imageLoader:        provider.ImageLoader.GetKubernetesImageLoader(),
 		logger:             provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:      provider.Monitor.GetKubernetesMonitor(cfg),
 		syncer:             provider.Syncer.GetKubernetesSyncer(podSelector),
@@ -137,6 +140,10 @@ func (k *Deployer) GetStatusMonitor() status.Monitor {
 
 func (k *Deployer) GetSyncer() sync.Syncer {
 	return k.syncer
+}
+
+func (k *Deployer) GetImageLoader() loader.ImageLoader {
+	return k.imageLoader
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -43,6 +43,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	kloader "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
 	kstatus "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/status"
@@ -99,6 +100,7 @@ type Config interface {
 	kubectl.Config
 	kstatus.Config
 	portforward.Config
+	kloader.Config
 }
 
 // NewDeployer generates a new Deployer object contains the kptDeploy schema.
@@ -109,7 +111,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		podSelector:        podSelector,
 		accessor:           provider.Accessor.GetKubernetesAccessor(cfg, podSelector),
 		debugger:           provider.Debugger.GetKubernetesDebugger(podSelector),
-		imageLoader:        provider.ImageLoader.GetKubernetesImageLoader(),
+		imageLoader:        provider.ImageLoader.GetKubernetesImageLoader(cfg),
 		logger:             provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:      provider.Monitor.GetKubernetesMonitor(cfg),
 		syncer:             provider.Syncer.GetKubernetesSyncer(podSelector),

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -84,8 +84,8 @@ type Deployer struct {
 	syncer        sync.Syncer
 
 	podSelector    *kubernetes.ImageList
-	originalImages []graph.Artifact
-	localImages    []graph.Artifact
+	originalImages []graph.Artifact // the set of images parsed from the Deployer's manifest set
+	localImages    []graph.Artifact // the set of images marked as "local" by the Runner
 
 	insecureRegistries map[string]bool
 	labels             map[string]string
@@ -220,7 +220,7 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	}
 	endTrace()
 
-	childCtx, endTrace := instrumentation.StartTrace(ctx, "Deploy_renderManifests")
+	childCtx, endTrace := instrumentation.StartTrace(ctx, "Deploy_loadImages")
 	if err := k.imageLoader.LoadImages(childCtx, out, k.localImages, k.originalImages, builds); err != nil {
 		endTrace(instrumentation.TraceEndError(err))
 		return nil, err

--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -31,6 +31,7 @@ import (
 	deploy "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/types"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	kloader "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
 	kstatus "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/status"
@@ -50,6 +51,7 @@ type CLI struct {
 type Config interface {
 	kubectl.Config
 	kstatus.Config
+	kloader.Config
 	portforward.Config
 	deploy.Config
 	ForceDeploy() bool

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -60,8 +60,8 @@ type Deployer struct {
 	statusMonitor status.Monitor
 	syncer        sync.Syncer
 
-	originalImages     []graph.Artifact
-	localImages        []graph.Artifact
+	originalImages     []graph.Artifact // the set of images marked as "local" by the Runner
+	localImages        []graph.Artifact // the set of images parsed from the Deployer's manifest set
 	podSelector        *kubernetes.ImageList
 	hydratedManifests  []string
 	workingDir         string
@@ -179,6 +179,7 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	if len(manifests) == 0 {
 		return nil, nil
 	}
+	endTrace()
 
 	_, endTrace = instrumentation.StartTrace(ctx, "Deploy_LoadImages")
 	if err := k.imageLoader.LoadImages(childCtx, out, k.localImages, k.originalImages, builds); err != nil {

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -93,7 +93,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		podSelector:        podSelector,
 		accessor:           provider.Accessor.GetKubernetesAccessor(cfg, podSelector),
 		debugger:           provider.Debugger.GetKubernetesDebugger(podSelector),
-		imageLoader:        provider.ImageLoader.GetKubernetesImageLoader(),
+		imageLoader:        provider.ImageLoader.GetKubernetesImageLoader(cfg),
 		logger:             provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:      provider.Monitor.GetKubernetesMonitor(cfg),
 		syncer:             provider.Syncer.GetKubernetesSyncer(podSelector),

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -39,6 +39,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -52,6 +53,7 @@ type Deployer struct {
 	*latestV1.KubectlDeploy
 
 	accessor      access.Accessor
+	imageLoader   loader.ImageLoader
 	logger        log.Logger
 	debugger      debug.Debugger
 	statusMonitor status.Monitor
@@ -89,6 +91,7 @@ func NewDeployer(cfg Config, labels map[string]string, provider deploy.Component
 		podSelector:        podSelector,
 		accessor:           provider.Accessor.GetKubernetesAccessor(cfg, podSelector),
 		debugger:           provider.Debugger.GetKubernetesDebugger(podSelector),
+		imageLoader:        provider.ImageLoader.GetKubernetesImageLoader(),
 		logger:             provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:      provider.Monitor.GetKubernetesMonitor(cfg),
 		syncer:             provider.Syncer.GetKubernetesSyncer(podSelector),
@@ -121,6 +124,10 @@ func (k *Deployer) GetStatusMonitor() status.Monitor {
 
 func (k *Deployer) GetSyncer() sync.Syncer {
 	return k.syncer
+}
+
+func (k *Deployer) GetImageLoader() loader.ImageLoader {
+	return k.imageLoader
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -39,6 +39,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -104,6 +105,7 @@ type Deployer struct {
 
 	accessor      access.Accessor
 	logger        log.Logger
+	imageLoader   loader.ImageLoader
 	debugger      debug.Debugger
 	statusMonitor status.Monitor
 	syncer        sync.Syncer
@@ -138,6 +140,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, provider deploy.C
 		podSelector:         podSelector,
 		accessor:            provider.Accessor.GetKubernetesAccessor(cfg, podSelector),
 		debugger:            provider.Debugger.GetKubernetesDebugger(podSelector),
+		imageLoader:         provider.ImageLoader.GetKubernetesImageLoader(),
 		logger:              provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:       provider.Monitor.GetKubernetesMonitor(cfg),
 		syncer:              provider.Syncer.GetKubernetesSyncer(podSelector),
@@ -167,6 +170,10 @@ func (k *Deployer) GetStatusMonitor() status.Monitor {
 
 func (k *Deployer) GetSyncer() sync.Syncer {
 	return k.syncer
+}
+
+func (k *Deployer) GetImageLoader() loader.ImageLoader {
+	return k.imageLoader
 }
 
 func (k *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -111,8 +111,8 @@ type Deployer struct {
 	syncer        sync.Syncer
 
 	podSelector    *kubernetes.ImageList
-	originalImages []graph.Artifact
-	localImages    []graph.Artifact
+	originalImages []graph.Artifact // the set of images parsed from the Deployer's manifest set
+	localImages    []graph.Artifact // the set of images marked as "local" by the Runner
 
 	kubectl             kubectl.CLI
 	insecureRegistries  map[string]bool
@@ -205,14 +205,7 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 		"DeployerType": "kustomize",
 	})
 
-	childCtx, endTrace := instrumentation.StartTrace(ctx, "Deploy_LoadImages")
-	if err := k.imageLoader.LoadImages(childCtx, out, k.localImages, k.originalImages, builds); err != nil {
-		endTrace(instrumentation.TraceEndError(err))
-		return nil, err
-	}
-	endTrace()
-
-	childCtx, endTrace = instrumentation.StartTrace(ctx, "Deploy_renderManifests")
+	childCtx, endTrace := instrumentation.StartTrace(ctx, "Deploy_renderManifests")
 	manifests, err := k.renderManifests(childCtx, out, builds)
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(err))
@@ -222,6 +215,13 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	if len(manifests) == 0 {
 		endTrace()
 		return nil, nil
+	}
+	endTrace()
+
+	childCtx, endTrace = instrumentation.StartTrace(ctx, "Deploy_LoadImages")
+	if err := k.imageLoader.LoadImages(childCtx, out, k.localImages, k.originalImages, builds); err != nil {
+		endTrace(instrumentation.TraceEndError(err))
+		return nil, err
 	}
 	endTrace()
 

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -141,7 +141,7 @@ func NewDeployer(cfg kubectl.Config, labels map[string]string, provider deploy.C
 		podSelector:         podSelector,
 		accessor:            provider.Accessor.GetKubernetesAccessor(cfg, podSelector),
 		debugger:            provider.Debugger.GetKubernetesDebugger(podSelector),
-		imageLoader:         provider.ImageLoader.GetKubernetesImageLoader(),
+		imageLoader:         provider.ImageLoader.GetKubernetesImageLoader(cfg),
 		logger:              provider.Logger.GetKubernetesLogger(podSelector),
 		statusMonitor:       provider.Monitor.GetKubernetesMonitor(cfg),
 		syncer:              provider.Syncer.GetKubernetesSyncer(podSelector),

--- a/pkg/skaffold/kubernetes/loader/load.go
+++ b/pkg/skaffold/kubernetes/loader/load.go
@@ -41,6 +41,8 @@ type ImageLoader struct {
 }
 
 type Config interface {
+	kubectl.Config
+
 	GetKubeContext() string
 	LoadImages() bool
 }

--- a/pkg/skaffold/kubernetes/loader/load_test.go
+++ b/pkg/skaffold/kubernetes/loader/load_test.go
@@ -33,7 +33,6 @@ import (
 type ImageLoadingTest = struct {
 	description   string
 	cluster       string
-	built         []graph.Artifact
 	deployed      []graph.Artifact
 	commands      util.Command
 	shouldErr     bool
@@ -45,7 +44,6 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 		{
 			description: "load image",
 			cluster:     "kind",
-			built:       []graph.Artifact{{Tag: "tag1"}},
 			deployed:    []graph.Artifact{{Tag: "tag1"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
@@ -54,7 +52,6 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 		{
 			description: "load missing image",
 			cluster:     "other-kind",
-			built:       []graph.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			deployed:    []graph.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag1").
@@ -63,14 +60,12 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 		{
 			description: "no new images",
 			cluster:     "kind",
-			built:       []graph.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
 			deployed:    []graph.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag0 docker.io/library/tag1 docker.io/library/tag2 gcr.io/test/tag3 someregistry.com/tag4"),
 		},
 		{
 			description: "inspect error",
-			built:       []graph.Artifact{{Tag: "tag"}},
 			deployed:    []graph.Artifact{{Tag: "tag"}},
 			commands: testutil.
 				CmdRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "", errors.New("BUG")),
@@ -80,7 +75,6 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 		{
 			description: "load error",
 			cluster:     "kind",
-			built:       []graph.Artifact{{Tag: "tag"}},
 			deployed:    []graph.Artifact{{Tag: "tag"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
@@ -89,22 +83,8 @@ func TestLoadImagesInKindNodes(t *testing.T) {
 			expectedError: "output: error!",
 		},
 		{
-			description: "ignore image that's not built",
-			cluster:     "kind",
-			built:       []graph.Artifact{{Tag: "built"}},
-			deployed:    []graph.Artifact{{Tag: "built"}, {Tag: "busybox"}},
-			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
-				AndRunOut("kind load docker-image --name kind built", ""),
-		},
-		{
 			description: "no artifact",
 			deployed:    []graph.Artifact{},
-		},
-		{
-			description: "no built artifact",
-			built:       []graph.Artifact{},
-			deployed:    []graph.Artifact{{Tag: "busybox"}},
 		},
 	}
 
@@ -118,7 +98,6 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 		{
 			description: "load image",
 			cluster:     "k3d",
-			built:       []graph.Artifact{{Tag: "tag1"}},
 			deployed:    []graph.Artifact{{Tag: "tag1"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
@@ -127,7 +106,6 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 		{
 			description: "load missing image",
 			cluster:     "other-k3d",
-			built:       []graph.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			deployed:    []graph.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag1").
@@ -136,14 +114,12 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 		{
 			description: "no new images",
 			cluster:     "k3d",
-			built:       []graph.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
 			deployed:    []graph.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag0 docker.io/library/tag1 docker.io/library/tag2 gcr.io/test/tag3 someregistry.com/tag4"),
 		},
 		{
 			description: "inspect error",
-			built:       []graph.Artifact{{Tag: "tag"}},
 			deployed:    []graph.Artifact{{Tag: "tag"}},
 			commands: testutil.
 				CmdRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "", errors.New("BUG")),
@@ -153,7 +129,6 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 		{
 			description: "load error",
 			cluster:     "k3d",
-			built:       []graph.Artifact{{Tag: "tag"}},
 			deployed:    []graph.Artifact{{Tag: "tag"}},
 			commands: testutil.
 				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
@@ -162,22 +137,8 @@ func TestLoadImagesInK3dNodes(t *testing.T) {
 			expectedError: "output: error!",
 		},
 		{
-			description: "ignore image that's not built",
-			cluster:     "k3d",
-			built:       []graph.Artifact{{Tag: "built"}},
-			deployed:    []graph.Artifact{{Tag: "built"}, {Tag: "busybox"}},
-			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
-				AndRunOut("k3d image import --cluster k3d built", ""),
-		},
-		{
 			description: "no artifact",
 			deployed:    []graph.Artifact{},
-		},
-		{
-			description: "no built artifact",
-			built:       []graph.Artifact{},
-			deployed:    []graph.Artifact{{Tag: "busybox"}},
 		},
 	}
 
@@ -199,7 +160,6 @@ func runImageLoadingTests(t *testing.T, tests []ImageLoadingTest, loadingFunc fu
 			}
 
 			i := NewImageLoader(runCtx.KubeContext, kubectl.NewCLI(runCtx, ""))
-			i.builds = test.built
 			err := loadingFunc(i, test)
 
 			if test.shouldErr {
@@ -207,6 +167,65 @@ func runImageLoadingTests(t *testing.T, tests []ImageLoadingTest, loadingFunc fu
 			} else {
 				t.CheckNoError(err)
 			}
+		})
+	}
+}
+
+func TestImagesToLoad(t *testing.T) {
+	tests := []struct {
+		name           string
+		localImages    []graph.Artifact
+		deployerImages []graph.Artifact
+		builtImages    []graph.Artifact
+		expectedImages []graph.Artifact
+	}{
+		{
+			name:           "single image marked as local",
+			localImages:    []graph.Artifact{{ImageName: "image1", Tag: "foo"}},
+			deployerImages: []graph.Artifact{{ImageName: "image1", Tag: "foo"}},
+			builtImages:    []graph.Artifact{{ImageName: "image1", Tag: "foo"}},
+			expectedImages: []graph.Artifact{{ImageName: "image1", Tag: "foo"}},
+		},
+		{
+			name:           "single image, but not marked as local",
+			localImages:    []graph.Artifact{},
+			deployerImages: []graph.Artifact{{ImageName: "image1", Tag: "foo"}},
+			builtImages:    []graph.Artifact{{ImageName: "image1", Tag: "foo"}},
+			expectedImages: nil,
+		},
+		{
+			name:           "single image, marked as local but not found in deployer's manifests",
+			localImages:    []graph.Artifact{{ImageName: "image1", Tag: "foo"}},
+			deployerImages: []graph.Artifact{},
+			builtImages:    []graph.Artifact{{ImageName: "image1", Tag: "foo"}},
+			expectedImages: nil,
+		},
+		{
+			name:           "two images marked as local",
+			localImages:    []graph.Artifact{{ImageName: "image1", Tag: "foo"}, {ImageName: "image2", Tag: "bar"}},
+			deployerImages: []graph.Artifact{{ImageName: "image1", Tag: "foo"}, {ImageName: "image2", Tag: "bar"}},
+			builtImages:    []graph.Artifact{{ImageName: "image1", Tag: "foo"}, {ImageName: "image2", Tag: "bar"}},
+			expectedImages: []graph.Artifact{{ImageName: "image1", Tag: "foo"}, {ImageName: "image2", Tag: "bar"}},
+		},
+		{
+			name:           "two images, one marked as local and one not",
+			localImages:    []graph.Artifact{{ImageName: "image2", Tag: "bar"}},
+			deployerImages: []graph.Artifact{{ImageName: "image1", Tag: "foo"}, {ImageName: "image2", Tag: "bar"}},
+			builtImages:    []graph.Artifact{{ImageName: "image1", Tag: "foo"}, {ImageName: "image2", Tag: "bar"}},
+			expectedImages: []graph.Artifact{{ImageName: "image2", Tag: "bar"}},
+		},
+		{
+			name:           "two images, marked as local but only one found from the deployer's manifests",
+			localImages:    []graph.Artifact{{ImageName: "image1", Tag: "foo"}, {ImageName: "image2", Tag: "bar"}},
+			deployerImages: []graph.Artifact{{ImageName: "image2", Tag: "bar"}},
+			builtImages:    []graph.Artifact{{ImageName: "image1", Tag: "foo"}, {ImageName: "image2", Tag: "bar"}},
+			expectedImages: []graph.Artifact{{ImageName: "image2", Tag: "bar"}},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expectedImages, imagesToLoad(test.localImages, test.deployerImages, test.builtImages))
 		})
 	}
 }

--- a/pkg/skaffold/loader/loader.go
+++ b/pkg/skaffold/loader/loader.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"context"
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+)
+
+// ImageLoader defines the behavior for loading images into a cluster.
+type ImageLoader interface {
+	// LoadImages loads the images into the cluster.
+	LoadImages(context.Context, io.Writer, []graph.Artifact) error
+}
+
+type NoopImageLoader struct{}
+
+func (n *NoopImageLoader) LoadImages(context.Context, io.Writer, []graph.Artifact) error { return nil }

--- a/pkg/skaffold/loader/loader.go
+++ b/pkg/skaffold/loader/loader.go
@@ -26,9 +26,13 @@ import (
 // ImageLoader defines the behavior for loading images into a cluster.
 type ImageLoader interface {
 	// LoadImages loads the images into the cluster.
-	LoadImages(context.Context, io.Writer, []graph.Artifact) error
+	LoadImages(context.Context, io.Writer, []graph.Artifact, []graph.Artifact, []graph.Artifact) error
 }
 
 type NoopImageLoader struct{}
 
-func (n *NoopImageLoader) LoadImages(context.Context, io.Writer, []graph.Artifact) error { return nil }
+func (n *NoopImageLoader) LoadImages(context.Context, io.Writer, []graph.Artifact, []graph.Artifact, []graph.Artifact) error {
+	return nil
+}
+
+func (n *NoopImageLoader) TrackBuildArtifacts([]graph.Artifact, []graph.Artifact) {}

--- a/pkg/skaffold/loader/loader_mux.go
+++ b/pkg/skaffold/loader/loader_mux.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"context"
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+)
+
+type ImageLoaderMux []ImageLoader
+
+func (i ImageLoaderMux) LoadImages(ctx context.Context, out io.Writer, images []graph.Artifact) error {
+	for _, loader := range i {
+		if err := loader.LoadImages(ctx, out, images); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/skaffold/loader/loader_mux.go
+++ b/pkg/skaffold/loader/loader_mux.go
@@ -25,9 +25,9 @@ import (
 
 type ImageLoaderMux []ImageLoader
 
-func (i ImageLoaderMux) LoadImages(ctx context.Context, out io.Writer, images []graph.Artifact) error {
+func (i ImageLoaderMux) LoadImages(ctx context.Context, out io.Writer, localImages, originalImages, images []graph.Artifact) error {
 	for _, loader := range i {
-		if err := loader.LoadImages(ctx, out, images); err != nil {
+		if err := loader.LoadImages(ctx, out, localImages, originalImages, images); err != nil {
 			return err
 		}
 	}

--- a/pkg/skaffold/loader/provider.go
+++ b/pkg/skaffold/loader/provider.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loader
+
+import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/loader"
+)
+
+type Provider interface {
+	GetKubernetesImageLoader() ImageLoader
+	GetNoopImageLoader() ImageLoader
+}
+
+type fullProvider struct {
+	loadImages  bool
+	kubeContext string
+	cli         *kubectl.CLI
+}
+
+func NewImageLoaderProvider(config loader.Config, cli *kubectl.CLI) Provider {
+	return &fullProvider{
+		loadImages:  config.LoadImages(),
+		kubeContext: config.GetKubeContext(),
+		cli:         cli,
+	}
+}
+
+func (p *fullProvider) GetKubernetesImageLoader() ImageLoader {
+	if p.loadImages {
+		return loader.NewImageLoader(p.kubeContext, p.cli)
+	}
+	return &NoopImageLoader{}
+}
+
+func (p *fullProvider) GetNoopImageLoader() ImageLoader {
+	return &NoopImageLoader{}
+}
+
+// NoopProvider is used in tests
+type NoopProvider struct{}
+
+func (p *NoopProvider) GetKubernetesImageLoader() ImageLoader {
+	return &NoopImageLoader{}
+}
+
+func (p *NoopProvider) GetNoopImageLoader() ImageLoader {
+	return &NoopImageLoader{}
+}

--- a/pkg/skaffold/loader/provider.go
+++ b/pkg/skaffold/loader/provider.go
@@ -22,27 +22,19 @@ import (
 )
 
 type Provider interface {
-	GetKubernetesImageLoader() ImageLoader
+	GetKubernetesImageLoader(loader.Config) ImageLoader
 	GetNoopImageLoader() ImageLoader
 }
 
-type fullProvider struct {
-	loadImages  bool
-	kubeContext string
-	cli         *kubectl.CLI
+type fullProvider struct{}
+
+func NewImageLoaderProvider() Provider {
+	return &fullProvider{}
 }
 
-func NewImageLoaderProvider(config loader.Config, cli *kubectl.CLI) Provider {
-	return &fullProvider{
-		loadImages:  config.LoadImages(),
-		kubeContext: config.GetKubeContext(),
-		cli:         cli,
-	}
-}
-
-func (p *fullProvider) GetKubernetesImageLoader() ImageLoader {
-	if p.loadImages {
-		return loader.NewImageLoader(p.kubeContext, p.cli)
+func (p *fullProvider) GetKubernetesImageLoader(config loader.Config) ImageLoader {
+	if config.LoadImages() {
+		return loader.NewImageLoader(config.GetKubeContext(), kubectl.NewCLI(config, ""))
 	}
 	return &NoopImageLoader{}
 }
@@ -54,7 +46,7 @@ func (p *fullProvider) GetNoopImageLoader() ImageLoader {
 // NoopProvider is used in tests
 type NoopProvider struct{}
 
-func (p *NoopProvider) GetKubernetesImageLoader() ImageLoader {
+func (p *NoopProvider) GetKubernetesImageLoader(loader.Config) ImageLoader {
 	return &NoopImageLoader{}
 }
 

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -177,6 +177,7 @@ func (rc *RunContext) GetKubeConfig() string                         { return rc
 func (rc *RunContext) GetKubeNamespace() string                      { return rc.Opts.Namespace }
 func (rc *RunContext) GlobalConfig() string                          { return rc.Opts.GlobalConfig }
 func (rc *RunContext) HydratedManifests() []string                   { return rc.Opts.HydratedManifests }
+func (rc *RunContext) LoadImages() bool                              { return rc.Cluster.LoadImages }
 func (rc *RunContext) MinikubeProfile() string                       { return rc.Opts.MinikubeProfile }
 func (rc *RunContext) Muted() config.Muted                           { return rc.Opts.Muted }
 func (rc *RunContext) NoPruneChildren() bool                         { return rc.Opts.NoPruneChildren }

--- a/pkg/skaffold/runner/v1/apply.go
+++ b/pkg/skaffold/runner/v1/apply.go
@@ -51,21 +51,15 @@ func (r *SkaffoldRunner) applyResources(ctx context.Context, out io.Writer, arti
 		return fmt.Errorf("unable to connect to Kubernetes: %w", err)
 	}
 
-	ctx, endTrace := instrumentation.StartTrace(ctx, "applyResources_LoadImagesIntoCluster")
-	if err := r.deployer.GetImageLoader().LoadImages(ctx, out, localImages); err != nil {
-		endTrace(instrumentation.TraceEndError(err))
-		return err
-	}
-	endTrace()
-
 	deployOut, postDeployFn, err := deployutil.WithLogFile(time.Now().Format(deployutil.TimeFormat)+".log", out, r.runCtx.Muted())
 	if err != nil {
 		return err
 	}
 
 	event.DeployInProgress()
-	ctx, endTrace = instrumentation.StartTrace(ctx, "applyResources_Deploying")
+	ctx, endTrace := instrumentation.StartTrace(ctx, "applyResources_Deploying")
 	defer endTrace()
+	r.deployer.RegisterLocalImages(localImages)
 	namespaces, err := r.deployer.Deploy(ctx, deployOut, artifacts)
 	postDeployFn()
 	if err != nil {

--- a/pkg/skaffold/runner/v1/apply.go
+++ b/pkg/skaffold/runner/v1/apply.go
@@ -52,12 +52,9 @@ func (r *SkaffoldRunner) applyResources(ctx context.Context, out io.Writer, arti
 	}
 
 	ctx, endTrace := instrumentation.StartTrace(ctx, "applyResources_LoadImagesIntoCluster")
-	if len(localImages) > 0 && r.runCtx.Cluster.LoadImages {
-		err := r.loadImagesIntoCluster(ctx, out, localImages)
-		if err != nil {
-			endTrace(instrumentation.TraceEndError(err))
-			return err
-		}
+	if err := r.deployer.GetImageLoader().LoadImages(ctx, out, localImages); err != nil {
+		endTrace(instrumentation.TraceEndError(err))
+		return err
 	}
 	endTrace()
 

--- a/pkg/skaffold/runner/v1/deploy.go
+++ b/pkg/skaffold/runner/v1/deploy.go
@@ -101,10 +101,6 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 		return fmt.Errorf("unable to connect to Kubernetes: %w", err)
 	}
 
-	if err := r.deployer.GetImageLoader().LoadImages(ctx, out, localImages); err != nil {
-		return err
-	}
-
 	deployOut, postDeployFn, err := deployutil.WithLogFile(time.Now().Format(deployutil.TimeFormat)+".log", out, r.runCtx.Muted())
 	if err != nil {
 		return err
@@ -115,6 +111,7 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 	ctx, endTrace := instrumentation.StartTrace(ctx, "Deploy_Deploying")
 	defer endTrace()
 
+	r.deployer.RegisterLocalImages(localImages)
 	namespaces, err := r.deployer.Deploy(ctx, deployOut, artifacts)
 	postDeployFn()
 	if err != nil {

--- a/pkg/skaffold/runner/v1/deploy.go
+++ b/pkg/skaffold/runner/v1/deploy.go
@@ -23,9 +23,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	deployutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
@@ -33,7 +31,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
-	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 )
 
@@ -104,11 +101,8 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 		return fmt.Errorf("unable to connect to Kubernetes: %w", err)
 	}
 
-	if len(localImages) > 0 && r.runCtx.Cluster.LoadImages {
-		err := r.loadImagesIntoCluster(ctx, out, localImages)
-		if err != nil {
-			return err
-		}
+	if err := r.deployer.GetImageLoader().LoadImages(ctx, out, localImages); err != nil {
+		return err
 	}
 
 	deployOut, postDeployFn, err := deployutil.WithLogFile(time.Now().Format(deployutil.TimeFormat)+".log", out, r.runCtx.Muted())
@@ -147,46 +141,6 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 		return r.deployer.GetStatusMonitor().Check(ctx, statusCheckOut)
 	}
 	return nil
-}
-
-func (r *SkaffoldRunner) loadImagesIntoCluster(ctx context.Context, out io.Writer, artifacts []graph.Artifact) error {
-	currentContext, err := r.getCurrentContext()
-	if err != nil {
-		return err
-	}
-
-	if config.IsKindCluster(r.runCtx.GetKubeContext()) {
-		kindCluster := config.KindClusterName(currentContext.Cluster)
-
-		// With `kind`, docker images have to be loaded with the `kind` CLI.
-		if err := r.loadImagesInKindNodes(ctx, out, kindCluster, artifacts); err != nil {
-			return fmt.Errorf("loading images into kind nodes: %w", err)
-		}
-	}
-
-	if config.IsK3dCluster(r.runCtx.GetKubeContext()) {
-		k3dCluster := config.K3dClusterName(currentContext.Cluster)
-
-		// With `k3d`, docker images have to be loaded with the `k3d` CLI.
-		if err := r.loadImagesInK3dNodes(ctx, out, k3dCluster, artifacts); err != nil {
-			return fmt.Errorf("loading images into k3d nodes: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (r *SkaffoldRunner) getCurrentContext() (*api.Context, error) {
-	currentCfg, err := kubectx.CurrentConfig()
-	if err != nil {
-		return nil, fmt.Errorf("unable to get kubernetes config: %w", err)
-	}
-
-	currentContext, present := currentCfg.Contexts[r.runCtx.GetKubeContext()]
-	if !present {
-		return nil, fmt.Errorf("unable to get current kubernetes context: %w", err)
-	}
-	return currentContext, nil
 }
 
 // failIfClusterIsNotReachable checks that Kubernetes is reachable.

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -34,6 +34,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	pkgkubectl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
@@ -86,11 +87,12 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 
 	var deployer deploy.Deployer
 	provider := deploy.ComponentProvider{
-		Accessor: access.NewAccessorProvider(labeller),
-		Debugger: debug.NewDebugProvider(runCtx),
-		Logger:   log.NewLogProvider(runCtx, kubectlCLI),
-		Monitor:  status.NewMonitorProvider(labeller),
-		Syncer:   sync.NewSyncProvider(runCtx, kubectlCLI),
+		Accessor:    access.NewAccessorProvider(labeller),
+		Debugger:    debug.NewDebugProvider(runCtx),
+		ImageLoader: loader.NewImageLoaderProvider(runCtx, kubectlCLI),
+		Logger:      log.NewLogProvider(runCtx, kubectlCLI),
+		Monitor:     status.NewMonitorProvider(labeller),
+		Syncer:      sync.NewSyncProvider(runCtx, kubectlCLI),
 	}
 
 	deployer, err = runner.GetDeployer(runCtx, provider, labeller.Labels())

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -89,7 +89,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 	provider := deploy.ComponentProvider{
 		Accessor:    access.NewAccessorProvider(labeller),
 		Debugger:    debug.NewDebugProvider(runCtx),
-		ImageLoader: loader.NewImageLoaderProvider(runCtx, kubectlCLI),
+		ImageLoader: loader.NewImageLoaderProvider(),
 		Logger:      log.NewLogProvider(runCtx, kubectlCLI),
 		Monitor:     status.NewMonitorProvider(labeller),
 		Syncer:      sync.NewSyncProvider(runCtx, kubectlCLI),

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
@@ -123,6 +124,10 @@ func (t *TestBench) GetStatusMonitor() status.Monitor {
 
 func (t *TestBench) GetSyncer() sync.Syncer {
 	return t
+}
+
+func (t *TestBench) GetImageLoader() loader.ImageLoader {
+	return &loader.NoopImageLoader{}
 }
 
 func (t *TestBench) TrackBuildArtifacts(_ []graph.Artifact) {}

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/loader"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
@@ -126,10 +125,7 @@ func (t *TestBench) GetSyncer() sync.Syncer {
 	return t
 }
 
-func (t *TestBench) GetImageLoader() loader.ImageLoader {
-	return &loader.NoopImageLoader{}
-}
-
+func (t *TestBench) RegisterLocalImages(_ []graph.Artifact) {}
 func (t *TestBench) TrackBuildArtifacts(_ []graph.Artifact) {}
 
 func (t *TestBench) TestDependencies(*latestV1.Artifact) ([]string, error) { return nil, nil }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->

**Related**: #6117, #6107

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
The `Runner` has historically been responsible for loading images into local kubernetes clusters before running, as is required by `kind`, `k3d`, and even `minikube` (when running with `containerd`). However, this is really a behavior that should be carried out by the `Deployer`, as it is the component that has knowledge of the cluster - the `Runner` is just an orchestrator.

This change creates an `ImageLoader` component, which is responsible for performing any image loading into the cluster before doing a deploy.

This component has a single method on it:

```golang
type ImageLoader interface {
  LoadImages(context.Context, io.Writer, images []graph.Artifact)
}
```

A single implementation of this interface is added in the `pkg/skaffold/kubernetes/loader` package, which embeds the existing image load logic from the `Runner` inside of it.

One method is added to the `Deployer` interface to give the `Runner` the ability to pass images it has marked as local:

```golang
type Deployer interface {
  ...

  RegisterLocalImages([]graph.Artifact)
}
```
---

**Update**: Each `Deployer` is now responsible for loading the set of images that it will be deploying, similar to the way each `Deployer` only tracks its own images for logging. This is determined by the union of the following 3 sets:
* Images which have been deemed by the `Runner` as local
* Images which have been found in a `Deployer`'s set of manifests
* Images which are passed by the `Deployer` to be loaded