### PR TITLE
Deterministic ports for grpc/http api servers

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -187,7 +187,7 @@ var flagRegistry = []Flag{
 	},
 	{
 		Name:          "rpc-port",
-		Usage:         "tcp port to expose event API",
+		Usage:         "tcp port to expose event API (0: chosen randomly at runtime)",
 		Value:         &opts.RPCPort,
 		DefValue:      constants.DefaultRPCPort,
 		FlagAddMethod: "IntVar",
@@ -195,7 +195,7 @@ var flagRegistry = []Flag{
 	},
 	{
 		Name:          "rpc-http-port",
-		Usage:         "tcp port to expose event REST API over HTTP",
+		Usage:         "tcp port to expose event REST API over HTTP (0: chosen randomly at runtime)",
 		Value:         &opts.RPCHTTPPort,
 		DefValue:      constants.DefaultRPCHTTPPort,
 		FlagAddMethod: "IntVar",

--- a/docs/content/en/docs/design/api.md
+++ b/docs/content/en/docs/design/api.md
@@ -24,27 +24,20 @@ over the individual phases of the pipeline (build, deploy, and sync).
 
 ## Connecting to the Skaffold API
 The Skaffold API is `gRPC` based, and it is also exposed via the gRPC gateway as a JSON over HTTP service.
-The server is hosted locally on the same host where the skaffold process is running, and will serve by default on ports 50051 and 50052.
-These ports can be configured through the `--rpc-port` and `--rpc-http-port` flags.
+
+The server is hosted locally on the same host where the skaffold process is running, and by default will serve
+on randomly chosen available ports (logged at INFO level). However, these ports can be configured through the `--rpc-port` and `--rpc-http-port` flags.
 
 For reference, we generate the server's [gRPC service definitions and message protos]({{< relref "/docs/references/api/grpc" >}}) as well as the [Swagger based HTTP API Spec]({{< relref "/docs/references/api/swagger" >}}).
 
-
 ### HTTP server
-The HTTP API is exposed on port `50052` by default. The default HTTP port can be overridden with the `--rpc-http-port` flag. 
-If the HTTP API port is taken, Skaffold will find the next available port.
-The final port can be found from Skaffold's startup logs.
-
-```code
-$ skaffold dev
-WARN[0000] port 50052 for gRPC HTTP server already in use: using 50055 instead
-```
+The HTTP API starts on a random available port by default (logged in INFO level) and can be overridden with the `--rpc-http-port` flag. 
+If the specified custom port is not available, Skaffold will exit with failure.
 
 ### gRPC Server
 
-The gRPC API is exposed on port `50051` by default and can be overridden with the `--rpc-port` flag.
-As with the HTTP API, if this port is taken, Skaffold will find the next available port.
-You can find this port from Skaffold's logs on startup.
+The gRPC API starts on a random available port by default (logged in INFO level) and can be overridden with the `--rpc-port` flag.
+If the specified custom port is not available, Skaffold will exit with failure.
 
 ```code
 $ skaffold dev
@@ -52,7 +45,8 @@ WARN[0000] port 50051 for gRPC server already in use: using 50053 instead
 ```
 
 #### Creating a gRPC Client
-To connect to the `gRPC` server at default port `50051`, create a client using the following code snippet.
+
+To connect to the `gRPC` server at the specified port, create a client using the following code snippet.
 
 {{< alert title="Note" >}}
 The skaffold gRPC server is not compatible with HTTPS, so connections need to be marked as insecure with `grpc.WithInsecure()`

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -210,8 +210,8 @@ Options:
       --push=: Push the built images to the specified image repository.
   -q, --quiet=false: Suppress the build output and print image built on success. See --output to format output.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
-      --rpc-http-port=50052: tcp port to expose event REST API over HTTP
-      --rpc-port=50051: tcp port to expose event API
+      --rpc-http-port=0: tcp port to expose event REST API over HTTP (0: chosen randomly at runtime)
+      --rpc-port=0: tcp port to expose event API (0: chosen randomly at runtime)
       --skip-tests=false: Whether to skip the tests after building
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
@@ -442,8 +442,8 @@ Options:
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --protocols=[]: Priority sorted order of debugger protocols to support.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
-      --rpc-http-port=50052: tcp port to expose event REST API over HTTP
-      --rpc-port=50051: tcp port to expose event API
+      --rpc-http-port=0: tcp port to expose event REST API over HTTP (0: chosen randomly at runtime)
+      --rpc-port=0: tcp port to expose event API (0: chosen randomly at runtime)
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
@@ -599,8 +599,8 @@ Options:
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
-      --rpc-http-port=50052: tcp port to expose event REST API over HTTP
-      --rpc-port=50051: tcp port to expose event API
+      --rpc-http-port=0: tcp port to expose event REST API over HTTP (0: chosen randomly at runtime)
+      --rpc-port=0: tcp port to expose event API (0: chosen randomly at runtime)
       --skip-render=false: Don't render the manifests, just deploy them
       --status-check=true: Wait for deployed resources to stabilize
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
@@ -692,8 +692,8 @@ Options:
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
-      --rpc-http-port=50052: tcp port to expose event REST API over HTTP
-      --rpc-port=50051: tcp port to expose event API
+      --rpc-http-port=0: tcp port to expose event REST API over HTTP (0: chosen randomly at runtime)
+      --rpc-port=0: tcp port to expose event API (0: chosen randomly at runtime)
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
@@ -1005,8 +1005,8 @@ Options:
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
-      --rpc-http-port=50052: tcp port to expose event REST API over HTTP
-      --rpc-port=50051: tcp port to expose event API
+      --rpc-http-port=0: tcp port to expose event REST API over HTTP (0: chosen randomly at runtime)
+      --rpc-port=0: tcp port to expose event API (0: chosen randomly at runtime)
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
@@ -1175,8 +1175,8 @@ Options:
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
-      --rpc-http-port=50052: tcp port to expose event REST API over HTTP
-      --rpc-port=50051: tcp port to expose event API
+      --rpc-http-port=0: tcp port to expose event REST API over HTTP (0: chosen randomly at runtime)
+      --rpc-port=0: tcp port to expose event API (0: chosen randomly at runtime)
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
 
 Usage:

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -61,8 +61,8 @@ const (
 	DefaultCacheFile   = "cache"
 	DefaultMetricFile  = "metrics"
 
-	DefaultRPCPort     = 50051
-	DefaultRPCHTTPPort = 50052
+	DefaultRPCPort     = 0 // choose an available port at runtime
+	DefaultRPCHTTPPort = 0 // choose an available port at runtime
 
 	DefaultPortForwardAddress = "127.0.0.1"
 


### PR DESCRIPTION
Fixes #6425
Fixes #6417
Fixes #6375

**Description**

skaffold tries to find as different available port
than the specified port. As outlined in #6425,
this poses several problems such as not being api
to atomically secure an available port,
redundant internal bookkeeping of port numbers
that are allocated (unused code), and making life
harder for API callers as they need to parse
unstructured logs to find out the port numbers.

This patch makes skaffold more strict about how
port numbers for its internal APIs are bind()ed.

This patch also fixes test flakes for the following
integration tests (each ran 100 times): 

- TestEventsRPC #6417 
- TestRunPortForward #6375

**User facing changes**

This patch changes the visible behavior of API servers
(for users of skaffold API):

* no more default ports 50051 and 50052 for APIs
  (they are decided randomly by default)

* if given port is busy, we fail with error so the
  caller can specify another port (TODO we need
  to discuss if we want a custom exitcode to
  signal this)

**Follow-up Work (remove if N/A)**

Determine if we need a custom exitcode indicating
"port you specified is not available" for callers
of the API (e.g. Cloud Code).