### PR TITLE
fix: linters for go1.17

### DIFF
--- a/cmd/skaffold/app/signals_test.go
+++ b/cmd/skaffold/app/signals_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -69,6 +69,8 @@ def file_passes(filename, refs, regexs):
 
     # remove build tags from the top of Go files
     if extension == "go":
+        p = regexs["go117_build_constraints"]
+        (data, found) = p.subn("", data, 1)
         p = regexs["go_build_constraints"]
         (data, found) = p.subn("", data, 1)
 
@@ -146,6 +148,8 @@ def get_regexs():
     regexs["date"] = re.compile( '(2019|2020|2021)' )
     # strip // +build \n\n build constraints
     regexs["go_build_constraints"] = re.compile(r"^(// \+build.*\n)+\n", re.MULTILINE)
+    # strip //go:build \n build constraints (for go1.17 and higher)
+    regexs["go117_build_constraints"] = re.compile(r"^(//go:build.*\n)", re.MULTILINE)
     # strip #!.* from shell scripts
     regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
     return regexs

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 /*

--- a/pkg/skaffold/build/jib/jib_non_windows_test.go
+++ b/pkg/skaffold/build/jib/jib_non_windows_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/skaffold/build/jib/jib_windows_test.go
+++ b/pkg/skaffold/build/jib/jib_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/pkg/skaffold/gcp/auth_test.go
+++ b/pkg/skaffold/gcp/auth_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/skaffold/kubectl/exec.go
+++ b/pkg/skaffold/kubectl/exec.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/skaffold/tag/git_commit_test.go
+++ b/pkg/skaffold/tag/git_commit_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/skaffold/tags/paths_test.go
+++ b/pkg/skaffold/tags/paths_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/skaffold/util/wrapper_unix.go
+++ b/pkg/skaffold/util/wrapper_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/skaffold/util/wrapper_unix_test.go
+++ b/pkg/skaffold/util/wrapper_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/skaffold/util/wrapper_windows_test.go
+++ b/pkg/skaffold/util/wrapper_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*


### PR DESCRIPTION
Go v1.17 changes the format for specifying build tags

From https://tip.golang.org/doc/go1.17
![image](https://user-images.githubusercontent.com/39389231/132494915-a51b5f3d-1b0f-4b75-8e47-2d17a3d0e32f.png)

This PR modifies `boilerplate` checks and adds both versions of the build tags (as suggested above) so that the project can work with go1.17 without linter warnings. These changes shouldn't affect building for older go versions.