### PR TITLE
fix: allow quotes on base image tags in Dockerfiles

### DIFF
--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -440,13 +440,14 @@ func fromInstruction(node *parser.Node) from {
 // unquote remove single quote/double quote pairs around a string value.
 // It looks like FROM "scratch" and FROM 'scratch' and FROM """scratch"""...
 // are valid forms of FROM scratch.
+// Quotes are also accepted on tags, e.g. golang:"1.15".
 func unquote(v string) string {
-	unquoted := strings.TrimFunc(v, func(r rune) bool { return r == '"' })
+	unquoted := strings.ReplaceAll(v, "\"", "")
 	if unquoted != v {
 		return unquoted
 	}
 
-	unquoted = strings.TrimFunc(v, func(r rune) bool { return r == '\'' })
+	unquoted = strings.ReplaceAll(v, "'", "")
 	return unquoted
 }
 

--- a/pkg/skaffold/docker/parse_test.go
+++ b/pkg/skaffold/docker/parse_test.go
@@ -36,6 +36,8 @@ func TestUnquote(t *testing.T) {
 	testutil.CheckDeepEqual(t, `scratch`, unquote(`'scratch'`))
 	testutil.CheckDeepEqual(t, `scratch`, unquote(`''scratch''`))
 	testutil.CheckDeepEqual(t, `'scratch'`, unquote(`"'scratch'"`))
+	testutil.CheckDeepEqual(t, `golang:1.15`, unquote(`golang:"1.15"`))
+	testutil.CheckDeepEqual(t, `golang:1.15`, unquote(`golang:'1.15'`))
 }
 
 func TestRemoveExtraBuildArgs(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/7026

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Previously, our logic to remove quotes on base images just removed leading/trailing quotes, which was fine for strings like `FROM "scratch"` but failed with strings like `FROM golang:"1.15"`, which is a valid image reference. This change uses `strings.ReplaceAll` instead of `strings.TrimFunc` which should fix this issue.

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
