### PR TITLE
Extend `--artifact` API schema to allow for manifest generation

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -138,6 +138,23 @@ func TestInitWithCLIArtifact(t *testing.T) {
 	})
 }
 
+func TestInitWithCLIArtifactAndManifestGeneration(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	testutil.Run(t, "init with cli artifact and manifests", func (t *testutil.T) {
+		ns, _ := SetupNamespace(t.T)
+		dir := "testdata/init/hello"
+
+		initArgs := append([]string{"--force"},
+			`--artifact={"builder":"Docker","payload":{"path":"./Dockerfile"},"image":"dockerfile-image","manifest":{"generate":true,"port":8080}}`)
+		skaffold.Init(initArgs...).InDir(dir).WithConfig("skaffold.yaml.out").RunOrFail(t.T)
+
+		checkGeneratedManifests(t, dir, []string{"./deployment.yaml"})
+
+		skaffold.Run().InDir(dir).WithConfig("skaffold.yaml.out").InNs(ns.Name).RunOrFail(t.T)
+	})
+}
+
 func checkGeneratedConfig(t *testutil.T, dir string) {
 	expectedOutput, err := ioutil.ReadFile(filepath.Join(dir, "skaffold.yaml"))
 	t.CheckNoError(err)

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -141,7 +141,7 @@ func TestInitWithCLIArtifact(t *testing.T) {
 func TestInitWithCLIArtifactAndManifestGeneration(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 
-	testutil.Run(t, "init with cli artifact and manifests", func (t *testutil.T) {
+	testutil.Run(t, "init with cli artifact and manifests", func(t *testutil.T) {
 		ns, _ := SetupNamespace(t.T)
 		dir := "testdata/init/hello"
 

--- a/pkg/skaffold/initializer/build/builders.go
+++ b/pkg/skaffold/initializer/build/builders.go
@@ -48,9 +48,10 @@ type InitBuilder interface {
 	Path() string
 }
 
-type NoneBuilder struct {}
+type NoneBuilder struct{}
 
 const NoneBuilderName = "none"
+
 func (b NoneBuilder) Name() string {
 	return NoneBuilderName
 }

--- a/pkg/skaffold/initializer/build/builders.go
+++ b/pkg/skaffold/initializer/build/builders.go
@@ -100,7 +100,7 @@ type Initializer interface {
 	// PrintAnalysis writes the project analysis to the provided out stream
 	PrintAnalysis(io.Writer) error
 	// GenerateManifests generates image names and manifests for all unresolved pairs
-	GenerateManifests(io.Writer, bool) (map[GeneratedArtifactInfo][]byte, error)
+	GenerateManifests(out io.Writer, force, enableManifestGeneration bool) (map[GeneratedArtifactInfo][]byte, error)
 }
 
 type emptyBuildInitializer struct {
@@ -118,7 +118,7 @@ func (e *emptyBuildInitializer) PrintAnalysis(io.Writer) error {
 	return nil
 }
 
-func (e *emptyBuildInitializer) GenerateManifests(io.Writer, bool) (map[GeneratedArtifactInfo][]byte, error) {
+func (e *emptyBuildInitializer) GenerateManifests(io.Writer, bool, bool) (map[GeneratedArtifactInfo][]byte, error) {
 	return nil, nil
 }
 

--- a/pkg/skaffold/initializer/build/builders.go
+++ b/pkg/skaffold/initializer/build/builders.go
@@ -48,11 +48,35 @@ type InitBuilder interface {
 	Path() string
 }
 
+type NoneBuilder struct {}
+
+const NoneBuilderName = "none"
+func (b NoneBuilder) Name() string {
+	return NoneBuilderName
+}
+
+func (b NoneBuilder) Describe() string {
+	return ""
+}
+
+func (b NoneBuilder) ArtifactType(string) latestV1.ArtifactType {
+	return latestV1.ArtifactType{}
+}
+
+func (b NoneBuilder) ConfiguredImage() string {
+	return ""
+}
+
+func (b NoneBuilder) Path() string {
+	return ""
+}
+
 // ArtifactInfo defines a builder and the image it builds
 type ArtifactInfo struct {
 	Builder   InitBuilder
 	ImageName string
 	Workspace string
+	Manifest  ManifestInfo
 }
 
 // GeneratedArtifactInfo pairs a discovered builder with a
@@ -60,6 +84,11 @@ type ArtifactInfo struct {
 type GeneratedArtifactInfo struct {
 	ArtifactInfo
 	ManifestPath string
+}
+
+type ManifestInfo struct {
+	Generate bool
+	Port     int
 }
 
 type Initializer interface {

--- a/pkg/skaffold/initializer/build/cli.go
+++ b/pkg/skaffold/initializer/build/cli.go
@@ -20,18 +20,22 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path/filepath"
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/generator"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
 type cliBuildInitializer struct {
 	cliArtifacts    []string
 	artifactInfos   []ArtifactInfo
+	manifests       []*generator.Container
 	builders        []InitBuilder
 	skipBuild       bool
 	enableNewFormat bool
@@ -48,17 +52,45 @@ func (c *cliBuildInitializer) ProcessImages(images []string) error {
 }
 
 func (c *cliBuildInitializer) BuildConfig() (latestV1.BuildConfig, []*latestV1.PortForwardResource) {
+	pf := []*latestV1.PortForwardResource{}
+
+	for _, manifestInfo := range c.manifests {
+		// Port value is set to 0 if user decides to not port forward service
+		if manifestInfo.Port != 0 {
+			pf = append(pf, &latestV1.PortForwardResource{
+				Type: "service",
+				Name: manifestInfo.Name,
+				Port: util.FromInt(manifestInfo.Port),
+			})
+		}
+	}
+
 	return latestV1.BuildConfig{
 		Artifacts: Artifacts(c.artifactInfos),
-	}, nil
+	}, pf
 }
 
 func (c *cliBuildInitializer) PrintAnalysis(out io.Writer) error {
 	return printAnalysis(out, c.enableNewFormat, c.skipBuild, c.artifactInfos, c.builders, nil)
 }
 
-func (c *cliBuildInitializer) GenerateManifests(io.Writer, bool) (map[GeneratedArtifactInfo][]byte, error) {
-	return nil, nil
+func (c *cliBuildInitializer) GenerateManifests(out io.Writer, force bool) (map[GeneratedArtifactInfo][]byte, error) {
+	generatedManifests := map[GeneratedArtifactInfo][]byte{}
+	for _, info := range c.artifactInfos {
+		if info.Manifest.Generate {
+			generatedInfo := GeneratedArtifactInfo{
+				ArtifactInfo: info,
+				ManifestPath: filepath.Join(info.Builder.Path(), "deployment.yaml"),
+			}
+			manifest, manifestInfo, err := generator.Generate(info.ImageName, info.Manifest.Port)
+			if err != nil {
+				return nil, fmt.Errorf("generating kubernetes manifest: %w", err)
+			}
+			generatedManifests[generatedInfo] = manifest
+			c.manifests = append(c.manifests, manifestInfo)
+		}
+	}
+	return generatedManifests, nil
 }
 
 func (c *cliBuildInitializer) processCliArtifacts() error {
@@ -82,6 +114,10 @@ func processCliArtifacts(cliArtifacts []string) ([]ArtifactInfo, error) {
 			Name      string `json:"builder"`
 			Image     string `json:"image"`
 			Workspace string `json:"context"`
+			Manifest  struct {
+				Generate bool `json:"generate"`
+				Port     int  `json:"port"`
+			} `json:"manifest"`
 		}{}
 		if err := json.Unmarshal([]byte(artifact), &a); err != nil {
 			// Not JSON, use backwards compatible method
@@ -95,6 +131,10 @@ func processCliArtifacts(cliArtifacts []string) ([]ArtifactInfo, error) {
 			})
 			continue
 		}
+		manifestInfo := ManifestInfo{
+			Generate: a.Manifest.Generate,
+			Port:     a.Manifest.Port,
+		}
 
 		// Use builder type to parse payload
 		switch a.Name {
@@ -105,7 +145,7 @@ func processCliArtifacts(cliArtifacts []string) ([]ArtifactInfo, error) {
 			if err := json.Unmarshal([]byte(artifact), &parsed); err != nil {
 				return nil, err
 			}
-			info := ArtifactInfo{Builder: parsed.Payload, ImageName: a.Image, Workspace: a.Workspace}
+			info := ArtifactInfo{Builder: parsed.Payload, ImageName: a.Image, Workspace: a.Workspace, Manifest: manifestInfo}
 			artifactInfos = append(artifactInfos, info)
 
 		// FIXME: shouldn't use a human-readable name?
@@ -117,7 +157,7 @@ func processCliArtifacts(cliArtifacts []string) ([]ArtifactInfo, error) {
 				return nil, err
 			}
 			parsed.Payload.BuilderName = a.Name
-			info := ArtifactInfo{Builder: parsed.Payload, ImageName: a.Image, Workspace: a.Workspace}
+			info := ArtifactInfo{Builder: parsed.Payload, ImageName: a.Image, Workspace: a.Workspace, Manifest: manifestInfo}
 			artifactInfos = append(artifactInfos, info)
 
 		case buildpacks.Name:
@@ -127,7 +167,11 @@ func processCliArtifacts(cliArtifacts []string) ([]ArtifactInfo, error) {
 			if err := json.Unmarshal([]byte(artifact), &parsed); err != nil {
 				return nil, err
 			}
-			info := ArtifactInfo{Builder: parsed.Payload, ImageName: a.Image, Workspace: a.Workspace}
+			info := ArtifactInfo{Builder: parsed.Payload, ImageName: a.Image, Workspace: a.Workspace, Manifest: manifestInfo}
+			artifactInfos = append(artifactInfos, info)
+
+		case "None":
+			info := ArtifactInfo{Builder: NoneBuilder{}, ImageName: a.Image, Manifest: manifestInfo}
 			artifactInfos = append(artifactInfos, info)
 
 		default:

--- a/pkg/skaffold/initializer/build/init.go
+++ b/pkg/skaffold/initializer/build/init.go
@@ -78,8 +78,12 @@ func (d *defaultBuildInitializer) PrintAnalysis(out io.Writer) error {
 	return printAnalysis(out, d.enableNewFormat, d.skipBuild, d.artifactInfos, d.builders, d.unresolvedImages)
 }
 
-func (d *defaultBuildInitializer) GenerateManifests(out io.Writer, force bool) (map[GeneratedArtifactInfo][]byte, error) {
+func (d *defaultBuildInitializer) GenerateManifests(out io.Writer, force, enableManifestGeneration bool) (map[GeneratedArtifactInfo][]byte, error) {
 	generatedManifests := map[GeneratedArtifactInfo][]byte{}
+	if !enableManifestGeneration {
+		return generatedManifests, nil
+	}
+
 	for _, info := range d.generatedArtifactInfos {
 		port := 8080
 		var err error

--- a/pkg/skaffold/initializer/build/init_test.go
+++ b/pkg/skaffold/initializer/build/init_test.go
@@ -182,7 +182,7 @@ spec:
 				generatedArtifactInfos: test.generatedInfos,
 			}
 
-			manifests, err := d.GenerateManifests(nil, test.force)
+			manifests, err := d.GenerateManifests(nil, test.force, true)
 
 			expected := make(map[GeneratedArtifactInfo][]byte)
 			for i, info := range test.generatedInfos {

--- a/pkg/skaffold/initializer/build/resolve.go
+++ b/pkg/skaffold/initializer/build/resolve.go
@@ -39,7 +39,7 @@ func (d *defaultBuildInitializer) resolveBuilderImages() error {
 	if len(d.builders) == 1 {
 		if len(d.unresolvedImages) == 0 {
 			// no image was parsed from k8s manifests, so we create an image name
-			d.generatedArtifactInfos = append(d.generatedArtifactInfos, getGeneratedBuilderPair(d.builders[0]))
+			d.generatedArtifactInfos = append(d.generatedArtifactInfos, getGeneratedArtifactInfo(d.builders[0]))
 			return nil
 		}
 		// we already have the image, just use it and return
@@ -130,13 +130,13 @@ func (d *defaultBuildInitializer) resolveBuilderImagesInteractively() error {
 		}
 
 		for _, choice := range chosen {
-			d.generatedArtifactInfos = append(d.generatedArtifactInfos, getGeneratedBuilderPair(choiceMap[choice]))
+			d.generatedArtifactInfos = append(d.generatedArtifactInfos, getGeneratedArtifactInfo(choiceMap[choice]))
 		}
 	}
 	return nil
 }
 
-func getGeneratedBuilderPair(b InitBuilder) GeneratedArtifactInfo {
+func getGeneratedArtifactInfo(b InitBuilder) GeneratedArtifactInfo {
 	path := b.Path()
 	var imageName string
 	// if the builder is in a nested directory, use that as the image name AND the path to write the manifest

--- a/pkg/skaffold/initializer/build/util.go
+++ b/pkg/skaffold/initializer/build/util.go
@@ -65,6 +65,10 @@ func Artifacts(artifactInfos []ArtifactInfo) []*latestV1.Artifact {
 	var artifacts []*latestV1.Artifact
 
 	for _, info := range artifactInfos {
+		// Don't create artifact build config for "None" builder
+		if info.Builder.Name() == NoneBuilderName {
+			continue
+		}
 		workspace := info.Workspace
 		if workspace == "" {
 			workspace = filepath.Dir(info.Builder.Path())

--- a/pkg/skaffold/initializer/config_test.go
+++ b/pkg/skaffold/initializer/config_test.go
@@ -67,7 +67,7 @@ func (s stubBuildInitializer) BuildConfig() (latestV1.BuildConfig, []*latestV1.P
 	}, nil
 }
 
-func (s stubBuildInitializer) GenerateManifests(io.Writer, bool) (map[build.GeneratedArtifactInfo][]byte, error) {
+func (s stubBuildInitializer) GenerateManifests(io.Writer, bool, bool) (map[build.GeneratedArtifactInfo][]byte, error) {
 	panic("no thank you")
 }
 

--- a/pkg/skaffold/initializer/init.go
+++ b/pkg/skaffold/initializer/init.go
@@ -103,16 +103,15 @@ func Initialize(out io.Writer, c config.Config, a *analyze.ProjectAnalysis) (*la
 
 func generateManifests(out io.Writer, c config.Config, bInitializer build.Initializer, dInitializer deploy.Initializer) (map[string][]byte, error) {
 	var generatedManifests map[string][]byte
-	if c.EnableManifestGeneration {
-		generatedManifestPairs, err := bInitializer.GenerateManifests(out, c.Force)
-		if err != nil {
-			return nil, err
-		}
-		generatedManifests = make(map[string][]byte, len(generatedManifestPairs))
-		for pair, manifest := range generatedManifestPairs {
-			dInitializer.AddManifestForImage(pair.ManifestPath, pair.ImageName)
-			generatedManifests[pair.ManifestPath] = manifest
-		}
+
+	generatedManifestPairs, err := bInitializer.GenerateManifests(out, c.Force, c.EnableManifestGeneration)
+	if err != nil {
+		return nil, err
+	}
+	generatedManifests = make(map[string][]byte, len(generatedManifestPairs))
+	for pair, manifest := range generatedManifestPairs {
+		dInitializer.AddManifestForImage(pair.ManifestPath, pair.ImageName)
+		generatedManifests[pair.ManifestPath] = manifest
 	}
 
 	return generatedManifests, nil


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6249, #6248 <!-- tracking issues that this PR will close -->

**Description**
CC: @briandealwis @j-windsor

Users can now generate manifests using the `--artifact` (or `-a`) flag by passing some additional information in their json objects.

The schema changes are as follows:
Before: 
```json
{
  "builder": string,
  "payload": {
    "path": string,
  },
  "image": string,
},
```

After:
```json
{
  "builder": string,
  "payload": {
    "path": string,
  },
  "image": string,
  "manifest-info:": {
    "path": string,
    "port": int,
  },
}
```

**Follow-up Work**
Document this feature