### PR TITLE
Doc tweaks

### DIFF
--- a/docs/content/en/docs/install/_index.md
+++ b/docs/content/en/docs/install/_index.md
@@ -18,39 +18,52 @@ Your use of this software is subject to the [Google Privacy Policy](https://poli
 
 
 {{% tabs %}}
+{{% tab "GOOGLE CLOUD SHELL" %}}
+
+Google Cloud Platform's [_Cloud Shell_](http://cloud.google.com/shell)
+provides a free [browser-based terminal/CLI and editor](https://cloud.google.com/shell#product-demo)
+with Skaffold, Minikube, and Docker pre-installed.
+(Requires a [Google Account](https://accounts.google.com/SignUp).)
+
+Cloud Shell is a great way to try Skaffold out.
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?shellonly=true&cloudshell_git_repo=https%3A%2F%2Fgithub.com%2FGoogleContainerTools%2Fskaffold&cloudshell_working_dir=examples%2Fgetting-started)
+
+{{% /tab %}}
+
 {{% tab "LINUX" %}}
 The latest **stable** binaries can be found here:
 
-https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
-https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-arm64
+- Linux x86_64 (amd64): https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
+- Linux ARMv8 (arm64): https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-arm64
 
 Simply download the appropriate binary and add it to your `PATH`. Or, copy+paste one of the following commands in your terminal:
 
 ```bash
-# For Linux AMD64
+# For Linux x86_64 (amd64)
 curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64 && \
 sudo install skaffold /usr/local/bin/
 ```
 
 ```bash
-# For Linux ARM64
+# For Linux ARMv8 (arm64)
 curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-arm64 && \
 sudo install skaffold /usr/local/bin/
 ```
 
 We also release a **bleeding edge** build, built from the latest commit:
 
-https://storage.googleapis.com/skaffold/builds/latest/skaffold-linux-amd64
-https://storage.googleapis.com/skaffold/builds/latest/skaffold-linux-arm64
+- Linux x86_64 (amd64): https://storage.googleapis.com/skaffold/builds/latest/skaffold-linux-amd64
+- Linux ARMv8 (arm64): https://storage.googleapis.com/skaffold/builds/latest/skaffold-linux-arm64
 
 ```bash
-# For Linux on AMD64
+# For Linux on x86_64 (amd64)
 curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/latest/skaffold-linux-amd64 && \
 sudo install skaffold /usr/local/bin/
 ```
 
 ```bash
-# For Linux on ARM64
+# For Linux on ARMv8 (arm64)
 curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/latest/skaffold-linux-arm64 && \
 sudo install skaffold /usr/local/bin/
 ```
@@ -61,36 +74,36 @@ sudo install skaffold /usr/local/bin/
 
 The latest **stable** binaries can be found here:
 
-https://storage.googleapis.com/skaffold/releases/latest/skaffold-darwin-amd64
-https://storage.googleapis.com/skaffold/releases/latest/skaffold-darwin-arm64
+- Darwin x86_64 (amd64): https://storage.googleapis.com/skaffold/releases/latest/skaffold-darwin-amd64
+- Darwin ARMv8 (arm64): https://storage.googleapis.com/skaffold/releases/latest/skaffold-darwin-arm64
 
 Simply download the appropriate binary and add it to your `PATH`. Or, copy+paste one of the following commands in your terminal:
 
 ```bash
-# For macOS on AMD64
+# For macOS on x86_64 (amd64)
 curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-darwin-amd64 && \
 sudo install skaffold /usr/local/bin/
 ```
 
 ```bash
-# For macOS on ARM64
+# For macOS on ARMv8 (arm64)
 curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-darwin-arm64 && \
 sudo install skaffold /usr/local/bin/
 ```
 
 We also release a **bleeding edge** build, built from the latest commit:
 
-https://storage.googleapis.com/skaffold/builds/latest/skaffold-darwin-amd64
-https://storage.googleapis.com/skaffold/builds/latest/skaffold-darwin-arm64
+- Darwin x86_64 (amd64): https://storage.googleapis.com/skaffold/builds/latest/skaffold-darwin-amd64
+- Darwin ARMv8 (arm64): https://storage.googleapis.com/skaffold/builds/latest/skaffold-darwin-arm64
 
 ```bash
-# For macOS on AMD64
+# For macOS on x86_64 (amd64)
 curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/latest/skaffold-darwin-amd64 && \
 sudo install skaffold /usr/local/bin/
 ```
 
 ```bash
-# For macOS on ARM64
+# For macOS on ARMv8 (arm64)
 curl -Lo skaffold https://storage.googleapis.com/skaffold/builds/latest/skaffold-darwin-arm64 && \
 sudo install skaffold /usr/local/bin/
 ```
@@ -125,6 +138,15 @@ https://storage.googleapis.com/skaffold/builds/latest/skaffold-windows-amd64.exe
 
 ---
 
+### Scoop
+
+Skaffold can be installed using the [Scoop package manager](https://scoop.sh/).
+This package is not maintained by the Skaffold team.
+
+```powershell
+scoop install skaffold
+```
+
 ### Chocolatey
 
 Skaffold can be installed using the [Chocolatey package manager](https://chocolatey.org/packages/skaffold).
@@ -143,16 +165,6 @@ For more information about this defect see
 ```bash
 choco install -y skaffold
 ```
-
-### Scoop
-
-Skaffold can be installed using the [Scoop package manager](https://scoop.sh/).
-This package is not maintained by the Skaffold team.
-
-```powershell
-scoop install skaffold
-```
-
 {{% /tab %}}
 
 {{% tab "DOCKER" %}}

--- a/docs/content/en/docs/quickstart/_index.md
+++ b/docs/content/en/docs/quickstart/_index.md
@@ -182,6 +182,6 @@ using [Builders]({{<relref "/docs/pipeline-stages/builders" >}}), [Taggers]({{< 
 
 [Skaffold Tutorials]({{< relref "/docs/tutorials" >}}) details some of the common use cases of Skaffold.
 
-Questions?  See our [Community section]({{< relref "/docs/resources#Community" }}) for ways to get in touch.
+Questions?  See our [Community section]({{< relref "/docs/resources#Community" >}}) for ways to get in touch.
 
 :mega: **Please fill out our [quick 5-question survey](https://forms.gle/BMTbGQXLWSdn7vEs6)** to tell us how satisfied you are with Skaffold, and what improvements we should make. Thank you! :dancers:

--- a/docs/content/en/docs/quickstart/_index.md
+++ b/docs/content/en/docs/quickstart/_index.md
@@ -182,4 +182,6 @@ using [Builders]({{<relref "/docs/pipeline-stages/builders" >}}), [Taggers]({{< 
 
 [Skaffold Tutorials]({{< relref "/docs/tutorials" >}}) details some of the common use cases of Skaffold.
 
+Questions?  See our [Community section]({{< relref "/docs/resources#Community" }}) for ways to get in touch.
+
 :mega: **Please fill out our [quick 5-question survey](https://forms.gle/BMTbGQXLWSdn7vEs6)** to tell us how satisfied you are with Skaffold, and what improvements we should make. Thank you! :dancers:

--- a/docs/content/en/docs/resources/_index.md
+++ b/docs/content/en/docs/resources/_index.md
@@ -7,12 +7,11 @@ no_list: true
 
 ## Community
 
-You can join the Skaffold community and discuss the project at:
+Join the Skaffold community and discuss the project at:
 
-* The [`skaffold` tag on StackOverflow](https://stackoverflow.com/questions/tagged/skaffold)
+* StackOverflow using the [`skaffold` tag](https://stackoverflow.com/questions/tagged/skaffold)
 * [Skaffold Mailing List]
-* [Skaffold Topic on Kubernetes Slack](https://kubernetes.slack.com/messages/CABQMSZA6/) (click on _Create
-* an account_ to join)
+* [#Skaffold channel on Kubernetes Slack](https://kubernetes.slack.com/messages/CABQMSZA6/) (click on _Create an account_ to join)
 * [Give us feedback](feedback)
 
 The Skaffold Project also holds a monthly meeting on the last

--- a/docs/content/en/docs/resources/_index.md
+++ b/docs/content/en/docs/resources/_index.md
@@ -5,32 +5,22 @@ weight: 130
 no_list: true
 ---
 
-## 2020 Roadmap
+## Community
 
-This now lives [on Github](https://github.com/GoogleContainerTools/skaffold/blob/master/ROADMAP.md).
+You can join the Skaffold community and discuss the project at:
 
-## 2019 Roadmap
+* The [`skaffold` tag on StackOverflow](https://stackoverflow.com/questions/tagged/skaffold)
+* [Skaffold Mailing List]
+* [Skaffold Topic on Kubernetes Slack](https://kubernetes.slack.com/messages/CABQMSZA6/) (click on _Create
+* an account_ to join)
+* [Give us feedback](feedback)
 
-* Plugin model for builders
-   * DONE - see custom artifacts
-* IDE integration VSCode and IntelliJ Skaffold dev/build/run/deploy support, Skaffold Config code completion
-   * DONE, see [Cloud Code](http://cloud.google.com/code)
-* Debugging JVM applications 
-    * DONE, we have Java, go, python and node for [debugging]({{<relref "/docs/workflows/debug">}})
-* Skaffold keeps track of what it built, for faster restarts
-    * DONE, artifact caching is enabled by default, can be controlled with the `--cache-artifacts` flag
-* Pipeline CRD integration
-    * DONE - we have Tekton pipeline generation in alpha, docs to come
+The Skaffold Project also holds a monthly meeting on the last
+Wednesday of the month at 9:30am PST on [Google Meet](https://meet.google.com/tje-kwpx-ixv)!
+Everyone is welcome to attend!  If you join the [Skaffold Mailing List],
+a calendar invite will be sent to your Google Calendar.
 
-In 2019 we also focused a major part of our efforts in fixing bugs, improve our triage, pull request and design processes, created better documentation, and continuously increased test coverage.
-
-We reprioritized these items for next year: 
-
-* Provide help with integration testing
-* Automated Kubernetes manifest generation
-* Infrastructure scaffolding for CI/CD on GCP/GKE
-* Document end-to-end solutions
-* Status dashboard for build (test) and deployment besides logging
+[Skaffold Mailing List]: https://groups.google.com/forum#!forum/skaffold-users
 
 ## Contributing
 
@@ -43,16 +33,6 @@ on GitHub.
 
 See [Release Notes](https://github.com/GoogleContainerTools/skaffold/blob/master/CHANGELOG.md) on Github.
 
-## Community
+## Roadmap
 
-You can join the Skaffold community and discuss the project at:
-
-* [Skaffold Mailing List](https://groups.google.com/forum#!forum/skaffold-users)
-* [Skaffold Topic on Kubernetes Slack](https://kubernetes.slack.com/messages/CABQMSZA6/)
-* [Give us feedback](feedback)
-
-The Skaffold Project also holds a bi-weekly meeting at 9:30am PST on Google
-Hangouts. Everyone is welcome to add suggestions to the [Meeting Agenda](https://docs.google.com/document/d/1mnCC_fAI3pmg3Vb2nMJyPk8Qtjjuapw_BTyqI_dX7sk/edit)
-and [attend the meeting](https://hangouts.google.com/hangouts/_/google.com/skaffold).
-If you join the Skaffold Mailing List, a calendar invite will be sent to your Google
-Calendar.
+See our roadmap [in GitHub](https://github.com/GoogleContainerTools/skaffold/blob/master/ROADMAP.md).


### PR DESCRIPTION
Small doc tweaks
    
- add stackoverflow link to _Community_ (in response to HaTS feedback).
- reorganize Resources page to put Community to the top
- remove 2019 Roadmap
- add Cloud Shell as an installation option
- incorporate `x86_64` and `ARMv8` to make it easier to differentiate between `AMD64` and `ARM64` (I've misclicked a few times)