### PR TITLE
Fix Workdir error when --filename flag is used.

### DIFF
--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -19,6 +19,7 @@ package runcontext
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
@@ -208,10 +209,14 @@ func GetRunContext(opts config.SkaffoldOptions, configs []schemaUtil.VersionedCo
 	kubeContext := kubeConfig.CurrentContext
 	logrus.Infof("Using kubectl context: %s", kubeContext)
 
-	// TODO(dgageot): this should be the folder containing skaffold.yaml. Should also be moved elsewhere.
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("finding current directory: %w", err)
+	var cwd string
+	if opts.ConfigurationFile == "" {
+		cwd, err = os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("finding current directory: %w", err)
+		}
+	} else {
+		cwd = filepath.Dir(opts.ConfigurationFile)
 	}
 
 	// combine all provided lists of insecure registries into a map

--- a/pkg/skaffold/runner/runcontext/context_test.go
+++ b/pkg/skaffold/runner/runcontext/context_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package runcontext
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	schemaUtil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestGetRunContextDefaultWorkdir(t *testing.T) {
+	testutil.Run(t, "default workdir", func(t *testutil.T) {
+		rctx, err := GetRunContext(config.SkaffoldOptions{}, []schemaUtil.VersionedConfig{})
+		pwd, _ := os.Getwd()
+		t.CheckDeepEqual(pwd, rctx.WorkingDir)
+		t.CheckNoError(err)
+	})
+}
+
+func TestGetRunContextCustomWorkdir(t *testing.T) {
+	testutil.Run(t, "default workdir", func(t *testutil.T) {
+		tmpDir := t.NewTempDir()
+		tmpDir.Write("skaffold.yaml", fmt.Sprintf("apiVersion: %s\nkind: Config", latestV1.Version)).
+			Chdir()
+		rctx, err := GetRunContext(config.SkaffoldOptions{
+			ConfigurationFile: filepath.Join(tmpDir.Root(), "skaffold.yaml"),
+		}, []schemaUtil.VersionedConfig{})
+		t.CheckDeepEqual(tmpDir.Root(), rctx.WorkingDir)
+		t.CheckNoError(err)
+	})
+}


### PR DESCRIPTION
**Related**: #5673 

**Description**
When --filename (skaffold.yaml) is used, the workdir shall be switched to where the custom skaffold.yaml lives. But current skaffold does not support switching the workdir.  

@dgageot 