### PR TITLE
Implement Debugger for Docker Deployer

### DIFF
--- a/cmd/skaffold/app/cmd/debug.go
+++ b/cmd/skaffold/app/cmd/debug.go
@@ -50,6 +50,7 @@ func NewCmdDebug() *cobra.Command {
 }
 
 func runDebug(ctx context.Context, out io.Writer) error {
+	// TODO(nkubala)[08/31/21]: remove in favor of conditionally executing transforms on active command at runtime
 	manifest.AddTransform(debugging.ApplyDebuggingTransforms)
 	dockerdebug.EnableTransforms()
 

--- a/cmd/skaffold/app/cmd/debug.go
+++ b/cmd/skaffold/app/cmd/debug.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
+	dockerdebug "github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker/debugger"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/debugging"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 )
@@ -50,6 +51,7 @@ func NewCmdDebug() *cobra.Command {
 
 func runDebug(ctx context.Context, out io.Writer) error {
 	manifest.AddTransform(debugging.ApplyDebuggingTransforms)
+	dockerdebug.EnableTransforms()
 
 	return doDev(ctx, out)
 }

--- a/cmd/skaffold/app/cmd/debug.go
+++ b/cmd/skaffold/app/cmd/debug.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
-	dockerdebug "github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker/debugger"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/debugging"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 )
@@ -52,7 +51,7 @@ func NewCmdDebug() *cobra.Command {
 func runDebug(ctx context.Context, out io.Writer) error {
 	// TODO(nkubala)[08/31/21]: remove in favor of conditionally executing transforms on active command at runtime
 	manifest.AddTransform(debugging.ApplyDebuggingTransforms)
-	dockerdebug.EnableTransforms()
+	opts.Debug = true
 
 	return doDev(ctx, out)
 }

--- a/cmd/skaffold/app/cmd/debug.go
+++ b/cmd/skaffold/app/cmd/debug.go
@@ -51,7 +51,7 @@ func NewCmdDebug() *cobra.Command {
 func runDebug(ctx context.Context, out io.Writer) error {
 	// TODO(nkubala)[08/31/21]: remove in favor of conditionally executing transforms on active command at runtime
 	manifest.AddTransform(debugging.ApplyDebuggingTransforms)
-	opts.Debug = true
+	opts.ContainerDebugging = true
 
 	return doDev(ctx, out)
 }

--- a/docs/content/en/schemas/v2beta22.json
+++ b/docs/content/en/schemas/v2beta22.json
@@ -1169,6 +1169,11 @@
     },
     "DeployConfig": {
       "properties": {
+        "docker": {
+          "$ref": "#/definitions/DockerDeploy",
+          "description": "*alpha* uses the `docker` CLI to create application containers in Docker.",
+          "x-intellij-html-description": "<em>alpha</em> uses the <code>docker</code> CLI to create application containers in Docker."
+        },
         "helm": {
           "$ref": "#/definitions/HelmDeploy",
           "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
@@ -1214,6 +1219,7 @@
         }
       },
       "preferredOrder": [
+        "docker",
         "helm",
         "kpt",
         "kubectl",

--- a/docs/content/en/schemas/v2beta22.json
+++ b/docs/content/en/schemas/v2beta22.json
@@ -1169,11 +1169,6 @@
     },
     "DeployConfig": {
       "properties": {
-        "docker": {
-          "$ref": "#/definitions/DockerDeploy",
-          "description": "*alpha* uses the `docker` CLI to create application containers in Docker.",
-          "x-intellij-html-description": "<em>alpha</em> uses the <code>docker</code> CLI to create application containers in Docker."
-        },
         "helm": {
           "$ref": "#/definitions/HelmDeploy",
           "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
@@ -1219,7 +1214,6 @@
         }
       },
       "preferredOrder": [
-        "docker",
         "helm",
         "kpt",
         "kubectl",

--- a/docs/content/en/schemas/v2beta23.json
+++ b/docs/content/en/schemas/v2beta23.json
@@ -1169,6 +1169,11 @@
     },
     "DeployConfig": {
       "properties": {
+        "docker": {
+          "$ref": "#/definitions/DockerDeploy",
+          "description": "*alpha* uses the `docker` CLI to create application containers in Docker.",
+          "x-intellij-html-description": "<em>alpha</em> uses the <code>docker</code> CLI to create application containers in Docker."
+        },
         "helm": {
           "$ref": "#/definitions/HelmDeploy",
           "description": "*beta* uses the `helm` CLI to apply the charts to the cluster.",
@@ -1214,6 +1219,7 @@
         }
       },
       "preferredOrder": [
+        "docker",
         "helm",
         "kpt",
         "kubectl",

--- a/examples/docker-deploy/skaffold.yaml
+++ b/examples/docker-deploy/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v2beta22
+apiVersion: skaffold/v2beta21
 kind: Config
 build:
   local:

--- a/examples/docker-deploy/skaffold.yaml
+++ b/examples/docker-deploy/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v2beta21
+apiVersion: skaffold/v2beta22
 kind: Config
 build:
   local:

--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -160,10 +160,10 @@ func TestDockerDebug(t *testing.T) {
 		}
 
 		if !verifyEntrypointRewrite {
-			t.Error()
+			t.Error("couldn't verify rewritten container")
 		}
 		if !verifySupportContainer {
-			t.Error()
+			t.Error("couldn't verify support container was created")
 		}
 	})
 }

--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -42,6 +42,7 @@ func (d debugConfig) GetKubeContext() string                 { return d.kubeCont
 func (d debugConfig) MinikubeProfile() string                { return "" }
 func (d debugConfig) GlobalConfig() string                   { return "" }
 func (d debugConfig) Prune() bool                            { return false }
+func (d debugConfig) Debug() bool                            { return false }
 func (d debugConfig) GetInsecureRegistries() map[string]bool { return nil }
 func (d debugConfig) Mode() config.RunMode                   { return "" }
 

--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -26,25 +26,10 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 
 	"github.com/GoogleContainerTools/skaffold/integration/skaffold"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/types"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
-
-type debugConfig struct {
-	kubeContext string
-}
-
-func (d debugConfig) GetKubeContext() string                 { return d.kubeContext }
-func (d debugConfig) MinikubeProfile() string                { return "" }
-func (d debugConfig) GlobalConfig() string                   { return "" }
-func (d debugConfig) Prune() bool                            { return false }
-func (d debugConfig) Debug() bool                            { return false }
-func (d debugConfig) GetInsecureRegistries() map[string]bool { return nil }
-func (d debugConfig) Mode() config.RunMode                   { return "" }
 
 func TestDebug(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
@@ -140,18 +125,7 @@ func TestDockerDebug(t *testing.T) {
 
 		// use docker client to verify container has been created properly
 		// check this container and verify entrypoint has been rewritten
-		kubeConfig, err := kubectx.CurrentConfig()
-		if err != nil {
-			t.Log("unable to get current cluster context: %w", err)
-			t.Logf("test might not be running against the right docker daemon")
-		}
-		kubeContext := kubeConfig.CurrentContext
-		// log.Entry(context.TODO()).Infof("Using kubectl context: %s", kubeContext)
-		// client, err := docker.DefaultAPIClient(kubeContext)
-		client, err := docker.NewAPIClient(context.Background(), debugConfig{kubeContext: kubeContext})
-		if err != nil {
-			t.Fail()
-		}
+		client := SetupDockerClient(t)
 		var (
 			verifyEntrypointRewrite bool
 			verifySupportContainer  bool

--- a/integration/diagnose_test.go
+++ b/integration/diagnose_test.go
@@ -60,7 +60,9 @@ func folders(root string) ([]string, error) {
 	}
 
 	for _, f := range files {
-		folders = append(folders, f.Name())
+		if f.Mode().IsDir() {
+			folders = append(folders, f.Name())
+		}
 	}
 
 	return folders, err

--- a/integration/diagnose_test.go
+++ b/integration/diagnose_test.go
@@ -60,10 +60,7 @@ func folders(root string) ([]string, error) {
 	}
 
 	for _, f := range files {
-		// TODO(nkubala): remove once yaml is unhidden
-		if f.Mode().IsDir() && f.Name() != "docker-deploy" && f.Name() != "react-reload-docker" {
-			folders = append(folders, f.Name())
-		}
+		folders = append(folders, f.Name())
 	}
 
 	return folders, err

--- a/integration/testdata/debug/skaffold.yaml
+++ b/integration/testdata/debug/skaffold.yaml
@@ -65,3 +65,14 @@ profiles:
     #  context: netcore
     #  buildpacks:
     #    builder: "gcr.io/buildpacks/builder:v1"
+- name: docker
+  patches:
+  - op: remove
+    path: /deploy/kubectl
+  build:
+    artifacts:
+    - image: skaffold-debug-nodejs
+      context: nodejs
+  deploy:
+    docker:
+      images: [skaffold-debug-nodejs]

--- a/pkg/skaffold/build/docker/docker_test.go
+++ b/pkg/skaffold/build/docker/docker_test.go
@@ -225,3 +225,7 @@ func (m mockConfig) Mode() config.RunMode {
 func (m mockConfig) Prune() bool {
 	return m.prune
 }
+
+func (m mockConfig) Debug() bool {
+	return false
+}

--- a/pkg/skaffold/build/docker/docker_test.go
+++ b/pkg/skaffold/build/docker/docker_test.go
@@ -226,6 +226,6 @@ func (m mockConfig) Prune() bool {
 	return m.prune
 }
 
-func (m mockConfig) Debug() bool {
+func (m mockConfig) ContainerDebugging() bool {
 	return false
 }

--- a/pkg/skaffold/build/docker/docker_test.go
+++ b/pkg/skaffold/build/docker/docker_test.go
@@ -206,6 +206,10 @@ func (m mockConfig) GetKubeContext() string {
 	return ""
 }
 
+func (m mockConfig) GlobalConfig() string {
+	return ""
+}
+
 func (m mockConfig) MinikubeProfile() string {
 	return ""
 }

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -52,7 +52,7 @@ type SkaffoldOptions struct {
 	MinikubeProfile       string
 	RepoCacheDir          string
 	Apply                 bool
-	Debug                 bool
+	ContainerDebugging    bool
 	Cleanup               bool
 	Notification          bool
 	Tail                  bool

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -33,14 +33,26 @@ type WaitForDeletions struct {
 // SkaffoldOptions are options that are set by command line arguments not included
 // in the config file itself
 type SkaffoldOptions struct {
-	ConfigurationFile     string
-	ConfigurationFilter   []string
-	HydratedManifests     []string
-	GlobalConfig          string
-	EventLogFile          string
-	RenderOutput          string
-	User                  string
+	ConfigurationFile string
+	Command           string
+	GlobalConfig      string
+	EventLogFile      string
+	RenderOutput      string
+	User              string
+	CustomTag         string
+	Namespace         string
+	CacheFile         string
+	Trigger           string
+	KubeContext       string
+	KubeConfig        string
+	DigestSource      string
+	// TODO(https://github.com/GoogleContainerTools/skaffold/issues/3668):
+	// remove minikubeProfile from here and instead detect it by matching the
+	// kubecontext API Server to minikube profiles
+	MinikubeProfile       string
+	RepoCacheDir          string
 	Apply                 bool
+	Debug                 bool
 	Cleanup               bool
 	Notification          bool
 	Tail                  bool
@@ -61,7 +73,6 @@ type SkaffoldOptions struct {
 	SkipRender            bool
 	SkipConfigDefaults    bool
 	PropagateProfiles     bool
-
 	// Add Skaffold-specific labels including runID, deployer labels, etc.
 	// `CustomLabels` are still applied if this is false. Must only be used in
 	// commands which don't deploy (e.g. `skaffold render`) since the runID
@@ -69,38 +80,27 @@ type SkaffoldOptions struct {
 	AddSkaffoldLabels    bool
 	DetectMinikube       bool
 	IterativeStatusCheck bool
+	ForceLoadImages      bool
+	WaitForConnection    bool
+	MakePathsAbsolute    *bool
 	StatusCheck          BoolOrUndefined
+	PortForward          PortForwardOptions
+	DefaultRepo          StringOrUndefined
+	PushImages           BoolOrUndefined
+	CustomLabels         []string
+	TargetImages         []string
+	Profiles             []string
+	InsecureRegistries   []string
+	ConfigurationFilter  []string
+	HydratedManifests    []string
+	Muted                Muted
+	BuildConcurrency     int
+	WatchPollInterval    int
+	RPCPort              IntOrUndefined
+	RPCHTTPPort          IntOrUndefined
 
-	PortForward        PortForwardOptions
-	CustomTag          string
-	Namespace          string
-	CacheFile          string
-	Trigger            string
-	KubeContext        string
-	KubeConfig         string
-	DigestSource       string
-	WatchPollInterval  int
-	DefaultRepo        StringOrUndefined
-	PushImages         BoolOrUndefined
-	CustomLabels       []string
-	TargetImages       []string
-	Profiles           []string
-	InsecureRegistries []string
-	Muted              Muted
-	Command            string
-	RPCPort            IntOrUndefined
-	RPCHTTPPort        IntOrUndefined
-	BuildConcurrency   int
-	MakePathsAbsolute  *bool
-	// TODO(https://github.com/GoogleContainerTools/skaffold/issues/3668):
-	// remove minikubeProfile from here and instead detect it by matching the
-	// kubecontext API Server to minikube profiles
-	MinikubeProfile   string
-	RepoCacheDir      string
-	SyncRemoteCache   SyncRemoteCacheOption
-	WaitForDeletions  WaitForDeletions
-	ForceLoadImages   bool
-	WaitForConnection bool
+	SyncRemoteCache  SyncRemoteCacheOption
+	WaitForDeletions WaitForDeletions
 }
 
 type RunMode string

--- a/pkg/skaffold/debug/apply_transforms.go
+++ b/pkg/skaffold/debug/apply_transforms.go
@@ -29,7 +29,7 @@ import (
 
 var ConfigRetriever = func(ctx context.Context, image string, builds []graph.Artifact, registries map[string]bool) (ImageConfiguration, error) {
 	if artifact := findArtifact(image, builds); artifact != nil {
-		return retrieveImageConfiguration(ctx, artifact, registries)
+		return RetrieveImageConfiguration(ctx, artifact, registries)
 	}
 	return ImageConfiguration{}, fmt.Errorf("no build artifact for %q", image)
 }
@@ -52,7 +52,7 @@ func findArtifact(image string, builds []graph.Artifact) *graph.Artifact {
 
 // retrieveImageConfiguration retrieves the image container configuration for
 // the given build artifact
-func retrieveImageConfiguration(ctx context.Context, artifact *graph.Artifact, insecureRegistries map[string]bool) (ImageConfiguration, error) {
+func RetrieveImageConfiguration(ctx context.Context, artifact *graph.Artifact, insecureRegistries map[string]bool) (ImageConfiguration, error) {
 	// TODO: use the proper RunContext
 	apiClient, err := docker.NewAPIClient(ctx, &runcontext.RunContext{
 		InsecureRegistries: insecureRegistries,

--- a/pkg/skaffold/debug/apply_transforms.go
+++ b/pkg/skaffold/debug/apply_transforms.go
@@ -50,7 +50,7 @@ func findArtifact(image string, builds []graph.Artifact) *graph.Artifact {
 	return nil
 }
 
-// retrieveImageConfiguration retrieves the image container configuration for
+// RetrieveImageConfiguration retrieves the image container configuration for
 // the given build artifact
 func RetrieveImageConfiguration(ctx context.Context, artifact *graph.Artifact, insecureRegistries map[string]bool) (ImageConfiguration, error) {
 	// TODO: use the proper RunContext

--- a/pkg/skaffold/deploy/deploy_problems_test.go
+++ b/pkg/skaffold/deploy/deploy_problems_test.go
@@ -115,6 +115,7 @@ func (m mockConfig) ConfigurationFile() string                         { return 
 func (m mockConfig) DefaultRepo() *string                              { return &m.minikube }
 func (m mockConfig) SkipRender() bool                                  { return true }
 func (m mockConfig) Prune() bool                                       { return true }
+func (m mockConfig) Debug() bool                                       { return false }
 func (m mockConfig) GetKubeContext() string                            { return m.kubeContext }
 func (m mockConfig) GetInsecureRegistries() map[string]bool            { return map[string]bool{} }
 func (m mockConfig) Mode() config.RunMode                              { return config.RunModes.Dev }

--- a/pkg/skaffold/deploy/deploy_problems_test.go
+++ b/pkg/skaffold/deploy/deploy_problems_test.go
@@ -115,7 +115,7 @@ func (m mockConfig) ConfigurationFile() string                         { return 
 func (m mockConfig) DefaultRepo() *string                              { return &m.minikube }
 func (m mockConfig) SkipRender() bool                                  { return true }
 func (m mockConfig) Prune() bool                                       { return true }
-func (m mockConfig) Debug() bool                                       { return false }
+func (m mockConfig) ContainerDebugging() bool                          { return false }
 func (m mockConfig) GetKubeContext() string                            { return m.kubeContext }
 func (m mockConfig) GetInsecureRegistries() map[string]bool            { return map[string]bool{} }
 func (m mockConfig) Mode() config.RunMode                              { return config.RunModes.Dev }

--- a/pkg/skaffold/deploy/docker/deploy.go
+++ b/pkg/skaffold/deploy/docker/deploy.go
@@ -193,7 +193,6 @@ func (d *Deployer) deploy(ctx context.Context, out io.Writer, b graph.Artifact) 
 		Mounts:   mounts,
 	}
 
-	// TODO(nkubala)[08/16/21]: events for debugging, port forwarding
 	id, err := d.client.Run(ctx, out, containerCfg, opts)
 	if err != nil {
 		return errors.Wrap(err, "creating container in local docker")

--- a/pkg/skaffold/deploy/docker/deploy.go
+++ b/pkg/skaffold/deploy/docker/deploy.go
@@ -74,7 +74,7 @@ func NewDeployer(ctx context.Context, cfg dockerutil.Config, labeller *label.Def
 	}
 
 	var dbg *debugger.DebugManager
-	if cfg.Debug() {
+	if cfg.ContainerDebugging() {
 		debugHelpersRegistry, err := config.GetDebugHelpersRegistry(cfg.GlobalConfig())
 		if err != nil {
 			return nil, deployerr.DebugHelperRetrieveErr(fmt.Errorf("retrieving debug helpers registry: %w", err))

--- a/pkg/skaffold/deploy/docker/deploy.go
+++ b/pkg/skaffold/deploy/docker/deploy.go
@@ -167,6 +167,9 @@ func (d *Deployer) deploy(ctx context.Context, out io.Writer, b graph.Artifact) 
 			// skip duplication of init containers
 			continue
 		}
+		if err := d.client.Pull(ctx, out, c.Image); err != nil {
+			return errors.Wrap(err, "pulling init container image")
+		}
 		id, err := d.client.Run(ctx, out, c, dockerutil.ContainerCreateOpts{})
 		if err != nil {
 			return errors.Wrap(err, "creating container in local docker")

--- a/pkg/skaffold/deploy/docker/port_test.go
+++ b/pkg/skaffold/deploy/docker/port_test.go
@@ -22,6 +22,7 @@ import (
 	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
+	"github.com/docker/docker/api/types/container"
 )
 
 func TestGetPorts(t *testing.T) {
@@ -68,8 +69,9 @@ func TestGetPorts(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.name, func(t *testutil.T) {
 			pm := NewPortManager()
-			s, m, err := pm.getPorts(test.name, collectResources(test.resources))
-			for port := range s { // the PortSet contains the local ports, so we grab the bindings keyed off these
+			cfg := container.Config{}
+			m, err := pm.getPorts(test.name, collectResources(test.resources), &cfg)
+			for port := range cfg.ExposedPorts { // the image config's PortSet contains the local ports, so we grab the bindings keyed off these
 				bindings := m[port]
 				t.CheckDeepEqual(len(bindings), 1) // we always have a 1-1 mapping of resource to binding
 				t.CheckError(false, err)           // shouldn't error, unless GetAvailablePort is broken

--- a/pkg/skaffold/deploy/docker/port_test.go
+++ b/pkg/skaffold/deploy/docker/port_test.go
@@ -19,10 +19,11 @@ package docker
 import (
 	"testing"
 
+	"github.com/docker/docker/api/types/container"
+
 	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
-	"github.com/docker/docker/api/types/container"
 )
 
 func TestGetPorts(t *testing.T) {

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -53,6 +53,7 @@ var (
 
 type Config interface {
 	Prune() bool
+	Debug() bool
 	GlobalConfig() string
 	GetKubeContext() string
 	MinikubeProfile() string

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -53,10 +53,20 @@ var (
 
 type Config interface {
 	Prune() bool
+	GlobalConfig() string
 	GetKubeContext() string
 	MinikubeProfile() string
 	GetInsecureRegistries() map[string]bool
 	Mode() config.RunMode
+}
+
+func DefaultAPIClient() (LocalDaemon, error) {
+	env, apiClient, err := newEnvAPIClient()
+	if err != nil {
+		return nil, err
+	}
+	cli := NewLocalDaemon(apiClient, env, false, nil)
+	return cli, nil
 }
 
 // NewAPIClientImpl guesses the docker client to use based on current Kubernetes context.

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -60,15 +60,6 @@ type Config interface {
 	Mode() config.RunMode
 }
 
-func DefaultAPIClient() (LocalDaemon, error) {
-	env, apiClient, err := newEnvAPIClient()
-	if err != nil {
-		return nil, err
-	}
-	cli := NewLocalDaemon(apiClient, env, false, nil)
-	return cli, nil
-}
-
 // NewAPIClientImpl guesses the docker client to use based on current Kubernetes context.
 func NewAPIClientImpl(ctx context.Context, cfg Config) (LocalDaemon, error) {
 	dockerAPIClientOnce.Do(func() {

--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -53,7 +53,7 @@ var (
 
 type Config interface {
 	Prune() bool
-	Debug() bool
+	ContainerDebugging() bool
 	GlobalConfig() string
 	GetKubeContext() string
 	MinikubeProfile() string

--- a/pkg/skaffold/docker/debugger/adapter.go
+++ b/pkg/skaffold/docker/debugger/adapter.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debugger
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/types"
+)
+
+type DockerAdapter struct {
+	cfg        *container.Config
+	executable *types.ExecutableContainer
+}
+
+func NewAdapter(cfg *container.Config) *DockerAdapter {
+	return &DockerAdapter{
+		cfg:        cfg,
+		executable: ExecutableContainerForConfig(cfg),
+	}
+}
+
+func (d *DockerAdapter) GetContainer() *types.ExecutableContainer {
+	return d.executable
+}
+
+func ExecutableContainerForConfig(cfg *container.Config) *types.ExecutableContainer {
+	return &types.ExecutableContainer{
+		Name:    cfg.Image,
+		Command: cfg.Cmd,
+		Env:     dockerEnvToContainerEnv(cfg.Env),
+		Ports:   dockerPortsToContainerPorts(cfg.ExposedPorts),
+	}
+}
+
+// Apply transfers the configuration changes from the intermediate container
+// to the underlying container config.
+// Since container.Config doesn't have an Args field, we combine the ExecutableContainer
+// Args with the Cmd and slot them in there.
+func (d *DockerAdapter) Apply() {
+	d.cfg.Cmd = d.executable.Command
+	d.cfg.Cmd = append(d.cfg.Cmd, d.executable.Args...)
+	d.cfg.Env = containerEnvToDockerEnv(d.executable.Env)
+	d.cfg.ExposedPorts = containerPortsToDockerPorts(d.executable.Ports)
+}
+
+func dockerEnvToContainerEnv(dockerEnv []string) types.ContainerEnv {
+	env := make(map[string]string, len(dockerEnv))
+	var order []string
+	for _, entry := range dockerEnv {
+		parts := strings.SplitN(entry, "=", 2) // split to max 2 substrings, `=` is a valid character in the env value
+		if len(parts) != 2 {
+			logrus.Warnf("malformed env entry %s: skipping", entry)
+			continue
+		}
+		order = append(order, parts[0])
+		env[parts[0]] = parts[1]
+	}
+	return types.ContainerEnv{
+		Order: order,
+		Env:   env,
+	}
+}
+
+func containerEnvToDockerEnv(env types.ContainerEnv) []string {
+	var dockerEnv []string
+	for _, k := range env.Order {
+		dockerEnv = append(dockerEnv, fmt.Sprintf("%s=%s", k, env.Env[k]))
+	}
+	return dockerEnv
+}
+
+func dockerPortsToContainerPorts(ports nat.PortSet) []types.ContainerPort {
+	var containerPorts []types.ContainerPort
+	for k := range ports {
+		// net.Port is a typecast of a string
+		containerPorts = append(containerPorts, types.ContainerPort{
+			Name:          string(k),
+			ContainerPort: int32(k.Int()),
+			Protocol:      k.Proto(),
+		})
+	}
+	return containerPorts
+}
+
+func containerPortsToDockerPorts(containerPorts []types.ContainerPort) nat.PortSet {
+	dockerPorts := make(nat.PortSet, len(containerPorts))
+	for _, port := range containerPorts {
+		portStr := strconv.Itoa(int(port.ContainerPort))
+		dockerPort, err := nat.NewPort(port.Protocol, portStr)
+		if err != nil {
+			logrus.Warnf("error translating port %s - debug might not work correctly!", portStr)
+		}
+		dockerPorts[dockerPort] = struct{}{}
+	}
+	return dockerPorts
+}

--- a/pkg/skaffold/docker/debugger/adapter.go
+++ b/pkg/skaffold/docker/debugger/adapter.go
@@ -17,15 +17,16 @@ limitations under the License.
 package debugger
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
-	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/types"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 )
 
 type DockerAdapter struct {
@@ -70,7 +71,7 @@ func dockerEnvToContainerEnv(dockerEnv []string) types.ContainerEnv {
 	for _, entry := range dockerEnv {
 		parts := strings.SplitN(entry, "=", 2) // split to max 2 substrings, `=` is a valid character in the env value
 		if len(parts) != 2 {
-			logrus.Warnf("malformed env entry %s: skipping", entry)
+			log.Entry(context.TODO()).Warnf("malformed env entry %s: skipping", entry)
 			continue
 		}
 		order = append(order, parts[0])
@@ -109,7 +110,7 @@ func containerPortsToDockerPorts(containerPorts []types.ContainerPort) nat.PortS
 		portStr := strconv.Itoa(int(port.ContainerPort))
 		dockerPort, err := nat.NewPort(port.Protocol, portStr)
 		if err != nil {
-			logrus.Warnf("error translating port %s - debug might not work correctly!", portStr)
+			log.Entry(context.TODO()).Warnf("error translating port %s - debug might not work correctly!", portStr)
 		}
 		dockerPorts[dockerPort] = struct{}{}
 	}

--- a/pkg/skaffold/docker/debugger/debug.go
+++ b/pkg/skaffold/docker/debugger/debug.go
@@ -79,6 +79,9 @@ func (d *DebugManager) SupportMounts() map[string]mount.Mount {
 }
 
 func (d *DebugManager) Start(context.Context) error {
+	if d == nil {
+		return nil
+	}
 	for _, image := range d.images {
 		config := d.configurations[image]
 		notifyDebuggingContainerStarted(
@@ -95,6 +98,9 @@ func (d *DebugManager) Start(context.Context) error {
 }
 
 func (d *DebugManager) Stop() {
+	if d == nil {
+		return
+	}
 	for _, image := range d.images {
 		config := d.configurations[image]
 		notifyDebuggingContainerTerminated(
@@ -114,6 +120,9 @@ func (d *DebugManager) Stop() {
 func (d *DebugManager) Name() string { return "Docker Debug Manager" }
 
 func (d *DebugManager) TransformImage(ctx context.Context, artifact graph.Artifact, cfg *container.Config) ([]*container.Config, error) {
+	if d == nil {
+		return nil, nil
+	}
 	configurations, initContainers, err := TransformImage(ctx, artifact, cfg, d.insecureRegistries, d.debugHelpersRegistry)
 	if err != nil {
 		return nil, err

--- a/pkg/skaffold/docker/debugger/debug.go
+++ b/pkg/skaffold/docker/debugger/debug.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debugger
+
+import (
+	"context"
+	"sync"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/types"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+)
+
+var (
+	// For testing
+	notifyDebuggingContainerStarted    = event.DebuggingContainerStarted
+	notifyDebuggingContainerTerminated = event.DebuggingContainerTerminated
+	debuggingContainerStartedV2        = eventV2.DebuggingContainerStarted
+	debuggingContainerTerminatedV2     = eventV2.DebuggingContainerTerminated
+)
+
+type DebugManager struct {
+	insecureRegistries   map[string]bool
+	debugHelpersRegistry string
+
+	images         []string
+	configurations map[string]types.ContainerDebugConfiguration
+
+	supportMounts map[string]mount.Mount
+	mountLock     sync.Mutex
+}
+
+func NewDebugManager(insecureRegistries map[string]bool, debugHelpersRegistry string) *DebugManager {
+	return &DebugManager{
+		insecureRegistries:   insecureRegistries,
+		debugHelpersRegistry: debugHelpersRegistry,
+		configurations:       make(map[string]types.ContainerDebugConfiguration),
+		supportMounts:        make(map[string]mount.Mount),
+	}
+}
+
+func (d *DebugManager) AddSupportMount(image, mountID string) {
+	d.mountLock.Lock()
+	defer d.mountLock.Unlock()
+	d.supportMounts[image] = mount.Mount{
+		Type:   mount.TypeVolume,
+		Source: mountID,
+		Target: "/dbg",
+	}
+}
+
+func (d *DebugManager) HasMount(image string) bool {
+	d.mountLock.Lock()
+	defer d.mountLock.Unlock()
+	_, ok := d.supportMounts[image]
+	return ok
+}
+
+func (d *DebugManager) SupportMounts() map[string]mount.Mount {
+	return d.supportMounts
+}
+
+func (d *DebugManager) Start(context.Context) error {
+	for _, image := range d.images {
+		config := d.configurations[image]
+		notifyDebuggingContainerStarted(
+			"", // no pod
+			image,
+			"", // no namespace
+			config.Artifact,
+			config.Runtime,
+			config.WorkingDir,
+			config.Ports)
+		debuggingContainerStartedV2("", image, "", config.Artifact, config.Runtime, config.WorkingDir, config.Ports)
+	}
+	return nil
+}
+
+func (d *DebugManager) Stop() {
+	for _, image := range d.images {
+		config := d.configurations[image]
+		notifyDebuggingContainerTerminated(
+			"", // no pod
+			image,
+			"", // no namespace
+			config.Artifact,
+			config.Runtime,
+			config.WorkingDir,
+			config.Ports)
+		debuggingContainerTerminatedV2("", image, "", config.Artifact, config.Runtime, config.WorkingDir, config.Ports)
+	}
+	d.images = nil
+	d.configurations = make(map[string]types.ContainerDebugConfiguration)
+}
+
+func (d *DebugManager) Name() string { return "Docker Debug Manager" }
+
+func (d *DebugManager) TransformImage(ctx context.Context, artifact graph.Artifact, cfg *container.Config) ([]*container.Config, error) {
+	configurations, initContainers, err := TransformImage(ctx, artifact, cfg, d.insecureRegistries, d.debugHelpersRegistry)
+	if err != nil {
+		return nil, err
+	}
+	d.images = append(d.images, cfg.Image)
+	for k, v := range configurations {
+		d.configurations[k] = v
+	}
+
+	return initContainers, nil
+}

--- a/pkg/skaffold/docker/debugger/debug_test.go
+++ b/pkg/skaffold/docker/debugger/debug_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debugger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/types"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+	"github.com/docker/docker/api/types/container"
+)
+
+func TestConfigurationsAndImages(t *testing.T) {
+	tests := []struct {
+		name      string
+		artifacts []graph.Artifact
+	}{
+		{
+			name:      "no artifacts doesn't error",
+			artifacts: []graph.Artifact{},
+		},
+		{
+			name: "one artifact, one configuration",
+			artifacts: []graph.Artifact{
+				{ImageName: "foo", Tag: "foo:bar"},
+			},
+		},
+		{
+			name: "two artifacts, two configurations",
+			artifacts: []graph.Artifact{
+				{ImageName: "foo", Tag: "foo:bar"},
+				{ImageName: "another", Tag: "another:image"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		testutil.Run(t, test.name, func(t *testutil.T) {
+			t.Override(&TransformImage, func(_ context.Context, a graph.Artifact, _ *container.Config, _ map[string]bool, _ string) (map[string]types.ContainerDebugConfiguration, []*container.Config, error) {
+				m := make(map[string]types.ContainerDebugConfiguration)
+				m[a.ImageName] = types.ContainerDebugConfiguration{
+					Artifact: a.ImageName,
+				}
+				return m, nil, nil
+			})
+
+			m := NewDebugManager(nil, "")
+
+			for _, a := range test.artifacts {
+				m.TransformImage(context.TODO(), a, &container.Config{Image: a.ImageName})
+			}
+
+			for _, a := range test.artifacts {
+				if !findArtifactInImageList(m.images, a) {
+					t.Errorf("unable to find artifact %+v in image list: %v", a, m.images)
+				}
+
+				if !validateConfiguration(m.configurations, a) {
+					t.Errorf("unable to find configuration for artifact %+v in map: %+v", a, m.configurations)
+				}
+			}
+		})
+	}
+}
+
+func findArtifactInImageList(list []string, target graph.Artifact) bool {
+	var found bool
+	for _, item := range list {
+		if item == target.ImageName {
+			found = true
+		}
+	}
+	return found
+}
+
+func validateConfiguration(config map[string]types.ContainerDebugConfiguration, a graph.Artifact) bool {
+	var validated bool
+	for i, c := range config {
+		if i == a.ImageName {
+			validated = c.Artifact == a.ImageName
+		}
+	}
+	return validated
+}

--- a/pkg/skaffold/docker/debugger/debug_test.go
+++ b/pkg/skaffold/docker/debugger/debug_test.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/docker/docker/api/types/container"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/types"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/testutil"
-	"github.com/docker/docker/api/types/container"
 )
 
 func TestConfigurationsAndImages(t *testing.T) {

--- a/pkg/skaffold/docker/debugger/debug_test.go
+++ b/pkg/skaffold/docker/debugger/debug_test.go
@@ -27,6 +27,15 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
+func TestZeroValue(t *testing.T) {
+	t.Run("nil DebugManager should not raise nil pointer dereference", func(t *testing.T) {
+		var d *DebugManager
+		d.Start(context.TODO())
+		d.Stop()
+		d.TransformImage(context.TODO(), graph.Artifact{}, nil)
+	})
+}
+
 func TestConfigurationsAndImages(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/pkg/skaffold/docker/debugger/transform.go
+++ b/pkg/skaffold/docker/debugger/transform.go
@@ -61,17 +61,17 @@ func transformImage(ctx context.Context, artifact graph.Artifact, cfg *container
 	if configuration, requiredImage, err := debug.TransformContainer(adapter, imageConfig, portAlloc); err == nil {
 		configurations[adapter.GetContainer().Name] = configuration
 		if len(requiredImage) > 0 {
-			log.Entry(context.TODO()).Infof("%q requires debugging support image %q", cfg.Image, requiredImage)
+			log.Entry(ctx).Infof("%q requires debugging support image %q", cfg.Image, requiredImage)
 			containersRequiringSupport = append(containersRequiringSupport, cfg)
 			requiredSupportImages[requiredImage] = true
 		}
 	} else {
-		log.Entry(context.TODO()).Warnf("Image %q not configured for debugging: %v", cfg.Image, err)
+		log.Entry(ctx).Warnf("Image %q not configured for debugging: %v", cfg.Image, err)
 	}
 
 	// check if we have any images requiring additional debugging support files
 	if len(containersRequiringSupport) > 0 {
-		log.Entry(context.TODO()).Infof("Configuring installation of debugging support files")
+		log.Entry(ctx).Infof("Configuring installation of debugging support files")
 		// the initContainers are responsible for populating the contents of `/dbg`
 		for imageID := range requiredSupportImages {
 			supportFilesInitContainer := &container.Config{

--- a/pkg/skaffold/docker/debugger/transform.go
+++ b/pkg/skaffold/docker/debugger/transform.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debugger
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/volume"
+	"github.com/sirupsen/logrus"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug/types"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+var (
+	shouldTransform    bool
+	SupportVolumeMount = volume.VolumeCreateBody{Name: debug.DebuggingSupportFilesVolume}
+	TransformImage     = transformImage // For testing
+)
+
+type Transform func(string) string
+
+func EnableTransforms() {
+	shouldTransform = true
+}
+
+func transformImage(ctx context.Context, artifact graph.Artifact, cfg *container.Config, insecureRegistries map[string]bool, debugHelpersRegistry string) (map[string]types.ContainerDebugConfiguration, []*container.Config, error) {
+	if !shouldTransform {
+		return nil, nil, nil
+	}
+	portAvailable := func(port int32) bool {
+		return isPortAvailable(cfg, port)
+	}
+	portAlloc := func(desiredPort int32) int32 {
+		return util.AllocatePort(portAvailable, desiredPort)
+	}
+
+	adapter := NewAdapter(cfg)
+	imageConfig, err := debug.RetrieveImageConfiguration(ctx, &artifact, insecureRegistries)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	configurations := make(map[string]types.ContainerDebugConfiguration)
+	var initContainers []*container.Config
+	// the container images that require debugging support files
+	var containersRequiringSupport []*container.Config
+	// the set of image IDs required to provide debugging support files
+	requiredSupportImages := make(map[string]bool)
+
+	if configuration, requiredImage, err := debug.TransformContainer(adapter, imageConfig, portAlloc); err == nil {
+		configurations[adapter.GetContainer().Name] = configuration
+		if len(requiredImage) > 0 {
+			logrus.Infof("%q requires debugging support image %q", cfg.Image, requiredImage)
+			containersRequiringSupport = append(containersRequiringSupport, cfg)
+			requiredSupportImages[requiredImage] = true
+		}
+	} else {
+		logrus.Warnf("Image %q not configured for debugging: %v", cfg.Image, err)
+	}
+
+	// check if we have any images requiring additional debugging support files
+	if len(containersRequiringSupport) > 0 {
+		logrus.Infof("Configuring installation of debugging support files")
+		// the initContainers are responsible for populating the contents of `/dbg`
+		for imageID := range requiredSupportImages {
+			supportFilesInitContainer := &container.Config{
+				Image:   fmt.Sprintf("%s/%s", debugHelpersRegistry, imageID),
+				Volumes: map[string]struct{}{"/dbg": {}},
+			}
+			initContainers = append(initContainers, supportFilesInitContainer)
+		}
+		// the populated volume is then mounted in the containers at `/dbg` too
+		for _, container := range containersRequiringSupport {
+			if container.Volumes == nil {
+				container.Volumes = make(map[string]struct{})
+			}
+			container.Volumes["/dbg"] = struct{}{}
+		}
+	}
+
+	return configurations, initContainers, nil
+}
+
+// isPortAvailable returns true if none of the pod's containers specify the given port.
+func isPortAvailable(cfg *container.Config, port int32) bool {
+	for exposedPort := range cfg.ExposedPorts {
+		if int32(exposedPort.Int()) == port {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/skaffold/kubernetes/debugging/transform.go
+++ b/pkg/skaffold/kubernetes/debugging/transform.go
@@ -40,6 +40,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/debugging/adapter"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 var (
@@ -108,28 +109,6 @@ func describe(obj runtime.Object) (group, version, kind, description string) {
 		description = fmt.Sprintf("%s.%s/%s", strings.ToLower(kind), group, name)
 	}
 	return
-}
-
-// allocatePort walks the podSpec's containers looking for an available port that is close to desiredPort.
-// We deal with wrapping and avoid allocating ports < 1024
-func allocatePort(podSpec *v1.PodSpec, desiredPort int32) int32 {
-	var maxPort int32 = 65535 // ports are normally [1-65535]
-	if desiredPort < 1024 || desiredPort > maxPort {
-		desiredPort = 1024 // skip reserved ports
-	}
-	// We assume ports are rather sparsely allocated, so even if desiredPort
-	// is allocated, desiredPort+1 or desiredPort+2 are likely to be free
-	for port := desiredPort; port < maxPort; port++ {
-		if isPortAvailable(podSpec, port) {
-			return port
-		}
-	}
-	for port := desiredPort; port > 1024; port-- {
-		if isPortAvailable(podSpec, port) {
-			return port
-		}
-	}
-	panic("cannot find available port") // exceedingly unlikely
 }
 
 // isPortAvailable returns true if none of the pod's containers specify the given port.
@@ -265,8 +244,11 @@ func rewriteContainers(metadata *metav1.ObjectMeta, podSpec *v1.PodSpec, retriev
 		return false
 	}
 
+	portAvailable := func(port int32) bool {
+		return isPortAvailable(podSpec, port)
+	}
 	portAlloc := func(desiredPort int32) int32 {
-		return allocatePort(podSpec, desiredPort)
+		return util.AllocatePort(portAvailable, desiredPort)
 	}
 	// map of containers -> debugging configuration maps; k8s ensures that a pod's containers are uniquely named
 	configurations := make(map[string]types.ContainerDebugConfiguration)

--- a/pkg/skaffold/kubernetes/debugging/transform_test.go
+++ b/pkg/skaffold/kubernetes/debugging/transform_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -103,7 +104,10 @@ func TestAllocatePort(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			result := allocatePort(&test.pod, test.desiredPort)
+			portAvailable := func(port int32) bool {
+				return isPortAvailable(&test.pod, port)
+			}
+			result := util.AllocatePort(portAvailable, test.desiredPort)
 
 			t.CheckDeepEqual(test.result, result)
 		})

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -78,7 +78,8 @@ func GetDeployer(ctx context.Context, runCtx *runcontext.RunContext, labeller *l
 				return nil, err
 			}
 			// Override the cluster on the runcontext.
-			// This is used to determine whether we should push images, and we want to avoid that unless explicitly asked for
+			// This is used to determine whether we should push images, and we want to avoid that unless explicitly asked for.
+			// Safe to do because we explicitly disallow simultaneous remote and local deployments.
 			runCtx.Cluster = config.Cluster{
 				Local:      true,
 				PushImages: false,

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/helm"
@@ -75,6 +76,13 @@ func GetDeployer(ctx context.Context, runCtx *runcontext.RunContext, labeller *l
 			d, err := docker.NewDeployer(ctx, runCtx, labeller, d.DockerDeploy, runCtx.PortForwardResources())
 			if err != nil {
 				return nil, err
+			}
+			// Override the cluster on the runcontext.
+			// This is used to determine whether we should push images, and we want to avoid that unless explicitly asked for
+			runCtx.Cluster = config.Cluster{
+				Local:      true,
+				PushImages: false,
+				LoadImages: false,
 			}
 			deployers = append(deployers, d)
 		}

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -177,7 +177,7 @@ func (rc *RunContext) AddSkaffoldLabels() bool                       { return rc
 func (rc *RunContext) AutoBuild() bool                               { return rc.Opts.AutoBuild }
 func (rc *RunContext) AutoDeploy() bool                              { return rc.Opts.AutoDeploy }
 func (rc *RunContext) AutoSync() bool                                { return rc.Opts.AutoSync }
-func (rc *RunContext) Debug() bool                                   { return rc.Opts.Debug }
+func (rc *RunContext) ContainerDebugging() bool                      { return rc.Opts.ContainerDebugging }
 func (rc *RunContext) CacheArtifacts() bool                          { return rc.Opts.CacheArtifacts }
 func (rc *RunContext) CacheFile() string                             { return rc.Opts.CacheFile }
 func (rc *RunContext) ConfigurationFile() string                     { return rc.Opts.ConfigurationFile }

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -177,6 +177,7 @@ func (rc *RunContext) AddSkaffoldLabels() bool                       { return rc
 func (rc *RunContext) AutoBuild() bool                               { return rc.Opts.AutoBuild }
 func (rc *RunContext) AutoDeploy() bool                              { return rc.Opts.AutoDeploy }
 func (rc *RunContext) AutoSync() bool                                { return rc.Opts.AutoSync }
+func (rc *RunContext) Debug() bool                                   { return rc.Opts.Debug }
 func (rc *RunContext) CacheArtifacts() bool                          { return rc.Opts.CacheArtifacts }
 func (rc *RunContext) CacheFile() string                             { return rc.Opts.CacheFile }
 func (rc *RunContext) ConfigurationFile() string                     { return rc.Opts.ConfigurationFile }

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -58,14 +58,6 @@ func NewForConfig(ctx context.Context, runCtx *runcontext.RunContext) (*Skaffold
 	g := graph.ToArtifactGraph(runCtx.Artifacts())
 	sourceDependencies := graph.NewSourceDependenciesCache(runCtx, store, g)
 
-	var builder build.Builder
-	builder, err = build.NewBuilderMux(runCtx, store, func(p latestV1.Pipeline) (build.PipelineBuilder, error) {
-		return runner.GetBuilder(ctx, runCtx, store, sourceDependencies, p)
-	})
-	if err != nil {
-		endTrace(instrumentation.TraceEndError(err))
-		return nil, fmt.Errorf("creating builder: %w", err)
-	}
 	isLocalImage := func(imageName string) (bool, error) {
 		return isImageLocal(runCtx, imageName)
 	}
@@ -81,6 +73,17 @@ func NewForConfig(ctx context.Context, runCtx *runcontext.RunContext) (*Skaffold
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(err))
 		return nil, fmt.Errorf("creating deployer: %w", err)
+	}
+
+	// The Builder must be instantiated AFTER the Deployer, because the Deploy target influences
+	// the Cluster object on the RunContext, which in turn influences whether or not we will push images.
+	var builder build.Builder
+	builder, err = build.NewBuilderMux(runCtx, store, func(p latestV1.Pipeline) (build.PipelineBuilder, error) {
+		return runner.GetBuilder(ctx, runCtx, store, sourceDependencies, p)
+	})
+	if err != nil {
+		endTrace(instrumentation.TraceEndError(err))
+		return nil, fmt.Errorf("creating builder: %w", err)
 	}
 
 	depLister := func(ctx context.Context, artifact *latestV1.Artifact) ([]string, error) {
@@ -179,6 +182,11 @@ func isImageLocal(runCtx *runcontext.RunContext, imageName string) (bool, error)
 	}
 	if pipeline.Build.GoogleCloudBuild != nil || pipeline.Build.Cluster != nil {
 		return false, nil
+	}
+
+	// if we're deploying to local Docker, all images must be local
+	if pipeline.Deploy.DockerDeploy != nil {
+		return true, nil
 	}
 
 	cl := runCtx.GetCluster()

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -527,7 +527,7 @@ type DeployConfig struct {
 // time for hybrid workflows.
 type DeployType struct {
 	// DockerDeploy *alpha* uses the `docker` CLI to create application containers in Docker.
-	DockerDeploy *DockerDeploy `yaml:"-,omitempty"`
+	DockerDeploy *DockerDeploy `yaml:"docker,omitempty"`
 
 	// HelmDeploy *beta* uses the `helm` CLI to apply the charts to the cluster.
 	HelmDeploy *HelmDeploy `yaml:"helm,omitempty"`

--- a/pkg/skaffold/util/port.go
+++ b/pkg/skaffold/util/port.go
@@ -173,3 +173,26 @@ func IsPortFree(address string, p int) bool {
 	}
 	return true
 }
+
+// AllocatePort looks for a port close to desiredPort, using the provided implementation of
+// isPortAvailable to determine what ports can be used.
+// We deal with wrapping and avoid allocating ports < 1024
+func AllocatePort(isPortAvailable func(int32) bool, desiredPort int32) int32 {
+	var maxPort int32 = 65535 // ports are normally [1-65535]
+	if desiredPort < 1024 || desiredPort > maxPort {
+		desiredPort = 1024 // skip reserved ports
+	}
+	// We assume ports are rather sparsely allocated, so even if desiredPort
+	// is allocated, desiredPort+1 or desiredPort+2 are likely to be free
+	for port := desiredPort; port < maxPort; port++ {
+		if isPortAvailable(port) {
+			return port
+		}
+	}
+	for port := desiredPort; port > 1024; port-- {
+		if isPortAvailable(port) {
+			return port
+		}
+	}
+	panic("cannot find available port") // exceedingly unlikely
+}

--- a/pkg/skaffold/util/port.go
+++ b/pkg/skaffold/util/port.go
@@ -177,6 +177,7 @@ func IsPortFree(address string, p int) bool {
 // AllocatePort looks for a port close to desiredPort, using the provided implementation of
 // isPortAvailable to determine what ports can be used.
 // We deal with wrapping and avoid allocating ports < 1024
+// TODO(nkubala)[09/14/21]: plumb through context from callers
 func AllocatePort(isPortAvailable func(int32) bool, desiredPort int32) int32 {
 	var maxPort int32 = 65535 // ports are normally [1-65535]
 	if desiredPort < 1024 || desiredPort > maxPort {

--- a/pkg/skaffold/util/port.go
+++ b/pkg/skaffold/util/port.go
@@ -180,6 +180,7 @@ func IsPortFree(address string, p int) bool {
 func AllocatePort(isPortAvailable func(int32) bool, desiredPort int32) int32 {
 	var maxPort int32 = 65535 // ports are normally [1-65535]
 	if desiredPort < 1024 || desiredPort > maxPort {
+		log.Entry(context.TODO()).Debugf("skipping reserved port %d", desiredPort)
 		desiredPort = 1024 // skip reserved ports
 	}
 	// We assume ports are rather sparsely allocated, so even if desiredPort


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes https://github.com/GoogleContainerTools/skaffold/issues/6107

**NOTE: This change also unhides the Docker deployer, making it publicly available for use.**

**Description**
This change implements debug support for the Docker deployer, the final piece of the initial implementation for the Deployer.

Any containers created by the Docker deployer will go through the existing entrypoint rewriting logic in Skaffold, which will generate a set of modified applications containers along with a set of init containers. These init containers will be created before the application containers, and will create volumes in the local docker daemon that will be mounted into the application containers. These volumes function in a similar way to the ones created in the existing Kubernetes debug implementation, which contain the shared debugging files necessary to get the debugging binaries into the application containers.


A `DebugManager` object is created in the Deployer, which is primarily responsible for tracking the modified resources during a debug run. The `DebugManager` also tracks the support resources created to ensure smooth creation of init containers, as well as emitting events during the skaffold lifecycle.

The port allocation logic from the existing debugging implementation has been slightly modified to consume a Deployer-specific implementation of the `isPortAvailable()` function, such that it can be reused across multiple packages.