### PR TITLE
Cleanup pod `SkaffoldLogEvent` messages

### DIFF
--- a/pkg/skaffold/event/v2/status_check.go
+++ b/pkg/skaffold/event/v2/status_check.go
@@ -80,7 +80,7 @@ func ResourceStatusCheckEventUpdatedMessage(r string, message string, ae proto.A
 	handler.handleSkaffoldLogEvent(&proto.SkaffoldLogEvent{
 		TaskId:    fmt.Sprintf("%s-%d", constants.Deploy, handler.iteration),
 		SubtaskId: r,
-		Message:   fmt.Sprintf("%s %s", message, ae.Message),
+		Message:   fmt.Sprintf("%s %s\n", message, ae.Message),
 		Level:     -1,
 	})
 }

--- a/pkg/skaffold/kubernetes/status/resource/deployment.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment.go
@@ -294,17 +294,20 @@ func (d *Deployment) fetchPods(ctx context.Context) error {
 		originalPod, found := d.pods[p.String()]
 		if !found || originalPod.StatusUpdated(p) {
 			d.status.changed = true
-			prefix := fmt.Sprintf("%s %s: ", tabHeader, p.String())
+			prefix := fmt.Sprintf("%s %s:", tabHeader, p.String())
 			switch p.ActionableError().ErrCode {
 			case proto.StatusCode_STATUSCHECK_CONTAINER_CREATING,
 				proto.StatusCode_STATUSCHECK_POD_INITIALIZING:
 				event.ResourceStatusCheckEventUpdated(p.String(), p.ActionableError())
-				eventV2.ResourceStatusCheckEventUpdatedMessage(p.String(), prefix, sErrors.V2fromV1(p.ActionableError()))
+				eventV2.ResourceStatusCheckEventUpdatedMessage(
+					p.String(),
+					prefix,
+					sErrors.V2fromV1(p.ActionableError()))
 			default:
 				event.ResourceStatusCheckEventCompleted(p.String(), p.ActionableError())
 				eventV2.ResourceStatusCheckEventCompletedMessage(
 					p.String(),
-					fmt.Sprintf("%s%s created.", prefix, p.String()),
+					fmt.Sprintf("%s running.\n", prefix),
 					sErrors.V2fromV1(p.ActionableError()))
 			}
 		}


### PR DESCRIPTION
**Related**: #5368 

**Description**
This PR fixes some of the messages that are emitted during the status check phase. Namely, it adds newlines for the pod messages.


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
