### PR TITLE
docs(ko): Shorter example values in config schema

### DIFF
--- a/docs/content/en/schemas/v2beta26.json
+++ b/docs/content/en/schemas/v2beta26.json
@@ -2520,7 +2520,7 @@
           "x-intellij-html-description": "environment variables, in the <code>key=value</code> form, passed to the build. These environment variables are only used at build time. They are <em>not</em> set in the resulting container image.",
           "default": "[]",
           "examples": [
-            "[\"GOPRIVATE=source.developers.google.com\", \"GOCACHE=/workspace/.gocache\"]"
+            "[\"GOPRIVATE=git.example.com\", \"GOCACHE=/workspace/.gocache\"]"
           ]
         },
         "flags": {
@@ -2549,7 +2549,7 @@
           "x-intellij-html-description": "key-value string pairs to add to the image config.",
           "default": "{}",
           "examples": [
-            "{\"org.opencontainers.image.source\":\"https://github.com/GoogleContainerTools/skaffold\"}"
+            "{\"foo\":\"bar\"}"
           ]
         },
         "ldflags": {

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -1358,7 +1358,7 @@ type KoArtifact struct {
 	// Env are environment variables, in the `key=value` form, passed to the build.
 	// These environment variables are only used at build time.
 	// They are _not_ set in the resulting container image.
-	// For example: `["GOPRIVATE=source.developers.google.com", "GOCACHE=/workspace/.gocache"]`.
+	// For example: `["GOPRIVATE=git.example.com", "GOCACHE=/workspace/.gocache"]`.
 	Env []string `yaml:"env,omitempty"`
 
 	// Flags are additional build flags passed to `go build`.
@@ -1366,7 +1366,7 @@ type KoArtifact struct {
 	Flags []string `yaml:"flags,omitempty"`
 
 	// Labels are key-value string pairs to add to the image config.
-	// For example: `{"org.opencontainers.image.source":"https://github.com/GoogleContainerTools/skaffold"}`.
+	// For example: `{"foo":"bar"}`.
 	Labels map[string]string `yaml:"labels,omitempty"`
 
 	// Ldflags are linker flags passed to the builder.


### PR DESCRIPTION
Shorten the example values in the config schema. This fixes the issue on the `skaffold.yaml` reference page of the website, where long example values push the descriptions to a very narrow space on the page, making them hard to read.

Tracking: #6041
