### PR TITLE
Implement file sync for Docker deployer

### DIFF
--- a/integration/examples/react-reload-docker/skaffold.yaml
+++ b/integration/examples/react-reload-docker/skaffold.yaml
@@ -6,6 +6,12 @@ build:
   artifacts:
   - image: react-reload-docker
     context: app
+    sync:
+      manual:
+      - src: 'src/components/*'
+        dest: .
+      - src: 'src/styles/*'
+        dest: .
 deploy:
   docker:
     images: [react-reload-docker]

--- a/pkg/skaffold/deploy/docker/deploy.go
+++ b/pkg/skaffold/deploy/docker/deploy.go
@@ -78,7 +78,7 @@ func NewDeployer(cfg dockerutil.Config, labeller *label.DefaultLabeller, d *v1.D
 		debugger:    &debug.NoopDebugger{},
 		logger:      l,
 		monitor:     &status.NoopMonitor{},
-		syncer:      &pkgsync.NoopSyncer{},
+		syncer:      pkgsync.NewContainerSyncer(),
 	}, nil
 }
 

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -524,7 +524,7 @@ type DeployConfig struct {
 // time for hybrid workflows.
 type DeployType struct {
 	// DockerDeploy *alpha* uses the `docker` CLI to create application containers in Docker.
-	DockerDeploy *DockerDeploy `yaml:",omitempty"`
+	DockerDeploy *DockerDeploy `yaml:"-,omitempty"`
 
 	// HelmDeploy *beta* uses the `helm` CLI to apply the charts to the cluster.
 	HelmDeploy *HelmDeploy `yaml:"helm,omitempty"`

--- a/pkg/skaffold/sync/docker.go
+++ b/pkg/skaffold/sync/docker.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+type ContainerSyncer struct{}
+
+func NewContainerSyncer() *ContainerSyncer {
+	return &ContainerSyncer{}
+}
+
+func (s *ContainerSyncer) Sync(ctx context.Context, _ io.Writer, item *Item) error {
+	if len(item.Copy) > 0 {
+		logrus.Infoln("Copying files:", item.Copy, "to", item.Image)
+		if _, err := util.RunCmdOut(s.copyFileFn(ctx, item.Artifact.ImageName, item.Copy)); err != nil {
+			return fmt.Errorf("copying files: %w", err)
+		}
+	}
+
+	if len(item.Delete) > 0 {
+		logrus.Infoln("Deleting files:", item.Delete, "from", item.Image)
+		if _, err := util.RunCmdOut(s.deleteFileFn(ctx, item.Artifact.ImageName, item.Delete)); err != nil {
+			return fmt.Errorf("deleting files: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (s *ContainerSyncer) deleteFileFn(ctx context.Context, containerName string, files syncMap) *exec.Cmd {
+	var args []string
+	args = append(args, "exec", "-i", containerName, "rm", "-rf", "--")
+	for _, dsts := range files {
+		args = append(args, dsts...)
+	}
+	return exec.CommandContext(ctx, "docker", args...)
+}
+
+func (s *ContainerSyncer) copyFileFn(ctx context.Context, containerName string, files syncMap) *exec.Cmd {
+	reader, writer := io.Pipe()
+	go func() {
+		if err := util.CreateMappedTar(writer, "/", files); err != nil {
+			writer.CloseWithError(err)
+		} else {
+			writer.Close()
+		}
+	}()
+
+	copyCmd := exec.CommandContext(ctx, "docker", "exec", "-i", containerName, "tar", "xmf", "-", "-C", "/", "--no-same-owner")
+	copyCmd.Stdin = reader
+	return copyCmd
+}

--- a/pkg/skaffold/sync/docker_test.go
+++ b/pkg/skaffold/sync/docker_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestDockerSync(t *testing.T) {
+	tests := []struct {
+		description string
+		item        *Item
+		expected    []string
+	}{
+		{
+			description: "additions are added via tar",
+			item: &Item{
+				Image: "image:123",
+				Artifact: &latestV1.Artifact{
+					ImageName: "image",
+				},
+				Copy: syncMap{"test.go": {"/test.go"}},
+			},
+			expected: []string{"docker exec -i image tar xmf - -C / --no-same-owner"},
+		},
+		{
+			description: "one deletion",
+			item: &Item{
+				Image: "image:123",
+				Artifact: &latestV1.Artifact{
+					ImageName: "image",
+				},
+				Delete: syncMap{"test.go": {"/test.go"}},
+			},
+			expected: []string{"docker exec -i image rm -rf -- /test.go"},
+		},
+		{
+			description: "two deletions",
+			item: &Item{
+				Image: "image:123",
+				Artifact: &latestV1.Artifact{
+					ImageName: "image",
+				},
+				Delete: syncMap{"test.go": {"/test.go"}, "foobar.js": {"/dev/js/foobar.js"}},
+			},
+			expected: []string{"docker exec -i image rm -rf -- /dev/js/foobar.js /test.go"},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			cmdRecord := &TestCmdRecorder{}
+
+			t.Override(&util.DefaultExecCommand, cmdRecord)
+			NewContainerSyncer().Sync(context.Background(), nil, test.item)
+
+			// sync maps are unordered, but we can split the resulting command strings and compare elements
+			t.CheckElementsMatch(strings.Split(test.expected[0], " "), strings.Split(cmdRecord.cmds[0], " "))
+		})
+	}
+}

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -848,7 +848,7 @@ func (t *TestCmdRecorder) RunCmdOut(cmd *exec.Cmd) ([]byte, error) {
 	return nil, t.RunCmd(cmd)
 }
 
-func fakeCmd(ctx context.Context, p v1.Pod, c v1.Container, files syncMap) *exec.Cmd {
+func fakeCmd(ctx context.Context, _ v1.Pod, _ v1.Container, files syncMap) *exec.Cmd {
 	var args []string
 
 	for src, dsts := range files {


### PR DESCRIPTION
This change implements file sync behavior for the Docker deployer. The commands used to add/remove files from running containers are very similar to those used for running pods: `docker exec` is used in place of `kubectl exec`. Files to be added are still packaged into a tarball which is extracted in the running container.

**Try the react-reload-docker example.**