### PR TITLE
fix: Sanitize image names when default repo unset

### DIFF
--- a/pkg/skaffold/build/scheduler.go
+++ b/pkg/skaffold/build/scheduler.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/event"
 	eventV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/event/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
@@ -152,5 +153,6 @@ func performBuild(ctx context.Context, cw io.Writer, tags tag.ImageTags, artifac
 	if !present {
 		return "", fmt.Errorf("unable to find tag for image %s", artifact.ImageName)
 	}
+	tag = docker.SanitizeImageName(tag)
 	return build(ctx, cw, artifact, tag)
 }

--- a/pkg/skaffold/build/scheduler_test.go
+++ b/pkg/skaffold/build/scheduler_test.go
@@ -59,6 +59,18 @@ func TestGetBuild(t *testing.T) {
 			expectedOut: "Building [skaffold/image1]...\nbuild succeeds",
 		},
 		{
+			description: "tag with ko scheme prefix and Go import path with uppercase characters is sanitized",
+			buildArtifact: func(ctx context.Context, out io.Writer, artifact *latestV1.Artifact, tag string) (string, error) {
+				out.Write([]byte("build succeeds"))
+				return fmt.Sprintf("%s@sha256:abac", tag), nil
+			},
+			tags: tag.ImageTags{
+				"skaffold/image1": "ko://github.com/GoogleContainerTools/skaffold/cmd/skaffold:v0.0.1",
+			},
+			expectedTag: "github.com/googlecontainertools/skaffold/cmd/skaffold:v0.0.1@sha256:abac",
+			expectedOut: "Building [skaffold/image1]...\nbuild succeeds",
+		},
+		{
 			description: "build fails",
 			buildArtifact: func(ctx context.Context, out io.Writer, artifact *latestV1.Artifact, tag string) (string, error) {
 				return "", fmt.Errorf("build fails")


### PR DESCRIPTION
**Description**
This change ensures that image names from `skaffold.yaml` are sanitized even when the Skaffold default repo is not set.

This is relevant for ko images with names that consist of the `ko://` scheme prefixed, followed by a Go import path that may contain uppercase characters, e.g., `ko://github.com/GoogleContainerTools/skaffold/cmd/skaffold`.

Fixes: #6675
Tracking: #6041
Related: #4952
