### PR TITLE
Check release workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -18,8 +18,11 @@ jobs:
       uses: actions-ecosystem/action-regex-match@v2
       with:
         text: ${{ github.event.head_commit.message }}
-        # allow v1.2.3 and v1.2.3-beta.1
-        regex: '^release: v?([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.])?)$'
+        # Allow optional `v` prefix and GitHub PR reference suffix on first line only
+        #   release: v1.2.3
+        #   release: 1.2.3-beta.1
+        #   release: v1.2.3-beta.1 (#9456)
+        regex: '^release: v?([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.])?)(\s+\(#[0-9]+\))?$'
         flags: m
 
     - name: Determine if applicable

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -11,25 +11,33 @@ jobs:
   check:
     name: Check if release commit
     runs-on: ubuntu-latest
+    if: "startsWith(github.event.head_commit.message, 'release: ')"
+    steps:
+    - name: Apply release-matching regexp to commit message
+      id: regex-match
+      uses: actions-ecosystem/action-regex-match@v2
+      with:
+        text: ${{ github.event.head_commit.message }}
+        # allow v1.2.3 and v1.2.3-beta.1
+        regex: '^release: v?([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.])?)$'
+        flags: m
+
+    - name: Determine if applicable
+      id: check-commit-message
+      if: steps.regex-match.outputs.group1 != ''
+      run: |
+        echo "::set-output name=applicable::true"
+        echo "This is a release commit: ${{ steps.regex-match.outputs.group1 }}"
     outputs:
       applicable: ${{ steps.check-commit-message.outputs.applicable }}
-    steps:
-    - name: Check commit message
-      id: check-commit-message
-      run: |
-        str='${{ github.event.head_commit.message }}'
-        regex="^release\s*:\s*(v[0-9]+\.[0-9]+\.[0-9]+|[0-9]+\.[0-9]+\.[0-9]+)"
-        if [[ "$str" =~ $regex ]]; then
-          echo "::set-output name=applicable::true"
-          echo This is a release commit.
-        fi
+      version: ${{ steps.regex-match.outputs.group1 }}
 
   release:
+    name: Create Tag and Draft Release
     needs: check
     if: needs.check.outputs.applicable == 'true'
     permissions:
       contents: write
-    name: Create Tag and Draft Release
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -37,15 +45,10 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Calculate Tag and release names
+    - name: Calculate Tag and Release names
       run: |
-        t=$(echo ${{ github.event.head_commit.message }} | sed -ne 's/.*\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p')
-        if [ -z "$t" ]; then
-        echo Malformed commit message; failed to extract semVer tag
-        return 1
-        fi
-        echo TAG_NAME="v${t}" >> $GITHUB_ENV
-        echo RELEASE_NAME="v${t} Release" >> $GITHUB_ENV
+        echo TAG_NAME="${{ needs.check.outputs.version }}" >> $GITHUB_ENV
+        echo RELEASE_NAME="v${{ needs.check.outputs.version }} Release" >> $GITHUB_ENV
 
     - name: Create and push Tag
       run: |
@@ -62,7 +65,7 @@ jobs:
 
     - name: Download release artifacts
       run: |
-        #Wait 60m for all artifacts to be available
+        # Wait up to 60m for all artifacts to be available
         retries=20
         found=0
         while [ $found -lt 10 -a $retries -gt 0 ]

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -22,7 +22,7 @@ jobs:
         #   release: v1.2.3
         #   release: 1.2.3-beta.1
         #   release: v1.2.3-beta.1 (#9456)
-        regex: '^release: v?([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.])?)(\s+\(#[0-9]+\))?$'
+        regex: '^release: v?([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?)(\s+\(#[0-9]+\))?$'
         flags: m
 
     - name: Determine if applicable

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: Calculate Tag and Release names
       run: |
-        echo TAG_NAME="${{ needs.check.outputs.version }}" >> $GITHUB_ENV
+        echo TAG_NAME="v${{ needs.check.outputs.version }}" >> $GITHUB_ENV
         echo RELEASE_NAME="v${{ needs.check.outputs.version }} Release" >> $GITHUB_ENV
 
     - name: Create and push Tag


### PR DESCRIPTION
Change `draft-release` workflow to use the actions-ecosystem/action-regex-match workflow for extracting regexs from the PR commit message, and to ignore the trailing PR number.

Although it adds the ability to include pre-release labels (e.g., 1.2.3-beta.1) to let us try cutting pre-release versions, our current post-release workflows (such as to publish docs to skaffold.dev) don't check that a tag is a full release.