### PR TITLE
Bump docker deploy config version to v2beta20

### DIFF
--- a/docs/content/en/schemas/v2beta19.json
+++ b/docs/content/en/schemas/v2beta19.json
@@ -1335,36 +1335,6 @@
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
-    "DockerDeploy": {
-      "required": [
-        "images"
-      ],
-      "properties": {
-        "images": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array",
-          "description": "container images to run in Docker.",
-          "x-intellij-html-description": "container images to run in Docker.",
-          "default": "[]"
-        },
-        "useCompose": {
-          "type": "boolean",
-          "description": "tells skaffold whether or not to deploy using `docker-compose`.",
-          "x-intellij-html-description": "tells skaffold whether or not to deploy using <code>docker-compose</code>.",
-          "default": "false"
-        }
-      },
-      "preferredOrder": [
-        "useCompose",
-        "images"
-      ],
-      "additionalProperties": false,
-      "type": "object",
-      "description": "uses the `docker` CLI to create application containers in Docker.",
-      "x-intellij-html-description": "uses the <code>docker</code> CLI to create application containers in Docker."
-    },
     "DockerSecret": {
       "required": [
         "id"

--- a/docs/content/en/schemas/v2beta20.json
+++ b/docs/content/en/schemas/v2beta20.json
@@ -1335,6 +1335,36 @@
       "description": "contains information about the docker `config.json` to mount.",
       "x-intellij-html-description": "contains information about the docker <code>config.json</code> to mount."
     },
+    "DockerDeploy": {
+      "required": [
+        "images"
+      ],
+      "properties": {
+        "images": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "container images to run in Docker.",
+          "x-intellij-html-description": "container images to run in Docker.",
+          "default": "[]"
+        },
+        "useCompose": {
+          "type": "boolean",
+          "description": "tells skaffold whether or not to deploy using `docker-compose`.",
+          "x-intellij-html-description": "tells skaffold whether or not to deploy using <code>docker-compose</code>.",
+          "default": "false"
+        }
+      },
+      "preferredOrder": [
+        "useCompose",
+        "images"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "uses the `docker` CLI to create application containers in Docker.",
+      "x-intellij-html-description": "uses the <code>docker</code> CLI to create application containers in Docker."
+    },
     "DockerSecret": {
       "required": [
         "id"

--- a/integration/examples/docker-deploy/skaffold.yaml
+++ b/integration/examples/docker-deploy/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v2beta19
+apiVersion: skaffold/v2beta20
 kind: Config
 build:
   local:


### PR DESCRIPTION
https://github.com/GoogleContainerTools/skaffold/pull/6117 was merged shortly after `v2beta20` config version was cut, and as a result was not auto-rebased by GitHub to show a failing CI.