### PR TITLE
fix: kubeContext override via flag

### DIFF
--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -41,7 +41,8 @@ type deployerCtx struct {
 }
 
 func (d *deployerCtx) GetKubeContext() string {
-	if d.deploy.KubeContext != "" {
+	// if the kubeContext is not overridden by CLI flag or env. variable then use the value provided in config.
+	if d.RunContext.IsDefaultKubeContext() && d.deploy.KubeContext != "" {
 		return d.deploy.KubeContext
 	}
 	return d.RunContext.GetKubeContext()

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -191,6 +191,7 @@ func (rc *RunContext) WaitForDeletions() config.WaitForDeletions     { return rc
 func (rc *RunContext) WatchPollInterval() int                        { return rc.Opts.WatchPollInterval }
 func (rc *RunContext) BuildConcurrency() int                         { return rc.Opts.BuildConcurrency }
 func (rc *RunContext) IsMultiConfig() bool                           { return rc.Pipelines.IsMultiPipeline() }
+func (rc *RunContext) IsDefaultKubeContext() bool                    { return rc.Opts.KubeContext == "" }
 func (rc *RunContext) GetRunID() string                              { return rc.RunID }
 func (rc *RunContext) RPCPort() int                                  { return rc.Opts.RPCPort }
 func (rc *RunContext) RPCHTTPPort() int                              { return rc.Opts.RPCHTTPPort }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6316 <!-- tracking issues that this PR will close -->
#6024 made some fixes around setting `kubeContext` but reversed the order of preference between `kubeContext` set via flag and set via deploy config

**Description**
This PR ensures the following order:
- flag or env variable overrides the current set kubeContext and also the deploy config kubeContext
- deploy config kubeContext overrides the current set kubeContext
- if neither flag, env var nor config define kubeContext then the current set value is used.
