### PR TITLE
revert: fix: change init builder-prompt to a single-select

### DIFF
--- a/pkg/skaffold/initializer/build/builders_test.go
+++ b/pkg/skaffold/initializer/build/builders_test.go
@@ -139,8 +139,8 @@ func TestResolveBuilderImages(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&prompt.ChooseBuilderFunc, func(choices []string) (string, error) {
-				return choices[0], nil
+			t.Override(&prompt.ChooseBuildersFunc, func(choices []string) ([]string, error) {
+				return choices, nil
 			})
 			// Overrides prompt.BuildConfigFunc to choose first option rather than using the interactive menu
 			t.Override(&prompt.BuildConfigFunc, func(image string, choices []string) (string, error) {

--- a/pkg/skaffold/initializer/build/resolve.go
+++ b/pkg/skaffold/initializer/build/resolve.go
@@ -124,12 +124,14 @@ func (d *defaultBuildInitializer) resolveBuilderImagesInteractively() error {
 		d.unresolvedImages = util.RemoveFromSlice(d.unresolvedImages, image)
 	}
 	if len(choices) > 0 {
-		choice, err := prompt.ChooseBuilderFunc(choices)
+		chosen, err := prompt.ChooseBuildersFunc(choices)
 		if err != nil {
 			return err
 		}
 
-		d.generatedArtifactInfos = append(d.generatedArtifactInfos, getGeneratedArtifactInfo(choiceMap[choice]))
+		for _, choice := range chosen {
+			d.generatedArtifactInfos = append(d.generatedArtifactInfos, getGeneratedArtifactInfo(choiceMap[choice]))
+		}
 	}
 	return nil
 }

--- a/pkg/skaffold/initializer/prompt/prompt.go
+++ b/pkg/skaffold/initializer/prompt/prompt.go
@@ -32,7 +32,7 @@ import (
 // For testing
 var (
 	BuildConfigFunc         = buildConfig
-	ChooseBuilderFunc       = chooseBuilder
+	ChooseBuildersFunc      = chooseBuilders
 	PortForwardResourceFunc = portForwardResource
 	askOne                  = survey.AskOne
 	ask                     = survey.Ask
@@ -77,16 +77,16 @@ func WriteSkaffoldConfig(out io.Writer, pipeline []byte, generatedManifests map[
 	return !response, nil
 }
 
-// chooseBuilder prompts the user to select which builders they'd like to create associated kubernetes manifests for
-func chooseBuilder(builders []string) (string, error) {
-	var chosen string
-	prompt := &survey.Select{
+// chooseBuilders prompts the user to select which builders they'd like to create associated kubernetes manifests for
+func chooseBuilders(builders []string) ([]string, error) {
+	chosen := []string{}
+	prompt := &survey.MultiSelect{
 		Message: "Which builders would you like to create kubernetes resources for?",
 		Options: builders,
 	}
 	err := askOne(prompt, &chosen)
 	if err != nil {
-		return "", fmt.Errorf("getting user choices: %w", err)
+		return []string{}, fmt.Errorf("getting user choices")
 	}
 
 	return chosen, err

--- a/pkg/skaffold/initializer/prompt/prompt_test.go
+++ b/pkg/skaffold/initializer/prompt/prompt_test.go
@@ -79,27 +79,36 @@ func TestChooseBuilders(t *testing.T) {
 	tests := []struct {
 		description    string
 		choices        []string
-		promptResponse string
-		expected       string
+		promptResponse []string
+		expected       []string
 		shouldErr      bool
 	}{
 		{
-			description:    "last chosen",
+			description:    "couple chosen",
 			choices:        []string{"a", "b", "c"},
-			promptResponse: "c",
-			expected:       "c",
+			promptResponse: []string{"a", "c"},
+			expected:       []string{"a", "c"},
 			shouldErr:      false,
 		},
 		{
-			description: "error",
-			choices:     []string{"a", "b", "c"},
-			shouldErr:   true,
+			description:    "none chosen",
+			choices:        []string{"a", "b", "c"},
+			promptResponse: []string{},
+			expected:       []string{},
+			shouldErr:      false,
+		},
+		{
+			description:    "error",
+			choices:        []string{"a", "b", "c"},
+			promptResponse: []string{"a", "b"},
+			expected:       []string{},
+			shouldErr:      true,
 		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&askOne, func(_ survey.Prompt, response interface{}, _ ...survey.AskOpt) error {
-				r := response.(*string)
+				r := response.(*[]string)
 				*r = test.promptResponse
 
 				if test.shouldErr {
@@ -108,8 +117,8 @@ func TestChooseBuilders(t *testing.T) {
 				return nil
 			})
 
-			choice, err := ChooseBuilderFunc(test.choices)
-			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, choice)
+			chosen, err := ChooseBuildersFunc(test.choices)
+			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expected, chosen)
 		})
 	}
 }


### PR DESCRIPTION
Reverts #6665 — the multiselect is necessary for the multiple image situation:
```
$ cd examples/microservices
$ rm  skafold.yaml leeroy-*/kubernetes/deployment.yaml
$ skaffold init --generate-manifests
? Which builders would you like to create kubernetes resources for?  [Use arrows to move, type to filter]
> Docker (base/Dockerfile)
  Docker (leeroy-app/Dockerfile)
  Docker (leeroy-web/Dockerfile)
```
