### PR TITLE
Run CodeQL analysis nightly and cache the go modules cache

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,6 @@
 name: "CodeQL"
+# Run the GitHub CodeQL analysis tasks against Skaffold
+# https://codeql.github.com/docs/
 
 on:
   # run nightly rather than on every PR as scan takes 35m

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,9 +31,12 @@ jobs:
 
     - uses: actions/cache@v2
       with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-gopkgmod-${{ hashFiles('**/go.sum') }}
-        restore-keys: ${{ runner.os }}-gopkgmod-
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,9 +1,10 @@
 name: "CodeQL"
 
 on:
-  # just run nightly as scan takes 35m
+  # run nightly rather than on every PR as scan takes 35m
   schedule:
-    - cron: '23 17 * * 3'
+    - cron: '23 4 * * *'
+  workflow_dispatch:
 
 permissions: read-all
 
@@ -27,6 +28,12 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+
+    - uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-gopkgmod-${{ hashFiles('**/go.sum') }}
+        restore-keys: ${{ runner.os }}-gopkgmod-
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
The CodeQL analysis was set up to run weekly rather than nightly.  We can also speed up the build by caching the Go build cache and modules cache as per [the actions/cache docs](https://github.com/actions/cache/blob/main/examples.md#go---modules).