### PR TITLE
Move deployment controller check to pod validator

### DIFF
--- a/pkg/skaffold/kubernetes/status/status_check_test.go
+++ b/pkg/skaffold/kubernetes/status/status_check_test.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
-	appsclient "k8s.io/client-go/kubernetes/typed/apps/v1"
 	utilpointer "k8s.io/utils/pointer"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/diag"
@@ -217,9 +216,6 @@ func TestGetDeployments(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&getReplicaSet, func(_ *appsv1.Deployment, _ appsclient.AppsV1Interface) ([]*appsv1.ReplicaSet, []*appsv1.ReplicaSet, *appsv1.ReplicaSet, error) {
-				return nil, nil, &appsv1.ReplicaSet{}, nil
-			})
 			objs := make([]runtime.Object, len(test.deps))
 			for i, dep := range test.deps {
 				objs[i] = dep


### PR DESCRIPTION
Fixes NPE seen in our integration tests https://app.travis-ci.com/github/GoogleContainerTools/skaffold/jobs/530583442#L1835

If a cluster is busy, it takes longer for a replicate set for a deployment to be created.
 #6378 add logic to fetch pods for a deployment corresponding to a `NewReplicaSet` field. However at the time a deployment is created, replica set might not exist.  The `controller` object could be null [here](https://github.com/GoogleContainerTools/skaffold/blob/main/pkg/skaffold/kubernetes/status/status_check.go#L212) 

Moving this logic to Validator so at the time of fetching pods, we could check if a deployment has a replicate set. If it does, then fetch pods and filter based on replica set.

