### PR TITLE
remove single `kubeContext` validation

### DIFF
--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -80,7 +80,6 @@ func Process(configs parser.SkaffoldConfigSet, validateConfig Options) error {
 		errs = append(errs, wrapWithContext(config, cfgErrs...)...)
 	}
 	errs = append(errs, validateArtifactDependencies(configs)...)
-	errs = append(errs, validateSingleKubeContext(configs)...)
 	if validateConfig.CheckDeploySource {
 		// TODO(6050) validate for other deploy types - helm, kpt, etc.
 		errs = append(errs, validateKubectlManifests(configs)...)
@@ -551,19 +550,6 @@ func validateLogPrefix(lc latestV1.LogsConfig) []error {
 		return []error{fmt.Errorf("invalid log prefix '%s'. Valid values are 'auto', 'container', 'podAndContainer' or 'none'", lc.Prefix)}
 	}
 
-	return nil
-}
-
-func validateSingleKubeContext(configs parser.SkaffoldConfigSet) []error {
-	if len(configs) < 2 {
-		return nil
-	}
-	k := configs[0].Deploy.KubeContext
-	for _, c := range configs {
-		if c.Deploy.KubeContext != k {
-			return []error{errors.New("all configs should have the same value for `deploy.kubeContext`")}
-		}
-	}
 	return nil
 }
 

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -18,7 +18,6 @@ package validation
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1246,80 +1245,6 @@ func TestValidateUniqueDependencyAliases(t *testing.T) {
 	}
 	errs := validateArtifactDependencies(cfgs)
 	testutil.CheckDeepEqual(t, expected, errs, cmp.Comparer(errorsComparer))
-}
-
-func TestValidateSingleKubeContext(t *testing.T) {
-	tests := []struct {
-		description string
-		configs     []*latestV1.SkaffoldConfig
-		err         []error
-	}{
-		{
-			description: "different kubeContext specified",
-			configs: []*latestV1.SkaffoldConfig{
-				{
-					Pipeline: latestV1.Pipeline{
-						Deploy: latestV1.DeployConfig{
-							KubeContext: "",
-						},
-					},
-				},
-				{
-					Pipeline: latestV1.Pipeline{
-						Deploy: latestV1.DeployConfig{
-							KubeContext: "foo",
-						},
-					},
-				},
-			},
-			err: []error{errors.New("all configs should have the same value for `deploy.kubeContext`")},
-		},
-		{
-			description: "same kubeContext specified",
-			configs: []*latestV1.SkaffoldConfig{
-				{
-					Pipeline: latestV1.Pipeline{
-						Deploy: latestV1.DeployConfig{
-							KubeContext: "foo",
-						},
-					},
-				},
-				{
-					Pipeline: latestV1.Pipeline{
-						Deploy: latestV1.DeployConfig{
-							KubeContext: "foo",
-						},
-					},
-				},
-			},
-		},
-		{
-			description: "no kubeContext specified",
-			configs: []*latestV1.SkaffoldConfig{
-				{
-					Pipeline: latestV1.Pipeline{
-						Deploy: latestV1.DeployConfig{},
-					},
-				},
-				{
-					Pipeline: latestV1.Pipeline{
-						Deploy: latestV1.DeployConfig{},
-					},
-				},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		testutil.Run(t, test.description, func(t *testutil.T) {
-			set := parser.SkaffoldConfigSet{}
-			for _, c := range test.configs {
-				set = append(set, &parser.SkaffoldConfigEntry{SkaffoldConfig: c})
-			}
-			errs := validateSingleKubeContext(set)
-			t.CheckDeepEqual(test.err, errs, cmp.Comparer(errorsComparer))
-		})
-	}
 }
 
 func TestValidateValidDependencyAliases(t *testing.T) {


### PR DESCRIPTION
In #6331 and #6368 we fixed `kubeContext` resolution issues. We should now be able to define different `kubeContext` per skaffold module. This PR removes this validation. 

Testing instruction:
Modify `examples/microservices/skaffold.yaml` to:
```yaml
apiVersion: skaffold/v2beta21
kind: Config
build:
  artifacts:
    - image: leeroy-web
      context: leeroy-web
      requires:
        - image: base
          alias: BASE
    - image: leeroy-app
      context: leeroy-app
      requires:
        - image: base
          alias: BASE
    - image: base
      context: base
deploy:
  kubeContext: kind-kind1
  kubectl:
    manifests:
      - leeroy-web/kubernetes/*
      - leeroy-app/kubernetes/*
portForward:
  - resourceType: deployment
    resourceName: leeroy-web
    port: 8080
    localPort: 9000
  - resourceType: deployment
    resourceName: leeroy-app
    port: http
    localPort: 9001
---
apiVersion: skaffold/v2beta20
kind: Config
deploy:
  kubeContext: kind-kind2
  kubectl:
    manifests:
      - leeroy-web/kubernetes/*
      - leeroy-app/kubernetes/*
portForward:
  - resourceType: deployment
    resourceName: leeroy-web
    port: 8080
    localPort: 9002
  - resourceType: deployment
    resourceName: leeroy-app
    port: http
    localPort: 9003
```

This just copies the `deploy` to another config and both configs deploy to different clusters (`kind1` and `kind2` in this case).
Running `skaffold dev` should deploy to both clusters, show logs from both clusters and port-forward from both clusters. 