### PR TITLE
feat(lsp): add virtual file system support to ReadConfiguration and use this in LSP for buffer files and lint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,12 +78,13 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0
 	github.com/segmentio/textio v1.2.0
 	github.com/sirupsen/logrus v1.8.1
+	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/tektoncd/pipeline v0.5.1-0.20190731183258-9d7e37e85bf8
 	github.com/xeipuuv/gojsonschema v1.2.0
-	go.lsp.dev/protocol v0.11.2
 	go.lsp.dev/jsonrpc2 v0.9.0
+	go.lsp.dev/protocol v0.11.2
 	go.lsp.dev/uri v0.3.0
 	go.opentelemetry.io/otel v0.20.0
 	go.opentelemetry.io/otel/exporters/stdout v0.20.0

--- a/pkg/skaffold/lint/dockerfiles.go
+++ b/pkg/skaffold/lint/dockerfiles.go
@@ -18,7 +18,6 @@ package lint
 
 import (
 	"context"
-	"io/ioutil"
 	"path/filepath"
 
 	"github.com/moby/buildkit/frontend/dockerfile/command"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // for testing
@@ -140,7 +140,7 @@ func GetDockerfilesLintResults(ctx context.Context, opts Options, dockerCfg dock
 					continue
 				}
 				seen[fp] = true
-				b, err := ioutil.ReadFile(fp)
+				b, err := util.ReadFile(fp)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/skaffold/lint/k8smanifests.go
+++ b/pkg/skaffold/lint/k8smanifests.go
@@ -18,7 +18,6 @@ package lint
 
 import (
 	"context"
-	"io/ioutil"
 	"path/filepath"
 
 	"go.lsp.dev/protocol"
@@ -84,7 +83,7 @@ func GetK8sManifestsLintResults(ctx context.Context, opts Options) (*[]Result, e
 			}
 
 			for _, relPath := range expanded {
-				b, err := ioutil.ReadFile(relPath)
+				b, err := util.ReadFile(relPath)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/skaffold/lint/lint.go
+++ b/pkg/skaffold/lint/lint.go
@@ -34,11 +34,13 @@ func GetAllLintResults(ctx context.Context, opts Options, dockerCfg docker.Confi
 	}
 	results = append(results, *skaffoldYamlResults...)
 
-	dockerfileCommandResults, err := GetDockerfilesLintResults(ctx, opts, dockerCfg)
-	if err != nil {
-		return nil, err
+	if dockerCfg != nil {
+		dockerfileCommandResults, err := GetDockerfilesLintResults(ctx, opts, dockerCfg)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, *dockerfileCommandResults...)
 	}
-	results = append(results, *dockerfileCommandResults...)
 
 	k8sManifestResults, err := GetK8sManifestsLintResults(ctx, opts)
 	if err != nil {

--- a/pkg/skaffold/lint/skaffoldyamls.go
+++ b/pkg/skaffold/lint/skaffoldyamls.go
@@ -19,7 +19,6 @@ package lint
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -122,7 +121,7 @@ var skaffoldYamlLintRules = []Rule{
 					return explanationInfo{}, err
 				}
 				for _, relPath := range expanded {
-					b, err := ioutil.ReadFile(relPath)
+					b, err := util.ReadFile(relPath)
 					if err != nil {
 						return explanationInfo{}, err
 					}
@@ -168,7 +167,7 @@ func GetSkaffoldYamlsLintResults(ctx context.Context, opts Options) (*[]Result, 
 	}
 	l := []Result{}
 	for _, c := range cfgs {
-		b, err := ioutil.ReadFile(c.SourceFile)
+		b, err := util.ReadFile(c.SourceFile)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/skaffold/lsp/document_manager.go
+++ b/pkg/skaffold/lsp/document_manager.go
@@ -17,35 +17,31 @@ limitations under the License.
 package lsp
 
 import (
-	"sync"
+	"github.com/spf13/afero"
 )
 
-// DocumentManager manages syncing documents for the LSP server
+// DocumentManager manages syncing memMapFs for the LSP server
 type DocumentManager struct {
-	documents map[string]string
-	mtx       sync.RWMutex
+	memMapFs afero.Fs
 }
 
 // NewDocumentManager creates a new DocumentManager object
-func NewDocumentManager() *DocumentManager {
+func NewDocumentManager(fs afero.Fs) *DocumentManager {
 	return &DocumentManager{
-		documents: make(map[string]string),
+		memMapFs: fs,
 	}
 }
 
-// UpdateDocument updates the string value for a document
+// UpdateDocument updates the string value for a memMapFs
 func (m *DocumentManager) UpdateDocument(documentURI string, doc string) {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-	m.documents[documentURI] = doc
+	afero.WriteFile(m.memMapFs, documentURI, []byte(doc), 0644)
 }
 
-// GetDocument gets the string value for a document
+// GetDocument gets the string value for a memMapFs
 func (m *DocumentManager) GetDocument(documentURI string) string {
-	m.mtx.RLock()
-	defer m.mtx.RUnlock()
-	if doc, ok := m.documents[documentURI]; ok {
-		return doc
+	b, err := afero.ReadFile(m.memMapFs, documentURI)
+	if err != nil {
+		return ""
 	}
-	return ""
+	return string(b)
 }


### PR DESCRIPTION
this change modifies ReadConfiguration to use an afero Virtual file system - https://github.com/spf13/afero under the hood.  By default it uses an `OS` filesystem (identical to what was used prior under the hood) but this is modified when using the LSP to a memory mapped filesystem so that the LSP can use buffered file information (vs only linting on save, it can lint on each keystroke even if unsaved).  Using a VFS also allows for possibly refactoring tests to use in memory skaffold.yaml files (vs on disk) for speedup

One possible issue is that currently the `Fs` var is a global value and it is possible to have a race as there is no mutex.  As this is only changed for the LSP, I think this should be ok.  Adding a mutex might possibly slowdown any future requirements/desire for parellelizing config/file reading so it is not done atm