### PR TITLE
fix(ko): Display correct tag for sideloaded images

### DIFF
--- a/integration/ko_test.go
+++ b/integration/ko_test.go
@@ -70,7 +70,8 @@ func TestBuildAndPushKoImageProgrammatically(t *testing.T) {
 		Workspace: exampleAppDir,
 	}
 	imageName := fmt.Sprintf("%s/%s", registryAddr, "skaffold-ko")
-	digest, err := b.Build(context.Background(), &imageFullNameBuffer, artifact, imageName)
+	imageNameWithTag := fmt.Sprintf("%s:%s", imageName, "latest")
+	digest, err := b.Build(context.Background(), &imageFullNameBuffer, artifact, imageNameWithTag)
 	if err != nil {
 		t.Fatalf("b.Build(): %+v", err)
 	}

--- a/pkg/skaffold/build/ko/build.go
+++ b/pkg/skaffold/build/ko/build.go
@@ -52,7 +52,13 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, a *latestV1.Artifact
 	if err != nil {
 		return "", fmt.Errorf("could not build and publish ko image %q: %w", a.ImageName, err)
 	}
-	fmt.Fprintln(out, imageRef.Name())
+
+	outputRef := ref
+	if strings.HasSuffix(ref, ":latest") {
+		// handle tagPolicy sha256
+		outputRef = imageRef.Name()
+	}
+	fmt.Fprintln(out, outputRef)
 
 	return b.getImageIdentifier(ctx, imageRef, ref)
 }


### PR DESCRIPTION
Display the expected tag after successfully building a ko image, for both sideloaded and published images.

Also handles the `tagPolicy.sha256` scenarios.

Fixes: #6835
Tracking: #6041
