### PR TITLE
change ptypes call to timestamppb to fix linters

### DIFF
--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -25,8 +25,8 @@ import (
 
 	//nolint:golint,staticcheck
 	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
@@ -554,7 +554,7 @@ func (ev *eventHandler) handleFileSyncEvent(e *proto.FileSyncEvent) {
 func LogMetaEvent() {
 	metadata := handler.state.Metadata
 	handler.logEvent(proto.LogEntry{
-		Timestamp: ptypes.TimestampNow(),
+		Timestamp: timestamppb.Now(),
 		Event: &proto.Event{
 			EventType: &proto.Event_MetaEvent{
 				MetaEvent: &proto.MetaEvent{
@@ -569,7 +569,7 @@ func LogMetaEvent() {
 func (ev *eventHandler) handle(event *proto.Event) {
 	ev.eventChan <- firedEvent{
 		event: event,
-		ts:    ptypes.TimestampNow(),
+		ts:    timestamppb.Now(),
 	}
 	if _, ok := event.GetEventType().(*proto.Event_TerminationEvent); ok {
 		// close the event channel indicating there are no more events to all the

--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -25,7 +25,7 @@ import (
 
 	//nolint:golint,staticcheck
 	"github.com/golang/protobuf/jsonpb"
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
@@ -376,7 +376,7 @@ func (ev *eventHandler) setState(state proto.State) {
 }
 
 func (ev *eventHandler) handle(event *proto.Event) {
-	event.Timestamp = ptypes.TimestampNow()
+	event.Timestamp = timestamppb.Now()
 	ev.eventChan <- event
 	if _, ok := event.GetEventType().(*proto.Event_TerminationEvent); ok {
 		// close the event channel indicating there are no more events to all the


### PR DESCRIPTION
Seeing this error in CI:
full logs: https://app.travis-ci.com/github/GoogleContainerTools/skaffold/jobs/522665097

snippet
```
INFO [runner] linters took 2m39.517708463s with stages: goanalysis_metalinter: 2m15.060735761s, unused: 24.3748312s 
pkg/skaffold/event/event.go:557:14: SA1019: ptypes.TimestampNow is deprecated: Call the timestamppb.Now function instead. (staticcheck)
		Timestamp: ptypes.TimestampNow(),
		           ^
pkg/skaffold/event/event.go:572:10: SA1019: ptypes.TimestampNow is deprecated: Call the timestamppb.Now function instead. (staticcheck)
		ts:    ptypes.TimestampNow(),
		       ^
pkg/skaffold/event/event.go:28:2: SA1019: package github.com/golang/protobuf/ptypes is deprecated: Well-known types have specialized functionality directly injected into the generated packages for each message type. See the deprecation notice for each function for the suggested alternative. (staticcheck)
	"github.com/golang/protobuf/ptypes"
	^
pkg/skaffold/event/v2/event.go:379:20: SA1019: ptypes.TimestampNow is deprecated: Call the timestamppb.Now function instead. (staticcheck)
	event.Timestamp = ptypes.TimestampNow()
	                  ^
pkg/skaffold/event/v2/event.go:28:2: SA1019: package github.com/golang/protobuf/ptypes is deprecated: Well-known types have specialized functionality directly injected into the generated packages for each message type. See the deprecation notice for each function for the suggested alternative. (staticcheck)
	"github.com/golang/protobuf/ptypes"
	^
```