### PR TITLE
feat: fetch default-repo from local cluster

### DIFF
--- a/pkg/skaffold/config/types.go
+++ b/pkg/skaffold/config/types.go
@@ -31,6 +31,14 @@ type StringOrUndefined struct {
 	value *string
 }
 
+func (s StringOrUndefined) Equal(o StringOrUndefined) bool {
+	if s.value == nil || o.value == nil {
+		return s.value == o.value
+	}
+
+	return *s.value == *o.value
+}
+
 func (s *StringOrUndefined) Type() string {
 	return "string"
 }
@@ -54,6 +62,10 @@ func (s *StringOrUndefined) String() string {
 		return ""
 	}
 	return *s.value
+}
+
+func NewStringOrUndefined(v *string) StringOrUndefined {
+	return StringOrUndefined{value: v}
 }
 
 // BoolOrUndefined holds the value of a flag of type `bool`,
@@ -159,7 +171,8 @@ func (m Muted) mute(phase string) bool {
 }
 
 type Cluster struct {
-	Local      bool
-	PushImages bool
-	LoadImages bool
+	Local       bool
+	PushImages  bool
+	LoadImages  bool
+	DefaultRepo StringOrUndefined
 }

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -246,8 +246,8 @@ func GetCluster(ctx context.Context, configFile string, defaultRepo StringOrUnde
 		local = false
 	}
 
-	if defaultRepo.Value() != nil && config.DefaultRepo != "" {
-		defaultRepo = NewStringOrUndefined(&config.DefaultRepo)
+	if defaultRepo.Value() != nil && cfg.DefaultRepo != "" {
+		defaultRepo = NewStringOrUndefined(&cfg.DefaultRepo)
 	}
 
 	if local && defaultRepo.Value() == nil {

--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -60,7 +60,9 @@ var (
 
 	ReadConfigFile             = readConfigFileCached
 	GetConfigForCurrentKubectx = getConfigForCurrentKubectx
-	current                    = time.Now
+	DiscoverLocalRegistry      = discoverLocalRegistry
+
+	current = time.Now
 
 	// update global config with the time the survey was last taken
 	updateLastTaken = "skaffold config set --survey --global last-taken %s"
@@ -339,7 +341,7 @@ func K3dClusterName(clusterName string) string {
 	return clusterName
 }
 
-func DiscoverLocalRegistry(ctx context.Context, kubeContext string) (*string, error) {
+func discoverLocalRegistry(ctx context.Context, kubeContext string) (*string, error) {
 	clientset, err := kubeclient.Client(kubeContext)
 	if err != nil {
 		return nil, err
@@ -361,14 +363,14 @@ func DiscoverLocalRegistry(ctx context.Context, kubeContext string) (*string, er
 	}
 
 	dst := struct {
-		Host string `yaml:"host"`
+		Host *string `yaml:"host"`
 	}{}
 
 	if err := yaml.Unmarshal([]byte(data), &dst); err != nil {
 		return nil, errors.New("invalid local-registry-hosting ConfigMap")
 	}
 
-	return &dst.Host, nil
+	return dst.Host, nil
 }
 
 func IsUpdateCheckEnabled(configfile string) bool {

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -400,10 +400,20 @@ func TestGetCluster(t *testing.T) {
 			t.Override(&DiscoverLocalRegistry, func(context.Context, string) (*string, error) { return test.registry, nil })
 			t.Override(&cluster.GetClient, func() cluster.Client { return fakeClient{} })
 
-			cluster, _ := GetCluster(ctx, "dummyname", test.defaultRepo, test.profile, true)
+			cluster, _ := GetCluster(ctx, GetClusterOpts{
+				ConfigFile:      "dummyname",
+				DefaultRepo:     test.defaultRepo,
+				MinikubeProfile: test.profile,
+				DetectMinikube:  true,
+			})
 			t.CheckDeepEqual(test.expected, cluster)
 
-			cluster, _ = GetCluster(ctx, "dummyname", test.defaultRepo, test.profile, false)
+			cluster, _ = GetCluster(ctx, GetClusterOpts{
+				ConfigFile:      "dummyname",
+				DefaultRepo:     test.defaultRepo,
+				MinikubeProfile: test.profile,
+				DetectMinikube:  false,
+			})
 			t.CheckDeepEqual(test.expected, cluster)
 		})
 	}

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -25,15 +25,16 @@ import (
 	"testing"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/cluster"
 	kubeclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 	"github.com/GoogleContainerTools/skaffold/testutil"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
 )
 
 func TestReadConfig(t *testing.T) {

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -290,6 +290,7 @@ func (fakeClient) MinikubeExec(context.Context, ...string) (*exec.Cmd, error) { 
 func TestGetCluster(t *testing.T) {
 	var registry = "localhost:5000"
 	var registryConfig = `host: "localhost:5000"`
+	var defaultRepo = "localhost:4000"
 
 	tests := []struct {
 		description    string
@@ -309,6 +310,12 @@ func TestGetCluster(t *testing.T) {
 			cfg:            &ContextConfig{Kubecontext: "kind-other"},
 			registryConfig: registryConfig,
 			expected:       Cluster{Local: true, LoadImages: false, PushImages: true, DefaultRepo: NewStringOrUndefined(&registry)},
+		},
+		{
+			description: "kind with default-repo=localhost:4000",
+			cfg:         &ContextConfig{Kubecontext: "kind-other"},
+			defaultRepo: NewStringOrUndefined(&defaultRepo),
+			expected:    Cluster{Local: true, LoadImages: true, PushImages: false, DefaultRepo: NewStringOrUndefined(&defaultRepo)},
 		},
 		{
 			description: "kind with local-cluster=false",

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -188,7 +188,7 @@ func (rc *RunContext) CacheFile() string                             { return rc
 func (rc *RunContext) ConfigurationFile() string                     { return rc.Opts.ConfigurationFile }
 func (rc *RunContext) CustomLabels() []string                        { return rc.Opts.CustomLabels }
 func (rc *RunContext) CustomTag() string                             { return rc.Opts.CustomTag }
-func (rc *RunContext) DefaultRepo() *string                          { return rc.Opts.DefaultRepo.Value() }
+func (rc *RunContext) DefaultRepo() *string                          { return rc.Cluster.DefaultRepo.Value() }
 func (rc *RunContext) MultiLevelRepo() *bool                         { return rc.Opts.MultiLevelRepo }
 func (rc *RunContext) Mode() config.RunMode                          { return rc.Opts.Mode() }
 func (rc *RunContext) DigestSource() string                          { return rc.Opts.DigestSource }
@@ -264,7 +264,7 @@ func GetRunContext(ctx context.Context, opts config.SkaffoldOptions, configs []s
 	// TODO(https://github.com/GoogleContainerTools/skaffold/issues/3668):
 	// remove minikubeProfile from here and instead detect it by matching the
 	// kubecontext API Server to minikube profiles
-	cluster, err := config.GetCluster(ctx, opts.GlobalConfig, opts.MinikubeProfile, opts.DetectMinikube)
+	cluster, err := config.GetCluster(ctx, opts.GlobalConfig, opts.DefaultRepo, opts.MinikubeProfile, opts.DetectMinikube)
 	if err != nil {
 		return nil, fmt.Errorf("getting cluster: %w", err)
 	}

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -264,7 +264,12 @@ func GetRunContext(ctx context.Context, opts config.SkaffoldOptions, configs []s
 	// TODO(https://github.com/GoogleContainerTools/skaffold/issues/3668):
 	// remove minikubeProfile from here and instead detect it by matching the
 	// kubecontext API Server to minikube profiles
-	cluster, err := config.GetCluster(ctx, opts.GlobalConfig, opts.DefaultRepo, opts.MinikubeProfile, opts.DetectMinikube)
+	cluster, err := config.GetCluster(ctx, config.GetClusterOpts{
+		ConfigFile:      opts.GlobalConfig,
+		DefaultRepo:     opts.DefaultRepo,
+		MinikubeProfile: opts.MinikubeProfile,
+		DetectMinikube:  opts.DetectMinikube,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("getting cluster: %w", err)
 	}


### PR DESCRIPTION
Fixes: #6558 

**Description**
If no default-repo is specified via CLI or config and local cluster is being used try to look up config map describing local registry following [KEP-1755](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/generic/1755-communicating-a-local-registry).

Sample script for setting up local registry for Kind: https://kind.sigs.k8s.io/docs/user/local-registry/

Demo:
* Clone [github.com/shaxbee/todo-app-skaffold](https://github.com/shaxbee/todo-app-skaffold)
* `make bootstrap`
* `skaffold run --force`

You will observe that local registry is automatically used as default-repo and images are pushed instead of being loaded without need to use `skaffold config`.
