### PR TITLE
 [v2] Update UX naming based on the feedback.

### DIFF
--- a/pkg/skaffold/render/renderer/renderer_test.go
+++ b/pkg/skaffold/render/renderer/renderer_test.go
@@ -120,7 +120,7 @@ pipeline:
 			description: "manifests with transformation rule.",
 			renderConfig: &latestV2.RenderConfig{
 				Generate:  latestV2.Generate{RawK8s: []string{"pod.yaml"}},
-				Transform: &[]latestV2.Transformer{{Name: "set-labels", ConfigMapData: []string{"owner:tester"}}},
+				Transform: &[]latestV2.Transformer{{Name: "set-labels", ConfigMap: []string{"owner:tester"}}},
 			},
 			originalKptfile: initKptfile,
 			updatedKptfile: `apiVersion: kpt.dev/v1alpha2
@@ -138,7 +138,7 @@ pipeline:
 			description: "manifests with updated transformation rule.",
 			renderConfig: &latestV2.RenderConfig{
 				Generate:  latestV2.Generate{RawK8s: []string{"pod.yaml"}},
-				Transform: &[]latestV2.Transformer{{Name: "set-labels", ConfigMapData: []string{"owner:tester"}}},
+				Transform: &[]latestV2.Transformer{{Name: "set-labels", ConfigMap: []string{"owner:tester"}}},
 			},
 			originalKptfile: `apiVersion: kpt.dev/v1alpha2
 kind: Kptfile

--- a/pkg/skaffold/render/transform/transform.go
+++ b/pkg/skaffold/render/transform/transform.go
@@ -92,8 +92,8 @@ func validateTransformers(config []latestV2.Transformer) ([]kptfile.Function, er
 		if !ok {
 			return nil, errors.UnknownTransformerError(c.Name, AllowListedTransformer)
 		}
-		if c.ConfigMapData != nil {
-			for _, stringifiedData := range c.ConfigMapData {
+		if c.ConfigMap != nil {
+			for _, stringifiedData := range c.ConfigMap {
 				items := strings.Split(stringifiedData, ":")
 				if len(items) != 2 {
 					return nil, errors.BadTransformerParamsError(c.Name)

--- a/pkg/skaffold/render/transform/transform_test.go
+++ b/pkg/skaffold/render/transform/transform_test.go
@@ -34,7 +34,7 @@ func TestNewTransformer(t *testing.T) {
 		{
 			description: "set-label",
 			config: []latestV2.Transformer{
-				{Name: "set-annotations", ConfigMapData: []string{"owner:skaffold-test"}},
+				{Name: "set-annotations", ConfigMap: []string{"owner:skaffold-test"}},
 			},
 		},
 	}

--- a/pkg/skaffold/schema/latest/v2/config.go
+++ b/pkg/skaffold/schema/latest/v2/config.go
@@ -518,7 +518,7 @@ type RenderConfig struct {
 
 // Generate defines the dry manifests from a variety of sources.
 type Generate struct {
-	RawK8s    []string `yaml:"rawYaml/k8s,omitempty"`
+	RawK8s    []string `yaml:"rawYaml,omitempty"`
 	Kustomize []string `yaml:"kustomize,omitempty"`
 	Helm      Helm     `yaml:"helm,omitempty"`
 	Kpt       []string `yaml:"kpt,omitempty"`
@@ -538,16 +538,16 @@ type GenerateType struct {
 type Transformer struct {
 	// Name is the transformer name. Can only accept skaffold whitelisted tools.
 	Name string `yaml:"name" yamltags:"required"`
-	// ConfigMapData allows users to provide additional config data to the kpt function.
-	ConfigMapData []string `yaml:"configMapData,omitempty"`
+	// ConfigMap allows users to provide additional config data to the kpt function.
+	ConfigMap []string `yaml:"configMap,omitempty"`
 }
 
 // Validator describes the supported kpt validators.
 type Validator struct {
 	// Name is the Validator name. Can only accept skaffold whitelisted tools.
 	Name string `yaml:"name" yamltags:"required"`
-	// ConfigMapData allows users to provide additional config data to the kpt function.
-	ConfigMapData []string `yaml:"configMapData,omitempty"`
+	// ConfigMap allows users to provide additional config data to the kpt function.
+	ConfigMap []string `yaml:"configMap,omitempty"`
 }
 
 // KptV2Deploy contains all the configuration needed by the deploy steps.

--- a/pkg/skaffold/schema/v3alpha1/config.go
+++ b/pkg/skaffold/schema/v3alpha1/config.go
@@ -520,7 +520,7 @@ type RenderConfig struct {
 
 // Generate defines the dry manifests from a variety of sources.
 type Generate struct {
-	RawK8s    []string `yaml:"rawYaml/k8s,omitempty"`
+	RawK8s    []string `yaml:"rawYaml,omitempty"`
 	Kustomize []string `yaml:"kustomize,omitempty"`
 	Helm      Helm     `yaml:"helm,omitempty"`
 	Kpt       []string `yaml:"kpt,omitempty"`
@@ -540,16 +540,16 @@ type GenerateType struct {
 type Transformer struct {
 	// Name is the transformer name. Can only accept skaffold whitelisted tools.
 	Name string `yaml:"name" yamltags:"required"`
-	// ConfigMapData allows users to provide additional config data to the kpt function.
-	ConfigMapData []string `yaml:"configMapData,omitempty"`
+	// ConfigMap allows users to provide additional config data to the kpt function.
+	ConfigMap []string `yaml:"configMap,omitempty"`
 }
 
 // Validator describes the supported kpt validators.
 type Validator struct {
 	// Name is the Validator name. Can only accept skaffold whitelisted tools.
 	Name string `yaml:"name" yamltags:"required"`
-	// ConfigMapData allows users to provide additional config data to the kpt function.
-	ConfigMapData []string `yaml:"configMapData,omitempty"`
+	// ConfigMap allows users to provide additional config data to the kpt function.
+	ConfigMap []string `yaml:"configMap,omitempty"`
 }
 
 // KptV2Deploy contains all the configuration needed by the deploy steps.


### PR DESCRIPTION
**Description**
`manifest.generate.rawYaml/k8s` --> `manifest.generate.rawYaml`
`manifest.transform[*].configMapData` --> `manifest.transform[*].configMap`
`manifest.validate[*].configMapData` --> `manifest.validate[*].configMap`

**Related**: #5673 
