### PR TITLE
feat: add multi-level-repo support to arbitrary repositories beyond just GCR and AR

### DIFF
--- a/cmd/skaffold/app/cmd/config.go
+++ b/cmd/skaffold/app/cmd/config.go
@@ -40,6 +40,7 @@ func NewCmdSet() *cobra.Command {
 		WithDescription("Set a value in the global Skaffold config").
 		WithExample("Mark a registry as insecure", "config set insecure-registries <insecure1.io>").
 		WithExample("Globally set the default image repository", "config set default-repo <myrepo>").
+		WithExample("Globally set multi-level repo support", "config set multi-level-repo true").
 		WithExample("Disable pushing images for a given Kubernetes context", "config set --kube-context <mycluster> local-cluster true").
 		WithFlagAdder(func(f *pflag.FlagSet) {
 			config.AddCommonFlags(f)

--- a/cmd/skaffold/app/cmd/config/list_test.go
+++ b/cmd/skaffold/app/cmd/config/list_test.go
@@ -47,12 +47,14 @@ func TestList(t *testing.T) {
 					{
 						Kubecontext:        "another_context",
 						DefaultRepo:        "other-value",
+						MultiLevelRepo:     util.BoolPtr(false),
 						LocalCluster:       util.BoolPtr(false),
 						InsecureRegistries: []string{"good.io", "better.io"},
 					},
 					{
 						Kubecontext:        "this_is_a_context",
 						DefaultRepo:        "value",
+						MultiLevelRepo:     util.BoolPtr(true),
 						LocalCluster:       util.BoolPtr(true),
 						InsecureRegistries: []string{"bad.io", "worse.io"},
 					},
@@ -60,6 +62,7 @@ func TestList(t *testing.T) {
 			},
 			expectedOutput: `kube-context: this_is_a_context
 default-repo: value
+multi-level-repo: true
 local-cluster: true
 insecure-registries:
 - bad.io
@@ -72,6 +75,7 @@ insecure-registries:
 			cfg: &config.GlobalConfig{
 				Global: &config.ContextConfig{
 					DefaultRepo:        "default-repo-value",
+					MultiLevelRepo:     util.BoolPtr(true),
 					LocalCluster:       util.BoolPtr(true),
 					InsecureRegistries: []string{"mediocre.io"},
 				},
@@ -83,6 +87,7 @@ insecure-registries:
 				},
 			},
 			expectedOutput: `default-repo: default-repo-value
+multi-level-repo: true
 local-cluster: true
 insecure-registries:
 - mediocre.io
@@ -94,6 +99,7 @@ insecure-registries:
 			cfg: &config.GlobalConfig{
 				Global: &config.ContextConfig{
 					DefaultRepo:        "default-repo-value",
+					MultiLevelRepo:     util.BoolPtr(true),
 					LocalCluster:       util.BoolPtr(true),
 					InsecureRegistries: []string{"mediocre.io"},
 				},
@@ -107,6 +113,7 @@ insecure-registries:
 			expectedOutput: `
 global:
   default-repo: default-repo-value
+  multi-level-repo: true
   local-cluster: true
   insecure-registries:
   - mediocre.io
@@ -121,6 +128,7 @@ kubeContexts:
 			cfg: &config.GlobalConfig{
 				Global: &config.ContextConfig{
 					DefaultRepo:        "default-repo-value",
+					MultiLevelRepo:     util.BoolPtr(true),
 					LocalCluster:       util.BoolPtr(true),
 					InsecureRegistries: []string{"mediocre.io"},
 				},

--- a/cmd/skaffold/app/cmd/config/set_test.go
+++ b/cmd/skaffold/app/cmd/config/set_test.go
@@ -63,6 +63,27 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			},
 		},
 		{
+			description: "set multi-level repo",
+			key:         "multi-level-repo",
+			value:       "false",
+			kubecontext: "this_is_a_context",
+			expectedSetCfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
+					{
+						Kubecontext:    "this_is_a_context",
+						MultiLevelRepo: util.BoolPtr(false),
+					},
+				},
+			},
+			expectedUnsetCfg: &config.GlobalConfig{
+				ContextConfigs: []*config.ContextConfig{
+					{
+						Kubecontext: "this_is_a_context",
+					},
+				},
+			},
+		},
+		{
 			description: "set local cluster",
 			key:         "local-cluster",
 			value:       "false",
@@ -104,6 +125,22 @@ func TestSetAndUnsetConfig(t *testing.T) {
 			expectedSetCfg: &config.GlobalConfig{
 				Global: &config.ContextConfig{
 					DefaultRepo: "global",
+				},
+				ContextConfigs: []*config.ContextConfig{},
+			},
+			expectedUnsetCfg: &config.GlobalConfig{
+				Global:         &config.ContextConfig{},
+				ContextConfigs: []*config.ContextConfig{},
+			},
+		},
+		{
+			description: "set global multi-level repo",
+			key:         "multi-level-repo",
+			value:       "true",
+			global:      true,
+			expectedSetCfg: &config.GlobalConfig{
+				Global: &config.ContextConfig{
+					MultiLevelRepo: util.BoolPtr(true),
 				},
 				ContextConfigs: []*config.ContextConfig{},
 			},
@@ -378,7 +415,7 @@ func TestGetConfigStructWithIndex(t *testing.T) {
 			description: "survey flag set",
 			cfg:         &config.ContextConfig{},
 			survey:      true,
-			expectedIdx: []int{6},
+			expectedIdx: []int{7},
 		},
 		{
 			description: "no survey flag set",

--- a/deploy/webhook/Dockerfile
+++ b/deploy/webhook/Dockerfile
@@ -36,7 +36,7 @@ ENV KUBECTL_URL https://storage.googleapis.com/kubernetes-release/release/${KUBE
 RUN wget -O kubectl "${KUBECTL_URL}"
 RUN chmod +x kubectl
 
-FROM node:10.15.3-stretch as runtime_deps
+FROM node:12.22.7-stretch as runtime_deps
 ENV FIREBASE_TOOLS_VERSION 7.13.1
 RUN npm install -g firebase-tools@${FIREBASE_TOOLS_VERSION} postcss postcss-cli
 WORKDIR /app/docs

--- a/docs/content/en/docs/design/global-config.md
+++ b/docs/content/en/docs/design/global-config.md
@@ -2,7 +2,7 @@
 title: "Global Configuration"
 linkTitle: "Global Configuration"
 weight: 50
-featureId: global_config
+featureId: global\_config
 
 ---
 
@@ -13,6 +13,7 @@ The options are:
 | Option | Type | Description |
 | ------ | ---- | ----------- |
 | `default-repo` | string | The image registry where built artifact images are published (see [image name rewriting]({{< relref "/docs/environment/image-registries.md" >}})). |
+| `multi-level-repo` | boolean | If true, do not replace '.' and '/' with '\_' in image name. |
 | `debug-helpers-registry` | string | The image registry where debug support images are retrieved (see [debugging]({{< relref "/docs/workflows/debug.md" >}})). |
 | `insecure-registries` | list of strings | A list of image registries that may be accessed without TLS. |
 | `k3d-disable-load` | boolean | If true, do not use `k3d import image` to load images locally. |

--- a/docs/content/en/docs/pipeline-stages/lifecycle-hooks.md
+++ b/docs/content/en/docs/pipeline-stages/lifecycle-hooks.md
@@ -105,6 +105,7 @@ $SKAFFOLD_DEFAULT_REPO | The resolved default repository | All
 $SKAFFOLD_RPC_PORT | TCP port to expose event API | All
 $SKAFFOLD_HTTP_PORT | TCP port to expose event REST API over HTTP | All
 $SKAFFOLD_KUBE_CONTEXT | The resolved Kubernetes context | Sync, Deploy
+$SKAFFOLD_MULTI_LEVEL_REPO | The multi-level support of the repository | All
 $SKAFFOLD_NAMESPACES | Comma separated list of Kubernetes namespaces | Sync, Deploy
 $SKAFFOLD_WORK_DIR | The workspace root directory | All
 Local environment variables | The current state of the local environment (e.g. $HOST, $PATH). Determined by the golang os.Environ function. | All

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -328,6 +328,9 @@ Examples:
   # Globally set the default image repository
   skaffold config set default-repo <myrepo>
 
+  # Globally set multi-level repo support
+  skaffold config set multi-level-repo true
+
   # Disable pushing images for a given Kubernetes context
   skaffold config set --kube-context <mycluster> local-cluster true
 

--- a/docs/design_proposals/lifecycle-hooks.md
+++ b/docs/design_proposals/lifecycle-hooks.md
@@ -227,6 +227,11 @@ deploy: ...
 <td>All</td>
 </tr>
 <tr>
+<td>$SKAFFOLD_MULTI_LEVEL_REPO</td>
+<td>The multi-level support of the repository</td>
+<td>All</td>
+</tr>
+<tr>
 <td>$SKAFFOLD_NAMESPACES</td>
 <td>Comma separated list of Kubernetes namespaces</td>
 <td>All</td>

--- a/examples/ko/cloudbuild.yaml
+++ b/examples/ko/cloudbuild.yaml
@@ -19,6 +19,7 @@ options:
   env:
   - 'KUBECONFIG=/workspace/.kubeconfig'
   - 'SKAFFOLD_DEFAULT_REPO=$_IMAGE_REPO'
+  - 'SKAFFOLD_MULTI_LEVEL_REPO=true'
   - 'SKAFFOLD_DETECT_MINIKUBE=false'
   - 'SKAFFOLD_INTERACTIVE=false'
   - 'SKAFFOLD_TIMESTAMPS=true'

--- a/examples/lifecycle-hooks/hook.bat
+++ b/examples/lifecycle-hooks/hook.bat
@@ -2,6 +2,7 @@
 
 echo Build specification:
 echo    DefaultRepo:    %SKAFFOLD_DEFAULT_REPO%
+echo    MultiLevelRepo: %SKAFFOLD_MULTI_LEVEL_REPO%
 echo    RPCPort:        %SKAFFOLD_RPC_PORT%
 echo    HTTPPort:       %SKAFFOLD_HTTP_PORT%
 echo    WorkDir:        %SKAFFOLD_WORK_DIR%

--- a/examples/lifecycle-hooks/hook.sh
+++ b/examples/lifecycle-hooks/hook.sh
@@ -3,6 +3,7 @@
 cat << EOF
 Build specification:
     DefaultRepo:    $SKAFFOLD_DEFAULT_REPO
+    MultiLevelRepo: $SKAFFOLD_MULTI_LEVEL_REPO
     RPCPort:        $SKAFFOLD_RPC_PORT
     HTTPPort:       $SKAFFOLD_HTTP_PORT
     WorkDir:        $SKAFFOLD_WORK_DIR

--- a/integration/config_test.go
+++ b/integration/config_test.go
@@ -29,6 +29,7 @@ func TestConfigListForContext(t *testing.T) {
 	out := skaffold.Config("list", "-c", "testdata/config/config.yaml", "-k", "test-context").RunOrFailOutput(t)
 
 	testutil.CheckContains(t, "default-repo: context-local-repository", string(out))
+	testutil.CheckContains(t, "multi-level-repo: true", string(out))
 }
 
 func TestConfigListForAll(t *testing.T) {
@@ -39,8 +40,10 @@ func TestConfigListForAll(t *testing.T) {
 	for _, output := range []string{
 		"global:",
 		"default-repo: global-repository",
+		"multi-level-repo: false",
 		"kube-context: test-context",
 		"default-repo: context-local-repository",
+		"multi-level-repo: true",
 	} {
 		testutil.CheckContains(t, output, string(out))
 	}
@@ -65,6 +68,17 @@ func TestSetDefaultRepoForContext(t *testing.T) {
 	testutil.CheckContains(t, "default-repo: REPO1", string(out))
 }
 
+func TestSetMultiLevelRepoForContext(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	file := testutil.TempFile(t, "config", nil)
+
+	skaffold.Config("set", "multi-level-repo", "false", "-c", file, "-k", "test-context").RunOrFail(t)
+	out := skaffold.Config("list", "-c", file, "-k", "test-context").RunOrFailOutput(t)
+
+	testutil.CheckContains(t, "multi-level-repo: false", string(out))
+}
+
 func TestSetGlobalDefaultRepo(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 
@@ -74,4 +88,15 @@ func TestSetGlobalDefaultRepo(t *testing.T) {
 	out := skaffold.Config("list", "-c", file, "--all").RunOrFailOutput(t)
 
 	testutil.CheckContains(t, "default-repo: REPO2", string(out))
+}
+
+func TestSetGlobalMultiLevelRepo(t *testing.T) {
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+
+	file := testutil.TempFile(t, "config", nil)
+
+	skaffold.Config("set", "multi-level-repo", "true", "-c", file, "--global").RunOrFail(t)
+	out := skaffold.Config("list", "-c", file, "--all").RunOrFailOutput(t)
+
+	testutil.CheckContains(t, "multi-level-repo: true", string(out))
 }

--- a/integration/examples/ko/cloudbuild.yaml
+++ b/integration/examples/ko/cloudbuild.yaml
@@ -19,6 +19,7 @@ options:
   env:
   - 'KUBECONFIG=/workspace/.kubeconfig'
   - 'SKAFFOLD_DEFAULT_REPO=$_IMAGE_REPO'
+  - 'SKAFFOLD_MULTI_LEVEL_REPO=true'
   - 'SKAFFOLD_DETECT_MINIKUBE=false'
   - 'SKAFFOLD_INTERACTIVE=false'
   - 'SKAFFOLD_TIMESTAMPS=true'

--- a/integration/examples/lifecycle-hooks/hook.bat
+++ b/integration/examples/lifecycle-hooks/hook.bat
@@ -2,6 +2,7 @@
 
 echo Build specification:
 echo    DefaultRepo:    %SKAFFOLD_DEFAULT_REPO%
+echo    MultiLevelRepo: %SKAFFOLD_MULTI_LEVEL_REPO%
 echo    RPCPort:        %SKAFFOLD_RPC_PORT%
 echo    HTTPPort:       %SKAFFOLD_HTTP_PORT%
 echo    WorkDir:        %SKAFFOLD_WORK_DIR%

--- a/integration/examples/lifecycle-hooks/hook.sh
+++ b/integration/examples/lifecycle-hooks/hook.sh
@@ -3,6 +3,7 @@
 cat << EOF
 Build specification:
     DefaultRepo:    $SKAFFOLD_DEFAULT_REPO
+    MultiLevelRepo: $SKAFFOLD_MULTI_LEVEL_REPO
     RPCPort:        $SKAFFOLD_RPC_PORT
     HTTPPort:       $SKAFFOLD_HTTP_PORT
     WorkDir:        $SKAFFOLD_WORK_DIR

--- a/integration/testdata/config/config.yaml
+++ b/integration/testdata/config/config.yaml
@@ -1,5 +1,7 @@
 global:
   default-repo: global-repository
+  multi-level-repo: false
 kubeContexts:
 - kube-context: test-context
   default-repo: context-local-repository
+  multi-level-repo: true

--- a/pkg/skaffold/build/builder_mux.go
+++ b/pkg/skaffold/build/builder_mux.go
@@ -41,6 +41,7 @@ type BuilderMux struct {
 type Config interface {
 	GetPipelines() []latestV1.Pipeline
 	DefaultRepo() *string
+	MultiLevelRepo() *bool
 	GlobalConfig() string
 	BuildConcurrency() int
 }

--- a/pkg/skaffold/build/builder_mux_test.go
+++ b/pkg/skaffold/build/builder_mux_test.go
@@ -104,6 +104,7 @@ func (m *mockConfig) DefaultRepo() *string {
 	}
 	return nil
 }
+func (m *mockConfig) MultiLevelRepo() *bool { return nil }
 func (m *mockConfig) BuildConcurrency() int { return -1 }
 
 type mockPipelineBuilder struct {

--- a/pkg/skaffold/config/global_config.go
+++ b/pkg/skaffold/config/global_config.go
@@ -28,6 +28,7 @@ type GlobalConfig struct {
 type ContextConfig struct {
 	Kubecontext        string   `yaml:"kube-context,omitempty"`
 	DefaultRepo        string   `yaml:"default-repo,omitempty"`
+	MultiLevelRepo     *bool    `yaml:"multi-level-repo,omitempty"`
 	LocalCluster       *bool    `yaml:"local-cluster,omitempty"`
 	InsecureRegistries []string `yaml:"insecure-registries,omitempty"`
 	// DebugHelpersRegistry is the registry from which the debug helper images are used.

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -89,6 +89,7 @@ type SkaffoldOptions struct {
 
 	BuildConcurrency  int
 	DefaultRepo       StringOrUndefined
+	MultiLevelRepo    *bool
 	MakePathsAbsolute *bool
 	Muted             Muted
 	PortForward       PortForwardOptions

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -175,6 +175,17 @@ func GetDefaultRepo(configFile string, cliValue *string) (string, error) {
 	return cfg.DefaultRepo, nil
 }
 
+func GetMultiLevelRepo(configFile string) (*bool, error) {
+	cfg, err := GetConfigForCurrentKubectx(configFile)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.MultiLevelRepo != nil {
+		log.Entry(context.TODO()).Infof("Using multi-level-repo=%t from config", *cfg.MultiLevelRepo)
+	}
+	return cfg.MultiLevelRepo, nil
+}
+
 func GetInsecureRegistries(configFile string) ([]string, error) {
 	cfg, err := GetConfigForCurrentKubectx(configFile)
 	if err != nil {

--- a/pkg/skaffold/deploy/deploy_problems_test.go
+++ b/pkg/skaffold/deploy/deploy_problems_test.go
@@ -115,6 +115,7 @@ func (m mockConfig) GetNamespace() string                              { return 
 func (m mockConfig) GlobalConfig() string                              { return "" }
 func (m mockConfig) ConfigurationFile() string                         { return "" }
 func (m mockConfig) DefaultRepo() *string                              { return &m.minikube }
+func (m mockConfig) MultiLevelRepo() *bool                             { return nil }
 func (m mockConfig) SkipRender() bool                                  { return true }
 func (m mockConfig) Prune() bool                                       { return true }
 func (m mockConfig) ContainerDebugging() bool                          { return false }

--- a/pkg/skaffold/deploy/kubectl/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl.go
@@ -73,6 +73,7 @@ type Deployer struct {
 	globalConfig       string
 	gcsManifestDir     string
 	defaultRepo        *string
+	multiLevelRepo     *bool
 	kubectl            CLI
 	insecureRegistries map[string]bool
 	labeller           *label.DefaultLabeller
@@ -115,6 +116,7 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latestV1.Kubect
 		workingDir:         cfg.GetWorkingDir(),
 		globalConfig:       cfg.GlobalConfig(),
 		defaultRepo:        cfg.DefaultRepo(),
+		multiLevelRepo:     cfg.MultiLevelRepo(),
 		kubectl:            kubectl,
 		insecureRegistries: cfg.GetInsecureRegistries(),
 		skipRender:         cfg.SkipRender(),

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -691,8 +691,9 @@ spec:
 				CmdRunOut("kubectl version --client -ojson", KubectlVersion112).
 				AndRunOut("kubectl --context kubecontext create --dry-run -oyaml -f "+tmpDir.Path("deployment.yaml"), test.input))
 			deployer, err := NewDeployer(&kubectlConfig{
-				workingDir:  ".",
-				defaultRepo: "gcr.io/project",
+				workingDir:     ".",
+				defaultRepo:    "gcr.io/project",
+				multiLevelRepo: util.BoolPtr(true),
 			}, &label.DefaultLabeller{}, &latestV1.KubectlDeploy{
 				Manifests: []string{tmpDir.Path("deployment.yaml")},
 			})
@@ -788,6 +789,7 @@ type kubectlConfig struct {
 	runcontext.RunContext // Embedded to provide the default values.
 	workingDir            string
 	defaultRepo           string
+	multiLevelRepo        *bool
 	skipRender            bool
 	force                 bool
 	waitForDeletions      config.WaitForDeletions
@@ -799,5 +801,6 @@ func (c *kubectlConfig) WorkingDir() string                                    {
 func (c *kubectlConfig) SkipRender() bool                                      { return c.skipRender }
 func (c *kubectlConfig) ForceDeploy() bool                                     { return c.force }
 func (c *kubectlConfig) DefaultRepo() *string                                  { return &c.defaultRepo }
+func (c *kubectlConfig) MultiLevelRepo() *bool                                 { return c.multiLevelRepo }
 func (c *kubectlConfig) WaitForDeletions() config.WaitForDeletions             { return c.waitForDeletions }
 func (c *kubectlConfig) PortForwardResources() []*latestV1.PortForwardResource { return nil }

--- a/pkg/skaffold/deploy/types/types.go
+++ b/pkg/skaffold/deploy/types/types.go
@@ -32,6 +32,7 @@ type Config interface {
 	GlobalConfig() string
 	ConfigurationFile() string
 	DefaultRepo() *string
+	MultiLevelRepo() *bool
 	SkipRender() bool
 	TransformableAllowList() []latestV1.ResourceFilter
 }

--- a/pkg/skaffold/deploy/util/util.go
+++ b/pkg/skaffold/deploy/util/util.go
@@ -38,7 +38,12 @@ func ApplyDefaultRepo(globalConfig string, defaultRepo *string, tag string) (str
 		return "", fmt.Errorf("getting default repo: %w", err)
 	}
 
-	newTag, err := docker.SubstituteDefaultRepoIntoImage(repo, tag)
+	multiLevel, err := config.GetMultiLevelRepo(globalConfig)
+	if err != nil {
+		return "", fmt.Errorf("getting multi-level repo support: %w", err)
+	}
+
+	newTag, err := docker.SubstituteDefaultRepoIntoImage(repo, multiLevel, tag)
 	if err != nil {
 		return "", fmt.Errorf("applying default repo to %q: %w", tag, err)
 	}

--- a/pkg/skaffold/docker/default_repo_test.go
+++ b/pkg/skaffold/docker/default_repo_test.go
@@ -19,16 +19,18 @@ package docker
 import (
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
 func TestImageReplaceDefaultRepo(t *testing.T) {
 	tests := []struct {
-		description   string
-		image         string
-		defaultRepo   string
-		expectedImage string
-		shouldErr     bool
+		description    string
+		image          string
+		defaultRepo    string
+		multiLevelRepo *bool
+		expectedImage  string
+		shouldErr      bool
 	}{
 		{
 			description:   "basic GCR concatenation",
@@ -37,10 +39,24 @@ func TestImageReplaceDefaultRepo(t *testing.T) {
 			expectedImage: "gcr.io/default/gcr.io/some/registry",
 		},
 		{
+			description:    "basic GCR concatenation without multi-level",
+			image:          "gcr.io/some/registry",
+			defaultRepo:    "gcr.io/default",
+			multiLevelRepo: util.BoolPtr(false),
+			expectedImage:  "gcr.io/default/gcr.io/some/registry",
+		},
+		{
 			description:   "basic AR concatenation",
 			image:         "github.com/org/app",
 			defaultRepo:   "us-central1-docker.pkg.dev/default",
 			expectedImage: "us-central1-docker.pkg.dev/default/github.com/org/app",
+		},
+		{
+			description:    "basic AR concatenation without multi-level",
+			image:          "github.com/org/app",
+			defaultRepo:    "us-central1-docker.pkg.dev/default",
+			multiLevelRepo: util.BoolPtr(false),
+			expectedImage:  "us-central1-docker.pkg.dev/default/github.com/org/app",
 		},
 		{
 			description:   "no default repo set",
@@ -72,6 +88,13 @@ func TestImageReplaceDefaultRepo(t *testing.T) {
 			expectedImage: "aws_account_id.dkr.ecr.region.amazonaws.com/gcr_io_some_registry",
 		},
 		{
+			description:    "aws multi-level",
+			image:          "gcr.io/some/registry",
+			defaultRepo:    "aws_account_id.dkr.ecr.region.amazonaws.com",
+			multiLevelRepo: util.BoolPtr(true),
+			expectedImage:  "aws_account_id.dkr.ecr.region.amazonaws.com/gcr.io/some/registry",
+		},
+		{
 			description:   "aws over 255 chars",
 			image:         "gcr.io/herewehaveanincrediblylongregistryname/herewealsohaveanabnormallylongimagename/doubtyouveseenanimagethislong/butyouneverknowdoyouimeanpeopledosomecrazystuffoutthere/goodluckpushingthistoanyregistrymyfriend",
 			defaultRepo:   "aws_account_id.dkr.ecr.region.amazonaws.com",
@@ -96,10 +119,17 @@ func TestImageReplaceDefaultRepo(t *testing.T) {
 			expectedImage: "gcr.io/default/example.com/cmd/app",
 		},
 		{
-			description:   "ko with not GCR",
+			description:   "ko not with GCR",
 			image:         "ko://example.com/cmd/app",
 			defaultRepo:   "myrepo",
 			expectedImage: "myrepo/example_com_cmd_app",
+		},
+		{
+			description:    "ko multi-level not with GCR",
+			image:          "ko://example.com/cmd/app",
+			defaultRepo:    "myrepo",
+			multiLevelRepo: util.BoolPtr(true),
+			expectedImage:  "myrepo/example.com/cmd/app",
 		},
 		{
 			description:   "keep tag",
@@ -128,7 +158,7 @@ func TestImageReplaceDefaultRepo(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			replaced, err := SubstituteDefaultRepoIntoImage(test.defaultRepo, test.image)
+			replaced, err := SubstituteDefaultRepoIntoImage(test.defaultRepo, test.multiLevelRepo, test.image)
 
 			t.CheckErrorAndDeepEqual(test.shouldErr, err, test.expectedImage, replaced)
 		})

--- a/pkg/skaffold/hooks/env.go
+++ b/pkg/skaffold/hooks/env.go
@@ -27,10 +27,11 @@ var staticEnvOpts StaticEnvOpts
 
 // StaticEnvOpts contains the environment variables to be set in a lifecycle hook executor that don't change during the lifetime of the process.
 type StaticEnvOpts struct {
-	DefaultRepo *string
-	RPCPort     *int
-	HTTPPort    *int
-	WorkDir     string
+	DefaultRepo    *string
+	MultiLevelRepo *bool
+	RPCPort        *int
+	HTTPPort       *int
+	WorkDir        string
 }
 
 // BuildEnvOpts contains the environment variables to be set in a build type lifecycle hook executor.
@@ -61,6 +62,7 @@ type DeployEnvOpts struct {
 
 type Config interface {
 	DefaultRepo() *string
+	MultiLevelRepo() *bool
 	GetWorkingDir() string
 	RPCPort() *int
 	RPCHTTPPort() *int
@@ -68,10 +70,11 @@ type Config interface {
 
 func SetupStaticEnvOptions(cfg Config) {
 	staticEnvOpts = StaticEnvOpts{
-		DefaultRepo: cfg.DefaultRepo(),
-		WorkDir:     cfg.GetWorkingDir(),
-		RPCPort:     cfg.RPCPort(),
-		HTTPPort:    cfg.RPCHTTPPort(),
+		DefaultRepo:    cfg.DefaultRepo(),
+		MultiLevelRepo: cfg.MultiLevelRepo(),
+		WorkDir:        cfg.GetWorkingDir(),
+		RPCPort:        cfg.RPCPort(),
+		HTTPPort:       cfg.RPCHTTPPort(),
 	}
 }
 

--- a/pkg/skaffold/hooks/env_test.go
+++ b/pkg/skaffold/hooks/env_test.go
@@ -29,13 +29,15 @@ func TestSetupStaticEnvOptions(t *testing.T) {
 	}()
 
 	cfg := mockCfg{
-		defaultRepo: util.StringPtr("gcr.io/foo"),
-		workDir:     ".",
-		rpcPort:     util.IntPtr(8080),
-		httpPort:    util.IntPtr(8081),
+		defaultRepo:    util.StringPtr("gcr.io/foo"),
+		multiLevelRepo: util.BoolPtr(true),
+		workDir:        ".",
+		rpcPort:        util.IntPtr(8080),
+		httpPort:       util.IntPtr(8081),
 	}
 	SetupStaticEnvOptions(cfg)
 	testutil.CheckDeepEqual(t, cfg.defaultRepo, staticEnvOpts.DefaultRepo)
+	testutil.CheckDeepEqual(t, cfg.multiLevelRepo, staticEnvOpts.MultiLevelRepo)
 	testutil.CheckDeepEqual(t, cfg.workDir, staticEnvOpts.WorkDir)
 	testutil.CheckDeepEqual(t, cfg.rpcPort, staticEnvOpts.RPCPort)
 	testutil.CheckDeepEqual(t, cfg.httpPort, staticEnvOpts.HTTPPort)
@@ -50,13 +52,15 @@ func TestGetEnv(t *testing.T) {
 		{
 			description: "static env opts, all defined",
 			input: StaticEnvOpts{
-				DefaultRepo: util.StringPtr("gcr.io/foo"),
-				RPCPort:     util.IntPtr(8080),
-				HTTPPort:    util.IntPtr(8081),
-				WorkDir:     "./foo",
+				DefaultRepo:    util.StringPtr("gcr.io/foo"),
+				MultiLevelRepo: util.BoolPtr(true),
+				RPCPort:        util.IntPtr(8080),
+				HTTPPort:       util.IntPtr(8081),
+				WorkDir:        "./foo",
 			},
 			expected: []string{
 				"SKAFFOLD_DEFAULT_REPO=gcr.io/foo",
+				"SKAFFOLD_MULTI_LEVEL_REPO=true",
 				"SKAFFOLD_RPC_PORT=8080",
 				"SKAFFOLD_HTTP_PORT=8081",
 				"SKAFFOLD_WORK_DIR=./foo",
@@ -150,13 +154,15 @@ func TestGetEnv(t *testing.T) {
 }
 
 type mockCfg struct {
-	defaultRepo *string
-	workDir     string
-	rpcPort     *int
-	httpPort    *int
+	defaultRepo    *string
+	multiLevelRepo *bool
+	workDir        string
+	rpcPort        *int
+	httpPort       *int
 }
 
 func (m mockCfg) DefaultRepo() *string  { return m.defaultRepo }
+func (m mockCfg) MultiLevelRepo() *bool { return m.multiLevelRepo }
 func (m mockCfg) GetWorkingDir() string { return m.workDir }
 func (m mockCfg) RPCPort() *int         { return m.rpcPort }
 func (m mockCfg) RPCHTTPPort() *int     { return m.httpPort }

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -189,6 +189,7 @@ func (rc *RunContext) ConfigurationFile() string                     { return rc
 func (rc *RunContext) CustomLabels() []string                        { return rc.Opts.CustomLabels }
 func (rc *RunContext) CustomTag() string                             { return rc.Opts.CustomTag }
 func (rc *RunContext) DefaultRepo() *string                          { return rc.Opts.DefaultRepo.Value() }
+func (rc *RunContext) MultiLevelRepo() *bool                         { return rc.Opts.MultiLevelRepo }
 func (rc *RunContext) Mode() config.RunMode                          { return rc.Opts.Mode() }
 func (rc *RunContext) DigestSource() string                          { return rc.Opts.DigestSource }
 func (rc *RunContext) DryRun() bool                                  { return rc.Opts.DryRun }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: [_Relevant tracking issues, for context_](https://github.com/GoogleContainerTools/skaffold/issues/1930)
**Merge before/after**: N/A
**Description**
While the data model is a little clunky, as it would be preferable for multi-level support to be an attribute of a repository, given the one-to-one relationship of default repository to global or kube context, however, this adds configurable multi-level repository support per context.

The current behavior is that only GCR and AR support multi-level repositories, with an exemption granted if the name of the image being built has the same prefix as the default repository for the current context. Otherwise forward slashes and periods in image names are substituted with underscores.

GitLab container image registry is another repository that supports, and requires one to adhere to, multi-level image naming conventions. Permission is denied when one violates the organization/repository/nested/sub-directory naming conventions. The problem is that self-hosted registry domain names are not subject to string comparison like GCR and AR. It's easy enough to workaround this by prefixing the image name in skaffold.yaml with the default repository, but then the skaffold configuration is no longer portable. Hence this PR.

**Note**: The version of node was updated in the Dockerfile to support the latest version of postcss.

**User facing changes (remove if N/A)**
The user is now eligible to set for either the global or kube context multi-level support of the repository to which they intend to push images. The default behavior is equivalent to the behavior prior to this PR.

**Follow-up Work (remove if N/A)**
I was uncertain whether this feature should only be supported via config or also as a command line flag, and so there were no changes made to `flags.go`.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
