### PR TITLE
Update deps and restore k3d tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,30 +114,30 @@ jobs:
       <<: *registry_mirror
       script:
         - env IT_PARTITION=3 make integration-in-kind
-    # - name: "k3d integration partition 0"
-    #   <<: *integration_test
-    #   <<: *upgrade_docker
-    #   <<: *registry_mirror
-    #   script:
-    #     - env IT_PARTITION=0 make integration-in-k3d
-    # - name: "k3d integration partition 1"
-    #   <<: *integration_test
-    #   <<: *upgrade_docker
-    #   <<: *registry_mirror
-    #   script:
-    #     - env IT_PARTITION=1 make integration-in-k3d
-    # - name: "k3d integration partition 2"
-    #   <<: *integration_test
-    #   <<: *upgrade_docker
-    #   <<: *registry_mirror
-    #   script:
-    #     - env IT_PARTITION=2 make integration-in-k3d
-    # - name: "k3d integration partition 3"
-    #   <<: *integration_test
-    #   <<: *upgrade_docker
-    #   <<: *registry_mirror
-    #   script:
-    #     - env IT_PARTITION=3 make integration-in-k3d
+    - name: "k3d integration partition 0"
+      <<: *integration_test
+      <<: *upgrade_docker
+      <<: *registry_mirror
+      script:
+        - env IT_PARTITION=0 make integration-in-k3d
+    - name: "k3d integration partition 1"
+      <<: *integration_test
+      <<: *upgrade_docker
+      <<: *registry_mirror
+      script:
+        - env IT_PARTITION=1 make integration-in-k3d
+    - name: "k3d integration partition 2"
+      <<: *integration_test
+      <<: *upgrade_docker
+      <<: *registry_mirror
+      script:
+        - env IT_PARTITION=2 make integration-in-k3d
+    - name: "k3d integration partition 3"
+      <<: *integration_test
+      <<: *upgrade_docker
+      <<: *registry_mirror
+      script:
+        - env IT_PARTITION=3 make integration-in-k3d
     - os: linux
       name: "diag/Linux unit"
       <<: *registry_mirror

--- a/deploy/skaffold/Dockerfile
+++ b/deploy/skaffold/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This base image has to be updated manually after running `make build_deps`
-FROM gcr.io/k8s-skaffold/build_deps:6477c2b624b633dee1d4c66bdd02821d25ce3f86 as build
+FROM gcr.io/k8s-skaffold/build_deps:e34c0c143e9fe6c39a4f119547289d7142afcb0d as build
 WORKDIR /skaffold
 
 FROM build as builder

--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -23,7 +23,7 @@ RUN chmod +x kubectl
 
 # Download helm (see https://github.com/helm/helm/releases/latest)
 FROM alpine:3.10 as download-helm
-ENV HELM_VERSION v3.6.2
+ENV HELM_VERSION v3.6.3
 ENV HELM_URL https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz
 RUN wget -O helm.tar.gz "${HELM_URL}"
 RUN tar -xvf helm.tar.gz --strip-components 1
@@ -37,14 +37,14 @@ RUN tar -xvf kustomize.tar.gz
 
 # Download kpt
 FROM alpine:3.10 as download-kpt
-ENV KPT_VERSION 1.0.0-beta.1
+ENV KPT_VERSION 1.0.0-beta.2
 ENV KPT_URL https://github.com/GoogleContainerTools/kpt/releases/download/v${KPT_VERSION}/kpt_linux_amd64
 RUN wget -O kpt "${KPT_URL}"
 RUN chmod +x kpt
 
 # Download kompose
 FROM alpine:3.10 as download-kompose
-ENV KOMPOSE_VERSION v1.22.0
+ENV KOMPOSE_VERSION v1.23.0
 ENV KOMPOSE_URL https://github.com/kubernetes/kompose/releases/download/${KOMPOSE_VERSION}/kompose-linux-amd64
 RUN wget -O kompose "${KOMPOSE_URL}"
 RUN chmod +x kompose
@@ -65,14 +65,14 @@ RUN chmod +x kind
 
 # Download k3d
 FROM alpine:3.10 as download-k3d
-ENV K3D_VERSION v4.4.6
+ENV K3D_VERSION v4.4.7
 ENV K3D_URL https://github.com/rancher/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64
 RUN wget -O k3d "${K3D_URL}"
 RUN chmod +x k3d
 
 # Download gcloud
 FROM alpine:3.10 as download-gcloud
-ENV GCLOUD_VERSION 347.0.0
+ENV GCLOUD_VERSION 349.0.0
 ENV GCLOUD_URL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-x86_64.tar.gz
 RUN wget -O gcloud.tar.gz "${GCLOUD_URL}"
 RUN tar -zxf gcloud.tar.gz


### PR DESCRIPTION
Periodic update of dependency versions in `deploy/skaffold`.  Re-enable k3d tests since [k3d 4.4.7](https://github.com/rancher/k3d/releases/tag/v4.4.7) includes https://github.com/rancher/k3d/pull/672 

**User facing changes**
Update Skaffold image:
- Google Cloud SDK 349.0.0
- kpt 1.0.0-beta.2
- kompose 1.23.0
- k3d 4.4.7
