### PR TITLE
Fix skaffold inspect tests flags and help message

### DIFF
--- a/cmd/skaffold/app/cmd/inspect_tests.go
+++ b/cmd/skaffold/app/cmd/inspect_tests.go
@@ -30,7 +30,6 @@ import (
 func cmdTests() *cobra.Command {
 	return NewCmd("tests").
 		WithDescription("View skaffold test information").
-		WithPersistentFlagAdder(cmdTestsFlags).
 		WithCommands(cmdTestsList())
 }
 
@@ -39,6 +38,7 @@ func cmdTestsList() *cobra.Command {
 		WithExample("Get list of tests", "inspect tests list --format json").
 		WithExample("Get list of tests targeting a specific configuration", "inspect tests list --profile local --format json").
 		WithDescription("Print the list of tests that would be run for a given configuration (default skaffold configuration, specific module, specific profile, etc).").
+		WithFlagAdder(cmdTestsListFlags).
 		NoArgs(listTests)
 }
 
@@ -48,10 +48,11 @@ func listTests(ctx context.Context, out io.Writer) error {
 		RepoCacheDir: inspectFlags.repoCacheDir,
 		OutFormat:    inspectFlags.outFormat,
 		Modules:      inspectFlags.modules,
+		TestsOptions: inspect.TestsOptions{TestsProfiles: inspectFlags.profiles},
 	})
 }
 
-func cmdTestsFlags(f *pflag.FlagSet) {
-	f.StringSliceVarP(&inspectFlags.modules, "module", "m", nil, "Names of modules to filter target action by.")
+func cmdTestsListFlags(f *pflag.FlagSet) {
 	f.StringSliceVarP(&inspectFlags.profiles, "profile", "p", nil, `Profile names to activate`)
+	f.StringSliceVarP(&inspectFlags.modules, "module", "m", nil, "Names of modules to filter target action by.")
 }

--- a/pkg/skaffold/inspect/tests/list.go
+++ b/pkg/skaffold/inspect/tests/list.go
@@ -36,7 +36,12 @@ type structureTestEntry struct {
 
 func PrintTestsList(ctx context.Context, out io.Writer, opts inspect.Options) error {
 	formatter := inspect.OutputFormatter(out, opts.OutFormat)
-	cfgs, err := inspect.GetConfigSet(ctx, config.SkaffoldOptions{ConfigurationFile: opts.Filename, ConfigurationFilter: opts.Modules, RepoCacheDir: opts.RepoCacheDir})
+	cfgs, err := inspect.GetConfigSet(ctx, config.SkaffoldOptions{
+		ConfigurationFile:   opts.Filename,
+		ConfigurationFilter: opts.Modules,
+		RepoCacheDir:        opts.RepoCacheDir,
+		Profiles:            opts.TestsProfiles,
+	})
 	if err != nil {
 		return formatter.WriteErr(err)
 	}

--- a/pkg/skaffold/inspect/types.go
+++ b/pkg/skaffold/inspect/types.go
@@ -37,6 +37,15 @@ type Options struct {
 	ModulesOptions
 	ProfilesOptions
 	BuildEnvOptions
+	TestsOptions
+}
+
+// TestsOptions holds flag values for various `skaffold inspect tests` commands
+type TestsOptions struct {
+	// Profiles is the slice of profile names to activate.
+	TestsProfiles []string
+	// Profile is a target profile to create or edit
+	TestsProfile string
 }
 
 // ModulesOptions holds flag values for various `skaffold inspect modules` commands


### PR DESCRIPTION
skaffold inspect tests did not display its flag in its help message initially, the changes here fix this.  Additionally the profile and modules flags were not wired up/plumbed properly initially.  They are now tested and working as expected