### PR TITLE
chore: install gke-gcloud-auth-plugin in skaffold images

### DIFF
--- a/deploy/skaffold/Dockerfile.deps
+++ b/deploy/skaffold/Dockerfile.deps
@@ -143,7 +143,8 @@ RUN /google-cloud-sdk/install.sh \
     --bash-completion=false \
     --disable-installation-options
 ENV PATH=$PATH:/google-cloud-sdk/bin
-RUN gcloud auth configure-docker
+RUN gcloud auth configure-docker && \
+    gcloud components install gke-gcloud-auth-plugin
 
 FROM runtime_deps
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \

--- a/deploy/skaffold/Dockerfile.deps.lts
+++ b/deploy/skaffold/Dockerfile.deps.lts
@@ -87,7 +87,8 @@ RUN /google-cloud-sdk/install.sh \
     --bash-completion=false \
     --disable-installation-options
 ENV PATH=$PATH:/google-cloud-sdk/bin
-RUN gcloud auth configure-docker
+RUN gcloud auth configure-docker && \
+    gcloud components install gke-gcloud-auth-plugin
 
 FROM runtime_deps
 RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y \


### PR DESCRIPTION
Fixes: #7059 

Install `gke-gcloud-auth-plugin` into `gcr.io/k8s-skaffold/skaffold` images.

cc: @ekupershlak 