### PR TITLE
Document multi-stage dockerfile limitations of filesync

### DIFF
--- a/docs/content/en/docs/pipeline-stages/filesync.md
+++ b/docs/content/en/docs/pipeline-stages/filesync.md
@@ -16,9 +16,9 @@ Multiple types of sync are supported by Skaffold:
  + `manual`: The user must specify both the files in their local workspace and the destination in the running container.
    This is supported by every type of artifact.
 
- + `infer`: The destinations for each changed file is inferred from instructions in a Dockerfile.
-   This is supported by docker and kaniko artifacts and also for custom artifacts that declare a
-   dependency on a Dockerfile.
+ + `infer`: The destinations for each changed file is inferred from the builder.
+   The docker and kaniko builders examine instructions in a Dockerfile.
+   This inference is also supported for custom artifacts that declare a dependency on a Dockerfile.
 
 + `auto`: Skaffold automatically configures the sync.  This mode is only supported by Jib and Buildpacks artifacts.
    Auto sync mode is enabled by default for Buildpacks artifacts.
@@ -46,7 +46,8 @@ The following example showcases manual filesync:
 
 ### Inferred sync mode
 
-For docker artifacts, Skaffold knows how to infer the desired destination from the artifact's `Dockerfile`.
+For docker artifacts, Skaffold knows how to infer the desired destination from the artifact's `Dockerfile`
+by examining the `ADD` and `COPY` instructions.
 To enable syncing, you only need to specify which files are eligible for syncing in the sync rules.
 The sync rules for inferred sync mode is just a list of glob patterns.
 The following example showcases this filesync mode:
@@ -75,6 +76,9 @@ And a `skaffold.yaml` with the following sync configuration:
   
 Inferred sync mode only applies to modified and added files.
 File deletion will always cause a complete rebuild.
+
+For multi-stage Dockerfiles, Skaffold only examines the last stage.
+Use manual sync rules to sync file copies from other stages.
 
 ### Auto sync mode
 


### PR DESCRIPTION
Fixes: #6525 

**Description**
Document the limitations of the `infer` sync rules with multi-stage dockerfiles.