### PR TITLE
fix: make `client.Client` kubernetesContext aware

### DIFF
--- a/integration/util.go
+++ b/integration/util.go
@@ -98,7 +98,7 @@ func Run(t *testing.T, dir, command string, args ...string) {
 
 // SetupNamespace creates a Kubernetes namespace to run a test.
 func SetupNamespace(t *testing.T) (*v1.Namespace, *NSKubernetesClient) {
-	client, err := kubernetesclient.Client()
+	client, err := kubernetesclient.DefaultClient()
 	if err != nil {
 		t.Fatalf("Test setup error: getting Kubernetes client: %s", err)
 	}
@@ -128,7 +128,7 @@ func SetupNamespace(t *testing.T) (*v1.Namespace, *NSKubernetesClient) {
 }
 
 func DefaultNamespace(t *testing.T) (*v1.Namespace, *NSKubernetesClient) {
-	client, err := kubernetesclient.Client()
+	client, err := kubernetesclient.DefaultClient()
 	if err != nil {
 		t.Fatalf("Test setup error: getting Kubernetes client: %s", err)
 	}

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -54,7 +54,7 @@ func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace 
 	}
 	artifact.BuildArgs = buildArgs
 
-	client, err := kubernetesclient.Client()
+	client, err := kubernetesclient.DefaultClient()
 	if err != nil {
 		return "", fmt.Errorf("getting Kubernetes client: %w", err)
 	}

--- a/pkg/skaffold/build/cluster/secret.go
+++ b/pkg/skaffold/build/cluster/secret.go
@@ -42,7 +42,7 @@ func (b *Builder) setupPullSecret(ctx context.Context, out io.Writer) (func(), e
 	}
 
 	output.Default.Fprintf(out, "Checking for kaniko secret [%s/%s]...\n", b.Namespace, b.PullSecretName)
-	client, err := kubernetesclient.Client()
+	client, err := kubernetesclient.DefaultClient()
 	if err != nil {
 		return nil, fmt.Errorf("getting Kubernetes client: %w", err)
 	}
@@ -97,7 +97,7 @@ func (b *Builder) setupDockerConfigSecret(ctx context.Context, out io.Writer) (f
 
 	output.Default.Fprintf(out, "Creating docker config secret [%s]...\n", b.DockerConfig.SecretName)
 
-	client, err := kubernetesclient.Client()
+	client, err := kubernetesclient.DefaultClient()
 	if err != nil {
 		return nil, fmt.Errorf("getting Kubernetes client: %w", err)
 	}

--- a/pkg/skaffold/build/cluster/secret_test.go
+++ b/pkg/skaffold/build/cluster/secret_test.go
@@ -35,7 +35,7 @@ func TestCreateSecret(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		tmpDir := t.NewTempDir().Touch("secret.json")
 		fakeKubernetesclient := fake.NewSimpleClientset()
-		t.Override(&client.Client, func() (kubernetes.Interface, error) {
+		t.Override(&client.DefaultClient, func() (kubernetes.Interface, error) {
 			return fakeKubernetesclient, nil
 		})
 
@@ -66,7 +66,7 @@ func TestCreateSecret(t *testing.T) {
 
 func TestExistingSecretNotFound(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
-		t.Override(&client.Client, func() (kubernetes.Interface, error) {
+		t.Override(&client.DefaultClient, func() (kubernetes.Interface, error) {
 			return fake.NewSimpleClientset(), nil
 		})
 
@@ -85,7 +85,7 @@ func TestExistingSecretNotFound(t *testing.T) {
 
 func TestExistingSecret(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
-		t.Override(&client.Client, func() (kubernetes.Interface, error) {
+		t.Override(&client.DefaultClient, func() (kubernetes.Interface, error) {
 			return fake.NewSimpleClientset(&v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "kaniko-secret",
@@ -109,7 +109,7 @@ func TestExistingSecret(t *testing.T) {
 
 func TestSkipSecretCreation(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
-		t.Override(&client.Client, func() (kubernetes.Interface, error) {
+		t.Override(&client.DefaultClient, func() (kubernetes.Interface, error) {
 			return nil, nil
 		})
 

--- a/pkg/skaffold/deploy/component/kubernetes/accessor_test.go
+++ b/pkg/skaffold/deploy/component/kubernetes/accessor_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/access"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/portforward"
 	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -67,7 +68,7 @@ func TestGetAccessor(t *testing.T) {
 			if test.enabled {
 				opts.Append("1") // default enabled mode
 			}
-			a := NewAccessor(mockAccessConfig{opts: opts}, test.description, nil, nil, label.NewLabeller(false, nil, ""), nil)
+			a := NewAccessor(mockAccessConfig{opts: opts}, test.description, &kubectl.CLI{}, nil, label.NewLabeller(false, nil, ""), nil)
 			fmt.Fprintf(os.Stdout, "retrieved accessor: %+v\n", a)
 			t.CheckDeepEqual(test.isNoop, reflect.Indirect(reflect.ValueOf(a)).Type() == reflect.TypeOf(access.NoopAccessor{}))
 		})

--- a/pkg/skaffold/deploy/component/kubernetes/component.go
+++ b/pkg/skaffold/deploy/component/kubernetes/component.go
@@ -72,12 +72,12 @@ func newAccessor(cfg portforward.Config, kubeContext string, cli *kubectl.CLI, p
 	return k8sAccessor[kubeContext]
 }
 
-func newDebugger(mode config.RunMode, podSelector kubernetes.PodSelector, namespaces *[]string) debug.Debugger {
+func newDebugger(mode config.RunMode, podSelector kubernetes.PodSelector, namespaces *[]string, kubeContext string) debug.Debugger {
 	if mode != config.RunModes.Debug {
 		return &debug.NoopDebugger{}
 	}
 
-	return debugging.NewContainerManager(podSelector, namespaces)
+	return debugging.NewContainerManager(podSelector, namespaces, kubeContext)
 }
 
 func newImageLoader(cfg k8sloader.Config, cli *kubectl.CLI) loader.ImageLoader {

--- a/pkg/skaffold/deploy/component/kubernetes/debugger_test.go
+++ b/pkg/skaffold/deploy/component/kubernetes/debugger_test.go
@@ -48,7 +48,7 @@ func TestGetDebugger(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			d := NewDebugger(test.runMode, nil, nil)
+			d := NewDebugger(test.runMode, nil, nil, "")
 			t.CheckDeepEqual(test.isNoop, reflect.Indirect(reflect.ValueOf(d)).Type() == reflect.TypeOf(debug.NoopDebugger{}))
 		})
 	}

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -122,7 +122,7 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latestV1.KptDep
 		podSelector:        podSelector,
 		namespaces:         &namespaces,
 		accessor:           component.NewAccessor(cfg, cfg.GetKubeContext(), kubectl, podSelector, labeller, &namespaces),
-		debugger:           component.NewDebugger(cfg.Mode(), podSelector, &namespaces),
+		debugger:           component.NewDebugger(cfg.Mode(), podSelector, &namespaces, cfg.GetKubeContext()),
 		imageLoader:        component.NewImageLoader(cfg, kubectl),
 		logger:             logger,
 		statusMonitor:      component.NewMonitor(cfg, cfg.GetKubeContext(), labeller, &namespaces),
@@ -232,7 +232,7 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	// Check that the cluster is reachable.
 	// This gives a better error message when the cluster can't
 	// be reached.
-	if err := kubernetes.FailIfClusterIsNotReachable(); err != nil {
+	if err := kubernetes.FailIfClusterIsNotReachable(k.kubeContext); err != nil {
 		return fmt.Errorf("unable to connect to Kubernetes: %w", err)
 	}
 

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -102,7 +102,7 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latestV1.Kubect
 		podSelector:        podSelector,
 		namespaces:         &namespaces,
 		accessor:           component.NewAccessor(cfg, cfg.GetKubeContext(), kubectl.CLI, podSelector, labeller, &namespaces),
-		debugger:           component.NewDebugger(cfg.Mode(), podSelector, &namespaces),
+		debugger:           component.NewDebugger(cfg.Mode(), podSelector, &namespaces, cfg.GetKubeContext()),
 		imageLoader:        component.NewImageLoader(cfg, kubectl.CLI),
 		logger:             logger,
 		statusMonitor:      component.NewMonitor(cfg, cfg.GetKubeContext(), labeller, &namespaces),
@@ -167,7 +167,7 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	// Check that the cluster is reachable.
 	// This gives a better error message when the cluster can't
 	// be reached.
-	if err := kubernetes.FailIfClusterIsNotReachable(); err != nil {
+	if err := kubernetes.FailIfClusterIsNotReachable(k.kubectl.KubeContext); err != nil {
 		return fmt.Errorf("unable to connect to Kubernetes: %w", err)
 	}
 

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -150,7 +150,7 @@ func NewDeployer(cfg kubectl.Config, labeller *label.DefaultLabeller, d *latestV
 		podSelector:         podSelector,
 		namespaces:          &namespaces,
 		accessor:            component.NewAccessor(cfg, cfg.GetKubeContext(), kubectl.CLI, podSelector, labeller, &namespaces),
-		debugger:            component.NewDebugger(cfg.Mode(), podSelector, &namespaces),
+		debugger:            component.NewDebugger(cfg.Mode(), podSelector, &namespaces, cfg.GetKubeContext()),
 		imageLoader:         component.NewImageLoader(cfg, kubectl.CLI),
 		logger:              logger,
 		statusMonitor:       component.NewMonitor(cfg, cfg.GetKubeContext(), labeller, &namespaces),
@@ -222,7 +222,7 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	// Check that the cluster is reachable.
 	// This gives a better error message when the cluster can't
 	// be reached.
-	if err := kubernetes.FailIfClusterIsNotReachable(); err != nil {
+	if err := kubernetes.FailIfClusterIsNotReachable(k.kubectl.KubeContext); err != nil {
 		return fmt.Errorf("unable to connect to Kubernetes: %w", err)
 	}
 

--- a/pkg/skaffold/deploy/label/labels.go
+++ b/pkg/skaffold/deploy/label/labels.go
@@ -43,18 +43,18 @@ const (
 )
 
 // Apply applies all provided labels to the created Kubernetes resources
-func Apply(ctx context.Context, labels map[string]string, results []deploy.Artifact) error {
+func Apply(ctx context.Context, labels map[string]string, results []deploy.Artifact, kubeContext string) error {
 	if len(labels) == 0 {
 		return nil
 	}
 
 	// use the kubectl client to update all k8s objects with a skaffold watermark
-	dynClient, err := kubernetesclient.DynamicClient()
+	dynClient, err := kubernetesclient.DynamicClient(kubeContext)
 	if err != nil {
 		return fmt.Errorf("error getting Kubernetes dynamic client: %w", err)
 	}
 
-	client, err := kubernetesclient.Client()
+	client, err := kubernetesclient.Client(kubeContext)
 	if err != nil {
 		return fmt.Errorf("error getting Kubernetes client: %w", err)
 	}

--- a/pkg/skaffold/deploy/label/labels_test.go
+++ b/pkg/skaffold/deploy/label/labels_test.go
@@ -34,14 +34,14 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func mockClient(m kubernetes.Interface) func() (kubernetes.Interface, error) {
-	return func() (kubernetes.Interface, error) {
+func mockClient(m kubernetes.Interface) func(string) (kubernetes.Interface, error) {
+	return func(string) (kubernetes.Interface, error) {
 		return m, nil
 	}
 }
 
-func mockDynamicClient(m dynamic.Interface) func() (dynamic.Interface, error) {
-	return func() (dynamic.Interface, error) {
+func mockDynamicClient(m dynamic.Interface) func(string) (dynamic.Interface, error) {
+	return func(string) (dynamic.Interface, error) {
 		return m, nil
 	}
 }
@@ -108,7 +108,7 @@ func TestApplyLabels(t *testing.T) {
 			t.Override(&kubernetesclient.DynamicClient, mockDynamicClient(dynClient))
 
 			// Patch labels
-			Apply(context.Background(), test.appliedLabels, []types.Artifact{{Obj: dep}})
+			Apply(context.Background(), test.appliedLabels, []types.Artifact{{Obj: dep}}, "")
 
 			// Check modified value
 			modified, err := dynClient.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Get(context.Background(), "foo", metav1.GetOptions{})

--- a/pkg/skaffold/deploy/util/util.go
+++ b/pkg/skaffold/deploy/util/util.go
@@ -57,7 +57,7 @@ func AddTagsToPodSelector(artifacts []graph.Artifact, deployerArtifacts []graph.
 	}
 }
 
-func MockK8sClient() (k8s.Interface, error) {
+func MockK8sClient(string) (k8s.Interface, error) {
 	return fakekubeclientset.NewSimpleClientset(), nil
 }
 

--- a/pkg/skaffold/hooks/container.go
+++ b/pkg/skaffold/hooks/container.go
@@ -65,7 +65,7 @@ type containerHook struct {
 func (h containerHook) run(ctx context.Context, out io.Writer) error {
 	errs, ctx := errgroup.WithContext(ctx)
 
-	client, err := kubernetesclient.Client()
+	client, err := kubernetesclient.Client(h.cli.KubeContext)
 	if err != nil {
 		return fmt.Errorf("getting Kubernetes client: %w", err)
 	}

--- a/pkg/skaffold/hooks/container_test.go
+++ b/pkg/skaffold/hooks/container_test.go
@@ -98,7 +98,7 @@ func TestContainerRun(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, test.cmd)
-			t.Override(&kubernetesclient.Client, func() (kubernetes.Interface, error) {
+			t.Override(&kubernetesclient.Client, func(string) (kubernetes.Interface, error) {
 				return fakeclient.NewSimpleClientset(test.objects...), nil
 			})
 			h := containerHook{

--- a/pkg/skaffold/hooks/sync_test.go
+++ b/pkg/skaffold/hooks/sync_test.go
@@ -117,7 +117,7 @@ func TestSyncHooks(t *testing.T) {
 	})
 }
 
-func fakeKubernetesClient() (kubernetes.Interface, error) {
+func fakeKubernetesClient(string) (kubernetes.Interface, error) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod1",

--- a/pkg/skaffold/kubernetes/client/client.go
+++ b/pkg/skaffold/kubernetes/client/client.go
@@ -32,20 +32,29 @@ import (
 var (
 	Client        = getClientset
 	DynamicClient = getDynamicClient
+	DefaultClient = getDefaultClientset
 )
 
-func getClientset() (kubernetes.Interface, error) {
-	config, err := context.GetRestClientConfig()
+func getClientset(kubeContext string) (kubernetes.Interface, error) {
+	config, err := context.GetRestClientConfig(kubeContext)
 	if err != nil {
 		return nil, fmt.Errorf("getting client config for Kubernetes client: %w", err)
 	}
 	return kubernetes.NewForConfig(config)
 }
 
-func getDynamicClient() (dynamic.Interface, error) {
-	config, err := context.GetRestClientConfig()
+func getDynamicClient(kubeContext string) (dynamic.Interface, error) {
+	config, err := context.GetRestClientConfig(kubeContext)
 	if err != nil {
 		return nil, fmt.Errorf("getting client config for dynamic client: %w", err)
 	}
 	return dynamic.NewForConfig(config)
+}
+
+func getDefaultClientset() (kubernetes.Interface, error) {
+	config, err := context.GetDefaultRestClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("getting client config for Kubernetes client: %w", err)
+	}
+	return kubernetes.NewForConfig(config)
 }

--- a/pkg/skaffold/kubernetes/context/context.go
+++ b/pkg/skaffold/kubernetes/context/context.go
@@ -54,12 +54,17 @@ func ConfigureKubeConfig(cliKubeConfig, cliKubeContext string) {
 	})
 }
 
-// GetRestClientConfig returns a REST client config for API calls against the Kubernetes API.
+// GetDefaultRestClientConfig returns a REST client config for API calls against the Kubernetes API.
 // If ConfigureKubeConfig was called before, the CurrentContext will be overridden.
 // The kubeconfig used will be cached for the life of the skaffold process after the first call.
 // If the CurrentContext is empty and the resulting config is empty, this method attempts to
 // create a RESTClient with an in-cluster config.
-func GetRestClientConfig() (*restclient.Config, error) {
+func GetDefaultRestClientConfig() (*restclient.Config, error) {
+	return getRestClientConfig(kubeContext, kubeConfigFile)
+}
+
+// GetRestClientConfig returns a REST client config for API calls against the Kubernetes API for the given context.
+func GetRestClientConfig(kubeContext string) (*restclient.Config, error) {
 	return getRestClientConfig(kubeContext, kubeConfigFile)
 }
 

--- a/pkg/skaffold/kubernetes/context/context_test.go
+++ b/pkg/skaffold/kubernetes/context/context_test.go
@@ -124,7 +124,7 @@ func TestGetRestClientConfig(t *testing.T) {
 	testutil.Run(t, "valid context", func(t *testutil.T) {
 		resetKubeConfig(t, validKubeConfig)
 
-		cfg, err := GetRestClientConfig()
+		cfg, err := GetRestClientConfig("")
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual("https://foo.com", cfg.Host)
@@ -134,7 +134,7 @@ func TestGetRestClientConfig(t *testing.T) {
 		resetKubeConfig(t, validKubeConfig)
 
 		kubeContext = clusterBarContext
-		cfg, err := GetRestClientConfig()
+		cfg, err := GetRestClientConfig("")
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual("https://bar.com", cfg.Host)
@@ -143,7 +143,7 @@ func TestGetRestClientConfig(t *testing.T) {
 	testutil.Run(t, "invalid context", func(t *testutil.T) {
 		resetKubeConfig(t, "invalid")
 
-		_, err := GetRestClientConfig()
+		_, err := GetRestClientConfig("")
 
 		t.CheckError(true, err)
 	})
@@ -155,7 +155,7 @@ func TestGetRestClientConfig(t *testing.T) {
 		t.SetEnvs(map[string]string{"KUBECONFIG": kubeConfig})
 		resetConfig()
 
-		cfg, err := GetRestClientConfig()
+		cfg, err := GetRestClientConfig("")
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual("https://bar.com", cfg.Host)
@@ -164,7 +164,7 @@ func TestGetRestClientConfig(t *testing.T) {
 			t.Error(err)
 		}
 
-		cfg, err = GetRestClientConfig()
+		cfg, err = GetRestClientConfig("")
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual("https://bar.com", cfg.Host)
@@ -173,10 +173,10 @@ func TestGetRestClientConfig(t *testing.T) {
 	testutil.Run(t, "change context after first execution", func(t *testutil.T) {
 		resetKubeConfig(t, validKubeConfig)
 
-		_, err := GetRestClientConfig()
+		_, err := GetRestClientConfig("")
 		t.CheckNoError(err)
 		kubeContext = clusterBarContext
-		cfg, err := GetRestClientConfig()
+		cfg, err := GetRestClientConfig("")
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual("https://bar.com", cfg.Host)

--- a/pkg/skaffold/kubernetes/debugging/container_manager.go
+++ b/pkg/skaffold/kubernetes/debugging/container_manager.go
@@ -43,9 +43,10 @@ type ContainerManager struct {
 	events      chan kubernetes.PodEvent
 	stopWatcher func()
 	namespaces  *[]string
+	kubeContext string
 }
 
-func NewContainerManager(podSelector kubernetes.PodSelector, namespaces *[]string) *ContainerManager {
+func NewContainerManager(podSelector kubernetes.PodSelector, namespaces *[]string, kubeContext string) *ContainerManager {
 	// Create the channel here as Stop() may be called before Start() when a build fails, thus
 	// avoiding the possibility of closing a nil channel. Channels are cheap.
 	return &ContainerManager{
@@ -54,6 +55,7 @@ func NewContainerManager(podSelector kubernetes.PodSelector, namespaces *[]strin
 		events:      make(chan kubernetes.PodEvent),
 		stopWatcher: func() {},
 		namespaces:  namespaces,
+		kubeContext: kubeContext,
 	}
 }
 
@@ -64,7 +66,7 @@ func (d *ContainerManager) Start(ctx context.Context) error {
 	}
 
 	d.podWatcher.Register(d.events)
-	stopWatcher, err := d.podWatcher.Start(*d.namespaces)
+	stopWatcher, err := d.podWatcher.Start(d.kubeContext, *d.namespaces)
 	if err != nil {
 		return err
 	}

--- a/pkg/skaffold/kubernetes/logger/log.go
+++ b/pkg/skaffold/kubernetes/logger/log.go
@@ -118,7 +118,7 @@ func (a *LogAggregator) Start(ctx context.Context, out io.Writer) error {
 	a.output = out
 
 	a.podWatcher.Register(a.events)
-	stopWatcher, err := a.podWatcher.Start(*a.namespaces)
+	stopWatcher, err := a.podWatcher.Start(a.kubectlcli.KubeContext, *a.namespaces)
 	a.stopWatcher = stopWatcher
 	if err != nil {
 		return err

--- a/pkg/skaffold/kubernetes/owner.go
+++ b/pkg/skaffold/kubernetes/owner.go
@@ -28,7 +28,7 @@ import (
 
 // TopLevelOwnerKey returns a key associated with the top level
 // owner of a Kubernetes resource in the form Kind-Name
-func TopLevelOwnerKey(ctx context.Context, obj metav1.Object, kind string) string {
+func TopLevelOwnerKey(ctx context.Context, obj metav1.Object, kubeContext string, kind string) string {
 	for {
 		or := obj.GetOwnerReferences()
 		if or == nil {
@@ -36,7 +36,7 @@ func TopLevelOwnerKey(ctx context.Context, obj metav1.Object, kind string) strin
 		}
 		var err error
 		kind = or[0].Kind
-		obj, err = ownerMetaObject(ctx, obj.GetNamespace(), or[0])
+		obj, err = ownerMetaObject(ctx, obj.GetNamespace(), kubeContext, or[0])
 		if err != nil {
 			logrus.Warnf("unable to get owner from reference: %v", or[0])
 			return ""
@@ -44,8 +44,8 @@ func TopLevelOwnerKey(ctx context.Context, obj metav1.Object, kind string) strin
 	}
 }
 
-func ownerMetaObject(ctx context.Context, ns string, owner metav1.OwnerReference) (metav1.Object, error) {
-	client, err := kubernetesclient.Client()
+func ownerMetaObject(ctx context.Context, ns string, kubeContext string, owner metav1.OwnerReference) (metav1.Object, error) {
+	client, err := kubernetesclient.Client(kubeContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/kubernetes/owner_test.go
+++ b/pkg/skaffold/kubernetes/owner_test.go
@@ -33,8 +33,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-func mockClient(m kubernetes.Interface) func() (kubernetes.Interface, error) {
-	return func() (kubernetes.Interface, error) {
+func mockClient(m kubernetes.Interface) func(string) (kubernetes.Interface, error) {
+	return func(string) (kubernetes.Interface, error) {
 		return m, nil
 	}
 }
@@ -105,7 +105,7 @@ func TestTopLevelOwnerKey(t *testing.T) {
 			client := fakekubeclientset.NewSimpleClientset(test.objects...)
 			t.Override(&kubernetesclient.Client, mockClient(client))
 
-			actual := TopLevelOwnerKey(context.Background(), test.initialObject, test.kind)
+			actual := TopLevelOwnerKey(context.Background(), test.initialObject, "", test.kind)
 
 			t.CheckDeepEqual(test.expected, actual)
 		})
@@ -281,7 +281,7 @@ func TestOwnerMetaObject(t *testing.T) {
 			client := fakekubeclientset.NewSimpleClientset(test.objects...)
 			t.Override(&kubernetesclient.Client, mockClient(client))
 
-			actual, err := ownerMetaObject(context.Background(), "ns", test.or)
+			actual, err := ownerMetaObject(context.Background(), "ns", "", test.or)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)

--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
@@ -70,15 +70,15 @@ func NewForwarderManager(cli *kubectl.CLI, podSelector kubernetes.PodSelector, l
 
 	var forwarders []Forwarder
 	if options.ForwardUser(runMode) {
-		forwarders = append(forwarders, NewUserDefinedForwarder(entryManager, userDefined))
+		forwarders = append(forwarders, NewUserDefinedForwarder(entryManager, cli.KubeContext, userDefined))
 	}
 	if options.ForwardServices(runMode) {
-		forwarders = append(forwarders, NewServicesForwarder(entryManager, label))
+		forwarders = append(forwarders, NewServicesForwarder(entryManager, cli.KubeContext, label))
 	}
 	if options.ForwardPods(runMode) {
-		forwarders = append(forwarders, NewWatchingPodForwarder(entryManager, podSelector, allPorts))
+		forwarders = append(forwarders, NewWatchingPodForwarder(entryManager, cli.KubeContext, podSelector, allPorts))
 	} else if options.ForwardDebug(runMode) {
-		forwarders = append(forwarders, NewWatchingPodForwarder(entryManager, podSelector, debugPorts))
+		forwarders = append(forwarders, NewWatchingPodForwarder(entryManager, cli.KubeContext, podSelector, debugPorts))
 	}
 
 	return &ForwarderManager{

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -119,7 +119,7 @@ func (k *KubectlForwarder) forward(parentCtx context.Context, pfe *portForwardEn
 		ctx, cancel := context.WithCancel(parentCtx)
 		pfe.cancel = cancel
 
-		args := portForwardArgs(ctx, pfe)
+		args := portForwardArgs(ctx, k.kubectl.KubeContext, pfe)
 		var buf bytes.Buffer
 		cmd := k.kubectl.CommandWithStrictCancellation(ctx, "port-forward", args...)
 		cmd.Stdout = &buf
@@ -160,14 +160,14 @@ func (k *KubectlForwarder) forward(parentCtx context.Context, pfe *portForwardEn
 	}
 }
 
-func portForwardArgs(ctx context.Context, pfe *portForwardEntry) []string {
+func portForwardArgs(ctx context.Context, kubeContext string, pfe *portForwardEntry) []string {
 	args := []string{"--pod-running-timeout", "1s", "--namespace", pfe.resource.Namespace}
 
 	_, disableServiceForwarding := os.LookupEnv("SKAFFOLD_DISABLE_SERVICE_FORWARDING")
 	switch {
 	case pfe.resource.Type == "service" && !disableServiceForwarding:
 		// Services need special handling: https://github.com/GoogleContainerTools/skaffold/issues/4522
-		podName, remotePort, err := findNewestPodForSvc(ctx, pfe.resource.Namespace, pfe.resource.Name, pfe.resource.Port)
+		podName, remotePort, err := findNewestPodForSvc(ctx, kubeContext, pfe.resource.Namespace, pfe.resource.Name, pfe.resource.Port)
 		if err == nil {
 			args = append(args, fmt.Sprintf("pod/%s", podName), fmt.Sprintf("%d:%d", pfe.localPort, remotePort))
 			break
@@ -244,8 +244,8 @@ func (*KubectlForwarder) monitorLogs(ctx context.Context, logs io.Reader, cmd *k
 // findNewestPodForService queries the cluster to find a pod that fulfills the given service, giving
 // preference to pods that were most recently created.  This is in contrast to the selection algorithm
 // used by kubectl (see https://github.com/GoogleContainerTools/skaffold/issues/4522 for details).
-func findNewestPodForService(ctx context.Context, ns, serviceName string, servicePort schemautil.IntOrString) (string, int, error) {
-	client, err := kubernetesclient.Client()
+func findNewestPodForService(ctx context.Context, kubeContext, ns, serviceName string, servicePort schemautil.IntOrString) (string, int, error) {
+	client, err := kubernetesclient.Client(kubeContext)
 	if err != nil {
 		return "", -1, fmt.Errorf("getting Kubernetes client: %w", err)
 	}

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder_test.go
@@ -235,11 +235,11 @@ func TestPortForwardArgs(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 
-			t.Override(&findNewestPodForSvc, func(ctx context.Context, ns, serviceName string, servicePort schemautil.IntOrString) (string, int, error) {
+			t.Override(&findNewestPodForSvc, func(ctx context.Context, kCtx, ns, serviceName string, servicePort schemautil.IntOrString) (string, int, error) {
 				return test.servicePod, test.servicePort, test.serviceErr
 			})
 
-			args := portForwardArgs(ctx, test.input)
+			args := portForwardArgs(ctx, "", test.input)
 			t.CheckDeepEqual(test.result, args)
 		})
 	}
@@ -416,11 +416,11 @@ func TestFindNewestPodForService(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 			defer cancel()
 
-			t.Override(&client.Client, func() (kubernetes.Interface, error) {
+			t.Override(&client.Client, func(string) (kubernetes.Interface, error) {
 				return fake.NewSimpleClientset(test.clientResources...), test.clientErr
 			})
 
-			pod, port, err := findNewestPodForService(ctx, "", test.serviceName, schemautil.FromInt(test.servicePort))
+			pod, port, err := findNewestPodForService(ctx, "", "", test.serviceName, schemautil.FromInt(test.servicePort))
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.chosenPod, pod)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.chosenPort, port)
 		})

--- a/pkg/skaffold/kubernetes/portforward/pod_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/pod_forwarder_test.go
@@ -405,7 +405,7 @@ func TestAutomaticPortForwardPod(t *testing.T) {
 			testEvent.InitializeState([]latestV1.Pipeline{{}})
 			taken := map[int]struct{}{}
 			t.Override(&retrieveAvailablePort, mockRetrieveAvailablePort(util.Loopback, taken, test.availablePorts))
-			t.Override(&topLevelOwnerKey, func(context.Context, metav1.Object, string) string { return "owner" })
+			t.Override(&topLevelOwnerKey, func(context.Context, metav1.Object, string, string) string { return "owner" })
 
 			if test.forwarder == nil {
 				test.forwarder = newTestForwarder()
@@ -413,7 +413,7 @@ func TestAutomaticPortForwardPod(t *testing.T) {
 			entryManager := NewEntryManager(nil)
 			entryManager.entryForwarder = test.forwarder
 
-			p := NewWatchingPodForwarder(entryManager, kubernetes.NewImageList(), allPorts)
+			p := NewWatchingPodForwarder(entryManager, "", kubernetes.NewImageList(), allPorts)
 			p.Start(context.Background(), ioutil.Discard, nil)
 			for _, pod := range test.pods {
 				err := p.portForwardPod(context.Background(), pod)
@@ -477,7 +477,7 @@ func TestStartPodForwarder(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			testEvent.InitializeState([]latestV1.Pipeline{{}})
-			t.Override(&topLevelOwnerKey, func(context.Context, metav1.Object, string) string { return "owner" })
+			t.Override(&topLevelOwnerKey, func(context.Context, metav1.Object, string, string) string { return "owner" })
 			t.Override(&newPodWatcher, func(kubernetes.PodSelector) kubernetes.PodWatcher {
 				return &fakePodWatcher{
 					events: []kubernetes.PodEvent{test.event},
@@ -490,7 +490,7 @@ func TestStartPodForwarder(t *testing.T) {
 			fakeForwarder := newTestForwarder()
 			entryManager := NewEntryManager(fakeForwarder)
 
-			p := NewWatchingPodForwarder(entryManager, imageList, allPorts)
+			p := NewWatchingPodForwarder(entryManager, "", imageList, allPorts)
 			p.Start(context.Background(), ioutil.Discard, nil)
 
 			// wait for the pod resource to be forwarded
@@ -516,7 +516,7 @@ func (f *fakePodWatcher) Register(receiver chan<- kubernetes.PodEvent) {
 
 func (f *fakePodWatcher) Deregister(_ chan<- kubernetes.PodEvent) {} // noop
 
-func (f *fakePodWatcher) Start(namespaces []string) (func(), error) {
+func (f *fakePodWatcher) Start(kubeContext string, namespaces []string) (func(), error) {
 	go func() {
 		for _, event := range f.events {
 			f.receiver <- event

--- a/pkg/skaffold/kubernetes/status/status_check.go
+++ b/pkg/skaffold/kubernetes/status/status_check.go
@@ -86,6 +86,7 @@ type Monitor struct {
 	seenResources   resource.Group
 	singleRun       singleflight.Group
 	namespaces      *[]string
+	kubeContext     string
 }
 
 // NewStatusMonitor returns a status monitor which runs checks on deployments and pods.
@@ -98,6 +99,7 @@ func NewStatusMonitor(cfg Config, labeller *label.DefaultLabeller, namespaces *[
 		seenResources:   make(resource.Group),
 		singleRun:       singleflight.Group{},
 		namespaces:      namespaces,
+		kubeContext:     cfg.GetKubeContext(),
 	}
 }
 
@@ -132,7 +134,7 @@ func (s *Monitor) Reset() {
 }
 
 func (s *Monitor) statusCheck(ctx context.Context, out io.Writer) (proto.StatusCode, error) {
-	client, err := kubernetesclient.Client()
+	client, err := kubernetesclient.Client(s.kubeContext)
 	if err != nil {
 		return proto.StatusCode_STATUSCHECK_KUBECTL_CLIENT_FETCH_ERR, fmt.Errorf("getting Kubernetes client: %w", err)
 	}

--- a/pkg/skaffold/kubernetes/util.go
+++ b/pkg/skaffold/kubernetes/util.go
@@ -155,8 +155,8 @@ func parseImagesFromYaml(obj interface{}) []string {
 
 // FailIfClusterIsNotReachable checks that Kubernetes is reachable.
 // This gives a clear early error when the cluster can't be reached.
-func FailIfClusterIsNotReachable() error {
-	c, err := client.Client()
+func FailIfClusterIsNotReachable(kubeContext string) error {
+	c, err := client.Client(kubeContext)
 	if err != nil {
 		return err
 	}

--- a/pkg/skaffold/kubernetes/watcher.go
+++ b/pkg/skaffold/kubernetes/watcher.go
@@ -33,7 +33,7 @@ import (
 type PodWatcher interface {
 	Register(receiver chan<- PodEvent)
 	Deregister(receiver chan<- PodEvent)
-	Start(ns []string) (func(), error)
+	Start(kubeContext string, ns []string) (func(), error)
 }
 
 // podWatcher is a pod watcher for multiple namespaces.
@@ -67,7 +67,7 @@ func (w *podWatcher) Deregister(receiver chan<- PodEvent) {
 	w.receiverLock.Unlock()
 }
 
-func (w *podWatcher) Start(namespaces []string) (func(), error) {
+func (w *podWatcher) Start(kubeContext string, namespaces []string) (func(), error) {
 	if len(w.receivers) == 0 {
 		return func() {}, errors.New("no receiver was registered")
 	}
@@ -79,7 +79,7 @@ func (w *podWatcher) Start(namespaces []string) (func(), error) {
 		}
 	}
 
-	kubeclient, err := client.Client()
+	kubeclient, err := client.Client(kubeContext)
 	if err != nil {
 		return func() {}, fmt.Errorf("getting k8s client: %w", err)
 	}

--- a/pkg/skaffold/runner/deployer_test.go
+++ b/pkg/skaffold/runner/deployer_test.go
@@ -175,7 +175,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 		t.Override(&component.NewAccessor, func(portforward.Config, string, *pkgkubectl.CLI, kubernetes.PodSelector, label.Config, *[]string) access.Accessor {
 			return &access.NoopAccessor{}
 		})
-		t.Override(&component.NewDebugger, func(config.RunMode, kubernetes.PodSelector, *[]string) debug.Debugger {
+		t.Override(&component.NewDebugger, func(config.RunMode, kubernetes.PodSelector, *[]string, string) debug.Debugger {
 			return &debug.NoopDebugger{}
 		})
 		t.Override(&component.NewMonitor, func(k8sstatus.Config, string, *label.DefaultLabeller, *[]string) status.Monitor {

--- a/pkg/skaffold/runner/v1/dev_test.go
+++ b/pkg/skaffold/runner/v1/dev_test.go
@@ -95,7 +95,7 @@ func (t *TestMonitor) Run(bool) error {
 
 func (t *TestMonitor) Reset() {}
 
-func mockK8sClient() (k8s.Interface, error) {
+func mockK8sClient(string) (k8s.Interface, error) {
 	return fakekubeclientset.NewSimpleClientset(), nil
 }
 

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -960,11 +960,11 @@ func TestPerform(t *testing.T) {
 			cmdRecord := &TestCmdRecorder{err: test.cmdErr}
 
 			t.Override(&util.DefaultExecCommand, cmdRecord)
-			t.Override(&client.Client, func() (kubernetes.Interface, error) {
+			t.Override(&client.Client, func(string) (kubernetes.Interface, error) {
 				return fake.NewSimpleClientset(test.pod), test.clientErr
 			})
 
-			err := Perform(context.Background(), test.image, test.files, test.cmdFn, []string{""})
+			err := Perform(context.Background(), test.image, test.files, test.cmdFn, []string{""}, "")
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, cmdRecord.cmds)
 		})

--- a/pkg/webhook/kubernetes/deployment.go
+++ b/pkg/webhook/kubernetes/deployment.go
@@ -49,7 +49,7 @@ const (
 // 		2. A container to run hugo server
 // and one emptyDir volume to hold the git repository
 func CreateDeployment(pr *github.PullRequestEvent, svc *v1.Service, externalIP string) (*appsv1.Deployment, error) {
-	client, err := kubernetesclient.Client()
+	client, err := kubernetesclient.DefaultClient()
 	if err != nil {
 		return nil, fmt.Errorf("getting Kubernetes client: %w", err)
 	}
@@ -125,7 +125,7 @@ func CreateDeployment(pr *github.PullRequestEvent, svc *v1.Service, externalIP s
 
 // WaitForDeploymentToStabilize waits till the Deployment has stabilized
 func WaitForDeploymentToStabilize(d *appsv1.Deployment, ip string) error {
-	client, err := kubernetesclient.Client()
+	client, err := kubernetesclient.DefaultClient()
 	if err != nil {
 		return fmt.Errorf("getting Kubernetes client: %w", err)
 	}

--- a/pkg/webhook/kubernetes/service.go
+++ b/pkg/webhook/kubernetes/service.go
@@ -34,7 +34,7 @@ import (
 // CreateService creates a service for the deployment to bind to
 // and returns the external IP of the service
 func CreateService(pr *github.PullRequestEvent) (*v1.Service, error) {
-	client, err := kubernetesclient.Client()
+	client, err := kubernetesclient.DefaultClient()
 	if err != nil {
 		return nil, fmt.Errorf("getting Kubernetes client: %w", err)
 	}
@@ -83,7 +83,7 @@ func serviceName(prNumber int) string {
 }
 
 func getService(svc *v1.Service) (*v1.Service, error) {
-	client, err := kubernetesclient.Client()
+	client, err := kubernetesclient.DefaultClient()
 	if err != nil {
 		return nil, fmt.Errorf("getting Kubernetes client: %w", err)
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6336, #6078 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR mainly changes the signature for functions `client.Client` and `client.DynamicClient` to require a `kubeContext`. The previous behavior of just using the statically set `kubeContext` is fulfilled where required using a new `client.DefaultClient` function.

All other changes are from needing to plumb the correct `kubeContext` across. This is done by either adding a function or method parameter or struct field.

This change should finally fix all scenarios overriding the kubecontext in the `deploy.kubeContext` field in skaffold config.