### PR TITLE
Disable k3d integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,30 +113,30 @@ jobs:
       <<: *registry_mirror
       script:
         - env IT_PARTITION=3 make integration-in-kind
-    - name: "k3d integration partition 0"
-      <<: *integration_test
-      <<: *upgrade_docker
-      <<: *registry_mirror
-      script:
-        - env IT_PARTITION=0 make integration-in-k3d
-    - name: "k3d integration partition 1"
-      <<: *integration_test
-      <<: *upgrade_docker
-      <<: *registry_mirror
-      script:
-        - env IT_PARTITION=1 make integration-in-k3d
-    - name: "k3d integration partition 2"
-      <<: *integration_test
-      <<: *upgrade_docker
-      <<: *registry_mirror
-      script:
-        - env IT_PARTITION=2 make integration-in-k3d
-    - name: "k3d integration partition 3"
-      <<: *integration_test
-      <<: *upgrade_docker
-      <<: *registry_mirror
-      script:
-        - env IT_PARTITION=3 make integration-in-k3d
+    # - name: "k3d integration partition 0"
+    #   <<: *integration_test
+    #   <<: *upgrade_docker
+    #   <<: *registry_mirror
+    #   script:
+    #     - env IT_PARTITION=0 make integration-in-k3d
+    # - name: "k3d integration partition 1"
+    #   <<: *integration_test
+    #   <<: *upgrade_docker
+    #   <<: *registry_mirror
+    #   script:
+    #     - env IT_PARTITION=1 make integration-in-k3d
+    # - name: "k3d integration partition 2"
+    #   <<: *integration_test
+    #   <<: *upgrade_docker
+    #   <<: *registry_mirror
+    #   script:
+    #     - env IT_PARTITION=2 make integration-in-k3d
+    # - name: "k3d integration partition 3"
+    #   <<: *integration_test
+    #   <<: *upgrade_docker
+    #   <<: *registry_mirror
+    #   script:
+    #     - env IT_PARTITION=3 make integration-in-k3d
     - os: linux
       name: "diag/Linux unit"
       <<: *registry_mirror


### PR DESCRIPTION
`k3d` integration tests have been failing with an error that seems to be unrelated to skaffold code, and it's causing CI to fail on many unrelated PRs. Let's disable the tests until we can diagnose and fix the issue.