### PR TITLE
feat: add dry run option to skaffold delete

### DIFF
--- a/cmd/skaffold/app/cmd/delete.go
+++ b/cmd/skaffold/app/cmd/delete.go
@@ -26,16 +26,24 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
 
+var (
+	dryRun bool
+)
+
 // NewCmdDelete describes the CLI command to delete deployed resources.
 func NewCmdDelete() *cobra.Command {
 	return NewCmd("delete").
 		WithDescription("Delete any resources deployed by Skaffold").
 		WithCommonFlags().
+		WithExample("Print the resources to be deleted", "delete --dry-run").
+		WithFlags([]*Flag{
+			{Value: &dryRun, Name: "dry-run", DefValue: false, Usage: "Don't delete resources, just print them.", IsEnum: true},
+		}).
 		NoArgs(doDelete)
 }
 
 func doDelete(ctx context.Context, out io.Writer) error {
 	return withRunner(ctx, out, func(r runner.Runner, _ []util.VersionedConfig) error {
-		return r.Cleanup(ctx, out)
+		return r.Cleanup(ctx, out, dryRun)
 	})
 }

--- a/cmd/skaffold/app/cmd/dev.go
+++ b/cmd/skaffold/app/cmd/dev.go
@@ -72,7 +72,7 @@ func runDev(ctx context.Context, out io.Writer) error {
 
 				if r.HasDeployed() {
 					cleanup = func() {
-						if err := r.Cleanup(context.Background(), out); err != nil {
+						if err := r.Cleanup(context.Background(), out, false); err != nil {
 							log.Entry(ctx).Warn("deployer cleanup:", err)
 						}
 					}

--- a/cmd/skaffold/app/cmd/dev_test.go
+++ b/cmd/skaffold/app/cmd/dev_test.go
@@ -58,7 +58,7 @@ func (r *mockDevRunner) Prune(context.Context, io.Writer) error {
 	return nil
 }
 
-func (r *mockDevRunner) Cleanup(context.Context, io.Writer) error {
+func (r *mockDevRunner) Cleanup(context.Context, io.Writer, bool) error {
 	r.calls = append(r.calls, "Cleanup")
 	return nil
 }
@@ -139,7 +139,7 @@ func (m *mockConfigChangeRunner) Prune(context.Context, io.Writer) error {
 	return nil
 }
 
-func (m *mockConfigChangeRunner) Cleanup(context.Context, io.Writer) error {
+func (m *mockConfigChangeRunner) Cleanup(context.Context, io.Writer, bool) error {
 	return nil
 }
 

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -494,10 +494,15 @@ Delete any resources deployed by Skaffold
 ```
 
 
+Examples:
+  # Print the resources to be deleted
+  skaffold delete --dry-run
+
 Options:
   -c, --config='': File for global configurations (defaults to $HOME/.skaffold/config)
   -d, --default-repo='': Default repository value (overrides global config)
       --detect-minikube=true: Use heuristics to detect a minikube cluster
+      --dry-run=false: Don't delete resources, just print them.
   -f, --filename='skaffold.yaml': Path or URL to the Skaffold config file
       --kube-context='': Deploy to this Kubernetes context
       --kubeconfig='': Path to the kubeconfig file to use for CLI requests.
@@ -521,6 +526,7 @@ Env vars:
 * `SKAFFOLD_CONFIG` (same as `--config`)
 * `SKAFFOLD_DEFAULT_REPO` (same as `--default-repo`)
 * `SKAFFOLD_DETECT_MINIKUBE` (same as `--detect-minikube`)
+* `SKAFFOLD_DRY_RUN` (same as `--dry-run`)
 * `SKAFFOLD_FILENAME` (same as `--filename`)
 * `SKAFFOLD_KUBE_CONTEXT` (same as `--kube-context`)
 * `SKAFFOLD_KUBECONFIG` (same as `--kubeconfig`)

--- a/pkg/skaffold/deploy/deploy.go
+++ b/pkg/skaffold/deploy/deploy.go
@@ -40,7 +40,7 @@ type Deployer interface {
 	Dependencies() ([]string, error)
 
 	// Cleanup deletes what was deployed by calling Deploy.
-	Cleanup(context.Context, io.Writer) error
+	Cleanup(context.Context, io.Writer, bool) error
 
 	// Render generates the Kubernetes manifests replacing the build results and
 	// writes them to the given file path

--- a/pkg/skaffold/deploy/deploy_mux.go
+++ b/pkg/skaffold/deploy/deploy_mux.go
@@ -158,10 +158,13 @@ func (m DeployerMux) Dependencies() ([]string, error) {
 	return deps.ToList(), nil
 }
 
-func (m DeployerMux) Cleanup(ctx context.Context, w io.Writer) error {
+func (m DeployerMux) Cleanup(ctx context.Context, w io.Writer, dryRun bool) error {
 	for _, deployer := range m.deployers {
 		ctx, endTrace := instrumentation.StartTrace(ctx, "Cleanup")
-		if err := deployer.Cleanup(ctx, w); err != nil {
+		if dryRun {
+			output.Yellow.Fprintln(w, "Following resources would be deleted:")
+		}
+		if err := deployer.Cleanup(ctx, w, dryRun); err != nil {
 			return err
 		}
 		endTrace()

--- a/pkg/skaffold/deploy/deploy_mux_test.go
+++ b/pkg/skaffold/deploy/deploy_mux_test.go
@@ -88,7 +88,7 @@ func (m *MockDeployer) Dependencies() ([]string, error) {
 	return m.dependencies, m.dependenciesErr
 }
 
-func (m *MockDeployer) Cleanup(context.Context, io.Writer) error {
+func (m *MockDeployer) Cleanup(context.Context, io.Writer, bool) error {
 	return m.cleanupErr
 }
 

--- a/pkg/skaffold/deploy/docker/deploy.go
+++ b/pkg/skaffold/deploy/docker/deploy.go
@@ -37,6 +37,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker/tracker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 	olog "github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/status"
@@ -265,13 +266,19 @@ func (d *Deployer) Dependencies() ([]string, error) {
 	return nil, nil
 }
 
-func (d *Deployer) Cleanup(ctx context.Context, out io.Writer) error {
+func (d *Deployer) Cleanup(ctx context.Context, out io.Writer, dryRun bool) error {
+	if dryRun {
+		for _, container := range d.tracker.DeployedContainers() {
+			output.Yellow.Fprintln(out, container.ID)
+		}
+		return nil
+	}
 	for _, container := range d.tracker.DeployedContainers() {
 		if err := d.client.Delete(ctx, out, container.ID); err != nil {
 			// TODO(nkubala): replace with actionable error
 			return errors.Wrap(err, "cleaning up deployed container")
 		}
-		d.portManager.relinquishPorts(container.Name)
+		d.portManager.relinquishPorts(container.ID)
 	}
 
 	for _, m := range d.debugger.SupportMounts() {

--- a/pkg/skaffold/deploy/helm/deploy.go
+++ b/pkg/skaffold/deploy/helm/deploy.go
@@ -345,7 +345,7 @@ func (h *Deployer) Dependencies() ([]string, error) {
 }
 
 // Cleanup deletes what was deployed by calling Deploy.
-func (h *Deployer) Cleanup(ctx context.Context, out io.Writer) error {
+func (h *Deployer) Cleanup(ctx context.Context, out io.Writer, dryRun bool) error {
 	instrumentation.AddAttributesToCurrentSpanFromContext(ctx, map[string]string{
 		"DeployerType": "helm",
 	})
@@ -360,8 +360,14 @@ func (h *Deployer) Cleanup(ctx context.Context, out io.Writer) error {
 		if err != nil {
 			return err
 		}
+		args := []string{}
+		if dryRun {
+			args = append(args, "get", "manifest")
+		} else {
+			args = append(args, "delete")
+		}
+		args = append(args, releaseName)
 
-		args := []string{"delete", releaseName}
 		if namespace != "" {
 			args = append(args, "--namespace", namespace)
 		}

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -1113,7 +1113,17 @@ func TestHelmCleanup(t *testing.T) {
 		namespace        string
 		builds           []graph.Artifact
 		expectedWarnings []string
+		dryRun           bool
 	}{
+		{
+			description: "helm3 cleanup dry-run",
+			commands: testutil.
+				CmdRunWithOutput("helm version --client", version31).
+				AndRun("helm --kube-context kubecontext get manifest skaffold-helm --kubeconfig kubeconfig"),
+			helm:   testDeployConfig,
+			builds: testBuilds,
+			dryRun: true,
+		},
 		{
 			description: "helm3 cleanup success",
 			commands: testutil.
@@ -1169,7 +1179,7 @@ func TestHelmCleanup(t *testing.T) {
 			}, &label.DefaultLabeller{}, &test.helm)
 			t.RequireNoError(err)
 
-			deployer.Cleanup(context.Background(), ioutil.Discard)
+			deployer.Cleanup(context.Background(), ioutil.Discard, test.dryRun)
 
 			t.CheckDeepEqual(test.expectedWarnings, fakeWarner.Warnings)
 		})

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -337,7 +337,7 @@ func (k *Deployer) Dependencies() ([]string, error) {
 }
 
 // Cleanup deletes what was deployed by calling `kpt live destroy`.
-func (k *Deployer) Cleanup(ctx context.Context, out io.Writer) error {
+func (k *Deployer) Cleanup(ctx context.Context, out io.Writer, dryRun bool) error {
 	instrumentation.AddAttributesToCurrentSpanFromContext(ctx, map[string]string{
 		"DeployerType": "kpt",
 	})

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -438,7 +438,7 @@ func TestKpt_Cleanup(t *testing.T) {
 				},
 			})
 
-			err := k.Cleanup(context.Background(), ioutil.Discard)
+			err := k.Cleanup(context.Background(), ioutil.Discard, false)
 
 			t.CheckError(test.shouldErr, err)
 		})

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -468,7 +468,7 @@ func (k *Deployer) renderManifests(ctx context.Context, out io.Writer, builds []
 }
 
 // Cleanup deletes what was deployed by calling Deploy.
-func (k *Deployer) Cleanup(ctx context.Context, out io.Writer) error {
+func (k *Deployer) Cleanup(ctx context.Context, out io.Writer, dryRun bool) error {
 	instrumentation.AddAttributesToCurrentSpanFromContext(ctx, map[string]string{
 		"DeployerType": "kubectl",
 	})
@@ -476,7 +476,12 @@ func (k *Deployer) Cleanup(ctx context.Context, out io.Writer) error {
 	if err != nil {
 		return err
 	}
-
+	if dryRun {
+		for _, manifest := range manifests {
+			output.White.Fprintf(out, "---\n%s", manifest)
+		}
+		return nil
+	}
 	// revert remote manifests
 	// TODO(dgageot): That seems super dangerous and I don't understand
 	// why we need to update resources just before we delete them.

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -261,7 +261,19 @@ func TestKubectlCleanup(t *testing.T) {
 		kubectl     latestV1.KubectlDeploy
 		commands    util.Command
 		shouldErr   bool
+		dryRun      bool
 	}{
+		{
+			description: "cleanup dry-run",
+			kubectl: latestV1.KubectlDeploy{
+				Manifests: []string{"deployment.yaml"},
+			},
+			commands: testutil.
+				CmdRunOut("kubectl version --client -ojson", KubectlVersion112).
+				AndRunOut("kubectl --context kubecontext --namespace testNamespace create --dry-run -oyaml -f deployment.yaml", DeploymentWebYAML).
+				AndRun("kubectl --context kubecontext --namespace testNamespace delete --dry-run --ignore-not-found=true --wait=false -f -"),
+			dryRun: true,
+		},
 		{
 			description: "cleanup success",
 			kubectl: latestV1.KubectlDeploy{
@@ -322,7 +334,7 @@ func TestKubectlCleanup(t *testing.T) {
 			}, &label.DefaultLabeller{}, &test.kubectl)
 			t.RequireNoError(err)
 
-			err = k.Cleanup(context.Background(), ioutil.Discard)
+			err = k.Cleanup(context.Background(), ioutil.Discard, test.dryRun)
 
 			t.CheckError(test.shouldErr, err)
 		})
@@ -369,7 +381,7 @@ func TestKubectlDeployerRemoteCleanup(t *testing.T) {
 			}, &label.DefaultLabeller{}, &test.kubectl)
 			t.RequireNoError(err)
 
-			err = k.Cleanup(context.Background(), ioutil.Discard)
+			err = k.Cleanup(context.Background(), ioutil.Discard, false)
 
 			t.CheckNoError(err)
 		})

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -341,7 +341,7 @@ func (k *Deployer) renderManifests(ctx context.Context, out io.Writer, builds []
 }
 
 // Cleanup deletes what was deployed by calling Deploy.
-func (k *Deployer) Cleanup(ctx context.Context, out io.Writer) error {
+func (k *Deployer) Cleanup(ctx context.Context, out io.Writer, dryRun bool) error {
 	instrumentation.AddAttributesToCurrentSpanFromContext(ctx, map[string]string{
 		"DeployerType": "kustomize",
 	})
@@ -349,7 +349,12 @@ func (k *Deployer) Cleanup(ctx context.Context, out io.Writer) error {
 	if err != nil {
 		return err
 	}
-
+	if dryRun {
+		for _, manifest := range manifests {
+			output.White.Fprintf(out, "---\n%s", manifest)
+		}
+		return nil
+	}
 	if err := k.kubectl.Delete(ctx, textio.NewPrefixWriter(out, " - "), manifests); err != nil {
 		return err
 	}

--- a/pkg/skaffold/deploy/kustomize/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize_test.go
@@ -211,7 +211,18 @@ func TestKustomizeCleanup(t *testing.T) {
 		kustomize   latestV1.KustomizeDeploy
 		commands    util.Command
 		shouldErr   bool
+		dryRun      bool
 	}{
+		{
+			description: "cleanup dry-run",
+			kustomize: latestV1.KustomizeDeploy{
+				KustomizePaths: []string{tmpDir.Root()},
+			},
+			commands: testutil.
+				CmdRunOut("kustomize build "+tmpDir.Root(), kubectl.DeploymentWebYAML).
+				AndRun("kubectl --context kubecontext --namespace testNamespace delete --dry-run --ignore-not-found=true --wait=false -f -"),
+			dryRun: true,
+		},
 		{
 			description: "cleanup success",
 			kustomize: latestV1.KustomizeDeploy{
@@ -262,7 +273,7 @@ func TestKustomizeCleanup(t *testing.T) {
 					Namespace: kubectl.TestNamespace}},
 			}, &label.DefaultLabeller{}, &test.kustomize)
 			t.RequireNoError(err)
-			err = k.Cleanup(context.Background(), ioutil.Discard)
+			err = k.Cleanup(context.Background(), ioutil.Discard, test.dryRun)
 
 			t.CheckError(test.shouldErr, err)
 		})

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -40,7 +40,7 @@ type Runner interface {
 	Apply(context.Context, io.Writer) error
 	ApplyDefaultRepo(tag string) (string, error)
 	Build(context.Context, io.Writer, []*latestV1.Artifact) ([]graph.Artifact, error)
-	Cleanup(context.Context, io.Writer) error
+	Cleanup(context.Context, io.Writer, bool) error
 	Dev(context.Context, io.Writer, []*latestV1.Artifact) error
 	Deploy(context.Context, io.Writer, []graph.Artifact) error
 	DeployAndLog(context.Context, io.Writer, []graph.Artifact) error

--- a/pkg/skaffold/runner/timings.go
+++ b/pkg/skaffold/runner/timings.go
@@ -90,11 +90,11 @@ func (w withTimings) Deploy(ctx context.Context, out io.Writer, builds []graph.A
 	return err
 }
 
-func (w withTimings) Cleanup(ctx context.Context, out io.Writer) error {
+func (w withTimings) Cleanup(ctx context.Context, out io.Writer, dryRun bool) error {
 	start := time.Now()
 	output.Default.Fprintln(out, "Cleaning up...")
 
-	err := w.Deployer.Cleanup(ctx, out)
+	err := w.Deployer.Cleanup(ctx, out, dryRun)
 	if err != nil {
 		return err
 	}

--- a/pkg/skaffold/runner/timings_test.go
+++ b/pkg/skaffold/runner/timings_test.go
@@ -78,7 +78,7 @@ func (m *mockDeployer) Deploy(context.Context, io.Writer, []graph.Artifact) erro
 	return nil
 }
 
-func (m *mockDeployer) Cleanup(context.Context, io.Writer) error {
+func (m *mockDeployer) Cleanup(context.Context, io.Writer, bool) error {
 	if m.err {
 		return errors.New("Unable to cleanup")
 	}
@@ -256,7 +256,7 @@ func TestTimingsCleanup(t *testing.T) {
 			_, _, deployer := WithTimings(nil, nil, d, false)
 
 			var out bytes.Buffer
-			err := deployer.Cleanup(context.Background(), &out)
+			err := deployer.Cleanup(context.Background(), &out, false)
 
 			t.CheckError(test.shouldErr, err)
 			t.CheckMatches(test.shouldOutput, out.String())

--- a/pkg/skaffold/runner/v1/cleanup.go
+++ b/pkg/skaffold/runner/v1/cleanup.go
@@ -21,6 +21,6 @@ import (
 	"io"
 )
 
-func (r *SkaffoldRunner) Cleanup(ctx context.Context, out io.Writer) error {
-	return r.deployer.Cleanup(ctx, out)
+func (r *SkaffoldRunner) Cleanup(ctx context.Context, out io.Writer, dryRun bool) error {
+	return r.deployer.Cleanup(ctx, out, dryRun)
 }

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -131,9 +131,9 @@ func (t *TestBench) TrackBuildArtifacts(_ []graph.Artifact) {}
 func (t *TestBench) TestDependencies(context.Context, *latestV1.Artifact) ([]string, error) {
 	return nil, nil
 }
-func (t *TestBench) Dependencies() ([]string, error)                  { return nil, nil }
-func (t *TestBench) Cleanup(ctx context.Context, out io.Writer) error { return nil }
-func (t *TestBench) Prune(ctx context.Context, out io.Writer) error   { return nil }
+func (t *TestBench) Dependencies() ([]string, error)                               { return nil, nil }
+func (t *TestBench) Cleanup(ctx context.Context, out io.Writer, dryRun bool) error { return nil }
+func (t *TestBench) Prune(ctx context.Context, out io.Writer) error                { return nil }
 
 func (t *TestBench) enterNewCycle() {
 	t.actions = append(t.actions, t.currentActions)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6156

 
**Description**
Added dry-run option to `skaffold` delete.

Before:
```
$skaffold delete
Cleaning up...
```

After:
- Helm deployer:
```
$skaffold delete --dry-run
Cleaning up...
Following resources would be deleted:
---
# Source: skaffold-helm/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: skaffold-helm
  labels:
    app: skaffold-helm
spec:
  selector:
    matchLabels:
      app: skaffold-helm
  replicas: 2
  template:
    metadata:
      labels:
        app: skaffold-helm
    spec:
      containers:
      - name: skaffold-helm
        image: localhost:5000/skaffold-helm:0b11d46a3029cb1e0e60765f81e7e9e85b22708f67d807311345834c2ca9ea92
```
kubectl deployer:
```
skaffold delete --dry-run
Cleaning up...
Following resources would be deleted:
[apiVersion: v1
kind: Pod
metadata:
  name: getting-started
  namespace: default
spec:
  containers:
  - image: skaffold-example
    name: getting-started
]
```

<!-- Describe your changes here. The more detail, the easier the review! -->

<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work**
<!-- Mention any related follow up work to this PR. -->

- Since I found a bit useless the `dry-run` option on `helm uninstall `, I decided to explicitly show the resources that would be deleted. 

 - Some new tests also would be useful, but I would like somebody to have a look at this PR first.

- Kustomize usage test also necessary.

cc @briandealwis 

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
