### PR TITLE
Fix #6508 - Add `skaffold apply` to CLI docs header

### DIFF
--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -19,6 +19,7 @@ Pipeline building blocks for CI/CD:
 * [skaffold deploy](#skaffold-deploy) - to deploy the given image(s)
 * [skaffold delete](#skaffold-delete) - to cleanup the deployed artifacts
 * [skaffold render](#skaffold-render) - build and tag images, and output templated Kubernetes manifests
+* [skaffold apply](#skaffold-apply) - to apply hydrated manifests to a cluster
 
 Getting started with a new project:
 

--- a/docs/content/en/docs/references/cli/index_header
+++ b/docs/content/en/docs/references/cli/index_header
@@ -19,6 +19,7 @@ Pipeline building blocks for CI/CD:
 * [skaffold deploy](#skaffold-deploy) - to deploy the given image(s)
 * [skaffold delete](#skaffold-delete) - to cleanup the deployed artifacts
 * [skaffold render](#skaffold-render) - build and tag images, and output templated Kubernetes manifests
+* [skaffold apply](#skaffold-apply) - to apply hydrated manifests to a cluster
 
 Getting started with a new project:
 


### PR DESCRIPTION

Fixes: #6508

**Description**
Added `skaffold apply` to CLI docs and ran `generate-man.sh`

**User facing changes (remove if N/A)**
CLI Docs will now show `skaffold apply` in header
