### PR TITLE
docs: Remove references to XXenableJibInit and XXenableBuildpacksInit from init docs

### DIFF
--- a/docs/content/en/docs/pipeline-stages/init.md
+++ b/docs/content/en/docs/pipeline-stages/init.md
@@ -16,8 +16,8 @@ and [deploy](#deploy-config-initialization) config.
 `skaffold init` currently supports build detection for those builders:
 
 1. [Docker]({{<relref "/docs/pipeline-stages/builders/docker">}})
-2. [Jib]({{<relref "/docs/pipeline-stages/builders/jib">}}) (with `--XXenableJibInit` flag)
-2. [Buildpacks]({{<relref "/docs/pipeline-stages/builders/buildpacks">}}) (with `--XXenableBuildpacksInit` flag)
+2. [Jib]({{<relref "/docs/pipeline-stages/builders/jib">}})
+2. [Buildpacks]({{<relref "/docs/pipeline-stages/builders/buildpacks">}})
 
 `skaffold init` walks your project directory and looks for any build configuration files such as `Dockerfile`,
 `build.gradle/pom.xml`, `package.json`, `requirements.txt` or `go.mod`. `init` skips files that are larger
@@ -41,12 +41,12 @@ If this image is one you want Skaffold to build, you'll need to manually set up 
 {{</alert>}}
 
 `skaffold` init also recognizes Maven and Gradle projects, and will auto-suggest the [`jib`]({{<relref "/docs/pipeline-stages/builders#/local#jib-maven-and-gradle">}}) builder.
-Currently `jib` artifact detection is disabled by default, but can be enabled using the flag `--XXenableJibInit`.
+As of v1.27.0, `jib` artifact detection is enabled by default.
 
 You can try this out on our example [jib project](https://github.com/GoogleContainerTools/skaffold/tree/main/examples/jib-multimodule)
 
 ```bash
-skaffold init --XXenableJibInit
+skaffold init
 ```
 
 ![jib-multimodule](/images/jib-multimodule-init-flow.png)

--- a/docs/content/en/docs/pipeline-stages/init.md
+++ b/docs/content/en/docs/pipeline-stages/init.md
@@ -35,13 +35,12 @@ skaffold init
 
 
 {{< alert title="Note" >}}
-You can choose <code>None (image not built from these sources)</code> if none of the suggested 
+You can choose <code>None (image not built from these sources)</code> if none of the suggested
 options are correct, or this image is not built by any of your source code.<br>
 If this image is one you want Skaffold to build, you'll need to manually set up the build configuration for this artifact.
 {{</alert>}}
 
 `skaffold` init also recognizes Maven and Gradle projects, and will auto-suggest the [`jib`]({{<relref "/docs/pipeline-stages/builders#/local#jib-maven-and-gradle">}}) builder.
-As of v1.27.0, `jib` artifact detection is enabled by default.
 
 You can try this out on our example [jib project](https://github.com/GoogleContainerTools/skaffold/tree/main/examples/jib-multimodule)
 
@@ -71,7 +70,7 @@ deploy:
 
 ### kustomize
 For projects deploying with `kustomize`, Skaffold will scan your project and look for `kustomization.yaml`s as well as Kubernetes manifests.
-It will attempt to infer the project structure based on the recommended project structure from the Kustomize project: thus, 
+It will attempt to infer the project structure based on the recommended project structure from the Kustomize project: thus,
 **it is highly recommended to match your project structure to the recommended base/ and overlay/ structure from Kustomize!**
 
 This generally looks like this:
@@ -99,9 +98,9 @@ When overlay directories are found, these will be listed in the generated Skaffo
 
 *Note: order is guaranteed, since Skaffold's directory parsing is always deterministic.*
 
-## `--generate-manifests` Flag 
+## `--generate-manifests` Flag
 {{< maturity "init.generate_manifests" >}}
-`skaffold init` allows for use of a `--generate-manifests` flag, which will try to generate basic kubernetes manifests for a user's project to help get things up and running. 
+`skaffold init` allows for use of a `--generate-manifests` flag, which will try to generate basic kubernetes manifests for a user's project to help get things up and running.
 
 If bringing a project to skaffold that has no kubernetes manifests yet, it may be helpful to run `skaffold init` with this flag.
 
@@ -116,9 +115,9 @@ In a situation where one image is detected, but multiple possible builders are d
 ## Init API
 `skaffold init` also exposes an API which tools like IDEs can integrate with via flags.
 
-This API can be used to 
+This API can be used to
 
-1. Analyze a project workspace and discover all build definitions (e.g. `Dockerfile`s) and artifacts (image names from the Kubernetes manifests) - this then provides an ability for tools to ask the user to pair the artifacts with Dockerfiles interactively. 
+1. Analyze a project workspace and discover all build definitions (e.g. `Dockerfile`s) and artifacts (image names from the Kubernetes manifests) - this then provides an ability for tools to ask the user to pair the artifacts with Dockerfiles interactively.
 2. Given a pairing between the image names (artifacts) and build definitions (e.g. Dockerfiles), generate Skaffold `build` config for a given artifact.
 
 The resulting `skaffold.yaml` will look something like this:
@@ -142,12 +141,12 @@ profiles:
 
 | API | flag | input/output |
 | ---- | --- | --- |
-| Analyze | `--analyze` | json encoded output of builders and images|  
+| Analyze | `--analyze` | json encoded output of builders and images|
 | Generate | `--artifact`| "`=` delimited" build definition/image pair (for example: `=path1/Dockerfile=artifact1`) or <br>JSON string (for example: `{"builder":"Docker","payload":{"path":"Dockerfile"},"image":"artifact")`|
 
 
 ### Analyze API
-Analyze API walks through all files in your project workspace and looks for 
+Analyze API walks through all files in your project workspace and looks for
 `Dockerfile` files.
 
 To get all image names and dockerfiles, run


### PR DESCRIPTION
After https://github.com/GoogleContainerTools/skaffold/pull/6063 , I'm led to believe that both the buildpack and jib integrations are enabled by default so these references to enable them manually should be removed from the docs.

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
**Related**: #6063


**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

**User facing changes (remove if N/A)**
Better docs!
