### PR TITLE
fix: helm resource labeller checking wrong kubectl context

### DIFF
--- a/pkg/skaffold/deploy/label/labels.go
+++ b/pkg/skaffold/deploy/label/labels.go
@@ -62,7 +62,7 @@ func Apply(ctx context.Context, labels map[string]string, results []deploy.Artif
 	for _, res := range results {
 		err = nil
 		for i := 0; i < tries; i++ {
-			if err = updateRuntimeObject(ctx, dynClient, client.Discovery(), labels, res); err == nil {
+			if err = updateRuntimeObject(ctx, dynClient, client.Discovery(), labels, res, kubeContext); err == nil {
 				break
 			}
 			time.Sleep(sleeptime)
@@ -84,7 +84,7 @@ func addLabels(labels map[string]string, accessor metav1.Object) {
 	accessor.SetLabels(kv)
 }
 
-func updateRuntimeObject(ctx context.Context, client dynamic.Interface, disco discovery.DiscoveryInterface, labels map[string]string, res deploy.Artifact) error {
+func updateRuntimeObject(ctx context.Context, client dynamic.Interface, disco discovery.DiscoveryInterface, labels map[string]string, res deploy.Artifact, kubeContext string) error {
 	originalJSON, _ := json.Marshal(res.Obj)
 	modifiedObj := res.Obj.DeepCopyObject()
 	accessor, err := meta.Accessor(modifiedObj)
@@ -111,7 +111,7 @@ func updateRuntimeObject(ctx context.Context, client dynamic.Interface, disco di
 			namespace = res.Namespace
 		}
 
-		ns, err := resolveNamespace(namespace)
+		ns, err := resolveNamespace(namespace, kubeContext)
 		if err != nil {
 			return fmt.Errorf("resolving namespace: %w", err)
 		}
@@ -130,7 +130,7 @@ func updateRuntimeObject(ctx context.Context, client dynamic.Interface, disco di
 	return nil
 }
 
-func resolveNamespace(ns string) (string, error) {
+func resolveNamespace(ns, kubeContext string) (string, error) {
 	if ns != "" {
 		return ns, nil
 	}
@@ -139,7 +139,7 @@ func resolveNamespace(ns string) (string, error) {
 		return "", fmt.Errorf("getting kubeconfig: %w", err)
 	}
 
-	current, present := cfg.Contexts[cfg.CurrentContext]
+	current, present := cfg.Contexts[kubeContext]
 	if present && current.Namespace != "" {
 		return current.Namespace, nil
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6510 <!-- tracking issues that this PR will close -->

Can be tested on `examples/helm-deployment` using two kind clusters

### Prep:

* Create first cluster
```
kind create cluster --name kind1     
```
* Create second cluster
```
kind create cluster --name kind2
```
* Create namespace
```
kubectl create namespace nsp2
```
* Set namespace for context
```
kubectl config set-context --current --namespace=nsp2
```
* Switch back to first cluster
```
kubectl config use-context kind-kind1
```
* In project `examples/helm-deployment`, modify skaffold.yaml:
```
apiVersion: skaffold/v2beta22
kind: Config
build:
  artifacts:
  - image: skaffold-helm
deploy:
  kubeContext: kind-kind2
  helm:
    releases:
    - name: skaffold-helm
      chartPath: charts
      artifactOverrides:
        image: skaffold-helm
```
* Run skaffold
```
skaffold dev
```
---

### Before:
```
Starting deploy...
...
WARN[0006] error adding label to runtime object: patching resource default/"skaffold-helm": deployments.apps "skaffold-helm" not found  subtask=0 task=Deploy
Waiting for deployments to stabilize...
```

### After:
```
Starting deploy...
...
Waiting for deployments to stabilize...
```
