### PR TITLE
Add `Dir` config field to ko builder

### DIFF
--- a/docs/design_proposals/ko-builder.md
+++ b/docs/design_proposals/ko-builder.md
@@ -244,6 +244,27 @@ build:
 The `target` field is ignored if the `image` field starts with the `ko://`
 scheme prefix.
 
+## Debugging ko images using Skaffold
+
+Ko provides the
+[`DisableOptimizations`](https://github.com/google/ko/blob/780c2812926cd706423e2ba65aeb1beb842c04af/pkg/commands/options/build.go#L34)
+build option to
+[set `gcflags` to disable optimizations and inlining](https://github.com/google/ko/blob/335c1ac8a6fdcc5eb0bb26579e4b44b4c62a9565/pkg/build/gobuild.go#L709-L712).
+The ko builder will set `DisableOptimizations` to `true` when the Skaffold
+`runMode` is `Debug`.
+
+Skaffold can
+[recognize Go-based container images](https://skaffold.dev/docs/workflows/debug/#go-runtime-go-protocols-dlv)
+built by ko by the presence of the
+[`KO_DATA_PATH` environment variable](https://github.com/google/ko/blob/9a256a4b1920ed5fd5fbf77d987fddbfb9733c40/pkg/build/gobuild.go#L803-L810).
+This allows Skaffold to transform Pod specifications to enable remote
+debugging.
+
+The ko builder implementation work will add `KO_DATA_PATH` to
+[the set of environment variables used to detect Go-based applications](https://github.com/GoogleContainerTools/skaffold/blob/c75c55133e709b2fee906eb158be13c7ccfa72cd/pkg/skaffold/debug/transform_go.go#L67-L72)
+and updating the associated unit tests and
+[documentation](https://github.com/GoogleContainerTools/skaffold/blob/01a833614efd780ddece99198aa7fdcf3f355706/docs/content/en/docs/workflows/debug.md#L103).
+
 ## Design
 
 Adding the ko builder requires making config changes to the Skaffold schema.
@@ -266,7 +287,7 @@ Adding the ko builder requires making config changes to the Skaffold schema.
       // Dir is the directory where the `go` tool will be run.
       // The value is a directory path relative to the `context` directory.
       // If empty, the `go` tool will run in the `context` directory.
-      // Example: `my-go-mod-is-in-this-dir`
+      // Examples: `live-at-head`, `compat-go114`
       Dir string `yaml:"dir,omitempty"`
 
     	// Env are environment variables, in the `key=value` form, passed to the build.

--- a/pkg/skaffold/build/ko/build_test.go
+++ b/pkg/skaffold/build/ko/build_test.go
@@ -104,7 +104,7 @@ func Test_getImportPath(t *testing.T) {
 				ArtifactType: latestV1.ArtifactType{
 					KoArtifact: &latestV1.KoArtifact{},
 				},
-				ImageName: "foo",
+				ImageName: "any-image-name-1",
 			},
 			expectedImportPath: "ko://github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko", // this package
 		},
@@ -114,7 +114,7 @@ func Test_getImportPath(t *testing.T) {
 				ArtifactType: latestV1.ArtifactType{
 					KoArtifact: &latestV1.KoArtifact{},
 				},
-				ImageName: "bar",
+				ImageName: "any-image-name-2",
 				Workspace: "./testdata/package-main-in-root",
 			},
 			expectedImportPath: "ko://github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/testdata/package-main-in-root",
@@ -127,8 +127,22 @@ func Test_getImportPath(t *testing.T) {
 						Target: "./baz",
 					},
 				},
-				ImageName: "baz-image",
+				ImageName: "any-image-name-3",
 				Workspace: "./testdata/package-main-not-in-root",
+			},
+			expectedImportPath: "ko://github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/testdata/package-main-not-in-root/baz",
+		},
+		{
+			description: "plain image name with workspace directory and target and source directory",
+			artifact: &latestV1.Artifact{
+				ArtifactType: latestV1.ArtifactType{
+					KoArtifact: &latestV1.KoArtifact{
+						Dir:    "package-main-not-in-root",
+						Target: "./baz",
+					},
+				},
+				ImageName: "any-image-name-4",
+				Workspace: "./testdata",
 			},
 			expectedImportPath: "ko://github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/testdata/package-main-not-in-root/baz",
 		},

--- a/pkg/skaffold/build/ko/builder.go
+++ b/pkg/skaffold/build/ko/builder.go
@@ -18,6 +18,7 @@ package ko
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/ko/pkg/build"
@@ -30,16 +31,16 @@ import (
 )
 
 func (b *Builder) newKoBuilder(ctx context.Context, a *latestV1.Artifact) (build.Interface, error) {
-	bo := buildOptions(a.KoArtifact.BaseImage, a.KoArtifact.Platforms, a.Workspace)
+	bo := buildOptions(a.KoArtifact.BaseImage, a.KoArtifact.Platforms, a.Workspace, a.KoArtifact.Dir)
 	return commands.NewBuilder(ctx, bo)
 }
 
-func buildOptions(baseImage string, platforms []string, workspace string) *options.BuildOptions {
+func buildOptions(baseImage string, platforms []string, workspace string, sourceDir string) *options.BuildOptions {
 	return &options.BuildOptions{
 		BaseImage:        baseImage,
 		ConcurrentBuilds: 1,
 		Platform:         strings.Join(platforms, ","),
 		UserAgent:        version.UserAgentWithClient(),
-		WorkingDirectory: workspace,
+		WorkingDirectory: filepath.Join(workspace, sourceDir),
 	}
 }

--- a/pkg/skaffold/build/ko/schema/temporary.go
+++ b/pkg/skaffold/build/ko/schema/temporary.go
@@ -27,6 +27,12 @@ type KoArtifact struct {
 	// Dependencies are the file dependencies that Skaffold should watch for both rebuilding and file syncing for this artifact.
 	Dependencies *KoDependencies `yaml:"dependencies,omitempty"`
 
+	// Dir is the directory where the `go` tool will be run.
+	// The value is a directory path relative to the `context` directory.
+	// If empty, the `go` tool will run in the `context` directory.
+	// Example: `./my-app-sources`
+	Dir string `yaml:"dir,omitempty"`
+
 	// Labels are key-value string pairs to add to the image config.
 	// For example: `{"foo":"bar"}`.
 	Labels map[string]string `yaml:"labels,omitempty"`


### PR DESCRIPTION
**Description**
The `Dir` config field supports users who have directory layouts where the Go sources and `go.mod` file are in subdirectories of the `context` directory.

The value of `Dir` is a directory path relative to the `context` directory, and it specifies the directory where `go build` is run.

This change also moves forward some of the additional ko builder flags in the implementation plan, since the relevant ko PRs have been merged.

Context: https://github.com/GoogleContainerTools/skaffold/pull/6054#discussion_r677729891

Tracking: #6041 
Related: #6437 #6447 
