### PR TITLE
[v2] Enable kubectl deployer in v2.

### DIFF
--- a/pkg/skaffold/deploy/v2/kpt/kpt.go
+++ b/pkg/skaffold/deploy/v2/kpt/kpt.go
@@ -240,8 +240,8 @@ func (k *Deployer) Render(context.Context, io.Writer, []graph.Artifact, bool, st
 	return fmt.Errorf("shall not be called")
 }
 
+// Dependencies is the v1 function required by "deployer" interface. It shall be no-op for v2 deployers.
 func (k *Deployer) Dependencies() ([]string, error) {
-	// TODO(yuwenma): This should be the render denpendencies.
 	return []string{}, nil
 }
 

--- a/pkg/skaffold/runner/deployer_test.go
+++ b/pkg/skaffold/runner/deployer_test.go
@@ -81,7 +81,7 @@ func TestGetDeployer(tOuter *testing.T) {
 						Pipelines: v2.NewPipelines([]latestV2.Pipeline{{}}),
 					}, nil, deploy.NoopComponentProvider, &latestV2.KubectlDeploy{
 						Flags: latestV2.KubectlFlags{},
-					})).(deploy.Deployer),
+					}, "")).(deploy.Deployer),
 				}, false),
 			},
 			{
@@ -107,7 +107,7 @@ func TestGetDeployer(tOuter *testing.T) {
 					Pipelines: v2.NewPipelines([]latestV2.Pipeline{{}}),
 				}, nil, deploy.NoopComponentProvider, &latestV2.KubectlDeploy{
 					Flags: latestV2.KubectlFlags{},
-				})).(deploy.Deployer),
+				}, "")).(deploy.Deployer),
 			},
 			{
 				description: "apply forces creation of kubectl deployer with helm config",
@@ -124,7 +124,7 @@ func TestGetDeployer(tOuter *testing.T) {
 					Pipelines: v2.NewPipelines([]latestV2.Pipeline{{}}),
 				}, nil, deploy.NoopComponentProvider, &latestV2.KubectlDeploy{
 					Flags: latestV2.KubectlFlags{},
-				})).(deploy.Deployer),
+				}, "")).(deploy.Deployer),
 			},
 			{
 				description: "multiple deployers",
@@ -159,7 +159,7 @@ func TestGetDeployer(tOuter *testing.T) {
 						Apply: test.apply,
 					},
 					Pipelines: v2.NewPipelines([]latestV2.Pipeline{test.cfg}),
-				}, deploy.NoopComponentProvider, nil)
+				}, deploy.NoopComponentProvider, nil, "")
 
 				t.CheckError(test.shouldErr, err)
 				t.CheckTypeEquality(test.expected, deployer)
@@ -194,7 +194,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 					Pipelines: v2.NewPipelines([]latestV2.Pipeline{{}}),
 				}, nil, deploy.NoopComponentProvider, &latestV2.KubectlDeploy{
 					Flags: latestV2.KubectlFlags{},
-				})).(*kubectl.Deployer),
+				}, "")).(*kubectl.Deployer),
 			},
 			{
 				name: "one config with kubectl deploy, with flags",
@@ -213,7 +213,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 						Apply:  []string{"--foo"},
 						Global: []string{"--bar"},
 					},
-				})).(*kubectl.Deployer),
+				}, "")).(*kubectl.Deployer),
 			},
 			{
 				name: "two kubectl configs with mismatched flags should fail",
@@ -244,7 +244,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 					Pipelines: v2.NewPipelines([]latestV2.Pipeline{{}}),
 				}, nil, deploy.NoopComponentProvider, &latestV2.KubectlDeploy{
 					Flags: latestV2.KubectlFlags{},
-				})).(*kubectl.Deployer),
+				}, "")).(*kubectl.Deployer),
 			},
 			{
 				name: "one config with kustomize deploy",
@@ -255,7 +255,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 					Pipelines: v2.NewPipelines([]latestV2.Pipeline{{}}),
 				}, nil, deploy.NoopComponentProvider, &latestV2.KubectlDeploy{
 					Flags: latestV2.KubectlFlags{},
-				})).(*kubectl.Deployer),
+				}, "")).(*kubectl.Deployer),
 			},
 		}
 
@@ -271,7 +271,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 				}
 				deployer, err := getDefaultDeployer(&v2.RunContext{
 					Pipelines: v2.NewPipelines(pipelines),
-				}, deploy.NoopComponentProvider, nil)
+				}, deploy.NoopComponentProvider, nil, "")
 
 				t.CheckErrorAndFailNow(test.shouldErr, err)
 

--- a/pkg/skaffold/runner/v2/new.go
+++ b/pkg/skaffold/runner/v2/new.go
@@ -106,7 +106,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 		return nil, fmt.Errorf("creating renderer: %w", err)
 	}
 
-	deployer, err = runner.GetDeployer(runCtx, provider, labeller.Labels())
+	deployer, err = runner.GetDeployer(runCtx, provider, labeller.Labels(), hydrationDir)
 
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(err))


### PR DESCRIPTION

**Related**: #5673 

**Description**
Add kubectl deployer v2

1. If `.deploy.kubectl.manifests` are given, the v1 kubectl deployer is used to make this backward compatible and satisfy some use cases that v2 does not support (remote manifests.
2. By default, v2 kubectl deployer deploys the manifests that are hydrated and stored in the default hydration dir (.kpt-pipeline) from render step
3. The v2 kubectl deployer does not have "Dependencies", the filewatcher monitors the renderer's manifest dependencies to kick off re-deploy.

**Follow-up work** 
Enable the related integration test.