### PR TITLE
`git fetch` origin/main before `make checks`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
       <<: *registry_mirror
       name: "checks"
       script:
-        - git fetch --depth=1 https://github.com/GoogleContainerTools/skaffold.git main
+        - git remote set-branches --add origin main && git fetch
         - make checks
       cache:
         directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ jobs:
       <<: *registry_mirror
       name: "checks"
       script:
+        - git fetch --depth=1 https://github.com/GoogleContainerTools/skaffold.git main
         - make checks
       cache:
         directories:


### PR DESCRIPTION
Fixes: #5656 

**Description**
Sets up tracking of `origin/main` and uses `git fetch` to make sure we don't run into 
```
FATA[0000] failed running [/usr/bin/git diff --name-only origin/master -- pkg/skaffold/schema]: running [/usr/bin/git diff --name-only origin/main -- pkg/skaffold/schema]
 - stdout: ""
 - stderr: "fatal: bad revision 'origin/main'\n"
 - cause: exit status 128 
```

