### PR TITLE
Skip tests if no tests defined in pipelines

### DIFF
--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -147,6 +147,10 @@ func (rc *RunContext) StatusCheckDeadlineSeconds() int {
 	return rc.Pipelines.StatusCheckDeadlineSeconds()
 }
 
+func (rc *RunContext) SkipTests() bool {
+	return rc.Opts.SkipTests || len(rc.TestCases()) == 0
+}
+
 func (rc *RunContext) DefaultPipeline() latestV1.Pipeline            { return rc.Pipelines.Head() }
 func (rc *RunContext) GetKubeContext() string                        { return rc.KubeContext }
 func (rc *RunContext) GetPipelines() []latestV1.Pipeline             { return rc.Pipelines.All() }
@@ -184,7 +188,6 @@ func (rc *RunContext) Prune() bool                                   { return rc
 func (rc *RunContext) RenderOnly() bool                              { return rc.Opts.RenderOnly }
 func (rc *RunContext) RenderOutput() string                          { return rc.Opts.RenderOutput }
 func (rc *RunContext) SkipRender() bool                              { return rc.Opts.SkipRender }
-func (rc *RunContext) SkipTests() bool                               { return rc.Opts.SkipTests || len(rc.Pipelines.TestCases()) == 0 }
 func (rc *RunContext) StatusCheck() *bool                            { return rc.Opts.StatusCheck.Value() }
 func (rc *RunContext) IterativeStatusCheck() bool                    { return rc.Opts.IterativeStatusCheck }
 func (rc *RunContext) Tail() bool                                    { return rc.Opts.Tail }

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -263,7 +263,7 @@ func createRunner(t *testutil.T, testBench *TestBench, monitor filemon.Monitor, 
 	var tests []*latestV1.TestCase
 	for _, a := range artifacts {
 		tests = append(tests, &latestV1.TestCase{
-			ImageName:         a.ImageName,
+			ImageName: a.ImageName,
 		})
 	}
 	cfg := &latestV1.SkaffoldConfig{
@@ -275,7 +275,7 @@ func createRunner(t *testutil.T, testBench *TestBench, monitor filemon.Monitor, 
 				},
 				Artifacts: artifacts,
 			},
-			Test: tests,
+			Test:   tests,
 			Deploy: latestV1.DeployConfig{StatusCheckDeadlineSeconds: 60},
 		},
 	}


### PR DESCRIPTION
**Description**
Currently we enter the test function even if there are no tests defined in the user's `skaffold.yaml`. This means we always see a `Starting test...` output, even tho no tests are going to be run. To avoid this, this PR checks if there are any test cases defined in the user's pipelines. If not, then it just returns early.