### PR TITLE
Add ContainerTracker for tracking deployed docker containers

### DIFF
--- a/pkg/skaffold/docker/tracker/tracker.go
+++ b/pkg/skaffold/docker/tracker/tracker.go
@@ -41,10 +41,10 @@ func NewContainerTracker() *ContainerTracker {
 	}
 }
 
-// GetNotifier returns the notifier channel for this tracker.
+// Notifier returns the notifier channel for this tracker.
 // Used by the log streamer to be notified when a new container is
 // added to the tracker.
-func (t *ContainerTracker) GetNotifier() chan string {
+func (t *ContainerTracker) Notifier() chan string {
 	return t.notifier
 }
 
@@ -54,7 +54,7 @@ func (t *ContainerTracker) ArtifactForContainer(id string) graph.Artifact {
 	return t.containerToArtifact[id]
 }
 
-// DeployedContainerForImage returns a the ID of a deployed container create from
+// DeployedContainerForImage returns a the ID of a deployed container created from
 // the provided image, if it exists.
 func (t *ContainerTracker) DeployedContainerForImage(image string) string {
 	t.Lock()

--- a/pkg/skaffold/docker/tracker/tracker.go
+++ b/pkg/skaffold/docker/tracker/tracker.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracker
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+)
+
+type ContainerTracker struct {
+	sync.RWMutex
+	deployedContainers  map[string]string         // image name -> container id
+	containers          map[string]bool           // set of tracked container ids
+	containerToArtifact map[string]graph.Artifact // container id -> graph.Artifact
+	notifier            chan string
+}
+
+// NewContainerTracker creates a new ContainerTracker.
+func NewContainerTracker() *ContainerTracker {
+	return &ContainerTracker{
+		deployedContainers:  make(map[string]string),
+		containers:          make(map[string]bool),
+		containerToArtifact: make(map[string]graph.Artifact),
+		notifier:            make(chan string, 1),
+	}
+}
+
+// GetNotifier returns the notifier channel for this tracker.
+// Used by the log streamer to be notified when a new container is
+// added to the tracker.
+func (t *ContainerTracker) GetNotifier() chan string {
+	return t.notifier
+}
+
+// ImageForContainer maps a container id to the image tag it was created from.
+// Used by the ColorPicker to maintain consistency between images and colors.
+func (t *ContainerTracker) ArtifactForContainer(id string) graph.Artifact {
+	return t.containerToArtifact[id]
+}
+
+// DeployedContainerForImage returns a the ID of a deployed container create from
+// the provided image, if it exists.
+func (t *ContainerTracker) DeployedContainerForImage(image string) string {
+	t.Lock()
+	defer t.Unlock()
+	if id, found := t.deployedContainers[image]; found {
+		return id
+	}
+	return ""
+}
+
+// DeployedContainers returns the list of all containers deployed
+// during this run.
+func (t *ContainerTracker) DeployedContainers() []string {
+	var containers []string
+	for _, id := range t.deployedContainers {
+		containers = append(containers, id)
+	}
+	sort.Strings(containers)
+	return containers
+}
+
+// Reset resets the entire tracker when a new dev cycle starts.
+func (t *ContainerTracker) Reset() {
+	for c := range t.containers {
+		delete(t.containers, c)
+	}
+}
+
+// Add adds a container to the list.
+func (t *ContainerTracker) Add(artifact graph.Artifact, id string) {
+	t.Lock()
+	defer t.Unlock()
+	t.containers[id] = true
+	t.deployedContainers[artifact.ImageName] = id
+	t.containerToArtifact[id] = artifact
+	go func() {
+		t.notifier <- id
+	}()
+}

--- a/pkg/skaffold/docker/tracker/tracker_test.go
+++ b/pkg/skaffold/docker/tracker/tracker_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracker
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+type ArtifactIDPair struct {
+	artifact graph.Artifact
+	id       string
+}
+
+func TestDeployedContainers(t *testing.T) {
+	tests := []struct {
+		name               string
+		containers         []ArtifactIDPair
+		expectedContainers []string
+	}{
+		{
+			name:               "one container",
+			containers:         []ArtifactIDPair{{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"}},
+			expectedContainers: []string{"deadbeef"},
+		},
+		{
+			name: "two containers",
+			containers: []ArtifactIDPair{
+				{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"},
+				{artifact: graph.Artifact{ImageName: "image2"}, id: "foobar"},
+			},
+			expectedContainers: []string{"deadbeef", "foobar"},
+		},
+		{
+			name: "adding the same artifact overwrites previous ID",
+			containers: []ArtifactIDPair{
+				{artifact: graph.Artifact{ImageName: "image1"}, id: "this will be ignored"},
+				{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"},
+				{artifact: graph.Artifact{ImageName: "image2"}, id: "foobar"},
+			},
+			expectedContainers: []string{"deadbeef", "foobar"},
+		},
+		{
+			name: "tags are ignored (keyed only on image name)",
+			containers: []ArtifactIDPair{
+				{artifact: graph.Artifact{ImageName: "image1", Tag: "image1:tag1"}, id: "this will be ignored"},
+				{artifact: graph.Artifact{ImageName: "image1", Tag: "image1:tag2"}, id: "deadbeef"},
+				{artifact: graph.Artifact{ImageName: "image2"}, id: "foobar"},
+			},
+			expectedContainers: []string{"deadbeef", "foobar"},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			tracker := NewContainerTracker()
+			for _, pair := range test.containers {
+				tracker.Add(pair.artifact, pair.id)
+			}
+			t.CheckDeepEqual(test.expectedContainers, tracker.DeployedContainers())
+		})
+	}
+}
+
+func TestDeployedContainerForImage(t *testing.T) {
+	tests := []struct {
+		name       string
+		containers []ArtifactIDPair
+		target     string
+		expected   string
+	}{
+		{
+			name:       "one container",
+			containers: []ArtifactIDPair{{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"}},
+			target:     "image1",
+			expected:   "deadbeef",
+		},
+		{
+			name: "two containers, retrieve the second",
+			containers: []ArtifactIDPair{
+				{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"},
+				{artifact: graph.Artifact{ImageName: "image2"}, id: "foobar"},
+			},
+			target:   "image2",
+			expected: "foobar",
+		},
+		{
+			name: "adding the same artifact overwrites previous ID",
+			containers: []ArtifactIDPair{
+				{artifact: graph.Artifact{ImageName: "image1"}, id: "this will be ignored"},
+				{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"},
+				{artifact: graph.Artifact{ImageName: "image2"}, id: "foobar"},
+			},
+			target:   "image1",
+			expected: "deadbeef",
+		},
+		{
+			name: "tags are ignored (keyed only on image name)",
+			containers: []ArtifactIDPair{
+				{artifact: graph.Artifact{ImageName: "image1", Tag: "image1:tag1"}, id: "this will be ignored"},
+				{artifact: graph.Artifact{ImageName: "image1", Tag: "image1:tag2"}, id: "deadbeef"},
+				{artifact: graph.Artifact{ImageName: "image2"}, id: "foobar"},
+			},
+			target:   "image1",
+			expected: "deadbeef",
+		},
+		{
+			name:       "untracked image returns nothing",
+			containers: []ArtifactIDPair{{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"}},
+			target:     "bogus",
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			tracker := NewContainerTracker()
+			for _, pair := range test.containers {
+				tracker.Add(pair.artifact, pair.id)
+			}
+			t.CheckDeepEqual(test.expected, tracker.DeployedContainerForImage(test.target))
+		})
+	}
+}
+
+func TestArtifactForContainer(t *testing.T) {
+	tests := []struct {
+		name       string
+		containers []ArtifactIDPair
+		target     string
+		expected   graph.Artifact
+	}{
+		{
+			name:       "one container",
+			containers: []ArtifactIDPair{{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"}},
+			target:     "deadbeef",
+			expected:   graph.Artifact{ImageName: "image1"},
+		},
+		{
+			name: "two containers, retrieve the second",
+			containers: []ArtifactIDPair{
+				{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"},
+				{artifact: graph.Artifact{ImageName: "image2"}, id: "foobar"},
+			},
+			target:   "foobar",
+			expected: graph.Artifact{ImageName: "image2"},
+		},
+		{
+			name: "adding the same artifact overwrites previous ID",
+			containers: []ArtifactIDPair{
+				{artifact: graph.Artifact{ImageName: "image1"}, id: "this will be ignored"},
+				{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"},
+				{artifact: graph.Artifact{ImageName: "image2"}, id: "foobar"},
+			},
+			target:   "deadbeef",
+			expected: graph.Artifact{ImageName: "image1"},
+		},
+		{
+			name: "tags are updated on artifact",
+			containers: []ArtifactIDPair{
+				{artifact: graph.Artifact{ImageName: "image1", Tag: "image1:tag1"}, id: "deadbeef"},
+				{artifact: graph.Artifact{ImageName: "image1", Tag: "image1:tag2"}, id: "deadbeef"},
+				{artifact: graph.Artifact{ImageName: "image2"}, id: "foobar"},
+			},
+			target:   "deadbeef",
+			expected: graph.Artifact{ImageName: "image1", Tag: "image1:tag2"},
+		},
+		{
+			name:       "untracked id returns empty artifact",
+			containers: []ArtifactIDPair{{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"}},
+			target:     "bogus",
+			expected:   graph.Artifact{},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			tracker := NewContainerTracker()
+			for _, pair := range test.containers {
+				tracker.Add(pair.artifact, pair.id)
+			}
+			t.CheckDeepEqual(test.expected, tracker.ArtifactForContainer(test.target))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: https://github.com/GoogleContainerTools/skaffold/issues/6107 

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This change adds a `ContainerTracker` object, which tracks all containers deployed to the local Docker daemon by Skaffold. This object's purpose is analogous to the `PodSelector`, which is used for all Kubernetes-based `Deployer` sub-components. 

The `ContainerTracker` will be passed to all future implementations of these sub-components in the Docker deployer, and will inform those components which resources to retrieve and operate on. It will also help the `ColorPicker` select the proper colors for individual container logs (when implemented).

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->
Use `ContainerTracker` to implement `Deployer` sub-components for the Docker deployer.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
