### PR TITLE
ci: remove cross compilation step of cloud build job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ endif
 integration: install integration-tests
 
 .PHONY: release
-release: cross $(BUILD_DIR)/VERSION
+release: $(BUILD_DIR)/VERSION
 	docker build \
 		--build-arg VERSION=$(VERSION) \
 		-f deploy/skaffold/Dockerfile \
@@ -151,9 +151,6 @@ release: cross $(BUILD_DIR)/VERSION
 		-t gcr.io/$(GCP_PROJECT)/skaffold:latest \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:$(VERSION) \
 		.
-	gsutil -m cp $(BUILD_DIR)/$(PROJECT)-* $(GSC_RELEASE_PATH)/
-	gsutil -m cp $(BUILD_DIR)/VERSION $(GSC_RELEASE_PATH)/VERSION
-	gsutil -m cp -r $(GSC_RELEASE_PATH)/* $(GSC_RELEASE_LATEST)
 
 .PHONY: release-build
 release-build: cross


### PR DESCRIPTION
**Related**: https://github.com/GoogleContainerTools/skaffold/issues/6348

**Description**
This PR removes the `cross` target dependency from the `release` target, as well as the uploading to our gcs bucket. These things are now handled in our kokoro jobs and no longer need to be done here.

**Follow-up Work (remove if N/A)**
Move over the rest of our jobs to kokoro (release-lts, latest builds)
