### PR TITLE
api: Strict port number handling and --enable-rpc deprecation

### DIFF
--- a/cmd/skaffold/app/cmd/debug_test.go
+++ b/cmd/skaffold/app/cmd/debug_test.go
@@ -40,7 +40,6 @@ func TestNewCmdDebug(t *testing.T) {
 
 		t.CheckDeepEqual(true, opts.Tail)
 		t.CheckDeepEqual(false, opts.Force)
-		t.CheckDeepEqual(true, opts.EnableRPC)
 	})
 }
 

--- a/cmd/skaffold/app/cmd/dev_test.go
+++ b/cmd/skaffold/app/cmd/dev_test.go
@@ -176,6 +176,5 @@ func TestNewCmdDev(t *testing.T) {
 
 		t.CheckDeepEqual(true, opts.Tail)
 		t.CheckDeepEqual(false, opts.Force)
-		t.CheckDeepEqual(true, opts.EnableRPC)
 	})
 }

--- a/cmd/skaffold/app/cmd/init_test.go
+++ b/cmd/skaffold/app/cmd/init_test.go
@@ -157,7 +157,7 @@ func TestFlagsToConfigVersion(t *testing.T) {
 
 			// we ignore Skaffold options
 			test.expectedConfig.Opts = capturedConfig.Opts
-			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedConfig, capturedConfig, cmp.AllowUnexported(cfg.StringOrUndefined{}, cfg.BoolOrUndefined{}, cfg.SyncRemoteCacheOption{}))
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedConfig, capturedConfig, cmp.AllowUnexported(cfg.StringOrUndefined{}, cfg.BoolOrUndefined{}, cfg.IntOrUndefined{}, cfg.SyncRemoteCacheOption{}))
 		})
 	}
 }

--- a/docs/content/en/docs/design/api.md
+++ b/docs/content/en/docs/design/api.md
@@ -21,38 +21,36 @@ To retrieve information about the Skaffold pipeline, the Skaffold API provides t
 To control the individual phases of the Skaffold, the Skaffold API provides [fine-grained control]({{< relref "#control-api" >}})
 over the individual phases of the pipeline (build, deploy, and sync).
 
-
 ## Connecting to the Skaffold API
 The Skaffold API is `gRPC` based, and it is also exposed via the gRPC gateway as a JSON over HTTP service.
-The server is hosted locally on the same host where the skaffold process is running, and will serve by default on ports 50051 and 50052.
-These ports can be configured through the `--rpc-port` and `--rpc-http-port` flags.
+
+The API can be enabled via setting the `--rpc-port` or `--rpc-http-port` flags (or both)
+depending on whether you want to enable the gRPC API or the HTTP REST API, respectively.
+
+
+{{< alert title="Note">}}
+The `--enable-rpc` flag is now deprecated in favor of `--rpc-port` and `--rpc-http-port` flags.
+{{</alert>}}
+
 
 For reference, we generate the server's [gRPC service definitions and message protos]({{< relref "/docs/references/api/grpc" >}}) as well as the [Swagger based HTTP API Spec]({{< relref "/docs/references/api/swagger" >}}).
 
+## gRPC Server
+
+The gRPC API can be started by specifying the `--rpc-port` flag. If the specified port is not available, Skaffold will
+exit with failure.
 
 ### HTTP server
-The HTTP API is exposed on port `50052` by default. The default HTTP port can be overridden with the `--rpc-http-port` flag. 
-If the HTTP API port is taken, Skaffold will find the next available port.
-The final port can be found from Skaffold's startup logs.
 
-```code
-$ skaffold dev
-WARN[0000] port 50052 for gRPC HTTP server already in use: using 50055 instead
-```
+The HTTP REST API can be started by specifying the `--rpc-http-port` flag. If the specified port is not available,
+Skaffold will exit with failure.
 
-### gRPC Server
-
-The gRPC API is exposed on port `50051` by default and can be overridden with the `--rpc-port` flag.
-As with the HTTP API, if this port is taken, Skaffold will find the next available port.
-You can find this port from Skaffold's logs on startup.
-
-```code
-$ skaffold dev
-WARN[0000] port 50051 for gRPC server already in use: using 50053 instead
-```
+Starting the HTTP REST API will also start the gRPC API as it proxies the requests to the gRPC API. By default, Skaffold
+chooses a random available port for gRPC, but it can be customized (see below).
 
 #### Creating a gRPC Client
-To connect to the `gRPC` server at default port `50051`, create a client using the following code snippet.
+
+To connect to the `gRPC` server at the specified port, create a client using the following code snippet.
 
 {{< alert title="Note" >}}
 The skaffold gRPC server is not compatible with HTTPS, so connections need to be marked as insecure with `grpc.WithInsecure()`

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -121,7 +121,6 @@ Examples:
 
 Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
-      --enable-rpc=false: Enable gRPC for exposing Skaffold events
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime!
       --iterative-status-check=false: Run `status-check` iteratively after each deploy step, instead of all-together at the end of all deploys (default).
@@ -146,7 +145,6 @@ Use "skaffold options" for a list of global command-line options (applies to all
 Env vars:
 
 * `SKAFFOLD_CONFIG` (same as `--config`)
-* `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)
 * `SKAFFOLD_ITERATIVE_STATUS_CHECK` (same as `--iterative-status-check`)
@@ -196,7 +194,6 @@ Options:
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
       --dry-run=false: Don't build images, just compute the tag for each artifact.
-      --enable-rpc=false: Enable gRPC for exposing Skaffold events
       --file-output='': Filename to write build images to
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --insecure-registry=[]: Target registries for built images which are not secure
@@ -212,8 +209,8 @@ Options:
       --push=: Push the built images to the specified image repository.
   -q, --quiet=false: Suppress the build output and print image built on success. See --output to format output.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
-      --rpc-http-port=50052: tcp port to expose event REST API over HTTP
-      --rpc-port=50051: tcp port to expose event API
+      --rpc-http-port=: tcp port to expose the Skaffold API over HTTP REST
+      --rpc-port=: tcp port to expose the Skaffold API over gRPC
       --skip-tests=false: Whether to skip the tests after building
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
@@ -237,7 +234,6 @@ Env vars:
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
 * `SKAFFOLD_DRY_RUN` (same as `--dry-run`)
-* `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILE_OUTPUT` (same as `--file-output`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_INSECURE_REGISTRY` (same as `--insecure-registry`)
@@ -402,7 +398,6 @@ Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
-      --enable-rpc=true: Enable gRPC for exposing Skaffold events
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime!
       --insecure-registry=[]: Target registries for built images which are not secure
@@ -421,8 +416,8 @@ Options:
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --protocols=[]: Priority sorted order of debugger protocols to support.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
-      --rpc-http-port=50052: tcp port to expose event REST API over HTTP
-      --rpc-port=50051: tcp port to expose event API
+      --rpc-http-port=: tcp port to expose the Skaffold API over HTTP REST
+      --rpc-port=: tcp port to expose the Skaffold API over gRPC
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
@@ -458,7 +453,6 @@ Env vars:
 * `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
-* `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)
 * `SKAFFOLD_INSECURE_REGISTRY` (same as `--insecure-registry`)
@@ -564,7 +558,6 @@ Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
-      --enable-rpc=false: Enable gRPC for exposing Skaffold events
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime!
   -i, --images=: A list of pre-built images to deploy
@@ -581,8 +574,8 @@ Options:
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
-      --rpc-http-port=50052: tcp port to expose event REST API over HTTP
-      --rpc-port=50051: tcp port to expose event API
+      --rpc-http-port=: tcp port to expose the Skaffold API over HTTP REST
+      --rpc-port=: tcp port to expose the Skaffold API over gRPC
       --skip-render=false: Don't render the manifests, just deploy them
       --status-check=true: Wait for deployed resources to stabilize
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
@@ -608,7 +601,6 @@ Env vars:
 * `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
-* `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)
 * `SKAFFOLD_IMAGES` (same as `--images`)
@@ -659,7 +651,6 @@ Options:
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
       --digest-source='remote': Set to 'remote' to skip builds and resolve the digest of images by tag from the remote registry. Set to 'local' to build images locally and use digests from built images. Set to 'tag' to use tags directly from the build. Set to 'none' to use tags directly from the Kubernetes manifests.
-      --enable-rpc=true: Enable gRPC for exposing Skaffold events
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime!
       --insecure-registry=[]: Target registries for built images which are not secure
@@ -677,8 +668,8 @@ Options:
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
-      --rpc-http-port=50052: tcp port to expose event REST API over HTTP
-      --rpc-port=50051: tcp port to expose event API
+      --rpc-http-port=: tcp port to expose the Skaffold API over HTTP REST
+      --rpc-port=: tcp port to expose the Skaffold API over gRPC
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
@@ -715,7 +706,6 @@ Env vars:
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
 * `SKAFFOLD_DIGEST_SOURCE` (same as `--digest-source`)
-* `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)
 * `SKAFFOLD_INSECURE_REGISTRY` (same as `--insecure-registry`)
@@ -907,7 +897,6 @@ Options:
       --cache-artifacts=true: Set to false to disable default caching of artifacts
   -d, --default-repo='': Default repository value (overrides global config)
       --digest-source='remote': Set to 'remote' to skip builds and resolve the digest of images by tag from the remote registry. Set to 'local' to build images locally and use digests from built images. Set to 'tag' to use tags directly from the build. Set to 'none' to use tags directly from the Kubernetes manifests.
-      --enable-rpc=false: Enable gRPC for exposing Skaffold events
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
   -l, --label=[]: Add custom labels to deployed objects. Set multiple times for multiple labels
       --loud=false: Show the build logs and output
@@ -935,7 +924,6 @@ Env vars:
 * `SKAFFOLD_CACHE_ARTIFACTS` (same as `--cache-artifacts`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DIGEST_SOURCE` (same as `--digest-source`)
-* `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_LABEL` (same as `--label`)
 * `SKAFFOLD_LOUD` (same as `--loud`)
@@ -976,7 +964,6 @@ Options:
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
       --digest-source='remote': Set to 'remote' to skip builds and resolve the digest of images by tag from the remote registry. Set to 'local' to build images locally and use digests from built images. Set to 'tag' to use tags directly from the build. Set to 'none' to use tags directly from the Kubernetes manifests.
-      --enable-rpc=false: Enable gRPC for exposing Skaffold events
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --force=false: Recreate Kubernetes resources if necessary for deployment, warning: might cause downtime!
       --insecure-registry=[]: Target registries for built images which are not secure
@@ -994,8 +981,8 @@ Options:
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
-      --rpc-http-port=50052: tcp port to expose event REST API over HTTP
-      --rpc-port=50051: tcp port to expose event API
+      --rpc-http-port=: tcp port to expose the Skaffold API over HTTP REST
+      --rpc-port=: tcp port to expose the Skaffold API over gRPC
       --skip-tests=false: Whether to skip the tests after building
       --status-check=true: Wait for deployed resources to stabilize
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
@@ -1027,7 +1014,6 @@ Env vars:
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
 * `SKAFFOLD_DIGEST_SOURCE` (same as `--digest-source`)
-* `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_FORCE` (same as `--force`)
 * `SKAFFOLD_INSECURE_REGISTRY` (same as `--insecure-registry`)
@@ -1130,15 +1116,14 @@ Examples:
 Options:
   -a, --build-artifacts=: File containing build result from a previous 'skaffold build --file-output'
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
-      --enable-rpc=false: Enable gRPC for exposing Skaffold events
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
   -m, --module=[]: Filter Skaffold configs to only the provided named modules
   -p, --profile=[]: Activate profiles by name (prefixed with `-` to disable a profile)
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
-      --rpc-http-port=50052: tcp port to expose event REST API over HTTP
-      --rpc-port=50051: tcp port to expose event API
+      --rpc-http-port=: tcp port to expose the Skaffold API over HTTP REST
+      --rpc-port=: tcp port to expose the Skaffold API over gRPC
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
       --wait-for-connection=false: Blocks execution until the /v2/events gRPC/HTTP endpoint is hit
 
@@ -1153,7 +1138,6 @@ Env vars:
 
 * `SKAFFOLD_BUILD_ARTIFACTS` (same as `--build-artifacts`)
 * `SKAFFOLD_CONFIG` (same as `--config`)
-* `SKAFFOLD_ENABLE_RPC` (same as `--enable-rpc`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_MODULE` (same as `--module`)
 * `SKAFFOLD_PROFILE` (same as `--profile`)

--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -143,7 +143,7 @@ func TestDebugEventsRPC_StatusCheck(t *testing.T) {
 	ns, client := SetupNamespace(t)
 
 	rpcAddr := randomPort()
-	skaffold.Debug("--enable-rpc", "--rpc-port", rpcAddr).InDir("testdata/jib").InNs(ns.Name).RunBackground(t)
+	skaffold.Debug("--rpc-port", rpcAddr).InDir("testdata/jib").InNs(ns.Name).RunBackground(t)
 
 	waitForDebugEvent(t, client, rpcAddr)
 }
@@ -157,7 +157,7 @@ func TestDebugEventsRPC_NoStatusCheck(t *testing.T) {
 	ns, client := SetupNamespace(t)
 
 	rpcAddr := randomPort()
-	skaffold.Debug("--enable-rpc", "--rpc-port", rpcAddr, "--status-check=false").InDir("testdata/jib").InNs(ns.Name).RunBackground(t)
+	skaffold.Debug("--rpc-port", rpcAddr, "--status-check=false").InDir("testdata/jib").InNs(ns.Name).RunBackground(t)
 
 	waitForDebugEvent(t, client, rpcAddr)
 }

--- a/integration/port_forward_test.go
+++ b/integration/port_forward_test.go
@@ -58,7 +58,7 @@ func TestRunPortForward(t *testing.T) {
 	ns, _ := SetupNamespace(t)
 
 	rpcAddr := randomPort()
-	skaffold.Run("--port-forward", "--rpc-port", rpcAddr, "--enable-rpc").InDir("examples/microservices").InNs(ns.Name).RunBackground(t)
+	skaffold.Run("--port-forward", "--rpc-port", rpcAddr).InDir("examples/microservices").InNs(ns.Name).RunBackground(t)
 
 	_, entries := apiEvents(t, rpcAddr)
 
@@ -72,7 +72,7 @@ func TestRunUserPortForwardResource(t *testing.T) {
 	ns, _ := SetupNamespace(t)
 
 	rpcAddr := randomPort()
-	skaffold.Run("--port-forward", "--rpc-port", rpcAddr, "--enable-rpc").InDir("examples/microservices").InNs(ns.Name).RunBackground(t)
+	skaffold.Run("--port-forward", "--rpc-port", rpcAddr).InDir("examples/microservices").InNs(ns.Name).RunBackground(t)
 
 	_, entries := apiEvents(t, rpcAddr)
 
@@ -86,7 +86,7 @@ func TestRunPortForwardByPortName(t *testing.T) {
 	ns, _ := SetupNamespace(t)
 
 	rpcAddr := randomPort()
-	skaffold.Run("--port-forward", "--rpc-port", rpcAddr, "--enable-rpc").InDir("examples/microservices").InNs(ns.Name).RunBackground(t)
+	skaffold.Run("--port-forward", "--rpc-port", rpcAddr).InDir("examples/microservices").InNs(ns.Name).RunBackground(t)
 
 	_, entries := apiEvents(t, rpcAddr)
 

--- a/integration/rpc_test.go
+++ b/integration/rpc_test.go
@@ -46,6 +46,19 @@ var (
 	waitTime          = 1 * time.Second
 )
 
+func TestEnableRPCFlagDeprecation(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+	rpcPort := randomPort()
+	out, err := skaffold.Build("--enable-rpc", "--rpc-port", rpcPort).InDir("testdata/build").RunWithCombinedOutput(t)
+	testutil.CheckError(t, false, err)
+	testutil.CheckContains(t, "Flag --enable-rpc has been deprecated", string(out))
+
+	rpcPort = randomPort()
+	out, err = skaffold.Build("--rpc-port", rpcPort).InDir("testdata/build").RunWithCombinedOutput(t)
+	testutil.CheckError(t, false, err)
+	testutil.CheckNotContains(t, "Flag --enable-rpc has been deprecated", string(out))
+}
+
 func TestEventsRPC(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -88,8 +88,8 @@ type SkaffoldOptions struct {
 	InsecureRegistries []string
 	Muted              Muted
 	Command            string
-	RPCPort            int
-	RPCHTTPPort        int
+	RPCPort            IntOrUndefined
+	RPCHTTPPort        IntOrUndefined
 	BuildConcurrency   int
 	MakePathsAbsolute  *bool
 	// TODO(https://github.com/GoogleContainerTools/skaffold/issues/3668):

--- a/pkg/skaffold/config/types.go
+++ b/pkg/skaffold/config/types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"strconv"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
@@ -104,6 +106,47 @@ func NewBoolOrUndefined(v *bool) BoolOrUndefined {
 // Muted lists phases for which logs are muted.
 type Muted struct {
 	Phases []string
+}
+
+// IntOrUndefined holds the value of a flag of type `int`,
+// that's by default `undefined`.
+// We use this instead of just `int` to differentiate `undefined`
+// and `zero` values.
+type IntOrUndefined struct {
+	value *int
+}
+
+func (s *IntOrUndefined) Type() string {
+	return "int"
+}
+
+func (s *IntOrUndefined) Value() *int {
+	return s.value
+}
+
+func (s *IntOrUndefined) Set(v string) error {
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return err
+	}
+	s.value = &i
+	return nil
+}
+
+func (s *IntOrUndefined) SetNil() error {
+	s.value = nil
+	return nil
+}
+
+func (s *IntOrUndefined) String() string {
+	if s.value == nil {
+		return ""
+	}
+	return strconv.Itoa(*s.value)
+}
+
+func NewIntOrUndefined(v *int) IntOrUndefined {
+	return IntOrUndefined{value: v}
 }
 
 func (m Muted) MuteBuild() bool       { return m.mute("build") }

--- a/pkg/skaffold/constants/constants.go
+++ b/pkg/skaffold/constants/constants.go
@@ -61,9 +61,6 @@ const (
 	DefaultCacheFile   = "cache"
 	DefaultMetricFile  = "metrics"
 
-	DefaultRPCPort     = 50051
-	DefaultRPCHTTPPort = 50052
-
 	DefaultPortForwardAddress = "127.0.0.1"
 
 	DefaultProjectDescriptor = "project.toml"

--- a/pkg/skaffold/hooks/env.go
+++ b/pkg/skaffold/hooks/env.go
@@ -28,8 +28,8 @@ var staticEnvOpts StaticEnvOpts
 // StaticEnvOpts contains the environment variables to be set in a lifecycle hook executor that don't change during the lifetime of the process.
 type StaticEnvOpts struct {
 	DefaultRepo *string
-	RPCPort     int
-	HTTPPort    int
+	RPCPort     *int
+	HTTPPort    *int
 	WorkDir     string
 }
 
@@ -62,8 +62,8 @@ type DeployEnvOpts struct {
 type Config interface {
 	DefaultRepo() *string
 	GetWorkingDir() string
-	RPCPort() int
-	RPCHTTPPort() int
+	RPCPort() *int
+	RPCHTTPPort() *int
 }
 
 func SetupStaticEnvOptions(cfg Config) {

--- a/pkg/skaffold/hooks/env_test.go
+++ b/pkg/skaffold/hooks/env_test.go
@@ -31,8 +31,8 @@ func TestSetupStaticEnvOptions(t *testing.T) {
 	cfg := mockCfg{
 		defaultRepo: util.StringPtr("gcr.io/foo"),
 		workDir:     ".",
-		rpcPort:     8080,
-		httpPort:    8081,
+		rpcPort:     util.IntPtr(8080),
+		httpPort:    util.IntPtr(8081),
 	}
 	SetupStaticEnvOptions(cfg)
 	testutil.CheckDeepEqual(t, cfg.defaultRepo, staticEnvOpts.DefaultRepo)
@@ -51,8 +51,8 @@ func TestGetEnv(t *testing.T) {
 			description: "static env opts, all defined",
 			input: StaticEnvOpts{
 				DefaultRepo: util.StringPtr("gcr.io/foo"),
-				RPCPort:     8080,
-				HTTPPort:    8081,
+				RPCPort:     util.IntPtr(8080),
+				HTTPPort:    util.IntPtr(8081),
 				WorkDir:     "./foo",
 			},
 			expected: []string{
@@ -65,8 +65,8 @@ func TestGetEnv(t *testing.T) {
 		{
 			description: "static env opts, some missing",
 			input: StaticEnvOpts{
-				RPCPort:  8080,
-				HTTPPort: 8081,
+				RPCPort:  util.IntPtr(8080),
+				HTTPPort: util.IntPtr(8081),
 				WorkDir:  "./foo",
 			},
 			expected: []string{
@@ -152,11 +152,11 @@ func TestGetEnv(t *testing.T) {
 type mockCfg struct {
 	defaultRepo *string
 	workDir     string
-	rpcPort     int
-	httpPort    int
+	rpcPort     *int
+	httpPort    *int
 }
 
 func (m mockCfg) DefaultRepo() *string  { return m.defaultRepo }
 func (m mockCfg) GetWorkingDir() string { return m.workDir }
-func (m mockCfg) RPCPort() int          { return m.rpcPort }
-func (m mockCfg) RPCHTTPPort() int      { return m.httpPort }
+func (m mockCfg) RPCPort() *int         { return m.rpcPort }
+func (m mockCfg) RPCHTTPPort() *int     { return m.httpPort }

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -198,8 +198,8 @@ func (rc *RunContext) BuildConcurrency() int                         { return rc
 func (rc *RunContext) IsMultiConfig() bool                           { return rc.Pipelines.IsMultiPipeline() }
 func (rc *RunContext) IsDefaultKubeContext() bool                    { return rc.Opts.KubeContext == "" }
 func (rc *RunContext) GetRunID() string                              { return rc.RunID }
-func (rc *RunContext) RPCPort() int                                  { return rc.Opts.RPCPort }
-func (rc *RunContext) RPCHTTPPort() int                              { return rc.Opts.RPCHTTPPort }
+func (rc *RunContext) RPCPort() *int                                 { return rc.Opts.RPCPort.Value() }
+func (rc *RunContext) RPCHTTPPort() *int                             { return rc.Opts.RPCHTTPPort.Value() }
 func (rc *RunContext) PushImages() config.BoolOrUndefined            { return rc.Opts.PushImages }
 
 func GetRunContext(ctx context.Context, opts config.SkaffoldOptions, configs []schemaUtil.VersionedConfig) (*RunContext, error) {

--- a/pkg/skaffold/server/server.go
+++ b/pkg/skaffold/server/server.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 
@@ -99,8 +98,14 @@ func SetAutoSyncCallback(callback func(bool)) {
 func Initialize(opts config.SkaffoldOptions) (func() error, error) {
 	emptyCallback := func() error { return nil }
 	if !opts.EnableRPC && opts.RPCPort.Value() == nil && opts.RPCHTTPPort.Value() == nil {
-		logrus.Debug("skaffold API not starting as it's not requested")
+		log.Entry(context.TODO()).Debug("skaffold API not starting as it's not requested")
 		return emptyCallback, nil
+	}
+
+	if opts.EnableRPC && opts.RPCPort.Value() == nil && opts.RPCHTTPPort.Value() == nil {
+		log.Entry(context.TODO()).Warn("--enable-rpc is specified without --rpc-port or --rpc-http-port. " +
+			"Skaffold will choose random port numbers for the API endpoints (run with --verbosity=info) " +
+			"while --enable-rpc flag is being deprecated.")
 	}
 
 	preferredGRPCPort := 0 // bind to an available port atomically

--- a/pkg/skaffold/server/server.go
+++ b/pkg/skaffold/server/server.go
@@ -137,7 +137,7 @@ func Initialize(opts config.SkaffoldOptions) (func() error, error) {
 		return callback, fmt.Errorf("starting HTTP server: %w", err)
 	}
 
-	if opts.EnableRPC && opts.RPCPort.Value() == nil {
+	if opts.EnableRPC && opts.RPCPort.Value() == nil && opts.RPCHTTPPort.Value() == nil {
 		log.Entry(context.TODO()).Warnf("started skaffold gRPC API on random port %d", grpcPort)
 	}
 

--- a/pkg/skaffold/server/server_test.go
+++ b/pkg/skaffold/server/server_test.go
@@ -37,8 +37,8 @@ func TestServerStartup(t *testing.T) {
 	// start up servers
 	shutdown, err := Initialize(config.SkaffoldOptions{
 		EnableRPC:   true,
-		RPCPort:     rpcAddr,
-		RPCHTTPPort: httpAddr,
+		RPCPort:     config.NewIntOrUndefined(&rpcAddr),
+		RPCHTTPPort: config.NewIntOrUndefined(&httpAddr),
 	})
 	defer shutdown()
 	testutil.CheckError(t, false, err)


### PR DESCRIPTION
Fixes #6425
Fixes #6417
Fixes #6375
**Related**: #6425 (proposal), supersedes #6443

**Description**

This path implements the proposal in #6425 and contains various breaking
changes to most users of Skaffold APIs regarding enabling the Skaffold API,
and how port numbers behave.

This patch also fixes the test flakes for the following integration tests (each
ran 100 times) by behaving more strictly around busy ports.

- TestEventsRPC (#6417)
- TestRunPortForward (#6375)

**User facing changes (remove if N/A)**

* API is no longer enabled by default for "dev" and "debug" commands.
  This might be a breaking change for some users who were relying on the
  behavior.

* APIs are only enabled if --rpc-port or --rpc-http-port (or both) are set.
  These flags no longer have defaults 50051 and 50052.

* --enable-rpc flag is now marked as "deprecated" for 1.31 release.
  It will be removed in 3 months or 1 release (whichever is longer) since the
  Skaffold API is a beta feature.

* If given port is busy, skaffold now fails with an error instead of trying
  to find an available port and printing it to logs.

**Follow-up Work**

Since Skaffold API feature is _beta_, `--enable-rpc` flag deprecation will
start in the release this is incorporated in, and will be removed in the next
release or 3 months (whichever is longer) per deprecation policy.

Subsequently, we can remove the tests and code looking for this flag.