### PR TITLE
feat: add Argo Workflows - WorkflowTemplate to transformable allow list

### DIFF
--- a/pkg/skaffold/kubernetes/manifest/visitor.go
+++ b/pkg/skaffold/kubernetes/manifest/visitor.go
@@ -41,6 +41,7 @@ var transformableAllowlist = map[apimachinery.GroupKind]bool{
 	{Group: "agones.dev", Kind: "Fleet"}:            true,
 	{Group: "agones.dev", Kind: "GameServer"}:       true,
 	{Group: "argoproj.io", Kind: "Rollout"}:         true,
+	{Group: "argoproj.io", Kind: "WorkflowTemplate"}:true,
 }
 
 // FieldVisitor represents the aggregation/transformation that should be performed on each traversed field.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/4081#issuecomment-632464048<!-- tracking issues that this PR will close -->
**Related**: [_Relevant tracking issues, for context_](https://github.com/GoogleContainerTools/skaffold/pull/4488/files#diff-4801638abf03c0b1299baf33fed7d9c8dc308ff9a0e70333cd1f17a6880db157)

**Description**
Argo Workflows support a custom CRD (`apiVersion: argoproj.io/v1alpha1`, `kind: WorkflowTemplate`). When I use skaffold to build an image, the image is created successfully, but the image name from the Argo Workflows manifest is not transformed. The image is located at `spec.templates.container.image`

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
