### PR TITLE
fix: Quotes in dockerfiles env vars break copy dependency checks

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -41,8 +41,14 @@ var tests = []struct {
 	targetLog   string
 }{
 	{
-		description: "getting-started",
+		description: "copying directory",
 		dir:         "examples/getting-started",
+		pods:        []string{"getting-started"},
+		targetLog:   "Hello world!",
+	},
+	{
+		description: "getting-started",
+		dir:         "testdata/getting-started",
 		pods:        []string{"getting-started"},
 		targetLog:   "Hello world!",
 	},

--- a/integration/testdata/getting-started/Dockerfile
+++ b/integration/testdata/getting-started/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.15 as builder
+COPY main.go .
+COPY testdir .
+
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
+
+FROM alpine:3
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/getting-started/README.md
+++ b/integration/testdata/getting-started/README.md
@@ -1,0 +1,9 @@
+### Example: Getting started with a simple go app
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/getting-started)
+
+This is a simple example based on:
+
+* **building** a single Go file app and with a multistage `Dockerfile` using local docker to build
+* **tagging** using the default tagPolicy (`gitCommit`)
+* **deploying** a single container pod using `kubectl`

--- a/integration/testdata/getting-started/k8s-pod.yaml
+++ b/integration/testdata/getting-started/k8s-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+  - name: getting-started
+    image: skaffold-example

--- a/integration/testdata/getting-started/main.go
+++ b/integration/testdata/getting-started/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/testdata/getting-started/skaffold.yaml
+++ b/integration/testdata/getting-started/skaffold.yaml
@@ -1,0 +1,9 @@
+apiVersion: skaffold/v2beta25
+kind: Config
+build:
+  artifacts:
+  - image: skaffold-example
+deploy:
+  kubectl:
+    manifests:
+      - k8s-*

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -262,7 +262,7 @@ func extractCopyCommands(ctx context.Context, nodes []*parser.Node, onlyLastImag
 		case command.Env:
 			// one env command may define multiple variables
 			for node := node.Next; node != nil && node.Next != nil; node = node.Next.Next {
-				envs = append(envs, fmt.Sprintf("%s=%s", node.Value, node.Next.Value))
+				envs = append(envs, fmt.Sprintf("%s=%s", node.Value, unquote(node.Next.Value)))
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #6762
Signed-off-by: Pablo Caderno <kaderno@gmail.com>

<!-- Thank you for your contribution! -->


**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

Fixes the issue with quoted variables and "COPY" commands.

Before:
```
skaffold build
Generating tags...
 - bert -> bert:151b8d3-dirty
 - ernie -> ernie:151b8d3
Checking cache...
 - bert: Error checking cache.
getting hash for artifact "bert": getting dependencies for "bert": file pattern [./src/"some_dir"] must match at least one file
```
After:
```
skaffold build
Generating tags...
 - bert -> bert:151b8d3-dirty
 - ernie -> ernie:151b8d3
Checking cache...
 - bert: Not found. Building
 - ernie: Found Locally
Starting build...
Found [ed-ks2] context, using local docker daemon.
Building [bert]...
Sending build context to Docker daemon  7.168kB
Step 1/20 : FROM golang:1.15 as builder
 ---> 40349a2425ef
Step 2/20 : COPY main.go .
 ---> Using cache
 ---> 5bcddb464805
Step 3/20 : ARG SKAFFOLD_GO_GCFLAGS
 ---> Using cache
 ---> 0fe720d5c3d6
Step 4/20 : RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app main.go
 ---> Using cache
 ---> b0fa60be1cbd
Step 5/20 : FROM alpine:3.10
 ---> e7b300aee9f9
Step 6/20 : ENV MY_NAME="John Doe" MY_DOG=Rex\ The\ Dog     MY_CAT=fluffy
 ---> Using cache
 ---> 0a651a254ade
Step 7/20 : ENV GOTRACEBACK=single
 ---> Using cache
 ---> 0588ba733bf7
Step 8/20 : ENV DIR2=some_dir
 ---> Using cache
 ---> ac1901e9b83c
Step 9/20 : ENV DIRNAME="some_dir"
 ---> Using cache
 ---> 0a5beef983fa
Step 10/20 : ENV NOBREAK="asdf'asdf"
 ---> Running in 48d6824c02ad
 ---> 17df958a420a
Step 11/20 : COPY $NOBREAK .
 ---> 1fcafb39acb1
Step 12/20 : COPY a .
 ---> 428b63829342
Step 13/20 : COPY src/ .
 ---> 4e55fcb5d5c5
Step 14/20 : COPY ./src/$DIR2 /tmp/
 ---> 59df6382498d
Step 15/20 : COPY ./src/$DIRNAME  /tmp/
 ---> 4d182523b4f3
Step 16/20 : COPY ./src/$MY_NAME /tmp/
 ---> a4ef10e6fe6b
Step 17/20 : COPY ./src/$MY_DOG /tmp/
 ---> 043c8a3062a3
Step 18/20 : COPY ./src/$MY_CAT /tmp/
 ---> 8c1d5aa9b2c7
Step 19/20 : CMD ["./app"]
 ---> Running in 7e5a5b6a9c9d
 ---> 45c93161726d
Step 20/20 : COPY --from=builder /app .
 ---> 29276d711899
Successfully built 29276d711899
Successfully tagged bert:151b8d3-dirty
```
