### PR TITLE
Add Labels to Metadata

### DIFF
--- a/pkg/skaffold/schema/latest/v2/config.go
+++ b/pkg/skaffold/schema/latest/v2/config.go
@@ -62,6 +62,13 @@ type SkaffoldConfig struct {
 type Metadata struct {
 	// Name is an identifier for the project.
 	Name string `yaml:"name,omitempty"`
+
+	// Labels is a map of labels identifying the project.
+	Labels map[string]string `yaml:"labels,omitempty"`
+
+	// Annotations is a map of annotations providing additional
+	// metadata about the project.
+	Annotations map[string]string `yaml:"annotations,omitempty"`
 }
 
 // Pipeline describes a Skaffold pipeline.


### PR DESCRIPTION
**Description**
* Add labels to metadata so that skaffold files can have labels identifying
  the config.

* Using labels is useful for being able to match skaffold files.
* Concretely, we want to use labels to identify the different environments
  corresponding to a skaffold file (e.g. dev/prod etc...). These labels
  our used by our CD tooling to identify the skaffold files which need to
  be built.


**User facing changes (remove if N/A)**

After this change users can include labels in their skaffold.yaml files; e.g.

```
kind: Config
metadata:
  name: some config
  labels:
     dev: "true"
```
