### PR TITLE
Check for nil when retrieving docker support mounts

### DIFF
--- a/pkg/skaffold/docker/debugger/debug.go
+++ b/pkg/skaffold/docker/debugger/debug.go
@@ -75,6 +75,9 @@ func (d *DebugManager) HasMount(image string) bool {
 }
 
 func (d *DebugManager) SupportMounts() map[string]mount.Mount {
+	if d == nil {
+		return nil
+	}
 	return d.supportMounts
 }
 

--- a/pkg/skaffold/docker/debugger/debug_test.go
+++ b/pkg/skaffold/docker/debugger/debug_test.go
@@ -32,6 +32,7 @@ func TestZeroValue(t *testing.T) {
 		var d *DebugManager
 		d.Start(context.TODO())
 		d.Stop()
+		d.SupportMounts()
 		d.TransformImage(context.TODO(), graph.Artifact{}, nil)
 	})
 }


### PR DESCRIPTION
This was causing a nil pointer exception when `ctrl+c`ing out of `skaffold dev`.