### PR TITLE
Implement Target support for ko builder

### DIFF
--- a/pkg/skaffold/build/ko/build_test.go
+++ b/pkg/skaffold/build/ko/build_test.go
@@ -87,10 +87,12 @@ func Test_getImportPath(t *testing.T) {
 		expectedImportPath string
 	}{
 		{
-			description: "image name is ko-prefixed full Go import path",
+			description: "target is ignored when image name is ko-prefixed full Go import path",
 			artifact: &latestV1.Artifact{
 				ArtifactType: latestV1.ArtifactType{
-					KoArtifact: &latestV1.KoArtifact{},
+					KoArtifact: &latestV1.KoArtifact{
+						Target: "./target-should-be-ignored",
+					},
 				},
 				ImageName: "ko://git.example.com/org/foo",
 			},
@@ -113,9 +115,22 @@ func Test_getImportPath(t *testing.T) {
 					KoArtifact: &latestV1.KoArtifact{},
 				},
 				ImageName: "bar",
-				Workspace: "../docker",
+				Workspace: "./testdata/package-main-in-root",
 			},
-			expectedImportPath: "ko://github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/docker", // this package + "../docker"
+			expectedImportPath: "ko://github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/testdata/package-main-in-root",
+		},
+		{
+			description: "plain image name with workspace directory and target",
+			artifact: &latestV1.Artifact{
+				ArtifactType: latestV1.ArtifactType{
+					KoArtifact: &latestV1.KoArtifact{
+						Target: "./baz",
+					},
+				},
+				ImageName: "baz-image",
+				Workspace: "./testdata/package-main-not-in-root",
+			},
+			expectedImportPath: "ko://github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/testdata/package-main-not-in-root/baz",
 		},
 	}
 	for _, test := range tests {
@@ -124,7 +139,7 @@ func Test_getImportPath(t *testing.T) {
 			koBuilder, err := b.newKoBuilder(context.Background(), test.artifact)
 			t.CheckNoError(err)
 
-			gotImportPath, err := getImportPath(test.artifact.ImageName, koBuilder)
+			gotImportPath, err := getImportPath(test.artifact, koBuilder)
 			t.CheckNoError(err)
 
 			t.CheckDeepEqual(test.expectedImportPath, gotImportPath)

--- a/pkg/skaffold/build/ko/schema/temporary.go
+++ b/pkg/skaffold/build/ko/schema/temporary.go
@@ -36,6 +36,14 @@ type KoArtifact struct {
 	// Defaults to `all` to build for all platforms supported by the
 	// base image.
 	Platforms []string `yaml:"platforms,omitempty"`
+
+	// Target is the location of the main package.
+	// If target is specified as a relative path, it is relative to the `context` directory.
+	// If target is empty, the ko builder looks for the main package in the `context` directory only, but not in any subdirectories.
+	// If target is a pattern with wildcards, such as `./...`, the expansion must contain only one main package, otherwise ko fails.
+	// Target is ignored if the `ImageName` starts with `ko://`.
+	// Example: `./cmd/foo`
+	Target string `yaml:"target,omitempty"`
 }
 
 // KoDependencies is used to specify dependencies for an artifact built by ko.

--- a/pkg/skaffold/build/ko/testdata/package-main-in-root/go.mod
+++ b/pkg/skaffold/build/ko/testdata/package-main-in-root/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/testdata/package-main-in-root
+
+go 1.13

--- a/pkg/skaffold/build/ko/testdata/package-main-in-root/main.go
+++ b/pkg/skaffold/build/ko/testdata/package-main-in-root/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/pkg/skaffold/build/ko/testdata/package-main-not-in-root/baz/main.go
+++ b/pkg/skaffold/build/ko/testdata/package-main-not-in-root/baz/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/pkg/skaffold/build/ko/testdata/package-main-not-in-root/go.mod
+++ b/pkg/skaffold/build/ko/testdata/package-main-not-in-root/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/testdata/package-main-not-in-root
+
+go 1.13


### PR DESCRIPTION
**Description**

This implements support for the `Target` config field for the ko builder.

The `Target` field allows users to specify a target for `go build`. This is necessary where the main package is not in the context directory.

Creates a `testdata` directory under `./pkg/skaffold/build/ko` with test samples. This is to avoid depending on test samples from other packages.

Tracking: #6041
Related: #6054, #6437
