### PR TITLE
fix(log): Send Go std `log` to `logrus`, and output `ggcr` logs

### DIFF
--- a/pkg/skaffold/output/log/log.go
+++ b/pkg/skaffold/output/log/log.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	stdlog "log"
 
 	ggcrlogs "github.com/google/go-containerregistry/pkg/logs"
 	"github.com/sirupsen/logrus"
@@ -97,19 +98,47 @@ func SetupLogs(stdErr io.Writer, level string, timestamp bool, hook logrus.Hook)
 		FullTimestamp: timestamp,
 	})
 	logrus.AddHook(hook)
-	setupGGCRLogging(stdErr, lvl)
+	setupStdLog(logrus.StandardLogger(), lvl)
+	setupGGCRLogging(logrus.StandardLogger(), lvl)
 	return nil
 }
 
-func setupGGCRLogging(stdErr io.Writer, lvl logrus.Level) {
+// setupStdLog writes Go's standard library `log` messages to logrus at Info level.
+//
+// This function uses SetFlags() to standardize the output format.
+//
+// TODO(halvards) Add *stdlog.Logger argument (from stdlog.Default) when the build moves to Go >= 1.16.
+// We can't unit test this function in isolation when we're modifying the singleton stdlog instance.
+func setupStdLog(logger *logrus.Logger, lvl logrus.Level) {
+	stdlog.SetFlags(0)
+	if lvl >= logrus.InfoLevel {
+		stdlog.SetOutput(logger.WriterLevel(logrus.InfoLevel))
+	}
+}
+
+// setupGGCRLogging enables go-containerregistry logging, mapping its levels to logrus.
+//
+// The mapping is:
+// - ggcr Warn -> logrus Error
+// - ggcr Progress -> logrus Info
+// - ggcr Debug -> logrus Trace
+//
+// The reasons for this mapping are:
+// - `ggcr` defines `Warn` as "non-fatal errors": https://github.com/google/go-containerregistry/blob/main/pkg/logs/logs.go#L24
+// - `ggcr` `Debug` logging is _very_ verbose and includes HTTP requests and responses, with non-sensitive headers and non-binary payloads.
+//
+// This function uses SetFlags() to standardize the output format.
+func setupGGCRLogging(logger *logrus.Logger, lvl logrus.Level) {
 	if lvl >= logrus.ErrorLevel {
-		ggcrlogs.Warn.SetOutput(stdErr)
+		ggcrlogs.Warn.SetOutput(logger.WriterLevel(logrus.ErrorLevel))
+		ggcrlogs.Warn.SetFlags(0)
 	}
 	if lvl >= logrus.InfoLevel {
-		ggcrlogs.Progress.SetOutput(stdErr)
+		ggcrlogs.Progress.SetOutput(logger.WriterLevel(logrus.InfoLevel))
+		ggcrlogs.Progress.SetFlags(0)
 	}
 	if lvl >= logrus.TraceLevel {
-		// ggcr Debug logging includes HTTP request and responses (with known sensitive header values redacted)
-		ggcrlogs.Debug.SetOutput(stdErr)
+		ggcrlogs.Debug.SetOutput(logger.WriterLevel(logrus.TraceLevel))
+		ggcrlogs.Debug.SetFlags(0)
 	}
 }

--- a/pkg/skaffold/output/log/log.go
+++ b/pkg/skaffold/output/log/log.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 
+	ggcrlogs "github.com/google/go-containerregistry/pkg/logs"
 	"github.com/sirupsen/logrus"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
@@ -96,5 +97,19 @@ func SetupLogs(stdErr io.Writer, level string, timestamp bool, hook logrus.Hook)
 		FullTimestamp: timestamp,
 	})
 	logrus.AddHook(hook)
+	setupGGCRLogging(stdErr, lvl)
 	return nil
+}
+
+func setupGGCRLogging(stdErr io.Writer, lvl logrus.Level) {
+	if lvl >= logrus.ErrorLevel {
+		ggcrlogs.Warn.SetOutput(stdErr)
+	}
+	if lvl >= logrus.InfoLevel {
+		ggcrlogs.Progress.SetOutput(stdErr)
+	}
+	if lvl >= logrus.TraceLevel {
+		// ggcr Debug logging includes HTTP request and responses (with known sensitive header values redacted)
+		ggcrlogs.Debug.SetOutput(stdErr)
+	}
 }

--- a/pkg/skaffold/output/log/log_test.go
+++ b/pkg/skaffold/output/log/log_test.go
@@ -18,12 +18,10 @@ package log
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	ggcrlogs "github.com/google/go-containerregistry/pkg/logs"
 	"github.com/sirupsen/logrus"
-	logrustest "github.com/sirupsen/logrus/hooks/test"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -93,7 +91,7 @@ func TestKanikoLogLevel(t *testing.T) {
 	}
 }
 
-func TestSetupLogsEnablesGGCRLogging(t *testing.T) {
+func TestSetupGGCRLogging(t *testing.T) {
 	tests := []struct {
 		description           string
 		logLevel              logrus.Level
@@ -137,10 +135,19 @@ func TestSetupLogsEnablesGGCRLogging(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			SetupLogs(os.Stderr, test.logLevel.String(), true, &logrustest.Hook{})
+			setupGGCRLogging(logrus.New(), test.logLevel)
 			t.CheckDeepEqual(test.expectWarnEnabled, ggcrlogs.Enabled(ggcrlogs.Warn))
 			t.CheckDeepEqual(test.expectProgressEnabled, ggcrlogs.Enabled(ggcrlogs.Progress))
 			t.CheckDeepEqual(test.expectDebugEnabled, ggcrlogs.Enabled(ggcrlogs.Debug))
+			if test.expectWarnEnabled {
+				t.CheckDeepEqual(0, ggcrlogs.Warn.Flags())
+			}
+			if test.expectProgressEnabled {
+				t.CheckDeepEqual(0, ggcrlogs.Progress.Flags())
+			}
+			if test.expectDebugEnabled {
+				t.CheckDeepEqual(0, ggcrlogs.Debug.Flags())
+			}
 		})
 	}
 }


### PR DESCRIPTION
This change directs log messages sent to Go's standard `log` package to `logrus` instead.

Also, previously, Skaffold discarded log messages from [`go-containerregistry`](https://github.com/google/go-containerregistry) (a.k.a. `ggcr`).
This change enables `ggcr` log messages, with severity tied to Skaffold's log level.

Related: #6041
