### PR TITLE
chore: log errors when retrieving build logs

### DIFF
--- a/pkg/skaffold/build/result.go
+++ b/pkg/skaffold/build/result.go
@@ -109,6 +109,9 @@ func (l *logAggregatorImpl) writeToChannel(r io.Reader, lines chan string) {
 	for scanner.Scan() {
 		lines <- scanner.Text()
 	}
+	if scanner.Err() != nil {
+		log.Entry(context.TODO()).Error("error occurred retrieving build logs: %v", scanner.Err())
+	}
 	close(lines)
 }
 


### PR DESCRIPTION
Try to get more information for #6126 by logging errors when handling builder logs.