### PR TITLE
Set exit code 127 for CLI validation errors

### DIFF
--- a/cmd/skaffold/app/exitcode.go
+++ b/cmd/skaffold/app/exitcode.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package app
+
+import (
+	"errors"
+	"regexp"
+)
+
+type ExitCoder interface {
+	ExitCode() int
+}
+
+// ExitCode extracts the exit code from the error.
+func ExitCode(err error) int {
+	var exitCoder ExitCoder
+	if errors.As(err, &exitCoder) {
+		return exitCoder.ExitCode()
+	}
+	return 1
+}
+
+type invalidUsageError struct{ err error }
+
+func (i invalidUsageError) Unwrap() error { return i.err }
+func (i invalidUsageError) Error() string { return i.err.Error() }
+func (i invalidUsageError) ExitCode() int { return 127 }
+
+// compiled list of common validation error prefixes from cobra/args.go and cobra/command.go based on skaffold's usage
+var cobraUsageErrorPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`^unknown command`),
+	regexp.MustCompile(`^unknown( shorthand)? flag`),
+	regexp.MustCompile(`^flag needs an argument:`),
+	regexp.MustCompile(`^invalid argument `),
+	regexp.MustCompile(`^accepts.*, received `),
+}
+
+func extractInvalidUsageError(err error) error {
+	if err == nil {
+		return nil
+	}
+	for _, pattern := range cobraUsageErrorPatterns {
+		if pattern.MatchString(err.Error()) {
+			return invalidUsageError{err}
+		}
+	}
+	return err
+}

--- a/cmd/skaffold/app/exitcode_test.go
+++ b/cmd/skaffold/app/exitcode_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package app
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestExitCode(t *testing.T) {
+	testutil.CheckDeepEqual(t, 1, ExitCode(fmt.Errorf("some error")))
+	testutil.CheckDeepEqual(t, 127, ExitCode(invalidUsageError{err: fmt.Errorf("some error")}))
+	testutil.CheckDeepEqual(t, 127, ExitCode(fmt.Errorf("wrapped: %w", invalidUsageError{err: fmt.Errorf("some error")})))
+}
+
+func Test_extractInvalidUsageError(t *testing.T) {
+	tests := []struct {
+		name                string
+		err                 error
+		wantInvalidUsageErr bool
+	}{
+		{name: "nil err",
+			err:                 nil,
+			wantInvalidUsageErr: false},
+		{name: "other error",
+			err:                 fmt.Errorf("some error"),
+			wantInvalidUsageErr: false},
+		{name: "cobra unknown cmd error",
+			err:                 fmt.Errorf(`unknown command "x" for "skaffold"`),
+			wantInvalidUsageErr: true},
+		{name: "cobra unknown shorthand flag error",
+			err:                 fmt.Errorf(`unknown shorthand flag: 'x' in -x`),
+			wantInvalidUsageErr: true},
+		{name: "cobra unknown flag error",
+			err:                 fmt.Errorf(`unknown flag: --unknown`),
+			wantInvalidUsageErr: true},
+		{name: "cobra argument validation error",
+			err:                 fmt.Errorf(`invalid argument "1" for "-a, --build-artifacts" flag: stat 1: no such file or directory`),
+			wantInvalidUsageErr: true},
+		{name: "cobra exactargs validation error",
+			err:                 fmt.Errorf(`accepts 2 arg(s), received 0`),
+			wantInvalidUsageErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := extractInvalidUsageError(tt.err)
+			_, ok := out.(invalidUsageError)
+			if tt.wantInvalidUsageErr && !ok {
+				t.Errorf("wanted invalidUsageError, got %T", out)
+			} else if !tt.wantInvalidUsageErr && ok {
+				t.Errorf("unwanted invalidUsageError: %v", out)
+			}
+		})
+	}
+}

--- a/cmd/skaffold/app/skaffold.go
+++ b/cmd/skaffold/app/skaffold.go
@@ -44,5 +44,6 @@ func Run(out, stderr io.Writer) error {
 		logrus.Debugf("Retrieving command line from SKAFFOLD_CMDLINE: %q", parsed)
 		c.SetArgs(parsed)
 	}
-	return c.ExecuteContext(ctx)
+	err := c.ExecuteContext(ctx)
+	return extractInvalidUsageError(err)
 }

--- a/cmd/skaffold/app/skaffold_test.go
+++ b/cmd/skaffold/app/skaffold_test.go
@@ -83,3 +83,24 @@ func TestSkaffoldCmdline_MainUnknownCommand(t *testing.T) {
 		t.CheckError(true, err)
 	})
 }
+
+func TestMain_InvalidUsageExitCode(t *testing.T) {
+	testutil.Run(t, "unknown command", func(t *testutil.T) {
+		// --interactive=false removes the update check and survey prompt.
+		t.Override(&os.Args, []string{"skaffold", "unknown", "--interactive=false"})
+		err := Run(ioutil.Discard, ioutil.Discard)
+		t.CheckErrorAndExitCode(127, err)
+	})
+	testutil.Run(t, "unknown flag", func(t *testutil.T) {
+		// --interactive=false removes the update check and survey prompt.
+		t.Override(&os.Args, []string{"skaffold", "--help2", "--interactive=false"})
+		err := Run(ioutil.Discard, ioutil.Discard)
+		t.CheckErrorAndExitCode(127, err)
+	})
+	testutil.Run(t, "exactargs error", func(t *testutil.T) {
+		// --interactive=false removes the update check and survey prompt.
+		t.Override(&os.Args, []string{"skaffold", "config", "set", "a", "b", "c"})
+		err := Run(ioutil.Discard, ioutil.Discard)
+		t.CheckErrorAndExitCode(127, err)
+	})
+}

--- a/cmd/skaffold/skaffold.go
+++ b/cmd/skaffold/skaffold.go
@@ -31,10 +31,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
 
-type ExitCoder interface {
-	ExitCode() int
-}
-
 func main() {
 	if _, ok := os.LookupEnv("SKAFFOLD_PROFILER"); ok {
 		err := profiler.Start(profiler.Config{
@@ -61,18 +57,9 @@ func main() {
 			// before we print an error to get the right coloring.
 			errOut := output.GetWriter(os.Stderr, output.DefaultColorCode, false, false)
 			output.Red.Fprintln(errOut, err)
-			code = exitCode(err)
+			code = app.ExitCode(err)
 		}
 	}
 	instrumentation.ShutdownAndFlush(context.Background(), code)
 	os.Exit(code)
-}
-
-func exitCode(err error) int {
-	var exitCoder ExitCoder
-	if errors.As(err, &exitCoder) {
-		return exitCoder.ExitCode()
-	}
-
-	return 1
 }

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -136,6 +136,11 @@ func (t *T) CheckErrorAndDeepEqual(shouldErr bool, err error, expected, actual i
 	CheckErrorAndDeepEqual(t.T, shouldErr, err, expected, actual, opts...)
 }
 
+func (t *T) CheckErrorAndExitCode(expectedCode int, err error) {
+	t.Helper()
+	CheckErrorAndExitCode(t.T, expectedCode, err)
+}
+
 func (t *T) CheckError(shouldErr bool, err error) {
 	t.Helper()
 	CheckError(t.T, shouldErr, err)
@@ -318,6 +323,20 @@ func CheckError(t *testing.T, shouldErr bool, err error) {
 	t.Helper()
 	if err := checkErr(shouldErr, err); err != nil {
 		t.Error(err)
+	}
+}
+
+func CheckErrorAndExitCode(t *testing.T, expectedCode int, err error) {
+	t.Helper()
+	CheckErrorAndFailNow(t, true, err)
+	type exitCoder interface {
+		ExitCode() int
+	}
+	var ec exitCoder
+	if ok := errors.As(err, &ec); !ok {
+		t.Errorf("error %q did not contain an exit code", err)
+	} else if ec.ExitCode() != expectedCode {
+		t.Errorf("expected exit code %d from err, but was %d", expectedCode, ec.ExitCode())
 	}
 }
 


### PR DESCRIPTION
Parsing error strings from cobra.Execute to detect invalid commands and
arguments to fail with exit code 127.

Pending: discussion whether we need to document this as a feature or a hidden
property of the program.

Fixes: #5867