### PR TITLE
doc: address newcomer confusion when joining k8s slack channel

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -104,7 +104,10 @@ breadcrumb_disable = false
 	icon = "fab fa-github"
 [[params.links.developer]]
 	name = "Slack"
-	url = "https://kubernetes.slack.com/messages/CABQMSZA6/"
+        # don't link to the slack channel as the join process is
+        # confusing for newcomers
+	#url = "https://kubernetes.slack.com/messages/CABQMSZA6/"
+	url = "/docs/resources/#community"
 	icon = "fab fa-slack"
 [[params.links.developer]]
 	name = "Mailing List"
@@ -133,6 +136,6 @@ breadcrumb_disable = false
 	[[menu.main]]
 		identifier = "slack"
 		pre = "<i class='fab fa-slack'></i>"
-		url = "https://kubernetes.slack.com/messages/CABQMSZA6/"
+                url = "/docs/resources/#community"
 		icon = "fab fa-slack"
 		weight = -200

--- a/docs/content/en/docs/resources/_index.md
+++ b/docs/content/en/docs/resources/_index.md
@@ -10,14 +10,14 @@ no_list: true
 Join the Skaffold community and discuss the project at:
 
 * StackOverflow using the [`skaffold` tag](https://stackoverflow.com/questions/tagged/skaffold)
-* [Skaffold Mailing List]
-* [#Skaffold channel on Kubernetes Slack](https://kubernetes.slack.com/messages/CABQMSZA6/) (click on _Create an account_ to join)
-* [Give us feedback](feedback)
+* The [Skaffold Mailing List]
+* The [#Skaffold channel](https://kubernetes.slack.com/messages/CABQMSZA6/) on the Kubernetes Slack
+  (sign up at [slack.k8s.io](https://slack.k8s.io))
+* [Give us feedback](feedback)!
 
 The Skaffold Project also holds a monthly meeting on the last
 Wednesday of the month at 9:30am PST on [Google Meet](https://meet.google.com/tje-kwpx-ixv)!
-Everyone is welcome to attend!  If you join the [Skaffold Mailing List],
-a calendar invite will be sent to your Google Calendar.
+Everyone is welcome to attend! You will receive a calendar invite when you join the [Skaffold Mailing List].
 
 [Skaffold Mailing List]: https://groups.google.com/forum#!forum/skaffold-users
 


### PR DESCRIPTION
Change the docs boilerplate to refer to our _Resources > Community_ section for joining the `#skaffold` Slack channel as  the sign-up process is confusing for newcomers.