### PR TITLE
fix(labelling): hotfix for issues related to deploy erroring due to nested yaml field overriding in StatefulSet w/ PVC

### DIFF
--- a/pkg/skaffold/kubernetes/manifest/images.go
+++ b/pkg/skaffold/kubernetes/manifest/images.go
@@ -37,7 +37,7 @@ type imageSaver struct {
 	Images []graph.Artifact
 }
 
-func (is *imageSaver) Visit(o map[string]interface{}, k string, v interface{}) bool {
+func (is *imageSaver) Visit(navpath string, o map[string]interface{}, k string, v interface{}) bool {
 	if k != "image" {
 		return true
 	}
@@ -112,7 +112,7 @@ func newImageReplacer(builds []graph.Artifact, selector imageSelector) *imageRep
 	}
 }
 
-func (r *imageReplacer) Visit(o map[string]interface{}, k string, v interface{}) bool {
+func (r *imageReplacer) Visit(navpath string, o map[string]interface{}, k string, v interface{}) bool {
 	if k != "image" {
 		return true
 	}

--- a/pkg/skaffold/kubernetes/manifest/labels.go
+++ b/pkg/skaffold/kubernetes/manifest/labels.go
@@ -49,7 +49,7 @@ func newLabelsSetter(labels map[string]string) *labelsSetter {
 	}
 }
 
-func (r *labelsSetter) Visit(o map[string]interface{}, k string, v interface{}) bool {
+func (r *labelsSetter) Visit(navpath string, o map[string]interface{}, k string, v interface{}) bool {
 	if k != "metadata" {
 		return true
 	}

--- a/pkg/skaffold/kubernetes/manifest/namespaces.go
+++ b/pkg/skaffold/kubernetes/manifest/namespaces.go
@@ -48,7 +48,7 @@ func newNamespaceCollector() *namespaceCollector {
 	}
 }
 
-func (r *namespaceCollector) Visit(o map[string]interface{}, k string, v interface{}) bool {
+func (r *namespaceCollector) Visit(navpath string, o map[string]interface{}, k string, v interface{}) bool {
 	if k != "metadata" {
 		return true
 	}

--- a/pkg/skaffold/kubernetes/manifest/visitor.go
+++ b/pkg/skaffold/kubernetes/manifest/visitor.go
@@ -18,6 +18,7 @@ package manifest
 
 import (
 	"fmt"
+	"path"
 
 	apimachinery "k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -46,7 +47,7 @@ var transformableAllowlist = map[apimachinery.GroupKind]bool{
 type FieldVisitor interface {
 	// Visit is called for each transformable key contained in the object and may apply transformations/aggregations on it.
 	// It should return true to allow recursive traversal or false when the entry was transformed.
-	Visit(object map[string]interface{}, key string, value interface{}) bool
+	Visit(path string, object map[string]interface{}, key string, value interface{}) bool
 }
 
 // Visit recursively visits all transformable object fields within the manifests and lets the visitor apply transformations/aggregations on them.
@@ -81,7 +82,7 @@ func traverseManifestFields(manifest map[string]interface{}, visitor FieldVisito
 	if shouldTransformManifest(manifest) {
 		visitor = &recursiveVisitorDecorator{visitor}
 	}
-	visitFields(manifest, visitor)
+	visitFields("/", manifest, visitor)
 }
 
 func shouldTransformManifest(manifest map[string]interface{}) bool {
@@ -123,23 +124,29 @@ type recursiveVisitorDecorator struct {
 	delegate FieldVisitor
 }
 
-func (d *recursiveVisitorDecorator) Visit(o map[string]interface{}, k string, v interface{}) bool {
-	if d.delegate.Visit(o, k, v) {
-		visitFields(v, d)
+func (d *recursiveVisitorDecorator) Visit(path string, o map[string]interface{}, k string, v interface{}) bool {
+	if d.delegate.Visit(path, o, k, v) {
+		visitFields(path, v, d)
 	}
 	return false
 }
 
 // visitFields traverses all fields and calls the visitor for each.
-func visitFields(o interface{}, visitor FieldVisitor) {
+// navpath: a '/' delimited path representing the fields navigated to this point
+func visitFields(navpath string, o interface{}, visitor FieldVisitor) {
 	switch entries := o.(type) {
 	case []interface{}:
 		for _, v := range entries {
-			visitFields(v, visitor)
+			// this case covers lists so we don't update the navpath
+			visitFields(navpath, v, visitor)
 		}
 	case map[string]interface{}:
 		for k, v := range entries {
-			visitor.Visit(entries, k, v)
+			// TODO(6416) temporary fix for StatefulSet + PVC use case, need to do something similar to the proposal in #6236 for full fix
+			if navpath == "/spec/volumeClaimTemplates" {
+				continue
+			}
+			visitor.Visit(path.Join(navpath, k), entries, k, v)
 		}
 	}
 }

--- a/pkg/skaffold/kubernetes/manifest/visitor_test.go
+++ b/pkg/skaffold/kubernetes/manifest/visitor_test.go
@@ -30,7 +30,7 @@ type mockVisitor struct {
 	replaceWith interface{}
 }
 
-func (m *mockVisitor) Visit(o map[string]interface{}, k string, v interface{}) bool {
+func (m *mockVisitor) Visit(navpath string, o map[string]interface{}, k string, v interface{}) bool {
 	s := fmt.Sprintf("%+v", v)
 	if len(s) > 4 {
 		s = s[:4] + "..."


### PR DESCRIPTION
Hotfix for an issue that is being seen in which when skaffold attempts to redeploy manifests with nested objects and "immutable" fields, skaffold fails as it will attempt to override the label/image when doing so will result in a deployment error.

Minimal repro:

Skaffold.yaml
```
apiVersion: skaffold/v2beta12
kind: Config
deploy:
  kubectl:
    manifests:
      - k8-*
```
k8-pod.yaml:

```
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: web
spec:
  selector:
    matchLabels:
      app: echoserver # has to match .spec.template.metadata.labels
  serviceName: "echoserver"
  replicas: 3 # by default is 1
  template:
    metadata:
      labels:
        app: echoserver 
    spec:
      terminationGracePeriodSeconds: 10
      containers:
      - image: k8s.gcr.io/echoserver:1.4
        name: echoserver
        volumeMounts:
        - name: www
          mountPath: /usr/share/nginx/html
  volumeClaimTemplates:
  - metadata:
      name: www
    spec:
      accessModes: [ "ReadWriteOnce" ]
      resources:
        requests:
          storage: 1Gi
```
run "skaffold deploy" twice w/o this PR fails with:
```
aprindle@aprindle ~/repro-6416 $ skaffold deploy
Tags used in deployment:
Starting deploy...
 - The StatefulSet "web" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', 'updateStrategy' and 'minReadySeconds' are forbidden
kubectl apply: exit status 1[
```

works w/ this change.

A more extensible/robust approach to fixing this issue is in progress as well that will implement something similar to the proposed idea from - https://github.com/GoogleContainerTools/skaffold/pull/6236 (found here - https://github.com/GoogleContainerTools/skaffold/blob/main/docs/design_proposals/configurable-transformable-allowlist.md)