### PR TITLE
Add state to event handler to track `logrus` output events

### DIFF
--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -52,6 +52,7 @@ var handler = newHandler()
 func newHandler() *eventHandler {
 	h := &eventHandler{
 		eventChan: make(chan *proto.Event),
+		task:      constants.DevLoop,
 	}
 	go func() {
 		for {
@@ -75,6 +76,7 @@ type eventHandler struct {
 	cfg                 Config
 
 	iteration               int
+	task                    constants.Phase
 	state                   proto.State
 	stateLock               sync.Mutex
 	eventChan               chan *proto.Event
@@ -319,6 +321,7 @@ func TaskInProgress(task constants.Phase, description string) {
 		handler.skaffoldLogs = []proto.Event{}
 	}
 
+	handler.task = task
 	handler.handleTaskEvent(&proto.TaskEvent{
 		Id:          fmt.Sprintf("%s-%d", task, handler.iteration),
 		Task:        string(task),
@@ -329,6 +332,7 @@ func TaskInProgress(task constants.Phase, description string) {
 }
 
 func TaskFailed(task constants.Phase, err error) {
+	handler.task = constants.DevLoop
 	ae := sErrors.ActionableErrV2(handler.cfg, task, err)
 	handler.handleTaskEvent(&proto.TaskEvent{
 		Id:            fmt.Sprintf("%s-%d", task, handler.iteration),
@@ -340,6 +344,7 @@ func TaskFailed(task constants.Phase, err error) {
 }
 
 func TaskSucceeded(task constants.Phase) {
+	handler.task = constants.DevLoop
 	handler.handleTaskEvent(&proto.TaskEvent{
 		Id:        fmt.Sprintf("%s-%d", task, handler.iteration),
 		Task:      string(task),

--- a/pkg/skaffold/event/v2/logger.go
+++ b/pkg/skaffold/event/v2/logger.go
@@ -81,10 +81,10 @@ func (h logHook) Levels() []logrus.Level {
 // Fire constructs a SkaffoldLogEvent and sends it to the event channel
 func (h logHook) Fire(entry *logrus.Entry) error {
 	handler.handleSkaffoldLogEvent(&proto.SkaffoldLogEvent{
-		TaskId: fmt.Sprintf("%s-%d", handler.task, handler.iteration),
+		TaskId:    fmt.Sprintf("%s-%d", handler.task, handler.iteration),
 		SubtaskId: SubtaskIDNone,
-		Level:   levelFromEntry(entry),
-		Message: entry.Message,
+		Level:     levelFromEntry(entry),
+		Message:   entry.Message,
 	})
 	return nil
 }

--- a/pkg/skaffold/event/v2/logger.go
+++ b/pkg/skaffold/event/v2/logger.go
@@ -81,6 +81,8 @@ func (h logHook) Levels() []logrus.Level {
 // Fire constructs a SkaffoldLogEvent and sends it to the event channel
 func (h logHook) Fire(entry *logrus.Entry) error {
 	handler.handleSkaffoldLogEvent(&proto.SkaffoldLogEvent{
+		TaskId: fmt.Sprintf("%s-%d", handler.task, handler.iteration),
+		SubtaskId: SubtaskIDNone,
 		Level:   levelFromEntry(entry),
 		Message: entry.Message,
 	})


### PR DESCRIPTION
**Related**: #5368 

**Description**
This PR adds a `task` field to the `eventHandler` type to track what the current phase of skaffold is. This is used to populate the `SkaffoldLogEvent`s that come from `logrus` output.
