### PR TITLE
Add 'make linters' and 'make checks' per-pr tests to gh actions. 

### DIFF
--- a/.github/workflows/linters-and-checks-linux.yml
+++ b/.github/workflows/linters-and-checks-linux.yml
@@ -1,0 +1,31 @@
+name: per-pr linters and checks (linux)
+
+# Triggers the workflow on push or pull request events
+on: [push, pull_request]
+
+permissions: read-all
+
+jobs:
+
+  build:
+    name: PR Linters and Checks tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.14
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Run make linters
+      run: |
+        make linters
+
+    - name: Run make checks
+      run: |
+        make checks


### PR DESCRIPTION
Add 'make linters' and 'make checks' per-pr tests to gh actions. Step towards migrating off of travis
