### PR TITLE
fix: use go 1.17.x in verify-examples github action

### DIFF
--- a/.github/workflows/verify-examples.yml
+++ b/.github/workflows/verify-examples.yml
@@ -18,6 +18,12 @@ jobs:
       with:
         fetch-depth: 0
 
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.*
+      id: go
+
     # Skip changes not affecting examples or integration/examples
     - name: Computes number of changes to examples
       # can't use github.event.before as it may represent

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -277,7 +277,7 @@ func TestHelmRender(t *testing.T) {
 				},
 			},
 			helmReleases: []latestV1.HelmRelease{{
-				Name:      "gke_loadbalancer",
+				Name:      "gke-loadbalancer",
 				ChartPath: "testdata/gke_loadbalancer/loadbalancer-helm",
 				ArtifactOverrides: map[string]string{
 					"image": "gke-loadbalancer",


### PR DESCRIPTION
**Description**
This PR uses the setup-go action to make sure we are using go v1.17.x in our job that verifies changes to skaffold's examples.
