### PR TITLE
test(ko): Simple integration test for ko builder

### DIFF
--- a/integration/diagnose_test.go
+++ b/integration/diagnose_test.go
@@ -45,6 +45,10 @@ func TestDiagnose(t *testing.T) {
 			if _, err := os.Stat(filepath.Join(dir, "skaffold.yaml")); os.IsNotExist(err) {
 				t.Skip("skipping diagnose in " + dir)
 			}
+			// TODO(halvards): Stop ignoring ko exmples once unmarshalling of ko config is enabled.
+			if filepath.Base(dir) == "ko" {
+				t.Skip("skipping diagnose in " + dir)
+			}
 
 			skaffold.Diagnose().InDir(dir).RunOrFail(t)
 		})

--- a/integration/examples/ko/README.md
+++ b/integration/examples/ko/README.md
@@ -1,0 +1,8 @@
+### Example: ko builder
+
+This is an example demonstrating building a Go app with the
+[ko](https://github.com/google/ko) builder.
+
+The included [Cloud Build](https://cloud.google.com/build/docs) configuration
+file shows how users can set up a simple pipeline using `skaffold build` and
+`skaffold deploy`, without having to create a custom builder image.

--- a/integration/examples/ko/cloudbuild.yaml
+++ b/integration/examples/ko/cloudbuild.yaml
@@ -1,0 +1,63 @@
+# Copyright 2021 The Skaffold Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Demonstrate Skaffold build using ko builder and deploy to GKE.
+
+options:
+  dynamic_substitutions: true
+  env:
+  - 'KUBECONFIG=/workspace/.kubeconfig'
+  - 'SKAFFOLD_DEFAULT_REPO=$_IMAGE_REPO'
+  - 'SKAFFOLD_DETECT_MINIKUBE=false'
+  - 'SKAFFOLD_INTERACTIVE=false'
+  - 'SKAFFOLD_TIMESTAMPS=true'
+  - 'SKAFFOLD_UPDATE_CHECK=false'
+  - 'SKAFFOLD_VERBOSITY=info'
+
+steps:
+- id: creds
+  name: $_GCLOUD_IMAGE
+  entrypoint: gcloud
+  args:
+  - container
+  - clusters
+  - get-credentials
+  - $_GKE_CLUSTER_NAME
+  - --project=$_GKE_CLUSTER_PROJECT_ID
+  - --zone=$_GKE_CLUSTER_ZONE
+
+- id: build
+  name: $_SKAFFOLD_IMAGE
+  entrypoint: skaffold
+  args:
+  - build
+  - --file-output=artifacts.json
+
+- id: deploy
+  name: $_SKAFFOLD_IMAGE
+  entrypoint: skaffold
+  args:
+  - deploy
+  - --build-artifacts=artifacts.json
+  - --status-check=true
+
+substitutions:
+  _GKE_CLUSTER_NAME: skaffold-ko
+  _GKE_CLUSTER_PROJECT_ID: $PROJECT_ID
+  _GKE_CLUSTER_ZONE: us-central1-f
+  _IMAGE_REPO: gcr.io/${PROJECT_ID}
+  _GCLOUD_IMAGE: gcr.io/k8s-skaffold/skaffold
+  _SKAFFOLD_IMAGE: gcr.io/k8s-skaffold/skaffold
+
+timeout: 1200s

--- a/integration/examples/ko/go.mod
+++ b/integration/examples/ko/go.mod
@@ -1,0 +1,17 @@
+// Copyright 2021 The Skaffold Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module github.com/GoogleContainerTools/skaffold/examples/ko
+
+go 1.13

--- a/integration/examples/ko/k8s/example.yaml
+++ b/integration/examples/ko/k8s/example.yaml
@@ -1,0 +1,45 @@
+# Copyright 2021 The Skaffold Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ko
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+  selector:
+    app: ko
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ko
+spec:
+  selector:
+    matchLabels:
+      app: ko
+  template:
+    metadata:
+      labels:
+        app: ko
+    spec:
+      containers:
+      - image: skaffold-ko
+        name: ko
+        ports:
+        - containerPort: 8080

--- a/integration/examples/ko/main.go
+++ b/integration/examples/ko/main.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/", hello)
+
+	log.Println("Listening on port 8080")
+	http.ListenAndServe(":8080", nil)
+}
+
+func hello(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "Hello, World!")
+}

--- a/integration/examples/ko/skaffold.yaml
+++ b/integration/examples/ko/skaffold.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 The Skaffold Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skaffold/v2beta25
+kind: Config
+build:
+  artifacts:
+  - image: skaffold-ko
+    ko: {}

--- a/integration/ko_test.go
+++ b/integration/ko_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	stdlog "log"
+	"net/http/httptest"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/crane"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+)
+
+func TestBuildAndPushKoImageProgrammatically(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	// Start a local registry server.
+	// This registry hosts the base image, and it is the target registry for the built image.
+	baseimageNamespace := "baseimage"
+	registryServer, err := registryServerWithImage(baseimageNamespace)
+	if err != nil {
+		t.Fatalf("could not create test registry server: %v", err)
+	}
+	defer registryServer.Close()
+	registryAddr := registryServer.Listener.Addr().String()
+	baseImage := fmt.Sprintf("%s/%s", registryAddr, baseimageNamespace)
+
+	// Get the directory of the basic ko sample app from the `examples` directory.
+	exampleAppDir, err := koExampleAppDir()
+	if err != nil {
+		t.Fatalf("could not get ko example app dir: %+v", err)
+	}
+
+	// Build the artifact
+	b := ko.NewArtifactBuilder(nil, true, config.RunModes.Build, nil)
+	var imageFullNameBuffer bytes.Buffer
+	artifact := &latestV1.Artifact{
+		ArtifactType: latestV1.ArtifactType{
+			KoArtifact: &latestV1.KoArtifact{
+				BaseImage: baseImage,
+			},
+		},
+		Workspace: exampleAppDir,
+	}
+	imageName := fmt.Sprintf("%s/%s", registryAddr, "skaffold-ko")
+	digest, err := b.Build(context.Background(), &imageFullNameBuffer, artifact, imageName)
+	if err != nil {
+		t.Fatalf("b.Build(): %+v", err)
+	}
+
+	wantImageFullName := fmt.Sprintf("%s@%s", imageName, digest)
+	gotImageFullName := strings.TrimSuffix(imageFullNameBuffer.String(), "\n")
+	if diff := cmp.Diff(wantImageFullName, gotImageFullName); diff != "" {
+		t.Errorf("image name mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// registryServerWithImage starts a local registry and pushes a random image.
+// Use this to speed up tests, by not having to reach out to a real registry.
+// The registry uses a NOP logger to avoid spamming test logs.
+// Remember to call `defer Close()` on the returned `httptest.Server`.
+func registryServerWithImage(namespace string) (*httptest.Server, error) {
+	nopLog := stdlog.New(ioutil.Discard, "", 0)
+	r := registry.New(registry.Logger(nopLog))
+	s := httptest.NewServer(r)
+	imageName := fmt.Sprintf("%s/%s", s.Listener.Addr().String(), namespace)
+	image, err := random.Image(1024, 1)
+	if err != nil {
+		return nil, fmt.Errorf("random.Image(): %+v", err)
+	}
+	err = crane.Push(image, imageName)
+	if err != nil {
+		return nil, fmt.Errorf("crane.Push(): %+v", err)
+	}
+	return s, nil
+}
+
+// koExampleAppDir returns the directory path of the basic ko builder sample app.
+func koExampleAppDir() (string, error) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("could not get current filename")
+	}
+	basepath := filepath.Dir(filename)
+	exampleDir, err := filepath.Abs(filepath.Join(basepath, "examples", "ko"))
+	if err != nil {
+		return "", fmt.Errorf("could not get absolute path of example from basepath %q: %w", basepath, err)
+	}
+	return exampleDir, nil
+}

--- a/pkg/skaffold/build/ko/publisher.go
+++ b/pkg/skaffold/build/ko/publisher.go
@@ -29,7 +29,11 @@ import (
 )
 
 func (b *Builder) newKoPublisher(ref string) (publish.Interface, error) {
-	po, err := publishOptions(ref, b.pushImages, b.localDocker.RawClient(), b.insecureRegistries)
+	var dockerClient daemon.Client
+	if b.localDocker != nil {
+		dockerClient = b.localDocker.RawClient()
+	}
+	po, err := publishOptions(ref, b.pushImages, dockerClient, b.insecureRegistries)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/schema/validation/samples_test.go
+++ b/pkg/skaffold/schema/validation/samples_test.go
@@ -38,7 +38,8 @@ const (
 )
 
 var (
-	ignoredExamples = []string{"docker-deploy", "react-reload-docker"}
+	// TODO(halvards): Remove ko exmples from ignoredExamples once unmarshalling of ko config is enabled.
+	ignoredExamples = []string{"docker-deploy", "ko", "react-reload-docker"}
 	ignoredSamples  = []string{"structureTest.yaml", "build.sh", "globalConfig.yaml", "Dockerfile.app", "Dockerfile.base"}
 )
 


### PR DESCRIPTION
Programmatic integration test to build and push a container image using the ko builder.

CLI-type end-to-end integration tests will require Skaffold config unmarshalling support for the ko builder.

Tracking: #6041
