### PR TITLE
fix: add podforwaders correctly for multimodule projects

### DIFF
--- a/pkg/skaffold/deploy/component/kubernetes/component.go
+++ b/pkg/skaffold/deploy/component/kubernetes/component.go
@@ -67,6 +67,8 @@ func newAccessor(cfg portforward.Config, kubeContext string, cli *kubectl.CLI, p
 		} else {
 			k8sAccessor[kubeContext] = m
 		}
+	} else if accessor, ok := k8sAccessor[kubeContext].(*portforward.ForwarderManager); ok {
+		accessor.AddPodForwarder(cli, podSelector, cfg.Mode(), cfg.PortForwardOptions())
 	}
 
 	return k8sAccessor[kubeContext]

--- a/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
+++ b/pkg/skaffold/kubernetes/portforward/forwarder_manager.go
@@ -177,3 +177,11 @@ func (p *ForwarderManager) stop() {
 func (p *ForwarderManager) Name() string {
 	return "PortForwarding"
 }
+
+func (p *ForwarderManager) AddPodForwarder(cli *kubectl.CLI, podSelector kubernetes.PodSelector, runMode config.RunMode, options config.PortForwardOptions) {
+	if options.ForwardPods(runMode) {
+		p.forwarders = append(p.forwarders, NewWatchingPodForwarder(p.entryManager, cli.KubeContext, podSelector, allPorts))
+	} else if options.ForwardDebug(runMode) {
+		p.forwarders = append(p.forwarders, NewWatchingPodForwarder(p.entryManager, cli.KubeContext, podSelector, debugPorts))
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6604 <!-- tracking issues that this PR will close -->
**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
We were creating a single instance of `access.Accessor` but maintaining multiple `kubernetes.PodSelector` structs per deployer. This PR add the method `AddPodForwarder` on `PortForwardManager` so that we can add new pods to be forwarded to the singleton instance of the accessor. 