### PR TITLE
Simplify `BuildSubtaskEvent` ID setting/handling

### DIFF
--- a/pkg/skaffold/build/scheduler.go
+++ b/pkg/skaffold/build/scheduler.go
@@ -108,7 +108,7 @@ func (s *scheduler) build(ctx context.Context, tags tag.ImageTags, i int) error 
 	}
 	defer closeFn()
 
-	w = output.WithEventContext(w, constants.Build, strconv.Itoa(eventV2.GetArtifactID(a)), "skaffold")
+	w = output.WithEventContext(w, constants.Build, a.ImageName, "skaffold")
 	finalTag, err := performBuild(ctx, w, tags, a, s.artifactBuilder)
 	if err != nil {
 		event.BuildFailed(a.ImageName, err)

--- a/pkg/skaffold/event/v2/build.go
+++ b/pkg/skaffold/event/v2/build.go
@@ -18,11 +18,9 @@ package v2
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	proto "github.com/GoogleContainerTools/skaffold/proto/v2"
 )
 
@@ -30,22 +28,6 @@ const (
 	Cache = "Cache"
 	Build = "Build"
 )
-
-var artifactIDs = map[string]int{}
-
-func AssignArtifactIDs(artifacts []*latestV1.Artifact) {
-	for i, a := range artifacts {
-		artifactIDs[a.ImageName] = i
-	}
-}
-
-func GetArtifactID(a *latestV1.Artifact) int {
-	if id, ok := artifactIDs[a.ImageName]; ok {
-		return id
-	}
-
-	return -1
-}
 
 func CacheCheckInProgress(artifact string) {
 	buildSubtaskEvent(artifact, Cache, InProgress, nil)
@@ -77,7 +59,7 @@ func buildSubtaskEvent(artifact, step, status string, err error) {
 		aErr = sErrors.ActionableErrV2(handler.cfg, constants.Build, err)
 	}
 	handler.handleBuildSubtaskEvent(&proto.BuildSubtaskEvent{
-		Id:            strconv.Itoa(artifactIDs[artifact]),
+		Id:            artifact,
 		TaskId:        fmt.Sprintf("%s-%d", constants.Build, handler.iteration),
 		Artifact:      artifact,
 		Step:          step,

--- a/pkg/skaffold/runner/build.go
+++ b/pkg/skaffold/runner/build.go
@@ -65,7 +65,6 @@ func (r *Builder) GetBuilds() []graph.Artifact {
 // Build builds a list of artifacts.
 func (r *Builder) Build(ctx context.Context, out io.Writer, artifacts []*latestV1.Artifact) ([]graph.Artifact, error) {
 	eventV2.TaskInProgress(constants.Build, "Build containers")
-	eventV2.AssignArtifactIDs(artifacts)
 	out = output.WithEventContext(out, constants.Build, eventV2.SubtaskIDNone, "skaffold")
 
 	// Use tags directly from the Kubernetes manifests.


### PR DESCRIPTION
**Related**: #5368 #5370 

**Description**
Changes the ID field `BuildSubtaskEvent`s to be the artifact name, rather than an integer corresponding to the artifact name. This makes the code more simple and easier, especially when it comes to tying to the `skaffoldLogEvent` output

