### PR TITLE
Fix buildpacks builder output to go through Event API

### DIFF
--- a/pkg/skaffold/build/buildpacks/lifecycle.go
+++ b/pkg/skaffold/build/buildpacks/lifecycle.go
@@ -32,7 +32,6 @@ import (
 	"github.com/buildpacks/pack/project"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
@@ -97,7 +96,7 @@ func (b *Builder) build(ctx context.Context, out io.Writer, a *latestV1.Artifact
 
 	builderImage, runImage, pullPolicy := resolveDependencyImages(artifact, b.artifacts, a.Dependencies, b.pushImages)
 
-	if err := runPackBuildFunc(ctx, output.GetUnderlyingWriter(out), b.localDocker, pack.BuildOptions{
+	if err := runPackBuildFunc(ctx, out, b.localDocker, pack.BuildOptions{
 		AppPath:         workspace,
 		Builder:         builderImage,
 		RunImage:        runImage,

--- a/pkg/skaffold/build/buildpacks/logger.go
+++ b/pkg/skaffold/build/buildpacks/logger.go
@@ -20,10 +20,7 @@ import (
 	"io"
 
 	"github.com/buildpacks/pack/logging"
-	"github.com/mattn/go-colorable"
 	"github.com/sirupsen/logrus"
-
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // logger exists to meet the requirements of the pack logger.
@@ -33,11 +30,6 @@ type logger struct {
 }
 
 func NewLogger(out io.Writer) logging.Logger {
-	// If out is not a terminal, let's make sure no colors are printed.
-	if _, isTerm := util.IsTerminal(out); !isTerm {
-		out = colorable.NewNonColorable(out)
-	}
-
 	l := logrus.New()
 	l.SetOutput(out)
 


### PR DESCRIPTION
Fixes: #6541 

**Description**
The output we were sending to buildpacks client was stripped from our `output.SkaffoldWriter` type, when we really do want to use that type. This PR fixes that. We should now see output from buildpacks builder in the Event API.

I've removed the check for terminal on the io.Writer as well because this already happens at the beginning of execution. 