### PR TITLE
fix: Use gcloud spec pool instead of deprecated WorkerPool

### DIFF
--- a/pkg/skaffold/build/gcb/spec.go
+++ b/pkg/skaffold/build/gcb/spec.go
@@ -46,7 +46,9 @@ func (b *Builder) buildSpec(ctx context.Context, artifact *latestV1.Artifact, ta
 	}
 	buildSpec.Options.DiskSizeGb = b.DiskSizeGb
 	buildSpec.Options.MachineType = b.MachineType
-	buildSpec.Options.WorkerPool = b.WorkerPool
+	if b.WorkerPool != "" {
+		buildSpec.Options.Pool = &cloudbuild.PoolOption{Name: b.WorkerPool}
+	}
 	buildSpec.Options.Logging = b.Logging
 	buildSpec.Options.LogStreamingOption = b.LogStreamingOption
 	buildSpec.Timeout = b.Timeout


### PR DESCRIPTION
The field `WorkerPool` is deprecated since v0.50.0 in CloudBuild API
 https://github.com/googleapis/google-api-go-client/blob/v0.58.0/cloudbuild/v1alpha1/cloudbuild-gen.go#L744

Switching to `PoolOption` in the Cloud Build Spec.
