### PR TITLE
docs: Add "Open in Cloud Shell" link to examples

### DIFF
--- a/integration/examples/bazel/README.md
+++ b/integration/examples/bazel/README.md
@@ -1,5 +1,7 @@
 ### Example: bazel
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/bazel)
+
 Bazel is one of the supported builders in Skaffold.
 
 The way you configure it in `skaffold.yaml` is the following build stanza:

--- a/integration/examples/buildpacks-java/README.md
+++ b/integration/examples/buildpacks-java/README.md
@@ -1,5 +1,7 @@
 ### Example: buildpacks (Java)
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/buildpacks-java)
+
 This is an example demonstrating:
 
 * **building** a Java app built with [Cloud Native Buildpacks](https://buildpacks.io/)

--- a/integration/examples/buildpacks-node/README.md
+++ b/integration/examples/buildpacks-node/README.md
@@ -1,5 +1,7 @@
 ### Example: buildpacks (NodeJS)
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/buildpacks-node)
+
 This is an example demonstrating:
 
 * **building** a simple NodeJS app built with [Cloud Native Buildpacks](https://buildpacks.io/)

--- a/integration/examples/buildpacks-python/README.md
+++ b/integration/examples/buildpacks-python/README.md
@@ -1,5 +1,7 @@
 ### Example: buildpacks (Python)
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/buildpacks-python)
+
 This is an example demonstrating:
 
 * **building** a Python app built with [Cloud Native Buildpacks](https://buildpacks.io/)

--- a/integration/examples/buildpacks/README.md
+++ b/integration/examples/buildpacks/README.md
@@ -1,5 +1,7 @@
 ### Example: buildpacks (Go)
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/buildpacks)
+
 This is an example demonstrating:
 
 * **building** a single Go file app built with [Cloud Native Buildpacks](https://buildpacks.io/)

--- a/integration/examples/compose/README.md
+++ b/integration/examples/compose/README.md
@@ -1,5 +1,7 @@
 ### Example: running Skaffold with docker-compose files
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/compose)
+
 This example provides a simple application set up to run with 
 [Docker Compose](https://docs.docker.com/compose/).
 

--- a/integration/examples/custom-buildx/README.md
+++ b/integration/examples/custom-buildx/README.md
@@ -1,5 +1,7 @@
 ### Example: use the custom builder with `docker buildx`
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/custom-buildx)
+
 [Docker Buildx](https://github.com/docker/buildx#buildx) is an
 experimental feature for building container images for multiple
 platforms.  This example shows how `docker buildx` can be used as

--- a/integration/examples/custom-tests/README.md
+++ b/integration/examples/custom-tests/README.md
@@ -1,5 +1,7 @@
 ### Example: Running custom tests on built images
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/custom-tests)
+
 This example shows how to run _custom tests_ on newly built images in the skaffold dev loop. 
 
 Custom tests are associated with single image artifacts. When test dependencies change, no build will happen but tests would get re-run. Tests are configured in the `skaffold.yaml` in the `test` stanza, e.g.

--- a/integration/examples/custom/README.md
+++ b/integration/examples/custom/README.md
@@ -1,5 +1,7 @@
 ### Example: use the custom builder with ko
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/custom)
+
 This example shows how the custom builder can be used to
 build artifacts with [ko](https://github.com/google/ko).
 

--- a/integration/examples/docker-deploy/README.md
+++ b/integration/examples/docker-deploy/README.md
@@ -1,5 +1,7 @@
 ### Example: Deploying a simple go app to Docker
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/docker-deploy)
+
 This is a simple example based on:
 
 * **building** a two single Go file apps, each with a multistage `Dockerfile` using local docker to build

--- a/integration/examples/gcb-kaniko/README.md
+++ b/integration/examples/gcb-kaniko/README.md
@@ -1,5 +1,7 @@
 ### Example: Getting started with a simple go app
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/gcb-kaniko)
+
 This is a simple example based on:
 
 * **building** a single Go file app and with a multistage `Dockerfile` using [kaniko](https://github.com/GoogleContainerTools/kaniko) in Google Cloud Build

--- a/integration/examples/generate-pipeline/README.md
+++ b/integration/examples/generate-pipeline/README.md
@@ -1,5 +1,7 @@
 ### Example: Getting started with skaffold and CI/CD using Tekton
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/generate-pipeline)
+
 This is a simple example to show users how to run the generate-pipeline command
 
 _Please keep in mind that the generate-pipeline command is still a WIP_

--- a/integration/examples/getting-started-kustomize/README.md
+++ b/integration/examples/getting-started-kustomize/README.md
@@ -1,4 +1,6 @@
 ### Example: Getting started with a simple go app using Kustomize
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/getting-started-kustomize)
+
 This is a variation of the `getting started` example, using `kustomize` to deploy instead of `kubectl`.
 

--- a/integration/examples/getting-started/README.md
+++ b/integration/examples/getting-started/README.md
@@ -1,5 +1,7 @@
 ### Example: Getting started with a simple go app
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/getting-started)
+
 This is a simple example based on:
 
 * **building** a single Go file app and with a multistage `Dockerfile` using local docker to build

--- a/integration/examples/google-cloud-build/README.md
+++ b/integration/examples/google-cloud-build/README.md
@@ -1,5 +1,7 @@
 ### Example: Getting started with a simple go app
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/google-cloud-build)
+
 This is a simple example based on:
 
 * **building** a single Go file app and with a multistage `Dockerfile` using Google Cloud Build

--- a/integration/examples/helm-deployment-dependencies/README.md
+++ b/integration/examples/helm-deployment-dependencies/README.md
@@ -1,5 +1,7 @@
 ### Example: deploy helm charts with local dependencies
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/helm-deployment-dependencies)
+
 This example follows the [helm](../helm-deployment) example, but with a local chart as a dependency.
 
 The `skipBuildDependencies` option is used to skip the `helm dep build` command. This must be disabled for charts with local dependencies.

--- a/integration/examples/helm-deployment/README.md
+++ b/integration/examples/helm-deployment/README.md
@@ -1,5 +1,7 @@
 ### Example: deploy multiple releases with Helm
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/helm-deployment)
+
 You can deploy multiple releases with skaffold, each will need a chartPath, a values file, and namespace.
 Skaffold can inject intermediate build tags in the the values map in the skaffold.yaml.
 

--- a/integration/examples/helm-remote-repo/README.md
+++ b/integration/examples/helm-remote-repo/README.md
@@ -1,5 +1,7 @@
 ### Example: deploy remote helm chart
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/helm-remote-repo)
+
 This example shows how to deploy a remote helm chart from a remote repo. This can be helpful for consuming other helm packages as part of your app.
 
 

--- a/integration/examples/hot-reload/README.md
+++ b/integration/examples/hot-reload/README.md
@@ -1,5 +1,7 @@
 ### Example: hot-reload with Node and Python
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/hot-reload)
+
 Application demonstrating the file synchronization mode with both NodeJS and Python.
 
 #### Init

--- a/integration/examples/jaeger-skaffold-trace/README.md
+++ b/integration/examples/jaeger-skaffold-trace/README.md
@@ -1,5 +1,7 @@
 ### Example: Skaffold Command Tracing with Jaeger
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/jaegar-skaffold-trace)
+
 
 _**WARNING: Skaffold's trace functionality is experimental and may change without notice.**_
 

--- a/integration/examples/jib-gradle/README.md
+++ b/integration/examples/jib-gradle/README.md
@@ -1,5 +1,7 @@
 ### Example: Jib (Gradle)
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/jib-gradle)
+
 [Jib](https://github.com/GoogleContainerTools/jib) is one of the supported builders in Skaffold.
 It builds Docker and OCI images
 for your Java applications and is available as plugins for Maven and Gradle.

--- a/integration/examples/jib-multimodule/README.md
+++ b/integration/examples/jib-multimodule/README.md
@@ -1,5 +1,7 @@
 ### Example: Jib Multi-Module
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/jib-multimodule)
+
 [Jib](https://github.com/GoogleContainerTools/jib) is one of the supported builders in Skaffold.
 It builds Docker and OCI images
 for your Java applications and is available as plugins for Maven and Gradle.

--- a/integration/examples/jib-sync/README.md
+++ b/integration/examples/jib-sync/README.md
@@ -1,5 +1,7 @@
 ### Example: Jib Sync
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/jib-sync)
+
 [Jib](https://github.com/GoogleContainerTools/jib) is one of the supported builders in Skaffold. Jib
 has special sync support using the `auto` configuration.
 

--- a/integration/examples/jib/README.md
+++ b/integration/examples/jib/README.md
@@ -1,5 +1,7 @@
 ### Example: Jib (Maven)
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/jib)
+
 [Jib](https://github.com/GoogleContainerTools/jib) is one of the supported builders in Skaffold.
 It builds Docker and OCI images
 for your Java applications and is available as plugins for Maven and Gradle.

--- a/integration/examples/kaniko/README.md
+++ b/integration/examples/kaniko/README.md
@@ -1,5 +1,7 @@
 ### Example: kaniko
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/kaniko)
+
 This is an example demonstrating:
 
 * **building** a single Go file app and with a single stage `Dockerfile` using [kaniko](https://github.com/GoogleContainerTools/kaniko) to build on a K8S cluster

--- a/integration/examples/kustomize/README.md
+++ b/integration/examples/kustomize/README.md
@@ -1,5 +1,7 @@
 ### Example: kustomize
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/kustomize)
+
 This is an example demonstrating: how skaffold can work with kustomize with the `skaffold deploy` command.
 
 Can be run with:

--- a/integration/examples/lifecycle-hooks/README.md
+++ b/integration/examples/lifecycle-hooks/README.md
@@ -1,5 +1,7 @@
 ### Example: Running skaffold lifecycle hooks
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/lifecycle-hooks)
+
 This is a simple example to show how to inject skaffold lifecycles with user-defined hooks.
 
 Run:

--- a/integration/examples/microservices/README.md
+++ b/integration/examples/microservices/README.md
@@ -1,5 +1,7 @@
 ### Example: µSvcs with Skaffold
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/microservices)
+
 In this example:
 
 * Deploy multiple applications with skaffold

--- a/integration/examples/multi-config-microservices/README.md
+++ b/integration/examples/multi-config-microservices/README.md
@@ -1,5 +1,7 @@
 ### Example: Multiple configs µSvcs with Skaffold
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/multi-config-microservices)
+
 In this example:
 
 * Deploy microservice applications individually or in a group.

--- a/integration/examples/nodejs/README.md
+++ b/integration/examples/nodejs/README.md
@@ -1,5 +1,7 @@
 ### Example: Node.js with hot-reload
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/nodejs)
+
 Simple example based on Node.js demonstrating the file synchronization mode.
 
 #### Init

--- a/integration/examples/profile-patches/README.md
+++ b/integration/examples/profile-patches/README.md
@@ -1,5 +1,7 @@
 ### Example: Getting started with a simple go app
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/profile-patches)
+
 This is a simple show-case of how Skaffold profiles can be patched.
 Patched profiles e.g. can be used in development to provide a composable development setup.
 Here, a "base" service is always started. Two additional services "hello" and "world" can be activated via profiles.

--- a/integration/examples/profiles/README.md
+++ b/integration/examples/profiles/README.md
@@ -1,5 +1,7 @@
 ### Example: Getting started with a simple go app
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/profiles)
+
 This is a simple show-case of Skaffold profiles
 
 #### Init

--- a/integration/examples/react-reload-docker/README.md
+++ b/integration/examples/react-reload-docker/README.md
@@ -1,5 +1,7 @@
 ### Example: React app with hot-reload
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/react-reload-docker)
+
 Simple React app demonstrating the file synchronization mode in conjunction with webpack hot module reload.
 
 #### Init

--- a/integration/examples/react-reload/README.md
+++ b/integration/examples/react-reload/README.md
@@ -1,5 +1,7 @@
 ### Example: React app with hot-reload
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/react-reload)
+
 Simple React app demonstrating the file synchronization mode in conjunction with webpack hot module reload.
 
 #### Init

--- a/integration/examples/remote-multi-config-microservices/README.md
+++ b/integration/examples/remote-multi-config-microservices/README.md
@@ -1,5 +1,7 @@
 ### Example: Remote config µSvcs with Skaffold
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/remote-multi-config-microservices)
+
 In this example:
 
 * Deploy microservice applications from a remote git repository using Skaffold.

--- a/integration/examples/ruby/README.md
+++ b/integration/examples/ruby/README.md
@@ -1,5 +1,7 @@
 ### Example: Ruby/Rack with hot-reload
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/ruby)
+
 Simple example based on Ruby/Rack application demonstrating the file synchronization mode.
 
 #### Init

--- a/integration/examples/structure-tests/README.md
+++ b/integration/examples/structure-tests/README.md
@@ -1,5 +1,7 @@
 ### Example: Running container-structure-test on built images
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/structure-tests)
+
 This example shows how to run
 [structure tests](https://github.com/GoogleContainerTools/container-structure-test)
 on newly built images in your skaffold dev loop. Tests are associated with single

--- a/integration/examples/tagging-with-environment-variables/README.md
+++ b/integration/examples/tagging-with-environment-variables/README.md
@@ -1,5 +1,7 @@
 ### Example: using the envTemplate tag policy
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/tagging-with-environment-variables)
+
 This example uses an environment variable `FOO` to tag the image.
 The way you configure it in `skaffold.yaml` is the following build stanza:
 

--- a/integration/examples/templated-fields/README.md
+++ b/integration/examples/templated-fields/README.md
@@ -1,5 +1,7 @@
 ### Example: use image values in templated fields for build and deploy 
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/templated-fields)
+
 This example shows how `IMAGE_REPO` and `IMAGE_TAG` keywords are available in templated fields for custom build and helm deploy
 
 * **building** a single Go file app with ko

--- a/integration/examples/typescript/README.md
+++ b/integration/examples/typescript/README.md
@@ -1,5 +1,7 @@
 ### Example: TypeScript + Node.js with hot-reload
 
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/typescript)
+
 Seeks to be functionally identical to the [Node.js](../nodejs) example, except with TypeScript.
 
 Swaps [nodemon](https://nodemon.io/) for [tsc-watch](https://github.com/gilamran/tsc-watch#the-nodemon-for-typescript)


### PR DESCRIPTION
**Description**

Adding Open in Cloud Shell buttons to all skaffold examples

This allows users to test the examples in Cloud Shell with skaffold pre-installed.

Examples omitted:
- dev-journey-buildpacks - tutorial.md has OiCS
- simple-artifact-registry - no README
