### PR TITLE
fix: distinguish docker build errors from streaming errors

### DIFF
--- a/integration/build_dependencies_test.go
+++ b/integration/build_dependencies_test.go
@@ -60,12 +60,12 @@ func TestBuildDependenciesOrder(t *testing.T) {
 		{
 			description: "build failure with concurrency=1",
 			args:        []string{"-p", "failed-dependency"},
-			failure:     `unable to stream build output: The command '/bin/sh -c [ "${FAIL}" == "0" ] || false' returned a non-zero code: 1`,
+			failure:     `The command '/bin/sh -c [ "${FAIL}" == "0" ] || false' returned a non-zero code: 1`,
 		},
 		{
 			description: "build failure with concurrency=0",
 			args:        []string{"-p", "failed-dependency", "-p", "concurrency-0"},
-			failure:     `unable to stream build output: The command '/bin/sh -c [ "${FAIL}" == "0" ] || false' returned a non-zero code: 1`,
+			failure:     `The command '/bin/sh -c [ "${FAIL}" == "0" ] || false' returned a non-zero code: 1`,
 		},
 	}
 

--- a/integration/build_dependencies_test.go
+++ b/integration/build_dependencies_test.go
@@ -60,12 +60,12 @@ func TestBuildDependenciesOrder(t *testing.T) {
 		{
 			description: "build failure with concurrency=1",
 			args:        []string{"-p", "failed-dependency"},
-			failure:     `The command '/bin/sh -c [ "${FAIL}" == "0" ] || false' returned a non-zero code: 1`,
+			failure:     `docker build failure: The command '/bin/sh -c [ "${FAIL}" == "0" ] || false' returned a non-zero code: 1`,
 		},
 		{
 			description: "build failure with concurrency=0",
 			args:        []string{"-p", "failed-dependency", "-p", "concurrency-0"},
-			failure:     `The command '/bin/sh -c [ "${FAIL}" == "0" ] || false' returned a non-zero code: 1`,
+			failure:     `docker build failure: The command '/bin/sh -c [ "${FAIL}" == "0" ] || false' returned a non-zero code: 1`,
 		},
 	}
 

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -364,6 +365,10 @@ func (l *localDaemon) Build(ctx context.Context, out io.Writer, workspace string
 	}
 
 	if err := streamDockerMessages(out, resp.Body, auxCallback); err != nil {
+		var jm *jsonmessage.JSONError
+		if errors.As(err, &jm) {
+			return "", err
+		}
 		return "", fmt.Errorf("unable to stream build output: %w", err)
 	}
 

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -367,7 +367,7 @@ func (l *localDaemon) Build(ctx context.Context, out io.Writer, workspace string
 	if err := streamDockerMessages(out, resp.Body, auxCallback); err != nil {
 		var jm *jsonmessage.JSONError
 		if errors.As(err, &jm) {
-			return "", err
+			return "", fmt.Errorf("docker build failure: %w", err)
 		}
 		return "", fmt.Errorf("unable to stream build output: %w", err)
 	}


### PR DESCRIPTION
In trying to reproduce #6126, I noticed that docker build errors are oddly prefixed with "`unable to stream build output:`".
```
Canceled build for leeroy-app
unable to stream build output: The command '/bin/sh -c exit 1' returned a non-zero code: 1. Please fix the Dockerfile and try again..
```

It turns out that the Docker code for parsing and interpreting the JSON message stream from the Docker daemon parses build failures as a `JSONError` object, which behaves like an `error`.  This PR changes our error-handling code to return such errors directly.