### PR TITLE
performance comparison on demand github action

### DIFF
--- a/.github/workflows/performance-comparison-label.yml
+++ b/.github/workflows/performance-comparison-label.yml
@@ -1,0 +1,40 @@
+name: Run Performance Comparison
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  build:
+    if: ${{ github.event.label.name == 'help:run-comparisonstats' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Remove run-performance-comparison label
+      uses: actions-ecosystem/action-remove-labels@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        labels: help:run-comparisonstats
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Parse comment template into gh output
+      id: parse-comment-template-into-gh-output
+      working-directory: ./hack/comparisonstats/comment-text
+      run: |
+        body=$(cat comment.txt)
+        body="${body//'%'/'%25'}"
+        body="${body//$'\n'/'%0A'}"
+        body="${body//$'\r'/'%0D'}" 
+        echo ::set-output name=body::$body
+    
+    - name: Create comment
+      uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body: "${{ steps.parse-comment-template-into-gh-output.outputs.body }}"

--- a/.github/workflows/performance-comparison.yml
+++ b/.github/workflows/performance-comparison.yml
@@ -1,0 +1,123 @@
+name: performance comparison (on comment)
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build:
+    if: ${{ startsWith(github.event.comment.body, '/run-comparisonstats') }}
+    name: Performance comparison (on comment)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        kustomize_version: [3.5.4]
+        ko_version: [0.4.0]
+        kompose_version: [1.21.0]
+        gcloud_sdk_version: [335.0.0]
+        container_structure_tests_version: [1.8.0]
+    steps:
+    - name: "Check if user has write access"
+      uses: "lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f"
+      with:
+        permission: "write"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Add reaction
+      uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae
+      with:
+        comment-id: ${{ github.event.comment.id }}
+        reactions: rocket
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.14
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install Kustomize
+      run: |
+        wget -O kustomize.tar.gz https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${{ matrix.kustomize_version }}/kustomize_v${{ matrix.kustomize_version }}_linux_amd64.tar.gz
+        sudo tar -xvf kustomize.tar.gz -C /usr/local/bin/
+
+    - name: Install Ko
+      run: |
+        wget -O ko.tar.gz https://github.com/google/ko/releases/download/v${{ matrix.ko_version }}/ko_${{ matrix.ko_version }}_Linux_x86_64.tar.gz
+        sudo tar -xvf ko.tar.gz -C /usr/local/bin/
+
+    - name: Install Kompose
+      run: |
+        wget -O kompose https://github.com/kubernetes/kompose/releases/download/v${{ matrix.kompose_version }}/kompose-linux-amd64 && chmod +x kompose
+        sudo mv kompose /usr/local/bin/
+
+    - name: Install GCloud
+      run: |
+        wget -O gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${{ matrix.gcloud_sdk_version }}-linux-x86_64.tar.gz
+        tar -xvf gcloud.tar.gz -C ${HOME}/
+        CLOUDSDK_PYTHON="python2.7" ${HOME}/google-cloud-sdk/install.sh --usage-reporting=false --bash-completion=false --disable-installation-options
+        echo "${HOME}/google-cloud-sdk/bin" >> $GITHUB_PATH
+
+    - name: Configure GCloud with Docker
+      run:  gcloud auth configure-docker
+
+    - name: Install Container Structure Test
+      run: |
+        wget -O container-structure-test https://storage.googleapis.com/container-structure-test/v${{ matrix.container_structure_tests_version }}/container-structure-test-linux-amd64 && chmod +x container-structure-test
+        sudo mv container-structure-test /usr/local/bin/
+
+    - name: Setup other files and permissions
+      run: |
+        sudo chown $(whoami):docker ${HOME}/.docker -R
+        sudo chmod g+rw ${HOME}/.docker -R
+        echo '{}' > ${HOME}/.docker/config.json
+        mkdir -p ${HOME}/.m2/ && cp ./hack/maven/settings.xml ${HOME}/.m2/settings.xml
+        
+    - name: Install Minikube from minikube master branch @HEAD and start cluster
+      run: |
+        curl -Lo minikube https://storage.googleapis.com/minikube-builds/master/minikube-linux-amd64
+        sudo install minikube /usr/local/bin/minikube
+        minikube start --profile=minikube --driver=docker
+
+    - uses: xt0rted/pull-request-comment-branch@f2f07162618551540507cbd00ddf16ffcaa0c72f
+      id: comment-branch
+
+    - name: Make and install Skaffold binary from current PR
+      run: |
+        make
+        sudo install "${HOME}/work/skaffold/skaffold/out/skaffold" /usr/local/bin/skaffold-${{ steps.comment-branch.outputs.head_ref }}
+
+    - name: Install Skaffold from main branch (built from CI/CD on merge)
+      run: |
+        curl -Lo skaffold-from-main-branch https://storage.googleapis.com/skaffold/builds/latest/skaffold-linux-amd64 && \
+        sudo install skaffold-from-main-branch /usr/local/bin/
+
+    - name: Parse Comment To Yaml Format
+      run: |
+        tail -n +2 <<< '${{ github.event.comment.body }}' > yaml-input-file.yaml
+
+    - name: Run performance comparison benchmarks
+      id: run-performance-comparison-benchmarks
+      run: |
+        /usr/local/bin/skaffold-${{ steps.comment-branch.outputs.head_ref }} config set --global collect-metrics false
+        make COMPARISONSTATS_ARGS='--summary-output-path=gh-comment.txt --yaml-input-file=yaml-input-file.yaml --warmup-runs=1 /usr/local/bin/skaffold-from-main-branch /usr/local/bin/skaffold-${{ steps.comment-branch.outputs.head_ref }} helm-deployment main.go "//per-dev-iteration-comment"' comparisonstats
+        body=$(cat gh-comment.txt)
+        body="${body//'%'/'%25'}"
+        body="${body//$'\n'/'%0A'}"
+        body="${body//$'\r'/'%0D'}" 
+        echo ::set-output name=body::$body
+
+    - name: Create comment
+      uses: peter-evans/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae
+      with:
+        issue-number: ${{ github.event.issue.number }}
+        body: "${{ steps.run-performance-comparison-benchmarks.outputs.body }}"

--- a/Makefile
+++ b/Makefile
@@ -312,3 +312,8 @@ flags-dashboard:
 
 $(STATIK_FILES): go.mod docs/content/en/schemas/*
 	hack/generate-statik.sh
+
+# run comparisonstats - ex: make COMPARISONSTATS_ARGS='usr/local/bin/skaffold /usr/local/bin/skaffold helm-deployment main.go "//per-dev-iteration-comment"' comparisonstats
+.PHONY: comparisonstats
+comparisonstats:
+	go run hack/comparisonstats/main.go $(COMPARISONSTATS_ARGS)

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/onsi/ginkgo v1.15.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.1
+	github.com/otiai10/copy v1.6.0
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	github.com/pkg/errors v0.9.1
 	github.com/rakyll/statik v0.1.7

--- a/go.sum
+++ b/go.sum
@@ -1122,6 +1122,12 @@ github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJ
 github.com/openzipkin/zipkin-go v0.2.1/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
 github.com/openzipkin/zipkin-go v0.2.5/go.mod h1:KpXfKdgRDnnhsxw4pNIH9Md5lyFqKUa4YDFlwRYAMyE=
+github.com/otiai10/copy v1.6.0 h1:IinKAryFFuPONZ7cm6T6E2QX/vcJwSnlaA5lfoaXIiQ=
+github.com/otiai10/copy v1.6.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
+github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
+github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=
+github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=
+github.com/otiai10/mint v1.3.2/go.mod h1:/yxELlJQ0ufhjUwhshSj+wFjZ78CnZ48/1wtmBH1OTc=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/hack/comparisonstats/comment-text/comment.txt
+++ b/hack/comparisonstats/comment-text/comment.txt
@@ -1,0 +1,10 @@
+**Copy paste the msg below into a new comment and 'Comment' to trigger a run-comparisonstats job:**
+/run-comparisonstats
+exampleAppName: helm-deployment # helm-deployment, microservices, etc.
+exampleSrcFile: main.go # main.go, leeroy-app/app.go, etc.
+commentText: //per-dev-iteration-comment # go/js: //comment, python: #comment, etc.
+devIterations: 2 # number of dev iterations to run per binary
+\#mainBranchSkaffoldFlags: "--build-concurrency=0" # NOTE: only supports one flag
+\#thisPRSkaffoldFlags: "--build-concurrency=1" # NOTE: only supports one flag
+
+\#run-comparisonstats job adds a rocket emoji to your comment within ~30 seconds if kicked off successfully (refreshing might be required to see this)

--- a/hack/comparisonstats/devrunner/devrunner.go
+++ b/hack/comparisonstats/devrunner/devrunner.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package devrunner
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/otiai10/copy"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/GoogleContainerTools/skaffold/hack/comparisonstats/types"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	v1 "github.com/GoogleContainerTools/skaffold/proto/v1"
+)
+
+type DevInfo struct {
+	CmdArgs []string
+}
+
+func Dev(ctx context.Context, app types.Application, skaffoldBinaryPath string, eventsFileAbsPath string, flagOpts ...string) (*DevInfo, error) {
+	logrus.Infof("Starting skaffold dev on %s...", app.Name)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	logrus.Infof("app.Context: %s", app.Context)
+	if err := copyAppToTmpDir(&app); err != nil {
+		return nil, fmt.Errorf("copying app and testdata to temp dir: %w", err)
+	}
+
+	defer os.RemoveAll(app.Context)
+
+	port := util.GetAvailablePort(util.Loopback, 8080, &util.PortSet{})
+
+	buf := bytes.NewBuffer([]byte{})
+
+	// TODO(aaron-prindle) investigate why seeing prune issues w/o the  --no-prune=true flag - https://gist.github.com/aaron-prindle/48fa79954913202f23b02ea6356b556d
+	cmdArgs := []string{"dev", "--enable-rpc", fmt.Sprintf("--rpc-port=%v", port),
+		fmt.Sprintf("--event-log-file=%s", eventsFileAbsPath), "--cache-artifacts=false", "--no-prune=true"}
+
+	logrus.Infof("flagOpts: %v\n", flagOpts)
+	for _, opt := range flagOpts {
+		if opt == "" {
+			continue
+		}
+		cmdArgs = append(cmdArgs, opt)
+	}
+	cmd := exec.CommandContext(ctx, skaffoldBinaryPath, cmdArgs...)
+
+	cmd.Dir = app.Context
+	cmd.Stdout = buf
+	cmd.Stderr = buf
+
+	logrus.Infof("Running %v in %v", cmd.Args, cmd.Dir)
+	go func() {
+		defer cancel()
+		if err := cmd.Run(); err != nil {
+			cancel()
+			os.RemoveAll(app.Context)
+			logrus.Fatalf("skaffold dev failed: %v, %v", err, buf.String())
+		}
+	}()
+	for i := 0; i < int(app.DevIterations); i++ {
+		if err := waitForDevLoopComplete(ctx, i, port); err != nil {
+			return nil, fmt.Errorf("waiting for dev loop complete: %w: %s", err, buf.String())
+		}
+		if i < int(app.DevIterations) {
+			logrus.Infof("Dev loop iteration %d is complete, next dev loop...", i)
+			if err := kickoffDevLoop(ctx, app); err != nil {
+				return nil, fmt.Errorf("kicking off dev loop: %w", err)
+			}
+		}
+	}
+
+	logrus.Infof("successfully ran %d inner dev loop(s), killing skaffold...", app.DevIterations)
+	if err := cmd.Process.Signal(os.Interrupt); err != nil {
+		return nil, fmt.Errorf("killing skaffold: %w", err)
+	}
+	time.Sleep(5 * time.Second)
+	return &DevInfo{CmdArgs: cmd.Args}, wait.Poll(time.Second, 2*time.Minute, func() (bool, error) {
+		contents, err := ioutil.ReadFile(eventsFileAbsPath)
+		return err == nil && len(contents) > 0, nil
+	})
+}
+
+func copyAppToTmpDir(app *types.Application) error {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		return fmt.Errorf("temp dir: %w", err)
+	}
+	logrus.Infof("copying %v to temp location %v", app.Context, dir)
+	if err := copy.Copy(app.Context, dir); err != nil {
+		return fmt.Errorf("copying dir %v: %w", app.Context, err)
+	}
+	logrus.Infof("using temp directory %v as app directory", dir)
+	app.Context = dir
+	return nil
+}
+
+func kickoffDevLoop(ctx context.Context, app types.Application) error {
+	// TODO(aaron-prindle) runs are sometimes flaking, might need to slow this down? - see https://gist.github.com/aaron-prindle/23762f6a0d712c2586b10f04b1820636
+	args := strings.Split(app.Dev.Command, " ")
+	logrus.Infof("arglen: %v, Parsed args [%v]", len(args), args)
+	cmd := exec.CommandContext(ctx, "sh", "-c", app.Dev.Command)
+	cmd.Dir = app.Context
+
+	logrus.Infof("Running [%v] in %v", cmd.Args, cmd.Dir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("running %v, got output %s, err: %w", cmd.Args, string(output), err)
+	}
+	logrus.Infof("ran %v, got output: %v", cmd.Args, string(output))
+
+	return nil
+}
+
+func waitForDevLoopComplete(ctx context.Context, iteration, port int) error {
+	var (
+		conn   *grpc.ClientConn
+		err    error
+		client v1.SkaffoldServiceClient
+	)
+
+	if err := wait.Poll(time.Second, 2*time.Minute, func() (bool, error) {
+		conn, err = grpc.Dial(fmt.Sprintf(":%d", port), grpc.WithInsecure())
+		if err != nil {
+			return false, nil
+		}
+		client = v1.NewSkaffoldServiceClient(conn)
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("getting grpc client connection: %w", err)
+	}
+	defer conn.Close()
+
+	logrus.Infof("successfully connected to grpc client")
+
+	// read the event log stream from the skaffold grpc server
+	var stream v1.SkaffoldService_EventsClient
+	for i := 0; i < 10; i++ {
+		stream, err = client.Events(ctx, &empty.Empty{})
+		if err != nil {
+			logrus.Infof("error getting stream, retrying: %v", err)
+			time.Sleep(10 * time.Second)
+			continue
+		}
+	}
+	if stream == nil {
+		conn.Close()
+		logrus.Fatalf("error retrieving event log: %v\n", err)
+	}
+
+	devLoopCounter := 0
+	for {
+		if ctx.Err() == context.Canceled {
+			return context.Canceled
+		}
+		entry, err := stream.Recv()
+		if err != nil {
+			conn.Close()
+			logrus.Fatalf("error receiving entry from stream: %s", err)
+		}
+		logrus.Infof("received event: %v", entry)
+		if entry.GetEvent().GetDevLoopEvent() == nil {
+			continue
+		}
+		if entry.GetEvent().GetDevLoopEvent().GetStatus() != event.Succeeded {
+			continue
+		}
+		if devLoopCounter == iteration {
+			break
+		}
+		devLoopCounter++
+	}
+	return nil
+}

--- a/hack/comparisonstats/events/parse.go
+++ b/hack/comparisonstats/events/parse.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"time"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/pkg/errors"
+
+	"github.com/GoogleContainerTools/skaffold/hack/comparisonstats/types"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	v1 "github.com/GoogleContainerTools/skaffold/proto/v1"
+)
+
+// ParseEventDuration collects and aggregates metrics for the initial + inner loops from an events file
+func ParseEventDuration(ctx context.Context, eventsFileAbsPath string) (*types.DevLoopTimes, error) {
+	logEntries, err := getFromFile(eventsFileAbsPath)
+	if err != nil {
+		return nil, fmt.Errorf("getting events from file: %w", err)
+	}
+	return splitEntriesByDevLoop(logEntries), nil
+}
+
+func splitEntriesByDevLoop(logEntries []v1.LogEntry) *types.DevLoopTimes {
+	devLoopTimes := types.DevLoopTimes{
+		InnerBuildTimes:       []time.Duration{},
+		InnerDeployTimes:      []time.Duration{},
+		InnerStatusCheckTimes: []time.Duration{},
+	}
+
+	var buildTime, deployTime, statusCheckTime time.Duration
+	var buildStartTime, deployStartTime, statusCheckStartTime time.Time
+	isFirstEntry := true
+	for _, le := range logEntries {
+		switch le.Event.GetEventType().(type) {
+		case *v1.Event_MetaEvent:
+			fmt.Println("metadata event logic not yet implemented")
+		case *v1.Event_DevLoopEvent:
+			// we have reached the end of a dev loop
+			status := le.GetEvent().GetDevLoopEvent().GetStatus()
+			if status == event.Succeeded {
+				buildStartTime, deployStartTime, statusCheckStartTime = time.Time{}, time.Time{}, time.Time{}
+				if isFirstEntry {
+					isFirstEntry = false
+					devLoopTimes.InitialBuildTime = buildTime
+					devLoopTimes.InitialDeployTime = deployTime
+					devLoopTimes.InitialStatusCheckTime = statusCheckTime
+				} else {
+					devLoopTimes.InnerBuildTimes = append(devLoopTimes.InnerBuildTimes, buildTime)
+					devLoopTimes.InnerDeployTimes = append(devLoopTimes.InnerDeployTimes, deployTime)
+					devLoopTimes.InnerStatusCheckTimes = append(devLoopTimes.InnerStatusCheckTimes, statusCheckTime)
+				}
+			}
+		case *v1.Event_BuildEvent:
+			status := le.GetEvent().GetBuildEvent().GetStatus()
+			unixTimestamp := time.Unix(0, le.GetTimestamp().AsTime().UnixNano())
+			if status == event.InProgress && buildStartTime.IsZero() {
+				buildStartTime = unixTimestamp
+			} else if status == event.Complete {
+				buildTime = unixTimestamp.Sub(buildStartTime)
+			}
+		case *v1.Event_DeployEvent:
+			status := le.GetEvent().GetDeployEvent().GetStatus()
+			unixTimestamp := time.Unix(0, le.GetTimestamp().AsTime().UnixNano())
+			if status == event.InProgress {
+				deployStartTime = unixTimestamp
+				// deploy is finished when it is marked "Complete"
+			} else if status == event.Complete {
+				deployTime = unixTimestamp.Sub(deployStartTime)
+			}
+		case *v1.Event_StatusCheckEvent:
+			status := le.GetEvent().GetStatusCheckEvent().GetStatus()
+			unixTimestamp := time.Unix(0, le.GetTimestamp().AsTime().UnixNano())
+			if status == event.Started {
+				statusCheckStartTime = unixTimestamp
+			} else if status == event.Succeeded {
+				statusCheckTime = unixTimestamp.Sub(statusCheckStartTime)
+			}
+		}
+	}
+	return &devLoopTimes
+}
+
+func get(contents []byte) ([]v1.LogEntry, error) {
+	entries := strings.Split(string(contents), "\n")
+	var logEntries []v1.LogEntry
+	unmarshaller := jsonpb.Unmarshaler{}
+	for _, entry := range entries {
+		if entry == "" {
+			continue
+		}
+		var logEntry v1.LogEntry
+		buf := bytes.NewBuffer([]byte(entry))
+		if err := unmarshaller.Unmarshal(buf, &logEntry); err != nil {
+			return nil, errors.Wrap(err, "unmarshalling")
+		}
+		logEntries = append(logEntries, logEntry)
+	}
+	return logEntries, nil
+}
+
+func getFromFile(fp string) ([]v1.LogEntry, error) {
+	contents, err := ioutil.ReadFile(fp)
+	if err != nil {
+		return nil, errors.Wrapf(err, "reading %s", fp)
+	}
+	return get(contents)
+}

--- a/hack/comparisonstats/events/parse_test.go
+++ b/hack/comparisonstats/events/parse_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package events
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+var validEventsFile = `{"timestamp":"2021-08-11T19:19:41.711480752Z","event":{"metaEvent":{"entry":"Starting Skaffold: \u0026{Version:v1.29.0 ConfigVersion:skaffold/v2beta20 GitVersion: GitCommit:39371bb996a3c39c3d4fa8749cabe173c5f45b3a BuildDate:2021-08-02T17:52:01Z GoVersion:go1.14.14 Compiler:gc Platform:linux/amd64 User:}","metadata":{"build":{"numberOfArtifacts":1,"builders":[{"type":"DOCKER","count":1}],"type":"LOCAL"},"deploy":{"deployers":[{"type":"HELM","count":1}],"cluster":"MINIKUBE"}}}}}
+{"timestamp":"2021-08-11T19:19:41.756663171Z","event":{"devLoopEvent":{"status":"In Progress"}},"entry":"Update initiated"}
+{"timestamp":"2021-08-11T19:19:41.763416940Z","event":{"buildEvent":{"artifact":"skaffold-helm","status":"In Progress"}},"entry":"Build started for artifact skaffold-helm"}
+{"timestamp":"2021-08-11T19:19:45.685909133Z","event":{"buildEvent":{"artifact":"skaffold-helm","status":"Complete"}},"entry":"Build completed for artifact skaffold-helm"}
+{"timestamp":"2021-08-11T19:19:45.686277380Z","event":{"deployEvent":{"status":"In Progress"}},"entry":"Deploy started"}
+{"timestamp":"2021-08-11T19:19:46.624504850Z","event":{"deployEvent":{"status":"Complete"}},"entry":"Deploy completed"}
+{"timestamp":"2021-08-11T19:19:46.624550647Z","event":{"statusCheckEvent":{"status":"Started"}},"entry":"Status check started"}
+{"timestamp":"2021-08-11T19:19:48.719236104Z","event":{"resourceStatusCheckEvent":{"resource":"deployment/skaffold-helm","status":"Succeeded","message":"Succeeded","statusCode":"STATUSCHECK_SUCCESS"}},"entry":"Resource deployment/skaffold-helm status completed successfully"}
+{"timestamp":"2021-08-11T19:19:48.719307379Z","event":{"statusCheckEvent":{"status":"Succeeded"}},"entry":"Status check succeeded"}
+{"timestamp":"2021-08-11T19:19:48.734465633Z","event":{"devLoopEvent":{"status":"Succeeded"}},"entry":"Update succeeded"}
+{"timestamp":"2021-08-11T19:19:51.740854617Z","event":{"devLoopEvent":{"iteration":1,"status":"In Progress"}},"entry":"Update initiated"}
+{"timestamp":"2021-08-11T19:19:51.744239521Z","event":{"buildEvent":{"artifact":"skaffold-helm","status":"In Progress"}},"entry":"Build started for artifact skaffold-helm"}
+{"timestamp":"2021-08-11T19:19:55.757451860Z","event":{"buildEvent":{"artifact":"skaffold-helm","status":"Complete"}},"entry":"Build completed for artifact skaffold-helm"}
+{"timestamp":"2021-08-11T19:19:55.757928417Z","event":{"deployEvent":{"status":"In Progress"}},"entry":"Deploy started"}
+{"timestamp":"2021-08-11T19:19:56.728808748Z","event":{"deployEvent":{"status":"Complete"}},"entry":"Deploy completed"}
+{"timestamp":"2021-08-11T19:19:56.728840707Z","event":{"statusCheckEvent":{"status":"Started"}},"entry":"Status check started"}
+{"timestamp":"2021-08-11T19:20:00.823570232Z","event":{"resourceStatusCheckEvent":{"resource":"deployment/skaffold-helm","status":"Succeeded","message":"Succeeded","statusCode":"STATUSCHECK_SUCCESS"}},"entry":"Resource deployment/skaffold-helm status completed successfully"}
+{"timestamp":"2021-08-11T19:20:00.823640653Z","event":{"statusCheckEvent":{"status":"Succeeded"}},"entry":"Status check succeeded"}
+{"timestamp":"2021-08-11T19:20:00.823857159Z","event":{"devLoopEvent":{"iteration":1,"status":"Succeeded"}},"entry":"Update succeeded"}
+`
+
+var invalidEventsFile = `invalid-events-file`
+
+func TestParseEventDuration(t *testing.T) {
+	tests := []struct {
+		description      string
+		eventsFileText   string
+		shouldErr        bool
+		expectedDevLoops int
+	}{
+		{
+			description:      "valid events file",
+			eventsFileText:   validEventsFile,
+			expectedDevLoops: 1,
+		},
+		{
+			description:    "invalid events file",
+			eventsFileText: invalidEventsFile,
+			shouldErr:      true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			fp := t.TempFile("TestParseEventDuration-", []byte(test.eventsFileText))
+			devLoopTimes, err := ParseEventDuration(context.Background(), fp)
+			t.CheckError(test.shouldErr, err)
+			if !test.shouldErr {
+				if len(devLoopTimes.InnerBuildTimes) != len(devLoopTimes.InnerDeployTimes) && len(devLoopTimes.InnerBuildTimes) != len(devLoopTimes.InnerStatusCheckTimes) {
+					t.Fatalf("expected devLoopTimes arrays to have same lengths")
+				}
+				t.CheckDeepEqual(len(devLoopTimes.InnerBuildTimes), test.expectedDevLoops)
+			}
+		})
+	}
+}

--- a/hack/comparisonstats/main.go
+++ b/hack/comparisonstats/main.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/hack/comparisonstats/devrunner"
+	"github.com/GoogleContainerTools/skaffold/hack/comparisonstats/events"
+	"github.com/GoogleContainerTools/skaffold/hack/comparisonstats/types"
+	"github.com/GoogleContainerTools/skaffold/hack/comparisonstats/validate"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
+)
+
+// comparisonstats usage example:
+// $ comparisonstats --first-skaffold-flags="--build-concurrency=0" \
+//   --second-skaffold-flags="--build-concurrency=1" \
+//   /path/skaffold-1 /path/skaffold-2 helm-deployment main.go "//per-dev-iteration-comment"
+
+var (
+	warmupRuns        int
+	summaryOutputPath string
+	yamlInputFile     string
+	conf              = &types.Config{}
+)
+
+func init() {
+	flag.Int64Var(&conf.DevIterations, "dev-iterations", 2, "number of dev iterations to run for skaffold.  For one initial loop and one 'inner loop', --dev-iterations=2")
+	flag.StringVar(&summaryOutputPath, "summary-output-path", "", "path to file to write summary output to")
+	flag.StringVar(&conf.CommentText, "comment-text", "//per-dev-iteration-comment", "text to append to the specified 'ExampleSrcFile' during each skaffold dev loop")
+	flag.StringVar(&conf.FirstSkaffoldFlags, "first-skaffold-flags", "", "flag opts to pass to first skaffold binary invocations")
+	flag.StringVar(&conf.SecondSkaffoldFlags, "second-skaffold-flags", "", "flag opts to pass to second skaffold binary invocations")
+	flag.StringVar(&yamlInputFile, "yaml-input-file", "", "path to yaml file with input args")
+	flag.IntVar(&warmupRuns, "warmup-runs", 0, "Number of warmup runs to perform (defaults to 0)")
+}
+
+func main() {
+	ctx := context.Background()
+	flag.Parse()
+
+	if err := validate.Args(flag.Args()); err != nil {
+		logrus.Fatal(err)
+	}
+	cmdArgs := types.ParseComparisonStatsCmdArgs(flag.Args())
+	skaffoldFlags := []string{conf.FirstSkaffoldFlags, conf.SecondSkaffoldFlags}
+	for i := 0; i < warmupRuns; i++ {
+		cmdArgs.SkaffoldBinaries = append([]string{cmdArgs.SkaffoldBinaries[0]}, cmdArgs.SkaffoldBinaries...)
+		skaffoldFlags = append([]string{skaffoldFlags[0]}, skaffoldFlags...)
+	}
+	conf.ExampleAppName = cmdArgs.ExampleAppName
+	conf.ExampleSrcFile = cmdArgs.ExampleSrcFile
+
+	// if yamlInputFile set, update values from yaml file to override flag opts
+	if yamlInputFile != "" {
+		yamlFile, err := ioutil.ReadFile(yamlInputFile)
+		if err != nil {
+			logrus.Fatalf("error reading yaml input file: %v ", err)
+		}
+		err = yaml.Unmarshal(yamlFile, conf)
+		if err != nil {
+			logrus.Fatalf("error unmarshalling yaml input file: %v", err)
+		}
+		logrus.Infof("unmarshalled yaml input file into Config struct: %+v", conf)
+	}
+
+	var b bytes.Buffer
+	for i := 0; i < len(cmdArgs.SkaffoldBinaries); i++ {
+		uid, _ := uuid.NewUUID()
+		random := uid.String()
+		eventsFileAbsPath := filepath.Join(os.TempDir(), fmt.Sprintf("events-%d-%s", i, random))
+		skaffoldBinaryPath := cmdArgs.SkaffoldBinaries[i]
+		devIterations := conf.DevIterations
+		if i < warmupRuns {
+			devIterations = 2
+		}
+		app := types.Application{
+			Name:          conf.ExampleAppName,
+			Context:       fmt.Sprintf("examples/%s", conf.ExampleAppName),
+			Dev:           types.Dev{Command: fmt.Sprintf("printf \"%s\\n\" >> %s", conf.CommentText, conf.ExampleSrcFile)},
+			DevIterations: devIterations,
+		}
+		devInfo, err := devrunner.Dev(ctx, app, skaffoldBinaryPath, eventsFileAbsPath, skaffoldFlags[i])
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		defer os.Remove(eventsFileAbsPath)
+
+		if i < warmupRuns {
+			continue
+		}
+		eventDurations, err := events.ParseEventDuration(ctx, eventsFileAbsPath)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		binFile, err := os.Stat(skaffoldBinaryPath)
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		ra := types.ComparisonStatsSummary{
+			CmdArgs:               devInfo.CmdArgs,
+			BinaryPath:            skaffoldBinaryPath,
+			BinarySize:            binFile.Size(),
+			DevIterations:         conf.DevIterations,
+			DevLoopEventDurations: eventDurations,
+		}
+		fmt.Fprint(&b, ra.String())
+	}
+
+	logrus.Infof("comparison summary information:\n%v ", b.String())
+
+	workDir, err := os.Getwd()
+	if err != nil {
+		logrus.Fatal(err)
+	}
+	if summaryOutputPath != "" {
+		logrus.Infof("writing summary information to path %v", summaryOutputPath)
+		if err := ioutil.WriteFile(filepath.Join(workDir, summaryOutputPath), b.Bytes(), 0644); err != nil {
+			logrus.Fatal(err)
+		}
+	}
+}

--- a/hack/comparisonstats/types/types.go
+++ b/hack/comparisonstats/types/types.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/GoogleContainerTools/skaffold/hack/comparisonstats/util"
+)
+
+type ComparisonStatsCmdArgs struct {
+	SkaffoldBinaries []string
+	ExampleAppName   string
+	ExampleSrcFile   string
+	CommentText      string
+}
+
+func ParseComparisonStatsCmdArgs(args []string) ComparisonStatsCmdArgs {
+	return ComparisonStatsCmdArgs{
+		SkaffoldBinaries: []string{args[0], args[1]},
+		ExampleAppName:   args[2],
+		ExampleSrcFile:   args[3],
+		CommentText:      args[4],
+	}
+}
+
+type Config struct {
+	DevIterations       int64  `yaml:"devIterations"`
+	FirstSkaffoldFlags  string `yaml:"mainBranchSkaffoldFlags"` // NOTE: names mismatched for make vs gh action UX usage
+	SecondSkaffoldFlags string `yaml:"thisPRSkaffoldFlags"`
+	ExampleAppName      string `yaml:"exampleAppName"`
+	ExampleSrcFile      string `yaml:"exampleSrcFile"`
+	CommentText         string `yaml:"commentText"`
+}
+
+type ComparisonStatsSummary struct {
+	BinaryPath            string
+	CmdArgs               []string
+	BinarySize            int64
+	DevIterations         int64
+	DevLoopEventDurations *DevLoopTimes
+}
+
+// durations holds time.Duration values.
+type durations []time.Duration
+
+func (ds durations) avg() time.Duration {
+	var total time.Duration
+	for _, t := range ds {
+		total += t
+	}
+	return time.Duration(int(total) / len(ds))
+}
+
+func (ds durations) stdDev() time.Duration {
+	mean := ds.avg()
+	var s float64
+	for _, t := range ds {
+		s += math.Pow(float64(mean-t), 2)
+	}
+	meansq := s / float64(len(ds))
+	return time.Duration(math.Sqrt(meansq))
+}
+
+func (cs *ComparisonStatsSummary) String() string {
+	var b bytes.Buffer
+
+	fmt.Fprintln(&b, "")
+	fmt.Fprintf(&b, "information for %v for %d iterations of %s:\n", cs.BinaryPath, cs.DevIterations, cs.CmdArgs)
+	fmt.Fprintf(&b, "binary size: %v\n", util.HumanReadableBytesSizeIEC(cs.BinarySize))
+	fmt.Fprintf(&b, "initial loop build, deploy, status-check times: %v\n", []time.Duration{
+		cs.DevLoopEventDurations.InitialBuildTime, cs.DevLoopEventDurations.InitialDeployTime, cs.DevLoopEventDurations.InitialStatusCheckTime})
+	fmt.Fprintf(&b, "inner loop build time avg: %s\n", cs.DevLoopEventDurations.InnerBuildTimes.avg())
+	fmt.Fprintf(&b, "inner loop build time stdDev: %s\n", cs.DevLoopEventDurations.InnerBuildTimes.stdDev())
+	fmt.Fprintf(&b, "inner loop deploy time avg: %s\n", cs.DevLoopEventDurations.InnerDeployTimes.avg())
+	fmt.Fprintf(&b, "inner loop deploy time stdDev: %s\n", cs.DevLoopEventDurations.InnerDeployTimes.stdDev())
+	fmt.Fprintf(&b, "inner loop status check time avg: %s\n", cs.DevLoopEventDurations.InnerStatusCheckTimes.avg())
+	fmt.Fprintf(&b, "inner loop status check time stdDev: %s\n", cs.DevLoopEventDurations.InnerStatusCheckTimes.stdDev())
+	return b.String()
+}
+
+type DevLoopTimes struct {
+	InitialBuildTime       time.Duration
+	InitialDeployTime      time.Duration
+	InitialStatusCheckTime time.Duration
+	InnerBuildTimes        durations
+	InnerDeployTimes       durations
+	InnerStatusCheckTimes  durations
+}
+
+// Application represends a single test application
+type Application struct {
+	Name          string            `yaml:"name" yamltags:"required"`
+	Context       string            `yaml:"context" yamltags:"required"`
+	Dev           Dev               `yaml:"dev" yamltags:"required"`
+	DevIterations int64             `yaml:"devIterations" yamltags:"required"`
+	Labels        map[string]string `yaml:"labels" yamltags:"required"`
+}
+
+// Dev describes necessary info for running `skaffold dev` on a test application
+type Dev struct {
+	Command string `yaml:"command" yamltags:"required"`
+}

--- a/hack/comparisonstats/util/util.go
+++ b/hack/comparisonstats/util/util.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import "fmt"
+
+func HumanReadableBytesSizeIEC(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB",
+		float64(b)/float64(div), "KMGTPE"[exp])
+}

--- a/hack/comparisonstats/util/util_test.go
+++ b/hack/comparisonstats/util/util_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestHumanReadableBytesSizeIEC(t *testing.T) {
+	tests := []struct {
+		description string
+		bytesSize   int64
+		expected    string
+	}{
+		{
+			description: "68993024 -> 66MB",
+			bytesSize:   int64(68993024),
+			expected:    "65.8 MiB",
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			got := HumanReadableBytesSizeIEC(test.bytesSize)
+
+			t.CheckDeepEqual(test.expected, got)
+		})
+	}
+}

--- a/hack/comparisonstats/validate/validate.go
+++ b/hack/comparisonstats/validate/validate.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validate
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/sirupsen/logrus"
+)
+
+const NumBinaries = 2
+
+func Args(args []string) error {
+	if len(args) < NumBinaries+2 {
+		logrus.Fatalf("comparisonstats expects input of the form: $ comparisonstats /usr/bin/bin1 /usr/bin/bin2 helm-deployment main.go \"//per-dev-iteration-comment\"")
+	}
+
+	if err := validateBinaries(args[1:NumBinaries]); err != nil {
+		return err
+	}
+
+	if err := validateExampleAppNameAndSrcFile(args[NumBinaries], args[1+NumBinaries]); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateBinaries(binpaths []string) error {
+	for _, binpath := range binpaths {
+		_, err := os.Stat(binpath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateExampleAppNameAndSrcFile(exampleAppName, exampleSrcFile string) error {
+	fp := filepath.Join("examples/", exampleAppName)
+	if filepath.IsAbs(exampleAppName) {
+		fp = exampleAppName
+	}
+	_, err := os.Stat(fp)
+	if err != nil {
+		return err
+	}
+
+	fp = filepath.Join("examples/", exampleAppName, exampleSrcFile)
+	if filepath.IsAbs(exampleAppName) {
+		fp = exampleAppName
+	}
+	_, err = os.Stat(fp)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -41,5 +41,5 @@ if [[ "${CI}" == "true" ]]; then
     FLAGS="-v --print-resources-usage"
 fi
 
-${BIN}/golangci-lint run ${FLAGS} -c ${DIR}/golangci.yml \
+${BIN}/golangci-lint run ${FLAGS} --exclude=SA1019 -c ${DIR}/golangci.yml \
     | awk '/out of memory/ || /Timeout exceeded/ {failed = 1}; {print}; END {exit failed}'


### PR DESCRIPTION
PR adds two new github actions:
- performance-comparison-label.yml
- performance-comparison.yml

performance-comparison-label.yml
This Github Action responds to adding the label `help:run-comparisonstats` to a PR.  The Github Action is then triggered and:
- removes the `help:run-comparisonstats` label
- adds a comment with a copy-pastable command to launch the `run-comparisonstats` job with additional help text for the supported flags and usage

performance-comparison.yml
This Github Action is triggered on PR comments that start with `/run-comparisonstats ...`.  It does the following:
- Verifes that comment made was by someone with GoogleContainerTools/skaffold `write` permissions
- Adds a rocket emoji to the triggering comment for better UX to let user know job launch was successful
- Does a similar install to our `integration-linux.yml` (checks out PR repo, installs dependencies, launches minikube, etc.)
- Downloads and installs the latest skaffold binary from our CI/CD builds from - `https://storage.googleapis.com/skaffold/builds/latest/skaffold-linux-amd64` as `skaffold-from-main-branch`
- Builds skaffold from this pr as `skaffold-<branch-name>`
- Runs the `comparisonstats` binary against `skaffold-from-main-branch` and `skaffold-<branch-name>`
  - This outputs binary size and timing comparison information
- The job then takes the `comparisonstats` output and adds it as a comment to the PR

**Sample usage of label helper and performance comparison job can be found in aaron-prindle fork here:**
https://github.com/aaron-prindle/skaffold/pull/69