### PR TITLE
Add image label support to ko builder

### DIFF
--- a/pkg/skaffold/build/ko/builder.go
+++ b/pkg/skaffold/build/ko/builder.go
@@ -21,6 +21,7 @@ package ko
 // the real schema in pkg/skaffold/schema/latest/v1.
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -55,8 +56,17 @@ func buildOptions(a *latestV1.Artifact, runMode config.RunMode) *options.BuildOp
 		},
 		ConcurrentBuilds:     1,
 		DisableOptimizations: runMode == config.RunModes.Debug,
+		Labels:               labels(a),
 		Platform:             strings.Join(a.KoArtifact.Platforms, ","),
 		UserAgent:            version.UserAgentWithClient(),
 		WorkingDirectory:     workingDirectory,
 	}
+}
+
+func labels(a *latestV1.Artifact) []string {
+	labels := []string{}
+	for k, v := range a.KoArtifact.Labels {
+		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+	}
+	return labels
 }


### PR DESCRIPTION
**Description**
This enables users to label images built by the ko builder, similar to the `LABEL` instruction in `Dockerfile`s.

The Open Container Initiative Image Format Specification lists a number of [pre-defined annotation (label) keys](https://github.com/opencontainers/image-spec/blob/main/annotations.md). Some image registries use these, An example is [GitHub Container Registry](https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package#connecting-a-repository-to-a-container-image-using-the-command-line), which uses the `org.opencontainers.image.source` label to connect a Git repository to a container image.

**Tracking:** #6041
