### PR TITLE
build: 30 min timeout for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ ifeq ($(GCP_ONLY),true)
 		--zone $(GKE_ZONE) \
 		--project $(GCP_PROJECT)
 endif
-	@ GCP_ONLY=$(GCP_ONLY) ./hack/gotest.sh -v $(REPOPATH)/integration/binpack $(REPOPATH)/integration -timeout 50m $(INTEGRATION_TEST_ARGS)
+	@ GCP_ONLY=$(GCP_ONLY) ./hack/gotest.sh -v $(REPOPATH)/integration/binpack $(REPOPATH)/integration -timeout 30m $(INTEGRATION_TEST_ARGS)
 
 .PHONY: integration
 integration: install integration-tests


### PR DESCRIPTION
**Description**
Integration tests on Kokoro either pass within 20-24 minutes, or `TestDevGracefulCancel` hangs until the build times out.

A shorter timeout would help us by failing builds that hang sooner.

**Related**: #6424, #6643, #6662
