### PR TITLE
Don't update survey prompt if survey prompt is not shown to stdout

### DIFF
--- a/pkg/skaffold/survey/survey.go
+++ b/pkg/skaffold/survey/survey.go
@@ -43,9 +43,9 @@ Tip: To permanently disable the survey prompt, run:
 
 var (
 	// for testing
-	isStdOut     = output.IsStdout
-	open         = browser.OpenURL
-	updateConfig = sConfig.UpdateGlobalSurveyPrompted
+	isStdOut             = output.IsStdout
+	open                 = browser.OpenURL
+	updateSurveyPrompted = sConfig.UpdateGlobalSurveyPrompted
 )
 
 type Runner struct {
@@ -79,10 +79,11 @@ func recentlyPromptedOrTaken(cfg *sConfig.ContextConfig) bool {
 }
 
 func (s *Runner) DisplaySurveyPrompt(out io.Writer) error {
-	if isStdOut(out) {
-		output.Green.Fprintf(out, hats.prompt())
+	if !isStdOut(out) {
+		return nil
 	}
-	return updateConfig(s.configFile)
+	output.Green.Fprintf(out, hats.prompt())
+	return updateSurveyPrompted(s.configFile)
 }
 
 func (s *Runner) OpenSurveyForm(_ context.Context, out io.Writer, id string) error {

--- a/pkg/skaffold/survey/survey_test.go
+++ b/pkg/skaffold/survey/survey_test.go
@@ -30,14 +30,14 @@ import (
 
 func TestDisplaySurveyForm(t *testing.T) {
 	tests := []struct {
-		description string
+		description        string
 		mockSurveyPrompted func(_ string) error
-		expected    string
-		mockStdOut  bool
+		expected           string
+		mockStdOut         bool
 	}{
 		{
-			description: "std out",
-			mockStdOut:  true,
+			description:        "std out",
+			mockStdOut:         true,
 			mockSurveyPrompted: func(_ string) error { return nil },
 			expected: `Help improve Skaffold with our 2-minute anonymous survey: run 'skaffold survey'
 `,

--- a/pkg/skaffold/survey/survey_test.go
+++ b/pkg/skaffold/survey/survey_test.go
@@ -31,17 +31,22 @@ import (
 func TestDisplaySurveyForm(t *testing.T) {
 	tests := []struct {
 		description string
-		mockStdOut  bool
+		mockSurveyPrompted func(_ string) error
 		expected    string
+		mockStdOut  bool
 	}{
 		{
 			description: "std out",
 			mockStdOut:  true,
+			mockSurveyPrompted: func(_ string) error { return nil },
 			expected: `Help improve Skaffold with our 2-minute anonymous survey: run 'skaffold survey'
 `,
 		},
 		{
 			description: "not std out",
+			mockSurveyPrompted: func(_ string) error {
+				return fmt.Errorf("not expected to call")
+			},
 		},
 	}
 	for _, test := range tests {
@@ -50,9 +55,10 @@ func TestDisplaySurveyForm(t *testing.T) {
 			t.Override(&isStdOut, mock)
 			mockOpen := func(string) error { return nil }
 			t.Override(&open, mockOpen)
-			t.Override(&updateConfig, func(_ string) error { return nil })
+			t.Override(&updateSurveyPrompted, test.mockSurveyPrompted)
 			var buf bytes.Buffer
-			New("test").DisplaySurveyPrompt(&buf)
+			err := New("test").DisplaySurveyPrompt(&buf)
+			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, buf.String())
 		})
 	}


### PR DESCRIPTION
relates to #6166 

While looking in to code on when skaffold updates prompt show, i discovered a bug. 


1) Made sure the test failed when we do update the timestamp when std out is not set.
```
/private/var/folders/gk/s778hvkj0lb0zl95ywvw0snr00cfc0/T/___TestDisplaySurveyForm_in_github_com_GoogleContainerTools_skaffold_pkg_skaffold_survey -test.v -test.paniconexit0 -test.run ^\QTestDisplaySurveyForm\E$
=== RUN   TestDisplaySurveyForm
=== RUN   TestDisplaySurveyForm/std_out
=== RUN   TestDisplaySurveyForm/not_std_out
    survey_test.go:61: unexpected error: not expected to call
--- FAIL: TestDisplaySurveyForm (0.00s)
    --- PASS: TestDisplaySurveyForm/std_out (0.00s)
    --- FAIL: TestDisplaySurveyForm/not_std_out (0.00s)

FAIL

Process finished with exit code 1
```

