### PR TITLE
[V2] refactor: remove pointers from render code. 

### DIFF
--- a/pkg/skaffold/render/generate/generate.go
+++ b/pkg/skaffold/render/generate/generate.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package generate
 
 import (
@@ -39,8 +40,8 @@ import (
 )
 
 // NewGenerator instantiates a Generator object.
-func NewGenerator(workingDir string, config latestV2.Generate, hydrationDir string) *Generator {
-	return &Generator{
+func NewGenerator(workingDir string, config latestV2.Generate, hydrationDir string) Generator {
+	return Generator{
 		workingDir:   workingDir,
 		hydrationDir: hydrationDir,
 		config:       config,
@@ -72,7 +73,7 @@ func excludeRemote(paths []string) []string {
 
 // Generate parses the config resources from the paths in .Generate.Manifests. This path can be the path to raw manifest,
 // kustomize manifests, helm charts or kpt function configs. All should be file-watched.
-func (g *Generator) Generate(ctx context.Context, out io.Writer) (manifest.ManifestList, error) {
+func (g Generator) Generate(ctx context.Context, out io.Writer) (manifest.ManifestList, error) {
 	var manifests manifest.ManifestList
 
 	// Generate kustomize Manifests
@@ -210,7 +211,7 @@ func isKptDir(path string) (string, bool) {
 // walkManifests finds out all the manifests from the `.manifests.generate`, so they can be registered in the file watcher.
 // Note: the logic about manifest dependencies shall separate from the "Generate" function, which requires "context" and
 // only be called when a renderig action is needed (normally happens after the file watcher registration).
-func (g *Generator) walkManifests() ([]string, error) {
+func (g Generator) walkManifests() ([]string, error) {
 	var dependencyPaths []string
 	// Generate kustomize Manifests
 	kustomizePaths := excludeRemote(g.config.Kustomize)
@@ -241,7 +242,7 @@ func (g *Generator) walkManifests() ([]string, error) {
 	return dependencyPaths, nil
 }
 
-func (g *Generator) ManifestDeps() ([]string, error) {
+func (g Generator) ManifestDeps() ([]string, error) {
 	deps := stringset.New()
 
 	dependencyPaths, err := g.walkManifests()

--- a/pkg/skaffold/render/renderer/renderer.go
+++ b/pkg/skaffold/render/renderer/renderer.go
@@ -54,7 +54,7 @@ type Renderer interface {
 func NewSkaffoldRenderer(config *latestV2.RenderConfig, workingDir, hydrationDir string,
 	labels map[string]string) (Renderer, error) {
 	generator := generate.NewGenerator(workingDir, config.Generate, hydrationDir)
-	var validator *validate.Validator
+	var validator validate.Validator
 	if config.Validate != nil {
 		var err error
 		validator, err = validate.NewValidator(*config.Validate)
@@ -65,7 +65,7 @@ func NewSkaffoldRenderer(config *latestV2.RenderConfig, workingDir, hydrationDir
 		validator, _ = validate.NewValidator([]latestV2.Validator{})
 	}
 
-	var transformer *transform.Transformer
+	var transformer transform.Transformer
 	if config.Transform != nil {
 		var err error
 		transformer, err = transform.NewTransformer(*config.Transform)
@@ -75,7 +75,7 @@ func NewSkaffoldRenderer(config *latestV2.RenderConfig, workingDir, hydrationDir
 	} else {
 		transformer, _ = transform.NewTransformer([]latestV2.Transformer{})
 	}
-	return &SkaffoldRenderer{Generator: *generator, Validator: *validator, Transformer: *transformer,
+	return &SkaffoldRenderer{Generator: generator, Validator: validator, Transformer: transformer,
 		hydrationDir: hydrationDir, labels: labels}, nil
 }
 

--- a/pkg/skaffold/render/transform/transform.go
+++ b/pkg/skaffold/render/transform/transform.go
@@ -60,12 +60,12 @@ var (
 )
 
 // NewTransformer instantiates a Transformer object.
-func NewTransformer(config []latestV2.Transformer) (*Transformer, error) {
+func NewTransformer(config []latestV2.Transformer) (Transformer, error) {
 	newFuncs, err := validateTransformers(config)
 	if err != nil {
-		return nil, err
+		return Transformer{}, err
 	}
-	return &Transformer{kptFn: newFuncs, needRefresh: true, config: config}, nil
+	return Transformer{kptFn: newFuncs, needRefresh: true, config: config}, nil
 }
 
 type Transformer struct {
@@ -75,7 +75,7 @@ type Transformer struct {
 }
 
 // GetDeclarativeValidators transforms and returns the skaffold validators defined in skaffold.yaml
-func (v *Transformer) GetDeclarativeTransformers() ([]kptfile.Function, error) {
+func (v Transformer) GetDeclarativeTransformers() ([]kptfile.Function, error) {
 	// TODO: guarantee the v.kptFn is updated once users changed skaffold.yaml file.
 	if v.needRefresh {
 		newFuncs, err := validateTransformers(v.config)

--- a/pkg/skaffold/render/validate/validate.go
+++ b/pkg/skaffold/render/validate/validate.go
@@ -33,13 +33,13 @@ var (
 )
 
 // NewValidator instantiates a Validator object.
-func NewValidator(config []latestV2.Validator) (*Validator, error) {
+func NewValidator(config []latestV2.Validator) (Validator, error) {
 	var fns []kptfile.Function
 	for _, c := range config {
 		fn, ok := validatorAllowlist[c.Name]
 		if !ok {
 			// TODO: Add links to explain "skaffold-managed mode" and "kpt-managed mode".
-			return nil, sErrors.NewErrorWithStatusCode(
+			return Validator{}, sErrors.NewErrorWithStatusCode(
 				&proto.ActionableErr{
 					Message: fmt.Sprintf("unsupported validator %q", c.Name),
 					ErrCode: proto.StatusCode_CONFIG_UNKNOWN_VALIDATOR,
@@ -55,7 +55,7 @@ func NewValidator(config []latestV2.Validator) (*Validator, error) {
 		}
 		fns = append(fns, fn)
 	}
-	return &Validator{kptFn: fns}, nil
+	return Validator{kptFn: fns}, nil
 }
 
 type Validator struct {
@@ -63,7 +63,7 @@ type Validator struct {
 }
 
 // GetDeclarativeValidators transforms and returns the skaffold validators defined in skaffold.yaml
-func (v *Validator) GetDeclarativeValidators() []kptfile.Function {
+func (v Validator) GetDeclarativeValidators() []kptfile.Function {
 	// TODO: guarantee the v.kptFn is updated once users changed skaffold.yaml file.
 	return v.kptFn
 }


### PR DESCRIPTION
Removing pointers from render package. 
Generators, Validators and Transformers don't need to be pointer and can be empty structs.

All the above objects struct fields are arrays, string or boolean. Converting these to object will avoid any NPE

