### PR TITLE
feat(lsp): add new command skaffold lsp and working lsp functionality w/ lint rules

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -196,6 +196,7 @@ func NewSkaffoldCommand(out, errOut io.Writer) *cobra.Command {
 	rootCmd.AddCommand(NewCmdSurvey())
 	rootCmd.AddCommand(NewCmdInspect())
 	rootCmd.AddCommand(NewCmdLint())
+	rootCmd.AddCommand(NewCmdLSP())
 
 	templates.ActsAsRootCommand(rootCmd, nil, groups...)
 	rootCmd.PersistentFlags().StringVarP(&v, "verbosity", "v", log.DefaultLogLevel.String(), fmt.Sprintf("Log level: one of %v", log.AllLevels))

--- a/cmd/skaffold/app/cmd/lsp.go
+++ b/cmd/skaffold/app/cmd/lsp.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"go.lsp.dev/jsonrpc2"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/lsp"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
+)
+
+var port int
+
+func NewCmdLSP() *cobra.Command {
+	return NewCmd("lsp").
+		WithDescription("Starts skaffold LSP language server that provides lint suggestions to IDEs").
+		WithCommonFlags().
+		WithFlags([]*Flag{
+			{Value: &port, Name: "port", DefValue: 4389,
+				Usage: "port number that the skaffold lsp will expose for connections, '4389' is the default port value"}}).
+		Hidden().
+		NoArgs(doLSP)
+}
+
+func doLSP(ctx context.Context, out io.Writer) error {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		for sig := range c {
+			if sig == os.Interrupt {
+				os.Exit(0)
+			}
+		}
+	}()
+	// TODO(aaron-prindle) plumb context based termination as well on os.Kill and os.Interrupt
+	addr := "localhost:" + strconv.Itoa(port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		log.Entry(ctx).Fatalf("Could not bind to address %s: %v", addr, err)
+	}
+	defer listener.Close()
+
+	fmt.Fprintf(out, "skaffold lsp listening for TCP connections on: %v\n", addr)
+	connectionCount := 0
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Entry(ctx).Fatalf("encountered error attempting to accept tcp connection: %v", err)
+		}
+		connectionCount++
+		log.Entry(ctx).Infof("skaffold lsp received incoming connection #%d\n", connectionCount)
+		stream := jsonrpc2.NewStream(conn)
+		jsonConn := jsonrpc2.NewConn(stream)
+		jsonConn.Go(ctx, lsp.GetHandler(jsonConn, out, opts, createRunner))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,8 @@ require (
 	github.com/tektoncd/pipeline v0.5.1-0.20190731183258-9d7e37e85bf8
 	github.com/xeipuuv/gojsonschema v1.2.0
 	go.lsp.dev/protocol v0.11.2
+	go.lsp.dev/jsonrpc2 v0.9.0
+	go.lsp.dev/uri v0.3.0
 	go.opentelemetry.io/otel v0.20.0
 	go.opentelemetry.io/otel/exporters/stdout v0.20.0
 	go.opentelemetry.io/otel/exporters/trace/jaeger v0.20.0

--- a/pkg/skaffold/lsp/document_manager.go
+++ b/pkg/skaffold/lsp/document_manager.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lsp
+
+import (
+	"sync"
+)
+
+// DocumentManager manages syncing documents for the LSP server
+type DocumentManager struct {
+	documents map[string]string
+	mtx       sync.RWMutex
+}
+
+// NewDocumentManager creates a new DocumentManager object
+func NewDocumentManager() *DocumentManager {
+	return &DocumentManager{
+		documents: make(map[string]string),
+	}
+}
+
+// UpdateDocument updates the string value for a document
+func (m *DocumentManager) UpdateDocument(documentURI string, doc string) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	m.documents[documentURI] = doc
+}
+
+// GetDocument gets the string value for a document
+func (m *DocumentManager) GetDocument(documentURI string) string {
+	m.mtx.RLock()
+	defer m.mtx.RUnlock()
+	if doc, ok := m.documents[documentURI]; ok {
+		return doc
+	}
+	return ""
+}

--- a/pkg/skaffold/lsp/handler.go
+++ b/pkg/skaffold/lsp/handler.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"runtime/debug"
+
+	"go.lsp.dev/jsonrpc2"
+	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/lint"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
+)
+
+var h Handler
+
+// Handler is the server handler for the skaffold LSP.  It implements the LSP spec and supports connection over TCP
+type Handler struct {
+	documentManager *DocumentManager
+	diagnostics     map[string][]protocol.Diagnostic
+	initialized     bool
+	conn            jsonrpc2.Conn
+}
+
+// NewHandler initializes a new Handler object
+func NewHandler(conn jsonrpc2.Conn) *Handler {
+	return &Handler{
+		initialized:     false,
+		documentManager: NewDocumentManager(),
+		conn:            conn,
+	}
+}
+
+func GetHandler(conn jsonrpc2.Conn, out io.Writer, opts config.SkaffoldOptions, createRunner func(ctx context.Context, out io.Writer, opts config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error)) jsonrpc2.Handler {
+	var runCtx *runcontext.RunContext
+	h = *NewHandler(conn)
+
+	return func(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+		// Recover if a panic occurs in the handlers
+		defer func() {
+			err := recover()
+			if err != nil {
+				log.Entry(ctx).Errorf("recovered from panic at %s: %v\n", req.Method(), err)
+				log.Entry(ctx).Errorf("stacktrace from panic: \n" + string(debug.Stack()))
+			}
+		}()
+		log.Entry(ctx).Debugf("req.Method():  %q\n", req.Method())
+		switch req.Method() {
+		case protocol.MethodInitialize:
+			var params protocol.InitializeParams
+			json.Unmarshal(req.Params(), &params)
+			log.Entry(ctx).Debugf("InitializeParams: %+v\n", params)
+			log.Entry(ctx).Debugf("InitializeParams.Capabilities.TextDocument: %+v\n", params.Capabilities.TextDocument)
+			// TODO(aaron-prindle) currently this only supports workspaces of length one (or the first of the list of workspaces)
+			// This used to be a single workspace field/value before lsp spec changes and I only know how to open one workspace per
+			// session in VSCode atm so this should be ok initially
+			if len(params.WorkspaceFolders) == 0 {
+				return fmt.Errorf("expected WorkspaceFolders to have at least one value, got 0")
+			}
+			err := os.Chdir(uriToFilename(uri.URI(params.WorkspaceFolders[0].URI)))
+			if err != nil {
+				return err
+			}
+			_, _, runCtx, err = createRunner(ctx, out, opts)
+			if err != nil {
+				return err
+			}
+
+			// TODO(aaron-prindle) might need some checks to verify the initialize requests supports these,
+			// right now assuming VS Code w/ supported methods - seems like an ok assumption for now
+			if err := reply(ctx, protocol.InitializeResult{
+				Capabilities: protocol.ServerCapabilities{
+					TextDocumentSync: protocol.TextDocumentSyncOptions{
+						Change:    protocol.TextDocumentSyncKindFull,
+						OpenClose: true,
+						Save: &protocol.SaveOptions{
+							IncludeText: true,
+						},
+					},
+				},
+			}, nil); err != nil {
+				return err
+			}
+			h.initialized = true
+			return nil
+		case protocol.MethodInitialized:
+			var params protocol.InitializedParams
+			json.Unmarshal(req.Params(), &params)
+			log.Entry(ctx).Debugf("InitializedParams: %+v\n", params)
+			if err := lintFilesAndSendDiagnostics(ctx, runCtx, opts, req); err != nil {
+				return err
+			}
+			return nil
+		}
+		if !h.initialized {
+			reply(ctx, nil, jsonrpc2.Errorf(jsonrpc2.ServerNotInitialized, "not initialized yet"))
+			return nil
+		}
+
+		switch req.Method() {
+		case protocol.MethodTextDocumentDidOpen:
+			var params protocol.DidOpenTextDocumentParams
+			json.Unmarshal(req.Params(), &params)
+			log.Entry(ctx).Debugf("DidOpenTextDocumentParams: %+v\n", params)
+			documentURI := uriToFilename(params.TextDocument.URI)
+			if documentURI != "" {
+				if err := h.updateDocument(ctx, documentURI, params.TextDocument.Text); err != nil {
+					return err
+				}
+				if err := lintFilesAndSendDiagnostics(ctx, runCtx, opts, req); err != nil {
+					return err
+				}
+			}
+		case protocol.MethodTextDocumentDidChange:
+			var params protocol.DidChangeTextDocumentParams
+			json.Unmarshal(req.Params(), &params)
+			log.Entry(ctx).Debugf("DidChangeTextDocumentParams: %+v\n", params)
+			documentURI := uriToFilename(params.TextDocument.URI)
+			if documentURI != "" && len(params.ContentChanges) > 0 {
+				if err := h.updateDocument(ctx, documentURI, params.ContentChanges[0].Text); err != nil {
+					return err
+				}
+				if err := lintFilesAndSendDiagnostics(ctx, runCtx, opts, req); err != nil {
+					return err
+				}
+			}
+		case protocol.MethodTextDocumentDidSave:
+			var params protocol.DidSaveTextDocumentParams
+			json.Unmarshal(req.Params(), &params)
+			log.Entry(ctx).Debugf("DidSaveTextDocumentParams: %+v\n", params)
+			documentURI := uriToFilename(params.TextDocument.URI)
+			if documentURI != "" {
+				if err := h.updateDocument(ctx, documentURI, params.Text); err != nil {
+					return err
+				}
+				if err := lintFilesAndSendDiagnostics(ctx, runCtx, opts, req); err != nil {
+					return err
+				}
+			}
+		// TODO(aaron-prindle) implement additional methods here - eg: lsp.MethodTextDocumentHover, etc.
+		default:
+			return nil
+		}
+		return nil
+	}
+}
+
+func (h *Handler) updateDocument(ctx context.Context, documentURI, content string) error {
+	h.documentManager.UpdateDocument(documentURI, content)
+	log.Entry(ctx).Debugf("updated document for %q with %d chars\n", documentURI, len(content))
+	return nil
+}
+
+func lintFilesAndSendDiagnostics(ctx context.Context, runCtx docker.Config,
+	opts config.SkaffoldOptions, req jsonrpc2.Request) error {
+	// TODO(aaron-prindle) currently lint checks only filesystem, instead need to check VFS w/ documentManager info
+	results, err := lint.GetAllLintResults(ctx, lint.Options{
+		Filename:     opts.ConfigurationFile,
+		RepoCacheDir: opts.RepoCacheDir,
+		OutFormat:    lint.PlainTextOutput,
+		Modules:      opts.ConfigurationFilter,
+		Profiles:     opts.Profiles,
+	}, runCtx)
+
+	if err != nil {
+		return err
+	}
+
+	var params protocol.TextDocumentPositionParams
+	json.Unmarshal(req.Params(), &params)
+	tmpDiags := make(map[string][]protocol.Diagnostic)
+	for _, result := range results {
+		diag := protocol.Diagnostic{
+			Range: protocol.Range{
+				Start: protocol.Position{Line: uint32(result.Line - 1), Character: uint32(result.Column - 1)},
+				// TODO(aaron-prindle) should implement and pass end range from lint as well (currently a hack and just flags to end of line vs end of flagged text)
+				End: protocol.Position{Line: uint32(result.Line), Character: 0},
+			},
+			Severity: result.Rule.Severity,
+			Code:     result.Rule.RuleID,
+			Source:   result.AbsFilePath,
+			Message:  result.Explanation,
+		}
+		if _, ok := tmpDiags[result.AbsFilePath]; ok {
+			tmpDiags[result.AbsFilePath] = append(tmpDiags[result.AbsFilePath], diag)
+			continue
+		}
+		tmpDiags[result.AbsFilePath] = []protocol.Diagnostic{diag}
+	}
+	h.diagnostics = tmpDiags
+
+	if h.diagnostics != nil && len(h.diagnostics) > 0 {
+		fmt.Fprintf(os.Stderr, "publishing diagnostics (%d).\n", len(h.diagnostics))
+		for k, v := range h.diagnostics {
+			fmt.Fprintf(os.Stderr, "> %s\n", k)
+			h.conn.Notify(ctx, protocol.MethodTextDocumentPublishDiagnostics, protocol.PublishDiagnosticsParams{
+				URI:         uri.File(k),
+				Diagnostics: v,
+			})
+		}
+		h.diagnostics = map[string][]protocol.Diagnostic{}
+	}
+	return nil
+}

--- a/pkg/skaffold/lsp/handler_test.go
+++ b/pkg/skaffold/lsp/handler_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"os"
+	"reflect"
+	"testing"
+
+	"go.lsp.dev/jsonrpc2"
+	"go.lsp.dev/protocol"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+type callTest struct {
+	description string
+	method      string
+	params      interface{}
+	expected    interface{}
+}
+
+var callTests = []callTest{
+	{
+		description: "verify lsp 'initialize' method returns expected results",
+		method:      protocol.MethodInitialize,
+		params: protocol.InitializeParams{
+			WorkspaceFolders: []protocol.WorkspaceFolder{
+				{
+					URI:  "overwritten by test",
+					Name: "test name",
+				},
+			},
+			Capabilities: protocol.ClientCapabilities{
+				TextDocument: &protocol.TextDocumentClientCapabilities{
+					// TODO(aaron-prindle) make sure the values here make sense (similar to VSCode, hit more edge cases (missing capability, versioning, old fields), etc.)
+					PublishDiagnostics: &protocol.PublishDiagnosticsClientCapabilities{
+						RelatedInformation: true,
+						TagSupport: &protocol.PublishDiagnosticsClientCapabilitiesTagSupport{
+							ValueSet: []protocol.DiagnosticTag{protocol.DiagnosticTagDeprecated},
+						},
+						VersionSupport:         true,
+						CodeDescriptionSupport: true,
+						DataSupport:            true,
+					},
+				},
+			},
+		},
+		expected: protocol.InitializeResult{
+			Capabilities: protocol.ServerCapabilities{
+				TextDocumentSync: protocol.TextDocumentSyncOptions{
+					Change:    protocol.TextDocumentSyncKindFull,
+					OpenClose: true,
+					Save: &protocol.SaveOptions{
+						IncludeText: true,
+					},
+				},
+			},
+		},
+	},
+	// TODO(aaron-prindle) add error cases and full set of functionality (textDocument/* reqs, etc.)
+}
+
+func TestRequest(t *testing.T) {
+	ctx := context.Background()
+	a, b, done := prepare(ctx, t)
+	defer done()
+	workdir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("error getting working directory: %v", err)
+	}
+	for _, test := range callTests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			// need to marshal and unmarshal to get proper formatting for matching as structs not represented identically w/o this for verification
+			expectedData, err := json.Marshal(test.expected)
+			if err != nil {
+				t.Fatalf("marshalling expected response to json failed: %v", err)
+			}
+			var expected protocol.InitializeResult
+			json.Unmarshal(expectedData, &expected)
+			test.expected = expected
+
+			params := test.params
+			if v, ok := test.params.(protocol.InitializeParams); ok {
+				v.WorkspaceFolders[0].URI = "file://" + workdir
+				params = v
+			}
+
+			results := test.newResults()
+			if _, err := a.Call(ctx, test.method, params, results); err != nil {
+				t.Fatalf("%v call failed: %v", test.method, err)
+			}
+
+			test.verifyResults(t.T, results)
+
+			if _, err := b.Call(ctx, test.method, params, results); err != nil {
+				t.Fatalf("%v call failed: %v", test.method, err)
+			}
+			test.verifyResults(t.T, results)
+		})
+	}
+}
+
+func (test *callTest) newResults() interface{} {
+	switch e := test.expected.(type) {
+	case []interface{}:
+		var r []interface{}
+		for _, v := range e {
+			r = append(r, reflect.New(reflect.TypeOf(v)).Interface())
+		}
+		return r
+
+	case nil:
+		return nil
+
+	default:
+		return reflect.New(reflect.TypeOf(test.expected)).Interface()
+	}
+}
+
+func (test *callTest) verifyResults(t *testing.T, results interface{}) {
+	t.Helper()
+
+	if results == nil {
+		return
+	}
+
+	val := reflect.Indirect(reflect.ValueOf(results)).Interface()
+	if !reflect.DeepEqual(val, test.expected) {
+		t.Errorf("%v results are incorrect, got %+v expect %+v", test.method, val, test.expected)
+	}
+}
+
+func prepare(ctx context.Context, t *testing.T) (a, b jsonrpc2.Conn, done func()) {
+	t.Helper()
+
+	// make a wait group that can be used to wait for the system to shut down
+	aPipe, bPipe := net.Pipe()
+	a = run(ctx, aPipe)
+	b = run(ctx, bPipe)
+	done = func() {
+		a.Close()
+		b.Close()
+		<-a.Done()
+		<-b.Done()
+	}
+
+	return a, b, done
+}
+
+func run(ctx context.Context, nc io.ReadWriteCloser) jsonrpc2.Conn {
+	stream := jsonrpc2.NewStream(nc)
+	conn := jsonrpc2.NewConn(stream)
+	conn.Go(ctx, GetHandler(conn, nil, config.SkaffoldOptions{}, func(ctx context.Context, out io.Writer, opts config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+		return nil, nil, nil, nil
+	}))
+
+	return conn
+}

--- a/pkg/skaffold/lsp/util.go
+++ b/pkg/skaffold/lsp/util.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lsp
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	"go.lsp.dev/uri"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
+)
+
+const gitPrefix = "git:/"
+
+func uriToFilename(v uri.URI) string {
+	s := string(v)
+	fixed, ok := fixURI(s)
+
+	if !ok {
+		unescaped, err := url.PathUnescape(s)
+		if err != nil {
+			log.Entry(context.TODO()).Warnf("Unsupported URI (not a filepath): %q\n", s)
+		} else {
+			log.Entry(context.TODO()).Warnf("Unsupported URI (not a filepath): %q\n", unescaped)
+		}
+		return ""
+	}
+	v = uri.URI(fixed)
+
+	return v.Filename()
+}
+
+// workaround for unsupported file paths (git + invalid file://-prefix )
+func fixURI(s string) (string, bool) {
+	if strings.HasPrefix(s, gitPrefix) {
+		return "file:///" + s[len(gitPrefix):], true
+	}
+	if !strings.HasPrefix(s, "file:///") {
+		// VS Code sends URLs with only two slashes, which are invalid. golang/go#39789.
+		if strings.HasPrefix(s, "file://") {
+			return "file:///" + s[len("file://"):], true
+		}
+		return "", false
+	}
+	return s, true
+}


### PR DESCRIPTION
This PR adds a new command `skaffold lsp` which runs a skaffold lsp language server on the specified `--port` (default is `--port`=`:4389`).  Currently the `skaffold lsp` supports syncing text documents (textDocument/DidOpen, etc.) and sending [Diagnostics](https://microsoft.github.io/language-server-protocol/specification#diagnostic) to an LSP client/IDE (for example VSCode).  These diagnostics are wired up to the linting logic from `skaffold lint` such that those lint rules are displayed and correctly updated as files are opened/modified in the IDE when the skaffold LSP is running and wired up to an IDE.  My current development approach for setting a working client + server for VSCode is as follows.
- Requirements
    - Pull down my branch `skaffold-lsp` for https://github.com/aaron-prindle/vscode-extension-samples (forked from https://github.com/microsoft/vscode-extension-samples)
```
$ git checkout git@github.com:aaron-prindle/vscode-extension-samples.git
$ cd  vscode-extension-samples
$ git checkout skaffold-lsp
```
- Start the `skaffold lsp` server (likely w/ debugging set to help w/ any issues)- NOTE: to use the flow recommended here use the default `--port`=`:4389` value as the client is setup to use that value.  Other values will not work unless you modify the port in `vscode-extension-samples` as well
```
$ skaffold lsp -v debug
```
- Navigate to vscode-extension-samples/lsp-sample in the git directory you cloned, build the configured VSCode LSP language client and then start a new VSCode session from that dir:
```
$ cd vscode-extension-samples/lsp-sample # or cd lsp-sample
$ npm install
$ npm run compile
$ code .
$ code . # launch VSCode using this dir as the working directory
```
- With VSCode open and your workspace as `vscode-extension-samples/lsp-sample`, start a debugging session:
![image](https://user-images.githubusercontent.com/1951658/142288952-a7be1f43-33ad-4238-a5c8-d0c085fc5cbe.png)

- This will open a new VSCode window
    - This new VSCode window will create an LSP Language Client that will connect to the skaffold LSP language server.  From the new VSCode window, change the workspace to something like `skaffold/examples/microservices` and change the API version to something old `s/v2beta26/v2beta20` and you should see some lint message!
![image](https://user-images.githubusercontent.com/1951658/142289493-a7346e3f-cd26-4af9-99c3-16fbfd49f7e3.png)

Current known issues:
- Currently skaffold lint only looks at files in the filesystem.  While the LSP properly handles getting text updates from the LSP client via textDocument/* methods, the lint logic uses the direct filesystem and not the files in the LSP buffer.  Future work will include adding virtual filesystem support to the lint logic and then using the files from the LSP server to populate the VFS in between lint runs