### PR TITLE
feat: allow and deny list support for schema field overwriting (namely label and image fields atm)

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -606,6 +606,14 @@ var flagRegistry = []Flag{
 		FlagAddMethod: "BoolVar",
 		DefinedOn:     []string{"deploy"},
 	},
+	{
+		Name:          "resource-selector-rules-file",
+		Usage:         "Path to JSON file specifying the deny list of yaml objects for skaffold to NOT transform with 'image' and 'label' field replacements.  NOTE: this list is additive to skaffold's default denylist and denylist has priority over allowlist",
+		Value:         &opts.TransformRulesFile,
+		DefValue:      "",
+		FlagAddMethod: "StringVar",
+		DefinedOn:     []string{"dev", "render", "run", "debug", "deploy"},
+	},
 }
 
 func methodNameByType(v reflect.Value) string {

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -422,6 +422,7 @@ Options:
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --protocols=[]: Priority sorted order of debugger protocols to support.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
+      --resource-selector-rules-file='': Path to JSON file specifying the deny list of yaml objects for skaffold to NOT transform with 'image' and 'label' field replacements.  NOTE: this list is additive to skaffold's default denylist and denylist has priority over allowlist
       --rpc-http-port=: tcp port to expose the Skaffold API over HTTP REST
       --rpc-port=: tcp port to expose the Skaffold API over gRPC
       --skip-tests=false: Whether to skip the tests after building
@@ -478,6 +479,7 @@ Env vars:
 * `SKAFFOLD_PROPAGATE_PROFILES` (same as `--propagate-profiles`)
 * `SKAFFOLD_PROTOCOLS` (same as `--protocols`)
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
+* `SKAFFOLD_RESOURCE_SELECTOR_RULES_FILE` (same as `--resource-selector-rules-file`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
@@ -588,6 +590,7 @@ Options:
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
+      --resource-selector-rules-file='': Path to JSON file specifying the deny list of yaml objects for skaffold to NOT transform with 'image' and 'label' field replacements.  NOTE: this list is additive to skaffold's default denylist and denylist has priority over allowlist
       --rpc-http-port=: tcp port to expose the Skaffold API over HTTP REST
       --rpc-port=: tcp port to expose the Skaffold API over gRPC
       --skip-render=false: Don't render the manifests, just deploy them
@@ -632,6 +635,7 @@ Env vars:
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
 * `SKAFFOLD_PROPAGATE_PROFILES` (same as `--propagate-profiles`)
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
+* `SKAFFOLD_RESOURCE_SELECTOR_RULES_FILE` (same as `--resource-selector-rules-file`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_RENDER` (same as `--skip-render`)
@@ -684,6 +688,7 @@ Options:
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
+      --resource-selector-rules-file='': Path to JSON file specifying the deny list of yaml objects for skaffold to NOT transform with 'image' and 'label' field replacements.  NOTE: this list is additive to skaffold's default denylist and denylist has priority over allowlist
       --rpc-http-port=: tcp port to expose the Skaffold API over HTTP REST
       --rpc-port=: tcp port to expose the Skaffold API over gRPC
       --skip-tests=false: Whether to skip the tests after building
@@ -740,6 +745,7 @@ Env vars:
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
 * `SKAFFOLD_PROPAGATE_PROFILES` (same as `--propagate-profiles`)
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
+* `SKAFFOLD_RESOURCE_SELECTOR_RULES_FILE` (same as `--resource-selector-rules-file`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)
@@ -934,6 +940,7 @@ Options:
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
+      --resource-selector-rules-file='': Path to JSON file specifying the deny list of yaml objects for skaffold to NOT transform with 'image' and 'label' field replacements.  NOTE: this list is additive to skaffold's default denylist and denylist has priority over allowlist
       --sync-remote-cache='always': Controls how Skaffold manages the remote config cache (see `remote-cache-dir`). One of `always` (default), `missing`, or `never`. `always` syncs remote repositories to latest on access. `missing` only clones remote repositories if they do not exist locally. `never` means the user takes responsibility for updating remote repositories.
       --wait-for-connection=false: Blocks ending execution of skaffold until the /v2/events gRPC/HTTP endpoint is hit
 
@@ -962,6 +969,7 @@ Env vars:
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
 * `SKAFFOLD_PROPAGATE_PROFILES` (same as `--propagate-profiles`)
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
+* `SKAFFOLD_RESOURCE_SELECTOR_RULES_FILE` (same as `--resource-selector-rules-file`)
 * `SKAFFOLD_SYNC_REMOTE_CACHE` (same as `--sync-remote-cache`)
 * `SKAFFOLD_WAIT_FOR_CONNECTION` (same as `--wait-for-connection`)
 
@@ -1009,6 +1017,7 @@ Options:
       --profile-auto-activation=true: Set to false to disable profile auto activation
       --propagate-profiles=true: Setting '--propagate-profiles=false' disables propagating profiles set by the '--profile' flag across config dependencies. This mean that only profiles defined directly in the target 'skaffold.yaml' file are activated.
       --remote-cache-dir='': Specify the location of the git repositories cache (default $HOME/.skaffold/repos)
+      --resource-selector-rules-file='': Path to JSON file specifying the deny list of yaml objects for skaffold to NOT transform with 'image' and 'label' field replacements.  NOTE: this list is additive to skaffold's default denylist and denylist has priority over allowlist
       --rpc-http-port=: tcp port to expose the Skaffold API over HTTP REST
       --rpc-port=: tcp port to expose the Skaffold API over gRPC
       --skip-tests=false: Whether to skip the tests after building
@@ -1060,6 +1069,7 @@ Env vars:
 * `SKAFFOLD_PROFILE_AUTO_ACTIVATION` (same as `--profile-auto-activation`)
 * `SKAFFOLD_PROPAGATE_PROFILES` (same as `--propagate-profiles`)
 * `SKAFFOLD_REMOTE_CACHE_DIR` (same as `--remote-cache-dir`)
+* `SKAFFOLD_RESOURCE_SELECTOR_RULES_FILE` (same as `--resource-selector-rules-file`)
 * `SKAFFOLD_RPC_HTTP_PORT` (same as `--rpc-http-port`)
 * `SKAFFOLD_RPC_PORT` (same as `--rpc-port`)
 * `SKAFFOLD_SKIP_TESTS` (same as `--skip-tests`)

--- a/docs/content/en/schemas/v2beta28.json
+++ b/docs/content/en/schemas/v2beta28.json
@@ -3301,6 +3301,11 @@
           "description": "describes user defined resources to port-forward.",
           "x-intellij-html-description": "describes user defined resources to port-forward."
         },
+        "resourceSelector": {
+          "$ref": "#/definitions/ResourceSelectorConfig",
+          "description": "describes user defined filters describing how skaffold should treat objects/fields during rendering.",
+          "x-intellij-html-description": "describes user defined filters describing how skaffold should treat objects/fields during rendering."
+        },
         "test": {
           "items": {
             "$ref": "#/definitions/TestCase"
@@ -3317,7 +3322,8 @@
         "build",
         "test",
         "deploy",
-        "portForward"
+        "portForward",
+        "resourceSelector"
       ],
       "additionalProperties": false,
       "type": "object",
@@ -3355,9 +3361,14 @@
     },
     "ResourceFilter": {
       "required": [
-        "type"
+        "groupKind"
       ],
       "properties": {
+        "groupKind": {
+          "type": "string",
+          "description": "compact format of a resource type.",
+          "x-intellij-html-description": "compact format of a resource type."
+        },
         "image": {
           "items": {
             "type": "string"
@@ -3375,15 +3386,10 @@
           "description": "an optional slide of JSON-path-like paths of where to add a labels block if missing.",
           "x-intellij-html-description": "an optional slide of JSON-path-like paths of where to add a labels block if missing.",
           "default": "[]"
-        },
-        "type": {
-          "type": "string",
-          "description": "compact format of a resource type.",
-          "x-intellij-html-description": "compact format of a resource type."
         }
       },
       "preferredOrder": [
-        "type",
+        "groupKind",
         "image",
         "labels"
       ],
@@ -3460,6 +3466,34 @@
       "description": "describes the resource requirements for the kaniko pod.",
       "x-intellij-html-description": "describes the resource requirements for the kaniko pod."
     },
+    "ResourceSelectorConfig": {
+      "properties": {
+        "allow": {
+          "items": {
+            "$ref": "#/definitions/ResourceFilter"
+          },
+          "type": "array",
+          "description": "configures an allowlist for transforming manifests.",
+          "x-intellij-html-description": "configures an allowlist for transforming manifests."
+        },
+        "deny": {
+          "items": {
+            "$ref": "#/definitions/ResourceFilter"
+          },
+          "type": "array",
+          "description": "configures an allowlist for transforming manifests.",
+          "x-intellij-html-description": "configures an allowlist for transforming manifests."
+        }
+      },
+      "preferredOrder": [
+        "allow",
+        "deny"
+      ],
+      "additionalProperties": false,
+      "type": "object",
+      "description": "contains all the configuration needed by the deploy steps.",
+      "x-intellij-html-description": "contains all the configuration needed by the deploy steps."
+    },
     "ResourceType": {
       "type": "string",
       "description": "describes the Kubernetes resource types used for port forwarding.",
@@ -3526,6 +3560,11 @@
           "description": "describes a list of other required configs for the current config.",
           "x-intellij-html-description": "describes a list of other required configs for the current config."
         },
+        "resourceSelector": {
+          "$ref": "#/definitions/ResourceSelectorConfig",
+          "description": "describes user defined filters describing how skaffold should treat objects/fields during rendering.",
+          "x-intellij-html-description": "describes user defined filters describing how skaffold should treat objects/fields during rendering."
+        },
         "test": {
           "items": {
             "$ref": "#/definitions/TestCase"
@@ -3544,6 +3583,7 @@
         "test",
         "deploy",
         "portForward",
+        "resourceSelector",
         "profiles"
       ],
       "additionalProperties": false,

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -46,12 +46,13 @@ type SkaffoldOptions struct {
 	// TODO(https://github.com/GoogleContainerTools/skaffold/issues/3668):
 	// remove minikubeProfile from here and instead detect it by matching the
 	// kubecontext API Server to minikube profiles
-	MinikubeProfile string
-	Namespace       string
-	RenderOutput    string
-	RepoCacheDir    string
-	Trigger         string
-	User            string
+	MinikubeProfile    string
+	Namespace          string
+	RenderOutput       string
+	RepoCacheDir       string
+	Trigger            string
+	User               string
+	TransformRulesFile string
 
 	ConfigurationFilter []string
 	CustomLabels        []string

--- a/pkg/skaffold/deploy/deploy_problems_test.go
+++ b/pkg/skaffold/deploy/deploy_problems_test.go
@@ -108,18 +108,20 @@ type mockConfig struct {
 	kubeContext string
 }
 
-func (m mockConfig) MinikubeProfile() string                           { return m.minikube }
-func (m mockConfig) GetPipelines() []latestV1.Pipeline                 { return []latestV1.Pipeline{} }
-func (m mockConfig) GetWorkingDir() string                             { return "" }
-func (m mockConfig) GetNamespace() string                              { return "" }
-func (m mockConfig) GlobalConfig() string                              { return "" }
-func (m mockConfig) ConfigurationFile() string                         { return "" }
-func (m mockConfig) DefaultRepo() *string                              { return &m.minikube }
-func (m mockConfig) MultiLevelRepo() *bool                             { return nil }
-func (m mockConfig) SkipRender() bool                                  { return true }
-func (m mockConfig) Prune() bool                                       { return true }
-func (m mockConfig) ContainerDebugging() bool                          { return false }
-func (m mockConfig) GetKubeContext() string                            { return m.kubeContext }
-func (m mockConfig) GetInsecureRegistries() map[string]bool            { return map[string]bool{} }
-func (m mockConfig) Mode() config.RunMode                              { return config.RunModes.Dev }
-func (m mockConfig) TransformableAllowList() []latestV1.ResourceFilter { return nil }
+func (m mockConfig) MinikubeProfile() string                       { return m.minikube }
+func (m mockConfig) GetPipelines() []latestV1.Pipeline             { return []latestV1.Pipeline{} }
+func (m mockConfig) GetWorkingDir() string                         { return "" }
+func (m mockConfig) GetNamespace() string                          { return "" }
+func (m mockConfig) GlobalConfig() string                          { return "" }
+func (m mockConfig) ConfigurationFile() string                     { return "" }
+func (m mockConfig) DefaultRepo() *string                          { return &m.minikube }
+func (m mockConfig) MultiLevelRepo() *bool                         { return nil }
+func (m mockConfig) SkipRender() bool                              { return true }
+func (m mockConfig) Prune() bool                                   { return true }
+func (m mockConfig) ContainerDebugging() bool                      { return false }
+func (m mockConfig) GetKubeContext() string                        { return m.kubeContext }
+func (m mockConfig) GetInsecureRegistries() map[string]bool        { return map[string]bool{} }
+func (m mockConfig) Mode() config.RunMode                          { return config.RunModes.Dev }
+func (m mockConfig) TransformAllowList() []latestV1.ResourceFilter { return nil }
+func (m mockConfig) TransformDenyList() []latestV1.ResourceFilter  { return nil }
+func (m mockConfig) TransformRulesFile() string                    { return "" }

--- a/pkg/skaffold/deploy/kpt/kpt.go
+++ b/pkg/skaffold/deploy/kpt/kpt.go
@@ -30,6 +30,7 @@ import (
 
 	"golang.org/x/mod/semver"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	apimachinery "k8s.io/apimachinery/pkg/runtime/schema"
 	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/access"
@@ -100,6 +101,9 @@ type Deployer struct {
 	namespace          string
 
 	namespaces *[]string
+
+	transformableAllowlist map[apimachinery.GroupKind]latestV1.ResourceFilter
+	transformableDenylist  map[apimachinery.GroupKind]latestV1.ResourceFilter
 }
 
 type Config interface {
@@ -110,7 +114,7 @@ type Config interface {
 }
 
 // NewDeployer generates a new Deployer object contains the kptDeploy schema.
-func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latestV1.KptDeploy) *Deployer {
+func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latestV1.KptDeploy) (*Deployer, error) {
 	podSelector := kubernetes.NewImageList()
 	kubectl := pkgkubectl.NewCLI(cfg, cfg.GetKubeNamespace())
 	namespaces, err := deployutil.GetAllPodNamespaces(cfg.GetNamespace(), cfg.GetPipelines())
@@ -118,24 +122,30 @@ func NewDeployer(cfg Config, labeller *label.DefaultLabeller, d *latestV1.KptDep
 		olog.Entry(context.TODO()).Warn("unable to parse namespaces - deploy might not work correctly!")
 	}
 	logger := component.NewLogger(cfg, kubectl, podSelector, &namespaces)
-	return &Deployer{
-		KptDeploy:          d,
-		podSelector:        podSelector,
-		namespaces:         &namespaces,
-		accessor:           component.NewAccessor(cfg, cfg.GetKubeContext(), kubectl, podSelector, labeller, &namespaces),
-		debugger:           component.NewDebugger(cfg.Mode(), podSelector, &namespaces, cfg.GetKubeContext()),
-		imageLoader:        component.NewImageLoader(cfg, kubectl),
-		logger:             logger,
-		statusMonitor:      component.NewMonitor(cfg, cfg.GetKubeContext(), labeller, &namespaces),
-		syncer:             component.NewSyncer(kubectl, &namespaces, logger.GetFormatter()),
-		insecureRegistries: cfg.GetInsecureRegistries(),
-		labels:             labeller.Labels(),
-		globalConfig:       cfg.GlobalConfig(),
-		hasKustomization:   hasKustomization,
-		kubeContext:        cfg.GetKubeContext(),
-		kubeConfig:         cfg.GetKubeConfig(),
-		namespace:          cfg.GetKubeNamespace(),
+	transformableAllowlist, transformableDenylist, err := deployutil.ConsolidateTransformConfiguration(cfg)
+	if err != nil {
+		return nil, err
 	}
+	return &Deployer{
+		KptDeploy:              d,
+		podSelector:            podSelector,
+		namespaces:             &namespaces,
+		accessor:               component.NewAccessor(cfg, cfg.GetKubeContext(), kubectl, podSelector, labeller, &namespaces),
+		debugger:               component.NewDebugger(cfg.Mode(), podSelector, &namespaces, cfg.GetKubeContext()),
+		imageLoader:            component.NewImageLoader(cfg, kubectl),
+		logger:                 logger,
+		statusMonitor:          component.NewMonitor(cfg, cfg.GetKubeContext(), labeller, &namespaces),
+		syncer:                 component.NewSyncer(kubectl, &namespaces, logger.GetFormatter()),
+		insecureRegistries:     cfg.GetInsecureRegistries(),
+		labels:                 labeller.Labels(),
+		globalConfig:           cfg.GlobalConfig(),
+		hasKustomization:       hasKustomization,
+		kubeContext:            cfg.GetKubeContext(),
+		kubeConfig:             cfg.GetKubeConfig(),
+		namespace:              cfg.GetKubeNamespace(),
+		transformableAllowlist: transformableAllowlist,
+		transformableDenylist:  transformableDenylist,
+	}, nil
 }
 
 func (k *Deployer) trackNamespaces(namespaces []string) {
@@ -475,12 +485,12 @@ func (k *Deployer) renderManifests(ctx context.Context, builds []graph.Artifact)
 		return nil, fmt.Errorf("excluding kpt functions from manifests: %w", err)
 	}
 	if k.originalImages == nil {
-		k.originalImages, err = manifests.GetImages()
+		k.originalImages, err = manifests.GetImages(manifest.NewResourceSelectorImages(k.transformableAllowlist, k.transformableDenylist))
 		if err != nil {
 			return nil, err
 		}
 	}
-	manifests, err = manifests.ReplaceImages(ctx, builds)
+	manifests, err = manifests.ReplaceImages(ctx, builds, manifest.NewResourceSelectorImages(k.transformableAllowlist, k.transformableDenylist))
 	if err != nil {
 		return nil, fmt.Errorf("replacing images in manifests: %w", err)
 	}
@@ -489,7 +499,7 @@ func (k *Deployer) renderManifests(ctx context.Context, builds []graph.Artifact)
 		return nil, err
 	}
 
-	return manifests.SetLabels(k.labels)
+	return manifests.SetLabels(k.labels, manifest.NewResourceSelectorLabels(k.transformableAllowlist, k.transformableDenylist))
 }
 
 func sink(ctx context.Context, buf []byte, sinkDir string) error {

--- a/pkg/skaffold/deploy/kustomize/kustomize.go
+++ b/pkg/skaffold/deploy/kustomize/kustomize.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/segmentio/textio"
 	yamlv3 "gopkg.in/yaml.v3"
+	apimachinery "k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/access"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
@@ -127,6 +128,9 @@ type Deployer struct {
 	useKubectlKustomize bool
 
 	namespaces *[]string
+
+	transformableAllowlist map[apimachinery.GroupKind]latestV1.ResourceFilter
+	transformableDenylist  map[apimachinery.GroupKind]latestV1.ResourceFilter
 }
 
 func NewDeployer(cfg kubectl.Config, labeller *label.DefaultLabeller, d *latestV1.KustomizeDeploy) (*Deployer, error) {
@@ -149,22 +153,28 @@ func NewDeployer(cfg kubectl.Config, labeller *label.DefaultLabeller, d *latestV
 		olog.Entry(context.TODO()).Warn("unable to parse namespaces - deploy might not work correctly!")
 	}
 	logger := component.NewLogger(cfg, kubectl.CLI, podSelector, &namespaces)
+	transformableAllowlist, transformableDenylist, err := deployutil.ConsolidateTransformConfiguration(cfg)
+	if err != nil {
+		return nil, err
+	}
 	return &Deployer{
-		KustomizeDeploy:     d,
-		podSelector:         podSelector,
-		namespaces:          &namespaces,
-		accessor:            component.NewAccessor(cfg, cfg.GetKubeContext(), kubectl.CLI, podSelector, labeller, &namespaces),
-		debugger:            component.NewDebugger(cfg.Mode(), podSelector, &namespaces, cfg.GetKubeContext()),
-		hookRunner:          hooks.NewDeployRunner(kubectl.CLI, d.LifecycleHooks, &namespaces, logger.GetFormatter(), hooks.NewDeployEnvOpts(labeller.GetRunID(), kubectl.KubeContext, namespaces)),
-		imageLoader:         component.NewImageLoader(cfg, kubectl.CLI),
-		logger:              logger,
-		statusMonitor:       component.NewMonitor(cfg, cfg.GetKubeContext(), labeller, &namespaces),
-		syncer:              component.NewSyncer(kubectl.CLI, &namespaces, logger.GetFormatter()),
-		kubectl:             kubectl,
-		insecureRegistries:  cfg.GetInsecureRegistries(),
-		globalConfig:        cfg.GlobalConfig(),
-		labels:              labeller.Labels(),
-		useKubectlKustomize: useKubectlKustomize,
+		KustomizeDeploy:        d,
+		podSelector:            podSelector,
+		namespaces:             &namespaces,
+		accessor:               component.NewAccessor(cfg, cfg.GetKubeContext(), kubectl.CLI, podSelector, labeller, &namespaces),
+		debugger:               component.NewDebugger(cfg.Mode(), podSelector, &namespaces, cfg.GetKubeContext()),
+		hookRunner:             hooks.NewDeployRunner(kubectl.CLI, d.LifecycleHooks, &namespaces, logger.GetFormatter(), hooks.NewDeployEnvOpts(labeller.GetRunID(), kubectl.KubeContext, namespaces)),
+		imageLoader:            component.NewImageLoader(cfg, kubectl.CLI),
+		logger:                 logger,
+		statusMonitor:          component.NewMonitor(cfg, cfg.GetKubeContext(), labeller, &namespaces),
+		syncer:                 component.NewSyncer(kubectl.CLI, &namespaces, logger.GetFormatter()),
+		kubectl:                kubectl,
+		insecureRegistries:     cfg.GetInsecureRegistries(),
+		globalConfig:           cfg.GlobalConfig(),
+		labels:                 labeller.Labels(),
+		useKubectlKustomize:    useKubectlKustomize,
+		transformableAllowlist: transformableAllowlist,
+		transformableDenylist:  transformableDenylist,
 	}, nil
 }
 
@@ -325,13 +335,13 @@ func (k *Deployer) renderManifests(ctx context.Context, out io.Writer, builds []
 	}
 
 	if len(k.originalImages) == 0 {
-		k.originalImages, err = manifests.GetImages()
+		k.originalImages, err = manifests.GetImages(manifest.NewResourceSelectorImages(k.transformableAllowlist, k.transformableDenylist))
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	manifests, err = manifests.ReplaceImages(ctx, builds)
+	manifests, err = manifests.ReplaceImages(ctx, builds, manifest.NewResourceSelectorImages(k.transformableAllowlist, k.transformableDenylist))
 	if err != nil {
 		return nil, err
 	}
@@ -340,7 +350,7 @@ func (k *Deployer) renderManifests(ctx context.Context, out io.Writer, builds []
 		return nil, err
 	}
 
-	return manifests.SetLabels(k.labels)
+	return manifests.SetLabels(k.labels, manifest.NewResourceSelectorLabels(k.transformableAllowlist, k.transformableDenylist))
 }
 
 // Cleanup deletes what was deployed by calling Deploy.

--- a/pkg/skaffold/deploy/types/types.go
+++ b/pkg/skaffold/deploy/types/types.go
@@ -34,7 +34,9 @@ type Config interface {
 	DefaultRepo() *string
 	MultiLevelRepo() *bool
 	SkipRender() bool
-	TransformableAllowList() []latestV1.ResourceFilter
+	TransformAllowList() []latestV1.ResourceFilter
+	TransformDenyList() []latestV1.ResourceFilter
+	TransformRulesFile() string
 }
 
 // Artifact contains all information about a completed deployment

--- a/pkg/skaffold/deploy/util/util.go
+++ b/pkg/skaffold/deploy/util/util.go
@@ -18,6 +18,8 @@ package util
 
 import (
 	"fmt"
+	"io/ioutil"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -25,10 +27,14 @@ import (
 	fakekubeclientset "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/types"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util/stringset"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 )
 
 // ApplyDefaultRepo applies the default repo to a given image tag.
@@ -97,4 +103,93 @@ func GroupVersionResource(disco discovery.DiscoveryInterface, gvk schema.GroupVe
 	}
 
 	return false, schema.GroupVersionResource{}, fmt.Errorf("could not find resource for %s", gvk.String())
+}
+
+func ConsolidateTransformConfiguration(cfg types.Config) (map[schema.GroupKind]latestV1.ResourceFilter, map[schema.GroupKind]latestV1.ResourceFilter, error) {
+	// TODO(aaron-prindle) currently this also modifies the flag & config to support a JSON path syntax for input.
+	// this should be done elsewhere eventually
+
+	transformableAllowlist := map[schema.GroupKind]latestV1.ResourceFilter{}
+	transformableDenylist := map[schema.GroupKind]latestV1.ResourceFilter{}
+	// add default values
+	for _, rf := range manifest.TransformAllowlist {
+		groupKind := schema.ParseGroupKind(rf.GroupKind)
+		transformableAllowlist[groupKind] = convertJSONPathIndex(rf)
+	}
+	for _, rf := range manifest.TransformDenylist {
+		groupKind := schema.ParseGroupKind(rf.GroupKind)
+		transformableDenylist[groupKind] = convertJSONPathIndex(rf)
+	}
+
+	// add user schema values, override defaults
+	for _, rf := range cfg.TransformAllowList() {
+		groupKind := schema.ParseGroupKind(rf.GroupKind)
+		transformableAllowlist[groupKind] = convertJSONPathIndex(rf)
+		delete(transformableDenylist, groupKind)
+	}
+	for _, rf := range cfg.TransformDenyList() {
+		groupKind := schema.ParseGroupKind(rf.GroupKind)
+		transformableDenylist[groupKind] = convertJSONPathIndex(rf)
+		delete(transformableAllowlist, groupKind)
+	}
+
+	// add user flag values, override user schema values and defaults
+	// TODO(aaron-prindle) see if workdir needs to be considered in this read
+	if cfg.TransformRulesFile() != "" {
+		transformRulesFromFile, err := ioutil.ReadFile(cfg.TransformRulesFile())
+		if err != nil {
+			return nil, nil, err
+		}
+		rsc := latestV1.ResourceSelectorConfig{}
+		err = yaml.Unmarshal(transformRulesFromFile, &rsc)
+		if err != nil {
+			return nil, nil, err
+		}
+		for _, rf := range rsc.Allow {
+			groupKind := schema.ParseGroupKind(rf.GroupKind)
+			transformableAllowlist[groupKind] = convertJSONPathIndex(rf)
+			delete(transformableDenylist, groupKind)
+		}
+
+		for _, rf := range rsc.Deny {
+			groupKind := schema.ParseGroupKind(rf.GroupKind)
+			transformableDenylist[groupKind] = convertJSONPathIndex(rf)
+			delete(transformableAllowlist, groupKind)
+		}
+	}
+
+	return transformableAllowlist, transformableDenylist, nil
+}
+
+func convertJSONPathIndex(rf latestV1.ResourceFilter) latestV1.ResourceFilter {
+	nrf := latestV1.ResourceFilter{}
+	nrf.GroupKind = rf.GroupKind
+
+	if len(rf.Labels) > 0 {
+		nlabels := []string{}
+		for _, str := range rf.Labels {
+			if str == ".*" {
+				nlabels = append(nlabels, str)
+				continue
+			}
+			nstr := strings.ReplaceAll(str, ".*", "")
+			nlabels = append(nlabels, nstr)
+		}
+		nrf.Labels = nlabels
+	}
+
+	if len(rf.Image) > 0 {
+		nimage := []string{}
+		for _, str := range rf.Image {
+			if str == ".*" {
+				nimage = append(nimage, str)
+				continue
+			}
+			nstr := strings.ReplaceAll(str, ".*", "")
+			nimage = append(nimage, nstr)
+		}
+		nrf.Image = nimage
+	}
+
+	return nrf
 }

--- a/pkg/skaffold/kubernetes/manifest/images_test.go
+++ b/pkg/skaffold/kubernetes/manifest/images_test.go
@@ -55,7 +55,7 @@ spec:
 		},
 	}
 
-	actual, err := manifests.GetImages()
+	actual, err := manifests.GetImages(NewResourceSelectorImages(TransformAllowlist, TransformDenylist))
 	testutil.CheckErrorAndDeepEqual(t, false, err, expectedImages, actual)
 }
 
@@ -121,7 +121,7 @@ spec:
 		fakeWarner := &warnings.Collect{}
 		t.Override(&warnings.Printf, fakeWarner.Warnf)
 
-		resultManifest, err := manifests.ReplaceRemoteManifestImages(context.TODO(), builds)
+		resultManifest, err := manifests.ReplaceRemoteManifestImages(context.TODO(), builds, NewResourceSelectorImages(TransformAllowlist, TransformDenylist))
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(expected.String(), resultManifest.String())
@@ -196,7 +196,7 @@ spec:
 		fakeWarner := &warnings.Collect{}
 		t.Override(&warnings.Printf, fakeWarner.Warnf)
 
-		resultManifest, err := manifests.ReplaceImages(context.TODO(), builds)
+		resultManifest, err := manifests.ReplaceImages(context.TODO(), builds, NewResourceSelectorImages(TransformAllowlist, TransformDenylist))
 
 		t.CheckNoError(err)
 		t.CheckDeepEqual(expected.String(), resultManifest.String())
@@ -207,7 +207,7 @@ func TestReplaceEmptyManifest(t *testing.T) {
 	manifests := ManifestList{[]byte(""), []byte("  ")}
 	expected := ManifestList{}
 
-	resultManifest, err := manifests.ReplaceImages(context.TODO(), nil)
+	resultManifest, err := manifests.ReplaceImages(context.TODO(), nil, NewResourceSelectorImages(TransformAllowlist, TransformDenylist))
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected.String(), resultManifest.String())
 }
@@ -215,7 +215,7 @@ func TestReplaceEmptyManifest(t *testing.T) {
 func TestReplaceInvalidManifest(t *testing.T) {
 	manifests := ManifestList{[]byte("INVALID")}
 
-	_, err := manifests.ReplaceImages(context.TODO(), nil)
+	_, err := manifests.ReplaceImages(context.TODO(), nil, NewResourceSelectorImages(TransformAllowlist, TransformDenylist))
 
 	testutil.CheckError(t, true, err)
 }
@@ -228,7 +228,7 @@ image:
 - value2
 `)}
 
-	output, err := manifests.ReplaceImages(context.TODO(), nil)
+	output, err := manifests.ReplaceImages(context.TODO(), nil, NewResourceSelectorImages(TransformAllowlist, TransformDenylist))
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, manifests.String(), output.String())
 }

--- a/pkg/skaffold/kubernetes/manifest/labels.go
+++ b/pkg/skaffold/kubernetes/manifest/labels.go
@@ -18,18 +18,100 @@ package manifest
 
 import (
 	"context"
+	"strings"
+
+	apimachinery "k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 )
 
+type ResourceSelectorLabels struct {
+	allowlist map[apimachinery.GroupKind]latestV1.ResourceFilter
+	denylist  map[apimachinery.GroupKind]latestV1.ResourceFilter
+}
+
+func NewResourceSelectorLabels(allowlist map[apimachinery.GroupKind]latestV1.ResourceFilter, denylist map[apimachinery.GroupKind]latestV1.ResourceFilter) *ResourceSelectorLabels {
+	return &ResourceSelectorLabels{
+		allowlist: allowlist,
+		denylist:  denylist,
+	}
+}
+
+func (rsi *ResourceSelectorLabels) allowByGroupKind(gk apimachinery.GroupKind) bool {
+	if _, allowed := rsi.allowlist[gk]; allowed {
+		// TODO(aaron-prindle) see if it makes sense to make this only use the allowlist...
+		if rf, disallowed := rsi.denylist[gk]; disallowed {
+			for _, s := range rf.Labels {
+				if s == ".*" {
+					return false
+				}
+			}
+			for _, s := range rf.Image {
+				if s == ".*" {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func (rsi *ResourceSelectorLabels) allowByNavpath(gk apimachinery.GroupKind, navpath string, k string) (string, bool) {
+	for _, w := range ConfigConnectorResourceSelector {
+		if w.Matches(gk.Group, gk.Kind) {
+			return "labels", true
+		}
+	}
+
+	if rf, ok := rsi.denylist[gk]; ok {
+		for _, denypath := range rf.Labels {
+			if denypath == ".*" {
+				return "", false
+			}
+			// truncate the last part of the labels path and see if this matches
+			lastDot := strings.LastIndex(denypath, ".")
+			if lastDot == -1 {
+				// no dot exists in denypath, denypath is invalid
+				break
+			}
+			if navpath == denypath[:lastDot] {
+				return "", false
+			}
+		}
+	}
+
+	if rf, ok := rsi.allowlist[gk]; ok {
+		for _, allowpath := range rf.Labels {
+			if allowpath == ".*" {
+				if k != "metadata" {
+					return "", false
+				}
+				return "labels", true
+			}
+			// truncate the last part of the labels path and see if this matches
+			lastDot := strings.LastIndex(allowpath, ".")
+			if lastDot == -1 {
+				// no dot exists in allowpath, allowpath is invalid
+				continue
+			}
+			if navpath == allowpath[:lastDot] {
+				return allowpath[lastDot+1:], true
+			}
+		}
+	}
+	return "", false
+}
+
 // SetLabels add labels to a list of Kubernetes manifests.
-func (l *ManifestList) SetLabels(labels map[string]string) (ManifestList, error) {
+func (l *ManifestList) SetLabels(labels map[string]string, rs ResourceSelector) (ManifestList, error) {
 	if len(labels) == 0 {
 		return *l, nil
 	}
 
 	replacer := newLabelsSetter(labels)
-	updated, err := l.Visit(replacer)
+	updated, err := l.Visit(replacer, rs)
 	if err != nil {
 		return nil, labelSettingErr(err)
 	}
@@ -49,37 +131,34 @@ func newLabelsSetter(labels map[string]string) *labelsSetter {
 	}
 }
 
-func (r *labelsSetter) Visit(navpath string, o map[string]interface{}, k string, v interface{}) bool {
-	if k != "metadata" {
+func (r *labelsSetter) Visit(gk apimachinery.GroupKind, navpath string, o map[string]interface{}, k string, v interface{}, rs ResourceSelector) bool {
+	labelsField, ok := rs.allowByNavpath(gk, navpath, k)
+	if !ok {
 		return true
 	}
 
 	if len(r.labels) == 0 {
 		return false
 	}
-
 	metadata, ok := v.(map[string]interface{})
 	if !ok {
 		return true
 	}
 
-	l, present := metadata["labels"]
+	l, present := metadata[labelsField]
 	if !present {
-		metadata["labels"] = r.labels
+		metadata[labelsField] = r.labels
 		return false
 	}
-
 	labels, ok := l.(map[string]interface{})
 	if !ok {
 		return true
 	}
-
 	for k, v := range r.labels {
 		// Don't overwrite existing labels
 		if _, present := labels[k]; !present {
 			labels[k] = v
 		}
 	}
-
 	return false
 }

--- a/pkg/skaffold/kubernetes/manifest/labels_test.go
+++ b/pkg/skaffold/kubernetes/manifest/labels_test.go
@@ -19,6 +19,9 @@ package manifest
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	v1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -51,7 +54,7 @@ spec:
 	resultManifest, err := manifests.SetLabels(map[string]string{
 		"key1": "value1",
 		"key2": "value2",
-	})
+	}, NewResourceSelectorLabels(TransformAllowlist, TransformDenylist))
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected.String(), resultManifest.String())
 }
@@ -89,7 +92,7 @@ spec:
 		"key0": "should-be-ignored",
 		"key1": "value1",
 		"key2": "value2",
-	})
+	}, NewResourceSelectorLabels(TransformAllowlist, TransformDenylist))
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected.String(), resultManifest.String())
 }
@@ -117,7 +120,7 @@ spec:
     name: example
 `)}
 
-	resultManifest, err := manifests.SetLabels(nil)
+	resultManifest, err := manifests.SetLabels(nil, NewResourceSelectorLabels(TransformAllowlist, TransformDenylist))
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected.String(), resultManifest.String())
 }
@@ -136,7 +139,7 @@ metadata:
   name: getting-started
 `)}
 
-	resultManifest, err := manifests.SetLabels(map[string]string{"key0": "value0"})
+	resultManifest, err := manifests.SetLabels(map[string]string{"key0": "value0"}, NewResourceSelectorLabels(TransformAllowlist, TransformDenylist))
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, manifests.String(), resultManifest.String())
 }
@@ -184,7 +187,13 @@ spec:
 	resultManifest, err := manifests.SetLabels(map[string]string{
 		"key0": "value0",
 		"key1": "value1",
-	})
+	}, NewResourceSelectorLabels(map[schema.GroupKind]v1.ResourceFilter{
+		{Group: "apiextensions.k8s.io", Kind: "CustomResourceDefinition"}: {
+			GroupKind: "CustomResourceDefinition.apiextensions.k8s.io",
+			Image:     []string{".*"},
+			Labels:    []string{".metadata.labels"},
+		},
+	}, nil))
 
 	testutil.CheckErrorAndDeepEqual(t, false, err, expected.String(), resultManifest.String())
 }

--- a/pkg/skaffold/kubernetes/manifest/visitor.go
+++ b/pkg/skaffold/kubernetes/manifest/visitor.go
@@ -18,43 +18,129 @@ package manifest
 
 import (
 	"fmt"
-	"path"
 
 	apimachinery "k8s.io/apimachinery/pkg/runtime/schema"
 
+	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 )
 
-// transformableAllowlist is the set of kinds that can be transformed by Skaffold.
-var transformableAllowlist = map[apimachinery.GroupKind]bool{
-	{Group: "", Kind: "Pod"}:                                true,
-	{Group: "apps", Kind: "DaemonSet"}:                      true,
-	{Group: "apps", Kind: "Deployment"}:                     true, // v1beta1, v1beta2: deprecated in K8s 1.9, removed in 1.16
-	{Group: "apps", Kind: "ReplicaSet"}:                     true,
-	{Group: "apps", Kind: "StatefulSet"}:                    true,
-	{Group: "batch", Kind: "CronJob"}:                       true,
-	{Group: "batch", Kind: "Job"}:                           true,
-	{Group: "extensions", Kind: "DaemonSet"}:                true, // v1beta1: deprecated in K8s 1.9, removed in 1.16
-	{Group: "extensions", Kind: "Deployment"}:               true, // v1beta1: deprecated in K8s 1.9, removed in 1.16
-	{Group: "extensions", Kind: "ReplicaSet"}:               true, // v1beta1: deprecated in K8s 1.9, removed in 1.16
-	{Group: "serving.knative.dev", Kind: "Service"}:         true,
-	{Group: "agones.dev", Kind: "Fleet"}:                    true,
-	{Group: "agones.dev", Kind: "GameServer"}:               true,
-	{Group: "argoproj.io", Kind: "Rollout"}:                 true,
-	{Group: "argoproj.io", Kind: "ClusterWorkflowTemplate"}: true,
-	{Group: "argoproj.io", Kind: "Workflow"}:                true,
-	{Group: "argoproj.io", Kind: "WorkflowTemplate"}:        true,
+type ResourceSelector interface {
+	allowByGroupKind(apimachinery.GroupKind) bool
+	allowByNavpath(apimachinery.GroupKind, string, string) (string, bool)
+}
+
+// TransformAllowlist is the default allowlist of kinds that can be transformed by Skaffold.
+var TransformAllowlist = map[apimachinery.GroupKind]latestV1.ResourceFilter{
+	{Group: "", Kind: "Pod"}: {
+		GroupKind: "Pod",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "", Kind: "Service"}: {
+		GroupKind: "Service",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "apps", Kind: "DaemonSet"}: {
+		GroupKind: "DaemonSet.apps",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "apps", Kind: "Deployment"}: {
+		GroupKind: "Deployment.apps",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "apps", Kind: "ReplicaSet"}: {
+		GroupKind: "ReplicaSet.apps",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "apps", Kind: "StatefulSet"}: {
+		GroupKind: "StatefulSet.apps",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "batch", Kind: "CronJob"}: {
+		GroupKind: "CronJob.batch",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "batch", Kind: "Job"}: {
+		GroupKind: "Job.batch",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "extensions", Kind: "DaemonSet"}: {
+		GroupKind: "DaemonSet.extensions",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "extensions", Kind: "Deployment"}: {
+		GroupKind: "Deployment.extensions",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "extensions", Kind: "ReplicaSet"}: {
+		GroupKind: "ReplicaSet.extensions",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "serving.knative.dev", Kind: "Service"}: {
+		GroupKind: "Service.serving.knative.dev",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "agones.dev", Kind: "Fleet"}: {
+		GroupKind: "Fleet.agones.dev",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "agones.dev", Kind: "GameServer"}: {
+		GroupKind: "GameServer.agones.dev",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "argoproj.io", Kind: "Rollout"}: {
+		GroupKind: "Rollout.argoproj.io",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "argoproj.io", Kind: "ClusterWorkflowTemplate"}: {
+		GroupKind: "ClusterWorkflowTemplate.argoproj.io",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "argoproj.io", Kind: "Workflow"}: {
+		GroupKind: "Workflow.argoproj.io",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+	{Group: "argoproj.io", Kind: "WorkflowTemplate"}: {
+		GroupKind: "WorkflowTemplate.argoproj.io",
+		Image:     []string{".*"},
+		Labels:    []string{".*"},
+	},
+}
+
+// TransformDenylist is the default denylist on the set of kinds that can be transformed by Skaffold.
+var TransformDenylist = map[apimachinery.GroupKind]latestV1.ResourceFilter{
+	{Group: "apps", Kind: "StatefulSet"}: {
+		GroupKind: "StatefulSet.apps",
+		Labels:    []string{".spec.volumeClaimTemplates.metadata.labels"},
+	},
 }
 
 // FieldVisitor represents the aggregation/transformation that should be performed on each traversed field.
 type FieldVisitor interface {
 	// Visit is called for each transformable key contained in the object and may apply transformations/aggregations on it.
 	// It should return true to allow recursive traversal or false when the entry was transformed.
-	Visit(path string, object map[string]interface{}, key string, value interface{}) bool
+	Visit(gk apimachinery.GroupKind, navpath string, object map[string]interface{}, key string, value interface{}, rs ResourceSelector) bool
 }
 
 // Visit recursively visits all transformable object fields within the manifests and lets the visitor apply transformations/aggregations on them.
-func (l *ManifestList) Visit(visitor FieldVisitor) (ManifestList, error) {
+func (l *ManifestList) Visit(visitor FieldVisitor, rs ResourceSelector) (ManifestList, error) {
 	var updated ManifestList
 
 	for _, manifest := range *l {
@@ -67,7 +153,7 @@ func (l *ManifestList) Visit(visitor FieldVisitor) (ManifestList, error) {
 			continue
 		}
 
-		traverseManifestFields(m, visitor)
+		traverseManifestFields(m, visitor, rs)
 
 		updatedManifest, err := yaml.Marshal(m)
 		if err != nil {
@@ -81,14 +167,30 @@ func (l *ManifestList) Visit(visitor FieldVisitor) (ManifestList, error) {
 }
 
 // traverseManifest traverses all transformable fields contained within the manifest.
-func traverseManifestFields(manifest map[string]interface{}, visitor FieldVisitor) {
-	if shouldTransformManifest(manifest) {
+func traverseManifestFields(manifest map[string]interface{}, visitor FieldVisitor, rs ResourceSelector) {
+	var groupKind apimachinery.GroupKind
+	var apiVersion string
+	if value, ok := manifest["apiVersion"].(string); ok {
+		apiVersion = value
+	}
+	var kind string
+	if value, ok := manifest["kind"].(string); ok {
+		kind = value
+	}
+
+	gvk := apimachinery.FromAPIVersionAndKind(apiVersion, kind)
+	groupKind = apimachinery.GroupKind{
+		Group: gvk.Group,
+		Kind:  gvk.Kind,
+	}
+
+	if shouldTransformManifest(manifest, rs) {
 		visitor = &recursiveVisitorDecorator{visitor}
 	}
-	visitFields("/", manifest, visitor)
+	visitFields(groupKind, "", manifest, visitor, rs)
 }
 
-func shouldTransformManifest(manifest map[string]interface{}) bool {
+func shouldTransformManifest(manifest map[string]interface{}, rs ResourceSelector) bool {
 	var apiVersion string
 	switch value := manifest["apiVersion"].(type) {
 	case string:
@@ -111,14 +213,16 @@ func shouldTransformManifest(manifest map[string]interface{}) bool {
 		Kind:  gvk.Kind,
 	}
 
-	if result, found := transformableAllowlist[groupKind]; found {
-		return result
+	if rs.allowByGroupKind(groupKind) {
+		return true
 	}
+
 	for _, w := range ConfigConnectorResourceSelector {
 		if w.Matches(gvk.Group, gvk.Kind) {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -127,29 +231,25 @@ type recursiveVisitorDecorator struct {
 	delegate FieldVisitor
 }
 
-func (d *recursiveVisitorDecorator) Visit(path string, o map[string]interface{}, k string, v interface{}) bool {
-	if d.delegate.Visit(path, o, k, v) {
-		visitFields(path, v, d)
+func (d *recursiveVisitorDecorator) Visit(gk apimachinery.GroupKind, navpath string, o map[string]interface{}, k string, v interface{}, rs ResourceSelector) bool {
+	if d.delegate.Visit(gk, navpath, o, k, v, rs) {
+		visitFields(gk, navpath, v, d, rs)
 	}
 	return false
 }
 
 // visitFields traverses all fields and calls the visitor for each.
-// navpath: a '/' delimited path representing the fields navigated to this point
-func visitFields(navpath string, o interface{}, visitor FieldVisitor) {
+// navpath: a '.' delimited path representing the fields navigated to this point
+func visitFields(gk apimachinery.GroupKind, navpath string, o interface{}, visitor FieldVisitor, rs ResourceSelector) {
 	switch entries := o.(type) {
 	case []interface{}:
 		for _, v := range entries {
 			// this case covers lists so we don't update the navpath
-			visitFields(navpath, v, visitor)
+			visitFields(gk, navpath, v, visitor, rs)
 		}
 	case map[string]interface{}:
 		for k, v := range entries {
-			// TODO(6416) temporary fix for StatefulSet + PVC use case, need to do something similar to the proposal in #6236 for full fix
-			if navpath == "/spec/volumeClaimTemplates" {
-				continue
-			}
-			visitor.Visit(path.Join(navpath, k), entries, k, v)
+			visitor.Visit(gk, navpath+"."+k, entries, k, v, rs)
 		}
 	}
 }

--- a/pkg/skaffold/render/renderer/renderer.go
+++ b/pkg/skaffold/render/renderer/renderer.go
@@ -139,11 +139,13 @@ func (r *SkaffoldRenderer) Render(ctx context.Context, out io.Writer, builds []g
 	if err != nil {
 		return err
 	}
-	manifests, err = manifests.ReplaceImages(ctx, builds)
+	// TODO(aaron-prindle) wire proper transform allow/deny list args when going to V2
+	manifests, err = manifests.ReplaceImages(ctx, builds, manifest.NewResourceSelectorImages(manifest.TransformAllowlist, manifest.TransformDenylist))
 	if err != nil {
 		return err
 	}
-	manifests.SetLabels(r.labels)
+	// TODO(aaron-prindle) wire proper transform allow/deny list args when going to V2
+	manifests.SetLabels(r.labels, manifest.NewResourceSelectorLabels(manifest.TransformAllowlist, manifest.TransformDenylist))
 
 	// cache the dry manifests to the temp directory. manifests.yaml will be truncated if already exists.
 	dryConfigPath := filepath.Join(r.hydrationDir, dryFileName)

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -135,8 +135,11 @@ func GetDeployer(ctx context.Context, runCtx *runcontext.RunContext, labeller *l
 		}
 
 		if d.KptDeploy != nil {
-			deployer := kpt.NewDeployer(dCtx, labeller, d.KptDeploy)
-			deployers = append(deployers, deployer)
+			k, err := kpt.NewDeployer(dCtx, labeller, d.KptDeploy)
+			if err != nil {
+				return nil, err
+			}
+			deployers = append(deployers, k)
 		}
 
 		if d.KubectlDeploy != nil {

--- a/pkg/skaffold/runner/runcontext/context.go
+++ b/pkg/skaffold/runner/runcontext/context.go
@@ -107,15 +107,26 @@ func (ps Pipelines) TestCases() []*latestV1.TestCase {
 	return tests
 }
 
-// TransformableAllowList returns combined allowlist from pipelines
-func (ps Pipelines) TransformableAllowList() []latestV1.ResourceFilter {
-	var allowList []latestV1.ResourceFilter
+// TransformAllowList returns combined allowlist from pipelines
+func (ps Pipelines) TransformAllowList() []latestV1.ResourceFilter {
+	var allowlist []latestV1.ResourceFilter
 	for _, p := range ps.pipelines {
-		if p.Deploy.TransformableAllowList != nil {
-			allowList = append(allowList, p.Deploy.TransformableAllowList...)
+		if p.ResourceSelector.Allow != nil {
+			allowlist = append(allowlist, p.ResourceSelector.Allow...)
 		}
 	}
-	return allowList
+	return allowlist
+}
+
+// TransformDenyList returns combined denylist from pipelines
+func (ps Pipelines) TransformDenyList() []latestV1.ResourceFilter {
+	var denylist []latestV1.ResourceFilter
+	for _, p := range ps.pipelines {
+		if p.ResourceSelector.Deny != nil {
+			denylist = append(denylist, p.ResourceSelector.Deny...)
+		}
+	}
+	return denylist
 }
 
 func (ps Pipelines) StatusCheckDeadlineSeconds() int {
@@ -166,8 +177,12 @@ func (rc *RunContext) IsTestPhaseActive() bool {
 	return !rc.SkipTests() && len(rc.TestCases()) != 0
 }
 
-func (rc *RunContext) TransformableAllowList() []latestV1.ResourceFilter {
-	return rc.Pipelines.TransformableAllowList()
+func (rc *RunContext) TransformAllowList() []latestV1.ResourceFilter {
+	return rc.Pipelines.TransformAllowList()
+}
+
+func (rc *RunContext) TransformDenyList() []latestV1.ResourceFilter {
+	return rc.Pipelines.TransformDenyList()
 }
 
 // AddSkaffoldLabels tells the Runner whether to add skaffold-specific labels.
@@ -227,6 +242,7 @@ func (rc *RunContext) GetRunID() string                              { return rc
 func (rc *RunContext) RPCPort() *int                                 { return rc.Opts.RPCPort.Value() }
 func (rc *RunContext) RPCHTTPPort() *int                             { return rc.Opts.RPCHTTPPort.Value() }
 func (rc *RunContext) PushImages() config.BoolOrUndefined            { return rc.Opts.PushImages }
+func (rc *RunContext) TransformRulesFile() string                    { return rc.Opts.TransformRulesFile }
 func (rc *RunContext) JSONParseConfig() latestV1.JSONParseConfig {
 	return rc.DefaultPipeline().Deploy.Logs.JSONParse
 }

--- a/pkg/skaffold/runner/v1/runner_test.go
+++ b/pkg/skaffold/runner/v1/runner_test.go
@@ -437,8 +437,12 @@ func TestNewForConfig(t *testing.T) {
 					DeployType: latestV1.DeployType{
 						KubectlDeploy: &latestV1.KubectlDeploy{},
 					},
-					TransformableAllowList: []latestV1.ResourceFilter{
-						{Type: "example.com/Application"},
+				},
+				ResourceSelector: latestV1.ResourceSelectorConfig{
+					Allow: []latestV1.ResourceFilter{
+						{
+							GroupKind: "example.com/Application",
+						},
 					},
 				},
 			},
@@ -487,9 +491,9 @@ func TestNewForConfig(t *testing.T) {
 				},
 			}
 			// Test transformableAllowList
-			filters := runCtx.TransformableAllowList()
-			if test.pipeline.Deploy.TransformableAllowList != nil {
-				t.CheckDeepEqual(test.pipeline.Deploy.TransformableAllowList, filters)
+			filters := runCtx.TransformAllowList()
+			if test.pipeline.ResourceSelector.Allow != nil {
+				t.CheckDeepEqual(test.pipeline.ResourceSelector.Allow, filters)
 			} else {
 				t.CheckEmpty(filters)
 			}

--- a/pkg/skaffold/schema/latest/v1/config.go
+++ b/pkg/skaffold/schema/latest/v1/config.go
@@ -73,6 +73,9 @@ type Pipeline struct {
 
 	// PortForward describes user defined resources to port-forward.
 	PortForward []*PortForwardResource `yaml:"portForward,omitempty"`
+
+	// ResourceSelector describes user defined filters describing how skaffold should treat objects/fields during rendering.
+	ResourceSelector ResourceSelectorConfig `yaml:"resourceSelector,omitempty"`
 }
 
 // GitInfo contains information on the origin of skaffold configurations cloned from a git repository.
@@ -143,6 +146,14 @@ type PortForwardResource struct {
 
 	// LocalPort is the local port to forward to. If the port is unavailable, Skaffold will choose a random open port to forward to. *Optional*.
 	LocalPort int `yaml:"localPort,omitempty"`
+}
+
+// ResourceSelectorConfig contains all the configuration needed by the deploy steps.
+type ResourceSelectorConfig struct {
+	// Allow configures an allowlist for transforming manifests.
+	Allow []ResourceFilter `yaml:"allow,omitempty"`
+	// Deny configures an allowlist for transforming manifests.
+	Deny []ResourceFilter `yaml:"deny,omitempty"`
 }
 
 // BuildConfig contains all the configuration for the build steps.
@@ -526,9 +537,6 @@ type DeployConfig struct {
 
 	// Logs configures how container logs are printed as a result of a deployment.
 	Logs LogsConfig `yaml:"logs,omitempty"`
-
-	// TransformableAllowList configures an allowlist for transforming manifests.
-	TransformableAllowList []ResourceFilter `yaml:"-"`
 }
 
 // DeployType contains the specific implementation and parameters needed
@@ -1504,8 +1512,8 @@ type NamedContainerHook struct {
 
 // ResourceFilter contains definition to filter which resource to transform.
 type ResourceFilter struct {
-	// Type is the compact format of a resource type.
-	Type string `yaml:"type" yamltags:"required"`
+	// GroupKind is the compact format of a resource type.
+	GroupKind string `yaml:"groupKind" yamltags:"required"`
 	// Image is an optional slice of JSON-path-like paths of where to rewrite images.
 	Image []string `yaml:"image,omitempty"`
 	// Labels is an optional slide of JSON-path-like paths of where to add a labels block if missing.


### PR DESCRIPTION
fixes #6416 
Related DD here: [go/skaffold-field-overwriting](https://goto.google.com/skaffold-field-overwriting)
This PR adds the abillity to configure what K8s Group Kind's and which fields specifically are overwritten by skaffold when it renders & deploys manifests.  Use cases and related issues include:
- rendering & deploying custom CRDs as part of a skaffold dev session (currently skaffold only supports a set of hardcoded CRDs [here](https://github.com/GoogleContainerTools/skaffold/blob/main/pkg/skaffold/kubernetes/manifest/visitor.go#L40-L46))
- rendering and deploying any schema that has immutable spec that would previously cause skaffold to fail on re-deployment
  - example: a StatefulSet w/ .spec.volumeClaimTemplates.* entry will fail on re-deploy prior to #7011 as skaffold would try to overwrite a StatefulSet's `.spec.volumeClaimTemplates.*.metadata.labels` immutable field.  While #7011 fixed that specific issue, this PR generalizes to work with any such immutable field as it is user configurable.  

- Related Issues
https://github.com/GoogleContainerTools/skaffold/issues/4489
https://github.com/GoogleContainerTools/skaffold/issues/6416
https://github.com/GoogleContainerTools/skaffold/issues/6998
https://github.com/GoogleContainerTools/skaffold/issues/4081


Example usage of the `transform` field:
```
deploy:
  transform:
    allow:
    - type: Function.openfaas.com
      image: [.spec.image]
      labels: [.spec.metadata.labels]
```


Open Questions:
- Is `transform` a good name.  IIUC, skaffold v2 introduces a `render` phase which also has something like `render.transform` as a field.  Any opinions on better alternatives for naming or if that might be a source of confusion worth addressing now once V2 is introduced?

Future Work:
- 

