### PR TITLE
fix: Wait for context cancel in k8s pod watcher

### DIFF
--- a/pkg/skaffold/kubernetes/portforward/pod_forwarder_test.go
+++ b/pkg/skaffold/kubernetes/portforward/pod_forwarder_test.go
@@ -519,7 +519,7 @@ func (f *fakePodWatcher) Register(receiver chan<- kubernetes.PodEvent) {
 
 func (f *fakePodWatcher) Deregister(_ chan<- kubernetes.PodEvent) {} // noop
 
-func (f *fakePodWatcher) Start(kubeContext string, namespaces []string) (func(), error) {
+func (f *fakePodWatcher) Start(_ context.Context, _ string, _ []string) (func(), error) {
 	go func() {
 		for _, event := range f.events {
 			f.receiver <- event

--- a/pkg/skaffold/kubernetes/watcher_test.go
+++ b/pkg/skaffold/kubernetes/watcher_test.go
@@ -61,7 +61,7 @@ func (h *hasName) Select(pod *v1.Pod) bool {
 func TestPodWatcher(t *testing.T) {
 	testutil.Run(t, "need to register first", func(t *testutil.T) {
 		watcher := NewPodWatcher(&anyPod{})
-		cleanup, err := watcher.Start("", []string{"ns"})
+		cleanup, err := watcher.Start(context.Background(), "", []string{"ns"})
 		defer cleanup()
 
 		t.CheckErrorContains("no receiver was registered", err)
@@ -72,7 +72,7 @@ func TestPodWatcher(t *testing.T) {
 
 		watcher := NewPodWatcher(&anyPod{})
 		watcher.Register(make(chan PodEvent))
-		cleanup, err := watcher.Start("", []string{"ns"})
+		cleanup, err := watcher.Start(context.Background(), "", []string{"ns"})
 		defer cleanup()
 
 		t.CheckErrorContains("unable to get client", err)
@@ -88,7 +88,7 @@ func TestPodWatcher(t *testing.T) {
 
 		watcher := NewPodWatcher(&anyPod{})
 		watcher.Register(make(chan PodEvent))
-		cleanup, err := watcher.Start("", []string{"ns"})
+		cleanup, err := watcher.Start(context.Background(), "", []string{"ns"})
 		defer cleanup()
 
 		t.CheckErrorContains("unable to watch", err)
@@ -104,7 +104,7 @@ func TestPodWatcher(t *testing.T) {
 		events := make(chan PodEvent)
 		watcher := NewPodWatcher(podSelector)
 		watcher.Register(events)
-		cleanup, err := watcher.Start("", []string{"ns1", "ns2"})
+		cleanup, err := watcher.Start(context.Background(), "", []string{"ns1", "ns2"})
 		defer cleanup()
 		t.CheckNoError(err)
 


### PR DESCRIPTION
**Description**
Make the Kubernetes pod watcher context aware, and select on `context.Done()`. This means we can stop waiting, and acting on, pod events when the context has been cancelled.

Remove waiting on `context.Done()` in the Kubernetes log aggregator, container manager, and pod port forwarder. This is to eliminate the chance that the pod watcher sends a `PodEvent` on a channel without a waiting receiver.

This should help avoid deadlocks that can occur when pod watcher event receivers stop reading from the channel that they've registered with the pod watcher.

We still close the channels on the receiver side, which could increase the chances of regression and re-occurrence of this issue.

Also uses a RWMutex in the pod watcher, though we could move this change to a separate PR.

Fixes: #6424 
