### PR TITLE
Replace missing template values with empty string

### DIFF
--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -117,7 +117,7 @@ var testDeployConfigTemplated = latestV1.HelmDeploy{
 		SetValueTemplates: map[string]string{
 			"some.key":    "somevalue",
 			"other.key":   "{{.FOO}}",
-			"missing.key": "{{.MISSING}}",
+			"missing.key": `{{default "<MISSING>" .MISSING}}`,
 			"image.name":  "{{.IMAGE_NAME}}",
 			"image.tag":   "{{.DIGEST}}",
 			"{{.FOO}}":    "somevalue",
@@ -881,7 +881,7 @@ func TestHelmDeploy(t *testing.T) {
 				CmdRunWithOutput("helm version --client", version31).
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
-				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set image.name=skaffold-helm --set image.tag=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set missing.key= --set other.key=FOOBAR --set some.key=somevalue --set FOOBAR=somevalue -f skaffold-overrides.yaml --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set image.name=skaffold-helm --set image.tag=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set missing.key=<MISSING> --set other.key=FOOBAR --set some.key=somevalue --set FOOBAR=somevalue -f skaffold-overrides.yaml --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:   testDeployConfigTemplated,
 			builds: testBuilds,
@@ -1328,7 +1328,7 @@ func TestHelmRender(t *testing.T) {
 			shouldErr:   false,
 			commands: testutil.
 				CmdRunWithOutput("helm version --client", version31).
-				AndRun("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set image.name=skaffold-helm --set image.tag=skaffold-helm:tag1 --set missing.key= --set other.key=FOOBAR --set some.key=somevalue --set FOOBAR=somevalue --kubeconfig kubeconfig"),
+				AndRun("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set image.name=skaffold-helm --set image.tag=skaffold-helm:tag1 --set missing.key=<MISSING> --set other.key=FOOBAR --set some.key=somevalue --set FOOBAR=somevalue --kubeconfig kubeconfig"),
 			helm: testDeployConfigTemplated,
 			builds: []graph.Artifact{
 				{

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -881,7 +881,7 @@ func TestHelmDeploy(t *testing.T) {
 				CmdRunWithOutput("helm version --client", version31).
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext dep build examples/test --kubeconfig kubeconfig").
-				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set image.name=skaffold-helm --set image.tag=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set missing.key=<no value> --set other.key=FOOBAR --set some.key=somevalue --set FOOBAR=somevalue -f skaffold-overrides.yaml --kubeconfig kubeconfig").
+				AndRun("helm --kube-context kubecontext upgrade skaffold-helm examples/test --set-string image=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set image.name=skaffold-helm --set image.tag=docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184 --set missing.key= --set other.key=FOOBAR --set some.key=somevalue --set FOOBAR=somevalue -f skaffold-overrides.yaml --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:   testDeployConfigTemplated,
 			builds: testBuilds,
@@ -1328,7 +1328,7 @@ func TestHelmRender(t *testing.T) {
 			shouldErr:   false,
 			commands: testutil.
 				CmdRunWithOutput("helm version --client", version31).
-				AndRun("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set image.name=skaffold-helm --set image.tag=skaffold-helm:tag1 --set missing.key=<no value> --set other.key=FOOBAR --set some.key=somevalue --set FOOBAR=somevalue --kubeconfig kubeconfig"),
+				AndRun("helm --kube-context kubecontext template skaffold-helm examples/test --set-string image=skaffold-helm:tag1 --set image.name=skaffold-helm --set image.tag=skaffold-helm:tag1 --set missing.key= --set other.key=FOOBAR --set some.key=somevalue --set FOOBAR=somevalue --kubeconfig kubeconfig"),
 			helm: testDeployConfigTemplated,
 			builds: []graph.Artifact{
 				{

--- a/pkg/skaffold/util/env_template.go
+++ b/pkg/skaffold/util/env_template.go
@@ -53,7 +53,7 @@ func ExpandEnvTemplateOrFail(s string, envMap map[string]string) (string, error)
 
 // ParseEnvTemplate is a simple wrapper to parse an env template
 func ParseEnvTemplate(t string) (*template.Template, error) {
-	return template.New("envTemplate").Parse(t)
+	return template.New("envTemplate").Option("missingkey=zero").Parse(t)
 }
 
 // ExecuteEnvTemplate executes an envTemplate based on OS environment variables and a custom map

--- a/pkg/skaffold/util/env_template_test.go
+++ b/pkg/skaffold/util/env_template_test.go
@@ -65,9 +65,8 @@ func TestEnvTemplate_ExecuteEnvTemplate(t *testing.T) {
 		{
 			description: "missing results in empty",
 			template:    "{{.FOO}}:{{.BAR}}",
-			customMap: map[string]string{
-			},
-			want: ":",
+			customMap:   map[string]string{},
+			want:        ":",
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/util/env_template_test.go
+++ b/pkg/skaffold/util/env_template_test.go
@@ -62,6 +62,13 @@ func TestEnvTemplate_ExecuteEnvTemplate(t *testing.T) {
 			env:         []string{"VAL=KEY"},
 			shouldErr:   true,
 		},
+		{
+			description: "missing results in empty",
+			template:    "{{.FOO}}:{{.BAR}}",
+			customMap: map[string]string{
+			},
+			want: ":",
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
@@ -85,7 +92,6 @@ func TestEnvTemplate_ExpandEnvTemplateOrFail(t *testing.T) {
 		template    string
 		customMap   map[string]string
 		env         []string
-		option      string
 		want        string
 		shouldErr   bool
 	}{
@@ -102,7 +108,6 @@ func TestEnvTemplate_ExpandEnvTemplateOrFail(t *testing.T) {
 		{
 			description: "variable does not exist",
 			template:    "{{.DOES_NOT_EXIST}}",
-			option:      "missingkey=error",
 			shouldErr:   true,
 		},
 	}

--- a/pkg/skaffold/util/env_template_test.go
+++ b/pkg/skaffold/util/env_template_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -64,9 +65,9 @@ func TestEnvTemplate_ExecuteEnvTemplate(t *testing.T) {
 		},
 		{
 			description: "missing results in empty",
-			template:    "{{.FOO}}:{{.BAR}}",
+			template:    `{{default "a" .FOO}}:{{.BAR}}`,
 			customMap:   map[string]string{},
-			want:        ":",
+			want:        "a:<no value>",
 		},
 	}
 	for _, test := range tests {
@@ -175,6 +176,26 @@ func TestMapToFlag(t *testing.T) {
 			got, err := MapToFlag(test.args.m, test.args.flag)
 			t.CheckNoError(err)
 			t.CheckErrorAndDeepEqual(test.wantErr, err, test.want, got)
+		})
+	}
+}
+
+func TestDefaultFunc(t *testing.T) {
+	for _, empty := range []interface{}{nil, false, 0, "", []string{}} {
+		t.Run(fmt.Sprintf("empties: %v (%T)", empty, empty), func(t *testing.T) {
+			dflt := "default"
+			if defaultFunc(dflt, empty) != dflt {
+				t.Error("did not return default")
+			}
+		})
+	}
+	s := "string"
+	for _, nonEmpty := range []interface{}{&s, true, 1, "hoot", []string{"hoot"}} {
+		t.Run(fmt.Sprintf("non-empty: %v (%T)", nonEmpty, nonEmpty), func(t *testing.T) {
+			dflt := "default"
+			if defaultFunc(dflt, nonEmpty) == dflt {
+				t.Error("should not return default")
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes: #6128

**Description**
Introduce new `default` function, modelled on [sprig's `default` function](https://masterminds.github.io/sprig/defaults.html#default):

     {{default "value" .MISSING}}

results in `"value"` if `.MISSING` is nil or a zero value.
