### PR TITLE
fix: iterative-status-check only for deployers defining hooks

### DIFF
--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -48,6 +48,18 @@ type MockDeployer struct {
 	renderErr       error
 }
 
+func (m *MockDeployer) HasRunnableHooks() bool {
+	return true
+}
+
+func (m *MockDeployer) PreDeployHooks(context.Context, io.Writer) error {
+	return nil
+}
+
+func (m *MockDeployer) PostDeployHooks(context.Context, io.Writer) error {
+	return nil
+}
+
 func (m *MockDeployer) GetAccessor() access.Accessor {
 	return &access.NoopAccessor{}
 }

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -436,6 +436,10 @@ func (h *Deployer) Render(ctx context.Context, out io.Writer, builds []graph.Art
 	return manifest.Write(renderedManifests.String(), filepath, out)
 }
 
+func (h *Deployer) HasRunnableHooks() bool {
+	return len(h.HelmDeploy.LifecycleHooks.PreHooks) > 0 || len(h.HelmDeploy.LifecycleHooks.PostHooks) > 0
+}
+
 func (h *Deployer) PreDeployHooks(ctx context.Context, out io.Writer) error {
 	childCtx, endTrace := instrumentation.StartTrace(ctx, "Deploy_PreHooks")
 	if err := h.hookRunner.RunPreHooks(childCtx, out); err != nil {

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -1686,3 +1686,39 @@ MANIFEST:
 ---
 %s`, namespace, manifest)
 }
+
+func TestHasRunnableHooks(t *testing.T) {
+	tests := []struct {
+		description string
+		cfg         latestV1.HelmDeploy
+		expected    bool
+	}{
+		{
+			description: "no hooks defined",
+			cfg:         latestV1.HelmDeploy{},
+		},
+		{
+			description: "has pre-deploy hook defined",
+			cfg: latestV1.HelmDeploy{
+				LifecycleHooks: latestV1.DeployHooks{PreHooks: []latestV1.DeployHookItem{{}}},
+			},
+			expected: true,
+		},
+		{
+			description: "has post-deploy hook defined",
+			cfg: latestV1.HelmDeploy{
+				LifecycleHooks: latestV1.DeployHooks{PostHooks: []latestV1.DeployHookItem{{}}},
+			},
+			expected: true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", version31))
+			k, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &test.cfg)
+			t.RequireNoError(err)
+			actual := k.HasRunnableHooks()
+			t.CheckDeepEqual(test.expected, actual)
+		})
+	}
+}

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -239,6 +239,10 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	return nil
 }
 
+func (k *Deployer) HasRunnableHooks() bool {
+	return len(k.KubectlDeploy.LifecycleHooks.PreHooks) > 0 || len(k.KubectlDeploy.LifecycleHooks.PostHooks) > 0
+}
+
 func (k *Deployer) PreDeployHooks(ctx context.Context, out io.Writer) error {
 	childCtx, endTrace := instrumentation.StartTrace(ctx, "Deploy_PreHooks")
 	if err := k.hookRunner.RunPreHooks(childCtx, out); err != nil {

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -737,6 +737,41 @@ func TestGCSManifests(t *testing.T) {
 	}
 }
 
+func TestHasRunnableHooks(t *testing.T) {
+	tests := []struct {
+		description string
+		cfg         latestV1.KubectlDeploy
+		expected    bool
+	}{
+		{
+			description: "no hooks defined",
+			cfg:         latestV1.KubectlDeploy{},
+		},
+		{
+			description: "has pre-deploy hook defined",
+			cfg: latestV1.KubectlDeploy{
+				LifecycleHooks: latestV1.DeployHooks{PreHooks: []latestV1.DeployHookItem{{}}},
+			},
+			expected: true,
+		},
+		{
+			description: "has post-deploy hook defined",
+			cfg: latestV1.KubectlDeploy{
+				LifecycleHooks: latestV1.DeployHooks{PostHooks: []latestV1.DeployHookItem{{}}},
+			},
+			expected: true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			k, err := NewDeployer(&kubectlConfig{}, &label.DefaultLabeller{}, &test.cfg)
+			t.RequireNoError(err)
+			actual := k.HasRunnableHooks()
+			t.CheckDeepEqual(test.expected, actual)
+		})
+	}
+}
+
 type kubectlConfig struct {
 	runcontext.RunContext // Embedded to provide the default values.
 	workingDir            string

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -206,6 +206,10 @@ func kustomizeBinaryExists() bool {
 	return err == nil
 }
 
+func (k *Deployer) HasRunnableHooks() bool {
+	return len(k.KustomizeDeploy.LifecycleHooks.PreHooks) > 0 || len(k.KustomizeDeploy.LifecycleHooks.PostHooks) > 0
+}
+
 func (k *Deployer) PreDeployHooks(ctx context.Context, out io.Writer) error {
 	childCtx, endTrace := instrumentation.StartTrace(ctx, "Deploy_PreHooks")
 	if err := k.hookRunner.RunPreHooks(childCtx, out); err != nil {

--- a/pkg/skaffold/deploy/kustomize/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize_test.go
@@ -772,6 +772,41 @@ spec:
 	}
 }
 
+func TestHasRunnableHooks(t *testing.T) {
+	tests := []struct {
+		description string
+		cfg         latestV1.KustomizeDeploy
+		expected    bool
+	}{
+		{
+			description: "no hooks defined",
+			cfg:         latestV1.KustomizeDeploy{},
+		},
+		{
+			description: "has pre-deploy hook defined",
+			cfg: latestV1.KustomizeDeploy{
+				LifecycleHooks: latestV1.DeployHooks{PreHooks: []latestV1.DeployHookItem{{}}},
+			},
+			expected: true,
+		},
+		{
+			description: "has post-deploy hook defined",
+			cfg: latestV1.KustomizeDeploy{
+				LifecycleHooks: latestV1.DeployHooks{PostHooks: []latestV1.DeployHookItem{{}}},
+			},
+			expected: true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			k, err := NewDeployer(&kustomizeConfig{}, &label.DefaultLabeller{}, &test.cfg)
+			t.RequireNoError(err)
+			actual := k.HasRunnableHooks()
+			t.CheckDeepEqual(test.expected, actual)
+		})
+	}
+}
+
 type kustomizeConfig struct {
 	runcontext.RunContext // Embedded to provide the default values.
 	force                 bool


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6564 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

- Enable iterative status checks for deployers that define at least one deploy hook.
- The regression is caused by enabling iterative status checks erroneously for all deployers that satisfy the hook runner interface.
