### PR TITLE
add skaffold inspect tests list command

### DIFF
--- a/cmd/skaffold/app/cmd/inspect.go
+++ b/cmd/skaffold/app/cmd/inspect.go
@@ -39,7 +39,7 @@ func NewCmdInspect() *cobra.Command {
 		WithDescription("Helper commands for Cloud Code IDEs to interact with and modify skaffold configuration files.").
 		WithPersistentFlagAdder(cmdInspectFlags).
 		Hidden().
-		WithCommands(cmdModules(), cmdProfiles(), cmdBuildEnv())
+		WithCommands(cmdModules(), cmdProfiles(), cmdBuildEnv(), cmdTests())
 }
 
 func cmdInspectFlags(f *pflag.FlagSet) {

--- a/cmd/skaffold/app/cmd/inspect_tests.go
+++ b/cmd/skaffold/app/cmd/inspect_tests.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"io"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/inspect"
+	tests "github.com/GoogleContainerTools/skaffold/pkg/skaffold/inspect/tests"
+)
+
+func cmdTests() *cobra.Command {
+	return NewCmd("tests").
+		WithDescription("View skaffold test information").
+		WithPersistentFlagAdder(cmdTestsFlags).
+		WithCommands(cmdTestsList())
+}
+
+func cmdTestsList() *cobra.Command {
+	return NewCmd("list").
+		WithExample("Get list of tests", "inspect tests list --format json").
+		WithExample("Get list of tests targeting a specific configuration", "inspect tests list --profile local --format json").
+		WithDescription("Print the list of tests that would be run for a given configuration (default skaffold configuration, specific module, specific profile, etc).").
+		NoArgs(listTests)
+}
+
+func listTests(ctx context.Context, out io.Writer) error {
+	return tests.PrintTestsList(ctx, out, inspect.Options{
+		Filename:     inspectFlags.filename,
+		RepoCacheDir: inspectFlags.repoCacheDir,
+		OutFormat:    inspectFlags.outFormat,
+		Modules:      inspectFlags.modules,
+	})
+}
+
+func cmdTestsFlags(f *pflag.FlagSet) {
+	f.StringSliceVarP(&inspectFlags.modules, "module", "m", nil, "Names of modules to filter target action by.")
+	f.StringSliceVarP(&inspectFlags.profiles, "profile", "p", nil, `Profile names to activate`)
+}

--- a/pkg/skaffold/inspect/tests/list.go
+++ b/pkg/skaffold/inspect/tests/list.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inspect
+
+import (
+	"context"
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/inspect"
+)
+
+type testList struct {
+	Tests []interface{} `json:"tests"`
+}
+
+// CustomTest entries are handled by CustomTest struct, there is no StructureTest so structureTestEntry is required
+type structureTestEntry struct {
+	StructureTest     string   `json:"structureTest"`
+	StructureTestArgs []string `json:"structureTestArgs"`
+}
+
+func PrintTestsList(ctx context.Context, out io.Writer, opts inspect.Options) error {
+	formatter := inspect.OutputFormatter(out, opts.OutFormat)
+	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, RepoCacheDir: opts.RepoCacheDir})
+	if err != nil {
+		return formatter.WriteErr(err)
+	}
+
+	l := &testList{Tests: []interface{}{}}
+	for _, c := range cfgs {
+		for _, t := range c.Test {
+			for _, ct := range t.CustomTests {
+				l.Tests = append(l.Tests, ct)
+			}
+			for _, st := range t.StructureTests {
+				l.Tests = append(l.Tests, structureTestEntry{StructureTest: st, StructureTestArgs: t.StructureTestArgs})
+			}
+		}
+	}
+	return formatter.Write(l)
+}

--- a/pkg/skaffold/inspect/tests/list_test.go
+++ b/pkg/skaffold/inspect/tests/list_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inspect
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/inspect"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser"
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/errors"
+	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestPrintTestsList(t *testing.T) {
+	tests := []struct {
+		description string
+		profiles    []string
+		module      []string
+		err         error
+		expected    string
+	}{
+		{
+			description: "print all tests",
+			expected:    `{"tests":[{"structureTest":"structure-test-i0","structureTestArgs":null},{"Command":"custom-test-i0","TimeoutSeconds":0,"Dependencies":null}]}` + "\n",
+		},
+		{
+			description: "print all tests for one module",
+			expected:    `{"tests":[{"structureTest":"structure-test-i0","structureTestArgs":null}]}` + "\n",
+			module:      []string{"cfg1"},
+		},
+		{
+			description: "print all tests for two activated profiles",
+
+			expected: `{"tests":[{"structureTest":"structure-test-i0","structureTestArgs":null},{"Command":"custom-test-i0","TimeoutSeconds":0,"Dependencies":null}]}` + "\n",
+			profiles: []string{"custom-test", "structure-test"},
+		},
+		{
+			description: "print all tests for one module and an activated profile",
+
+			expected: `{"tests":[{"structureTest":"structure-test-i0","structureTestArgs":null}]}` + "\n",
+			module:   []string{"cfg1"},
+			profiles: []string{"custom-test"},
+		},
+		{
+			description: "actionable error",
+			err:         sErrors.MainConfigFileNotFoundErr("path/to/skaffold.yaml", fmt.Errorf("failed to read file : %q", "skaffold.yaml")),
+			expected:    `{"errorCode":"CONFIG_FILE_NOT_FOUND_ERR","errorMessage":"unable to find configuration file \"path/to/skaffold.yaml\": failed to read file : \"skaffold.yaml\". Check that the specified configuration file exists at \"path/to/skaffold.yaml\"."}` + "\n",
+		},
+		{
+			description: "generic error",
+			err:         errors.New("some error occurred"),
+			expected:    `{"errorCode":"INSPECT_UNKNOWN_ERR","errorMessage":"some error occurred"}` + "\n",
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			configSet := parser.SkaffoldConfigSet{
+				&parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{
+					Metadata: v1.Metadata{Name: "cfg1"},
+					Pipeline: v1.Pipeline{Test: []*v1.TestCase{{StructureTests: []string{"structure-test-i0"}}}},
+					Profiles: []v1.Profile{
+						{Name: "custom-test", Pipeline: v1.Pipeline{Test: []*v1.TestCase{{CustomTests: []v1.CustomTest{{Command: "custom-test-i0"}}}}}}},
+				}, SourceFile: "path/to/cfg1"},
+				&parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{
+					Metadata: v1.Metadata{Name: "cfg2"},
+					Pipeline: v1.Pipeline{Test: []*v1.TestCase{{CustomTests: []v1.CustomTest{{Command: "custom-test-i0"}}}}},
+					Profiles: []v1.Profile{
+						{Name: "structure-test", Pipeline: v1.Pipeline{Test: []*v1.TestCase{{StructureTests: []string{"structure-test-i0"}}}}}},
+				}, SourceFile: "path/to/cfg1"},
+			}
+			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+				// mock profile activation
+				var set parser.SkaffoldConfigSet
+				for _, c := range configSet {
+					if len(opts.ConfigurationFilter) > 0 && !util.StrSliceContains(opts.ConfigurationFilter, c.Metadata.Name) {
+						continue
+					}
+					for _, pName := range opts.Profiles {
+						for _, profile := range c.Profiles {
+							if profile.Name != pName {
+								continue
+							}
+							c.Test = profile.Test
+						}
+					}
+					set = append(set, c)
+				}
+				return set, test.err
+			})
+			var buf bytes.Buffer
+			err := PrintTestsList(context.Background(), &buf, inspect.Options{OutFormat: "json", Modules: test.module})
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expected, buf.String())
+		})
+	}
+}


### PR DESCRIPTION
###  What is the problem being solved?
Fixes #6355, adding skaffold command to verify if tests will be run.  This is done by extending the `skaffold inspect` command to have a new subcommand `skaffold inspect tests` and `skaffold inspect tests list`.  This is needed as an upstream project that depends on skaffold requires the ability to introspect from a users skaffold configuration (all `skaffold.yamls`, modules, profiles, etc.) whether a test will run or not.  

###  Why is this the best approach?
This approach is best as it re-uses the previously created `skaffold inspect` command, the goal if which (inspecting skaffold configuration and outputting usable json) is nearly identical to what is desired for #6355. The only small issue is that currently this outputs a flat list of json objects which represent both `CustomTest` and `StructureTest` tests.  The upstream project mentioned they only require the ability to know `will tests run for these configs+modules+profiles`.  This can be done though via some jq or other ingestion of the json, for example `jq -e '.tests | select(length != 0)' inspect-tests-list.json` (returns exitCode: 4 if array is empty)

### What other approaches did you consider?
Other approaches included:
- `skaffold test --dry-run` surface (vs `skaffold inspect tests lists`) to see what tests might be run.  A bit cludgy espectially considering `skaffold inspect already exists`
- Making `skaffold inspect tests lists` surface have custom outputter that could output bools to specifically answer the question required w/ no json parsing - `will tests run for these configs+modules+profiles`

###  What side effects will this approach have?
There shouldn't be any side effects w/ this approach as this is a new command and the `skaffold inspect` command itself is hidden from users and not widely used by most skaffold users

###  What future work remains to be done?
Future work includes:
    - possibly adding `skaffold inspect [build|deploy] list` to flesh out `skaffold inspect` for all phases
    - possibly adding more outputters/flag-opts for specific `skaffold inspect` use cases