### PR TITLE
Use dlog to parse docker container logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/AlecAivazis/survey/v2 v2.2.15
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.20.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v0.20.0
+	github.com/ahmetb/dlog v0.0.0-20170105205344-4fb5f8204f26 // indirect
 	github.com/aws/aws-sdk-go v1.36.30 // indirect
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bmatcuk/doublestar v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
+github.com/ahmetb/dlog v0.0.0-20170105205344-4fb5f8204f26 h1:3YVZUqkoev4mL+aCwVOSWV4M7pN+NURHL38Z2zq5JKA=
+github.com/ahmetb/dlog v0.0.0-20170105205344-4fb5f8204f26/go.mod h1:ymXt5bw5uSNu4jveerFxE0vNYxF8ncqbptntMaFMg3k=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/jsonschema v0.0.0-20180308105923-f2c93856175a/go.mod h1:qpebaTNSsyUn5rPSJMsfqEtDw71TTggXM6stUDI16HA=

--- a/pkg/skaffold/docker/logger/log.go
+++ b/pkg/skaffold/docker/logger/log.go
@@ -22,6 +22,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ahmetb/dlog"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker/tracker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
@@ -92,8 +94,9 @@ func (l *Logger) streamLogsFromContainer(ctx context.Context, id string) {
 		_ = tw.Close()
 	}()
 
+	dr := dlog.NewReader(tr) // https://ahmet.im/blog/docker-logs-api-binary-format-explained/
 	formatter := NewDockerLogFormatter(l.colorPicker, l.tracker, l.IsMuted, id)
-	if err := logstream.StreamRequest(ctx, l.out, formatter, tr); err != nil {
+	if err := logstream.StreamRequest(ctx, l.out, formatter, dr); err != nil {
 		log.Entry(ctx).Errorf("streaming request: %s", err)
 	}
 }


### PR DESCRIPTION
Big thanks to @ahmetb for connecting the dots and pulling this solution out of his magic hat 🪄 

https://ahmet.im/blog/docker-logs-api-binary-format-explained/

Docker's log format has some quirks that, when not dealt with, result in seemingly random characters printed to the terminal. `dlog` is a simple solution to deal with this format and clean up the log output before surfacing to users.

Using the `react-reload-docker` example:

Before:
```
[react-reload-docker] > react-reload@1.0.0 dev /app
[react-reload-docker] .> webpack-dev-server --mode development --hot
[react-reload-docker] 
[react-reload-docker] Nℹ ｢wds｣: Project is running at http://0.0.0.0:8080/
[react-reload-docker] Cℹ ｢wds｣: webpack output is served from /
[react-reload-docker] Pℹ ｢wds｣: Content not from webpack is served from /app
[react-reload-docker] >ℹ ｢wdm｣: Hash: 0614fa9d31d389d62b08
[react-reload-docker] Version: webpack 4.46.0
Time: 1765msd-docker] 
[react-reload-docker]  Built at: 09/02/2021 5:43:16 PM
[react-reload-docker] 6     Asset       Size  Chunks             Chunk Names
[react-reload-docker] +index.html  295 bytes          [emitted]  
[react-reload-docker] /   main.js   1.36 MiB    main  [emitted]  main
[react-reload-docker] Entrypoint main = main.js
[react-reload-docker] |[0] multi (webpack)-dev-server/client?http://0.0.0.0:8080 (webpack)/hot/dev-server.js ./src/main.js 52 bytes {main} [built]
[react-reload-docker] <[./node_modules/react-dom/index.js] 1.33 KiB {main} [built]
[react-reload-docker] 9[./node_modules/react/index.js] 190 bytes {main} [built]
[react-reload-docker] >[./node_modules/strip-ansi/index.js] 161 bytes {main} [built]
[react-reload-docker] �[./node_modules/webpack-dev-server/client/index.js?http://0.0.0.0:8080] (webpack)-dev-server/client?http://0.0.0.0:8080 4.29 KiB {main} [built]
[react-reload-docker] u[./node_modules/webpack-dev-server/client/overlay.js] (webpack)-dev-server/client/overlay.js 3.51 KiB {main} [built]
[react-reload-docker] s[./node_modules/webpack-dev-server/client/socket.js] (webpack)-dev-server/client/socket.js 1.53 KiB {main} [built]
[react-reload-docker] �[./node_modules/webpack-dev-server/client/utils/createSocketUrl.js] (webpack)-dev-server/client/utils/createSocketUrl.js 2.91 KiB {main} [built]
[react-reload-docker] z[./node_modules/webpack-dev-server/client/utils/log.js] (webpack)-dev-server/client/utils/log.js 964 bytes {main} [built]
[react-reload-docker] �[./node_modules/webpack-dev-server/client/utils/reloadApp.js] (webpack)-dev-server/client/utils/reloadApp.js 1.59 KiB {main} [built]
[react-reload-docker] �[./node_modules/webpack-dev-server/client/utils/sendMessage.js] (webpack)-dev-server/client/utils/sendMessage.js 402 bytes {main} [built]
[react-reload-docker] o[./node_modules/webpack/hot sync ^\.\/log$] (webpack)/hot sync nonrecursive ^\.\/log$ 170 bytes {main} [built]
[react-reload-docker] _[./node_modules/webpack/hot/dev-server.js] (webpack)/hot/dev-server.js 1.59 KiB {main} [built]
[react-reload-docker] Y[./node_modules/webpack/hot/emitter.js] (webpack)/hot/emitter.js 75 bytes {main} [built]
[react-reload-docker] )[./src/main.js] 220 bytes {main} [built]
[react-reload-docker]     + 38 hidden modules
[react-reload-docker] ,Child html-webpack-plugin for "index.html":
     1 assetd-docker] 
[react-reload-docker] &    Entrypoint undefined = index.html
[react-reload-docker] ^    [./node_modules/html-webpack-plugin/lib/loader.js!./src/index.html] 446 bytes {0} [built]
[react-reload-docker] :    [./node_modules/lodash/lodash.js] 531 KiB {0} [built]
[react-reload-docker] a    [./node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 472 bytes {0} [built]
[react-reload-docker] a    [./node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]
[react-reload-docker] :ℹ ｢wdm｣: Compiled successfully.
```

After:

```
[react-reload-docker] > react-reload@1.0.0 dev /app
[react-reload-docker] > webpack-dev-server --mode development --hot
[react-reload-docker] 
[react-reload-docker] ℹ ｢wds｣: Project is running at http://0.0.0.0:8080/
[react-reload-docker] ℹ ｢wds｣: webpack output is served from /
[react-reload-docker] ℹ ｢wds｣: Content not from webpack is served from /app
[react-reload-docker] ℹ ｢wdm｣: Hash: 0614fa9d31d389d62b08
[react-reload-docker] Version: webpack 4.46.0
[react-reload-docker] Time: 1697ms
[react-reload-docker] Built at: 09/02/2021 6:03:06 PM
[react-reload-docker]      Asset       Size  Chunks             Chunk Names
[react-reload-docker] index.html  295 bytes          [emitted]  
[react-reload-docker]    main.js   1.36 MiB    main  [emitted]  main
[react-reload-docker] Entrypoint main = main.js
[react-reload-docker] [0] multi (webpack)-dev-server/client?http://0.0.0.0:8080 (webpack)/hot/dev-server.js ./src/main.js 52 bytes {main} [built]
[react-reload-docker] [./node_modules/react-dom/index.js] 1.33 KiB {main} [built]
[react-reload-docker] [./node_modules/react/index.js] 190 bytes {main} [built]
[react-reload-docker] [./node_modules/strip-ansi/index.js] 161 bytes {main} [built]
[react-reload-docker] [./node_modules/webpack-dev-server/client/index.js?http://0.0.0.0:8080] (webpack)-dev-server/client?http://0.0.0.0:8080 4.29 KiB {main} [built]
[react-reload-docker] [./node_modules/webpack-dev-server/client/overlay.js] (webpack)-dev-server/client/overlay.js 3.51 KiB {main} [built]
[react-reload-docker] [./node_modules/webpack-dev-server/client/socket.js] (webpack)-dev-server/client/socket.js 1.53 KiB {main} [built]
[react-reload-docker] [./node_modules/webpack-dev-server/client/utils/createSocketUrl.js] (webpack)-dev-server/client/utils/createSocketUrl.js 2.91 KiB {main} [built]
[react-reload-docker] [./node_modules/webpack-dev-server/client/utils/log.js] (webpack)-dev-server/client/utils/log.js 964 bytes {main} [built]
[react-reload-docker] [./node_modules/webpack-dev-server/client/utils/reloadApp.js] (webpack)-dev-server/client/utils/reloadApp.js 1.59 KiB {main} [built]
[react-reload-docker] [./node_modules/webpack-dev-server/client/utils/sendMessage.js] (webpack)-dev-server/client/utils/sendMessage.js 402 bytes {main} [built]
[react-reload-docker] [./node_modules/webpack/hot sync ^\.\/log$] (webpack)/hot sync nonrecursive ^\.\/log$ 170 bytes {main} [built]
[react-reload-docker] [./node_modules/webpack/hot/dev-server.js] (webpack)/hot/dev-server.js 1.59 KiB {main} [built]
[react-reload-docker] [./node_modules/webpack/hot/emitter.js] (webpack)/hot/emitter.js 75 bytes {main} [built]
[react-reload-docker] [./src/main.js] 220 bytes {main} [built]
[react-reload-docker]     + 38 hidden modules
[react-reload-docker] Child html-webpack-plugin for "index.html":
[react-reload-docker]      1 asset
[react-reload-docker]     Entrypoint undefined = index.html
[react-reload-docker]     [./node_modules/html-webpack-plugin/lib/loader.js!./src/index.html] 446 bytes {0} [built]
[react-reload-docker]     [./node_modules/lodash/lodash.js] 531 KiB {0} [built]
[react-reload-docker]     [./node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 472 bytes {0} [built]
[react-reload-docker]     [./node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 497 bytes {0} [built]
[react-reload-docker] ℹ ｢wdm｣: Compiled successfully.
```