### PR TITLE
Dependency config image.custom.dependencies.command is executed in the parent working directory.

### DIFF
--- a/pkg/skaffold/build/custom/dependencies.go
+++ b/pkg/skaffold/build/custom/dependencies.go
@@ -38,6 +38,7 @@ func GetDependencies(ctx context.Context, workspace string, artifactName string,
 	case a.Dependencies.Command != "":
 		split := strings.Split(a.Dependencies.Command, " ")
 		cmd := exec.CommandContext(ctx, split[0], split[1:]...)
+		cmd.Dir = workspace
 		output, err := util.RunCmdOut(cmd)
 		if err != nil {
 			return nil, fmt.Errorf("getting dependencies from command: %q: %w", a.Dependencies.Command, err)


### PR DESCRIPTION
Dependencies from another directory or a git repository appear to run the custom `dependencies.command`
in the wrong working directory.

### Expected behavior

Successful deployment of dependency and parent.

### Actual behavior

(Added indenting for readability.)

```
getting hash for artifact "foobar": 
  getting dependencies for "foobar": 
    getting dependencies from command: "./test.sh": 
      starting command ./test.sh: 
        fork/exec ./test.sh: no such file or directory
```

### Information

- Skaffold version: v1.28.1
- Operating system: macOS 11.5
- Installed via: homebrew
- Contents of skaffold.yaml:

```
apiVersion: skaffold/v2beta19
kind: Config
build:
  artifacts:
  - image: foobar
    custom:
      buildCommand: ...
      dependencies:
        # This command is not run in the correct working directory 
        # if included as an out of tree dependency (path or git).
        command: ./test.sh 
```

```
apiVersion: skaffold/v2beta19
kind: Config
requires:
  - path: ../dependency
```

See example repo linked below.

### Steps to reproduce the behavior

1.  https://github.com/glennpratt/skaffold-examples
2. `cd parent && skaffold run`
3. See errors

```
❯ skaffold run -vdebug
INFO[0000] Skaffold &{Version:v1.28.1 ConfigVersion:skaffold/v2beta19 GitVersion: GitCommit:7b855e136dc0f9cc5544ed2808c9d5feb767118c BuildDate:2021-07-21T09:34:54Z GoVersion:go1.16.6 Compiler:gc Platform:darwin/amd64 User:} 
INFO[0000] Loaded Skaffold defaults from "/Users/glenn.pratt/.skaffold/config" 
DEBU[0000] found config for context "microk8s"          
DEBU[0000] parsed 1 configs from configuration file /Users/glenn.pratt/Code/skaffold-examples/parent/skaffold.yaml 
DEBU[0000] Defaulting build type to local build         
DEBU[0000] parsed 1 configs from configuration file /Users/glenn.pratt/Code/skaffold-examples/dependency/skaffold.yaml 
DEBU[0000] Defaulting build type to local build         
INFO[0000] Using kubectl context: microk8s              
INFO[0000] Using insecure-registries=[192.168.64.2:32000 localhost:32000 localhost:32000 localhost:32000] from config 
DEBU[0000] Running command: [minikube version --output=json] 
DEBU[0000] Command output: [{"commit":"09ee84d530de4a92f00f1c5dbc34cead092b95bc","minikubeVersion":"v1.18.1"}
] 
DEBU[0000] setting Docker user agent to skaffold-v1.28.1 
DEBU[0000] Using builder: local                         
DEBU[0000] push value not present in NewBuilder, defaulting to true because cluster.PushImages is true 
INFO[0000] build concurrency first set to 1 parsed from *local.Builder[0] 
DEBU[0000] Using builder: local                         
DEBU[0000] push value not present in NewBuilder, defaulting to true because cluster.PushImages is true 
INFO[0000] build concurrency value 0 parsed from *local.Builder[1] is ignored since it's not less than previously set value 1 
INFO[0000] final build concurrency value is 1           
Generating tags...
 - foobar -> DEBU[0000] Running command: [git describe --tags --always] 
DEBU[0000] Command output: [4d191e9
]                   
DEBU[0000] Running command: [git status . --porcelain]  
DEBU[0000] Command output: []                           
INFO[0000] Using default-repo=localhost:32000 from config 
localhost:32000/foobar:4d191e9
INFO[0000] Tags generated in 51.886852ms                
Checking cache...
DEBU[0000] Running command: [./test.sh]                 
 - foobar: Error checking cache.
DEBU[0000] Running command: [tput colors]               
DEBU[0000] Command output: [256
]                       
getting hash for artifact "foobar": getting dependencies for "foobar": getting dependencies from command: "./test.sh": starting command ./test.sh: fork/exec ./test.sh: no such file or directory
DEBU[0000] exporting metrics        
```
