### PR TITLE
Prefix port forward links with `http://`

### DIFF
--- a/pkg/skaffold/kubernetes/portforward/entry_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/entry_manager.go
@@ -126,7 +126,7 @@ func (b *EntryManager) forwardPortForwardEntry(ctx context.Context, out io.Write
 	if err := b.entryForwarder.Forward(ctx, entry); err == nil {
 		output.Green.Fprintln(
 			out,
-			fmt.Sprintf("Port forwarding %s/%s in namespace %s, remote port %s -> %s:%d",
+			fmt.Sprintf("Port forwarding %s/%s in namespace %s, remote port %s -> http://%s:%d",
 				entry.resource.Type,
 				entry.resource.Name,
 				entry.resource.Namespace,


### PR DESCRIPTION
**Description**
This PR changes the output line that we display when port forwarding by prefixing the links with `http://`. This was requested by IDE team to make the links clickable. This also seems to make them clickable in terminals as well which is nice.