### PR TITLE
Ensure Cleanup is called if Deploy creates resources but fails

### DIFF
--- a/pkg/skaffold/runner/v1/apply.go
+++ b/pkg/skaffold/runner/v1/apply.go
@@ -53,13 +53,13 @@ func (r *SkaffoldRunner) applyResources(ctx context.Context, out io.Writer, arti
 	defer endTrace()
 	r.deployer.RegisterLocalImages(localImages)
 	err = r.deployer.Deploy(ctx, deployOut, artifacts)
+	r.hasDeployed = true // set even if deploy may have failed, because we want to cleanup any partially created resources
 	postDeployFn()
 	if err != nil {
 		event.DeployFailed(err)
 		endTrace(instrumentation.TraceEndError(err))
 		return err
 	}
-	r.hasDeployed = true
 	event.DeployComplete()
 	return nil
 }

--- a/pkg/skaffold/runner/v1/deploy.go
+++ b/pkg/skaffold/runner/v1/deploy.go
@@ -113,6 +113,7 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 
 	r.deployer.RegisterLocalImages(localAndBuiltImages)
 	err = r.deployer.Deploy(ctx, deployOut, artifacts)
+	r.hasDeployed = true // set even if deploy may have failed, because we want to cleanup any partially created resources
 	postDeployFn()
 	if err != nil {
 		event.DeployFailed(err)
@@ -120,8 +121,6 @@ See https://skaffold.dev/docs/pipeline-stages/taggers/#how-tagging-works`)
 		endTrace(instrumentation.TraceEndError(err))
 		return err
 	}
-
-	r.hasDeployed = true
 
 	statusCheckOut, postStatusCheckFn, err := deployutil.WithStatusCheckLogFile(time.Now().Format(deployutil.TimeFormat)+".log", out, r.runCtx.Muted())
 	defer postStatusCheckFn()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: https://github.com/GoogleContainerTools/skaffold/issues/6285

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
When `skaffold dev` is invoked, an initial `Deploy()` is called. If this call fails, Skaffold will exit, but will not attempt to clean up any deployed resources, because the `Deploy` failed. However, it is possible that some resources were successfully created during this initial deploy, so Skaffold should attempt to clean up in the event this happens so that it does not abandon resources.

Tried on https://github.com/ZeroVocabulary/skaffold-namespace-manifests-inconsistency.

**Before**:
```
➜  skaffold dev
Listing files to watch...
Generating tags...
Checking cache...
Starting test...
Tags used in deployment:
Starting deploy...
 - namespace/test created
 - Error from server (NotFound): error when creating "STDIN": namespaces "test" not found
 - Error from server (NotFound): error when creating "STDIN": namespaces "test" not found
kubectl apply: exit status 1

➜  kubectl get namespaces
NAME                     STATUS   AGE
test                     Active   3s
```

**After**:

```
➜  skaffold dev         
Listing files to watch...
Generating tags...
Checking cache...
Starting test...
Tags used in deployment:
Starting deploy...
 - namespace/test created
 - Error from server (NotFound): error when creating "STDIN": namespaces "test" not found
 - Error from server (NotFound): error when creating "STDIN": namespaces "test" not found
Cleaning up...
 - warning: deleting cluster-scoped resources, not scoped to the provided namespace
 - namespace "test" deleted
kubectl apply: exit status 1

➜  kubectl get namespaces
NAME                     STATUS   AGE
```
