### PR TITLE
Fix new version generation

### DIFF
--- a/hack/versions/cmd/new/templates/upgrade.template.go
+++ b/hack/versions/cmd/new/templates/upgrade.template.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package %PREV_VERSION%
+
+import (
+	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
+	pkgutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+// Upgrade upgrades a configuration to the next version.
+// Config changes from %PREV_VERSION% to %NEXT_VERSION%
+func (c *SkaffoldConfig) Upgrade() (util.VersionedConfig, error) {
+	var newConfig next.SkaffoldConfig
+	pkgutil.CloneThroughJSON(c, &newConfig)
+	newConfig.APIVersion = next.Version
+
+	err := util.UpgradePipelines(c, &newConfig, upgradeOnePipeline)
+	return &newConfig, err
+}
+
+func upgradeOnePipeline(oldPipeline, newPipeline interface{}) error {
+	return nil
+}

--- a/hack/versions/cmd/new/templates/upgrade_test.template.go
+++ b/hack/versions/cmd/new/templates/upgrade_test.template.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package %PREV_VERSION%
+
+import (
+	"testing"
+
+	next "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestUpgrade(t *testing.T) {
+	yaml := `apiVersion: skaffold/%PREV_VERSION%
+kind: Config
+build:
+  artifacts:
+  - image: gcr.io/k8s-skaffold/skaffold-example
+    docker:
+      dockerfile: path/to/Dockerfile
+      secret:
+        id: id
+        src: /file.txt
+  - image: gcr.io/k8s-skaffold/bazel
+    bazel:
+      target: //mytarget
+  - image: gcr.io/k8s-skaffold/jib-maven
+    jib:
+      args: ['-v', '--activate-profiles', 'prof']
+      project: dir
+  - image: gcr.io/k8s-skaffold/jib-gradle
+    jib:
+      args: ['-v']
+  - image: gcr.io/k8s-skaffold/buildpacks
+    buildpacks:
+      builder: gcr.io/buildpacks/builder:v1
+    sync:
+      auto: true
+  googleCloudBuild:
+    projectId: test-project
+test:
+  - image: gcr.io/k8s-skaffold/skaffold-example
+    structureTests:
+     - ./test/*
+deploy:
+  kubectl:
+    manifests:
+    - k8s-*
+  kustomize:
+    paths:
+    - kustomization-main
+portForward:
+  - resourceType: deployment
+    resourceName: leeroy-app
+    port: 8080
+    localPort: 9001
+profiles:
+  - name: test profile
+    build:
+      artifacts:
+      - image: gcr.io/k8s-skaffold/skaffold-example
+        kaniko:
+          cache: {}
+      cluster:
+        pullSecretName: e2esecret
+        pullSecretPath: secret.json
+        namespace: default
+    test:
+     - image: gcr.io/k8s-skaffold/skaffold-example
+       structureTests:
+         - ./test/*
+    deploy:
+      kubectl:
+        manifests:
+        - k8s-*
+      kustomize:
+        paths:
+        - kustomization-test
+  - name: test local
+    build:
+      artifacts:
+      - image: gcr.io/k8s-skaffold/skaffold-example
+        docker:
+          dockerfile: path/to/Dockerfile
+      local:
+        push: false
+    deploy:
+      kubectl:
+        manifests:
+        - k8s-*
+      kustomize: {}
+`
+	expected := `apiVersion: skaffold/%NEXT_VERSION%
+kind: Config
+build:
+  artifacts:
+  - image: gcr.io/k8s-skaffold/skaffold-example
+    docker:
+      dockerfile: path/to/Dockerfile
+      secret:
+        id: id
+        src: /file.txt
+  - image: gcr.io/k8s-skaffold/bazel
+    bazel:
+      target: //mytarget
+  - image: gcr.io/k8s-skaffold/jib-maven
+    jib:
+      args: ['-v', '--activate-profiles', 'prof']
+      project: dir
+  - image: gcr.io/k8s-skaffold/jib-gradle
+    jib:
+      args: ['-v']
+  - image: gcr.io/k8s-skaffold/buildpacks
+    buildpacks:
+      builder: gcr.io/buildpacks/builder:v1
+    sync:
+      auto: true
+  googleCloudBuild:
+    projectId: test-project
+test:
+  - image: gcr.io/k8s-skaffold/skaffold-example
+    structureTests:
+     - ./test/*
+deploy:
+  kubectl:
+    manifests:
+    - k8s-*
+  kustomize:
+    paths:
+    - kustomization-main
+portForward:
+  - resourceType: deployment
+    resourceName: leeroy-app
+    port: 8080
+    localPort: 9001
+profiles:
+  - name: test profile
+    build:
+      artifacts:
+      - image: gcr.io/k8s-skaffold/skaffold-example
+        kaniko:
+          cache: {}
+      cluster:
+        pullSecretName: e2esecret
+        pullSecretPath: secret.json
+        namespace: default
+    test:
+     - image: gcr.io/k8s-skaffold/skaffold-example
+       structureTests:
+         - ./test/*
+    deploy:
+      kubectl:
+        manifests:
+        - k8s-*
+      kustomize:
+        paths:
+        - kustomization-test
+  - name: test local
+    build:
+      artifacts:
+      - image: gcr.io/k8s-skaffold/skaffold-example
+        docker:
+          dockerfile: path/to/Dockerfile
+      local:
+        push: false
+    deploy:
+      kubectl:
+        manifests:
+        - k8s-*
+      kustomize: {}
+`
+	verifyUpgrade(t, yaml, expected)
+}
+
+func verifyUpgrade(t *testing.T, input, output string) {
+	config := NewSkaffoldConfig()
+	err := yaml.UnmarshalStrict([]byte(input), config)
+	testutil.CheckErrorAndDeepEqual(t, false, err, Version, config.GetVersion())
+
+	upgraded, err := config.Upgrade()
+	testutil.CheckError(t, false, err)
+
+	expected := next.NewSkaffoldConfig()
+	err = yaml.UnmarshalStrict([]byte(output), expected)
+
+	testutil.CheckErrorAndDeepEqual(t, false, err, expected, upgraded)
+}

--- a/hack/versions/cmd/new/version.go
+++ b/hack/versions/cmd/new/version.go
@@ -61,14 +61,14 @@ func main() {
 	})
 
 	// Create code to upgrade from current to new
-	cp(path(prev, "upgrade.go"), path(current, "upgrade.go"))
-	sed(path(current, "upgrade.go"), current, next)
-	sed(path(current, "upgrade.go"), prev, current)
+	cp(template("upgrade.template.go"), path(current, "upgrade.go"))
+	sed(path(current, "upgrade.go"), "%NEXT_VERSION%", next)
+	sed(path(current, "upgrade.go"), "%PREV_VERSION%", current)
 
 	// Create a test for the upgrade from current to new
-	cp(path(prev, "upgrade_test.go"), path(current, "upgrade_test.go"))
-	sed(path(current, "upgrade_test.go"), current, next)
-	sed(path(current, "upgrade_test.go"), prev, current)
+	cp(template("upgrade_test.template.go"), path(current, "upgrade_test.go"))
+	sed(path(current, "upgrade_test.go"), "%NEXT_VERSION%", next)
+	sed(path(current, "upgrade_test.go"), "%PREV_VERSION%", current)
 
 	// Previous version now upgrades to current instead of latest
 	sed(path(prev, "upgrade.go"), "latest/v1", current)
@@ -155,6 +155,10 @@ func bumpVersion(version string) string {
 
 func path(elem ...string) string {
 	return filepath.Join(append([]string{"pkg", "skaffold", "schema"}, elem...)...)
+}
+
+func template(file string) string {
+	return filepath.Join(append([]string{"hack", "versions", "cmd", "new", "templates"}, file)...)
 }
 
 func read(path string) []byte {


### PR DESCRIPTION

<!-- Include if applicable: -->
Fixes: #6615  <!-- tracking issues that this PR will close -->

**Description**
- Creates a template to use when generating a new skaffold version as opposed to copying existing upgrade files
- Uses template appropriate in `/hack/new_version.sh` script
