### PR TITLE
Detect ko images for debugging, by image author

### DIFF
--- a/pkg/skaffold/debug/apply_transforms.go
+++ b/pkg/skaffold/debug/apply_transforms.go
@@ -73,6 +73,7 @@ func retrieveImageConfiguration(ctx context.Context, artifact *graph.Artifact, i
 	// need to duplicate slices as apiClient caches requests
 	return ImageConfiguration{
 		Artifact:   artifact.ImageName,
+		Author:     manifest.Author,
 		Env:        envAsMap(config.Env),
 		Entrypoint: dupArray(config.Entrypoint),
 		Arguments:  dupArray(config.Cmd),

--- a/pkg/skaffold/debug/transform.go
+++ b/pkg/skaffold/debug/transform.go
@@ -73,6 +73,7 @@ type ImageConfiguration struct {
 	// Artifact is the corresponding Artifact's image name (`pkg/skaffold/build.Artifact.ImageName`)
 	Artifact string
 
+	Author     string
 	Labels     map[string]string
 	Env        map[string]string
 	Entrypoint []string

--- a/pkg/skaffold/debug/transform_go.go
+++ b/pkg/skaffold/debug/transform_go.go
@@ -70,6 +70,11 @@ func (t dlvTransformer) IsApplicable(config ImageConfiguration) bool {
 			return true
 		}
 	}
+	// Detect ko image by author, see https://github.com/google/ko/blob/v0.8.3/pkg/build/gobuild.go#L610
+	if config.Author == "github.com/google/ko" {
+		log.Entry(context.TODO()).Infof("Artifact %q has Go runtime: has author %q", config.Artifact, config.Author)
+		return true
+	}
 
 	// FIXME: as there is currently no way to identify a buildpacks-produced image as holding a Go binary,
 	// nor to cause certain environment variables to be defined in the resulting image, look at the image's

--- a/pkg/skaffold/debug/transform_go_test.go
+++ b/pkg/skaffold/debug/transform_go_test.go
@@ -98,6 +98,11 @@ func TestDlvTransformer_IsApplicable(t *testing.T) {
 			result:      true,
 		},
 		{
+			description: "ko author",
+			source:      ImageConfiguration{Author: "github.com/google/ko"},
+			result:      true,
+		},
+		{
 			description: "entrypoint /bin/sh",
 			source:      ImageConfiguration{Entrypoint: []string{"/bin/sh"}},
 			result:      false,


### PR DESCRIPTION
**Description**

Container images built by ko have the [author](https://github.com/opencontainers/image-spec/blob/main/config.md#properties) property set to the value [`github.com/google/ko`](https://github.com/google/ko/blob/v0.8.3/pkg/build/gobuild.go#L610).

Skaffold debug can use this property to detect a Go runtime artifact.

This feature can be used for images built using Skaffold's ko builder (when ready), and for images build using ko via a custom build (usable now).

**Tracking**: #6041
**Related**: #6563
**Context**: https://github.com/GoogleContainerTools/skaffold/pull/6496#discussion_r698503432
