### PR TITLE
Ko: disable compiler optimizations and inlining when debugging

### DIFF
--- a/docs/design_proposals/ko-builder.md
+++ b/docs/design_proposals/ko-builder.md
@@ -250,7 +250,7 @@ Ko provides the
 [`DisableOptimizations`](https://github.com/google/ko/blob/780c2812926cd706423e2ba65aeb1beb842c04af/pkg/commands/options/build.go#L34)
 build option to
 [set `gcflags` to disable optimizations and inlining](https://github.com/google/ko/blob/335c1ac8a6fdcc5eb0bb26579e4b44b4c62a9565/pkg/build/gobuild.go#L709-L712).
-The ko builder will set `DisableOptimizations` to `true` when the Skaffold
+The ko builder sets `DisableOptimizations` to `true` when the Skaffold
 `runMode` is `Debug`.
 
 Skaffold can

--- a/pkg/skaffold/build/ko/build_test.go
+++ b/pkg/skaffold/build/ko/build_test.go
@@ -32,6 +32,7 @@ import (
 
 	// latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/schema"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
@@ -149,7 +150,7 @@ func Test_getImportPath(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			b := NewArtifactBuilder(nil, false)
+			b := NewArtifactBuilder(nil, false, config.RunModes.Build)
 			koBuilder, err := b.newKoBuilder(context.Background(), test.artifact)
 			t.CheckNoError(err)
 
@@ -210,7 +211,7 @@ func Test_getImageIdentifier(t *testing.T) {
 func stubKoArtifactBuilder(ref string, imageID string, pushImages bool, importpath string) *Builder {
 	api := (&testutil.FakeAPIClient{}).Add(ref, imageID)
 	localDocker := fakeLocalDockerDaemon(api)
-	b := NewArtifactBuilder(localDocker, pushImages)
+	b := NewArtifactBuilder(localDocker, pushImages, config.RunModes.Build)
 
 	// Fake implementation of the `publishImages` function.
 	// Returns a map with one entry: importpath -> ref

--- a/pkg/skaffold/build/ko/builder.go
+++ b/pkg/skaffold/build/ko/builder.go
@@ -30,15 +30,16 @@ import (
 
 	// latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/schema"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
 
 func (b *Builder) newKoBuilder(ctx context.Context, a *latestV1.Artifact) (build.Interface, error) {
-	bo := buildOptions(a)
+	bo := buildOptions(a, b.runMode)
 	return commands.NewBuilder(ctx, bo)
 }
 
-func buildOptions(a *latestV1.Artifact) *options.BuildOptions {
+func buildOptions(a *latestV1.Artifact, runMode config.RunMode) *options.BuildOptions {
 	workingDirectory := filepath.Join(a.Workspace, a.KoArtifact.Dir)
 	return &options.BuildOptions{
 		BaseImage: a.KoArtifact.BaseImage,
@@ -52,9 +53,10 @@ func buildOptions(a *latestV1.Artifact) *options.BuildOptions {
 				Main:    a.KoArtifact.Target,
 			},
 		},
-		ConcurrentBuilds: 1,
-		Platform:         strings.Join(a.KoArtifact.Platforms, ","),
-		UserAgent:        version.UserAgentWithClient(),
-		WorkingDirectory: workingDirectory,
+		ConcurrentBuilds:     1,
+		DisableOptimizations: runMode == config.RunModes.Debug,
+		Platform:             strings.Join(a.KoArtifact.Platforms, ","),
+		UserAgent:            version.UserAgentWithClient(),
+		WorkingDirectory:     workingDirectory,
 	}
 }

--- a/pkg/skaffold/build/ko/ko.go
+++ b/pkg/skaffold/build/ko/ko.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/ko/pkg/commands"
 	"github.com/google/ko/pkg/publish"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 )
 
@@ -31,16 +32,18 @@ import (
 type Builder struct {
 	localDocker docker.LocalDaemon
 	pushImages  bool
+	runMode     config.RunMode
 
 	// publishImages can be overridden for unit testing purposes.
 	publishImages func(context.Context, []string, publish.Interface, build.Interface) (map[string]name.Reference, error)
 }
 
 // NewArtifactBuilder returns a new ko artifact builder
-func NewArtifactBuilder(localDocker docker.LocalDaemon, pushImages bool) *Builder {
+func NewArtifactBuilder(localDocker docker.LocalDaemon, pushImages bool, runMode config.RunMode) *Builder {
 	return &Builder{
 		localDocker:   localDocker,
 		pushImages:    pushImages,
+		runMode:       runMode,
 		publishImages: commands.PublishImages,
 	}
 }

--- a/pkg/skaffold/build/ko/ko_test.go
+++ b/pkg/skaffold/build/ko/ko_test.go
@@ -18,10 +18,12 @@ package ko
 
 import (
 	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 )
 
 func TestNewArtifactBuilderCanPublishImages(t *testing.T) {
-	b := NewArtifactBuilder(nil, true)
+	b := NewArtifactBuilder(nil, true, config.RunModes.Build)
 	if b.publishImages == nil {
 		t.Errorf("constructor function should populate publishImages func")
 	}


### PR DESCRIPTION
**Description**
Disable Go compiler optimizations and inlining when building an artifact with the ko builder, and the Skaffold run mode is debug.

Use ko's existing support: https://github.com/google/ko/blob/7f145a7e1057f2f2a099827ab9d7e66a31cd1868/pkg/build/gobuild.go#L709-L712

**Tracking**: #6041
**Related**: #6563, #6569
