### PR TITLE
fix: ensure run-id is added to resources in skaffold apply

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -471,19 +471,6 @@ var flagRegistry = []Flag{
 		DefinedOn:     []string{"dev", "debug"},
 	},
 	{
-		Name:     "add-skaffold-labels",
-		Usage:    "Add Skaffold-specific labels to rendered manifest. Custom labels will still be applied. Helpful for GitOps model where Skaffold is not the deployer.",
-		Value:    &opts.AddSkaffoldLabels,
-		DefValue: true,
-		DefValuePerCommand: map[string]interface{}{
-			"render": false,
-		},
-		FlagAddMethod: "BoolVar",
-		DefinedOn:     []string{"dev", "debug", "render", "run"},
-		IsEnum:        true,
-		Deprecated:    "Adding Skaffold-specific labels in `render` is deprecated.",
-	},
-	{
 		Name:          "mute-logs",
 		Usage:         "mute logs for specified stages in pipeline (build, deploy, status-check, none, all)",
 		Value:         &opts.Muted.Phases,

--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -75,3 +75,12 @@ func TestRenderApplyHelmDeployment(t *testing.T) {
 		t.CheckNotNil(depApp)
 	})
 }
+
+// Ensure that an intentionally broken deployment fails the status check in `skaffold apply`.
+func TestApplyStatusCheckFailure(t *testing.T) {
+	testutil.Run(t, "ApplyStatusCheckFailure", func(t *testutil.T) {
+		err := skaffold.Apply("deployment.yaml").InDir("testdata/apply").Run(t.T)
+
+		t.CheckError(true, err)
+	})
+}

--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -41,7 +41,7 @@ func TestDiagnoseRenderApply(t *testing.T) {
 
 		tmpDir.Write("skaffold-diagnose.yaml", string(out))
 
-		out = skaffold.Render("--digest-source=local", "--add-skaffold-labels=false", "-f", "skaffold-diagnose.yaml").InNs(ns.Name).RunOrFailOutput(t.T)
+		out = skaffold.Render("--digest-source=local", "-f", "skaffold-diagnose.yaml").InNs(ns.Name).RunOrFailOutput(t.T)
 		tmpDir.Write("render.yaml", string(out))
 
 		skaffold.Apply("render.yaml", "-f", "skaffold-diagnose.yaml").InNs(ns.Name).RunOrFail(t.T)
@@ -66,7 +66,7 @@ func TestRenderApplyHelmDeployment(t *testing.T) {
 
 		tmpDir.Write("skaffold-diagnose.yaml", string(out))
 
-		out = skaffold.Render("--digest-source=local", "--add-skaffold-labels=false", "-f", "skaffold-diagnose.yaml").InNs(ns.Name).RunOrFailOutput(t.T)
+		out = skaffold.Render("--digest-source=local", "-f", "skaffold-diagnose.yaml").InNs(ns.Name).RunOrFailOutput(t.T)
 		tmpDir.Write("render.yaml", string(out))
 
 		skaffold.Apply("render.yaml", "-f", "skaffold-diagnose.yaml").InNs(ns.Name).RunOrFail(t.T)

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -246,9 +246,7 @@ spec:
 						},
 					},
 				}}),
-				Opts: config.SkaffoldOptions{
-					AddSkaffoldLabels: true,
-				},
+				Opts: config.SkaffoldOptions{},
 			}, &label.DefaultLabeller{}, &latestV1.KubectlDeploy{
 				Manifests: []string{"deployment.yaml"},
 			})

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path"
 	"regexp"
-	"strconv"
 	"testing"
 
 	yaml "gopkg.in/yaml.v2"
@@ -454,7 +453,6 @@ func TestRenderFromBuildOutput(t *testing.T) {
 		config              string
 		buildOutputFilePath string
 		offline             bool
-		addSkaffoldLabels   bool
 		input               map[string]string // file path => content
 		expectedOut         string
 	}{
@@ -475,7 +473,6 @@ deploy:
 `,
 			buildOutputFilePath: "testdata/render/build-output.json",
 			offline:             false,
-			addSkaffoldLabels:   false,
 			input: map[string]string{"deployment.yaml": `
 apiVersion: v1
 kind: Pod
@@ -520,7 +517,6 @@ deploy:
 `,
 			buildOutputFilePath: "testdata/render/build-output.json",
 			offline:             true,
-			addSkaffoldLabels:   false,
 			input: map[string]string{"deployment.yaml": `
 apiVersion: v1
 kind: Pod
@@ -564,7 +560,6 @@ deploy:
 `,
 			buildOutputFilePath: "testdata/render/build-output.json",
 			offline:             true,
-			addSkaffoldLabels:   true,
 			input: map[string]string{"deployment.yaml": `
 apiVersion: v1
 kind: Pod
@@ -581,8 +576,6 @@ spec:
 			expectedOut: `apiVersion: v1
 kind: Pod
 metadata:
-  labels:
-    skaffold.dev/run-id: SOMEDYNAMICVALUE
   name: my-pod-123
 spec:
   containers:
@@ -608,7 +601,6 @@ deploy:
 `,
 			buildOutputFilePath: "testdata/render/build-output.json",
 			offline:             true,
-			addSkaffoldLabels:   false,
 			input: map[string]string{"deployment.yaml": `
 apiVersion: v1
 kind: Pod
@@ -659,7 +651,6 @@ deploy:
 `,
 			buildOutputFilePath: "testdata/render/build-output.json",
 			offline:             true,
-			addSkaffoldLabels:   true,
 			input: map[string]string{"deployment.yaml": `
 apiVersion: v1
 kind: Pod
@@ -684,7 +675,6 @@ resources:
 kind: Pod
 metadata:
   labels:
-    skaffold.dev/run-id: SOMEDYNAMICVALUE
     this-is-from: kustomization.yaml
   name: my-pod-123
 spec:
@@ -713,7 +703,7 @@ spec:
 
 			tmpDir.Chdir()
 
-			args := []string{"--digest-source=local", "--build-artifacts=" + path.Join(testDir, test.buildOutputFilePath), "--add-skaffold-labels=" + strconv.FormatBool(test.addSkaffoldLabels), "--output", "rendered.yaml"}
+			args := []string{"--digest-source=local", "--build-artifacts=" + path.Join(testDir, test.buildOutputFilePath), "--output", "rendered.yaml"}
 
 			if test.offline {
 				env := []string{"KUBECONFIG=not-supposed-to-be-used-in-offline-mode"}

--- a/integration/testdata/apply/deployment.yaml
+++ b/integration/testdata/apply/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zz-image-doesnt-exist
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: apply-status-check-failure
+  template:
+    metadata:
+      labels:
+        app: apply-status-check-failure
+    spec:
+      containers:
+      - image: zz-image-doesnt-exist
+        name: apply-status-check-failure

--- a/integration/testdata/apply/skaffold.yaml
+++ b/integration/testdata/apply/skaffold.yaml
@@ -1,0 +1,2 @@
+apiVersion: skaffold/v2beta24
+kind: Config

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -73,31 +73,26 @@ type SkaffoldOptions struct {
 	SkipRender            bool
 	SkipConfigDefaults    bool
 	PropagateProfiles     bool
-	// Add Skaffold-specific labels including runID, deployer labels, etc.
-	// `CustomLabels` are still applied if this is false. Must only be used in
-	// commands which don't deploy (e.g. `skaffold render`) since the runID
-	// label isn't available.
-	AddSkaffoldLabels    bool
-	DetectMinikube       bool
-	IterativeStatusCheck bool
-	ForceLoadImages      bool
-	WaitForConnection    bool
-	MakePathsAbsolute    *bool
-	StatusCheck          BoolOrUndefined
-	PortForward          PortForwardOptions
-	DefaultRepo          StringOrUndefined
-	PushImages           BoolOrUndefined
-	CustomLabels         []string
-	TargetImages         []string
-	Profiles             []string
-	InsecureRegistries   []string
-	ConfigurationFilter  []string
-	HydratedManifests    []string
-	Muted                Muted
-	BuildConcurrency     int
-	WatchPollInterval    int
-	RPCPort              IntOrUndefined
-	RPCHTTPPort          IntOrUndefined
+	DetectMinikube        bool
+	IterativeStatusCheck  bool
+	ForceLoadImages       bool
+	WaitForConnection     bool
+	MakePathsAbsolute     *bool
+	StatusCheck           BoolOrUndefined
+	PortForward           PortForwardOptions
+	DefaultRepo           StringOrUndefined
+	PushImages            BoolOrUndefined
+	CustomLabels          []string
+	TargetImages          []string
+	Profiles              []string
+	InsecureRegistries    []string
+	ConfigurationFilter   []string
+	HydratedManifests     []string
+	Muted                 Muted
+	BuildConcurrency      int
+	WatchPollInterval     int
+	RPCPort               IntOrUndefined
+	RPCHTTPPort           IntOrUndefined
 
 	SyncRemoteCache  SyncRemoteCacheOption
 	WaitForDeletions WaitForDeletions

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -173,7 +173,6 @@ func (rc *RunContext) GetInsecureRegistries() map[string]bool        { return rc
 func (rc *RunContext) GetWorkingDir() string                         { return rc.WorkingDir }
 func (rc *RunContext) GetCluster() config.Cluster                    { return rc.Cluster }
 func (rc *RunContext) GetNamespace() string                          { return rc.Opts.Namespace }
-func (rc *RunContext) AddSkaffoldLabels() bool                       { return rc.Opts.AddSkaffoldLabels }
 func (rc *RunContext) AutoBuild() bool                               { return rc.Opts.AutoBuild }
 func (rc *RunContext) AutoDeploy() bool                              { return rc.Opts.AutoDeploy }
 func (rc *RunContext) AutoSync() bool                                { return rc.Opts.AutoSync }

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -166,6 +166,12 @@ func (rc *RunContext) TransformableAllowList() []latestV1.ResourceFilter {
 	return rc.Pipelines.TransformableAllowList()
 }
 
+// AddSkaffoldLabels tells the Runner whether to add skaffold-specific labels.
+// We only ever skip adding labels during a `skaffold render`.
+func (rc *RunContext) AddSkaffoldLabels() bool {
+	return rc.Opts.Mode() != config.RunModes.Render
+}
+
 func (rc *RunContext) DefaultPipeline() latestV1.Pipeline            { return rc.Pipelines.Head() }
 func (rc *RunContext) GetKubeContext() string                        { return rc.KubeContext }
 func (rc *RunContext) GetPipelines() []latestV1.Pipeline             { return rc.Pipelines.All() }

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
@@ -64,7 +63,7 @@ func NewForConfig(ctx context.Context, runCtx *runcontext.RunContext) (*Skaffold
 	}
 
 	// Always add skaffold-specific labels, except during `skaffold render`
-	labeller := label.NewLabeller(runCtx.Mode() != config.RunModes.Render, runCtx.CustomLabels(), runCtx.GetRunID())
+	labeller := label.NewLabeller(runCtx.AddSkaffoldLabels(), runCtx.CustomLabels(), runCtx.GetRunID())
 	tester, err := getTester(ctx, runCtx, isLocalImage)
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(err))

--- a/pkg/skaffold/runner/v1/new.go
+++ b/pkg/skaffold/runner/v1/new.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/label"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
@@ -61,7 +62,9 @@ func NewForConfig(ctx context.Context, runCtx *runcontext.RunContext) (*Skaffold
 	isLocalImage := func(imageName string) (bool, error) {
 		return isImageLocal(runCtx, imageName)
 	}
-	labeller := label.NewLabeller(runCtx.AddSkaffoldLabels(), runCtx.CustomLabels(), runCtx.GetRunID())
+
+	// Always add skaffold-specific labels, except during `skaffold render`
+	labeller := label.NewLabeller(runCtx.Mode() != config.RunModes.Render, runCtx.CustomLabels(), runCtx.GetRunID())
 	tester, err := getTester(ctx, runCtx, isLocalImage)
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(err))


### PR DESCRIPTION
Fixes: #6657

**Description**
This change ensures that we add the `skaffold.dev/run-id` labels to all resources created in `skaffold apply`. This was not happening before this change, as the `--add-skaffold-labels` flag was not defined on the `apply` subcommand, causing the value to default to `false`.

The `--add-skaffold-labels` flag was deprecated in https://github.com/GoogleContainerTools/skaffold/pull/5653 on May 5, 2021, putting us at just over 5 months since deprecation. Our deprecation policy would mandate a 6 month period, but I would propose an exception to this rule as this is the correct way to address this issue, and is a scenario that does not "fit neatly into this policy": https://skaffold.dev/docs/references/deprecation/#exceptions

As a result of this change, we will now **always** apply and skaffold-specific labels in Skaffold, with the exception of during `skaffold render` in which we will **never** apply them.
