### PR TITLE
feat(ko): Add ko builder to local artifact builder

### DIFF
--- a/pkg/skaffold/build/ko/dependencies.go
+++ b/pkg/skaffold/build/ko/dependencies.go
@@ -16,9 +16,6 @@ limitations under the License.
 
 package ko
 
-// TODO(halvards)[09/14/2021]: Replace the latestV1 import path with the
-// real schema import path once the contents of ./schema has been added to
-// the real schema in pkg/skaffold/schema/latest/v1.
 import (
 	"context"
 
@@ -27,15 +24,14 @@ import (
 )
 
 // GetDependencies returns a list of files to watch for changes to rebuild.
-// TODO(halvards)[09/17/2021]: Call this function from sourceDependenciesForArtifact() in pkg/skaffold/graph/dependencies.go
-func GetDependencies(ctx context.Context, workspace string, a *latestV1.KoArtifact) ([]string, error) {
+func GetDependencies(_ context.Context, workspace string, a *latestV1.KoArtifact) ([]string, error) {
 	if a.Dependencies == nil || (a.Dependencies.Paths == nil && a.Dependencies.Ignore == nil) {
 		a.Dependencies = defaultKoDependencies()
 	}
 	return list.Files(workspace, a.Dependencies.Paths, a.Dependencies.Ignore)
 }
 
-// defaultKoDependencies behavior is to watch all files in the context directory
+// defaultKoDependencies behavior is to watch all Go files in the context directory and its subdirectories.
 func defaultKoDependencies() *latestV1.KoDependencies {
 	return &latestV1.KoDependencies{
 		Paths:  []string{"**/*.go"},

--- a/pkg/skaffold/build/ko/dependencies_test.go
+++ b/pkg/skaffold/build/ko/dependencies_test.go
@@ -16,9 +16,6 @@ limitations under the License.
 
 package ko
 
-// TODO(halvards)[09/17/2021]: Replace the latestV1 import path with the
-// real schema import path once the contents of ./schema has been added to
-// the real schema in pkg/skaffold/schema/latest/v1.
 import (
 	"context"
 	"path/filepath"

--- a/pkg/skaffold/build/ko/ko.go
+++ b/pkg/skaffold/build/ko/ko.go
@@ -40,7 +40,6 @@ type Builder struct {
 }
 
 // NewArtifactBuilder returns a new ko artifact builder
-// TODO(halvards)[09/17/2021]: Call this function from newPerArtifactBuilder() in pkg/skaffold/build/local/types.go
 func NewArtifactBuilder(localDocker docker.LocalDaemon, pushImages bool, runMode config.RunMode, insecureRegistries map[string]bool) *Builder {
 	return &Builder{
 		localDocker:        localDocker,

--- a/pkg/skaffold/build/local/types.go
+++ b/pkg/skaffold/build/local/types.go
@@ -27,6 +27,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/custom"
 	dockerbuilder "github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
@@ -160,6 +161,9 @@ func newPerArtifactBuilder(b *Builder, a *latestV1.Artifact) (artifactBuilder, e
 
 	case a.BuildpackArtifact != nil:
 		return buildpacks.NewArtifactBuilder(b.localDocker, b.pushImages, b.mode, b.artifactStore), nil
+
+	case a.KoArtifact != nil:
+		return ko.NewArtifactBuilder(b.localDocker, b.pushImages, b.mode, b.insecureRegistries), nil
 
 	default:
 		return nil, fmt.Errorf("unexpected type %q for local artifact:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))

--- a/pkg/skaffold/build/local/types_test.go
+++ b/pkg/skaffold/build/local/types_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestNewPerArtifactBuilder(t *testing.T) {
+	tests := []struct {
+		description     string
+		builder         *Builder
+		artifact        *latestV1.Artifact
+		expectedBuilder artifactBuilder
+	}{
+		{
+			description: "ko",
+			builder:     &Builder{},
+			artifact: &latestV1.Artifact{
+				ArtifactType: latestV1.ArtifactType{
+					KoArtifact: &latestV1.KoArtifact{},
+				},
+			},
+			expectedBuilder: &ko.Builder{},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			builder, err := newPerArtifactBuilder(test.builder, test.artifact)
+			t.CheckNoError(err)
+			t.CheckDeepEqual(fmt.Sprintf("%T", test.expectedBuilder), fmt.Sprintf("%T", builder))
+		})
+	}
+}

--- a/pkg/skaffold/graph/dependencies.go
+++ b/pkg/skaffold/graph/dependencies.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/custom"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
@@ -142,6 +143,9 @@ func sourceDependenciesForArtifact(ctx context.Context, a *latestV1.Artifact, cf
 
 	case a.BuildpackArtifact != nil:
 		paths, err = buildpacks.GetDependencies(ctx, a.Workspace, a.BuildpackArtifact)
+
+	case a.KoArtifact != nil:
+		paths, err = ko.GetDependencies(ctx, a.Workspace, a.KoArtifact)
 
 	default:
 		return nil, fmt.Errorf("unexpected artifact type %q:\n%s", misc.ArtifactType(a), misc.FormatArtifact(a))

--- a/pkg/skaffold/graph/dependencies_test.go
+++ b/pkg/skaffold/graph/dependencies_test.go
@@ -18,7 +18,10 @@ package graph
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -54,4 +57,42 @@ func TestSourceDependenciesCache(t *testing.T) {
 			t.CheckDeepEqual(v, 1)
 		}
 	})
+}
+
+func TestSourceDependenciesForArtifact(t *testing.T) {
+	tmpDir := testutil.NewTempDir(t).Touch(
+		"foo.java",
+		"bar.go",
+		"dir1/baz.java",
+		"dir2/frob.go",
+	)
+	tests := []struct {
+		description            string
+		artifact               *latestV1.Artifact
+		dockerConfig           docker.Config
+		dockerArtifactResolver docker.ArtifactResolver
+		expectedPaths          []string
+	}{
+		{
+			description: "ko default dependencies",
+			artifact: &latestV1.Artifact{
+				ArtifactType: latestV1.ArtifactType{
+					KoArtifact: &latestV1.KoArtifact{},
+				},
+				Workspace: tmpDir.Root(),
+			},
+			expectedPaths: []string{
+				filepath.Join(tmpDir.Root(), "dir2/frob.go"),
+				filepath.Join(tmpDir.Root(), "bar.go"),
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			paths, err := sourceDependenciesForArtifact(context.Background(), test.artifact, test.dockerConfig, test.dockerArtifactResolver)
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expectedPaths, paths,
+				cmpopts.SortSlices(func(x, y string) bool { return x < y }))
+		})
+	}
 }


### PR DESCRIPTION
**Description**
Call the ko builder from the local artifact builder and dependency graph resolver.

**User facing changes**
None. Config file unmarshalling still skips ko config.

Tracking: #6041
