### PR TITLE
mute application logs when a new iteration starts.

### DIFF
--- a/pkg/skaffold/kubernetes/logger/formatter.go
+++ b/pkg/skaffold/kubernetes/logger/formatter.go
@@ -60,6 +60,9 @@ func newKubernetesLogFormatter(config Config, colorPicker output.ColorPicker, is
 func (k *kubernetesLogFormatter) Name() string { return k.prefix }
 
 func (k *kubernetesLogFormatter) PrintLine(out io.Writer, line string) {
+	if k.isMuted() {
+		return
+	}
 	formattedPrefix := k.prefix
 	if output.IsColorable(out) {
 		formattedPrefix = k.color().Sprintf("%s", k.prefix)
@@ -72,11 +75,9 @@ func (k *kubernetesLogFormatter) PrintLine(out io.Writer, line string) {
 	formattedLine := fmt.Sprintf("%s%s", formattedPrefix, line)
 	eventV2.ApplicationLog(k.pod.Name, k.container.Name, formattedPrefix, line, formattedLine)
 
-	if !k.isMuted() {
-		k.lock.Lock()
-		defer k.lock.Unlock()
-		fmt.Fprint(out, formattedLine)
-	}
+	k.lock.Lock()
+	defer k.lock.Unlock()
+	fmt.Fprint(out, formattedLine)
 }
 
 func (k *kubernetesLogFormatter) color() output.Color {

--- a/pkg/skaffold/kubernetes/logger/formatter_test.go
+++ b/pkg/skaffold/kubernetes/logger/formatter_test.go
@@ -222,3 +222,32 @@ func TestPrefix(t *testing.T) {
 		})
 	}
 }
+
+func TestPrintline(t *testing.T) {
+	tests := []struct {
+		description string
+		isMuted     bool
+		expected    string
+	}{
+		{
+			description: "muted",
+			isMuted:     true,
+		},
+		{
+			description: "unmuted",
+			expected:    "[hello container]test line",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			pod := podWithName("hello")
+			f := newKubernetesLogFormatter(&mockConfig{log: latestV1.LogsConfig{
+				Prefix: "auto",
+			}}, &mockColorPicker{}, func() bool { return test.isMuted }, &pod,
+				containerWithName("container"))
+			var out bytes.Buffer
+			f.PrintLine(&out, "test line")
+			t.CheckDeepEqual(test.expected, out.String())
+		})
+	}
+}


### PR DESCRIPTION
Mute application logs when a new dev iteration starts. 
Before:
Skaffold would read logs from pod and send these to application log endpoint. Skaffold will **mute logs** on CLI.
 Due to this, 
1) If you make a change to frontend, it will trigger a re-build.  
2) while its building, old frontend pod is still running 
3) now go to the portforwarded frontend url and make a request. 
4) IDE users will see a logs from prev pod which served the request and new pod which got initialized
The two pods shown in IDE view confuses the users. 

https://user-images.githubusercontent.com/1534539/128949393-0c0a502b-5ad4-4d04-95cc-04b89f84ab3a.mov

Resolution:
1) Mute logs keep the behaviour same on CLI and event api v2.


