### PR TITLE
introduce PostRunHooks for cmd builder

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -323,6 +323,15 @@ func isQuietMode() bool {
 	}
 }
 
+func apiServerShutdownHook(err error) error {
+	// clean up server at end of the execution since cobra post run hooks
+	// are only executed if RunE is successful.
+	if shutdownAPIServer != nil {
+		shutdownAPIServer()
+	}
+	return err
+}
+
 func updateCheckForReleasedVersionsIfNotDisabled(s string) string {
 	if preReleaseVersion(s) {
 		logrus.Debug("Skipping update check for pre-release version")

--- a/cmd/skaffold/app/cmd/commands.go
+++ b/cmd/skaffold/app/cmd/commands.go
@@ -40,10 +40,12 @@ type Builder interface {
 	NoArgs(action func(context.Context, io.Writer) error) *cobra.Command
 	WithCommands(cmds ...*cobra.Command) *cobra.Command
 	WithPersistentFlagAdder(adder func(*pflag.FlagSet)) Builder
+	WithPostRunHook(hook func(error) error) Builder
 }
 
 type builder struct {
-	cmd cobra.Command
+	cmd          cobra.Command
+	postRunHooks []func(error) error
 }
 
 // NewCmd creates a new command builder.
@@ -109,45 +111,41 @@ func (b *builder) Hidden() Builder {
 	return b
 }
 
+// WithPostRunHook adds a post run hook to the action executed regardless if
+// the RunE action returns an error or not. Executed in the order they are
+// added.
+func (b *builder) WithPostRunHook(hook func(error) error) Builder {
+	b.postRunHooks = append(b.postRunHooks, hook)
+	return b
+}
+
 func (b *builder) ExactArgs(argCount int, action func(context.Context, io.Writer, []string) error) *cobra.Command {
 	b.cmd.Args = cobra.ExactArgs(argCount)
 	b.cmd.RunE = func(_ *cobra.Command, args []string) error {
-		err := action(b.cmd.Context(), b.cmd.OutOrStdout(), args)
-		// clean up server at end of the execution since post run hooks are only executed if
-		// RunE is successful
-		if shutdownAPIServer != nil {
-			shutdownAPIServer()
-		}
-		return err
+		return action(b.cmd.Context(), b.cmd.OutOrStdout(), args)
 	}
+	b.WithPostRunHook(apiServerShutdownHook)
+	applyPostRunHooks(&b.cmd, b.postRunHooks)
 	return &b.cmd
 }
 
 func (b *builder) NoArgs(action func(context.Context, io.Writer) error) *cobra.Command {
 	b.cmd.Args = cobra.NoArgs
 	b.cmd.RunE = func(*cobra.Command, []string) error {
-		err := action(b.cmd.Context(), b.cmd.OutOrStdout())
-		// clean up server at end of the execution since post run hooks are only executed if
-		// RunE is successful
-		if shutdownAPIServer != nil {
-			shutdownAPIServer()
-		}
-		return err
+		return action(b.cmd.Context(), b.cmd.OutOrStdout())
 	}
+	b.WithPostRunHook(apiServerShutdownHook)
+	applyPostRunHooks(&b.cmd, b.postRunHooks)
 	return &b.cmd
 }
 
 func (b *builder) WithArgs(f cobra.PositionalArgs, action func(context.Context, io.Writer, []string) error) *cobra.Command {
 	b.cmd.Args = f
 	b.cmd.RunE = func(_ *cobra.Command, args []string) error {
-		err := action(b.cmd.Context(), b.cmd.OutOrStdout(), args)
-		// clean up server at end of the execution since post run hooks are only executed if
-		// RunE is successful
-		if shutdownAPIServer != nil {
-			shutdownAPIServer()
-		}
-		return err
+		return action(b.cmd.Context(), b.cmd.OutOrStdout(), args)
 	}
+	b.WithPostRunHook(apiServerShutdownHook)
+	applyPostRunHooks(&b.cmd, b.postRunHooks)
 	return &b.cmd
 }
 
@@ -156,4 +154,15 @@ func (b *builder) WithCommands(cmds ...*cobra.Command) *cobra.Command {
 		b.cmd.AddCommand(c)
 	}
 	return &b.cmd
+}
+
+func applyPostRunHooks(cmd *cobra.Command, postRunHooks []func(error) error) {
+	for _, hook := range postRunHooks {
+		cur := cmd.RunE
+		h := hook // need to capture for the closure
+		new := func(c *cobra.Command, args []string) error {
+			return h(cur(c, args))
+		}
+		cmd.RunE = new
+	}
 }

--- a/cmd/skaffold/app/cmd/commands_test.go
+++ b/cmd/skaffold/app/cmd/commands_test.go
@@ -128,6 +128,26 @@ func TestNewCmdHidden(t *testing.T) {
 	testutil.CheckDeepEqual(t, true, cmd.Hidden)
 }
 
+func TestNewCmdWithPostRunHooks(t *testing.T) {
+	var callOrder []int
+	cmd := NewCmd("").
+		WithPostRunHook(func(err error) error {
+			callOrder = append(callOrder, 1)
+			return err
+		}).
+		WithPostRunHook(func(err error) error {
+			callOrder = append(callOrder, 2)
+			return err
+		}).
+		NoArgs(func(c context.Context, w io.Writer) error {
+			return fmt.Errorf("some err")
+		})
+	err := cmd.RunE(nil, nil)
+	testutil.CheckErrorAndFailNow(t, true, err)
+	testutil.CheckDeepEqual(t, err.Error(), "some err")
+	testutil.CheckDeepEqual(t, []int{1, 2}, callOrder)
+}
+
 func listFlags(set *pflag.FlagSet) map[string]*pflag.Flag {
 	flagsByName := make(map[string]*pflag.Flag)
 


### PR DESCRIPTION
This helps clean up some deduplication we had in cmd builder to call
shutdownAPIServer. Now it can be done more modularly and more post-RunE() hooks
can be added (as cobra's own PostRunE() does not work if RunE returns error).

Thought it might help, but I might've also overdone it. No hard feelings if
rejected.