### PR TITLE
fix: make kcc status-check less aggressive

### DIFF
--- a/integration/testdata/apply/skaffold.yaml
+++ b/integration/testdata/apply/skaffold.yaml
@@ -12,4 +12,5 @@ profiles:
   - name: configconnector
     deploy:
       kubectl:
+        statusCheckDeadlineSeconds: 10
         manifests: ["configconnector.yaml"]

--- a/pkg/diag/validator/config_connector.go
+++ b/pkg/diag/validator/config_connector.go
@@ -69,16 +69,11 @@ func getResourceStatus(res unstructured.Unstructured) (kstatus.Status, *proto.Ac
 	case kstatus.CurrentStatus:
 		ae = proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_SUCCESS}
 	case kstatus.InProgressStatus:
-		if result.Message == "" {
-			ae = proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_CONFIG_CONNECTOR_IN_PROGRESS, Message: result.Message}
-		} else {
-			// TODO: config connector resource status doesn't distinguish between resource that is making progress towards reconciling from one that is doomed.
-			// This is tracked in b/187759279 internally. As such to avoid stalling the status check phase until timeout in case of a failed resource,
-			// we report an error if there's any message reported without the status being success. This can cause skaffold to fail even when resources
-			// are rightly in an InProgress state, say while adding new nodes.
-			ae = proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_CONFIG_CONNECTOR_FAILED, Message: result.Message}
-		}
-
+		// TODO: config connector resource status doesn't distinguish between resource that is making progress towards reconciling from one that is doomed.
+		// This is tracked in b/187759279 internally. As such to avoid stalling the status check phase until timeout in case of a failed resource,
+		// we report an error if there's any message reported without the status being success. This can cause skaffold to fail even when resources
+		// are rightly in an InProgress state, say while adding new nodes.
+		ae = proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_CONFIG_CONNECTOR_IN_PROGRESS, Message: result.Message}
 	case kstatus.FailedStatus:
 		ae = proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_CONFIG_CONNECTOR_FAILED, Message: result.Message}
 	case kstatus.TerminatingStatus:

--- a/pkg/diag/validator/config_connector_test.go
+++ b/pkg/diag/validator/config_connector_test.go
@@ -56,23 +56,23 @@ func TestConfigConnectorValidator(t *testing.T) {
 			},
 		},
 		{
-			description: "resource failed",
+			description: "resource in progress with message",
 			status: map[string]interface{}{
 				"status":  "False",
 				"type":    "Ready",
-				"message": "error",
+				"message": "waiting on dependency",
 			},
 			expected: []Resource{
 				{
 					kind:   "bar",
 					name:   "foo1",
 					status: "InProgress",
-					ae:     &proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_CONFIG_CONNECTOR_FAILED, Message: "error"},
+					ae:     &proto.ActionableErr{ErrCode: proto.StatusCode_STATUSCHECK_CONFIG_CONNECTOR_IN_PROGRESS, Message: "waiting on dependency"},
 				},
 			},
 		},
 		{
-			description: "resource in progress",
+			description: "resource in progress without message",
 			status: map[string]interface{}{
 				"status": "False",
 				"type":   "Ready",


### PR DESCRIPTION
Fixes #6842
We cannot reliably use `message` field to determine if the resource has failed deployment. We're making it less aggressive.


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
