### PR TITLE
add set command for survey ids

### DIFF
--- a/cmd/skaffold/app/cmd/config/flags.go
+++ b/cmd/skaffold/app/cmd/config/flags.go
@@ -21,8 +21,8 @@ import (
 )
 
 var (
-	configFile, kubecontext string
-	showAll, global, survey bool
+	configFile, kubecontext, surveyID string
+	showAll, global, survey           bool
 )
 
 func AddCommonFlags(f *pflag.FlagSet) {
@@ -37,5 +37,8 @@ func AddListFlags(f *pflag.FlagSet) {
 func AddSetUnsetFlags(f *pflag.FlagSet) {
 	f.BoolVarP(&global, "global", "g", false, "Set value for global config")
 	f.BoolVarP(&survey, "survey", "s", false, "Set value for skaffold survey config")
+	f.StringVarP(&surveyID, "id", "i", "", "Set value for given survey config")
+
 	f.MarkHidden("survey")
+	f.MarkHidden("id")
 }

--- a/cmd/skaffold/app/cmd/config/set.go
+++ b/cmd/skaffold/app/cmd/config/set.go
@@ -151,7 +151,7 @@ func userSurveyStruct(as *config.UserSurvey, t reflect.Type, idx []int) (*cfgStr
 	}, nil
 }
 
-func parseAsType(value interface{}, field reflect.Value, idx int, v string) (reflect.Value, error) {
+func parseAsType(value interface{}, field reflect.Value, childIdx int, childValue string) (reflect.Value, error) {
 	fieldType := field.Type()
 	switch fieldType.String() {
 	case "string":
@@ -171,18 +171,18 @@ func parseAsType(value interface{}, field reflect.Value, idx int, v string) (ref
 		}
 		return reflect.ValueOf(&valBase), nil
 	case "[]*config.UserSurvey":
-		cs := field.Interface().([]*config.UserSurvey)
-		updated, index := hasUserSurvey(cs)
-		childField := reflect.Indirect(updated).FieldByIndex([]int{idx})
-		if v1, err := parseAsType(v, childField, 0, ""); err != nil {
+		us := field.Interface().([]*config.UserSurvey)
+		parentVal, parentIdx := hasUserSurvey(us)
+		childField := reflect.Indirect(parentVal).FieldByIndex([]int{childIdx})
+		v1, err := parseAsType(childValue, childField, 0, "")
+		if err != nil {
 			return reflect.Value{}, err
-		} else {
-			childField.Set(v1)
 		}
-		if index == -1 {
-			return reflect.Append(field, updated), nil
+		childField.Set(v1)
+		if parentIdx == -1 {
+			return reflect.Append(field, parentVal), nil
 		}
-		field.Index(index).Set(updated)
+		field.Index(parentIdx).Set(parentVal)
 		return field, nil
 	default:
 		return reflect.Value{}, fmt.Errorf("unsupported type: %s", fieldType)

--- a/cmd/skaffold/app/cmd/config/set.go
+++ b/cmd/skaffold/app/cmd/config/set.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	surveyFieldName = "Survey"
+	surveyFieldName      = "Survey"
+	userSurveysFieldName = "UserSurveys"
 )
 
 type cfgStruct struct {
@@ -52,46 +53,66 @@ func setConfigValue(name string, value string) error {
 		return err
 	}
 
-	fieldIdx, err := getFieldIndex(cfg, name)
+	fieldIdx, valI, err := getFieldIndex(cfg, name, value)
 	if err != nil {
 		return err
 	}
 
+	lastIdx := 0
+	if isUserSurvey() {
+		lastIdx = fieldIdx[len(fieldIdx)-1]
+		fieldIdx = fieldIdx[:len(fieldIdx)-1]
+	}
 	field := reflect.Indirect(reflect.ValueOf(cfg)).FieldByIndex(fieldIdx)
-	val, err := parseAsType(value, field)
+	val, err := parseAsType(valI, field, lastIdx, value)
 	if err != nil {
 		return fmt.Errorf("%s is not a valid value for field %s", value, name)
 	}
-
 	reflect.ValueOf(cfg).Elem().FieldByIndex(fieldIdx).Set(val)
 
 	return writeConfig(cfg)
 }
 
-func getFieldIndex(cfg *config.ContextConfig, name string) ([]int, error) {
+func getFieldIndex(cfg *config.ContextConfig, name string, val string) ([]int, interface{}, error) {
+	valI := getValueInterface(cfg, val)
 	cs, err := getConfigStructWithIndex(cfg)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	for i := 0; i < cs.value.NumField(); i++ {
 		fieldType := cs.rType.Field(i)
 		for _, tag := range strings.Split(fieldType.Tag.Get("yaml"), ",") {
 			if tag == name {
 				if f, ok := cs.rType.FieldByName(fieldType.Name); ok {
-					return append(cs.idx, f.Index...), nil
+					return append(cs.idx, f.Index...), valI, nil
 				}
-				return nil, fmt.Errorf("could not find config field %s", name)
+				return nil, valI, fmt.Errorf("could not find config field %s", name)
 			}
 		}
 	}
-	return nil, fmt.Errorf("%s is not a valid config field", name)
+	return nil, nil, fmt.Errorf("%s is not a valid config field", name)
+}
+
+func getValueInterface(cfg *config.ContextConfig, value string) interface{} {
+	if !isUserSurvey() {
+		return value
+	}
+	if cfg.Survey == nil {
+		cfg.Survey = &config.SurveyConfig{}
+	}
+	if cfg.Survey.UserSurveys == nil {
+		cfg.Survey.UserSurveys = []*config.UserSurvey{}
+	}
+	return cfg.Survey.UserSurveys
 }
 
 func getConfigStructWithIndex(cfg *config.ContextConfig) (*cfgStruct, error) {
 	t := reflect.TypeOf(*cfg)
 	if survey {
 		if cfg.Survey == nil {
-			cfg.Survey = &config.SurveyConfig{}
+			cfg.Survey = &config.SurveyConfig{
+				UserSurveys: []*config.UserSurvey{},
+			}
 		}
 		return surveyStruct(cfg.Survey, t)
 	}
@@ -103,18 +124,34 @@ func getConfigStructWithIndex(cfg *config.ContextConfig) (*cfgStruct, error) {
 }
 
 func surveyStruct(s *config.SurveyConfig, t reflect.Type) (*cfgStruct, error) {
-	surveyType := reflect.TypeOf(*s)
-	if surveyField, ok := t.FieldByName(surveyFieldName); ok {
-		return &cfgStruct{
-			value: reflect.Indirect(reflect.ValueOf(s)),
-			rType: surveyType,
-			idx:   surveyField.Index,
-		}, nil
+	field, ok := t.FieldByName(surveyFieldName)
+	if !ok {
+		return nil, fmt.Errorf("survey config field %q not found in config struct %s", surveyFieldName, t.Name())
 	}
-	return nil, fmt.Errorf("survey config field 'Survey' not found in config struct %s", t.Name())
+	rType := reflect.TypeOf(*s)
+	if isUserSurvey() {
+		return userSurveyStruct(&config.UserSurvey{}, rType, field.Index)
+	}
+	return &cfgStruct{
+		value: reflect.Indirect(reflect.ValueOf(s)),
+		rType: rType,
+		idx:   field.Index,
+	}, nil
 }
 
-func parseAsType(value string, field reflect.Value) (reflect.Value, error) {
+func userSurveyStruct(as *config.UserSurvey, t reflect.Type, idx []int) (*cfgStruct, error) {
+	field, ok := t.FieldByName(userSurveysFieldName)
+	if !ok {
+		return nil, fmt.Errorf("survey config field %q not found in config struct %s", userSurveysFieldName, t.Name())
+	}
+	return &cfgStruct{
+		value: reflect.Indirect(reflect.ValueOf(as)),
+		rType: reflect.TypeOf(*as),
+		idx:   append(idx, field.Index...),
+	}, nil
+}
+
+func parseAsType(value interface{}, field reflect.Value, idx int, v string) (reflect.Value, error) {
 	fieldType := field.Type()
 	switch fieldType.String() {
 	case "string":
@@ -128,14 +165,37 @@ func parseAsType(value string, field reflect.Value) (reflect.Value, error) {
 		if value == "" {
 			return reflect.Zero(fieldType), nil
 		}
-		valBase, err := strconv.ParseBool(value)
+		valBase, err := strconv.ParseBool(value.(string))
 		if err != nil {
 			return reflect.Value{}, err
 		}
 		return reflect.ValueOf(&valBase), nil
+	case "[]*config.UserSurvey":
+		cs := field.Interface().([]*config.UserSurvey)
+		updated, index := hasUserSurvey(cs)
+		childField := reflect.Indirect(updated).FieldByIndex([]int{idx})
+		if v1, err := parseAsType(v, childField, 0, ""); err != nil {
+			return reflect.Value{}, err
+		} else {
+			childField.Set(v1)
+		}
+		if index == -1 {
+			return reflect.Append(field, updated), nil
+		}
+		field.Index(index).Set(updated)
+		return field, nil
 	default:
 		return reflect.Value{}, fmt.Errorf("unsupported type: %s", fieldType)
 	}
+}
+
+func hasUserSurvey(cs []*config.UserSurvey) (reflect.Value, int) {
+	for i, f := range cs {
+		if f.ID == surveyID {
+			return reflect.ValueOf(f), i
+		}
+	}
+	return reflect.ValueOf(&config.UserSurvey{ID: surveyID}), -1
 }
 
 func writeConfig(cfg *config.ContextConfig) error {
@@ -166,4 +226,8 @@ func logSetConfigForUser(out io.Writer, key string, value string) {
 	} else {
 		fmt.Fprintf(out, "set value %s to %s for context %s\n", key, value, kubecontext)
 	}
+}
+
+func isUserSurvey() bool {
+	return survey && surveyID != ""
 }

--- a/cmd/skaffold/app/cmd/config/set_test.go
+++ b/cmd/skaffold/app/cmd/config/set_test.go
@@ -36,6 +36,7 @@ func TestSetAndUnsetConfig(t *testing.T) {
 		key              string
 		value            string
 		kubecontext      string
+		surveyID         string
 		global           bool
 		survey           bool
 		shouldErr        bool
@@ -301,6 +302,31 @@ func TestSetAndUnsetConfig(t *testing.T) {
 				ContextConfigs: []*config.ContextConfig{},
 			},
 		},
+		{
+			description: "set global survey id taken for a key",
+			key:         "taken",
+			value:       "true",
+			global:      true,
+			survey:      true,
+			surveyID:    "helm",
+			expectedSetCfg: &config.GlobalConfig{
+				Global: &config.ContextConfig{
+					Survey: &config.SurveyConfig{
+						UserSurveys: []*config.UserSurvey{
+							{ID: "helm", Taken: util.BoolPtr(true)}}},
+				},
+				ContextConfigs: []*config.ContextConfig{},
+			},
+			expectedUnsetCfg: &config.GlobalConfig{
+				Global: &config.ContextConfig{
+					Survey: &config.SurveyConfig{
+						UserSurveys: []*config.UserSurvey{
+							{ID: "helm"}},
+					},
+				},
+				ContextConfigs: []*config.ContextConfig{},
+			},
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
@@ -311,6 +337,7 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			t.Override(&configFile, cfg)
 			t.Override(&global, test.global)
 			t.Override(&survey, test.survey)
+			t.Override(&surveyID, test.surveyID)
 			if test.kubecontext != "" {
 				t.Override(&kubecontext, test.kubecontext)
 			} else {

--- a/pkg/skaffold/config/global_config.go
+++ b/pkg/skaffold/config/global_config.go
@@ -42,9 +42,15 @@ type ContextConfig struct {
 
 // SurveyConfig is the survey config information
 type SurveyConfig struct {
-	DisablePrompt *bool  `yaml:"disable-prompt,omitempty"`
-	LastTaken     string `yaml:"last-taken,omitempty"`
-	LastPrompted  string `yaml:"last-prompted,omitempty"`
+	DisablePrompt *bool         `yaml:"disable-prompt,omitempty"`
+	LastTaken     string        `yaml:"last-taken,omitempty"`
+	LastPrompted  string        `yaml:"last-prompted,omitempty"`
+	UserSurveys   []*UserSurvey `yaml:"user-surveys,omitempty"`
+}
+
+type UserSurvey struct {
+	ID    string `yaml:"id"`
+	Taken *bool  `yaml:"taken,omitempty"`
 }
 
 // UpdateConfig is the update config information


### PR DESCRIPTION
This PR  last task in in #6166 

Please review #6196  before.

In this PR,  add support to manually set the `taken` field in `UserSurvey` if skaffold fails to update the global config. 
See #6186 on what the `UserSurvey` config is


Users can now run 
```
skaffold config set --global --survey --id helm taken true
```


