### PR TITLE
fix: dont update last-prompted if check-update is false

### DIFF
--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -387,6 +387,10 @@ func IsUpdateCheckEnabled(configfile string) bool {
 	if err != nil {
 		return true
 	}
+	return IsUpdateCheckEnabledForContext(cfg)
+}
+
+func IsUpdateCheckEnabledForContext(cfg *ContextConfig) bool {
 	return cfg == nil || cfg.UpdateCheck == nil || *cfg.UpdateCheck
 }
 
@@ -414,6 +418,9 @@ func UpdateMsgDisplayed(configFile string) error {
 	fullConfig, err := ReadConfigFile(configFile)
 	if err != nil {
 		return err
+	}
+	if !IsUpdateCheckEnabledForContext(fullConfig.Global) {
+		return nil
 	}
 	if fullConfig.Global == nil {
 		fullConfig.Global = &ContextConfig{}

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -866,7 +866,6 @@ func TestShouldDisplayUpdateMsg(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&GetConfigForCurrentKubectx, func(string) (*ContextConfig, error) { return test.cfg, nil })
-			// HERE
 			t.CheckDeepEqual(test.expected, ShouldDisplayUpdateMsg("dummyconfig"))
 		})
 	}

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -792,16 +792,31 @@ kubeContexts: []`,
 			},
 		},
 		{
-			description: "update global context when update config last taken is in past",
+			description: "don't add LastPrompted if UpdateCheck is disabled",
 			cfg: `
 global:
-  update-config:
-    last-taken: "some date in past"
+  update-check: false
 kubeContexts: []`,
 			expectedCfg: &GlobalConfig{
 				Global: &ContextConfig{
+					UpdateCheck: util.BoolPtr(false),
+				},
+				ContextConfigs: []*ContextConfig{},
+			},
+		},
+		{
+			description: "don't update LastPrompted if UpdateCheck is disabled",
+			cfg: `
+global:
+  update-check: false
+  update:
+    last-prompted: "some date"
+kubeContexts: []`,
+			expectedCfg: &GlobalConfig{
+				Global: &ContextConfig{
+					UpdateCheck: util.BoolPtr(false),
 					UpdateCheckConfig: &UpdateConfig{
-						LastPrompted: "2021-01-01T00:00:00Z"},
+						LastPrompted: "some date"},
 				},
 				ContextConfigs: []*ContextConfig{},
 			},
@@ -851,6 +866,7 @@ func TestShouldDisplayUpdateMsg(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&GetConfigForCurrentKubectx, func(string) (*ContextConfig, error) { return test.cfg, nil })
+			// HERE
 			t.CheckDeepEqual(test.expected, ShouldDisplayUpdateMsg("dummyconfig"))
 		})
 	}


### PR DESCRIPTION
Fixes: #7051

**Description**
When check-update is set to false, the config property last-prompted was being updated even though the user is not prompted. This has been fixed.

**Notes**
Also removed a test regarding the survey prompt that was being ran as part of the update message unit tests (coverage not affected)

