### PR TITLE
fix: correct English wording in error message

### DIFF
--- a/pkg/skaffold/build/build_problems.go
+++ b/pkg/skaffold/build/build_problems.go
@@ -136,7 +136,7 @@ func suggestBuildPushAccessDeniedAction(cfg interface{}) []*proto.Suggestion {
 
 	return []*proto.Suggestion{{
 		SuggestionCode: proto.SuggestionCode_ADD_DEFAULT_REPO,
-		Action:         "Trying running with `--default-repo` flag",
+		Action:         "Try running with `--default-repo` flag",
 	}}
 }
 

--- a/pkg/skaffold/build/build_problems_test.go
+++ b/pkg/skaffold/build/build_problems_test.go
@@ -60,13 +60,13 @@ func TestBuildProblems(t *testing.T) {
 		{
 			description: "Push access denied when neither default repo or global config is defined",
 			err:         fmt.Errorf("skaffold build failed: could not push image: denied: push access to resource"),
-			expected:    "Build Failed. No push access to specified image repository. Trying running with `--default-repo` flag.",
+			expected:    "Build Failed. No push access to specified image repository. Try running with `--default-repo` flag.",
 			expectedAE: &proto.ActionableErr{
 				ErrCode: proto.StatusCode_BUILD_PUSH_ACCESS_DENIED,
 				Message: "skaffold build failed: could not push image: denied: push access to resource",
 				Suggestions: []*proto.Suggestion{{
 					SuggestionCode: proto.SuggestionCode_ADD_DEFAULT_REPO,
-					Action:         "Trying running with `--default-repo` flag",
+					Action:         "Try running with `--default-repo` flag",
 				},
 				}},
 		},


### PR DESCRIPTION
Should be "Try running" instead of "Trying running."
