### PR TITLE
feat: allow specifying hook command directory

### DIFF
--- a/docs/content/en/schemas/v2beta27.json
+++ b/docs/content/en/schemas/v2beta27.json
@@ -2091,6 +2091,11 @@
           "x-intellij-html-description": "command to execute.",
           "default": "[]"
         },
+        "dir": {
+          "type": "string",
+          "description": "specifies the working directory of the command. If empty, the command runs in the calling process's current directory.",
+          "x-intellij-html-description": "specifies the working directory of the command. If empty, the command runs in the calling process's current directory."
+        },
         "os": {
           "items": {
             "type": "string"
@@ -2103,7 +2108,8 @@
       },
       "preferredOrder": [
         "command",
-        "os"
+        "os",
+        "dir"
       ],
       "additionalProperties": false,
       "type": "object",

--- a/integration/examples/lifecycle-hooks/skaffold.yaml
+++ b/integration/examples/lifecycle-hooks/skaffold.yaml
@@ -7,8 +7,10 @@ build:
       before:
         - command: ["sh", "-c", "./hook.sh"]
           os: [darwin, linux]
+          dir: .
         - command: ["cmd.exe", "/C", "hook.bat"]
           os: [windows]
+          dir: .
       after:
         - command: ["sh", "-c", "docker images $SKAFFOLD_IMAGE --digests"]
           os: [darwin, linux]

--- a/pkg/skaffold/hooks/host.go
+++ b/pkg/skaffold/hooks/host.go
@@ -58,6 +58,7 @@ func (h hostHook) retrieveCmd(ctx context.Context, out io.Writer) *exec.Cmd {
 	cmd.Stderr = out
 	cmd.Env = append(cmd.Env, h.env...)
 	cmd.Env = append(cmd.Env, util.OSEnviron()...)
+	cmd.Dir = h.cfg.Dir
 
 	return cmd
 }

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -1465,6 +1465,9 @@ type HostHook struct {
 	Command []string `yaml:"command" yamltags:"required"`
 	// OS is an optional slice of operating system names. If the host machine OS is different, then it skips execution.
 	OS []string `yaml:"os,omitempty"`
+	// Dir specifies the working directory of the command.
+	// If empty, the command runs in the calling process's current directory.
+	Dir string `yaml:"dir,omitempty" skaffold:"filepath"`
 }
 
 // ContainerHook describes a lifecycle hook definition to execute on a container. The container name is inferred from the scope in which this hook is defined.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6969  <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR allows specifying command directory for host hooks. Also the default behavior of running hooks from the process's current directory is made explicit.
