### PR TITLE
fix(ko): Fall back to build configs in `.ko.yaml`

### DIFF
--- a/docs/content/en/docs/pipeline-stages/builders/ko.md
+++ b/docs/content/en/docs/pipeline-stages/builders/ko.md
@@ -212,9 +212,18 @@ Useful tips for existing `ko` users:
   [`default-repo` functionality]({{< relref "/docs/environment/image-registries" >}}).
   The ko builder does _not_ read the `KO_DOCKER_REPO` environment variable.
 
-- The ko builder supports reading base image configuration from the `.ko.yaml`
-  file. If you already configure your base images using this file, you do not
-  need to repeat this configuration in `skaffold.yaml`.
+- The ko builder supports reading
+  [base image configuration](https://github.com/google/ko#overriding-base-images)
+  from the `.ko.yaml` file. If you already configure your base images using
+  this file, you do not need to specify the `fromImage` field for the
+  artifact in `skaffold.yaml`.
+
+- The ko builder supports reading
+  [build configs](https://github.com/google/ko#overriding-go-build-settings)
+  from the `.ko.yaml` file if `skaffold.yaml` does not specify any of the build
+  config fields (`dir`, `main`, `env`, `flags`, and `ldflags`). If you already
+  specify these fields in `.ko.yaml`, you do not need to repeat them in
+  `skaffold.yaml`.
 
 - When you use the Skaffold ko builder, Skaffold takes care of replacing the
   image placeholder name in your Kubernetes manifest files using its

--- a/pkg/skaffold/build/ko/builder_test.go
+++ b/pkg/skaffold/build/ko/builder_test.go
@@ -28,8 +28,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-// Most of the test cases set the artifact image name to a `ko://`-prefixed import path.
-// This speeds up the tests, as the code under test doesn't need to repeatedly determine the import path of this package.
 func TestBuildOptions(t *testing.T) {
 	tests := []struct {
 		description              string
@@ -48,7 +46,6 @@ func TestBuildOptions(t *testing.T) {
 					KoArtifact: &latestV1.KoArtifact{},
 				},
 			},
-			wantImportPath: "github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko", // this package
 		},
 		{
 			description: "base image",
@@ -60,7 +57,6 @@ func TestBuildOptions(t *testing.T) {
 				},
 				ImageName: "ko://example.com/foo",
 			},
-			wantImportPath: "example.com/foo",
 		},
 		{
 			description: "empty platforms",
@@ -72,7 +68,6 @@ func TestBuildOptions(t *testing.T) {
 				},
 				ImageName: "ko://example.com/foo",
 			},
-			wantImportPath: "example.com/foo",
 		},
 		{
 			description: "multiple platforms",
@@ -84,8 +79,7 @@ func TestBuildOptions(t *testing.T) {
 				},
 				ImageName: "ko://example.com/foo",
 			},
-			wantPlatform:   "linux/amd64,linux/arm64",
-			wantImportPath: "example.com/foo",
+			wantPlatform: "linux/amd64,linux/arm64",
 		},
 		{
 			description: "workspace",
@@ -97,7 +91,6 @@ func TestBuildOptions(t *testing.T) {
 				Workspace: "my-app-subdirectory",
 			},
 			wantWorkingDirectory: "my-app-subdirectory",
-			wantImportPath:       "example.com/foo",
 		},
 		{
 			description: "source dir",
@@ -136,7 +129,6 @@ func TestBuildOptions(t *testing.T) {
 			},
 			runMode:                  config.RunModes.Debug,
 			wantDisableOptimizations: true,
-			wantImportPath:           "example.com/foo",
 		},
 		{
 			description: "labels",
@@ -151,8 +143,7 @@ func TestBuildOptions(t *testing.T) {
 				},
 				ImageName: "ko://example.com/foo",
 			},
-			wantLabels:     []string{"foo=bar", "frob=baz"},
-			wantImportPath: "example.com/foo",
+			wantLabels: []string{"foo=bar", "frob=baz"},
 		},
 	}
 	for _, test := range tests {
@@ -170,7 +161,7 @@ func TestBuildOptions(t *testing.T) {
 			t.CheckDeepEqual(test.wantLabels, bo.Labels,
 				cmpopts.SortSlices(func(x, y string) bool { return x < y }),
 				cmpopts.EquateEmpty())
-			if len(bo.BuildConfigs) != 1 {
+			if test.wantImportPath != "" && len(bo.BuildConfigs) != 1 {
 				t.Fatalf("expected exactly one build config, got %d", len(bo.BuildConfigs))
 			}
 			for importpath := range bo.BuildConfigs {


### PR DESCRIPTION
ko build configs are optional, and can either be specified in `skaffold.yaml` or [`.ko.yaml`](https://github.com/google/ko#overriding-go-build-settings).

Prior to this change, the Skaffold ko builder would ignore any build configs present in `.ko.yaml`. This happened because we always passed a build config map with one entry, corresponding to the artifact being built.

With this change, build configs from `.ko.yaml` will be used as a fallback if the artifact config in `skaffold.yaml` does not specify any of the fields that are part of the build config. This is helpful to existing `ko` users who want to adopt Skaffold.

We achieve the fallback behavior by passing an empty build config map, which hits this conditional in `ko`: https://github.com/google/ko/blob/0015a815375d456baed846579ec02cf936b99307/pkg/commands/options/build.go#L120

Tracking: #6041
