### PR TITLE
fix(ko): Default repo for pushing `ko://` images

### DIFF
--- a/docs/content/en/docs/pipeline-stages/builders/ko.md
+++ b/docs/content/en/docs/pipeline-stages/builders/ko.md
@@ -243,6 +243,10 @@ Useful tips for existing `ko` users:
   Skaffold removes the `ko://` prefix, if present, before determining the image
   name.
 
+- If your image references use the `ko://` prefix _and_ you are pushing the
+  images to a registry, you must set the
+  [default repo]({{< relref "/docs/environment/image-registries" >}}).
+
 - The ko builder supports reading
   [base image configuration](https://github.com/google/ko#overriding-base-images)
   from the `.ko.yaml` file. If you already configure your base images using

--- a/pkg/skaffold/build/ko/build.go
+++ b/pkg/skaffold/build/ko/build.go
@@ -37,6 +37,9 @@ import (
 // identifier. The image identifier is the tag or digest for pushed images, or
 // the docker image ID for sideloaded images.
 func (b *Builder) Build(ctx context.Context, out io.Writer, a *latestV1.Artifact, ref string) (string, error) {
+	if b.pushImages && strings.HasPrefix(ref, build.StrictScheme) {
+		return "", fmt.Errorf("default repo must be set when using the 'ko://' prefix and pushing to a registry: %s, see https://skaffold.dev/docs/environment/image-registries/", a.ImageName)
+	}
 	koBuilder, err := b.newKoBuilder(ctx, a)
 	if err != nil {
 		return "", fmt.Errorf("error creating ko builder: %w", err)


### PR DESCRIPTION
When using the `ko://` scheme prefix for the Skaffold image name, the rest of the image name that follows the prefix, is a Go import path.

This import path maps to the Git repository location (typically), and won't match an image registry name (e.g., `ko://github.com/org/repo` vs `gcr.io/project_id`). Currently, the result is a hard-to-understand error resulting from a failed push to the non-existent host called `ko` (see #6933).

With this change, if _all_ of the following are true, the build results in an error that instructs the user to set the default repo:

- the image name in `skaffold.yaml` uses the `ko://` prefix; and
- the Skaffold default repo is _not_ set; and
- the image is being pushed to a registry (rather than sideloaded to a Docker daemon).

Fixes: #6933
Tracking: #6041
