### PR TITLE
Clarify custom local dependencies example

### DIFF
--- a/docs/content/en/samples/builders/artifact-dependencies/custom-local.yaml
+++ b/docs/content/en/samples/builders/artifact-dependencies/custom-local.yaml
@@ -2,9 +2,16 @@ build:
   artifacts:
   - image: image1
     custom:
-      # environment variable $IMG2 set to the built image2
-      buildCommand: docker build --build-arg IMG2 .
+      # environment variable $IMG2 will be set to the build of image2
+      buildCommand: |
+        cat <<EOF | docker build --tag=$IMAGE --build-arg $IMG2 -
+        FROM busybox
+        ARG IMG2
+        RUN echo 'Got ARG IMG2=$IMG2'
+        EOF
     requires:
     - image: image2
       alias: IMG2
   - image: image2
+    custom:
+      buildCommand: echo 'FROM busybox' | docker build --tag=$IMAGE -


### PR DESCRIPTION
**Description**
The example for [custom local artifact dependencies](https://skaffold.dev/docs/pipeline-stages/builders/custom/#configuration) is not completely clear and it was not correctly referring to the injected env var. This PR proposes are clearer example.

