### PR TITLE
ci: ensure build_deps:latest and build_deps:latest-lts are pushed on change

### DIFF
--- a/deploy/cloudbuild-lts.yaml
+++ b/deploy/cloudbuild-lts.yaml
@@ -45,6 +45,7 @@ steps:
     - 'version'
 
 images:
+- 'gcr.io/$PROJECT_ID/build_deps:latest-lts'
 - 'gcr.io/$PROJECT_ID/skaffold:edge-lts'
 - 'gcr.io/$PROJECT_ID/skaffold:$COMMIT_SHA-lts'
 

--- a/deploy/cloudbuild.yaml
+++ b/deploy/cloudbuild.yaml
@@ -43,6 +43,7 @@ steps:
     - 'version'
 
 images:
+- 'gcr.io/$PROJECT_ID/build_deps:latest'
 - 'gcr.io/$PROJECT_ID/skaffold:edge'
 - 'gcr.io/$PROJECT_ID/skaffold:$COMMIT_SHA'
 


### PR DESCRIPTION
We discovered that the build_deps image isn't being updated from the Kokoro failure in #6979.