### PR TITLE
fix: fix non-determinism in skaffoldyamls_test.go

### DIFF
--- a/pkg/skaffold/lint/skaffoldyamls_test.go
+++ b/pkg/skaffold/lint/skaffoldyamls_test.go
@@ -121,7 +121,10 @@ func TestGetSkaffoldYamlsLintResults(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			tmpdir := t.TempDir()
 			configSet := parser.SkaffoldConfigSet{}
-			for module, skaffoldyamlText := range test.moduleAndSkaffoldYamls {
+			// iteration done to enforce result order
+			for i := 0; i < len(test.moduleAndSkaffoldYamls); i++ {
+				module := fmt.Sprintf("cfg%d", i)
+				skaffoldyamlText := test.moduleAndSkaffoldYamls[module]
 				fp := filepath.Join(tmpdir, fmt.Sprintf("%s.yaml", module))
 				err := ioutil.WriteFile(fp, []byte(skaffoldyamlText), 0644)
 				if err != nil {


### PR DESCRIPTION
This PR fixes an issue in skaffoldyamls_test.go in which the skaffold configs from the test input are ordered non-deterministically and this can lead to test errors.  This PR enforces an order of iteration on the maps keys so that the order of the lint rules is determinitic when doing the DeepEquals compare.  A map is still used (vs a list) to make the mapping more explicit as to what rules correspond to which skaffold modules/configs