### PR TITLE
fix: `deploy --skip-render` not applying skaffold labels, causes status check to not work

### DIFF
--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -191,6 +191,11 @@ func (k *Deployer) Deploy(ctx context.Context, out io.Writer, builds []graph.Art
 	case k.skipRender:
 		childCtx, endTrace = instrumentation.StartTrace(ctx, "Deploy_readManifests")
 		manifests, err = k.readManifests(childCtx, false)
+		if err != nil {
+			endTrace(instrumentation.TraceEndError(err))
+			return err
+		}
+		manifests, err = manifests.SetLabels(k.labeller.Labels())
 		endTrace()
 	default:
 		childCtx, endTrace = instrumentation.StartTrace(ctx, "Deploy_renderManifests")


### PR DESCRIPTION

<!-- Include if applicable: -->
**Related**: https://github.com/GoogleContainerTools/skaffold/pull/6674

`skaffold deploy` invoked with the `--skip-render` flag should still apply skaffold labels so that status checker can function correctly.