### PR TITLE
Add switch to conditionally add color to `ApplicationLogEvent`'s messages

### DIFF
--- a/pkg/skaffold/log/stream/stream.go
+++ b/pkg/skaffold/log/stream/stream.go
@@ -49,14 +49,18 @@ func StreamRequest(ctx context.Context, out io.Writer, headerColor output.Color,
 				return fmt.Errorf("reading bytes from log stream: %w", err)
 			}
 
-			formattedLine := headerColor.Sprintf("%s ", prefix) + line
-			printLogLine(headerColor, out, isMuted, lock, prefix, line)
-			eventV2.ApplicationLog(podName, containerName, line, formattedLine)
+			printLogLine(headerColor, out, isMuted, lock, podName, containerName, prefix, line)
 		}
 	}
 }
 
-func printLogLine(headerColor output.Color, out io.Writer, isMuted func() bool, lock sync.Locker, prefix, text string) {
+func printLogLine(headerColor output.Color, out io.Writer, isMuted func() bool, lock sync.Locker, podName, containerName, prefix, text string) {
+	formattedLine := fmt.Sprintf("%s ", prefix) + text
+	if output.IsColorable(out) {
+		formattedLine = headerColor.Sprintf("%s ", prefix) + text
+	}
+	eventV2.ApplicationLog(podName, containerName, text, formattedLine)
+
 	if !isMuted() {
 		lock.Lock()
 

--- a/pkg/skaffold/log/stream/stream_test.go
+++ b/pkg/skaffold/log/stream/stream_test.go
@@ -42,7 +42,7 @@ func TestPrintLogLine(t *testing.T) {
 
 			go func() {
 				for i := 0; i < linesPerGroup; i++ {
-					printLogLine(output.Default, &buf, func() bool { return false }, &lock, "PREFIX", "TEXT\n")
+					printLogLine(output.Default, &buf, func() bool { return false }, &lock, "PODNAME", "CONTAINERNAME", "PREFIX", "TEXT\n")
 				}
 				wg.Done()
 			}()


### PR DESCRIPTION
Fixes #6224

**Description**
This PR adds a switch to add color to application log events only if the writer being used for writing container logs supports color as well.