### PR TITLE
Wrap tester in `SkaffoldRunner` to improve `SkaffoldLogEvent` labelling

### DIFF
--- a/pkg/skaffold/runner/v1/dev.go
+++ b/pkg/skaffold/runner/v1/dev.go
@@ -259,7 +259,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	for i := range artifacts {
 		artifact := artifacts[i]
 		if err := r.monitor.Register(
-			func() ([]string, error) { return r.Tester.TestDependencies(artifact) },
+			func() ([]string, error) { return r.tester.TestDependencies(artifact) },
 			func(filemon.Events) { r.changeSet.AddRetest(artifact) },
 		); err != nil {
 			event.DevLoopFailedWithErrorCode(r.devIteration, proto.StatusCode_DEVINIT_REGISTER_TEST_DEPS, err)

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -124,7 +124,7 @@ func NewForConfig(runCtx *runcontext.RunContext) (*SkaffoldRunner, error) {
 	return &SkaffoldRunner{
 		Builder:            *rbuilder,
 		Pruner:             runner.Pruner{Builder: builder},
-		Tester:             tester,
+		tester:             tester,
 		deployer:           deployer,
 		monitor:            monitor,
 		listener:           runner.NewSkaffoldListener(monitor, rtrigger, sourceDependencies, intentChan),

--- a/pkg/skaffold/runner/v1/runner.go
+++ b/pkg/skaffold/runner/v1/runner.go
@@ -31,7 +31,7 @@ import (
 type SkaffoldRunner struct {
 	runner.Builder
 	runner.Pruner
-	test.Tester
+	tester test.Tester
 
 	deployer deploy.Deployer
 	monitor  filemon.Monitor

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -287,7 +287,7 @@ func createRunner(t *testutil.T, testBench *TestBench, monitor filemon.Monitor, 
 
 	// TODO(yuwenma):builder.builder looks weird. Avoid the nested struct.
 	runner.Builder.Builder = testBench
-	runner.Tester = testBench
+	runner.tester = testBench
 	runner.deployer = testBench
 	runner.listener = testBench
 	runner.monitor = monitor
@@ -463,7 +463,7 @@ func TestNewForConfig(t *testing.T) {
 				} else {
 					t.CheckNoError(err)
 					t.CheckTypeEquality(b, cfg.Pruner.Builder)
-					t.CheckTypeEquality(_t, cfg.Tester)
+					t.CheckTypeEquality(_t, cfg.tester)
 					t.CheckTypeEquality(d, cfg.deployer)
 				}
 			}

--- a/pkg/skaffold/runner/v1/test.go
+++ b/pkg/skaffold/runner/v1/test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+)
+
+func (r *SkaffoldRunner) Test(ctx context.Context, out io.Writer, artifacts []graph.Artifact) error {
+	eventV2.TaskInProgress(constants.Test, "Test")
+	out, ctx = output.WithEventContext(ctx, out, constants.Test, constants.SubtaskIDNone)
+
+	if err := r.tester.Test(ctx, out, artifacts); err != nil {
+		eventV2.TaskFailed(constants.Test, err)
+		return err
+	}
+
+	eventV2.TaskSucceeded(constants.Test)
+	return nil
+}

--- a/pkg/skaffold/test/test_factory.go
+++ b/pkg/skaffold/test/test_factory.go
@@ -23,7 +23,6 @@ import (
 	"io"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
@@ -76,7 +75,6 @@ func (t FullTester) Test(ctx context.Context, out io.Writer, bRes []graph.Artifa
 		return nil
 	}
 
-	eventV2.TaskInProgress(constants.Test, "")
 	output.Default.Fprintln(out, "Testing images...")
 
 	if t.muted.MuteTest() {
@@ -103,11 +101,9 @@ func (t FullTester) Test(ctx context.Context, out io.Writer, bRes []graph.Artifa
 	}
 
 	if err := t.runTests(ctx, out, bRes); err != nil {
-		eventV2.TaskFailed(constants.Test, err)
 		return err
 	}
 
-	eventV2.TaskSucceeded(constants.Test)
 	return nil
 }
 


### PR DESCRIPTION
Fixes: #5368 

**Description**
This PR adds proper labelling of `SkaffoldLogEvent`s that come from Skaffold's testing phase. I've also added a `Test` function onto the `SkaffoldRunner` rather than embedding a tester. This allows us to use `output.WithEventContext` in a way that's more consistent with how we use it for build and deploy phases.

`SkaffoldLogEvent`s starting from `Starting Test...` up to, but not including, `Tags used in deployment` should now have proper task information set.

Tests were not added for `SkaffoldRunner.Test` as there is no real logic there, it's simply calling the underlying data structures Test function.
