### PR TITLE
fix: bugs for skaffold.yaml files read in via stdin

### DIFF
--- a/pkg/skaffold/parser/config.go
+++ b/pkg/skaffold/parser/config.go
@@ -107,7 +107,7 @@ func getConfigs(ctx context.Context, cfgOpts configOpts, opts config.SkaffoldOpt
 		return nil, sErrors.ConfigParsingError(err)
 	}
 
-	if !util.IsURL(cfgOpts.file) && !filepath.IsAbs(cfgOpts.file) {
+	if !util.IsURL(cfgOpts.file) && !filepath.IsAbs(cfgOpts.file) && cfgOpts.file != "-" {
 		cwd, _ := util.RealWorkDir()
 		// convert `file` path to absolute value as it's used as a map key in several places.
 		cfgOpts.file = filepath.Join(cwd, cfgOpts.file)

--- a/pkg/skaffold/util/config.go
+++ b/pkg/skaffold/util/config.go
@@ -25,6 +25,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 )
 
+var stdin []byte
+
 // ReadConfiguration reads a `skaffold.yaml` configuration and
 // returns its content.
 func ReadConfiguration(filename string) ([]byte, error) {
@@ -32,7 +34,14 @@ func ReadConfiguration(filename string) ([]byte, error) {
 	case filename == "":
 		return nil, errors.New("filename not specified")
 	case filename == "-":
-		return ioutil.ReadAll(os.Stdin)
+		if len(stdin) == 0 {
+			var err error
+			stdin, err = ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				return []byte{}, err
+			}
+		}
+		return stdin, nil
 	case IsURL(filename):
 		return Download(filename)
 	default:


### PR DESCRIPTION
This fix modifies the behavior for 2 pieces of how skaffold.yaml's read in via stdin work:
1. Makes it so that the `SourceFile` field for a SkaffoldConfigEntry is `-` for files read in via `stdin` instead of /abs/path/skaffold.yaml/- which is what the value is currently. 
2. Makes it so that `util.ReadConfiguration` is idempotent for skaffold.yaml files read in via `stdin` by storing the []byte from `os.Stdin` that are read in.  Currently once the `Reader` that is os.Stdin is read, subsequent calls to `util.ReadConfiguration` are empty for `stdin` skaffold.yaml files

These changes are required for supporting `stdin` for skaffold.yaml's with the line # support that https://github.com/GoogleContainerTools/skaffold/pull/6955 provides