### PR TITLE
Port `DebuggingContainerEvent`s from API V1 to V2

### DIFF
--- a/pkg/skaffold/event/v2/debugging.go
+++ b/pkg/skaffold/event/v2/debugging.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import proto "github.com/GoogleContainerTools/skaffold/proto/v2"
+
+// DebuggingContainerStarted notifies that a debuggable container has appeared.
+func DebuggingContainerStarted(podName, containerName, namespace, artifact, runtime, workingDir string, debugPorts map[string]uint32) {
+	handler.handle(&proto.Event{
+		EventType: &proto.Event_DebuggingContainerEvent{
+			DebuggingContainerEvent: &proto.DebuggingContainerEvent{
+				Status:        Started,
+				PodName:       podName,
+				ContainerName: containerName,
+				Namespace:     namespace,
+				Artifact:      artifact,
+				Runtime:       runtime,
+				WorkingDir:    workingDir,
+				DebugPorts:    debugPorts,
+			},
+		},
+	})
+}
+
+// DebuggingContainerTerminated notifies that a debuggable container has disappeared.
+func DebuggingContainerTerminated(podName, containerName, namespace, artifact, runtime, workingDir string, debugPorts map[string]uint32) {
+	handler.handle(&proto.Event{
+		EventType: &proto.Event_DebuggingContainerEvent{
+			DebuggingContainerEvent: &proto.DebuggingContainerEvent{
+				Status:        Terminated,
+				PodName:       podName,
+				ContainerName: containerName,
+				Namespace:     namespace,
+				Artifact:      artifact,
+				Runtime:       runtime,
+				WorkingDir:    workingDir,
+				DebugPorts:    debugPorts,
+			},
+		},
+	})
+}

--- a/pkg/skaffold/event/v2/debugging_test.go
+++ b/pkg/skaffold/event/v2/debugging_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"testing"
+
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+)
+
+func TestDebuggingContainer(t *testing.T) {
+	defer func() { handler = newHandler() }()
+
+	handler = newHandler()
+	handler.state = emptyState(mockCfg([]latestV1.Pipeline{{}}, "test"))
+
+	found := func() bool {
+		for _, dc := range handler.getState().DebuggingContainers {
+			if dc.Namespace == "ns" && dc.PodName == "pod" && dc.ContainerName == "container" {
+				return true
+			}
+		}
+		return false
+	}
+	notFound := func() bool { return !found() }
+	wait(t, notFound)
+	DebuggingContainerStarted("pod", "container", "ns", "artifact", "runtime", "/", nil)
+	wait(t, found)
+	DebuggingContainerTerminated("pod", "container", "ns", "artifact", "runtime", "/", nil)
+	wait(t, notFound)
+}

--- a/pkg/skaffold/kubernetes/debugging/container_manager.go
+++ b/pkg/skaffold/kubernetes/debugging/container_manager.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/annotations"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 )
 
@@ -32,6 +33,8 @@ var (
 	// For testing
 	notifyDebuggingContainerStarted    = event.DebuggingContainerStarted
 	notifyDebuggingContainerTerminated = event.DebuggingContainerTerminated
+	debuggingContainerStartedV2        = eventV2.DebuggingContainerStarted
+	debuggingContainerTerminatedV2     = eventV2.DebuggingContainerTerminated
 )
 
 type ContainerManager struct {
@@ -126,6 +129,7 @@ func (d *ContainerManager) checkPod(pod *v1.Pod) {
 					config.Runtime,
 					config.WorkingDir,
 					config.Ports)
+				debuggingContainerStartedV2(pod.Name, c.Name, pod.Namespace, config.Artifact, config.Runtime, config.WorkingDir, config.Ports)
 
 			case c.State.Terminated != nil && seen:
 				delete(d.active, key)
@@ -134,6 +138,7 @@ func (d *ContainerManager) checkPod(pod *v1.Pod) {
 					config.Runtime,
 					config.WorkingDir,
 					config.Ports)
+				debuggingContainerTerminatedV2(pod.Name, c.Name, pod.Namespace, config.Artifact, config.Runtime, config.WorkingDir, config.Ports)
 			}
 		}
 	}

--- a/pkg/skaffold/kubernetes/debugging/container_manager_test.go
+++ b/pkg/skaffold/kubernetes/debugging/container_manager_test.go
@@ -30,10 +30,15 @@ func TestContainerManager(t *testing.T) {
 	testutil.Run(t, "simulation", func(t *testutil.T) {
 		startCount := 0
 		terminatedCount := 0
+		// Override event v1 funcs to do nothing to avoid additional overhead
 		t.Override(&notifyDebuggingContainerStarted, func(podName string, containerName string, namespace string, artifactImage string, runtime string, workingDir string, debugPorts map[string]uint32) {
-			startCount++
 		})
 		t.Override(&notifyDebuggingContainerTerminated, func(podName string, containerName string, namespace string, artifactImage string, runtime string, workingDir string, debugPorts map[string]uint32) {
+		})
+		t.Override(&debuggingContainerStartedV2, func(podName string, containerName string, namespace string, artifactImage string, runtime string, workingDir string, debugPorts map[string]uint32) {
+			startCount++
+		})
+		t.Override(&debuggingContainerTerminatedV2, func(podName string, containerName string, namespace string, artifactImage string, runtime string, workingDir string, debugPorts map[string]uint32) {
 			terminatedCount++
 		})
 		pod := v1.Pod{


### PR DESCRIPTION
**Description**
This PR brings the `DebuggingContainerEvent` type over from V1 to V2 of the event API, as requested by IDE teams.
