### PR TITLE
feat(kustomize): Template `paths`

### DIFF
--- a/docs/content/en/docs/environment/templating.md
+++ b/docs/content/en/docs/environment/templating.md
@@ -24,6 +24,7 @@ List of fields that support templating:
 * `deploy.helm.releases.version` (see [Deploying with helm]({{< relref "/docs/pipeline-stages/deployers#deploying-with-helm)" >}}))
 * `deploy.kubectl.defaultNamespace`
 * `deploy.kustomize.defaultNamespace`
+* `deploy.kustomize.paths.[]`
 * `portForward.namespace`
 * `portForward.resourceName`
 

--- a/pkg/skaffold/deploy/kustomize/kustomize_test.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize_test.go
@@ -122,6 +122,26 @@ func TestKustomizeDeploy(t *testing.T) {
 			kustomizeCmdPresent: true,
 		},
 		{
+			description: "deploy success (kustomizePaths with env template)",
+			kustomize: latestV1.KustomizeDeploy{
+				KustomizePaths: []string{"/a/b/{{ .MYENV }}"},
+			},
+			commands: testutil.
+				CmdRunOut("kubectl version --client -ojson", kubectl.KubectlVersion118).
+				AndRunOut("kustomize build /a/b/c", kubectl.DeploymentWebYAML).
+				AndRunInputOut("kubectl --context kubecontext --namespace testNamespace get -f - --ignore-not-found -ojson", kubectl.DeploymentWebYAMLv1, "").
+				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f - --force --grace-period=0"),
+			builds: []graph.Artifact{{
+				ImageName: "leeroy-web",
+				Tag:       "leeroy-web:v1",
+			}},
+			forceDeploy: true,
+			envs: map[string]string{
+				"MYENV": "c",
+			},
+			kustomizeCmdPresent: true,
+		},
+		{
 			description: "deploy success with multiple kustomizations",
 			kustomize: latestV1.KustomizeDeploy{
 				KustomizePaths: []string{"a", "b"},


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
We have been using Skaffold to allow our developers to create ephemeral namespaces to test code changes within. We were partly able to get this to work by creating a `pre-deploy` hook that templates the namespace manifest via environment variables, however this has a limitation as you cannot manage multiple namespaces due to not being able to template the Kustomize `path`.

This PR introduces templating to the Kustomize `path` by calling the `ExpandEnvTemplate` utility function. An example project illustrating an example of this workflow can be seen [here](https://github.com/sbe-genomics/skaffold-path-templating-example). With this PR you would be able to create and delete multiple namespaces by setting the `NAMESPACE` environment variable. The following set of commands would work in this repository if this PR was merged:
```
NAMESPACE=foo skaffold run
NAMESPACE=bar skaffold run
NAMESPACE=foo skaffold delete
```
