### PR TITLE
chore: use ad-hoc signing on darwin to avoid network popups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,9 @@ $(BUILD_DIR)/$(PROJECT): $(STATIK_FILES) $(GO_FILES) $(BUILD_DIR)
 	$(eval tags = $(GO_BUILD_TAGS_$(GOOS)) $(GO_BUILD_TAGS_$(GOOS)_$(GOARCH)))
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=1 \
 	    go build -gcflags="all=-N -l" -tags "$(tags)" -ldflags "$(ldflags)" -o $@ $(BUILD_PACKAGE)
+ifeq ($(GOOS),darwin)
+	codesign --force --deep --sign - $@
+endif
 
 .PHONY: install
 install: $(BUILD_DIR)/$(PROJECT)


### PR DESCRIPTION
Add a `codesign` step to sign the Skaffold binary with an ad-hoc signature.  This seems to avoid the macOS prompts to accept incoming network connections.

![unnamed](https://user-images.githubusercontent.com/202851/137752425-40fe5595-cabf-4933-9d89-4ef81cce6bab.png)
 