### PR TITLE
fix: sanity check kpt deployer versions

### DIFF
--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -68,7 +68,7 @@ const (
 
 	kptDownloadLink        = "https://googlecontainertools.github.io/kpt/installation/"
 	kptMinVersionInclusive = "v0.38.1"
-	kptMaxVersionExclusive = "v1.0.0"
+	kptMaxVersionExclusive = "v1.0.0-alpha.1"
 
 	kustomizeDownloadLink  = "https://kubernetes-sigs.github.io/kustomize/installation/"
 	kustomizeMinVersion    = "v3.2.3"

--- a/pkg/skaffold/deploy/kpt/kpt_test.go
+++ b/pkg/skaffold/deploy/kpt/kpt_test.go
@@ -1091,13 +1091,13 @@ func TestVersionCheck(t *testing.T) {
 				kptMinVersionInclusive, kptMaxVersionExclusive, kptDownloadLink),
 		},
 		{
-			description: "kpt version is too new (>=1.0.0)",
+			description: "kpt version is too new (>=1.0.0-alpha)",
 			commands: testutil.
-				CmdRunOut("kpt version", `1.0.0`),
+				CmdRunOut("kpt version", `1.0.0-beta.4`),
 			kustomizations: map[string]string{"Kustomization": `resources:
 					- foo.yaml`},
 			shouldErr: true,
-			error: fmt.Errorf("you are using kpt \"v1.0.0\"\nPlease install "+
+			error: fmt.Errorf("you are using kpt \"v1.0.0-beta.4\"\nPlease install "+
 				"kpt %v <= version < %v\nSee kpt installation: %v",
 				kptMinVersionInclusive, kptMaxVersionExclusive, kptDownloadLink),
 		},


### PR DESCRIPTION

Fixes: #6602 <!-- tracking issues that this PR will close -->

**Description**
Skaffold v1 only supports kpt versions v0.x.xx release. Since kpt v1 is in beta rather than GA, the semver check should against v1.0.0-alpha.1 instead of v1.0.0
