### PR TITLE
[docs fixit] update skaffold fix text to have full description of command

### DIFF
--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -23,7 +23,7 @@ Pipeline building blocks for CI/CD:
 Getting started with a new project:
 
 * [skaffold init](#skaffold-init) - to bootstrap Skaffold config
-* [skaffold fix](#skaffold-fix) - to upgrade from
+* [skaffold fix](#skaffold-fix) - to upgrade from older skaffold.yaml schema version to newer skaffold.yaml schema version 
 
 Other Commands:
 

--- a/docs/content/en/docs/references/cli/index_header
+++ b/docs/content/en/docs/references/cli/index_header
@@ -23,7 +23,7 @@ Pipeline building blocks for CI/CD:
 Getting started with a new project:
 
 * [skaffold init](#skaffold-init) - to bootstrap Skaffold config
-* [skaffold fix](#skaffold-fix) - to upgrade from
+* [skaffold fix](#skaffold-fix) - to upgrade from older skaffold.yaml schema version to newer skaffold.yaml schema version 
 
 Other Commands:
 


### PR DESCRIPTION
PR updates skaffold fix text on the CLI tab of the `skaffold.dev` page to be a complete statement about the command with an accurate description