### PR TITLE
Use `ResourceStatusCheckEvent[Updated/Completed]` where appropriate

### DIFF
--- a/pkg/skaffold/kubernetes/status/resource/deployment.go
+++ b/pkg/skaffold/kubernetes/status/resource/deployment.go
@@ -136,8 +136,8 @@ func (d *Deployment) CheckStatus(ctx context.Context, cfg kubectl.Config) {
 	ae := parseKubectlRolloutError(details, d.deadline, err)
 	d.UpdateStatus(ae)
 	// send event update in check status.
-	event.ResourceStatusCheckEventCompleted(d.String(), ae)
-	eventV2.ResourceStatusCheckEventCompleted(d.String(), sErrors.V2fromV1(ae))
+	event.ResourceStatusCheckEventUpdated(d.String(), ae)
+	eventV2.ResourceStatusCheckEventUpdated(d.String(), sErrors.V2fromV1(ae))
 	// if deployment is successfully rolled out, send pod success event to make sure
 	// all pod are marked as success in V2
 	// See https://github.com/GoogleCloudPlatform/cloud-code-vscode-internal/issues/5277

--- a/pkg/skaffold/kubernetes/status/status_check.go
+++ b/pkg/skaffold/kubernetes/status/status_check.go
@@ -288,6 +288,8 @@ func (s *Monitor) printStatusCheckSummary(out io.Writer, r *resource.Deployment,
 		// another deployment failed
 		return
 	}
+	event.ResourceStatusCheckEventCompleted(r.String(), ae)
+	eventV2.ResourceStatusCheckEventCompleted(r.String(), sErrors.V2fromV1(ae))
 	out, _ = output.WithEventContext(context.Background(), out, constants.Deploy, r.String())
 	status := fmt.Sprintf("%s %s", tabHeader, r)
 	if ae.ErrCode != proto.StatusCode_STATUSCHECK_SUCCESS {


### PR DESCRIPTION
Related: https://github.com/GoogleCloudPlatform/cloud-code-vscode-internal/issues/5277

**Description**
This PR changes some of the events that are being emitted by status check phase. We were sending out event completed when we shouldn't be in https://github.com/GoogleContainerTools/skaffold/pull/6534 which was causing issues.

 Also removes some duplicate pod events and messages