### PR TITLE
Detect ko images for debugging, by envvar

### DIFF
--- a/pkg/skaffold/debug/transform_go.go
+++ b/pkg/skaffold/debug/transform_go.go
@@ -64,7 +64,7 @@ func isLaunchingDlv(args []string) bool {
 }
 
 func (t dlvTransformer) IsApplicable(config ImageConfiguration) bool {
-	for _, name := range []string{"GODEBUG", "GOGC", "GOMAXPROCS", "GOTRACEBACK"} {
+	for _, name := range []string{"GODEBUG", "GOGC", "GOMAXPROCS", "GOTRACEBACK", "KO_DATA_PATH"} {
 		if _, found := config.Env[name]; found {
 			log.Entry(context.TODO()).Infof("Artifact %q has Go runtime: has env %q", config.Artifact, name)
 			return true

--- a/pkg/skaffold/debug/transform_go_test.go
+++ b/pkg/skaffold/debug/transform_go_test.go
@@ -87,6 +87,12 @@ func TestDlvTransformer_IsApplicable(t *testing.T) {
 			result:      true,
 		},
 		{
+			// detect images built by ko: https://github.com/google/ko#static-assets
+			description: "KO_DATA_PATH",
+			source:      ImageConfiguration{Env: map[string]string{"KO_DATA_PATH": "cmd/app/kodata/"}},
+			result:      true,
+		},
+		{
 			description: "entrypoint with dlv",
 			source:      ImageConfiguration{Entrypoint: []string{"dlv", "exec", "--headless"}},
 			result:      true,


### PR DESCRIPTION
**Description**

All container images built by ko have the `KO_DATA_PATH` environment variable set: https://github.com/google/ko#static-assets

This can be used for images built using Skaffold's ko builder (when ready), and for images built using ko via a custom build (usable now).

**Tracking**: #6041
**Related**: #6569
**Context**: https://github.com/GoogleContainerTools/skaffold/pull/6496#discussion_r698503432
