### PR TITLE
fix: limit number of simultaneous taggers to GOMAXPROCS

### DIFF
--- a/pkg/skaffold/runner/build.go
+++ b/pkg/skaffold/runner/build.go
@@ -24,6 +24,8 @@ import (
 	"runtime"
 	"time"
 
+	"golang.org/x/sync/semaphore"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/cache"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
@@ -36,8 +38,6 @@ import (
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/tag"
 	timeutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util/time"
-
-	"golang.org/x/sync/semaphore"
 )
 
 func NewBuilder(builder build.Builder, tagger tag.Tagger, cache cache.Cache, runCtx *runcontext.RunContext) *Builder {


### PR DESCRIPTION
Fixes: #4954

**Description**
#4954 demonstrates a pathological case with a build with dozens of artifacts using the gitCommit tagger.  This causes a flood of calls to `git describe`, some of which fail due to `too many open files` and result in using the fall-back tagger.
```
 - local/zmarouf/78 -> DEBU[0001] generating tag: unable to find git commit: starting command /usr/bin/git describe --tags --always: fork/exec /usr/bin/git: too many open files  subtask=local/zmarouf/78 task=Build
DEBU[0001] Using a fall-back tagger                      subtask=local/zmarouf/78 task=Build
```

This patch uses a counting semaphore (using golang.org/x/sync's weighted semaphore) to restrict the number of simultaneous calls to `GOMAXPROCS` (initialized to the number of CPUs).  It's possible that a system may support more than this number of simultaneous calls, but our taggers ideally shouldn't be that slow.

A future optimization would be to either have the taggers use memoization somehow to allow reusing previously-computed values, or provide a tagger lifecycle to allow taggers to cache and discarding caches.

