### PR TITLE
Support passing additional CLI flags to docker build

### DIFF
--- a/docs/content/en/schemas/v2beta21.json
+++ b/docs/content/en/schemas/v2beta21.json
@@ -1293,6 +1293,15 @@
             "[\"golang:1.10.1-alpine3.7\", \"alpine:3.7\"]"
           ]
         },
+        "cliFlags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "any additional flags to pass to the local daemon during a build. These flags are only used during a build through the Docker CLI.",
+          "x-intellij-html-description": "any additional flags to pass to the local daemon during a build. These flags are only used during a build through the Docker CLI.",
+          "default": "[]"
+        },
         "dockerfile": {
           "type": "string",
           "description": "locates the Dockerfile relative to workspace.",
@@ -1345,6 +1354,7 @@
         "network",
         "addHost",
         "cacheFrom",
+        "cliFlags",
         "noCache",
         "squash",
         "secret",

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -599,6 +599,8 @@ func ToCLIBuildArgs(a *latestV1.DockerArtifact, evaluatedArgs map[string]*string
 		args = append(args, "--cache-from", from)
 	}
 
+	args = append(args, a.CliFlags...)
+
 	if a.Target != "" {
 		args = append(args, "--target", a.Target)
 	}

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -309,6 +309,13 @@ func TestGetBuildArgs(t *testing.T) {
 			want: []string{"--cache-from", "gcr.io/foo/bar", "--cache-from", "baz:latest"},
 		},
 		{
+			description: "additional CLI flags",
+			artifact: &latestV1.DockerArtifact{
+				CliFlags: []string{"--foo", "--bar"},
+			},
+			want: []string{"--foo", "--bar"},
+		},
+		{
 			description: "target",
 			artifact: &latestV1.DockerArtifact{
 				Target: "stage1",
@@ -371,8 +378,9 @@ func TestGetBuildArgs(t *testing.T) {
 				CacheFrom:   []string{"foo"},
 				Target:      "stage1",
 				NetworkMode: "None",
+				CliFlags:    []string{"--foo", "--bar"},
 			},
-			want: []string{"--build-arg", "key1=value1", "--cache-from", "foo", "--target", "stage1", "--network", "none"},
+			want: []string{"--build-arg", "key1=value1", "--cache-from", "foo", "--foo", "--bar", "--target", "stage1", "--network", "none"},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -1286,6 +1286,10 @@ type DockerArtifact struct {
 	// For example: `["golang:1.10.1-alpine3.7", "alpine:3.7"]`.
 	CacheFrom []string `yaml:"cacheFrom,omitempty"`
 
+	// CliFlags are any additional flags to pass to the local daemon during a build.
+	// These flags are only used during a build through the Docker CLI.
+	CliFlags []string `yaml:"cliFlags,omitempty"`
+
 	// NoCache used to pass in --no-cache to docker build to prevent caching.
 	NoCache bool `yaml:"noCache,omitempty"`
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/5638

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This change introduces a new config field, `build.artifacts.docker.cliFlags`, which allows users to send arbitrary flags to the Docker CLI when performing a build. Existing natively-supported flags will be left untouched to preserve backwards compatibility, but we should probably refrain from adding any additional flags via fields in the `DockerArtifact` type.