### PR TITLE
feat: Add Lts Images.

### DIFF
--- a/deploy/cloudbuild-lts.yaml
+++ b/deploy/cloudbuild-lts.yaml
@@ -1,0 +1,52 @@
+# using default substitutions, provided by Google Cloud Build
+# see: https://cloud.google.com/container-builder/docs/configuring-builds/substitute-variable-values#using_default_substitutions
+steps:
+# Build and tag skaffold-deps image using docker with cache-from
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '-t'
+  - 'gcr.io/$PROJECT_ID/build_deps:latest-lts'
+  - '--cache-from'
+  - 'gcr.io/k8s-skaffold/build_deps:latest-lts'
+  - '-f'
+  - 'deploy/skaffold/Dockerfile.deps.lts'
+  - '.'
+
+# Grab secret credentials from gcp bucket
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: 'bash'
+    args: ['deploy/setup-secret.sh','-p', $PROJECT_ID]
+
+# Build and tag skaffold builder
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/$PROJECT_ID/skaffold-builder:latest-lts'
+    - '-f'
+    - 'deploy/skaffold/Dockerfile'
+    - '.'
+
+# Do the go build & push the results to GCS
+  - name: 'gcr.io/$PROJECT_ID/skaffold-builder:latest-lts'
+    args:
+    - 'make'
+    - 'release-build'
+    - 'RELEASE_BUCKET=$_RELEASE_BUCKET'
+    - 'GCP_PROJECT=$PROJECT_ID'
+
+# Check that skaffold is in the image
+  - name: 'gcr.io/$PROJECT_ID/skaffold:edge-lts'
+    args:
+    - 'skaffold'
+    - 'version'
+
+images:
+- 'gcr.io/$PROJECT_ID/skaffold:edge-lts'
+- 'gcr.io/$PROJECT_ID/skaffold:$COMMIT_SHA-lts'
+
+options:
+  machineType: 'N1_HIGHCPU_8'
+
+timeout: 1200s

--- a/deploy/cloudbuild-release-lts.yaml
+++ b/deploy/cloudbuild-release-lts.yaml
@@ -1,0 +1,54 @@
+# using default substitutions, provided by Google Cloud Build
+# see: https://cloud.google.com/container-builder/docs/configuring-builds/substitute-variable-values#using_default_substitutions
+steps:
+
+# Build and tag skaffold-deps image using docker with cache-from
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'build'
+  - '-t'
+  - 'gcr.io/$PROJECT_ID/build_deps:latest-lts'
+  - '--cache-from'
+  - 'gcr.io/k8s-skaffold/build_deps:latest-lts'
+  - '-f'
+  - 'deploy/skaffold/Dockerfile.deps'
+  - '.'
+
+# Grab secret credentials from gcp bucket
+  - name: gcr.io/cloud-builders/gcloud
+    entrypoint: 'bash'
+    args: ['deploy/setup-secret.sh','-p', $PROJECT_ID]
+
+# Build and tag skaffold builder
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/$PROJECT_ID/skaffold-builder:latest-lts'
+    - '-f'
+    - 'deploy/skaffold/Dockerfile'
+    - '.'
+
+# Do the go build & push the results to GCS
+  - name: 'gcr.io/$PROJECT_ID/skaffold-builder:latest-lts'
+    args:
+    - 'make'
+    - 'release'
+    - 'VERSION=$TAG_NAME'
+    - 'RELEASE_BUCKET=$_RELEASE_BUCKET'
+    - 'GCP_PROJECT=$PROJECT_ID'
+
+# Check that skaffold is in the image
+  - name: 'gcr.io/$PROJECT_ID/skaffold:latest-lts'
+    args:
+    - 'skaffold'
+    - 'version'
+
+images:
+- 'gcr.io/$PROJECT_ID/skaffold:lts'
+- 'gcr.io/$PROJECT_ID/skaffold:$TAG_NAME-lts'
+
+options:
+  machineType: 'N1_HIGHCPU_8'
+
+timeout: 1200s

--- a/deploy/cloudbuild-release.yaml
+++ b/deploy/cloudbuild-release.yaml
@@ -1,6 +1,19 @@
 # using default substitutions, provided by Google Cloud Build
 # see: https://cloud.google.com/container-builder/docs/configuring-builds/substitute-variable-values#using_default_substitutions
 steps:
+
+# Build and tag skaffold-deps image using docker with cache-from
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/$PROJECT_ID/build_deps:latest'
+    - '--cache-from'
+    - 'gcr.io/k8s-skaffold/build_deps:latest'
+    - '-f'
+    - 'deploy/skaffold/Dockerfile.deps'
+    - '.'
+
 # Grab secret credentials from gcp bucket
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: 'bash'

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -1,6 +1,18 @@
 # using default substitutions, provided by Google Cloud Build
 # see: https://cloud.google.com/container-builder/docs/configuring-builds/substitute-variable-values#using_default_substitutions
 steps:
+# Build and tag skaffold-deps image using docker with cache-from
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/$PROJECT_ID/build_deps:latest'
+    - '--cache-from'
+    - 'gcr.io/k8s-skaffold/build_deps:latest'
+    - '-f'
+    - 'deploy/skaffold/Dockerfile.deps'
+    - '.'
+
 # Grab secret credentials from gcp bucket
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: 'bash'

--- a/deploy/skaffold/Dockerfile
+++ b/deploy/skaffold/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This base image has to be updated manually after running `make build_deps`
-FROM gcr.io/k8s-skaffold/build_deps:a2f5d630a6cf9f3f7cb777f4e6f7cf46045d4846 as build
+# This base image is built using docker from cache every single time as build step.
+FROM gcr.io/k8s-skaffold/build_deps:latest as build
 WORKDIR /skaffold
 
 FROM build as builder

--- a/deploy/skaffold/Dockerfile.deps.lts
+++ b/deploy/skaffold/Dockerfile.deps.lts
@@ -1,0 +1,113 @@
+# Copyright 2019 The Skaffold Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG ARCH=amd64
+
+# Download kubectl
+FROM alpine:3.10 as download-kubectl
+ARG ARCH
+# Track default version installed by Google Cloud SDK: 358.0.0 moved to 1.20(.10)
+# https://cloud.google.com/sdk/docs/release-notes
+ENV KUBECTL_VERSION v1.20.10
+ENV KUBECTL_URL https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
+# SHAs at gs://kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/
+COPY digests/kubectl.${ARCH}.sha512 .
+RUN wget -O kubectl "${KUBECTL_URL}" && sha512sum -c kubectl.${ARCH}.sha512
+RUN chmod +x kubectl
+
+# Download helm (see https://github.com/helm/helm/releases/latest)
+FROM alpine:3.10 as download-helm
+ARG ARCH
+RUN echo arch=$ARCH
+ENV HELM_VERSION v3.7.1
+ENV HELM_URL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz
+COPY digests/helm.${ARCH}.sha256 .
+RUN wget -O helm.tar.gz "${HELM_URL}" && sha256sum -c helm.${ARCH}.sha256
+RUN tar -xvf helm.tar.gz --strip-components 1
+
+# Download kustomize
+FROM alpine:3.10 as download-kustomize
+ARG ARCH
+ENV KUSTOMIZE_VERSION 4.4.0
+ENV KUSTOMIZE_URL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
+COPY digests/kustomize.${ARCH}.sha256 .
+RUN wget -O kustomize.tar.gz "${KUSTOMIZE_URL}" && sha256sum -c kustomize.${ARCH}.sha256
+RUN tar -xvf kustomize.tar.gz
+
+# Download kpt
+FROM alpine:3.10 as download-kpt
+ARG ARCH
+ENV KPT_VERSION 0.39.3
+ENV KPT_URL https://github.com/GoogleContainerTools/kpt/releases/download/v${KPT_VERSION}/kpt_linux_amd64
+COPY digests/kpt.${ARCH}.sha256 .
+RUN wget -O kpt "${KPT_URL}" && sha256sum -c kpt.${ARCH}.sha256
+RUN chmod +x kpt
+
+# Download container-structure-test (https://github.com/GoogleContainerTools/container-structure-test/releases/latest)
+FROM alpine:3.10 as download-container-structure-test
+ARG ARCH
+ENV CONTAINER_STRUCTURE_TEST_VERSION v1.10.0
+ENV CONTAINER_STRUCTURE_TEST_URL https://storage.googleapis.com/container-structure-test/${CONTAINER_STRUCTURE_TEST_VERSION}/container-structure-test-linux-${ARCH}
+COPY digests/container-structure-test.${ARCH}.sha512 .
+RUN wget -O container-structure-test "${CONTAINER_STRUCTURE_TEST_URL}" && sha512sum -c container-structure-test.${ARCH}.sha512
+RUN chmod +x container-structure-test
+
+# Download gcloud
+FROM alpine:3.10 as download-gcloud
+ARG ARCH
+ENV GCLOUD_VERSION 360.0.0
+ENV GCLOUD_URL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-GCLOUDARCH.tar.gz
+# SHAs listed at https://cloud.google.com/sdk/docs/downloads-versioned-archives
+COPY digests/gcloud.${ARCH}.sha256 .
+RUN \
+    GCLOUDARCH=$(case "${ARCH}" in amd64) echo x86_64;; *) echo ${ARCH};; esac); \
+    wget -O gcloud.tar.gz $(echo "${GCLOUD_URL}" | sed "s/GCLOUDARCH/${GCLOUDARCH}/g") && \
+    sha256sum -c gcloud.${ARCH}.sha256
+RUN tar -zxf gcloud.tar.gz
+
+
+FROM gcr.io/gcp-runtimes/ubuntu_18_0_4 as runtime_deps
+
+RUN apt-get update && \
+    apt-get install --no-install-recommends --no-install-suggests -y \
+    git python unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=download-kubectl kubectl /usr/local/bin/
+COPY --from=download-helm helm /usr/local/bin/
+COPY --from=download-kustomize kustomize /usr/local/bin/
+COPY --from=download-kpt kpt /usr/local/bin/
+COPY --from=download-container-structure-test container-structure-test /usr/local/bin/
+COPY --from=download-gcloud google-cloud-sdk/ /google-cloud-sdk/
+
+# Finish installation of gcloud
+RUN /google-cloud-sdk/install.sh \
+    --usage-reporting=false \
+    --bash-completion=false \
+    --disable-installation-options
+ENV PATH=$PATH:/google-cloud-sdk/bin
+RUN gcloud auth configure-docker
+
+FROM runtime_deps
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \
+    build-essential \
+    python-setuptools \
+    lsb-release \
+    openjdk-11-jdk \
+    software-properties-common \
+    jq \
+    apt-transport-https && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=golang:1.15 /usr/local/go /usr/local/go
+ENV PATH /usr/local/go/bin:/root/go/bin:$PATH

--- a/deploy/skaffold/Dockerfile.lts
+++ b/deploy/skaffold/Dockerfile.lts
@@ -1,0 +1,26 @@
+# Copyright 2019 The Skaffold Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This base image is built using docker from cache every single time as build step.
+FROM gcr.io/k8s-skaffold/build_deps:latest-lts as build
+WORKDIR /skaffold
+
+FROM build as builder
+ARG VERSION
+COPY . .
+RUN make clean out/skaffold VERSION=$VERSION && mv out/skaffold /usr/bin/skaffold && rm -rf secrets $SECRET cmd/skaffold/app/cmd/statik/statik.go
+
+FROM build as release
+COPY --from=builder /usr/bin/skaffold /usr/bin/skaffold
+RUN skaffold credits -d /THIRD_PARTY_NOTICES


### PR DESCRIPTION
This is draft PR to get consensus on who LTS skaffold image should look.

The output will be:

1) A skaffold builder LTS image: `gcr.io/k8s-skaffold/skaffold-builder:latest-lts`
   This image will be consumed internally to build the public skaffold LTS image
   This image will contain following binaries
   1) Kubectl
   2) Helm
   3) Kustomize
   4) Kpt
   5) Gcloud
   6) Container structure tests. ( Not sure if this is needed for CD)

2) A skaffold LTS image: 
    1) Latest Image: `gcr.io/k8s-skaffold/skaffold:lts` 
    2)  Image by Tag: `gcr.io/k8s-skaffold/skaffold:v1.35.0-lts`
