### PR TITLE
hooks:  `sync` refactor

### DIFF
--- a/pkg/skaffold/runner/v1/dev.go
+++ b/pkg/skaffold/runner/v1/dev.go
@@ -92,7 +92,7 @@ func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer) error {
 			output.Default.Fprintf(out, "Syncing %d files for %s\n", fileCount, s.Image)
 			fileSyncInProgress(fileCount, s.Image)
 
-			if err := r.deployer.GetSyncer().Sync(childCtx, s); err != nil {
+			if err := r.deployer.GetSyncer().Sync(childCtx, out, s); err != nil {
 				logrus.Warnln("Skipping deploy due to sync error:", err)
 				fileSyncFailed(fileCount, s.Image, err)
 				event.DevLoopFailedInPhase(r.devIteration, constants.Sync, err)

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -161,7 +161,7 @@ func (t *TestBench) Build(_ context.Context, _ io.Writer, _ tag.ImageTags, artif
 	return builds, nil
 }
 
-func (t *TestBench) Sync(_ context.Context, item *sync.Item) error {
+func (t *TestBench) Sync(_ context.Context, _ io.Writer, item *sync.Item) error {
 	if len(t.syncErrors) > 0 {
 		err := t.syncErrors[0]
 		t.syncErrors = t.syncErrors[1:]

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os/exec"
 	"path"
 	"path/filepath"
@@ -100,7 +101,7 @@ func syncItem(a *latestV1.Artifact, tag string, e filemon.Events, syncRules []*l
 		return nil, nil
 	}
 
-	return &Item{Image: tag, Copy: toCopy, Delete: toDelete}, nil
+	return &Item{Image: tag, Artifact: a, Copy: toCopy, Delete: toDelete}, nil
 }
 
 func inferredSyncItem(a *latestV1.Artifact, tag string, e filemon.Events, cfg docker.Config) (*Item, error) {
@@ -144,7 +145,7 @@ func inferredSyncItem(a *latestV1.Artifact, tag string, e filemon.Events, cfg do
 		}
 	}
 
-	return &Item{Image: tag, Copy: toCopy}, nil
+	return &Item{Image: tag, Artifact: a, Copy: toCopy}, nil
 }
 
 func syncMapForArtifact(a *latestV1.Artifact, cfg docker.Config) (map[string][]string, error) {
@@ -187,7 +188,7 @@ func autoSyncItem(ctx context.Context, a *latestV1.Artifact, tag string, e filem
 			// do a rebuild
 			return nil, nil
 		}
-		return &Item{Image: tag, Copy: toCopy, Delete: toDelete}, nil
+		return &Item{Image: tag, Artifact: a, Copy: toCopy, Delete: toDelete}, nil
 
 	default:
 		// TODO: this error does appear a little late in the build, perhaps it could surface at first run, rather than first sync?
@@ -252,7 +253,7 @@ func matchSyncRules(syncRules []*latestV1.SyncRule, relPath, containerWd string)
 	return dsts, nil
 }
 
-func (s *podSyncer) Sync(ctx context.Context, item *Item) error {
+func (s *podSyncer) Sync(ctx context.Context, out io.Writer, item *Item) error {
 	if len(item.Copy) > 0 {
 		logrus.Infoln("Copying files:", item.Copy, "to", item.Image)
 

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -758,7 +758,9 @@ func TestNewSyncItem(t *testing.T) {
 			})
 
 			actual, err := NewItem(ctx, test.artifact, test.evt, test.builds, &mockConfig{}, 0)
-
+			if test.expected != nil {
+				test.expected.Artifact = test.artifact
+			}
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, actual)
 		})
 	}

--- a/pkg/skaffold/sync/syncer_mux.go
+++ b/pkg/skaffold/sync/syncer_mux.go
@@ -16,13 +16,16 @@ limitations under the License.
 
 package sync
 
-import "context"
+import (
+	"context"
+	"io"
+)
 
 type SyncerMux []Syncer
 
-func (s SyncerMux) Sync(ctx context.Context, item *Item) error {
+func (s SyncerMux) Sync(ctx context.Context, out io.Writer, item *Item) error {
 	for _, syncer := range s {
-		if err := syncer.Sync(ctx, item); err != nil {
+		if err := syncer.Sync(ctx, out, item); err != nil {
 			return err
 		}
 	}

--- a/pkg/skaffold/sync/types.go
+++ b/pkg/skaffold/sync/types.go
@@ -18,20 +18,23 @@ package sync
 
 import (
 	"context"
+	"io"
 
 	pkgkubectl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 type syncMap map[string][]string
 
 type Item struct {
-	Image  string
-	Copy   map[string][]string
-	Delete map[string][]string
+	Image    string
+	Artifact *v1.Artifact
+	Copy     map[string][]string
+	Delete   map[string][]string
 }
 
 type Syncer interface {
-	Sync(context.Context, *Item) error
+	Sync(context.Context, io.Writer, *Item) error
 }
 
 type podSyncer struct {
@@ -45,6 +48,10 @@ type Config interface {
 
 type NoopSyncer struct{}
 
-func (s *NoopSyncer) Sync(context.Context, *Item) error {
+func (s *NoopSyncer) Sync(context.Context, io.Writer, *Item) error {
 	return nil
+}
+
+func (i *Item) HasChanges() bool {
+	return i != nil && (len(i.Copy) > 0 || len(i.Delete) > 0)
 }


### PR DESCRIPTION
### Hooks PR 2 of n

Related: #1441, #6147, #6159

Please refer to #6147 for the complete set of changes. This PR only modifies the following:
- add `v1.Artifact` reference to `podSyncer`
we want to be able to reference the `v1.Artifact.Sync.Hooks` struct from within the podSyncer which run the pre and post sync hooks.
- add `io.Writer` parameter to `Sync` method 
we need an output writer for the hooks executor.
~~Merge after #6159, only review last commit.~~