### PR TITLE
docs: update skaffold development guide to include information about commit messages

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -297,13 +297,15 @@ make -j release GCP_PROJECT=<personalproject> RELEASE_BUCKET=<personal-bucket>
 
 When you have changes you would like to propose to skaffold, you will need to:
 
-1. Ensure the commit message(s) describe what issue you are fixing and how you are fixing it
+1. Ensure the commit message(s) follow the [conventional commits guidelines](https://www.conventionalcommits.org/en/v1.0.0/). The Skaffold repo has a bot to check that commit messages follow this style.
+1. Ensure the PR description describes what issue you are fixing and how you are fixing it
    (include references to [issue numbers](https://help.github.com/articles/closing-issues-using-keywords/)
    if appropriate)
 1. Add unit tests. Unit test coverage should increase or stay the same with every PR.
 1. [Create a pull request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
 
 Please follow our [small Pull Requests guidelines](./docs/community/small-prs.md) for quicker response time.
+
 ### Reviews
 
 Each PR must be reviewed by a maintainer. This maintainer will add the `kokoro:run` label


### PR DESCRIPTION
**Description**
This PR adds a bullet point to DEVELOPMENT.md to tell the developer that they should follow conventional commits guidelines.

