### PR TITLE
feat(lint): added lib for getting yaml line #s for a given schema struct, sub-element and sub-fields.  supports patches & profiles

### DIFF
--- a/pkg/skaffold/parser/config.go
+++ b/pkg/skaffold/parser/config.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/git"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser/configlocations"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/errors"
@@ -80,7 +81,7 @@ func GetAllConfigs(ctx context.Context, opts config.SkaffoldOptions) ([]schemaUt
 func GetConfigSet(ctx context.Context, opts config.SkaffoldOptions) (SkaffoldConfigSet, error) {
 	cOpts := configOpts{file: opts.ConfigurationFile, selection: nil, profiles: opts.Profiles, isRequired: false, isDependency: false}
 	r := newRecord()
-	cfgs, err := getConfigs(ctx, cOpts, opts, r)
+	cfgs, fieldsOverrodeByProfile, err := getConfigs(ctx, cOpts, opts, r)
 	if err != nil {
 		return nil, err
 	}
@@ -94,17 +95,28 @@ func GetConfigSet(ctx context.Context, opts config.SkaffoldOptions) (SkaffoldCon
 	if unmatched := unmatchedProfiles(r.appliedProfiles, opts.Profiles); len(unmatched) != 0 {
 		return nil, sErrors.ConfigProfilesNotMatchedErr(unmatched)
 	}
+
+	for _, c := range cfgs {
+		yinfos, err := configlocations.Parse(c.SourceFile, c.SkaffoldConfig, fieldsOverrodeByProfile)
+		if err != nil {
+			return nil, err
+		}
+		c.YAMLInfos = yinfos
+	}
+
 	return cfgs, nil
 }
 
 // getConfigs recursively parses all configs and their dependencies in the specified `skaffold.yaml`
-func getConfigs(ctx context.Context, cfgOpts configOpts, opts config.SkaffoldOptions, r *record) (SkaffoldConfigSet, error) {
+func getConfigs(ctx context.Context, cfgOpts configOpts, opts config.SkaffoldOptions, r *record) (SkaffoldConfigSet, map[string]configlocations.YAMLOverrideInfo, error) {
+	fieldsOverrodeByProfile := map[string]configlocations.YAMLOverrideInfo{}
+
 	parsed, err := schema.ParseConfigAndUpgrade(cfgOpts.file)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return nil, sErrors.MainConfigFileNotFoundErr(cfgOpts.file, err)
+			return nil, nil, sErrors.MainConfigFileNotFoundErr(cfgOpts.file, err)
 		}
-		return nil, sErrors.ConfigParsingError(err)
+		return nil, nil, sErrors.ConfigParsingError(err)
 	}
 
 	if !util.IsURL(cfgOpts.file) && !filepath.IsAbs(cfgOpts.file) && cfgOpts.file != "-" {
@@ -114,7 +126,7 @@ func getConfigs(ctx context.Context, cfgOpts configOpts, opts config.SkaffoldOpt
 	}
 
 	if len(parsed) == 0 {
-		return nil, sErrors.ZeroConfigsParsedErr(cfgOpts.file)
+		return nil, nil, sErrors.ZeroConfigsParsedErr(cfgOpts.file)
 	}
 	log.Entry(context.TODO()).Debugf("parsed %d configs from configuration file %s", len(parsed), cfgOpts.file)
 
@@ -126,7 +138,7 @@ func getConfigs(ctx context.Context, cfgOpts configOpts, opts config.SkaffoldOpt
 			continue
 		}
 		if seen[cfgName] {
-			return nil, sErrors.DuplicateConfigNamesInSameFileErr(cfgName, cfgOpts.file)
+			return nil, nil, sErrors.DuplicateConfigNamesInSameFileErr(cfgName, cfgOpts.file)
 		}
 		seen[cfgName] = true
 	}
@@ -134,18 +146,18 @@ func getConfigs(ctx context.Context, cfgOpts configOpts, opts config.SkaffoldOpt
 	var configs SkaffoldConfigSet
 	for i, cfg := range parsed {
 		config := cfg.(*latestV1.SkaffoldConfig)
-		processed, err := processEachConfig(ctx, config, cfgOpts, opts, r, i)
+		processed, err := processEachConfig(ctx, config, cfgOpts, opts, r, i, fieldsOverrodeByProfile)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		configs = append(configs, processed...)
 	}
-	return configs, nil
+	return configs, fieldsOverrodeByProfile, nil
 }
 
 // processEachConfig processes each parsed config by applying profiles and recursively processing its dependencies.
 // The `index` parameter specifies the index of the current config in its `skaffold.yaml` file. We use the `index` instead of the config `metadata.name` property to uniquely identify each config since not all configs define `name`.
-func processEachConfig(ctx context.Context, config *latestV1.SkaffoldConfig, cfgOpts configOpts, opts config.SkaffoldOptions, r *record, index int) (SkaffoldConfigSet, error) {
+func processEachConfig(ctx context.Context, config *latestV1.SkaffoldConfig, cfgOpts configOpts, opts config.SkaffoldOptions, r *record, index int, fieldsOverrodeByProfile map[string]configlocations.YAMLOverrideInfo) (SkaffoldConfigSet, error) {
 	// check that the same config name isn't repeated in multiple files.
 	if config.Metadata.Name != "" {
 		prevConfig, found := r.configNameToFile[config.Metadata.Name]
@@ -164,7 +176,7 @@ func processEachConfig(ctx context.Context, config *latestV1.SkaffoldConfig, cfg
 	// `requiredConfigs` specifies if we are already in the dependency-tree of a required config, so all selected configs are required even if they are not explicitly named via the configuration flag.
 	required := cfgOpts.isRequired || len(opts.ConfigurationFilter) == 0 || stringslice.Contains(opts.ConfigurationFilter, config.Metadata.Name)
 
-	profiles, err := schema.ApplyProfiles(config, opts, cfgOpts.profiles)
+	profiles, _, err := schema.ApplyProfiles(config, fieldsOverrodeByProfile, opts, cfgOpts.profiles)
 	if err != nil {
 		return nil, sErrors.ConfigProfileActivationErr(config.Metadata.Name, cfgOpts.file, err)
 	}
@@ -279,7 +291,7 @@ func processEachDependency(ctx context.Context, d latestV1.ConfigDependency, cfg
 	cfgOpts.isDependency = cfgOpts.isDependency || path != cfgOpts.file
 	cfgOpts.file = path
 	cfgOpts.selection = d.Names
-	depConfigs, err := getConfigs(ctx, cfgOpts, opts, r)
+	depConfigs, _, err := getConfigs(ctx, cfgOpts, opts, r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/parser/config_test.go
+++ b/pkg/skaffold/parser/config_test.go
@@ -21,12 +21,16 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
+
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/git"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser/configlocations"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	schemaUtil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -1346,6 +1350,215 @@ requires:
 					t.Fail()
 				}
 			}
+		})
+	}
+}
+
+var testSkaffoldYaml = `apiVersion: skaffold/v2beta26
+kind: Config
+build:
+  artifacts:
+    - image: app-0
+deploy:
+  kubectl:
+    manifests:
+      - manifests-0
+profiles:
+  - name: profile-0
+    build:
+      artifacts:
+        - image: app-0-profile
+          context: app-0-profile
+    deploy:
+      kubectl:
+        manifests:
+          - manifests-0-profile
+    patches:
+      - op: replace
+        path: /build/artifacts/0
+        value:
+          image: app-0-patch
+      - op: add
+        path: /deploy/kubectl/manifests/1
+        value: 'manifests-1'
+  - name: profile-1
+    build:
+      artifacts:
+        - image: app-1-profile
+          context: app-1-profile
+    deploy:
+      kubectl:
+        manifests:
+          - manifests-1-profile
+`
+
+func TestConfigLocationsParse(t *testing.T) {
+	tests := []struct {
+		description      string
+		skaffoldYamlText string
+		profiles         []string
+		missingNodeCount int
+		expected         [][]kyaml.Filter
+	}{
+		{
+			description:      "find all expected yaml nodes for input skaffold.yaml file",
+			skaffoldYamlText: testSkaffoldYaml,
+			profiles:         []string{},
+			expected: [][]kyaml.Filter{
+				{kyaml.Lookup("apiVersion")},
+				{kyaml.Lookup("kind")},
+				{kyaml.Lookup("build")},
+				{kyaml.Lookup("build", "artifacts")},
+				{kyaml.Lookup("deploy")},
+				{kyaml.Lookup("deploy", "kubectl")},
+				{kyaml.Lookup("deploy", "kubectl", "manifests")},
+			},
+		},
+		{
+			description:      "verify profile nodes not in yaml nodes when there is no profile",
+			skaffoldYamlText: testSkaffoldYaml,
+			profiles:         []string{},
+			expected: [][]kyaml.Filter{
+				{kyaml.Lookup("apiVersion")},
+				{kyaml.Lookup("profiles"), kyaml.MatchElementList([]string{"name"}, []string{"profile-0"}), kyaml.Lookup("build"), kyaml.Lookup("artifacts")},
+			},
+			missingNodeCount: 1,
+		},
+		{
+			description:      "find all expected yaml nodes for input skaffold.yaml file and input profile",
+			skaffoldYamlText: testSkaffoldYaml,
+			profiles:         []string{"profile-0"},
+			expected: [][]kyaml.Filter{
+				{kyaml.Lookup("apiVersion")},
+				{kyaml.Lookup("kind")},
+				{kyaml.Lookup("build")},
+				{kyaml.Lookup("profiles"), kyaml.MatchElementList([]string{"name"}, []string{"profile-0"}), kyaml.Lookup("build"), kyaml.Lookup("artifacts")},
+				{kyaml.Lookup("profiles"), kyaml.MatchElementList([]string{"name"}, []string{"profile-0"}),
+					kyaml.Lookup("patches"), kyaml.GetElementByIndex(0), kyaml.Lookup("value"), kyaml.Lookup("image")},
+				{kyaml.Lookup("profiles"), kyaml.MatchElementList([]string{"name"}, []string{"profile-0"}),
+					kyaml.Lookup("patches"), kyaml.GetElementByIndex(1), kyaml.Lookup("value")},
+				{kyaml.Lookup("deploy")},
+				{kyaml.Lookup("profiles"), kyaml.MatchElementList([]string{"name"}, []string{"profile-0"}), kyaml.Lookup("deploy"), kyaml.Lookup("kubectl")},
+				{kyaml.Lookup("profiles"), kyaml.MatchElementList([]string{"name"}, []string{"profile-0"}), kyaml.Lookup("deploy"), kyaml.Lookup("kubectl"), kyaml.Lookup("manifests")},
+			},
+		},
+		{
+			description:      "verify default nodes not in yaml nodes when there is an active profile overwriting the default node",
+			skaffoldYamlText: testSkaffoldYaml,
+			profiles:         []string{},
+			expected: [][]kyaml.Filter{
+				{kyaml.Lookup("apiVersion")},
+				{kyaml.Lookup("build", "artifacts")},
+			},
+			missingNodeCount: 1,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			missingNodeCount := 0
+
+			fp := t.TempFile("skaffoldyaml-", []byte(test.skaffoldYamlText))
+			cfgs, err := GetConfigSet(context.TODO(), config.SkaffoldOptions{ConfigurationFile: fp, Profiles: test.profiles})
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+			root, err := kyaml.Parse(test.skaffoldYamlText)
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+			var seen bool
+			for _, filters := range test.expected {
+				seen = false
+				expectedNode := root
+				var err error
+				for _, filter := range filters {
+					expectedNode, err = expectedNode.Pipe(filter)
+					if err != nil {
+						t.Fatalf(err.Error())
+					}
+				}
+				if expectedNode == nil {
+					t.Errorf("test query led to nil node, should not be the case for kyaml filters: %v", filters)
+				}
+				for _, yamlInfos := range cfgs[0].YAMLInfos.YamlInfos {
+					for _, v := range yamlInfos {
+						if reflect.DeepEqual(expectedNode, v.RNode) {
+							seen = true
+						}
+					}
+				}
+				if seen != true && test.missingNodeCount == 0 {
+					str, _ := expectedNode.String()
+					t.Errorf("unable to find expected yaml node text: %q in the generated yaml node map: %v", str, cfgs[0].YAMLInfos.YamlInfos)
+				}
+				if seen != true && test.missingNodeCount > 0 {
+					missingNodeCount++
+					if missingNodeCount > test.missingNodeCount {
+						t.Errorf("expected %d missing nodes in test, found %d missing nodes", test.missingNodeCount, missingNodeCount)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestConfigLocationsLocate(t *testing.T) {
+	tests := []struct {
+		description      string
+		skaffoldYamlText string
+		profiles         []string
+		expected         []configlocations.Location
+	}{
+		{
+			description:      "verify location for SkaffoldConfig.Build.Artifacts[0] is as expected",
+			skaffoldYamlText: testSkaffoldYaml,
+			profiles:         []string{},
+			expected: []configlocations.Location{
+				{
+					StartLine:   5,
+					StartColumn: 14,
+					EndLine:     6,
+					EndColumn:   0,
+				},
+			},
+		},
+		{
+			description:      "verify location for SkaffoldConfig.Build.Artifacts[0] is as expected with active profile with a patch",
+			skaffoldYamlText: testSkaffoldYaml,
+			profiles:         []string{"profile-0"},
+			expected: []configlocations.Location{
+				{
+					StartLine:   24,
+					StartColumn: 18,
+					EndLine:     25,
+					EndColumn:   0,
+				},
+			},
+		},
+		{
+			description:      "verify location for SkaffoldConfig.Build.Artifacts[0] is as expected with active profile with no patch",
+			skaffoldYamlText: testSkaffoldYaml,
+			profiles:         []string{"profile-1"},
+			expected: []configlocations.Location{
+				{
+					StartLine:   31,
+					StartColumn: 18,
+					EndLine:     32,
+					EndColumn:   0,
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			fp := t.TempFile("skaffoldyaml-", []byte(test.skaffoldYamlText))
+			cfgs, err := GetConfigSet(context.TODO(), config.SkaffoldOptions{ConfigurationFile: fp, Profiles: test.profiles})
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+			artifact0Location := cfgs.Locate(cfgs[0].SkaffoldConfig.Build.Artifacts[0])
+			artifact0Location.SourceFile = ""
+			t.CheckDeepEqual(&test.expected[0], artifact0Location)
 		})
 	}
 }

--- a/pkg/skaffold/parser/configlocations/configlocations.go
+++ b/pkg/skaffold/parser/configlocations/configlocations.go
@@ -1,0 +1,309 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package configlocations
+
+import (
+	"context"
+	"path"
+	"reflect"
+	"strconv"
+	"strings"
+
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/errors"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+type YAMLInfo struct {
+	RNode      *kyaml.RNode
+	SourceFile string
+}
+
+type Location struct {
+	SourceFile  string
+	StartLine   int
+	StartColumn int
+	EndLine     int
+	EndColumn   int
+}
+
+type YAMLInfos struct {
+	// TODO(aaron-prindle)make private again once Parse is setup properly
+	YamlInfos map[uintptr]map[string]YAMLInfo
+	// rename FieldsOverrodeByProfile -> SchemaPathsOverrodeByProfile
+	FieldsOverrodeByProfile map[string]YAMLOverrideInfo // map of schema path -> profile name
+}
+
+func MissingLocation() *Location {
+	return &Location{
+		SourceFile:  "",
+		StartLine:   -1,
+		StartColumn: -1,
+		EndLine:     -1,
+		EndColumn:   -1,
+	}
+}
+
+func NewYAMLInfos() *YAMLInfos {
+	return &YAMLInfos{
+		YamlInfos: map[uintptr]map[string]YAMLInfo{},
+	}
+}
+
+type YAMLOverrideInfo struct {
+	ProfileName    string
+	PatchIndex     int
+	PatchOperation string
+	PatchCopyFrom  string
+}
+
+// Parse parses a skaffold config entry collecting file location information for each schema config object
+func Parse(sourceFile string, config *latestV1.SkaffoldConfig, fieldsOverrodeByProfile map[string]YAMLOverrideInfo) (*YAMLInfos, error) {
+	yamlInfos, err := buildMapOfSchemaObjPointerToYAMLInfos(sourceFile, config, map[uintptr]map[string]YAMLInfo{}, fieldsOverrodeByProfile)
+	return &YAMLInfos{
+			YamlInfos:               yamlInfos,
+			FieldsOverrodeByProfile: fieldsOverrodeByProfile,
+		},
+		err
+}
+
+// Locate gets the location for a skaffold schema struct pointer
+func (m *YAMLInfos) Locate(obj interface{}) *Location {
+	return m.locate(obj, "")
+}
+
+// Locate gets the location for a skaffold schema struct pointer
+func (m *YAMLInfos) LocateElement(obj interface{}, idx int) *Location {
+	return m.locate(obj, strconv.Itoa(idx))
+}
+
+// Locate gets the location for a skaffold schema struct pointer
+func (m *YAMLInfos) LocateField(obj interface{}, fieldName string) *Location {
+	return m.locate(obj, fieldName)
+}
+
+func (m *YAMLInfos) locate(obj interface{}, key string) *Location {
+	kind := reflect.ValueOf(obj).Kind()
+	if kind != reflect.Ptr {
+		log.Entry(context.TODO()).Infof("non pointer object passed to Locate: %v of type %T", obj, obj)
+		return MissingLocation()
+	}
+	if _, ok := m.YamlInfos[reflect.ValueOf(obj).Pointer()]; !ok {
+		log.Entry(context.TODO()).Infof("no map entry found when attempting Locate for %v of type %T and pointer: %d", obj, obj, reflect.ValueOf(obj).Pointer())
+		return MissingLocation()
+	}
+	node, ok := m.YamlInfos[reflect.ValueOf(obj).Pointer()][key]
+	if !ok {
+		log.Entry(context.TODO()).Infof("no map entry found when attempting Locate for %v of type %T and pointer: %d", obj, obj, reflect.ValueOf(obj).Pointer())
+		return MissingLocation()
+	}
+	// iterate over kyaml.RNode text to get endline and endcolumn information
+	nodeText, err := node.RNode.String()
+	if err != nil {
+		return MissingLocation()
+	}
+	log.Entry(context.TODO()).Infof("map entry found when executing Locate for %v of type %T and pointer: %d", obj, obj, reflect.ValueOf(obj).Pointer())
+	lines, cols := getLinesAndColsOfString(nodeText)
+
+	// TODO(aaron-prindle) all line & col values seem 1 greater than expected in actual use, will need to check to see how it works with IDE
+	return &Location{
+		SourceFile:  node.SourceFile,
+		StartLine:   node.RNode.Document().Line,
+		StartColumn: node.RNode.Document().Column,
+		EndLine:     node.RNode.Document().Line + lines,
+		EndColumn:   cols,
+	}
+}
+
+func getLinesAndColsOfString(str string) (int, int) {
+	line := 0
+	col := 0
+	for i := range str {
+		col++
+		if str[i] == '\n' {
+			line++
+			col = 0
+		}
+	}
+	return line, col
+}
+
+func buildMapOfSchemaObjPointerToYAMLInfos(sourceFile string, config *latestV1.SkaffoldConfig, yamlInfos map[uintptr]map[string]YAMLInfo,
+	fieldsOverrodeByProfile map[string]YAMLOverrideInfo) (map[uintptr]map[string]YAMLInfo, error) {
+	skaffoldConfigText, err := util.ReadConfiguration(sourceFile)
+	if err != nil {
+		return nil, sErrors.ConfigParsingError(err)
+	}
+	root, err := kyaml.Parse(string(skaffoldConfigText))
+	if err != nil {
+		return nil, err
+	}
+	// TODO(aaron-prindle) perhaps add some defensive logic to recover from panic when using reflection and instead return error?
+	return generateObjPointerToYAMLNodeMap(sourceFile, reflect.ValueOf(config), reflect.ValueOf(nil), "", "", []string{}, root, root, -1, fieldsOverrodeByProfile, map[interface{}]bool{}, yamlInfos, false)
+}
+
+// generateObjPointerToYAMLNodeMap recursively walks through a structs fields (taking into account profile and patch profile overrides)
+// and collects the corresponding yaml node for each field
+func generateObjPointerToYAMLNodeMap(sourceFile string, v reflect.Value, parentV reflect.Value, fieldName, yamlTag string, schemaPath []string,
+	rootRNode *kyaml.RNode, rNode *kyaml.RNode, containerIdx int, fieldPathsOverrodeByProfiles map[string]YAMLOverrideInfo,
+	visited map[interface{}]bool, yamlInfos map[uintptr]map[string]YAMLInfo, isPatchProfileElemOverride bool) (map[uintptr]map[string]YAMLInfo, error) {
+	// TODO(aaron-prindle) need to verify if generateObjPointerToYAMLNodeMap adds entries for 'map' types, luckily the skaffold schema
+	// only has map[string]string and they are leaf nodes as well which this should work fine for doing the recursion for the time being
+	var err error
+
+	// add current obj/field to schema path if criteria met
+	switch {
+	case containerIdx >= 0:
+		schemaPath = append(schemaPath, strconv.Itoa(containerIdx))
+	case yamlTag != "":
+		schemaPath = append(schemaPath, yamlTag)
+	}
+	// check if current obj/field was overridden by a profile
+	if yamlOverrideInfo, ok := fieldPathsOverrodeByProfiles["/"+path.Join(schemaPath...)]; ok {
+		// reset yaml node path from root path to given profile path ("/" -> "/profile/name=profileName/etc...")
+		rNode, err = rootRNode.Pipe(kyaml.Lookup("profiles"), kyaml.MatchElementList([]string{"name"}, []string{yamlOverrideInfo.ProfileName}))
+		if err != nil {
+			return nil, err
+		}
+		switch {
+		case yamlOverrideInfo.PatchIndex < 0: // this schema obj/field has a profile override (NOT a patch profile override)
+			// moves parent node path from being rooted at default yaml '/' to being rooted at '/profile/name=profileName/...'
+			for i := 0; i < len(schemaPath)-1; i++ {
+				rNode, err = rNode.Pipe(kyaml.Lookup(schemaPath[i]))
+				if err != nil {
+					return nil, err
+				}
+			}
+		default: // this schema obj/field has a patch profile override
+			// NOTE: 'remove' patch operations are not included in fieldPathsOverrodeByProfiles as there
+			//  is no work to be done on them (they were already removed from the schema)
+
+			// TODO(aaron-prindle) verify UX makes sense to use the "FROM" copy node to get yaml information from
+			if yamlOverrideInfo.PatchOperation == "copy" {
+				fromPath := strings.Split(yamlOverrideInfo.PatchCopyFrom, "/")
+				var kf kyaml.Filter
+				for i := 0; i < len(fromPath)-1; i++ {
+					if pathNum, err := strconv.Atoi(fromPath[i]); err == nil {
+						// this path element is a number
+						kf = kyaml.ElementIndexer{Index: pathNum}
+					} else {
+						// this path element isn't a number
+						kf = kyaml.Lookup(fromPath[i])
+					}
+					rNode, err = rNode.Pipe(kf)
+					if err != nil {
+						return nil, err
+					}
+				}
+			} else {
+				rNode, err = rNode.Pipe(kyaml.Lookup("patches"), kyaml.ElementIndexer{Index: yamlOverrideInfo.PatchIndex})
+				if err != nil {
+					return nil, err
+				}
+				yamlTag = "value"
+			}
+			isPatchProfileElemOverride = true
+		}
+	}
+	if rNode == nil {
+		return yamlInfos, nil
+	}
+
+	// drill down through pointers and interfaces to get a value we can use
+	for v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface {
+		if v.Kind() == reflect.Ptr {
+			// Check for recursive data
+			if visited[v.Interface()] {
+				return yamlInfos, nil
+			}
+			visited[v.Interface()] = true
+		}
+		v = v.Elem()
+	}
+
+	if yamlTag != "" { // this check is done to not emit entries for structs that are `yaml:",inline"`
+		// traverse kyaml node tree to current obj/field location
+		var kf kyaml.Filter
+		switch {
+		case rNode.YNode().Kind == kyaml.SequenceNode:
+			kf = kyaml.ElementIndexer{Index: containerIdx}
+		default:
+			kf = kyaml.Lookup(yamlTag)
+		}
+		rNode, err = rNode.Pipe(kf)
+		if err != nil {
+			return nil, err
+		}
+
+		if rNode != nil {
+			if v.CanAddr() {
+				if _, ok := yamlInfos[v.Addr().Pointer()]; !ok {
+					yamlInfos[v.Addr().Pointer()] = map[string]YAMLInfo{}
+				}
+				// add current node entry to yaml info map
+				yamlInfos[v.Addr().Pointer()][""] = YAMLInfo{
+					RNode:      rNode,
+					SourceFile: sourceFile,
+				}
+			}
+
+			if parentV.CanAddr() {
+				if _, ok := yamlInfos[parentV.Addr().Pointer()]; !ok {
+					yamlInfos[parentV.Addr().Pointer()] = map[string]YAMLInfo{}
+				}
+				// add parent relationship entry to yaml info map
+				if containerIdx >= 0 {
+					yamlInfos[parentV.Addr().Pointer()][strconv.Itoa(containerIdx)] = YAMLInfo{
+						RNode:      rNode,
+						SourceFile: sourceFile,
+					}
+				} else {
+					yamlInfos[parentV.Addr().Pointer()][fieldName] = YAMLInfo{
+						RNode:      rNode,
+						SourceFile: sourceFile,
+					}
+				}
+			}
+		}
+	}
+	switch v.Kind() {
+	// TODO(aaron-prindle) add reflect.Map support here as well, currently no struct fields have nested struct in map field so ok for now
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			generateObjPointerToYAMLNodeMap(sourceFile, v.Index(i), v, fieldName+"["+strconv.Itoa(i)+"]", yamlTag+"["+strconv.Itoa(i)+"]", schemaPath, rootRNode, rNode, i, fieldPathsOverrodeByProfiles, visited, yamlInfos, isPatchProfileElemOverride)
+		}
+	case reflect.Struct:
+		t := v.Type() // use type to get number and names of fields
+		for i := 0; i < t.NumField(); i++ {
+			field := t.Field(i)
+			// TODO(aaron-prindle) verify this value works for structs that are `yaml:",inline"`
+			newYamlTag := field.Name
+			if yamlTagToken := field.Tag.Get("yaml"); yamlTagToken != "" && yamlTagToken != "-" {
+				// check for possible comma as in "...,omitempty"
+				var commaIdx int
+				if commaIdx = strings.Index(yamlTagToken, ","); commaIdx < 0 {
+					commaIdx = len(yamlTagToken)
+				}
+				newYamlTag = yamlTagToken[:commaIdx]
+			}
+			generateObjPointerToYAMLNodeMap(sourceFile, v.Field(i), v, field.Name, newYamlTag, schemaPath, rootRNode, rNode, -1, fieldPathsOverrodeByProfiles, visited, yamlInfos, isPatchProfileElemOverride)
+		}
+	}
+	return yamlInfos, nil
+}

--- a/pkg/skaffold/parser/types.go
+++ b/pkg/skaffold/parser/types.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package parser
 
-import latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser/configlocations"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
+)
 
 // SkaffoldConfigSet encapsulates a slice of skaffold configurations.
 type SkaffoldConfigSet []*SkaffoldConfigEntry
@@ -28,6 +31,7 @@ type SkaffoldConfigEntry struct {
 	SourceIndex  int
 	IsRootConfig bool
 	IsRemote     bool
+	YAMLInfos    *configlocations.YAMLInfos
 }
 
 // SelectRootConfigs filters SkaffoldConfigSet to only configs read from the root skaffold.yaml file
@@ -39,4 +43,15 @@ func (s SkaffoldConfigSet) SelectRootConfigs() SkaffoldConfigSet {
 		}
 	}
 	return filteredSet
+}
+
+// Locate gets the location for a skaffold schema struct pointer
+func (s SkaffoldConfigSet) Locate(obj interface{}) *configlocations.Location {
+	loc := configlocations.MissingLocation()
+	for _, c := range s {
+		if l := c.YAMLInfos.Locate(obj); l.StartLine != -1 {
+			loc = l
+		}
+	}
+	return loc
 }

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/parser/configlocations"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -91,7 +92,7 @@ func TestValidateSchema(t *testing.T) {
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
-			err := Process(parser.SkaffoldConfigSet{&parser.SkaffoldConfigEntry{SkaffoldConfig: test.cfg}},
+			err := Process(parser.SkaffoldConfigSet{&parser.SkaffoldConfigEntry{SkaffoldConfig: test.cfg, YAMLInfos: configlocations.NewYAMLInfos()}},
 				Options{CheckDeploySource: false})
 
 			t.CheckError(test.shouldErr, err)
@@ -964,6 +965,7 @@ func TestValidateImageNames(t *testing.T) {
 			err := Process(
 				parser.SkaffoldConfigSet{
 					&parser.SkaffoldConfigEntry{
+						YAMLInfos: configlocations.NewYAMLInfos(),
 						SkaffoldConfig: &latestV1.SkaffoldConfig{
 							Pipeline: latestV1.Pipeline{
 								Build: latestV1.BuildConfig{
@@ -1496,7 +1498,7 @@ func TestValidateKubectlManifests(t *testing.T) {
 
 			set := parser.SkaffoldConfigSet{}
 			for _, c := range test.configs {
-				set = append(set, &parser.SkaffoldConfigEntry{SkaffoldConfig: c})
+				set = append(set, &parser.SkaffoldConfigEntry{SkaffoldConfig: c, YAMLInfos: configlocations.NewYAMLInfos()})
 			}
 			errs := validateKubectlManifests(set)
 			var err error


### PR DESCRIPTION
This PR adds functionality for getting the line & column info for a skaffold schema object/field.  This is done by adding a new `YAMLInfos` field to SkaffoldConfigEntry:
```
type SkaffoldConfigEntry struct {
	*latestV1.SkaffoldConfig
	SourceFile   string
	SourceIndex  int
	IsRootConfig bool
	IsRemote     bool
	YAMLInfos    *configlocations.YAMLInfos
}
```
which has the information/functionality required to query the location of any field in the `*latestV1.SkaffoldConfig`.  Here is an example of how this can be used:

skaffold.yaml file:
```
apiVersion: skaffold/v2beta21
kind: Config
build:
  artifacts:
    - image: leeroy-web
```

`Locate` usage:
```
artifactImageNameLocation := c.YAMLInfos.LocateField(c.Build.Artifacts[i], "ImageName")
# artifactImageNameLocation.SourceFile, artifactImageNameLocation.StartLine, artifactImageNameLocation.EndLine, etc. now accessible  
```

The method used here has 2 phases.  During the initial construction of the `*latestV1.SkaffoldConfig` information related to what fields were overwritten by profiles and patch profiles is stored in `fieldPathElementsOverrodeByProfile` (these are the changes made in `pkg/skaffold/parser/config.go`). This map contains entries that map from the directory representation of a yaml field - ex:`/build/artifacts/0` to the override information of that field.  So something like `/build/artifacts/0` -> overriden by profileName:"profile-name" and patchProfile[0] (the first patch profile in the list of patch profiles)

This map is then passed to the `Parse` logic in `pkg/skaffold/configlocations/types.go` which uses reflection to recursively go through the populated `*latestV1.SkaffoldConfig`  as well as the kyaml Nodes (yaml nodes w/ location information), mapping each obj/field to the corresponding yaml node.  If a node is overwritten by a profile/patch, the logic there assigns the correct node from the `fieldPathElementsOverrodeByProfile` information