### PR TITLE
docs: add helpful message about `--default-repo`

### DIFF
--- a/examples/hot-reload/README.md
+++ b/examples/hot-reload/README.md
@@ -7,8 +7,11 @@ Application demonstrating the file synchronization mode with both NodeJS and Pyt
 #### Init
 
 ```bash
-skaffold dev
+skaffold dev [--default-repo docker.io/my-repo]
 ```
+
+You'll need to specify `--default-repo` to push to a repo you own.
+The default value for `--default-repo` is `docker.io/library/`.
 
 #### Workflow
 

--- a/examples/hot-reload/README.md
+++ b/examples/hot-reload/README.md
@@ -10,7 +10,7 @@ Application demonstrating the file synchronization mode with both NodeJS and Pyt
 skaffold dev [--default-repo docker.io/my-repo]
 ```
 
-You'll need to specify `--default-repo` to push to a repo you own.
+If you're not running against a local cluster like `minikube` or `kind`, then you'll need to specify the `--default-repo` flag to push to an image repository of your own.
 The default value for `--default-repo` is `docker.io/library/`.
 
 #### Workflow


### PR DESCRIPTION
to hot-reload example. Currently `skaffold dev` results in
the following errors (one for python-reload, one for node-example).

```
The push refers to repository [docker.io/library/python-reload]
...
Building [node-example]...
Canceled build for node-example
Build Failed. No push access to specified image repository. Trying running with `--default-repo` flag.
```
