### PR TITLE
    [v2] Improve user experience on specifying inventory in kpt v2 deployer.

### DIFF
--- a/pkg/skaffold/deploy/v2/kpt/errors.go
+++ b/pkg/skaffold/deploy/v2/kpt/errors.go
@@ -86,7 +86,7 @@ func liveApplyErr(err error, path string) error {
 					Action: fmt.Sprintln("if you encounter an inventory mismatch (or can't adopt) error, it indicates " +
 						"the manifests have been deployed before and may not be properly cleaned up. We provide two solutions:\n " +
 						"#1: Update your skaffold.yaml by adding the `--inventory-policy=adopt` in the " +
-						"`.deploy.kpt.flags`. This will override the resources' inventory.\n " +
+						"`.deploy.kpt.applyFlags`. This will override the resources' inventory.\n " +
 						"#2: Find the existing inventory from your cluster resource's annotation \"cli-utils.sigs.k8s.io/inventory-id\", " +
 						" then use this inventory-id to look for the inventory name and namespace by running " +
 						"`kubectl get resourcegroups.kpt.dev -oyaml | grep <YOUR_INVENTORY_ID> -C20 | grep \"name: inventory-\" -C1` " +

--- a/pkg/skaffold/schema/latest/v2/config.go
+++ b/pkg/skaffold/schema/latest/v2/config.go
@@ -555,7 +555,10 @@ type KptV2Deploy struct {
 	// hydrated path `<WORKDIR>/.kpt-pipeline`.
 	Dir string `yaml:"dir,omitempty"`
 
-	// Flags are additional flags passed to `kpt live apply`.
+	// ApplyFlags are additional flags passed to `kpt live apply`.
+	ApplyFlags []string `yaml:"applyFlags,omitempty"`
+
+	// Flags are kpt global flags.
 	Flags []string `yaml:"flags,omitempty"`
 
 	// Name *alpha* is the inventory object name.
@@ -564,6 +567,9 @@ type KptV2Deploy struct {
 	InventoryID string `yaml:"inventoryID,omitempty"`
 	// InventoryNamespace *alpha* sets the inventory namespace.
 	InventoryNamespace string `yaml:"namespace,omitempty"`
+
+	// Forces is used in `kpt live init`, which forces the inventory values to be updated, even if they are already set.
+	Force bool `yaml:"false,omitempty"`
 
 	// LifecycleHooks describes a set of lifecycle hooks that are executed before and after every deploy.
 	LifecycleHooks DeployHooks `yaml:"-"`

--- a/pkg/skaffold/schema/v3alpha1/config.go
+++ b/pkg/skaffold/schema/v3alpha1/config.go
@@ -551,12 +551,14 @@ type Validator struct {
 
 // KptV2Deploy contains all the configuration needed by the deploy steps.
 type KptV2Deploy struct {
-
-	// Dir is equivalent to the dir in `kpt live apply <dir>`. If not provided, skaffold renders the raw manifests
-	// and store them to a a hidden directory `.kpt-pipeline`, and deploys the hidden directory.
+	// Dir is equivalent to the dir in `kpt live apply <dir>`. If not provided, skaffold deploys from the default
+	// hydrated path `<WORKDIR>/.kpt-pipeline`.
 	Dir string `yaml:"dir,omitempty"`
 
-	// Flags are additional flags passed to `kpt live apply`.
+	// ApplyFlags are additional flags passed to `kpt live apply`.
+	ApplyFlags []string `yaml:"applyFlags,omitempty"`
+
+	// Flags are kpt global flags.
 	Flags []string `yaml:"flags,omitempty"`
 
 	// Name *alpha* is the inventory object name.
@@ -565,6 +567,9 @@ type KptV2Deploy struct {
 	InventoryID string `yaml:"inventoryID,omitempty"`
 	// InventoryNamespace *alpha* sets the inventory namespace.
 	InventoryNamespace string `yaml:"namespace,omitempty"`
+
+	// Forces is used in `kpt live init`, which forces the inventory values to be updated, even if they are already set.
+	Force bool `yaml:"false,omitempty"`
 
 	// LifecycleHooks describes a set of lifecycle hooks that are executed before and after every deploy.
 	LifecycleHooks DeployHooks `yaml:"-"`


### PR DESCRIPTION
**Related**: #5673 
**Merge after**: #6388

**Description**
1. separate `deploy.kpt.flags` to global flags and applyFlags
2. handle default namespace.

