### PR TITLE
fix(sync): more descriptive error for custom build inferred sync misconfiguration

### DIFF
--- a/docs/content/en/docs/pipeline-stages/filesync.md
+++ b/docs/content/en/docs/pipeline-stages/filesync.md
@@ -18,7 +18,7 @@ Multiple types of sync are supported by Skaffold:
 
  + `infer`: The destinations for each changed file is inferred from the builder.
    The docker and kaniko builders examine instructions in a Dockerfile.
-   This inference is also supported for custom artifacts that declare a dependency on a Dockerfile.
+   This inference is also supported for custom artifacts that **explicitly declare a dependency on a Dockerfile.**
 
 + `auto`: Skaffold automatically configures the sync.  This mode is only supported by Jib and Buildpacks artifacts.
    Auto sync mode is enabled by default for Buildpacks artifacts.

--- a/pkg/skaffold/build/build.go
+++ b/pkg/skaffold/build/build.go
@@ -65,12 +65,6 @@ func (ErrSyncMapNotSupported) Error() string {
 	return "SyncMap is not supported by this builder"
 }
 
-type ErrCustomBuildNoDependencies struct{}
-
-func (ErrCustomBuildNoDependencies) Error() string {
-	return "inferred sync with custom build requires explicitly declared dependencies"
-}
-
 type ErrCustomBuildNoDockerfile struct{}
 
 func (ErrCustomBuildNoDockerfile) Error() string {

--- a/pkg/skaffold/build/build.go
+++ b/pkg/skaffold/build/build.go
@@ -64,3 +64,15 @@ type ErrSyncMapNotSupported struct{}
 func (ErrSyncMapNotSupported) Error() string {
 	return "SyncMap is not supported by this builder"
 }
+
+type ErrCustomBuildNoDependencies struct{}
+
+func (ErrCustomBuildNoDependencies) Error() string {
+	return "inferred sync with custom build requires explicitly declared dependencies"
+}
+
+type ErrCustomBuildNoDockerfile struct{}
+
+func (ErrCustomBuildNoDockerfile) Error() string {
+	return "inferred sync with custom build requires explicitly declared Dockerfile dependency"
+}

--- a/pkg/skaffold/diagnose/diagnose.go
+++ b/pkg/skaffold/diagnose/diagnose.go
@@ -66,19 +66,22 @@ func CheckArtifacts(ctx context.Context, cfg Config, out io.Writer) error {
 			fmt.Fprintln(out, " - Dependencies:", len(deps), "files")
 			fmt.Fprintf(out, " - Time to list dependencies: %v (2nd time: %v)\n", timeDeps1, timeDeps2)
 
-			timeSyncMap1, err := timeToConstructSyncMap(ctx, artifact, cfg)
-			if err != nil {
-				if _, isNotSupported := err.(build.ErrSyncMapNotSupported); !isNotSupported {
-					return fmt.Errorf("construct artifact dependencies: %w", err)
+			// Only check sync map if inferred sync is configured on artifact
+			if artifact.Sync != nil && len(artifact.Sync.Infer) > 0 {
+				timeSyncMap1, err := timeToConstructSyncMap(ctx, artifact, cfg)
+				if err != nil {
+					if _, isNotSupported := err.(build.ErrSyncMapNotSupported); !isNotSupported {
+						return fmt.Errorf("constructing inferred sync map: %w", err)
+					}
 				}
-			}
-			timeSyncMap2, err := timeToConstructSyncMap(ctx, artifact, cfg)
-			if err != nil {
-				if _, isNotSupported := err.(build.ErrSyncMapNotSupported); !isNotSupported {
-					return fmt.Errorf("construct artifact dependencies: %w", err)
+				timeSyncMap2, err := timeToConstructSyncMap(ctx, artifact, cfg)
+				if err != nil {
+					if _, isNotSupported := err.(build.ErrSyncMapNotSupported); !isNotSupported {
+						return fmt.Errorf("constructing inferred sync map: %w", err)
+					}
+				} else {
+					fmt.Fprintf(out, " - Time to construct sync map: %v (2nd time: %v)\n", timeSyncMap1, timeSyncMap2)
 				}
-			} else {
-				fmt.Fprintf(out, " - Time to construct sync-map: %v (2nd time: %v)\n", timeSyncMap1, timeSyncMap2)
 			}
 
 			timeMTimes1, err := timeToComputeMTimes(deps)

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -155,10 +155,7 @@ func syncMapForArtifact(ctx context.Context, a *latestV1.Artifact, cfg docker.Co
 		return docker.SyncMap(ctx, a.Workspace, a.DockerArtifact.DockerfilePath, a.DockerArtifact.BuildArgs, cfg)
 
 	case a.CustomArtifact != nil:
-		if a.CustomArtifact.Dependencies == nil {
-			return nil, build.ErrCustomBuildNoDockerfile{}
-		}
-		if a.CustomArtifact.Dependencies.Dockerfile == nil {
+		if a.CustomArtifact.Dependencies == nil || a.CustomArtifact.Dependencies.Dockerfile == nil {
 			return nil, build.ErrCustomBuildNoDockerfile{}
 		}
 		return docker.SyncMap(ctx, a.Workspace, a.CustomArtifact.Dependencies.Dockerfile.Path, a.CustomArtifact.Dependencies.Dockerfile.BuildArgs, cfg)

--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -154,7 +154,13 @@ func syncMapForArtifact(ctx context.Context, a *latestV1.Artifact, cfg docker.Co
 	case a.DockerArtifact != nil:
 		return docker.SyncMap(ctx, a.Workspace, a.DockerArtifact.DockerfilePath, a.DockerArtifact.BuildArgs, cfg)
 
-	case a.CustomArtifact != nil && a.CustomArtifact.Dependencies != nil && a.CustomArtifact.Dependencies.Dockerfile != nil:
+	case a.CustomArtifact != nil:
+		if a.CustomArtifact.Dependencies == nil {
+			return nil, build.ErrCustomBuildNoDockerfile{}
+		}
+		if a.CustomArtifact.Dependencies.Dockerfile == nil {
+			return nil, build.ErrCustomBuildNoDockerfile{}
+		}
 		return docker.SyncMap(ctx, a.Workspace, a.CustomArtifact.Dependencies.Dockerfile.Path, a.CustomArtifact.Dependencies.Dockerfile.BuildArgs, cfg)
 
 	case a.KanikoArtifact != nil:


### PR DESCRIPTION
fixes: #6772 

this change improves the error message we surface when an inferred sync rule is configured with a custom builder that doesn't have the required dependencies.