### PR TITLE
Fix log line container not found in logging api

### DIFF
--- a/pkg/diag/validator/pod_test.go
+++ b/pkg/diag/validator/pod_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,7 +45,7 @@ func TestRun(t *testing.T) {
 	after := before.Add(3 * time.Second)
 	tests := []struct {
 		description string
-		ownerRef    metav1.OwnerReference
+		ownerRef    metav1.Object
 		pods        []*v1.Pod
 		logOutput   mockLogOutput
 		events      []v1.Event
@@ -730,7 +731,7 @@ func TestRun(t *testing.T) {
 		// Check to diagnose pods with owner references
 		{
 			description: "pods owned by a uuid",
-			ownerRef:    metav1.OwnerReference{UID: "foo"},
+			ownerRef:    &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{UID: "foo"}},
 			pods: []*v1.Pod{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "foo",
@@ -786,9 +787,9 @@ func TestRun(t *testing.T) {
 }
 
 // testPodValidator initializes a PodValidator like NewPodValidator except for loading custom rules
-func testPodValidator(k kubernetes.Interface, ownerRef metav1.OwnerReference) *PodValidator {
+func testPodValidator(k kubernetes.Interface, ownerRef metav1.Object) *PodValidator {
 	rs := []Recommender{recommender.ContainerError{}}
-	return &PodValidator{k: k, recos: rs, ownerRef: ownerRef}
+	return &PodValidator{k: k, recos: rs, controller: ownerRef}
 }
 
 func TestPodConditionChecks(t *testing.T) {

--- a/pkg/skaffold/kubernetes/logger/log.go
+++ b/pkg/skaffold/kubernetes/logger/log.go
@@ -224,7 +224,6 @@ func (a *LogAggregator) Unmute() {
 		// Logs are not activated.
 		return
 	}
-	
 	atomic.StoreInt32(&a.muted, 0)
 }
 

--- a/pkg/skaffold/kubernetes/logger/log.go
+++ b/pkg/skaffold/kubernetes/logger/log.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
@@ -138,6 +139,10 @@ func (a *LogAggregator) Start(ctx context.Context, out io.Writer) error {
 
 				// TODO(dgageot): Add EphemeralContainerStatuses
 				pod := evt.Pod
+				if evt.Type == watch.Deleted {
+					continue
+				}
+
 				for _, c := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
 					if c.ContainerID == "" {
 						if c.State.Waiting != nil && c.State.Waiting.Message != "" {
@@ -219,7 +224,7 @@ func (a *LogAggregator) Unmute() {
 		// Logs are not activated.
 		return
 	}
-
+	
 	atomic.StoreInt32(&a.muted, 0)
 }
 

--- a/pkg/skaffold/kubernetes/status/resource/deployment.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment.go
@@ -56,10 +56,21 @@ var (
 	}
 )
 
-type Group map[string]*Deployment
+type Group map[string]struct{}
 
 func (r Group) Add(d *Deployment) {
-	r[d.ID()] = d
+	r[d.ID()] = struct{}{}
+}
+
+func (r Group) AddPods(d *Deployment) {
+	for _, p := range d.pods {
+		id := fmt.Sprintf("%s:%s:%s", p.Name(), p.Namespace(), p.Kind())
+		r[id] = struct{}{}
+	}
+}
+
+func (r Group) AddID(id string) {
+	r[id] = struct{}{}
 }
 
 func (r Group) Contains(d *Deployment) bool {

--- a/pkg/skaffold/kubernetes/status/resource/deployment.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment.go
@@ -56,21 +56,10 @@ var (
 	}
 )
 
-type Group map[string]struct{}
+type Group map[string]*Deployment
 
 func (r Group) Add(d *Deployment) {
-	r[d.ID()] = struct{}{}
-}
-
-func (r Group) AddPods(d *Deployment) {
-	for _, p := range d.pods {
-		id := fmt.Sprintf("%s:%s:%s", p.Name(), p.Namespace(), p.Kind())
-		r[id] = struct{}{}
-	}
-}
-
-func (r Group) AddID(id string) {
-	r[id] = struct{}{}
+	r[d.ID()] = d
 }
 
 func (r Group) Contains(d *Deployment) bool {

--- a/pkg/skaffold/log/stream/stream.go
+++ b/pkg/skaffold/log/stream/stream.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -38,8 +39,11 @@ func StreamRequest(ctx context.Context, out io.Writer, formatter log.Formatter, 
 		default:
 			// Read up to newline
 			line, err := r.ReadString('\n')
+			// As per https://github.com/kubernetes/kubernetes/blob/017b359770e333eacd3efcb4174f1d464c208400/test/e2e/storage/podlogs/podlogs.go#L214
+			// Filter out the expected "end of stream" error message and
+			// attempts to read logs from a container that isn't ready (yet?!).
 			if err == io.EOF {
-				if line != "" {
+				if !isEmptyOrContainerNotReady(line) {
 					formatter.PrintLine(out, line)
 				}
 				return nil
@@ -50,4 +54,11 @@ func StreamRequest(ctx context.Context, out io.Writer, formatter log.Formatter, 
 			formatter.PrintLine(out, line)
 		}
 	}
+}
+
+func isEmptyOrContainerNotReady(line string) bool {
+	return line == "" ||
+		strings.HasPrefix(line, "rpc error: code = Unknown desc = Error: No such container:") ||
+		strings.HasPrefix(line, "unable to retrieve container logs for ") ||
+		strings.HasPrefix(line, "Unable to retrieve container logs for ")
 }

--- a/pkg/skaffold/log/stream/stream.go
+++ b/pkg/skaffold/log/stream/stream.go
@@ -41,7 +41,8 @@ func StreamRequest(ctx context.Context, out io.Writer, formatter log.Formatter, 
 			line, err := r.ReadString('\n')
 			// As per https://github.com/kubernetes/kubernetes/blob/017b359770e333eacd3efcb4174f1d464c208400/test/e2e/storage/podlogs/podlogs.go#L214
 			// Filter out the expected "end of stream" error message and
-			// attempts to read logs from a container that isn't ready (yet?!).
+			// attempts to read logs from a container that was deleted due to re-deploy or
+			// attempts to read logs from a container that is not ready yet.
 			if err == io.EOF {
 				if !isEmptyOrContainerNotReady(line) {
 					formatter.PrintLine(out, line)

--- a/pkg/skaffold/log/stream/stream_test.go
+++ b/pkg/skaffold/log/stream/stream_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stream
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestIsEmptyOrContainerNotReady(t *testing.T) {
+	tests := []struct {
+		description string
+		line        string
+		expected    bool
+	}{
+		{
+			description: "empty line",
+			line:        "",
+			expected:    true,
+		},
+		{
+			description: "container not ready",
+			line:        "rpc error: code = Unknown desc = Error: No such container: fa7802b2206f84f4f1e166a7a640523a281031c4c95d1709d38d62680391b97c",
+			expected:    true,
+		},
+		{
+			description: "logs could not be retrieved",
+			line:        "unable to retrieve container logs for fa7802b2206f84f4f1e166a7a640523a281031c4c95d1709d38d62680391b97c",
+			expected:    true,
+		},
+		{
+			description: "logs could not be retrieved",
+			line:        "Unable to retrieve container logs for fa7802b2206f84f4f1e166a7a640523a281031c4c95d1709d38d62680391b97c",
+			expected:    true,
+		},
+		{
+			description: "actual log",
+			line:        "log line",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.CheckDeepEqual(test.expected, isEmptyOrContainerNotReady(test.line))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
relates to GoogleCloudPlatform/cloud-code-intellij-internal#4323
follow from testing of #6370

When testing #6370, @etanshaul mentioned, he saw `ApplicationLogEvent`

```
applicationLogEvent {
  containerName: "frontend"
  podName: "java-guestbook-frontend-8cd49999c-tlbr9"
  prefix: "\033[92m[frontend]\033[0m "
  message: "rpc error: code = Unknown desc = Error: No such container: fa7802b2206f84f4f1e166a7a640523a281031c4c95d1709d38d62680391b97c"
  richFormattedMessage: "\033[92m[frontend]\033[0m rpc error: code = Unknown desc = Error: No such container: fa7802b2206f84f4f1e166a7a640523a281031c4c95d1709d38d62680391b97c"
}


```


<details> 
<summary> Steps to reproduce </summary>
1) Run the guestbook app (I used the Java one)
2) Introduce a build error (I made a compilation error in frontend) - let skaffold run and error out
3) Fix the error - let skaffold run
4) Make another change in frontend (one that doesn't break the build) and let skaffold run -> I see multiple frontend containers in app log events
</details>

### Description of change:
After digging in the code, we stream container logs in pkg/skaffold/kubernetes/logger here https://github.com/GoogleContainerTools/skaffold/blob/main/pkg/skaffold/kubernetes/logger/log.go#L150
in `Logger.Start()`
However, we never stop this process when a new dev iteration is starts. We **only** mute logs before a new dev iteration starts. Muting will make sure that no container logs are read and printed since that point of time.
Skaffold relies on the `kubectl logs` behaviour which exits when an error encounters.  `kubectl logs pod/xxx -c xxx -f`  print line `rpc error: code = Unknown desc = Error: No such container: ` before exiting.

We have a race condition here  between
1) When a logger is muted and
2) When `kubectl log` gets killed.

If 1) happens before 2) then you don't see the `rpc error: code = Unknown desc = Error: No such container: fa7802b2206f84f4f1e166a7a640523a281031c4c95d1709d38d62680391b97c` line. 
If 2) happens before 1) then unfortunately this line will be read from log stream and relayed to event API



### CLI Reproduction steps. 
On master before this change, 
1.  run `skaffold dev` on any example
2.  run `kubectl logs -f pod/frontend-XXXXX
3. Make a change to frontend and you will see the 
```
kubectl logs -f java-guestbook-frontend-56c884765d-527wm
Picked up JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y
ping....
  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::                (v2.5.1)
....

rpc error: code = Unknown desc = Error: No such container: 51dcf01b9b4c70f785dbe77f1b576baaca406d3f728ca144cedfc9d2c3e7e5cb% 
```


In this PR, 
1) if log for a container are not found, we will ignore them.

2) Don't add containers to track if a pod is deleted so we don't stream logs for deleted pod, containers. 

Follow up
1) Should we stop logger instead of mute, unmute between dev loops?