### PR TITLE
Set up `logrus.Logger` in `output.WithEventContext`, improve usage of `output.GetWriter()`

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -85,7 +85,8 @@ func NewSkaffoldCommand(out, errOut io.Writer) *cobra.Command {
 			// These are used for command completion and send debug messages on stderr.
 			if cmd.Name() != cobra.ShellCompRequestCmd && cmd.Name() != cobra.ShellCompNoDescRequestCmd {
 				instrumentation.SetCommand(cmd.Name())
-				out := output.GetWriter(out, defaultColor, forceColors, timestamps)
+				lvl, _ := logrus.ParseLevel(v)
+				out := output.GetWriter(out, defaultColor, forceColors, timestamps, lvl)
 				cmd.Root().SetOutput(out)
 
 				// Setup logs

--- a/cmd/skaffold/skaffold.go
+++ b/cmd/skaffold/skaffold.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
@@ -59,7 +60,7 @@ func main() {
 			// As we allow some color setup using CLI flags for the main run, we can't run SetupColors()
 			// for the entire skaffold run here. It's possible SetupColors() was never called, so call it again
 			// before we print an error to get the right coloring.
-			errOut := output.GetWriter(os.Stderr, output.DefaultColorCode, false, false)
+			errOut := output.GetWriter(os.Stderr, output.DefaultColorCode, false, false, constants.DefaultLogLevel)
 			output.Red.Fprintln(errOut, err)
 			code = exitCode(err)
 		}

--- a/pkg/skaffold/build/result.go
+++ b/pkg/skaffold/build/result.go
@@ -62,8 +62,8 @@ func (l *logAggregatorImpl) GetWriter() (io.Writer, func(), error) {
 	r, w := io.Pipe()
 
 	writer := io.Writer(w)
-	if output.IsColorable(l.out) {
-		writer = output.GetWriter(writer, output.DefaultColorCode, false, false)
+	if output.IsSkaffoldWriter(l.out) {
+		writer = output.GetWriter(writer, output.DefaultColorCode, output.IsColorable(l.out), output.GetTimestamps(l.out), output.GetVerbosity(l.out))
 	}
 	ch := make(chan string, buffSize)
 	l.messages <- ch

--- a/pkg/skaffold/output/output_test.go
+++ b/pkg/skaffold/output/output_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
@@ -153,7 +154,7 @@ func TestWithEventContext(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
 			got, _ := WithEventContext(test.writer, test.phase, test.subtaskID)
-			t.CheckDeepEqual(test.expected, got, cmpopts.IgnoreTypes(false))
+			t.CheckDeepEqual(test.expected, got, cmpopts.IgnoreTypes(false, logrus.WarnLevel))
 		})
 	}
 }


### PR DESCRIPTION
**Related**: #5368 

**Description**
This PR changes adds setup of `logrus.Logger`s to `WithEventContext()` function. It modifies the `output.skaffoldWriter` type to contain information about the verbosity level, which is then used when creating the loggers that are returned. Currently, these returned loggers aren't being used just yet. I'll be opening a follow up PR to utilize these in functions that make calls to `logrus` functions.

**Follow-up Work (remove if N/A)**
Plump `logrus.Logger`s returned from `WithEventContext()` into functions that will be making `logrus` calls.
