### PR TITLE
Add eventV2.BuildCancelled

### DIFF
--- a/pkg/skaffold/build/scheduler.go
+++ b/pkg/skaffold/build/scheduler.go
@@ -18,6 +18,7 @@ package build
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -113,7 +114,7 @@ func (s *scheduler) build(ctx context.Context, tags tag.ImageTags, i int) error 
 	finalTag, err := performBuild(ctx, w, tags, a, s.artifactBuilder)
 	if err != nil {
 		event.BuildFailed(a.ImageName, err)
-		if ctx.Err() == context.Canceled {
+		if errors.Is(ctx.Err(), context.Canceled) {
 			output.Yellow.Fprintf(w, "Canceled build for %s\n", a.ImageName)
 			eventV2.BuildCanceled(a.ImageName, err)
 		} else {

--- a/pkg/skaffold/build/scheduler.go
+++ b/pkg/skaffold/build/scheduler.go
@@ -86,6 +86,7 @@ func (s *scheduler) build(ctx context.Context, tags tag.ImageTags, i int) error 
 	if err != nil {
 		// `waitForDependencies` only returns `context.Canceled` error
 		event.BuildCanceled(a.ImageName)
+		eventV2.BuildCanceled(a.ImageName, fmt.Errorf("one or more artifact builds failed"))
 		return err
 	}
 	release := s.concurrencySem.acquire()

--- a/pkg/skaffold/build/scheduler.go
+++ b/pkg/skaffold/build/scheduler.go
@@ -114,6 +114,7 @@ func (s *scheduler) build(ctx context.Context, tags tag.ImageTags, i int) error 
 	if err != nil {
 		event.BuildFailed(a.ImageName, err)
 		if ctx.Err() == context.Canceled {
+			output.Yellow.Fprintf(w, "Canceled build for %s\n", a.ImageName)
 			eventV2.BuildCanceled(a.ImageName, err)
 		} else {
 			eventV2.BuildFailed(a.ImageName, err)

--- a/pkg/skaffold/event/v2/build.go
+++ b/pkg/skaffold/event/v2/build.go
@@ -53,6 +53,10 @@ func BuildSucceeded(artifact string) {
 	buildSubtaskEvent(artifact, Build, Succeeded, nil)
 }
 
+func BuildCanceled(artifact string, err error) {
+	buildSubtaskEvent(artifact, Build, Canceled, err)
+}
+
 func buildSubtaskEvent(artifact, step, status string, err error) {
 	var aErr *proto.ActionableErr
 	if err != nil {


### PR DESCRIPTION
Fixes #6307

Add build cancelled if any dependent artifact build fails.

TODO:
- [x] Add build cancelled when dependent artifacts don't fail but other build fails.