### PR TITLE
Check for 1st commit message for release draft

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -11,7 +11,7 @@ jobs:
   check:
     name: Check if release commit
     runs-on: ubuntu-latest
-    if: "startsWith(github.event.head_commit.message, 'release: ')"
+    if: "startsWith(github.event.commits[0].message, 'release: ')"
     steps:
     - name: Apply release-matching regexp to commit message
       id: regex-match


### PR DESCRIPTION
Release process docs mention, commit needs to follow a patten for release workflow.

However, during code review process, dev could make additional commits. 

Changing the draft workflow to check for first commit.

