### PR TITLE
chore(deps): bump puma from 4.3.9 to 4.3.11 in ruby example

### DIFF
--- a/examples/ruby/backend/Gemfile.lock
+++ b/examples/ruby/backend/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     nio4r (2.5.8)
-    puma (4.3.9)
+    puma (4.3.11)
       nio4r (~> 2.0)
     rack (2.1.4)
     rack-unreloader (1.7.0)

--- a/integration/examples/ruby/backend/Gemfile.lock
+++ b/integration/examples/ruby/backend/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     nio4r (2.5.8)
-    puma (4.3.9)
+    puma (4.3.11)
       nio4r (~> 2.0)
     rack (2.1.4)
     rack-unreloader (1.7.0)


### PR DESCRIPTION
**Description**
Move https://github.com/GoogleContainerTools/skaffold/pull/7106 into a PR that also modifies `integration/examples`
