### PR TITLE
Ko builder: Implement file watch dependencies

### DIFF
--- a/docs/design_proposals/ko-builder.md
+++ b/docs/design_proposals/ko-builder.md
@@ -350,13 +350,13 @@ Adding the ko builder requires making config changes to the Skaffold schema.
     ```go
     // KoDependencies is used to specify dependencies for an artifact built by ko.
     type KoDependencies struct {
-	  	// Paths should be set to the file dependencies for this artifact, so that the skaffold file watcher knows when to rebuild and perform file synchronization.
-	  	// Defaults to {"go.mod", "**.go"}
-	  	Paths []string `yaml:"paths,omitempty" yamltags:"oneOf=dependency"`
+    	// Paths should be set to the file dependencies for this artifact, so that the skaffold file watcher knows when to rebuild and perform file synchronization.
+    	// Defaults to ["."].
+    	Paths []string `yaml:"paths,omitempty" yamltags:"oneOf=dependency"`
 
-	  	// Ignore specifies the paths that should be ignored by skaffold's file watcher.
+    	// Ignore specifies the paths that should be ignored by skaffold's file watcher.
     	// If a file exists in both `paths` and in `ignore`, it will be ignored, and will be excluded from both rebuilds and file synchronization.
-	  	Ignore []string `yaml:"ignore,omitempty"`
+    	Ignore []string `yaml:"ignore,omitempty"`
     }
     ```
 
@@ -409,7 +409,7 @@ apiVersion: skaffold/v2beta19
 kind: Config
 build:
   artifacts:
-  - image: ko://github.com/GoogleContainerTools/skaffold/examples/ko-complete
+  - image: skaffold-example-ko-comprehensive
     ko:
       asmflags: []
       fromImage: gcr.io/distroless/base:nonroot

--- a/pkg/skaffold/build/ko/dependencies.go
+++ b/pkg/skaffold/build/ko/dependencies.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ko
+
+// TODO(halvards)[09/14/2021]: Replace the latestV1 import path with the
+// real schema import path once the contents of ./schema has been added to
+// the real schema in pkg/skaffold/schema/latest/v1.
+import (
+	"context"
+
+	// latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/schema"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/list"
+)
+
+// GetDependencies returns a list of files to watch for changes to rebuild.
+// TODO(halvards)[09/17/2021]: Call this function from sourceDependenciesForArtifact() in pkg/skaffold/graph/dependencies.go
+func GetDependencies(ctx context.Context, workspace string, a *latestV1.KoArtifact) ([]string, error) {
+	if a.Dependencies == nil || (a.Dependencies.Paths == nil && a.Dependencies.Ignore == nil) {
+		a.Dependencies = defaultKoDependencies()
+	}
+	return list.Files(workspace, a.Dependencies.Paths, a.Dependencies.Ignore)
+}
+
+// defaultKoDependencies behavior is to watch all files in the context directory
+func defaultKoDependencies() *latestV1.KoDependencies {
+	return &latestV1.KoDependencies{
+		Paths:  []string{"**/*.go"},
+		Ignore: []string{},
+	}
+}

--- a/pkg/skaffold/build/ko/dependencies_test.go
+++ b/pkg/skaffold/build/ko/dependencies_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ko
+
+// TODO(halvards)[09/17/2021]: Replace the latestV1 import path with the
+// real schema import path once the contents of ./schema has been added to
+// the real schema in pkg/skaffold/schema/latest/v1.
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	// latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/schema"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestGetDependencies(t *testing.T) {
+	allFiles := []string{
+		".ko.yaml",
+		"cmd/foo/foo.go",
+		"cmd/run.go",
+		"go.mod",
+		"main.go",
+		"pkg/bar/bar.go",
+	}
+	tmpDir := testutil.NewTempDir(t).Touch(allFiles...)
+
+	tests := []struct {
+		description string
+		paths       []string
+		ignore      []string
+		expected    []string
+		shouldErr   bool
+	}{
+		{
+			description: "default is to watch **/*.go",
+			expected: []string{
+				// TODO(halvards)[10/01/2021]: Uncomment all files below when #6605 is merged
+				// "cmd/foo/root.go",
+				"cmd/run.go",
+				// "main.go",
+				// "pkg/bar/bar.go",
+			},
+		},
+		{
+			description: "ignore everything with nil paths",
+			ignore:      []string{"."},
+		},
+		{
+			description: "ignore everything",
+			paths:       []string{"."},
+			ignore:      []string{"."},
+		},
+		{
+			description: "watch everything with empty string path",
+			paths:       []string{""},
+			expected:    allFiles,
+		},
+		{
+			description: "watch everything star",
+			paths:       []string{"*"},
+			expected:    allFiles,
+		},
+		{
+			description: "watch everything globstar",
+			paths:       []string{"**"},
+			expected:    allFiles,
+		},
+		{
+			description: "ignore a directory",
+			paths:       []string{"."},
+			ignore:      []string{"cmd"},
+			expected: []string{
+				".ko.yaml",
+				"go.mod",
+				"main.go",
+				"pkg/bar/bar.go",
+			},
+		},
+		{
+			description: "error",
+			paths:       []string{"unknown"},
+			shouldErr:   true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			deps, err := GetDependencies(context.Background(), tmpDir.Root(), &latestV1.KoArtifact{
+				Dependencies: &latestV1.KoDependencies{
+					Paths:  test.paths,
+					Ignore: test.ignore,
+				},
+			})
+			t.CheckError(test.shouldErr, err)
+			t.CheckDeepEqual(test.expected, deps,
+				cmpopts.AcyclicTransformer("separator", filepath.FromSlash),
+			)
+		})
+	}
+}

--- a/pkg/skaffold/build/ko/ko.go
+++ b/pkg/skaffold/build/ko/ko.go
@@ -40,6 +40,7 @@ type Builder struct {
 }
 
 // NewArtifactBuilder returns a new ko artifact builder
+// TODO(halvards)[09/17/2021]: Call this function from newPerArtifactBuilder() in pkg/skaffold/build/local/types.go
 func NewArtifactBuilder(localDocker docker.LocalDaemon, pushImages bool, runMode config.RunMode, insecureRegistries map[string]bool) *Builder {
 	return &Builder{
 		localDocker:        localDocker,


### PR DESCRIPTION
**Description**
Add support for the `dependencies` section in the ko builder config.

Use `**/*.go` as the default file watch pattern, this prevents unintended image rebuilds based on changes to files in `.git/`, `.idea/`, and `*.swap` files and similar.

For this pattern to be effective, the changes in #6605 are required.

**Tracking:** #6041
**Related:** #6605
