### PR TITLE
docs: reorder `skaffold debug` docs

### DIFF
--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -328,7 +328,7 @@ local machine.
 One notable difference from `skaffold dev` is that `debug` disables image rebuilding and
 syncing as it leads to users accidentally terminating debugging sessions by saving file changes.
 These behaviours can be re-enabled with the `--auto-build`, `--auto-deploy`, and `--auto-sync`
-flags.
+flags, or triggering a [devloop iteration]({{< relref "/docs/design/api#control-api" >}}) using the Skaffold API.
 
 Enabling debugging has two phases:
 

--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -6,7 +6,7 @@ featureId: debug
 aliases: [/docs/how-tos/debug]
 ---
 
-Skaffold lets you debug your application running on a local or remote Kubernetes cluster, almost exactly how you'd do it if the code were running locally on your machine. Skaffold does this by detecting the runtime of your project and transparently configuring the containers in pods for debugging against that framework.
+Skaffold lets you debug your application running on a local or remote Kubernetes cluster, almost exactly how you would do it if the code were running locally on your machine. Skaffold does this by detecting the runtime of your project and transparently configuring the containers in pods for debugging against that framework.
 
 Debugging is currently supported for five language runtimes.
 

--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -6,20 +6,7 @@ featureId: debug
 aliases: [/docs/how-tos/debug]
 ---
 
-`skaffold debug` acts like `skaffold dev`, but it configures containers in pods
-for debugging as required for each container's runtime technology.
-The associated debugging ports are exposed and labelled so that they can be port-forwarded to the
-local machine.
-
-To debug in an IDE that uses Skaffold events to automatically configure debug sessions, you can use
-[Google Cloud Code for VS Code](https://cloud.google.com/code/docs/vscode/debug),
-[Cloud Code for IntelliJ](https://cloud.google.com/code/docs/intellij/kubernetes-debugging),
-or, for an IDE in your browser, [Cloud Code for Cloud Shell](https://cloud.google.com/code/docs/shell/debug).
-
-One notable difference from `skaffold dev` is that `debug` disables image rebuilding and
-syncing as it leads to users accidentally terminating debugging sessions by saving file changes.
-These behaviours can be re-enabled with the `--auto-build`, `--auto-deploy`, and `--auto-sync`
-flags.
+Skaffold lets you debug your application running on a local or remote Kubernetes cluster, almost exactly how you'd do it if the code were running locally on your machine. Skaffold does this by detecting the runtime of your project and transparently configuring the containers in pods for debugging against that framework.
 
 Debugging is currently supported for five language runtimes.
 
@@ -29,97 +16,28 @@ Debugging is currently supported for five language runtimes.
   - Python 3.5+ (runtime ID: `python`) using `debugpy` (Debug Adapter Protocol) or `pydevd`
   - .NET Core (runtime ID: `netcore`) using `vsdbg`
 
+Skaffold can usually detect the correct language runtime if present. However if you're having difficulty getting it running for your application then checkout the [Supported Language Runtimes]({{< relref "#supported-language-runtimes">}}) section for the exact heuristics that skaffold uses and you can modify your application accordingly.
 
-## How It works
+## (Recommended) Debugging using Cloud Code
 
-Enabling debugging has two phases:
+The easiest way to debug using Skaffold is by using the [Cloud Code IDE extension]({{< relref "../install/#managed-ide">}}) for Visual Studio Code, JetBrains IDEs, and Cloud Shell. Cloud Code will automatically configure container images for debugging so you can debug Kubernetes services just like how you would debug a local service in your IDE. 
 
-1. **Configuring:** Skaffold automatically examines each built container image and
-   attempts to recognize the underlying language runtime.  Container images can be
-   explicitly configured too.
-3. **Monitoring:** Skaffold watches the cluster to detect when debuggable containers
-   start execution.
+For more information, see the corresponding documentation for [VS Code](https://cloud.google.com/code/docs/vscode/debug), [IntelliJ](https://cloud.google.com/code/docs/intellij/kubernetes-debugging) and [Cloud Shell](https://cloud.google.com/code/docs/shell/debug).
 
-### Configuring container images for debugging
+## Detailed debugger configuration and setup
 
-`skaffold debug` examines the *built artifacts* to determine the underlying language runtime technology.
-Kubernetes manifests that reference these artifacts are transformed on-the-fly to enable the
-language runtime's debugging functionality.  These transforms add or alter environment variables
-and entrypoints, and more.
-
-Some language runtimes require additional support files to enable debugging.
-For these languages, a special set of [runtime-specific images](https://github.com/GoogleContainerTools/container-debug-support)
-are configured as _init-containers_ to populate a shared-volume that is mounted into
-each of the appropriate containers.  These images are hosted at
-`gcr.io/k8s-skaffold/skaffold-debug-support`; alternative locations can be
-specified in [Skaffold's global configuration]({{< relref "/docs/design/global-config.md" >}}).
-
-For images that are successfully recognized, Skaffold adds a `debug.cloud.google.com/config`
-annotation to the corresponding Kubernetes pod-spec that encode the debugging parameters.
-
-### Monitoring for debuggable containers
-
-Once the application is deployed, `debug` monitors the cluster looking for debuggable pods with a
-`debug.cloud.google.com/config` annotation.  For each new debuggable pod,  Skaffold emits
-an event that can be used by tools like IDEs to establish a debug session.
-
-### Additional changes
-
-`debug` makes some other adjustments to simplify the debug experience:
-
-  - *Replica Counts*: `debug` rewrites  the replica counts to 1 for
-    deployments, replica sets, and stateful sets.  This results in
-    requests being serialized so that one request is processed at a time.
-
-  - *Kubernetes Probes*:  `debug` changes the timeouts on HTTP-based
-    [liveness, readiness, and startup probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
-    to 600 seconds (10 minutes) from the default of 1 second.
-    This change allows probes to be debugged, and avoids negative
-    consequences from blocked probes when the app is already suspended
-    during a debugging session.
-    Failed liveness probes in particular result in the container
-    being terminated and restarted.
-
-	The probe timeout value can be set on a per-podspec basis by setting
-	a `debug.cloud.google.com/probe/timeouts` annotation on the podspec's metadata
-	with a valid duration (see [Go's time.ParseDuration()](https://pkg.go.dev/time#ParseDuration)).
-    This probe timeout-rewriting can be skipped entirely by using `skip`.  For example:
-    ```yaml
-    metadata:
-      annotations:
-        debug.cloud.google.com/probe/timeouts: skip
-    spec: ...
-    ```
-
-## Supported Language Runtimes
-
-This section describes how `debug` recognizes the language runtime used in a
-container image, and how the container image is configured for debugging.
+This section describes how Skaffold configures the container image for debugging for the supported language runtimes, and how to setup with certain IDEs.
 
 Note that many debuggers may require additional information for the location of source files.
 We are looking for ways to identify this information and to pass it back if found.
+
+{{% tabs %}}
+{{% tab "GO" %}}
 
 #### Go (runtime: `go`, protocols: `dlv`)
 
 Go-based applications are configured to run under
 [Delve](https://github.com/go-delve/delve) in its headless-server mode.
-
-Go-based container images are recognized by:
-
-- the presence of one of the
-  [standard Go runtime environment variables](https://godoc.org/runtime):
-  `GODEBUG`, `GOGC`, `GOMAXPROCS`, or `GOTRACEBACK`, or
-- the presence of the
-  [`KO_DATA_PATH` environment variable](https://github.com/google/ko#static-assets)
-  in container images built by
-  [`ko`]({{< relref "/docs/pipeline-stages/builders/ko" >}}), or
-- is launching using `dlv`.
-
-Unless you built your container image using `ko`, set one of the standard Go
-environment variables to allow Skaffold to detect your container as Go.
-`GOTRACEBACK=single` is the default setting for Go, so you can add this
-environment variable without changing behavior. Alternatively, `GOTRACEBACK=all`
-is a useful setting in many situtions.
 
 On recognizing a Go-based container image, `debug` rewrites the container image's
 entrypoint to invoke your application using `dlv`:
@@ -127,30 +45,6 @@ entrypoint to invoke your application using `dlv`:
 ```
 dlv exec --headless --continue --accept-multiclient --listen=:56268 --api-version=2 <app> -- <args> ...
 ```
-
-Your application should be built with the `-gcflags='all=-N -l'` flag to
-disable optimizations and inlining. If you do not add this flag, debugging can
-becoming confusing due to seemingly-random execution jumps that happen due to
-statement reordering and inlining. Skaffold configures Docker builds with a
-`SKAFFOLD_GO_GCFLAGS` build argument that you should use in your `Dockerfile`:
-
-```
-FROM golang
-ENV GOTRACEBACK=all
-COPY . .
-ARG SKAFFOLD_GO_GCFLAGS
-RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app .
-```
-
-Note that the Alpine Linux-based `golang` container images do not include a
-C compiler which is required to build with `-gcflags='all=-N -l'`.
-
-The ko builder adds `-gcflags='all=-N -l'` automatically when you use
-`skaffold debug`.
-
-We recommend that you do _not_ add the `-trimpath` flag when debugging, as this
-flag removes information from the resulting binary that aids debugging.
-
 ##### Skaffold debug using the VS Code Go extension
 
 If you use the debug functionality of the
@@ -210,29 +104,12 @@ the source path in your IDE. In this case, the value for `remotePath` will
 match `cwd`. If the values of both `cwd` and `remotePath` are
 `${workspaceFolder}`, you can omit these properties.
 
-#### Java and Other JVM Languages (runtime: `jvm`, protocols: `jdwp`)
-
-Java/JVM applications are configured to expose the JDWP agent using the `JAVA_TOOL_OPTIONS`
-environment variable.
-Note that the use of `JAVA_TOOL_OPTIONS` causes extra debugging output from the JVM on launch.
-
-JVM application are recognized by:
-- the presence of a `JAVA_VERSION` or `JAVA_TOOL_OPTIONS` environment variable, or
-- the container command-line invokes `java`.
-
-On recognizing a JVM-based container image, `debug` rewrites the container image's
-environment to set:
-```
-JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y
-```
+{{% /tab %}}
+{{% tab "NODEJS" %}}
 
 #### NodeJS (runtime: `nodejs`, protocols: `devtools`)
 
 NodeJS applications are configured to use the Chrome DevTools inspector via the `--inspect` argument.
-
-NodeJS images are recognized by:
-- the presence of a `NODE_VERSION`, `NODEJS_VERSION`, or `NODE_ENV` environment variable, or
-- the container command-line invokes `node` or `npm`.
 
 On recognizing a NodeJS-based container image, `debug` rewrites the container image's
 entrypoint to invoke your application with `--inspect`:
@@ -249,8 +126,24 @@ and skips scripts located in <tt>node_modules</tt>.  For more details see the
 <a href="https://github.com/GoogleContainerTools/container-debug-support/pull/34">associated PR</a>.
 {{< /alert >}}
 
-Note that a debugging client must first obtain [the inspector UUID](https://github.com/nodejs/node/issues/9185#issuecomment-254872466).
+A debugging client must first obtain [the inspector UUID](https://github.com/nodejs/node/issues/9185#issuecomment-254872466).
 
+{{% /tab %}}
+{{% tab "JAVA" %}}
+
+#### Java and Other JVM Languages (runtime: `jvm`, protocols: `jdwp`)
+
+Java/JVM applications are configured to expose the JDWP agent using the `JAVA_TOOL_OPTIONS`
+environment variable.
+Note that the use of `JAVA_TOOL_OPTIONS` causes extra debugging output from the JVM on launch.
+
+On recognizing a JVM-based container image, `debug` rewrites the container image's
+environment to set:
+```
+JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,address=5005,suspend=n,quiet=y
+```
+{{% /tab %}}
+{{% tab "PYTHON" %}}
 
 #### Python (runtime: `python`, protocols: `dap` or `pydevd`)
 
@@ -259,14 +152,6 @@ wrapper around [`pydevd`](https://github.com/fabioz/PyDev.Debugger).  `debugpy` 
 [_debug adapter protocol_ (DAP)](https://microsoft.github.io/debug-adapter-protocol/) which
 is supported by Visual Studio Code, [Eclipse LSP4e](https://projects.eclipse.org/projects/technology.lsp4e),
 [and other editors and IDEs](https://microsoft.github.io/debug-adapter-protocol/implementors/tools/).
-
-Python application are recognized by:
-- the presence of a standard Python environment variable:
-  `PYTHON_VERSION`, `PYTHONVERBOSE`, `PYTHONINSPECT`, `PYTHONOPTIMIZE`,
-  `PYTHONUSERSITE`, `PYTHONUNBUFFERED`, `PYTHONPATH`, `PYTHONUSERBASE`,
-  `PYTHONWARNINGS`, `PYTHONHOME`, `PYTHONCASEOK`, `PYTHONIOENCODING`,
-  `PYTHONHASHSEED`, `PYTHONDONTWRITEBYTECODE`, or
-- the container command-line invokes `python`, `python2`, or `python3`.
 
 On recognizing a Python-based container image, `debug` rewrites the container image's
 entrypoint to invoke Python using either the `pydevd` or `debugpy` modules:
@@ -284,21 +169,13 @@ As many Python web frameworks use launcher scripts, like `gunicorn`, Skaffold no
 a debug launcher that examines the app command-line.
 {{< /alert >}}
 
+{{% /tab %}}
+{{% tab ".NETCORE" %}}
 
 #### .NET Core (runtime: `dotnet`, protocols: `vsdbg`)
 
 .NET Core applications are configured to be deployed along with `vsdbg`
 for VS Code.
-
-
-.NET Core application are recognized by:
-- the presence of a standard .NET environment variable:
-  `ASPNETCORE_URLS`, `DOTNET_RUNNING_IN_CONTAINER`,
-  `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT`, or
-- the container command-line invokes the [dotnet](https://github.com/dotnet/sdk) cli
-
-Furthermore, your app must be built with the `--configuration Debug` options to disable optimizations.
-
 
 {{< alert title="JetBrains Rider" >}}
 This set up does not yet work automatically with [Cloud Code for IntelliJ in JetBrains Rider](https://github.com/GoogleCloudPlatform/cloud-code-intellij/issues/2903).
@@ -342,6 +219,175 @@ your base image.  (`//` comments must be stripped.)
 }
 ```
 {{< /alert >}}
+
+{{% /tab %}}
+{{% /tabs %}}
+
+## Supported Language Runtimes
+
+This section describes how `debug` recognizes the language runtime used in a
+container image for specific language runtimes.
+
+{{% tabs %}}
+{{% tab "GO" %}}
+#### Go (runtime: `go`)
+
+Go-based container images are recognized by:
+
+- the presence of one of the
+  [standard Go runtime environment variables](https://godoc.org/runtime):
+  `GODEBUG`, `GOGC`, `GOMAXPROCS`, or `GOTRACEBACK`, or
+- the presence of the
+  [`KO_DATA_PATH` environment variable](https://github.com/google/ko#static-assets)
+  in container images built by
+  [`ko`]({{< relref "/docs/pipeline-stages/builders/ko" >}}), or
+- is launching using `dlv`.
+
+Unless you built your container image using `ko`, set one of the standard Go
+environment variables to allow Skaffold to detect your container as Go.
+`GOTRACEBACK=single` is the default setting for Go, so you can add this
+environment variable without changing behavior. Alternatively, `GOTRACEBACK=all`
+is a useful setting in many situtions.
+
+Your application should be built with the `-gcflags='all=-N -l'` flag to
+disable optimizations and inlining. If you do not add this flag, debugging can
+becoming confusing due to seemingly-random execution jumps that happen due to
+statement reordering and inlining. Skaffold configures Docker builds with a
+`SKAFFOLD_GO_GCFLAGS` build argument that you should use in your `Dockerfile`:
+
+```
+FROM golang
+ENV GOTRACEBACK=all
+COPY . .
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /app .
+```
+
+Note that the Alpine Linux-based `golang` container images do not include a
+C compiler which is required to build with `-gcflags='all=-N -l'`.
+
+The ko builder adds `-gcflags='all=-N -l'` automatically when you use
+`skaffold debug`.
+
+We recommend that you do _not_ add the `-trimpath` flag when debugging, as this
+flag removes information from the resulting binary that aids debugging.
+
+{{% /tab %}}
+{{% tab "JAVA" %}}
+
+#### Java and Other JVM Languages (runtime: `jvm`)
+
+JVM application are recognized by:
+- the presence of a `JAVA_VERSION` or `JAVA_TOOL_OPTIONS` environment variable, or
+- the container command-line invokes `java`.
+
+{{% /tab %}}
+{{% tab "NODEJS" %}}
+
+#### NodeJS (runtime: `nodejs`)
+
+NodeJS images are recognized by:
+- the presence of a `NODE_VERSION`, `NODEJS_VERSION`, or `NODE_ENV` environment variable, or
+- the container command-line invokes `node` or `npm`.
+
+{{% /tab %}}
+{{% tab "PYTHON" %}}
+
+#### Python (runtime: `python`)
+
+Python application are recognized by:
+- the presence of a standard Python environment variable:
+  `PYTHON_VERSION`, `PYTHONVERBOSE`, `PYTHONINSPECT`, `PYTHONOPTIMIZE`,
+  `PYTHONUSERSITE`, `PYTHONUNBUFFERED`, `PYTHONPATH`, `PYTHONUSERBASE`,
+  `PYTHONWARNINGS`, `PYTHONHOME`, `PYTHONCASEOK`, `PYTHONIOENCODING`,
+  `PYTHONHASHSEED`, `PYTHONDONTWRITEBYTECODE`, or
+- the container command-line invokes `python`, `python2`, or `python3`.
+
+{{% /tab %}}
+{{% tab ".NETCORE" %}}
+
+#### .NET Core (runtime: `dotnet`)
+
+.NET Core application are recognized by:
+- the presence of a standard .NET environment variable:
+  `ASPNETCORE_URLS`, `DOTNET_RUNNING_IN_CONTAINER`,
+  `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT`, or
+- the container command-line invokes the [dotnet](https://github.com/dotnet/sdk) cli
+
+Furthermore, your app must be built with the `--configuration Debug` options to disable optimizations.
+
+{{% /tab %}}
+{{% /tabs %}}
+
+## How It works
+
+`skaffold debug` acts like `skaffold dev`, but it configures containers in pods
+for debugging as required for each container's runtime technology.
+The associated debugging ports are exposed and labelled so that they can be port-forwarded to the
+local machine.
+One notable difference from `skaffold dev` is that `debug` disables image rebuilding and
+syncing as it leads to users accidentally terminating debugging sessions by saving file changes.
+These behaviours can be re-enabled with the `--auto-build`, `--auto-deploy`, and `--auto-sync`
+flags.
+
+Enabling debugging has two phases:
+
+1. **Configuring:** Skaffold automatically examines each built container image and
+   attempts to recognize the underlying language runtime.  Container images can be
+   explicitly configured too.
+3. **Monitoring:** Skaffold watches the cluster to detect when debuggable containers
+   start execution.
+
+### Configuring container images for debugging
+
+`skaffold debug` examines the *built artifacts* to determine the underlying language runtime technology.
+Kubernetes manifests that reference these artifacts are transformed on-the-fly to enable the
+language runtime's debugging functionality.  These transforms add or alter environment variables
+and entrypoints, and more.
+
+Some language runtimes require additional support files to enable debugging.
+For these languages, a special set of [runtime-specific images](https://github.com/GoogleContainerTools/container-debug-support)
+are configured as _init-containers_ to populate a shared-volume that is mounted into
+each of the appropriate containers.  These images are hosted at
+`gcr.io/k8s-skaffold/skaffold-debug-support`; alternative locations can be
+specified in [Skaffold's global configuration]({{< relref "/docs/design/global-config.md" >}}).
+
+For images that are successfully recognized, Skaffold adds a `debug.cloud.google.com/config`
+annotation to the corresponding Kubernetes pod-spec that encode the debugging parameters.
+
+### Monitoring for debuggable containers
+
+Once the application is deployed, `debug` monitors the cluster looking for debuggable pods with a
+`debug.cloud.google.com/config` annotation.  For each new debuggable pod,  Skaffold emits
+an event that can be used by tools like IDEs to establish a debug session.
+
+### Additional changes
+
+`debug` makes some other adjustments to simplify the debug experience:
+
+  - *Replica Counts*: `debug` rewrites  the replica counts to 1 for
+    deployments, replica sets, and stateful sets.  This results in
+    requests being serialized so that one request is processed at a time.
+
+  - *Kubernetes Probes*:  `debug` changes the timeouts on HTTP-based
+    [liveness, readiness, and startup probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
+    to 600 seconds (10 minutes) from the default of 1 second.
+    This change allows probes to be debugged, and avoids negative
+    consequences from blocked probes when the app is already suspended
+    during a debugging session.
+    Failed liveness probes in particular result in the container
+    being terminated and restarted.
+
+	The probe timeout value can be set on a per-podspec basis by setting
+	a `debug.cloud.google.com/probe/timeouts` annotation on the podspec's metadata
+	with a valid duration (see [Go's time.ParseDuration()](https://pkg.go.dev/time#ParseDuration)).
+    This probe timeout-rewriting can be skipped entirely by using `skip`.  For example:
+    ```yaml
+    metadata:
+      annotations:
+        debug.cloud.google.com/probe/timeouts: skip
+    spec: ...
+    ```
 
 ## Troubleshooting
 

--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -16,7 +16,7 @@ Debugging is currently supported for five language runtimes.
   - Python 3.5+ (runtime ID: `python`) using `debugpy` (Debug Adapter Protocol) or `pydevd`
   - .NET Core (runtime ID: `netcore`) using `vsdbg`
 
-Skaffold can usually detect the correct language runtime if present. However if you're having difficulty getting it running for your application then checkout the [Supported Language Runtimes]({{< relref "#supported-language-runtimes">}}) section for the exact heuristics that skaffold uses and you can modify your application accordingly.
+Skaffold can usually detect the correct language runtime if present. However if you encounter difficulties then checkout the [Supported Language Runtimes]({{< relref "#supported-language-runtimes">}}) section for the exact heuristics that skaffold uses and you can modify your application accordingly.
 
 ## (Recommended) Debugging using Cloud Code
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6691  <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR reorders sections of the `Debugging` documentation page. 
The original writeup lacked a simple introduction. Also sections describing the language runtime detection heuristics was intertwined with the debugger setup information that made it difficult to parse the relevant information about heuristics separately. It also made it difficult to add a `debugging with Cloud Code` section since heuristic setup is still required for that, and it only automates parts of working with the debugger set up.


See: http://34.94.139.93:1313/docs/workflows/debug/