### PR TITLE
Bump puma from 4.3.5 to 4.3.8 in integration/examples/ruby/backend

### DIFF
--- a/integration/examples/ruby/backend/Gemfile.lock
+++ b/integration/examples/ruby/backend/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    nio4r (2.5.2)
-    puma (4.3.5)
+    nio4r (2.5.7)
+    puma (4.3.8)
       nio4r (~> 2.0)
     rack (2.1.4)
     rack-unreloader (1.7.0)


### PR DESCRIPTION
Apply updates from #6110 to `integration/examples/ruby/backend` too.