### PR TITLE
fix: correct ko package imports and logging function call

### DIFF
--- a/pkg/skaffold/build/ko/dependencies.go
+++ b/pkg/skaffold/build/ko/dependencies.go
@@ -22,9 +22,8 @@ package ko
 import (
 	"context"
 
-	// latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/list"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
 // GetDependencies returns a list of files to watch for changes to rebuild.

--- a/pkg/skaffold/build/ko/dependencies_test.go
+++ b/pkg/skaffold/build/ko/dependencies_test.go
@@ -26,8 +26,7 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	// latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
-	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko/schema"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -52,11 +51,10 @@ func TestGetDependencies(t *testing.T) {
 		{
 			description: "default is to watch **/*.go",
 			expected: []string{
-				// TODO(halvards)[10/01/2021]: Uncomment all files below when #6605 is merged
-				// "cmd/foo/root.go",
+				"cmd/foo/foo.go",
 				"cmd/run.go",
-				// "main.go",
-				// "pkg/bar/bar.go",
+				"main.go",
+				"pkg/bar/bar.go",
 			},
 		},
 		{

--- a/pkg/skaffold/build/result.go
+++ b/pkg/skaffold/build/result.go
@@ -110,7 +110,7 @@ func (l *logAggregatorImpl) writeToChannel(r io.Reader, lines chan string) {
 		lines <- scanner.Text()
 	}
 	if scanner.Err() != nil {
-		log.Entry(context.TODO()).Error("error occurred retrieving build logs: %v", scanner.Err())
+		log.Entry(context.TODO()).Errorf("error occurred retrieving build logs: %v", scanner.Err())
 	}
 	close(lines)
 }


### PR DESCRIPTION
Related: https://github.com/GoogleContainerTools/skaffold/pull/6647, https://github.com/GoogleContainerTools/skaffold/pull/6617, https://github.com/GoogleContainerTools/skaffold/pull/6663

**Description**
This PR fixes some ko imports which got a bit messed up because of PRs getting merged in an incorrect order. It also changes a call of `...Error()` to `...Errorf()`
