### PR TITLE
Add --wait=false flag to skaffold cleanup kubectl delete to speedup the phase

### DIFF
--- a/pkg/skaffold/deploy/kubectl/cli.go
+++ b/pkg/skaffold/deploy/kubectl/cli.go
@@ -74,7 +74,7 @@ func NewCLI(cfg Config, flags latestV1.KubectlFlags, defaultNamespace string) CL
 
 // Delete runs `kubectl delete` on a list of manifests.
 func (c *CLI) Delete(ctx context.Context, out io.Writer, manifests manifest.ManifestList) error {
-	args := c.args(c.Flags.Delete, "--ignore-not-found=true", "-f", "-")
+	args := c.args(c.Flags.Delete, "--ignore-not-found=true", "--wait=false", "-f", "-")
 	if err := c.Run(ctx, manifests.Reader(), out, "delete", args...); err != nil {
 		return deployerr.CleanupErr(fmt.Errorf("kubectl delete: %w", err))
 	}

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -270,7 +270,7 @@ func TestKubectlCleanup(t *testing.T) {
 			commands: testutil.
 				CmdRunOut("kubectl version --client -ojson", KubectlVersion112).
 				AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run -oyaml -f deployment.yaml", DeploymentWebYAML).
-				AndRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true -f -"),
+				AndRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true --wait=false -f -"),
 		},
 		{
 			description: "cleanup success (kubectl v1.18)",
@@ -280,7 +280,7 @@ func TestKubectlCleanup(t *testing.T) {
 			commands: testutil.
 				CmdRunOut("kubectl version --client -ojson", KubectlVersion118).
 				AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run=client -oyaml -f deployment.yaml", DeploymentWebYAML).
-				AndRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true -f -"),
+				AndRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true --wait=false -f -"),
 		},
 		{
 			description: "cleanup error",
@@ -290,7 +290,7 @@ func TestKubectlCleanup(t *testing.T) {
 			commands: testutil.
 				CmdRunOut("kubectl version --client -ojson", KubectlVersion112).
 				AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run -oyaml -f deployment.yaml", DeploymentWebYAML).
-				AndRunErr("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true -f -", errors.New("BUG")),
+				AndRunErr("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true --wait=false -f -", errors.New("BUG")),
 			shouldErr: true,
 		},
 		{
@@ -306,7 +306,7 @@ func TestKubectlCleanup(t *testing.T) {
 			commands: testutil.
 				CmdRunOut("kubectl version --client -ojson", KubectlVersion112).
 				AndRunOut("kubectl --context kubecontext --namespace testNamespace create -v=0 --dry-run -oyaml -f deployment.yaml", DeploymentWebYAML).
-				AndRun("kubectl --context kubecontext --namespace testNamespace delete -v=0 --grace-period=1 --ignore-not-found=true -f -"),
+				AndRun("kubectl --context kubecontext --namespace testNamespace delete -v=0 --grace-period=1 --ignore-not-found=true --wait=false -f -"),
 		},
 	}
 	for _, test := range tests {
@@ -342,7 +342,7 @@ func TestKubectlDeployerRemoteCleanup(t *testing.T) {
 			},
 			commands: testutil.
 				CmdRun("kubectl --context kubecontext --namespace testNamespace get pod/leeroy-web -o yaml").
-				AndRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true -f -").
+				AndRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true --wait=false -f -").
 				AndRunInput("kubectl --context kubecontext --namespace testNamespace apply -f -", DeploymentWebYAML),
 		},
 		{
@@ -352,7 +352,7 @@ func TestKubectlDeployerRemoteCleanup(t *testing.T) {
 			},
 			commands: testutil.
 				CmdRun("kubectl --context kubecontext --namespace anotherNamespace get pod/leeroy-web -o yaml").
-				AndRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true -f -").
+				AndRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true --wait=false -f -").
 				AndRunInput("kubectl --context kubecontext --namespace anotherNamespace apply -f -", DeploymentWebYAML),
 		},
 	}

--- a/pkg/skaffold/deploy/kustomize/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize_test.go
@@ -215,7 +215,7 @@ func TestKustomizeCleanup(t *testing.T) {
 			},
 			commands: testutil.
 				CmdRunOut("kustomize build "+tmpDir.Root(), kubectl.DeploymentWebYAML).
-				AndRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true -f -"),
+				AndRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true --wait=false -f -"),
 		},
 		{
 			description: "cleanup success with multiple kustomizations",
@@ -225,7 +225,7 @@ func TestKustomizeCleanup(t *testing.T) {
 			commands: testutil.
 				CmdRunOut("kustomize build "+tmpDir.Path("a"), kubectl.DeploymentWebYAML).
 				AndRunOut("kustomize build "+tmpDir.Path("b"), kubectl.DeploymentAppYAML).
-				AndRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true -f -"),
+				AndRun("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true --wait=false -f -"),
 		},
 		{
 			description: "cleanup error",
@@ -234,7 +234,7 @@ func TestKustomizeCleanup(t *testing.T) {
 			},
 			commands: testutil.
 				CmdRunOut("kustomize build "+tmpDir.Root(), kubectl.DeploymentWebYAML).
-				AndRunErr("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true -f -", errors.New("BUG")),
+				AndRunErr("kubectl --context kubecontext --namespace testNamespace delete --ignore-not-found=true --wait=false -f -", errors.New("BUG")),
 			shouldErr: true,
 		},
 		{


### PR DESCRIPTION
## What is the problem being solved
Fixes #6123, Skaffold process takes a long time to terminate after ctrl-c. This PR:
- adds `--wait=false` flag to kubectl delete that is used during skaffold's Cleanup phase

## Why is this the best approach?
This is the best approach because it makes the cleanup phase take considerably less time which is good from a UX perpective and more in line with what a user expects when sending a SIGTERM (Ctl-c).  Before this change the Cleanup phase could take from ~800ms -> ~10s.  With this change, the Cleanup phase is consistently ~600ms for the same app and skaffold.yaml.

## What other approaches did you consider?
The alternative approach would be to add a line to stdout that explain to the user what skaffold is deleting items which can sometimes take a bit (vs making this change).  Currently w/o no explanation skaffold hanging can be a bit confusing.
.

## What side effects will this approach have?
If users rely on skaffold waiting for the kubectl delete to finish, then this approach might alter/break those use cases.

## What future work remains to be done?
N/A.
