### PR TITLE
Fix issue with displaying survey prompts when we shouldn't

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -122,7 +122,7 @@ func NewSkaffoldCommand(out, errOut io.Writer) *cobra.Command {
 			return nil
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
-			if isQuietMode() && !isHouseKeepingMessagesAllowed(cmd) {
+			if isQuietMode() || !isHouseKeepingMessagesAllowed(cmd) {
 				return
 			}
 			select {


### PR DESCRIPTION
Fixes: #6353

**Description**
Currently in `PersistentPostRun`, we do `if isQuietMode() && !isHouseKeepingMessagesAllowed(cmd)`, but it should be `if isQuietMode() || !isHouseKeepingMessagesAllowed(cmd)`. This change will fix users seeing housekeeping messages when they shouldn't.
