### PR TITLE
feat: add pullParent support for docker builds

### DIFF
--- a/docs/content/en/schemas/v2beta26.json
+++ b/docs/content/en/schemas/v2beta26.json
@@ -1410,6 +1410,12 @@
           "x-intellij-html-description": "used to pass in --no-cache to docker build to prevent caching.",
           "default": "false"
         },
+        "pullParent": {
+          "type": "boolean",
+          "description": "used to attempt pulling the parent image even if an older image exists locally.",
+          "x-intellij-html-description": "used to attempt pulling the parent image even if an older image exists locally.",
+          "default": "false"
+        },
         "secrets": {
           "items": {
             "$ref": "#/definitions/DockerSecret"
@@ -1443,6 +1449,7 @@
         "addHost",
         "cacheFrom",
         "cliFlags",
+        "pullParent",
         "noCache",
         "squash",
         "secrets",

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -342,6 +342,7 @@ func (l *localDaemon) Build(ctx context.Context, out io.Writer, workspace string
 		NetworkMode: strings.ToLower(a.NetworkMode),
 		ExtraHosts:  a.AddHost,
 		NoCache:     a.NoCache,
+		PullParent:  a.PullParent,
 	})
 	if err != nil {
 		return "", fmt.Errorf("docker build: %w", err)
@@ -635,6 +636,10 @@ func ToCLIBuildArgs(a *latestV1.DockerArtifact, evaluatedArgs map[string]*string
 
 	if a.Squash {
 		args = append(args, "--squash")
+	}
+
+	if a.PullParent {
+		args = append(args, "--pull")
 	}
 
 	for _, secret := range a.Secrets {

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -139,6 +139,7 @@ func TestBuild(t *testing.T) {
 				Target:      "target",
 				NetworkMode: "None",
 				NoCache:     true,
+				PullParent:  true,
 			},
 			mode: config.RunModes.Dev,
 			expected: types.ImageBuildOptions{
@@ -154,6 +155,7 @@ func TestBuild(t *testing.T) {
 				Target:      "target",
 				NetworkMode: "none",
 				NoCache:     true,
+				PullParent:  true,
 			},
 		},
 		{
@@ -337,6 +339,13 @@ func TestGetBuildArgs(t *testing.T) {
 			want: []string{"--no-cache"},
 		},
 		{
+			description: "pullParent",
+			artifact: &latestV1.DockerArtifact{
+				PullParent: true,
+			},
+			want: []string{"--pull"},
+		},
+		{
 			description: "squash",
 			artifact: &latestV1.DockerArtifact{
 				Squash: true,
@@ -397,8 +406,9 @@ func TestGetBuildArgs(t *testing.T) {
 				Target:      "stage1",
 				NetworkMode: "None",
 				CliFlags:    []string{"--foo", "--bar"},
+				PullParent:  true,
 			},
-			want: []string{"--build-arg", "key1=value1", "--cache-from", "foo", "--foo", "--bar", "--target", "stage1", "--network", "none"},
+			want: []string{"--build-arg", "key1=value1", "--cache-from", "foo", "--foo", "--bar", "--target", "stage1", "--network", "none", "--pull"},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -1301,6 +1301,9 @@ type DockerArtifact struct {
 	// These flags are only used during a build through the Docker CLI.
 	CliFlags []string `yaml:"cliFlags,omitempty"`
 
+	// PullParent is used to attempt pulling the parent image even if an older image exists locally.
+	PullParent bool `yaml:"pullParent,omitempty"`
+
 	// NoCache used to pass in --no-cache to docker build to prevent caching.
 	NoCache bool `yaml:"noCache,omitempty"`
 


### PR DESCRIPTION
Add pullParent support for docker builds

1. If `true`, attempt to pull the parent image even if an image is present.
2. Add new `pullParent` to `build.docker` in skaffold.yaml

More info on the `pull` feature:
1. https://docs.docker.com/engine/reference/commandline/build/  OR
1. https://docs.docker.com/engine/api/v1.41/#operation/ImageBuild

```yaml
...
- name: my-build
  build:
    artifacts:
    - image: my-image
      context: docker/my-image
      docker:
        pullParent: true # <-- New field!!
...
```

```bash
./skaffold build -p my-build
Generating tags...
 - my-image-> my-image:da3855f51-dirty
Checking cache...
 - my-image: Not found. Building
Starting build...
Building [my-image]...
Sending build context to Docker daemon  609.3kB
Step 1/16 : FROM gcr.io/yada/yada:7.2.0-latest-postcommit
7.2.0-latest-postcommit: Pulling from yada/yada
Digest: sha256:fd30db4773bb......6478
Status: Image is up to date for gcr.io/yada/yada:7.2.0-latest-postcommit   # <-- New!
```

If `gcr.io/yada/yada:7.2.0-latest-postcommit` is updated upstream, `skaffold build` will pull the new image and build.


Fixes #6824


**User facing changes**
1. Updated docs and config schema, 


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
