### PR TITLE
ci: use consistent go build paths caching

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,11 +35,18 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    # Retrieve build locations with `go env`
+    # <https://markphelps.me/posts/speed-up-your-go-builds-with-actions-cache/>
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
     - uses: actions/cache@v2
       with:
         path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
+          ${{ steps.go-cache-paths.outputs.go-build }}
+          ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-

--- a/.github/workflows/integration-darwin.yml
+++ b/.github/workflows/integration-darwin.yml
@@ -16,16 +16,32 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.14
-      id: go
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.*
+      id: go
+
+    # Retrieve build locations with `go env`
+    # <https://markphelps.me/posts/speed-up-your-go-builds-with-actions-cache/>
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ${{ steps.go-cache-paths.outputs.go-build }}
+          ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     # Skip integration tests for `docs`-only changes (only works for PR-based dev workflows like Skaffold's).
     # NOTE: grep output is stored in env var with `|| true` as the run command cannot fail or action will fail

--- a/.github/workflows/integration-linux.yml
+++ b/.github/workflows/integration-linux.yml
@@ -23,16 +23,33 @@ jobs:
         container_structure_tests_version: [1.8.0]
         integration_test_partitions: [0, 1, 2, 3]
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.14
-      id: go
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.*
+      id: go
+
+    # Retrieve build locations with `go env`
+    # <https://markphelps.me/posts/speed-up-your-go-builds-with-actions-cache/>
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ${{ steps.go-cache-paths.outputs.go-build }}
+          ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     # Skip integration tests for `docs`-only changes (only works for PR-based dev workflows like Skaffold's).
     # NOTE: grep output is stored in env var with `|| true` as the run command cannot fail or action will fail

--- a/.github/workflows/integration-windows.yml
+++ b/.github/workflows/integration-windows.yml
@@ -16,16 +16,32 @@ jobs:
     runs-on: windows-latest
     steps:
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.14
-      id: go
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.*
+      id: go
+
+    # Retrieve build locations with `go env`
+    # <https://markphelps.me/posts/speed-up-your-go-builds-with-actions-cache/>
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ${{ steps.go-cache-paths.outputs.go-build }}
+          ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     # TODO(aaron-prindle) skip integration tests for doc only changes on Windows.  Figure out the proper syntax, etc.
     - name: Run skaffold unit tests on windows

--- a/.github/workflows/unit-tests-darwin.yml
+++ b/.github/workflows/unit-tests-darwin.yml
@@ -15,16 +15,32 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ^1.14
-      id: go
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.*
+      id: go
+
+    # Retrieve build locations with `go env`
+    # <https://markphelps.me/posts/speed-up-your-go-builds-with-actions-cache/>
+    - id: go-cache-paths
+      run: |
+        echo "::set-output name=go-build::$(go env GOCACHE)"
+        echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ${{ steps.go-cache-paths.outputs.go-build }}
+          ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     # Skip integration tests for `docs`-only changes (only works for PR-based dev workflows like Skaffold's).
     # NOTE: grep output is stored in env var with `|| true` as the run command cannot fail or action will fail


### PR DESCRIPTION
Noticed the Windows tests weren't caching the go build or modules locations.  Follow the suggestion [here](https://markphelps.me/posts/speed-up-your-go-builds-with-actions-cache/) to use `go env` to retrieve the appropriate  paths to cache.