### PR TITLE
docs(debug): Improve Go debugging documentation

### DIFF
--- a/docs/content/en/docs/pipeline-stages/builders/ko.md
+++ b/docs/content/en/docs/pipeline-stages/builders/ko.md
@@ -327,7 +327,7 @@ To build images in parallel, consider setting the `SKAFFOLD_BUILD_CONCURRENCY`
 environment variable value to `0`:
 
 ```shell
-SKAFFOLD_BUILD_CONCURRENCY=0 skaffold render [...]
+SKAFFOLD_BUILD_CONCURRENCY=0 skaffold [...]
 ```
 
 You can also set the concurrency value in your `skaffold.yaml`:
@@ -349,6 +349,20 @@ can debug images built using `ko`.
 Images built using `ko` are automatically identified as Go apps by the presence
 of the
 [`KO_DATA_PATH` environment variable](https://github.com/google/ko#static-assets).
+
+Skaffold configures `ko` to build with compiler optimizations and inlining
+disabled (`-gcflags='all=-N -l'`) when you run `skaffold debug` or use
+Cloud Code to
+[debug a Kubernetes application](https://cloud.google.com/code/docs/vscode/debug).
+
+If you debug using VS Code and need to configure a "remote path" or "path on
+remote container", then this value should match your local path, typically
+`${workspaceFolder}`. The reason is that "remote path" in this case means the
+path to your Go source code where it was compiled. The `ko` builder currently
+only supports `local` builds, so the remote path will be same as the local path.
+
+To learn more about how Skaffold debugs Go applications, read the
+[Go section in the Debugging guide]({{< relref "/docs/workflows/debug#go-runtime-go-protocols-dlv" >}}).
 
 ### File sync
 

--- a/integration/examples/ko/README.md
+++ b/integration/examples/ko/README.md
@@ -1,7 +1,8 @@
 ### Example: ko builder
 
-This is an example demonstrating building a Go app with the
-[ko](https://github.com/google/ko) builder.
+This example uses the
+[`ko` builder](https://skaffold.dev/docs/pipeline-stages/builders/ko/)
+to build a container image for a Go app.
 
 The included [Cloud Build](https://cloud.google.com/build/docs) configuration
 file shows how users can set up a simple pipeline using `skaffold build` and

--- a/integration/examples/ko/main.go
+++ b/integration/examples/ko/main.go
@@ -24,11 +24,10 @@ import (
 
 func main() {
 	http.HandleFunc("/", hello)
-
 	log.Println("Listening on port 8080")
 	http.ListenAndServe(":8080", nil)
 }
 
 func hello(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Hello, World!")
+	fmt.Fprintln(w, "Hello, World!")
 }

--- a/integration/examples/ko/skaffold.yaml
+++ b/integration/examples/ko/skaffold.yaml
@@ -17,4 +17,6 @@ kind: Config
 build:
   artifacts:
   - image: skaffold-ko
-    ko: {}
+    ko:
+      flags:
+      - -v


### PR DESCRIPTION
Update explanation of how Go debugging works in Skaffold and add explanations for `ko` builder users.

Also update links to the VS Code Go extension.

Related: #6843
Tracking: #6041
