### PR TITLE
Use default values rather than return error in logrus hook

### DIFF
--- a/pkg/skaffold/event/v2/logger.go
+++ b/pkg/skaffold/event/v2/logger.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v2
 
 import (
-	"errors"
 	"fmt"
 	"io"
 
@@ -83,11 +82,11 @@ func (h logHook) Levels() []logrus.Level {
 func (h logHook) Fire(entry *logrus.Entry) error {
 	task, ok := entry.Data["task"]
 	if !ok {
-		return errors.New("could not get task from logrus entry")
+		task = constants.DevLoop
 	}
 	subtask, ok := entry.Data["subtask"]
 	if !ok {
-		return errors.New("could not get subtask from logrus entry")
+		subtask = constants.SubtaskIDNone
 	}
 
 	handler.handleSkaffoldLogEvent(&proto.SkaffoldLogEvent{


### PR DESCRIPTION
**Description**
This PR changes the `logHook.Fire()` function to set default values rather than return an error in the case that it can't retrieve data from the `logrus.Entry`'s data field. This will prevent messy output seen by the user.