### PR TITLE
Pin `go-licenses` version to avoid go 1.16.x dependencies

### DIFF
--- a/hack/generate-statik.sh
+++ b/hack/generate-statik.sh
@@ -35,7 +35,7 @@ elif ! [ -x "$(command -v ${LICENSES})" ]; then
     # from a dependency.
     echo "Installing go-licenses"
     pushd $(mktemp -d ${TMPDIR:-/tmp}/generate-statik.XXXXXX)
-    go mod init tmp; GOBIN=${BIN} go get github.com/google/go-licenses
+    go mod init tmp; GOBIN=${BIN} go get github.com/google/go-licenses@9376cf9847a05cae04f4589fe4898b9bce37e684
     popd
 fi
 

--- a/hack/generate-statik.sh
+++ b/hack/generate-statik.sh
@@ -35,6 +35,7 @@ elif ! [ -x "$(command -v ${LICENSES})" ]; then
     # from a dependency.
     echo "Installing go-licenses"
     pushd $(mktemp -d ${TMPDIR:-/tmp}/generate-statik.XXXXXX)
+    #TODO(marlongamez): unpin this version once we're able to build using go 1.16.x
     go mod init tmp; GOBIN=${BIN} go get github.com/google/go-licenses@9376cf9847a05cae04f4589fe4898b9bce37e684
     popd
 fi


### PR DESCRIPTION
**Description**
CI is failing because of `go-licenses`'s dependency on go 1.16.x packages. This PR fixes that by pinning to a previous version without those dependencies.
