### PR TITLE
[v2] Enable `skaffold dev`

### DIFF
--- a/hack/versions/pkg/schema/check.go
+++ b/hack/versions/pkg/schema/check.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/hack/versions/pkg/diff"
 )
 
-const baseRef = "origin/master"
+const baseRef = "origin/main"
 
 func RunSchemaCheckOnChangedFiles() error {
 	git, err := newGit(baseRef)

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -73,6 +73,8 @@ const (
 	GithubIssueLink = "https://github.com/GoogleContainerTools/skaffold/issues/new"
 
 	Windows = "windows"
+
+	DefaultHydrationDir = ".kpt-pipeline"
 )
 
 type Phase string

--- a/pkg/skaffold/deploy/v2/kpt/kpt.go
+++ b/pkg/skaffold/deploy/v2/kpt/kpt.go
@@ -235,6 +235,11 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	return namespaces, nil
 }
 
+// TODO(yuwenma)[07/23/22]: remove Render func from all deployers and deployerMux.
+func (k *Deployer) Render(context.Context, io.Writer, []graph.Artifact, bool, string) error {
+	return fmt.Errorf("shall not be called")
+}
+
 func (k *Deployer) Dependencies() ([]string, error) {
 	// TODO(yuwenma): This should be the render denpendencies.
 	return []string{}, nil

--- a/pkg/skaffold/runner/deployer_test.go
+++ b/pkg/skaffold/runner/deployer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kpt"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
+	kptV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/v2/kpt"
 	v2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v2"
 	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -85,6 +86,13 @@ func TestGetDeployer(tOuter *testing.T) {
 				cfg:         latestV2.DeployType{KptDeploy: &latestV2.KptDeploy{}},
 				expected: deploy.NewDeployerMux([]deploy.Deployer{
 					&kpt.Deployer{},
+				}, false),
+			},
+			{
+				description: "kpt V2 deployer",
+				cfg:         latestV2.DeployType{KptV2Deploy: &latestV2.KptV2Deploy{}},
+				expected: deploy.NewDeployerMux([]deploy.Deployer{
+					&kptV2.Deployer{},
 				}, false),
 			},
 			{

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -47,6 +47,8 @@ type Runner interface {
 	HasBuilt() bool
 	HasDeployed() bool
 	Prune(context.Context, io.Writer) error
-	Render(context.Context, io.Writer, []graph.Artifact, bool, string) error
+
+	// "output" arg is only used in Render v1.
+	Render(ctx context.Context, out io.Writer, builds []graph.Artifact, offline bool, output string) error
 	Test(context.Context, io.Writer, []graph.Artifact) error
 }

--- a/pkg/skaffold/runner/v2/cleanup.go
+++ b/pkg/skaffold/runner/v2/cleanup.go
@@ -17,10 +17,9 @@ package v2
 
 import (
 	"context"
-	"fmt"
 	"io"
 )
 
 func (r *SkaffoldRunner) Cleanup(ctx context.Context, out io.Writer) error {
-	return fmt.Errorf("not implemented error: SkaffoldRunner(v2).Cleanup")
+	return r.deployer.Cleanup(ctx, out)
 }

--- a/pkg/skaffold/runner/v2/deploy.go
+++ b/pkg/skaffold/runner/v2/deploy.go
@@ -68,10 +68,6 @@ func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifa
 }
 
 func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []graph.Artifact) error {
-	if r.runCtx.RenderOnly() {
-		return r.Render(ctx, out, artifacts, false, r.runCtx.RenderOutput())
-	}
-
 	out = output.WithEventContext(out, constants.Deploy, eventV2.SubtaskIDNone, "skaffold")
 
 	output.Default.Fprintln(out, "Tags used in deployment:")

--- a/pkg/skaffold/runner/v2/deploy.go
+++ b/pkg/skaffold/runner/v2/deploy.go
@@ -13,20 +13,186 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v2
 
 import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	deployutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/util"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
+	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
+	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 )
 
-func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []graph.Artifact) error {
-	return fmt.Errorf("not implemented error: SkaffoldRunner(v2).Deploy")
+// DeployAndLog deploys a list of already built artifacts and optionally show the logs.
+func (r *SkaffoldRunner) DeployAndLog(ctx context.Context, out io.Writer, artifacts []graph.Artifact) error {
+	defer r.deployer.GetLogger().Stop()
+
+	// Logs should be retrieved up to just before the deploy
+	r.deployer.GetLogger().SetSince(time.Now())
+	// First deploy
+	if err := r.Deploy(ctx, out, artifacts); err != nil {
+		return err
+	}
+
+	defer r.deployer.GetAccessor().Stop()
+
+	if err := r.deployer.GetAccessor().Start(ctx, out, r.runCtx.GetNamespaces()); err != nil {
+		logrus.Warnln("Error starting port forwarding:", err)
+	}
+
+	// Start printing the logs after deploy is finished
+	if err := r.deployer.GetLogger().Start(ctx, out, r.runCtx.GetNamespaces()); err != nil {
+		return fmt.Errorf("starting logger: %w", err)
+	}
+
+	if r.runCtx.Tail() || r.runCtx.PortForward() {
+		output.Yellow.Fprintln(out, "Press Ctrl+C to exit")
+		<-ctx.Done()
+	}
+
+	return nil
 }
 
-func (r *SkaffoldRunner) DeployAndLog(context.Context, io.Writer, []graph.Artifact) error {
-	return fmt.Errorf("not implemented error: SkaffoldRunner(v2).DeployAndLog")
+func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []graph.Artifact) error {
+	if r.runCtx.RenderOnly() {
+		return r.Render(ctx, out, artifacts, false, r.runCtx.RenderOutput())
+	}
+
+	out = output.WithEventContext(out, constants.Deploy, eventV2.SubtaskIDNone, "skaffold")
+
+	output.Default.Fprintln(out, "Tags used in deployment:")
+
+	for _, artifact := range artifacts {
+		output.Default.Fprintf(out, " - %s -> ", artifact.ImageName)
+		fmt.Fprintln(out, artifact.Tag)
+	}
+
+	var localImages []graph.Artifact
+	for _, a := range artifacts {
+		if isLocal, err := r.isLocalImage(a.ImageName); err != nil {
+			return err
+		} else if isLocal {
+			localImages = append(localImages, a)
+		}
+	}
+
+	if len(localImages) > 0 {
+		logrus.Debugln(`Local images can't be referenced by digest.
+They are tagged and referenced by a unique, local only, tag instead.
+See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
+	}
+
+	// Check that the cluster is reachable.
+	// This gives a better error message when the cluster can't
+	// be reached.
+	if err := failIfClusterIsNotReachable(); err != nil {
+		return fmt.Errorf("unable to connect to Kubernetes: %w", err)
+	}
+
+	if len(localImages) > 0 && r.runCtx.Cluster.LoadImages {
+		err := r.loadImagesIntoCluster(ctx, out, localImages)
+		if err != nil {
+			return err
+		}
+	}
+
+	deployOut, postDeployFn, err := deployutil.WithLogFile(time.Now().Format(deployutil.TimeFormat)+".log", out, r.runCtx.Muted())
+	if err != nil {
+		return err
+	}
+
+	event.DeployInProgress()
+	eventV2.TaskInProgress(constants.Deploy, "Deploy to cluster")
+	ctx, endTrace := instrumentation.StartTrace(ctx, "Deploy_Deploying")
+	defer endTrace()
+
+	namespaces, err := r.deployer.Deploy(ctx, deployOut, artifacts)
+	postDeployFn()
+	if err != nil {
+		event.DeployFailed(err)
+		eventV2.TaskFailed(constants.Deploy, err)
+		endTrace(instrumentation.TraceEndError(err))
+		return err
+	}
+
+	r.hasDeployed = true
+
+	statusCheckOut, postStatusCheckFn, err := deployutil.WithStatusCheckLogFile(time.Now().Format(deployutil.TimeFormat)+".log", out, r.runCtx.Muted())
+	defer postStatusCheckFn()
+	if err != nil {
+		endTrace(instrumentation.TraceEndError(err))
+		return err
+	}
+
+	event.DeployComplete()
+	eventV2.TaskSucceeded(constants.Deploy)
+	r.runCtx.UpdateNamespaces(namespaces)
+	sErr := r.deployer.GetStatusMonitor().Check(ctx, statusCheckOut)
+	return sErr
+}
+
+func (r *SkaffoldRunner) loadImagesIntoCluster(ctx context.Context, out io.Writer, artifacts []graph.Artifact) error {
+	currentContext, err := r.getCurrentContext()
+	if err != nil {
+		return err
+	}
+
+	if config.IsKindCluster(r.runCtx.GetKubeContext()) {
+		kindCluster := config.KindClusterName(currentContext.Cluster)
+
+		// With `kind`, docker images have to be loaded with the `kind` CLI.
+		if err := r.loadImagesInKindNodes(ctx, out, kindCluster, artifacts); err != nil {
+			return fmt.Errorf("loading images into kind nodes: %w", err)
+		}
+	}
+
+	if config.IsK3dCluster(r.runCtx.GetKubeContext()) {
+		k3dCluster := config.K3dClusterName(currentContext.Cluster)
+
+		// With `k3d`, docker images have to be loaded with the `k3d` CLI.
+		if err := r.loadImagesInK3dNodes(ctx, out, k3dCluster, artifacts); err != nil {
+			return fmt.Errorf("loading images into k3d nodes: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *SkaffoldRunner) getCurrentContext() (*api.Context, error) {
+	currentCfg, err := kubectx.CurrentConfig()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get kubernetes config: %w", err)
+	}
+
+	currentContext, present := currentCfg.Contexts[r.runCtx.GetKubeContext()]
+	if !present {
+		return nil, fmt.Errorf("unable to get current kubernetes context: %w", err)
+	}
+	return currentContext, nil
+}
+
+// failIfClusterIsNotReachable checks that Kubernetes is reachable.
+// This gives a clear early error when the cluster can't be reached.
+func failIfClusterIsNotReachable() error {
+	client, err := kubernetesclient.Client()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Discovery().ServerVersion()
+	return err
 }

--- a/pkg/skaffold/runner/v2/deploy_test.go
+++ b/pkg/skaffold/runner/v2/deploy_test.go
@@ -25,13 +25,8 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd/api"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
-	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v2"
 	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -112,29 +107,4 @@ func TestDeployNamespace(t *testing.T) {
 			t.CheckDeepEqual(test.expected, r.runCtx.GetNamespaces())
 		})
 	}
-}
-
-func TestSkaffoldDeployRenderOnly(t *testing.T) {
-	testutil.Run(t, "does not make kubectl calls", func(t *testutil.T) {
-		runCtx := &runcontext.RunContext{
-			Opts: config.SkaffoldOptions{
-				Namespace:  "testNamespace",
-				RenderOnly: true,
-			},
-			KubeContext: "does-not-exist",
-		}
-
-		deployer, err := runner.GetDeployer(runCtx, deploy.NoopComponentProvider, nil)
-		t.RequireNoError(err)
-		r := SkaffoldRunner{
-			runCtx:     runCtx,
-			kubectlCLI: kubectl.NewCLI(runCtx, ""),
-			deployer:   deployer,
-		}
-		var builds []graph.Artifact
-
-		err = r.Deploy(context.Background(), ioutil.Discard, builds)
-
-		t.CheckNoError(err)
-	})
 }

--- a/pkg/skaffold/runner/v2/deploy_test.go
+++ b/pkg/skaffold/runner/v2/deploy_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/ioutil"
+	"testing"
+
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v2"
+	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDeploy(t *testing.T) {
+	tests := []struct {
+		description string
+		testBench   *TestBench
+		shouldErr   bool
+	}{
+		{
+			description: "deploy succeeds",
+			testBench:   &TestBench{},
+		},
+		{
+			description: "deploy fails",
+			testBench:   &TestBench{deployErrors: []error{errors.New("deploy error")}},
+			shouldErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
+			t.Override(&client.Client, mockK8sClient)
+
+			r := createRunner(t, test.testBench, nil, []*latestV2.Artifact{{ImageName: "img1"}, {ImageName: "img2"}}, nil)
+			out := new(bytes.Buffer)
+
+			err := r.Deploy(context.Background(), out, []graph.Artifact{
+				{ImageName: "img1", Tag: "img1:tag1"},
+				{ImageName: "img2", Tag: "img2:tag2"},
+			})
+			t.CheckError(test.shouldErr, err)
+		})
+	}
+}
+
+func TestDeployNamespace(t *testing.T) {
+	tests := []struct {
+		description string
+		Namespaces  []string
+		testBench   *TestBench
+		expected    []string
+	}{
+		{
+			description: "deploy shd add all namespaces to run Context",
+			Namespaces:  []string{"test", "test-ns"},
+			testBench:   NewTestBench().WithDeployNamespaces([]string{"test-ns", "test-ns-1"}),
+			expected:    []string{"test", "test-ns", "test-ns-1"},
+		},
+		{
+			description: "deploy without command opts namespace",
+			testBench:   NewTestBench().WithDeployNamespaces([]string{"test-ns", "test-ns-1"}),
+			expected:    []string{"test-ns", "test-ns-1"},
+		},
+		{
+			description: "deploy with no namespaces returned",
+			Namespaces:  []string{"test"},
+			testBench:   &TestBench{},
+			expected:    []string{"test"},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
+			t.Override(&client.Client, mockK8sClient)
+
+			r := createRunner(t, test.testBench, nil, []*latestV2.Artifact{{ImageName: "img1"}, {ImageName: "img2"}}, nil)
+			r.runCtx.Namespaces = test.Namespaces
+
+			err := r.Deploy(context.Background(), ioutil.Discard, []graph.Artifact{
+				{ImageName: "img1", Tag: "img1:tag1"},
+				{ImageName: "img2", Tag: "img2:tag2"},
+			})
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expected, r.runCtx.GetNamespaces())
+		})
+	}
+}
+
+func TestSkaffoldDeployRenderOnly(t *testing.T) {
+	testutil.Run(t, "does not make kubectl calls", func(t *testutil.T) {
+		runCtx := &runcontext.RunContext{
+			Opts: config.SkaffoldOptions{
+				Namespace:  "testNamespace",
+				RenderOnly: true,
+			},
+			KubeContext: "does-not-exist",
+		}
+
+		deployer, err := runner.GetDeployer(runCtx, deploy.NoopComponentProvider, nil)
+		t.RequireNoError(err)
+		r := SkaffoldRunner{
+			runCtx:     runCtx,
+			kubectlCLI: kubectl.NewCLI(runCtx, ""),
+			deployer:   deployer,
+		}
+		var builds []graph.Artifact
+
+		err = r.Deploy(context.Background(), ioutil.Discard, builds)
+
+		t.CheckNoError(err)
+	})
+}

--- a/pkg/skaffold/runner/v2/dev.go
+++ b/pkg/skaffold/runner/v2/dev.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Skaffold Authors
+Copyright 2019 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,16 +13,361 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v2
 
 import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
+	"time"
 
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/proto/v1"
 )
 
+var (
+	// For testing
+	fileSyncInProgress = event.FileSyncInProgress
+	fileSyncFailed     = event.FileSyncFailed
+	fileSyncSucceeded  = event.FileSyncSucceeded
+)
+
+func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer) error {
+	// never queue intents from user, even if they're not used
+	defer r.intents.Reset()
+
+	if r.changeSet.NeedsReload() {
+		return runner.ErrorConfigurationChanged
+	}
+
+	buildIntent, syncIntent, deployIntent := r.intents.GetIntents()
+	logrus.Tracef("dev intents: build %t, sync %t, deploy %t\n", buildIntent, syncIntent, deployIntent)
+	needsSync := syncIntent && len(r.changeSet.NeedsResync()) > 0
+	needsBuild := buildIntent && len(r.changeSet.NeedsRebuild()) > 0
+	needsTest := len(r.changeSet.NeedsRetest()) > 0
+	needsDeploy := deployIntent && r.changeSet.NeedsRedeploy()
+	if !needsSync && !needsBuild && !needsTest && !needsDeploy {
+		return nil
+	}
+
+	r.deployer.GetLogger().Mute()
+	// if any action is going to be performed, reset the monitor's changed component tracker for debouncing
+	defer r.monitor.Reset()
+	defer r.listener.LogWatchToUser(out)
+
+	event.DevLoopInProgress(r.devIteration)
+	eventV2.InitializeState(r.runCtx)
+	eventV2.TaskInProgress(constants.DevLoop, "")
+	defer func() { r.devIteration++ }()
+	eventV2.LogMetaEvent()
+	ctx, endTrace := instrumentation.StartTrace(ctx, "doDev_DevLoopInProgress", map[string]string{
+		"devIteration": strconv.Itoa(r.devIteration),
+	})
+
+	meterUpdated := false
+	if needsSync {
+		childCtx, endTrace := instrumentation.StartTrace(ctx, "doDev_needsSync")
+		defer func() {
+			r.changeSet.ResetSync()
+			r.intents.ResetSync()
+		}()
+		instrumentation.AddDevIteration("sync")
+		meterUpdated = true
+		for _, s := range r.changeSet.NeedsResync() {
+			fileCount := len(s.Copy) + len(s.Delete)
+			output.Default.Fprintf(out, "Syncing %d files for %s\n", fileCount, s.Image)
+			fileSyncInProgress(fileCount, s.Image)
+
+			if err := r.deployer.GetSyncer().Sync(childCtx, s); err != nil {
+				logrus.Warnln("Skipping deploy due to sync error:", err)
+				fileSyncFailed(fileCount, s.Image, err)
+				event.DevLoopFailedInPhase(r.devIteration, constants.Sync, err)
+				eventV2.TaskFailed(constants.DevLoop, err)
+				endTrace(instrumentation.TraceEndError(err))
+
+				return nil
+			}
+
+			fileSyncSucceeded(fileCount, s.Image)
+		}
+		endTrace()
+	}
+
+	var bRes []graph.Artifact
+	if needsBuild {
+		childCtx, endTrace := instrumentation.StartTrace(ctx, "doDev_needsBuild")
+		event.ResetStateOnBuild()
+		defer func() {
+			r.changeSet.ResetBuild()
+			r.intents.ResetBuild()
+		}()
+		if !meterUpdated {
+			instrumentation.AddDevIteration("build")
+			meterUpdated = true
+		}
+
+		var err error
+		bRes, err = r.Build(childCtx, out, r.changeSet.NeedsRebuild())
+		if err != nil {
+			logrus.Warnln("Skipping test and deploy due to build error:", err)
+			event.DevLoopFailedInPhase(r.devIteration, constants.Build, err)
+			eventV2.TaskFailed(constants.DevLoop, err)
+			endTrace(instrumentation.TraceEndError(err))
+			return nil
+		}
+		r.changeSet.Redeploy()
+		needsDeploy = deployIntent
+		endTrace()
+	}
+
+	// Trigger retest when there are newly rebuilt artifacts or untested previous artifacts; and it's not explicitly skipped
+	if (len(bRes) > 0 || needsTest) && !r.runCtx.SkipTests() {
+		childCtx, endTrace := instrumentation.StartTrace(ctx, "doDev_needsTest")
+		event.ResetStateOnTest()
+		defer func() {
+			r.changeSet.ResetTest()
+		}()
+		for _, a := range bRes {
+			delete(r.changeSet.NeedsRetest(), a.ImageName)
+		}
+		for _, a := range r.Builds {
+			if r.changeSet.NeedsRetest()[a.ImageName] {
+				bRes = append(bRes, a)
+			}
+		}
+		if err := r.Test(childCtx, out, bRes); err != nil {
+			if needsDeploy {
+				logrus.Warnln("Skipping deploy due to test error:", err)
+			}
+			event.DevLoopFailedInPhase(r.devIteration, constants.Test, err)
+			eventV2.TaskFailed(constants.DevLoop, err)
+			endTrace(instrumentation.TraceEndError(err))
+			return nil
+		}
+		endTrace()
+	}
+
+	if needsDeploy {
+		childCtx, endTrace := instrumentation.StartTrace(ctx, "doDev_needsDeploy")
+		event.ResetStateOnDeploy()
+		defer func() {
+			r.changeSet.ResetDeploy()
+			r.intents.ResetDeploy()
+		}()
+
+		logrus.Debugln("stopping accessor")
+		r.deployer.GetAccessor().Stop()
+
+		logrus.Debugln("stopping debugger")
+		r.deployer.GetDebugger().Stop()
+
+		if !meterUpdated {
+			instrumentation.AddDevIteration("deploy")
+		}
+		if err := r.Deploy(childCtx, out, r.Builds); err != nil {
+			logrus.Warnln("Skipping deploy due to error:", err)
+			event.DevLoopFailedInPhase(r.devIteration, constants.Deploy, err)
+			eventV2.TaskFailed(constants.DevLoop, err)
+			endTrace(instrumentation.TraceEndError(err))
+			return nil
+		}
+
+		if err := r.deployer.GetAccessor().Start(childCtx, out, r.runCtx.GetNamespaces()); err != nil {
+			logrus.Warnf("failed to start accessor: %v", err)
+		}
+
+		if err := r.deployer.GetDebugger().Start(childCtx, r.runCtx.GetNamespaces()); err != nil {
+			logrus.Warnf("failed to start debugger: %v", err)
+		}
+
+		endTrace()
+	}
+	event.DevLoopComplete(r.devIteration)
+	eventV2.TaskSucceeded(constants.DevLoop)
+	endTrace()
+	r.deployer.GetLogger().Unmute()
+	return nil
+}
+
+// Dev watches for changes and runs the skaffold build, test and deploy
+// config until interrupted by the user.
 func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*latestV2.Artifact) error {
-	return fmt.Errorf("not implemented error: SkaffoldRunner(v2).Dev")
+	event.DevLoopInProgress(r.devIteration)
+	eventV2.InitializeState(r.runCtx)
+	eventV2.TaskInProgress(constants.DevLoop, "")
+	defer func() { r.devIteration++ }()
+	eventV2.LogMetaEvent()
+	ctx, endTrace := instrumentation.StartTrace(ctx, "Dev", map[string]string{
+		"devIteration": strconv.Itoa(r.devIteration),
+	})
+
+	g := getTransposeGraph(artifacts)
+	// Watch artifacts
+	start := time.Now()
+	output.Default.Fprintln(out, "Listing files to watch...")
+
+	for i := range artifacts {
+		artifact := artifacts[i]
+		if !r.runCtx.Opts.IsTargetImage(artifact) {
+			continue
+		}
+
+		output.Default.Fprintf(out, " - %s\n", artifact.ImageName)
+
+		select {
+		case <-ctx.Done():
+			return context.Canceled
+		default:
+			if err := r.monitor.Register(
+				func() ([]string, error) {
+					return r.sourceDependencies.TransitiveArtifactDependencies(ctx, artifact)
+				},
+				func(e filemon.Events) {
+					s, err := sync.NewItem(ctx, artifact, e, r.Builds, r.runCtx, len(g[artifact.ImageName]))
+					switch {
+					case err != nil:
+						logrus.Warnf("error adding dirty artifact to changeset: %s", err.Error())
+					case s != nil:
+						r.changeSet.AddResync(s)
+					default:
+						r.changeSet.AddRebuild(artifact)
+					}
+				},
+			); err != nil {
+				event.DevLoopFailedWithErrorCode(r.devIteration, proto.StatusCode_DEVINIT_REGISTER_BUILD_DEPS, err)
+				eventV2.TaskFailed(constants.DevLoop, err)
+				endTrace()
+				return fmt.Errorf("watching files for artifact %q: %w", artifact.ImageName, err)
+			}
+		}
+	}
+
+	// Watch test configuration
+	for i := range artifacts {
+		artifact := artifacts[i]
+		if err := r.monitor.Register(
+			func() ([]string, error) { return r.Tester.TestDependencies(artifact) },
+			func(filemon.Events) { r.changeSet.AddRetest(artifact) },
+		); err != nil {
+			event.DevLoopFailedWithErrorCode(r.devIteration, proto.StatusCode_DEVINIT_REGISTER_TEST_DEPS, err)
+			eventV2.TaskFailed(constants.DevLoop, err)
+			endTrace()
+			return fmt.Errorf("watching test files: %w", err)
+		}
+	}
+
+	// Watch deployment configuration
+	if err := r.monitor.Register(
+		r.deployer.Dependencies,
+		func(filemon.Events) { r.changeSet.Redeploy() },
+	); err != nil {
+		event.DevLoopFailedWithErrorCode(r.devIteration, proto.StatusCode_DEVINIT_REGISTER_DEPLOY_DEPS, err)
+		eventV2.TaskFailed(constants.DevLoop, err)
+		endTrace()
+		return fmt.Errorf("watching files for deployer: %w", err)
+	}
+
+	// Watch Skaffold configuration
+	if err := r.monitor.Register(
+		func() ([]string, error) { return []string{r.runCtx.ConfigurationFile()}, nil },
+		func(filemon.Events) { r.changeSet.Reload() },
+	); err != nil {
+		event.DevLoopFailedWithErrorCode(r.devIteration, proto.StatusCode_DEVINIT_REGISTER_CONFIG_DEP, err)
+		eventV2.TaskFailed(constants.DevLoop, err)
+		endTrace()
+		return fmt.Errorf("watching skaffold configuration %q: %w", r.runCtx.ConfigurationFile(), err)
+	}
+
+	logrus.Infoln("List generated in", util.ShowHumanizeTime(time.Since(start)))
+
+	// Init Sync State
+	if err := sync.Init(ctx, artifacts); err != nil {
+		event.DevLoopFailedWithErrorCode(r.devIteration, proto.StatusCode_SYNC_INIT_ERROR, err)
+		eventV2.TaskFailed(constants.DevLoop, err)
+		endTrace()
+		return fmt.Errorf("exiting dev mode because initializing sync state failed: %w", err)
+	}
+
+	// First build
+	bRes, err := r.Build(ctx, out, artifacts)
+	if err != nil {
+		event.DevLoopFailedInPhase(r.devIteration, constants.Build, err)
+		eventV2.TaskFailed(constants.DevLoop, err)
+		endTrace()
+		return fmt.Errorf("exiting dev mode because first build failed: %w", err)
+	}
+	// First test
+	if !r.runCtx.SkipTests() {
+		if err = r.Test(ctx, out, bRes); err != nil {
+			event.DevLoopFailedInPhase(r.devIteration, constants.Build, err)
+			eventV2.TaskFailed(constants.DevLoop, err)
+			endTrace()
+			return fmt.Errorf("exiting dev mode because test failed after first build: %w", err)
+		}
+	}
+
+	defer r.deployer.GetLogger().Stop()
+	defer r.deployer.GetDebugger().Stop()
+
+	// Logs should be retrieved up to just before the deploy
+	r.deployer.GetLogger().SetSince(time.Now())
+
+	// First deploy
+	if err := r.Deploy(ctx, out, r.Builds); err != nil {
+		event.DevLoopFailedInPhase(r.devIteration, constants.Deploy, err)
+		eventV2.TaskFailed(constants.DevLoop, err)
+		endTrace()
+		return fmt.Errorf("exiting dev mode because first deploy failed: %w", err)
+	}
+
+	defer r.deployer.GetAccessor().Stop()
+
+	if err := r.deployer.GetAccessor().Start(ctx, out, r.runCtx.GetNamespaces()); err != nil {
+		logrus.Warnln("Error starting resource accessor:", err)
+	}
+	if err := r.deployer.GetDebugger().Start(ctx, r.runCtx.GetNamespaces()); err != nil {
+		logrus.Warnln("Error starting debug container notification:", err)
+	}
+	// Start printing the logs after deploy is finished
+	if err := r.deployer.GetLogger().Start(ctx, out, r.runCtx.GetNamespaces()); err != nil {
+		return fmt.Errorf("starting logger: %w", err)
+	}
+
+	output.Yellow.Fprintln(out, "Press Ctrl+C to exit")
+
+	event.DevLoopComplete(r.devIteration)
+	eventV2.TaskSucceeded(constants.DevLoop)
+	endTrace()
+	r.devIteration++
+	return r.listener.WatchForChanges(ctx, out, func() error {
+		return r.doDev(ctx, out)
+	})
+}
+
+// graph represents the artifact graph
+type devGraph map[string][]*latestV2.Artifact
+
+// getTransposeGraph builds the transpose of the graph represented by the artifacts slice, with edges directed from required artifact to the dependent artifact.
+func getTransposeGraph(artifacts []*latestV2.Artifact) devGraph {
+	g := make(map[string][]*latestV2.Artifact)
+	for _, a := range artifacts {
+		for _, d := range a.Dependencies {
+			g[d.ImageName] = append(g[d.ImageName], a)
+		}
+	}
+	return g
 }

--- a/pkg/skaffold/runner/v2/dev_test.go
+++ b/pkg/skaffold/runner/v2/dev_test.go
@@ -1,0 +1,552 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	k8s "k8s.io/client-go/kubernetes"
+	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
+	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/sync"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+type NoopMonitor struct{}
+
+func (t *NoopMonitor) Register(func() ([]string, error), func(filemon.Events)) error {
+	return nil
+}
+
+func (t *NoopMonitor) Run(bool) error {
+	return nil
+}
+
+func (t *NoopMonitor) Reset() {}
+
+type FailMonitor struct{}
+
+func (t *FailMonitor) Register(func() ([]string, error), func(filemon.Events)) error {
+	return nil
+}
+
+func (t *FailMonitor) Run(bool) error {
+	return errors.New("BUG")
+}
+
+func (t *FailMonitor) Reset() {}
+
+type TestMonitor struct {
+	events    []filemon.Events
+	callbacks []func(filemon.Events)
+	testBench *TestBench
+}
+
+func (t *TestMonitor) Register(_ func() ([]string, error), onChange func(filemon.Events)) error {
+	t.callbacks = append(t.callbacks, onChange)
+	return nil
+}
+
+func (t *TestMonitor) Run(bool) error {
+	if t.testBench.intentTrigger {
+		return nil
+	}
+
+	evt := t.events[t.testBench.currentCycle]
+
+	for _, file := range evt.Modified {
+		switch file {
+		case "file1":
+			t.callbacks[0](evt) // 1st artifact changed
+		case "file2":
+			t.callbacks[1](evt) // 2nd artifact changed
+		// callbacks[2] and callbacks[3] are for `test` dependency triggers
+		case "manifest.yaml":
+			t.callbacks[4](evt) // deployment configuration changed
+		}
+	}
+
+	return nil
+}
+
+func (t *TestMonitor) Reset() {}
+
+func mockK8sClient() (k8s.Interface, error) {
+	return fakekubeclientset.NewSimpleClientset(), nil
+}
+
+func TestDevFailFirstCycle(t *testing.T) {
+	tests := []struct {
+		description     string
+		testBench       *TestBench
+		monitor         filemon.Monitor
+		expectedActions []Actions
+	}{
+		{
+			description:     "fails to build the first time",
+			testBench:       &TestBench{buildErrors: []error{errors.New("")}},
+			monitor:         &NoopMonitor{},
+			expectedActions: []Actions{{}},
+		},
+		{
+			description: "fails to test the first time",
+			testBench:   &TestBench{testErrors: []error{errors.New("")}},
+			monitor:     &NoopMonitor{},
+			expectedActions: []Actions{{
+				Built: []string{"img:1"},
+			}},
+		},
+		{
+			description: "fails to deploy the first time",
+			testBench:   &TestBench{deployErrors: []error{errors.New("")}},
+			monitor:     &NoopMonitor{},
+			expectedActions: []Actions{{
+				Built:  []string{"img:1"},
+				Tested: []string{"img:1"},
+			}},
+		},
+		{
+			description: "fails to watch after first cycle",
+			testBench:   &TestBench{},
+			monitor:     &FailMonitor{},
+			expectedActions: []Actions{{
+				Built:    []string{"img:1"},
+				Tested:   []string{"img:1"},
+				Deployed: []string{"img:1"},
+			}},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
+			t.Override(&client.Client, mockK8sClient)
+			artifacts := []*latestV2.Artifact{{
+				ImageName: "img",
+			}}
+			r := createRunner(t, test.testBench, test.monitor, artifacts, nil)
+			test.testBench.firstMonitor = test.monitor.Run
+
+			err := r.Dev(context.Background(), ioutil.Discard, artifacts)
+
+			t.CheckErrorAndDeepEqual(true, err, test.expectedActions, test.testBench.Actions())
+		})
+	}
+}
+
+func TestDev(t *testing.T) {
+	tests := []struct {
+		description     string
+		testBench       *TestBench
+		watchEvents     []filemon.Events
+		expectedActions []Actions
+	}{
+		{
+			description: "ignore subsequent build errors",
+			testBench:   NewTestBench().WithBuildErrors([]error{nil, errors.New("")}),
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1", "file2"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{},
+			},
+		},
+		{
+			description: "ignore subsequent test errors",
+			testBench:   &TestBench{testErrors: []error{nil, errors.New("")}},
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1", "file2"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{
+					Built: []string{"img1:2", "img2:2"},
+				},
+			},
+		},
+		{
+			description: "ignore subsequent deploy errors",
+			testBench:   &TestBench{deployErrors: []error{nil, errors.New("")}},
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1", "file2"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{
+					Built:  []string{"img1:2", "img2:2"},
+					Tested: []string{"img1:2", "img2:2"},
+				},
+			},
+		},
+		{
+			description: "full cycle twice",
+			testBench:   &TestBench{},
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1", "file2"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{
+					Built:    []string{"img1:2", "img2:2"},
+					Tested:   []string{"img1:2", "img2:2"},
+					Deployed: []string{"img1:2", "img2:2"},
+				},
+			},
+		},
+		{
+			description: "only change second artifact",
+			testBench:   &TestBench{},
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file2"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{
+					Built:    []string{"img2:2"},
+					Tested:   []string{"img2:2"},
+					Deployed: []string{"img1:1", "img2:2"},
+				},
+			},
+		},
+		{
+			description: "redeploy",
+			testBench:   &TestBench{},
+			watchEvents: []filemon.Events{
+				{Modified: []string{"manifest.yaml"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
+			t.Override(&client.Client, mockK8sClient)
+			test.testBench.cycles = len(test.watchEvents)
+			artifacts := []*latestV2.Artifact{
+				{ImageName: "img1"},
+				{ImageName: "img2"},
+			}
+			r := createRunner(t, test.testBench, &TestMonitor{
+				events:    test.watchEvents,
+				testBench: test.testBench,
+			}, artifacts, nil)
+
+			err := r.Dev(context.Background(), ioutil.Discard, artifacts)
+
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expectedActions, test.testBench.Actions())
+		})
+	}
+}
+
+func TestDevAutoTriggers(t *testing.T) {
+	tests := []struct {
+		description     string
+		watchEvents     []filemon.Events
+		expectedActions []Actions
+		autoTriggers    triggerState // the state of auto triggers
+		singleTriggers  triggerState // the state of single intent triggers at the end of dev loop
+		userIntents     []func(i *runner.Intents)
+	}{
+		{
+			description: "build on; sync on; deploy on",
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1"}},
+				{Modified: []string{"file2"}},
+			},
+			autoTriggers:   triggerState{true, true, true},
+			singleTriggers: triggerState{true, true, true},
+			expectedActions: []Actions{
+				{
+					Synced: []string{"img1:1"},
+				},
+				{
+					Built:    []string{"img2:2"},
+					Tested:   []string{"img2:2"},
+					Deployed: []string{"img1:1", "img2:2"},
+				},
+			},
+		},
+		{
+			description: "build off; sync off; deploy off",
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1"}},
+				{Modified: []string{"file2"}},
+			},
+			expectedActions: []Actions{{}, {}},
+		},
+		{
+			description: "build on; sync off; deploy off",
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1"}},
+				{Modified: []string{"file2"}},
+			},
+			autoTriggers:   triggerState{true, false, false},
+			singleTriggers: triggerState{true, false, false},
+			expectedActions: []Actions{{}, {
+				Built:  []string{"img2:2"},
+				Tested: []string{"img2:2"},
+			}},
+		},
+		{
+			description: "build off; sync on; deploy off",
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1"}},
+				{Modified: []string{"file2"}},
+			},
+			autoTriggers:   triggerState{false, true, false},
+			singleTriggers: triggerState{false, true, false},
+			expectedActions: []Actions{{
+				Synced: []string{"img1:1"},
+			}, {}},
+		},
+		{
+			description: "build off; sync off; deploy on",
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1"}},
+				{Modified: []string{"file2"}},
+			},
+			autoTriggers:    triggerState{false, false, true},
+			singleTriggers:  triggerState{false, false, true},
+			expectedActions: []Actions{{}, {}},
+		},
+		{
+			description:     "build off; sync off; deploy off; user requests build, but no change so intent is discarded",
+			watchEvents:     []filemon.Events{},
+			autoTriggers:    triggerState{false, false, false},
+			singleTriggers:  triggerState{false, false, false},
+			expectedActions: []Actions{},
+			userIntents: []func(i *runner.Intents){
+				func(i *runner.Intents) {
+					i.SetBuild(true)
+				},
+			},
+		},
+		{
+			description:     "build off; sync off; deploy off; user requests build, and then sync, but no change so both intents are discarded",
+			watchEvents:     []filemon.Events{},
+			autoTriggers:    triggerState{false, false, false},
+			singleTriggers:  triggerState{false, false, false},
+			expectedActions: []Actions{},
+			userIntents: []func(i *runner.Intents){
+				func(i *runner.Intents) {
+					i.SetBuild(true)
+					i.SetSync(true)
+				},
+			},
+		},
+		{
+			description:     "build off; sync off; deploy off; user requests build, and then sync, but no change so both intents are discarded",
+			watchEvents:     []filemon.Events{},
+			autoTriggers:    triggerState{false, false, false},
+			singleTriggers:  triggerState{false, false, false},
+			expectedActions: []Actions{},
+			userIntents: []func(i *runner.Intents){
+				func(i *runner.Intents) {
+					i.SetBuild(true)
+				},
+				func(i *runner.Intents) {
+					i.SetSync(true)
+				},
+			},
+		},
+	}
+	// first build-test-deploy sequence always happens
+	firstAction := Actions{
+		Built:    []string{"img1:1", "img2:1"},
+		Tested:   []string{"img1:1", "img2:1"},
+		Deployed: []string{"img1:1", "img2:1"},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
+			t.Override(&client.Client, mockK8sClient)
+			t.Override(&sync.WorkingDir, func(string, docker.Config) (string, error) { return "/", nil })
+			testBench := &TestBench{}
+			testBench.cycles = len(test.watchEvents)
+			testBench.userIntents = test.userIntents
+			artifacts := []*latestV2.Artifact{
+				{
+					ImageName: "img1",
+					Sync: &latestV2.Sync{
+						Manual: []*latestV2.SyncRule{{Src: "file1", Dest: "file1"}},
+					},
+				},
+				{
+					ImageName: "img2",
+				},
+			}
+			r := createRunner(t, testBench, &TestMonitor{
+				events:    test.watchEvents,
+				testBench: testBench,
+			}, artifacts, &test.autoTriggers)
+
+			testBench.intents = r.intents
+
+			err := r.Dev(context.Background(), ioutil.Discard, artifacts)
+
+			t.CheckNoError(err)
+			t.CheckDeepEqual(append([]Actions{firstAction}, test.expectedActions...), testBench.Actions())
+
+			build, _sync, deploy := r.intents.GetIntentsAttrs()
+			singleTriggers := triggerState{
+				build:  build,
+				sync:   _sync,
+				deploy: deploy,
+			}
+			t.CheckDeepEqual(test.singleTriggers, singleTriggers, cmp.AllowUnexported(triggerState{}))
+		})
+	}
+}
+
+func TestDevSync(t *testing.T) {
+	type fileSyncEventCalls struct {
+		InProgress int
+		Failed     int
+		Succeeded  int
+	}
+
+	tests := []struct {
+		description                string
+		testBench                  *TestBench
+		watchEvents                []filemon.Events
+		expectedActions            []Actions
+		expectedFileSyncEventCalls fileSyncEventCalls
+	}{
+		{
+			description: "sync",
+			testBench:   &TestBench{},
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{
+					Synced: []string{"img1:1"},
+				},
+			},
+			expectedFileSyncEventCalls: fileSyncEventCalls{
+				InProgress: 1,
+				Failed:     0,
+				Succeeded:  1,
+			},
+		},
+		{
+			description: "sync twice",
+			testBench:   &TestBench{},
+			watchEvents: []filemon.Events{
+				{Modified: []string{"file1"}},
+				{Modified: []string{"file1"}},
+			},
+			expectedActions: []Actions{
+				{
+					Built:    []string{"img1:1", "img2:1"},
+					Tested:   []string{"img1:1", "img2:1"},
+					Deployed: []string{"img1:1", "img2:1"},
+				},
+				{
+					Synced: []string{"img1:1"},
+				},
+				{
+					Synced: []string{"img1:1"},
+				},
+			},
+			expectedFileSyncEventCalls: fileSyncEventCalls{
+				InProgress: 2,
+				Failed:     0,
+				Succeeded:  2,
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			var actualFileSyncEventCalls fileSyncEventCalls
+			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
+			t.Override(&client.Client, mockK8sClient)
+			t.Override(&fileSyncInProgress, func(int, string) { actualFileSyncEventCalls.InProgress++ })
+			t.Override(&fileSyncFailed, func(int, string, error) { actualFileSyncEventCalls.Failed++ })
+			t.Override(&fileSyncSucceeded, func(int, string) { actualFileSyncEventCalls.Succeeded++ })
+			t.Override(&sync.WorkingDir, func(string, docker.Config) (string, error) { return "/", nil })
+			test.testBench.cycles = len(test.watchEvents)
+			artifacts := []*latestV2.Artifact{
+				{
+					ImageName: "img1",
+					Sync: &latestV2.Sync{
+						Manual: []*latestV2.SyncRule{{Src: "file1", Dest: "file1"}},
+					},
+				},
+				{
+					ImageName: "img2",
+				},
+			}
+			r := createRunner(t, test.testBench, &TestMonitor{
+				events:    test.watchEvents,
+				testBench: test.testBench,
+			}, artifacts, nil)
+
+			err := r.Dev(context.Background(), ioutil.Discard, artifacts)
+
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expectedActions, test.testBench.Actions())
+			t.CheckDeepEqual(test.expectedFileSyncEventCalls, actualFileSyncEventCalls)
+		})
+	}
+}

--- a/pkg/skaffold/runner/v2/load_images.go
+++ b/pkg/skaffold/runner/v2/load_images.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/docker/distribution/reference"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+// loadImagesInKindNodes loads artifact images into every node of a kind cluster.
+func (r *SkaffoldRunner) loadImagesInKindNodes(ctx context.Context, out io.Writer, kindCluster string, artifacts []graph.Artifact) error {
+	output.Default.Fprintln(out, "Loading images into kind cluster nodes...")
+	return r.loadImages(ctx, out, artifacts, func(tag string) *exec.Cmd {
+		return exec.CommandContext(ctx, "kind", "load", "docker-image", "--name", kindCluster, tag)
+	})
+}
+
+// loadImagesInK3dNodes loads artifact images into every node of a k3s cluster.
+func (r *SkaffoldRunner) loadImagesInK3dNodes(ctx context.Context, out io.Writer, k3dCluster string, artifacts []graph.Artifact) error {
+	output.Default.Fprintln(out, "Loading images into k3d cluster nodes...")
+	return r.loadImages(ctx, out, artifacts, func(tag string) *exec.Cmd {
+		return exec.CommandContext(ctx, "k3d", "image", "import", "--cluster", k3dCluster, tag)
+	})
+}
+
+func (r *SkaffoldRunner) loadImages(ctx context.Context, out io.Writer, artifacts []graph.Artifact, createCmd func(tag string) *exec.Cmd) error {
+	start := time.Now()
+
+	var knownImages []string
+
+	for _, artifact := range artifacts {
+		// Only load images that this runner built
+		if !r.wasBuilt(artifact.Tag) {
+			continue
+		}
+
+		output.Default.Fprintf(out, " - %s -> ", artifact.Tag)
+
+		// Only load images that are unknown to the node
+		if knownImages == nil {
+			var err error
+			if knownImages, err = findKnownImages(ctx, r.kubectlCLI); err != nil {
+				return fmt.Errorf("unable to retrieve node's images: %w", err)
+			}
+		}
+		normalizedImageRef, err := reference.ParseNormalizedNamed(artifact.Tag)
+		if err != nil {
+			return err
+		}
+		if util.StrSliceContains(knownImages, normalizedImageRef.String()) {
+			output.Green.Fprintln(out, "Found")
+			continue
+		}
+
+		cmd := createCmd(artifact.Tag)
+		if cmdOut, err := util.RunCmdOut(cmd); err != nil {
+			output.Red.Fprintln(out, "Failed")
+			return fmt.Errorf("unable to load image %q into cluster: %w, %s", artifact.Tag, err, cmdOut)
+		}
+
+		output.Green.Fprintln(out, "Loaded")
+	}
+
+	output.Default.Fprintln(out, "Images loaded in", util.ShowHumanizeTime(time.Since(start)))
+	return nil
+}
+
+func findKnownImages(ctx context.Context, cli *kubectl.CLI) ([]string, error) {
+	nodeGetOut, err := cli.RunOut(ctx, "get", "nodes", `-ojsonpath='{@.items[*].status.images[*].names[*]}'`)
+	if err != nil {
+		return nil, fmt.Errorf("unable to inspect the nodes: %w", err)
+	}
+
+	knownImages := strings.Split(string(nodeGetOut), " ")
+	return knownImages, nil
+}
+
+func (r *SkaffoldRunner) wasBuilt(tag string) bool {
+	for _, built := range r.Builds {
+		if built.Tag == tag {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/skaffold/runner/v2/load_images_test.go
+++ b/pkg/skaffold/runner/v2/load_images_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2019 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+	"errors"
+	"io/ioutil"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
+	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+type ImageLoadingTest = struct {
+	description   string
+	cluster       string
+	built         []graph.Artifact
+	deployed      []graph.Artifact
+	commands      util.Command
+	shouldErr     bool
+	expectedError string
+}
+
+func TestLoadImagesInKindNodes(t *testing.T) {
+	tests := []ImageLoadingTest{
+		{
+			description: "load image",
+			cluster:     "kind",
+			built:       []graph.Artifact{{Tag: "tag1"}},
+			deployed:    []graph.Artifact{{Tag: "tag1"}},
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				AndRunOut("kind load docker-image --name kind tag1", "output: image loaded"),
+		},
+		{
+			description: "load missing image",
+			cluster:     "other-kind",
+			built:       []graph.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
+			deployed:    []graph.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag1").
+				AndRunOut("kind load docker-image --name other-kind tag2", "output: image loaded"),
+		},
+		{
+			description: "no new images",
+			cluster:     "kind",
+			built:       []graph.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
+			deployed:    []graph.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag0 docker.io/library/tag1 docker.io/library/tag2 gcr.io/test/tag3 someregistry.com/tag4"),
+		},
+		{
+			description: "inspect error",
+			built:       []graph.Artifact{{Tag: "tag"}},
+			deployed:    []graph.Artifact{{Tag: "tag"}},
+			commands: testutil.
+				CmdRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "", errors.New("BUG")),
+			shouldErr:     true,
+			expectedError: "unable to inspect",
+		},
+		{
+			description: "load error",
+			cluster:     "kind",
+			built:       []graph.Artifact{{Tag: "tag"}},
+			deployed:    []graph.Artifact{{Tag: "tag"}},
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				AndRunOutErr("kind load docker-image --name kind tag", "output: error!", errors.New("BUG")),
+			shouldErr:     true,
+			expectedError: "output: error!",
+		},
+		{
+			description: "ignore image that's not built",
+			cluster:     "kind",
+			built:       []graph.Artifact{{Tag: "built"}},
+			deployed:    []graph.Artifact{{Tag: "built"}, {Tag: "busybox"}},
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				AndRunOut("kind load docker-image --name kind built", ""),
+		},
+		{
+			description: "no artifact",
+			deployed:    []graph.Artifact{},
+		},
+		{
+			description: "no built artifact",
+			built:       []graph.Artifact{},
+			deployed:    []graph.Artifact{{Tag: "busybox"}},
+		},
+	}
+
+	runImageLoadingTests(t, tests, func(r *SkaffoldRunner, test ImageLoadingTest) error {
+		return r.loadImagesInKindNodes(context.Background(), ioutil.Discard, test.cluster, test.deployed)
+	})
+}
+
+func TestLoadImagesInK3dNodes(t *testing.T) {
+	tests := []ImageLoadingTest{
+		{
+			description: "load image",
+			cluster:     "k3d",
+			built:       []graph.Artifact{{Tag: "tag1"}},
+			deployed:    []graph.Artifact{{Tag: "tag1"}},
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				AndRunOut("k3d image import --cluster k3d tag1", "output: image loaded"),
+		},
+		{
+			description: "load missing image",
+			cluster:     "other-k3d",
+			built:       []graph.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
+			deployed:    []graph.Artifact{{Tag: "tag1"}, {Tag: "tag2"}},
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag1").
+				AndRunOut("k3d image import --cluster other-k3d tag2", "output: image loaded"),
+		},
+		{
+			description: "no new images",
+			cluster:     "k3d",
+			built:       []graph.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
+			deployed:    []graph.Artifact{{Tag: "tag0"}, {Tag: "docker.io/library/tag1"}, {Tag: "docker.io/tag2"}, {Tag: "gcr.io/test/tag3"}, {Tag: "someregistry.com/tag4"}},
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "docker.io/library/tag0 docker.io/library/tag1 docker.io/library/tag2 gcr.io/test/tag3 someregistry.com/tag4"),
+		},
+		{
+			description: "inspect error",
+			built:       []graph.Artifact{{Tag: "tag"}},
+			deployed:    []graph.Artifact{{Tag: "tag"}},
+			commands: testutil.
+				CmdRunOutErr("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "", errors.New("BUG")),
+			shouldErr:     true,
+			expectedError: "unable to inspect",
+		},
+		{
+			description: "load error",
+			cluster:     "k3d",
+			built:       []graph.Artifact{{Tag: "tag"}},
+			deployed:    []graph.Artifact{{Tag: "tag"}},
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				AndRunOutErr("k3d image import --cluster k3d tag", "output: error!", errors.New("BUG")),
+			shouldErr:     true,
+			expectedError: "output: error!",
+		},
+		{
+			description: "ignore image that's not built",
+			cluster:     "k3d",
+			built:       []graph.Artifact{{Tag: "built"}},
+			deployed:    []graph.Artifact{{Tag: "built"}, {Tag: "busybox"}},
+			commands: testutil.
+				CmdRunOut("kubectl --context kubecontext --namespace namespace get nodes -ojsonpath='{@.items[*].status.images[*].names[*]}'", "").
+				AndRunOut("k3d image import --cluster k3d built", ""),
+		},
+		{
+			description: "no artifact",
+			deployed:    []graph.Artifact{},
+		},
+		{
+			description: "no built artifact",
+			built:       []graph.Artifact{},
+			deployed:    []graph.Artifact{{Tag: "busybox"}},
+		},
+	}
+
+	runImageLoadingTests(t, tests, func(r *SkaffoldRunner, test ImageLoadingTest) error {
+		return r.loadImagesInK3dNodes(context.Background(), ioutil.Discard, test.cluster, test.deployed)
+	})
+}
+
+func runImageLoadingTests(t *testing.T, tests []ImageLoadingTest, loadingFunc func(r *SkaffoldRunner, test ImageLoadingTest) error) {
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&util.DefaultExecCommand, test.commands)
+
+			runCtx := &runcontext.RunContext{
+				Opts: config.SkaffoldOptions{
+					Namespace: "namespace",
+				},
+				KubeContext: "kubecontext",
+			}
+
+			r := &SkaffoldRunner{
+				runCtx:     runCtx,
+				kubectlCLI: kubectl.NewCLI(runCtx, ""),
+				Builder:    runner.Builder{Builds: test.built},
+			}
+			err := loadingFunc(r, test)
+
+			if test.shouldErr {
+				t.CheckErrorContains(test.expectedError, err)
+			} else {
+				t.CheckNoError(err)
+			}
+		})
+	}
+}

--- a/pkg/skaffold/runner/v2/new.go
+++ b/pkg/skaffold/runner/v2/new.go
@@ -94,7 +94,13 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		Syncer:   sync.NewSyncProvider(runCtx, kubectlCLI),
 	}
 
-	renderer, err := renderer.NewSkaffoldRenderer(getRenderConfig(runCtx), runCtx.GetWorkingDir())
+	hydrationDir, err := runCtx.GetRenderOutputPath()
+	if err != nil {
+		return nil, fmt.Errorf("getting render output path: %w", err)
+	}
+
+	renderer, err := renderer.NewSkaffoldRenderer(
+		runCtx.GetRenderConfig(), runCtx.GetWorkingDir(), hydrationDir)
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(err))
 		return nil, fmt.Errorf("creating renderer: %w", err)

--- a/pkg/skaffold/runner/v2/render.go
+++ b/pkg/skaffold/runner/v2/render.go
@@ -21,25 +21,14 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
-	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v2"
-	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
 )
 
-func (r *SkaffoldRunner) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, offline bool, filepath string) error {
+func (r *SkaffoldRunner) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, offline bool, _ string) error {
 	ctx, endTrace := instrumentation.StartTrace(ctx, "Render")
-	if err := r.renderer.Render(ctx, out, builds, offline, filepath); err != nil {
+	if err := r.renderer.Render(ctx, out, builds, offline, ""); err != nil {
 		endTrace(instrumentation.TraceEndError(err))
 		return err
 	}
 	endTrace()
 	return nil
-}
-
-func getRenderConfig(runCtx *runcontext.RunContext) *latestV2.RenderConfig {
-	p := runCtx.GetPipelines()
-	if len(p) > 0 {
-		// TODO: support multi-config
-		return &p[0].Render
-	}
-	return &latestV2.RenderConfig{}
 }

--- a/pkg/skaffold/runner/v2/runner.go
+++ b/pkg/skaffold/runner/v2/runner.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v2"
@@ -42,12 +43,21 @@ type SkaffoldRunner struct {
 
 	kubectlCLI         *kubectl.CLI
 	cache              cache.Cache
+	changeSet          runner.ChangeSet
 	runCtx             *runcontext.RunContext
 	labeller           *label.DefaultLabeller
 	artifactStore      build.ArtifactStore
 	sourceDependencies graph.SourceDependenciesCache
-	intents            *runner.Intents
-	isLocalImage       func(imageName string) (bool, error)
+	// podSelector is used to determine relevant pods for logging and portForwarding
+	podSelector kubernetes.ImageListMux
+
+	devIteration int
+	isLocalImage func(imageName string) (bool, error)
+	hasDeployed  bool
+	intents      *runner.Intents
 }
 
-func (r *SkaffoldRunner) HasDeployed() bool { return true }
+// HasDeployed returns true if this runner has deployed something.
+func (r *SkaffoldRunner) HasDeployed() bool {
+	return r.hasDeployed
+}

--- a/pkg/skaffold/runner/v2/runner.go
+++ b/pkg/skaffold/runner/v2/runner.go
@@ -23,7 +23,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	runcontext "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v2"
@@ -48,8 +47,6 @@ type SkaffoldRunner struct {
 	labeller           *label.DefaultLabeller
 	artifactStore      build.ArtifactStore
 	sourceDependencies graph.SourceDependenciesCache
-	// podSelector is used to determine relevant pods for logging and portForwarding
-	podSelector kubernetes.ImageListMux
 
 	devIteration int
 	isLocalImage func(imageName string) (bool, error)

--- a/pkg/skaffold/schema/v3alpha1/config.go
+++ b/pkg/skaffold/schema/v3alpha1/config.go
@@ -550,7 +550,7 @@ type Validator struct {
 type KptV2Deploy struct {
 
 	// Dir is equivalent to the dir in `kpt live apply <dir>`. If not provided, skaffold renders the raw manifests
-	// and store them to a a hidden directory `.kpt-hydrated`, and deploys the hidden directory.
+	// and store them to a a hidden directory `.kpt-pipeline`, and deploys the hidden directory.
 	Dir string `yaml:"dir,omitempty"`
 
 	// Flags are additional flags passed to `kpt live apply`.
@@ -608,10 +608,6 @@ type DeployType struct {
 
 	// KptV2Deploy *alpha* uses the `kpt` v1 to manage and deploy manifests.
 	KptV2Deploy *KptV2Deploy `yaml:"kptV2,omitempty"`
-
-	// KubectlV2Deploy *alpha* uses a client side `kubectl apply` to deploy manifests.
-	// You'll need a `kubectl` CLI version installed that's compatible with your cluster.
-	KubectlV2Deploy *KubectlV2Deploy `yaml:"kubectl,omitempty"`
 }
 
 type KubectlV2Deploy struct {


### PR DESCRIPTION
**Related**: #5673

**Description**
1. Add kptV2 deployer to the deployerMux initialization. 
2. Add `hydrationDir` as a RunContext field, which is used for both Renderer and Deployer to cache and hydrate the manifests.  
   - default to <WORKDIR>/.kpt-pipeline
   - can be overriden by `--output` flag in `skaffold render` (Render Step)
   - can be overriden by `.deploy.kpt.dir` field in skaffold.yaml in `skaffold dev` and `skaffold run` (Deploy step)  
3. Render is used to be called by deployers in `skaffold dev` and `skaffold run`. This logic is now removed.

**Follow-up work**
1. Update kubectl deployer (default) to apply the manifests from hydrationDir.
2. Enable other commands

**To reviewers**

This PR has two commits. The first one is just back port the v1 code (See related work in #6257 ) for dev, load-images, deploy and corresponding tests.  Please review the second commit