### PR TITLE
fix: propagate-profiles flag missing from `skaffold inspect` command

### DIFF
--- a/cmd/skaffold/app/cmd/inspect.go
+++ b/cmd/skaffold/app/cmd/inspect.go
@@ -22,16 +22,19 @@ import (
 )
 
 var inspectFlags = struct {
-	filename     string
-	outFormat    string
-	modules      []string
-	repoCacheDir string
-	buildEnv     string
-	profiles     []string
-	strict       bool
+	filename          string
+	outFormat         string
+	modules           []string
+	repoCacheDir      string
+	buildEnv          string
+	profiles          []string
+	profile           string
+	propagateProfiles bool
+	strict            bool
 }{
-	filename: "skaffold.yaml",
-	strict:   true,
+	filename:          "skaffold.yaml",
+	strict:            true,
+	propagateProfiles: true,
 }
 
 func NewCmdInspect() *cobra.Command {

--- a/cmd/skaffold/app/cmd/inspect_build_env.go
+++ b/cmd/skaffold/app/cmd/inspect_build_env.go
@@ -29,8 +29,6 @@ import (
 )
 
 var buildEnvFlags = struct {
-	profile string
-
 	// Common
 	timeout     string
 	concurrency int
@@ -163,7 +161,7 @@ func addClusterBuildEnv(ctx context.Context, out io.Writer) error {
 }
 
 func cmdBuildEnvAddFlags(f *pflag.FlagSet) {
-	f.StringVarP(&buildEnvFlags.profile, "profile", "p", "", `Profile name to add the new build env definition in. If the profile name doesn't exist then the profile will be created in all the target configs. If this flag is not specified then the build env is added to the default pipeline of the target configs.`)
+	f.StringVarP(&inspectFlags.profile, "profile", "p", "", `Profile name to add the new build env definition in. If the profile name doesn't exist then the profile will be created in all the target configs. If this flag is not specified then the build env is added to the default pipeline of the target configs.`)
 }
 
 func cmdBuildEnvLocalFlags(f *pflag.FlagSet) {
@@ -181,7 +179,7 @@ func cmdBuildEnvLocalFlags(f *pflag.FlagSet) {
 }
 
 func cmdBuildEnvModifyFlags(f *pflag.FlagSet) {
-	f.StringVarP(&buildEnvFlags.profile, "profile", "p", "", `If specified then the modify actions are performed on all pipelines from profiles that match flag value. It must match at least one existing profile name. If unspecified then only the default pipeline in the target 'skaffold.yaml' file are modified`)
+	f.StringVarP(&inspectFlags.profile, "profile", "p", "", `If specified then the modify actions are performed on all pipelines from profiles that match flag value. It must match at least one existing profile name. If unspecified then only the default pipeline in the target 'skaffold.yaml' file are modified`)
 	f.BoolVar(&inspectFlags.strict, "strict", true, "If set to 'false' then do not fail on mismatch of build env type or missing definitions. If set to 'true' then all default pipelines or those matching the `--profile` flag need to match the build env type exactly. Defaults to 'true'")
 }
 
@@ -221,17 +219,17 @@ func cmdBuildEnvFlags(f *pflag.FlagSet) {
 
 func cmdBuildEnvListFlags(f *pflag.FlagSet) {
 	f.StringSliceVarP(&inspectFlags.profiles, "profile", "p", nil, `Profile names to activate`)
+	f.BoolVar(&inspectFlags.propagateProfiles, "propagate-profiles", true, `Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.`)
 }
 
 func printBuildEnvsListOptions() inspect.Options {
 	return inspect.Options{
-		Filename:     inspectFlags.filename,
-		RepoCacheDir: inspectFlags.repoCacheDir,
-		OutFormat:    inspectFlags.outFormat,
-		Modules:      inspectFlags.modules,
-		BuildEnvOptions: inspect.BuildEnvOptions{
-			Profiles: inspectFlags.profiles,
-		},
+		Filename:          inspectFlags.filename,
+		RepoCacheDir:      inspectFlags.repoCacheDir,
+		OutFormat:         inspectFlags.outFormat,
+		Modules:           inspectFlags.modules,
+		Profiles:          inspectFlags.profiles,
+		PropagateProfiles: inspectFlags.propagateProfiles,
 	}
 }
 
@@ -241,8 +239,8 @@ func localBuildEnvOptions() inspect.Options {
 		RepoCacheDir: inspectFlags.repoCacheDir,
 		OutFormat:    inspectFlags.outFormat,
 		Modules:      inspectFlags.modules,
+		Profile:      inspectFlags.profile,
 		BuildEnvOptions: inspect.BuildEnvOptions{
-			Profile:          buildEnvFlags.profile,
 			Push:             buildEnvFlags.push.Value(),
 			TryImportMissing: buildEnvFlags.tryImportMissing.Value(),
 			UseDockerCLI:     buildEnvFlags.useDockerCLI.Value(),
@@ -257,8 +255,8 @@ func gcbBuildEnvOptions() inspect.Options {
 		Filename:  inspectFlags.filename,
 		OutFormat: inspectFlags.outFormat,
 		Modules:   inspectFlags.modules,
+		Profile:   inspectFlags.profile,
 		BuildEnvOptions: inspect.BuildEnvOptions{
-			Profile:            buildEnvFlags.profile,
 			ProjectID:          buildEnvFlags.projectID,
 			DiskSizeGb:         buildEnvFlags.diskSizeGb,
 			MachineType:        buildEnvFlags.machineType,
@@ -278,8 +276,8 @@ func addClusterBuildEnvOptions() inspect.Options {
 		RepoCacheDir: inspectFlags.repoCacheDir,
 		OutFormat:    inspectFlags.outFormat,
 		Modules:      inspectFlags.modules,
+		Profile:      inspectFlags.profile,
 		BuildEnvOptions: inspect.BuildEnvOptions{
-			Profile:                  buildEnvFlags.profile,
 			PullSecretPath:           buildEnvFlags.pullSecretPath,
 			PullSecretName:           buildEnvFlags.pullSecretName,
 			PullSecretMountPath:      buildEnvFlags.pullSecretMountPath,

--- a/cmd/skaffold/app/cmd/inspect_tests.go
+++ b/cmd/skaffold/app/cmd/inspect_tests.go
@@ -44,15 +44,17 @@ func cmdTestsList() *cobra.Command {
 
 func listTests(ctx context.Context, out io.Writer) error {
 	return tests.PrintTestsList(ctx, out, inspect.Options{
-		Filename:     inspectFlags.filename,
-		RepoCacheDir: inspectFlags.repoCacheDir,
-		OutFormat:    inspectFlags.outFormat,
-		Modules:      inspectFlags.modules,
-		TestsOptions: inspect.TestsOptions{TestsProfiles: inspectFlags.profiles},
+		Filename:          inspectFlags.filename,
+		RepoCacheDir:      inspectFlags.repoCacheDir,
+		OutFormat:         inspectFlags.outFormat,
+		Modules:           inspectFlags.modules,
+		Profiles:          inspectFlags.profiles,
+		PropagateProfiles: inspectFlags.propagateProfiles,
 	})
 }
 
 func cmdTestsListFlags(f *pflag.FlagSet) {
 	f.StringSliceVarP(&inspectFlags.profiles, "profile", "p", nil, `Profile names to activate`)
+	f.BoolVar(&inspectFlags.propagateProfiles, "propagate-profiles", true, `Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.`)
 	f.StringSliceVarP(&inspectFlags.modules, "module", "m", nil, "Names of modules to filter target action by.")
 }

--- a/pkg/skaffold/inspect/buildEnv/add_cluster_test.go
+++ b/pkg/skaffold/inspect/buildEnv/add_cluster_test.go
@@ -85,7 +85,8 @@ profiles:
 		},
 		{
 			description:  "add to existing profile",
-			buildEnvOpts: inspect.BuildEnvOptions{RunAsUser: -1, PullSecretPath: "path/to/secret", DockerConfigPath: "path/to/docker/config", Timeout: "128", Concurrency: 2, Profile: "p1"},
+			profile:      "p1",
+			buildEnvOpts: inspect.BuildEnvOptions{RunAsUser: -1, PullSecretPath: "path/to/secret", DockerConfigPath: "path/to/docker/config", Timeout: "128", Concurrency: 2},
 			expectedConfigs: []string{
 				`apiVersion: ""
 kind: ""
@@ -144,7 +145,8 @@ profiles:
 		},
 		{
 			description:  "add to new profile",
-			buildEnvOpts: inspect.BuildEnvOptions{RunAsUser: -1, PullSecretPath: "path/to/secret", DockerConfigPath: "path/to/docker/config", Timeout: "128", Concurrency: 2, Profile: "p2"},
+			profile:      "p2",
+			buildEnvOpts: inspect.BuildEnvOptions{RunAsUser: -1, PullSecretPath: "path/to/secret", DockerConfigPath: "path/to/docker/config", Timeout: "128", Concurrency: 2},
 			expectedConfigs: []string{
 				`apiVersion: ""
 kind: ""
@@ -213,7 +215,8 @@ profiles:
 		{
 			description:  "add to new profile in selected modules",
 			modules:      []string{"cfg1_1"},
-			buildEnvOpts: inspect.BuildEnvOptions{RunAsUser: -1, PullSecretPath: "path/to/secret", DockerConfigPath: "path/to/docker/config", Timeout: "128", Concurrency: 2, Profile: "p2"},
+			profile:      "p2",
+			buildEnvOpts: inspect.BuildEnvOptions{RunAsUser: -1, PullSecretPath: "path/to/secret", DockerConfigPath: "path/to/docker/config", Timeout: "128", Concurrency: 2},
 			expectedConfigs: []string{
 				`apiVersion: ""
 kind: ""
@@ -274,7 +277,8 @@ profiles:
 		{
 			description:  "add to new profile in nested module",
 			modules:      []string{"cfg2"},
-			buildEnvOpts: inspect.BuildEnvOptions{RunAsUser: -1, PullSecretPath: "path/to/secret", DockerConfigPath: "path/to/docker/config", Timeout: "128", Concurrency: 2, Profile: "p2"},
+			profile:      "p2",
+			buildEnvOpts: inspect.BuildEnvOptions{RunAsUser: -1, PullSecretPath: "path/to/secret", DockerConfigPath: "path/to/docker/config", Timeout: "128", Concurrency: 2},
 			expectedConfigs: []string{"",
 				`apiVersion: ""
 kind: ""
@@ -370,7 +374,7 @@ profiles:
 			})
 
 			var buf bytes.Buffer
-			err := AddClusterBuildEnv(context.Background(), &buf, inspect.Options{OutFormat: "json", Modules: test.modules, BuildEnvOptions: test.buildEnvOpts})
+			err := AddClusterBuildEnv(context.Background(), &buf, inspect.Options{OutFormat: "json", Modules: test.modules, Profile: test.profile, BuildEnvOptions: test.buildEnvOpts})
 			t.CheckError(test.err != nil, err)
 			if test.err == nil {
 				t.CheckDeepEqual(test.expectedConfigs[0], actualCfg1)

--- a/pkg/skaffold/inspect/buildEnv/add_gcb_test.go
+++ b/pkg/skaffold/inspect/buildEnv/add_gcb_test.go
@@ -90,7 +90,8 @@ profiles:
 		},
 		{
 			description:  "add to existing profile",
-			buildEnvOpts: inspect.BuildEnvOptions{ProjectID: "project1", DiskSizeGb: 2, MachineType: "machine1", Timeout: "128", Concurrency: 2, Profile: "p1"},
+			profile:      "p1",
+			buildEnvOpts: inspect.BuildEnvOptions{ProjectID: "project1", DiskSizeGb: 2, MachineType: "machine1", Timeout: "128", Concurrency: 2},
 			expectedConfigs: []string{
 				`apiVersion: ""
 kind: ""
@@ -149,7 +150,8 @@ profiles:
 		},
 		{
 			description:  "add to new profile",
-			buildEnvOpts: inspect.BuildEnvOptions{ProjectID: "project1", DiskSizeGb: 2, MachineType: "machine1", Timeout: "128", Concurrency: 2, Profile: "p2"},
+			profile:      "p2",
+			buildEnvOpts: inspect.BuildEnvOptions{ProjectID: "project1", DiskSizeGb: 2, MachineType: "machine1", Timeout: "128", Concurrency: 2},
 			expectedConfigs: []string{
 				`apiVersion: ""
 kind: ""
@@ -218,7 +220,8 @@ profiles:
 		{
 			description:  "add to new profile in selected modules",
 			modules:      []string{"cfg1_1"},
-			buildEnvOpts: inspect.BuildEnvOptions{ProjectID: "project1", DiskSizeGb: 2, MachineType: "machine1", Timeout: "128", Concurrency: 2, Profile: "p2"},
+			profile:      "p2",
+			buildEnvOpts: inspect.BuildEnvOptions{ProjectID: "project1", DiskSizeGb: 2, MachineType: "machine1", Timeout: "128", Concurrency: 2},
 			expectedConfigs: []string{
 				`apiVersion: ""
 kind: ""
@@ -279,7 +282,8 @@ profiles:
 		{
 			description:  "add to new profile in nested module",
 			modules:      []string{"cfg2"},
-			buildEnvOpts: inspect.BuildEnvOptions{ProjectID: "project1", DiskSizeGb: 2, MachineType: "machine1", Timeout: "128", Concurrency: 2, Profile: "p2"},
+			profile:      "p2",
+			buildEnvOpts: inspect.BuildEnvOptions{ProjectID: "project1", DiskSizeGb: 2, MachineType: "machine1", Timeout: "128", Concurrency: 2},
 			expectedConfigs: []string{"",
 				`apiVersion: ""
 kind: ""
@@ -375,7 +379,7 @@ profiles:
 			})
 
 			var buf bytes.Buffer
-			err := AddGcbBuildEnv(context.Background(), &buf, inspect.Options{OutFormat: "json", Modules: test.modules, BuildEnvOptions: test.buildEnvOpts})
+			err := AddGcbBuildEnv(context.Background(), &buf, inspect.Options{OutFormat: "json", Modules: test.modules, Profile: test.profile, BuildEnvOptions: test.buildEnvOpts})
 			t.CheckError(test.err != nil, err)
 			if test.err == nil {
 				t.CheckDeepEqual(test.expectedConfigs[0], actualCfg1)

--- a/pkg/skaffold/inspect/buildEnv/add_local_test.go
+++ b/pkg/skaffold/inspect/buildEnv/add_local_test.go
@@ -80,7 +80,8 @@ profiles:
 		},
 		{
 			description:  "add to existing profile",
-			buildEnvOpts: inspect.BuildEnvOptions{Push: util.BoolPtr(true), TryImportMissing: util.BoolPtr(false), UseDockerCLI: util.BoolPtr(false), UseBuildkit: nil, Concurrency: 2, Profile: "p1"},
+			profile:      "p1",
+			buildEnvOpts: inspect.BuildEnvOptions{Push: util.BoolPtr(true), TryImportMissing: util.BoolPtr(false), UseDockerCLI: util.BoolPtr(false), UseBuildkit: nil, Concurrency: 2},
 			expectedConfigs: []string{
 				`apiVersion: ""
 kind: ""
@@ -126,7 +127,8 @@ profiles:
 		},
 		{
 			description:  "add to new profile",
-			buildEnvOpts: inspect.BuildEnvOptions{Push: util.BoolPtr(true), TryImportMissing: util.BoolPtr(false), UseDockerCLI: util.BoolPtr(false), UseBuildkit: nil, Concurrency: 2, Profile: "p2"},
+			profile:      "p2",
+			buildEnvOpts: inspect.BuildEnvOptions{Push: util.BoolPtr(true), TryImportMissing: util.BoolPtr(false), UseDockerCLI: util.BoolPtr(false), UseBuildkit: nil, Concurrency: 2},
 			expectedConfigs: []string{
 				`apiVersion: ""
 kind: ""
@@ -182,7 +184,8 @@ profiles:
 		{
 			description:  "add to new profile in selected modules",
 			modules:      []string{"cfg1_1"},
-			buildEnvOpts: inspect.BuildEnvOptions{Push: util.BoolPtr(true), TryImportMissing: util.BoolPtr(false), UseDockerCLI: util.BoolPtr(false), UseBuildkit: nil, Concurrency: 2, Profile: "p2"},
+			profile:      "p2",
+			buildEnvOpts: inspect.BuildEnvOptions{Push: util.BoolPtr(true), TryImportMissing: util.BoolPtr(false), UseDockerCLI: util.BoolPtr(false), UseBuildkit: nil, Concurrency: 2},
 			expectedConfigs: []string{
 				`apiVersion: ""
 kind: ""
@@ -233,7 +236,8 @@ profiles:
 		{
 			description:  "add to new profile in nested module",
 			modules:      []string{"cfg2"},
-			buildEnvOpts: inspect.BuildEnvOptions{Push: util.BoolPtr(true), TryImportMissing: util.BoolPtr(false), UseDockerCLI: util.BoolPtr(false), UseBuildkit: nil, Concurrency: 2, Profile: "p2"},
+			profile:      "p2",
+			buildEnvOpts: inspect.BuildEnvOptions{Push: util.BoolPtr(true), TryImportMissing: util.BoolPtr(false), UseDockerCLI: util.BoolPtr(false), UseBuildkit: nil, Concurrency: 2},
 			expectedConfigs: []string{"",
 				`apiVersion: ""
 kind: ""
@@ -326,7 +330,7 @@ profiles:
 			})
 
 			var buf bytes.Buffer
-			err := AddLocalBuildEnv(context.Background(), &buf, inspect.Options{OutFormat: "json", Modules: test.modules, BuildEnvOptions: test.buildEnvOpts})
+			err := AddLocalBuildEnv(context.Background(), &buf, inspect.Options{OutFormat: "json", Modules: test.modules, Profile: test.profile, BuildEnvOptions: test.buildEnvOpts})
 			t.CheckError(test.err != nil, err)
 			if test.err == nil {
 				t.CheckDeepEqual(test.expectedConfigs[0], actualCfg1)

--- a/pkg/skaffold/inspect/buildEnv/list.go
+++ b/pkg/skaffold/inspect/buildEnv/list.go
@@ -40,6 +40,7 @@ func PrintBuildEnvsList(ctx context.Context, out io.Writer, opts inspect.Options
 		ConfigurationFile:   opts.Filename,
 		RepoCacheDir:        opts.RepoCacheDir,
 		Profiles:            opts.Profiles,
+		PropagateProfiles:   opts.PropagateProfiles,
 		ConfigurationFilter: opts.Modules,
 	})
 	if err != nil {

--- a/pkg/skaffold/inspect/buildEnv/list_test.go
+++ b/pkg/skaffold/inspect/buildEnv/list_test.go
@@ -120,7 +120,7 @@ func TestPrintBuildEnvsList(t *testing.T) {
 				return set, test.err
 			})
 			var buf bytes.Buffer
-			err := PrintBuildEnvsList(context.Background(), &buf, inspect.Options{OutFormat: "json", Modules: test.module, BuildEnvOptions: inspect.BuildEnvOptions{Profiles: test.profiles}})
+			err := PrintBuildEnvsList(context.Background(), &buf, inspect.Options{OutFormat: "json", Modules: test.module, Profiles: test.profiles})
 			t.CheckError(test.err != nil, err)
 			t.CheckDeepEqual(test.expected, buf.String())
 		})

--- a/pkg/skaffold/inspect/buildEnv/modify_gcb_test.go
+++ b/pkg/skaffold/inspect/buildEnv/modify_gcb_test.go
@@ -69,7 +69,8 @@ profiles:
 		{
 			description:  "modify profile pipeline; strict true",
 			strict:       true,
-			buildEnvOpts: inspect.BuildEnvOptions{ProjectID: "project2", Profile: "p1"},
+			profile:      "p1",
+			buildEnvOpts: inspect.BuildEnvOptions{ProjectID: "project2"},
 			expectedConfigs: []string{
 				`apiVersion: ""
 kind: ""
@@ -105,13 +106,15 @@ profiles:
 		{
 			description:  "add to non-existing profile; strict true",
 			strict:       true,
-			buildEnvOpts: inspect.BuildEnvOptions{MachineType: "machine2", Concurrency: 2, Profile: "p3"},
+			profile:      "p3",
+			buildEnvOpts: inspect.BuildEnvOptions{MachineType: "machine2", Concurrency: 2},
 			errCode:      proto.StatusCode_INSPECT_PROFILE_NOT_FOUND_ERR,
 		},
 		{
 			description:  "add to profile with wrong build env type; strict true",
 			strict:       true,
-			buildEnvOpts: inspect.BuildEnvOptions{MachineType: "machine2", Concurrency: 2, Profile: "p2"},
+			profile:      "p2",
+			buildEnvOpts: inspect.BuildEnvOptions{MachineType: "machine2", Concurrency: 2},
 			errCode:      proto.StatusCode_INSPECT_BUILD_ENV_INCORRECT_TYPE_ERR,
 		},
 		{
@@ -142,7 +145,8 @@ profiles:
 		{
 			description:  "modify profile pipeline; strict false",
 			strict:       false,
-			buildEnvOpts: inspect.BuildEnvOptions{ProjectID: "project2", Profile: "p1"},
+			profile:      "p1",
+			buildEnvOpts: inspect.BuildEnvOptions{ProjectID: "project2"},
 			expectedConfigs: []string{
 				`apiVersion: ""
 kind: ""
@@ -178,13 +182,15 @@ profiles:
 		{
 			description:  "add to non-existing profile; strict false",
 			strict:       false,
-			buildEnvOpts: inspect.BuildEnvOptions{MachineType: "machine2", Concurrency: 2, Profile: "p3"},
+			profile:      "p3",
+			buildEnvOpts: inspect.BuildEnvOptions{MachineType: "machine2", Concurrency: 2},
 			errCode:      proto.StatusCode_INSPECT_PROFILE_NOT_FOUND_ERR,
 		},
 		{
 			description:  "add to profile with wrong build env type; strict false",
 			strict:       false,
-			buildEnvOpts: inspect.BuildEnvOptions{MachineType: "machine2", Concurrency: 2, Profile: "p2"},
+			profile:      "p2",
+			buildEnvOpts: inspect.BuildEnvOptions{MachineType: "machine2", Concurrency: 2},
 			expectedConfigs: []string{
 				`apiVersion: ""
 kind: ""
@@ -268,7 +274,7 @@ profiles:
 			})
 
 			var buf bytes.Buffer
-			err := ModifyGcbBuildEnv(context.Background(), &buf, inspect.Options{OutFormat: "json", Modules: test.modules, BuildEnvOptions: test.buildEnvOpts, Strict: test.strict})
+			err := ModifyGcbBuildEnv(context.Background(), &buf, inspect.Options{OutFormat: "json", Modules: test.modules, Profile: test.profile, BuildEnvOptions: test.buildEnvOpts, Strict: test.strict})
 			t.CheckNoError(err)
 			if test.errCode == proto.StatusCode_OK {
 				t.CheckDeepEqual(test.expectedConfigs[0], actualCfg1)

--- a/pkg/skaffold/inspect/tests/list.go
+++ b/pkg/skaffold/inspect/tests/list.go
@@ -47,7 +47,8 @@ func PrintTestsList(ctx context.Context, out io.Writer, opts inspect.Options) er
 		ConfigurationFile:   opts.Filename,
 		ConfigurationFilter: opts.Modules,
 		RepoCacheDir:        opts.RepoCacheDir,
-		Profiles:            opts.TestsProfiles,
+		Profiles:            opts.Profiles,
+		PropagateProfiles:   opts.PropagateProfiles,
 	})
 	if err != nil {
 		formatter.WriteErr(err)

--- a/pkg/skaffold/inspect/tests/list_test.go
+++ b/pkg/skaffold/inspect/tests/list_test.go
@@ -109,7 +109,7 @@ func TestPrintTestsList(t *testing.T) {
 			})
 			var buf bytes.Buffer
 			err := PrintTestsList(context.Background(), &buf, inspect.Options{
-				OutFormat: "json", Modules: test.module, TestsOptions: inspect.TestsOptions{TestsProfiles: test.profiles}})
+				OutFormat: "json", Modules: test.module, Profiles: test.profiles})
 			t.CheckError(test.err != nil, err)
 			t.CheckDeepEqual(test.expected, buf.String())
 		})

--- a/pkg/skaffold/inspect/types.go
+++ b/pkg/skaffold/inspect/types.go
@@ -31,21 +31,18 @@ type Options struct {
 	OutFormat string
 	// Modules is the module filter for specific commands
 	Modules []string
+	// Profiles is the slice of profile names to activate.
+	Profiles []string
+	// Profile is a target profile to create or edit
+	Profile string
+	// PropagateProfiles specifies if profiles specified by the '--profile' flag should be searched across config dependencies. Otherwise only profiles defined directly in the target 'skaffold.yaml' file are activated.
+	PropagateProfiles bool
 	// Strict specifies the error-tolerance for specific commands
 	Strict bool
 
 	ModulesOptions
 	ProfilesOptions
 	BuildEnvOptions
-	TestsOptions
-}
-
-// TestsOptions holds flag values for various `skaffold inspect tests` commands
-type TestsOptions struct {
-	// Profiles is the slice of profile names to activate.
-	TestsProfiles []string
-	// Profile is a target profile to create or edit
-	TestsProfile string
 }
 
 // ModulesOptions holds flag values for various `skaffold inspect modules` commands
@@ -62,10 +59,6 @@ type ProfilesOptions struct {
 
 // BuildEnvOptions holds flag values for various `skaffold inspect build-env` commands
 type BuildEnvOptions struct {
-	// Profiles is the slice of profile names to activate.
-	Profiles []string
-	// Profile is a target profile to create or edit
-	Profile string
 	// Push specifies if images should be pushed to a registry.
 	Push *bool
 	// TryImportMissing specifies whether to attempt to import artifacts from Docker (either a local or remote registry) if not in the cache


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6800 <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Fixes #6800, the flag `propagate-profiles` was not added to the `inspect` command. So `inspect` command was only looking in the immediate `skaffold.yaml` file for profile names.

### Testing instructions:
1. open up Cloud Code [NodeJS Guestbook Samples](https://github.com/GoogleCloudPlatform/cloud-code-samples/tree/v1/nodejs/nodejs-guestbook) (this one uses skaffold modules)
2. run `skaffold inspect build-env list --profile cloudbuild` (cloudbuild profile exists in both modules)
```
skaffold inspect build-env list --profile cloudbuild | jq
{
  "build_envs": [
    {
      "type": "googleCloudBuild",
      "path": "/Users/gaghosh/Code/Work/fork/cloud-code-samples/nodejs/nodejs-guestbook/src/frontend/skaffold.yaml",
      "module": "frontend"
    },
    {
      "type": "googleCloudBuild",
      "path": "/Users/gaghosh/Code/Work/fork/cloud-code-samples/nodejs/nodejs-guestbook/src/backend/skaffold.yaml",
      "module": "backend"
    },
    {
      "type": "local",
      "path": "/Users/gaghosh/Code/Work/fork/cloud-code-samples/nodejs/nodejs-guestbook/skaffold.yaml"
    }
  ]
}
```

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
