### PR TITLE
fix: make `useBuildkit` field nullable across all config versions

### DIFF
--- a/docs/content/en/schemas/v1.json
+++ b/docs/content/en/schemas/v1.json
@@ -1669,9 +1669,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v1beta10.json
+++ b/docs/content/en/schemas/v1beta10.json
@@ -1464,9 +1464,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v1beta11.json
+++ b/docs/content/en/schemas/v1beta11.json
@@ -1479,9 +1479,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v1beta12.json
+++ b/docs/content/en/schemas/v1beta12.json
@@ -1479,9 +1479,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v1beta13.json
+++ b/docs/content/en/schemas/v1beta13.json
@@ -1538,9 +1538,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v1beta14.json
+++ b/docs/content/en/schemas/v1beta14.json
@@ -1497,9 +1497,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v1beta15.json
+++ b/docs/content/en/schemas/v1beta15.json
@@ -1517,9 +1517,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v1beta16.json
+++ b/docs/content/en/schemas/v1beta16.json
@@ -1566,9 +1566,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v1beta17.json
+++ b/docs/content/en/schemas/v1beta17.json
@@ -1566,9 +1566,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v1beta5.json
+++ b/docs/content/en/schemas/v1beta5.json
@@ -1270,9 +1270,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v1beta6.json
+++ b/docs/content/en/schemas/v1beta6.json
@@ -1320,9 +1320,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v1beta7.json
+++ b/docs/content/en/schemas/v1beta7.json
@@ -1411,9 +1411,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v1beta8.json
+++ b/docs/content/en/schemas/v1beta8.json
@@ -1457,9 +1457,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v1beta9.json
+++ b/docs/content/en/schemas/v1beta9.json
@@ -1360,9 +1360,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2alpha1.json
+++ b/docs/content/en/schemas/v2alpha1.json
@@ -1690,9 +1690,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2alpha2.json
+++ b/docs/content/en/schemas/v2alpha2.json
@@ -1613,9 +1613,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2alpha3.json
+++ b/docs/content/en/schemas/v2alpha3.json
@@ -1663,9 +1663,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2alpha4.json
+++ b/docs/content/en/schemas/v2alpha4.json
@@ -1663,9 +1663,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta1.json
+++ b/docs/content/en/schemas/v2beta1.json
@@ -1668,9 +1668,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta10.json
+++ b/docs/content/en/schemas/v2beta10.json
@@ -2256,9 +2256,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta11.json
+++ b/docs/content/en/schemas/v2beta11.json
@@ -2306,9 +2306,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta12.json
+++ b/docs/content/en/schemas/v2beta12.json
@@ -2349,9 +2349,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta13.json
+++ b/docs/content/en/schemas/v2beta13.json
@@ -2423,9 +2423,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta14.json
+++ b/docs/content/en/schemas/v2beta14.json
@@ -2428,9 +2428,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta15.json
+++ b/docs/content/en/schemas/v2beta15.json
@@ -2441,9 +2441,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta16.json
+++ b/docs/content/en/schemas/v2beta16.json
@@ -2447,9 +2447,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta17.json
+++ b/docs/content/en/schemas/v2beta17.json
@@ -2478,9 +2478,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta18.json
+++ b/docs/content/en/schemas/v2beta18.json
@@ -2488,9 +2488,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta19.json
+++ b/docs/content/en/schemas/v2beta19.json
@@ -2622,9 +2622,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta2.json
+++ b/docs/content/en/schemas/v2beta2.json
@@ -1668,9 +1668,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta20.json
+++ b/docs/content/en/schemas/v2beta20.json
@@ -2700,9 +2700,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta21.json
+++ b/docs/content/en/schemas/v2beta21.json
@@ -2722,9 +2722,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta22.json
+++ b/docs/content/en/schemas/v2beta22.json
@@ -2734,9 +2734,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta23.json
+++ b/docs/content/en/schemas/v2beta23.json
@@ -2734,9 +2734,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta3.json
+++ b/docs/content/en/schemas/v2beta3.json
@@ -1691,9 +1691,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta4.json
+++ b/docs/content/en/schemas/v2beta4.json
@@ -1691,9 +1691,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta5.json
+++ b/docs/content/en/schemas/v2beta5.json
@@ -1729,9 +1729,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta6.json
+++ b/docs/content/en/schemas/v2beta6.json
@@ -1757,9 +1757,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta7.json
+++ b/docs/content/en/schemas/v2beta7.json
@@ -1911,9 +1911,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta8.json
+++ b/docs/content/en/schemas/v2beta8.json
@@ -1997,9 +1997,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/docs/content/en/schemas/v2beta9.json
+++ b/docs/content/en/schemas/v2beta9.json
@@ -2250,9 +2250,8 @@
         },
         "useBuildkit": {
           "type": "boolean",
-          "description": "use BuildKit to build Docker images.",
-          "x-intellij-html-description": "use BuildKit to build Docker images.",
-          "default": "false"
+          "description": "use BuildKit to build Docker images. If unspecified, uses the Docker default.",
+          "x-intellij-html-description": "use BuildKit to build Docker images. If unspecified, uses the Docker default."
         },
         "useDockerCLI": {
           "type": "boolean",

--- a/integration/testdata/inspect/cluster/skaffold.cluster.yaml
+++ b/integration/testdata/inspect/cluster/skaffold.cluster.yaml
@@ -12,5 +12,4 @@ profiles:
     local:
       concurrency: 1
       tryImportMissing: false
-      useBuildkit: false
       useDockerCLI: false

--- a/integration/testdata/inspect/cluster/skaffold.local.yaml
+++ b/integration/testdata/inspect/cluster/skaffold.local.yaml
@@ -6,7 +6,6 @@ build:
   local:
     concurrency: 1
     tryImportMissing: false
-    useBuildkit: false
     useDockerCLI: false
 profiles:
 - name: cluster

--- a/integration/testdata/inspect/gcb/skaffold.gcb.yaml
+++ b/integration/testdata/inspect/gcb/skaffold.gcb.yaml
@@ -18,5 +18,4 @@ profiles:
     local:
       concurrency: 1
       tryImportMissing: false
-      useBuildkit: false
       useDockerCLI: false

--- a/integration/testdata/inspect/gcb/skaffold.local.yaml
+++ b/integration/testdata/inspect/gcb/skaffold.local.yaml
@@ -6,7 +6,6 @@ build:
   local:
     concurrency: 1
     tryImportMissing: false
-    useBuildkit: false
     useDockerCLI: false
 profiles:
 - name: gcb

--- a/pkg/skaffold/build/docker/docker.go
+++ b/pkg/skaffold/build/docker/docker.go
@@ -54,7 +54,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, a *latestV1.Artifact
 
 	var imageID string
 
-	if b.useCLI || b.useBuildKit {
+	if b.useCLI || (b.useBuildKit != nil && *b.useBuildKit) {
 		imageID, err = b.dockerCLIBuild(ctx, output.GetUnderlyingWriter(out), a.Workspace, dockerfile, a.ArtifactType.DockerArtifact, opts)
 	} else {
 		imageID, err = b.localDocker.Build(ctx, out, a.Workspace, a.ImageName, a.ArtifactType.DockerArtifact, opts)
@@ -91,8 +91,12 @@ func (b *Builder) dockerCLIBuild(ctx context.Context, out io.Writer, workspace s
 
 	cmd := exec.CommandContext(ctx, "docker", args...)
 	cmd.Env = append(util.OSEnviron(), b.localDocker.ExtraEnv()...)
-	if b.useBuildKit {
-		cmd.Env = append(cmd.Env, "DOCKER_BUILDKIT=1")
+	if b.useBuildKit != nil {
+		if *b.useBuildKit {
+			cmd.Env = append(cmd.Env, "DOCKER_BUILDKIT=1")
+		} else {
+			cmd.Env = append(cmd.Env, "DOCKER_BUILDKIT=0")
+		}
 	}
 	cmd.Stdout = out
 	cmd.Stderr = out

--- a/pkg/skaffold/build/docker/docker.go
+++ b/pkg/skaffold/build/docker/docker.go
@@ -54,6 +54,8 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, a *latestV1.Artifact
 
 	var imageID string
 
+	// ignore useCLI boolean if buildkit is enabled since buildkit is only implemented for docker CLI at the moment in skaffold.
+	// we might consider a different approach in the future.
 	if b.useCLI || (b.useBuildKit != nil && *b.useBuildKit) {
 		imageID, err = b.dockerCLIBuild(ctx, output.GetUnderlyingWriter(out), a.Workspace, dockerfile, a.ArtifactType.DockerArtifact, opts)
 	} else {

--- a/pkg/skaffold/build/docker/docker_test.go
+++ b/pkg/skaffold/build/docker/docker_test.go
@@ -60,18 +60,18 @@ func TestDockerCLIBuild(t *testing.T) {
 		},
 		{
 			description: "buildkit",
-			localBuild:  latestV1.LocalBuild{UseBuildkit: true},
+			localBuild:  latestV1.LocalBuild{UseBuildkit: util.BoolPtr(true)},
 			expectedEnv: []string{"KEY=VALUE", "DOCKER_BUILDKIT=1"},
 		},
 		{
 			description: "buildkit and extra env",
-			localBuild:  latestV1.LocalBuild{UseBuildkit: true},
+			localBuild:  latestV1.LocalBuild{UseBuildkit: util.BoolPtr(true)},
 			extraEnv:    []string{"OTHER=VALUE"},
 			expectedEnv: []string{"KEY=VALUE", "OTHER=VALUE", "DOCKER_BUILDKIT=1"},
 		},
 		{
 			description: "env var collisions",
-			localBuild:  latestV1.LocalBuild{UseBuildkit: true},
+			localBuild:  latestV1.LocalBuild{UseBuildkit: util.BoolPtr(true)},
 			extraEnv:    []string{"KEY=OTHER_VALUE", "DOCKER_BUILDKIT=0"},
 			// env var collisions are handled by cmd.Run(). Last one wins.
 			expectedEnv: []string{"KEY=VALUE", "KEY=OTHER_VALUE", "DOCKER_BUILDKIT=0", "DOCKER_BUILDKIT=1"},
@@ -135,7 +135,7 @@ func TestDockerCLIBuild(t *testing.T) {
 					test.err,
 				)
 				t.Override(&util.DefaultExecCommand, mockCmd)
-			} else if test.localBuild.UseBuildkit || test.localBuild.UseDockerCLI {
+			} else if (test.localBuild.UseBuildkit != nil && *test.localBuild.UseBuildkit) || test.localBuild.UseDockerCLI {
 				mockCmd = testutil.CmdRunEnv(
 					"docker build . --file "+dockerfilePath+" -t tag",
 					test.expectedEnv,

--- a/pkg/skaffold/build/docker/docker_test.go
+++ b/pkg/skaffold/build/docker/docker_test.go
@@ -42,6 +42,7 @@ func TestDockerCLIBuild(t *testing.T) {
 		cfg             mockConfig
 		extraEnv        []string
 		expectedEnv     []string
+		wantDockerCLI   bool
 		err             error
 		expectedErr     error
 		expectedErrCode proto.StatusCode
@@ -59,20 +60,23 @@ func TestDockerCLIBuild(t *testing.T) {
 			expectedEnv: []string{"KEY=VALUE", "OTHER=VALUE"},
 		},
 		{
-			description: "buildkit",
-			localBuild:  latestV1.LocalBuild{UseBuildkit: util.BoolPtr(true)},
-			expectedEnv: []string{"KEY=VALUE", "DOCKER_BUILDKIT=1"},
+			description:   "buildkit",
+			localBuild:    latestV1.LocalBuild{UseBuildkit: util.BoolPtr(true)},
+			wantDockerCLI: true,
+			expectedEnv:   []string{"KEY=VALUE", "DOCKER_BUILDKIT=1"},
 		},
 		{
-			description: "buildkit and extra env",
-			localBuild:  latestV1.LocalBuild{UseBuildkit: util.BoolPtr(true)},
-			extraEnv:    []string{"OTHER=VALUE"},
-			expectedEnv: []string{"KEY=VALUE", "OTHER=VALUE", "DOCKER_BUILDKIT=1"},
+			description:   "buildkit and extra env",
+			localBuild:    latestV1.LocalBuild{UseBuildkit: util.BoolPtr(true)},
+			wantDockerCLI: true,
+			extraEnv:      []string{"OTHER=VALUE"},
+			expectedEnv:   []string{"KEY=VALUE", "OTHER=VALUE", "DOCKER_BUILDKIT=1"},
 		},
 		{
-			description: "env var collisions",
-			localBuild:  latestV1.LocalBuild{UseBuildkit: util.BoolPtr(true)},
-			extraEnv:    []string{"KEY=OTHER_VALUE", "DOCKER_BUILDKIT=0"},
+			description:   "env var collisions",
+			localBuild:    latestV1.LocalBuild{UseBuildkit: util.BoolPtr(true)},
+			wantDockerCLI: true,
+			extraEnv:      []string{"KEY=OTHER_VALUE", "DOCKER_BUILDKIT=0"},
 			// env var collisions are handled by cmd.Run(). Last one wins.
 			expectedEnv: []string{"KEY=VALUE", "KEY=OTHER_VALUE", "DOCKER_BUILDKIT=0", "DOCKER_BUILDKIT=1"},
 		},
@@ -135,7 +139,8 @@ func TestDockerCLIBuild(t *testing.T) {
 					test.err,
 				)
 				t.Override(&util.DefaultExecCommand, mockCmd)
-			} else if (test.localBuild.UseBuildkit != nil && *test.localBuild.UseBuildkit) || test.localBuild.UseDockerCLI {
+			}
+			if test.wantDockerCLI {
 				mockCmd = testutil.CmdRunEnv(
 					"docker build . --file "+dockerfilePath+" -t tag",
 					test.expectedEnv,

--- a/pkg/skaffold/build/docker/docker_test.go
+++ b/pkg/skaffold/build/docker/docker_test.go
@@ -42,9 +42,9 @@ func TestDockerCLIBuild(t *testing.T) {
 		cfg             mockConfig
 		extraEnv        []string
 		expectedEnv     []string
-		wantDockerCLI   bool
 		err             error
 		expectedErr     error
+		wantDockerCLI   bool
 		expectedErrCode proto.StatusCode
 	}{
 		{

--- a/pkg/skaffold/build/docker/errors_test.go
+++ b/pkg/skaffold/build/docker/errors_test.go
@@ -59,7 +59,7 @@ Refer https://skaffold.dev/docs/references/yaml/#build-artifacts-docker for deta
 				"docker build . --file "+dockerfilePath+" -t tag",
 			))
 			t.Override(&docker.DefaultAuthHelper, stubAuth{})
-			builder := NewArtifactBuilder(fakeLocalDaemonWithExtraEnv([]string{}), mockConfig{}, true, false, false, mockArtifactResolver{make(map[string]string)}, nil)
+			builder := NewArtifactBuilder(fakeLocalDaemonWithExtraEnv([]string{}), mockConfig{}, true, nil, false, mockArtifactResolver{make(map[string]string)}, nil)
 
 			artifact := &latestV1.Artifact{
 				ImageName: "test-image",

--- a/pkg/skaffold/build/docker/types.go
+++ b/pkg/skaffold/build/docker/types.go
@@ -29,7 +29,7 @@ type Builder struct {
 	cfg                docker.Config
 	pushImages         bool
 	useCLI             bool
-	useBuildKit        bool
+	useBuildKit        *bool
 	artifacts          ArtifactResolver
 	sourceDependencies TransitiveSourceDependenciesResolver
 }
@@ -45,7 +45,7 @@ type TransitiveSourceDependenciesResolver interface {
 }
 
 // NewBuilder returns an new instance of a docker builder
-func NewArtifactBuilder(localDocker docker.LocalDaemon, cfg docker.Config, useCLI, useBuildKit, pushImages bool, ar ArtifactResolver, dr TransitiveSourceDependenciesResolver) *Builder {
+func NewArtifactBuilder(localDocker docker.LocalDaemon, cfg docker.Config, useCLI bool, useBuildKit *bool, pushImages bool, ar ArtifactResolver, dr TransitiveSourceDependenciesResolver) *Builder {
 	return &Builder{
 		localDocker:        localDocker,
 		pushImages:         pushImages,

--- a/pkg/skaffold/inspect/buildEnv/add_local.go
+++ b/pkg/skaffold/inspect/buildEnv/add_local.go
@@ -85,8 +85,6 @@ func constructLocalDefinition(existing *latestV1.LocalBuild, opts inspect.BuildE
 	if opts.UseDockerCLI != nil {
 		b.UseDockerCLI = *opts.UseDockerCLI
 	}
-	if opts.UseBuildkit != nil {
-		b.UseBuildkit = *opts.UseBuildkit
-	}
+	b.UseBuildkit = opts.UseBuildkit
 	return &b
 }

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -280,8 +280,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/latest/v2/config.go
+++ b/pkg/skaffold/schema/latest/v2/config.go
@@ -282,8 +282,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v1/config.go
+++ b/pkg/skaffold/schema/v1/config.go
@@ -189,8 +189,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v1beta10/config.go
+++ b/pkg/skaffold/schema/v1beta10/config.go
@@ -153,8 +153,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v1beta11/config.go
+++ b/pkg/skaffold/schema/v1beta11/config.go
@@ -155,8 +155,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v1beta12/config.go
+++ b/pkg/skaffold/schema/v1beta12/config.go
@@ -180,8 +180,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v1beta13/config.go
+++ b/pkg/skaffold/schema/v1beta13/config.go
@@ -189,8 +189,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v1beta14/config.go
+++ b/pkg/skaffold/schema/v1beta14/config.go
@@ -189,8 +189,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v1beta15/config.go
+++ b/pkg/skaffold/schema/v1beta15/config.go
@@ -189,8 +189,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v1beta16/config.go
+++ b/pkg/skaffold/schema/v1beta16/config.go
@@ -189,8 +189,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v1beta17/config.go
+++ b/pkg/skaffold/schema/v1beta17/config.go
@@ -189,8 +189,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v1beta5/config.go
+++ b/pkg/skaffold/schema/v1beta5/config.go
@@ -164,8 +164,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v1beta6/config.go
+++ b/pkg/skaffold/schema/v1beta6/config.go
@@ -166,8 +166,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v1beta7/config.go
+++ b/pkg/skaffold/schema/v1beta7/config.go
@@ -165,8 +165,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v1beta8/config.go
+++ b/pkg/skaffold/schema/v1beta8/config.go
@@ -175,8 +175,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v1beta9/config.go
+++ b/pkg/skaffold/schema/v1beta9/config.go
@@ -153,8 +153,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v2alpha1/config.go
+++ b/pkg/skaffold/schema/v2alpha1/config.go
@@ -194,8 +194,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 }
 
 // GoogleCloudBuild *beta* describes how to do a remote build on

--- a/pkg/skaffold/schema/v2alpha2/config.go
+++ b/pkg/skaffold/schema/v2alpha2/config.go
@@ -194,8 +194,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2alpha3/config.go
+++ b/pkg/skaffold/schema/v2alpha3/config.go
@@ -194,8 +194,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2alpha4/config.go
+++ b/pkg/skaffold/schema/v2alpha4/config.go
@@ -194,8 +194,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta1/config.go
+++ b/pkg/skaffold/schema/v2beta1/config.go
@@ -194,8 +194,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta10/config.go
+++ b/pkg/skaffold/schema/v2beta10/config.go
@@ -224,8 +224,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta11/config.go
+++ b/pkg/skaffold/schema/v2beta11/config.go
@@ -255,8 +255,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta12/config.go
+++ b/pkg/skaffold/schema/v2beta12/config.go
@@ -273,8 +273,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta13/config.go
+++ b/pkg/skaffold/schema/v2beta13/config.go
@@ -273,8 +273,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta14/config.go
+++ b/pkg/skaffold/schema/v2beta14/config.go
@@ -279,8 +279,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta15/config.go
+++ b/pkg/skaffold/schema/v2beta15/config.go
@@ -279,8 +279,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta16/config.go
+++ b/pkg/skaffold/schema/v2beta16/config.go
@@ -279,8 +279,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta17/config.go
+++ b/pkg/skaffold/schema/v2beta17/config.go
@@ -279,8 +279,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta18/config.go
+++ b/pkg/skaffold/schema/v2beta18/config.go
@@ -279,8 +279,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta19/config.go
+++ b/pkg/skaffold/schema/v2beta19/config.go
@@ -279,8 +279,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta2/config.go
+++ b/pkg/skaffold/schema/v2beta2/config.go
@@ -194,8 +194,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta20/config.go
+++ b/pkg/skaffold/schema/v2beta20/config.go
@@ -280,8 +280,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta21/config.go
+++ b/pkg/skaffold/schema/v2beta21/config.go
@@ -280,8 +280,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta22/config.go
+++ b/pkg/skaffold/schema/v2beta22/config.go
@@ -280,8 +280,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta3/config.go
+++ b/pkg/skaffold/schema/v2beta3/config.go
@@ -197,8 +197,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta4/config.go
+++ b/pkg/skaffold/schema/v2beta4/config.go
@@ -197,8 +197,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta5/config.go
+++ b/pkg/skaffold/schema/v2beta5/config.go
@@ -197,8 +197,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta6/config.go
+++ b/pkg/skaffold/schema/v2beta6/config.go
@@ -220,8 +220,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta7/config.go
+++ b/pkg/skaffold/schema/v2beta7/config.go
@@ -220,8 +220,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta8/config.go
+++ b/pkg/skaffold/schema/v2beta8/config.go
@@ -224,8 +224,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v2beta9/config.go
+++ b/pkg/skaffold/schema/v2beta9/config.go
@@ -224,8 +224,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.

--- a/pkg/skaffold/schema/v3alpha1/config.go
+++ b/pkg/skaffold/schema/v3alpha1/config.go
@@ -281,8 +281,8 @@ type LocalBuild struct {
 	// UseDockerCLI use `docker` command-line interface instead of Docker Engine APIs.
 	UseDockerCLI bool `yaml:"useDockerCLI,omitempty"`
 
-	// UseBuildkit use BuildKit to build Docker images.
-	UseBuildkit bool `yaml:"useBuildkit,omitempty"`
+	// UseBuildkit use BuildKit to build Docker images. If unspecified, uses the Docker default.
+	UseBuildkit *bool `yaml:"useBuildkit,omitempty"`
 
 	// Concurrency is how many artifacts can be built concurrently. 0 means "no-limit".
 	// Defaults to `1`.


### PR DESCRIPTION
fix: setting `useBuildkit: false` actually turns off buildkit for docker builder

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: #4936

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Currently setting `useBuildkit: false` in the `skaffold.yaml` config doesn't actually disable buildkit. This PR fixes that by setting `DOCKER_BUILDKIT =0` env variable when `useBuildkit: false` is set in the config.

In `pkg/skaffold/build/docker/docker.go `:
```diff
-	if b.useBuildKit {
-		cmd.Env = append(cmd.Env, "DOCKER_BUILDKIT=1")
+	if b.useBuildKit != nil {
+		if *b.useBuildKit {
+			cmd.Env = append(cmd.Env, "DOCKER_BUILDKIT=1")
+		} else {
+			cmd.Env = append(cmd.Env, "DOCKER_BUILDKIT=0")
+		}
	}
``` 

This change in itself would however break backwards compatibility since for previous versions of the config even if `useBuildkit` property is not set, it'd default to `false` and now start disabling buildkit which is not how it worked previously (so that bug essentially became a feature, that if `useBuildkit` is unspecified it should use the Docker default).

So we additionally make the config change to all config versions, so that a missing `useBuildkit` field can be identified separately from an explicitly set `useBuildkit: false`

**User facing changes (remove if N/A)**
There are no user facing changes other than if users were setting `useBuildkit: false` in the config, skaffold will now actually disable buildkit.
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->

Fix #4936 after this is merged.
<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->

> Changes discussed with @briandealwis 

> The `make checks` will be failing since we generally prohibit making changes to already released configs. But this PR only changes a single field from `bool` to `*bool`.