### PR TITLE
docs(ko): Update debug docs for ko images

### DIFF
--- a/docs/content/en/docs/pipeline-stages/builders/_index.md
+++ b/docs/content/en/docs/pipeline-stages/builders/_index.md
@@ -15,6 +15,7 @@ Skaffold supports different tools for building images:
 | **Jib Maven and Gradle** | [Yes]({{< relref "/docs/pipeline-stages/builders/jib#jib-maven-and-gradle-locally" >}}) | - | [Yes]({{< relref "/docs/pipeline-stages/builders/jib#remotely-with-google-cloud-build" >}}) |
 | **Cloud Native Buildpacks** | [Yes]({{< relref "/docs/pipeline-stages/builders/buildpacks" >}}) | - | [Yes]({{< relref "/docs/pipeline-stages/builders/buildpacks" >}}) |
 | **Bazel** | [Yes]({{< relref "/docs/pipeline-stages/builders/bazel" >}}) | - | - |
+| **ko** | [Yes]({{< relref "/docs/pipeline-stages/builders/ko" >}}) | - | - |
 | **Custom Script** | [Yes]({{<relref "/docs/pipeline-stages/builders/custom#custom-build-script-locally" >}}) | [Yes]({{<relref "/docs/pipeline-stages/builders/custom#custom-build-script-in-cluster" >}}) | - |
 
 **Configuration**

--- a/docs/content/en/docs/pipeline-stages/builders/ko.md
+++ b/docs/content/en/docs/pipeline-stages/builders/ko.md
@@ -85,7 +85,7 @@ is `linux/amd64`, but you can configure a list of platforms using the
       - linux/arm64
 ```
 
-You can also supply `[all]` as the value of `platforms`. `all` means that the
+You can also supply `["all"]` as the value of `platforms`. `all` means that the
 ko builder builds images for all platforms supported by the base image.
 
 ### Labels / annotations
@@ -346,8 +346,9 @@ build:
 [`skaffold debug`]({{< relref "/docs/references/cli#skaffold-debug" >}})
 can debug images built using `ko`.
 
-Images built using `ko` are identified as Go apps by the presence of the
-`KO_DATA_PATH` environment variable.
+Images built using `ko` are automatically identified as Go apps by the presence
+of the
+[`KO_DATA_PATH` environment variable](https://github.com/google/ko#static-assets).
 
 ### File sync
 

--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -106,6 +106,9 @@ Go-based applications are configured to run under [Delve](https://github.com/go-
 Go-based container images are recognized by:
 - the presence of one of the [standard Go runtime environment variables](https://godoc.org/runtime):
   `GODEBUG`, `GOGC`, `GOMAXPROCS`, or `GOTRACEBACK`, or
+- the presence of the
+  [`KO_DATA_PATH` environment variable](https://github.com/google/ko#static-assets)
+  in container images built by [`ko`]({{< relref "/docs/pipeline-stages/builders/ko" >}}), or
 - is launching using `dlv`.
 
 Virtually all container images will need to set one of the Go environment variables.


### PR DESCRIPTION
Explain that images built by `ko` are detected as Go apps for debugging automatically, by the presence of the `KO_DATA_PATH` envvar.

Also a couple of other minor doc updates for the ko builder.

Tracking: #6041
