### PR TITLE
Add support for Kaniko flag --image-fs-extract-retry

### DIFF
--- a/docs/content/en/schemas/v2beta21.json
+++ b/docs/content/en/schemas/v2beta21.json
@@ -2146,6 +2146,11 @@
           "description": "Docker image used by the Kaniko pod. Defaults to the latest released version of `gcr.io/kaniko-project/executor`.",
           "x-intellij-html-description": "Docker image used by the Kaniko pod. Defaults to the latest released version of <code>gcr.io/kaniko-project/executor</code>."
         },
+        "imageFSExtractRetry": {
+          "type": "string",
+          "description": "number of retries that should happen for extracting an image filesystem.",
+          "x-intellij-html-description": "number of retries that should happen for extracting an image filesystem."
+        },
         "imageNameWithDigestFile": {
           "type": "string",
           "description": "specify a file to save the image name with digest of the built image to.",
@@ -2325,6 +2330,7 @@
         "initImage",
         "image",
         "digestFile",
+        "imageFSExtractRetry",
         "imageNameWithDigestFile",
         "logFormat",
         "ociLayoutPath",

--- a/pkg/skaffold/build/gcb/kaniko_test.go
+++ b/pkg/skaffold/build/gcb/kaniko_test.go
@@ -108,6 +108,16 @@ func TestKanikoBuildSpec(t *testing.T) {
 			},
 		},
 		{
+			description: "with ImageFSExtractRetry",
+			artifact: &latestV1.KanikoArtifact{
+				DockerfilePath:      "Dockerfile",
+				ImageFSExtractRetry: "5",
+			},
+			expectedArgs: []string{
+				"--image-fs-extract-retry", "5",
+			},
+		},
+		{
 			description: "with ImageNameWithDigestFile",
 			artifact: &latestV1.KanikoArtifact{
 				DockerfilePath:          "Dockerfile",

--- a/pkg/skaffold/build/kaniko/args.go
+++ b/pkg/skaffold/build/kaniko/args.go
@@ -73,6 +73,10 @@ func Args(artifact *latestV1.KanikoArtifact, tag, context string) ([]string, err
 		args = append(args, ForceFlag)
 	}
 
+	if artifact.ImageFSExtractRetry != "" {
+		args = append(args, ImageFSExtractRetryFlag, artifact.ImageFSExtractRetry)
+	}
+
 	if artifact.ImageNameWithDigestFile != "" {
 		args = append(args, ImageNameWithDigestFileFlag, artifact.ImageNameWithDigestFile)
 	}

--- a/pkg/skaffold/build/kaniko/types.go
+++ b/pkg/skaffold/build/kaniko/types.go
@@ -35,6 +35,8 @@ const (
 	DigestFileFlag = "--digest-file"
 	// ForceFlag additional flag
 	ForceFlag = "--force"
+	// ImageFSExtractRetry additional flag
+	ImageFSExtractRetryFlag = "--image-fs-extract-retry"
 	// ImageNameWithDigestFileFlag  additional flag
 	ImageNameWithDigestFileFlag = "--image-name-with-digest-file"
 	// InsecureFlag additional flag

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -1197,6 +1197,9 @@ type KanikoArtifact struct {
 	// This can be used to automatically track the exact image built by kaniko.
 	DigestFile string `yaml:"digestFile,omitempty"`
 
+	// ImageFSExtractRetry is the number of retries that should happen for extracting an image filesystem.
+	ImageFSExtractRetry string `yaml:"imageFSExtractRetry,omitempty"`
+
 	// ImageNameWithDigestFile specify a file to save the image name with digest of the built image to.
 	ImageNameWithDigestFile string `yaml:"imageNameWithDigestFile,omitempty"`
 


### PR DESCRIPTION
Hi! My first pull request here 👋 

**Related**: 
- PR I used for reference: #6211
- PR that added the flag to Kaniko: https://github.com/GoogleContainerTools/kaniko/pull/1685

**Description**
Adds support for a newly introduced Kaniko flag, `--image-fs-extract-retry`. This is important for GCB users, as builds fail often and need to be retried by hand without this flag.

**User facing changes**
New configuration option `imageFSExtractRetry` in the kaniko section.

_Side Note:_ I wanted to play with the `--cache-copy-layers` flag as well, but this is also missing. Perhaps the previous architecture where the user could add additionalFlags themselves was better ([changed here](https://github.com/GoogleContainerTools/skaffold/pull/4900/files)). It would definitely be useful to be able to add custom flags without waiting for a skaffold release.