### PR TITLE
Retrieve initial namespaces when creating Deployer

### DIFF
--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -98,6 +98,15 @@ func TestDeployTail(t *testing.T) {
 	WaitForLogs(t, out, "Hello world!")
 }
 
+func TestDeployTailDefaultNamespace(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	// `--default-repo=` is used to cancel the default repo that is set by default.
+	out := skaffold.Deploy("--tail", "--images", "busybox:latest", "--default-repo=").InDir("testdata/deploy-hello-tail").RunLive(t)
+
+	WaitForLogs(t, out, "Hello world!")
+}
+
 func TestDeployWithInCorrectConfig(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -198,7 +198,7 @@ func TestRunTailDefaultNamespace(t *testing.T) {
 			if test.targetLog == "" {
 				t.SkipNow()
 			}
-			ns, client := DefaultNamespace(t)
+			_, client := DefaultNamespace(t)
 
 			args := append(test.args, "--tail")
 			out := skaffold.Run(args...).InDir(test.dir).WithEnv(test.env).RunLive(t)
@@ -208,7 +208,7 @@ func TestRunTailDefaultNamespace(t *testing.T) {
 
 			WaitForLogs(t, out, test.targetLog)
 
-			skaffold.Delete().InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunOrFail(t)
+			skaffold.Delete().InDir(test.dir).WithEnv(test.env).RunOrFail(t)
 		})
 	}
 }

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -175,13 +175,10 @@ func TestRunTail(t *testing.T) {
 			if test.targetLog == "" {
 				t.SkipNow()
 			}
-			ns, client := SetupNamespace(t)
+			ns, _ := SetupNamespace(t)
 
 			args := append(test.args, "--tail")
 			out := skaffold.Run(args...).InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunLive(t)
-
-			client.WaitForPodsReady(test.pods...)
-			client.WaitForDeploymentsToStabilize(test.deployments...)
 
 			WaitForLogs(t, out, test.targetLog)
 
@@ -198,13 +195,9 @@ func TestRunTailDefaultNamespace(t *testing.T) {
 			if test.targetLog == "" {
 				t.SkipNow()
 			}
-			_, client := DefaultNamespace(t)
 
 			args := append(test.args, "--tail")
 			out := skaffold.Run(args...).InDir(test.dir).WithEnv(test.env).RunLive(t)
-
-			client.WaitForPodsReady(test.pods...)
-			client.WaitForDeploymentsToStabilize(test.deployments...)
 
 			WaitForLogs(t, out, test.targetLog)
 

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -29,119 +29,129 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
+// Note: `custom-buildx` is not included as it depends on having a
+// `skaffold-builder` builder configured and a registry to push to.
+var tests = []struct {
+	description string
+	dir         string
+	args        []string
+	deployments []string
+	pods        []string
+	env         []string
+	targetLog   string
+}{
+	{
+		description: "getting-started",
+		dir:         "examples/getting-started",
+		pods:        []string{"getting-started"},
+		targetLog:   "Hello world!",
+	},
+	{
+		description: "nodejs",
+		dir:         "examples/nodejs",
+		deployments: []string{"node"},
+		targetLog:   "Example app listening on port",
+	},
+	{
+		description: "structure-tests",
+		dir:         "examples/structure-tests",
+		pods:        []string{"getting-started"},
+	},
+	{
+		description: "custom-tests",
+		dir:         "examples/custom-tests",
+		pods:        []string{"custom-test"},
+	},
+	{
+		description: "microservices",
+		dir:         "examples/microservices",
+		// See https://github.com/GoogleContainerTools/skaffold/issues/2372
+		args:        []string{"--status-check=false"},
+		deployments: []string{"leeroy-app", "leeroy-web"},
+	},
+	{
+		description: "multi-config-microservices",
+		dir:         "examples/multi-config-microservices",
+		deployments: []string{"leeroy-app", "leeroy-web"},
+	},
+	{
+		description: "remote-multi-config-microservices",
+		dir:         "examples/remote-multi-config-microservices",
+		deployments: []string{"leeroy-app", "leeroy-web"},
+	},
+	{
+		description: "envTagger",
+		dir:         "examples/tagging-with-environment-variables",
+		pods:        []string{"getting-started"},
+		env:         []string{"FOO=foo"},
+	},
+	{
+		description: "bazel",
+		dir:         "examples/bazel",
+		pods:        []string{"bazel"},
+	},
+	{
+		description: "jib",
+		dir:         "testdata/jib",
+		deployments: []string{"web"},
+	},
+	{
+		description: "jib gradle",
+		dir:         "examples/jib-gradle",
+		deployments: []string{"web"},
+	},
+	{
+		description: "profiles",
+		dir:         "examples/profiles",
+		args:        []string{"-p", "minikube-profile"},
+		pods:        []string{"hello-service"},
+	},
+	{
+		description: "multiple deployers",
+		dir:         "testdata/deploy-multiple",
+		pods:        []string{"deploy-kubectl", "deploy-kustomize"},
+	},
+	{
+		description: "custom builder",
+		dir:         "examples/custom",
+		pods:        []string{"getting-started"},
+	},
+	{
+		description: "buildpacks Go",
+		dir:         "examples/buildpacks",
+		deployments: []string{"web"},
+	},
+	{
+		description: "buildpacks NodeJS",
+		dir:         "examples/buildpacks-node",
+		deployments: []string{"web"},
+	},
+	{
+		description: "buildpacks Python",
+		dir:         "examples/buildpacks-python",
+		deployments: []string{"web"},
+	},
+	{
+		description: "buildpacks Java",
+		dir:         "examples/buildpacks-java",
+		deployments: []string{"web"},
+	},
+	{
+		description: "kustomize",
+		dir:         "examples/getting-started-kustomize",
+		deployments: []string{"skaffold-kustomize-dev"},
+		targetLog:   "Hello world!",
+	},
+	{
+		description: "helm",
+		dir:         "examples/helm-deployment",
+		deployments: []string{"skaffold-helm"},
+		targetLog:   "Hello world!",
+	},
+}
+
 func TestRun(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
-
-	// Note: `custom-buildx` is not included as it depends on having a
-	// `skaffold-builder` builder configured and a registry to push to.
-	tests := []struct {
-		description string
-		dir         string
-		args        []string
-		deployments []string
-		pods        []string
-		env         []string
-	}{
-		{
-			description: "getting-started",
-			dir:         "examples/getting-started",
-			pods:        []string{"getting-started"},
-		},
-		{
-			description: "nodejs",
-			dir:         "examples/nodejs",
-			deployments: []string{"node"},
-		},
-		{
-			description: "structure-tests",
-			dir:         "examples/structure-tests",
-			pods:        []string{"getting-started"},
-		},
-		{
-			description: "custom-tests",
-			dir:         "examples/custom-tests",
-			pods:        []string{"custom-test"},
-		},
-		{
-			description: "microservices",
-			dir:         "examples/microservices",
-			// See https://github.com/GoogleContainerTools/skaffold/issues/2372
-			args:        []string{"--status-check=false"},
-			deployments: []string{"leeroy-app", "leeroy-web"},
-		},
-		{
-			description: "multi-config-microservices",
-			dir:         "examples/multi-config-microservices",
-			deployments: []string{"leeroy-app", "leeroy-web"},
-		},
-		{
-			description: "remote-multi-config-microservices",
-			dir:         "examples/remote-multi-config-microservices",
-			deployments: []string{"leeroy-app", "leeroy-web"},
-		},
-		{
-			description: "envTagger",
-			dir:         "examples/tagging-with-environment-variables",
-			pods:        []string{"getting-started"},
-			env:         []string{"FOO=foo"},
-		},
-		{
-			description: "bazel",
-			dir:         "examples/bazel",
-			pods:        []string{"bazel"},
-		},
-		{
-			description: "jib",
-			dir:         "testdata/jib",
-			deployments: []string{"web"},
-		},
-		{
-			description: "jib gradle",
-			dir:         "examples/jib-gradle",
-			deployments: []string{"web"},
-		},
-		{
-			description: "profiles",
-			dir:         "examples/profiles",
-			args:        []string{"-p", "minikube-profile"},
-			pods:        []string{"hello-service"},
-		},
-		{
-			description: "multiple deployers",
-			dir:         "testdata/deploy-multiple",
-			pods:        []string{"deploy-kubectl", "deploy-kustomize"},
-		},
-		{
-			description: "custom builder",
-			dir:         "examples/custom",
-			pods:        []string{"getting-started"},
-		},
-		{
-			description: "buildpacks Go",
-			dir:         "examples/buildpacks",
-			deployments: []string{"web"},
-		},
-		{
-			description: "buildpacks NodeJS",
-			dir:         "examples/buildpacks-node",
-			deployments: []string{"web"},
-		},
-		{
-			description: "buildpacks Python",
-			dir:         "examples/buildpacks-python",
-			deployments: []string{"web"},
-		},
-		{
-			description: "buildpacks Java",
-			dir:         "examples/buildpacks-java",
-			deployments: []string{"web"},
-		},
-		{
-			description: "kustomize",
-			dir:         "examples/getting-started-kustomize",
-			deployments: []string{"skaffold-kustomize-dev"},
-		},
-	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			ns, client := SetupNamespace(t)
@@ -151,6 +161,52 @@ func TestRun(t *testing.T) {
 
 			client.WaitForPodsReady(test.pods...)
 			client.WaitForDeploymentsToStabilize(test.deployments...)
+
+			skaffold.Delete().InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunOrFail(t)
+		})
+	}
+}
+
+func TestRunTail(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			if test.targetLog == "" {
+				t.SkipNow()
+			}
+			ns, client := SetupNamespace(t)
+
+			args := append(test.args, "--tail")
+			out := skaffold.Run(args...).InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunLive(t)
+
+			client.WaitForPodsReady(test.pods...)
+			client.WaitForDeploymentsToStabilize(test.deployments...)
+
+			WaitForLogs(t, out, test.targetLog)
+
+			skaffold.Delete().InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunOrFail(t)
+		})
+	}
+}
+
+func TestRunTailDefaultNamespace(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			if test.targetLog == "" {
+				t.SkipNow()
+			}
+			ns, client := DefaultNamespace(t)
+
+			args := append(test.args, "--tail")
+			out := skaffold.Run(args...).InDir(test.dir).WithEnv(test.env).RunLive(t)
+
+			client.WaitForPodsReady(test.pods...)
+			client.WaitForDeploymentsToStabilize(test.deployments...)
+
+			WaitForLogs(t, out, test.targetLog)
 
 			skaffold.Delete().InDir(test.dir).InNs(ns.Name).WithEnv(test.env).RunOrFail(t)
 		})

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -32,31 +32,32 @@ import (
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 )
 
+var syncTests = []struct {
+	description string
+	trigger     string
+	config      string
+}{
+	{
+		description: "manual sync with polling trigger",
+		trigger:     "polling",
+		config:      "skaffold-manual.yaml",
+	},
+	{
+		description: "manual sync with notify trigger",
+		trigger:     "notify",
+		config:      "skaffold-manual.yaml",
+	},
+	{
+		description: "inferred sync with notify trigger",
+		trigger:     "notify",
+		config:      "skaffold-infer.yaml",
+	},
+}
+
 func TestDevSync(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 
-	tests := []struct {
-		description string
-		trigger     string
-		config      string
-	}{
-		{
-			description: "manual sync with polling trigger",
-			trigger:     "polling",
-			config:      "skaffold-manual.yaml",
-		},
-		{
-			description: "manual sync with notify trigger",
-			trigger:     "notify",
-			config:      "skaffold-manual.yaml",
-		},
-		{
-			description: "inferred sync with notify trigger",
-			trigger:     "notify",
-			config:      "skaffold-infer.yaml",
-		},
-	}
-	for _, test := range tests {
+	for _, test := range syncTests {
 		t.Run(test.description, func(t *testing.T) {
 			// Run skaffold build first to fail quickly on a build failure
 			skaffold.Build().InDir("testdata/file-sync").WithConfig(test.config).RunOrFail(t)
@@ -72,6 +73,32 @@ func TestDevSync(t *testing.T) {
 
 			err := wait.PollImmediate(time.Millisecond*500, 1*time.Minute, func() (bool, error) {
 				out, _ := exec.Command("kubectl", "exec", "test-file-sync", "-n", ns.Name, "--", "cat", "foo").Output()
+				return string(out) == "foo", nil
+			})
+			failNowIfError(t, err)
+		})
+	}
+}
+
+func TestDevSyncDefaultNamespace(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	for _, test := range syncTests {
+		t.Run(test.description, func(t *testing.T) {
+			// Run skaffold build first to fail quickly on a build failure
+			skaffold.Build().InDir("testdata/file-sync").WithConfig(test.config).RunOrFail(t)
+
+			_, client := DefaultNamespace(t)
+
+			skaffold.Dev("--trigger", test.trigger).InDir("testdata/file-sync").WithConfig(test.config).RunBackground(t)
+
+			client.WaitForPodsReady("test-file-sync")
+
+			ioutil.WriteFile("testdata/file-sync/foo", []byte("foo"), 0644)
+			defer func() { os.Truncate("testdata/file-sync/foo", 0) }()
+
+			err := wait.PollImmediate(time.Millisecond*500, 1*time.Minute, func() (bool, error) {
+				out, _ := exec.Command("kubectl", "exec", "test-file-sync", "--", "cat", "foo").Output()
 				return string(out) == "foo", nil
 			})
 			failNowIfError(t, err)

--- a/integration/util.go
+++ b/integration/util.go
@@ -127,6 +127,22 @@ func SetupNamespace(t *testing.T) (*v1.Namespace, *NSKubernetesClient) {
 	return ns, nsClient
 }
 
+func DefaultNamespace(t *testing.T) (*v1.Namespace, *NSKubernetesClient) {
+	client, err := kubernetesclient.Client()
+	if err != nil {
+		t.Fatalf("Test setup error: getting Kubernetes client: %s", err)
+	}
+	ns, err := client.CoreV1().Namespaces().Get(context.Background(), "default", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("getting default namespace: %s", err)
+	}
+	return ns, &NSKubernetesClient{
+		t:      t,
+		client: client,
+		ns:     ns.Name,
+	}
+}
+
 // NSKubernetesClient wraps a Kubernetes Client for a given namespace.
 type NSKubernetesClient struct {
 	t      *testing.T

--- a/pkg/skaffold/deploy/deploy_problems_test.go
+++ b/pkg/skaffold/deploy/deploy_problems_test.go
@@ -109,6 +109,7 @@ type mockConfig struct {
 func (m mockConfig) MinikubeProfile() string                { return m.minikube }
 func (m mockConfig) GetPipelines() []latestV1.Pipeline      { return []latestV1.Pipeline{} }
 func (m mockConfig) GetWorkingDir() string                  { return "" }
+func (m mockConfig) GetNamespace() string                   { return "" }
 func (m mockConfig) GlobalConfig() string                   { return "" }
 func (m mockConfig) ConfigurationFile() string              { return "" }
 func (m mockConfig) DefaultRepo() *string                   { return &m.minikube }

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -147,7 +147,10 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, h *latestV1.HelmDe
 
 	podSelector := kubernetes.NewImageList()
 	kubectl := pkgkubectl.NewCLI(cfg, cfg.GetKubeNamespace())
-	namespaces := []string{}
+	namespaces, err := deployutil.GetAllPodNamespaces(cfg.GetNamespace(), cfg.GetPipelines())
+	if err != nil {
+		logrus.Warnf("unable to parse namespaces - deploy might not work correctly!")
+	}
 
 	return &Deployer{
 		HelmDeploy:     h,

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -524,7 +524,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployConfig,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm3.0beta namespaced context deploy success",
@@ -537,7 +537,7 @@ func TestHelmDeploy(t *testing.T) {
 			helm:               testDeployConfig,
 			namespace:          kubectl.TestNamespace,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm3.0 deploy success",
@@ -549,7 +549,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployConfig,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm3.0 namespaced deploy success",
@@ -561,7 +561,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all --namespace testReleaseNamespace skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployNamespacedConfig,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm3.0 namespaced (with env template) deploy success",
@@ -586,7 +586,7 @@ func TestHelmDeploy(t *testing.T) {
 			helm:               testDeployConfig,
 			namespace:          kubectl.TestNamespace,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm3.0 namespaced context deploy success overrides release namespaces",
@@ -599,7 +599,7 @@ func TestHelmDeploy(t *testing.T) {
 			helm:               testDeployNamespacedConfig,
 			namespace:          kubectl.TestNamespace,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm3.1 deploy success",
@@ -611,7 +611,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployConfig,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm3.1 namespaced deploy success",
@@ -623,7 +623,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all --namespace testReleaseNamespace skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployNamespacedConfig,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm3.1 namespaced deploy (with env template) success",
@@ -647,7 +647,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployConfigRemoteRepo,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm3.1 namespaced context deploy success",
@@ -660,7 +660,7 @@ func TestHelmDeploy(t *testing.T) {
 			helm:               testDeployConfig,
 			namespace:          kubectl.TestNamespace,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm3.1 namespaced context deploy success overrides release namespaces",
@@ -673,7 +673,7 @@ func TestHelmDeploy(t *testing.T) {
 			helm:               testDeployNamespacedConfig,
 			namespace:          kubectl.TestNamespace,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy success with recreatePods",
@@ -685,7 +685,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployRecreatePodsConfig,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy success with skipBuildDependencies",
@@ -696,7 +696,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeploySkipBuildDependenciesConfig,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy should error for unmatched parameter",
@@ -709,7 +709,7 @@ func TestHelmDeploy(t *testing.T) {
 			helm:               testDeployConfigParameterUnmatched,
 			builds:             testBuilds,
 			shouldErr:          true,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy success remote chart with skipBuildDependencies",
@@ -720,7 +720,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeploySkipBuildDependencies,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy success when `upgradeOnChange: false` and does not upgrade",
@@ -728,7 +728,7 @@ func TestHelmDeploy(t *testing.T) {
 				CmdRunWithOutput("helm version --client", version31).
 				AndRun("helm --kube-context kubecontext get all skaffold-helm-upgradeOnChange --kubeconfig kubeconfig"),
 			helm:               testDeployUpgradeOnChange,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy remote chart",
@@ -738,7 +738,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext install skaffold-helm-remote stable/chartmuseum --repo https://charts.helm.sh/stable --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext get all skaffold-helm-remote --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployRemoteChart,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy remote chart with version",
@@ -748,7 +748,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext install skaffold-helm-remote --version 1.0.0 stable/chartmuseum --repo https://charts.helm.sh/stable --kubeconfig kubeconfig").
 				AndRun("helm --kube-context kubecontext get all skaffold-helm-remote --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployRemoteChartVersion,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy error with remote chart",
@@ -758,7 +758,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRunErr("helm --kube-context kubecontext install skaffold-helm-remote stable/chartmuseum --repo https://charts.helm.sh/stable --kubeconfig kubeconfig", fmt.Errorf("building helm dependencies")),
 			helm:               testDeployRemoteChart,
 			shouldErr:          true,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "get failure should install not upgrade",
@@ -770,7 +770,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployConfig,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm3 get failure should install not upgrade",
@@ -782,7 +782,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployConfig,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "get failure should install not upgrade with helm image strategy",
@@ -794,7 +794,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployHelmStyleConfig,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm image strategy with explicit registry should set the Helm registry value",
@@ -806,7 +806,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployHelmExplicitRegistryStyleConfig,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "get success should upgrade by force, not install",
@@ -819,7 +819,7 @@ func TestHelmDeploy(t *testing.T) {
 			helm:               testDeployConfig,
 			force:              true,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "get success should upgrade without force, not install",
@@ -831,7 +831,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployConfig,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy error",
@@ -844,7 +844,7 @@ func TestHelmDeploy(t *testing.T) {
 			shouldErr:          true,
 			helm:               testDeployConfig,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "dep build error",
@@ -857,7 +857,7 @@ func TestHelmDeploy(t *testing.T) {
 			shouldErr:          true,
 			helm:               testDeployConfig,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm 3.0 beta should package chart and deploy",
@@ -871,7 +871,7 @@ func TestHelmDeploy(t *testing.T) {
 			shouldErr:          false,
 			helm:               testDeployFooWithPackaged,
 			builds:             testBuildsFoo,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm 3.1 should package chart and deploy",
@@ -885,7 +885,7 @@ func TestHelmDeploy(t *testing.T) {
 			shouldErr:          false,
 			helm:               testDeployFooWithPackaged,
 			builds:             testBuildsFoo,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "should fail to deploy when packaging fails",
@@ -897,7 +897,7 @@ func TestHelmDeploy(t *testing.T) {
 			shouldErr:          true,
 			helm:               testDeployFooWithPackaged,
 			builds:             testBuildsFoo,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description:        "deploy and get missing templated release name should fail",
@@ -905,7 +905,7 @@ func TestHelmDeploy(t *testing.T) {
 			helm:               testDeployWithTemplatedName,
 			builds:             testBuilds,
 			shouldErr:          true,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy and get templated release name",
@@ -918,7 +918,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all user-skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployWithTemplatedName,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy with templated values",
@@ -930,7 +930,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployConfigTemplated,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy with valuesFiles templated",
@@ -942,7 +942,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployConfigValuesFilesTemplated,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy with templated version",
@@ -955,7 +955,7 @@ func TestHelmDeploy(t *testing.T) {
 			env:                []string{"VERSION=1.0"},
 			helm:               testDeployConfigVersionTemplated,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy with setFiles",
@@ -967,7 +967,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testDeployConfigSetFiles,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "deploy without actual tags",
@@ -983,7 +983,7 @@ func TestHelmDeploy(t *testing.T) {
 				"See helm documentation on how to replace image names with their actual tags: https://skaffold.dev/docs/pipeline-stages/deployers/helm/#image-configuration",
 				"image [docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184] is not used.",
 			},
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "first release without tag, second with tag",
@@ -999,7 +999,7 @@ func TestHelmDeploy(t *testing.T) {
 				AndRun("helm --kube-context kubecontext get all skaffold-helm --template {{.Release.Manifest}} --kubeconfig kubeconfig"),
 			helm:               testTwoReleases,
 			builds:             testBuilds,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description:        "debug for helm3.0 failure",
@@ -1008,7 +1008,7 @@ func TestHelmDeploy(t *testing.T) {
 			helm:               testDeployConfig,
 			builds:             testBuilds,
 			configure:          func(deployer *Deployer) { deployer.enableDebug = true },
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "debug for helm3.1 success",
@@ -1022,7 +1022,7 @@ func TestHelmDeploy(t *testing.T) {
 			helm:               testDeployConfig,
 			builds:             testBuilds,
 			configure:          func(deployer *Deployer) { deployer.enableDebug = true },
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm3.1 should fail to deploy with createNamespace option",
@@ -1033,7 +1033,7 @@ func TestHelmDeploy(t *testing.T) {
 			helm:               testDeployCreateNamespaceConfig,
 			builds:             testBuilds,
 			shouldErr:          true,
-			expectedNamespaces: []string{},
+			expectedNamespaces: []string{""},
 		},
 		{
 			description: "helm3.2 get failure should install with createNamespace not upgrade",

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -28,6 +28,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"golang.org/x/mod/semver"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8syaml "sigs.k8s.io/yaml"
@@ -111,7 +112,10 @@ type Config interface {
 func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latestV1.KptDeploy) *Deployer {
 	podSelector := kubernetes.NewImageList()
 	kubectl := pkgkubectl.NewCLI(cfg, cfg.GetKubeNamespace())
-	namespaces := []string{}
+	namespaces, err := deployutil.GetAllPodNamespaces(cfg.GetNamespace(), cfg.GetPipelines())
+	if err != nil {
+		logrus.Warnf("unable to parse namespaces - deploy might not work correctly!")
+	}
 
 	return &Deployer{
 		KptDeploy:          d,

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -91,7 +91,10 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latestV1.Kubect
 
 	podSelector := kubernetes.NewImageList()
 	kubectl := NewCLI(cfg, d.Flags, defaultNamespace)
-	namespaces := []string{}
+	namespaces, err := deployutil.GetAllPodNamespaces(cfg.GetNamespace(), cfg.GetPipelines())
+	if err != nil {
+		logrus.Warnf("unable to parse namespaces - deploy might not work correctly!")
+	}
 
 	return &Deployer{
 		KubectlDeploy:      d,

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 
 	"github.com/segmentio/textio"
+	"github.com/sirupsen/logrus"
 	yamlv3 "gopkg.in/yaml.v3"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/access"
@@ -139,7 +140,10 @@ func NewDeployer(cfg kubectl.Config, labeller *label.DefaultLabeller, d *latestV
 	useKubectlKustomize := !KustomizeBinaryCheck() && kubectlVersionCheck(kubectl)
 
 	podSelector := kubernetes.NewImageList()
-	namespaces := []string{}
+	namespaces, err := deployutil.GetAllPodNamespaces(cfg.GetNamespace(), cfg.GetPipelines())
+	if err != nil {
+		logrus.Warnf("unable to parse namespaces - deploy might not work correctly!")
+	}
 
 	return &Deployer{
 		KustomizeDeploy:     d,

--- a/pkg/skaffold/deploy/types/types.go
+++ b/pkg/skaffold/deploy/types/types.go
@@ -26,6 +26,7 @@ import (
 type Config interface {
 	docker.Config
 
+	GetNamespace() string
 	GetPipelines() []latestV1.Pipeline
 	GetWorkingDir() string
 	GlobalConfig() string

--- a/pkg/skaffold/deploy/util/namespaces.go
+++ b/pkg/skaffold/deploy/util/namespaces.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2021 The Skaffold Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"sort"
+
+	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+)
+
+// GetAllPodNamespaces lists the namespaces that should be watched.
+// + The namespace passed on the command line
+// + Current kube context's namespace
+// + Namespaces referenced in Helm releases
+func GetAllPodNamespaces(configNamespace string, pipelines []latestV1.Pipeline) ([]string, error) {
+	nsMap := make(map[string]bool)
+
+	if configNamespace == "" {
+		// Get current kube context's namespace
+		config, err := kubectx.CurrentConfig()
+		if err != nil {
+			return nil, fmt.Errorf("getting k8s configuration: %w", err)
+		}
+
+		context, ok := config.Contexts[config.CurrentContext]
+		if ok {
+			nsMap[context.Namespace] = true
+		} else {
+			nsMap[""] = true
+		}
+	} else {
+		nsMap[configNamespace] = true
+	}
+
+	// Set additional namespaces each helm release referenced
+	for _, namespace := range collectHelmReleasesNamespaces(pipelines) {
+		nsMap[namespace] = true
+	}
+
+	// Collate the slice of namespaces.
+	namespaces := make([]string, 0, len(nsMap))
+	for ns := range nsMap {
+		namespaces = append(namespaces, ns)
+	}
+
+	sort.Strings(namespaces)
+	return namespaces, nil
+}
+
+func collectHelmReleasesNamespaces(pipelines []latestV1.Pipeline) []string {
+	var namespaces []string
+	for _, cfg := range pipelines {
+		if cfg.Deploy.HelmDeploy != nil {
+			for _, release := range cfg.Deploy.HelmDeploy.Releases {
+				if release.Namespace != "" {
+					namespaces = append(namespaces, release.Namespace)
+				}
+			}
+		}
+	}
+	return namespaces
+}

--- a/pkg/skaffold/deploy/util/namespaces.go
+++ b/pkg/skaffold/deploy/util/namespaces.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2021 The Skaffold Authors
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/skaffold/deploy/util/util.go
+++ b/pkg/skaffold/deploy/util/util.go
@@ -67,6 +67,6 @@ func ConsolidateNamespaces(original, new []string) []string {
 	}
 	namespaces := util.NewStringSet()
 	namespaces.Insert(append(original, new...)...)
-	namespaces.Delete("")
+	namespaces.Delete("") // if we have provided namespaces, remove the empty "default" namespace
 	return namespaces.ToList()
 }

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -152,6 +152,7 @@ func (rc *RunContext) GetPipelines() []latestV1.Pipeline             { return rc
 func (rc *RunContext) GetInsecureRegistries() map[string]bool        { return rc.InsecureRegistries }
 func (rc *RunContext) GetWorkingDir() string                         { return rc.WorkingDir }
 func (rc *RunContext) GetCluster() config.Cluster                    { return rc.Cluster }
+func (rc *RunContext) GetNamespace() string                          { return rc.Opts.Namespace }
 func (rc *RunContext) AddSkaffoldLabels() bool                       { return rc.Opts.AddSkaffoldLabels }
 func (rc *RunContext) AutoBuild() bool                               { return rc.Opts.AutoBuild }
 func (rc *RunContext) AutoDeploy() bool                              { return rc.Opts.AutoDeploy }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/6242

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
https://github.com/GoogleContainerTools/skaffold/pull/6170 moved the tracking of the deployed namespaces into the `Deployer` object. However, it inadvertently removed some pre-processing logic to retrieve the initial namespaces when creating the `Deployer`. Since the empty string (`""`) is interpreted as the "default" namespace when deploying to Kubernetes, this meant that all projects deploying to this namespace were not being considered for logging, port forwarding, or any other component that uses a `podSelector` to retrieve its resources.

This change adds back the `GetAllPodNamespaces()` function, which collects the namespaces being operated on before starting the `Deploy`, to ensure they're being tracked on the `Deployer` before starting the deploy. This function is moved from `pkg/skaffold/runner/util` to `pkg/skaffold/deploy/util`.

**Integration tests have been added**

~Integration tests coming. This slipped through because we create a unique namespace for **all** integration tests in skaffold, and so were not actually testing the case where no namespace is provided (aka deploying to the `default` namespace).~