### PR TITLE
fix new build tags errors from hack/gofmt.sh

### DIFF
--- a/cmd/skaffold/app/signals_test.go
+++ b/cmd/skaffold/app/signals_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 /*

--- a/pkg/skaffold/build/jib/jib_non_windows_test.go
+++ b/pkg/skaffold/build/jib/jib_non_windows_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/skaffold/build/jib/jib_windows_test.go
+++ b/pkg/skaffold/build/jib/jib_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/pkg/skaffold/gcp/auth_test.go
+++ b/pkg/skaffold/gcp/auth_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/skaffold/kubectl/exec.go
+++ b/pkg/skaffold/kubectl/exec.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/skaffold/tag/git_commit_test.go
+++ b/pkg/skaffold/tag/git_commit_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/skaffold/tags/paths_test.go
+++ b/pkg/skaffold/tags/paths_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/skaffold/util/wrapper_unix.go
+++ b/pkg/skaffold/util/wrapper_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/skaffold/util/wrapper_unix_test.go
+++ b/pkg/skaffold/util/wrapper_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/skaffold/util/wrapper_windows_test.go
+++ b/pkg/skaffold/util/wrapper_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*


### PR DESCRIPTION
Seeing errors using `make linters` locally.  This has the suggested fixes from the linter, seems build tags have a new syntax now at least from the lint suggestion