### PR TITLE
added support for kaniko pushretry

### DIFF
--- a/docs/content/en/schemas/v2beta20.json
+++ b/docs/content/en/schemas/v2beta20.json
@@ -2171,6 +2171,11 @@
           "description": "how Kaniko will snapshot the filesystem.",
           "x-intellij-html-description": "how Kaniko will snapshot the filesystem."
         },
+        "pushRetry": {
+          "type": "string",
+          "description": "sets the number of retries that should happen for the push of an image to a remote destination.",
+          "x-intellij-html-description": "sets the number of retries that should happen for the push of an image to a remote destination."
+        },
         "tarPath": {
           "type": "string",
           "description": "path to save the image as a tarball at path instead of pushing the image.",
@@ -2230,6 +2235,7 @@
         "ociLayoutPath",
         "registryMirror",
         "snapshotMode",
+        "pushRetry",
         "tarPath",
         "verbosity",
         "insecureRegistry",

--- a/docs/content/en/schemas/v2beta20.json
+++ b/docs/content/en/schemas/v2beta20.json
@@ -2113,6 +2113,11 @@
           "description": "to specify a directory in the container where the OCI image layout of a built image will be placed. This can be used to automatically track the exact image built by kaniko.",
           "x-intellij-html-description": "to specify a directory in the container where the OCI image layout of a built image will be placed. This can be used to automatically track the exact image built by kaniko."
         },
+        "pushRetry": {
+          "type": "string",
+          "description": "Set this flag to the number of retries that should happen for the push of an image to a remote destination.",
+          "x-intellij-html-description": "Set this flag to the number of retries that should happen for the push of an image to a remote destination."
+        },
         "registryCertificate": {
           "additionalProperties": {
             "type": "string"
@@ -2170,11 +2175,6 @@
           "type": "string",
           "description": "how Kaniko will snapshot the filesystem.",
           "x-intellij-html-description": "how Kaniko will snapshot the filesystem."
-        },
-        "pushRetry": {
-          "type": "string",
-          "description": "sets the number of retries that should happen for the push of an image to a remote destination.",
-          "x-intellij-html-description": "sets the number of retries that should happen for the push of an image to a remote destination."
         },
         "tarPath": {
           "type": "string",

--- a/pkg/skaffold/build/gcb/kaniko_test.go
+++ b/pkg/skaffold/build/gcb/kaniko_test.go
@@ -301,6 +301,16 @@ func TestKanikoBuildSpec(t *testing.T) {
 			},
 		},
 		{
+			description: "with PushRetry",
+			artifact: &latestV1.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				PushRetry:      "9",
+			},
+			expectedArgs: []string{
+				"--push-retry", "9",
+			},
+		},
+		{
 			description: "with TarPath",
 			artifact: &latestV1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",

--- a/pkg/skaffold/build/kaniko/args.go
+++ b/pkg/skaffold/build/kaniko/args.go
@@ -134,6 +134,11 @@ func Args(artifact *latestV1.KanikoArtifact, tag, context string) ([]string, err
 		args = append(args, SnapshotModeFlag, artifact.SnapshotMode)
 	}
 
+	if artifact.PushRetry != "" {
+		args = append(args, PushRetryFlag, artifact.PushRetry)
+
+	}
+
 	if artifact.TarPath != "" {
 		args = append(args, TarPathFlag, artifact.TarPath)
 	}

--- a/pkg/skaffold/build/kaniko/args.go
+++ b/pkg/skaffold/build/kaniko/args.go
@@ -136,7 +136,6 @@ func Args(artifact *latestV1.KanikoArtifact, tag, context string) ([]string, err
 
 	if artifact.PushRetry != "" {
 		args = append(args, PushRetryFlag, artifact.PushRetry)
-
 	}
 
 	if artifact.TarPath != "" {

--- a/pkg/skaffold/build/kaniko/types.go
+++ b/pkg/skaffold/build/kaniko/types.go
@@ -71,6 +71,8 @@ const (
 	SkipUnusedStagesFlag = "--skip-unused-stages"
 	// SnapshotModeFlag additional flag
 	SnapshotModeFlag = "--snapshotMode"
+	// PushRetryFlag additional flag
+	PushRetryFlag = "--push-retry"
 	// TarPathFlag additional flag
 	TarPathFlag = "--tarPath"
 	// UseNewRunFlag additional flag

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -1200,6 +1200,9 @@ type KanikoArtifact struct {
 	// SnapshotMode is how Kaniko will snapshot the filesystem.
 	SnapshotMode string `yaml:"snapshotMode,omitempty"`
 
+	// PushRetry Set this flag to the number of retries that should happen for the push of an image to a remote destination.
+	PushRetry string `yaml:"pushRetry,omitempty"`
+
 	// TarPath is path to save the image as a tarball at path instead of pushing the image.
 	TarPath string `yaml:"tarPath,omitempty"`
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5967  <!-- tracking issues that this PR will close -->
**Related**:  none
**Merge before/after**:  none

**Description**
Added support for --push-retry flag in Kaniko. Nothing major, just filled in a new constant, a new unit test and changed the api docs. 

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
New configuration option pushRetry in the kaniko section. 

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
