### PR TITLE
Make TestHelmDeploy hermetic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ ifeq ($(GCP_ONLY),true)
 		--zone $(GKE_ZONE) \
 		--project $(GCP_PROJECT)
 endif
-	@ GCP_ONLY=$(GCP_ONLY) ./hack/gotest.sh -v $(REPOPATH)/integration/binpack $(REPOPATH)/integration -timeout 45m $(INTEGRATION_TEST_ARGS)
+	@ GCP_ONLY=$(GCP_ONLY) ./hack/gotest.sh -v $(REPOPATH)/integration/binpack $(REPOPATH)/integration -timeout 50m $(INTEGRATION_TEST_ARGS)
 
 .PHONY: integration
 integration: install integration-tests

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
+	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
@@ -35,6 +36,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/hooks"
 	ctl "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
+	kubectx "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/context"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/logger"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -1079,6 +1081,9 @@ func TestHelmDeploy(t *testing.T) {
 			t.Override(&util.OSEnviron, func() []string { return env })
 			t.Override(&util.DefaultExecCommand, test.commands)
 			t.Override(&osExecutable, func() (string, error) { return "SKAFFOLD-BINARY", nil })
+			t.Override(&kubectx.CurrentConfig, func() (api.Config, error) {
+				return api.Config{CurrentContext: ""}, nil
+			})
 
 			deployer, err := NewDeployer(context.Background(), &helmConfig{
 				namespace:  test.namespace,


### PR DESCRIPTION
I'm seeing failures in `TestHelmDeploy` when running locally:
```
--- FAIL: TestHelmDeploy (0.02s)
    --- FAIL: TestHelmDeploy/helm3.0beta_deploy_success (0.00s)
        helm_test.go:1098: []string differ (-got, +want):   []string{
            - 	"default",
            + 	"",
              }
    --- FAIL: TestHelmDeploy/helm3.0beta_namespaced_context_deploy_success (0.00s)
        helm_test.go:1098: []string differ (-got, +want):   []string{
            - 	"default",
            + 	"",
              }
    --- FAIL: TestHelmDeploy/helm3.0_deploy_success (0.00s)
        helm_test.go:1098: []string differ (-got, +want):   []string{
            - 	"default",
            + 	"",
              }
```

The cause is that we're loading my ~/.kube/config, and my default minikube context explicitly specifies a namespace of `default`:
```
$ kubectl config get-contexts                                                                                           
CURRENT   NAME       CLUSTER    AUTHINFO   NAMESPACE                     
*         minikube   minikube   minikube   default
```


`TestHelmDeploy` calls `helm.NewDeployer` to create a new deployer instance.
https://github.com/GoogleContainerTools/skaffold/blob/51b296e57f911f34dc2cd14b3c6a6471b888a8fa/pkg/skaffold/deploy/helm/helm_test.go#L1083-L1087

As part of the creation, `helm.NewDeployer()` calls `deploy.util.GetAllPodNamespaces()` with the namespace from the provided config (the `helmConfig` instance):
https://github.com/GoogleContainerTools/skaffold/blob/51b296e57f911f34dc2cd14b3c6a6471b888a8fa/pkg/skaffold/deploy/helm/deploy.go#L152
But the `helmConfig` instance doesn't implement `GetNamespace()` and so it is forwarded to the `RunContext.GetNamespace()`, which returns an empty string:
https://github.com/GoogleContainerTools/skaffold/blob/51b296e57f911f34dc2cd14b3c6a6471b888a8fa/pkg/skaffold/deploy/helm/helm_test.go#L1656-L1668

`deploy.util.GetAllPodNamespaces()` checks if the provided namespace is empty and if so, retrieves the current context and uses its default context:
https://github.com/GoogleContainerTools/skaffold/blob/51b296e57f911f34dc2cd14b3c6a6471b888a8fa/pkg/skaffold/deploy/util/namespaces.go#L31-L46

An easy fix is to override `pkg/skaffold/kubernetes/context.CurrentConfig` so that there is not a default context.