### PR TITLE
feat: adding p0 skaffold.yaml rule recommending static port usage for relevant deployed resources

### DIFF
--- a/pkg/skaffold/kubernetes/debugging/transform_test.go
+++ b/pkg/skaffold/kubernetes/debugging/transform_test.go
@@ -130,7 +130,7 @@ func TestDescribe(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, reflect.TypeOf(test.in).Name(), func(t *testutil.T) {
 			gvk := test.in.GetObjectKind().GroupVersionKind()
-			group, version, kind, description := describe(test.in)
+			group, version, kind, description := Describe(test.in)
 
 			t.CheckDeepEqual(gvk.Group, group)
 			t.CheckDeepEqual(gvk.Kind, kind)

--- a/pkg/skaffold/lint/lint.go
+++ b/pkg/skaffold/lint/lint.go
@@ -33,6 +33,13 @@ func Lint(ctx context.Context, out io.Writer, opts Options) error {
 	results := []Result{}
 	results = append(results, *skaffoldYamlRuleList...)
 	// output flattened list
+	if opts.OutFormat == JSONOutput {
+		// need to remove some fields that cannot be serialized in the Rules of the Results
+		for _, res := range results {
+			res.Rule.ExplanationPopulator = nil
+			res.Rule.LintConditions = nil
+		}
+	}
 	formatter := OutputFormatter(out, opts.OutFormat)
 	return formatter.Write(results)
 }

--- a/pkg/skaffold/lint/linters_test.go
+++ b/pkg/skaffold/lint/linters_test.go
@@ -74,26 +74,27 @@ func TestRegExpLinter(t *testing.T) {
 			configFile:  helloWorldTextFile,
 			rules: &[]Rule{
 				{
-					RuleID:      DummyRuleIDForTesting,
-					RuleType:    RegExpLintLintRule,
-					Explanation: "test explanation",
-					Severity:    protocol.DiagnosticSeverityError,
-					Filter:      "World",
+					RuleID:              DummyRuleIDForTesting,
+					RuleType:            RegExpLintLintRule,
+					ExplanationTemplate: "test explanation",
+					Severity:            protocol.DiagnosticSeverityError,
+					Filter:              "World",
 				},
 			},
 			expected: &[]Result{
 				{
 					Rule: &Rule{
-						RuleID:      DummyRuleIDForTesting,
-						RuleType:    RegExpLintLintRule,
-						Explanation: "test explanation",
-						Severity:    protocol.DiagnosticSeverityError,
-						Filter:      "World",
+						RuleID:              DummyRuleIDForTesting,
+						RuleType:            RegExpLintLintRule,
+						ExplanationTemplate: "test explanation",
+						Severity:            protocol.DiagnosticSeverityError,
+						Filter:              "World",
 					},
 					AbsFilePath: "/abs/rel/path",
 					RelFilePath: "rel/path",
 					Line:        1,
 					Column:      6,
+					Explanation: "test explanation",
 				},
 			},
 		},
@@ -117,11 +118,11 @@ func TestRegExpLinter(t *testing.T) {
 			configFile:  helloWorldTextFile,
 			rules: &[]Rule{
 				{
-					RuleID:      DummyRuleIDForTesting,
-					RuleType:    RegExpLintLintRule,
-					Explanation: "test explanation",
-					Severity:    protocol.DiagnosticSeverityError,
-					Filter:      yaml.Get("incorrect filter type"),
+					RuleID:              DummyRuleIDForTesting,
+					RuleType:            RegExpLintLintRule,
+					ExplanationTemplate: "test explanation",
+					Severity:            protocol.DiagnosticSeverityError,
+					Filter:              yaml.Get("incorrect filter type"),
 				},
 			},
 			shouldErr: true,
@@ -134,7 +135,7 @@ func TestRegExpLinter(t *testing.T) {
 				return "", nil
 			})
 			linter := &RegExpLinter{}
-			recs, err := linter.Lint(test.configFile, test.rules)
+			recs, err := linter.Lint(InputParams{ConfigFile: test.configFile}, test.rules)
 			t.CheckError(test.shouldErr, err)
 			t.CheckDeepEqual(test.expected, recs)
 		})
@@ -156,10 +157,10 @@ func TestYamlFieldLinter(t *testing.T) {
 			configFile:  k8sYamlFile,
 			rules: &[]Rule{
 				{
-					RuleID:      DummyRuleIDForTesting,
-					RuleType:    YamlFieldLintRule,
-					Explanation: "test explanation",
-					Severity:    protocol.DiagnosticSeverityError,
+					RuleID:              DummyRuleIDForTesting,
+					RuleType:            YamlFieldLintRule,
+					ExplanationTemplate: "test explanation",
+					Severity:            protocol.DiagnosticSeverityError,
 					Filter: YamlFieldFilter{
 						Filter: yaml.FieldMatcher{Name: "apiVersion", StringValue: "apps/v1"},
 					},
@@ -168,10 +169,10 @@ func TestYamlFieldLinter(t *testing.T) {
 			expected: &[]Result{
 				{
 					Rule: &Rule{
-						RuleID:      DummyRuleIDForTesting,
-						RuleType:    YamlFieldLintRule,
-						Explanation: "test explanation",
-						Severity:    protocol.DiagnosticSeverityError,
+						RuleID:              DummyRuleIDForTesting,
+						RuleType:            YamlFieldLintRule,
+						ExplanationTemplate: "test explanation",
+						Severity:            protocol.DiagnosticSeverityError,
 						Filter: YamlFieldFilter{
 							Filter: yaml.FieldMatcher{Name: "apiVersion", StringValue: "apps/v1"},
 						},
@@ -179,7 +180,8 @@ func TestYamlFieldLinter(t *testing.T) {
 					AbsFilePath: "/abs/rel/path",
 					RelFilePath: "rel/path",
 					Line:        1,
-					Column:      12,
+					Column:      13,
+					Explanation: "test explanation",
 				},
 			},
 		},
@@ -188,10 +190,10 @@ func TestYamlFieldLinter(t *testing.T) {
 			configFile:  k8sYamlFile,
 			rules: &[]Rule{
 				{
-					RuleID:      DummyRuleIDForTesting,
-					RuleType:    YamlFieldLintRule,
-					Explanation: "test explanation",
-					Severity:    protocol.DiagnosticSeverityError,
+					RuleID:              DummyRuleIDForTesting,
+					RuleType:            YamlFieldLintRule,
+					ExplanationTemplate: "test explanation",
+					Severity:            protocol.DiagnosticSeverityError,
 					Filter: YamlFieldFilter{
 						Filter: yaml.FieldMatcher{Name: "missingField"},
 					},
@@ -204,10 +206,10 @@ func TestYamlFieldLinter(t *testing.T) {
 			configFile:  k8sYamlFile,
 			rules: &[]Rule{
 				{
-					RuleID:      DummyRuleIDForTesting,
-					RuleType:    YamlFieldLintRule,
-					Explanation: "test explanation",
-					Severity:    protocol.DiagnosticSeverityError,
+					RuleID:              DummyRuleIDForTesting,
+					RuleType:            YamlFieldLintRule,
+					ExplanationTemplate: "test explanation",
+					Severity:            protocol.DiagnosticSeverityError,
 					Filter: YamlFieldFilter{
 						Filter:      yaml.FieldMatcher{Name: "missingField"},
 						InvertMatch: true,
@@ -217,10 +219,10 @@ func TestYamlFieldLinter(t *testing.T) {
 			expected: &[]Result{
 				{
 					Rule: &Rule{
-						RuleID:      DummyRuleIDForTesting,
-						RuleType:    YamlFieldLintRule,
-						Explanation: "test explanation",
-						Severity:    protocol.DiagnosticSeverityError,
+						RuleID:              DummyRuleIDForTesting,
+						RuleType:            YamlFieldLintRule,
+						ExplanationTemplate: "test explanation",
+						Severity:            protocol.DiagnosticSeverityError,
 						Filter: YamlFieldFilter{
 							Filter:      yaml.FieldMatcher{Name: "missingField"},
 							InvertMatch: true,
@@ -229,7 +231,8 @@ func TestYamlFieldLinter(t *testing.T) {
 					AbsFilePath: "/abs/rel/path",
 					RelFilePath: "rel/path",
 					Line:        23,
-					Column:      0,
+					Column:      1,
+					Explanation: "test explanation",
 				},
 			},
 		},
@@ -249,11 +252,11 @@ func TestYamlFieldLinter(t *testing.T) {
 			configFile:  k8sYamlFile,
 			rules: &[]Rule{
 				{
-					RuleID:      DummyRuleIDForTesting,
-					RuleType:    YamlFieldLintRule,
-					Explanation: "test explanation",
-					Severity:    protocol.DiagnosticSeverityError,
-					Filter:      "incorrect filter type",
+					RuleID:              DummyRuleIDForTesting,
+					RuleType:            YamlFieldLintRule,
+					ExplanationTemplate: "test explanation",
+					Severity:            protocol.DiagnosticSeverityError,
+					Filter:              "incorrect filter type",
 				},
 			},
 			shouldErr: true,
@@ -266,7 +269,7 @@ func TestYamlFieldLinter(t *testing.T) {
 				return "", nil
 			})
 			linter := &YamlFieldLinter{}
-			recs, err := linter.Lint(test.configFile, test.rules)
+			recs, err := linter.Lint(InputParams{ConfigFile: test.configFile}, test.rules)
 			t.CheckError(test.shouldErr, err)
 			t.CheckDeepEqual(test.expected, recs)
 		})

--- a/pkg/skaffold/lint/output.go
+++ b/pkg/skaffold/lint/output.go
@@ -59,7 +59,7 @@ type plainTextOutput struct {
 
 func genColPointerLine(colIdx int) string {
 	s := ""
-	for i := 0; i < colIdx; i++ {
+	for i := 1; i < colIdx; i++ {
 		s += " "
 	}
 	s += "^"
@@ -76,7 +76,7 @@ func generatePlainTextOutput(res *Result) (string, error) {
 		LineNumber:     res.Line,
 		ColumnNumber:   res.Column,
 		RuleID:         res.Rule.RuleID.String(),
-		Explanation:    res.Rule.Explanation,
+		Explanation:    res.Explanation,
 		RuleType:       res.Rule.RuleType.String(),
 		FlaggedText:    strings.Split(string(text), "\n")[res.Line-1],
 		ColPointerLine: genColPointerLine(res.Column),

--- a/pkg/skaffold/lint/output_test.go
+++ b/pkg/skaffold/lint/output_test.go
@@ -42,18 +42,19 @@ func TestLintOutput(t *testing.T) {
 			results: []Result{
 				{
 					Rule: &Rule{
-						RuleID:      DummyRuleIDForTesting,
-						RuleType:    RegExpLintLintRule,
-						Explanation: "",
+						RuleID:              DummyRuleIDForTesting,
+						RuleType:            RegExpLintLintRule,
+						ExplanationTemplate: "",
 					},
+					Explanation: "test explanation",
 					AbsFilePath: "/abs/rel/path",
 					RelFilePath: "rel/path",
 					Line:        1,
-					Column:      0,
+					Column:      1,
 				},
 			},
-			text:     "first column of this line should be flagged in the result [1,0]",
-			expected: "rel/path:1:0: ID000001: : (RegExpLintLintRule)\nfirst column of this line should be flagged in the result [1,0]\n^\n",
+			text:     "first column of this line should be flagged in the result [1,1]",
+			expected: "rel/path:1:1: ID000000: test explanation: (RegExpLintLintRule)\nfirst column of this line should be flagged in the result [1,1]\n^\n",
 		},
 		{
 			description: "verify json lint output is as expected",
@@ -61,19 +62,20 @@ func TestLintOutput(t *testing.T) {
 			results: []Result{
 				{
 					Rule: &Rule{
-						RuleID:      DummyRuleIDForTesting,
-						RuleType:    RegExpLintLintRule,
-						Explanation: "",
-						Severity:    protocol.DiagnosticSeverityError,
+						RuleID:              DummyRuleIDForTesting,
+						RuleType:            RegExpLintLintRule,
+						ExplanationTemplate: "",
+						Severity:            protocol.DiagnosticSeverityError,
 					},
 					AbsFilePath: "/abs/rel/path",
 					RelFilePath: "rel/path",
 					Line:        1,
-					Column:      0,
+					Column:      1,
+					Explanation: "test explanation",
 				},
 			},
-			text:     "first column of this line should be flagged in the result [1,0]",
-			expected: `[{"Rule":{"RuleID":0,"RuleType":0,"Explanation":"","Severity":1,"Filter":null,"LintConditions":null},"AbsFilePath":%#v,"RelFilePath":"rel/path","Line":1,"Column":0}]` + "\n",
+			text:     "first column of this line should be flagged in the result [1,1]",
+			expected: `[{"Rule":{"RuleID":0,"RuleType":0,"ExplanationTemplate":"","Severity":1,"Filter":null},"AbsFilePath":%#v,"RelFilePath":"rel/path","Explanation":"test explanation","Line":1,"Column":1}]` + "\n",
 		},
 	}
 	for _, test := range tests {
@@ -100,7 +102,10 @@ func TestLintOutput(t *testing.T) {
 
 			var b bytes.Buffer
 			formatter := OutputFormatter(&b, test.outFormat)
-			formatter.Write(resultList)
+			err = formatter.Write(resultList)
+			if err != nil {
+				t.Fatalf("error occurred attempting to write output: %v", err)
+			}
 			if test.outFormat == PlainTextOutput {
 				t.CheckDeepEqual(b.String(), test.expected)
 			} else {

--- a/pkg/skaffold/lint/skaffoldyamls.go
+++ b/pkg/skaffold/lint/skaffoldyamls.go
@@ -20,16 +20,27 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
+	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/debugging"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 )
 
 // for testing
+var skaffoldYamlRules = &skaffoldYamlLintRules
 var getConfigSet = parser.GetConfigSet
 
 var SkaffoldYamlLinters = []Linter{
@@ -37,16 +48,102 @@ var SkaffoldYamlLinters = []Linter{
 	&YamlFieldLinter{},
 }
 
-// TODO(aaron-prindle) add highest priority lint rules in later PRs
-var skaffoldYamlRules = []Rule{
+type skaffoldYamlUseStaticPortTemplate struct {
+	ResourceType string
+	ResourceName string
+	Port         string
+	LocalPort    string
+}
+
+var skaffoldYamlLintRules = []Rule{
 	{
+		RuleID:   SkaffoldYamlAPIVersionOutOfDate,
+		RuleType: YamlFieldLintRule,
 		Filter: YamlFieldFilter{
 			Filter: yaml.FieldMatcher{Name: "apiVersion", StringRegexValue: fmt.Sprintf("[^%s]", version.Get().ConfigVersion)},
 		},
-		RuleID:   SkaffoldYamlAPIVersionOutOfDate,
-		RuleType: YamlFieldLintRule,
-		Explanation: fmt.Sprintf("Found 'apiVersion' field with value that is not the latest skaffold apiVersion. Modify the apiVersion to the latest version: `apiVersion: %s` "+
+		ExplanationTemplate: fmt.Sprintf("Found 'apiVersion' field with value that is not the latest skaffold apiVersion. Modify the apiVersion to the latest version: `apiVersion: %s` "+
 			"or run the 'skaffold fix' command to have skaffold upgrade this for you.", version.Get().ConfigVersion),
+	},
+	{
+		RuleID:   SkaffoldYamlUseStaticPort,
+		RuleType: YamlFieldLintRule,
+		Filter: YamlFieldFilter{
+			Filter:      yaml.FieldMatcher{Name: "portForward"},
+			InvertMatch: true,
+		},
+		ExplanationTemplate: "It is a skaffold best practice to specify a static port (vs skaffold dynamically choosing one) for port forwarding " +
+			"container based resources skaffold deploys.  This is helpful because wit this the local ports are predictable across dev sessions which " +
+			" makes testing/debugging easier. It is recommended to add the following stanza at the end of your skaffold.yaml for each shown deployed resource:\n" +
+			`portForward:{{range $k,$v := .FieldMap }}
+- resourceType: {{ $v.ResourceType }}
+  resourceName: {{ $v.ResourceName }}
+  port: {{ $v.Port }}
+  localPort: {{ $v.LocalPort }}{{end}}`,
+		LintConditions: []func(InputParams) bool{
+			func(params InputParams) bool {
+				// checks if deploy stanza exists
+				linter := &YamlFieldLinter{}
+				recs, err := linter.Lint(params, &[]Rule{
+					{
+						RuleType: YamlFieldLintRule,
+						Filter: YamlFieldFilter{
+							Filter: yaml.Lookup("deploy"),
+						},
+					},
+				})
+				if err != nil {
+					log.Entry(context.TODO()).Debugf("lint condition for rule %s encontered error: %v", SkaffoldYamlUseStaticPort, err)
+					return false
+				}
+				if len(*recs) > 0 {
+					return true
+				}
+				return false
+			},
+		},
+		ExplanationPopulator: func(lintInputs InputParams) (explanationInfo, error) {
+			fieldMap := map[string]interface{}{}
+			forwardedPorts := util.PortSet{}
+			for _, pattern := range lintInputs.SkaffoldConfig.Deploy.KubectlDeploy.Manifests {
+				// NOTE: pattern is a pattern that can have wildcards, eg: leeroy-app/kubernetes/*
+				if util.IsURL(pattern) {
+					log.Entry(context.TODO()).Infof("skaffold lint found url manifest when processing rule %d and is skipping lint rules for: %s", SkaffoldYamlUseStaticPort, pattern)
+					continue
+				}
+				// filepaths are all absolute from config parsing step via tags.MakeFilePathsAbsolute
+				expanded, err := filepath.Glob(pattern)
+				if err != nil {
+					return explanationInfo{}, err
+				}
+				for _, relPath := range expanded {
+					b, err := ioutil.ReadFile(relPath)
+					if err != nil {
+						return explanationInfo{}, err
+					}
+					decoder := scheme.Codecs.UniversalDeserializer()
+					for _, resourceYAML := range strings.Split(string(b), "---") {
+						// skip empty documents, `Decode` will fail on them
+						if len(resourceYAML) == 0 {
+							continue
+						}
+						obj, _, err := decoder.Decode([]byte(resourceYAML), nil, nil)
+						if err != nil {
+							return explanationInfo{}, err
+						}
+						suggestionTemplates := parseManifestUseStaticPortSuggestion(obj)
+						for _, tmplt := range suggestionTemplates {
+							localPort := util.GetAvailablePort(util.Loopback, 32581, &forwardedPorts)
+							forwardedPorts.Set(localPort)
+							tmplt.ResourceType = strings.ToLower(tmplt.ResourceType)
+							tmplt.LocalPort = strconv.Itoa(localPort)
+							fieldMap[uuid.NewString()] = tmplt
+						}
+					}
+				}
+			}
+			return explanationInfo{fieldMap}, nil
+		},
 	},
 }
 
@@ -60,7 +157,6 @@ func GetSkaffoldYamlsLintResults(ctx context.Context, opts Options) (*[]Result, 
 	if err != nil {
 		return nil, err
 	}
-
 	workdir, err := realWorkDir()
 	if err != nil {
 		return nil, err
@@ -78,7 +174,10 @@ func GetSkaffoldYamlsLintResults(ctx context.Context, opts Options) (*[]Result, 
 		}
 		results := []Result{}
 		for _, r := range SkaffoldYamlLinters {
-			recs, err := r.Lint(skaffoldyaml, &skaffoldYamlRules)
+			recs, err := r.Lint(InputParams{
+				ConfigFile:     skaffoldyaml,
+				SkaffoldConfig: c,
+			}, skaffoldYamlRules)
 			if err != nil {
 				return nil, err
 			}
@@ -87,4 +186,55 @@ func GetSkaffoldYamlsLintResults(ctx context.Context, opts Options) (*[]Result, 
 		l = append(l, results...)
 	}
 	return &l, nil
+}
+
+func parseManifestUseStaticPortSuggestion(obj runtime.Object) []skaffoldYamlUseStaticPortTemplate {
+	out := []skaffoldYamlUseStaticPortTemplate{}
+	switch o := obj.(type) {
+	case *v1.Pod:
+		for i := range o.Spec.Containers {
+			for j := range o.Spec.Containers[i].Ports {
+				out = append(out, skaffoldYamlUseStaticPortTemplate{
+					ResourceType: o.GroupVersionKind().Kind,
+					ResourceName: o.Name,
+					Port:         strconv.Itoa(int(o.Spec.Containers[i].Ports[j].ContainerPort)),
+				})
+			}
+		}
+	case *v1.PodList:
+		for _, item := range o.Items {
+			for i := range item.Spec.Containers {
+				for j := range item.Spec.Containers[i].Ports {
+					out = append(out, skaffoldYamlUseStaticPortTemplate{
+						ResourceType: item.GroupVersionKind().Kind,
+						ResourceName: item.Name,
+						Port:         strconv.Itoa(int(item.Spec.Containers[i].Ports[j].ContainerPort)),
+					})
+				}
+			}
+		}
+	case *appsv1.Deployment:
+		for i := range o.Spec.Template.Spec.Containers {
+			for j := range o.Spec.Template.Spec.Containers[i].Ports {
+				out = append(out, skaffoldYamlUseStaticPortTemplate{
+					ResourceType: o.GroupVersionKind().Kind,
+					ResourceName: o.Name,
+					Port:         strconv.Itoa(int(o.Spec.Template.Spec.Containers[i].Ports[j].ContainerPort)),
+				})
+			}
+		}
+	default:
+		group, version, _, description := debugging.Describe(obj)
+		if group == "apps" || group == "batch" {
+			if version != "v1" {
+				// treat deprecated objects as errors
+				log.Entry(context.Background()).Errorf("deprecated versions not supported by skaffold lint: %s (%s)", description, version)
+			} else {
+				log.Entry(context.Background()).Warnf("no skaffold lint parsing for: %s", description)
+			}
+		} else {
+			log.Entry(context.Background()).Debugf("no skaffold lint parsing for: %s", description)
+		}
+	}
+	return out
 }

--- a/pkg/skaffold/lint/skaffoldyamls_test.go
+++ b/pkg/skaffold/lint/skaffoldyamls_test.go
@@ -23,13 +23,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"sigs.k8s.io/kustomize/kyaml/yaml"
-
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser"
 	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util/stringslice"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/version"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -37,88 +34,149 @@ var testSkaffoldYaml = `apiVersion: skaffold/v2beta21
 kind: Config
 build:
   artifacts:
-    - image: test-app
+    - image: leeroy-app
+      context: leeroy-app
+      requires:
+        - image: base
+          alias: BASE
+deploy:
+  kubectl:
+    manifests:
+      - leeroy-app/kubernetes/*
+`
+
+var testManifest = `apiVersion: v1
+kind: Service
+metadata:
+  name: leeroy-app
+  labels:
+    app: leeroy-app
+spec:
+  clusterIP: None
+  ports:
+    - port: 50051
+      name: leeroy-app
+  selector:
+    app: leeroy-app
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: leeroy-app
+  labels:
+    app: leeroy-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: leeroy-app
+  template:
+    metadata:
+      labels:
+        app: leeroy-app
+    spec:
+      containers:
+      - name: leeroy-app
+        image: leeroy-app
+        ports:
+        - containerPort: 50051
+          name: http
 `
 
 var invalidSkaffoldYaml = `invalid{\{\Yaml}`
 
 func TestGetSkaffoldYamlsLintResults(t *testing.T) {
+	ruleIDToskaffoldYamlRule := map[RuleID]*Rule{}
+	for i := range skaffoldYamlLintRules {
+		ruleIDToskaffoldYamlRule[skaffoldYamlLintRules[i].RuleID] = &skaffoldYamlLintRules[i]
+	}
 	tests := []struct {
 		description            string
+		rules                  []RuleID
 		moduleAndSkaffoldYamls map[string]string
 		profiles               []string
-		module                 []string
+		modules                []string
 		shouldErr              bool
 		err                    error
 		expected               map[string]*[]Result
 	}{
 		{
-			description:            "get all skaffold yaml lint rules for 2 skaffold yaml files",
+			description:            "apply 1 skaffold lint rule for 2 skaffold yaml files",
+			rules:                  []RuleID{SkaffoldYamlAPIVersionOutOfDate},
 			moduleAndSkaffoldYamls: map[string]string{"cfg0": testSkaffoldYaml, "cfg1": testSkaffoldYaml},
 			expected: map[string]*[]Result{
 				"cfg0": {
 					{
-						Rule: &Rule{
-							Filter: YamlFieldFilter{
-								Filter: yaml.FieldMatcher{Name: "apiVersion", StringRegexValue: fmt.Sprintf("[^%s]", version.Get().ConfigVersion)},
-							},
-							RuleID:   SkaffoldYamlAPIVersionOutOfDate,
-							RuleType: YamlFieldLintRule,
-							Explanation: fmt.Sprintf("Found 'apiVersion' field with value that is not the latest skaffold apiVersion. Modify the apiVersion to the latest version: `apiVersion: %s` "+
-								"or run the 'skaffold fix' command to have skaffold upgrade this for you.", version.Get().ConfigVersion),
-						},
-						Line:   1,
-						Column: 12,
+						Rule:        ruleIDToskaffoldYamlRule[SkaffoldYamlAPIVersionOutOfDate],
+						Line:        1,
+						Column:      13,
+						Explanation: ruleIDToskaffoldYamlRule[SkaffoldYamlAPIVersionOutOfDate].ExplanationTemplate,
 					},
 				},
 				"cfg1": {
 					{
-						Rule: &Rule{
-							Filter: YamlFieldFilter{
-								Filter: yaml.FieldMatcher{Name: "apiVersion", StringRegexValue: fmt.Sprintf("[^%s]", version.Get().ConfigVersion)},
-							},
-							RuleID:   SkaffoldYamlAPIVersionOutOfDate,
-							RuleType: YamlFieldLintRule,
-							Explanation: fmt.Sprintf("Found 'apiVersion' field with value that is not the latest skaffold apiVersion. Modify the apiVersion to the latest version: `apiVersion: %s` "+
-								"or run the 'skaffold fix' command to have skaffold upgrade this for you.", version.Get().ConfigVersion),
-						},
-						Line:   1,
-						Column: 12,
+						Rule:        ruleIDToskaffoldYamlRule[SkaffoldYamlAPIVersionOutOfDate],
+						Line:        1,
+						Column:      13,
+						Explanation: ruleIDToskaffoldYamlRule[SkaffoldYamlAPIVersionOutOfDate].ExplanationTemplate,
 					},
 				},
 			},
 		},
 		{
 			description:            "get all skaffold yaml lint rules for one module",
+			rules:                  []RuleID{SkaffoldYamlAPIVersionOutOfDate},
 			moduleAndSkaffoldYamls: map[string]string{"cfg0": testSkaffoldYaml, "cfg1": testSkaffoldYaml},
-			module:                 []string{"cfg0"},
+			modules:                []string{"cfg0"},
 			expected: map[string]*[]Result{
 				"cfg0": {
 					{
-						Rule: &Rule{
-							Filter: YamlFieldFilter{
-								Filter: yaml.FieldMatcher{Name: "apiVersion", StringRegexValue: fmt.Sprintf("[^%s]", version.Get().ConfigVersion)},
-							},
-							RuleID:   SkaffoldYamlAPIVersionOutOfDate,
-							RuleType: YamlFieldLintRule,
-							Explanation: fmt.Sprintf("Found 'apiVersion' field with value that is not the latest skaffold apiVersion. Modify the apiVersion to the latest version: `apiVersion: %s` "+
-								"or run the 'skaffold fix' command to have skaffold upgrade this for you.", version.Get().ConfigVersion),
-						},
-						Line:   1,
-						Column: 12,
+						Rule:        ruleIDToskaffoldYamlRule[SkaffoldYamlAPIVersionOutOfDate],
+						Line:        1,
+						Column:      13,
+						Explanation: ruleIDToskaffoldYamlRule[SkaffoldYamlAPIVersionOutOfDate].ExplanationTemplate,
 					},
 				},
 			},
 		},
 		{
+			description:            "verify SkaffoldYamlUseStaticPort rule works as intended",
+			rules:                  []RuleID{SkaffoldYamlUseStaticPort},
+			moduleAndSkaffoldYamls: map[string]string{"cfg0": testSkaffoldYaml},
+			modules:                []string{"cfg0"},
+			expected: map[string]*[]Result{
+				"cfg0": {
+					{
+						Rule:   ruleIDToskaffoldYamlRule[SkaffoldYamlUseStaticPort],
+						Line:   14,
+						Column: 1,
+						Explanation: "It is a skaffold best practice to specify a static port (vs skaffold dynamically choosing one) for port forwarding " +
+							"container based resources skaffold deploys.  This is helpful because wit this the local ports are predictable across dev sessions which " +
+							" makes testing/debugging easier. It is recommended to add the following stanza at the end of your skaffold.yaml for each shown deployed resource:\n" +
+							`portForward:
+- resourceType: deployment
+  resourceName: leeroy-app
+  port: 50051
+  localPort: 32581`,
+					},
+				},
+			},
+		},
+		{
+			rules:                  []RuleID{SkaffoldYamlAPIVersionOutOfDate},
 			description:            "invalid skaffold yaml file",
 			moduleAndSkaffoldYamls: map[string]string{"cfg0": invalidSkaffoldYaml},
 			shouldErr:              true,
 		},
 	}
-
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
+			testRules := []Rule{}
+			for _, ruleID := range test.rules {
+				testRules = append(testRules, *(ruleIDToskaffoldYamlRule[ruleID]))
+			}
+			t.Override(skaffoldYamlRules, testRules)
+
 			tmpdir := t.TempDir()
 			configSet := parser.SkaffoldConfigSet{}
 			// iteration done to enforce result order
@@ -130,8 +188,16 @@ func TestGetSkaffoldYamlsLintResults(t *testing.T) {
 				if err != nil {
 					t.Fatalf("error creating skaffold.yaml file with name %s: %v", fp, err)
 				}
+				mp := filepath.Join(tmpdir, fmt.Sprintf("%s.yaml", "deployment"))
+				err = ioutil.WriteFile(mp, []byte(testManifest), 0644)
+				if err != nil {
+					t.Fatalf("error creating deployment.yaml file with name %s: %v", fp, err)
+				}
 				configSet = append(configSet, &parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{
 					Metadata: v1.Metadata{Name: module},
+					Pipeline: v1.Pipeline{Deploy: v1.DeployConfig{DeployType: v1.DeployType{KubectlDeploy: &v1.KubectlDeploy{Manifests: []string{
+						mp,
+					}}}}},
 				},
 					SourceFile: fp,
 				})
@@ -168,15 +234,20 @@ func TestGetSkaffoldYamlsLintResults(t *testing.T) {
 				return set, test.err
 			})
 			results, err := GetSkaffoldYamlsLintResults(context.Background(), Options{
-				OutFormat: "json", Modules: test.module, Profiles: test.profiles})
+				OutFormat: "json", Modules: test.modules, Profiles: test.profiles})
 			t.CheckError(test.shouldErr, err)
-			expectedResults := &[]Result{}
-
-			// this is done to enforce result order
-			for i := 0; i < len(test.expected); i++ {
-				*expectedResults = append(*expectedResults, *test.expected[fmt.Sprintf("cfg%d", i)]...)
-			}
 			if !test.shouldErr {
+				expectedResults := &[]Result{}
+				// this is done to enforce result order
+				for i := 0; i < len(test.expected); i++ {
+					*expectedResults = append(*expectedResults, *test.expected[fmt.Sprintf("cfg%d", i)]...)
+					(*expectedResults)[0].Rule.ExplanationPopulator = nil
+					(*expectedResults)[0].Rule.LintConditions = nil
+				}
+				for i := 0; i < len(*results); i++ {
+					(*results)[i].Rule.ExplanationPopulator = nil
+					(*results)[i].Rule.LintConditions = nil
+				}
 				t.CheckDeepEqual(expectedResults, results)
 			}
 		})


### PR DESCRIPTION
Adds a skaffold.yaml lint rule suggesting a user use static portforwards ports to aid in reproducible app behaviour and to aid with testing, iterating and debugging.  Example below is a sample lint recommendation from this PR for `/examples/microservices/skaffold.yaml` with the `deployment` stanza removed:

```
/skaffold.yaml:37:1: ID000002: It is a skaffold best practice to specify a static port (vs skaffold dynamically choosing one) for 
port forwarding container based resources skaffold deploys.  This is helpful because wit this the local ports are predictable
 across dev sessions which  makes testing/debugging easier. It is recommended to add the following stanza at the end of 
 your skaffold.yaml for each shown deployed resource:
portForward:
- resourceType: deployment
  resourceName: leeroy-web
  port: 8080
  localPort: 32581
- resourceType: deployment
  resourceName: leeroy-app
  port: 50051
  localPort: 32582: (YamlFieldLintRule)

```