### PR TITLE
hooks: add metrics

### DIFF
--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -39,6 +39,7 @@ var (
 		Builders:          map[string]int{},
 		BuildDependencies: map[string]int{},
 		SyncType:          map[string]bool{},
+		Hooks:             map[HookPhase]int{},
 		DevIterations:     []devIteration{},
 		StartTime:         time.Now(),
 		Version:           version.Get().Version,
@@ -86,13 +87,22 @@ func InitMeterFromConfig(configs []*latestV1.SkaffoldConfig, user string) {
 			if len(artifact.Dependencies) > 0 {
 				meter.BuildDependencies[yamltags.GetYamlTag(artifact.ArtifactType)]++
 			}
+			meter.Hooks[HookPhases.PreBuild] += len(artifact.LifecycleHooks.PreHooks)
+			meter.Hooks[HookPhases.PostBuild] += len(artifact.LifecycleHooks.PostHooks)
+
 			if artifact.Sync != nil {
 				meter.SyncType[yamltags.GetYamlTag(artifact.Sync)] = true
+				meter.Hooks[HookPhases.PreSync] += len(artifact.Sync.LifecycleHooks.PreHooks)
+				meter.Hooks[HookPhases.PostSync] += len(artifact.Sync.LifecycleHooks.PostHooks)
 			}
 		}
 		meter.Deployers = append(meter.Deployers, yamltags.GetYamlKeys(config.Deploy.DeployType)...)
 		if h := config.Deploy.HelmDeploy; h != nil {
 			meter.HelmReleasesCount = len(h.Releases)
+		}
+		if k := config.Deploy.KubectlDeploy; k != nil {
+			meter.Hooks[HookPhases.PreDeploy] += len(k.LifecycleHooks.PreHooks)
+			meter.Hooks[HookPhases.PostDeploy] += len(k.LifecycleHooks.PostHooks)
 		}
 		meter.BuildArtifacts += len(config.Pipeline.Build.Artifacts)
 	}

--- a/pkg/skaffold/instrumentation/types.go
+++ b/pkg/skaffold/instrumentation/types.go
@@ -73,6 +73,9 @@ type skaffoldMeter struct {
 	// SyncType Sync type used in the build configuration: infer, auto, and/or manual.
 	SyncType map[string]bool
 
+	// Hooks Enum values for all the configured lifecycle hooks.
+	Hooks map[HookPhase]int
+
 	// DevIterations Error results of the various dev iterations and the
 	// reasons they were triggered. The triggers can be one of sync, build, or deploy.
 	DevIterations []devIteration
@@ -108,4 +111,22 @@ type errHandler struct{}
 
 func (h errHandler) Handle(err error) {
 	logrus.Debugf("Error with metrics: %v", err)
+}
+
+type HookPhase string
+
+var HookPhases = struct {
+	PreBuild   HookPhase
+	PostBuild  HookPhase
+	PreSync    HookPhase
+	PostSync   HookPhase
+	PreDeploy  HookPhase
+	PostDeploy HookPhase
+}{
+	PreBuild:   "pre-build",
+	PostBuild:  "post-build",
+	PreSync:    "pre-sync",
+	PostSync:   "post-sync",
+	PreDeploy:  "pre-deploy",
+	PostDeploy: "post-deploy",
 }


### PR DESCRIPTION
This PR adds instrumentation for `lifecycle hooks` usage. It collects the number of hooks configured per phase.