### PR TITLE
fix: fix build pipeline to always rebuild builder deps from latest.

### DIFF
--- a/deploy/cloudbuild-release.yaml
+++ b/deploy/cloudbuild-release.yaml
@@ -51,4 +51,4 @@ images:
 options:
   machineType: 'N1_HIGHCPU_8'
 
-timeout: 1200s
+timeout: 1500s

--- a/deploy/cloudbuild-release.yaml
+++ b/deploy/cloudbuild-release.yaml
@@ -1,6 +1,19 @@
 # using default substitutions, provided by Google Cloud Build
 # see: https://cloud.google.com/container-builder/docs/configuring-builds/substitute-variable-values#using_default_substitutions
 steps:
+
+# Build and tag skaffold-deps image using docker with cache-from
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/$PROJECT_ID/build_deps:latest'
+    - '--cache-from'
+    - 'gcr.io/k8s-skaffold/build_deps:latest'
+    - '-f'
+    - 'deploy/skaffold/Dockerfile.deps'
+    - '.'
+
 # Grab secret credentials from gcp bucket
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: 'bash'

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -1,6 +1,18 @@
 # using default substitutions, provided by Google Cloud Build
 # see: https://cloud.google.com/container-builder/docs/configuring-builds/substitute-variable-values#using_default_substitutions
 steps:
+# Build and tag skaffold-deps image using docker with cache-from
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/$PROJECT_ID/build_deps:latest'
+    - '--cache-from'
+    - 'gcr.io/k8s-skaffold/build_deps:latest'
+    - '-f'
+    - 'deploy/skaffold/Dockerfile.deps'
+    - '.'
+
 # Grab secret credentials from gcp bucket
   - name: gcr.io/cloud-builders/gcloud
     entrypoint: 'bash'

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -49,4 +49,4 @@ images:
 options:
   machineType: 'N1_HIGHCPU_8'
 
-timeout: 1200s
+timeout: 1500s

--- a/deploy/skaffold/Dockerfile
+++ b/deploy/skaffold/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This base image has to be updated manually after running `make build_deps`
-FROM gcr.io/k8s-skaffold/build_deps:a2f5d630a6cf9f3f7cb777f4e6f7cf46045d4846 as build
+# This base image is built using docker from cache every single time as build step.
+FROM gcr.io/k8s-skaffold/build_deps:latest as build
 WORKDIR /skaffold
 
 FROM build as builder

--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -22,7 +22,7 @@ ARG ARCH
 ENV KUBECTL_VERSION v1.20.10
 ENV KUBECTL_URL https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl
 # SHAs at gs://kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/
-COPY digests/kubectl.${ARCH}.sha512 .
+COPY deploy/skaffold/digests/kubectl.${ARCH}.sha512 .
 RUN wget -O kubectl "${KUBECTL_URL}" && sha512sum -c kubectl.${ARCH}.sha512
 RUN chmod +x kubectl
 
@@ -32,7 +32,7 @@ ARG ARCH
 RUN echo arch=$ARCH
 ENV HELM_VERSION v3.7.1
 ENV HELM_URL https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz
-COPY digests/helm.${ARCH}.sha256 .
+COPY deploy/skaffold/digests/helm.${ARCH}.sha256 .
 RUN wget -O helm.tar.gz "${HELM_URL}" && sha256sum -c helm.${ARCH}.sha256
 RUN tar -xvf helm.tar.gz --strip-components 1
 
@@ -41,7 +41,7 @@ FROM alpine:3.10 as download-kustomize
 ARG ARCH
 ENV KUSTOMIZE_VERSION 4.4.0
 ENV KUSTOMIZE_URL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${ARCH}.tar.gz
-COPY digests/kustomize.${ARCH}.sha256 .
+COPY deploy/skaffold/digests/kustomize.${ARCH}.sha256 .
 RUN wget -O kustomize.tar.gz "${KUSTOMIZE_URL}" && sha256sum -c kustomize.${ARCH}.sha256
 RUN tar -xvf kustomize.tar.gz
 
@@ -50,7 +50,7 @@ FROM alpine:3.10 as download-kpt
 ARG ARCH
 ENV KPT_VERSION 0.39.3
 ENV KPT_URL https://github.com/GoogleContainerTools/kpt/releases/download/v${KPT_VERSION}/kpt_linux_amd64
-COPY digests/kpt.${ARCH}.sha256 .
+COPY deploy/skaffold/digests/kpt.${ARCH}.sha256 .
 RUN wget -O kpt "${KPT_URL}" && sha256sum -c kpt.${ARCH}.sha256
 RUN chmod +x kpt
 
@@ -59,7 +59,7 @@ FROM alpine:3.10 as download-kompose
 ARG ARCH
 ENV KOMPOSE_VERSION v1.24.0
 ENV KOMPOSE_URL https://github.com/kubernetes/kompose/releases/download/${KOMPOSE_VERSION}/kompose-linux-amd64
-COPY digests/kompose.${ARCH}.sha256 .
+COPY deploy/skaffold/digests/kompose.${ARCH}.sha256 .
 RUN wget -O kompose "${KOMPOSE_URL}" && sha256sum -c kompose.${ARCH}.sha256
 RUN chmod +x kompose
 
@@ -68,7 +68,7 @@ FROM alpine:3.10 as download-container-structure-test
 ARG ARCH
 ENV CONTAINER_STRUCTURE_TEST_VERSION v1.10.0
 ENV CONTAINER_STRUCTURE_TEST_URL https://storage.googleapis.com/container-structure-test/${CONTAINER_STRUCTURE_TEST_VERSION}/container-structure-test-linux-${ARCH}
-COPY digests/container-structure-test.${ARCH}.sha512 .
+COPY deploy/skaffold/digests/container-structure-test.${ARCH}.sha512 .
 RUN wget -O container-structure-test "${CONTAINER_STRUCTURE_TEST_URL}" && sha512sum -c container-structure-test.${ARCH}.sha512
 RUN chmod +x container-structure-test
 
@@ -77,7 +77,7 @@ FROM alpine:3.10 as download-kind
 ARG ARCH
 ENV KIND_VERSION v0.11.1
 ENV KIND_URL https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-${ARCH}
-COPY digests/kind.${ARCH}.sha512 .
+COPY deploy/skaffold/digests/kind.${ARCH}.sha512 .
 RUN wget -O kind "${KIND_URL}" && sha512sum -c kind.${ARCH}.sha512
 RUN chmod +x kind
 
@@ -86,7 +86,7 @@ FROM alpine:3.10 as download-k3d
 ARG ARCH
 ENV K3D_VERSION v5.0.3
 ENV K3D_URL https://github.com/rancher/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64
-COPY digests/k3d.${ARCH}.sha256 .
+COPY deploy/skaffold/digests/k3d.${ARCH}.sha256 .
 RUN wget -O k3d "${K3D_URL}" && sha256sum -c k3d.${ARCH}.sha256
 RUN chmod +x k3d
 
@@ -96,7 +96,7 @@ ARG ARCH
 ENV GCLOUD_VERSION 360.0.0
 ENV GCLOUD_URL https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_VERSION}-linux-GCLOUDARCH.tar.gz
 # SHAs listed at https://cloud.google.com/sdk/docs/downloads-versioned-archives
-COPY digests/gcloud.${ARCH}.sha256 .
+COPY deploy/skaffold/digests/gcloud.${ARCH}.sha256 .
 RUN \
     GCLOUDARCH=$(case "${ARCH}" in amd64) echo x86_64;; *) echo ${ARCH};; esac); \
     wget -O gcloud.tar.gz $(echo "${GCLOUD_URL}" | sed "s/GCLOUDARCH/${GCLOUDARCH}/g") && \
@@ -108,7 +108,7 @@ FROM alpine:3.10 as download-bazel
 ARG ARCH
 ENV BAZEL_VERSION 4.2.1
 ENV BAZEL_URL https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-linux-BAZELARCH
-COPY digests/bazel.${ARCH}.sha256 .
+COPY deploy/skaffold/digests/bazel.${ARCH}.sha256 .
 RUN \
     BAZELARCH=$(case "${ARCH}" in amd64) echo x86_64;; *) echo ${ARCH};; esac); \
     wget -O bazel $(echo "${BAZEL_URL}" | sed "s/BAZELARCH/${BAZELARCH}/g") && \


### PR DESCRIPTION
Fixes #6708

Changes:
1) Always build `build-deps` image and push it to latest. This will ensure all fixed vuln in base image are picked. It takes about 3 mins to build the `build_deps` images
2)  Update the base image to `ubuntu_20_04`
3) Bumping the time limit from 1200 seconds to 1500 seconds since the build taken was 20 mins 2 seconds.

**Sample Cloud Build with this new pipeline:**
https://pantheon.corp.google.com/cloud-build/builds;region=global/33ad659e-0c06-423b-b57c-aeb5c9c1a7ea?project=k8s-skaffold

Time: 20min 2 seconds.


