### PR TITLE
fix: include registry for `docker login` and `gcloud auth configure-docker`

### DIFF
--- a/pkg/skaffold/build/build_problems.go
+++ b/pkg/skaffold/build/build_problems.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/proto/v1"
@@ -141,14 +142,27 @@ func suggestBuildPushAccessDeniedAction(cfg interface{}) []*proto.Suggestion {
 }
 
 func makeAuthSuggestionsForRepo(repo string) *proto.Suggestion {
-	if re(`(.+\.)?gcr\.io.*`).MatchString(repo) || re(`.+-docker\.pkg\.dev.*`).MatchString(repo) {
+	// parse off the registry component; should have already been validated so unlikely to fail
+	if ref, _ := docker.ParseReference(repo); ref != nil {
+		repo = ref.Domain
+	}
+
+	if re(`(.+\.)?gcr\.io`).MatchString(repo) || re(`.+-docker\.pkg\.dev`).MatchString(repo) {
 		return &proto.Suggestion{
 			SuggestionCode: proto.SuggestionCode_GCLOUD_DOCKER_AUTH_CONFIGURE,
-			Action:         "try `gcloud auth configure-docker`",
+			Action:         fmt.Sprintf("try `gcloud auth configure-docker%s`", withSpace(repo)),
 		}
 	}
 	return &proto.Suggestion{
 		SuggestionCode: proto.SuggestionCode_DOCKER_AUTH_CONFIGURE,
-		Action:         "try `docker login`",
+		Action:         fmt.Sprintf("try `docker login%s`", withSpace(repo)),
 	}
+}
+
+// withSpace returns the given value with a space prepended when not empty.
+func withSpace(value string) string {
+	if len(value) > 0 {
+		return " " + value
+	}
+	return value
 }

--- a/pkg/skaffold/build/build_problems_test.go
+++ b/pkg/skaffold/build/build_problems_test.go
@@ -36,15 +36,15 @@ func TestMakeAuthSuggestionsForRepo(t *testing.T) {
 	}, makeAuthSuggestionsForRepo(""), protocmp.Transform())
 	testutil.CheckDeepEqual(t, &proto.Suggestion{
 		SuggestionCode: proto.SuggestionCode_GCLOUD_DOCKER_AUTH_CONFIGURE,
-		Action:         "try `gcloud auth configure-docker`",
+		Action:         "try `gcloud auth configure-docker gcr.io`",
 	}, makeAuthSuggestionsForRepo("gcr.io/test"), protocmp.Transform())
 	testutil.CheckDeepEqual(t, &proto.Suggestion{
 		SuggestionCode: proto.SuggestionCode_GCLOUD_DOCKER_AUTH_CONFIGURE,
-		Action:         "try `gcloud auth configure-docker`",
+		Action:         "try `gcloud auth configure-docker eu.gcr.io`",
 	}, makeAuthSuggestionsForRepo("eu.gcr.io/test"), protocmp.Transform())
 	testutil.CheckDeepEqual(t, &proto.Suggestion{
 		SuggestionCode: proto.SuggestionCode_GCLOUD_DOCKER_AUTH_CONFIGURE,
-		Action:         "try `gcloud auth configure-docker`",
+		Action:         "try `gcloud auth configure-docker us-docker.pkg.dev`",
 	}, makeAuthSuggestionsForRepo("us-docker.pkg.dev/k8s-skaffold/skaffold"), protocmp.Transform())
 }
 
@@ -74,7 +74,7 @@ func TestBuildProblems(t *testing.T) {
 			description: "Push access denied when default repo is defined",
 			optRepo:     "gcr.io/test",
 			err:         fmt.Errorf("skaffold build failed: could not push image image1 : denied: push access to resource"),
-			expected:    "Build Failed. No push access to specified image repository. Check your `--default-repo` value or try `gcloud auth configure-docker`.",
+			expected:    "Build Failed. No push access to specified image repository. Check your `--default-repo` value or try `gcloud auth configure-docker gcr.io`.",
 			expectedAE: &proto.ActionableErr{
 				ErrCode: proto.StatusCode_BUILD_PUSH_ACCESS_DENIED,
 				Message: "skaffold build failed: could not push image image1 : denied: push access to resource",
@@ -83,7 +83,7 @@ func TestBuildProblems(t *testing.T) {
 					Action:         "Check your `--default-repo` value",
 				}, {
 					SuggestionCode: proto.SuggestionCode_GCLOUD_DOCKER_AUTH_CONFIGURE,
-					Action:         "try `gcloud auth configure-docker`",
+					Action:         "try `gcloud auth configure-docker gcr.io`",
 				},
 				},
 			},
@@ -92,7 +92,7 @@ func TestBuildProblems(t *testing.T) {
 			description: "Push access denied when global repo is defined",
 			context:     config.ContextConfig{DefaultRepo: "docker.io/global"},
 			err:         fmt.Errorf("skaffold build failed: could not push image: denied: push access to resource"),
-			expected:    "Build Failed. No push access to specified image repository. Check your default-repo setting in skaffold config or try `docker login`.",
+			expected:    "Build Failed. No push access to specified image repository. Check your default-repo setting in skaffold config or try `docker login docker.io`.",
 			expectedAE: &proto.ActionableErr{
 				ErrCode: proto.StatusCode_BUILD_PUSH_ACCESS_DENIED,
 				Message: "skaffold build failed: could not push image: denied: push access to resource",
@@ -101,7 +101,7 @@ func TestBuildProblems(t *testing.T) {
 					Action:         "Check your default-repo setting in skaffold config",
 				}, {
 					SuggestionCode: proto.SuggestionCode_DOCKER_AUTH_CONFIGURE,
-					Action:         "try `docker login`",
+					Action:         "try `docker login docker.io`",
 				},
 				},
 			},


### PR DESCRIPTION
Fixes: #7036

**Description**
Include the registry in the suggestions to use `docker login` or `gcloud auth configure-docker`.  Specifying the registry  is necessary for Google Artifact Registry.
```
3a632ae03bb2: Preparing
07d3c46c9599: Preparing
Build Failed. No push access to specified image repository. Check your `--default-repo` value or try `gcloud auth configure-docker us-central1-docker.pkg.dev`.
```