### PR TITLE
feat: add 'branches' git tag variant

### DIFF
--- a/pkg/skaffold/tag/git_commit.go
+++ b/pkg/skaffold/tag/git_commit.go
@@ -44,6 +44,7 @@ var variants = map[string]func(context.Context, string) (string, error){
 	"abbrevcommitsha": gitAbbrevcommitsha,
 	"treesha":         gitTreesha,
 	"abbrevtreesha":   gitAbbrevtreesha,
+	"branches":        gitBranches,
 }
 
 // NewGitCommit creates a new git commit tagger. It fails if the tagger variant is invalid.
@@ -133,6 +134,15 @@ func gitAbbrevtreesha(ctx context.Context, workingDir string) (string, error) {
 	}
 
 	return runGit(ctx, workingDir, "rev-parse", "--short", "HEAD:"+gitPath+"/")
+}
+
+func gitBranches(ctx context.Context, workingDir string) (string, error) {
+	gitBranch, err := runGit(ctx, workingDir, "branch", "--show-current")
+	if err != nil {
+		return gitAbbrevcommitsha(ctx, workingDir)
+	}
+
+	return gitBranch, nil
 }
 
 func getGitPathToWorkdir(ctx context.Context, workingDir string) (string, error) {

--- a/pkg/skaffold/tag/git_commit_test.go
+++ b/pkg/skaffold/tag/git_commit_test.go
@@ -46,6 +46,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 		variantAbbrevCommitSha string
 		variantTreeSha         string
 		variantAbbrevTreeSha   string
+		variantBranches        string
 		createGitRepo          func(string)
 		subDir                 string
 		shouldErr              bool
@@ -58,6 +59,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "eefe1b9",
 			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c",
 			variantAbbrevTreeSha:   "3bed02c",
+			variantBranches:        "master",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -72,6 +74,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "aea33bc",
 			variantTreeSha:         "bc69d50cda6897a6f2054e64b9059f038dc6fb0e",
 			variantAbbrevTreeSha:   "bc69d50",
+			variantBranches:        "master",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -85,12 +88,46 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			},
 		},
 		{
+			description:            "clean worktree with a branch",
+			variantTags:            "589c4dc",
+			variantCommitSha:       "589c4dcf52df66d058c705db39f871dceacf6471",
+			variantAbbrevCommitSha: "589c4dc",
+			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c",
+			variantAbbrevTreeSha:   "3bed02c",
+			variantBranches:        "branch",
+			createGitRepo: func(dir string) {
+				gitInit(t, dir).
+					write("source.go", "code").
+					add("source.go").
+					commit("initial").
+					branch("branch").
+					commit("second")
+			},
+		},
+		{
+			description:            "clean worktree with a branch containing a slash",
+			variantTags:            "eefe1b9",
+			variantCommitSha:       "eefe1b9c44eb0aa87199c9a079f2d48d8eb8baed",
+			variantAbbrevCommitSha: "eefe1b9",
+			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c",
+			variantAbbrevTreeSha:   "3bed02c",
+			variantBranches:        "branch_withslash",
+			createGitRepo: func(dir string) {
+				gitInit(t, dir).
+					write("source.go", "code").
+					add("source.go").
+					commit("initial").
+					branch("branch/withslash")
+			},
+		},
+		{
 			description:            "dirty worktree with tag containing a slash",
 			variantTags:            "v_2-dirty",
 			variantCommitSha:       "aea33bcc86b5af8c8570ff45d8a643202d63c808-dirty",
 			variantAbbrevCommitSha: "aea33bc-dirty",
 			variantTreeSha:         "bc69d50cda6897a6f2054e64b9059f038dc6fb0e-dirty",
 			variantAbbrevTreeSha:   "bc69d50-dirty",
+			variantBranches:        "master-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -111,6 +148,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "aea33bc",
 			variantTreeSha:         "bc69d50cda6897a6f2054e64b9059f038dc6fb0e",
 			variantAbbrevTreeSha:   "bc69d50",
+			variantBranches:        "master",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -132,6 +170,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "aea33bc",
 			variantTreeSha:         "bc69d50cda6897a6f2054e64b9059f038dc6fb0e",
 			variantAbbrevTreeSha:   "bc69d50",
+			variantBranches:        "master",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -151,6 +190,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "aea33bc",
 			variantTreeSha:         "bc69d50cda6897a6f2054e64b9059f038dc6fb0e",
 			variantAbbrevTreeSha:   "bc69d50",
+			variantBranches:        "master",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -171,6 +211,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "b2f7a7d",
 			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c",
 			variantAbbrevTreeSha:   "3bed02c",
+			variantBranches:        "master",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "other code").
@@ -189,6 +230,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "eefe1b9-dirty",
 			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c-dirty",
 			variantAbbrevTreeSha:   "3bed02c-dirty",
+			variantBranches:        "master-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -204,6 +246,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "eefe1b9-dirty",
 			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c-dirty",
 			variantAbbrevTreeSha:   "3bed02c-dirty",
+			variantBranches:        "master-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -220,6 +263,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "eefe1b9-dirty",
 			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c-dirty",
 			variantAbbrevTreeSha:   "3bed02c-dirty",
+			variantBranches:        "master-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -235,6 +279,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "3cec6b9",
 			variantTreeSha:         "81eea360f7f81bc5c187498a8d6c4337e0361374",
 			variantAbbrevTreeSha:   "81eea36",
+			variantBranches:        "master",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -253,6 +298,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "279d53f-dirty",
 			variantTreeSha:         "039c20a072ceb72fb72d5883315df91659bb8ae4-dirty",
 			variantAbbrevTreeSha:   "039c20a-dirty",
+			variantBranches:        "master-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source1.go", "code1").
@@ -269,6 +315,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "eefe1b9-dirty",
 			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c-dirty",
 			variantAbbrevTreeSha:   "3bed02c-dirty",
+			variantBranches:        "master-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -284,6 +331,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "b610928",
 			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c",
 			variantAbbrevTreeSha:   "3bed02c",
+			variantBranches:        "master",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("artifact1").write("artifact1/source.go", "code").
@@ -300,6 +348,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "b610928",
 			variantTreeSha:         "36651c832d8bf5ca1e84c6dc23bb8678fa51cf3e",
 			variantAbbrevTreeSha:   "36651c8",
+			variantBranches:        "master",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("artifact1").write("artifact1/source.go", "code").
@@ -316,6 +365,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "b610928",
 			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c",
 			variantAbbrevTreeSha:   "3bed02c",
+			variantBranches:        "master",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("artifact1").write("artifact1/source.go", "code").
@@ -333,6 +383,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "b610928-dirty",
 			variantTreeSha:         "36651c832d8bf5ca1e84c6dc23bb8678fa51cf3e-dirty",
 			variantAbbrevTreeSha:   "36651c8-dirty",
+			variantBranches:        "master-dirty",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("artifact1").write("artifact1/source.go", "code").
@@ -350,6 +401,7 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			variantAbbrevCommitSha: "0d16f59",
 			variantTreeSha:         "3bed02ca656e336307e4eb4d80080d7221cba62c",
 			variantAbbrevTreeSha:   "3bed02c",
+			variantBranches:        "master",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					mkdir("artifact1").write("artifact1/source.go", "code").
@@ -370,7 +422,8 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 			shouldErr: true,
 		},
 		{
-			description: "git repo with no commit",
+			description:     "git repo with no commit",
+			variantBranches: "master",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir)
 			},
@@ -397,13 +450,16 @@ func TestGitCommit_GenerateTag(t *testing.T) {
 				"AbbrevCommitSha": test.variantAbbrevCommitSha,
 				"TreeSha":         test.variantTreeSha,
 				"AbbrevTreeSha":   test.variantAbbrevTreeSha,
+				"Branches":        test.variantBranches,
 			} {
 				tagger, err := NewGitCommit("", variant, test.ignoreChanges)
 				t.CheckNoError(err)
 
 				tag, err := tagger.GenerateTag(context.Background(), image)
 
-				t.CheckErrorAndDeepEqual(test.shouldErr, err, expectedTag, tag)
+				// If we explicitly expect a tag for a variant, it should not err
+				shouldErr := test.shouldErr && expectedTag == ""
+				t.CheckErrorAndDeepEqual(shouldErr, err, expectedTag, tag)
 			}
 		})
 	}
@@ -417,6 +473,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 		variantAbbrevCommitSha string
 		variantTreeSha         string
 		variantAbbrevTreeSha   string
+		variantBranches        string
 		createGitRepo          func(string)
 		subDir                 string
 		shouldErr              bool
@@ -428,6 +485,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 			variantAbbrevCommitSha: "test:eefe1b9",
 			variantTreeSha:         "test:3bed02ca656e336307e4eb4d80080d7221cba62c",
 			variantAbbrevTreeSha:   "test:3bed02c",
+			variantBranches:        "test:master",
 			createGitRepo: func(dir string) {
 				gitInit(t, dir).
 					write("source.go", "code").
@@ -459,6 +517,7 @@ func TestGitCommit_GenerateFullyQualifiedImageName(t *testing.T) {
 				"AbbrevCommitSha": test.variantAbbrevCommitSha,
 				"TreeSha":         test.variantTreeSha,
 				"AbbrevTreeSha":   test.variantAbbrevTreeSha,
+				"Branches":        test.variantBranches,
 			} {
 				tagger, err := NewGitCommit("", variant, false)
 				t.CheckNoError(err)
@@ -695,6 +754,20 @@ func (g *gitRepo) tag(tag string) *gitRepo {
 	t := plumbing.NewHashReference(n, head.Hash())
 
 	err = g.repo.Storer.SetReference(t)
+	failNowIfError(g.t, err)
+
+	return g
+}
+
+func (g *gitRepo) branch(newBranchName string) *gitRepo {
+	refName := plumbing.NewBranchReferenceName(newBranchName)
+	headRef, err := g.repo.Head()
+	failNowIfError(g.t, err)
+	ref := plumbing.NewHashReference(refName, headRef.Hash())
+	err = g.repo.Storer.SetReference(ref)
+	failNowIfError(g.t, err)
+
+	err = g.workTree.Checkout(&git.CheckoutOptions{Branch: ref.Name()})
 	failNowIfError(g.t, err)
 
 	return g


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6989 <!-- tracking issues that this PR will close -->

**Description**
Implements a new git tagpolicy variant `Branches`, which can be used as follows:
```
tagPolicy:
  gitCommit:
    variant: 'Branches'
```

When this tagPolicy is active, when currently tracking a git branch, the branch's name (`git branch --show-current`) with slashes replaced with underscores will be used as the tag, otherwise the current short sha commit will be used.