### PR TITLE
feat: add argo workflows kinds to transformable allow list

### DIFF
--- a/pkg/skaffold/kubernetes/manifest/visitor.go
+++ b/pkg/skaffold/kubernetes/manifest/visitor.go
@@ -27,20 +27,23 @@ import (
 
 // transformableAllowlist is the set of kinds that can be transformed by Skaffold.
 var transformableAllowlist = map[apimachinery.GroupKind]bool{
-	{Group: "", Kind: "Pod"}:                        true,
-	{Group: "apps", Kind: "DaemonSet"}:              true,
-	{Group: "apps", Kind: "Deployment"}:             true, // v1beta1, v1beta2: deprecated in K8s 1.9, removed in 1.16
-	{Group: "apps", Kind: "ReplicaSet"}:             true,
-	{Group: "apps", Kind: "StatefulSet"}:            true,
-	{Group: "batch", Kind: "CronJob"}:               true,
-	{Group: "batch", Kind: "Job"}:                   true,
-	{Group: "extensions", Kind: "DaemonSet"}:        true, // v1beta1: deprecated in K8s 1.9, removed in 1.16
-	{Group: "extensions", Kind: "Deployment"}:       true, // v1beta1: deprecated in K8s 1.9, removed in 1.16
-	{Group: "extensions", Kind: "ReplicaSet"}:       true, // v1beta1: deprecated in K8s 1.9, removed in 1.16
-	{Group: "serving.knative.dev", Kind: "Service"}: true,
-	{Group: "agones.dev", Kind: "Fleet"}:            true,
-	{Group: "agones.dev", Kind: "GameServer"}:       true,
-	{Group: "argoproj.io", Kind: "Rollout"}:         true,
+	{Group: "", Kind: "Pod"}:                                true,
+	{Group: "apps", Kind: "DaemonSet"}:                      true,
+	{Group: "apps", Kind: "Deployment"}:                     true, // v1beta1, v1beta2: deprecated in K8s 1.9, removed in 1.16
+	{Group: "apps", Kind: "ReplicaSet"}:                     true,
+	{Group: "apps", Kind: "StatefulSet"}:                    true,
+	{Group: "batch", Kind: "CronJob"}:                       true,
+	{Group: "batch", Kind: "Job"}:                           true,
+	{Group: "extensions", Kind: "DaemonSet"}:                true, // v1beta1: deprecated in K8s 1.9, removed in 1.16
+	{Group: "extensions", Kind: "Deployment"}:               true, // v1beta1: deprecated in K8s 1.9, removed in 1.16
+	{Group: "extensions", Kind: "ReplicaSet"}:               true, // v1beta1: deprecated in K8s 1.9, removed in 1.16
+	{Group: "serving.knative.dev", Kind: "Service"}:         true,
+	{Group: "agones.dev", Kind: "Fleet"}:                    true,
+	{Group: "agones.dev", Kind: "GameServer"}:               true,
+	{Group: "argoproj.io", Kind: "Rollout"}:                 true,
+	{Group: "argoproj.io", Kind: "ClusterWorkflowTemplate"}: true,
+	{Group: "argoproj.io", Kind: "Workflow"}:                true,
+	{Group: "argoproj.io", Kind: "WorkflowTemplate"}:        true,
 }
 
 // FieldVisitor represents the aggregation/transformation that should be performed on each traversed field.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/4081#issuecomment-632464048<!-- tracking issues that this PR will close -->
**Related**: [_Relevant tracking issues, for context_](https://github.com/GoogleContainerTools/skaffold/pull/4488/files#diff-4801638abf03c0b1299baf33fed7d9c8dc308ff9a0e70333cd1f17a6880db157)

**Description**
Argo Workflows support a custom CRD (`apiVersion: argoproj.io/v1alpha1`, `kind: [ClusterWorkflowTemplate] [WorkflowTemplate], and [Workflow]`). When I use skaffold to build an image, the image is created successfully, but the image name from the Argo Workflows manifest is not transformed. The image is located at `spec.templates.container.image`

<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
