### PR TITLE
Make inputDigest hash calculation independent of workspace path

### DIFF
--- a/pkg/skaffold/tag/input_digest.go
+++ b/pkg/skaffold/tag/input_digest.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
@@ -56,7 +57,7 @@ func (t *inputDigestTagger) GenerateTag(ctx context.Context, image latestV1.Arti
 	// must sort as hashing is sensitive to the order in which files are processed
 	sort.Strings(srcFiles)
 	for _, d := range srcFiles {
-		h, err := fileHasher(d)
+		h, err := fileHasher(d, image.Workspace)
 		if err != nil {
 			if os.IsNotExist(err) {
 				log.Entry(ctx).Tracef("skipping dependency %q for artifact cache calculation: %v", d, err)
@@ -82,13 +83,19 @@ func encode(inputs []string) (string, error) {
 }
 
 // fileHasher hashes the contents and name of a file
-func fileHasher(path string) (string, error) {
+func fileHasher(path string, workspacePath string) (string, error) {
 	h := md5.New()
 	fi, err := os.Lstat(path)
 	if err != nil {
 		return "", err
 	}
-	h.Write([]byte(filepath.Clean(path)))
+	// Always use the file path within workspace when calculating hash.
+	// This will ensure we will always get the same hash independent of workspace location and hierarchy.
+  if (workspacePath == ".") {
+    h.Write([]byte(filepath.Clean(path)))
+  } else {
+    h.Write([]byte(filepath.Clean(strings.Replace(path, workspacePath+string(os.PathSeparator), "", 1))))
+  }
 	if fi.Mode().IsRegular() {
 		f, err := os.Open(path)
 		if err != nil {

--- a/pkg/skaffold/tag/input_digest.go
+++ b/pkg/skaffold/tag/input_digest.go
@@ -91,11 +91,11 @@ func fileHasher(path string, workspacePath string) (string, error) {
 	}
 	// Always use the file path within workspace when calculating hash.
 	// This will ensure we will always get the same hash independent of workspace location and hierarchy.
-  if (workspacePath == ".") {
-    h.Write([]byte(filepath.Clean(path)))
-  } else {
-    h.Write([]byte(filepath.Clean(strings.Replace(path, workspacePath+string(os.PathSeparator), "", 1))))
-  }
+	if workspacePath == "." {
+		h.Write([]byte(filepath.Clean(path)))
+	} else {
+		h.Write([]byte(filepath.Clean(strings.Replace(path, workspacePath+string(os.PathSeparator), "", 1))))
+	}
 	if fi.Mode().IsRegular() {
 		f, err := os.Open(path)
 		if err != nil {


### PR DESCRIPTION
**Description**

The point of this change is to ensure that digest tag calculation is always independent of the workspace location. Put differently, with this change the same tag will be calculated for an image regardless of if it is defined directly in the skaffold configuration passed to skaffold or in a in another configuration referenced from the `requires` section. Previously the latter situation would result in absolute paths being used resulting in a different digest.