### PR TITLE
Plumb `context.Context` down into functions in pkg/skaffold/sync

### DIFF
--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -87,12 +87,12 @@ func syncItem(ctx context.Context, a *latestV1.Artifact, tag string, e filemon.E
 		return nil, fmt.Errorf("retrieving working dir for %q: %w", tag, err)
 	}
 
-	toCopy, err := intersect(a.Workspace, containerWd, syncRules, append(e.Added, e.Modified...))
+	toCopy, err := intersect(ctx, a.Workspace, containerWd, syncRules, append(e.Added, e.Modified...))
 	if err != nil {
 		return nil, fmt.Errorf("intersecting sync map and added, modified files: %w", err)
 	}
 
-	toDelete, err := intersect(a.Workspace, containerWd, syncRules, e.Deleted)
+	toDelete, err := intersect(ctx, a.Workspace, containerWd, syncRules, e.Deleted)
 	if err != nil {
 		return nil, fmt.Errorf("intersecting sync map and deleted files: %w", err)
 	}
@@ -134,14 +134,14 @@ func inferredSyncItem(ctx context.Context, a *latestV1.Artifact, tag string, e f
 			}
 		}
 		if !matches {
-			log.Entry(context.TODO()).Infof("Changed file %s does not match any sync pattern. Skipping sync", relPath)
+			log.Entry(ctx).Infof("Changed file %s does not match any sync pattern. Skipping sync", relPath)
 			return nil, nil
 		}
 
 		if dsts, ok := syncMap[relPath]; ok {
 			toCopy[f] = dsts
 		} else {
-			log.Entry(context.TODO()).Infof("Changed file %s is not syncable. Skipping sync", relPath)
+			log.Entry(ctx).Infof("Changed file %s is not syncable. Skipping sync", relPath)
 			return nil, nil
 		}
 	}
@@ -206,7 +206,7 @@ func latestTag(image string, builds []graph.Artifact) string {
 	return ""
 }
 
-func intersect(contextWd, containerWd string, syncRules []*latestV1.SyncRule, files []string) (syncMap, error) {
+func intersect(ctx context.Context, contextWd, containerWd string, syncRules []*latestV1.SyncRule, files []string) (syncMap, error) {
 	ret := make(syncMap)
 	for _, f := range files {
 		relPath, err := filepath.Rel(contextWd, f)
@@ -220,7 +220,7 @@ func intersect(contextWd, containerWd string, syncRules []*latestV1.SyncRule, fi
 		}
 
 		if len(dsts) == 0 {
-			log.Entry(context.TODO()).Infof("Changed file %s does not match any sync pattern. Skipping sync", relPath)
+			log.Entry(ctx).Infof("Changed file %s does not match any sync pattern. Skipping sync", relPath)
 			return nil, nil
 		}
 

--- a/pkg/skaffold/sync/sync_test.go
+++ b/pkg/skaffold/sync/sync_test.go
@@ -826,7 +826,7 @@ func TestIntersect(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			actual, err := intersect(test.context, test.workingDir, test.syncRules, test.files)
+			actual, err := intersect(context.TODO(), test.context, test.workingDir, test.syncRules, test.files)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, actual)
 		})


### PR DESCRIPTION
**Related**: #5368

**Description**
Finish plumbing context.Context through the sync functions.