### PR TITLE
fix status check showing unhealthy pods from prev iteration

### DIFF
--- a/pkg/diag/validator/pod_test.go
+++ b/pkg/diag/validator/pod_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,7 +45,7 @@ func TestRun(t *testing.T) {
 	after := before.Add(3 * time.Second)
 	tests := []struct {
 		description string
-		ownerRef    metav1.OwnerReference
+		ownerRef    metav1.Object
 		pods        []*v1.Pod
 		logOutput   mockLogOutput
 		events      []v1.Event
@@ -730,7 +731,7 @@ func TestRun(t *testing.T) {
 		// Check to diagnose pods with owner references
 		{
 			description: "pods owned by a uuid",
-			ownerRef:    metav1.OwnerReference{UID: "foo"},
+			ownerRef:    &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{UID: "foo"}},
 			pods: []*v1.Pod{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "foo",
@@ -786,9 +787,9 @@ func TestRun(t *testing.T) {
 }
 
 // testPodValidator initializes a PodValidator like NewPodValidator except for loading custom rules
-func testPodValidator(k kubernetes.Interface, ownerRef metav1.OwnerReference) *PodValidator {
+func testPodValidator(k kubernetes.Interface, ownerRef metav1.Object) *PodValidator {
 	rs := []Recommender{recommender.ContainerError{}}
-	return &PodValidator{k: k, recos: rs, ownerRef: ownerRef}
+	return &PodValidator{k: k, recos: rs, controller: ownerRef}
 }
 
 func TestPodConditionChecks(t *testing.T) {

--- a/pkg/skaffold/kubernetes/status/resource/deployment.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment.go
@@ -56,10 +56,21 @@ var (
 	}
 )
 
-type Group map[string]*Deployment
+type Group map[string]struct{}
 
 func (r Group) Add(d *Deployment) {
-	r[d.ID()] = d
+	r[d.ID()] = struct{}{}
+}
+
+func (r Group) AddPods(d *Deployment) {
+	for _, p := range d.pods {
+		id := fmt.Sprintf("%s:%s:%s", p.Name(), p.Namespace(), p.Kind())
+		r[id] = struct{}{}
+	}
+}
+
+func (r Group) AddID(id string) {
+	r[id] = struct{}{}
 }
 
 func (r Group) Contains(d *Deployment) bool {

--- a/pkg/skaffold/kubernetes/status/resource/deployment.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment.go
@@ -56,21 +56,10 @@ var (
 	}
 )
 
-type Group map[string]struct{}
+type Group map[string]*Deployment
 
 func (r Group) Add(d *Deployment) {
-	r[d.ID()] = struct{}{}
-}
-
-func (r Group) AddPods(d *Deployment) {
-	for _, p := range d.pods {
-		id := fmt.Sprintf("%s:%s:%s", p.Name(), p.Namespace(), p.Kind())
-		r[id] = struct{}{}
-	}
-}
-
-func (r Group) AddID(id string) {
-	r[id] = struct{}{}
+	r[d.ID()] = d
 }
 
 func (r Group) Contains(d *Deployment) bool {


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/cloud-code-intellij-internal/issues/4323

In this PR

1) Use owner reference to query pods for a deployment. 
A `Deployment` manages `ReplicaSets`.  When a deployment is updates, a new `ReplicaSet` object is created. 
A `ReplicaSet`'s purpose is to maintain a stable set of replica Pods running at any given time.
Pods are controlled/owned by `ReplicaSet`

When a deployment is updated, a new replicaset is created which controls pods.
This is evident by running `kubectl describe` 
<details> 

```
➜  go-guestbook git:(master) ✗ kubectl describe deployment/go-guestbook-frontend
Name:                   go-guestbook-frontend
...
OldReplicaSets:  <none>
NewReplicaSet:   go-guestbook-frontend-869d5b5fb4 (1/1 replicas created)

```

Make a change to frontend code 
```
➜  go-guestbook git:(master) ✗ kubectl describe deployment/go-guestbook-frontend
...
OldReplicaSets:  <none>
NewReplicaSet:   go-guestbook-frontend-5c8664b8cb (1/1 replicas created)
```
</details


This replica set is used to manage pods.  The appear in the `Pod.Metadata.OwnerReference` 

```
➜  go-guestbook git:(master) ✗ kubectl describe po/go-guestbook-frontend-869d5b5fb4-nsljc
Name:         go-guestbook-frontend-869d5b5fb4-nsljc
Labels:       app=guestbook
              app.kubernetes.io/managed-by=skaffold
              pod-template-hash=869d5b5fb4
              skaffold.dev/run-id=afc3bb01-54bf-4331-b854-3f9591a57ae0
              tier=frontend
Controlled By:  ReplicaSet/go-guestbook-frontend-869d5b5fb4

```

Pods from previous iteration have a different ReplicaSet id. 

This approach is correct because in case a deployment is not updated in a subsequent iteration, k8s scheduler does not spin up new pods for it.  Previous iteration pods keep running. 

Previously we were ignoring status check for previous seen pods. As a result of this, there were no events propagated to these pods. See testing notes -> https://github.com/GoogleContainerTools/skaffold/pull/6370#issuecomment-894339538 

With the updated logic, we rely on 
1) Current replica set for the deployment.
2) Fetch pods belonging to current replica set. 

If a deployment is updated and pods from previous iteration still exist, the diagnose will filter out of pods from previous iteration as they don't belong to updated replica set .

<details>
<summary> Prev approach </summary>
In this PR
 - [ ] Add `ignore` field to pod Validator to ignore pods matching a filter in given namespace
 - [ ] Add `prevPods` field to `kubernetes.StatusMonitor` which will collect all pods from previous iteration
 - [ ] Update the `prevPods` in `status.Monitor.Reset` method.
</details>
