### PR TITLE
fix: panic caused by multiple channel closes

### DIFF
--- a/pkg/skaffold/kubernetes/debugging/container_manager.go
+++ b/pkg/skaffold/kubernetes/debugging/container_manager.go
@@ -101,7 +101,6 @@ func (d *ContainerManager) Stop() {
 		return
 	}
 	d.podWatcher.Deregister(d.events)
-	close(d.events) // the receiver shouldn't really be the one to close the channel
 }
 
 func (d *ContainerManager) Name() string {

--- a/pkg/skaffold/kubernetes/portforward/pod_forwarder.go
+++ b/pkg/skaffold/kubernetes/portforward/pod_forwarder.go
@@ -107,7 +107,6 @@ func (p *WatchingPodForwarder) Start(ctx context.Context, out io.Writer, namespa
 func (p *WatchingPodForwarder) Stop() {
 	p.entryManager.Stop()
 	p.podWatcher.Deregister(p.events)
-	close(p.events) // the receiver shouldn't really be the one to close the channel
 }
 
 func (p *WatchingPodForwarder) portForwardPod(ctx context.Context, pod *v1.Pod) error {


### PR DESCRIPTION
**Description**
This PR removes a couple channel closes that were added in https://github.com/GoogleContainerTools/skaffold/pull/6643.

These were causing panics on `ctrl`+`c`, as well as issues where we weren't sending out `DebuggingContainerEvent`s past the first `skaffold dev`/`debug` iteration.

There are issues here with how we're closing since we're closing on the receiver side, when we should be closing on the sender side and keeping track of how many places we're sending out on so that we can close properly in the sender.

**Follow-up Work (remove if N/A)**
Fix up our channel closes.
