### PR TITLE
feat: add k8s manifest support to skaffold lint and one sample rule

### DIFF
--- a/pkg/skaffold/lint/k8smanifests.go
+++ b/pkg/skaffold/lint/k8smanifests.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lint
+
+import (
+	"context"
+	"io/ioutil"
+	"path/filepath"
+
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+// for testing
+var k8sManifestRules = &k8sManifestLintRules
+
+var K8sManifestLinters = []Linter{
+	&RegExpLinter{},
+	&YamlFieldLinter{},
+}
+
+var k8sManifestLintRules = []Rule{
+	{
+		Filter: YamlFieldFilter{
+			Filter: yaml.Lookup("metadata", "labels", "app.kubernetes.io/managed-by"),
+		},
+		RuleID:   K8sManifestManagedByLabelInUse,
+		RuleType: YamlFieldLintRule,
+		ExplanationTemplate: "Found usage of label 'app.kubernetes.io/managed-by'.  skaffold overwrites the 'app.kubernetes.io/managed-by' field to 'app.kubernetes.io/managed-by: skaffold'. " +
+			"and as such is recommended to remove this label",
+	},
+}
+
+func GetK8sManifestsLintResults(ctx context.Context, opts Options) (*[]Result, error) {
+	cfgs, err := getConfigSet(ctx, config.SkaffoldOptions{
+		ConfigurationFile:   opts.Filename,
+		ConfigurationFilter: opts.Modules,
+		RepoCacheDir:        opts.RepoCacheDir,
+		Profiles:            opts.Profiles,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	l := []Result{}
+	workdir, err := realWorkDir()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, c := range cfgs {
+		for _, pattern := range c.Deploy.KubectlDeploy.Manifests {
+			// NOTE: pattern is a pattern that can have wildcards, eg: leeroy-app/kubernetes/*
+			if util.IsURL(pattern) {
+				log.Entry(ctx).Debugf("skaffold lint found url manifest and is skipping lint rules for: %s", pattern)
+				continue
+			}
+			// filepaths are all absolute from config parsing step via tags.MakeFilePathsAbsolute
+			expanded, err := filepath.Glob(pattern)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, relPath := range expanded {
+				b, err := ioutil.ReadFile(relPath)
+				if err != nil {
+					return nil, err
+				}
+				k8syaml := ConfigFile{
+					AbsPath: filepath.Join(workdir, relPath),
+					RelPath: relPath,
+					Text:    string(b),
+				}
+				for _, r := range K8sManifestLinters {
+					recs, err := r.Lint(InputParams{
+						ConfigFile:     k8syaml,
+						SkaffoldConfig: c,
+					}, k8sManifestRules)
+					if err != nil {
+						return nil, err
+					}
+					l = append(l, *recs...)
+				}
+			}
+		}
+	}
+	return &l, nil
+}

--- a/pkg/skaffold/lint/k8smanifests_test.go
+++ b/pkg/skaffold/lint/k8smanifests_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lint
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser"
+	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util/stringslice"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+var testK8sManifest = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: leeroy-web
+  labels:
+    app: leeroy-web
+    app.kubernetes.io/managed-by: helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: leeroy-web
+  template:
+    metadata:
+      labels:
+        app: leeroy-web
+    spec:
+      containers:
+        - name: leeroy-web
+          image: leeroy-web
+          ports:
+            - containerPort: 8080
+`
+
+var invalidK8sManifest = `apiVersion: {{} `
+
+func TestGetK8sManifestsLintResults(t *testing.T) {
+	ruleIDToK8sManifestRule := map[RuleID]*Rule{}
+	for i := range k8sManifestLintRules {
+		ruleIDToK8sManifestRule[k8sManifestLintRules[i].RuleID] = &k8sManifestLintRules[i]
+	}
+	tests := []struct {
+		description            string
+		rules                  []RuleID
+		moduleAndSkaffoldYamls map[string]string
+		profiles               []string
+		modules                []string
+		k8sManifestText        string
+		shouldErr              bool
+		err                    error
+		expected               map[string]*[]Result
+	}{
+		{
+			description:            "verify K8sManifestManagedByLabelInUse rule works as intended",
+			rules:                  []RuleID{K8sManifestManagedByLabelInUse},
+			moduleAndSkaffoldYamls: map[string]string{"cfg0": testSkaffoldYaml},
+			modules:                []string{"cfg0"},
+			k8sManifestText:        testK8sManifest,
+			expected: map[string]*[]Result{
+				"cfg0": {
+					{
+						Rule:   ruleIDToK8sManifestRule[K8sManifestManagedByLabelInUse],
+						Line:   7,
+						Column: 35,
+						Explanation: `Found usage of label 'app.kubernetes.io/managed-by'.  skaffold overwrites the 'app.kubernetes.io/managed-by' ` +
+							`field to 'app.kubernetes.io/managed-by: skaffold'. and as such is recommended to remove this label`,
+					},
+				},
+			},
+		},
+		{
+			rules:                  []RuleID{K8sManifestManagedByLabelInUse},
+			description:            "invalid k8sManifest file",
+			k8sManifestText:        invalidK8sManifest,
+			moduleAndSkaffoldYamls: map[string]string{"cfg0": testSkaffoldYaml},
+			shouldErr:              true,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			testRules := []Rule{}
+			for _, ruleID := range test.rules {
+				testRules = append(testRules, *(ruleIDToK8sManifestRule[ruleID]))
+			}
+			t.Override(k8sManifestRules, testRules)
+			t.Override(&realWorkDir, func() (string, error) {
+				return "", nil
+			})
+			tmpdir := t.TempDir()
+			configSet := parser.SkaffoldConfigSet{}
+			// iteration done to enforce result order
+			for i := 0; i < len(test.moduleAndSkaffoldYamls); i++ {
+				module := fmt.Sprintf("cfg%d", i)
+				skaffoldyamlText := test.moduleAndSkaffoldYamls[module]
+				fp := filepath.Join(tmpdir, fmt.Sprintf("%s.yaml", module))
+				err := ioutil.WriteFile(fp, []byte(skaffoldyamlText), 0644)
+				if err != nil {
+					t.Fatalf("error creating skaffold.yaml file with name %s: %v", fp, err)
+				}
+				mp := filepath.Join(tmpdir, "deployment.yaml")
+				err = ioutil.WriteFile(mp, []byte(test.k8sManifestText), 0644)
+				if err != nil {
+					t.Fatalf("error creating deployment.yaml %s: %v", mp, err)
+				}
+				configSet = append(configSet, &parser.SkaffoldConfigEntry{SkaffoldConfig: &v1.SkaffoldConfig{
+					Metadata: v1.Metadata{Name: module},
+					Pipeline: v1.Pipeline{Deploy: v1.DeployConfig{DeployType: v1.DeployType{KubectlDeploy: &v1.KubectlDeploy{Manifests: []string{mp}}}}},
+				},
+				})
+				// test overwrites file paths for expected K8sManifestRules as they are made dynamically
+				results := test.expected[module]
+				if results == nil {
+					continue
+				}
+				for i := range *results {
+					(*results)[i].AbsFilePath = mp
+					(*results)[i].RelFilePath = mp
+				}
+			}
+			t.Override(&getConfigSet, func(_ context.Context, opts config.SkaffoldOptions) (parser.SkaffoldConfigSet, error) {
+				// mock profile activation
+				var set parser.SkaffoldConfigSet
+				for _, c := range configSet {
+					if len(opts.ConfigurationFilter) > 0 && !stringslice.Contains(opts.ConfigurationFilter, c.Metadata.Name) {
+						continue
+					}
+					for _, pName := range opts.Profiles {
+						for _, profile := range c.Profiles {
+							if profile.Name != pName {
+								continue
+							}
+							c.Test = profile.Test
+						}
+					}
+					set = append(set, c)
+				}
+				return set, test.err
+			})
+			results, err := GetK8sManifestsLintResults(context.Background(), Options{
+				OutFormat: "json", Modules: test.modules, Profiles: test.profiles})
+			t.CheckError(test.shouldErr, err)
+			if !test.shouldErr {
+				expectedResults := &[]Result{}
+				// this is done to enforce result order
+				for i := 0; i < len(test.expected); i++ {
+					*expectedResults = append(*expectedResults, *test.expected[fmt.Sprintf("cfg%d", i)]...)
+					(*expectedResults)[0].Rule.ExplanationPopulator = nil
+					(*expectedResults)[0].Rule.LintConditions = nil
+				}
+
+				if results == nil {
+					t.CheckDeepEqual(expectedResults, results)
+					return
+				}
+				for i := 0; i < len(*results); i++ {
+					(*results)[i].Rule.ExplanationPopulator = nil
+					(*results)[i].Rule.LintConditions = nil
+				}
+				t.CheckDeepEqual(expectedResults, results)
+			}
+		})
+	}
+}

--- a/pkg/skaffold/lint/lint.go
+++ b/pkg/skaffold/lint/lint.go
@@ -35,9 +35,14 @@ func Lint(ctx context.Context, out io.Writer, opts Options, dockerCfg docker.Con
 	if err != nil {
 		return err
 	}
+	k8sManifestRuleList, err := GetK8sManifestsLintResults(ctx, opts)
+	if err != nil {
+		return err
+	}
 	results := []Result{}
 	results = append(results, *skaffoldYamlRuleList...)
 	results = append(results, *dockerfileCommandRuleList...)
+	results = append(results, *k8sManifestRuleList...)
 	// output flattened list
 	if opts.OutFormat == JSONOutput {
 		// need to remove some fields that cannot be serialized in the Rules of the Results

--- a/pkg/skaffold/lint/linters_test.go
+++ b/pkg/skaffold/lint/linters_test.go
@@ -31,7 +31,7 @@ var helloWorldTextFile = ConfigFile{
 	RelPath: "rel/path",
 }
 
-var k8sYamlFile = ConfigFile{
+var k8sManifestFile = ConfigFile{
 	Text: `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -154,7 +154,7 @@ func TestYamlFieldLinter(t *testing.T) {
 	}{
 		{
 			description: "valid yaml field lint rule w/ match",
-			configFile:  k8sYamlFile,
+			configFile:  k8sManifestFile,
 			rules: &[]Rule{
 				{
 					RuleID:              DummyRuleIDForTesting,
@@ -187,7 +187,7 @@ func TestYamlFieldLinter(t *testing.T) {
 		},
 		{
 			description: "valid yaml field lint rule with no match",
-			configFile:  k8sYamlFile,
+			configFile:  k8sManifestFile,
 			rules: &[]Rule{
 				{
 					RuleID:              DummyRuleIDForTesting,
@@ -203,7 +203,7 @@ func TestYamlFieldLinter(t *testing.T) {
 		},
 		{
 			description: "valid yaml field lint rule match using InvertMatch",
-			configFile:  k8sYamlFile,
+			configFile:  k8sManifestFile,
 			rules: &[]Rule{
 				{
 					RuleID:              DummyRuleIDForTesting,
@@ -238,7 +238,7 @@ func TestYamlFieldLinter(t *testing.T) {
 		},
 		{
 			description: "yaml field linter w/ an different type lint rule",
-			configFile:  k8sYamlFile,
+			configFile:  k8sManifestFile,
 			rules: &[]Rule{
 				{
 					RuleID:   DummyRuleIDForTesting,
@@ -249,7 +249,7 @@ func TestYamlFieldLinter(t *testing.T) {
 		},
 		{
 			description: "yaml field command linter w/ an incorrect Filter type",
-			configFile:  k8sYamlFile,
+			configFile:  k8sManifestFile,
 			rules: &[]Rule{
 				{
 					RuleID:              DummyRuleIDForTesting,

--- a/pkg/skaffold/lint/types.go
+++ b/pkg/skaffold/lint/types.go
@@ -105,6 +105,8 @@ const (
 
 	DockerfileCopyOver1000Files
 	DockerfileCopyContainsGitDir
+
+	K8sManifestManagedByLabelInUse
 )
 
 func (a RuleID) String() string {


### PR DESCRIPTION
Related to #6098, adds k8s manifest support to `skaffold lint` and one sample rule:
- K8sManifestManagedByLabelInUse

The sample rule has the following output when triggered (note `skaffold lint` is run against modified version of `examples/microservices` here w/ misconfigurations added to the Dockerfiles, not the actual `examples/microservices`):
```
$ skaffold lint
leeroy-web/kubernetes/deployment.yaml:7:35: ID000004: Found usage of label 'app.kubernetes.io/managed-by'.  skaffold overwrites the 'app.kubernetes.io/managed-by' field to 'app.kubernetes.io/managed-by: skaffold'. and as such is recommended to remove this label: (YamlFieldLintRule)
    app.kubernetes.io/managed-by: helm
                                  ^
```

Future work for #6098 includes implementing the top 2 lint rules for k8s manifests on top of the framework in this PR.