### PR TITLE
fix: don't send error in skaffoldLogEvent if error is nil

### DIFF
--- a/pkg/skaffold/event/v2/event.go
+++ b/pkg/skaffold/event/v2/event.go
@@ -210,6 +210,10 @@ func SendErrorMessageOnce(task constants.Phase, subtaskID string, err error) {
 }
 
 func (ev *eventHandler) sendErrorMessage(task constants.Phase, subtask string, err error) {
+	if err == nil {
+		return
+	}
+
 	ev.errorOnce.Do(func() {
 		ev.handleSkaffoldLogEvent(&proto.SkaffoldLogEvent{
 			TaskId:    fmt.Sprintf("%s-%d", task, handler.iteration),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/6747

**Description**
This PR updated the function used to send our error message through the event stream. It now should not be sending a final error message if the error is `nil`
