### PR TITLE
feat:(build/docker): support env as secret source

### DIFF
--- a/docs/content/en/schemas/v2beta24.json
+++ b/docs/content/en/schemas/v2beta24.json
@@ -1454,6 +1454,11 @@
         "id"
       ],
       "properties": {
+        "env": {
+          "type": "string",
+          "description": "environment variable name containing the secret value.",
+          "x-intellij-html-description": "environment variable name containing the secret value."
+        },
         "id": {
           "type": "string",
           "description": "id of the secret.",
@@ -1467,7 +1472,8 @@
       },
       "preferredOrder": [
         "id",
-        "src"
+        "src",
+        "env"
       ],
       "additionalProperties": false,
       "type": "object",

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -642,6 +642,9 @@ func ToCLIBuildArgs(a *latestV1.DockerArtifact, evaluatedArgs map[string]*string
 		if secret.Source != "" {
 			secretString += ",src=" + secret.Source
 		}
+		if secret.Env != "" {
+			secretString += ",env=" + secret.Env
+		}
 		args = append(args, "--secret", secretString)
 	}
 

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -353,13 +353,22 @@ func TestGetBuildArgs(t *testing.T) {
 			want: []string{"--secret", "id=mysecret"},
 		},
 		{
-			description: "secret with source",
+			description: "secret with file source",
 			artifact: &latestV1.DockerArtifact{
 				Secrets: []*latestV1.DockerSecret{
 					{ID: "mysecret", Source: "foo.src"},
 				},
 			},
 			want: []string{"--secret", "id=mysecret,src=foo.src"},
+		},
+		{
+			description: "secret with env source",
+			artifact: &latestV1.DockerArtifact{
+				Secrets: []*latestV1.DockerSecret{
+					{ID: "mysecret", Env: "FOO"},
+				},
+			},
+			want: []string{"--secret", "id=mysecret,env=FOO"},
 		},
 		{
 			description: "multiple secrets",

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -1315,7 +1315,10 @@ type DockerSecret struct {
 	ID string `yaml:"id,omitempty" yamltags:"required"`
 
 	// Source is the path to the secret on the host machine.
-	Source string `yaml:"src,omitempty"`
+	Source string `yaml:"src,omitempty" yamltags:"oneOf=secretSource"`
+
+	// Env is the environment variable name containing the secret value.
+	Env string `yaml:"env,omitempty" yamltags:"oneOf=secretSource"`
 }
 
 // BazelArtifact describes an artifact built with [Bazel](https://bazel.build/).


### PR DESCRIPTION
Fixes: #6489

**Description**

Used in buildkit mode, allow users to specify docker secrets provided via env
vars to Skaffold (and hence docker/buildkit) in addition to file sources
("src").

I am setting "src" and "env" as mutually exclusive here in skaffold, however
docker currently does not enforce this (but "env" takes precedence regardless
of the order if both specified).

If we receive issues about this, we can relax
it in a backwards-compatible way.

**User facing changes (remove if N/A)**

A backwards-compatible new field introduced in the schema (DockerSecret.env)
mutually exclusive with DockerSecret.src.