### PR TITLE
Add option to wait for connection to `/v2/events` on gRPC/HTTP server

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -328,6 +328,7 @@ func apiServerShutdownHook(err error) error {
 	// clean up server at end of the execution since cobra post run hooks
 	// are only executed if RunE is successful.
 	if shutdownAPIServer != nil {
+		event.SendErrorMessageOnce(constants.DevLoop, constants.SubtaskIDNone, err)
 		shutdownAPIServer()
 	}
 	return err

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -325,8 +325,9 @@ func isQuietMode() bool {
 }
 
 func apiServerShutdownHook(err error) error {
-	// clean up server at end of the execution since cobra post run hooks
+	// Clean up server at end of the execution since cobra post run hooks
 	// are only executed if RunE is successful.
+	// Also sends out error message on event stream before shutting down server.
 	if shutdownAPIServer != nil {
 		event.SendErrorMessageOnce(constants.DevLoop, constants.SubtaskIDNone, err)
 		shutdownAPIServer()

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -183,6 +183,15 @@ var flagRegistry = []Flag{
 		IsEnum:        true,
 	},
 	{
+		Name:          "wait-for-connection",
+		Usage:         "Blocks execution until the /v2/events gRPC/HTTP endpoint is hit",
+		Value:         &opts.WaitForConnection,
+		DefValue:      false,
+		FlagAddMethod: "BoolVar",
+		DefinedOn:     []string{"dev", "debug"},
+		IsEnum:        true,
+	},
+	{
 		Name:          "event-log-file",
 		Usage:         "Save Skaffold events to the provided file after skaffold has finished executing, requires --enable-rpc=true",
 		Hidden:        true,

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -188,7 +188,7 @@ var flagRegistry = []Flag{
 		Value:         &opts.WaitForConnection,
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",
-		DefinedOn:     []string{"dev", "debug"},
+		DefinedOn:     []string{"dev", "build", "run", "debug", "deploy", "render", "apply", "test"},
 		IsEnum:        true,
 	},
 	{

--- a/cmd/skaffold/skaffold.go
+++ b/cmd/skaffold/skaffold.go
@@ -24,8 +24,6 @@ import (
 	"cloud.google.com/go/profiler"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
-	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
@@ -57,7 +55,7 @@ func main() {
 			// for the entire skaffold run here. It's possible SetupColors() was never called, so call it again
 			// before we print an error to get the right coloring.
 			errOut := output.SetupColors(context.Background(), os.Stderr, output.DefaultColorCode, false)
-			eventV2.SendErrorMessageOnce(constants.DevLoop, constants.SubtaskIDNone, err)
+			//eventV2.SendErrorMessageOnce(constants.DevLoop, constants.SubtaskIDNone, err)
 			output.Red.Fprintln(errOut, err)
 			code = app.ExitCode(err)
 		}

--- a/cmd/skaffold/skaffold.go
+++ b/cmd/skaffold/skaffold.go
@@ -55,7 +55,6 @@ func main() {
 			// for the entire skaffold run here. It's possible SetupColors() was never called, so call it again
 			// before we print an error to get the right coloring.
 			errOut := output.SetupColors(context.Background(), os.Stderr, output.DefaultColorCode, false)
-			//eventV2.SendErrorMessageOnce(constants.DevLoop, constants.SubtaskIDNone, err)
 			output.Red.Fprintln(errOut, err)
 			code = app.ExitCode(err)
 		}

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -426,6 +426,7 @@ Options:
       --tail=true: Stream logs from deployed objects
       --toot=false: Emit a terminal beep after the deploy is complete
       --trigger='notify': How is change detection triggered? (polling, notify, or manual)
+      --wait-for-connection=false: Blocks execution until the /v2/events gRPC/HTTP endpoint is hit
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
       --wait-for-deletions-delay=2s: Delay between two checks for pending deletions
       --wait-for-deletions-max=1m0s: Max duration to wait for pending deletions
@@ -481,6 +482,7 @@ Env vars:
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
 * `SKAFFOLD_TRIGGER` (same as `--trigger`)
+* `SKAFFOLD_WAIT_FOR_CONNECTION` (same as `--wait-for-connection`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_DELAY` (same as `--wait-for-deletions-delay`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_MAX` (same as `--wait-for-deletions-max`)
@@ -678,6 +680,7 @@ Options:
       --tail=true: Stream logs from deployed objects
       --toot=false: Emit a terminal beep after the deploy is complete
       --trigger='notify': How is change detection triggered? (polling, notify, or manual)
+      --wait-for-connection=false: Blocks execution until the /v2/events gRPC/HTTP endpoint is hit
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
       --wait-for-deletions-delay=2s: Delay between two checks for pending deletions
       --wait-for-deletions-max=1m0s: Max duration to wait for pending deletions
@@ -733,6 +736,7 @@ Env vars:
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
 * `SKAFFOLD_TRIGGER` (same as `--trigger`)
+* `SKAFFOLD_WAIT_FOR_CONNECTION` (same as `--wait-for-connection`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_DELAY` (same as `--wait-for-deletions-delay`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_MAX` (same as `--wait-for-deletions-max`)

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -134,6 +134,7 @@ Options:
       --status-check=true: Wait for deployed resources to stabilize
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
       --tail=false: Stream logs from deployed objects
+      --wait-for-connection=false: Blocks execution until the /v2/events gRPC/HTTP endpoint is hit
 
 Usage:
   skaffold apply [options]
@@ -158,6 +159,7 @@ Env vars:
 * `SKAFFOLD_STATUS_CHECK` (same as `--status-check`)
 * `SKAFFOLD_SYNC_REMOTE_CACHE` (same as `--sync-remote-cache`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
+* `SKAFFOLD_WAIT_FOR_CONNECTION` (same as `--wait-for-connection`)
 
 ### skaffold build
 
@@ -216,6 +218,7 @@ Options:
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --toot=false: Emit a terminal beep after the deploy is complete
+      --wait-for-connection=false: Blocks execution until the /v2/events gRPC/HTTP endpoint is hit
 
 Usage:
   skaffold build [options]
@@ -256,6 +259,7 @@ Env vars:
 * `SKAFFOLD_SYNC_REMOTE_CACHE` (same as `--sync-remote-cache`)
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
+* `SKAFFOLD_WAIT_FOR_CONNECTION` (same as `--wait-for-connection`)
 
 ### skaffold completion
 
@@ -585,6 +589,7 @@ Options:
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects
       --toot=false: Emit a terminal beep after the deploy is complete
+      --wait-for-connection=false: Blocks execution until the /v2/events gRPC/HTTP endpoint is hit
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
       --wait-for-deletions-delay=2s: Delay between two checks for pending deletions
       --wait-for-deletions-max=1m0s: Max duration to wait for pending deletions
@@ -628,6 +633,7 @@ Env vars:
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
+* `SKAFFOLD_WAIT_FOR_CONNECTION` (same as `--wait-for-connection`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_DELAY` (same as `--wait-for-deletions-delay`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_MAX` (same as `--wait-for-deletions-max`)
@@ -914,6 +920,7 @@ Options:
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
+      --wait-for-connection=false: Blocks execution until the /v2/events gRPC/HTTP endpoint is hit
 
 Usage:
   skaffold render [options]
@@ -941,6 +948,7 @@ Env vars:
 * `SKAFFOLD_PROPAGATE_PROFILES` (same as `--propagate-profiles`)
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
 * `SKAFFOLD_SYNC_REMOTE_CACHE` (same as `--sync-remote-cache`)
+* `SKAFFOLD_WAIT_FOR_CONNECTION` (same as `--wait-for-connection`)
 
 ### skaffold run
 
@@ -994,6 +1002,7 @@ Options:
   -t, --tag='': The optional custom tag to use for images which overrides the current Tagger configuration
       --tail=false: Stream logs from deployed objects
       --toot=false: Emit a terminal beep after the deploy is complete
+      --wait-for-connection=false: Blocks execution until the /v2/events gRPC/HTTP endpoint is hit
       --wait-for-deletions=true: Wait for pending deletions to complete before a deployment
       --wait-for-deletions-delay=2s: Delay between two checks for pending deletions
       --wait-for-deletions-max=1m0s: Max duration to wait for pending deletions
@@ -1044,6 +1053,7 @@ Env vars:
 * `SKAFFOLD_TAG` (same as `--tag`)
 * `SKAFFOLD_TAIL` (same as `--tail`)
 * `SKAFFOLD_TOOT` (same as `--toot`)
+* `SKAFFOLD_WAIT_FOR_CONNECTION` (same as `--wait-for-connection`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS` (same as `--wait-for-deletions`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_DELAY` (same as `--wait-for-deletions-delay`)
 * `SKAFFOLD_WAIT_FOR_DELETIONS_MAX` (same as `--wait-for-deletions-max`)
@@ -1130,6 +1140,7 @@ Options:
       --rpc-http-port=50052: tcp port to expose event REST API over HTTP
       --rpc-port=50051: tcp port to expose event API
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
+      --wait-for-connection=false: Blocks execution until the /v2/events gRPC/HTTP endpoint is hit
 
 Usage:
   skaffold test [options]
@@ -1152,6 +1163,7 @@ Env vars:
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SYNC_REMOTE_CACHE` (same as `--sync-remote-cache`)
+* `SKAFFOLD_WAIT_FOR_CONNECTION` (same as `--wait-for-connection`)
 
 ### skaffold version
 

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -95,11 +95,12 @@ type SkaffoldOptions struct {
 	// TODO(https://github.com/GoogleContainerTools/skaffold/issues/3668):
 	// remove minikubeProfile from here and instead detect it by matching the
 	// kubecontext API Server to minikube profiles
-	MinikubeProfile  string
-	RepoCacheDir     string
-	SyncRemoteCache  SyncRemoteCacheOption
-	WaitForDeletions WaitForDeletions
-	ForceLoadImages  bool
+	MinikubeProfile   string
+	RepoCacheDir      string
+	SyncRemoteCache   SyncRemoteCacheOption
+	WaitForDeletions  WaitForDeletions
+	ForceLoadImages   bool
+	WaitForConnection bool
 }
 
 type RunMode string

--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -51,6 +51,7 @@ var handler = newHandler()
 func newHandler() *eventHandler {
 	h := &eventHandler{
 		eventChan: make(chan *proto.Event),
+		wait:      make(chan bool, 1),
 	}
 	go func() {
 		for {
@@ -73,6 +74,7 @@ type eventHandler struct {
 
 	iteration               int
 	errorOnce               sync.Once
+	wait                    chan bool
 	state                   proto.State
 	stateLock               sync.Mutex
 	eventChan               chan *proto.Event
@@ -108,6 +110,11 @@ func Handle(event *proto.Event) error {
 		handler.handle(event)
 	}
 	return nil
+}
+
+// WaitForConnection will block execution until the server receives a connection
+func WaitForConnection() {
+	<-handler.wait
 }
 
 func (ev *eventHandler) getState() proto.State {
@@ -173,6 +180,9 @@ func (ev *eventHandler) forEach(listeners *[]*listener, log *[]proto.Event, lock
 }
 
 func (ev *eventHandler) forEachEvent(callback func(*proto.Event) error) error {
+	if len(handler.wait) != cap(handler.wait) {
+		handler.wait <- true
+	}
 	return ev.forEach(&ev.eventListeners, &ev.eventLog, &ev.logLock, callback)
 }
 

--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -180,8 +180,9 @@ func (ev *eventHandler) forEach(listeners *[]*listener, log *[]proto.Event, lock
 }
 
 func (ev *eventHandler) forEachEvent(callback func(*proto.Event) error) error {
-	if len(handler.wait) != cap(handler.wait) {
-		handler.wait <- true
+	select {
+	case handler.wait <- true:
+	default:
 	}
 	return ev.forEach(&ev.eventListeners, &ev.eventLog, &ev.logLock, callback)
 }

--- a/pkg/skaffold/server/server.go
+++ b/pkg/skaffold/server/server.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
+	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 	v2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/server/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -128,6 +129,11 @@ func Initialize(opts config.SkaffoldOptions) (func() error, error) {
 	}
 	if err != nil {
 		return callback, fmt.Errorf("starting HTTP server: %w", err)
+	}
+
+	// Optionally pause execution until endpoint hit
+	if opts.WaitForConnection {
+		eventV2.WaitForConnection()
 	}
 
 	return callback, nil


### PR DESCRIPTION
**Description**
This PR adds the option for the user to have skaffold pause execution on initialization of the gRPC/HTTP server. Execution will continue when a request to `/v2/events` is made. This will help ensure that users of the server can connect before Skaffold execution ends early in some cases.

This PR also moves the call to `event.SendErrorMessageOnce` to the server shutdown callback function, which ensures that the error message gets sent out before the server is shut down.
