### PR TITLE
refactor(lint): remove unused regexp linter

### DIFF
--- a/pkg/skaffold/lint/dockerfiles.go
+++ b/pkg/skaffold/lint/dockerfiles.go
@@ -33,7 +33,6 @@ var getDockerDependenciesForEachFromTo = docker.GetDependenciesByDockerCopyFromT
 var dockerfileRules = &dockerfileLintRules
 
 var DockerfileLinters = []Linter{
-	&RegExpLinter{},
 	&DockerfileCommandLinter{},
 }
 

--- a/pkg/skaffold/lint/k8smanifests.go
+++ b/pkg/skaffold/lint/k8smanifests.go
@@ -33,7 +33,6 @@ import (
 var k8sManifestRules = &k8sManifestLintRules
 
 var K8sManifestLinters = []Linter{
-	&RegExpLinter{},
 	&YamlFieldLinter{},
 }
 

--- a/pkg/skaffold/lint/linters_test.go
+++ b/pkg/skaffold/lint/linters_test.go
@@ -25,12 +25,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
-var helloWorldTextFile = ConfigFile{
-	Text:    "Hello World!",
-	AbsPath: "/abs/rel/path",
-	RelPath: "rel/path",
-}
-
 var k8sManifestFile = ConfigFile{
 	Text: `apiVersion: apps/v1
 kind: Deployment
@@ -57,89 +51,6 @@ spec:
 `,
 	AbsPath: "/abs/rel/path",
 	RelPath: "rel/path",
-}
-
-func TestRegExpLinter(t *testing.T) {
-	tests := []struct {
-		description string
-		configFile  ConfigFile
-		rules       *[]Rule
-		profiles    []string
-		module      []string
-		shouldErr   bool
-		expected    *[]Result
-	}{
-		{
-			description: "Test regexp linter",
-			configFile:  helloWorldTextFile,
-			rules: &[]Rule{
-				{
-					RuleID:              DummyRuleIDForTesting,
-					RuleType:            RegExpLintLintRule,
-					ExplanationTemplate: "test explanation",
-					Severity:            protocol.DiagnosticSeverityError,
-					Filter:              "World",
-				},
-			},
-			expected: &[]Result{
-				{
-					Rule: &Rule{
-						RuleID:              DummyRuleIDForTesting,
-						RuleType:            RegExpLintLintRule,
-						ExplanationTemplate: "test explanation",
-						Severity:            protocol.DiagnosticSeverityError,
-						Filter:              "World",
-					},
-					AbsFilePath: "/abs/rel/path",
-					RelFilePath: "rel/path",
-					Line:        1,
-					Column:      6,
-					Explanation: "test explanation",
-				},
-			},
-		},
-		{
-			description: "regexp linter w/ an different type lint rule",
-			configFile: ConfigFile{
-				Text:    "Hello World!",
-				AbsPath: "/abs/rel/path",
-				RelPath: "rel/path",
-			},
-			rules: &[]Rule{
-				{
-					RuleID:   DummyRuleIDForTesting,
-					RuleType: YamlFieldLintRule,
-				},
-			},
-			expected: &[]Result{},
-		},
-		{
-			description: "regexp linter w/ an incorrect Filter type",
-			configFile:  helloWorldTextFile,
-			rules: &[]Rule{
-				{
-					RuleID:              DummyRuleIDForTesting,
-					RuleType:            RegExpLintLintRule,
-					ExplanationTemplate: "test explanation",
-					Severity:            protocol.DiagnosticSeverityError,
-					Filter:              yaml.Get("incorrect filter type"),
-				},
-			},
-			shouldErr: true,
-		},
-	}
-
-	for _, test := range tests {
-		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&realWorkDir, func() (string, error) {
-				return "", nil
-			})
-			linter := &RegExpLinter{}
-			recs, err := linter.Lint(InputParams{ConfigFile: test.configFile}, test.rules)
-			t.CheckError(test.shouldErr, err)
-			t.CheckDeepEqual(test.expected, recs)
-		})
-	}
 }
 
 func TestYamlFieldLinter(t *testing.T) {
@@ -242,7 +153,7 @@ func TestYamlFieldLinter(t *testing.T) {
 			rules: &[]Rule{
 				{
 					RuleID:   DummyRuleIDForTesting,
-					RuleType: RegExpLintLintRule,
+					RuleType: DockerfileCommandLintRule,
 				},
 			},
 			expected: &[]Result{},

--- a/pkg/skaffold/lint/output_test.go
+++ b/pkg/skaffold/lint/output_test.go
@@ -43,7 +43,7 @@ func TestLintOutput(t *testing.T) {
 				{
 					Rule: &Rule{
 						RuleID:              DummyRuleIDForTesting,
-						RuleType:            RegExpLintLintRule,
+						RuleType:            DockerfileCommandLintRule,
 						ExplanationTemplate: "",
 					},
 					Explanation: "test explanation",
@@ -54,7 +54,7 @@ func TestLintOutput(t *testing.T) {
 				},
 			},
 			text:     "first column of this line should be flagged in the result [1,1]",
-			expected: "rel/path:1:1: ID000000: RegExpLintLintRule: test explanation\nfirst column of this line should be flagged in the result [1,1]\n^\n",
+			expected: "rel/path:1:1: ID000000: DockerfileCommandLintRule: test explanation\nfirst column of this line should be flagged in the result [1,1]\n^\n",
 		},
 		{
 			description: "verify json lint output is as expected",
@@ -63,7 +63,7 @@ func TestLintOutput(t *testing.T) {
 				{
 					Rule: &Rule{
 						RuleID:              DummyRuleIDForTesting,
-						RuleType:            RegExpLintLintRule,
+						RuleType:            DockerfileCommandLintRule,
 						ExplanationTemplate: "",
 						Severity:            protocol.DiagnosticSeverityError,
 					},
@@ -75,7 +75,7 @@ func TestLintOutput(t *testing.T) {
 				},
 			},
 			text:     "first column of this line should be flagged in the result [1,1]",
-			expected: `[{"Rule":{"RuleID":0,"RuleType":0,"ExplanationTemplate":"","Severity":1,"Filter":null},"AbsFilePath":%#v,"RelFilePath":"rel/path","Explanation":"test explanation","Line":1,"Column":1}]` + "\n",
+			expected: `[{"Rule":{"RuleID":0,"RuleType":1,"ExplanationTemplate":"","Severity":1,"Filter":null},"AbsFilePath":%#v,"RelFilePath":"rel/path","Explanation":"test explanation","Line":1,"Column":1}]` + "\n",
 		},
 	}
 	for _, test := range tests {

--- a/pkg/skaffold/lint/skaffoldyamls.go
+++ b/pkg/skaffold/lint/skaffoldyamls.go
@@ -45,7 +45,6 @@ var skaffoldYamlRules = &skaffoldYamlLintRules
 var getConfigSet = parser.GetConfigSet
 
 var SkaffoldYamlLinters = []Linter{
-	&RegExpLinter{},
 	&YamlFieldLinter{},
 }
 

--- a/pkg/skaffold/lint/types.go
+++ b/pkg/skaffold/lint/types.go
@@ -84,13 +84,12 @@ type ConfigFile struct {
 type RuleType int
 
 const (
-	RegExpLintLintRule RuleType = iota
-	YamlFieldLintRule
+	YamlFieldLintRule RuleType = iota
 	DockerfileCommandLintRule
 )
 
 func (a RuleType) String() string {
-	return [...]string{"RegExpLintLintRule", "YamlFieldLintRule", "DockerfileCommandLintRule"}[a]
+	return [...]string{"YamlFieldLintRule", "DockerfileCommandLintRule"}[a]
 }
 
 type RuleID int


### PR DESCRIPTION
This PR removes the unused RegExp linter and related logic.  As I am working on some additional refactoring, it makes sense to remove this unused linter to minimize the amount of work involved.  We can add it back later if it is required (additional files need checking that we don't have a schema parser for, etc.)