### PR TITLE
fix: remote manifest image substitution

### DIFF
--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -377,8 +377,8 @@ func (k *Deployer) renderManifests(ctx context.Context, out io.Writer, builds []
 	if err != nil {
 		return nil, deployerr.DebugHelperRetrieveErr(fmt.Errorf("retrieving debug helpers registry: %w", err))
 	}
-
-	manifests, err := k.readManifests(ctx, offline)
+	var localManifests, remoteManifests manifest.ManifestList
+	localManifests, err = k.readManifests(ctx, offline)
 	if err != nil {
 		return nil, err
 	}
@@ -389,17 +389,19 @@ func (k *Deployer) renderManifests(ctx context.Context, out io.Writer, builds []
 			return nil, err
 		}
 
-		manifests = append(manifests, manifest)
+		remoteManifests = append(remoteManifests, manifest)
 	}
 
+	originalManifests := append(localManifests, remoteManifests...)
+
 	if len(k.originalImages) == 0 {
-		k.originalImages, err = manifests.GetImages()
+		k.originalImages, err = originalManifests.GetImages()
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if len(manifests) == 0 {
+	if len(originalManifests) == 0 {
 		return nil, nil
 	}
 
@@ -415,17 +417,26 @@ func (k *Deployer) renderManifests(ctx context.Context, out io.Writer, builds []
 			})
 		}
 	}
+	if len(remoteManifests) > 0 {
+		remoteManifests, err = remoteManifests.ReplaceRemoteManifestImages(ctx, builds)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(localManifests) > 0 {
+		localManifests, err = localManifests.ReplaceImages(ctx, builds)
+		if err != nil {
+			return nil, err
+		}
+	}
 
-	manifests, err = manifests.ReplaceImages(ctx, builds)
-	if err != nil {
+	modifiedManifests := append(localManifests, remoteManifests...)
+
+	if modifiedManifests, err = manifest.ApplyTransforms(modifiedManifests, builds, k.insecureRegistries, debugHelpersRegistry); err != nil {
 		return nil, err
 	}
 
-	if manifests, err = manifest.ApplyTransforms(manifests, builds, k.insecureRegistries, debugHelpersRegistry); err != nil {
-		return nil, err
-	}
-
-	return manifests.SetLabels(k.labeller.Labels())
+	return modifiedManifests.SetLabels(k.labeller.Labels())
 }
 
 // Cleanup deletes what was deployed by calling Deploy.
@@ -451,7 +462,7 @@ func (k *Deployer) Cleanup(ctx context.Context, out io.Writer) error {
 			rm = append(rm, manifest)
 		}
 
-		upd, err := rm.ReplaceImages(ctx, k.originalImages)
+		upd, err := rm.ReplaceRemoteManifestImages(ctx, k.originalImages)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #5855 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Skaffold expects local kubernetes manifests to define `containers[i].image` property exactly equal to `skaffold.yaml`'s `artifacts[i].imageName` without a digest suffix or repository prefix. This works for `kubectl.remoteManifests` deployer only with local clusters like minikube or kind where the image is referenced without digests.

This PR separates the image substitution logic between `localManifests` that need the image name to match artifact `imageName` exactly; and `remoteManifests` that can specify images with digest and repository.

**Testing instructions**
In `examples/getting-started`:
- run `skaffold run`
- modify the skaffold.yaml file to:
```diff
deploy:
  kubectl:
-   manifests:
-     - k8s-*
+  remoteManifests:
+  - pod/getting-started 
```
- run `skaffold dev`
- change `main.go` to print something else
- rebuilt and redeployed pod should now print the new output