### PR TITLE
fix: TestDebug/buildpacks by pinning go version

### DIFF
--- a/integration/testdata/debug/skaffold.yaml
+++ b/integration/testdata/debug/skaffold.yaml
@@ -59,6 +59,8 @@ profiles:
       context: go
       buildpacks:
         builder: "gcr.io/buildpacks/builder:v1"
+        env:
+        - GOOGLE_RUNTIME_VERSION=1.16 # temporarily pin due to issue#6450
     #- image: skaffold-debug-netcore
     #  context: netcore
     #  buildpacks:


### PR DESCRIPTION
Fixes: #6450 <!-- tracking issues that this PR will close -->
**Related**: https://github.com/GoogleContainerTools/container-debug-support/pull/77

**Description**
This temporarily pins the Go version used by the buildpack-built image
used for testing in the "skaffold debug" integration test.

It does not fix the problem for the users (i.e. anyone using go1.17 with
skaffold debug will still hit this) but it helps us pass the tests on main
branch.

**Follow-up Work**
We need to find a solution to the user app <=> dlv version skew problem in
https://github.com/GoogleContainerTools/container-debug-support/pull/77
and remove this version pinning (as the pinning itself eventually won't work
for being too old by the newer versions of dlv as we update it).