### PR TITLE
log: use context.TODO for not yet plumbed ctx

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -108,9 +108,9 @@ func NewSkaffoldCommand(out, errOut io.Writer) *cobra.Command {
 			// Print version
 			versionInfo := version.Get()
 			version.SetClient(opts.User)
-			log.Entry(context.Background()).Infof("Skaffold %+v", versionInfo)
+			log.Entry(context.TODO()).Infof("Skaffold %+v", versionInfo)
 			if !isHouseKeepingMessagesAllowed(cmd) {
-				log.Entry(context.Background()).Debug("Disable housekeeping messages for command explicitly")
+				log.Entry(context.TODO()).Debug("Disable housekeeping messages for command explicitly")
 				return nil
 			}
 			s = survey.New(opts.GlobalConfig, opts.ConfigurationFile, opts.Command)
@@ -129,7 +129,7 @@ func NewSkaffoldCommand(out, errOut io.Writer) *cobra.Command {
 			select {
 			case msg := <-updateMsg:
 				if err := config.UpdateMsgDisplayed(opts.GlobalConfig); err != nil {
-					log.Entry(context.Background()).Debugf("could not update the 'last-prompted' config for 'update-config' section due to %s", err)
+					log.Entry(context.TODO()).Debugf("could not update the 'last-prompted' config for 'update-config' section due to %s", err)
 				}
 				fmt.Fprintf(cmd.OutOrStderr(), "%s\n", msg)
 			default:
@@ -236,7 +236,7 @@ func setFlagsFromEnvVariables(rootCmd *cobra.Command) {
 			// special case for backward compatibility.
 			if f.Name == "namespace" {
 				if val, present := os.LookupEnv("SKAFFOLD_DEPLOY_NAMESPACE"); present {
-					log.Entry(context.Background()).Warn("Using SKAFFOLD_DEPLOY_NAMESPACE env variable is deprecated. Please use SKAFFOLD_NAMESPACE instead.")
+					log.Entry(context.TODO()).Warn("Using SKAFFOLD_DEPLOY_NAMESPACE env variable is deprecated. Please use SKAFFOLD_NAMESPACE instead.")
 					cmd.Flags().Set(f.Name, val)
 				}
 			}
@@ -311,13 +311,13 @@ func preReleaseVersion(s string) bool {
 func isQuietMode() bool {
 	switch {
 	case !interactive:
-		log.Entry(context.Background()).Debug("Update check prompt, survey prompt and telemetry prompt disabled in non-interactive mode")
+		log.Entry(context.TODO()).Debug("Update check prompt, survey prompt and telemetry prompt disabled in non-interactive mode")
 		return true
 	case quietFlag:
-		log.Entry(context.Background()).Debug("Update check prompt, survey prompt and telemetry prompt disabled in quiet mode")
+		log.Entry(context.TODO()).Debug("Update check prompt, survey prompt and telemetry prompt disabled in quiet mode")
 		return true
 	case analyze:
-		log.Entry(context.Background()).Debug("Update check prompt, survey prompt and telemetry prompt disabled when running `init --analyze`")
+		log.Entry(context.TODO()).Debug("Update check prompt, survey prompt and telemetry prompt disabled when running `init --analyze`")
 		return true
 	default:
 		return false
@@ -335,16 +335,16 @@ func apiServerShutdownHook(err error) error {
 
 func updateCheckForReleasedVersionsIfNotDisabled(s string) string {
 	if preReleaseVersion(s) {
-		log.Entry(context.Background()).Debug("Skipping update check for pre-release version")
+		log.Entry(context.TODO()).Debug("Skipping update check for pre-release version")
 		return ""
 	}
 	if !update.EnableCheck {
-		log.Entry(context.Background()).Debug("Skipping update check for flag `--update-check` set to false")
+		log.Entry(context.TODO()).Debug("Skipping update check for flag `--update-check` set to false")
 		return ""
 	}
 	msg, err := updateCheck(opts.GlobalConfig)
 	if err != nil {
-		log.Entry(context.Background()).Infof("update check failed: %s", err)
+		log.Entry(context.TODO()).Infof("update check failed: %s", err)
 	}
 	return msg
 }

--- a/cmd/skaffold/app/cmd/config/util.go
+++ b/cmd/skaffold/app/cmd/config/util.go
@@ -34,10 +34,10 @@ func resolveKubectlContext() {
 	config, err := kctx.CurrentConfig()
 	switch {
 	case err != nil:
-		log.Entry(context.Background()).Warn("unable to retrieve current kubectl context, using global values")
+		log.Entry(context.TODO()).Warn("unable to retrieve current kubectl context, using global values")
 		global = true
 	case config.CurrentContext == "":
-		log.Entry(context.Background()).Info("no kubectl context currently set, using global values")
+		log.Entry(context.TODO()).Info("no kubectl context currently set, using global values")
 		global = true
 	default:
 		kubecontext = config.CurrentContext

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -661,7 +661,7 @@ func setDefaultValues(v interface{}, fl *Flag, cmdName string) {
 	} else if val, ok := v.(pflag.Value); ok {
 		val.Set(fmt.Sprintf("%v", d))
 	} else {
-		log.Entry(context.Background()).Fatalf("%s --%s: unhandled value type: %v (%T)", cmdName, fl.Name, v, v)
+		log.Entry(context.TODO()).Fatalf("%s --%s: unhandled value type: %v (%T)", cmdName, fl.Name, v, v)
 	}
 }
 

--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -152,10 +152,10 @@ func setDefaultDeployer(configs parser.SkaffoldConfigSet) {
 func warnIfUpdateIsAvailable() {
 	warning, err := update.CheckVersionOnError(opts.GlobalConfig)
 	if err != nil {
-		log.Entry(context.Background()).Infof("update check failed: %s", err)
+		log.Entry(context.TODO()).Infof("update check failed: %s", err)
 		return
 	}
 	if warning != "" {
-		log.Entry(context.Background()).Warn(warning)
+		log.Entry(context.TODO()).Warn(warning)
 	}
 }

--- a/cmd/skaffold/skaffold.go
+++ b/cmd/skaffold/skaffold.go
@@ -43,13 +43,13 @@ func main() {
 			ServiceVersion: version.Get().Version,
 		})
 		if err != nil {
-			log.Entry(context.Background()).Fatalf("failed to start the profiler: %v", err)
+			log.Entry(context.TODO()).Fatalf("failed to start the profiler: %v", err)
 		}
 	}
 	var code int
 	if err := app.Run(os.Stdout, os.Stderr); err != nil {
 		if errors.Is(err, context.Canceled) {
-			log.Entry(context.Background()).Debugln("ignore error since context is cancelled:", err)
+			log.Entry(context.TODO()).Debugln("ignore error since context is cancelled:", err)
 		} else {
 			// As we allow some color setup using CLI flags for the main run, we can't run SetupColors()
 			// for the entire skaffold run here. It's possible SetupColors() was never called, so call it again

--- a/pkg/diag/validator/pod.go
+++ b/pkg/diag/validator/pod.go
@@ -144,14 +144,14 @@ func getPodStatus(pod *v1.Pod) (proto.StatusCode, []string, error) {
 	}
 	// If the event type PodScheduled with status False is found then we check if it is due to taints and tolerations.
 	if c, ok := isPodNotScheduled(pod); ok {
-		log.Entry(context.Background()).Debugf("Pod %q not scheduled: checking tolerations", pod.Name)
+		log.Entry(context.TODO()).Debugf("Pod %q not scheduled: checking tolerations", pod.Name)
 		sc, err := getUntoleratedTaints(c.Reason, c.Message)
 		return sc, nil, err
 	}
 	// we can check the container status if the pod has been scheduled successfully. This can be determined by having the event
 	// PodScheduled with status True, or a ContainerReady or PodReady event with status False.
 	if isPodScheduledButNotReady(pod) {
-		log.Entry(context.Background()).Debugf("Pod %q scheduled but not ready: checking container statuses", pod.Name)
+		log.Entry(context.TODO()).Debugf("Pod %q scheduled but not ready: checking container statuses", pod.Name)
 		// TODO(dgageot): Add EphemeralContainerStatuses
 		cs := append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...)
 		// See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-states
@@ -171,11 +171,11 @@ func getPodStatus(pod *v1.Pod) (proto.StatusCode, []string, error) {
 	}
 
 	if c, ok := isPodStatusUnknown(pod); ok {
-		log.Entry(context.Background()).Debugf("Pod %q condition status of type %s is unknown", pod.Name, c.Type)
+		log.Entry(context.TODO()).Debugf("Pod %q condition status of type %s is unknown", pod.Name, c.Type)
 		return proto.StatusCode_STATUSCHECK_UNKNOWN, nil, fmt.Errorf(c.Message)
 	}
 
-	log.Entry(context.Background()).Debugf("Unable to determine current service state of pod %q", pod.Name)
+	log.Entry(context.TODO()).Debugf("Unable to determine current service state of pod %q", pod.Name)
 	return proto.StatusCode_STATUSCHECK_UNKNOWN, nil, fmt.Errorf("unable to determine current service state of pod %q", pod.Name)
 }
 
@@ -288,13 +288,13 @@ func processPodEvents(e corev1.EventInterface, pod v1.Pod, ps *podStatus) {
 	if _, ok := unknownConditionsOrSuccess[ps.ae.ErrCode]; !ok {
 		return
 	}
-	log.Entry(context.Background()).Debugf("Fetching events for pod %q", pod.Name)
+	log.Entry(context.TODO()).Debugf("Fetching events for pod %q", pod.Name)
 	// Get pod events.
 	scheme := runtime.NewScheme()
 	scheme.AddKnownTypes(v1.SchemeGroupVersion, &pod)
 	events, err := e.Search(scheme, &pod)
 	if err != nil {
-		log.Entry(context.Background()).Debugf("Could not fetch events for resource %q due to %v", pod.Name, err)
+		log.Entry(context.TODO()).Debugf("Could not fetch events for resource %q due to %v", pod.Name, err)
 		return
 	}
 	// find the latest failed event.
@@ -385,7 +385,7 @@ func extractErrorMessageFromWaitingContainerStatus(po *v1.Pod, c v1.ContainerSta
 			return proto.StatusCode_STATUSCHECK_RUN_CONTAINER_ERR, nil, fmt.Errorf("container %s in error: %s", c.Name, trimSpace(match[3]))
 		}
 	}
-	log.Entry(context.Background()).Debugf("Unknown waiting reason for container %q: %v", c.Name, c.State)
+	log.Entry(context.TODO()).Debugf("Unknown waiting reason for container %q: %v", c.Name, c.State)
 	return proto.StatusCode_STATUSCHECK_CONTAINER_WAITING_UNKNOWN, nil, fmt.Errorf("container %s in error: %v", c.Name, c.State.Waiting)
 }
 
@@ -405,7 +405,7 @@ func trimSpace(msg string) string {
 }
 
 func getPodLogs(po *v1.Pod, c string, sc proto.StatusCode) (proto.StatusCode, []string) {
-	log.Entry(context.Background()).Debugf("Fetching logs for container %s/%s", po.Name, c)
+	log.Entry(context.TODO()).Debugf("Fetching logs for container %s/%s", po.Name, c)
 	logCommand := []string{"kubectl", "logs", po.Name, "-n", po.Namespace, "-c", c}
 	logs, err := runCli(logCommand[0], logCommand[1:])
 	if err != nil {

--- a/pkg/skaffold/build/build_problems.go
+++ b/pkg/skaffold/build/build_problems.go
@@ -49,7 +49,7 @@ var (
 			Regexp:  re(fmt.Sprintf(".*%s.* denied: .*", PushImageErr)),
 			ErrCode: proto.StatusCode_BUILD_PUSH_ACCESS_DENIED,
 			Description: func(err error) string {
-				log.Entry(context.Background()).Tracef("error building %s", err)
+				log.Entry(context.TODO()).Tracef("error building %s", err)
 				return "Build Failed. No push access to specified image repository"
 			},
 			Suggestion: suggestBuildPushAccessDeniedAction,
@@ -65,7 +65,7 @@ var (
 		{
 			Regexp: re(unknownProjectErr),
 			Description: func(err error) string {
-				log.Entry(context.Background()).Tracef("error building %s", err)
+				log.Entry(context.TODO()).Tracef("error building %s", err)
 				matchExp := re(unknownProjectErr)
 				if match := matchExp.FindStringSubmatch(err.Error()); len(match) >= 2 {
 					return fmt.Sprintf("Build Failed. %s", match[1])
@@ -84,7 +84,7 @@ var (
 			Regexp:  re(dockerConnectionFailed),
 			ErrCode: proto.StatusCode_BUILD_DOCKER_DAEMON_NOT_RUNNING,
 			Description: func(err error) string {
-				log.Entry(context.Background()).Tracef("error building %s", err)
+				log.Entry(context.TODO()).Tracef("error building %s", err)
 				matchExp := re(dockerConnectionFailed)
 				if match := matchExp.FindStringSubmatch(err.Error()); len(match) >= 2 {
 					return fmt.Sprintf("Build Failed. %s", match[1])

--- a/pkg/skaffold/build/builder_mux.go
+++ b/pkg/skaffold/build/builder_mux.go
@@ -69,16 +69,16 @@ func NewBuilderMux(cfg Config, store ArtifactStore, builder func(p latestV1.Pipe
 			switch {
 			case minConcurrency < 0:
 				minConcurrency = concurrency
-				log.Entry(context.Background()).Infof("build concurrency first set to %d parsed from %s[%d]", minConcurrency, reflect.TypeOf(b).String(), i)
+				log.Entry(context.TODO()).Infof("build concurrency first set to %d parsed from %s[%d]", minConcurrency, reflect.TypeOf(b).String(), i)
 			case concurrency > 0 && (minConcurrency == 0 || concurrency < minConcurrency):
 				minConcurrency = concurrency
-				log.Entry(context.Background()).Infof("build concurrency updated to %d parsed from %s[%d]", minConcurrency, reflect.TypeOf(b).String(), i)
+				log.Entry(context.TODO()).Infof("build concurrency updated to %d parsed from %s[%d]", minConcurrency, reflect.TypeOf(b).String(), i)
 			default:
-				log.Entry(context.Background()).Infof("build concurrency value %d parsed from %s[%d] is ignored since it's not less than previously set value %d", concurrency, reflect.TypeOf(b).String(), i, minConcurrency)
+				log.Entry(context.TODO()).Infof("build concurrency value %d parsed from %s[%d] is ignored since it's not less than previously set value %d", concurrency, reflect.TypeOf(b).String(), i, minConcurrency)
 			}
 		}
 	}
-	log.Entry(context.Background()).Infof("final build concurrency value is %d", minConcurrency)
+	log.Entry(context.TODO()).Infof("final build concurrency value is %d", minConcurrency)
 
 	return &BuilderMux{builders: pb, byImageName: m, store: store, concurrency: minConcurrency}, nil
 }

--- a/pkg/skaffold/build/buildpacks/lifecycle.go
+++ b/pkg/skaffold/build/buildpacks/lifecycle.go
@@ -202,14 +202,14 @@ func resolveDependencyImages(artifact *latestV1.BuildpackArtifact, r ArtifactRes
 		if builderImage == d.Alias {
 			builderImage, found = r.GetImageTag(d.ImageName)
 			if !found {
-				log.Entry(context.Background()).Fatalf("failed to resolve build result for required artifact %q", d.ImageName)
+				log.Entry(context.TODO()).Fatalf("failed to resolve build result for required artifact %q", d.ImageName)
 			}
 			builderImageLocal = true
 		}
 		if runImage == d.Alias {
 			runImage, found = r.GetImageTag(d.ImageName)
 			if !found {
-				log.Entry(context.Background()).Fatalf("failed to resolve build result for required artifact %q", d.ImageName)
+				log.Entry(context.TODO()).Fatalf("failed to resolve build result for required artifact %q", d.ImageName)
 			}
 			runImageLocal = true
 		}
@@ -224,10 +224,10 @@ func resolveDependencyImages(artifact *latestV1.BuildpackArtifact, r ArtifactRes
 
 		// if remote image pull is disabled then the image that is not fetched from the required artifacts might not be latestV1.
 		if !pushImages && builderImageLocal {
-			log.Entry(context.Background()).Warn("Disabled remote image pull since builder image is built locally. Buildpacks run image may not be latestV1.")
+			log.Entry(context.TODO()).Warn("Disabled remote image pull since builder image is built locally. Buildpacks run image may not be latestV1.")
 		}
 		if !pushImages && runImageLocal {
-			log.Entry(context.Background()).Warn("Disabled remote image pull since run image is built locally. Buildpacks builder image may not be latestV1.")
+			log.Entry(context.TODO()).Warn("Disabled remote image pull since run image is built locally. Buildpacks builder image may not be latestV1.")
 		}
 	}
 

--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -81,13 +81,13 @@ func NewCache(cfg Config, isLocalImage func(imageName string) (bool, error), dep
 
 	cacheFile, err := resolveCacheFile(cfg.CacheFile())
 	if err != nil {
-		log.Entry(context.Background()).Warnf("Error resolving cache file, not using skaffold cache: %v", err)
+		log.Entry(context.TODO()).Warnf("Error resolving cache file, not using skaffold cache: %v", err)
 		return &noCache{}, nil
 	}
 
 	artifactCache, err := retrieveArtifactCache(cacheFile)
 	if err != nil {
-		log.Entry(context.Background()).Warnf("Error retrieving artifact cache, not using skaffold cache: %v", err)
+		log.Entry(context.TODO()).Warnf("Error retrieving artifact cache, not using skaffold cache: %v", err)
 		return &noCache{}, nil
 	}
 

--- a/pkg/skaffold/build/cluster/pod.go
+++ b/pkg/skaffold/build/cluster/pod.go
@@ -255,7 +255,7 @@ func kanikoArgs(artifact *latestV1.KanikoArtifact, tag string, insecureRegistrie
 		return nil, fmt.Errorf("unable build kaniko args: %w", err)
 	}
 
-	log.Entry(context.Background()).Trace("kaniko arguments are ", strings.Join(args, " "))
+	log.Entry(context.TODO()).Trace("kaniko arguments are ", strings.Join(args, " "))
 
 	return args, nil
 }

--- a/pkg/skaffold/build/gcb/buildpacks.go
+++ b/pkg/skaffold/build/gcb/buildpacks.go
@@ -72,7 +72,7 @@ func fromRequiredArtifacts(imageName string, r docker.ArtifactResolver, deps []*
 		if imageName == d.Alias {
 			image, found := r.GetImageTag(d.ImageName)
 			if !found {
-				log.Entry(context.Background()).Fatalf("failed to resolve build result for required artifact %q", d.ImageName)
+				log.Entry(context.TODO()).Fatalf("failed to resolve build result for required artifact %q", d.ImageName)
 			}
 			return image
 		}

--- a/pkg/skaffold/build/jib/errors.go
+++ b/pkg/skaffold/build/jib/errors.go
@@ -61,7 +61,7 @@ func dependencyErr(pType PluginType, workspace string, err error) error {
 	case JibGradle:
 		code = proto.StatusCode_BUILD_JIB_GRADLE_DEP_ERR
 	default:
-		log.Entry(context.Background()).Fatal("Unknown jib build type", pType)
+		log.Entry(context.TODO()).Fatal("Unknown jib build type", pType)
 	}
 	return sErrors.NewError(err,
 		proto.ActionableErr{

--- a/pkg/skaffold/build/jib/init.go
+++ b/pkg/skaffold/build/jib/init.go
@@ -86,7 +86,7 @@ type jibJSON struct {
 // validate checks if a file is a valid Jib configuration. Returns the list of Config objects corresponding to each Jib project built by the file, or nil if Jib is not configured.
 func validate(path string, enableGradleAnalysis bool) []ArtifactConfig {
 	if !JVMFound() {
-		log.Entry(context.Background()).Debugf("Skipping Jib for init for %q: no functioning Java VM", path)
+		log.Entry(context.TODO()).Debugf("Skipping Jib for init for %q: no functioning Java VM", path)
 		return nil
 	}
 	// Determine whether maven or gradle
@@ -140,7 +140,7 @@ func validate(path string, enableGradleAnalysis bool) []ArtifactConfig {
 		line := bytes.ReplaceAll(match[1], []byte(`\`), []byte(`\\`))
 		parsedJSON := jibJSON{}
 		if err := json.Unmarshal(line, &parsedJSON); err != nil {
-			log.Entry(context.Background()).Warnf("failed to parse jib json: %s", err.Error())
+			log.Entry(context.TODO()).Warnf("failed to parse jib json: %s", err.Error())
 			return nil
 		}
 

--- a/pkg/skaffold/build/jib/jib.go
+++ b/pkg/skaffold/build/jib/jib.go
@@ -233,7 +233,7 @@ func walkFiles(workspace string, watchedFiles []string, ignoredFiles []string, c
 		info, err := os.Stat(dep)
 		if err != nil {
 			if os.IsNotExist(err) {
-				log.Entry(context.Background()).Debugf("could not stat dependency: %s", err)
+				log.Entry(context.TODO()).Debugf("could not stat dependency: %s", err)
 				continue // Ignore files that don't exist
 			}
 			return fmt.Errorf("unable to stat file %q: %w", dep, err)
@@ -341,7 +341,7 @@ func baseImageArg(a *latestV1.JibArtifact, r ArtifactResolver, deps []*latestV1.
 		}
 		img, found := r.GetImageTag(d.ImageName)
 		if !found {
-			log.Entry(context.Background()).Fatalf("failed to resolve build result for required artifact %q", d.ImageName)
+			log.Entry(context.TODO()).Fatalf("failed to resolve build result for required artifact %q", d.ImageName)
 		}
 		if pushImages {
 			// pull image from the registry (prefix `registry://` is optional)

--- a/pkg/skaffold/build/jib/jvm.go
+++ b/pkg/skaffold/build/jib/jvm.go
@@ -54,7 +54,7 @@ func resolveJVM() bool {
 	cmd := exec.Command("java", "-version")
 	err := util.RunCmd(cmd)
 	if err != nil {
-		log.Entry(context.Background()).Warnf("Skipping Jib: no JVM: %v failed: %v", cmd.Args, err)
+		log.Entry(context.TODO()).Warnf("Skipping Jib: no JVM: %v failed: %v", cmd.Args, err)
 	}
 	return err == nil
 }

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -91,10 +91,10 @@ func NewBuilder(bCtx BuilderContext, buildCfg *latestV1.LocalBuild) (*Builder, e
 	switch {
 	case pushFlag.Value() != nil:
 		pushImages = *pushFlag.Value()
-		log.Entry(context.Background()).Debugf("push value set via skaffold build --push flag, --push=%t", *pushFlag.Value())
+		log.Entry(context.TODO()).Debugf("push value set via skaffold build --push flag, --push=%t", *pushFlag.Value())
 	case buildCfg.Push == nil:
 		pushImages = cluster.PushImages
-		log.Entry(context.Background()).Debugf("push value not present in NewBuilder, defaulting to %t because cluster.PushImages is %t", pushImages, cluster.PushImages)
+		log.Entry(context.TODO()).Debugf("push value not present in NewBuilder, defaulting to %t because cluster.PushImages is %t", pushImages, cluster.PushImages)
 	default:
 		pushImages = *buildCfg.Push
 	}

--- a/pkg/skaffold/build/result.go
+++ b/pkg/skaffold/build/result.go
@@ -157,7 +157,7 @@ func (ba *artifactStoreImpl) GetImageTag(imageName string) (string, bool) {
 	}
 	t, ok := v.(string)
 	if !ok {
-		log.Entry(context.Background()).Fatalf("invalid build output recorded for image %s", imageName)
+		log.Entry(context.TODO()).Fatalf("invalid build output recorded for image %s", imageName)
 	}
 	return t, true
 }

--- a/pkg/skaffold/cluster/minikube.go
+++ b/pkg/skaffold/cluster/minikube.go
@@ -71,7 +71,7 @@ func getClient() Client {
 
 func (clientImpl) IsMinikube(kubeContext string) bool {
 	if _, _, err := FindMinikubeBinary(); err != nil {
-		log.Entry(context.Background()).Tracef("Minikube cluster not detected: %v", err)
+		log.Entry(context.TODO()).Tracef("Minikube cluster not detected: %v", err)
 		return false
 	}
 	// short circuit if context is 'minikube'
@@ -81,21 +81,21 @@ func (clientImpl) IsMinikube(kubeContext string) bool {
 
 	cluster, err := getClusterInfo(kubeContext)
 	if err != nil {
-		log.Entry(context.Background()).Tracef("failed to get cluster info: %v", err)
+		log.Entry(context.TODO()).Tracef("failed to get cluster info: %v", err)
 		return false
 	}
 	if matchClusterCertPath(cluster.CertificateAuthority) {
-		log.Entry(context.Background()).Debugf("Minikube cluster detected: cluster certificate for context %q found inside the minikube directory", kubeContext)
+		log.Entry(context.TODO()).Debugf("Minikube cluster detected: cluster certificate for context %q found inside the minikube directory", kubeContext)
 		return true
 	}
 
 	if ok, err := matchServerURL(cluster.Server); err != nil {
-		log.Entry(context.Background()).Tracef("failed to match server url: %v", err)
+		log.Entry(context.TODO()).Tracef("failed to match server url: %v", err)
 	} else if ok {
-		log.Entry(context.Background()).Debugf("Minikube cluster detected: server url for context %q matches minikube node ip", kubeContext)
+		log.Entry(context.TODO()).Debugf("Minikube cluster detected: server url for context %q matches minikube node ip", kubeContext)
 		return true
 	}
-	log.Entry(context.Background()).Tracef("Minikube cluster not detected for context %q", kubeContext)
+	log.Entry(context.TODO()).Tracef("Minikube cluster not detected for context %q", kubeContext)
 	return false
 }
 
@@ -184,7 +184,7 @@ func matchServerURL(server string) (bool, error) {
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
-		log.Entry(context.Background()).Tracef("invalid server url: %v", err)
+		log.Entry(context.TODO()).Tracef("invalid server url: %v", err)
 	}
 
 	for _, v := range data.Valid {

--- a/pkg/skaffold/config/portforward.go
+++ b/pkg/skaffold/config/portforward.go
@@ -130,7 +130,7 @@ func (p *PortForwardOptions) Replace(options []string) error {
 	p.reset()
 	for _, o := range options {
 		if err := p.Append(o); err != nil {
-			log.Entry(context.Background()).Fatal(err) // should never happen since we validated the options
+			log.Entry(context.TODO()).Fatal(err) // should never happen since we validated the options
 		}
 	}
 	return nil

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -72,12 +72,12 @@ func readConfigFileCached(filename string) (*GlobalConfig, error) {
 		filenameOrDefault, err := ResolveConfigFile(filename)
 		if err != nil {
 			configFileErr = err
-			log.Entry(context.Background()).Warnf("Could not load global Skaffold defaults. Error resolving config file %q", filenameOrDefault)
+			log.Entry(context.TODO()).Warnf("Could not load global Skaffold defaults. Error resolving config file %q", filenameOrDefault)
 			return
 		}
 		configFile, configFileErr = ReadConfigFileNoCache(filenameOrDefault)
 		if configFileErr == nil {
-			log.Entry(context.Background()).Infof("Loaded Skaffold defaults from %q", filenameOrDefault)
+			log.Entry(context.TODO()).Infof("Loaded Skaffold defaults from %q", filenameOrDefault)
 		}
 	})
 	return configFile, configFileErr
@@ -100,12 +100,12 @@ func ResolveConfigFile(configFile string) (string, error) {
 func ReadConfigFileNoCache(configFile string) (*GlobalConfig, error) {
 	contents, err := ioutil.ReadFile(configFile)
 	if err != nil {
-		log.Entry(context.Background()).Warnf("Could not load global Skaffold defaults. Error encounter while reading file %q", configFile)
+		log.Entry(context.TODO()).Warnf("Could not load global Skaffold defaults. Error encounter while reading file %q", configFile)
 		return nil, fmt.Errorf("reading global config: %w", err)
 	}
 	config := GlobalConfig{}
 	if err := yaml.Unmarshal(contents, &config); err != nil {
-		log.Entry(context.Background()).Warnf("Could not load global Skaffold defaults. Error encounter while unmarshalling the contents of file %q", configFile)
+		log.Entry(context.TODO()).Warnf("Could not load global Skaffold defaults. Error encounter while unmarshalling the contents of file %q", configFile)
 		return nil, fmt.Errorf("unmarshalling global skaffold config: %w", err)
 	}
 	return &config, nil
@@ -143,7 +143,7 @@ func getConfigForKubeContextWithGlobalDefaults(cfg *GlobalConfig, kubeContext st
 	var mergedConfig ContextConfig
 	for _, contextCfg := range cfg.ContextConfigs {
 		if util.RegexEqual(contextCfg.Kubecontext, kubeContext) {
-			log.Entry(context.Background()).Debugf("found config for context %q", kubeContext)
+			log.Entry(context.TODO()).Debugf("found config for context %q", kubeContext)
 			mergedConfig = *contextCfg
 		}
 	}
@@ -170,7 +170,7 @@ func GetDefaultRepo(configFile string, cliValue *string) (string, error) {
 		return "", err
 	}
 	if cfg.DefaultRepo != "" {
-		log.Entry(context.Background()).Infof("Using default-repo=%s from config", cfg.DefaultRepo)
+		log.Entry(context.TODO()).Infof("Using default-repo=%s from config", cfg.DefaultRepo)
 	}
 	return cfg.DefaultRepo, nil
 }
@@ -181,7 +181,7 @@ func GetInsecureRegistries(configFile string) ([]string, error) {
 		return nil, err
 	}
 	if len(cfg.InsecureRegistries) > 0 {
-		log.Entry(context.Background()).Infof("Using insecure-registries=%v from config", cfg.InsecureRegistries)
+		log.Entry(context.TODO()).Infof("Using insecure-registries=%v from config", cfg.InsecureRegistries)
 	}
 	return cfg.InsecureRegistries, nil
 }
@@ -193,7 +193,7 @@ func GetDebugHelpersRegistry(configFile string) (string, error) {
 	}
 
 	if cfg.DebugHelpersRegistry != "" {
-		log.Entry(context.Background()).Infof("Using debug-helpers-registry=%s from config", cfg.DebugHelpersRegistry)
+		log.Entry(context.TODO()).Infof("Using debug-helpers-registry=%s from config", cfg.DebugHelpersRegistry)
 		return cfg.DebugHelpersRegistry, nil
 	}
 	return constants.DefaultDebugHelpersRegistry, nil
@@ -214,7 +214,7 @@ func GetCluster(configFile string, minikubeProfile string, detectMinikube bool) 
 		local = true
 
 	case cfg.LocalCluster != nil:
-		log.Entry(context.Background()).Infof("Using local-cluster=%t from config", *cfg.LocalCluster)
+		log.Entry(context.TODO()).Infof("Using local-cluster=%t from config", *cfg.LocalCluster)
 		local = *cfg.LocalCluster
 
 	case kubeContext == constants.DefaultMinikubeContext ||

--- a/pkg/skaffold/debug/apply_transforms.go
+++ b/pkg/skaffold/debug/apply_transforms.go
@@ -68,14 +68,14 @@ func applyDebuggingTransforms(l manifest.ManifestList, retriever configurationRe
 	for _, manifest := range l {
 		obj, _, err := decodeFromYaml(manifest, nil, nil)
 		if err != nil {
-			log.Entry(context.Background()).Debugf("Unable to interpret manifest for debugging: %v\n", err)
+			log.Entry(context.TODO()).Debugf("Unable to interpret manifest for debugging: %v\n", err)
 		} else if transformManifest(obj, retriever, debugHelpersRegistry) {
 			manifest, err = encodeAsYaml(obj)
 			if err != nil {
 				return nil, fmt.Errorf("marshalling yaml: %w", err)
 			}
 			if logrus.IsLevelEnabled(logrus.DebugLevel) {
-				log.Entry(context.Background()).Debugln("Applied debugging transform:\n", string(manifest))
+				log.Entry(context.TODO()).Debugln("Applied debugging transform:\n", string(manifest))
 			}
 		}
 		updated = append(updated, manifest)
@@ -88,12 +88,12 @@ func applyDebuggingTransforms(l manifest.ManifestList, retriever configurationRe
 // If `builds` is empty, then treat all `image` images as a build artifact.
 func findArtifact(image string, builds []graph.Artifact) *graph.Artifact {
 	if len(builds) == 0 {
-		log.Entry(context.Background()).Debugf("No build artifacts specified: using image as-is %q", image)
+		log.Entry(context.TODO()).Debugf("No build artifacts specified: using image as-is %q", image)
 		return &graph.Artifact{ImageName: image, Tag: image}
 	}
 	for _, artifact := range builds {
 		if image == artifact.ImageName || image == artifact.Tag {
-			log.Entry(context.Background()).Debugf("Found artifact for image %q", image)
+			log.Entry(context.TODO()).Debugf("Found artifact for image %q", image)
 			return &artifact
 		}
 	}

--- a/pkg/skaffold/debug/cnb.go
+++ b/pkg/skaffold/debug/cnb.go
@@ -203,7 +203,7 @@ func adjustCommandLine(m cnb.BuildMetadata, ic imageConfiguration) (imageConfigu
 	}
 
 	if len(ic.arguments) == 0 {
-		log.Entry(context.Background()).Warnf("no CNB launch found for %s", ic.artifact)
+		log.Entry(context.TODO()).Warnf("no CNB launch found for %s", ic.artifact)
 		return ic, nil
 	}
 

--- a/pkg/skaffold/debug/transform_go.go
+++ b/pkg/skaffold/debug/transform_go.go
@@ -63,7 +63,7 @@ func isLaunchingDlv(args []string) bool {
 func (t dlvTransformer) IsApplicable(config imageConfiguration) bool {
 	for _, name := range []string{"GODEBUG", "GOGC", "GOMAXPROCS", "GOTRACEBACK"} {
 		if _, found := config.env[name]; found {
-			log.Entry(context.Background()).Infof("Artifact %q has Go runtime: has env %q", config.artifact, name)
+			log.Entry(context.TODO()).Infof("Artifact %q has Go runtime: has env %q", config.artifact, name)
 			return true
 		}
 	}
@@ -79,7 +79,7 @@ func (t dlvTransformer) IsApplicable(config imageConfiguration) bool {
 	cnbBuildMetadata := config.labels["io.buildpacks.build.metadata"]
 	for _, id := range knownGoBuildpackIds {
 		if strings.Contains(cnbBuildMetadata, id) {
-			log.Entry(context.Background()).Infof("Artifact %q has Go buildpacks %q", config.artifact, id)
+			log.Entry(context.TODO()).Infof("Artifact %q has Go buildpacks %q", config.artifact, id)
 			return true
 		}
 	}
@@ -95,7 +95,7 @@ func (t dlvTransformer) IsApplicable(config imageConfiguration) bool {
 // Apply configures a container definition for Go with Delve.
 // Returns the debug configuration details, with the "go" support image
 func (t dlvTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (annotations.ContainerDebugConfiguration, string, error) {
-	log.Entry(context.Background()).Infof("Configuring %q for Go/Delve debugging", container.Name)
+	log.Entry(context.TODO()).Infof("Configuring %q for Go/Delve debugging", container.Name)
 
 	// try to find existing `dlv` command
 	spec := retrieveDlvSpec(config)

--- a/pkg/skaffold/debug/transform_jvm.go
+++ b/pkg/skaffold/debug/transform_jvm.go
@@ -67,7 +67,7 @@ type jdwpSpec struct {
 // Apply configures a container definition for JVM debugging.
 // Returns a simple map describing the debug configuration details.
 func (t jdwpTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (annotations.ContainerDebugConfiguration, string, error) {
-	log.Entry(context.Background()).Infof("Configuring %q for JVM debugging", container.Name)
+	log.Entry(context.TODO()).Infof("Configuring %q for JVM debugging", container.Name)
 	// try to find existing JAVA_TOOL_OPTIONS or jdwp command argument
 	spec := retrieveJdwpSpec(config)
 

--- a/pkg/skaffold/debug/transform_netcore.go
+++ b/pkg/skaffold/debug/transform_netcore.go
@@ -71,7 +71,7 @@ func (t netcoreTransformer) IsApplicable(config imageConfiguration) bool {
 // Apply configures a container definition for vsdbg.
 // Returns a simple map describing the debug configuration details.
 func (t netcoreTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (annotations.ContainerDebugConfiguration, string, error) {
-	log.Entry(context.Background()).Infof("Configuring %q for netcore debugging", container.Name)
+	log.Entry(context.TODO()).Infof("Configuring %q for netcore debugging", container.Name)
 
 	return annotations.ContainerDebugConfiguration{
 		Runtime: "netcore",

--- a/pkg/skaffold/debug/transform_nodejs.go
+++ b/pkg/skaffold/debug/transform_nodejs.go
@@ -78,7 +78,7 @@ func (t nodeTransformer) IsApplicable(config imageConfiguration) bool {
 // Apply configures a container definition for NodeJS Chrome V8 Inspector.
 // Returns a simple map describing the debug configuration details.
 func (t nodeTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (annotations.ContainerDebugConfiguration, string, error) {
-	log.Entry(context.Background()).Infof("Configuring %q for node.js debugging", container.Name)
+	log.Entry(context.TODO()).Infof("Configuring %q for node.js debugging", container.Name)
 
 	// try to find existing `--inspect` command
 	spec := retrieveNodeInspectSpec(config)
@@ -165,7 +165,7 @@ func extractInspectArg(arg string) *inspectSpec {
 		if split := strings.SplitN(address, ":", 2); len(split) == 1 {
 			port, err := strconv.ParseInt(split[0], 10, 32)
 			if err != nil {
-				log.Entry(context.Background()).Errorf("Invalid NodeJS inspect port %q: %s\n", address, err)
+				log.Entry(context.TODO()).Errorf("Invalid NodeJS inspect port %q: %s\n", address, err)
 				return nil
 			}
 			spec.port = int32(port)
@@ -173,7 +173,7 @@ func extractInspectArg(arg string) *inspectSpec {
 			spec.host = split[0]
 			port, err := strconv.ParseInt(split[1], 10, 32)
 			if err != nil {
-				log.Entry(context.Background()).Errorf("Invalid NodeJS inspect port %q: %s\n", address, err)
+				log.Entry(context.TODO()).Errorf("Invalid NodeJS inspect port %q: %s\n", address, err)
 				return nil
 			}
 			spec.port = int32(port)

--- a/pkg/skaffold/debug/transform_python.go
+++ b/pkg/skaffold/debug/transform_python.go
@@ -109,7 +109,7 @@ func (t pythonTransformer) IsApplicable(config imageConfiguration) bool {
 // Apply configures a container definition for Python with ptvsd/debugpy/pydevd.
 // Returns a simple map describing the debug configuration details.
 func (t pythonTransformer) Apply(container *v1.Container, config imageConfiguration, portAlloc portAllocator, overrideProtocols []string) (annotations.ContainerDebugConfiguration, string, error) {
-	log.Entry(context.Background()).Infof("Configuring %q for python debugging", container.Name)
+	log.Entry(context.TODO()).Infof("Configuring %q for python debugging", container.Name)
 
 	// try to find existing `-mptvsd` or `-mdebugpy` command
 	if spec := retrievePythonDebugSpec(config); spec != nil {
@@ -198,7 +198,7 @@ func extractPtvsdSpec(args []string) *pythonSpec {
 			port, err := strconv.ParseInt(args[i+1], 10, 32)
 			// spec.port, err := strconv.Atoi(args[i+1])
 			if err != nil {
-				log.Entry(context.Background()).Errorf("Invalid python ptvsd port %q: %s\n", args[i+1], err)
+				log.Entry(context.TODO()).Errorf("Invalid python ptvsd port %q: %s\n", args[i+1], err)
 				return nil
 			}
 			spec.port = int32(port)
@@ -227,7 +227,7 @@ func extractDebugpySpec(args []string) *pythonSpec {
 			}
 			port, err := strconv.ParseInt(s[len(s)-1], 10, 32)
 			if err != nil {
-				log.Entry(context.Background()).Errorf("Invalid port %q: %s\n", args[i+1], err)
+				log.Entry(context.TODO()).Errorf("Invalid port %q: %s\n", args[i+1], err)
 				return nil
 			}
 			spec.port = int32(port)
@@ -287,7 +287,7 @@ func (spec pythonSpec) launcherMode() string {
 	case debugpy:
 		return "debugpy"
 	}
-	log.Entry(context.Background()).Fatalf("invalid debugger type: %q", spec.debugger)
+	log.Entry(context.TODO()).Fatalf("invalid debugger type: %q", spec.debugger)
 	return ""
 }
 
@@ -298,7 +298,7 @@ func (spec pythonSpec) protocol() string {
 	case debugpy, ptvsd:
 		return dapProtocol
 	default:
-		log.Entry(context.Background()).Fatalf("invalid debugger type: %q", spec.debugger)
+		log.Entry(context.TODO()).Fatalf("invalid debugger type: %q", spec.debugger)
 		return dapProtocol
 	}
 }

--- a/pkg/skaffold/deploy/docker/port.go
+++ b/pkg/skaffold/deploy/docker/port.go
@@ -81,7 +81,7 @@ func (pm *PortManager) getPorts(containerName string, pf []*v1.PortForwardResour
 	var ports []int
 	for _, p := range pf {
 		if strings.ToLower(string(p.Type)) != "container" {
-			log.Entry(context.Background()).Debugf("skipping non-container port forward resource in Docker deploy: %s\n", p.Name)
+			log.Entry(context.TODO()).Debugf("skipping non-container port forward resource in Docker deploy: %s\n", p.Name)
 			continue
 		}
 		localPort := util.GetAvailablePort(p.Address, p.LocalPort, &pm.portSet)

--- a/pkg/skaffold/deploy/helm/args.go
+++ b/pkg/skaffold/deploy/helm/args.go
@@ -75,7 +75,7 @@ func constructOverrideArgs(r *latestV1.HelmRelease, builds []graph.Artifact, arg
 			envMap[k+suffix] = v
 		}
 	}
-	log.Entry(context.Background()).Debugf("EnvVarMap: %+v\n", envMap)
+	log.Entry(context.TODO()).Debugf("EnvVarMap: %+v\n", envMap)
 
 	for _, k := range sortKeys(r.SetValueTemplates) {
 		v, err := util.ExpandEnvTemplate(r.SetValueTemplates[k], envMap)

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -149,7 +149,7 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, h *latestV1.HelmDe
 	kubectl := pkgkubectl.NewCLI(cfg, cfg.GetKubeNamespace())
 	namespaces, err := deployutil.GetAllPodNamespaces(cfg.GetNamespace(), cfg.GetPipelines())
 	if err != nil {
-		olog.Entry(context.Background()).Warn("unable to parse namespaces - deploy might not work correctly!")
+		olog.Entry(context.TODO()).Warn("unable to parse namespaces - deploy might not work correctly!")
 	}
 	logger := component.NewLogger(cfg, kubectl, podSelector, &namespaces)
 	return &Deployer{

--- a/pkg/skaffold/deploy/helm/parse.go
+++ b/pkg/skaffold/deploy/helm/parse.go
@@ -41,22 +41,22 @@ func parseReleaseInfo(namespace string, b *bufio.Reader) []types.Artifact {
 			break
 		}
 		if err != nil {
-			log.Entry(context.Background()).Infof("error parsing object from string: %s", err.Error())
+			log.Entry(context.TODO()).Infof("error parsing object from string: %s", err.Error())
 			continue
 		}
 		objNamespace, err := getObjectNamespaceIfDefined(doc, namespace)
 		if err != nil {
-			log.Entry(context.Background()).Infof("error parsing object from string: %s", err.Error())
+			log.Entry(context.TODO()).Infof("error parsing object from string: %s", err.Error())
 			continue
 		}
 		obj, err := parseRuntimeObject(objNamespace, doc)
 		if err != nil {
 			if i > 0 {
-				log.Entry(context.Background()).Info(err.Error())
+				log.Entry(context.TODO()).Info(err.Error())
 			}
 		} else {
 			results = append(results, *obj)
-			log.Entry(context.Background()).Debugf("found deployed object: %+v", obj.Obj)
+			log.Entry(context.TODO()).Debugf("found deployed object: %+v", obj.Obj)
 		}
 	}
 

--- a/pkg/skaffold/deploy/helm/util.go
+++ b/pkg/skaffold/deploy/helm/util.go
@@ -180,7 +180,7 @@ func envVarForImage(imageName string, digest string) map[string]string {
 		customMap[constants.ImageRef.Tag] = ref.Tag
 		customMap[constants.ImageRef.Digest] = ref.Digest
 	} else {
-		log.Entry(context.Background()).Warnf("unable to extract values for %v, %v and %v from image %v due to error:\n%v", constants.ImageRef.Repo, constants.ImageRef.Tag, constants.ImageRef.Digest, digest, err)
+		log.Entry(context.TODO()).Warnf("unable to extract values for %v, %v and %v from image %v due to error:\n%v", constants.ImageRef.Repo, constants.ImageRef.Tag, constants.ImageRef.Digest, digest, err)
 	}
 
 	if digest == "" {

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -114,7 +114,7 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latestV1.KptDep
 	kubectl := pkgkubectl.NewCLI(cfg, cfg.GetKubeNamespace())
 	namespaces, err := deployutil.GetAllPodNamespaces(cfg.GetNamespace(), cfg.GetPipelines())
 	if err != nil {
-		olog.Entry(context.Background()).Warn("unable to parse namespaces - deploy might not work correctly!")
+		olog.Entry(context.TODO()).Warn("unable to parse namespaces - deploy might not work correctly!")
 	}
 	logger := component.NewLogger(cfg, kubectl, podSelector, &namespaces)
 	return &Deployer{

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -95,7 +95,7 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latestV1.Kubect
 	kubectl := NewCLI(cfg, d.Flags, defaultNamespace)
 	namespaces, err := deployutil.GetAllPodNamespaces(cfg.GetNamespace(), cfg.GetPipelines())
 	if err != nil {
-		olog.Entry(context.Background()).Warn("unable to parse namespaces - deploy might not work correctly!")
+		olog.Entry(context.TODO()).Warn("unable to parse namespaces - deploy might not work correctly!")
 	}
 	logger := component.NewLogger(cfg, kubectl.CLI, podSelector, &namespaces)
 
@@ -294,8 +294,8 @@ func (k *Deployer) manifestFiles(manifests []string) ([]string, error) {
 	for _, f := range list {
 		if !kubernetes.HasKubernetesFileExtension(f) {
 			if !util.StrSliceContains(manifests, f) {
-				olog.Entry(context.Background()).Infof("refusing to deploy/delete non {json, yaml} file %s", f)
-				olog.Entry(context.Background()).Info("If you still wish to deploy this file, please specify it directly, outside a glob pattern.")
+				olog.Entry(context.TODO()).Infof("refusing to deploy/delete non {json, yaml} file %s", f)
+				olog.Entry(context.TODO()).Info("If you still wish to deploy this file, please specify it directly, outside a glob pattern.")
 				continue
 			}
 		}

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -142,7 +142,7 @@ func NewDeployer(cfg kubectl.Config, labeller *label.DefaultLabeller, d *latestV
 	podSelector := kubernetes.NewImageList()
 	namespaces, err := deployutil.GetAllPodNamespaces(cfg.GetNamespace(), cfg.GetPipelines())
 	if err != nil {
-		olog.Entry(context.Background()).Warn("unable to parse namespaces - deploy might not work correctly!")
+		olog.Entry(context.TODO()).Warn("unable to parse namespaces - deploy might not work correctly!")
 	}
 	logger := component.NewLogger(cfg, kubectl.CLI, podSelector, &namespaces)
 	return &Deployer{

--- a/pkg/skaffold/docker/build_args.go
+++ b/pkg/skaffold/docker/build_args.go
@@ -108,7 +108,7 @@ func ResolveDependencyImages(deps []*latestV1.ArtifactDependency, r ArtifactReso
 		case found:
 			m[d.Alias] = &t
 		case missingIsFatal:
-			log.Entry(context.Background()).Fatalf("failed to resolve build result for required artifact %q", d.ImageName)
+			log.Entry(context.TODO()).Fatalf("failed to resolve build result for required artifact %q", d.ImageName)
 		default:
 			m[d.Alias] = nil
 		}

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -113,7 +113,7 @@ func newMinikubeAPIClient(minikubeProfile string) ([]string, client.CommonAPICli
 		var exitError ExitCoder
 		if errors.As(err, &exitError) && (exitError.ExitCode() == minikubeDriverConfictExitCode || exitError.ExitCode() == oldMinikubeBadUsageExitCode) {
 			// Let's ignore the error and fall back to local docker daemon.
-			log.Entry(context.Background()).Warnf("Could not get minikube docker env, falling back to local docker daemon: %s", err)
+			log.Entry(context.TODO()).Warnf("Could not get minikube docker env, falling back to local docker daemon: %s", err)
 			return newEnvAPIClient()
 		}
 
@@ -159,7 +159,7 @@ func newMinikubeAPIClient(minikubeProfile string) ([]string, client.CommonAPICli
 	}
 
 	if host != client.DefaultDockerHost {
-		log.Entry(context.Background()).Infof("Using minikube docker daemon at %s", host)
+		log.Entry(context.TODO()).Infof("Using minikube docker daemon at %s", host)
 	}
 
 	// Keep the minikube environment variables
@@ -174,7 +174,7 @@ func newMinikubeAPIClient(minikubeProfile string) ([]string, client.CommonAPICli
 
 func getUserAgentHeader() map[string]string {
 	userAgent := fmt.Sprintf("skaffold-%s", version.Get().Version)
-	log.Entry(context.Background()).Debugf("setting Docker user agent to %s", userAgent)
+	log.Entry(context.TODO()).Debugf("setting Docker user agent to %s", userAgent)
 	return map[string]string{
 		"User-Agent": userAgent,
 	}

--- a/pkg/skaffold/docker/docker_init.go
+++ b/pkg/skaffold/docker/docker_init.go
@@ -85,7 +85,7 @@ func (c ArtifactConfig) Path() string {
 func validate(path string) bool {
 	f, err := os.Open(path)
 	if err != nil {
-		log.Entry(context.Background()).Warnf("opening file %s: %s", path, err.Error())
+		log.Entry(context.TODO()).Warnf("opening file %s: %s", path, err.Error())
 		return false
 	}
 	defer f.Close()

--- a/pkg/skaffold/docker/image_util.go
+++ b/pkg/skaffold/docker/image_util.go
@@ -57,7 +57,7 @@ func RetrieveWorkingDir(tagged string, cfg Config) (string, error) {
 	case cf == nil:
 		return "/", nil
 	case cf.Config.WorkingDir == "":
-		log.Entry(context.Background()).Debugf("Using default workdir '/' for %s", tagged)
+		log.Entry(context.TODO()).Debugf("Using default workdir '/' for %s", tagged)
 		return "/", nil
 	default:
 		return cf.Config.WorkingDir, nil

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -199,7 +199,7 @@ func expandSrcGlobPatterns(workspace string, cpCmds []*copyCommand) ([]fromTo, e
 		}
 	}
 
-	log.Entry(context.Background()).Debugf("Found dependencies for dockerfile: %v", fts)
+	log.Entry(context.TODO()).Debugf("Found dependencies for dockerfile: %v", fts)
 	return fts, nil
 }
 
@@ -295,7 +295,7 @@ func readCopyCommand(value *parser.Node, envs []string, workdir string) (*copyCo
 	var srcs []string
 	for _, src := range paths[0 : len(paths)-1] {
 		if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
-			log.Entry(context.Background()).Debugln("Skipping watch on remote dependency", src)
+			log.Entry(context.TODO()).Debugln("Skipping watch on remote dependency", src)
 			continue
 		}
 
@@ -338,7 +338,7 @@ func expandOnbuildInstructions(nodes []*parser.Node, cfg Config) ([]*parser.Node
 			} else if ons, err := parseOnbuild(from.image, cfg); err == nil {
 				onbuildNodes = ons
 			} else if warnMsg, ok, _ := isOldImageManifestProblem(cfg, err); ok && warnMsg != "" {
-				log.Entry(context.Background()).Warn(warnMsg)
+				log.Entry(context.TODO()).Warn(warnMsg)
 			} else if !ok {
 				return nil, fmt.Errorf("parsing ONBUILD instructions: %w", err)
 			}
@@ -356,7 +356,7 @@ func expandOnbuildInstructions(nodes []*parser.Node, cfg Config) ([]*parser.Node
 }
 
 func parseOnbuild(image string, cfg Config) ([]*parser.Node, error) {
-	log.Entry(context.Background()).Tracef("Checking base image %s for ONBUILD triggers.", image)
+	log.Entry(context.TODO()).Tracef("Checking base image %s for ONBUILD triggers.", image)
 
 	// Image names are case SENSITIVE
 	img, err := RetrieveImage(image, cfg)
@@ -368,7 +368,7 @@ func parseOnbuild(image string, cfg Config) ([]*parser.Node, error) {
 		return []*parser.Node{}, nil
 	}
 
-	log.Entry(context.Background()).Tracef("Found ONBUILD triggers %v in image %s", img.Config.OnBuild, image)
+	log.Entry(context.TODO()).Tracef("Found ONBUILD triggers %v in image %s", img.Config.OnBuild, image)
 
 	obRes, err := parser.Parse(strings.NewReader(strings.Join(img.Config.OnBuild, "\n")))
 	if err != nil {

--- a/pkg/skaffold/docker/remote.go
+++ b/pkg/skaffold/docker/remote.go
@@ -37,7 +37,7 @@ var (
 )
 
 func AddRemoteTag(src, target string, cfg Config) error {
-	log.Entry(context.Background()).Debugf("attempting to add tag %s to src %s", target, src)
+	log.Entry(context.TODO()).Debugf("attempting to add tag %s to src %s", target, src)
 	img, err := getRemoteImage(src, cfg)
 	if err != nil {
 		return fmt.Errorf("getting image: %w", err)
@@ -126,7 +126,7 @@ func parseReference(s string, cfg Config, opts ...name.Option) (name.Reference, 
 	if IsInsecure(ref, cfg.GetInsecureRegistries()) {
 		ref, err = name.ParseReference(s, name.Insecure)
 		if err != nil {
-			log.Entry(context.Background()).Warnf("error getting insecure registry: %s\nremote references may not be retrieved", err.Error())
+			log.Entry(context.TODO()).Warnf("error getting insecure registry: %s\nremote references may not be retrieved", err.Error())
 		}
 	}
 

--- a/pkg/skaffold/filemon/changes.go
+++ b/pkg/skaffold/filemon/changes.go
@@ -41,7 +41,7 @@ func Stat(deps func() ([]string, error)) (FileMap, error) {
 		stat, err := os.Stat(path)
 		if err != nil {
 			if os.IsNotExist(err) {
-				log.Entry(context.Background()).Debugf("could not stat dependency: %s", err)
+				log.Entry(context.TODO()).Debugf("could not stat dependency: %s", err)
 				continue // Ignore files that don't exist
 			}
 			return nil, fmt.Errorf("unable to stat file %q: %w", path, err)
@@ -118,12 +118,12 @@ func sortEvents(e Events) {
 
 func logEvents(e Events) {
 	if e.Added != nil && len(e.Added) > 0 {
-		log.Entry(context.Background()).Infof("files added: %v", e.Added)
+		log.Entry(context.TODO()).Infof("files added: %v", e.Added)
 	}
 	if e.Modified != nil && len(e.Modified) > 0 {
-		log.Entry(context.Background()).Infof("files modified: %v", e.Modified)
+		log.Entry(context.TODO()).Infof("files modified: %v", e.Modified)
 	}
 	if e.Deleted != nil && len(e.Deleted) > 0 {
-		log.Entry(context.Background()).Infof("files deleted: %v", e.Deleted)
+		log.Entry(context.TODO()).Infof("files deleted: %v", e.Deleted)
 	}
 }

--- a/pkg/skaffold/gcp/auth.go
+++ b/pkg/skaffold/gcp/auth.go
@@ -44,7 +44,7 @@ var gcrPrefixes = []string{"gcr.io", "us.gcr.io", "eu.gcr.io", "asia.gcr.io", "s
 // This doesn't modify the ~/.docker/config.json. It's only in-memory
 func AutoConfigureGCRCredentialHelper(cf *configfile.ConfigFile) {
 	if path, _ := exec.LookPath("docker-credential-gcloud"); path == "" {
-		log.Entry(context.Background()).Debug("Skipping credential configuration because docker-credential-gcloud is not on PATH.")
+		log.Entry(context.TODO()).Debug("Skipping credential configuration because docker-credential-gcloud is not on PATH.")
 		return
 	}
 
@@ -64,8 +64,8 @@ func activeUserCredentials() (*google.Credentials, error) {
 		cmd := exec.Command("gcloud", "auth", "print-access-token", "--format=json")
 		body, err := util.RunCmdOut(cmd)
 		if err != nil {
-			log.Entry(context.Background()).Infof("unable to retrieve gcloud access token: %v", err)
-			log.Entry(context.Background()).Info("falling back to application default credentials")
+			log.Entry(context.TODO()).Infof("unable to retrieve gcloud access token: %v", err)
+			log.Entry(context.TODO()).Info("falling back to application default credentials")
 			credsErr = fmt.Errorf("retrieving gcloud access token: %w", err)
 			return
 		}
@@ -76,14 +76,14 @@ func activeUserCredentials() (*google.Credentials, error) {
 
 		c, err := google.CredentialsFromJSON(context.Background(), body)
 		if err != nil {
-			log.Entry(context.Background()).Infof("unable to retrieve google creds: %v", err)
-			log.Entry(context.Background()).Info("falling back to application default credentials")
+			log.Entry(context.TODO()).Infof("unable to retrieve google creds: %v", err)
+			log.Entry(context.TODO()).Info("falling back to application default credentials")
 			return
 		}
 		_, err = c.TokenSource.Token()
 		if err != nil {
-			log.Entry(context.Background()).Infof("unable to retrieve token: %v", err)
-			log.Entry(context.Background()).Info("falling back to application default credentials")
+			log.Entry(context.TODO()).Infof("unable to retrieve token: %v", err)
+			log.Entry(context.TODO()).Info("falling back to application default credentials")
 			return
 		}
 		creds = c

--- a/pkg/skaffold/initializer/analyze/analyze.go
+++ b/pkg/skaffold/initializer/analyze/analyze.go
@@ -148,7 +148,7 @@ func (a *ProjectAnalysis) Analyze(dir string) error {
 				continue
 			}
 			if stat.Size() > a.maxFileSize {
-				log.Entry(context.Background()).Debugf("skipping %s as it is larger (%d) than max allowed size %d", filePath, stat.Size(), a.maxFileSize)
+				log.Entry(context.TODO()).Debugf("skipping %s as it is larger (%d) than max allowed size %d", filePath, stat.Size(), a.maxFileSize)
 				continue
 			}
 		}

--- a/pkg/skaffold/initializer/config.go
+++ b/pkg/skaffold/initializer/config.go
@@ -38,7 +38,7 @@ var (
 func generateSkaffoldConfig(b build.Initializer, d deploy.Initializer) *latestV1.SkaffoldConfig {
 	// if we're here, the user has no skaffold yaml so we need to generate one
 	// if the user doesn't have any k8s yamls, generate one for each dockerfile
-	log.Entry(context.Background()).Info("generating skaffold config")
+	log.Entry(context.TODO()).Info("generating skaffold config")
 
 	name, err := suggestConfigName()
 	if err != nil {

--- a/pkg/skaffold/initializer/deploy/kustomize.go
+++ b/pkg/skaffold/initializer/deploy/kustomize.go
@@ -100,7 +100,7 @@ func (k *kustomize) DeployConfig() (latestV1.DeployConfig, []latestV1.Profile) {
 		default:
 			defaultKustomization = k.kustomizations[0]
 		}
-		log.Entry(context.Background()).Warnf("multiple kustomizations found but no default provided - defaulting to %s", defaultKustomization)
+		log.Entry(context.TODO()).Warnf("multiple kustomizations found but no default provided - defaulting to %s", defaultKustomization)
 	}
 
 	for _, kustomization := range k.kustomizations {

--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -140,7 +140,7 @@ func initCloudMonitoringExporterMetrics() (*basic.Controller, error) {
 			mexporter.WithMetricDescriptorTypeFormatter(formatter),
 			mexporter.WithMonitoringClientOptions(option.WithCredentialsJSON(b)),
 			mexporter.WithOnError(func(err error) {
-				log.Entry(context.Background()).Debugf("Error with metrics: %v", err)
+				log.Entry(context.TODO()).Debugf("Error with metrics: %v", err)
 			}),
 		},
 	)
@@ -333,20 +333,20 @@ func initTraceExporter(opts ...TraceExporterOption) (trace.TracerProvider, func(
 
 	switch os.Getenv("SKAFFOLD_TRACE") {
 	case "stdout":
-		log.Entry(context.Background()).Debug("using stdout trace exporter")
+		log.Entry(context.TODO()).Debug("using stdout trace exporter")
 		return initIOWriterTracer(teconf.writer)
 	case "gcp-adc":
-		log.Entry(context.Background()).Debug("using cloud trace exporter w/ application default creds")
+		log.Entry(context.TODO()).Debug("using cloud trace exporter w/ application default creds")
 		tp, shutdown, err := initCloudTraceExporterApplicationDefaultCreds()
 		return tp, func(context.Context) error { shutdown(); return nil }, err
 	case "jaeger":
-		log.Entry(context.Background()).Debug("using jaeger trace exporter")
+		log.Entry(context.TODO()).Debug("using jaeger trace exporter")
 		tp, shutdown, err := initJaegerTraceExporter()
 		return tp, func(context.Context) error { shutdown(); return nil }, err
 	}
 
 	if otelTraceExporterVal, ok := os.LookupEnv("OTEL_TRACES_EXPORTER"); ok {
-		log.Entry(context.Background()).Debugf("using otel default exporter - OTEL_TRACES_EXPORTER=%s", otelTraceExporterVal)
+		log.Entry(context.TODO()).Debugf("using otel default exporter - OTEL_TRACES_EXPORTER=%s", otelTraceExporterVal)
 		return nil, func(context.Context) error { return nil }, nil
 	}
 
@@ -376,7 +376,7 @@ func initCloudTraceExporterApplicationDefaultCreds() (trace.TracerProvider, func
 		[]texporter.Option{
 			texporter.WithProjectID(os.Getenv("GOOGLE_CLOUD_PROJECT")),
 			texporter.WithOnError(func(err error) {
-				log.Entry(context.Background()).Debugf("Error with metrics: %v", err)
+				log.Entry(context.TODO()).Debugf("Error with metrics: %v", err)
 			}),
 		},
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),

--- a/pkg/skaffold/instrumentation/trace.go
+++ b/pkg/skaffold/instrumentation/trace.go
@@ -60,7 +60,7 @@ func InitTraceFromEnvVar(opts ...TraceExporterOption) (trace.TracerProvider, fun
 		}
 	})
 	if tracerInitErr != nil {
-		log.Entry(context.Background()).Debugf("error initializing tracing: %v", tracerInitErr)
+		log.Entry(context.TODO()).Debugf("error initializing tracing: %v", tracerInitErr)
 	}
 	return tracerProvider, tracerShutdown, tracerInitErr
 }

--- a/pkg/skaffold/instrumentation/types.go
+++ b/pkg/skaffold/instrumentation/types.go
@@ -110,7 +110,7 @@ type creds struct {
 type errHandler struct{}
 
 func (h errHandler) Handle(err error) {
-	log.Entry(context.Background()).Debugf("Error with metrics: %v", err)
+	log.Entry(context.TODO()).Debugf("Error with metrics: %v", err)
 }
 
 type HookPhase string

--- a/pkg/skaffold/kubernetes/context/context.go
+++ b/pkg/skaffold/kubernetes/context/context.go
@@ -51,7 +51,7 @@ func ConfigureKubeConfig(cliKubeConfig, cliKubeContext string) {
 		kubeContext = cliKubeContext
 		kubeConfigFile = cliKubeConfig
 		if kubeContext != "" {
-			log.Entry(context.Background()).Infof("Activated kube-context %q", kubeContext)
+			log.Entry(context.TODO()).Infof("Activated kube-context %q", kubeContext)
 		}
 	})
 }
@@ -84,7 +84,7 @@ func GetClusterInfo(kctx string) (*clientcmdapi.Cluster, error) {
 }
 
 func getRestClientConfig(kctx string, kcfg string) (*restclient.Config, error) {
-	log.Entry(context.Background()).Debugf("getting client config for kubeContext: `%s`", kctx)
+	log.Entry(context.TODO()).Debugf("getting client config for kubeContext: `%s`", kctx)
 
 	rawConfig, err := getCurrentConfig()
 	if err != nil {
@@ -94,7 +94,7 @@ func getRestClientConfig(kctx string, kcfg string) (*restclient.Config, error) {
 	clientConfig := clientcmd.NewNonInteractiveClientConfig(rawConfig, kctx, &clientcmd.ConfigOverrides{CurrentContext: kctx}, clientcmd.NewDefaultClientConfigLoadingRules())
 	restConfig, err := clientConfig.ClientConfig()
 	if kctx == "" && kcfg == "" && clientcmd.IsEmptyConfig(err) {
-		log.Entry(context.Background()).Debug("no kube-context set and no kubeConfig found, attempting in-cluster config")
+		log.Entry(context.TODO()).Debug("no kube-context set and no kubeConfig found, attempting in-cluster config")
 		restConfig, err := restclient.InClusterConfig()
 		if err != nil {
 			return restConfig, fmt.Errorf("error creating REST client config in-cluster: %w", err)

--- a/pkg/skaffold/kubernetes/debugging/container_manager.go
+++ b/pkg/skaffold/kubernetes/debugging/container_manager.go
@@ -111,7 +111,7 @@ func (d *ContainerManager) checkPod(pod *v1.Pod) {
 	}
 	var configurations map[string]annotations.ContainerDebugConfiguration
 	if err := json.Unmarshal([]byte(debugConfigString), &configurations); err != nil {
-		log.Entry(context.Background()).Warnf("Unable to parse debug-config for pod %s/%s: '%s'", pod.Namespace, pod.Name, debugConfigString)
+		log.Entry(context.TODO()).Warnf("Unable to parse debug-config for pod %s/%s: '%s'", pod.Namespace, pod.Name, debugConfigString)
 		return
 	}
 	for _, c := range pod.Status.ContainerStatuses {

--- a/pkg/skaffold/kubernetes/manifest/images.go
+++ b/pkg/skaffold/kubernetes/manifest/images.go
@@ -48,7 +48,7 @@ func (is *imageSaver) Visit(o map[string]interface{}, k string, v interface{}) b
 	}
 	parsed, err := docker.ParseReference(image)
 	if err != nil {
-		log.Entry(context.Background()).Debugf("Couldn't parse image [%s]: %s", image, err.Error())
+		log.Entry(context.TODO()).Debugf("Couldn't parse image [%s]: %s", image, err.Error())
 		return false
 	}
 
@@ -123,7 +123,7 @@ func (r *imageReplacer) Visit(o map[string]interface{}, k string, v interface{})
 	}
 	parsed, err := docker.ParseReference(image)
 	if err != nil {
-		log.Entry(context.Background()).Debugf("Couldn't parse image [%s]: %s", image, err.Error())
+		log.Entry(context.TODO()).Debugf("Couldn't parse image [%s]: %s", image, err.Error())
 		return false
 	}
 	if imageName, tag, selected := r.selector(r.tagsByImageName, parsed); selected {
@@ -136,7 +136,7 @@ func (r *imageReplacer) Visit(o map[string]interface{}, k string, v interface{})
 func (r *imageReplacer) Check() {
 	for imageName := range r.tagsByImageName {
 		if !r.found[imageName] {
-			log.Entry(context.Background()).Debugf("image [%s] is not used by the current deployment", imageName)
+			log.Entry(context.TODO()).Debugf("image [%s] is not used by the current deployment", imageName)
 		}
 	}
 }

--- a/pkg/skaffold/kubernetes/manifest/labels.go
+++ b/pkg/skaffold/kubernetes/manifest/labels.go
@@ -34,7 +34,7 @@ func (l *ManifestList) SetLabels(labels map[string]string) (ManifestList, error)
 		return nil, labelSettingErr(err)
 	}
 
-	log.Entry(context.Background()).Debugln("manifests with labels", updated.String())
+	log.Entry(context.TODO()).Debugln("manifests with labels", updated.String())
 
 	return updated, nil
 }

--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
@@ -105,18 +105,18 @@ func debugPorts(pod *v1.Pod, c v1.Container) []v1.ContainerPort {
 	}
 	var configurations map[string]annotations.ContainerDebugConfiguration
 	if err := json.Unmarshal([]byte(annot), &configurations); err != nil {
-		log.Entry(context.Background()).Warnf("could not decode debug annotation on pod/%s (%q): %v", pod.Name, annot, err)
+		log.Entry(context.TODO()).Warnf("could not decode debug annotation on pod/%s (%q): %v", pod.Name, annot, err)
 		return nil
 	}
 	dc, found := configurations[c.Name]
 	if !found {
-		log.Entry(context.Background()).Debugf("no debug configuration found on pod/%s/%s", pod.Name, c.Name)
+		log.Entry(context.TODO()).Debugf("no debug configuration found on pod/%s/%s", pod.Name, c.Name)
 		return nil
 	}
 	for _, port := range c.Ports {
 		for _, exposed := range dc.Ports {
 			if uint32(port.ContainerPort) == exposed {
-				log.Entry(context.Background()).Debugf("selecting debug port for pod/%s/%s: %v", pod.Name, c.Name, port)
+				log.Entry(context.TODO()).Debugf("selecting debug port for pod/%s/%s: %v", pod.Name, c.Name, port)
 				ports = append(ports, port)
 			}
 		}

--- a/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/kubectl_forwarder.go
@@ -188,7 +188,7 @@ func portForwardArgs(ctx context.Context, kubeContext string, pfe *portForwardEn
 
 // Terminate terminates an existing kubectl port-forward command using SIGTERM
 func (*KubectlForwarder) Terminate(p *portForwardEntry) {
-	log.Entry(context.Background()).Debugf("Terminating port-forward %v", p)
+	log.Entry(context.TODO()).Debugf("Terminating port-forward %v", p)
 
 	p.terminationLock.Lock()
 	defer p.terminationLock.Unlock()

--- a/pkg/skaffold/kubernetes/status/resource/deployment.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment.go
@@ -201,7 +201,7 @@ func (d *Deployment) ReportSinceLastUpdated(isMuted bool) string {
 			// result.
 			out, writeTrimLines, err := withLogFile(p.Name(), &result, p.Logs(), isMuted)
 			if err != nil {
-				log.Entry(context.Background()).Debugf("could not create log file %v", err)
+				log.Entry(context.TODO()).Debugf("could not create log file %v", err)
 			}
 			trimLines := []string{}
 			for i, l := range p.Logs() {

--- a/pkg/skaffold/kubernetes/util.go
+++ b/pkg/skaffold/kubernetes/util.go
@@ -122,7 +122,7 @@ func parseKubernetesObjects(filepath string) ([]yamlObject, error) {
 func hasRequiredK8sManifestFields(doc map[string]interface{}) bool {
 	for _, field := range requiredFields {
 		if _, ok := doc[field]; !ok {
-			log.Entry(context.Background()).Debugf("%s not present in yaml, continuing", field)
+			log.Entry(context.TODO()).Debugf("%s not present in yaml, continuing", field)
 			return false
 		}
 	}

--- a/pkg/skaffold/kubernetes/watcher.go
+++ b/pkg/skaffold/kubernetes/watcher.go
@@ -100,7 +100,7 @@ func (w *podWatcher) Start(kubeContext string, namespaces []string) (func(), err
 			for evt := range watcher.ResultChan() {
 				// If the event's type is "ERROR", warn and continue.
 				if evt.Type == watch.Error {
-					log.Entry(context.Background()).Warnf("got unexpected event of type %s", evt.Type)
+					log.Entry(context.TODO()).Warnf("got unexpected event of type %s", evt.Type)
 					continue
 				}
 

--- a/pkg/skaffold/output/color.go
+++ b/pkg/skaffold/output/color.go
@@ -56,7 +56,7 @@ func SetupColors(out io.Writer, defaultColor int, forceColors bool) io.Writer {
 	_, isTerm := util.IsTerminal(out)
 	supportsColor, err := util.SupportsColor()
 	if err != nil {
-		log.Entry(context.Background()).Debugf("error checking for color support: %v", err)
+		log.Entry(context.TODO()).Debugf("error checking for color support: %v", err)
 	}
 
 	useColors := (isTerm && supportsColor) || forceColors

--- a/pkg/skaffold/parser/config.go
+++ b/pkg/skaffold/parser/config.go
@@ -115,7 +115,7 @@ func getConfigs(cfgOpts configOpts, opts config.SkaffoldOptions, r *record) (Ska
 	if len(parsed) == 0 {
 		return nil, sErrors.ZeroConfigsParsedErr(cfgOpts.file)
 	}
-	log.Entry(context.Background()).Debugf("parsed %d configs from configuration file %s", len(parsed), cfgOpts.file)
+	log.Entry(context.TODO()).Debugf("parsed %d configs from configuration file %s", len(parsed), cfgOpts.file)
 
 	// validate that config names are unique if specified
 	seen := make(map[string]bool)
@@ -295,7 +295,7 @@ func cacheRepo(g latestV1.GitInfo, opts config.SkaffoldOptions, r *record) (stri
 		case error:
 			return "", v
 		default:
-			log.Entry(context.Background()).Fatalf("unable to check download status of repo %s at ref %s", g.Repo, g.Ref)
+			log.Entry(context.TODO()).Fatalf("unable to check download status of repo %s at ref %s", g.Repo, g.Ref)
 			return "", nil
 		}
 	} else {
@@ -362,10 +362,10 @@ func isMakePathsAbsoluteSet(opts config.SkaffoldOptions) bool {
 
 func getBase(cfgOpts configOpts) (string, error) {
 	if cfgOpts.isDependency {
-		log.Entry(context.Background()).Tracef("found %s base dir for absolute path substitution within skaffold config %s", filepath.Dir(cfgOpts.file), cfgOpts.file)
+		log.Entry(context.TODO()).Tracef("found %s base dir for absolute path substitution within skaffold config %s", filepath.Dir(cfgOpts.file), cfgOpts.file)
 		return filepath.Dir(cfgOpts.file), nil
 	}
-	log.Entry(context.Background()).Tracef("found cwd as base for absolute path substitution within skaffold config %s", cfgOpts.file)
+	log.Entry(context.TODO()).Tracef("found cwd as base for absolute path substitution within skaffold config %s", cfgOpts.file)
 	return util.RealWorkDir()
 }
 

--- a/pkg/skaffold/runner/builder.go
+++ b/pkg/skaffold/runner/builder.go
@@ -50,7 +50,7 @@ func GetBuilder(r *runcontext.RunContext, s build.ArtifactStore, d graph.SourceD
 	bCtx := &builderCtx{artifactStore: s, sourceDependenciesCache: d, RunContext: r}
 	switch {
 	case p.Build.LocalBuild != nil:
-		log.Entry(context.Background()).Debug("Using builder: local")
+		log.Entry(context.TODO()).Debug("Using builder: local")
 		builder, err := local.NewBuilder(bCtx, p.Build.LocalBuild)
 		if err != nil {
 			return nil, err
@@ -58,12 +58,12 @@ func GetBuilder(r *runcontext.RunContext, s build.ArtifactStore, d graph.SourceD
 		return builder, nil
 
 	case p.Build.GoogleCloudBuild != nil:
-		log.Entry(context.Background()).Debug("Using builder: google cloud")
+		log.Entry(context.TODO()).Debug("Using builder: google cloud")
 		builder := gcb.NewBuilder(bCtx, p.Build.GoogleCloudBuild)
 		return builder, nil
 
 	case p.Build.Cluster != nil:
-		log.Entry(context.Background()).Debug("Using builder: cluster")
+		log.Entry(context.TODO()).Debug("Using builder: cluster")
 		builder, err := cluster.NewBuilder(bCtx, p.Build.Cluster)
 		if err != nil {
 			return nil, err

--- a/pkg/skaffold/runner/listen.go
+++ b/pkg/skaffold/runner/listen.go
@@ -91,7 +91,7 @@ func (l *SkaffoldListener) do(devLoop func() error) error {
 	// reset the dependencies resolver cache at the start of every dev loop.
 	l.sourceDependenciesCache.Reset()
 	if err := l.Monitor.Run(l.Trigger.Debounce()); err != nil {
-		log.Entry(context.Background()).Warnf("Ignoring changes: %s", err.Error())
+		log.Entry(context.TODO()).Warnf("Ignoring changes: %s", err.Error())
 		return nil
 	}
 
@@ -101,7 +101,7 @@ func (l *SkaffoldListener) do(devLoop func() error) error {
 		if errors.Is(err, ErrorConfigurationChanged) {
 			return err
 		}
-		log.Entry(context.Background()).Errorf("error running dev loop: %s", err.Error())
+		log.Entry(context.TODO()).Errorf("error running dev loop: %s", err.Error())
 	}
 
 	return nil

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -210,7 +210,7 @@ func GetRunContext(opts config.SkaffoldOptions, configs []schemaUtil.VersionedCo
 		return nil, fmt.Errorf("getting current cluster context: %w", err)
 	}
 	kubeContext := kubeConfig.CurrentContext
-	log.Entry(context.Background()).Infof("Using kubectl context: %s", kubeContext)
+	log.Entry(context.TODO()).Infof("Using kubectl context: %s", kubeContext)
 
 	// TODO(dgageot): this should be the folder containing skaffold.yaml. Should also be moved elsewhere.
 	cwd, err := os.Getwd()
@@ -221,7 +221,7 @@ func GetRunContext(opts config.SkaffoldOptions, configs []schemaUtil.VersionedCo
 	// combine all provided lists of insecure registries into a map
 	cfgRegistries, err := config.GetInsecureRegistries(opts.GlobalConfig)
 	if err != nil {
-		log.Entry(context.Background()).Warn("error retrieving insecure registries from global config: push/pull issues may exist...")
+		log.Entry(context.TODO()).Warn("error retrieving insecure registries from global config: push/pull issues may exist...")
 	}
 	var regList []string
 	regList = append(regList, opts.InsecureRegistries...)

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -154,7 +154,7 @@ func setupTrigger(triggerName string, setIntent func(bool), setAutoTrigger func(
 	// give the server a callback to set the intent value when a user request is received
 	singleTriggerCallback(func() {
 		if !getAutoTrigger() { // if auto trigger is disabled, we're in manual mode
-			log.Entry(context.Background()).Debugf("%s intent received, calling back to runner", triggerName)
+			log.Entry(context.TODO()).Debugf("%s intent received, calling back to runner", triggerName)
 			c <- true
 			setIntent(true)
 		}
@@ -162,7 +162,7 @@ func setupTrigger(triggerName string, setIntent func(bool), setAutoTrigger func(
 
 	// give the server a callback to update auto trigger value when a user request is received
 	autoTriggerCallback(func(val bool) {
-		log.Entry(context.Background()).Debugf("%s auto trigger update to %t received, calling back to runner", triggerName, val)
+		log.Entry(context.TODO()).Debugf("%s auto trigger update to %t received, calling back to runner", triggerName, val)
 		// signal chan only when auto trigger is set to true
 		if val {
 			c <- true
@@ -186,11 +186,11 @@ func isImageLocal(runCtx *runcontext.RunContext, imageName string) (bool, error)
 
 	switch {
 	case runCtx.Opts.PushImages.Value() != nil:
-		log.Entry(context.Background()).Debugf("push value set via skaffold build --push flag, --push=%t", *runCtx.Opts.PushImages.Value())
+		log.Entry(context.TODO()).Debugf("push value set via skaffold build --push flag, --push=%t", *runCtx.Opts.PushImages.Value())
 		pushImages = *runCtx.Opts.PushImages.Value()
 	case pipeline.Build.LocalBuild.Push == nil:
 		pushImages = cl.PushImages
-		log.Entry(context.Background()).Debugf("push value not present in isImageLocal(), defaulting to %t because cluster.PushImages is %t", pushImages, cl.PushImages)
+		log.Entry(context.TODO()).Debugf("push value not present in isImageLocal(), defaulting to %t because cluster.PushImages is %t", pushImages, cl.PushImages)
 	default:
 		pushImages = *pipeline.Build.LocalBuild.Push
 	}

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -123,7 +123,7 @@ func defaultToLocalBuild(c *latestV1.SkaffoldConfig) {
 		return
 	}
 
-	log.Entry(context.Background()).Debug("Defaulting build type to local build")
+	log.Entry(context.TODO()).Debug("Defaulting build type to local build")
 	c.Build.BuildType.LocalBuild = &latestV1.LocalBuild{}
 }
 
@@ -132,7 +132,7 @@ func defaultToKubectlDeploy(c *latestV1.SkaffoldConfig) {
 		return
 	}
 
-	log.Entry(context.Background()).Debug("Defaulting deploy type to kubectl")
+	log.Entry(context.TODO()).Debug("Defaulting deploy type to kubectl")
 	c.Deploy.DeployType.KubectlDeploy = &latestV1.KubectlDeploy{}
 }
 

--- a/pkg/skaffold/schema/profiles.go
+++ b/pkg/skaffold/schema/profiles.go
@@ -196,7 +196,7 @@ func isKubeContext(kubeContext string, opts cfg.SkaffoldOptions) (bool, error) {
 }
 
 func applyProfile(config *latestV1.SkaffoldConfig, profile latestV1.Profile) error {
-	log.Entry(context.Background()).Infof("applying profile: %s", profile.Name)
+	log.Entry(context.TODO()).Infof("applying profile: %s", profile.Name)
 
 	// Apply profile, field by field
 	mergedV := reflect.Indirect(reflect.ValueOf(&config.Pipeline))
@@ -294,7 +294,7 @@ func overlayOneOfField(config interface{}, profile interface{}) interface{} {
 		}
 	}
 	// if we're here, we didn't find any values set in the profile config. just return the original.
-	log.Entry(context.Background()).Infof("no values found in profile for field %s, using original config values", t.Name())
+	log.Entry(context.TODO()).Infof("no values found in profile for field %s, using original config values", t.Name())
 	return config
 }
 
@@ -317,7 +317,7 @@ func overlayStructField(config interface{}, profile interface{}) interface{} {
 func overlayProfileField(fieldName string, config interface{}, profile interface{}) interface{} {
 	v := reflect.ValueOf(profile) // the profile itself
 	t := reflect.TypeOf(profile)  // the type of the profile, used for getting struct field types
-	log.Entry(context.Background()).Debugf("overlaying profile on config for field %s", fieldName)
+	log.Entry(context.TODO()).Debugf("overlaying profile on config for field %s", fieldName)
 	switch v.Kind() {
 	case reflect.Struct:
 		// check the first field of the struct for a oneOf yamltag.
@@ -348,7 +348,7 @@ func overlayProfileField(fieldName string, config interface{}, profile interface
 		}
 		return v.Interface()
 	default:
-		log.Entry(context.Background()).Fatalf("Type mismatch in profile overlay for field '%s' with type %s; falling back to original config values", fieldName, v.Kind())
+		log.Entry(context.TODO()).Fatalf("Type mismatch in profile overlay for field '%s' with type %s; falling back to original config values", fieldName, v.Kind())
 		return config
 	}
 }

--- a/pkg/skaffold/schema/v1alpha1/upgrade.go
+++ b/pkg/skaffold/schema/v1alpha1/upgrade.go
@@ -72,7 +72,7 @@ func (config *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
 	var newKubectlDeploy *next.KubectlDeploy
 	if config.Deploy.DeployType.KubectlDeploy != nil {
 		var newManifests []string
-		log.Entry(context.Background()).Warn("Ignoring manifest parameters when transforming v1alpha1 config; check Kubernetes yaml before running skaffold")
+		log.Entry(context.TODO()).Warn("Ignoring manifest parameters when transforming v1alpha1 config; check Kubernetes yaml before running skaffold")
 		for _, manifest := range config.Deploy.DeployType.KubectlDeploy.Manifests {
 			newManifests = append(newManifests, manifest.Paths...)
 		}

--- a/pkg/skaffold/schema/v1beta9/upgrade.go
+++ b/pkg/skaffold/schema/v1beta9/upgrade.go
@@ -110,7 +110,7 @@ func convertSyncRules(artifacts []*Artifact) [][]*next.SyncRule {
 		a.Sync = nil
 	}
 	if len(incompatiblePatterns) > 0 {
-		log.Entry(context.Background()).Warnf(incompatibleSyncWarning, incompatiblePatterns)
+		log.Entry(context.TODO()).Warnf(incompatibleSyncWarning, incompatiblePatterns)
 	}
 	return newSync
 }

--- a/pkg/skaffold/schema/v2beta16/upgrade.go
+++ b/pkg/skaffold/schema/v2beta16/upgrade.go
@@ -39,7 +39,7 @@ func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
 func upgradeOnePipeline(oldPipeline, newPipeline interface{}) error {
 	for _, a := range oldPipeline.(*Pipeline).Build.Artifacts {
 		if a.DockerArtifact != nil && a.DockerArtifact.Secret != nil && a.DockerArtifact.Secret.Destination != "" {
-			log.Entry(context.Background()).Warnf("Artifact %q: Docker secret destination is no longer supported: %q", a.ImageName, a.DockerArtifact.Secret.Destination)
+			log.Entry(context.TODO()).Warnf("Artifact %q: Docker secret destination is no longer supported: %q", a.ImageName, a.DockerArtifact.Secret.Destination)
 		}
 	}
 	return nil

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -602,7 +602,7 @@ func validateKubectlManifests(configs parser.SkaffoldConfigSet) (errs []error) {
 			continue
 		}
 		if len(c.Deploy.KubectlDeploy.Manifests) == 1 && c.Deploy.KubectlDeploy.Manifests[0] == constants.DefaultKubectlManifests[0] {
-			log.Entry(context.Background()).Debug("skipping validating `kubectl` deployer manifests since only the default manifest list is defined")
+			log.Entry(context.TODO()).Debug("skipping validating `kubectl` deployer manifests since only the default manifest list is defined")
 			continue
 		}
 

--- a/pkg/skaffold/schema/versions.go
+++ b/pkg/skaffold/schema/versions.go
@@ -375,7 +375,7 @@ func UpgradeTo(configs []util.VersionedConfig, toVersion string) ([]util.Version
 	if !upgradeNeeded {
 		return configs, nil
 	}
-	log.Entry(context.Background()).Debugf("config version out of date: upgrading to latest %q", toVersion)
+	log.Entry(context.TODO()).Debugf("config version out of date: upgrading to latest %q", toVersion)
 	var err error
 	var upgraded []util.VersionedConfig
 	for _, cfg := range configs {

--- a/pkg/skaffold/server/server.go
+++ b/pkg/skaffold/server/server.go
@@ -140,9 +140,9 @@ func newGRPCServer(preferredPort int, usedPorts *util.PortSet) (func() error, in
 	}
 
 	if port != preferredPort {
-		log.Entry(context.Background()).Warnf("starting gRPC server on port %d. (%d is already in use)", port, preferredPort)
+		log.Entry(context.TODO()).Warnf("starting gRPC server on port %d. (%d is already in use)", port, preferredPort)
 	} else {
-		log.Entry(context.Background()).Infof("starting gRPC server on port %d", port)
+		log.Entry(context.TODO()).Infof("starting gRPC server on port %d", port)
 	}
 
 	s := grpc.NewServer()
@@ -167,7 +167,7 @@ func newGRPCServer(preferredPort int, usedPorts *util.PortSet) (func() error, in
 
 	go func() {
 		if err := s.Serve(l); err != nil {
-			log.Entry(context.Background()).Errorf("failed to start grpc server: %s", err)
+			log.Entry(context.TODO()).Errorf("failed to start grpc server: %s", err)
 		}
 	}()
 	return func() error {
@@ -207,9 +207,9 @@ func newHTTPServer(preferredPort, proxyPort int, usedPorts *util.PortSet) (func(
 	}
 
 	if port != preferredPort {
-		log.Entry(context.Background()).Warnf("starting gRPC HTTP server on port %d. (%d is already in use)", port, preferredPort)
+		log.Entry(context.TODO()).Warnf("starting gRPC HTTP server on port %d. (%d is already in use)", port, preferredPort)
 	} else {
-		log.Entry(context.Background()).Infof("starting gRPC HTTP server on port %d", port)
+		log.Entry(context.TODO()).Infof("starting gRPC HTTP server on port %d", port)
 	}
 
 	server := &http.Server{

--- a/pkg/skaffold/survey/survey.go
+++ b/pkg/skaffold/survey/survey.go
@@ -129,7 +129,7 @@ func (s *Runner) OpenSurveyForm(_ context.Context, out io.Writer, id string) err
 		return err
 	}
 	if err := open(sc.URL); err != nil {
-		log.Entry(context.Background()).Debugf("could not open url %s", sc.URL)
+		log.Entry(context.TODO()).Debugf("could not open url %s", sc.URL)
 		return err
 	}
 
@@ -168,7 +168,7 @@ func (s *Runner) selectSurvey(takenSurveys map[string]struct{}) string {
 	sortSurveys(candidates)
 	cfgs, err := parseConfig(s.skaffoldConfig)
 	if err != nil {
-		log.Entry(context.Background()).Debugf("error parsing skaffold.yaml %s", err)
+		log.Entry(context.TODO()).Debugf("error parsing skaffold.yaml %s", err)
 		return ""
 	}
 	for _, sc := range candidates {

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -134,14 +134,14 @@ func inferredSyncItem(a *latestV1.Artifact, tag string, e filemon.Events, cfg do
 			}
 		}
 		if !matches {
-			log.Entry(context.Background()).Infof("Changed file %s does not match any sync pattern. Skipping sync", relPath)
+			log.Entry(context.TODO()).Infof("Changed file %s does not match any sync pattern. Skipping sync", relPath)
 			return nil, nil
 		}
 
 		if dsts, ok := syncMap[relPath]; ok {
 			toCopy[f] = dsts
 		} else {
-			log.Entry(context.Background()).Infof("Changed file %s is not syncable. Skipping sync", relPath)
+			log.Entry(context.TODO()).Infof("Changed file %s is not syncable. Skipping sync", relPath)
 			return nil, nil
 		}
 	}
@@ -220,7 +220,7 @@ func intersect(contextWd, containerWd string, syncRules []*latestV1.SyncRule, fi
 		}
 
 		if len(dsts) == 0 {
-			log.Entry(context.Background()).Infof("Changed file %s does not match any sync pattern. Skipping sync", relPath)
+			log.Entry(context.TODO()).Infof("Changed file %s does not match any sync pattern. Skipping sync", relPath)
 			return nil, nil
 		}
 

--- a/pkg/skaffold/tag/custom_template.go
+++ b/pkg/skaffold/tag/custom_template.go
@@ -94,7 +94,7 @@ func ParseCustomTemplate(t string) (*template.Template, error) {
 // ExecuteCustomTemplate executes a customTemplate against a custom map.
 func ExecuteCustomTemplate(customTemplate *template.Template, customMap map[string]string) (string, error) {
 	var buf bytes.Buffer
-	log.Entry(context.Background()).Debugf("Executing custom template %v with custom map %v", customTemplate, customMap)
+	log.Entry(context.TODO()).Debugf("Executing custom template %v with custom map %v", customTemplate, customMap)
 	if err := customTemplate.Execute(&buf, customMap); err != nil {
 		return "", fmt.Errorf("executing template: %w", err)
 	}

--- a/pkg/skaffold/tag/git_commit.go
+++ b/pkg/skaffold/tag/git_commit.go
@@ -99,7 +99,7 @@ func sanitizeTag(tag string) string {
 	}
 
 	if tag != sanitized {
-		log.Entry(context.Background()).Warnf("Using %q instead of %q as an image tag", sanitized, tag)
+		log.Entry(context.TODO()).Warnf("Using %q instead of %q as an image tag", sanitized, tag)
 	}
 
 	return sanitized

--- a/pkg/skaffold/tags/paths.go
+++ b/pkg/skaffold/tags/paths.go
@@ -63,7 +63,7 @@ func makeFilePathsAbsolute(config interface{}, base string) []error {
 						continue
 					}
 					v.SetString(filepath.Join(base, path))
-					log.Entry(context.Background()).Tracef("setting absolute path %q for config field %q", filepath.Join(base, path), f.Name)
+					log.Entry(context.TODO()).Tracef("setting absolute path %q for config field %q", filepath.Join(base, path), f.Name)
 				case []string:
 					for j := 0; j < v.Len(); j++ {
 						elem := v.Index(j)
@@ -72,7 +72,7 @@ func makeFilePathsAbsolute(config interface{}, base string) []error {
 							continue
 						}
 						elem.SetString(filepath.Join(base, path))
-						log.Entry(context.Background()).Tracef("setting absolute paths for config field %q index %d", f.Name, j)
+						log.Entry(context.TODO()).Tracef("setting absolute paths for config field %q index %d", f.Name, j)
 					}
 				case map[string]string:
 					for _, key := range v.MapKeys() {
@@ -81,7 +81,7 @@ func makeFilePathsAbsolute(config interface{}, base string) []error {
 							continue
 						}
 						v.SetMapIndex(key, reflect.ValueOf(filepath.Join(base, path)))
-						log.Entry(context.Background()).Tracef("setting absolute paths for config field %q key %q", f.Name, key.String())
+						log.Entry(context.TODO()).Tracef("setting absolute paths for config field %q key %q", f.Name, key.String())
 					}
 				default:
 					return []error{fmt.Errorf("yaml tag `filepath` needs struct field %q to be string or string slice", f.Name)}

--- a/pkg/skaffold/timeutil/util.go
+++ b/pkg/skaffold/timeutil/util.go
@@ -26,7 +26,7 @@ import (
 func LessThan(date string, duration time.Duration) bool {
 	t, err := time.Parse(time.RFC3339, date)
 	if err != nil {
-		log.Entry(context.Background()).Debugf("could not parse date %q", date)
+		log.Entry(context.TODO()).Debugf("could not parse date %q", date)
 		return false
 	}
 	return time.Since(t) < duration

--- a/pkg/skaffold/update/update.go
+++ b/pkg/skaffold/update/update.go
@@ -52,7 +52,7 @@ func CheckVersionOnError(config string) (string, error) {
 
 func checkVersion(configfile string, onError bool) (string, error) {
 	if !isUpdateCheckEnabled(configfile) {
-		log.Entry(context.Background()).Debug("Update check not enabled, skipping.")
+		log.Entry(context.TODO()).Debug("Update check not enabled, skipping.")
 		return "", nil
 	}
 	latest, current, err := GetLatestAndCurrentVersion()
@@ -82,7 +82,7 @@ func getLatestAndCurrentVersion() (semver.Version, semver.Version, error) {
 	if err != nil {
 		return none, none, err
 	}
-	log.Entry(context.Background()).Tracef("latest skaffold version: %s", versionString)
+	log.Entry(context.TODO()).Tracef("latest skaffold version: %s", versionString)
 	latest, err := version.ParseVersion(versionString)
 	if err != nil {
 		return none, none, fmt.Errorf("parsing latest version from GCS: %w", err)

--- a/pkg/skaffold/util/cmd.go
+++ b/pkg/skaffold/util/cmd.go
@@ -70,7 +70,7 @@ type Commander struct{}
 
 // RunCmdOut runs an exec.Command and returns the stdout and error.
 func (*Commander) RunCmdOut(cmd *exec.Cmd) ([]byte, error) {
-	log.Entry(context.Background()).Debugf("Running command: %s", cmd.Args)
+	log.Entry(context.TODO()).Debugf("Running command: %s", cmd.Args)
 
 	stdout := bytes.Buffer{}
 	cmd.Stdout = &stdout
@@ -91,9 +91,9 @@ func (*Commander) RunCmdOut(cmd *exec.Cmd) ([]byte, error) {
 	}
 
 	if stderr.Len() > 0 {
-		log.Entry(context.Background()).Debugf("Command output: [%s], stderr: %s", stdout.String(), stderr.String())
+		log.Entry(context.TODO()).Debugf("Command output: [%s], stderr: %s", stdout.String(), stderr.String())
 	} else {
-		log.Entry(context.Background()).Debugf("Command output: [%s]", stdout.String())
+		log.Entry(context.TODO()).Debugf("Command output: [%s]", stdout.String())
 	}
 
 	return stdout.Bytes(), nil
@@ -101,6 +101,6 @@ func (*Commander) RunCmdOut(cmd *exec.Cmd) ([]byte, error) {
 
 // RunCmd runs an exec.Command.
 func (*Commander) RunCmd(cmd *exec.Cmd) error {
-	log.Entry(context.Background()).Debugf("Running command: %s", cmd.Args)
+	log.Entry(context.TODO()).Debugf("Running command: %s", cmd.Args)
 	return cmd.Run()
 }

--- a/pkg/skaffold/util/config.go
+++ b/pkg/skaffold/util/config.go
@@ -41,8 +41,8 @@ func ReadConfiguration(filename string) ([]byte, error) {
 			// If the config file is the default `skaffold.yaml`,
 			// then we also try to read `skaffold.yml`.
 			if filename == "skaffold.yaml" {
-				log.Entry(context.Background()).Infof("Could not open skaffold.yaml: \"%s\"", err)
-				log.Entry(context.Background()).Info("Trying to read from skaffold.yml instead")
+				log.Entry(context.TODO()).Infof("Could not open skaffold.yaml: \"%s\"", err)
+				log.Entry(context.TODO()).Info("Trying to read from skaffold.yml instead")
 				contents, errIgnored := ioutil.ReadFile("skaffold.yml")
 				if errIgnored != nil {
 					// Return original error because it's the one that matters

--- a/pkg/skaffold/util/env_template.go
+++ b/pkg/skaffold/util/env_template.go
@@ -74,7 +74,7 @@ func ExecuteEnvTemplate(envTemplate *template.Template, customMap map[string]str
 	}
 
 	var buf bytes.Buffer
-	log.Entry(context.Background()).Debugf("Executing template %v with environment %v", envTemplate, envMap)
+	log.Entry(context.TODO()).Debugf("Executing template %v with environment %v", envTemplate, envMap)
 	if err := envTemplate.Execute(&buf, envMap); err != nil {
 		return "", err
 	}

--- a/pkg/skaffold/util/port.go
+++ b/pkg/skaffold/util/port.go
@@ -100,10 +100,10 @@ func (f *PortSet) List() []int {
 //
 // See https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt
 func GetAvailablePort(address string, port int, usedPorts *PortSet) int {
-	log.Entry(context.Background()).Tracef("looking for port: %s:%d", address, port)
+	log.Entry(context.TODO()).Tracef("looking for port: %s:%d", address, port)
 	if port > 0 {
 		if getPortIfAvailable(address, port, usedPorts) {
-			log.Entry(context.Background()).Debugf("found open port: %d", port)
+			log.Entry(context.TODO()).Debugf("found open port: %d", port)
 			return port
 		}
 
@@ -111,7 +111,7 @@ func GetAvailablePort(address string, port int, usedPorts *PortSet) int {
 		for i := 0; i < 10; i++ {
 			port++
 			if getPortIfAvailable(address, port, usedPorts) {
-				log.Entry(context.Background()).Debugf("found open port: %d", port)
+				log.Entry(context.TODO()).Debugf("found open port: %d", port)
 				return port
 			}
 		}
@@ -119,7 +119,7 @@ func GetAvailablePort(address string, port int, usedPorts *PortSet) int {
 
 	for port = 4503; port <= 4533; port++ {
 		if getPortIfAvailable(address, port, usedPorts) {
-			log.Entry(context.Background()).Debugf("found open port: %d", port)
+			log.Entry(context.TODO()).Debugf("found open port: %d", port)
 			return port
 		}
 	}
@@ -138,7 +138,7 @@ func GetAvailablePort(address string, port int, usedPorts *PortSet) int {
 
 func getPortIfAvailable(address string, p int, usedPorts *PortSet) bool {
 	if alreadySet := usedPorts.LoadOrSet(p); alreadySet {
-		log.Entry(context.Background()).Tracef("port %d already allocated", p)
+		log.Entry(context.TODO()).Tracef("port %d already allocated", p)
 		return false
 	}
 
@@ -149,27 +149,27 @@ func IsPortFree(address string, p int) bool {
 	// Ensure the port is available across all interfaces
 	l, err := net.Listen("tcp", fmt.Sprintf(":%d", p))
 	if err != nil {
-		log.Entry(context.Background()).Tracef("port INADDR_ANY:%d already bound: %v", p, err)
+		log.Entry(context.TODO()).Tracef("port INADDR_ANY:%d already bound: %v", p, err)
 		return false
 	} else if l == nil {
-		log.Entry(context.Background()).Tracef("port INADDR_ANY:%d nil listener", p)
+		log.Entry(context.TODO()).Tracef("port INADDR_ANY:%d nil listener", p)
 		return false
 	}
 	l.Close()
-	log.Entry(context.Background()).Tracef("was able to obtain INADDR_ANY:%d", p)
+	log.Entry(context.TODO()).Tracef("was able to obtain INADDR_ANY:%d", p)
 
 	if address != Any {
 		// Ensure the port is available on the specific interface too
 		l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", address, p))
 		if err != nil {
-			log.Entry(context.Background()).Tracef("port %s:%d already bound: %v", address, p, err)
+			log.Entry(context.TODO()).Tracef("port %s:%d already bound: %v", address, p, err)
 			return false
 		} else if l == nil {
-			log.Entry(context.Background()).Tracef("port %s:%d nil listener", address, p)
+			log.Entry(context.TODO()).Tracef("port %s:%d nil listener", address, p)
 			return false
 		}
 		l.Close()
-		log.Entry(context.Background()).Tracef("was able to obtain %s:%d", address, p)
+		log.Entry(context.TODO()).Tracef("was able to obtain %s:%d", address, p)
 	}
 	return true
 }

--- a/pkg/skaffold/util/regex.go
+++ b/pkg/skaffold/util/regex.go
@@ -43,7 +43,7 @@ func regexMatch(expected, actual string) bool {
 
 	matcher, err := re.Compile(expected)
 	if err != nil {
-		log.Entry(context.Background()).Infof("context activation criteria '%s' is not a valid regexp, falling back to string", expected)
+		log.Entry(context.TODO()).Infof("context activation criteria '%s' is not a valid regexp, falling back to string", expected)
 		return false
 	}
 

--- a/pkg/skaffold/util/tar.go
+++ b/pkg/skaffold/util/tar.go
@@ -120,7 +120,7 @@ func addFileToTar(root string, src string, dst string, tw *tar.Writer, hm header
 		}
 
 		if filepath.IsAbs(target) {
-			log.Entry(context.Background()).Warnf("Skipping %s. Only relative symlinks are supported.", src)
+			log.Entry(context.TODO()).Warnf("Skipping %s. Only relative symlinks are supported.", src)
 			return nil
 		}
 

--- a/pkg/skaffold/util/util.go
+++ b/pkg/skaffold/util/util.go
@@ -114,7 +114,7 @@ func ExpandPathsGlob(workingDir string, paths []string) ([]string, error) {
 			return nil, fmt.Errorf("glob: %w", err)
 		}
 		if len(files) == 0 {
-			log.Entry(context.Background()).Warnf("%s did not match any file", p)
+			log.Entry(context.TODO()).Warnf("%s did not match any file", p)
 		}
 
 		for _, f := range files {

--- a/pkg/skaffold/yamltags/tags.go
+++ b/pkg/skaffold/yamltags/tags.go
@@ -33,7 +33,7 @@ type fieldSet map[string]struct{}
 func ValidateStruct(s interface{}) error {
 	parentStruct := reflect.Indirect(reflect.ValueOf(s))
 	t := parentStruct.Type()
-	log.Entry(context.Background()).Tracef("validating yamltags of struct %s", t.Name())
+	log.Entry(context.TODO()).Tracef("validating yamltags of struct %s", t.Name())
 
 	// Loop through the fields on the struct, looking for tags.
 	for i := 0; i < t.NumField(); i++ {
@@ -64,7 +64,7 @@ func YamlName(field reflect.StructField) string {
 func GetYamlTag(value interface{}) string {
 	buf, err := yaml.Marshal(value)
 	if err != nil {
-		log.Entry(context.Background()).Warnf("error marshaling %-v", value)
+		log.Entry(context.TODO()).Warnf("error marshaling %-v", value)
 		return ""
 	}
 	rawStr := string(buf)
@@ -145,7 +145,7 @@ func processTags(yamltags string, val reflect.Value, parentStruct reflect.Value,
 				Field: field,
 			}
 		default:
-			log.Entry(context.Background()).Panicf("unknown yaml tag in %s", yamltags)
+			log.Entry(context.TODO()).Panicf("unknown yaml tag in %s", yamltags)
 		}
 		if err := yt.Load(tagParts); err != nil {
 			return err


### PR DESCRIPTION
Fixes: #6461
**Related**: #6419

**Description**
Replacing context.Background() usage with context.TODO
(https://pkg.go.dev/context?utm_source=godoc#TODO) so we can clean up later on
more easily.