### PR TITLE
Fetch namespaces at time of sync

### DIFF
--- a/pkg/skaffold/sync/provider.go
+++ b/pkg/skaffold/sync/provider.go
@@ -43,8 +43,8 @@ func NewSyncProvider(config Config, cli *kubectl.CLI) Provider {
 		provider = &fullProvider{
 			kubernetesSyncer: func(podSelector *kubernetes.ImageList) Syncer {
 				return &podSyncer{
-					kubectl:    cli,
-					config: config,
+					kubectl: cli,
+					config:  config,
 				}
 			},
 			noopSyncer: func() Syncer {

--- a/pkg/skaffold/sync/provider.go
+++ b/pkg/skaffold/sync/provider.go
@@ -44,7 +44,7 @@ func NewSyncProvider(config Config, cli *kubectl.CLI) Provider {
 			kubernetesSyncer: func(podSelector *kubernetes.ImageList) Syncer {
 				return &podSyncer{
 					kubectl:    cli,
-					namespaces: config.GetNamespaces(),
+					config: config,
 				}
 			},
 			noopSyncer: func() Syncer {

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -256,7 +256,7 @@ func (s *podSyncer) Sync(ctx context.Context, item *Item) error {
 	if len(item.Copy) > 0 {
 		logrus.Infoln("Copying files:", item.Copy, "to", item.Image)
 
-		if err := Perform(ctx, item.Image, item.Copy, s.copyFileFn, s.namespaces); err != nil {
+		if err := Perform(ctx, item.Image, item.Copy, s.copyFileFn, s.config.GetNamespaces()); err != nil {
 			return fmt.Errorf("copying files: %w", err)
 		}
 	}
@@ -264,7 +264,7 @@ func (s *podSyncer) Sync(ctx context.Context, item *Item) error {
 	if len(item.Delete) > 0 {
 		logrus.Infoln("Deleting files:", item.Delete, "from", item.Image)
 
-		if err := Perform(ctx, item.Image, item.Delete, s.deleteFileFn, s.namespaces); err != nil {
+		if err := Perform(ctx, item.Image, item.Delete, s.deleteFileFn, s.config.GetNamespaces()); err != nil {
 			return fmt.Errorf("deleting files: %w", err)
 		}
 	}

--- a/pkg/skaffold/sync/types.go
+++ b/pkg/skaffold/sync/types.go
@@ -35,8 +35,8 @@ type Syncer interface {
 }
 
 type podSyncer struct {
-	kubectl    *pkgkubectl.CLI
-	namespaces []string
+	kubectl *pkgkubectl.CLI
+	config  Config
 }
 
 type Config interface {


### PR DESCRIPTION
Fixes: #5968

**Description**
The `podSyncer` is initialized with the set of namespaces from the configuration, and thus misses any namespace updates from the deployment.
https://github.com/GoogleContainerTools/skaffold/blob/823896bdd7464d79886664b32f56948957ea5f65/pkg/skaffold/sync/provider.go#L41-L49

This patch causes the config to be passed to the `podSyncer` such that it processes the known namespaces at sync time.
