### PR TITLE
fix(doc): add scoop-extras installation details

### DIFF
--- a/docs/content/en/docs/install/_index.md
+++ b/docs/content/en/docs/install/_index.md
@@ -162,7 +162,24 @@ This package is not maintained by the Skaffold team.
 
 ```powershell
 scoop install skaffold
+
 ```
+
+When installing with scoop, you might get an error that says **
+Couldn't find manifest for 'skaffold' **
+
+If you encountered the error above, follow below process to fix it
+
+Run 
+```powershell
+scoop bucket add extras
+```
+
+After running the above command and the extras bucket has been added successfully.
+
+Re run the scoop install skaffold 
+
+The above should solve the issue
 
 ### Chocolatey
 


### PR DESCRIPTION
Adding the solution to errors couldn't find manifest for 'skaffold' when installing with scoop. This error is due to lack of extras bucket when scoop is being installed. Default bucket that comes with scoop is main. In the absence of the extras bucket, users won't be able to install skaffold and couldn't find manifest for 'skaffold' error will be encountered

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
