### PR TITLE
Send success for pods for a deployment when its rolled out successfully

### DIFF
--- a/pkg/skaffold/kubernetes/status/resource/deployment_test.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment_test.go
@@ -27,9 +27,11 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/diag/validator"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
+	testEvent "github.com/GoogleContainerTools/skaffold/testutil/event"
 )
 
 func TestDeploymentCheckStatus(t *testing.T) {
@@ -101,6 +103,7 @@ func TestDeploymentCheckStatus(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
+			testEvent.InitializeState([]latestV1.Pipeline{{}})
 
 			r := NewDeployment("graph", "test", 0)
 			r.CheckStatus(context.Background(), &statusConfig{})

--- a/pkg/skaffold/kubernetes/status/resource/deployment_test.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/diag/validator"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
@@ -140,7 +141,7 @@ func TestParseKubectlError(t *testing.T) {
 			err:         errors.New("signal: killed"),
 			expectedAe: proto.ActionableErr{
 				ErrCode: proto.StatusCode_STATUSCHECK_KUBECTL_PID_KILLED,
-				Message: msgKubectlKilled,
+				Message: "received Ctrl-C or deployments could not stabilize within 10s: kubectl rollout status command interrupted\n",
 			},
 		},
 		{
@@ -162,7 +163,7 @@ func TestParseKubectlError(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			ae := parseKubectlRolloutError(test.details, test.err)
+			ae := parseKubectlRolloutError(test.details, 10 * time.Second, test.err)
 			t.CheckDeepEqual(test.expectedAe, ae)
 		})
 	}

--- a/pkg/skaffold/kubernetes/status/resource/deployment_test.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment_test.go
@@ -166,7 +166,7 @@ func TestParseKubectlError(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			ae := parseKubectlRolloutError(test.details, 10 * time.Second, test.err)
+			ae := parseKubectlRolloutError(test.details, 10*time.Second, test.err)
 			t.CheckDeepEqual(test.expectedAe, ae)
 		})
 	}

--- a/pkg/skaffold/kubernetes/status/status_check.go
+++ b/pkg/skaffold/kubernetes/status/status_check.go
@@ -288,8 +288,6 @@ func (s *Monitor) printStatusCheckSummary(out io.Writer, r *resource.Deployment,
 		// another deployment failed
 		return
 	}
-	event.ResourceStatusCheckEventCompleted(r.String(), ae)
-	eventV2.ResourceStatusCheckEventCompleted(r.String(), sErrors.V2fromV1(ae))
 	out, _ = output.WithEventContext(context.Background(), out, constants.Deploy, r.String())
 	status := fmt.Sprintf("%s %s", tabHeader, r)
 	if ae.ErrCode != proto.StatusCode_STATUSCHECK_SUCCESS {

--- a/pkg/skaffold/kubernetes/status/status_check_test.go
+++ b/pkg/skaffold/kubernetes/status/status_check_test.go
@@ -596,14 +596,6 @@ func TestPollDeployment(t *testing.T) {
 					"Pending",
 					proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_NODE_DISK_PRESSURE},
 					[]string{"err"})},
-				// pod recovered
-				{validator.NewResource(
-					"test",
-					"pod",
-					"dep-pod",
-					"Running",
-					proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_SUCCESS},
-					nil)},
 			},
 			expected: proto.StatusCode_STATUSCHECK_SUCCESS,
 		},


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/cloud-code-vscode-internal/issues/5277

I wanted to implement this approach last time in #6517. 
However, I decided to not and rely on `kubectl deployment rollout status` to return success if pods are up and healthy. 

I did try to investigate more on why `kubectl rollout status deployment` is returning a success and pods are unhealthy. 
As per the docs, this should not happen https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment

I am wondering if this could be due to fluctuating network. 

From, event logs @vincentjocodes  provided here https://github.com/GoogleCloudPlatform/cloud-code-vscode-internal/issues/5277#issuecomment-906806476, it seems the pod was created,  unhealthy, successful (probably health check passed) and then unhealthy again.  

See this
> (Look at line 301, 337, 389 (https://paste.googleplex.com/6664979378864128). The pod/ledgerwriter-74c84f5c7c-d7dh2 goes from 'InProgress' to 'Succeeded' to 'InProgress'. Doesn't resolve either 'Succeeded' or 'Failed'.)

The current logic, 
1) If deployment rolled out successfully,  we go fetch pods. 
It could be that, the pod passed the health check, deployment became successful and then due to network connectivity issues pod failed health check again. 
(The health check failure in this case was due to connection failure)
```
{"timestamp":"2021-08-26T23:13:41.666277Z","statusCheckSubtaskEvent":{"id":"pod/ledgerwriter-74c84f5c7c-d7dh2","task_id":"Deploy-1",
"resource":"pod/ledgerwriter-74c84f5c7c-d7dh2","
status":"InProgress",
"message":"Readiness probe failed: Get http://10.0.5.14:8080/ready: dial tcp 10.0.5.14:8080: connect: connection refused","statusCode":"STATUSCHECK_UNHEALTHY","actionableErr":{"errCode":"STATUSCHECK_UNHEALTHY","message":"Readiness probe failed: Get http://10.0.5.14:8080/ready: dial tcp 10.0.5.14:8080: connect: connection refused","suggestions":[{"suggestionCode":"CHECK_READINESS_PROBE","action":"Try checking container config `readinessProbe`"}]}}}
```

Solution:
1) If deployment is successful i.e. `kubectl rollout status dep/ledgerwriter` returns "deployment successfully rolled out`, send success event for all pods in the deployment.
This will ensure, we don't see the pending sign on VSC UI due to health checks instability.
2) Update the test to not expect a Validator run once deployment is successful.


 Side effects:
1) Depending on when a pod becomes healthy, we might see multiple pod successful event. See [here](https://github.com/GoogleContainerTools/skaffold/pull/6534#discussion_r697792015) The IDEs would not have any side effect due to this. /cc @etanshaul
2) If from last time skaffold fetched pods on a pending deployment, a new pod was allocated  and deployment rolled out successfully, then the new pod will be missed.
   * A new pod would be allocated if a node on which previous pod was running died, or a deployment was updated due to `kubectl apply` or pod was killed due to too many retrials.  However, all these scenarios are rare. Also note, the polling period is 1s. 

 
