### PR TITLE
Rename ko builder `target` field to `main`

### DIFF
--- a/docs/design_proposals/ko-builder.md
+++ b/docs/design_proposals/ko-builder.md
@@ -152,13 +152,13 @@ is `skaffold`, the resulting image name will be `gcr.io/k8s-skaffold/skaffold`.
 
 It is still necessary to resolve the Go import path for the underlying ko
 implementation. To do so, the ko builder determines the import path based on
-the value of the `target` config field. The `target` config field refers to the
-location of a main package and corresponds to a `go build` target, e.g.,
-`go build ./cmd/skaffold`. Using the `target` field results in deterministic
+the value of the `main` config field. The `main` config field refers to the
+location of a main package and corresponds to a `go build` pattern, e.g.,
+`go build ./cmd/skaffold`. Using the `main` field results in deterministic
 behavior even in cases where there are multiple main packages in different
 directories.
 
-If `target` is a relative path (and it will be most of the time), it is
+If `main` is a relative path (and it will be most of the time), it is
 relative to the current
 [`context`](https://skaffold.dev/docs/references/yaml/#build-artifacts-context)
 (a.k.a.
@@ -176,14 +176,15 @@ build:
   - image: skaffold
     context: .
     ko:
-      target: ./cmd/skaffold
+      main: ./cmd/skaffold
 ```
 
-Users can specify `./...` as a target to make ko locate the main package. If
-there are multiple main packages,
+Users can specify a `main` value using a pattern with the `...` wildcard, such
+as `./...`. In this case, ko locates the main package. If there are multiple
+main packages,
 [ko fails](https://github.com/google/ko/blob/780c2812926cd706423e2ba65aeb1beb842c04af/pkg/build/gobuild.go#L270).
 
-Implementation note: The value of `target` will be the input when invoking
+Implementation note: The value of `main` will be the input when invoking
 [`QualifyImport()`](https://github.com/GoogleContainerTools/skaffold/blob/953594000be68fa8fad0ec4636ab03f8153a1c08/pkg/skaffold/build/ko/build.go#L93).
 
 If the Go sources and the `go.mod` file are in a subdirectory of the `context`
@@ -241,7 +242,7 @@ build:
     ko: {}
 ```
 
-The `target` field is ignored if the `image` field starts with the `ko://`
+The `main` field is ignored if the `image` field starts with the `ko://`
 scheme prefix.
 
 ## Debugging ko images using Skaffold
@@ -312,6 +313,14 @@ Adding the ko builder requires making config changes to the Skaffold schema.
     	// For example: `["-buildid=", "-s", "-w"]`.
     	Ldflags []string `yaml:"ldflags,omitempty"`
 
+      // Main is the location of the main package. It is the pattern passed to `go build`.
+      // If main is specified as a relative path, it is relative to the `context` directory.
+      // If main is empty, the ko builder uses a default value of `.`.
+      // If main is a pattern with wildcards, such as `./...`, the expansion must contain only one main package, otherwise ko fails.
+      // Main is ignored if the `ImageName` starts with `ko://`.
+      // Example: `./cmd/foo`
+      Main string `yaml:"main,omitempty"`
+
     	// Platforms is the list of platforms to build images for. Each platform
     	// is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`.
     	// By default, the ko builder builds for `all` platforms supported by the
@@ -323,14 +332,6 @@ Adding the ko builder requires making config changes to the Skaffold schema.
     	// You can override this value by setting the `SOURCE_DATE_EPOCH`
     	// environment variable.
     	SourceDateEpoch uint64 `yaml:"sourceDateEpoch,omitempty"`
-
-      // Target is the location of the main package.
-      // If target is specified as a relative path, it is relative to the `context` directory.
-      // If target is empty, the ko builder looks for the main package in the `context` directory only, but not in any subdirectories.
-      // If target is a pattern with wildcards, such as `./...`, the expansion must contain only one main package, otherwise ko fails.
-      // Target is ignored if the `ImageName` starts with `ko://`.
-      // Example: `./cmd/foo`
-      Target string `yaml:"target,omitempty"`
     }
     ```
 
@@ -431,10 +432,10 @@ build:
       - -buildid=
       - -s
       - -w
+      main: ./cmd/foo
       platforms:
       - linux/amd64
       - linux/arm64
-      target: ./cmd/foo
 ```
 
 ko requires setting a
@@ -696,10 +697,10 @@ The steps roughly outlined:
             baz: frob
           ldflags:
           - -s
+          main: ./cmd/foo
           platforms:
           - linux/amd64
           - linux/arm64
-          target: ./cmd/foo
     ```
 
 3.  Implement Skaffold config support for additional ko config options not

--- a/pkg/skaffold/build/ko/build.go
+++ b/pkg/skaffold/build/ko/build.go
@@ -90,12 +90,12 @@ func getImportPath(a *latestV1.Artifact, koBuilder build.Interface) (string, err
 	if strings.HasPrefix(a.ImageName, build.StrictScheme) {
 		return a.ImageName, nil
 	}
-	target := a.KoArtifact.Target
-	if target == "" {
+	localImportPath := a.KoArtifact.Main
+	if localImportPath == "" {
 		// default to context directory
-		target = "."
+		localImportPath = "."
 	}
-	return koBuilder.QualifyImport(target)
+	return koBuilder.QualifyImport(localImportPath)
 }
 
 // getImageIdentifier returns the image tag or digest for published images (`pushImages=true`),

--- a/pkg/skaffold/build/ko/build_test.go
+++ b/pkg/skaffold/build/ko/build_test.go
@@ -87,11 +87,11 @@ func Test_getImportPath(t *testing.T) {
 		expectedImportPath string
 	}{
 		{
-			description: "target is ignored when image name is ko-prefixed full Go import path",
+			description: "main is ignored when image name is ko-prefixed full Go import path",
 			artifact: &latestV1.Artifact{
 				ArtifactType: latestV1.ArtifactType{
 					KoArtifact: &latestV1.KoArtifact{
-						Target: "./target-should-be-ignored",
+						Main: "./main-should-be-ignored",
 					},
 				},
 				ImageName: "ko://git.example.com/org/foo",
@@ -120,11 +120,11 @@ func Test_getImportPath(t *testing.T) {
 			expectedImportPath: "ko://github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/testdata/package-main-in-root",
 		},
 		{
-			description: "plain image name with workspace directory and target",
+			description: "plain image name with workspace directory and main",
 			artifact: &latestV1.Artifact{
 				ArtifactType: latestV1.ArtifactType{
 					KoArtifact: &latestV1.KoArtifact{
-						Target: "./baz",
+						Main: "./baz",
 					},
 				},
 				ImageName: "any-image-name-3",
@@ -133,12 +133,12 @@ func Test_getImportPath(t *testing.T) {
 			expectedImportPath: "ko://github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/testdata/package-main-not-in-root/baz",
 		},
 		{
-			description: "plain image name with workspace directory and target and source directory",
+			description: "plain image name with workspace directory and main and source directory",
 			artifact: &latestV1.Artifact{
 				ArtifactType: latestV1.ArtifactType{
 					KoArtifact: &latestV1.KoArtifact{
-						Dir:    "package-main-not-in-root",
-						Target: "./baz",
+						Dir:  "package-main-not-in-root",
+						Main: "./baz",
 					},
 				},
 				ImageName: "any-image-name-4",

--- a/pkg/skaffold/build/ko/builder.go
+++ b/pkg/skaffold/build/ko/builder.go
@@ -49,7 +49,7 @@ func buildOptions(a *latestV1.Artifact) *options.BuildOptions {
 				Env:     a.KoArtifact.Env,
 				Flags:   a.KoArtifact.Flags,
 				Ldflags: a.KoArtifact.Ldflags,
-				Main:    a.KoArtifact.Target,
+				Main:    a.KoArtifact.Main,
 			},
 		},
 		ConcurrentBuilds: 1,

--- a/pkg/skaffold/build/ko/schema/temporary.go
+++ b/pkg/skaffold/build/ko/schema/temporary.go
@@ -51,19 +51,19 @@ type KoArtifact struct {
 	// For example: `["-buildid=", "-s", "-w"]`.
 	Ldflags []string `yaml:"ldflags,omitempty"`
 
+	// Main is the location of the main package. It is the pattern passed to `go build`.
+	// If main is specified as a relative path, it is relative to the `context` directory.
+	// If main is empty, the ko builder uses a default value of `.`.
+	// If main is a pattern with wildcards, such as `./...`, the expansion must contain only one main package, otherwise ko fails.
+	// Main is ignored if the `ImageName` starts with `ko://`.
+	// Example: `./cmd/foo`
+	Main string `yaml:"main,omitempty"`
+
 	// Platforms is the list of platforms to build images for. Each platform
 	// is of the format `os[/arch[/variant]]`, e.g., `linux/amd64`.
 	// Defaults to `all` to build for all platforms supported by the
 	// base image.
 	Platforms []string `yaml:"platforms,omitempty"`
-
-	// Target is the location of the main package.
-	// If target is specified as a relative path, it is relative to the `context` directory.
-	// If target is empty, the ko builder looks for the main package in the `context` directory only, but not in any subdirectories.
-	// If target is a pattern with wildcards, such as `./...`, the expansion must contain only one main package, otherwise ko fails.
-	// Target is ignored if the `ImageName` starts with `ko://`.
-	// Example: `./cmd/foo`
-	Target string `yaml:"target,omitempty"`
 }
 
 // KoDependencies is used to specify dependencies for an artifact built by ko.


### PR DESCRIPTION
**Description**
This change aligns the config field name in Skaffold with the name used by [ko](https://github.com/google/ko/tree/7f145a7e1057f2f2a099827ab9d7e66a31cd1868#overriding-go-build-settings) and [GoReleaser](https://goreleaser.com/customization/build/).

The temporary ko builder schema hasn't been merged with the real config schema, so this change has no user impact.

**Related**: #6041