### PR TITLE
Strip `out/` prefix from SHA checksum files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ $(BUILD_DIR)/$(PROJECT)-%: $(STATIK_FILES) $(GO_FILES) $(BUILD_DIR) deploy/cross
 		.
 
 	docker run --rm skaffold/cross cat /build/skaffold > $@
-	shasum -a 256 $@ | tee $@.sha256
+	(cd `dirname $@`; shasum -a 256 `basename $@`) | tee $@.sha256
 	file $@ || true
 
 .PHONY: $(BUILD_DIR)/VERSION


### PR DESCRIPTION
Fixes: #6217

**Description**
As described in #6217, the `out/` prefix in the SHA checksum files is stripped by this PR.

**User facing changes**
This PR introduced *no user facing changes* concerning the skaffold command line interface itself.
It changes the way in which checksums might be calculated automcatically when installing Skaffold using Ansible or other automation tools, though.
