### PR TITLE
Allow multiple docker secrets - #6498

### DIFF
--- a/docs/content/en/schemas/v2beta23.json
+++ b/docs/content/en/schemas/v2beta23.json
@@ -1348,10 +1348,13 @@
           "x-intellij-html-description": "used to pass in --no-cache to docker build to prevent caching.",
           "default": "false"
         },
-        "secret": {
-          "$ref": "#/definitions/DockerSecret",
-          "description": "contains information about a local secret passed to `docker build`, along with optional destination information.",
-          "x-intellij-html-description": "contains information about a local secret passed to <code>docker build</code>, along with optional destination information."
+        "secrets": {
+          "items": {
+            "$ref": "#/definitions/DockerSecret"
+          },
+          "type": "array",
+          "description": "used to pass in --secret to docker build, `useBuildKit: true` is required.",
+          "x-intellij-html-description": "used to pass in --secret to docker build, <code>useBuildKit: true</code> is required."
         },
         "squash": {
           "type": "boolean",
@@ -1380,7 +1383,7 @@
         "cliFlags",
         "noCache",
         "squash",
-        "secret",
+        "secrets",
         "ssh"
       ],
       "additionalProperties": false,
@@ -1462,8 +1465,8 @@
       ],
       "additionalProperties": false,
       "type": "object",
-      "description": "contains information about a local secret passed to `docker build`, along with optional destination information.",
-      "x-intellij-html-description": "contains information about a local secret passed to <code>docker build</code>, along with optional destination information."
+      "description": "used to pass in --secret to docker build, `useBuildKit: true` is required.",
+      "x-intellij-html-description": "used to pass in --secret to docker build, <code>useBuildKit: true</code> is required."
     },
     "DockerfileDependency": {
       "properties": {

--- a/integration/testdata/build/secret/Dockerfile
+++ b/integration/testdata/build/secret/Dockerfile
@@ -3,3 +3,5 @@
 FROM alpine:3
 
 RUN --mount=type=secret,id=mysecret cat /run/secrets/mysecret
+
+RUN --mount=type=secret,id=mysecondsecret cat /run/secrets/mysecondsecret

--- a/integration/testdata/build/secret/mysecondsecret.txt
+++ b/integration/testdata/build/secret/mysecondsecret.txt
@@ -1,0 +1,1 @@
+secondsecret

--- a/integration/testdata/build/secret/skaffold.yaml
+++ b/integration/testdata/build/secret/skaffold.yaml
@@ -7,6 +7,8 @@ build:
   artifacts:
   - image: secret
     docker:
-      secret:
-        id: mysecret
+      secrets:
+      - id: mysecret
         src: mysecret.txt
+      - id: mysecondsecret
+        src: mysecondsecret.txt

--- a/pkg/skaffold/build/gcb/docker.go
+++ b/pkg/skaffold/build/gcb/docker.go
@@ -68,7 +68,7 @@ func (b *Builder) cacheFromSteps(artifact *latestV1.DockerArtifact) []*cloudbuil
 func (b *Builder) dockerBuildArgs(a *latestV1.Artifact, tag string, deps []*latestV1.ArtifactDependency) ([]string, error) {
 	d := a.DockerArtifact
 	// TODO(nkubala): remove when buildkit is supported in GCB (#4773)
-	if d.Secret != nil || d.SSH != "" {
+	if len(d.Secrets) > 0 || d.SSH != "" {
 		return nil, errors.New("docker build options, secrets and ssh, are not currently supported in GCB builds")
 	}
 	requiredImages := docker.ResolveDependencyImages(deps, b.artifactStore, true)

--- a/pkg/skaffold/build/gcb/docker_test.go
+++ b/pkg/skaffold/build/gcb/docker_test.go
@@ -110,8 +110,8 @@ func TestDockerBuildSpec(t *testing.T) {
 				ArtifactType: latestV1.ArtifactType{
 					DockerArtifact: &latestV1.DockerArtifact{
 						DockerfilePath: "Dockerfile",
-						Secret: &latestV1.DockerSecret{
-							ID: "secret",
+						Secrets: []*latestV1.DockerSecret{
+							{ID: "secret"},
 						},
 					},
 				},

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -275,7 +275,7 @@ func (l *localDaemon) ConfigFile(ctx context.Context, image string) (*v1.ConfigF
 }
 
 func (l *localDaemon) CheckCompatible(a *latestV1.DockerArtifact) error {
-	if a.Secret != nil || a.SSH != "" {
+	if len(a.Secrets) > 0 || a.SSH != "" {
 		return fmt.Errorf("docker build options, secrets and ssh, require BuildKit - set `useBuildkit: true` in your config, or run with `DOCKER_BUILDKIT=1`")
 	}
 	return nil
@@ -617,10 +617,10 @@ func ToCLIBuildArgs(a *latestV1.DockerArtifact, evaluatedArgs map[string]*string
 		args = append(args, "--squash")
 	}
 
-	if a.Secret != nil {
-		secretString := fmt.Sprintf("id=%s", a.Secret.ID)
-		if a.Secret.Source != "" {
-			secretString += ",src=" + a.Secret.Source
+	for _, secret := range a.Secrets {
+		secretString := fmt.Sprintf("id=%s", secret.ID)
+		if secret.Source != "" {
+			secretString += ",src=" + secret.Source
 		}
 		args = append(args, "--secret", secretString)
 	}

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -346,8 +346,8 @@ func TestGetBuildArgs(t *testing.T) {
 		{
 			description: "secret with no source",
 			artifact: &latestV1.DockerArtifact{
-				Secret: &latestV1.DockerSecret{
-					ID: "mysecret",
+				Secrets: []*latestV1.DockerSecret{
+					{ID: "mysecret"},
 				},
 			},
 			want: []string{"--secret", "id=mysecret"},
@@ -355,12 +355,21 @@ func TestGetBuildArgs(t *testing.T) {
 		{
 			description: "secret with source",
 			artifact: &latestV1.DockerArtifact{
-				Secret: &latestV1.DockerSecret{
-					ID:     "mysecret",
-					Source: "foo.src",
+				Secrets: []*latestV1.DockerSecret{
+					{ID: "mysecret", Source: "foo.src"},
 				},
 			},
 			want: []string{"--secret", "id=mysecret,src=foo.src"},
+		},
+		{
+			description: "miltiple secrets",
+			artifact: &latestV1.DockerArtifact{
+				Secrets: []*latestV1.DockerSecret{
+					{ID: "mysecret", Source: "foo.src"},
+					{ID: "anothersecret", Source: "bar.src"},
+				},
+			},
+			want: []string{"--secret", "id=mysecret,src=foo.src", "--secret", "id=anothersecret,src=bar.src"},
 		},
 		{
 			description: "ssh with no source",

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -362,7 +362,7 @@ func TestGetBuildArgs(t *testing.T) {
 			want: []string{"--secret", "id=mysecret,src=foo.src"},
 		},
 		{
-			description: "miltiple secrets",
+			description: "multiple secrets",
 			artifact: &latestV1.DockerArtifact{
 				Secrets: []*latestV1.DockerSecret{
 					{ID: "mysecret", Source: "foo.src"},

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -1302,16 +1302,14 @@ type DockerArtifact struct {
 	// Squash is used to pass in --squash to docker build to squash docker image layers into single layer.
 	Squash bool `yaml:"squash,omitempty"`
 
-	// Secret contains information about a local secret passed to `docker build`,
-	// along with optional destination information.
-	Secret *DockerSecret `yaml:"secret,omitempty"`
+	// Secrets is used to pass in --secret to docker build, `useBuildKit: true` is required.
+	Secrets []*DockerSecret `yaml:"secrets,omitempty"`
 
 	// SSH is used to pass in --ssh to docker build to use SSH agent. Format is "default|<id>[=<socket>|<key>[,<key>]]".
 	SSH string `yaml:"ssh,omitempty"`
 }
 
-// DockerSecret contains information about a local secret passed to `docker build`,
-// along with optional destination information.
+// DockerSecret is used to pass in --secret to docker build, `useBuildKit: true` is required.
 type DockerSecret struct {
 	// ID is the id of the secret.
 	ID string `yaml:"id,omitempty" yamltags:"required"`

--- a/pkg/skaffold/schema/v2beta22/upgrade.go
+++ b/pkg/skaffold/schema/v2beta22/upgrade.go
@@ -34,5 +34,26 @@ func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
 }
 
 func upgradeOnePipeline(oldPipeline, newPipeline interface{}) error {
+	oldBuild := &oldPipeline.(*Pipeline).Build
+	newBuild := &newPipeline.(*next.Pipeline).Build
+
+	// move: docker.Secret
+	//   to: docker.Secrets[]
+	for i, newArtifact := range newBuild.Artifacts {
+		oldArtifact := oldBuild.Artifacts[i]
+
+		docker := oldArtifact.DockerArtifact
+		if docker == nil {
+			continue
+		}
+
+		secret := docker.Secret
+		if secret == nil {
+			continue
+		}
+
+		newArtifact.DockerArtifact.Secrets = []*next.DockerSecret{{ID: secret.ID, Source: secret.Source}}
+	}
+
 	return nil
 }

--- a/pkg/skaffold/schema/v2beta22/upgrade_test.go
+++ b/pkg/skaffold/schema/v2beta22/upgrade_test.go
@@ -111,8 +111,8 @@ build:
   - image: gcr.io/k8s-skaffold/skaffold-example
     docker:
       dockerfile: path/to/Dockerfile
-      secret:
-        id: id
+      secrets:
+      - id: id
         src: /file.txt
   - image: gcr.io/k8s-skaffold/bazel
     bazel:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6498  <!-- tracking issues that this PR will close -->

**Description**
- Change skaffold schema to allow multiple secrets.
- Updated unit and integration tests.
- Updated documentation.
- Updated upgrade logic from v2beta22 to v2beta23.

**User facing changes (remove if N/A)**
- Skaffold.yaml will change from docker.secret to docker.secrets and allow multiple entries
- Docs will be updated to reflect the same
