### PR TITLE
Implement port forwarding for Docker deployer

### DIFF
--- a/docs/content/en/schemas/v2beta20.json
+++ b/docs/content/en/schemas/v2beta20.json
@@ -2789,8 +2789,8 @@
         },
         "namespace": {
           "type": "string",
-          "description": "namespace of the resource to port forward.",
-          "x-intellij-html-description": "namespace of the resource to port forward."
+          "description": "namespace of the resource to port forward. Does not apply to local containers.",
+          "x-intellij-html-description": "namespace of the resource to port forward. Does not apply to local containers."
         },
         "port": {
           "anyOf": [
@@ -2806,13 +2806,13 @@
         },
         "resourceName": {
           "type": "string",
-          "description": "name of the Kubernetes resource to port forward.",
-          "x-intellij-html-description": "name of the Kubernetes resource to port forward."
+          "description": "name of the Kubernetes resource or local container to port forward.",
+          "x-intellij-html-description": "name of the Kubernetes resource or local container to port forward."
         },
         "resourceType": {
           "type": "string",
-          "description": "Kubernetes type that should be port forwarded. Acceptable resource types include: `Service`, `Pod` and Controller resource type that has a pod spec: `ReplicaSet`, `ReplicationController`, `Deployment`, `StatefulSet`, `DaemonSet`, `Job`, `CronJob`.",
-          "x-intellij-html-description": "Kubernetes type that should be port forwarded. Acceptable resource types include: <code>Service</code>, <code>Pod</code> and Controller resource type that has a pod spec: <code>ReplicaSet</code>, <code>ReplicationController</code>, <code>Deployment</code>, <code>StatefulSet</code>, <code>DaemonSet</code>, <code>Job</code>, <code>CronJob</code>."
+          "description": "resource type that should be port forwarded. Acceptable resource types include kubernetes types: `Service`, `Pod` and Controller resource type that has a pod spec: `ReplicaSet`, `ReplicationController`, `Deployment`, `StatefulSet`, `DaemonSet`, `Job`, `CronJob`. Standalone `Container` is also valid for Docker deployments.",
+          "x-intellij-html-description": "resource type that should be port forwarded. Acceptable resource types include kubernetes types: <code>Service</code>, <code>Pod</code> and Controller resource type that has a pod spec: <code>ReplicaSet</code>, <code>ReplicationController</code>, <code>Deployment</code>, <code>StatefulSet</code>, <code>DaemonSet</code>, <code>Job</code>, <code>CronJob</code>. Standalone <code>Container</code> is also valid for Docker deployments."
         }
       },
       "preferredOrder": [

--- a/integration/diagnose_test.go
+++ b/integration/diagnose_test.go
@@ -61,7 +61,7 @@ func folders(root string) ([]string, error) {
 
 	for _, f := range files {
 		// TODO(nkubala): remove once yaml is unhidden
-		if f.Mode().IsDir() && f.Name() != "docker-deploy" {
+		if f.Mode().IsDir() && f.Name() != "docker-deploy" && f.Name() != "react-reload-docker" {
 			folders = append(folders, f.Name())
 		}
 	}

--- a/integration/examples/react-reload-docker/README.md
+++ b/integration/examples/react-reload-docker/README.md
@@ -1,0 +1,17 @@
+### Example: React app with hot-reload
+
+Simple React app demonstrating the file synchronization mode in conjunction with webpack hot module reload.
+
+#### Init
+
+```bash
+skaffold dev
+```
+
+#### Workflow
+
+* Make some changes to `HelloWorld.js`:
+    * The file will be synchronized to the cluster
+    * `webpack` will perform hot module reloading
+* Make some changes to `package.json`:
+    * The full build/push/deploy process will be triggered, fetching dependencies from `npm`

--- a/integration/examples/react-reload-docker/app/.babelrc
+++ b/integration/examples/react-reload-docker/app/.babelrc
@@ -1,0 +1,6 @@
+{
+    "presets": [
+        "@babel/preset-env",
+        "@babel/preset-react"
+    ]
+}

--- a/integration/examples/react-reload-docker/app/.dockerignore
+++ b/integration/examples/react-reload-docker/app/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+*.swp

--- a/integration/examples/react-reload-docker/app/.gitignore
+++ b/integration/examples/react-reload-docker/app/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+package-lock.json

--- a/integration/examples/react-reload-docker/app/Dockerfile
+++ b/integration/examples/react-reload-docker/app/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:14.9-alpine
+
+WORKDIR /app
+EXPOSE 8080
+CMD ["npm", "run", "dev"]
+
+COPY package* ./
+# examples don't use package-lock.json to minimize updates 
+RUN npm install --no-package-lock
+COPY . .

--- a/integration/examples/react-reload-docker/app/package.json
+++ b/integration/examples/react-reload-docker/app/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "react-reload",
+  "version": "1.0.0",
+  "description": "A React demo application for skaffold",
+  "main": "index.js",
+  "scripts": {
+    "dev": "webpack-dev-server --mode development --hot"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.11.6",
+    "@babel/preset-env": "^7.11.5",
+    "@babel/preset-react": "^7.10.4",
+    "babel-loader": "^8.1.0",
+    "css-loader": "^2.1.1",
+    "html-webpack-plugin": "^3.2.0",
+    "style-loader": "^0.23.1",
+    "webpack": "^4.44.1",
+    "webpack-cli": "^3.3.12",
+    "webpack-dev-server": "^3.11.0"
+  },
+  "dependencies": {
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
+  },
+  "browserslist": "> 2%, not dead"
+}

--- a/integration/examples/react-reload-docker/app/src/components/HelloWorld.js
+++ b/integration/examples/react-reload-docker/app/src/components/HelloWorld.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import '../styles/HelloWorld.css';
+
+export const HelloWorld = () => (
+	<div>
+		<h1>Hello world!</h1>
+	</div>
+);

--- a/integration/examples/react-reload-docker/app/src/index.html
+++ b/integration/examples/react-reload-docker/app/src/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>React demo app for skaffold</title>
+</head>
+<body>
+    <div id="root"/>
+</body>
+</html>

--- a/integration/examples/react-reload-docker/app/src/main.js
+++ b/integration/examples/react-reload-docker/app/src/main.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { HelloWorld } from './components/HelloWorld.js';
+
+ReactDOM.render( < HelloWorld/>, document.getElementById( 'root' ) );

--- a/integration/examples/react-reload-docker/app/src/styles/HelloWorld.css
+++ b/integration/examples/react-reload-docker/app/src/styles/HelloWorld.css
@@ -1,0 +1,6 @@
+h1 {
+    color: #27aedb;
+    text-align: center;
+    margin-top: 40vh;
+    font-size: 120pt;
+}

--- a/integration/examples/react-reload-docker/app/webpack.config.js
+++ b/integration/examples/react-reload-docker/app/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require( 'path' );
+const HtmlWebpackPlugin = require( 'html-webpack-plugin' );
+
+module.exports = {
+	entry: './src/main.js',
+	output: {
+		path: path.join( __dirname, '/dist' ),
+		filename: 'main.js'
+	},
+	devServer:{
+		host: '0.0.0.0'
+	},
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				exclude: /node_modules/,
+				use: [ 'babel-loader' ]
+			},
+			{
+				test: /\.css$/,
+				use: [ 'style-loader', 'css-loader' ]
+			}
+		]
+	},
+	plugins: [ new HtmlWebpackPlugin( { template: './src/index.html' } ) ]
+};

--- a/integration/examples/react-reload-docker/k8s/deployment.yaml
+++ b/integration/examples/react-reload-docker/k8s/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: node
+spec:
+  ports:
+  - port: 8080
+  type: LoadBalancer
+  selector:
+    app: node
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node
+spec:
+  selector:
+    matchLabels:
+      app: node
+  template:
+    metadata:
+      labels:
+        app: node
+    spec:
+      containers:
+      - name: react
+        image: react-reload-docker
+        ports:
+        - containerPort: 8080

--- a/integration/examples/react-reload-docker/skaffold.yaml
+++ b/integration/examples/react-reload-docker/skaffold.yaml
@@ -1,0 +1,16 @@
+apiVersion: skaffold/v2beta20
+kind: Config
+build:
+  local:
+    push: false
+  artifacts:
+  - image: react-reload-docker
+    context: app
+deploy:
+  docker:
+    images: [react-reload-docker]
+portForward:
+- resourceType: Container
+  resourceName: react-reload-docker
+  port: 8080
+  localPort: 9000

--- a/pkg/skaffold/deploy/docker/deploy.go
+++ b/pkg/skaffold/deploy/docker/deploy.go
@@ -49,7 +49,7 @@ type Deployer struct {
 
 	cfg         *v1.DockerDeploy
 	tracker     *tracker.ContainerTracker
-	portManager *portManager
+	portManager *PortManager
 	client      dockerutil.LocalDaemon
 	network     string
 	resources   []*v1.PortForwardResource
@@ -124,9 +124,9 @@ func (d *Deployer) deploy(ctx context.Context, out io.Writer, b graph.Artifact) 
 		return nil
 	}
 	if container, found := d.tracker.ContainerForImage(b.ImageName); found {
-		logrus.Debugf("removing old container %s for image %s", container.Id, b.ImageName)
-		if err := d.client.Delete(ctx, out, container.Id); err != nil {
-			return fmt.Errorf("failed to remove old container %s for image %s: %w", container.Id, b.ImageName, err)
+		logrus.Debugf("removing old container %s for image %s", container.ID, b.ImageName)
+		if err := d.client.Delete(ctx, out, container.ID); err != nil {
+			return fmt.Errorf("failed to remove old container %s for image %s: %w", container.ID, b.ImageName, err)
 		}
 		d.portManager.relinquishPorts(container.Name)
 	}
@@ -153,7 +153,7 @@ func (d *Deployer) deploy(ctx context.Context, out io.Writer, b graph.Artifact) 
 	if err != nil {
 		return errors.Wrap(err, "creating container in local docker")
 	}
-	d.TrackContainerFromBuild(b, tracker.Container{Name: containerName, Id: id})
+	d.TrackContainerFromBuild(b, tracker.Container{Name: containerName, ID: id})
 	containerPortForwardEvents(out, entries)
 	return nil
 }
@@ -182,7 +182,7 @@ func (d *Deployer) Dependencies() ([]string, error) {
 
 func (d *Deployer) Cleanup(ctx context.Context, out io.Writer) error {
 	for _, container := range d.tracker.DeployedContainers() {
-		if err := d.client.Delete(ctx, out, container.Id); err != nil {
+		if err := d.client.Delete(ctx, out, container.ID); err != nil {
 			// TODO(nkubala): replace with actionable error
 			return errors.Wrap(err, "cleaning up deployed container")
 		}

--- a/pkg/skaffold/deploy/docker/deploy.go
+++ b/pkg/skaffold/deploy/docker/deploy.go
@@ -47,11 +47,13 @@ type Deployer struct {
 	monitor  status.Monitor
 	syncer   pkgsync.Syncer
 
-	cfg     *v1.DockerDeploy
-	tracker *tracker.ContainerTracker
-	client  dockerutil.LocalDaemon
-	network string
-	once    sync.Once
+	cfg         *v1.DockerDeploy
+	tracker     *tracker.ContainerTracker
+	portManager *portManager
+	client      dockerutil.LocalDaemon
+	network     string
+	resources   []*v1.PortForwardResource
+	once        sync.Once
 }
 
 func NewDeployer(cfg dockerutil.Config, labeller *label.DefaultLabeller, d *v1.DockerDeploy, resources []*v1.PortForwardResource) (*Deployer, error) {
@@ -67,16 +69,18 @@ func NewDeployer(cfg dockerutil.Config, labeller *label.DefaultLabeller, d *v1.D
 	}
 
 	return &Deployer{
-		cfg:     d,
-		client:  client,
-		network: fmt.Sprintf("skaffold-network-%s", uuid.New().String()),
+		cfg:       d,
+		client:    client,
+		network:   fmt.Sprintf("skaffold-network-%s", uuid.New().String()),
+		resources: resources,
 		// TODO(nkubala): implement components
-		tracker:  tracker,
-		accessor: &access.NoopAccessor{},
-		debugger: &debug.NoopDebugger{},
-		logger:   l,
-		monitor:  &status.NoopMonitor{},
-		syncer:   &pkgsync.NoopSyncer{},
+		tracker:     tracker,
+		portManager: NewPortManager(),
+		accessor:    &access.NoopAccessor{},
+		debugger:    &debug.NoopDebugger{},
+		logger:      l,
+		monitor:     &status.NoopMonitor{},
+		syncer:      &pkgsync.NoopSyncer{},
 	}, nil
 }
 
@@ -84,10 +88,10 @@ func (d *Deployer) TrackBuildArtifacts(artifacts []graph.Artifact) {
 	d.logger.RegisterArtifacts(artifacts)
 }
 
-// TrackContainerFromBuild adds an artifact and its newly-associated container id
+// TrackContainerFromBuild adds an artifact and its newly-associated container
 // to the container tracker.
-func (d *Deployer) TrackContainerFromBuild(build graph.Artifact, id string) {
-	d.tracker.Add(build, id)
+func (d *Deployer) TrackContainerFromBuild(artifact graph.Artifact, container tracker.Container) {
+	d.tracker.Add(artifact, container)
 }
 
 // Deploy deploys built artifacts by creating containers in the local docker daemon
@@ -119,27 +123,56 @@ func (d *Deployer) deploy(ctx context.Context, out io.Writer, b graph.Artifact) 
 		logrus.Warnf("skipping deploy for image %s since it was not built by Skaffold", b.ImageName)
 		return nil
 	}
-	if containerID := d.tracker.DeployedContainerForImage(b.ImageName); containerID != "" {
-		logrus.Debugf("removing old container %s for image %s", containerID, b.ImageName)
-		if err := d.client.Delete(ctx, out, containerID); err != nil {
-			return fmt.Errorf("failed to remove old container %s for image %s: %w", containerID, b.ImageName, err)
+	if container, found := d.tracker.ContainerForImage(b.ImageName); found {
+		logrus.Debugf("removing old container %s for image %s", container.Id, b.ImageName)
+		if err := d.client.Delete(ctx, out, container.Id); err != nil {
+			return fmt.Errorf("failed to remove old container %s for image %s: %w", container.Id, b.ImageName, err)
 		}
+		d.portManager.relinquishPorts(container.Name)
 	}
 	if d.cfg.UseCompose {
 		// TODO(nkubala): implement
 		return fmt.Errorf("docker compose not yet supported by skaffold")
 	}
+
+	ports, bindings, entries, err := d.portManager.getPorts(b.ImageName, d.resources)
+	if err != nil {
+		return err
+	}
+
+	containerName := d.getContainerName(ctx, b.ImageName)
+
 	opts := dockerutil.ContainerCreateOpts{
-		Name:    b.ImageName,
-		Image:   b.Tag,
-		Network: d.network,
+		Name:     containerName,
+		Image:    b.Tag,
+		Network:  d.network,
+		Ports:    ports,
+		Bindings: bindings,
 	}
 	id, err := d.client.Run(ctx, out, opts)
 	if err != nil {
 		return errors.Wrap(err, "creating container in local docker")
 	}
-	d.TrackContainerFromBuild(b, id)
+	d.TrackContainerFromBuild(b, tracker.Container{Name: containerName, Id: id})
+	containerPortForwardEvents(out, entries)
 	return nil
+}
+
+func (d *Deployer) getContainerName(ctx context.Context, name string) string {
+	currentName := name
+	counter := 1
+	for {
+		if !d.client.ContainerExists(ctx, currentName) {
+			break
+		}
+		currentName = fmt.Sprintf("%s-%d", name, counter)
+		counter++
+	}
+
+	if currentName != name {
+		logrus.Debugf("container %s already present in local daemon: using %s instead", name, currentName)
+	}
+	return currentName
 }
 
 func (d *Deployer) Dependencies() ([]string, error) {
@@ -148,11 +181,12 @@ func (d *Deployer) Dependencies() ([]string, error) {
 }
 
 func (d *Deployer) Cleanup(ctx context.Context, out io.Writer) error {
-	for _, id := range d.tracker.DeployedContainers() {
-		if err := d.client.Delete(ctx, out, id); err != nil {
+	for _, container := range d.tracker.DeployedContainers() {
+		if err := d.client.Delete(ctx, out, container.Id); err != nil {
 			// TODO(nkubala): replace with actionable error
 			return errors.Wrap(err, "cleaning up deployed container")
 		}
+		d.portManager.relinquishPorts(container.Name)
 	}
 
 	err := d.client.NetworkRemove(ctx, d.network)

--- a/pkg/skaffold/deploy/docker/port.go
+++ b/pkg/skaffold/deploy/docker/port.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	schemautil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/sirupsen/logrus"
+
+	"github.com/docker/go-connections/nat"
+)
+
+type portManager struct {
+	containerPorts map[string][]int // maps containers to the ports they have allocated
+	portSet        util.PortSet
+
+	lock sync.Mutex
+}
+
+func NewPortManager() *portManager {
+	return &portManager{
+		containerPorts: make(map[string][]int),
+		portSet:        util.PortSet{},
+	}
+}
+
+// getPorts converts PortForwardResources into docker.PortSet/PortMap objects.
+// These are passed to ContainerCreate on Deploy to expose container ports on the host.
+// It also returns a list of containerPortForwardEntry, to be passed to the event handler
+func (pm *portManager) getPorts(containerName string, pf []*v1.PortForwardResource) (nat.PortSet, nat.PortMap, []containerPortForwardEntry, error) {
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
+	s := make(nat.PortSet)
+	m := make(nat.PortMap)
+	var entries []containerPortForwardEntry
+	var ports []int
+	for _, p := range pf {
+		if p.Type != "container" {
+			logrus.Debugf("skipping non-container port forward resource in Docker deploy: %s\n", p.Name)
+			continue
+		}
+		localPort := util.GetAvailablePort(p.Address, p.LocalPort, &pm.portSet)
+		ports = append(ports, localPort)
+		port, err := nat.NewPort("tcp", p.Port.String())
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		s[port] = struct{}{}
+		m[port] = []nat.PortBinding{
+			{HostIP: p.Address, HostPort: fmt.Sprintf("%d", localPort)},
+		}
+		entries = append(entries, containerPortForwardEntry{
+			container:       containerName,
+			resourceName:    p.Name,
+			resourceAddress: p.Address,
+			localPort:       int32(localPort),
+			remotePort:      p.Port,
+		})
+	}
+	pm.containerPorts[containerName] = ports
+	return s, m, entries, nil
+}
+
+func (pm *portManager) relinquishPorts(containerName string) {
+	pm.lock.Lock()
+	defer pm.lock.Unlock()
+	ports := pm.containerPorts[containerName]
+	for _, port := range ports {
+		pm.portSet.Delete(port)
+	}
+	pm.containerPorts[containerName] = nil
+}
+
+type containerPortForwardEntry struct {
+	container       string
+	resourceName    string
+	resourceAddress string
+	localPort       int32
+	remotePort      schemautil.IntOrString
+}
+
+func containerPortForwardEvents(out io.Writer, entries []containerPortForwardEntry) {
+	for _, entry := range entries {
+		event.PortForwarded(
+			entry.localPort,
+			entry.remotePort,
+			"",              // no pod name
+			entry.container, // container name
+			"",              // no namespace
+			"",              // no port name
+			"container",
+			entry.resourceName,
+			entry.resourceAddress,
+		)
+
+		eventV2.PortForwarded(
+			entry.localPort,
+			entry.remotePort,
+			"",              // no pod name
+			entry.container, // container name
+			"",              // no namespace
+			"",              // no port name
+			"container",
+			entry.resourceName,
+			entry.resourceAddress,
+		)
+
+		output.Green.Fprintln(out,
+			fmt.Sprintf("[%s] Forwarding container port %s -> local port %s:%d",
+				entry.container,
+				entry.remotePort.String(),
+				entry.resourceAddress,
+				entry.localPort,
+			))
+	}
+}

--- a/pkg/skaffold/deploy/docker/port_test.go
+++ b/pkg/skaffold/deploy/docker/port_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package docker
+
+import (
+	"testing"
+
+	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestGetPorts(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources map[int]*v1.PortForwardResource // we map local port to resources for ease of testing
+	}{
+		{
+			name: "one port, one resource",
+			resources: map[int]*v1.PortForwardResource{
+				9000: {
+					Port: util.IntOrString{
+						IntVal: 9000,
+						StrVal: "9000",
+					},
+					Address:   "127.0.0.1",
+					LocalPort: 9000,
+				},
+			},
+		},
+		{
+			name: "two ports, two resources",
+			resources: map[int]*v1.PortForwardResource{
+				1234: {
+					Port: util.IntOrString{
+						IntVal: 20,
+						StrVal: "20",
+					},
+					Address:   "192.168.999.999",
+					LocalPort: 1234,
+				},
+				4321: {
+					Port: util.IntOrString{
+						IntVal: 8080,
+						StrVal: "8080",
+					},
+					Address:   "localhost",
+					LocalPort: 4321,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			pm := NewPortManager()
+			s, m, _, err := pm.getPorts(test.name, collectResources(test.resources))
+			for port := range s { // the PortSet contains the local ports, so we grab the bindings keyed off these
+				bindings := m[port]
+				t.CheckDeepEqual(len(bindings), 1) // we always have a 1-1 mapping of resource to binding
+				t.CheckError(false, err)           // shouldn't error, unless GetAvailablePort is broken
+				t.CheckDeepEqual(bindings[0].HostIP, test.resources[port.Int()].Address)
+				t.CheckDeepEqual(bindings[0].HostPort, test.resources[port.Int()].Port.StrVal)
+			}
+		})
+	}
+}
+
+func collectResources(resourceMap map[int]*v1.PortForwardResource) []*v1.PortForwardResource {
+	var resources []*v1.PortForwardResource
+	for _, r := range resourceMap {
+		resources = append(resources, r)
+	}
+	return resources
+}

--- a/pkg/skaffold/deploy/docker/port_test.go
+++ b/pkg/skaffold/deploy/docker/port_test.go
@@ -68,7 +68,7 @@ func TestGetPorts(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
 			pm := NewPortManager()
-			s, m, _, err := pm.getPorts(test.name, collectResources(test.resources))
+			s, m, err := pm.getPorts(test.name, collectResources(test.resources))
 			for port := range s { // the PortSet contains the local ports, so we grab the bindings keyed off these
 				bindings := m[port]
 				t.CheckDeepEqual(len(bindings), 1) // we always have a 1-1 mapping of resource to binding

--- a/pkg/skaffold/deploy/resource/deployment.go
+++ b/pkg/skaffold/deploy/resource/deployment.go
@@ -140,7 +140,7 @@ func (d *Deployment) CheckStatus(ctx context.Context, cfg kubectl.Config) {
 
 	d.UpdateStatus(ae)
 	if err := d.fetchPods(ctx); err != nil {
-		logrus.Debugf("pod statuses could be fetched this time due to %s", err)
+		logrus.Debugf("pod statuses could not be fetched this time due to %s", err)
 	}
 }
 

--- a/pkg/skaffold/docker/logger/formatter_test.go
+++ b/pkg/skaffold/docker/logger/formatter_test.go
@@ -77,7 +77,7 @@ func TestPrintLogLineFormatted(t *testing.T) {
 			groups        = 5
 		)
 		ct := tracker.NewContainerTracker()
-		ct.Add(graph.Artifact{ImageName: "image", Tag: "image:tag"}, "id")
+		ct.Add(graph.Artifact{ImageName: "image", Tag: "image:tag"}, tracker.Container{Id: "id"})
 
 		f := NewDockerLogFormatter(&mockColorPicker{}, ct, func() bool { return false }, "id")
 

--- a/pkg/skaffold/docker/logger/formatter_test.go
+++ b/pkg/skaffold/docker/logger/formatter_test.go
@@ -77,7 +77,7 @@ func TestPrintLogLineFormatted(t *testing.T) {
 			groups        = 5
 		)
 		ct := tracker.NewContainerTracker()
-		ct.Add(graph.Artifact{ImageName: "image", Tag: "image:tag"}, tracker.Container{Id: "id"})
+		ct.Add(graph.Artifact{ImageName: "image", Tag: "image:tag"}, tracker.Container{ID: "id"})
 
 		f := NewDockerLogFormatter(&mockColorPicker{}, ct, func() bool { return false }, "id")
 

--- a/pkg/skaffold/docker/tracker/tracker.go
+++ b/pkg/skaffold/docker/tracker/tracker.go
@@ -24,7 +24,7 @@ import (
 
 type Container struct {
 	Name string
-	Id   string
+	ID   string
 }
 
 type ContainerTracker struct {
@@ -84,8 +84,8 @@ func (t *ContainerTracker) Add(artifact graph.Artifact, c Container) {
 	t.Lock()
 	defer t.Unlock()
 	t.deployedContainers[artifact.ImageName] = c
-	t.containerToArtifact[c.Id] = artifact
+	t.containerToArtifact[c.ID] = artifact
 	go func() {
-		t.notifier <- c.Id
+		t.notifier <- c.ID
 	}()
 }

--- a/pkg/skaffold/docker/tracker/tracker_test.go
+++ b/pkg/skaffold/docker/tracker/tracker_test.go
@@ -71,7 +71,7 @@ func TestDeployedContainers(t *testing.T) {
 		testutil.Run(t, test.name, func(t *testutil.T) {
 			tracker := NewContainerTracker()
 			for _, pair := range test.containers {
-				tracker.Add(pair.artifact, Container{Id: pair.id})
+				tracker.Add(pair.artifact, Container{ID: pair.id})
 			}
 			deployedContainers := tracker.DeployedContainers()
 
@@ -79,7 +79,7 @@ func TestDeployedContainers(t *testing.T) {
 			for _, c := range test.expectedContainers {
 				found := false
 				for _, container := range deployedContainers {
-					if container.Id == c {
+					if container.ID == c {
 						found = true
 					}
 				}
@@ -144,10 +144,10 @@ func TestDeployedContainerForImage(t *testing.T) {
 		testutil.Run(t, test.name, func(t *testutil.T) {
 			tracker := NewContainerTracker()
 			for _, pair := range test.containers {
-				tracker.Add(pair.artifact, Container{Id: pair.id})
+				tracker.Add(pair.artifact, Container{ID: pair.id})
 			}
 			container, _ := tracker.ContainerForImage(test.target)
-			t.CheckDeepEqual(test.expected, container.Id)
+			t.CheckDeepEqual(test.expected, container.ID)
 		})
 	}
 }

--- a/pkg/skaffold/docker/tracker/tracker_test.go
+++ b/pkg/skaffold/docker/tracker/tracker_test.go
@@ -71,9 +71,22 @@ func TestDeployedContainers(t *testing.T) {
 		testutil.Run(t, test.name, func(t *testutil.T) {
 			tracker := NewContainerTracker()
 			for _, pair := range test.containers {
-				tracker.Add(pair.artifact, pair.id)
+				tracker.Add(pair.artifact, Container{Id: pair.id})
 			}
-			t.CheckDeepEqual(test.expectedContainers, tracker.DeployedContainers())
+			deployedContainers := tracker.DeployedContainers()
+
+			// ensure each container exists in the returned map
+			for _, c := range test.expectedContainers {
+				found := false
+				for _, container := range deployedContainers {
+					if container.Id == c {
+						found = true
+					}
+				}
+				if !found {
+					t.Fail()
+				}
+			}
 		})
 	}
 }
@@ -131,70 +144,10 @@ func TestDeployedContainerForImage(t *testing.T) {
 		testutil.Run(t, test.name, func(t *testutil.T) {
 			tracker := NewContainerTracker()
 			for _, pair := range test.containers {
-				tracker.Add(pair.artifact, pair.id)
+				tracker.Add(pair.artifact, Container{Id: pair.id})
 			}
-			t.CheckDeepEqual(test.expected, tracker.DeployedContainerForImage(test.target))
-		})
-	}
-}
-
-func TestArtifactForContainer(t *testing.T) {
-	tests := []struct {
-		name       string
-		containers []ArtifactIDPair
-		target     string
-		expected   graph.Artifact
-	}{
-		{
-			name:       "one container",
-			containers: []ArtifactIDPair{{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"}},
-			target:     "deadbeef",
-			expected:   graph.Artifact{ImageName: "image1"},
-		},
-		{
-			name: "two containers, retrieve the second",
-			containers: []ArtifactIDPair{
-				{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"},
-				{artifact: graph.Artifact{ImageName: "image2"}, id: "foobar"},
-			},
-			target:   "foobar",
-			expected: graph.Artifact{ImageName: "image2"},
-		},
-		{
-			name: "adding the same artifact overwrites previous ID",
-			containers: []ArtifactIDPair{
-				{artifact: graph.Artifact{ImageName: "image1"}, id: "this will be ignored"},
-				{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"},
-				{artifact: graph.Artifact{ImageName: "image2"}, id: "foobar"},
-			},
-			target:   "deadbeef",
-			expected: graph.Artifact{ImageName: "image1"},
-		},
-		{
-			name: "tags are updated on artifact",
-			containers: []ArtifactIDPair{
-				{artifact: graph.Artifact{ImageName: "image1", Tag: "image1:tag1"}, id: "deadbeef"},
-				{artifact: graph.Artifact{ImageName: "image1", Tag: "image1:tag2"}, id: "deadbeef"},
-				{artifact: graph.Artifact{ImageName: "image2"}, id: "foobar"},
-			},
-			target:   "deadbeef",
-			expected: graph.Artifact{ImageName: "image1", Tag: "image1:tag2"},
-		},
-		{
-			name:       "untracked id returns empty artifact",
-			containers: []ArtifactIDPair{{artifact: graph.Artifact{ImageName: "image1"}, id: "deadbeef"}},
-			target:     "bogus",
-			expected:   graph.Artifact{},
-		},
-	}
-
-	for _, test := range tests {
-		testutil.Run(t, test.name, func(t *testutil.T) {
-			tracker := NewContainerTracker()
-			for _, pair := range test.containers {
-				tracker.Add(pair.artifact, pair.id)
-			}
-			t.CheckDeepEqual(test.expected, tracker.ArtifactForContainer(test.target))
+			container, _ := tracker.ContainerForImage(test.target)
+			t.CheckDeepEqual(test.expected, container.Id)
 		})
 	}
 }

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -124,14 +124,15 @@ type ResourceType string
 
 // PortForwardResource describes a resource to port forward.
 type PortForwardResource struct {
-	// Type is the Kubernetes type that should be port forwarded.
-	// Acceptable resource types include: `Service`, `Pod` and Controller resource type that has a pod spec: `ReplicaSet`, `ReplicationController`, `Deployment`, `StatefulSet`, `DaemonSet`, `Job`, `CronJob`.
+	// Type is the resource type that should be port forwarded.
+	// Acceptable resource types include kubernetes types: `Service`, `Pod` and Controller resource type that has a pod spec: `ReplicaSet`, `ReplicationController`, `Deployment`, `StatefulSet`, `DaemonSet`, `Job`, `CronJob`.
+	// Standalone `Container` is also valid for Docker deployments.
 	Type ResourceType `yaml:"resourceType,omitempty"`
 
-	// Name is the name of the Kubernetes resource to port forward.
+	// Name is the name of the Kubernetes resource or local container to port forward.
 	Name string `yaml:"resourceName,omitempty"`
 
-	// Namespace is the namespace of the resource to port forward.
+	// Namespace is the namespace of the resource to port forward. Does not apply to local containers.
 	Namespace string `yaml:"namespace,omitempty"`
 
 	// Port is the resource port that will be forwarded.

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -524,7 +524,7 @@ type DeployConfig struct {
 // time for hybrid workflows.
 type DeployType struct {
 	// DockerDeploy *alpha* uses the `docker` CLI to create application containers in Docker.
-	DockerDeploy *DockerDeploy `yaml:"-,omitempty"`
+	DockerDeploy *DockerDeploy `yaml:",omitempty"`
 
 	// HelmDeploy *beta* uses the `helm` CLI to apply the charts to the cluster.
 	HelmDeploy *HelmDeploy `yaml:"helm,omitempty"`

--- a/pkg/skaffold/schema/validation/samples_test.go
+++ b/pkg/skaffold/schema/validation/samples_test.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	ignoredExamples = []string{"docker-deploy"}
+	ignoredExamples = []string{"docker-deploy", "react-reload-docker"}
 	ignoredSamples  = []string{"structureTest.yaml", "build.sh", "globalConfig.yaml", "Dockerfile.app", "Dockerfile.base"}
 )
 

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -482,6 +482,7 @@ func validateSyncRules(artifacts []*latestV1.Artifact) []error {
 func validatePortForwardResources(pfrs []*latestV1.PortForwardResource) []error {
 	var errs []error
 	validResourceTypes := map[string]struct{}{
+		"container":             {},
 		"pod":                   {},
 		"deployment":            {},
 		"service":               {},


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: https://github.com/GoogleContainerTools/skaffold/issues/6107

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This change adds support for forwarding ports exposed through containers deployed to the local Docker daemon. Port forwarding is not a separate process from the `Deploy` (as is the case with Kubernetes-style deployments) - rather, ports are exposed on container creation, and surfaced through the skaffold-managed Docker network. This means that the implementation for the `Accessor` is and will remain a noop for the Docker deployer.

Ports are allocated and maintained by a `portManager` object stored on the `Deployer`, which reuses the `GetAvailablePort` method to ensure no port collisions are had.

A new port forward resource type, `"container"`, is added to indicate a port to be exposed on a local container. Only resources with type `container` will be used during Docker deployments.

**Try the `react-reload-docker` example**
