### PR TITLE
Improves code coverage (a little bit)

### DIFF
--- a/pkg/skaffold/diagnose/diagnose_test.go
+++ b/pkg/skaffold/diagnose/diagnose_test.go
@@ -86,7 +86,7 @@ func TestCheckArtifacts(t *testing.T) {
 				Workspace: tmpDir.Root(),
 				ArtifactType: latestV1.ArtifactType{
 					DockerArtifact: &latestV1.DockerArtifact{
-						DockerfilePath: tmpDir.Path("Dockerfile"),
+						DockerfilePath: "Dockerfile",
 					},
 				},
 			}},
@@ -105,6 +105,12 @@ func (c *mockConfig) PipelineForImage() latestV1.Pipeline {
 	var pipeline latestV1.Pipeline
 	pipeline.Build.Artifacts = c.artifacts
 	return pipeline
+}
+
+func (c *mockConfig) GetPipelines() []latestV1.Pipeline {
+	var pipelines []latestV1.Pipeline
+	pipelines = append(pipelines, c.PipelineForImage())
+	return pipelines
 }
 
 func (c *mockConfig) Artifacts() []*latestV1.Artifact {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: #6452
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
I've learned from the code coverage measurement of #6452  that when the base code coverage is a little beyond baseline (70%), it's hard for new PR to pass code coverage requirement. So I'm trying to use this PR to bump the code coverage a little bit so that it may leave more room for other PRs.

**Follow-up Work (remove if N/A)**
increase the base code coverage beyond baseline a little more to improve productivity of new PRs.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
