### PR TITLE
Make explicit that user needs to change PROJECT_ID

### DIFF
--- a/examples/google-cloud-build/skaffold.yaml
+++ b/examples/google-cloud-build/skaffold.yaml
@@ -2,6 +2,7 @@ apiVersion: skaffold/v2beta26
 kind: Config
 build:
   googleCloudBuild:
+    # Change `k8s-skaffold` with your PROJECT_ID
     projectId: k8s-skaffold
   artifacts:
   - image: skaffold-example

--- a/integration/examples/gcb-kaniko/skaffold.yaml
+++ b/integration/examples/gcb-kaniko/skaffold.yaml
@@ -2,6 +2,7 @@ apiVersion: skaffold/v2beta27
 kind: Config
 build:
   googleCloudBuild:
+    # Change `k8s-skaffold` with your PROJECT_ID
     projectId: k8s-skaffold
   artifacts:
   - image: skaffold-example

--- a/integration/examples/google-cloud-build/skaffold.yaml
+++ b/integration/examples/google-cloud-build/skaffold.yaml
@@ -2,6 +2,7 @@ apiVersion: skaffold/v2beta27
 kind: Config
 build:
   googleCloudBuild:
+    # Change `k8s-skaffold` with your PROJECT_ID
     projectId: k8s-skaffold
   artifacts:
   - image: skaffold-example


### PR DESCRIPTION
The word `k8s-skaffold` is quite easy to be overlooked. 

Fails this way:

```
creating bucket if not exists: getting bucket "k8s-skaffold_cloudbuild": googleapi: Error 403: RICCARDO_USER@gmail.com does not have storage.buckets.get access to the Google Cloud Storage bucket., forbidden```

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #nnn <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
