### PR TITLE
chore: add script to improve QOL when doing release

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -20,6 +20,8 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 EXAMPLES_DIR=${DIR}/../examples
 INTEGRATION_EXAMPLES_DIR=${DIR}/../integration/examples
 
+go run hack/release/changelog/main.go
+
 if ! [[ -x "${DIR}/release-notes" ]]; then
   echo >&2 'Installing release-notes'
   cd "${DIR}/tools"

--- a/hack/release/changelog/main.go
+++ b/hack/release/changelog/main.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
@@ -10,25 +26,36 @@ import (
 	"text/template"
 	"time"
 
-  "github.com/blang/semver"
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/blang/semver"
+
 	"github.com/GoogleContainerTools/skaffold/hack/versions/pkg/schema"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
-type ChangeLogData struct {
+type changelogData struct {
 	SkaffoldVersion string
-	Date string
-	SchemaString string
+	Date            string
+	SchemaString    string
 }
 
 // TODO(marlongamez): do some autosorting of `release-notes` binary output
 func main() {
-	data := ChangeLogData{}
+	data, err := getChangelogData(schema.IsReleased)
+	if err != nil {
+		os.Exit(1)
+	}
+	if err = updateChangelog(path.Join("CHANGELOG.md"), path.Join("hack", "release", "changelog", "template.md"), data); err != nil {
+		os.Exit(1)
+	}
+}
+
+func getChangelogData(schemaIsReleased func(string) (bool, error)) (changelogData, error) {
+	data := changelogData{}
 
 	// Get skaffold version from user
 	if err := survey.AskOne(&survey.Input{Message: "Input skaffold version:"}, &data.SkaffoldVersion); err != nil {
-		os.Exit(1)
+		return changelogData{}, fmt.Errorf("failed to get skaffold version from input: %w", err)
 	}
 	data.SkaffoldVersion = strings.TrimPrefix(data.SkaffoldVersion, "v")
 	semver.MustParse(data.SkaffoldVersion)
@@ -39,30 +66,39 @@ func main() {
 
 	// Add extra string if new schema version is being released
 	latest := path.Join("pkg", "skaffold", "schema", "latest", "v1", "config.go")
-	released, err := schema.IsReleased(latest)
+	released, err := schemaIsReleased(latest)
 	if err != nil {
-		os.Exit(1)
+		return changelogData{}, fmt.Errorf("checking if schema is released: %w", err)
 	}
 	if !released {
 		schemaVersion := strings.TrimPrefix(latestV1.Version, "skaffold/")
 		data.SchemaString = fmt.Sprintf("\nNote: This release comes with a new config version, `%s`. To upgrade your skaffold.yaml, use `skaffold fix`. If you choose not to upgrade, skaffold will auto-upgrade as best as it can.\n", schemaVersion)
 	}
 
+	return data, nil
+}
+
+func updateChangelog(filepath, templatePath string, data changelogData) error {
 	// Execute template and combine output with existing CHANGELOG.md contents
 	var buf bytes.Buffer
-	tmpl, err := template.ParseFiles(path.Join("hack", "release", "changelog", "template.md"))
-	if err = tmpl.Execute(&buf, data); err != nil {
-		os.Exit(1)
-	}
-	b, err := ioutil.ReadFile(path.Join("CHANGELOG.md"))
+	tmpl, err := template.ParseFiles(templatePath)
 	if err != nil {
-		os.Exit(1)
+		return fmt.Errorf("parsing template file: %w", err)
+	}
+	if err = tmpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("executing changelog template: %w", err)
+	}
+	b, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		return fmt.Errorf("reading changelog file: %w", err)
 	}
 	_, err = fmt.Fprint(&buf, string(b))
 	if err != nil {
-		os.Exit(1)
+		return fmt.Errorf("writing to changelog buffer: %w", err)
 	}
-	if err = ioutil.WriteFile(path.Join("CHANGELOG.md"), buf.Bytes(), 0644); err != nil {
-		os.Exit(1)
+	if err = ioutil.WriteFile(filepath, buf.Bytes(), 0644); err != nil {
+		return fmt.Errorf("writing to changelog file: %w", err)
 	}
+
+	return nil
 }

--- a/hack/release/changelog/main.go
+++ b/hack/release/changelog/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"text/template"
+	"time"
+
+  "github.com/blang/semver"
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/GoogleContainerTools/skaffold/hack/versions/pkg/schema"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+)
+
+type ChangeLogData struct {
+	SkaffoldVersion string
+	Date string
+	SchemaString string
+}
+
+// TODO(marlongamez): do some autosorting of `release-notes` binary output
+func main() {
+	data := ChangeLogData{}
+
+	// Get skaffold version from user
+	if err := survey.AskOne(&survey.Input{Message: "Input skaffold version:"}, &data.SkaffoldVersion); err != nil {
+		os.Exit(1)
+	}
+	data.SkaffoldVersion = strings.TrimPrefix(data.SkaffoldVersion, "v")
+	semver.MustParse(data.SkaffoldVersion)
+
+	// Get current time
+	currentTime := time.Now()
+	data.Date = currentTime.Format("01/02/2006")
+
+	// Add extra string if new schema version is being released
+	latest := path.Join("pkg", "skaffold", "schema", "latest", "v1", "config.go")
+	released, err := schema.IsReleased(latest)
+	if err != nil {
+		os.Exit(1)
+	}
+	if !released {
+		schemaVersion := strings.TrimPrefix(latestV1.Version, "skaffold/")
+		data.SchemaString = fmt.Sprintf("\nNote: This release comes with a new config version, `%s`. To upgrade your skaffold.yaml, use `skaffold fix`. If you choose not to upgrade, skaffold will auto-upgrade as best as it can.\n", schemaVersion)
+	}
+
+	// Execute template and combine output with existing CHANGELOG.md contents
+	var buf bytes.Buffer
+	tmpl, err := template.ParseFiles(path.Join("hack", "release", "changelog", "template.md"))
+	if err = tmpl.Execute(&buf, data); err != nil {
+		os.Exit(1)
+	}
+	b, err := ioutil.ReadFile(path.Join("CHANGELOG.md"))
+	if err != nil {
+		os.Exit(1)
+	}
+	_, err = fmt.Fprint(&buf, string(b))
+	if err != nil {
+		os.Exit(1)
+	}
+	if err = ioutil.WriteFile(path.Join("CHANGELOG.md"), buf.Bytes(), 0644); err != nil {
+		os.Exit(1)
+	}
+}

--- a/hack/release/changelog/main_test.go
+++ b/hack/release/changelog/main_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestUpdateChangelog(t *testing.T) {
+	data := changelogData{
+		SkaffoldVersion: "1.11.1",
+		Date:            "01/11/2001",
+		SchemaString:    "\nSomething about a schema\n",
+	}
+
+	// Read original `testdata/changelog.md` and write it back after test
+	changelogB, _ := ioutil.ReadFile(path.Join("testdata", "changelog.md"))
+	defer ioutil.WriteFile(path.Join("testdata", "changelog.md"), changelogB, 0644)
+
+	// function should only error on standard lib errors
+	err := updateChangelog(path.Join("testdata", "changelog.md"), path.Join("template.md"), data)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+
+	gotB, _ := ioutil.ReadFile(path.Join("testdata", "changelog.md"))
+	wantB, _ := ioutil.ReadFile(path.Join("testdata", "expected.md"))
+	gotB = bytes.ReplaceAll(gotB, []byte("\r\n"), []byte("\n"))
+	wantB = bytes.ReplaceAll(wantB, []byte("\r\n"), []byte("\n"))
+
+	testutil.CheckDeepEqual(t, wantB, gotB)
+}

--- a/hack/release/changelog/template.md
+++ b/hack/release/changelog/template.md
@@ -1,0 +1,29 @@
+# v{{.SkaffoldVersion}} Release - {{.Date}}
+**Linux amd64**
+`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v{{.SkaffoldVersion}}/skaffold-linux-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
+
+**Linux arm64**
+`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v{{.SkaffoldVersion}}/skaffold-linux-arm64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
+
+**macOS amd64**
+`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v{{.SkaffoldVersion}}/skaffold-darwin-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
+
+**macOS arm64**
+`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v{{.SkaffoldVersion}}/skaffold-darwin-arm64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
+
+**Windows**
+https://storage.googleapis.com/skaffold/releases/v{{.SkaffoldVersion}}/skaffold-windows-amd64.exe
+
+**Docker image**
+`gcr.io/k8s-skaffold/skaffold:v{{.SkaffoldVersion}}`
+{{.SchemaString}}
+Highlights:
+
+New Features and Additions:
+
+Fixes:
+
+Updates and Refactors:
+
+Docs, Test, and Release Updates:
+

--- a/hack/release/changelog/testdata/changelog.md
+++ b/hack/release/changelog/testdata/changelog.md
@@ -1,0 +1,1 @@
+# This should be at the bottom

--- a/hack/release/changelog/testdata/expected.md
+++ b/hack/release/changelog/testdata/expected.md
@@ -1,0 +1,32 @@
+# v1.11.1 Release - 01/11/2001
+**Linux amd64**
+`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.11.1/skaffold-linux-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
+
+**Linux arm64**
+`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.11.1/skaffold-linux-arm64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
+
+**macOS amd64**
+`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.11.1/skaffold-darwin-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
+
+**macOS arm64**
+`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.11.1/skaffold-darwin-arm64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
+
+**Windows**
+https://storage.googleapis.com/skaffold/releases/v1.11.1/skaffold-windows-amd64.exe
+
+**Docker image**
+`gcr.io/k8s-skaffold/skaffold:v1.11.1`
+
+Something about a schema
+
+Highlights:
+
+New Features and Additions:
+
+Fixes:
+
+Updates and Refactors:
+
+Docs, Test, and Release Updates:
+
+# This should be at the bottom

--- a/hack/versions/pkg/schema/version.go
+++ b/hack/versions/pkg/schema/version.go
@@ -76,3 +76,18 @@ func getLastReleasedConfigVersion() string {
 	logrus.Fatalf("can't determine latest released config version, failed to download %s: %s", lastTag, err)
 	return ""
 }
+
+// IsReleased takes a filepath to a skaffold config in pkg/skaffold/schema and returns true if it's released and false if otherwise.
+func IsReleased(filepath string) (bool, error) {
+	b, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		return false, err
+	}
+
+	s := string(b)
+	if strings.Contains(s, releasedComment) {
+		return true, nil
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
**Description**
This PR adds a script that runs with `hack/release.sh` that will prepend a template to the beginning of `CHANGELOG.md` for the person doing the release to fill out.

When running the `hack/release.sh` script, the user will now see this:
```
❯ hack/release.sh
? Input skaffold version:
```
After they input a version, everything else will happen like normal.

**Future Work**
Since we use conventional commit formatting now, it would be nice to try and automatically populate the different categories by parsing the output from `release-notes`.