### PR TITLE
fix remote branch lookup

### DIFF
--- a/pkg/skaffold/git/gitutil.go
+++ b/pkg/skaffold/git/gitutil.go
@@ -65,7 +65,7 @@ func branchExists(repo, branch string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	out, err := util.RunCmdOut(exec.Command(gitProgram, "ls-remote", repo, branch))
+	out, err := util.RunCmdOut(exec.Command(gitProgram, "ls-remote", "--heads", repo, branch))
 	if err != nil {
 		// stdErr contains the error message for os related errors, git permission errors
 		// and if repo doesn't exist
@@ -88,8 +88,7 @@ func getRepoDir(g latestV1.GitInfo) (string, error) {
 		return "", err
 	}
 
-	// UrlEncoding supports '-' as a 63rd character, which can cause dir name issues
-	return base64.StdEncoding.EncodeToString(hasher.Sum(nil))[:32], nil
+	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))[:32], nil
 }
 
 // GetRepoCacheDir returns the directory for the remote git repo cache
@@ -134,7 +133,7 @@ func syncRepo(g latestV1.GitInfo, opts config.SkaffoldOptions) (string, error) {
 		if opts.SyncRemoteCache.CloneDisabled() {
 			return "", SyncDisabledErr(g, repoCacheDir)
 		}
-		if _, err := r.Run("clone", g.Repo, hash, "--branch", ref, "--depth", "1"); err != nil {
+		if _, err := r.Run("clone", g.Repo, fmt.Sprintf("./%s", hash), "--branch", ref, "--depth", "1"); err != nil {
 			return "", fmt.Errorf("failed to clone repo: %w", err)
 		}
 	} else {

--- a/pkg/skaffold/git/gitutil_test.go
+++ b/pkg/skaffold/git/gitutil_test.go
@@ -55,14 +55,14 @@ func TestDefaultRef(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			var f *testutil.FakeCmd
 			if test.masterExists {
-				f = testutil.CmdRunOut("git ls-remote https://github.com/foo.git master", "8be3f718c015a5fe190bebf356079a25afe0ca57  refs/heads/master")
+				f = testutil.CmdRunOut("git ls-remote --heads https://github.com/foo.git master", "8be3f718c015a5fe190bebf356079a25afe0ca57  refs/heads/master")
 			} else {
-				f = testutil.CmdRunOut("git ls-remote https://github.com/foo.git master", "")
+				f = testutil.CmdRunOut("git ls-remote --heads https://github.com/foo.git master", "")
 			}
 			if test.mainExists {
-				f = f.AndRunOut("git ls-remote https://github.com/foo.git main", "8be3f718c015a5fe190bebf356079a25afe0ca58  refs/heads/main")
+				f = f.AndRunOut("git ls-remote --heads https://github.com/foo.git main", "8be3f718c015a5fe190bebf356079a25afe0ca58  refs/heads/main")
 			} else {
-				f = f.AndRunOut("git ls-remote https://github.com/foo.git main", "")
+				f = f.AndRunOut("git ls-remote --heads https://github.com/foo.git main", "")
 			}
 			t.Override(&findGit, func() (string, error) { return "git", nil })
 			t.Override(&util.DefaultExecCommand, f)
@@ -86,7 +86,7 @@ func TestSyncRepo(t *testing.T) {
 			description: "first time repo clone succeeds",
 			g:           latestV1.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
 			cmds: []cmdResponse{
-				{cmd: "git clone http://github.com/foo.git iSEL5rQfK5EJ2yLhnW8tUgcVOvDC8Wjl --branch master --depth 1"},
+				{cmd: "git clone http://github.com/foo.git ./iSEL5rQfK5EJ2yLhnW8tUgcVOvDC8Wjl --branch master --depth 1"},
 			},
 			syncFlag: "always",
 			expected: "iSEL5rQfK5EJ2yLhnW8tUgcVOvDC8Wjl",
@@ -95,7 +95,7 @@ func TestSyncRepo(t *testing.T) {
 			description: "first time repo clone fails",
 			g:           latestV1.GitInfo{Repo: "http://github.com/foo.git", Path: "bar/skaffold.yaml", Ref: "master"},
 			cmds: []cmdResponse{
-				{cmd: "git clone http://github.com/foo.git iSEL5rQfK5EJ2yLhnW8tUgcVOvDC8Wjl --branch master --depth 1", err: errors.New("error")},
+				{cmd: "git clone http://github.com/foo.git ./iSEL5rQfK5EJ2yLhnW8tUgcVOvDC8Wjl --branch master --depth 1", err: errors.New("error")},
 			},
 			syncFlag:  "always",
 			shouldErr: true,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6264  <!-- tracking issues that this PR will close -->


**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Without the `--heads` argument, this command was returning `refs/for/master` although there's no `master` branch on remote.
```diff
-	out, err := util.RunCmdOut(exec.Command(gitProgram, "ls-remote", repo, branch))
+	out, err := util.RunCmdOut(exec.Command(gitProgram, "ls-remote", "--heads", repo, branch))
```

Also changed the encoding back to `URLEncoding` from `StdEncoding` that was done in https://github.com/GoogleContainerTools/skaffold/pull/6071 because `StdEncoding` has `/` which gets interpreted as a filepath separator.
```diff
-	return base64.StdEncoding.EncodeToString(hasher.Sum(nil))[:32], nil
+	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))[:32], nil
```

 To fix the original issue (directory name starting with `-` being interpreted as flag), we preface the directory name with `./`
```diff
-		if _, err := r.Run("clone", g.Repo, hash, "--branch", ref, "--depth", "1"); err != nil {
+		if _, err := r.Run("clone", g.Repo, fmt.Sprintf("./%s", hash), "--branch", ref, "--depth", "1"); err != nil {
```