### PR TITLE
ci: update `deploy/cross/Dockerfile` to use `neilotoole/xcgo:go1.17` as base image

### DIFF
--- a/deploy/cross/Dockerfile
+++ b/deploy/cross/Dockerfile
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM dockercore/golang-cross:1.13.15 as base
-
-# Allow overriding the go toolchain version as required, though dockercore/golang-cross
-# only supports up to macOS 10.10, and Go 1.15 requires a later version.
-ARG GO_VERSION=1.14.14
-
-# The base image is not yet available for go 1.15.
-# Let's just replace the Go that's installed with a newer one.
-RUN rm -Rf /usr/local/go && mkdir /usr/local/go
-RUN curl --fail --show-error --silent --location https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz \
-    | tar xz --directory=/usr/local/go --strip-components=1
+FROM neilotoole/xcgo:go1.17 as base
 
 # Cross compile Skaffold for Linux, Windows and MacOS
 ARG GOOS


### PR DESCRIPTION
**Related**: https://github.com/GoogleContainerTools/skaffold/issues/6348

**Description**
This PR removes `dockercore/golang-cross` as the base image for our cross compilation Dockerfile, as this is limiting us to using `go 1.14`, which is pretty outdated at this point and is causing us issues with building skaffold. It now uses `neilotoole/xcgo:go1.17`, which currently uses `go 1.17.2`.

This image is quite a bit larger than our previous one (1.16 GB compared to 687 MB), but it will actually allow us to use newer versions of go