### PR TITLE
Add newlines to `SkaffoldLogEvent`s that come from `logrus`

### DIFF
--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -138,7 +138,7 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 		})
 	}
 
-	log.Entry(ctx).Info("Cache check completed in", util.ShowHumanizeTime(time.Since(start)))
+	log.Entry(ctx).Infoln("Cache check completed in", util.ShowHumanizeTime(time.Since(start)))
 
 	bRes, err := buildAndTest(ctx, out, tags, needToBuild)
 	if err != nil {

--- a/pkg/skaffold/event/v2/logger.go
+++ b/pkg/skaffold/event/v2/logger.go
@@ -94,7 +94,7 @@ func (h logHook) Fire(entry *logrus.Entry) error {
 		TaskId:    fmt.Sprintf("%s-%d", task, handler.iteration),
 		SubtaskId: fmt.Sprintf("%s", subtask),
 		Level:     levelFromEntry(entry),
-		Message:   entry.Message,
+		Message:   fmt.Sprintf("%s\n", entry.Message),
 	})
 	return nil
 }

--- a/pkg/skaffold/runner/build.go
+++ b/pkg/skaffold/runner/build.go
@@ -206,7 +206,7 @@ func (r *Builder) imageTags(ctx context.Context, out io.Writer, artifacts []*lat
 		output.Yellow.Fprintln(out, "Some taggers failed. Rerun with -vdebug for errors.")
 	}
 
-	log.Entry(ctx).Info("Tags generated in", util.ShowHumanizeTime(time.Since(start)))
+	log.Entry(ctx).Infoln("Tags generated in", util.ShowHumanizeTime(time.Since(start)))
 	return imageTags, nil
 }
 

--- a/pkg/skaffold/runner/v1/dev.go
+++ b/pkg/skaffold/runner/v1/dev.go
@@ -291,7 +291,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 		return fmt.Errorf("watching skaffold configuration %q: %w", r.runCtx.ConfigurationFile(), err)
 	}
 
-	log.Entry(ctx).Info("List generated in", util.ShowHumanizeTime(time.Since(start)))
+	log.Entry(ctx).Infoln("List generated in", util.ShowHumanizeTime(time.Since(start)))
 
 	// Init Sync State
 	if err := sync.Init(ctx, artifacts); err != nil {


### PR DESCRIPTION
**Related**: https://github.com/GoogleContainerTools/skaffold/issues/6492

**Description**
This PR adds line breaks to the end of messages that come from logrus and get sent out through `SkaffoldLogEvent`s. 
Before, we sent `entry.Message`, but now we will send `fmt.Sprintf("%s\n", entry.Message)`

Also fixes a few log lines that should be the `ln` form of their function call.

**Follow-up Work (remove if N/A)**
Another PR will be opened to add a default log level for basic output that comes from skaffold. That PR will close #6492 
