### PR TITLE
feat(deps): Update Skaffold images to Go 1.17.3

### DIFF
--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -155,5 +155,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=golang:1.15 /usr/local/go /usr/local/go
+COPY --from=golang:1.17.3 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH

--- a/deploy/skaffold/Dockerfile.deps.lts
+++ b/deploy/skaffold/Dockerfile.deps.lts
@@ -99,5 +99,5 @@ RUN apt-get update && apt-get install --no-install-recommends --no-install-sugge
     jq \
     apt-transport-https && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=golang:1.15 /usr/local/go /usr/local/go
+COPY --from=golang:1.17.3 /usr/local/go /usr/local/go
 ENV PATH /usr/local/go/bin:/root/go/bin:$PATH


### PR DESCRIPTION
This PR updates our Skaffold and deps images to include Go 1.17.3 (from Go 1.15).  Go 1.17.3 is the same as used for building our release binaries.  Otherwise our Kokoro build fails if we use or update a dependency that requires Go > 1.15.