### PR TITLE
docs: how to skip image building in hot-reload

### DIFF
--- a/examples/hot-reload/README.md
+++ b/examples/hot-reload/README.md
@@ -18,3 +18,16 @@ skaffold dev
 * Make some changes to `python/src/app.py`:
     * The file will be synchronized to the cluster
     * `flask` will restart the application
+
+#### Skip image build entirely
+
+If you have a pre-built image and want skaffold to skip building your image entirely
+and only sync code to the cluster, add the following to `skaffold.yaml`.
+
+```yaml
+build:
+  local:
+    tryImportMissing: true
+```
+
+Then add `--tag [image-tag]` to your `skaffold dev` command.


### PR DESCRIPTION
example. Took me a while to figure this out. Might be useful
for others.
