### PR TITLE
Allow caching from built artifact on local Docker build

### DIFF
--- a/docs/content/en/docs/pipeline-stages/builders/docker.md
+++ b/docs/content/en/docs/pipeline-stages/builders/docker.md
@@ -33,6 +33,10 @@ of `skaffold.yaml`. The following options can optionally be configured:
 
 {{< schema root="LocalBuild" >}}
 
+The `docker` builder replaces cache references to the
+artifact image with the tagged image to allow caching from the
+previously built image.
+
 **Example**
 
 The following `build` section instructs Skaffold to build a

--- a/docs/content/en/samples/builders/local.yaml
+++ b/docs/content/en/samples/builders/local.yaml
@@ -1,4 +1,9 @@
 build:
   artifacts:
   - image: gcr.io/k8s-skaffold/example
+    docker:
+      cacheFrom:
+      # Local Docker builder replaces cache references to the artifact image with
+      # the tagged image reference, useful for caching from the previous build.
+      - gcr.io/k8s-skaffold/example
   local: {}


### PR DESCRIPTION
Fixes #6809 

It's the same as [PR](https://github.com/GoogleContainerTools/skaffold/pull/5903), now for local Docker builder. 

**Description**
Cause Docker `cacheFrom` references to the artifact image (which is untagged) to be replaced with the tagged image (possibly affected by the default-repo).

For example:

```yaml
build:
  artifacts:
  - image: skaffold-example
    docker:
      cacheFrom:
      - skaffold-example
      - gcr.io/k8s-skaffold/skaffold-example:latest # used if the tagged image is not found
```

Allow disabling by setting `SKAFFOLD_DISABLE_DOCKER_CACHE_ADJUSTMENT` in the environment.

Note: Docker image caching is a bit complex, and this [StackOverflow](https://stackoverflow.com/q/54574821/600339) answer provides helpful details.

**User facing changes (remove if N/A)**

- Local Docker builds can cache from the previous build by including the artifact `image` in the `cacheFrom`.

cc: @briandealwis