### PR TITLE
fix: add diagnostic severity info to skaffold lint rules

### DIFF
--- a/pkg/skaffold/lint/dockerfiles.go
+++ b/pkg/skaffold/lint/dockerfiles.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	"github.com/moby/buildkit/frontend/dockerfile/command"
+	"go.lsp.dev/protocol"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
@@ -38,12 +39,13 @@ var DockerfileLinters = []Linter{
 
 var dockerfileLintRules = []Rule{
 	{
+		RuleID:   DockerfileCopyOver1000Files,
 		RuleType: DockerfileCommandLintRule,
+		Severity: protocol.DiagnosticSeverityWarning,
 		Filter: DockerCommandFilter{
 			DockerCommand:          command.Copy,
 			DockerCopySourceRegExp: `.*`,
 		},
-		RuleID: DockerfileCopyOver1000Files,
 		ExplanationTemplate: `Found docker 'COPY' command where the source directory "{{index .FieldMap "src"}}" has over 1000 files.  This has the potential to dramatically slow 'skaffold dev' down ` +
 			`as skaffold watches all sources files referenced in dockerfile COPY directives for changes. ` +
 			`If you notice skaffold rebuilding images unnecessarily when non-image-critical files are ` +
@@ -66,12 +68,13 @@ var dockerfileLintRules = []Rule{
 		}},
 	},
 	{
+		RuleID:   DockerfileCopyContainsGitDir,
 		RuleType: DockerfileCommandLintRule,
+		Severity: protocol.DiagnosticSeverityWarning,
 		Filter: DockerCommandFilter{
 			DockerCommand:          command.Copy,
 			DockerCopySourceRegExp: `.*`,
 		},
-		RuleID: DockerfileCopyContainsGitDir,
 		// TODO(aaron-prindle) suggest a full .dockerignore sample - .dockerignore:**/.git
 		ExplanationTemplate: `Found docker 'COPY' command where the source directory "{{index .FieldMap "src"}}" contains a '.git' directory at {{index .FieldMap "gitDirectoryAbsPath"}}.  This has the potential to dramatically slow 'skaffold dev' down ` +
 			`as skaffold will watch all of the files in the .git directory as skaffold watches all sources files referenced in dockerfile COPY directives for changes. ` +

--- a/pkg/skaffold/lint/k8smanifests.go
+++ b/pkg/skaffold/lint/k8smanifests.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"go.lsp.dev/protocol"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
@@ -38,12 +39,13 @@ var K8sManifestLinters = []Linter{
 
 var k8sManifestLintRules = []Rule{
 	{
+		RuleID:   K8sManifestManagedByLabelInUse,
+		RuleType: YamlFieldLintRule,
+		Severity: protocol.DiagnosticSeverityWarning,
 		Filter: YamlFieldFilter{
 			Filter:     yaml.Lookup("metadata", "labels"),
 			FieldMatch: "app.kubernetes.io/managed-by",
 		},
-		RuleID:   K8sManifestManagedByLabelInUse,
-		RuleType: YamlFieldLintRule,
 		ExplanationTemplate: "Found usage of label 'app.kubernetes.io/managed-by'.  skaffold overwrites the 'app.kubernetes.io/managed-by' field to 'app.kubernetes.io/managed-by: skaffold'. " +
 			"and as such is recommended to remove this label",
 	},

--- a/pkg/skaffold/lint/skaffoldyamls.go
+++ b/pkg/skaffold/lint/skaffoldyamls.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"go.lsp.dev/protocol"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -59,6 +60,7 @@ var skaffoldYamlLintRules = []Rule{
 	{
 		RuleID:   SkaffoldYamlAPIVersionOutOfDate,
 		RuleType: YamlFieldLintRule,
+		Severity: protocol.DiagnosticSeverityWarning,
 		Filter: YamlFieldFilter{
 			Filter: yaml.FieldMatcher{Name: "apiVersion", StringRegexValue: fmt.Sprintf("[^%s]", version.Get().ConfigVersion)},
 		},
@@ -68,6 +70,7 @@ var skaffoldYamlLintRules = []Rule{
 	{
 		RuleID:   SkaffoldYamlUseStaticPort,
 		RuleType: YamlFieldLintRule,
+		Severity: protocol.DiagnosticSeverityWarning,
 		Filter: YamlFieldFilter{
 			Filter:      yaml.FieldMatcher{Name: "portForward"},
 			InvertMatch: true,


### PR DESCRIPTION
Adds diagnostic severity info the skaffold lint rules that `skaffold lint` emits.  This is passed onto the skaffold lsp to be displayed correctly in an IDE.  Currently all of the lint rules are at `Warning` level which is yellow in the IDE.  There are the following severity types (from - https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#diagnosticSeverity):
- Error (red underline, shows up in `Problems section`)
- Warning (yellow underline, maybe shows up in Problems section?)
- Info (blue underline)
- Hint (subtle ellipses underline at the beginning area)