### PR TITLE
feat: add support for Kaniko flag --cache-copy-layers

### DIFF
--- a/docs/content/en/schemas/v2beta25.json
+++ b/docs/content/en/schemas/v2beta25.json
@@ -2408,6 +2408,12 @@
     },
     "KanikoCache": {
       "properties": {
+        "cacheCopyLayers": {
+          "type": "boolean",
+          "description": "enables caching of copy layers.",
+          "x-intellij-html-description": "enables caching of copy layers.",
+          "default": "false"
+        },
         "hostPath": {
           "type": "string",
           "description": "specifies a path on the host that is mounted to each pod as read only cache volume containing base images. If set, must exist on each node and prepopulated with kaniko-warmer.",
@@ -2422,11 +2428,6 @@
           "type": "string",
           "description": "Cache timeout in hours.",
           "x-intellij-html-description": "Cache timeout in hours."
-        },
-        "cacheCopyLayers": {
-          "type": "string",
-          "description": "caches copy layers.",
-          "x-intellij-html-description": "caches copy layers."
         }
       },
       "preferredOrder": [

--- a/docs/content/en/schemas/v2beta25.json
+++ b/docs/content/en/schemas/v2beta25.json
@@ -2422,12 +2422,18 @@
           "type": "string",
           "description": "Cache timeout in hours.",
           "x-intellij-html-description": "Cache timeout in hours."
+        },
+        "cacheCopyLayers": {
+          "type": "string",
+          "description": "caches copy layers.",
+          "x-intellij-html-description": "caches copy layers."
         }
       },
       "preferredOrder": [
         "repo",
         "hostPath",
-        "ttl"
+        "ttl",
+        "cacheCopyLayers"
       ],
       "additionalProperties": false,
       "type": "object",

--- a/pkg/skaffold/build/gcb/kaniko_test.go
+++ b/pkg/skaffold/build/gcb/kaniko_test.go
@@ -79,6 +79,17 @@ func TestKanikoBuildSpec(t *testing.T) {
 			},
 		},
 		{
+			description: "with Cache Copy Layers",
+			artifact: &latestV1.KanikoArtifact{
+				DockerfilePath: "Dockerfile",
+				Cache:          &latestV1.KanikoCache{CacheCopyLayers: true},
+			},
+			expectedArgs: []string{
+				kaniko.CacheFlag,
+				kaniko.CacheCopyLayersFlag,
+			},
+		},
+		{
 			description: "with Cleanup",
 			artifact: &latestV1.KanikoArtifact{
 				DockerfilePath: "Dockerfile",

--- a/pkg/skaffold/build/kaniko/args.go
+++ b/pkg/skaffold/build/kaniko/args.go
@@ -55,6 +55,9 @@ func Args(artifact *latestV1.KanikoArtifact, tag, context string) ([]string, err
 		if artifact.Cache.TTL != "" {
 			args = append(args, CacheTTLFlag, artifact.Cache.TTL)
 		}
+		if artifact.Cache.CacheCopyLayers {
+			args = append(args, CacheCopyLayersFlag)
+		}
 	}
 
 	if artifact.Target != "" {

--- a/pkg/skaffold/build/kaniko/types.go
+++ b/pkg/skaffold/build/kaniko/types.go
@@ -21,6 +21,8 @@ const (
 	BuildArgsFlag = "--build-arg"
 	// CacheFlag additional flag
 	CacheFlag = "--cache"
+	// CacheCopyLayersFlag additional flag
+	CacheCopyLayersFlag = "--cache-copy-layers"
 	// CacheDirFlag additional flag
 	CacheDirFlag = "--cache-dir"
 	// CacheRepoFlag additional flag

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -372,6 +372,8 @@ type KanikoCache struct {
 	HostPath string `yaml:"hostPath,omitempty"`
 	// TTL Cache timeout in hours.
 	TTL string `yaml:"ttl,omitempty"`
+	// CacheCopyLayers enables caching of copy layers.
+	CacheCopyLayers bool `yaml:"cacheCopyLayers,omitempty"`
 }
 
 // ClusterDetails *beta* describes how to do an on-cluster build.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: https://github.com/GoogleContainerTools/skaffold/pull/6380 references adding this flag and was used as a reference for this PR.

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Add Kaniko's "--cache-copy-layers" flag (https://github.com/GoogleContainerTools/kaniko#--cache-copy-layers), which tells Kaniko to cache COPY layers.

**User facing changes**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
New option `cacheCopyLayers` in kaniko section



<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
