### PR TITLE
Plumb `context.Context` down into functions that use `util/cmd` functions

### DIFF
--- a/cmd/skaffold/app/cmd/build_test.go
+++ b/cmd/skaffold/app/cmd/build_test.go
@@ -51,7 +51,7 @@ func (r *mockRunner) Stop() error {
 }
 
 func TestTagFlag(t *testing.T) {
-	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+	mockCreateRunner := func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
 		return &mockRunner{}, []util.VersionedConfig{&latestV1.SkaffoldConfig{}}, nil, nil
 	}
 
@@ -70,7 +70,7 @@ func TestTagFlag(t *testing.T) {
 }
 
 func TestQuietFlag(t *testing.T) {
-	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+	mockCreateRunner := func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
 		return &mockRunner{}, []util.VersionedConfig{&latestV1.SkaffoldConfig{}}, nil, nil
 	}
 
@@ -116,7 +116,7 @@ func TestQuietFlag(t *testing.T) {
 }
 
 func TestFileOutputFlag(t *testing.T) {
-	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+	mockCreateRunner := func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
 		return &mockRunner{}, []util.VersionedConfig{&latestV1.SkaffoldConfig{}}, nil, nil
 	}
 
@@ -179,16 +179,16 @@ func TestFileOutputFlag(t *testing.T) {
 }
 
 func TestRunBuild(t *testing.T) {
-	errRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+	errRunner := func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
 		return nil, nil, nil, errors.New("some error")
 	}
-	mockCreateRunner := func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+	mockCreateRunner := func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
 		return &mockRunner{}, []util.VersionedConfig{&latestV1.SkaffoldConfig{}}, nil, nil
 	}
 
 	tests := []struct {
 		description string
-		mock        func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error)
+		mock        func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error)
 		shouldErr   bool
 	}{
 		{

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -263,7 +263,7 @@ func setUpLogs(stdErr io.Writer, level string, timestamp bool) error {
 	logrus.SetFormatter(&logrus.TextFormatter{
 		FullTimestamp: timestamp,
 	})
-	logrus.AddHook(event.NewLogHook(constants.DevLoop, constants.SubtaskIDNone))
+	logrus.AddHook(event.NewLogHook())
 	return nil
 }
 

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -86,7 +86,7 @@ func NewSkaffoldCommand(out, errOut io.Writer) *cobra.Command {
 			// These are used for command completion and send debug messages on stderr.
 			if cmd.Name() != cobra.ShellCompRequestCmd && cmd.Name() != cobra.ShellCompNoDescRequestCmd {
 				instrumentation.SetCommand(cmd.Name())
-				out := output.GetWriter(out, defaultColor, forceColors, timestamps)
+				out := output.GetWriter(context.Background(), out, defaultColor, forceColors, timestamps)
 				cmd.Root().SetOutput(out)
 
 				// Setup logs

--- a/cmd/skaffold/app/cmd/debug_test.go
+++ b/cmd/skaffold/app/cmd/debug_test.go
@@ -50,7 +50,7 @@ func TestNewCmdDebug(t *testing.T) {
 func TestDebugIndependentFromDev(t *testing.T) {
 	mockRunner := &mockDevRunner{}
 	testutil.Run(t, "DevDebug", func(t *testutil.T) {
-		t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+		t.Override(&createRunner, func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
 			return mockRunner, []util.VersionedConfig{&latestV1.SkaffoldConfig{}}, nil, nil
 		})
 		t.Override(&opts, config.SkaffoldOptions{})

--- a/cmd/skaffold/app/cmd/dev_test.go
+++ b/cmd/skaffold/app/cmd/dev_test.go
@@ -97,7 +97,7 @@ func TestDoDev(t *testing.T) {
 				hasDeployed: test.hasDeployed,
 				errDev:      context.Canceled,
 			}
-			t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+			t.Override(&createRunner, func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
 				return mockRunner, []util.VersionedConfig{&latestV1.SkaffoldConfig{}}, nil, nil
 			})
 			t.Override(&opts, config.SkaffoldOptions{
@@ -147,7 +147,7 @@ func TestDevConfigChange(t *testing.T) {
 	testutil.Run(t, "test config change", func(t *testutil.T) {
 		mockRunner := &mockConfigChangeRunner{}
 
-		t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+		t.Override(&createRunner, func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
 			return mockRunner, []util.VersionedConfig{&latestV1.SkaffoldConfig{}}, nil, nil
 		})
 		t.Override(&opts, config.SkaffoldOptions{

--- a/cmd/skaffold/app/cmd/diagnose.go
+++ b/cmd/skaffold/app/cmd/diagnose.go
@@ -56,7 +56,7 @@ func NewCmdDiagnose() *cobra.Command {
 func doDiagnose(ctx context.Context, out io.Writer) error {
 	// force absolute path resolution during diagnose
 	opts.MakePathsAbsolute = util.BoolPtr(true)
-	configs, err := getCfgs(opts)
+	configs, err := getCfgs(ctx, opts)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func doDiagnose(ctx context.Context, out io.Writer) error {
 }
 
 func printArtifactDiagnostics(ctx context.Context, out io.Writer, configs []schemaUtil.VersionedConfig) error {
-	runCtx, err := getRunContext(opts, configs)
+	runCtx, err := getRunContext(ctx, opts, configs)
 	if err != nil {
 		return fmt.Errorf("getting run context: %w", err)
 	}

--- a/cmd/skaffold/app/cmd/diagnose_test.go
+++ b/cmd/skaffold/app/cmd/diagnose_test.go
@@ -58,11 +58,11 @@ metadata:
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&getRunContext, func(config.SkaffoldOptions, []util.VersionedConfig) (*runcontext.RunContext, error) {
+			t.Override(&getRunContext, func(context.Context, config.SkaffoldOptions, []util.VersionedConfig) (*runcontext.RunContext, error) {
 				return nil, fmt.Errorf("cannot get the runtime context")
 			})
 			t.Override(&yamlOnly, test.yamlOnly)
-			t.Override(&getCfgs, func(opts config.SkaffoldOptions) ([]util.VersionedConfig, error) {
+			t.Override(&getCfgs, func(context.Context, config.SkaffoldOptions) ([]util.VersionedConfig, error) {
 				return []util.VersionedConfig{
 					&latestV1.SkaffoldConfig{
 						APIVersion: "testVersion",

--- a/cmd/skaffold/app/cmd/run_test.go
+++ b/cmd/skaffold/app/cmd/run_test.go
@@ -93,7 +93,7 @@ func TestDoRun(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, "", func(t *testutil.T) {
 			mockRunner := &mockRunRunner{}
-			t.Override(&createRunner, func(io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+			t.Override(&createRunner, func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
 				return mockRunner, []util.VersionedConfig{
 					&latestV1.SkaffoldConfig{
 						Pipeline: latestV1.Pipeline{

--- a/cmd/skaffold/app/cmd/runner_test.go
+++ b/cmd/skaffold/app/cmd/runner_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"testing"
@@ -88,7 +89,7 @@ func TestCreateNewRunner(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&validation.DefaultConfig, validation.Options{CheckDeploySource: false})
-			t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
+			t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 				return docker.NewLocalDaemon(&testutil.FakeAPIClient{
 					ErrVersion: true,
 				}, nil, false, nil), nil
@@ -101,7 +102,7 @@ func TestCreateNewRunner(t *testing.T) {
 				Write("skaffold.yaml", fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latestV1.Version, test.config)).
 				Chdir()
 
-			_, _, _, err := createNewRunner(ctx, ioutil.Discard, test.options)
+			_, _, _, err := createNewRunner(context.Background(), ioutil.Discard, test.options)
 
 			t.CheckError(test.shouldErr, err)
 			if test.expectedError != "" {

--- a/cmd/skaffold/app/cmd/runner_test.go
+++ b/cmd/skaffold/app/cmd/runner_test.go
@@ -101,7 +101,7 @@ func TestCreateNewRunner(t *testing.T) {
 				Write("skaffold.yaml", fmt.Sprintf("apiVersion: %s\nkind: Config\n%s", latestV1.Version, test.config)).
 				Chdir()
 
-			_, _, _, err := createNewRunner(ioutil.Discard, test.options)
+			_, _, _, err := createNewRunner(ctx, ioutil.Discard, test.options)
 
 			t.CheckError(test.shouldErr, err)
 			if test.expectedError != "" {

--- a/cmd/skaffold/skaffold.go
+++ b/cmd/skaffold/skaffold.go
@@ -54,7 +54,7 @@ func main() {
 			// As we allow some color setup using CLI flags for the main run, we can't run SetupColors()
 			// for the entire skaffold run here. It's possible SetupColors() was never called, so call it again
 			// before we print an error to get the right coloring.
-			errOut := output.GetWriter(os.Stderr, output.DefaultColorCode, false, false)
+			errOut := output.GetWriter(context.Background(), os.Stderr, output.DefaultColorCode, false, false)
 			output.Red.Fprintln(errOut, err)
 			code = app.ExitCode(err)
 		}

--- a/hack/versions/pkg/schema/git.go
+++ b/hack/versions/pkg/schema/git.go
@@ -73,7 +73,7 @@ func (g *git) diffWithBaseline(path string) ([]byte, error) {
 
 func (g *git) run(args ...string) ([]byte, error) {
 	cmd := exec.Command(g.path, args...)
-	out, err := util.RunCmdOut(cmd)
+	out, err := util.RunCmdOut(ctx, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed running %v: %s\n%s", cmd.Args, err, string(out))
 	}

--- a/hack/versions/pkg/schema/git.go
+++ b/hack/versions/pkg/schema/git.go
@@ -17,6 +17,7 @@ limitations under the License.
 package schema
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -73,7 +74,7 @@ func (g *git) diffWithBaseline(path string) ([]byte, error) {
 
 func (g *git) run(args ...string) ([]byte, error) {
 	cmd := exec.Command(g.path, args...)
-	out, err := util.RunCmdOut(ctx, cmd)
+	out, err := util.RunCmdOut(context.Background(), cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed running %v: %s\n%s", cmd.Args, err, string(out))
 	}

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -183,7 +183,7 @@ func setupGitRepo(t *testing.T, dir string) {
 	for _, args := range gitArgs {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		if buf, err := util.RunCmdOut(cmd); err != nil {
+		if buf, err := util.RunCmdOut(ctx, cmd); err != nil {
 			t.Logf(string(buf))
 			t.Fatal(err)
 		}

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -113,7 +113,7 @@ func TestBuild(t *testing.T) {
 // TestExpectedBuildFailures verifies that `skaffold build` fails in expected ways
 func TestExpectedBuildFailures(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
-	if !jib.JVMFound() {
+	if !jib.JVMFound(context.Background()) {
 		t.Fatal("test requires Java VM")
 	}
 
@@ -155,7 +155,7 @@ func checkImageExists(t *testing.T, image string) {
 	failNowIfError(t, err)
 
 	// TODO: use the proper RunContext
-	client, err := docker.NewAPIClient(&runcontext.RunContext{
+	client, err := docker.NewAPIClient(context.Background(), &runcontext.RunContext{
 		KubeContext: cfg.CurrentContext,
 	})
 	failNowIfError(t, err)
@@ -183,7 +183,7 @@ func setupGitRepo(t *testing.T, dir string) {
 	for _, args := range gitArgs {
 		cmd := exec.Command("git", args...)
 		cmd.Dir = dir
-		if buf, err := util.RunCmdOut(ctx, cmd); err != nil {
+		if buf, err := util.RunCmdOut(context.Background(), cmd); err != nil {
 			t.Logf(string(buf))
 			t.Fatal(err)
 		}

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -425,7 +425,7 @@ spec:
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			deployer, err := helm.NewDeployer(ctx, &runcontext.RunContext{
+			deployer, err := helm.NewDeployer(context.Background(), &runcontext.RunContext{
 				Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{
 					Deploy: latestV1.DeployConfig{
 						DeployType: latestV1.DeployType{

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -425,7 +425,7 @@ spec:
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			deployer, err := helm.NewDeployer(&runcontext.RunContext{
+			deployer, err := helm.NewDeployer(ctx, &runcontext.RunContext{
 				Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{{
 					Deploy: latestV1.DeployConfig{
 						DeployType: latestV1.DeployType{

--- a/pkg/skaffold/build/bazel/build.go
+++ b/pkg/skaffold/build/bazel/build.go
@@ -67,7 +67,7 @@ func (b *Builder) buildTar(ctx context.Context, out io.Writer, workspace string,
 	cmd.Dir = workspace
 	cmd.Stdout = out
 	cmd.Stderr = out
-	if err := util.RunCmd(cmd); err != nil {
+	if err := util.RunCmd(ctx, cmd); err != nil {
 		return "", fmt.Errorf("running command: %w", err)
 	}
 
@@ -107,7 +107,7 @@ func bazelBin(ctx context.Context, workspace string, a *latestV1.BazelArtifact) 
 	cmd := exec.CommandContext(ctx, "bazel", args...)
 	cmd.Dir = workspace
 
-	buf, err := util.RunCmdOut(cmd)
+	buf, err := util.RunCmdOut(ctx, cmd)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/skaffold/build/bazel/dependencies.go
+++ b/pkg/skaffold/build/bazel/dependencies.go
@@ -63,7 +63,7 @@ func GetDependencies(ctx context.Context, dir string, a *latestV1.BazelArtifact)
 
 	cmd := exec.CommandContext(ctx, "bazel", "query", query(a.BuildTarget), "--noimplicit_deps", "--order_output=no", "--output=label")
 	cmd.Dir = dir
-	stdout, err := util.RunCmdOut(cmd)
+	stdout, err := util.RunCmdOut(ctx, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("getting bazel dependencies: %w", err)
 	}

--- a/pkg/skaffold/build/cache/cache.go
+++ b/pkg/skaffold/build/cache/cache.go
@@ -74,7 +74,7 @@ type Config interface {
 }
 
 // NewCache returns the current state of the cache
-func NewCache(cfg Config, isLocalImage func(imageName string) (bool, error), dependencies DependencyLister, graph graph.ArtifactGraph, store build.ArtifactStore) (Cache, error) {
+func NewCache(ctx context.Context, cfg Config, isLocalImage func(imageName string) (bool, error), dependencies DependencyLister, graph graph.ArtifactGraph, store build.ArtifactStore) (Cache, error) {
 	if !cfg.CacheArtifacts() {
 		return &noCache{}, nil
 	}
@@ -91,7 +91,7 @@ func NewCache(cfg Config, isLocalImage func(imageName string) (bool, error), dep
 		return &noCache{}, nil
 	}
 
-	client, err := docker.NewAPIClient(cfg)
+	client, err := docker.NewAPIClient(ctx, cfg)
 	if err != nil {
 		// error only if any pipeline is local.
 		for _, p := range cfg.GetPipelines() {

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -127,7 +127,7 @@ func TestCacheBuildLocal(t *testing.T) {
 		// Mock Docker
 		t.Override(&docker.DefaultAuthHelper, stubAuth{})
 		dockerDaemon := fakeLocalDaemon(&testutil.FakeAPIClient{})
-		t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 			return dockerDaemon, nil
 		})
 
@@ -142,7 +142,7 @@ func TestCacheBuildLocal(t *testing.T) {
 			cacheFile: tmpDir.Path("cache"),
 		}
 		store := make(mockArtifactStore)
-		artifactCache, err := NewCache(ctx, cfg, func(imageName string) (bool, error) { return true, nil }, deps, graph.ToArtifactGraph(artifacts), store)
+		artifactCache, err := NewCache(context.Background(), cfg, func(imageName string) (bool, error) { return true, nil }, deps, graph.ToArtifactGraph(artifacts), store)
 		t.CheckNoError(err)
 
 		// First build: Need to build both artifacts
@@ -213,7 +213,7 @@ func TestCacheBuildRemote(t *testing.T) {
 
 		// Mock Docker
 		dockerDaemon := fakeLocalDaemon(&testutil.FakeAPIClient{})
-		t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 			return dockerDaemon, nil
 		})
 		t.Override(&docker.DefaultAuthHelper, stubAuth{})
@@ -238,7 +238,7 @@ func TestCacheBuildRemote(t *testing.T) {
 			pipeline:  latestV1.Pipeline{Build: latestV1.BuildConfig{BuildType: latestV1.BuildType{LocalBuild: &latestV1.LocalBuild{TryImportMissing: false}}}},
 			cacheFile: tmpDir.Path("cache"),
 		}
-		artifactCache, err := NewCache(ctx, cfg, func(imageName string) (bool, error) { return false, nil }, deps, graph.ToArtifactGraph(artifacts), make(mockArtifactStore))
+		artifactCache, err := NewCache(context.Background(), cfg, func(imageName string) (bool, error) { return false, nil }, deps, graph.ToArtifactGraph(artifacts), make(mockArtifactStore))
 		t.CheckNoError(err)
 
 		// First build: Need to build both artifacts
@@ -298,7 +298,7 @@ func TestCacheFindMissing(t *testing.T) {
 
 		// Mock Docker
 		dockerDaemon := fakeLocalDaemon(&testutil.FakeAPIClient{})
-		t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 			return dockerDaemon, nil
 		})
 		t.Override(&docker.DefaultAuthHelper, stubAuth{})
@@ -323,7 +323,7 @@ func TestCacheFindMissing(t *testing.T) {
 			pipeline:  latestV1.Pipeline{Build: latestV1.BuildConfig{BuildType: latestV1.BuildType{LocalBuild: &latestV1.LocalBuild{TryImportMissing: true}}}},
 			cacheFile: tmpDir.Path("cache"),
 		}
-		artifactCache, err := NewCache(ctx, cfg, func(imageName string) (bool, error) { return false, nil }, deps, graph.ToArtifactGraph(artifacts), make(mockArtifactStore))
+		artifactCache, err := NewCache(context.Background(), cfg, func(imageName string) (bool, error) { return false, nil }, deps, graph.ToArtifactGraph(artifacts), make(mockArtifactStore))
 		t.CheckNoError(err)
 
 		// Because the artifacts are in the docker registry, we expect them to be imported correctly.

--- a/pkg/skaffold/build/cache/retrieve_test.go
+++ b/pkg/skaffold/build/cache/retrieve_test.go
@@ -142,7 +142,7 @@ func TestCacheBuildLocal(t *testing.T) {
 			cacheFile: tmpDir.Path("cache"),
 		}
 		store := make(mockArtifactStore)
-		artifactCache, err := NewCache(cfg, func(imageName string) (bool, error) { return true, nil }, deps, graph.ToArtifactGraph(artifacts), store)
+		artifactCache, err := NewCache(ctx, cfg, func(imageName string) (bool, error) { return true, nil }, deps, graph.ToArtifactGraph(artifacts), store)
 		t.CheckNoError(err)
 
 		// First build: Need to build both artifacts
@@ -238,7 +238,7 @@ func TestCacheBuildRemote(t *testing.T) {
 			pipeline:  latestV1.Pipeline{Build: latestV1.BuildConfig{BuildType: latestV1.BuildType{LocalBuild: &latestV1.LocalBuild{TryImportMissing: false}}}},
 			cacheFile: tmpDir.Path("cache"),
 		}
-		artifactCache, err := NewCache(cfg, func(imageName string) (bool, error) { return false, nil }, deps, graph.ToArtifactGraph(artifacts), make(mockArtifactStore))
+		artifactCache, err := NewCache(ctx, cfg, func(imageName string) (bool, error) { return false, nil }, deps, graph.ToArtifactGraph(artifacts), make(mockArtifactStore))
 		t.CheckNoError(err)
 
 		// First build: Need to build both artifacts
@@ -323,7 +323,7 @@ func TestCacheFindMissing(t *testing.T) {
 			pipeline:  latestV1.Pipeline{Build: latestV1.BuildConfig{BuildType: latestV1.BuildType{LocalBuild: &latestV1.LocalBuild{TryImportMissing: true}}}},
 			cacheFile: tmpDir.Path("cache"),
 		}
-		artifactCache, err := NewCache(cfg, func(imageName string) (bool, error) { return false, nil }, deps, graph.ToArtifactGraph(artifacts), make(mockArtifactStore))
+		artifactCache, err := NewCache(ctx, cfg, func(imageName string) (bool, error) { return false, nil }, deps, graph.ToArtifactGraph(artifacts), make(mockArtifactStore))
 		t.CheckNoError(err)
 
 		// Because the artifacts are in the docker registry, we expect them to be imported correctly.

--- a/pkg/skaffold/build/custom/dependencies.go
+++ b/pkg/skaffold/build/custom/dependencies.go
@@ -38,7 +38,7 @@ func GetDependencies(ctx context.Context, workspace string, artifactName string,
 	case a.Dependencies.Command != "":
 		split := strings.Split(a.Dependencies.Command, " ")
 		cmd := exec.CommandContext(ctx, split[0], split[1:]...)
-		output, err := util.RunCmdOut(cmd)
+		output, err := util.RunCmdOut(ctx, cmd)
 		if err != nil {
 			return nil, fmt.Errorf("getting dependencies from command: %q: %w", a.Dependencies.Command, err)
 		}

--- a/pkg/skaffold/build/docker/docker.go
+++ b/pkg/skaffold/build/docker/docker.go
@@ -97,7 +97,7 @@ func (b *Builder) dockerCLIBuild(ctx context.Context, out io.Writer, workspace s
 	cmd.Stdout = out
 	cmd.Stderr = out
 
-	if err := util.RunCmd(cmd); err != nil {
+	if err := util.RunCmd(ctx, cmd); err != nil {
 		return "", fmt.Errorf("running build: %w", err)
 	}
 

--- a/pkg/skaffold/build/gcb/buildpacks_test.go
+++ b/pkg/skaffold/build/gcb/buildpacks_test.go
@@ -193,7 +193,7 @@ func TestBuildpackBuildSpec(t *testing.T) {
 			builder := NewBuilder(&mockBuilderContext{artifactStore: store}, &latestV1.GoogleCloudBuild{
 				PackImage: "pack/image",
 			})
-			buildSpec, err := builder.buildSpec(artifact, "img", "bucket", "object")
+			buildSpec, err := builder.buildSpec(ctx, artifact, "img", "bucket", "object")
 			t.CheckError(test.shouldErr, err)
 
 			if !test.shouldErr {

--- a/pkg/skaffold/build/gcb/buildpacks_test.go
+++ b/pkg/skaffold/build/gcb/buildpacks_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gcb
 
 import (
+	"context"
 	"testing"
 
 	"google.golang.org/api/cloudbuild/v1"
@@ -193,7 +194,7 @@ func TestBuildpackBuildSpec(t *testing.T) {
 			builder := NewBuilder(&mockBuilderContext{artifactStore: store}, &latestV1.GoogleCloudBuild{
 				PackImage: "pack/image",
 			})
-			buildSpec, err := builder.buildSpec(ctx, artifact, "img", "bucket", "object")
+			buildSpec, err := builder.buildSpec(context.Background(), artifact, "img", "bucket", "object")
 			t.CheckError(test.shouldErr, err)
 
 			if !test.shouldErr {

--- a/pkg/skaffold/build/gcb/cloud_build.go
+++ b/pkg/skaffold/build/gcb/cloud_build.go
@@ -71,12 +71,12 @@ func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer
 		"Destination": instrumentation.PII(tag),
 	})
 	// TODO: [#4922] Implement required artifact resolution from the `artifactStore`
-	cbclient, err := cloudbuild.NewService(ctx, gcp.ClientOptions()...)
+	cbclient, err := cloudbuild.NewService(ctx, gcp.ClientOptions(ctx)...)
 	if err != nil {
 		return "", fmt.Errorf("getting cloudbuild client: %w", err)
 	}
 
-	c, err := cstorage.NewClient(ctx, gcp.ClientOptions()...)
+	c, err := cstorage.NewClient(ctx, gcp.ClientOptions(ctx)...)
 	if err != nil {
 		return "", fmt.Errorf("getting cloud storage client: %w", err)
 	}
@@ -124,7 +124,7 @@ func (b *Builder) buildArtifactWithCloudBuild(ctx context.Context, out io.Writer
 		return "", fmt.Errorf("uploading source archive: %w", err)
 	}
 
-	buildSpec, err := b.buildSpec(artifact, tag, cbBucket, buildObject)
+	buildSpec, err := b.buildSpec(ctx, artifact, tag, cbBucket, buildObject)
 	if err != nil {
 		return "", fmt.Errorf("could not create build description: %w", err)
 	}

--- a/pkg/skaffold/build/gcb/docker_test.go
+++ b/pkg/skaffold/build/gcb/docker_test.go
@@ -156,7 +156,7 @@ func TestDockerBuildSpec(t *testing.T) {
 				Timeout:     "10m",
 			})
 
-			desc, err := builder.buildSpec(test.artifact, "nginx", "bucket", "object")
+			desc, err := builder.buildSpec(ctx, test.artifact, "nginx", "bucket", "object")
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, desc)
 		})
 	}

--- a/pkg/skaffold/build/gcb/docker_test.go
+++ b/pkg/skaffold/build/gcb/docker_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gcb
 
 import (
+	"context"
 	"testing"
 
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
@@ -156,7 +157,7 @@ func TestDockerBuildSpec(t *testing.T) {
 				Timeout:     "10m",
 			})
 
-			desc, err := builder.buildSpec(ctx, test.artifact, "nginx", "bucket", "object")
+			desc, err := builder.buildSpec(context.Background(), test.artifact, "nginx", "bucket", "object")
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, desc)
 		})
 	}

--- a/pkg/skaffold/build/gcb/jib.go
+++ b/pkg/skaffold/build/gcb/jib.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gcb
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path/filepath"
@@ -29,8 +30,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
-func (b *Builder) jibBuildSpec(artifact *latestV1.Artifact, tag string) (cloudbuild.Build, error) {
-	t, err := jib.DeterminePluginType(artifact.Workspace, artifact.JibArtifact)
+func (b *Builder) jibBuildSpec(ctx context.Context, artifact *latestV1.Artifact, tag string) (cloudbuild.Build, error) {
+	t, err := jib.DeterminePluginType(ctx, artifact.Workspace, artifact.JibArtifact)
 	if err != nil {
 		return cloudbuild.Build{}, err
 	}

--- a/pkg/skaffold/build/gcb/jib_test.go
+++ b/pkg/skaffold/build/gcb/jib_test.go
@@ -85,7 +85,7 @@ func TestJibMavenBuildSpec(t *testing.T) {
 			})
 			builder.skipTests = test.skipTests
 
-			buildSpec, err := builder.buildSpec(artifact, "img", "bucket", "object")
+			buildSpec, err := builder.buildSpec(ctx, artifact, "img", "bucket", "object")
 			t.CheckNoError(err)
 
 			expected := []*cloudbuild.BuildStep{{
@@ -130,7 +130,7 @@ func TestJibGradleBuildSpec(t *testing.T) {
 			})
 			builder.skipTests = test.skipTests
 
-			buildSpec, err := builder.buildSpec(artifact, "img", "bucket", "object")
+			buildSpec, err := builder.buildSpec(ctx, artifact, "img", "bucket", "object")
 			t.CheckNoError(err)
 
 			expected := []*cloudbuild.BuildStep{{

--- a/pkg/skaffold/build/gcb/jib_test.go
+++ b/pkg/skaffold/build/gcb/jib_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gcb
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,7 +31,7 @@ import (
 
 func TestMain(m *testing.M) {
 	// these tests don't actually require a JVM
-	jib.JVMFound = func() bool { return true }
+	jib.JVMFound = func(context.Context) bool { return true }
 	os.Exit(m.Run())
 }
 
@@ -85,7 +86,7 @@ func TestJibMavenBuildSpec(t *testing.T) {
 			})
 			builder.skipTests = test.skipTests
 
-			buildSpec, err := builder.buildSpec(ctx, artifact, "img", "bucket", "object")
+			buildSpec, err := builder.buildSpec(context.Background(), artifact, "img", "bucket", "object")
 			t.CheckNoError(err)
 
 			expected := []*cloudbuild.BuildStep{{
@@ -130,7 +131,7 @@ func TestJibGradleBuildSpec(t *testing.T) {
 			})
 			builder.skipTests = test.skipTests
 
-			buildSpec, err := builder.buildSpec(ctx, artifact, "img", "bucket", "object")
+			buildSpec, err := builder.buildSpec(context.Background(), artifact, "img", "bucket", "object")
 			t.CheckNoError(err)
 
 			expected := []*cloudbuild.BuildStep{{

--- a/pkg/skaffold/build/gcb/kaniko_test.go
+++ b/pkg/skaffold/build/gcb/kaniko_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gcb
 
 import (
+	"context"
 	"testing"
 
 	"google.golang.org/api/cloudbuild/v1"
@@ -426,7 +427,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 				}
 				return m, nil
 			})
-			desc, err := builder.buildSpec(ctx, artifact, "gcr.io/nginx", "bucket", "object")
+			desc, err := builder.buildSpec(context.Background(), artifact, "gcr.io/nginx", "bucket", "object")
 
 			expected := cloudbuild.Build{
 				LogsBucket: "bucket",

--- a/pkg/skaffold/build/gcb/kaniko_test.go
+++ b/pkg/skaffold/build/gcb/kaniko_test.go
@@ -426,7 +426,7 @@ func TestKanikoBuildSpec(t *testing.T) {
 				}
 				return m, nil
 			})
-			desc, err := builder.buildSpec(artifact, "gcr.io/nginx", "bucket", "object")
+			desc, err := builder.buildSpec(ctx, artifact, "gcr.io/nginx", "bucket", "object")
 
 			expected := cloudbuild.Build{
 				LogsBucket: "bucket",

--- a/pkg/skaffold/build/gcb/spec.go
+++ b/pkg/skaffold/build/gcb/spec.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gcb
 
 import (
+	"context"
 	"fmt"
 
 	cloudbuild "google.golang.org/api/cloudbuild/v1"
@@ -25,9 +26,9 @@ import (
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
-func (b *Builder) buildSpec(artifact *latestV1.Artifact, tag, bucket, object string) (cloudbuild.Build, error) {
+func (b *Builder) buildSpec(ctx context.Context, artifact *latestV1.Artifact, tag, bucket, object string) (cloudbuild.Build, error) {
 	// Artifact specific build spec
-	buildSpec, err := b.buildSpecForArtifact(artifact, tag)
+	buildSpec, err := b.buildSpecForArtifact(ctx, artifact, tag)
 	if err != nil {
 		return buildSpec, err
 	}
@@ -53,7 +54,7 @@ func (b *Builder) buildSpec(artifact *latestV1.Artifact, tag, bucket, object str
 	return buildSpec, nil
 }
 
-func (b *Builder) buildSpecForArtifact(a *latestV1.Artifact, tag string) (cloudbuild.Build, error) {
+func (b *Builder) buildSpecForArtifact(ctx context.Context, a *latestV1.Artifact, tag string) (cloudbuild.Build, error) {
 	switch {
 	case a.KanikoArtifact != nil:
 		return b.kanikoBuildSpec(a, tag)
@@ -62,7 +63,7 @@ func (b *Builder) buildSpecForArtifact(a *latestV1.Artifact, tag string) (cloudb
 		return b.dockerBuildSpec(a, tag)
 
 	case a.JibArtifact != nil:
-		return b.jibBuildSpec(a, tag)
+		return b.jibBuildSpec(ctx, a, tag)
 
 	case a.BuildpackArtifact != nil:
 		return b.buildpackBuildSpec(a.BuildpackArtifact, tag, a.Dependencies)

--- a/pkg/skaffold/build/gcb/spec_test.go
+++ b/pkg/skaffold/build/gcb/spec_test.go
@@ -48,7 +48,7 @@ func TestBuildSpecFail(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			builder := NewBuilder(&mockBuilderContext{}, &latestV1.GoogleCloudBuild{})
 
-			_, err := builder.buildSpec(test.artifact, "tag", "bucket", "object")
+			_, err := builder.buildSpec(ctx, test.artifact, "tag", "bucket", "object")
 
 			t.CheckError(true, err)
 		})

--- a/pkg/skaffold/build/gcb/spec_test.go
+++ b/pkg/skaffold/build/gcb/spec_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package gcb
 
 import (
+	"context"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
@@ -48,7 +49,7 @@ func TestBuildSpecFail(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			builder := NewBuilder(&mockBuilderContext{}, &latestV1.GoogleCloudBuild{})
 
-			_, err := builder.buildSpec(ctx, test.artifact, "tag", "bucket", "object")
+			_, err := builder.buildSpec(context.Background(), test.artifact, "tag", "bucket", "object")
 
 			t.CheckError(true, err)
 		})

--- a/pkg/skaffold/build/jib/build.go
+++ b/pkg/skaffold/build/jib/build.go
@@ -32,7 +32,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latestV1.A
 		"Destination": instrumentation.PII(tag),
 	})
 
-	t, err := DeterminePluginType(artifact.Workspace, artifact.JibArtifact)
+	t, err := DeterminePluginType(ctx, artifact.Workspace, artifact.JibArtifact)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/skaffold/build/jib/gradle.go
+++ b/pkg/skaffold/build/jib/gradle.go
@@ -67,7 +67,7 @@ func (b *Builder) runGradleCommand(ctx context.Context, out io.Writer, workspace
 	cmd.Stderr = out
 
 	log.Entry(ctx).Infof("Building %s: %s, %v", workspace, cmd.Path, cmd.Args)
-	if err := util.RunCmd(&cmd); err != nil {
+	if err := util.RunCmd(ctx, &cmd); err != nil {
 		return fmt.Errorf("gradle build failed: %w", err)
 	}
 
@@ -78,7 +78,7 @@ func (b *Builder) runGradleCommand(ctx context.Context, out io.Writer, workspace
 // All paths are absolute.
 func getDependenciesGradle(ctx context.Context, workspace string, a *latestV1.JibArtifact) ([]string, error) {
 	cmd := getCommandGradle(ctx, workspace, a)
-	deps, err := getDependencies(workspace, cmd, a)
+	deps, err := getDependencies(ctx, workspace, cmd, a)
 	if err != nil {
 		return nil, dependencyErr(JibGradle, workspace, err)
 	}

--- a/pkg/skaffold/build/jib/init.go
+++ b/pkg/skaffold/build/jib/init.go
@@ -84,8 +84,8 @@ type jibJSON struct {
 }
 
 // validate checks if a file is a valid Jib configuration. Returns the list of Config objects corresponding to each Jib project built by the file, or nil if Jib is not configured.
-func validate(path string, enableGradleAnalysis bool) []ArtifactConfig {
-	if !JVMFound() {
+func validate(ctx context.Context, path string, enableGradleAnalysis bool) []ArtifactConfig {
+	if !JVMFound(ctx) {
 		log.Entry(context.Background()).Debugf("Skipping Jib for init for %q: no functioning Java VM", path)
 		return nil
 	}
@@ -123,7 +123,7 @@ func validate(path string, enableGradleAnalysis bool) []ArtifactConfig {
 	}
 	cmd := exec.Command(executable, taskName, "-q", consoleFlag)
 	cmd.Dir = filepath.Dir(path)
-	stdout, err := util.RunCmdOut(cmd)
+	stdout, err := util.RunCmdOut(ctx, cmd)
 	if err != nil {
 		return nil
 	}

--- a/pkg/skaffold/build/jib/init_test.go
+++ b/pkg/skaffold/build/jib/init_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package jib
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -172,7 +173,7 @@ BEGIN JIB JSON
 				test.stdout,
 			))
 
-			validated := Validate(tmpDir.Path(test.path), test.enableGradle)
+			validated := Validate(context.Background(), tmpDir.Path(test.path), test.enableGradle)
 
 			t.CheckDeepEqual(test.expectedConfig, validated)
 		})

--- a/pkg/skaffold/build/jib/jib_test.go
+++ b/pkg/skaffold/build/jib/jib_test.go
@@ -106,7 +106,7 @@ func TestGetDependencies(t *testing.T) {
 				test.stdout,
 			))
 
-			results, err := getDependencies(tmpDir.Root(), exec.Cmd{Args: []string{"ignored"}, Dir: tmpDir.Root()}, &latestV1.JibArtifact{Project: util.RandomID()})
+			results, err := getDependencies(ctx, tmpDir.Root(), exec.Cmd{Args: []string{"ignored"}, Dir: tmpDir.Root()}, &latestV1.JibArtifact{Project: util.RandomID()})
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedDeps, results)
 		})
@@ -128,7 +128,7 @@ func TestGetUpdatedDependencies(t *testing.T) {
 		artifact := &latestV1.JibArtifact{Project: util.RandomID()}
 
 		// List dependencies
-		_, err := getDependencies(tmpDir.Root(), listCmd, artifact)
+		_, err := getDependencies(ctx, tmpDir.Root(), listCmd, artifact)
 		t.CheckNoError(err)
 
 		// Create new build definition files
@@ -137,7 +137,7 @@ func TestGetUpdatedDependencies(t *testing.T) {
 			Write("settings.gradle", "")
 
 		// Update dependencies
-		_, err = getDependencies(tmpDir.Root(), listCmd, artifact)
+		_, err = getDependencies(ctx, tmpDir.Root(), listCmd, artifact)
 		t.CheckNoError(err)
 	})
 }
@@ -190,7 +190,7 @@ func TestDeterminePluginType(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			buildDir := t.NewTempDir()
 			buildDir.Touch(test.files...)
-			PluginType, err := DeterminePluginType(buildDir.Root(), test.artifact)
+			PluginType, err := DeterminePluginType(ctx, buildDir.Root(), test.artifact)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.PluginType, PluginType)
 		})
 	}

--- a/pkg/skaffold/build/jib/jib_test.go
+++ b/pkg/skaffold/build/jib/jib_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package jib
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -106,7 +107,7 @@ func TestGetDependencies(t *testing.T) {
 				test.stdout,
 			))
 
-			results, err := getDependencies(ctx, tmpDir.Root(), exec.Cmd{Args: []string{"ignored"}, Dir: tmpDir.Root()}, &latestV1.JibArtifact{Project: util.RandomID()})
+			results, err := getDependencies(context.Background(), tmpDir.Root(), exec.Cmd{Args: []string{"ignored"}, Dir: tmpDir.Root()}, &latestV1.JibArtifact{Project: util.RandomID()})
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedDeps, results)
 		})
@@ -128,7 +129,7 @@ func TestGetUpdatedDependencies(t *testing.T) {
 		artifact := &latestV1.JibArtifact{Project: util.RandomID()}
 
 		// List dependencies
-		_, err := getDependencies(ctx, tmpDir.Root(), listCmd, artifact)
+		_, err := getDependencies(context.Background(), tmpDir.Root(), listCmd, artifact)
 		t.CheckNoError(err)
 
 		// Create new build definition files
@@ -137,7 +138,7 @@ func TestGetUpdatedDependencies(t *testing.T) {
 			Write("settings.gradle", "")
 
 		// Update dependencies
-		_, err = getDependencies(ctx, tmpDir.Root(), listCmd, artifact)
+		_, err = getDependencies(context.Background(), tmpDir.Root(), listCmd, artifact)
 		t.CheckNoError(err)
 	})
 }
@@ -190,7 +191,7 @@ func TestDeterminePluginType(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			buildDir := t.NewTempDir()
 			buildDir.Touch(test.files...)
-			PluginType, err := DeterminePluginType(ctx, buildDir.Root(), test.artifact)
+			PluginType, err := DeterminePluginType(context.Background(), buildDir.Root(), test.artifact)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.PluginType, PluginType)
 		})
 	}

--- a/pkg/skaffold/build/jib/jvm.go
+++ b/pkg/skaffold/build/jib/jvm.go
@@ -35,11 +35,11 @@ var (
 )
 
 // jvmFound returns true if a Java VM was found and works.
-func jvmFound() bool {
+func jvmFound(ctx context.Context) bool {
 	// Check on demand: performing the check in an init() causes the
 	// check to be run even when no jib functionality was used.
 	resolveJVMOnce.Do(func() {
-		jvmPresent = resolveJVM()
+		jvmPresent = resolveJVM(ctx)
 	})
 	return jvmPresent
 }
@@ -47,12 +47,12 @@ func jvmFound() bool {
 // resolveJVM returns true if a Java VM was found and works.  It is intended for
 // `skaffold init` on macOS where calling out to the Maven Wrapper script (mvnw) can
 // hang if there is no installed Java VM found.
-func resolveJVM() bool {
+func resolveJVM(ctx context.Context) bool {
 	// Note that just checking for the existence of `java` is insufficient
 	// as macOS ships with /usr/bin/java that tries to hand off to a JVM
 	// installed in /Library/Java/JavaVirtualMachines
 	cmd := exec.Command("java", "-version")
-	err := util.RunCmd(cmd)
+	err := util.RunCmd(ctx, cmd)
 	if err != nil {
 		log.Entry(context.Background()).Warnf("Skipping Jib: no JVM: %v failed: %v", cmd.Args, err)
 	}

--- a/pkg/skaffold/build/jib/jvm_test.go
+++ b/pkg/skaffold/build/jib/jvm_test.go
@@ -44,7 +44,7 @@ func TestResolveJVM(t *testing.T) {
 		testutil.Run(t, test.name, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, test.cmd)
 
-			result := resolveJVM()
+			result := resolveJVM(ctx)
 			t.CheckDeepEqual(test.expected, result)
 		})
 	}

--- a/pkg/skaffold/build/jib/jvm_test.go
+++ b/pkg/skaffold/build/jib/jvm_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package jib
 
 import (
+	"context"
 	"errors"
 	"os"
 	"testing"
@@ -27,7 +28,7 @@ import (
 
 func TestMain(m *testing.M) {
 	// these tests don't actually require a JVM
-	JVMFound = func() bool { return true }
+	JVMFound = func(context.Context) bool { return true }
 	os.Exit(m.Run())
 }
 
@@ -44,7 +45,7 @@ func TestResolveJVM(t *testing.T) {
 		testutil.Run(t, test.name, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, test.cmd)
 
-			result := resolveJVM(ctx)
+			result := resolveJVM(context.Background())
 			t.CheckDeepEqual(test.expected, result)
 		})
 	}

--- a/pkg/skaffold/build/jib/maven.go
+++ b/pkg/skaffold/build/jib/maven.go
@@ -67,7 +67,7 @@ func (b *Builder) runMavenCommand(ctx context.Context, out io.Writer, workspace 
 	cmd.Stderr = out
 
 	log.Entry(ctx).Infof("Building %s: %s, %v", workspace, cmd.Path, cmd.Args)
-	if err := util.RunCmd(&cmd); err != nil {
+	if err := util.RunCmd(ctx, &cmd); err != nil {
 		return fmt.Errorf("maven build failed: %w", err)
 	}
 
@@ -77,7 +77,7 @@ func (b *Builder) runMavenCommand(ctx context.Context, out io.Writer, workspace 
 // getDependenciesMaven finds the source dependencies for the given jib-maven artifact.
 // All paths are absolute.
 func getDependenciesMaven(ctx context.Context, workspace string, a *latestV1.JibArtifact) ([]string, error) {
-	deps, err := getDependencies(workspace, getCommandMaven(ctx, workspace, a), a)
+	deps, err := getDependencies(ctx, workspace, getCommandMaven(ctx, workspace, a), a)
 	if err != nil {
 		return nil, dependencyErr(JibMaven, workspace, err)
 	}

--- a/pkg/skaffold/build/jib/sync.go
+++ b/pkg/skaffold/build/jib/sync.go
@@ -160,7 +160,7 @@ func getSyncMap(ctx context.Context, workspace string, artifact *latestV1.JibArt
 		return nil, fmt.Errorf("failed to get sync command: %w", err)
 	}
 
-	sm, err := getSyncMapFromSystem(cmd)
+	sm, err := getSyncMapFromSystem(ctx, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to obtain sync map from jib builder: %w", err)
 	}
@@ -168,7 +168,7 @@ func getSyncMap(ctx context.Context, workspace string, artifact *latestV1.JibArt
 }
 
 func getSyncMapCommand(ctx context.Context, workspace string, artifact *latestV1.JibArtifact) (*exec.Cmd, error) {
-	t, err := DeterminePluginType(workspace, artifact)
+	t, err := DeterminePluginType(ctx, workspace, artifact)
 	if err != nil {
 		return nil, err
 	}
@@ -183,9 +183,9 @@ func getSyncMapCommand(ctx context.Context, workspace string, artifact *latestV1
 	}
 }
 
-func getSyncMapFromSystem(cmd *exec.Cmd) (*SyncMap, error) {
+func getSyncMapFromSystem(ctx context.Context, cmd *exec.Cmd) (*SyncMap, error) {
 	jsm := JSONSyncMap{}
-	stdout, err := util.RunCmdOut(cmd)
+	stdout, err := util.RunCmdOut(ctx, cmd)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Jib sync map: %w", err)
 	}

--- a/pkg/skaffold/build/jib/sync_test.go
+++ b/pkg/skaffold/build/jib/sync_test.go
@@ -120,7 +120,7 @@ func TestGetSyncMapFromSystem(t *testing.T) {
 				test.stdout,
 			))
 
-			results, err := getSyncMapFromSystem(ctx, &exec.Cmd{Args: []string{"ignored"}})
+			results, err := getSyncMapFromSystem(context.Background(), &exec.Cmd{Args: []string{"ignored"}})
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, results)
 		})

--- a/pkg/skaffold/build/jib/sync_test.go
+++ b/pkg/skaffold/build/jib/sync_test.go
@@ -120,7 +120,7 @@ func TestGetSyncMapFromSystem(t *testing.T) {
 				test.stdout,
 			))
 
-			results, err := getSyncMapFromSystem(&exec.Cmd{Args: []string{"ignored"}})
+			results, err := getSyncMapFromSystem(ctx, &exec.Cmd{Args: []string{"ignored"}})
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, results)
 		})

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -224,7 +224,7 @@ func TestLocalRun(t *testing.T) {
 			t.Override(&docker.DefaultAuthHelper, testAuthHelper{})
 			fakeWarner := &warnings.Collect{}
 			t.Override(&warnings.Printf, fakeWarner.Warnf)
-			t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
+			t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 				return fakeLocalDaemon(test.api), nil
 			})
 			t.Override(&docker.EvalBuildArgs, func(_ config.RunMode, _ string, _ string, args map[string]*string, _ map[string]*string) (map[string]*string, error) {
@@ -238,7 +238,7 @@ func TestLocalRun(t *testing.T) {
 					},
 				}}})
 
-			builder, err := NewBuilder(ctx, &mockBuilderContext{artifactStore: build.NewArtifactStore()}, &latestV1.LocalBuild{
+			builder, err := NewBuilder(context.Background(), &mockBuilderContext{artifactStore: build.NewArtifactStore()}, &latestV1.LocalBuild{
 				Push:        util.BoolPtr(test.pushImages),
 				Concurrency: &constants.DefaultLocalConcurrency,
 			})
@@ -266,18 +266,18 @@ func TestNewBuilder(t *testing.T) {
 		cluster       config.Cluster
 		pushFlag      config.BoolOrUndefined
 		localBuild    latestV1.LocalBuild
-		localDockerFn func(docker.Config) (docker.LocalDaemon, error)
+		localDockerFn func(context.Context, docker.Config) (docker.LocalDaemon, error)
 	}{
 		{
 			description: "failed to get docker client",
-			localDockerFn: func(docker.Config) (docker.LocalDaemon, error) {
+			localDockerFn: func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 				return nil, errors.New("dummy docker error")
 			},
 			shouldErr: true,
 		},
 		{
 			description: "pushImages becomes cluster.PushImages when local:push and --push is not defined",
-			localDockerFn: func(docker.Config) (docker.LocalDaemon, error) {
+			localDockerFn: func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 				return dummyDaemon, nil
 			},
 			cluster:      config.Cluster{PushImages: true},
@@ -285,7 +285,7 @@ func TestNewBuilder(t *testing.T) {
 		},
 		{
 			description: "pushImages becomes config (local:push) when --push is not defined",
-			localDockerFn: func(docker.Config) (docker.LocalDaemon, error) {
+			localDockerFn: func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 				return dummyDaemon, nil
 			},
 			cluster: config.Cluster{PushImages: true},
@@ -297,7 +297,7 @@ func TestNewBuilder(t *testing.T) {
 		},
 		{
 			description: "pushImages defined in flags (--push=false), ignores cluster.PushImages",
-			localDockerFn: func(docker.Config) (docker.LocalDaemon, error) {
+			localDockerFn: func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 				return dummyDaemon, nil
 			},
 			cluster:      config.Cluster{PushImages: true},
@@ -307,7 +307,7 @@ func TestNewBuilder(t *testing.T) {
 		},
 		{
 			description: "pushImages defined in flags (--push=false), ignores config (local:push)",
-			localDockerFn: func(docker.Config) (docker.LocalDaemon, error) {
+			localDockerFn: func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 				return dummyDaemon, nil
 			},
 			pushFlag: config.NewBoolOrUndefined(util.BoolPtr(false)),
@@ -324,7 +324,7 @@ func TestNewBuilder(t *testing.T) {
 				t.Override(&docker.NewAPIClient, test.localDockerFn)
 			}
 
-			builder, err := NewBuilder(ctx, &mockBuilderContext{
+			builder, err := NewBuilder(context.Background(), &mockBuilderContext{
 				local:    test.localBuild,
 				cluster:  test.cluster,
 				pushFlag: test.pushFlag,
@@ -398,14 +398,14 @@ func TestGetArtifactBuilder(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
+			t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 				return fakeLocalDaemon(&testutil.FakeAPIClient{}), nil
 			})
 			t.Override(&docker.EvalBuildArgs, func(_ config.RunMode, _ string, _ string, args map[string]*string, _ map[string]*string) (map[string]*string, error) {
 				return args, nil
 			})
 
-			b, err := NewBuilder(ctx, &mockBuilderContext{artifactStore: build.NewArtifactStore()}, &latestV1.LocalBuild{Concurrency: &constants.DefaultLocalConcurrency})
+			b, err := NewBuilder(context.Background(), &mockBuilderContext{artifactStore: build.NewArtifactStore()}, &latestV1.LocalBuild{Concurrency: &constants.DefaultLocalConcurrency})
 			t.CheckNoError(err)
 
 			builder, err := newPerArtifactBuilder(b, test.artifact)

--- a/pkg/skaffold/build/local/local_test.go
+++ b/pkg/skaffold/build/local/local_test.go
@@ -238,11 +238,10 @@ func TestLocalRun(t *testing.T) {
 					},
 				}}})
 
-			builder, err := NewBuilder(&mockBuilderContext{artifactStore: build.NewArtifactStore()},
-				&latestV1.LocalBuild{
-					Push:        util.BoolPtr(test.pushImages),
-					Concurrency: &constants.DefaultLocalConcurrency,
-				})
+			builder, err := NewBuilder(ctx, &mockBuilderContext{artifactStore: build.NewArtifactStore()}, &latestV1.LocalBuild{
+				Push:        util.BoolPtr(test.pushImages),
+				Concurrency: &constants.DefaultLocalConcurrency,
+			})
 			t.CheckNoError(err)
 			ab := builder.Build(context.Background(), ioutil.Discard, test.artifact)
 			res, err := ab(context.Background(), ioutil.Discard, test.artifact, test.tag)
@@ -325,7 +324,7 @@ func TestNewBuilder(t *testing.T) {
 				t.Override(&docker.NewAPIClient, test.localDockerFn)
 			}
 
-			builder, err := NewBuilder(&mockBuilderContext{
+			builder, err := NewBuilder(ctx, &mockBuilderContext{
 				local:    test.localBuild,
 				cluster:  test.cluster,
 				pushFlag: test.pushFlag,
@@ -406,7 +405,7 @@ func TestGetArtifactBuilder(t *testing.T) {
 				return args, nil
 			})
 
-			b, err := NewBuilder(&mockBuilderContext{artifactStore: build.NewArtifactStore()}, &latestV1.LocalBuild{Concurrency: &constants.DefaultLocalConcurrency})
+			b, err := NewBuilder(ctx, &mockBuilderContext{artifactStore: build.NewArtifactStore()}, &latestV1.LocalBuild{Concurrency: &constants.DefaultLocalConcurrency})
 			t.CheckNoError(err)
 
 			builder, err := newPerArtifactBuilder(b, test.artifact)

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -78,8 +78,8 @@ type BuilderContext interface {
 }
 
 // NewBuilder returns an new instance of a local Builder.
-func NewBuilder(bCtx BuilderContext, buildCfg *latestV1.LocalBuild) (*Builder, error) {
-	localDocker, err := docker.NewAPIClient(bCtx)
+func NewBuilder(ctx context.Context, bCtx BuilderContext, buildCfg *latestV1.LocalBuild) (*Builder, error) {
+	localDocker, err := docker.NewAPIClient(ctx, bCtx)
 	if err != nil {
 		return nil, fmt.Errorf("getting docker client: %w", err)
 	}

--- a/pkg/skaffold/build/result.go
+++ b/pkg/skaffold/build/result.go
@@ -40,7 +40,7 @@ var (
 // The order of output is not guaranteed between multiple builds running concurrently.
 type logAggregator interface {
 	// GetWriter returns an output writer tracked by the logAggregator
-	GetWriter() (w io.Writer, close func(), err error)
+	GetWriter(ctx context.Context) (w io.Writer, close func(), err error)
 	// PrintInOrder prints the output from each allotted writer in build order.
 	// It blocks until the instantiated capacity of io writers have been all allotted and closed, or the context is cancelled.
 	PrintInOrder(ctx context.Context)
@@ -54,7 +54,7 @@ type logAggregatorImpl struct {
 	countMutex sync.Mutex
 }
 
-func (l *logAggregatorImpl) GetWriter() (io.Writer, func(), error) {
+func (l *logAggregatorImpl) GetWriter(ctx context.Context) (io.Writer, func(), error) {
 	if err := l.checkCapacity(); err != nil {
 		return nil, nil, err
 	}
@@ -62,7 +62,7 @@ func (l *logAggregatorImpl) GetWriter() (io.Writer, func(), error) {
 
 	writer := io.Writer(w)
 	if output.IsColorable(l.out) {
-		writer = output.GetWriter(writer, output.DefaultColorCode, false, false)
+		writer = output.GetWriter(ctx, writer, output.DefaultColorCode, false, false)
 	}
 	ch := make(chan string, buffSize)
 	l.messages <- ch
@@ -118,7 +118,7 @@ type noopLogAggregatorImpl struct {
 	out io.Writer
 }
 
-func (n *noopLogAggregatorImpl) GetWriter() (io.Writer, func(), error) {
+func (n *noopLogAggregatorImpl) GetWriter(context.Context) (io.Writer, func(), error) {
 	return n.out, func() {}, nil
 }
 

--- a/pkg/skaffold/build/scheduler.go
+++ b/pkg/skaffold/build/scheduler.go
@@ -101,7 +101,7 @@ func (s *scheduler) build(ctx context.Context, tags tag.ImageTags, i int) error 
 	})
 	defer endTrace()
 
-	w, closeFn, err := s.logger.GetWriter()
+	w, closeFn, err := s.logger.GetWriter(ctx)
 	if err != nil {
 		event.BuildFailed(a.ImageName, err)
 		eventV2.BuildFailed(a.ImageName, err)

--- a/pkg/skaffold/cluster/minikube_test.go
+++ b/pkg/skaffold/cluster/minikube_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cluster
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -99,18 +100,18 @@ func TestClientImpl_IsMinikube(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			if test.minikubeNotInPath {
 				ver := semver.Version{}
-				t.Override(&FindMinikubeBinary, func() (string, semver.Version, error) {
+				t.Override(&FindMinikubeBinary, func(context.Context) (string, semver.Version, error) {
 					return "", ver, fmt.Errorf("minikube not in PATH")
 				})
 			} else {
 				if test.minikuneWithoutUserFalg {
 					ver := semver.Version{Major: 1, Minor: 17, Patch: 0}
-					t.Override(&FindMinikubeBinary, func() (string, semver.Version, error) {
+					t.Override(&FindMinikubeBinary, func(context.Context) (string, semver.Version, error) {
 						return "", ver, fmt.Errorf("minikube not in PATH")
 					})
 				} else {
 					ver := semver.Version{Major: 1, Minor: 18, Patch: 1}
-					t.Override(&FindMinikubeBinary, func() (string, semver.Version, error) { return "minikube", ver, nil })
+					t.Override(&FindMinikubeBinary, func(context.Context) (string, semver.Version, error) { return "minikube", ver, nil })
 				}
 			}
 			t.Override(&util.DefaultExecCommand, test.minikubeProfileCmd)
@@ -121,7 +122,7 @@ func TestClientImpl_IsMinikube(t *testing.T) {
 				}, nil
 			})
 
-			ok := GetClient().IsMinikube(ctx, test.kubeContext)
+			ok := GetClient().IsMinikube(context.Background(), test.kubeContext)
 			t.CheckDeepEqual(test.expected, ok)
 		})
 	}
@@ -154,7 +155,7 @@ func TestGetVersion(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunOut("minikube version --output=json",
 				test.versionBlob),
 			)
-			actual, err := getCurrentVersion(ctx)
+			actual, err := getCurrentVersion(context.Background())
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, actual, test.expected)
 		})
 	}
@@ -189,10 +190,10 @@ func TestMinikubeExec(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&FindMinikubeBinary, func() (string, semver.Version, error) {
+			t.Override(&FindMinikubeBinary, func(context.Context) (string, semver.Version, error) {
 				return "", test.version, test.err
 			})
-			actual, err := minikubeExec(ctx, "test")
+			actual, err := minikubeExec(context.Background(), "test")
 			expected := []string{"", "test"}
 			if test.hasUserArg {
 				expected = append(expected, "--user=skaffold")

--- a/pkg/skaffold/cluster/minikube_test.go
+++ b/pkg/skaffold/cluster/minikube_test.go
@@ -121,7 +121,7 @@ func TestClientImpl_IsMinikube(t *testing.T) {
 				}, nil
 			})
 
-			ok := GetClient().IsMinikube(test.kubeContext)
+			ok := GetClient().IsMinikube(ctx, test.kubeContext)
 			t.CheckDeepEqual(test.expected, ok)
 		})
 	}
@@ -154,7 +154,7 @@ func TestGetVersion(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunOut("minikube version --output=json",
 				test.versionBlob),
 			)
-			actual, err := getCurrentVersion()
+			actual, err := getCurrentVersion(ctx)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, actual, test.expected)
 		})
 	}
@@ -192,7 +192,7 @@ func TestMinikubeExec(t *testing.T) {
 			t.Override(&FindMinikubeBinary, func() (string, semver.Version, error) {
 				return "", test.version, test.err
 			})
-			actual, err := minikubeExec("test")
+			actual, err := minikubeExec(ctx, "test")
 			expected := []string{"", "test"}
 			if test.hasUserArg {
 				expected = append(expected, "--user=skaffold")

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -199,7 +199,7 @@ func GetDebugHelpersRegistry(configFile string) (string, error) {
 	return constants.DefaultDebugHelpersRegistry, nil
 }
 
-func GetCluster(configFile string, minikubeProfile string, detectMinikube bool) (Cluster, error) {
+func GetCluster(ctx context.Context, configFile string, minikubeProfile string, detectMinikube bool) (Cluster, error) {
 	cfg, err := GetConfigForCurrentKubectx(configFile)
 	if err != nil {
 		return Cluster{}, err
@@ -224,7 +224,7 @@ func GetCluster(configFile string, minikubeProfile string, detectMinikube bool) 
 		local = true
 
 	case detectMinikube:
-		local = cluster.GetClient().IsMinikube(kubeContext)
+		local = cluster.GetClient().IsMinikube(ctx, kubeContext)
 
 	default:
 		local = false

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -268,7 +268,9 @@ func TestIsUpdateCheckEnabled(t *testing.T) {
 
 type fakeClient struct{}
 
-func (fakeClient) IsMinikube(ctx context.Context, kubeContext string) bool { return kubeContext == "minikube" }
+func (fakeClient) IsMinikube(ctx context.Context, kubeContext string) bool {
+	return kubeContext == "minikube"
+}
 func (fakeClient) MinikubeExec(context.Context, ...string) (*exec.Cmd, error) { return nil, nil }
 
 func TestGetCluster(t *testing.T) {

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -365,10 +365,10 @@ func TestGetCluster(t *testing.T) {
 			t.Override(&GetConfigForCurrentKubectx, func(string) (*ContextConfig, error) { return test.cfg, nil })
 			t.Override(&cluster.GetClient, func() cluster.Client { return fakeClient{} })
 
-			cluster, _ := GetCluster(ctx, "dummyname", test.profile, true)
+			cluster, _ := GetCluster(context.Background(), "dummyname", test.profile, true)
 			t.CheckDeepEqual(test.expected, cluster)
 
-			cluster, _ = GetCluster(ctx, "dummyname", test.profile, false)
+			cluster, _ = GetCluster(context.Background(), "dummyname", test.profile, false)
 			t.CheckDeepEqual(test.expected, cluster)
 		})
 	}

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"context"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -267,8 +268,8 @@ func TestIsUpdateCheckEnabled(t *testing.T) {
 
 type fakeClient struct{}
 
-func (fakeClient) IsMinikube(kubeContext string) bool        { return kubeContext == "minikube" }
-func (fakeClient) MinikubeExec(...string) (*exec.Cmd, error) { return nil, nil }
+func (fakeClient) IsMinikube(ctx context.Context, kubeContext string) bool { return kubeContext == "minikube" }
+func (fakeClient) MinikubeExec(context.Context, ...string) (*exec.Cmd, error) { return nil, nil }
 
 func TestGetCluster(t *testing.T) {
 	tests := []struct {
@@ -364,10 +365,10 @@ func TestGetCluster(t *testing.T) {
 			t.Override(&GetConfigForCurrentKubectx, func(string) (*ContextConfig, error) { return test.cfg, nil })
 			t.Override(&cluster.GetClient, func() cluster.Client { return fakeClient{} })
 
-			cluster, _ := GetCluster("dummyname", test.profile, true)
+			cluster, _ := GetCluster(ctx, "dummyname", test.profile, true)
 			t.CheckDeepEqual(test.expected, cluster)
 
-			cluster, _ = GetCluster("dummyname", test.profile, false)
+			cluster, _ = GetCluster(ctx, "dummyname", test.profile, false)
 			t.CheckDeepEqual(test.expected, cluster)
 		})
 	}

--- a/pkg/skaffold/debug/apply_transforms.go
+++ b/pkg/skaffold/debug/apply_transforms.go
@@ -104,7 +104,7 @@ func findArtifact(image string, builds []graph.Artifact) *graph.Artifact {
 // the given build artifact
 func retrieveImageConfiguration(ctx context.Context, artifact *graph.Artifact, insecureRegistries map[string]bool) (imageConfiguration, error) {
 	// TODO: use the proper RunContext
-	apiClient, err := docker.NewAPIClient(&runcontext.RunContext{
+	apiClient, err := docker.NewAPIClient(ctx, &runcontext.RunContext{
 		InsecureRegistries: insecureRegistries,
 	})
 	if err != nil {

--- a/pkg/skaffold/deploy/docker/deploy.go
+++ b/pkg/skaffold/deploy/docker/deploy.go
@@ -55,14 +55,14 @@ type Deployer struct {
 	once        sync.Once
 }
 
-func NewDeployer(cfg dockerutil.Config, labeller *label.DefaultLabeller, d *v1.DockerDeploy, resources []*v1.PortForwardResource) (*Deployer, error) {
-	client, err := dockerutil.NewAPIClient(cfg)
+func NewDeployer(ctx context.Context, cfg dockerutil.Config, labeller *label.DefaultLabeller, d *v1.DockerDeploy, resources []*v1.PortForwardResource) (*Deployer, error) {
+	client, err := dockerutil.NewAPIClient(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
 
 	tracker := tracker.NewContainerTracker()
-	l, err := logger.NewLogger(tracker, cfg)
+	l, err := logger.NewLogger(ctx, tracker, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -126,8 +126,8 @@ type Config interface {
 }
 
 // NewDeployer returns a configured Deployer.  Returns an error if current version of helm is less than 3.0.0.
-func NewDeployer(cfg Config, labeller *label.DefaultLabeller, h *latestV1.HelmDeploy) (*Deployer, error) {
-	hv, err := binVer()
+func NewDeployer(ctx context.Context, cfg Config, labeller *label.DefaultLabeller, h *latestV1.HelmDeploy) (*Deployer, error) {
+	hv, err := binVer(ctx)
 	if err != nil {
 		return nil, versionGetErr(err)
 	}

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -461,7 +461,7 @@ func TestBinVer(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", test.helmVersion))
-			ver, err := binVer(ctx)
+			ver, err := binVer(context.Background())
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, ver.String())
 		})
@@ -486,7 +486,7 @@ func TestNewDeployer(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", test.helmVersion))
 
-			_, err := NewDeployer(ctx, &helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig)
+			_, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig)
 			t.CheckError(test.shouldErr, err)
 		})
 	}
@@ -1075,7 +1075,7 @@ func TestHelmDeploy(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.Override(&osExecutable, func() (string, error) { return "SKAFFOLD-BINARY", nil })
 
-			deployer, err := NewDeployer(ctx, &helmConfig{
+			deployer, err := NewDeployer(context.Background(), &helmConfig{
 				namespace:  test.namespace,
 				force:      test.force,
 				configFile: "test.yaml",
@@ -1154,7 +1154,7 @@ func TestHelmCleanup(t *testing.T) {
 			t.Override(&util.OSEnviron, func() []string { return []string{"FOO=FOOBAR"} })
 			t.Override(&util.DefaultExecCommand, test.commands)
 
-			deployer, err := NewDeployer(ctx, &helmConfig{
+			deployer, err := NewDeployer(context.Background(), &helmConfig{
 				namespace: test.namespace,
 			}, &label.DefaultLabeller{}, &test.helm)
 			t.RequireNoError(err)
@@ -1259,7 +1259,7 @@ func TestHelmDependencies(t *testing.T) {
 				local = tmpDir.Root()
 			}
 
-			deployer, err := NewDeployer(ctx, &helmConfig{}, &label.DefaultLabeller{}, &latestV1.HelmDeploy{
+			deployer, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &latestV1.HelmDeploy{
 				Releases: []latestV1.HelmRelease{{
 					Name:                  "skaffold-helm",
 					ChartPath:             local,
@@ -1522,7 +1522,7 @@ func TestHelmRender(t *testing.T) {
 
 			t.Override(&util.OSEnviron, func() []string { return append([]string{"FOO=FOOBAR"}, test.env...) })
 			t.Override(&util.DefaultExecCommand, test.commands)
-			deployer, err := NewDeployer(ctx, &helmConfig{
+			deployer, err := NewDeployer(context.Background(), &helmConfig{
 				namespace: test.namespace,
 			}, &label.DefaultLabeller{}, &test.helm)
 			t.RequireNoError(err)
@@ -1593,7 +1593,7 @@ func TestGenerateSkaffoldDebugFilter(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", version31))
-			h, err := NewDeployer(ctx, &helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig)
+			h, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig)
 			t.RequireNoError(err)
 			result := h.generateSkaffoldDebugFilter(test.buildFile)
 			t.CheckDeepEqual(test.result, result)

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -461,7 +461,7 @@ func TestBinVer(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", test.helmVersion))
-			ver, err := binVer()
+			ver, err := binVer(ctx)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, ver.String())
 		})
@@ -486,7 +486,7 @@ func TestNewDeployer(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", test.helmVersion))
 
-			_, err := NewDeployer(&helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig)
+			_, err := NewDeployer(ctx, &helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig)
 			t.CheckError(test.shouldErr, err)
 		})
 	}
@@ -1075,7 +1075,7 @@ func TestHelmDeploy(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.Override(&osExecutable, func() (string, error) { return "SKAFFOLD-BINARY", nil })
 
-			deployer, err := NewDeployer(&helmConfig{
+			deployer, err := NewDeployer(ctx, &helmConfig{
 				namespace:  test.namespace,
 				force:      test.force,
 				configFile: "test.yaml",
@@ -1154,7 +1154,7 @@ func TestHelmCleanup(t *testing.T) {
 			t.Override(&util.OSEnviron, func() []string { return []string{"FOO=FOOBAR"} })
 			t.Override(&util.DefaultExecCommand, test.commands)
 
-			deployer, err := NewDeployer(&helmConfig{
+			deployer, err := NewDeployer(ctx, &helmConfig{
 				namespace: test.namespace,
 			}, &label.DefaultLabeller{}, &test.helm)
 			t.RequireNoError(err)
@@ -1259,7 +1259,7 @@ func TestHelmDependencies(t *testing.T) {
 				local = tmpDir.Root()
 			}
 
-			deployer, err := NewDeployer(&helmConfig{}, &label.DefaultLabeller{}, &latestV1.HelmDeploy{
+			deployer, err := NewDeployer(ctx, &helmConfig{}, &label.DefaultLabeller{}, &latestV1.HelmDeploy{
 				Releases: []latestV1.HelmRelease{{
 					Name:                  "skaffold-helm",
 					ChartPath:             local,
@@ -1522,7 +1522,7 @@ func TestHelmRender(t *testing.T) {
 
 			t.Override(&util.OSEnviron, func() []string { return append([]string{"FOO=FOOBAR"}, test.env...) })
 			t.Override(&util.DefaultExecCommand, test.commands)
-			deployer, err := NewDeployer(&helmConfig{
+			deployer, err := NewDeployer(ctx, &helmConfig{
 				namespace: test.namespace,
 			}, &label.DefaultLabeller{}, &test.helm)
 			t.RequireNoError(err)
@@ -1593,7 +1593,7 @@ func TestGenerateSkaffoldDebugFilter(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", version31))
-			h, err := NewDeployer(&helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig)
+			h, err := NewDeployer(ctx, &helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig)
 			t.RequireNoError(err)
 			result := h.generateSkaffoldDebugFilter(test.buildFile)
 			t.CheckDeepEqual(test.result, result)

--- a/pkg/skaffold/deploy/helm/util.go
+++ b/pkg/skaffold/deploy/helm/util.go
@@ -77,9 +77,9 @@ func sortKeys(m map[string]string) []string {
 }
 
 // binVer returns the version of the helm binary found in PATH.
-func binVer() (semver.Version, error) {
+func binVer(ctx context.Context) (semver.Version, error) {
 	cmd := exec.Command("helm", "version", "--client")
-	b, err := util.RunCmdOut(cmd)
+	b, err := util.RunCmdOut(ctx, cmd)
 	if err != nil {
 		return semver.Version{}, fmt.Errorf("helm version command failed %q: %w", string(b), err)
 	}
@@ -218,5 +218,5 @@ func (h *Deployer) exec(ctx context.Context, out io.Writer, useSecrets bool, env
 	cmd.Stdout = out
 	cmd.Stderr = out
 
-	return util.RunCmd(cmd)
+	return util.RunCmd(ctx, cmd)
 }

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -59,7 +59,7 @@ spec:
 //  Step 4. `kustomize build` (if the temp dir from step 3 has a Kustomization hydrate the manifest),
 //  Step 5. `kpt fn sink` (store the stdout in a given dir).
 func TestKpt_Deploy(t *testing.T) {
-	sanityCheck = func(dir string, buf io.Writer) error { return nil }
+	sanityCheck = func(ctx context.Context, dir string, buf io.Writer) error { return nil }
 	tests := []struct {
 		description      string
 		builds           []graph.Artifact
@@ -446,7 +446,7 @@ func TestKpt_Cleanup(t *testing.T) {
 }
 
 func TestKpt_Render(t *testing.T) {
-	sanityCheck = func(dir string, buf io.Writer) error { return nil }
+	sanityCheck = func(ctx context.Context, dir string, buf io.Writer) error { return nil }
 	// The follow are outputs to `kpt fn run` commands.
 	output1 := `apiVersion: v1
 kind: Pod
@@ -1155,7 +1155,7 @@ func TestVersionCheck(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			tmpDir := t.NewTempDir().Chdir()
 			tmpDir.WriteFiles(test.kustomizations)
-			err := versionCheck(ctx, "", io.Writer(&buf))
+			err := versionCheck(context.Background(), "", io.Writer(&buf))
 			t.CheckError(test.shouldErr, err)
 			if test.shouldErr {
 				testutil.CheckDeepEqual(t.T, test.error.Error(), err.Error())

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -1155,7 +1155,7 @@ func TestVersionCheck(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			tmpDir := t.NewTempDir().Chdir()
 			tmpDir.WriteFiles(test.kustomizations)
-			err := versionCheck("", io.Writer(&buf))
+			err := versionCheck(ctx, "", io.Writer(&buf))
 			t.CheckError(test.shouldErr, err)
 			if test.shouldErr {
 				testutil.CheckDeepEqual(t.T, test.error.Error(), err.Error())

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -409,7 +409,7 @@ func (k *Deployer) readManifests(ctx context.Context) (manifest.ManifestList, er
 			out, err = k.kubectl.Kustomize(ctx, BuildCommandArgs(k.BuildArgs, kustomizePath))
 		} else {
 			cmd := exec.CommandContext(ctx, "kustomize", append([]string{"build"}, BuildCommandArgs(k.BuildArgs, kustomizePath)...)...)
-			out, err = util.RunCmdOut(cmd)
+			out, err = util.RunCmdOut(ctx, cmd)
 		}
 
 		if err != nil {

--- a/pkg/skaffold/diagnose/diagnose.go
+++ b/pkg/skaffold/diagnose/diagnose.go
@@ -66,13 +66,13 @@ func CheckArtifacts(ctx context.Context, cfg Config, out io.Writer) error {
 			fmt.Fprintln(out, " - Dependencies:", len(deps), "files")
 			fmt.Fprintf(out, " - Time to list dependencies: %v (2nd time: %v)\n", timeDeps1, timeDeps2)
 
-			timeSyncMap1, err := timeToConstructSyncMap(artifact, cfg)
+			timeSyncMap1, err := timeToConstructSyncMap(ctx, artifact, cfg)
 			if err != nil {
 				if _, isNotSupported := err.(build.ErrSyncMapNotSupported); !isNotSupported {
 					return fmt.Errorf("construct artifact dependencies: %w", err)
 				}
 			}
-			timeSyncMap2, err := timeToConstructSyncMap(artifact, cfg)
+			timeSyncMap2, err := timeToConstructSyncMap(ctx, artifact, cfg)
 			if err != nil {
 				if _, isNotSupported := err.(build.ErrSyncMapNotSupported); !isNotSupported {
 					return fmt.Errorf("construct artifact dependencies: %w", err)
@@ -123,9 +123,9 @@ func timeToListDependencies(ctx context.Context, a *latestV1.Artifact, cfg Confi
 	return util.ShowHumanizeTime(time.Since(start)), paths, err
 }
 
-func timeToConstructSyncMap(a *latestV1.Artifact, cfg docker.Config) (string, error) {
+func timeToConstructSyncMap(ctx context.Context, a *latestV1.Artifact, cfg docker.Config) (string, error) {
 	start := time.Now()
-	_, err := sync.SyncMap(a, cfg)
+	_, err := sync.SyncMap(ctx, a, cfg)
 	return util.ShowHumanizeTime(time.Since(start)), err
 }
 

--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -150,7 +150,7 @@ DOCKER_HOST`),
 			t.Override(&util.DefaultExecCommand, test.command)
 			t.Override(&cluster.GetClient, func() cluster.Client { return fakeMinikubeClient{} })
 
-			env, _, err := newMinikubeAPIClient(ctx, "minikube")
+			env, _, err := newMinikubeAPIClient(context.Background(), "minikube")
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedEnv, env)
 		})

--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package docker
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -149,7 +150,7 @@ DOCKER_HOST`),
 			t.Override(&util.DefaultExecCommand, test.command)
 			t.Override(&cluster.GetClient, func() cluster.Client { return fakeMinikubeClient{} })
 
-			env, _, err := newMinikubeAPIClient("minikube")
+			env, _, err := newMinikubeAPIClient(ctx, "minikube")
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedEnv, env)
 		})
@@ -170,7 +171,7 @@ func (e *driverConflictErr) ExitCode() int { return 51 }
 
 type fakeMinikubeClient struct{}
 
-func (fakeMinikubeClient) IsMinikube(string) bool { return false }
-func (fakeMinikubeClient) MinikubeExec(arg ...string) (*exec.Cmd, error) {
+func (fakeMinikubeClient) IsMinikube(context.Context, string) bool { return false }
+func (fakeMinikubeClient) MinikubeExec(ctx context.Context, arg ...string) (*exec.Cmd, error) {
 	return exec.Command("minikube", arg...), nil
 }

--- a/pkg/skaffold/docker/dependencies.go
+++ b/pkg/skaffold/docker/dependencies.go
@@ -73,7 +73,7 @@ func GetDependencies(ctx context.Context, buildCfg BuildConfig, cfg Config) ([]s
 	if err != nil {
 		return nil, fmt.Errorf("normalizing dockerfilePath path: %w", err)
 	}
-	result := getDependencies(buildCfg.workspace, buildCfg.dockerfilePath, absDockerfilePath, buildCfg.args, cfg)
+	result := getDependencies(ctx, buildCfg.workspace, buildCfg.dockerfilePath, absDockerfilePath, buildCfg.args, cfg)
 	dependencyCache.Store(buildCfg.artifact, result)
 	return resultPair(result)
 }
@@ -87,7 +87,7 @@ func GetDependenciesCached(ctx context.Context, buildCfg BuildConfig, cfg Config
 	}
 
 	deps := dependencyCache.Exec(buildCfg.artifact, func() interface{} {
-		return getDependencies(buildCfg.workspace, buildCfg.dockerfilePath, absDockerfilePath, buildCfg.args, cfg)
+		return getDependencies(ctx, buildCfg.workspace, buildCfg.dockerfilePath, absDockerfilePath, buildCfg.args, cfg)
 	})
 	return resultPair(deps)
 }
@@ -103,7 +103,7 @@ func resultPair(deps interface{}) ([]string, error) {
 	}
 }
 
-func getDependencies(workspace string, dockerfilePath string, absDockerfilePath string, buildArgs map[string]*string, cfg Config) interface{} {
+func getDependencies(ctx context.Context, workspace string, dockerfilePath string, absDockerfilePath string, buildArgs map[string]*string, cfg Config) interface{} {
 	// If the Dockerfile doesn't exist, we can't compute the dependency.
 	// But since we know the Dockerfile is a dependency, let's return a list
 	// with only that file. It makes errors down the line more actionable
@@ -112,7 +112,7 @@ func getDependencies(workspace string, dockerfilePath string, absDockerfilePath 
 		return []string{dockerfilePath}
 	}
 
-	fts, err := readCopyCmdsFromDockerfile(false, absDockerfilePath, workspace, buildArgs, cfg)
+	fts, err := readCopyCmdsFromDockerfile(ctx, false, absDockerfilePath, workspace, buildArgs, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/skaffold/docker/dependencies_test.go
+++ b/pkg/skaffold/docker/dependencies_test.go
@@ -251,7 +251,7 @@ ADD ./file /etc/file
 
 type fakeImageFetcher struct{}
 
-func (f *fakeImageFetcher) fetch(image string, _ Config) (*v1.ConfigFile, error) {
+func (f *fakeImageFetcher) fetch(_ context.Context, image string, _ Config) (*v1.ConfigFile, error) {
 	switch image {
 	case "ubuntu:14.04", "busybox", "nginx", "golang:1.9.2", "jboss/wildfly:14.0.1.Final", "gcr.io/distroless/base":
 		return &v1.ConfigFile{}, nil
@@ -702,7 +702,7 @@ func TestGetDependenciesCached(t *testing.T) {
 	imageFetcher := fakeImageFetcher{}
 	tests := []struct {
 		description     string
-		retrieveImgMock func(_ string, _ Config) (*v1.ConfigFile, error)
+		retrieveImgMock func(context.Context, string, Config) (*v1.ConfigFile, error)
 		dependencyCache map[string]interface{}
 		expected        []string
 		shouldErr       bool
@@ -715,7 +715,7 @@ func TestGetDependenciesCached(t *testing.T) {
 		},
 		{
 			description: "with cached results getDependencies should read from cache",
-			retrieveImgMock: func(_ string, _ Config) (*v1.ConfigFile, error) {
+			retrieveImgMock: func(context.Context, string, Config) (*v1.ConfigFile, error) {
 				return nil, fmt.Errorf("unexpected call")
 			},
 			dependencyCache: map[string]interface{}{"dummy": []string{"random.go"}},
@@ -723,7 +723,7 @@ func TestGetDependenciesCached(t *testing.T) {
 		},
 		{
 			description: "with cached results is error getDependencies should read from cache",
-			retrieveImgMock: func(_ string, _ Config) (*v1.ConfigFile, error) {
+			retrieveImgMock: func(context.Context, string, Config) (*v1.ConfigFile, error) {
 				return &v1.ConfigFile{}, nil
 			},
 			dependencyCache: map[string]interface{}{"dummy": fmt.Errorf("remote manifest fetch")},

--- a/pkg/skaffold/docker/image_util.go
+++ b/pkg/skaffold/docker/image_util.go
@@ -26,7 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 )
 
-func RetrieveConfigFile(tagged string, cfg Config) (*v1.ConfigFile, error) {
+func RetrieveConfigFile(ctx context.Context, tagged string, cfg Config) (*v1.ConfigFile, error) {
 	if strings.ToLower(tagged) == "scratch" {
 		return nil, nil
 	}
@@ -34,7 +34,7 @@ func RetrieveConfigFile(tagged string, cfg Config) (*v1.ConfigFile, error) {
 	var cf *v1.ConfigFile
 	var err error
 
-	localDocker, err := NewAPIClient(cfg)
+	localDocker, err := NewAPIClient(ctx, cfg)
 	if err == nil {
 		cf, err = localDocker.ConfigFile(context.Background(), tagged)
 	}
@@ -49,8 +49,8 @@ func RetrieveConfigFile(tagged string, cfg Config) (*v1.ConfigFile, error) {
 	return cf, err
 }
 
-func RetrieveWorkingDir(tagged string, cfg Config) (string, error) {
-	cf, err := RetrieveConfigFile(tagged, cfg)
+func RetrieveWorkingDir(ctx context.Context, tagged string, cfg Config) (string, error) {
+	cf, err := RetrieveConfigFile(ctx, tagged, cfg)
 	switch {
 	case err != nil:
 		return "", err
@@ -64,8 +64,8 @@ func RetrieveWorkingDir(tagged string, cfg Config) (string, error) {
 	}
 }
 
-func RetrieveLabels(tagged string, cfg Config) (map[string]string, error) {
-	cf, err := RetrieveConfigFile(tagged, cfg)
+func RetrieveLabels(ctx context.Context, tagged string, cfg Config) (map[string]string, error) {
+	cf, err := RetrieveConfigFile(ctx, tagged, cfg)
 	switch {
 	case err != nil:
 		return nil, err

--- a/pkg/skaffold/docker/logger/log.go
+++ b/pkg/skaffold/docker/logger/log.go
@@ -38,8 +38,8 @@ type Logger struct {
 	muted       int32
 }
 
-func NewLogger(tracker *tracker.ContainerTracker, cfg docker.Config) (*Logger, error) {
-	cli, err := docker.NewAPIClient(cfg)
+func NewLogger(ctx context.Context, tracker *tracker.ContainerTracker, cfg docker.Config) (*Logger, error) {
+	cli, err := docker.NewAPIClient(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -71,7 +71,7 @@ var (
 	RetrieveImage = retrieveImage
 )
 
-func readCopyCmdsFromDockerfile(onlyLastImage bool, absDockerfilePath, workspace string, buildArgs map[string]*string, cfg Config) ([]fromTo, error) {
+func readCopyCmdsFromDockerfile(ctx context.Context, onlyLastImage bool, absDockerfilePath, workspace string, buildArgs map[string]*string, cfg Config) ([]fromTo, error) {
 	r, err := ioutil.ReadFile(absDockerfilePath)
 	if err != nil {
 		return nil, err
@@ -92,12 +92,12 @@ func readCopyCmdsFromDockerfile(onlyLastImage bool, absDockerfilePath, workspace
 		return nil, fmt.Errorf("putting build arguments: %w", err)
 	}
 
-	dockerfileLinesWithOnbuild, err := expandOnbuildInstructions(dockerfileLines, cfg)
+	dockerfileLinesWithOnbuild, err := expandOnbuildInstructions(ctx, dockerfileLines, cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	cpCmds, err := extractCopyCommands(dockerfileLinesWithOnbuild, onlyLastImage, cfg)
+	cpCmds, err := extractCopyCommands(ctx, dockerfileLinesWithOnbuild, onlyLastImage, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("listing copied files: %w", err)
 	}
@@ -203,7 +203,7 @@ func expandSrcGlobPatterns(workspace string, cpCmds []*copyCommand) ([]fromTo, e
 	return fts, nil
 }
 
-func extractCopyCommands(nodes []*parser.Node, onlyLastImage bool, cfg Config) ([]*copyCommand, error) {
+func extractCopyCommands(ctx context.Context, nodes []*parser.Node, onlyLastImage bool, cfg Config) ([]*copyCommand, error) {
 	stages := map[string]bool{
 		"scratch": true,
 	}
@@ -231,7 +231,7 @@ func extractCopyCommands(nodes []*parser.Node, onlyLastImage bool, cfg Config) (
 			// If `from` references a previous stage, then the `workdir`
 			// was already changed.
 			if !stages[strings.ToLower(from.image)] {
-				img, err := RetrieveImage(from.image, cfg)
+				img, err := RetrieveImage(ctx, from.image, cfg)
 				if err == nil {
 					workdir = img.Config.WorkingDir
 				} else if _, ok, err := isOldImageManifestProblem(cfg, err); !ok {
@@ -314,7 +314,7 @@ func readCopyCommand(value *parser.Node, envs []string, workdir string) (*copyCo
 	}, nil
 }
 
-func expandOnbuildInstructions(nodes []*parser.Node, cfg Config) ([]*parser.Node, error) {
+func expandOnbuildInstructions(ctx context.Context, nodes []*parser.Node, cfg Config) ([]*parser.Node, error) {
 	onbuildNodesCache := map[string][]*parser.Node{
 		"scratch": nil,
 	}
@@ -335,7 +335,7 @@ func expandOnbuildInstructions(nodes []*parser.Node, cfg Config) ([]*parser.Node
 				// some build args like artifact dependencies are not available until the first build sequence has completed.
 				// skip check if there are unavailable images
 				onbuildNodes = []*parser.Node{}
-			} else if ons, err := parseOnbuild(from.image, cfg); err == nil {
+			} else if ons, err := parseOnbuild(ctx, from.image, cfg); err == nil {
 				onbuildNodes = ons
 			} else if warnMsg, ok, _ := isOldImageManifestProblem(cfg, err); ok && warnMsg != "" {
 				log.Entry(context.Background()).Warn(warnMsg)
@@ -355,11 +355,11 @@ func expandOnbuildInstructions(nodes []*parser.Node, cfg Config) ([]*parser.Node
 	return expandedNodes, nil
 }
 
-func parseOnbuild(image string, cfg Config) ([]*parser.Node, error) {
+func parseOnbuild(ctx context.Context, image string, cfg Config) ([]*parser.Node, error) {
 	log.Entry(context.Background()).Tracef("Checking base image %s for ONBUILD triggers.", image)
 
 	// Image names are case SENSITIVE
-	img, err := RetrieveImage(image, cfg)
+	img, err := RetrieveImage(ctx, image, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving image %q: %w", image, err)
 	}
@@ -403,8 +403,8 @@ func unquote(v string) string {
 	return unquoted
 }
 
-func retrieveImage(image string, cfg Config) (*v1.ConfigFile, error) {
-	localDaemon, err := NewAPIClient(cfg)
+func retrieveImage(ctx context.Context, image string, cfg Config) (*v1.ConfigFile, error) {
+	localDaemon, err := NewAPIClient(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("getting docker client: %w", err)
 	}

--- a/pkg/skaffold/docker/syncmap.go
+++ b/pkg/skaffold/docker/syncmap.go
@@ -17,6 +17,7 @@ limitations under the License.
 package docker
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -28,14 +29,14 @@ import (
 // SyncMap creates a map of syncable files by looking at the COPY/ADD commands in the Dockerfile.
 // All keys are relative to the Skaffold root, the destinations are absolute container paths.
 // TODO(corneliusweig) destinations are not resolved across stages in multistage dockerfiles. Is there a use-case for that?
-func SyncMap(workspace string, dockerfilePath string, buildArgs map[string]*string, cfg Config) (map[string][]string, error) {
+func SyncMap(ctx context.Context, workspace string, dockerfilePath string, buildArgs map[string]*string, cfg Config) (map[string][]string, error) {
 	absDockerfilePath, err := NormalizeDockerfilePath(workspace, dockerfilePath)
 	if err != nil {
 		return nil, fmt.Errorf("normalizing dockerfile path: %w", err)
 	}
 
 	// only the COPY/ADD commands from the last image are syncable
-	fts, err := readCopyCmdsFromDockerfile(true, absDockerfilePath, workspace, buildArgs, cfg)
+	fts, err := readCopyCmdsFromDockerfile(ctx, true, absDockerfilePath, workspace, buildArgs, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/docker/syncmap_test.go
+++ b/pkg/skaffold/docker/syncmap_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package docker
 
 import (
+	"context"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -408,7 +409,7 @@ func TestSyncMap(t *testing.T) {
 			}
 
 			workspace := tmpDir.Path(test.workspace)
-			deps, err := SyncMap(ctx, workspace, "Dockerfile", test.buildArgs, nil)
+			deps, err := SyncMap(context.Background(), workspace, "Dockerfile", test.buildArgs, nil)
 
 			// destinations are not sorted, but for the test assertion they must be
 			for _, dsts := range deps {
@@ -505,7 +506,7 @@ ADD * .
 				Write("Dockerfile", test.dockerfile)
 
 			for i := 0; i < repeat; i++ {
-				deps, err := SyncMap(ctx, tmpDir.Root(), "Dockerfile", nil, nil)
+				deps, err := SyncMap(context.Background(), tmpDir.Root(), "Dockerfile", nil, nil)
 
 				// destinations are not sorted, but for the test assertion they must be
 				for _, dsts := range deps {

--- a/pkg/skaffold/docker/syncmap_test.go
+++ b/pkg/skaffold/docker/syncmap_test.go
@@ -408,7 +408,7 @@ func TestSyncMap(t *testing.T) {
 			}
 
 			workspace := tmpDir.Path(test.workspace)
-			deps, err := SyncMap(workspace, "Dockerfile", test.buildArgs, nil)
+			deps, err := SyncMap(ctx, workspace, "Dockerfile", test.buildArgs, nil)
 
 			// destinations are not sorted, but for the test assertion they must be
 			for _, dsts := range deps {
@@ -505,7 +505,7 @@ ADD * .
 				Write("Dockerfile", test.dockerfile)
 
 			for i := 0; i < repeat; i++ {
-				deps, err := SyncMap(tmpDir.Root(), "Dockerfile", nil, nil)
+				deps, err := SyncMap(ctx, tmpDir.Root(), "Dockerfile", nil, nil)
 
 				// destinations are not sorted, but for the test assertion they must be
 				for _, dsts := range deps {

--- a/pkg/skaffold/event/v2/logger.go
+++ b/pkg/skaffold/event/v2/logger.go
@@ -59,16 +59,10 @@ func (ev *eventHandler) handleSkaffoldLogEvent(e *proto.SkaffoldLogEvent) {
 }
 
 // logHook is an implementation of logrus.Hook used to send SkaffoldLogEvents
-type logHook struct {
-	task    constants.Phase
-	subtask string
-}
+type logHook struct{}
 
-func NewLogHook(task constants.Phase, subtask string) logrus.Hook {
-	return logHook{
-		task:    task,
-		subtask: subtask,
-	}
+func NewLogHook() logrus.Hook {
+	return logHook{}
 }
 
 // Levels returns all levels as we want to send events for all levels
@@ -87,8 +81,8 @@ func (h logHook) Levels() []logrus.Level {
 // Fire constructs a SkaffoldLogEvent and sends it to the event channel
 func (h logHook) Fire(entry *logrus.Entry) error {
 	handler.handleSkaffoldLogEvent(&proto.SkaffoldLogEvent{
-		TaskId:    fmt.Sprintf("%s-%d", h.task, handler.iteration),
-		SubtaskId: h.subtask,
+		TaskId:    fmt.Sprintf("%s-%d", entry.Data["task"], handler.iteration),
+		SubtaskId: fmt.Sprintf("%s", entry.Data["subtask"]),
 		Level:     levelFromEntry(entry),
 		Message:   entry.Message,
 	})

--- a/pkg/skaffold/event/v2/logger.go
+++ b/pkg/skaffold/event/v2/logger.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v2
 
 import (
+	"errors"
 	"fmt"
 	"io"
 
@@ -80,9 +81,18 @@ func (h logHook) Levels() []logrus.Level {
 
 // Fire constructs a SkaffoldLogEvent and sends it to the event channel
 func (h logHook) Fire(entry *logrus.Entry) error {
+	task, ok := entry.Data["task"]
+	if !ok {
+		return errors.New("could not get task from logrus entry")
+	}
+	subtask, ok := entry.Data["subtask"]
+	if !ok {
+		return errors.New("could not get subtask from logrus entry")
+	}
+
 	handler.handleSkaffoldLogEvent(&proto.SkaffoldLogEvent{
-		TaskId:    fmt.Sprintf("%s-%d", entry.Data["task"], handler.iteration),
-		SubtaskId: fmt.Sprintf("%s", entry.Data["subtask"]),
+		TaskId:    fmt.Sprintf("%s-%d", task, handler.iteration),
+		SubtaskId: fmt.Sprintf("%s", subtask),
 		Level:     levelFromEntry(entry),
 		Message:   entry.Message,
 	})

--- a/pkg/skaffold/gcp/auth.go
+++ b/pkg/skaffold/gcp/auth.go
@@ -59,10 +59,10 @@ func AutoConfigureGCRCredentialHelper(cf *configfile.ConfigFile) {
 	}
 }
 
-func activeUserCredentials() (*google.Credentials, error) {
+func activeUserCredentials(ctx context.Context) (*google.Credentials, error) {
 	credsOnce.Do(func() {
 		cmd := exec.Command("gcloud", "auth", "print-access-token", "--format=json")
-		body, err := util.RunCmdOut(cmd)
+		body, err := util.RunCmdOut(ctx, cmd)
 		if err != nil {
 			log.Entry(context.Background()).Infof("unable to retrieve gcloud access token: %v", err)
 			log.Entry(context.Background()).Info("falling back to application default credentials")

--- a/pkg/skaffold/gcp/client.go
+++ b/pkg/skaffold/gcp/client.go
@@ -17,6 +17,8 @@ limitations under the License.
 package gcp
 
 import (
+	"context"
+
 	"google.golang.org/api/option"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
@@ -24,12 +26,12 @@ import (
 
 // ClientOptions returns a list of options to be configured when
 // connecting to Google Cloud services.
-func ClientOptions() []option.ClientOption {
+func ClientOptions(ctx context.Context) []option.ClientOption {
 	options := []option.ClientOption{
 		option.WithUserAgent(version.UserAgent()),
 	}
 
-	creds, cErr := activeUserCredentials()
+	creds, cErr := activeUserCredentials(ctx)
 	if cErr == nil && creds != nil {
 		options = append(options, option.WithCredentials(creds))
 	}

--- a/pkg/skaffold/git/gitutil.go
+++ b/pkg/skaffold/git/gitutil.go
@@ -17,6 +17,7 @@
 package git
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -40,14 +41,14 @@ var findGit = func() (string, error) { return exec.LookPath("git") }
 
 // defaultRef returns the default ref as "master" if master branch exists in
 // remote repository, falls back to "main" if master branch doesn't exist
-func defaultRef(repo string) (string, error) {
+func defaultRef(ctx context.Context, repo string) (string, error) {
 	masterRef := "master"
 	mainRef := "main"
-	masterExists, err := branchExists(repo, masterRef)
+	masterExists, err := branchExists(ctx, repo, masterRef)
 	if err != nil {
 		return "", err
 	}
-	mainExists, err := branchExists(repo, mainRef)
+	mainExists, err := branchExists(ctx, repo, mainRef)
 	if err != nil {
 		return "", err
 	}
@@ -60,12 +61,12 @@ func defaultRef(repo string) (string, error) {
 }
 
 // BranchExists checks if branch is present in the input repo
-func branchExists(repo, branch string) (bool, error) {
+func branchExists(ctx context.Context, repo, branch string) (bool, error) {
 	gitProgram, err := findGit()
 	if err != nil {
 		return false, err
 	}
-	out, err := util.RunCmdOut(exec.Command(gitProgram, "ls-remote", "--heads", repo, branch))
+	out, err := util.RunCmdOut(ctx, exec.Command(gitProgram, "ls-remote", "--heads", repo, branch))
 	if err != nil {
 		// stdErr contains the error message for os related errors, git permission errors
 		// and if repo doesn't exist
@@ -105,7 +106,7 @@ func GetRepoCacheDir(opts config.SkaffoldOptions) (string, error) {
 	return filepath.Join(home, constants.DefaultSkaffoldDir, "repos"), nil
 }
 
-func syncRepo(g latestV1.GitInfo, opts config.SkaffoldOptions) (string, error) {
+func syncRepo(ctx context.Context, g latestV1.GitInfo, opts config.SkaffoldOptions) (string, error) {
 	skaffoldCacheDir, err := GetRepoCacheDir(opts)
 	r := gitCmd{Dir: skaffoldCacheDir}
 	if err != nil {
@@ -118,7 +119,7 @@ func syncRepo(g latestV1.GitInfo, opts config.SkaffoldOptions) (string, error) {
 
 	ref := g.Ref
 	if ref == "" {
-		ref, err = defaultRef(g.Repo)
+		ref, err = defaultRef(ctx, g.Repo)
 		if err != nil {
 			return "", fmt.Errorf("failed to clone repo %s: trouble getting default branch: %w", g.Repo, err)
 		}
@@ -133,13 +134,13 @@ func syncRepo(g latestV1.GitInfo, opts config.SkaffoldOptions) (string, error) {
 		if opts.SyncRemoteCache.CloneDisabled() {
 			return "", SyncDisabledErr(g, repoCacheDir)
 		}
-		if _, err := r.Run("clone", g.Repo, fmt.Sprintf("./%s", hash), "--branch", ref, "--depth", "1"); err != nil {
+		if _, err := r.Run(ctx, "clone", g.Repo, fmt.Sprintf("./%s", hash), "--branch", ref, "--depth", "1"); err != nil {
 			return "", fmt.Errorf("failed to clone repo: %w", err)
 		}
 	} else {
 		r.Dir = repoCacheDir
 		// check remote is defined
-		if remotes, err := r.Run("remote", "-v"); err != nil {
+		if remotes, err := r.Run(ctx, "remote", "-v"); err != nil {
 			return "", fmt.Errorf("failed to clone repo %s: trouble checking repository remote; run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", g.Repo, err)
 		} else if len(remotes) == 0 {
 			return "", fmt.Errorf("failed to clone repo %s: remote not set for existing clone", g.Repo)
@@ -155,26 +156,26 @@ func syncRepo(g latestV1.GitInfo, opts config.SkaffoldOptions) (string, error) {
 			return repoCacheDir, nil
 		}
 
-		if _, err = r.Run("fetch", "origin", ref); err != nil {
+		if _, err = r.Run(ctx, "fetch", "origin", ref); err != nil {
 			return "", fmt.Errorf("failed to clone repo %s: unable to find any matching refs %s; run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", g.Repo, ref, err)
 		}
 
 		// check if the downloaded repo has uncommitted changes.
-		if changes, err := r.Run("diff", "--name-only", "--ignore-submodules", "HEAD"); err != nil {
+		if changes, err := r.Run(ctx, "diff", "--name-only", "--ignore-submodules", "HEAD"); err != nil {
 			return "", fmt.Errorf("failed to clone repo %s: unable to check for uncommitted changes; run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", g.Repo, err)
 		} else if len(changes) > 0 {
 			return "", fmt.Errorf("failed to clone repo %s: there are uncommitted changes in the target directory %s; either set the repository `sync` property to false in the skaffold config, or manually commit and sync changes to remote, or revert the local changes", g.Repo, repoCacheDir)
 		}
 
 		// check if the downloaded repo has unpushed commits.
-		if changes, err := r.Run("diff", "--name-only", "--ignore-submodules", fmt.Sprintf("origin/%s...", ref)); err != nil {
+		if changes, err := r.Run(ctx, "diff", "--name-only", "--ignore-submodules", fmt.Sprintf("origin/%s...", ref)); err != nil {
 			return "", fmt.Errorf("failed to clone repo %s: unable to check for unpushed commits; run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", g.Repo, err)
 		} else if len(changes) > 0 {
 			return "", fmt.Errorf("failed to clone repo %s: there are unpushed commits in the target directory %s; either set the repository `sync` property to false in the skaffold config, or manually push commits to remote, or reset the local commits", g.Repo, repoCacheDir)
 		}
 
 		// reset the repo state
-		if _, err := r.Run("reset", "--hard", fmt.Sprintf("origin/%s", ref)); err != nil {
+		if _, err := r.Run(ctx, "reset", "--hard", fmt.Sprintf("origin/%s", ref)); err != nil {
 			return "", fmt.Errorf("failed to clone repo %s: trouble resetting branch to origin/%s; run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", g.Repo, ref, err)
 		}
 	}
@@ -189,7 +190,7 @@ type gitCmd struct {
 
 // Run runs a git command.
 // Omit the 'git' part of the command.
-func (g *gitCmd) Run(args ...string) ([]byte, error) {
+func (g *gitCmd) Run(ctx context.Context, args ...string) ([]byte, error) {
 	p, err := findGit()
 	if err != nil {
 		return nil, fmt.Errorf("no 'git' program on path: %w", err)
@@ -197,5 +198,5 @@ func (g *gitCmd) Run(args ...string) ([]byte, error) {
 
 	cmd := exec.Command(p, args...)
 	cmd.Dir = g.Dir
-	return util.RunCmdOut(cmd)
+	return util.RunCmdOut(ctx, cmd)
 }

--- a/pkg/skaffold/git/gitutil_test.go
+++ b/pkg/skaffold/git/gitutil_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package git
 
 import (
+	"context"
 	"errors"
 	"path/filepath"
 	"testing"
@@ -66,7 +67,7 @@ func TestDefaultRef(t *testing.T) {
 			}
 			t.Override(&findGit, func() (string, error) { return "git", nil })
 			t.Override(&util.DefaultExecCommand, f)
-			ref, err := defaultRef(ctx, "https://github.com/foo.git")
+			ref, err := defaultRef(context.Background(), "https://github.com/foo.git")
 			t.CheckErrorAndDeepEqual(test.err != nil, err, test.expected, ref)
 		})
 	}
@@ -247,7 +248,7 @@ func TestSyncRepo(t *testing.T) {
 			}
 			t.Override(&findGit, func() (string, error) { return "git", nil })
 			t.Override(&util.DefaultExecCommand, f)
-			path, err := syncRepo(ctx, test.g, opts)
+			path, err := syncRepo(context.Background(), test.g, opts)
 			var expected string
 			if !test.shouldErr {
 				expected = filepath.Join(td.Root(), test.expected)

--- a/pkg/skaffold/git/gitutil_test.go
+++ b/pkg/skaffold/git/gitutil_test.go
@@ -66,7 +66,7 @@ func TestDefaultRef(t *testing.T) {
 			}
 			t.Override(&findGit, func() (string, error) { return "git", nil })
 			t.Override(&util.DefaultExecCommand, f)
-			ref, err := defaultRef("https://github.com/foo.git")
+			ref, err := defaultRef(ctx, "https://github.com/foo.git")
 			t.CheckErrorAndDeepEqual(test.err != nil, err, test.expected, ref)
 		})
 	}
@@ -247,7 +247,7 @@ func TestSyncRepo(t *testing.T) {
 			}
 			t.Override(&findGit, func() (string, error) { return "git", nil })
 			t.Override(&util.DefaultExecCommand, f)
-			path, err := syncRepo(test.g, opts)
+			path, err := syncRepo(ctx, test.g, opts)
 			var expected string
 			if !test.shouldErr {
 				expected = filepath.Join(td.Root(), test.expected)

--- a/pkg/skaffold/hooks/container.go
+++ b/pkg/skaffold/hooks/container.go
@@ -120,7 +120,7 @@ func (h containerHook) run(ctx context.Context, out io.Writer) error {
 				containerName := c.Name
 				errs.Go(func() error {
 					defer tw.Close()
-					err := util.RunCmd(cmd)
+					err := util.RunCmd(ctx, cmd)
 					if err != nil {
 						return fmt.Errorf("hook execution failed for pod %q container %q: %w", podName, containerName, err)
 					}

--- a/pkg/skaffold/initializer/analyze/analyze.go
+++ b/pkg/skaffold/initializer/analyze/analyze.go
@@ -36,7 +36,7 @@ import (
 // It can manage state and react to walking events assuming a breadth first search.
 type analyzer interface {
 	enterDir(dir string)
-	analyzeFile(file string) error
+	analyzeFile(ctx context.Context, file string) error
 	exitDir(dir string)
 }
 
@@ -156,7 +156,7 @@ func (a *ProjectAnalysis) Analyze(dir string) error {
 		// to make skaffold.yaml more portable across OS-es we should always generate /-delimited filePaths
 		filePath = strings.ReplaceAll(filePath, string(os.PathSeparator), "/")
 		for _, analyzer := range a.analyzers() {
-			if err := analyzer.analyzeFile(filePath); err != nil {
+			if err := analyzer.analyzeFile(context.Background(), filePath); err != nil {
 				return err
 			}
 		}

--- a/pkg/skaffold/initializer/analyze/analyze_test.go
+++ b/pkg/skaffold/initializer/analyze/analyze_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package analyze
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -413,7 +414,7 @@ func fakeValidateDockerfile(path string) bool {
 	return strings.Contains(strings.ToLower(path), "dockerfile")
 }
 
-func fakeValidateJibConfig(path string, enableGradle bool) []jib.ArtifactConfig {
+func fakeValidateJibConfig(_ context.Context, path string, enableGradle bool) []jib.ArtifactConfig {
 	if strings.HasSuffix(path, "build.gradle") && enableGradle {
 		return []jib.ArtifactConfig{{BuilderName: jib.PluginName(jib.JibGradle), File: path}}
 	}

--- a/pkg/skaffold/initializer/analyze/config.go
+++ b/pkg/skaffold/initializer/analyze/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package analyze
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 
@@ -31,7 +32,7 @@ type skaffoldConfigAnalyzer struct {
 	targetConfig string
 }
 
-func (a *skaffoldConfigAnalyzer) analyzeFile(filePath string) error {
+func (a *skaffoldConfigAnalyzer) analyzeFile(ctx context.Context, filePath string) error {
 	if !schema.IsSkaffoldConfig(filePath) || a.force || a.analyzeMode {
 		return nil
 	}

--- a/pkg/skaffold/initializer/analyze/config_test.go
+++ b/pkg/skaffold/initializer/analyze/config_test.go
@@ -74,7 +74,7 @@ func TestConfigAnalyzer(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
-			err := test.analyzer.analyzeFile(test.inputFile)
+			err := test.analyzer.analyzeFile(ctx, test.inputFile)
 			t.CheckError(test.shouldErr, err)
 		})
 	}

--- a/pkg/skaffold/initializer/analyze/config_test.go
+++ b/pkg/skaffold/initializer/analyze/config_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package analyze
 
 import (
+	"context"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -74,7 +75,7 @@ func TestConfigAnalyzer(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
-			err := test.analyzer.analyzeFile(ctx, test.inputFile)
+			err := test.analyzer.analyzeFile(context.Background(), test.inputFile)
 			t.CheckError(test.shouldErr, err)
 		})
 	}

--- a/pkg/skaffold/initializer/analyze/directory.go
+++ b/pkg/skaffold/initializer/analyze/directory.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package analyze
 
+import "context"
+
 // directoryAnalyzer is a base analyzer that can be included in every analyzer as a convenience
 // it saves the current directory on enterDir events. Benefits to include this into other analyzers is that
 // they can rely on the current directory var, but also they don't have to implement enterDir and exitDir.
@@ -23,7 +25,7 @@ type directoryAnalyzer struct {
 	currentDir string
 }
 
-func (a *directoryAnalyzer) analyzeFile(_ string) error {
+func (a *directoryAnalyzer) analyzeFile(ctx context.Context, file string) error {
 	return nil
 }
 

--- a/pkg/skaffold/initializer/analyze/helm.go
+++ b/pkg/skaffold/initializer/analyze/helm.go
@@ -17,6 +17,8 @@ limitations under the License.
 package analyze
 
 import (
+	"context"
+
 	deploy "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/helm"
 )
 
@@ -26,7 +28,7 @@ type helmAnalyzer struct {
 	chartPaths []string
 }
 
-func (h *helmAnalyzer) analyzeFile(filePath string) error {
+func (h *helmAnalyzer) analyzeFile(ctx context.Context, filePath string) error {
 	if deploy.IsHelmChart(filePath) {
 		h.chartPaths = append(h.chartPaths, filePath)
 	}

--- a/pkg/skaffold/initializer/analyze/kubernetes.go
+++ b/pkg/skaffold/initializer/analyze/kubernetes.go
@@ -17,6 +17,8 @@ limitations under the License.
 package analyze
 
 import (
+	"context"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 )
@@ -27,7 +29,7 @@ type kubeAnalyzer struct {
 	kubernetesManifests []string
 }
 
-func (k *kubeAnalyzer) analyzeFile(filePath string) error {
+func (k *kubeAnalyzer) analyzeFile(ctx context.Context, filePath string) error {
 	if kubernetes.IsKubernetesManifest(filePath) && !schema.IsSkaffoldConfig(filePath) {
 		k.kubernetesManifests = append(k.kubernetesManifests, filePath)
 	}

--- a/pkg/skaffold/initializer/analyze/kustomize.go
+++ b/pkg/skaffold/initializer/analyze/kustomize.go
@@ -17,6 +17,7 @@ limitations under the License.
 package analyze
 
 import (
+	"context"
 	"path/filepath"
 
 	deploy "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
@@ -30,12 +31,12 @@ type kustomizeAnalyzer struct {
 	kustomizePaths []string
 }
 
-func (k *kustomizeAnalyzer) analyzeFile(path string) error {
+func (k *kustomizeAnalyzer) analyzeFile(ctx context.Context, filePath string) error {
 	switch {
-	case deploy.IsKustomizationBase(path):
-		k.bases = append(k.bases, filepath.Dir(path))
-	case deploy.IsKustomizationPath(path):
-		k.kustomizePaths = append(k.kustomizePaths, filepath.Dir(path))
+	case deploy.IsKustomizationBase(filePath):
+		k.bases = append(k.bases, filepath.Dir(filePath))
+	case deploy.IsKustomizationPath(filePath):
+		k.kustomizePaths = append(k.kustomizePaths, filepath.Dir(filePath))
 	}
 	return nil
 }

--- a/pkg/skaffold/initializer/kompose.go
+++ b/pkg/skaffold/initializer/kompose.go
@@ -33,6 +33,6 @@ func runKompose(ctx context.Context, composeFile string) error {
 
 	log.Entry(ctx).Infof("running 'kompose convert' for file %s", composeFile)
 	komposeCmd := exec.CommandContext(ctx, "kompose", "convert", "-f", composeFile)
-	_, err := util.RunCmdOut(komposeCmd)
+	_, err := util.RunCmdOut(ctx, komposeCmd)
 	return err
 }

--- a/pkg/skaffold/inspect/buildEnv/add_cluster.go
+++ b/pkg/skaffold/inspect/buildEnv/add_cluster.go
@@ -29,7 +29,7 @@ import (
 
 func AddClusterBuildEnv(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{
+	cfgs, err := inspect.GetConfigSet(ctx, config.SkaffoldOptions{
 		ConfigurationFile:   opts.Filename,
 		RepoCacheDir:        opts.RepoCacheDir,
 		ConfigurationFilter: opts.Modules,

--- a/pkg/skaffold/inspect/buildEnv/add_cluster_test.go
+++ b/pkg/skaffold/inspect/buildEnv/add_cluster_test.go
@@ -331,7 +331,7 @@ profiles:
 						{Name: "p1", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
 					}}, SourceFile: pathToCfg2, SourceIndex: 0},
 			}
-			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+			t.Override(&inspect.GetConfigSet, func(ctx context.Context, opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
 				if test.err != nil {
 					return nil, test.err
 				}

--- a/pkg/skaffold/inspect/buildEnv/add_gcb.go
+++ b/pkg/skaffold/inspect/buildEnv/add_gcb.go
@@ -29,7 +29,7 @@ import (
 
 func AddGcbBuildEnv(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{
+	cfgs, err := inspect.GetConfigSet(ctx, config.SkaffoldOptions{
 		ConfigurationFile:   opts.Filename,
 		RepoCacheDir:        opts.RepoCacheDir,
 		ConfigurationFilter: opts.Modules,

--- a/pkg/skaffold/inspect/buildEnv/add_gcb_test.go
+++ b/pkg/skaffold/inspect/buildEnv/add_gcb_test.go
@@ -336,7 +336,7 @@ profiles:
 						{Name: "p1", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
 					}}, SourceFile: pathToCfg2, SourceIndex: 0},
 			}
-			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+			t.Override(&inspect.GetConfigSet, func(ctx context.Context, opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
 				if test.err != nil {
 					return nil, test.err
 				}

--- a/pkg/skaffold/inspect/buildEnv/add_local.go
+++ b/pkg/skaffold/inspect/buildEnv/add_local.go
@@ -28,7 +28,7 @@ import (
 
 func AddLocalBuildEnv(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, SkipConfigDefaults: true, MakePathsAbsolute: util.BoolPtr(false)})
+	cfgs, err := inspect.GetConfigSet(ctx, config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, SkipConfigDefaults: true, MakePathsAbsolute: util.BoolPtr(false)})
 	if err != nil {
 		return formatter.WriteErr(err)
 	}

--- a/pkg/skaffold/inspect/buildEnv/add_local_test.go
+++ b/pkg/skaffold/inspect/buildEnv/add_local_test.go
@@ -286,7 +286,7 @@ profiles:
 						{Name: "p1", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{GoogleCloudBuild: &v1.GoogleCloudBuild{}}}}},
 					}}, SourceFile: pathToCfg2, SourceIndex: 0},
 			}
-			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+			t.Override(&inspect.GetConfigSet, func(ctx context.Context, opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
 				if test.err != nil {
 					return nil, test.err
 				}

--- a/pkg/skaffold/inspect/buildEnv/list.go
+++ b/pkg/skaffold/inspect/buildEnv/list.go
@@ -36,7 +36,7 @@ type buildEnvEntry struct {
 
 func PrintBuildEnvsList(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{
+	cfgs, err := inspect.GetConfigSet(ctx, config.SkaffoldOptions{
 		ConfigurationFile:   opts.Filename,
 		RepoCacheDir:        opts.RepoCacheDir,
 		Profiles:            opts.Profiles,

--- a/pkg/skaffold/inspect/buildEnv/list_test.go
+++ b/pkg/skaffold/inspect/buildEnv/list_test.go
@@ -100,7 +100,7 @@ func TestPrintBuildEnvsList(t *testing.T) {
 						{Name: "local", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{LocalBuild: &v1.LocalBuild{}}}}},
 					}}, SourceFile: "path/to/cfg2"},
 			}
-			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+			t.Override(&inspect.GetConfigSet, func(ctx context.Context, opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
 				// mock profile activation
 				var set parser.SkaffoldConfigSet
 				for _, c := range configSet {

--- a/pkg/skaffold/inspect/buildEnv/modify_gcb.go
+++ b/pkg/skaffold/inspect/buildEnv/modify_gcb.go
@@ -27,7 +27,7 @@ import (
 
 func ModifyGcbBuildEnv(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, SkipConfigDefaults: true, MakePathsAbsolute: util.BoolPtr(false)})
+	cfgs, err := inspect.GetConfigSet(ctx, config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, SkipConfigDefaults: true, MakePathsAbsolute: util.BoolPtr(false)})
 	if err != nil {
 		return formatter.WriteErr(err)
 	}

--- a/pkg/skaffold/inspect/buildEnv/modify_gcb_test.go
+++ b/pkg/skaffold/inspect/buildEnv/modify_gcb_test.go
@@ -236,7 +236,7 @@ profiles:
 						{Name: "p1", Pipeline: v1.Pipeline{Build: v1.BuildConfig{BuildType: v1.BuildType{GoogleCloudBuild: &v1.GoogleCloudBuild{ProjectID: "project1"}}}}},
 					}}, SourceFile: pathToCfg2, SourceIndex: 0},
 			}
-			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+			t.Override(&inspect.GetConfigSet, func(ctx context.Context, opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
 				if len(opts.ConfigurationFilter) == 0 || util.StrSliceContains(opts.ConfigurationFilter, "cfg1") {
 					return configSet, nil
 				}

--- a/pkg/skaffold/inspect/modules/list.go
+++ b/pkg/skaffold/inspect/modules/list.go
@@ -38,7 +38,7 @@ type moduleEntry struct {
 
 func PrintModulesList(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{ConfigurationFile: opts.Filename, RepoCacheDir: opts.RepoCacheDir})
+	cfgs, err := inspect.GetConfigSet(ctx, config.SkaffoldOptions{ConfigurationFile: opts.Filename, RepoCacheDir: opts.RepoCacheDir})
 	if err != nil {
 		return formatter.WriteErr(err)
 	}

--- a/pkg/skaffold/inspect/modules/list_test.go
+++ b/pkg/skaffold/inspect/modules/list_test.go
@@ -79,7 +79,7 @@ func TestPrintModulesList(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+			t.Override(&inspect.GetConfigSet, func(ctx context.Context, opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
 				if len(opts.ConfigurationFilter) == 0 {
 					return test.configSet, test.err
 				}

--- a/pkg/skaffold/inspect/profiles/list.go
+++ b/pkg/skaffold/inspect/profiles/list.go
@@ -36,7 +36,7 @@ type profileEntry struct {
 
 func PrintProfilesList(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, RepoCacheDir: opts.RepoCacheDir})
+	cfgs, err := inspect.GetConfigSet(ctx, config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, RepoCacheDir: opts.RepoCacheDir})
 	if err != nil {
 		return formatter.WriteErr(err)
 	}

--- a/pkg/skaffold/inspect/profiles/list_test.go
+++ b/pkg/skaffold/inspect/profiles/list_test.go
@@ -114,7 +114,7 @@ func TestPrintProfilesList(t *testing.T) {
 
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+			t.Override(&inspect.GetConfigSet, func(ctx context.Context, opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
 				if len(opts.ConfigurationFilter) == 0 {
 					return test.configSet, test.err
 				}

--- a/pkg/skaffold/inspect/tests/list.go
+++ b/pkg/skaffold/inspect/tests/list.go
@@ -36,7 +36,7 @@ type structureTestEntry struct {
 
 func PrintTestsList(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.GetConfigSet(config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, RepoCacheDir: opts.RepoCacheDir})
+	cfgs, err := inspect.GetConfigSet(ctx, config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, RepoCacheDir: opts.RepoCacheDir})
 	if err != nil {
 		return formatter.WriteErr(err)
 	}

--- a/pkg/skaffold/inspect/tests/list_test.go
+++ b/pkg/skaffold/inspect/tests/list_test.go
@@ -90,7 +90,7 @@ func TestPrintTestsList(t *testing.T) {
 						{Name: "structure-test", Pipeline: v1.Pipeline{Test: []*v1.TestCase{{StructureTests: []string{"structure-test-i0"}}}}}},
 				}, SourceFile: "path/to/cfg1"},
 			}
-			t.Override(&inspect.GetConfigSet, func(opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+			t.Override(&inspect.GetConfigSet, func(_ context.Context, opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
 				// mock profile activation
 				var set parser.SkaffoldConfigSet
 				for _, c := range configSet {

--- a/pkg/skaffold/kubectl/cli.go
+++ b/pkg/skaffold/kubectl/cli.go
@@ -74,7 +74,7 @@ func (c *CLI) Run(ctx context.Context, in io.Reader, out io.Writer, command stri
 	cmd.Stdin = in
 	cmd.Stdout = out
 	cmd.Stderr = out
-	return util.RunCmd(cmd)
+	return util.RunCmd(ctx, cmd)
 }
 
 // RunInNamespace shells out kubectl CLI with given namespace
@@ -83,20 +83,20 @@ func (c *CLI) RunInNamespace(ctx context.Context, in io.Reader, out io.Writer, c
 	cmd.Stdin = in
 	cmd.Stdout = out
 	cmd.Stderr = out
-	return util.RunCmd(cmd)
+	return util.RunCmd(ctx, cmd)
 }
 
 // RunOut shells out kubectl CLI.
 func (c *CLI) RunOut(ctx context.Context, command string, arg ...string) ([]byte, error) {
 	cmd := c.Command(ctx, command, arg...)
-	return util.RunCmdOut(cmd)
+	return util.RunCmdOut(ctx, cmd)
 }
 
 // RunOutInput shells out kubectl CLI with a given input stream.
 func (c *CLI) RunOutInput(ctx context.Context, in io.Reader, command string, arg ...string) ([]byte, error) {
 	cmd := c.Command(ctx, command, arg...)
 	cmd.Stdin = in
-	return util.RunCmdOut(cmd)
+	return util.RunCmdOut(ctx, cmd)
 }
 
 // CommandWithStrictCancellation ensures for windows OS that all child process get terminated on cancellation

--- a/pkg/skaffold/kubectl/cli_test.go
+++ b/pkg/skaffold/kubectl/cli_test.go
@@ -110,7 +110,7 @@ func TestCLI(t *testing.T) {
 				namespace:   test.namespace,
 			}, "")
 			cmd := cli.CommandWithStrictCancellation(context.Background(), "exec", "arg1", "arg2")
-			out, err := util.RunCmdOut(cmd.Cmd)
+			out, err := util.RunCmdOut(ctx, cmd.Cmd)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(string(out), output)

--- a/pkg/skaffold/kubectl/cli_test.go
+++ b/pkg/skaffold/kubectl/cli_test.go
@@ -110,7 +110,7 @@ func TestCLI(t *testing.T) {
 				namespace:   test.namespace,
 			}, "")
 			cmd := cli.CommandWithStrictCancellation(context.Background(), "exec", "arg1", "arg2")
-			out, err := util.RunCmdOut(ctx, cmd.Cmd)
+			out, err := util.RunCmdOut(context.Background(), cmd.Cmd)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(string(out), output)

--- a/pkg/skaffold/kubectl/version.go
+++ b/pkg/skaffold/kubectl/version.go
@@ -117,5 +117,5 @@ func (c *CLI) Version(ctx context.Context) ClientVersion {
 
 func (c *CLI) getVersion(ctx context.Context) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "kubectl", "version", "--client", "-ojson")
-	return util.RunCmdOut(cmd)
+	return util.RunCmdOut(ctx, cmd)
 }

--- a/pkg/skaffold/kubernetes/loader/load.go
+++ b/pkg/skaffold/kubernetes/loader/load.go
@@ -153,7 +153,7 @@ func (i *ImageLoader) loadImages(ctx context.Context, out io.Writer, artifacts [
 		}
 
 		cmd := createCmd(artifact.Tag)
-		if cmdOut, err := util.RunCmdOut(cmd); err != nil {
+		if cmdOut, err := util.RunCmdOut(ctx, cmd); err != nil {
 			output.Red.Fprintln(out, "Failed")
 			return fmt.Errorf("unable to load image %q into cluster: %w, %s", artifact.Tag, err, cmdOut)
 		}

--- a/pkg/skaffold/output/color.go
+++ b/pkg/skaffold/output/color.go
@@ -52,9 +52,9 @@ var DefaultColorCodes = []Color{
 }
 
 // SetupColors conditionally wraps the input `Writer` with a color enabled `Writer`.
-func SetupColors(out io.Writer, defaultColor int, forceColors bool) io.Writer {
+func SetupColors(ctx context.Context, out io.Writer, defaultColor int, forceColors bool) io.Writer {
 	_, isTerm := util.IsTerminal(out)
-	supportsColor, err := util.SupportsColor()
+	supportsColor, err := util.SupportsColor(ctx)
 	if err != nil {
 		log.Entry(context.Background()).Debugf("error checking for color support: %v", err)
 	}

--- a/pkg/skaffold/output/color_test.go
+++ b/pkg/skaffold/output/color_test.go
@@ -18,6 +18,7 @@ package output
 
 import (
 	"bytes"
+	"context"
 	"testing"
 )
 
@@ -29,20 +30,20 @@ func compareText(t *testing.T, expected, actual string) {
 }
 
 func TestFprintln(t *testing.T) {
-	defer func() { SetupColors(ctx, nil, DefaultColorCode, false) }()
+	defer func() { SetupColors(context.Background(), nil, DefaultColorCode, false) }()
 	var b bytes.Buffer
 
-	cw := SetupColors(ctx, &b, 0, true)
+	cw := SetupColors(context.Background(), &b, 0, true)
 	Green.Fprintln(cw, "2", "less", "chars!")
 
 	compareText(t, "\033[32m2 less chars!\033[0m\n", b.String())
 }
 
 func TestFprintf(t *testing.T) {
-	defer func() { SetupColors(ctx, nil, DefaultColorCode, false) }()
+	defer func() { SetupColors(context.Background(), nil, DefaultColorCode, false) }()
 	var b bytes.Buffer
 
-	cw := SetupColors(ctx, &b, 0, true)
+	cw := SetupColors(context.Background(), &b, 0, true)
 	Green.Fprintf(cw, "It's been %d %s", 1, "week")
 
 	compareText(t, "\033[32mIt's been 1 week\033[0m", b.String())
@@ -51,7 +52,7 @@ func TestFprintf(t *testing.T) {
 func TestFprintlnNoTTY(t *testing.T) {
 	var b bytes.Buffer
 
-	cw := SetupColors(ctx, &b, 0, false)
+	cw := SetupColors(context.Background(), &b, 0, false)
 	Green.Fprintln(cw, "2", "less", "chars!")
 
 	compareText(t, "2 less chars!\n", b.String())
@@ -60,7 +61,7 @@ func TestFprintlnNoTTY(t *testing.T) {
 func TestFprintfNoTTY(t *testing.T) {
 	var b bytes.Buffer
 
-	cw := SetupColors(ctx, &b, 0, false)
+	cw := SetupColors(context.Background(), &b, 0, false)
 	Green.Fprintf(cw, "It's been %d %s", 1, "week")
 
 	compareText(t, "It's been 1 week", b.String())
@@ -69,7 +70,7 @@ func TestFprintfNoTTY(t *testing.T) {
 func TestFprintlnDefaultColor(t *testing.T) {
 	var b bytes.Buffer
 
-	cw := SetupColors(ctx, &b, 34, true)
+	cw := SetupColors(context.Background(), &b, 34, true)
 	Default.Fprintln(cw, "2", "less", "chars!")
 	compareText(t, "\033[34m2 less chars!\033[0m\n", b.String())
 }
@@ -77,7 +78,7 @@ func TestFprintlnDefaultColor(t *testing.T) {
 func TestFprintlnChangeDefaultToNone(t *testing.T) {
 	var b bytes.Buffer
 
-	cw := SetupColors(ctx, &b, 0, true)
+	cw := SetupColors(context.Background(), &b, 0, true)
 	Default.Fprintln(cw, "2", "less", "chars!")
 	compareText(t, "2 less chars!\n", b.String())
 }
@@ -85,7 +86,7 @@ func TestFprintlnChangeDefaultToNone(t *testing.T) {
 func TestFprintlnChangeDefaultToUnknown(t *testing.T) {
 	var b bytes.Buffer
 
-	cw := SetupColors(ctx, &b, -1, true)
+	cw := SetupColors(context.Background(), &b, -1, true)
 	Default.Fprintln(cw, "2", "less", "chars!")
 	compareText(t, "2 less chars!\n", b.String())
 }

--- a/pkg/skaffold/output/color_test.go
+++ b/pkg/skaffold/output/color_test.go
@@ -29,20 +29,20 @@ func compareText(t *testing.T, expected, actual string) {
 }
 
 func TestFprintln(t *testing.T) {
-	defer func() { SetupColors(nil, DefaultColorCode, false) }()
+	defer func() { SetupColors(ctx, nil, DefaultColorCode, false) }()
 	var b bytes.Buffer
 
-	cw := SetupColors(&b, 0, true)
+	cw := SetupColors(ctx, &b, 0, true)
 	Green.Fprintln(cw, "2", "less", "chars!")
 
 	compareText(t, "\033[32m2 less chars!\033[0m\n", b.String())
 }
 
 func TestFprintf(t *testing.T) {
-	defer func() { SetupColors(nil, DefaultColorCode, false) }()
+	defer func() { SetupColors(ctx, nil, DefaultColorCode, false) }()
 	var b bytes.Buffer
 
-	cw := SetupColors(&b, 0, true)
+	cw := SetupColors(ctx, &b, 0, true)
 	Green.Fprintf(cw, "It's been %d %s", 1, "week")
 
 	compareText(t, "\033[32mIt's been 1 week\033[0m", b.String())
@@ -51,7 +51,7 @@ func TestFprintf(t *testing.T) {
 func TestFprintlnNoTTY(t *testing.T) {
 	var b bytes.Buffer
 
-	cw := SetupColors(&b, 0, false)
+	cw := SetupColors(ctx, &b, 0, false)
 	Green.Fprintln(cw, "2", "less", "chars!")
 
 	compareText(t, "2 less chars!\n", b.String())
@@ -60,7 +60,7 @@ func TestFprintlnNoTTY(t *testing.T) {
 func TestFprintfNoTTY(t *testing.T) {
 	var b bytes.Buffer
 
-	cw := SetupColors(&b, 0, false)
+	cw := SetupColors(ctx, &b, 0, false)
 	Green.Fprintf(cw, "It's been %d %s", 1, "week")
 
 	compareText(t, "It's been 1 week", b.String())
@@ -69,7 +69,7 @@ func TestFprintfNoTTY(t *testing.T) {
 func TestFprintlnDefaultColor(t *testing.T) {
 	var b bytes.Buffer
 
-	cw := SetupColors(&b, 34, true)
+	cw := SetupColors(ctx, &b, 34, true)
 	Default.Fprintln(cw, "2", "less", "chars!")
 	compareText(t, "\033[34m2 less chars!\033[0m\n", b.String())
 }
@@ -77,7 +77,7 @@ func TestFprintlnDefaultColor(t *testing.T) {
 func TestFprintlnChangeDefaultToNone(t *testing.T) {
 	var b bytes.Buffer
 
-	cw := SetupColors(&b, 0, true)
+	cw := SetupColors(ctx, &b, 0, true)
 	Default.Fprintln(cw, "2", "less", "chars!")
 	compareText(t, "2 less chars!\n", b.String())
 }
@@ -85,7 +85,7 @@ func TestFprintlnChangeDefaultToNone(t *testing.T) {
 func TestFprintlnChangeDefaultToUnknown(t *testing.T) {
 	var b bytes.Buffer
 
-	cw := SetupColors(&b, -1, true)
+	cw := SetupColors(ctx, &b, -1, true)
 	Default.Fprintln(cw, "2", "less", "chars!")
 	compareText(t, "2 less chars!\n", b.String())
 }

--- a/pkg/skaffold/output/output.go
+++ b/pkg/skaffold/output/output.go
@@ -64,13 +64,13 @@ func (s skaffoldWriter) Write(p []byte) (int, error) {
 	return written, nil
 }
 
-func GetWriter(out io.Writer, defaultColor int, forceColors bool, timestamps bool) io.Writer {
+func GetWriter(ctx context.Context, out io.Writer, defaultColor int, forceColors bool, timestamps bool) io.Writer {
 	if _, isSW := out.(skaffoldWriter); isSW {
 		return out
 	}
 
 	return skaffoldWriter{
-		MainWriter:  SetupColors(out, defaultColor, forceColors),
+		MainWriter:  SetupColors(ctx, out, defaultColor, forceColors),
 		EventWriter: eventV2.NewLogger(constants.DevLoop, "-1"),
 		timestamps:  timestamps,
 	}

--- a/pkg/skaffold/parser/config.go
+++ b/pkg/skaffold/parser/config.go
@@ -62,8 +62,8 @@ func newRecord() *record {
 }
 
 // GetAllConfigs returns the list of all skaffold configurations parsed from the target config file in addition to all resolved dependency configs.
-func GetAllConfigs(opts config.SkaffoldOptions) ([]schemaUtil.VersionedConfig, error) {
-	set, err := GetConfigSet(opts)
+func GetAllConfigs(ctx context.Context, opts config.SkaffoldOptions) ([]schemaUtil.VersionedConfig, error) {
+	set, err := GetConfigSet(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -76,10 +76,10 @@ func GetAllConfigs(opts config.SkaffoldOptions) ([]schemaUtil.VersionedConfig, e
 
 // GetConfigSet returns the list of all skaffold configurations parsed from the target config file in addition to all resolved dependency configs as a `SkaffoldConfigSet`.
 // This struct additionally contains the file location that each skaffold configuration is parsed from.
-func GetConfigSet(opts config.SkaffoldOptions) (SkaffoldConfigSet, error) {
+func GetConfigSet(ctx context.Context, opts config.SkaffoldOptions) (SkaffoldConfigSet, error) {
 	cOpts := configOpts{file: opts.ConfigurationFile, selection: nil, profiles: opts.Profiles, isRequired: false, isDependency: false}
 	r := newRecord()
-	cfgs, err := getConfigs(cOpts, opts, r)
+	cfgs, err := getConfigs(ctx, cOpts, opts, r)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func GetConfigSet(opts config.SkaffoldOptions) (SkaffoldConfigSet, error) {
 }
 
 // getConfigs recursively parses all configs and their dependencies in the specified `skaffold.yaml`
-func getConfigs(cfgOpts configOpts, opts config.SkaffoldOptions, r *record) (SkaffoldConfigSet, error) {
+func getConfigs(ctx context.Context, cfgOpts configOpts, opts config.SkaffoldOptions, r *record) (SkaffoldConfigSet, error) {
 	parsed, err := schema.ParseConfigAndUpgrade(cfgOpts.file)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -133,7 +133,7 @@ func getConfigs(cfgOpts configOpts, opts config.SkaffoldOptions, r *record) (Ska
 	var configs SkaffoldConfigSet
 	for i, cfg := range parsed {
 		config := cfg.(*latestV1.SkaffoldConfig)
-		processed, err := processEachConfig(config, cfgOpts, opts, r, i)
+		processed, err := processEachConfig(ctx, config, cfgOpts, opts, r, i)
 		if err != nil {
 			return nil, err
 		}
@@ -144,7 +144,7 @@ func getConfigs(cfgOpts configOpts, opts config.SkaffoldOptions, r *record) (Ska
 
 // processEachConfig processes each parsed config by applying profiles and recursively processing its dependencies.
 // The `index` parameter specifies the index of the current config in its `skaffold.yaml` file. We use the `index` instead of the config `metadata.name` property to uniquely identify each config since not all configs define `name`.
-func processEachConfig(config *latestV1.SkaffoldConfig, cfgOpts configOpts, opts config.SkaffoldOptions, r *record, index int) (SkaffoldConfigSet, error) {
+func processEachConfig(ctx context.Context, config *latestV1.SkaffoldConfig, cfgOpts configOpts, opts config.SkaffoldOptions, r *record, index int) (SkaffoldConfigSet, error) {
 	// check that the same config name isn't repeated in multiple files.
 	if config.Metadata.Name != "" {
 		prevConfig, found := r.configNameToFile[config.Metadata.Name]
@@ -203,7 +203,7 @@ func processEachConfig(config *latestV1.SkaffoldConfig, cfgOpts configOpts, opts
 			}
 		}
 		newOpts := configOpts{file: cfgOpts.file, profiles: depProfiles, isRequired: required, isDependency: cfgOpts.isDependency}
-		depConfigs, err := processEachDependency(d, newOpts, opts, r)
+		depConfigs, err := processEachDependency(ctx, d, newOpts, opts, r)
 		if err != nil {
 			return nil, err
 		}
@@ -245,11 +245,11 @@ func filterActiveProfiles(d latestV1.ConfigDependency, profiles []string) []stri
 }
 
 // processEachDependency parses a config dependency with the calculated set of activated profiles.
-func processEachDependency(d latestV1.ConfigDependency, cfgOpts configOpts, opts config.SkaffoldOptions, r *record) (SkaffoldConfigSet, error) {
+func processEachDependency(ctx context.Context, d latestV1.ConfigDependency, cfgOpts configOpts, opts config.SkaffoldOptions, r *record) (SkaffoldConfigSet, error) {
 	path := makeConfigPathAbsolute(d.Path, cfgOpts.file)
 
 	if d.GitRepo != nil {
-		cachePath, err := cacheRepo(*d.GitRepo, opts, r)
+		cachePath, err := cacheRepo(ctx, *d.GitRepo, opts, r)
 		if err != nil {
 			return nil, sErrors.ConfigParsingError(fmt.Errorf("caching remote dependency %s: %w", d.GitRepo.Repo, err))
 		}
@@ -278,7 +278,7 @@ func processEachDependency(d latestV1.ConfigDependency, cfgOpts configOpts, opts
 	cfgOpts.isDependency = cfgOpts.isDependency || path != cfgOpts.file
 	cfgOpts.file = path
 	cfgOpts.selection = d.Names
-	depConfigs, err := getConfigs(cfgOpts, opts, r)
+	depConfigs, err := getConfigs(ctx, cfgOpts, opts, r)
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +286,7 @@ func processEachDependency(d latestV1.ConfigDependency, cfgOpts configOpts, opts
 }
 
 // cacheRepo downloads the referenced git repository to skaffold's cache if required and returns the path to the target configuration file in that repository.
-func cacheRepo(g latestV1.GitInfo, opts config.SkaffoldOptions, r *record) (string, error) {
+func cacheRepo(ctx context.Context, g latestV1.GitInfo, opts config.SkaffoldOptions, r *record) (string, error) {
 	key := fmt.Sprintf("%s@%s", g.Repo, g.Ref)
 	if p, found := r.cachedRepos[key]; found {
 		switch v := p.(type) {
@@ -299,7 +299,7 @@ func cacheRepo(g latestV1.GitInfo, opts config.SkaffoldOptions, r *record) (stri
 			return "", nil
 		}
 	} else {
-		p, err := git.SyncRepo(g, opts)
+		p, err := git.SyncRepo(ctx, g, opts)
 		if err != nil {
 			r.cachedRepos[key] = err
 			return "", err

--- a/pkg/skaffold/parser/config_test.go
+++ b/pkg/skaffold/parser/config_test.go
@@ -1325,7 +1325,7 @@ requires:
 				expected = test.expected(wd)
 			}
 			t.Override(&git.SyncRepo, func(g latestV1.GitInfo, _ config.SkaffoldOptions) (string, error) { return g.Repo, nil })
-			cfgs, err := GetAllConfigs(config.SkaffoldOptions{
+			cfgs, err := GetAllConfigs(ctx, config.SkaffoldOptions{
 				Command:             "dev",
 				ConfigurationFile:   test.documents[0].path,
 				ConfigurationFilter: test.configFilter,

--- a/pkg/skaffold/parser/config_test.go
+++ b/pkg/skaffold/parser/config_test.go
@@ -1325,7 +1325,9 @@ requires:
 				wd, _ := util.RealWorkDir()
 				expected = test.expected(wd)
 			}
-			t.Override(&git.SyncRepo, func(ctx context.Context, g latestV1.GitInfo, _ config.SkaffoldOptions) (string, error) { return g.Repo, nil })
+			t.Override(&git.SyncRepo, func(ctx context.Context, g latestV1.GitInfo, _ config.SkaffoldOptions) (string, error) {
+				return g.Repo, nil
+			})
 			cfgs, err := GetAllConfigs(context.Background(), config.SkaffoldOptions{
 				Command:             "dev",
 				ConfigurationFile:   test.documents[0].path,

--- a/pkg/skaffold/parser/config_test.go
+++ b/pkg/skaffold/parser/config_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package parser
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -1324,8 +1325,8 @@ requires:
 				wd, _ := util.RealWorkDir()
 				expected = test.expected(wd)
 			}
-			t.Override(&git.SyncRepo, func(g latestV1.GitInfo, _ config.SkaffoldOptions) (string, error) { return g.Repo, nil })
-			cfgs, err := GetAllConfigs(ctx, config.SkaffoldOptions{
+			t.Override(&git.SyncRepo, func(ctx context.Context, g latestV1.GitInfo, _ config.SkaffoldOptions) (string, error) { return g.Repo, nil })
+			cfgs, err := GetAllConfigs(context.Background(), config.SkaffoldOptions{
 				Command:             "dev",
 				ConfigurationFile:   test.documents[0].path,
 				ConfigurationFilter: test.configFilter,

--- a/pkg/skaffold/render/generate/generate.go
+++ b/pkg/skaffold/render/generate/generate.go
@@ -95,7 +95,7 @@ func (g *Generator) Generate(ctx context.Context) (manifest.ManifestList, error)
 	for kPath := range kustomizePathMap {
 		// TODO:  support kustomize buildArgs (shall we support it in kpt-fn)?
 		cmd := exec.CommandContext(ctx, "kustomize", "build", kPath)
-		out, err := util.RunCmdOut(cmd)
+		out, err := util.RunCmdOut(ctx, cmd)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/skaffold/render/renderer/renderer.go
+++ b/pkg/skaffold/render/renderer/renderer.go
@@ -113,7 +113,7 @@ func (r *SkaffoldRenderer) prepareHydrationDir(ctx context.Context) error {
 	kptFilePath := filepath.Join(r.hydrationDir, kptfile.KptFileName)
 	if _, err := os.Stat(kptFilePath); os.IsNotExist(err) {
 		cmd := exec.CommandContext(ctx, "kpt", "pkg", "init", r.hydrationDir)
-		if _, err := util.RunCmdOut(cmd); err != nil {
+		if _, err := util.RunCmdOut(ctx, cmd); err != nil {
 			return sErrors.NewError(err,
 				proto.ActionableErr{
 					Message: fmt.Sprintf("unable to initialize Kptfile in %v", r.hydrationDir),

--- a/pkg/skaffold/runner/build.go
+++ b/pkg/skaffold/runner/build.go
@@ -161,7 +161,7 @@ func (r *Builder) imageTags(ctx context.Context, out io.Writer, artifacts []*lat
 
 		i := i
 		go func() {
-			_tag, err := tag.GenerateFullyQualifiedImageName(r.tagger, *artifacts[i])
+			_tag, err := tag.GenerateFullyQualifiedImageName(ctx, r.tagger, *artifacts[i])
 			tagErrs[i] <- tagErr{tag: _tag, err: err}
 		}()
 	}
@@ -183,7 +183,7 @@ func (r *Builder) imageTags(ctx context.Context, out io.Writer, artifacts []*lat
 				log.Entry(ctx).Debug(t.err)
 				log.Entry(ctx).Debug("Using a fall-back tagger")
 
-				fallbackTag, err := tag.GenerateFullyQualifiedImageName(&tag.ChecksumTagger{}, *artifact)
+				fallbackTag, err := tag.GenerateFullyQualifiedImageName(ctx, &tag.ChecksumTagger{}, *artifact)
 				if err != nil {
 					return nil, fmt.Errorf("generating checksum as fall-back tag for %q: %w", imageName, err)
 				}

--- a/pkg/skaffold/runner/builder.go
+++ b/pkg/skaffold/runner/builder.go
@@ -46,12 +46,12 @@ func (b *builderCtx) SourceDependenciesResolver() graph.SourceDependenciesCache 
 }
 
 // GetBuilder creates a builder from a given RunContext and build pipeline type.
-func GetBuilder(r *runcontext.RunContext, s build.ArtifactStore, d graph.SourceDependenciesCache, p latestV1.Pipeline) (build.PipelineBuilder, error) {
+func GetBuilder(ctx context.Context, r *runcontext.RunContext, s build.ArtifactStore, d graph.SourceDependenciesCache, p latestV1.Pipeline) (build.PipelineBuilder, error) {
 	bCtx := &builderCtx{artifactStore: s, sourceDependenciesCache: d, RunContext: r}
 	switch {
 	case p.Build.LocalBuild != nil:
 		log.Entry(context.Background()).Debug("Using builder: local")
-		builder, err := local.NewBuilder(bCtx, p.Build.LocalBuild)
+		builder, err := local.NewBuilder(ctx, bCtx, p.Build.LocalBuild)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package runner
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -58,7 +59,7 @@ func (d *deployerCtx) StatusCheck() *bool {
 }
 
 // GetDeployer creates a deployer from a given RunContext and deploy pipeline definitions.
-func GetDeployer(runCtx *runcontext.RunContext, labeller *label.DefaultLabeller) (deploy.Deployer, error) {
+func GetDeployer(ctx context.Context, runCtx *runcontext.RunContext, labeller *label.DefaultLabeller) (deploy.Deployer, error) {
 	if runCtx.Opts.Apply {
 		return getDefaultDeployer(runCtx, labeller)
 	}
@@ -71,7 +72,7 @@ func GetDeployer(runCtx *runcontext.RunContext, labeller *label.DefaultLabeller)
 	for _, d := range deployerCfg {
 		if d.DockerDeploy != nil {
 			localDeploy = true
-			d, err := docker.NewDeployer(runCtx, labeller, d.DockerDeploy, runCtx.PortForwardResources())
+			d, err := docker.NewDeployer(ctx, runCtx, labeller, d.DockerDeploy, runCtx.PortForwardResources())
 			if err != nil {
 				return nil, err
 			}
@@ -80,7 +81,7 @@ func GetDeployer(runCtx *runcontext.RunContext, labeller *label.DefaultLabeller)
 
 		dCtx := &deployerCtx{runCtx, d}
 		if d.HelmDeploy != nil {
-			h, err := helm.NewDeployer(dCtx, labeller, d.HelmDeploy)
+			h, err := helm.NewDeployer(ctx, dCtx, labeller, d.HelmDeploy)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/skaffold/runner/deployer_test.go
+++ b/pkg/skaffold/runner/deployer_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package runner
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -143,7 +144,7 @@ func TestGetDeployer(tOuter *testing.T) {
 					))
 				}
 
-				deployer, err := GetDeployer(ctx, &runcontext.RunContext{
+				deployer, err := GetDeployer(context.Background(), &runcontext.RunContext{
 					Opts: config.SkaffoldOptions{
 						Apply: test.apply,
 					},

--- a/pkg/skaffold/runner/deployer_test.go
+++ b/pkg/skaffold/runner/deployer_test.go
@@ -143,7 +143,7 @@ func TestGetDeployer(tOuter *testing.T) {
 					))
 				}
 
-				deployer, err := GetDeployer(&runcontext.RunContext{
+				deployer, err := GetDeployer(ctx, &runcontext.RunContext{
 					Opts: config.SkaffoldOptions{
 						Apply: test.apply,
 					},

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -198,7 +198,7 @@ func (rc *RunContext) RPCPort() int                                  { return rc
 func (rc *RunContext) RPCHTTPPort() int                              { return rc.Opts.RPCHTTPPort }
 func (rc *RunContext) PushImages() config.BoolOrUndefined            { return rc.Opts.PushImages }
 
-func GetRunContext(opts config.SkaffoldOptions, configs []schemaUtil.VersionedConfig) (*RunContext, error) {
+func GetRunContext(ctx context.Context, opts config.SkaffoldOptions, configs []schemaUtil.VersionedConfig) (*RunContext, error) {
 	var pipelines []latestV1.Pipeline
 	for _, cfg := range configs {
 		if cfg != nil {
@@ -238,7 +238,7 @@ func GetRunContext(opts config.SkaffoldOptions, configs []schemaUtil.VersionedCo
 	// TODO(https://github.com/GoogleContainerTools/skaffold/issues/3668):
 	// remove minikubeProfile from here and instead detect it by matching the
 	// kubecontext API Server to minikube profiles
-	cluster, err := config.GetCluster(opts.GlobalConfig, opts.MinikubeProfile, opts.DetectMinikube)
+	cluster, err := config.GetCluster(ctx, opts.GlobalConfig, opts.MinikubeProfile, opts.DetectMinikube)
 	if err != nil {
 		return nil, fmt.Errorf("getting cluster: %w", err)
 	}

--- a/pkg/skaffold/runner/v1/deploy.go
+++ b/pkg/skaffold/runner/v1/deploy.go
@@ -68,7 +68,7 @@ func (r *SkaffoldRunner) Deploy(ctx context.Context, out io.Writer, artifacts []
 	}
 	defer r.deployer.GetStatusMonitor().Reset()
 
-	out, _ = output.WithEventContext(ctx, out, constants.Deploy, constants.SubtaskIDNone)
+	out, ctx = output.WithEventContext(ctx, out, constants.Deploy, constants.SubtaskIDNone)
 
 	output.Default.Fprintln(out, "Tags used in deployment:")
 

--- a/pkg/skaffold/runner/v1/deploy_test.go
+++ b/pkg/skaffold/runner/v1/deploy_test.go
@@ -78,7 +78,7 @@ func TestSkaffoldDeployRenderOnly(t *testing.T) {
 			KubeContext: "does-not-exist",
 		}
 
-		deployer, err := runner.GetDeployer(ctx, runCtx, nil)
+		deployer, err := runner.GetDeployer(context.Background(), runCtx, nil)
 		t.RequireNoError(err)
 		r := SkaffoldRunner{
 			runCtx:   runCtx,

--- a/pkg/skaffold/runner/v1/deploy_test.go
+++ b/pkg/skaffold/runner/v1/deploy_test.go
@@ -78,7 +78,7 @@ func TestSkaffoldDeployRenderOnly(t *testing.T) {
 			KubeContext: "does-not-exist",
 		}
 
-		deployer, err := runner.GetDeployer(runCtx, nil)
+		deployer, err := runner.GetDeployer(ctx, runCtx, nil)
 		t.RequireNoError(err)
 		r := SkaffoldRunner{
 			runCtx:   runCtx,

--- a/pkg/skaffold/runner/v1/dev.go
+++ b/pkg/skaffold/runner/v1/dev.go
@@ -259,7 +259,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	for i := range artifacts {
 		artifact := artifacts[i]
 		if err := r.monitor.Register(
-			func() ([]string, error) { return r.Tester.TestDependencies(artifact) },
+			func() ([]string, error) { return r.Tester.TestDependencies(ctx, artifact) },
 			func(filemon.Events) { r.changeSet.AddRetest(artifact) },
 		); err != nil {
 			event.DevLoopFailedWithErrorCode(r.devIteration, proto.StatusCode_DEVINIT_REGISTER_TEST_DEPS, err)

--- a/pkg/skaffold/runner/v1/dev_test.go
+++ b/pkg/skaffold/runner/v1/dev_test.go
@@ -415,7 +415,7 @@ func TestDevAutoTriggers(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
 			t.Override(&client.Client, mockK8sClient)
-			t.Override(&sync.WorkingDir, func(string, docker.Config) (string, error) { return "/", nil })
+			t.Override(&sync.WorkingDir, func(context.Context, string, docker.Config) (string, error) { return "/", nil })
 			testBench := &TestBench{}
 			testBench.cycles = len(test.watchEvents)
 			testBench.userIntents = test.userIntents
@@ -524,7 +524,7 @@ func TestDevSync(t *testing.T) {
 			t.Override(&fileSyncInProgress, func(int, string) { actualFileSyncEventCalls.InProgress++ })
 			t.Override(&fileSyncFailed, func(int, string, error) { actualFileSyncEventCalls.Failed++ })
 			t.Override(&fileSyncSucceeded, func(int, string) { actualFileSyncEventCalls.Succeeded++ })
-			t.Override(&sync.WorkingDir, func(string, docker.Config) (string, error) { return "/", nil })
+			t.Override(&sync.WorkingDir, func(context.Context, string, docker.Config) (string, error) { return "/", nil })
 			test.testBench.cycles = len(test.watchEvents)
 			artifacts := []*latestV1.Artifact{
 				{

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -282,7 +282,7 @@ func createRunner(t *testutil.T, testBench *TestBench, monitor filemon.Monitor, 
 			AutoDeploy:        autoTriggers.deploy,
 		},
 	}
-	runner, err := NewForConfig(ctx, runCtx)
+	runner, err := NewForConfig(context.Background(), runCtx)
 	t.CheckNoError(err)
 
 	// TODO(yuwenma):builder.builder looks weird. Avoid the nested struct.
@@ -442,7 +442,7 @@ func TestNewForConfig(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
-			t.Override(&cluster.FindMinikubeBinary, func() (string, semver.Version, error) { return "", semver.Version{}, errors.New("not found") })
+			t.Override(&cluster.FindMinikubeBinary, func(context.Context) (string, semver.Version, error) { return "", semver.Version{}, errors.New("not found") })
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput(
 				"helm version --client", `version.BuildInfo{Version:"v3.0.0"}`).
 				AndRunWithOutput("kubectl version --client -ojson", "v1.5.6"))
@@ -454,7 +454,7 @@ func TestNewForConfig(t *testing.T) {
 				},
 			}
 
-			cfg, err := NewForConfig(ctx, runCtx)
+			cfg, err := NewForConfig(context.Background(), runCtx)
 			t.CheckError(test.shouldErr, err)
 			if cfg != nil {
 				b, _t, d := runner.WithTimings(&test.expectedBuilder, test.expectedTester, test.expectedDeployer, test.cacheArtifacts)
@@ -541,7 +541,7 @@ func TestTriggerCallbackAndIntents(t *testing.T) {
 					},
 				},
 			}
-			r, _ := NewForConfig(ctx, &runcontext.RunContext{
+			r, _ := NewForConfig(context.Background(), &runcontext.RunContext{
 				Opts:      opts,
 				Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{pipeline}),
 			})

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -128,10 +128,12 @@ func (t *TestBench) GetSyncer() sync.Syncer {
 func (t *TestBench) RegisterLocalImages(_ []graph.Artifact) {}
 func (t *TestBench) TrackBuildArtifacts(_ []graph.Artifact) {}
 
-func (t *TestBench) TestDependencies(context.Context, *latestV1.Artifact) ([]string, error) { return nil, nil }
-func (t *TestBench) Dependencies() ([]string, error)                       { return nil, nil }
-func (t *TestBench) Cleanup(ctx context.Context, out io.Writer) error      { return nil }
-func (t *TestBench) Prune(ctx context.Context, out io.Writer) error        { return nil }
+func (t *TestBench) TestDependencies(context.Context, *latestV1.Artifact) ([]string, error) {
+	return nil, nil
+}
+func (t *TestBench) Dependencies() ([]string, error)                  { return nil, nil }
+func (t *TestBench) Cleanup(ctx context.Context, out io.Writer) error { return nil }
+func (t *TestBench) Prune(ctx context.Context, out io.Writer) error   { return nil }
 
 func (t *TestBench) enterNewCycle() {
 	t.actions = append(t.actions, t.currentActions)
@@ -442,7 +444,9 @@ func TestNewForConfig(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.SetupFakeKubernetesContext(api.Config{CurrentContext: "cluster1"})
-			t.Override(&cluster.FindMinikubeBinary, func(context.Context) (string, semver.Version, error) { return "", semver.Version{}, errors.New("not found") })
+			t.Override(&cluster.FindMinikubeBinary, func(context.Context) (string, semver.Version, error) {
+				return "", semver.Version{}, errors.New("not found")
+			})
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput(
 				"helm version --client", `version.BuildInfo{Version:"v3.0.0"}`).
 				AndRunWithOutput("kubectl version --client -ojson", "v1.5.6"))

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -128,7 +128,7 @@ func (t *TestBench) GetSyncer() sync.Syncer {
 func (t *TestBench) RegisterLocalImages(_ []graph.Artifact) {}
 func (t *TestBench) TrackBuildArtifacts(_ []graph.Artifact) {}
 
-func (t *TestBench) TestDependencies(*latestV1.Artifact) ([]string, error) { return nil, nil }
+func (t *TestBench) TestDependencies(context.Context, *latestV1.Artifact) ([]string, error) { return nil, nil }
 func (t *TestBench) Dependencies() ([]string, error)                       { return nil, nil }
 func (t *TestBench) Cleanup(ctx context.Context, out io.Writer) error      { return nil }
 func (t *TestBench) Prune(ctx context.Context, out io.Writer) error        { return nil }
@@ -282,7 +282,7 @@ func createRunner(t *testutil.T, testBench *TestBench, monitor filemon.Monitor, 
 			AutoDeploy:        autoTriggers.deploy,
 		},
 	}
-	runner, err := NewForConfig(runCtx)
+	runner, err := NewForConfig(ctx, runCtx)
 	t.CheckNoError(err)
 
 	// TODO(yuwenma):builder.builder looks weird. Avoid the nested struct.
@@ -454,7 +454,7 @@ func TestNewForConfig(t *testing.T) {
 				},
 			}
 
-			cfg, err := NewForConfig(runCtx)
+			cfg, err := NewForConfig(ctx, runCtx)
 			t.CheckError(test.shouldErr, err)
 			if cfg != nil {
 				b, _t, d := runner.WithTimings(&test.expectedBuilder, test.expectedTester, test.expectedDeployer, test.cacheArtifacts)
@@ -541,7 +541,7 @@ func TestTriggerCallbackAndIntents(t *testing.T) {
 					},
 				},
 			}
-			r, _ := NewForConfig(&runcontext.RunContext{
+			r, _ := NewForConfig(ctx, &runcontext.RunContext{
 				Opts:      opts,
 				Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{pipeline}),
 			})

--- a/pkg/skaffold/schema/validation/validation.go
+++ b/pkg/skaffold/schema/validation/validation.go
@@ -97,9 +97,9 @@ func Process(configs parser.SkaffoldConfigSet, validateConfig Options) error {
 
 // ProcessWithRunContext checks if the Skaffold pipeline is valid when a RunContext is required.
 // It returns all encountered errors as a concatenated string.
-func ProcessWithRunContext(runCtx *runcontext.RunContext) error {
+func ProcessWithRunContext(ctx context.Context, runCtx *runcontext.RunContext) error {
 	var errs []error
-	errs = append(errs, validateDockerNetworkContainerExists(runCtx.Artifacts(), runCtx)...)
+	errs = append(errs, validateDockerNetworkContainerExists(ctx, runCtx.Artifacts(), runCtx)...)
 
 	if len(errs) == 0 {
 		return nil
@@ -329,16 +329,16 @@ func validateDockerNetworkMode(artifacts []*latestV1.Artifact) (errs []error) {
 }
 
 // Validates that a Docker Container with a Network Mode "container:<id|name>" points to an actually running container
-func validateDockerNetworkContainerExists(artifacts []*latestV1.Artifact, runCtx docker.Config) []error {
+func validateDockerNetworkContainerExists(ctx context.Context, artifacts []*latestV1.Artifact, runCtx docker.Config) []error {
 	var errs []error
-	apiClient, err := docker.NewAPIClient(runCtx)
+	apiClient, err := docker.NewAPIClient(ctx, runCtx)
 	if err != nil {
 		errs = append(errs, err)
 		return errs
 	}
 
 	client := apiClient.RawClient()
-	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
+	ctx, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Second))
 	defer cancel()
 
 	for _, a := range artifacts {

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -702,7 +702,7 @@ func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 				return docker.NewLocalDaemon(fakeClient, nil, false, nil), nil
 			})
 
-			err := ProcessWithRunContext(&runcontext.RunContext{
+			err := ProcessWithRunContext(ctx, &runcontext.RunContext{
 				Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{
 					{
 						Build: latestV1.BuildConfig{

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -692,7 +692,7 @@ func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 			// disable yamltags validation
 			t.Override(&validateYamltags, func(interface{}) error { return nil })
 			t.Override(&util.OSEnviron, func() []string { return test.env })
-			t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
+			t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 				fakeClient := &fakeCommonAPIClient{
 					CommonAPIClient: &testutil.FakeAPIClient{
 						ErrVersion: true,
@@ -702,7 +702,7 @@ func TestValidateNetworkModeDockerContainerExists(t *testing.T) {
 				return docker.NewLocalDaemon(fakeClient, nil, false, nil), nil
 			})
 
-			err := ProcessWithRunContext(ctx, &runcontext.RunContext{
+			err := ProcessWithRunContext(context.Background(), &runcontext.RunContext{
 				Pipelines: runcontext.NewPipelines([]latestV1.Pipeline{
 					{
 						Build: latestV1.BuildConfig{

--- a/pkg/skaffold/sync/docker.go
+++ b/pkg/skaffold/sync/docker.go
@@ -35,14 +35,14 @@ func NewContainerSyncer() *ContainerSyncer {
 func (s *ContainerSyncer) Sync(ctx context.Context, _ io.Writer, item *Item) error {
 	if len(item.Copy) > 0 {
 		log.Entry(ctx).Info("Copying files:", item.Copy, "to", item.Image)
-		if _, err := util.RunCmdOut(s.copyFileFn(ctx, item.Artifact.ImageName, item.Copy)); err != nil {
+		if _, err := util.RunCmdOut(ctx, s.copyFileFn(ctx, item.Artifact.ImageName, item.Copy)); err != nil {
 			return fmt.Errorf("copying files: %w", err)
 		}
 	}
 
 	if len(item.Delete) > 0 {
 		log.Entry(ctx).Info("Deleting files:", item.Delete, "from", item.Image)
-		if _, err := util.RunCmdOut(s.deleteFileFn(ctx, item.Artifact.ImageName, item.Delete)); err != nil {
+		if _, err := util.RunCmdOut(ctx, s.deleteFileFn(ctx, item.Artifact.ImageName, item.Delete)); err != nil {
 			return fmt.Errorf("deleting files: %w", err)
 		}
 	}

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -68,21 +68,21 @@ func NewItem(ctx context.Context, a *latestV1.Artifact, e filemon.Events, builds
 
 	switch {
 	case len(a.Sync.Manual) > 0:
-		return syncItem(a, tag, e, a.Sync.Manual, cfg)
+		return syncItem(ctx, a, tag, e, a.Sync.Manual, cfg)
 
 	case a.Sync.Auto != nil:
 		return autoSyncItem(ctx, a, tag, e, cfg)
 
 	case len(a.Sync.Infer) > 0:
-		return inferredSyncItem(a, tag, e, cfg)
+		return inferredSyncItem(ctx, a, tag, e, cfg)
 
 	default:
 		return nil, nil
 	}
 }
 
-func syncItem(a *latestV1.Artifact, tag string, e filemon.Events, syncRules []*latestV1.SyncRule, cfg docker.Config) (*Item, error) {
-	containerWd, err := WorkingDir(tag, cfg)
+func syncItem(ctx context.Context, a *latestV1.Artifact, tag string, e filemon.Events, syncRules []*latestV1.SyncRule, cfg docker.Config) (*Item, error) {
+	containerWd, err := WorkingDir(ctx, tag, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving working dir for %q: %w", tag, err)
 	}
@@ -105,13 +105,13 @@ func syncItem(a *latestV1.Artifact, tag string, e filemon.Events, syncRules []*l
 	return &Item{Image: tag, Artifact: a, Copy: toCopy, Delete: toDelete}, nil
 }
 
-func inferredSyncItem(a *latestV1.Artifact, tag string, e filemon.Events, cfg docker.Config) (*Item, error) {
+func inferredSyncItem(ctx context.Context, a *latestV1.Artifact, tag string, e filemon.Events, cfg docker.Config) (*Item, error) {
 	// deleted files are no longer contained in the syncMap, so we need to rebuild
 	if len(e.Deleted) > 0 {
 		return nil, nil
 	}
 
-	syncMap, err := SyncMap(a, cfg)
+	syncMap, err := SyncMap(ctx, a, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("inferring syncmap for image %q: %w", a.ImageName, err)
 	}
@@ -149,16 +149,16 @@ func inferredSyncItem(a *latestV1.Artifact, tag string, e filemon.Events, cfg do
 	return &Item{Image: tag, Artifact: a, Copy: toCopy}, nil
 }
 
-func syncMapForArtifact(a *latestV1.Artifact, cfg docker.Config) (map[string][]string, error) {
+func syncMapForArtifact(ctx context.Context, a *latestV1.Artifact, cfg docker.Config) (map[string][]string, error) {
 	switch {
 	case a.DockerArtifact != nil:
-		return docker.SyncMap(a.Workspace, a.DockerArtifact.DockerfilePath, a.DockerArtifact.BuildArgs, cfg)
+		return docker.SyncMap(ctx, a.Workspace, a.DockerArtifact.DockerfilePath, a.DockerArtifact.BuildArgs, cfg)
 
 	case a.CustomArtifact != nil && a.CustomArtifact.Dependencies != nil && a.CustomArtifact.Dependencies.Dockerfile != nil:
-		return docker.SyncMap(a.Workspace, a.CustomArtifact.Dependencies.Dockerfile.Path, a.CustomArtifact.Dependencies.Dockerfile.BuildArgs, cfg)
+		return docker.SyncMap(ctx, a.Workspace, a.CustomArtifact.Dependencies.Dockerfile.Path, a.CustomArtifact.Dependencies.Dockerfile.BuildArgs, cfg)
 
 	case a.KanikoArtifact != nil:
-		return docker.SyncMap(a.Workspace, a.KanikoArtifact.DockerfilePath, a.KanikoArtifact.BuildArgs, cfg)
+		return docker.SyncMap(ctx, a.Workspace, a.KanikoArtifact.DockerfilePath, a.KanikoArtifact.BuildArgs, cfg)
 
 	default:
 		return nil, build.ErrSyncMapNotSupported{}
@@ -168,7 +168,7 @@ func syncMapForArtifact(a *latestV1.Artifact, cfg docker.Config) (map[string][]s
 func autoSyncItem(ctx context.Context, a *latestV1.Artifact, tag string, e filemon.Events, cfg docker.Config) (*Item, error) {
 	switch {
 	case a.BuildpackArtifact != nil:
-		labels, err := Labels(tag, cfg)
+		labels, err := Labels(ctx, tag, cfg)
 		if err != nil {
 			return nil, fmt.Errorf("retrieving labels for %q: %w", tag, err)
 		}
@@ -178,7 +178,7 @@ func autoSyncItem(ctx context.Context, a *latestV1.Artifact, tag string, e filem
 			return nil, fmt.Errorf("extracting sync rules from labels for %q: %w", tag, err)
 		}
 
-		return syncItem(a, tag, e, rules, cfg)
+		return syncItem(ctx, a, tag, e, rules, cfg)
 
 	case a.JibArtifact != nil:
 		toCopy, toDelete, err := jib.GetSyncDiff(ctx, a.Workspace, a.JibArtifact, e)
@@ -335,7 +335,7 @@ func Perform(ctx context.Context, image string, files syncMap, cmdFn func(contex
 
 				cmd := cmdFn(ctx, p, c, files)
 				errs.Go(func() error {
-					_, err := util.RunCmdOut(cmd)
+					_, err := util.RunCmdOut(ctx, cmd)
 					return err
 				})
 				numSynced++

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -751,7 +751,9 @@ func TestNewSyncItem(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&WorkingDir, func(context.Context, string, docker.Config) (string, error) { return test.workingDir, nil })
-			t.Override(&SyncMap, func(context.Context, *latestV1.Artifact, docker.Config) (map[string][]string, error) { return test.dependencies, nil })
+			t.Override(&SyncMap, func(context.Context, *latestV1.Artifact, docker.Config) (map[string][]string, error) {
+				return test.dependencies, nil
+			})
 			t.Override(&Labels, func(context.Context, string, docker.Config) (map[string]string, error) { return test.labels, nil })
 			t.Override(&jib.GetSyncDiff, func(context.Context, string, *latestV1.JibArtifact, filemon.Events) (map[string][]string, map[string][]string, error) {
 				return map[string][]string{"file.class": {"/some/file.class"}}, nil, nil

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -836,7 +836,7 @@ type TestCmdRecorder struct {
 	err  error
 }
 
-func (t *TestCmdRecorder) RunCmd(cmd *exec.Cmd) error {
+func (t *TestCmdRecorder) RunCmd(ctx context.Context, cmd *exec.Cmd) error {
 	if t.err != nil {
 		return t.err
 	}
@@ -844,8 +844,8 @@ func (t *TestCmdRecorder) RunCmd(cmd *exec.Cmd) error {
 	return nil
 }
 
-func (t *TestCmdRecorder) RunCmdOut(cmd *exec.Cmd) ([]byte, error) {
-	return nil, t.RunCmd(cmd)
+func (t *TestCmdRecorder) RunCmdOut(ctx context.Context, cmd *exec.Cmd) ([]byte, error) {
+	return nil, t.RunCmd(ctx, cmd)
 }
 
 func fakeCmd(ctx context.Context, _ v1.Pod, _ v1.Container, files syncMap) *exec.Cmd {

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -750,9 +750,9 @@ func TestNewSyncItem(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&WorkingDir, func(string, docker.Config) (string, error) { return test.workingDir, nil })
-			t.Override(&SyncMap, func(*latestV1.Artifact, docker.Config) (map[string][]string, error) { return test.dependencies, nil })
-			t.Override(&Labels, func(string, docker.Config) (map[string]string, error) { return test.labels, nil })
+			t.Override(&WorkingDir, func(context.Context, string, docker.Config) (string, error) { return test.workingDir, nil })
+			t.Override(&SyncMap, func(context.Context, *latestV1.Artifact, docker.Config) (map[string][]string, error) { return test.dependencies, nil })
+			t.Override(&Labels, func(context.Context, string, docker.Config) (map[string]string, error) { return test.labels, nil })
 			t.Override(&jib.GetSyncDiff, func(context.Context, string, *latestV1.JibArtifact, filemon.Events) (map[string][]string, map[string][]string, error) {
 				return map[string][]string{"file.class": {"/some/file.class"}}, nil, nil
 			})
@@ -1041,7 +1041,7 @@ func TestSyncMap(t *testing.T) {
 			t.Override(&docker.RetrieveImage, imageFetcher.fetch)
 			t.NewTempDir().WriteFiles(test.files).Chdir()
 
-			syncMap, err := SyncMap(&latestV1.Artifact{ArtifactType: test.artifactType}, nil)
+			syncMap, err := SyncMap(context.Background(), &latestV1.Artifact{ArtifactType: test.artifactType}, nil)
 
 			t.CheckError(test.shouldErr, err)
 			t.CheckDeepEqual(test.expectedMap, syncMap)
@@ -1051,7 +1051,7 @@ func TestSyncMap(t *testing.T) {
 
 type fakeImageFetcher struct{}
 
-func (f *fakeImageFetcher) fetch(image string, _ docker.Config) (*registryv1.ConfigFile, error) {
+func (f *fakeImageFetcher) fetch(context.Context, string, docker.Config) (*registryv1.ConfigFile, error) {
 	return &registryv1.ConfigFile{}, nil
 }
 

--- a/pkg/skaffold/tag/custom.go
+++ b/pkg/skaffold/tag/custom.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"context"
 	"errors"
 
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -27,7 +28,7 @@ type CustomTag struct {
 }
 
 // GenerateTag generates a tag using the custom tag.
-func (t *CustomTag) GenerateTag(_ latestV1.Artifact) (string, error) {
+func (t *CustomTag) GenerateTag(ctx context.Context, image latestV1.Artifact) (string, error) {
 	tag := t.Tag
 	if tag == "" {
 		return "", errors.New("custom tag not provided")

--- a/pkg/skaffold/tag/custom_template.go
+++ b/pkg/skaffold/tag/custom_template.go
@@ -46,8 +46,8 @@ func NewCustomTemplateTagger(t string, components map[string]Tagger) (Tagger, er
 }
 
 // GenerateTag generates a tag from a template referencing tagging strategies.
-func (t *customTemplateTagger) GenerateTag(image latestV1.Artifact) (string, error) {
-	customMap, err := t.EvaluateComponents(image)
+func (t *customTemplateTagger) GenerateTag(ctx context.Context, image latestV1.Artifact) (string, error) {
+	customMap, err := t.EvaluateComponents(ctx, image)
 	if err != nil {
 		return "", err
 	}
@@ -62,14 +62,14 @@ func (t *customTemplateTagger) GenerateTag(image latestV1.Artifact) (string, err
 }
 
 // EvaluateComponents creates a custom mapping of component names to their tagger string representation.
-func (t *customTemplateTagger) EvaluateComponents(image latestV1.Artifact) (map[string]string, error) {
+func (t *customTemplateTagger) EvaluateComponents(ctx context.Context, image latestV1.Artifact) (map[string]string, error) {
 	customMap := map[string]string{}
 
 	gitTagger, _ := NewGitCommit("", "", false)
 	dateTimeTagger := NewDateTimeTagger("", "")
 
 	for k, v := range map[string]Tagger{"GIT": gitTagger, "DATE": dateTimeTagger, "SHA": &ChecksumTagger{}} {
-		tag, _ := v.GenerateTag(image)
+		tag, _ := v.GenerateTag(ctx, image)
 		customMap[k] = tag
 	}
 
@@ -77,7 +77,7 @@ func (t *customTemplateTagger) EvaluateComponents(image latestV1.Artifact) (map[
 		if _, ok := v.(*customTemplateTagger); ok {
 			return nil, fmt.Errorf("invalid component specified in custom template: %v", v)
 		}
-		tag, err := v.GenerateTag(image)
+		tag, err := v.GenerateTag(ctx, image)
 		if err != nil {
 			return nil, fmt.Errorf("evaluating custom template component: %w", err)
 		}

--- a/pkg/skaffold/tag/custom_template_test.go
+++ b/pkg/skaffold/tag/custom_template_test.go
@@ -107,7 +107,7 @@ func TestTagTemplate_GenerateTag(t *testing.T) {
 			image := latestV1.Artifact{
 				ImageName: "test",
 			}
-			tag, err := c.GenerateTag(image)
+			tag, err := c.GenerateTag(ctx, image)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, tag)
 		})

--- a/pkg/skaffold/tag/custom_template_test.go
+++ b/pkg/skaffold/tag/custom_template_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -107,7 +108,7 @@ func TestTagTemplate_GenerateTag(t *testing.T) {
 			image := latestV1.Artifact{
 				ImageName: "test",
 			}
-			tag, err := c.GenerateTag(ctx, image)
+			tag, err := c.GenerateTag(context.Background(), image)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, tag)
 		})

--- a/pkg/skaffold/tag/custom_test.go
+++ b/pkg/skaffold/tag/custom_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"context"
 	"testing"
 
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -47,7 +48,7 @@ func TestCustomTag_GenerateTag(t *testing.T) {
 		image := latestV1.Artifact{
 			ImageName: "test",
 		}
-		tag, err := test.c.GenerateTag(ctx, image)
+		tag, err := test.c.GenerateTag(context.Background(), image)
 		testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, tag)
 	}
 }

--- a/pkg/skaffold/tag/custom_test.go
+++ b/pkg/skaffold/tag/custom_test.go
@@ -47,7 +47,7 @@ func TestCustomTag_GenerateTag(t *testing.T) {
 		image := latestV1.Artifact{
 			ImageName: "test",
 		}
-		tag, err := test.c.GenerateTag(image)
+		tag, err := test.c.GenerateTag(ctx, image)
 		testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, tag)
 	}
 }

--- a/pkg/skaffold/tag/date_time.go
+++ b/pkg/skaffold/tag/date_time.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -45,7 +46,7 @@ func NewDateTimeTagger(format, timezone string) Tagger {
 }
 
 // GenerateTag generates a tag using the current timestamp.
-func (t *dateTimeTagger) GenerateTag(_ latestV1.Artifact) (string, error) {
+func (t *dateTimeTagger) GenerateTag(ctx context.Context, image latestV1.Artifact) (string, error) {
 	format := tagTime
 	if len(t.Format) > 0 {
 		format = t.Format

--- a/pkg/skaffold/tag/date_time_test.go
+++ b/pkg/skaffold/tag/date_time_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -73,7 +74,7 @@ func TestDateTime_GenerateTag(t *testing.T) {
 				ImageName: "test",
 			}
 
-			tag, err := c.GenerateTag(ctx, image)
+			tag, err := c.GenerateTag(context.Background(), image)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.want, tag)
 		})

--- a/pkg/skaffold/tag/date_time_test.go
+++ b/pkg/skaffold/tag/date_time_test.go
@@ -73,7 +73,7 @@ func TestDateTime_GenerateTag(t *testing.T) {
 				ImageName: "test",
 			}
 
-			tag, err := c.GenerateTag(image)
+			tag, err := c.GenerateTag(ctx, image)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.want, tag)
 		})

--- a/pkg/skaffold/tag/env_template.go
+++ b/pkg/skaffold/tag/env_template.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"context"
 	"fmt"
 	"text/template"
 
@@ -42,7 +43,7 @@ func NewEnvTemplateTagger(t string) (Tagger, error) {
 }
 
 // GenerateTag generates a tag from a template referencing environment variables.
-func (t *envTemplateTagger) GenerateTag(image latestV1.Artifact) (string, error) {
+func (t *envTemplateTagger) GenerateTag(ctx context.Context, image latestV1.Artifact) (string, error) {
 	// missingkey=error throws error when map is indexed with an undefined key
 	tag, err := util.ExecuteEnvTemplate(t.Template.Option("missingkey=error"), map[string]string{
 		"IMAGE_NAME": image.ImageName,

--- a/pkg/skaffold/tag/env_template_test.go
+++ b/pkg/skaffold/tag/env_template_test.go
@@ -104,7 +104,7 @@ func TestEnvTemplateTagger_GenerateTag(t *testing.T) {
 				ImageName: test.imageName,
 			}
 
-			got, err := c.GenerateTag(image)
+			got, err := c.GenerateTag(ctx, image)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, got)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)

--- a/pkg/skaffold/tag/env_template_test.go
+++ b/pkg/skaffold/tag/env_template_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"context"
 	"testing"
 
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -104,7 +105,7 @@ func TestEnvTemplateTagger_GenerateTag(t *testing.T) {
 				ImageName: test.imageName,
 			}
 
-			got, err := c.GenerateTag(ctx, image)
+			got, err := c.GenerateTag(context.Background(), image)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, got)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)

--- a/pkg/skaffold/tag/git_commit.go
+++ b/pkg/skaffold/tag/git_commit.go
@@ -33,11 +33,11 @@ import (
 // GitCommit tags an image by the git commit it was built at.
 type GitCommit struct {
 	prefix        string
-	runGitFn      func(string) (string, error)
+	runGitFn      func(context.Context, string) (string, error)
 	ignoreChanges bool
 }
 
-var variants = map[string]func(string) (string, error){
+var variants = map[string]func(context.Context, string) (string, error){
 	"":                gitTags,
 	"tags":            gitTags,
 	"commitsha":       gitCommitsha,
@@ -61,8 +61,8 @@ func NewGitCommit(prefix, variant string, ignoreChanges bool) (*GitCommit, error
 }
 
 // GenerateTag generates a tag from the git commit.
-func (t *GitCommit) GenerateTag(image latestV1.Artifact) (string, error) {
-	ref, err := t.runGitFn(image.Workspace)
+func (t *GitCommit) GenerateTag(ctx context.Context, image latestV1.Artifact) (string, error) {
+	ref, err := t.runGitFn(ctx, image.Workspace)
 	if err != nil {
 		return "", fmt.Errorf("unable to find git commit: %w", err)
 	}
@@ -70,7 +70,7 @@ func (t *GitCommit) GenerateTag(image latestV1.Artifact) (string, error) {
 	ref = sanitizeTag(ref)
 
 	if !t.ignoreChanges {
-		changes, err := runGit(image.Workspace, "status", ".", "--porcelain")
+		changes, err := runGit(ctx, image.Workspace, "status", ".", "--porcelain")
 		if err != nil {
 			return "", fmt.Errorf("getting git status: %w", err)
 		}
@@ -105,37 +105,37 @@ func sanitizeTag(tag string) string {
 	return sanitized
 }
 
-func gitTags(workingDir string) (string, error) {
-	return runGit(workingDir, "describe", "--tags", "--always")
+func gitTags(ctx context.Context, workingDir string) (string, error) {
+	return runGit(ctx, workingDir, "describe", "--tags", "--always")
 }
 
-func gitCommitsha(workingDir string) (string, error) {
-	return runGit(workingDir, "rev-list", "-1", "HEAD")
+func gitCommitsha(ctx context.Context, workingDir string) (string, error) {
+	return runGit(ctx, workingDir, "rev-list", "-1", "HEAD")
 }
 
-func gitAbbrevcommitsha(workingDir string) (string, error) {
-	return runGit(workingDir, "rev-list", "-1", "HEAD", "--abbrev-commit")
+func gitAbbrevcommitsha(ctx context.Context, workingDir string) (string, error) {
+	return runGit(ctx, workingDir, "rev-list", "-1", "HEAD", "--abbrev-commit")
 }
 
-func gitTreesha(workingDir string) (string, error) {
-	gitPath, err := getGitPathToWorkdir(workingDir)
+func gitTreesha(ctx context.Context, workingDir string) (string, error) {
+	gitPath, err := getGitPathToWorkdir(ctx, workingDir)
 	if err != nil {
 		return "", err
 	}
 
-	return runGit(workingDir, "rev-parse", "HEAD:"+gitPath+"/")
+	return runGit(ctx, workingDir, "rev-parse", "HEAD:"+gitPath+"/")
 }
 
-func gitAbbrevtreesha(workingDir string) (string, error) {
-	gitPath, err := getGitPathToWorkdir(workingDir)
+func gitAbbrevtreesha(ctx context.Context, workingDir string) (string, error) {
+	gitPath, err := getGitPathToWorkdir(ctx, workingDir)
 	if err != nil {
 		return "", err
 	}
 
-	return runGit(workingDir, "rev-parse", "--short", "HEAD:"+gitPath+"/")
+	return runGit(ctx, workingDir, "rev-parse", "--short", "HEAD:"+gitPath+"/")
 }
 
-func getGitPathToWorkdir(workingDir string) (string, error) {
+func getGitPathToWorkdir(ctx context.Context, workingDir string) (string, error) {
 	absWorkingDir, err := filepath.Abs(workingDir)
 	if err != nil {
 		return "", err
@@ -147,7 +147,7 @@ func getGitPathToWorkdir(workingDir string) (string, error) {
 		return "", err
 	}
 
-	gitRoot, err := runGit(workingDir, "rev-parse", "--show-toplevel")
+	gitRoot, err := runGit(ctx, workingDir, "rev-parse", "--show-toplevel")
 	if err != nil {
 		return "", err
 	}
@@ -155,11 +155,11 @@ func getGitPathToWorkdir(workingDir string) (string, error) {
 	return filepath.Rel(gitRoot, absWorkingDir)
 }
 
-func runGit(workingDir string, arg ...string) (string, error) {
+func runGit(ctx context.Context, workingDir string, arg ...string) (string, error) {
 	cmd := exec.Command("git", arg...)
 	cmd.Dir = workingDir
 
-	out, err := util.RunCmdOut(cmd)
+	out, err := util.RunCmdOut(ctx, cmd)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/skaffold/tag/git_commit_test.go
+++ b/pkg/skaffold/tag/git_commit_test.go
@@ -399,7 +399,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 				tagger, err := NewGitCommit("", variant, test.ignoreChanges)
 				t.CheckNoError(err)
 
-				tag, err := tagger.GenerateTag(image)
+				tag, err := tagger.GenerateTag(ctx, image)
 
 				t.CheckErrorAndDeepEqual(test.shouldErr, err, expectedTag, tag)
 			}
@@ -461,7 +461,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 				tagger, err := NewGitCommit("", variant, false)
 				t.CheckNoError(err)
 
-				tag, err := GenerateFullyQualifiedImageName(tagger, image)
+				tag, err := GenerateFullyQualifiedImageName(ctx, tagger, image)
 
 				t.CheckErrorAndDeepEqual(test.shouldErr, err, expectedTag, tag)
 			}
@@ -517,7 +517,7 @@ func TestGitCommit_CustomTemplate(t *testing.T) {
 
 			t.CheckNoError(err)
 
-			tag, err := c.GenerateTag(image)
+			tag, err := c.GenerateTag(ctx, image)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, tag)
@@ -536,30 +536,30 @@ func TestGitCommitSubDirectory(t *testing.T) {
 
 		tagger, err := NewGitCommit("", "Tags", false)
 		t.CheckNoError(err)
-		tag, err := tagger.GenerateTag(image)
+		tag, err := tagger.GenerateTag(ctx, image)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("a7b32a6", tag)
 
 		tagger, err = NewGitCommit("", "CommitSha", false)
 		t.CheckNoError(err)
-		tag, err = tagger.GenerateTag(image)
+		tag, err = tagger.GenerateTag(ctx, image)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("a7b32a69335a6daa51bd89cc1bf30bd31df228ba", tag)
 
 		tagger, err = NewGitCommit("", "AbbrevCommitSha", false)
 		t.CheckNoError(err)
-		tag, err = tagger.GenerateTag(image)
+		tag, err = tagger.GenerateTag(ctx, image)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("a7b32a6", tag)
 
 		tagger, err = NewGitCommit("", "TreeSha", false)
 		t.CheckNoError(err)
-		_, err = tagger.GenerateTag(image)
+		_, err = tagger.GenerateTag(ctx, image)
 		t.CheckErrorAndDeepEqual(true, err, "a7b32a6", tag)
 
 		tagger, err = NewGitCommit("", "AbbrevTreeSha", false)
 		t.CheckNoError(err)
-		_, err = tagger.GenerateTag(image)
+		_, err = tagger.GenerateTag(ctx, image)
 		t.CheckErrorAndDeepEqual(true, err, "a7b32a6", tag)
 	})
 }
@@ -575,13 +575,13 @@ func TestPrefix(t *testing.T) {
 
 		tagger, err := NewGitCommit("tag-", "Tags", false)
 		t.CheckNoError(err)
-		tag, err := tagger.GenerateTag(image)
+		tag, err := tagger.GenerateTag(ctx, image)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("tag-a7b32a6", tag)
 
 		tagger, err = NewGitCommit("commit-", "CommitSha", false)
 		t.CheckNoError(err)
-		tag, err = tagger.GenerateTag(image)
+		tag, err = tagger.GenerateTag(ctx, image)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("commit-a7b32a69335a6daa51bd89cc1bf30bd31df228ba", tag)
 	})

--- a/pkg/skaffold/tag/git_commit_test.go
+++ b/pkg/skaffold/tag/git_commit_test.go
@@ -19,6 +19,7 @@ limitations under the License.
 package tag
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -399,7 +400,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 				tagger, err := NewGitCommit("", variant, test.ignoreChanges)
 				t.CheckNoError(err)
 
-				tag, err := tagger.GenerateTag(ctx, image)
+				tag, err := tagger.GenerateTag(context.Background(), image)
 
 				t.CheckErrorAndDeepEqual(test.shouldErr, err, expectedTag, tag)
 			}
@@ -461,7 +462,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 				tagger, err := NewGitCommit("", variant, false)
 				t.CheckNoError(err)
 
-				tag, err := GenerateFullyQualifiedImageName(ctx, tagger, image)
+				tag, err := GenerateFullyQualifiedImageName(context.Background(), tagger, image)
 
 				t.CheckErrorAndDeepEqual(test.shouldErr, err, expectedTag, tag)
 			}
@@ -517,7 +518,7 @@ func TestGitCommit_CustomTemplate(t *testing.T) {
 
 			t.CheckNoError(err)
 
-			tag, err := c.GenerateTag(ctx, image)
+			tag, err := c.GenerateTag(context.Background(), image)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, tag)
@@ -536,30 +537,30 @@ func TestGitCommitSubDirectory(t *testing.T) {
 
 		tagger, err := NewGitCommit("", "Tags", false)
 		t.CheckNoError(err)
-		tag, err := tagger.GenerateTag(ctx, image)
+		tag, err := tagger.GenerateTag(context.Background(), image)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("a7b32a6", tag)
 
 		tagger, err = NewGitCommit("", "CommitSha", false)
 		t.CheckNoError(err)
-		tag, err = tagger.GenerateTag(ctx, image)
+		tag, err = tagger.GenerateTag(context.Background(), image)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("a7b32a69335a6daa51bd89cc1bf30bd31df228ba", tag)
 
 		tagger, err = NewGitCommit("", "AbbrevCommitSha", false)
 		t.CheckNoError(err)
-		tag, err = tagger.GenerateTag(ctx, image)
+		tag, err = tagger.GenerateTag(context.Background(), image)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("a7b32a6", tag)
 
 		tagger, err = NewGitCommit("", "TreeSha", false)
 		t.CheckNoError(err)
-		_, err = tagger.GenerateTag(ctx, image)
+		_, err = tagger.GenerateTag(context.Background(), image)
 		t.CheckErrorAndDeepEqual(true, err, "a7b32a6", tag)
 
 		tagger, err = NewGitCommit("", "AbbrevTreeSha", false)
 		t.CheckNoError(err)
-		_, err = tagger.GenerateTag(ctx, image)
+		_, err = tagger.GenerateTag(context.Background(), image)
 		t.CheckErrorAndDeepEqual(true, err, "a7b32a6", tag)
 	})
 }
@@ -575,13 +576,13 @@ func TestPrefix(t *testing.T) {
 
 		tagger, err := NewGitCommit("tag-", "Tags", false)
 		t.CheckNoError(err)
-		tag, err := tagger.GenerateTag(ctx, image)
+		tag, err := tagger.GenerateTag(context.Background(), image)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("tag-a7b32a6", tag)
 
 		tagger, err = NewGitCommit("commit-", "CommitSha", false)
 		t.CheckNoError(err)
-		tag, err = tagger.GenerateTag(ctx, image)
+		tag, err = tagger.GenerateTag(context.Background(), image)
 		t.CheckNoError(err)
 		t.CheckDeepEqual("commit-a7b32a69335a6daa51bd89cc1bf30bd31df228ba", tag)
 	})

--- a/pkg/skaffold/tag/input_digest.go
+++ b/pkg/skaffold/tag/input_digest.go
@@ -46,10 +46,8 @@ func NewInputDigestTagger(cfg docker.Config, ag graph.ArtifactGraph) (Tagger, er
 	}, nil
 }
 
-func (t *inputDigestTagger) GenerateTag(image latestV1.Artifact) (string, error) {
+func (t *inputDigestTagger) GenerateTag(ctx context.Context, image latestV1.Artifact) (string, error) {
 	var inputs []string
-	// TODO(nkubala): plumb through context into Tagger interface
-	ctx := context.TODO()
 	srcFiles, err := t.cache.TransitiveArtifactDependencies(ctx, &image)
 	if err != nil {
 		return "", err

--- a/pkg/skaffold/tag/sha256.go
+++ b/pkg/skaffold/tag/sha256.go
@@ -17,6 +17,8 @@ limitations under the License.
 package tag
 
 import (
+	"context"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
@@ -25,7 +27,7 @@ import (
 type ChecksumTagger struct{}
 
 // GenerateTag returns either the current tag or `latest`.
-func (t *ChecksumTagger) GenerateTag(image latestV1.Artifact) (string, error) {
+func (t *ChecksumTagger) GenerateTag(ctx context.Context, image latestV1.Artifact) (string, error) {
 	parsed, err := docker.ParseReference(image.ImageName)
 	if err != nil {
 		return "", err

--- a/pkg/skaffold/tag/sha256_test.go
+++ b/pkg/skaffold/tag/sha256_test.go
@@ -30,26 +30,26 @@ func TestSha256_GenerateTag(t *testing.T) {
 		ImageName: "img:tag",
 	}
 
-	tag, err := c.GenerateTag(image)
+	tag, err := c.GenerateTag(ctx, image)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "", tag)
 
 	image.ImageName = "img"
-	tag, err = c.GenerateTag(image)
+	tag, err = c.GenerateTag(ctx, image)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "latest", tag)
 
 	image.ImageName = "registry.example.com:8080/img:tag"
-	tag, err = c.GenerateTag(image)
+	tag, err = c.GenerateTag(ctx, image)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "", tag)
 
 	image.ImageName = "registry.example.com:8080/img"
-	tag, err = c.GenerateTag(image)
+	tag, err = c.GenerateTag(ctx, image)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "latest", tag)
 
 	image.ImageName = "registry.example.com/img"
-	tag, err = c.GenerateTag(image)
+	tag, err = c.GenerateTag(ctx, image)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "latest", tag)
 
 	image.ImageName = "registry.example.com:8080:garbage"
-	tag, err = c.GenerateTag(image)
+	tag, err = c.GenerateTag(ctx, image)
 	testutil.CheckErrorAndDeepEqual(t, true, err, "", tag)
 }

--- a/pkg/skaffold/tag/sha256_test.go
+++ b/pkg/skaffold/tag/sha256_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"context"
 	"testing"
 
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -30,26 +31,26 @@ func TestSha256_GenerateTag(t *testing.T) {
 		ImageName: "img:tag",
 	}
 
-	tag, err := c.GenerateTag(ctx, image)
+	tag, err := c.GenerateTag(context.Background(), image)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "", tag)
 
 	image.ImageName = "img"
-	tag, err = c.GenerateTag(ctx, image)
+	tag, err = c.GenerateTag(context.Background(), image)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "latest", tag)
 
 	image.ImageName = "registry.example.com:8080/img:tag"
-	tag, err = c.GenerateTag(ctx, image)
+	tag, err = c.GenerateTag(context.Background(), image)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "", tag)
 
 	image.ImageName = "registry.example.com:8080/img"
-	tag, err = c.GenerateTag(ctx, image)
+	tag, err = c.GenerateTag(context.Background(), image)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "latest", tag)
 
 	image.ImageName = "registry.example.com/img"
-	tag, err = c.GenerateTag(ctx, image)
+	tag, err = c.GenerateTag(context.Background(), image)
 	testutil.CheckErrorAndDeepEqual(t, false, err, "latest", tag)
 
 	image.ImageName = "registry.example.com:8080:garbage"
-	tag, err = c.GenerateTag(ctx, image)
+	tag, err = c.GenerateTag(context.Background(), image)
 	testutil.CheckErrorAndDeepEqual(t, true, err, "", tag)
 }

--- a/pkg/skaffold/tag/tag.go
+++ b/pkg/skaffold/tag/tag.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"context"
 	"fmt"
 
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -28,14 +29,14 @@ type ImageTags map[string]string
 // Tagger is an interface for tag strategies to be implemented against
 type Tagger interface {
 	// GenerateTag generates a tag for an artifact.
-	GenerateTag(image latestV1.Artifact) (string, error)
+	GenerateTag(ctx context.Context, image latestV1.Artifact) (string, error)
 }
 
 // GenerateFullyQualifiedImageName resolves the fully qualified image name for an artifact.
 // The workingDir is the root directory of the artifact with respect to the Skaffold root,
 // and imageName is the base name of the image.
-func GenerateFullyQualifiedImageName(t Tagger, image latestV1.Artifact) (string, error) {
-	tag, err := t.GenerateTag(image)
+func GenerateFullyQualifiedImageName(ctx context.Context, t Tagger, image latestV1.Artifact) (string, error) {
+	tag, err := t.GenerateTag(ctx, image)
 	if err != nil {
 		return "", fmt.Errorf("generating tag: %w", err)
 	}

--- a/pkg/skaffold/tag/tag_test.go
+++ b/pkg/skaffold/tag/tag_test.go
@@ -108,7 +108,7 @@ func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 				ImageName: test.imageName,
 			}
 
-			tag, err := GenerateFullyQualifiedImageName(test.tagger, image)
+			tag, err := GenerateFullyQualifiedImageName(ctx, test.tagger, image)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, tag)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
 		})

--- a/pkg/skaffold/tag/tag_test.go
+++ b/pkg/skaffold/tag/tag_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -108,7 +109,7 @@ func TestTagger_GenerateFullyQualifiedImageName(t *testing.T) {
 				ImageName: test.imageName,
 			}
 
-			tag, err := GenerateFullyQualifiedImageName(ctx, test.tagger, image)
+			tag, err := GenerateFullyQualifiedImageName(context.Background(), test.tagger, image)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, tag)
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
 		})

--- a/pkg/skaffold/tag/tagger_mux.go
+++ b/pkg/skaffold/tag/tagger_mux.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tag
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
@@ -29,12 +30,12 @@ type TaggerMux struct {
 	byImageName map[string]Tagger
 }
 
-func (t *TaggerMux) GenerateTag(image latestV1.Artifact) (string, error) {
+func (t *TaggerMux) GenerateTag(ctx context.Context, image latestV1.Artifact) (string, error) {
 	tagger, found := t.byImageName[image.ImageName]
 	if !found {
 		return "", fmt.Errorf("no valid tagger found for artifact: %q", image.ImageName)
 	}
-	return tagger.GenerateTag(image)
+	return tagger.GenerateTag(ctx, image)
 }
 
 func NewTaggerMux(runCtx *runcontext.RunContext) (Tagger, error) {

--- a/pkg/skaffold/test/custom/custom_test.go
+++ b/pkg/skaffold/test/custom/custom_test.go
@@ -43,7 +43,7 @@ func TestNewCustomTestRunner(t *testing.T) {
 		} else {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRun("sh -c echo Running Custom Test command."))
 		}
-		t.Override(&docker.NewAPIClient, func(cfg docker.Config) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 			return fakeLocalDaemonWithExtraEnv([]string{}), nil
 		})
 
@@ -116,7 +116,7 @@ func TestCustomCommandError(t *testing.T) {
 				command = test.expectedWindowsCmd
 			}
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunErr(command, fmt.Errorf(test.expectedError)))
-			t.Override(&docker.NewAPIClient, func(cfg docker.Config) (docker.LocalDaemon, error) {
+			t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 				return fakeLocalDaemonWithExtraEnv([]string{}), nil
 			})
 
@@ -181,7 +181,7 @@ func TestTestDependenciesCommand(t *testing.T) {
 		expected := []string{"file1", "file2", "file3"}
 		testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, custom)
 		t.CheckNoError(err)
-		deps, err := testRunner.TestDependencies(ctx)
+		deps, err := testRunner.TestDependencies(context.Background())
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(expected, deps)
@@ -252,7 +252,7 @@ func TestTestDependenciesPaths(t *testing.T) {
 
 			testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, custom)
 			t.CheckNoError(err)
-			deps, err := testRunner.TestDependencies(ctx)
+			deps, err := testRunner.TestDependencies(context.Background())
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, deps)
 		})
@@ -298,7 +298,7 @@ func TestGetEnv(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.OSEnviron, func() []string { return test.environ })
 			t.Override(&testContext, func(string) (string, error) { return test.testContext, nil })
-			t.Override(&docker.NewAPIClient, func(cfg docker.Config) (docker.LocalDaemon, error) {
+			t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 				return fakeLocalDaemonWithExtraEnv(test.extraEnv), nil
 			})
 			tmpDir := t.NewTempDir().Touch("test.yaml")
@@ -320,7 +320,7 @@ func TestGetEnv(t *testing.T) {
 
 			testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, custom)
 			t.CheckNoError(err)
-			actual, err := testRunner.getEnv(ctx, test.tag)
+			actual, err := testRunner.getEnv(context.Background(), test.tag)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)

--- a/pkg/skaffold/test/custom/custom_test.go
+++ b/pkg/skaffold/test/custom/custom_test.go
@@ -181,7 +181,7 @@ func TestTestDependenciesCommand(t *testing.T) {
 		expected := []string{"file1", "file2", "file3"}
 		testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, custom)
 		t.CheckNoError(err)
-		deps, err := testRunner.TestDependencies()
+		deps, err := testRunner.TestDependencies(ctx)
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(expected, deps)
@@ -252,7 +252,7 @@ func TestTestDependenciesPaths(t *testing.T) {
 
 			testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, custom)
 			t.CheckNoError(err)
-			deps, err := testRunner.TestDependencies()
+			deps, err := testRunner.TestDependencies(ctx)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, deps)
 		})
@@ -320,7 +320,7 @@ func TestGetEnv(t *testing.T) {
 
 			testRunner, err := New(cfg, testCase.ImageName, testCase.Workspace, custom)
 			t.CheckNoError(err)
-			actual, err := testRunner.getEnv(test.tag)
+			actual, err := testRunner.getEnv(ctx, test.tag)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expected, actual)

--- a/pkg/skaffold/test/structure/structure.go
+++ b/pkg/skaffold/test/structure/structure.go
@@ -40,8 +40,8 @@ type Runner struct {
 }
 
 // New creates a new structure.Runner.
-func New(cfg docker.Config, tc *latestV1.TestCase, imageIsLocal bool) (*Runner, error) {
-	localDaemon, err := docker.NewAPIClient(cfg)
+func New(ctx context.Context, cfg docker.Config, tc *latestV1.TestCase, imageIsLocal bool) (*Runner, error) {
+	localDaemon, err := docker.NewAPIClient(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func (cst *Runner) runStructureTests(ctx context.Context, out io.Writer, imageTa
 		}
 	}
 
-	files, err := cst.TestDependencies()
+	files, err := cst.TestDependencies(ctx)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (cst *Runner) runStructureTests(ctx context.Context, out io.Writer, imageTa
 	cmd.Stderr = out
 	cmd.Env = cst.env()
 
-	if err := util.RunCmd(cmd); err != nil {
+	if err := util.RunCmd(ctx, cmd); err != nil {
 		return fmt.Errorf("error running container-structure-test command: %w", err)
 	}
 
@@ -101,7 +101,7 @@ func (cst *Runner) runStructureTests(ctx context.Context, out io.Writer, imageTa
 }
 
 // TestDependencies returns dependencies listed for the structure tests
-func (cst *Runner) TestDependencies() ([]string, error) {
+func (cst *Runner) TestDependencies(context.Context) ([]string, error) {
 	files, err := util.ExpandPathsGlob(cst.workspace, cst.structureTests)
 	if err != nil {
 		return nil, expandingFilePathsErr(err)

--- a/pkg/skaffold/test/structure/structure_test.go
+++ b/pkg/skaffold/test/structure/structure_test.go
@@ -37,7 +37,7 @@ import (
 func TestNewRunner(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		tmpDir := t.NewTempDir().Touch("test.yaml")
-		t.Override(&cluster.FindMinikubeBinary, func() (string, semver.Version, error) { return "", semver.Version{}, errors.New("not found") })
+		t.Override(&cluster.FindMinikubeBinary, func(context.Context) (string, semver.Version, error) { return "", semver.Version{}, errors.New("not found") })
 
 		t.Override(&util.DefaultExecCommand, testutil.CmdRun("container-structure-test test -v warn --image image:tag --config "+tmpDir.Path("test.yaml")))
 
@@ -50,7 +50,7 @@ func TestNewRunner(t *testing.T) {
 
 		testEvent.InitializeState([]latestV1.Pipeline{{}})
 
-		testRunner, err := New(ctx, cfg, testCase, true)
+		testRunner, err := New(context.Background(), cfg, testCase, true)
 		t.CheckNoError(err)
 		err = testRunner.Test(context.Background(), ioutil.Discard, "image:tag")
 		t.CheckNoError(err)
@@ -60,7 +60,7 @@ func TestNewRunner(t *testing.T) {
 func TestIgnoreDockerNotFound(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		tmpDir := t.NewTempDir().Touch("test.yaml")
-		t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) {
+		t.Override(&docker.NewAPIClient, func(context.Context, docker.Config) (docker.LocalDaemon, error) {
 			return nil, errors.New("not found")
 		})
 
@@ -71,7 +71,7 @@ func TestIgnoreDockerNotFound(t *testing.T) {
 		}
 		cfg := &mockConfig{tests: []*latestV1.TestCase{testCase}}
 
-		testRunner, err := New(ctx, cfg, testCase, true)
+		testRunner, err := New(context.Background(), cfg, testCase, true)
 		t.CheckError(true, err)
 		t.CheckNil(testRunner)
 	})
@@ -99,7 +99,7 @@ func TestCustomParams(t *testing.T) {
 	for _, tc := range testCases {
 		testutil.Run(t, "", func(t *testutil.T) {
 			tmpDir := t.NewTempDir().Touch("test.yaml")
-			t.Override(&cluster.FindMinikubeBinary, func() (string, semver.Version, error) { return "", semver.Version{}, errors.New("not found") })
+			t.Override(&cluster.FindMinikubeBinary, func(context.Context) (string, semver.Version, error) { return "", semver.Version{}, errors.New("not found") })
 
 			expected := "container-structure-test test -v warn --image image:tag --config " + tmpDir.Path("test.yaml")
 			if len(tc.expectedExtras) > 0 {
@@ -117,7 +117,7 @@ func TestCustomParams(t *testing.T) {
 
 			testEvent.InitializeState([]latestV1.Pipeline{{}})
 
-			testRunner, err := New(ctx, cfg, testCase, true)
+			testRunner, err := New(context.Background(), cfg, testCase, true)
 			t.CheckNoError(err)
 			err = testRunner.Test(context.Background(), ioutil.Discard, "image:tag")
 			t.CheckNoError(err)

--- a/pkg/skaffold/test/structure/structure_test.go
+++ b/pkg/skaffold/test/structure/structure_test.go
@@ -37,7 +37,9 @@ import (
 func TestNewRunner(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		tmpDir := t.NewTempDir().Touch("test.yaml")
-		t.Override(&cluster.FindMinikubeBinary, func(context.Context) (string, semver.Version, error) { return "", semver.Version{}, errors.New("not found") })
+		t.Override(&cluster.FindMinikubeBinary, func(context.Context) (string, semver.Version, error) {
+			return "", semver.Version{}, errors.New("not found")
+		})
 
 		t.Override(&util.DefaultExecCommand, testutil.CmdRun("container-structure-test test -v warn --image image:tag --config "+tmpDir.Path("test.yaml")))
 
@@ -99,7 +101,9 @@ func TestCustomParams(t *testing.T) {
 	for _, tc := range testCases {
 		testutil.Run(t, "", func(t *testutil.T) {
 			tmpDir := t.NewTempDir().Touch("test.yaml")
-			t.Override(&cluster.FindMinikubeBinary, func(context.Context) (string, semver.Version, error) { return "", semver.Version{}, errors.New("not found") })
+			t.Override(&cluster.FindMinikubeBinary, func(context.Context) (string, semver.Version, error) {
+				return "", semver.Version{}, errors.New("not found")
+			})
 
 			expected := "container-structure-test test -v warn --image image:tag --config " + tmpDir.Path("test.yaml")
 			if len(tc.expectedExtras) > 0 {

--- a/pkg/skaffold/test/structure/structure_test.go
+++ b/pkg/skaffold/test/structure/structure_test.go
@@ -50,7 +50,7 @@ func TestNewRunner(t *testing.T) {
 
 		testEvent.InitializeState([]latestV1.Pipeline{{}})
 
-		testRunner, err := New(cfg, testCase, true)
+		testRunner, err := New(ctx, cfg, testCase, true)
 		t.CheckNoError(err)
 		err = testRunner.Test(context.Background(), ioutil.Discard, "image:tag")
 		t.CheckNoError(err)
@@ -71,7 +71,7 @@ func TestIgnoreDockerNotFound(t *testing.T) {
 		}
 		cfg := &mockConfig{tests: []*latestV1.TestCase{testCase}}
 
-		testRunner, err := New(cfg, testCase, true)
+		testRunner, err := New(ctx, cfg, testCase, true)
 		t.CheckError(true, err)
 		t.CheckNil(testRunner)
 	})
@@ -117,7 +117,7 @@ func TestCustomParams(t *testing.T) {
 
 			testEvent.InitializeState([]latestV1.Pipeline{{}})
 
-			testRunner, err := New(cfg, testCase, true)
+			testRunner, err := New(ctx, cfg, testCase, true)
 			t.CheckNoError(err)
 			err = testRunner.Test(context.Background(), ioutil.Discard, "image:tag")
 			t.CheckNoError(err)

--- a/pkg/skaffold/test/test_factory.go
+++ b/pkg/skaffold/test/test_factory.go
@@ -44,8 +44,8 @@ type Config interface {
 // NewTester parses the provided test cases from the Skaffold config,
 // and returns a Tester instance with all the necessary test runners
 // to run all specified tests.
-func NewTester(cfg Config, imagesAreLocal func(imageName string) (bool, error)) (Tester, error) {
-	testers, err := getImageTesters(cfg, imagesAreLocal, cfg.TestCases())
+func NewTester(ctx context.Context, cfg Config, imagesAreLocal func(imageName string) (bool, error)) (Tester, error) {
+	testers, err := getImageTesters(ctx, cfg, imagesAreLocal, cfg.TestCases())
 	if err != nil {
 		return nil, err
 	}
@@ -57,10 +57,10 @@ func NewTester(cfg Config, imagesAreLocal func(imageName string) (bool, error)) 
 }
 
 // TestDependencies returns the watch dependencies for the target artifact to the runner.
-func (t FullTester) TestDependencies(artifact *latestV1.Artifact) ([]string, error) {
+func (t FullTester) TestDependencies(ctx context.Context, artifact *latestV1.Artifact) ([]string, error) {
 	var deps []string
 	for _, tester := range t.Testers[artifact.ImageName] {
-		result, err := tester.TestDependencies()
+		result, err := tester.TestDependencies(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -127,7 +127,7 @@ func (t FullTester) runTests(ctx context.Context, out io.Writer, bRes []graph.Ar
 	return nil
 }
 
-func getImageTesters(cfg docker.Config, imagesAreLocal func(imageName string) (bool, error), tcs []*latestV1.TestCase) (ImageTesters, error) {
+func getImageTesters(ctx context.Context, cfg docker.Config, imagesAreLocal func(imageName string) (bool, error), tcs []*latestV1.TestCase) (ImageTesters, error) {
 	runners := make(map[string][]ImageTester)
 	for _, tc := range tcs {
 		isLocal, err := imagesAreLocal(tc.ImageName)
@@ -136,7 +136,7 @@ func getImageTesters(cfg docker.Config, imagesAreLocal func(imageName string) (b
 		}
 
 		if len(tc.StructureTests) != 0 {
-			structureRunner, err := structure.New(cfg, tc, isLocal)
+			structureRunner, err := structure.New(ctx, cfg, tc, isLocal)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/skaffold/test/test_factory_test.go
+++ b/pkg/skaffold/test/test_factory_test.go
@@ -42,9 +42,9 @@ func TestNoTestDependencies(t *testing.T) {
 		t.Override(&docker.NewAPIClient, func(docker.Config) (docker.LocalDaemon, error) { return nil, nil })
 
 		cfg := &mockConfig{}
-		tester, err := NewTester(cfg, func(imageName string) (bool, error) { return true, nil })
+		tester, err := NewTester(ctx, cfg, func(imageName string) (bool, error) { return true, nil })
 		t.CheckNoError(err)
-		deps, err := tester.TestDependencies(&latestV1.Artifact{ImageName: "foo"})
+		deps, err := tester.TestDependencies(ctx, &latestV1.Artifact{ImageName: "foo"})
 		t.CheckNoError(err)
 		t.CheckEmpty(deps)
 	})
@@ -62,9 +62,9 @@ func TestTestDependencies(t *testing.T) {
 			},
 		}
 
-		tester, err := NewTester(cfg, func(imageName string) (bool, error) { return true, nil })
+		tester, err := NewTester(ctx, cfg, func(imageName string) (bool, error) { return true, nil })
 		t.CheckNoError(err)
-		deps, err := tester.TestDependencies(&latestV1.Artifact{ImageName: "foo"})
+		deps, err := tester.TestDependencies(ctx, &latestV1.Artifact{ImageName: "foo"})
 
 		expectedDeps := tmpDir.Paths("tests/test1.yaml", "tests/test2.yaml", "test3.yaml")
 		t.CheckNoError(err)
@@ -81,10 +81,10 @@ func TestWrongPattern(t *testing.T) {
 			}},
 		}
 
-		tester, err := NewTester(cfg, func(imageName string) (bool, error) { return true, nil })
+		tester, err := NewTester(ctx, cfg, func(imageName string) (bool, error) { return true, nil })
 		t.CheckNoError(err)
 
-		_, err = tester.TestDependencies(&latestV1.Artifact{ImageName: "image"})
+		_, err = tester.TestDependencies(ctx, &latestV1.Artifact{ImageName: "image"})
 		t.CheckError(true, err)
 		testEvent.InitializeState([]latestV1.Pipeline{{}})
 
@@ -100,7 +100,7 @@ func TestNoTest(t *testing.T) {
 	testutil.Run(t, "", func(t *testutil.T) {
 		cfg := &mockConfig{}
 
-		tester, err := NewTester(cfg, func(imageName string) (bool, error) { return true, nil })
+		tester, err := NewTester(ctx, cfg, func(imageName string) (bool, error) { return true, nil })
 		t.CheckNoError(err)
 
 		err = tester.Test(context.Background(), ioutil.Discard, nil)
@@ -139,7 +139,7 @@ func TestTestSuccess(t *testing.T) {
 		}
 
 		imagesAreLocal := true
-		tester, err := NewTester(cfg, func(imageName string) (bool, error) { return imagesAreLocal, nil })
+		tester, err := NewTester(ctx, cfg, func(imageName string) (bool, error) { return imagesAreLocal, nil })
 		t.CheckNoError(err)
 		err = tester.Test(context.Background(), ioutil.Discard, []graph.Artifact{{
 			ImageName: "image",
@@ -165,7 +165,7 @@ func TestTestSuccessRemoteImage(t *testing.T) {
 		}
 
 		imagesAreLocal := false
-		tester, err := NewTester(cfg, func(imageName string) (bool, error) { return imagesAreLocal, nil })
+		tester, err := NewTester(ctx, cfg, func(imageName string) (bool, error) { return imagesAreLocal, nil })
 		t.CheckNoError(err)
 
 		err = tester.Test(context.Background(), ioutil.Discard, []graph.Artifact{{
@@ -193,7 +193,7 @@ func TestTestFailureRemoteImage(t *testing.T) {
 		}
 
 		imagesAreLocal := false
-		tester, err := NewTester(cfg, func(imageName string) (bool, error) { return imagesAreLocal, nil })
+		tester, err := NewTester(ctx, cfg, func(imageName string) (bool, error) { return imagesAreLocal, nil })
 		t.CheckNoError(err)
 
 		err = tester.Test(context.Background(), ioutil.Discard, []graph.Artifact{{
@@ -223,7 +223,7 @@ func TestTestFailure(t *testing.T) {
 			},
 		}
 
-		tester, err := NewTester(cfg, func(imageName string) (bool, error) { return true, nil })
+		tester, err := NewTester(ctx, cfg, func(imageName string) (bool, error) { return true, nil })
 		t.CheckNoError(err)
 
 		err = tester.Test(context.Background(), ioutil.Discard, []graph.Artifact{{
@@ -251,7 +251,7 @@ func TestTestMuted(t *testing.T) {
 		}
 
 		var buf bytes.Buffer
-		tester, err := NewTester(cfg, func(imageName string) (bool, error) { return true, nil })
+		tester, err := NewTester(ctx, cfg, func(imageName string) (bool, error) { return true, nil })
 		t.CheckNoError(err)
 
 		err = tester.Test(context.Background(), &buf, []graph.Artifact{{

--- a/pkg/skaffold/test/types.go
+++ b/pkg/skaffold/test/types.go
@@ -30,7 +30,7 @@ import (
 // a single test run.
 type Tester interface {
 	Test(context.Context, io.Writer, []graph.Artifact) error
-	TestDependencies(*latestV1.Artifact) ([]string, error)
+	TestDependencies(ctx context.Context, artifact *latestV1.Artifact) ([]string, error)
 }
 
 type Muted interface {
@@ -56,7 +56,7 @@ type FullTester struct {
 type ImageTester interface {
 	Test(ctx context.Context, out io.Writer, tag string) error
 
-	TestDependencies() ([]string, error)
+	TestDependencies(ctx context.Context) ([]string, error)
 }
 
 // ImageTesters is a collection of imageTester interfaces grouped by the target image name

--- a/pkg/skaffold/util/cmd.go
+++ b/pkg/skaffold/util/cmd.go
@@ -53,24 +53,24 @@ var DefaultExecCommand Command = &Commander{}
 // Command is an interface used to run commands. All packages should use this
 // interface instead of calling exec.Cmd directly.
 type Command interface {
-	RunCmdOut(cmd *exec.Cmd) ([]byte, error)
-	RunCmd(cmd *exec.Cmd) error
+	RunCmdOut(ctx context.Context, cmd *exec.Cmd) ([]byte, error)
+	RunCmd(ctx context.Context, cmd *exec.Cmd) error
 }
 
-func RunCmdOut(cmd *exec.Cmd) ([]byte, error) {
-	return DefaultExecCommand.RunCmdOut(cmd)
+func RunCmdOut(ctx context.Context, cmd *exec.Cmd) ([]byte, error) {
+	return DefaultExecCommand.RunCmdOut(ctx, cmd)
 }
 
-func RunCmd(cmd *exec.Cmd) error {
-	return DefaultExecCommand.RunCmd(cmd)
+func RunCmd(ctx context.Context, cmd *exec.Cmd) error {
+	return DefaultExecCommand.RunCmd(ctx, cmd)
 }
 
 // Commander is the exec.Cmd implementation of the Command interface
 type Commander struct{}
 
 // RunCmdOut runs an exec.Command and returns the stdout and error.
-func (*Commander) RunCmdOut(cmd *exec.Cmd) ([]byte, error) {
-	log.Entry(context.Background()).Debugf("Running command: %s", cmd.Args)
+func (*Commander) RunCmdOut(ctx context.Context, cmd *exec.Cmd) ([]byte, error) {
+	log.Entry(ctx).Debugf("Running command: %s", cmd.Args)
 
 	stdout := bytes.Buffer{}
 	cmd.Stdout = &stdout
@@ -91,16 +91,16 @@ func (*Commander) RunCmdOut(cmd *exec.Cmd) ([]byte, error) {
 	}
 
 	if stderr.Len() > 0 {
-		log.Entry(context.Background()).Debugf("Command output: [%s], stderr: %s", stdout.String(), stderr.String())
+		log.Entry(ctx).Debugf("Command output: [%s], stderr: %s", stdout.String(), stderr.String())
 	} else {
-		log.Entry(context.Background()).Debugf("Command output: [%s]", stdout.String())
+		log.Entry(ctx).Debugf("Command output: [%s]", stdout.String())
 	}
 
 	return stdout.Bytes(), nil
 }
 
 // RunCmd runs an exec.Command.
-func (*Commander) RunCmd(cmd *exec.Cmd) error {
-	log.Entry(context.Background()).Debugf("Running command: %s", cmd.Args)
+func (*Commander) RunCmd(ctx context.Context, cmd *exec.Cmd) error {
+	log.Entry(ctx).Debugf("Running command: %s", cmd.Args)
 	return cmd.Run()
 }

--- a/pkg/skaffold/util/cmd_test.go
+++ b/pkg/skaffold/util/cmd_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -90,7 +91,7 @@ func TestCmd_RunCmdOut(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			got, err := RunCmdOut(ctx, test.cmd)
+			got, err := RunCmdOut(context.Background(), test.cmd)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.want, string(got))
 		})

--- a/pkg/skaffold/util/cmd_test.go
+++ b/pkg/skaffold/util/cmd_test.go
@@ -90,7 +90,7 @@ func TestCmd_RunCmdOut(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			got, err := RunCmdOut(test.cmd)
+			got, err := RunCmdOut(ctx, test.cmd)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.want, string(got))
 		})

--- a/pkg/skaffold/util/gsutil.go
+++ b/pkg/skaffold/util/gsutil.go
@@ -36,7 +36,7 @@ func (g *Gsutil) Copy(ctx context.Context, src, dst string, recursive bool) erro
 	}
 	args = append(args, src, dst)
 	cmd := exec.CommandContext(ctx, GsutilExec, args...)
-	out, err := RunCmdOut(cmd)
+	out, err := RunCmdOut(ctx, cmd)
 	if err != nil {
 		return fmt.Errorf("copy file(s) with %s failed: %w", GsutilExec, err)
 	}

--- a/pkg/skaffold/util/term.go
+++ b/pkg/skaffold/util/term.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os/exec"
@@ -43,13 +44,13 @@ func IsTerminal(w io.Writer) (uintptr, bool) {
 	return 0, false
 }
 
-func SupportsColor() (bool, error) {
+func SupportsColor(ctx context.Context) (bool, error) {
 	if runtime.GOOS == constants.Windows {
 		return true, nil
 	}
 
 	cmd := exec.Command("tput", "colors")
-	res, err := RunCmdOut(cmd)
+	res, err := RunCmdOut(ctx, cmd)
 	if err != nil {
 		return false, fmt.Errorf("checking terminal colors: %w", err)
 	}

--- a/pkg/skaffold/util/term_test.go
+++ b/pkg/skaffold/util/term_test.go
@@ -77,7 +77,7 @@ func TestSupportsColor(t *testing.T) {
 				test.shouldErr = false
 			}
 
-			supportsColors, err := SupportsColor()
+			supportsColors, err := SupportsColor(ctx)
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, supportsColors)
 		})
 	}

--- a/pkg/skaffold/util/term_test.go
+++ b/pkg/skaffold/util/term_test.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"runtime"
 	"testing"
@@ -77,7 +78,7 @@ func TestSupportsColor(t *testing.T) {
 				test.shouldErr = false
 			}
 
-			supportsColors, err := SupportsColor(ctx)
+			supportsColors, err := SupportsColor(context.Background())
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, supportsColors)
 		})
 	}

--- a/testutil/cmd_helper.go
+++ b/testutil/cmd_helper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testutil
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"os/exec"
@@ -154,7 +155,7 @@ func (c *FakeCmd) AndRunEnv(command string, env []string) *FakeCmd {
 	})
 }
 
-func (c *FakeCmd) RunCmdOut(cmd *exec.Cmd) ([]byte, error) {
+func (c *FakeCmd) RunCmdOut(ctx context.Context, cmd *exec.Cmd) ([]byte, error) {
 	c.timesCalled++
 	command := strings.Join(cmd.Args, " ")
 
@@ -180,7 +181,7 @@ func (c *FakeCmd) RunCmdOut(cmd *exec.Cmd) ([]byte, error) {
 	return r.output, r.err
 }
 
-func (c *FakeCmd) RunCmd(cmd *exec.Cmd) error {
+func (c *FakeCmd) RunCmd(ctx context.Context, cmd *exec.Cmd) error {
 	c.timesCalled++
 	command := strings.Join(cmd.Args, " ")
 


### PR DESCRIPTION
Related: #5368 

**Description**
This PR plumbs `context.Context` parameter into functions in order to have a `context.Context` variable in `util.RunCmd` and related functions
