### PR TITLE
fix: unblock cloud build edge builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,15 +153,13 @@ release: $(BUILD_DIR)/VERSION
 		.
 
 .PHONY: release-build
-release-build: cross
+release-build:
 	docker build \
 		-f deploy/skaffold/Dockerfile \
 		--target release \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:edge \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:$(COMMIT) \
 		.
-	gsutil -m cp $(BUILD_DIR)/$(PROJECT)-* $(GSC_BUILD_PATH)/
-	gsutil -m cp -r $(GSC_BUILD_PATH)/* $(GSC_BUILD_LATEST)
 
 .PHONY: release-lts
 release-lts: $(BUILD_DIR)/VERSION
@@ -174,15 +172,13 @@ release-lts: $(BUILD_DIR)/VERSION
 		.
 
 .PHONY: release-lts-build
-release-lts-build: cross
+release-lts-build:
 	docker build \
 		-f deploy/skaffold/Dockerfile.lts \
 		--target release \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:edge-lts \
 		-t gcr.io/$(GCP_PROJECT)/skaffold:$(COMMIT)-lts \
 		.
-	gsutil -m cp $(BUILD_DIR)/$(PROJECT)-* $(GSC_LTS_BUILD_PATH)/
-	gsutil -m cp -r $(GSC_LTS_BUILD_PATH)/* $(GSC_LTS_BUILD_LATEST)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This PR unblocks cloud build per commit jobs that create our skaffold:edge images.

It removes the `cross` make target dependency and upload stages from the relevant make targets
