### PR TITLE
[v2] feat: Add kubectl renderer

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -652,6 +652,9 @@ github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.1/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/stdr v1.2.0/go.mod h1:YkVgnZu1ZjjL7xTxrfm/LLZBfkhTqSR1ydtm6jTKKwI=
 github.com/go-logr/zapr v0.1.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
@@ -1707,6 +1710,8 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0 h1:Q3C9yzW
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0/go.mod h1:2AboqHi0CiIZU0qwhtUfCYD1GeUzvvIXWNkhDt7ZMG4=
 go.opentelemetry.io/otel v0.20.0 h1:eaP0Fqu7SXHwvjiqDq83zImeehOHX8doTvU9AwXON8g=
 go.opentelemetry.io/otel v0.20.0/go.mod h1:Y3ugLH2oa81t5QO+Lty+zXf8zC9L26ax4Nzoxm/dooo=
+go.opentelemetry.io/otel v1.3.0 h1:APxLf0eiBwLl+SOXiJJCVYzA1OOJNyAoV8C5RNRyy7Y=
+go.opentelemetry.io/otel v1.3.0/go.mod h1:PWIKzi6JCp7sM0k9yZ43VX+T345uNbAkDKwHVjb2PTs=
 go.opentelemetry.io/otel/exporters/stdout v0.20.0 h1:NXKkOWV7Np9myYrQE0wqRS3SbwzbupHu07rDONKubMo=
 go.opentelemetry.io/otel/exporters/stdout v0.20.0/go.mod h1:t9LUU3JvYlmoPA61abhvsXxKh58xdyi3nMtI6JiR8v0=
 go.opentelemetry.io/otel/exporters/trace/jaeger v0.20.0 h1:FoclOadJNul1vUiKnZU0sKFWOZtZQq3jUzSbrX2jwNM=
@@ -1723,6 +1728,8 @@ go.opentelemetry.io/otel/sdk/metric v0.20.0 h1:7ao1wpzHRVKf0OQ7GIxiQJA6X7DLX9o14
 go.opentelemetry.io/otel/sdk/metric v0.20.0/go.mod h1:knxiS8Xd4E/N+ZqKmUPf3gTTZ4/0TjTXukfxjzSTpHE=
 go.opentelemetry.io/otel/trace v0.20.0 h1:1DL6EXUdcg95gukhuRRvLDO/4X5THh/5dIV52lqtnbw=
 go.opentelemetry.io/otel/trace v0.20.0/go.mod h1:6GjCW8zgDjwGHGa6GkyeB8+/5vjT16gUEi0Nf1iBdgw=
+go.opentelemetry.io/otel/trace v1.3.0 h1:doy8Hzb1RJ+I3yFhtDmwNc7tIyw1tNMOIsyPzp1NOGY=
+go.opentelemetry.io/otel/trace v1.3.0/go.mod h1:c/VDhno8888bvQYmbYLqe41/Ldmr/KKunbvWM4/fEjk=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.starlark.net v0.0.0-20190528202925-30ae18b8564f/go.mod h1:c1/X6cHgvdXj6pUlmWKMkuqRnW4K8x2vwt6JAaaircg=
 go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5/go.mod h1:nmDLcffg48OtT/PSW0Hg7FvpRQsQh5OSqIylirxKC7o=

--- a/pkg/skaffold/render/renderer/kpt/kpt.go
+++ b/pkg/skaffold/render/renderer/kpt/kpt.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2022 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kpt
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/errors"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/generate"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/kptfile"
+	rUtil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer/util"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/transform"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/validate"
+	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
+	"github.com/GoogleContainerTools/skaffold/proto/v1"
+)
+
+type Kpt struct {
+	generate.Generator
+	validate.Validator
+	transform.Transformer
+	hydrationDir string
+	labels       map[string]string
+}
+
+func New(config *latestV2.RenderConfig, workingDir, hydrationDir string,
+	labels map[string]string) (*Kpt, error) {
+	generator := generate.NewGenerator(workingDir, config.Generate, hydrationDir)
+	var validator validate.Validator
+	if config.Validate != nil {
+		var err error
+		validator, err = validate.NewValidator(*config.Validate)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		validator, _ = validate.NewValidator([]latestV2.Validator{})
+	}
+
+	var transformer transform.Transformer
+	if config.Transform != nil {
+		var err error
+		transformer, err = transform.NewTransformer(*config.Transform)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		transformer, _ = transform.NewTransformer([]latestV2.Transformer{})
+	}
+	return &Kpt{Generator: generator, Validator: validator, Transformer: transformer,
+		hydrationDir: hydrationDir, labels: labels}, nil
+}
+
+func (r *Kpt) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, _ bool, output string) error {
+
+	kptfilePath := filepath.Join(r.hydrationDir, kptfile.KptFileName)
+	kfConfig := &kptfile.KptFile{}
+
+	// Initialize the kpt hydration directory.
+	// This directory is used to cache DRY config and hydrates the DRY config to WET config in-place.
+	// This is needed because kpt v1 only supports in-place config while users may not want to have their config be
+	// hydrated in place.
+	// Once Kptfile is initialized, its "pipeline" field will be updated in each skaffold render, and its "inventory"
+	// will keep the same to guarantee accurate `kpt live apply`.
+	_, endTrace := instrumentation.StartTrace(ctx, "Render_initKptfile")
+	if _, err := os.Stat(kptfilePath); os.IsNotExist(err) {
+		if err := os.MkdirAll(r.hydrationDir, os.ModePerm); err != nil {
+			endTrace(instrumentation.TraceEndError(fmt.Errorf("create hydration dir %v:%w", r.hydrationDir, err)))
+			return err
+		}
+		cmd := exec.CommandContext(ctx, "kpt", "pkg", "init", r.hydrationDir)
+		if _, err := util.RunCmdOut(ctx, cmd); err != nil {
+			return sErrors.NewError(err,
+				&proto.ActionableErr{
+					Message: fmt.Sprintf("unable to initialize Kptfile in %v", r.hydrationDir),
+					ErrCode: proto.StatusCode_RENDER_KPTFILE_INIT_ERR,
+					Suggestions: []*proto.Suggestion{
+						{
+							SuggestionCode: proto.SuggestionCode_KPTFILE_MANUAL_INIT,
+							Action:         fmt.Sprintf("please manually run `kpt pkg init %v`", r.hydrationDir),
+						},
+					},
+				})
+		}
+	}
+	endTrace()
+	_, endTrace = instrumentation.StartTrace(ctx, "Render_readKptfile")
+	kptfileBytes, err := ioutil.ReadFile(kptfilePath)
+	if err != nil {
+		endTrace(instrumentation.TraceEndError(fmt.Errorf("read Kptfile from %v: %w",
+			filepath.Dir(kptfilePath), err)))
+		return err
+	}
+	if err := yaml.UnmarshalStrict(kptfileBytes, &kfConfig); err != nil {
+		return errors.ParseKptfileError(err, r.hydrationDir)
+	}
+	if err := os.RemoveAll(r.hydrationDir); err != nil {
+		return errors.DeleteKptfileError(err, r.hydrationDir)
+	}
+	endTrace()
+	rUtil.GenerateHydratedManifests(ctx, out, builds, r.Generator, r.hydrationDir, r.labels)
+
+	if kfConfig.Pipeline == nil {
+		kfConfig.Pipeline = &kptfile.Pipeline{}
+	}
+	kfConfig.Pipeline.Validators = r.GetDeclarativeValidators()
+	kfConfig.Pipeline.Mutators, err = r.GetDeclarativeTransformers()
+	if err != nil {
+		return err
+	}
+	configByte, err := yaml.Marshal(kfConfig)
+	if err != nil {
+		return err
+	}
+	if err = ioutil.WriteFile(kptfilePath, configByte, 0644); err != nil {
+		return err
+	}
+	endTrace()
+
+	rCtx, endTrace := instrumentation.StartTrace(ctx, "Render_kptRenderCommand")
+	cmd := exec.CommandContext(rCtx, "kpt", "fn", "render", r.hydrationDir)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := util.RunCmd(ctx, cmd); err != nil {
+		endTrace(instrumentation.TraceEndError(err))
+		// TODO(yuwenma): How to guide users when they face kpt error (may due to bad user config)?
+		return err
+	}
+
+	if output != "" {
+		r.writeManifestsToFile(ctx, out, output)
+	}
+	return nil
+}
+
+// writeManifestsToFile converts the structured manifest to a flatten format and store them in the given `output` file.
+func (r *Kpt) writeManifestsToFile(ctx context.Context, out io.Writer, output string) error {
+	rCtx, endTrace := instrumentation.StartTrace(ctx, "Render_outputManifests")
+	cmd := exec.CommandContext(rCtx, "kpt", "fn", "source", r.hydrationDir, "-o", "unwrap")
+	var buf []byte
+	cmd.Stderr = out
+	buf, err := util.RunCmdOut(ctx, cmd)
+	if err != nil {
+		endTrace(instrumentation.TraceEndError(err))
+		return err
+	}
+	return ioutil.WriteFile(output, buf, os.ModePerm)
+}

--- a/pkg/skaffold/render/renderer/kpt/kpt.go
+++ b/pkg/skaffold/render/renderer/kpt/kpt.go
@@ -77,7 +77,6 @@ func New(config *latestV2.RenderConfig, workingDir, hydrationDir string,
 }
 
 func (r *Kpt) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, _ bool, output string) error {
-
 	kptfilePath := filepath.Join(r.hydrationDir, kptfile.KptFileName)
 	kfConfig := &kptfile.KptFile{}
 

--- a/pkg/skaffold/render/renderer/kpt/kpt_test.go
+++ b/pkg/skaffold/render/renderer/kpt/kpt_test.go
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package renderer
+package kpt
 
 import (
 	"bytes"
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/kptfile"
+	rUtil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer/util"
 	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
@@ -168,7 +169,7 @@ pipeline:
 				Write(filepath.Join(constants.DefaultHydrationDir, kptfile.KptFileName), test.originalKptfile).
 				Touch("empty.ignored").
 				Chdir()
-			r, err := NewSkaffoldRenderer(test.renderConfig, tmpDirObj.Root(),
+			r, err := New(test.renderConfig, tmpDirObj.Root(),
 				filepath.Join(tmpDirObj.Root(), constants.DefaultHydrationDir), map[string]string{})
 			t.CheckNoError(err)
 			t.Override(&util.DefaultExecCommand,
@@ -178,7 +179,7 @@ pipeline:
 			err = r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}},
 				true, "")
 			t.CheckNoError(err)
-			t.CheckFileExistAndContent(filepath.Join(tmpDirObj.Root(), constants.DefaultHydrationDir, dryFileName), []byte(labeledPodYaml))
+			t.CheckFileExistAndContent(filepath.Join(tmpDirObj.Root(), constants.DefaultHydrationDir, rUtil.DryFileName), []byte(labeledPodYaml))
 			t.CheckFileExistAndContent(filepath.Join(tmpDirObj.Root(), constants.DefaultHydrationDir, kptfile.KptFileName), []byte(test.updatedKptfile))
 		})
 	}
@@ -231,7 +232,7 @@ inventory:
 			tmpDirObj.Write("pod.yaml", podYaml).
 				Write(filepath.Join(constants.DefaultHydrationDir, kptfile.KptFileName), test.originalKptfile).
 				Chdir()
-			r, err := NewSkaffoldRenderer(&latestV2.RenderConfig{
+			r, err := New(&latestV2.RenderConfig{
 				Generate: latestV2.Generate{RawK8s: []string{"pod.yaml"}},
 				Validate: &[]latestV2.Validator{{Name: "kubeval"}}}, tmpDirObj.Root(),
 				filepath.Join(tmpDirObj.Root(), constants.DefaultHydrationDir), map[string]string{})

--- a/pkg/skaffold/render/renderer/kubectl/kubectl.go
+++ b/pkg/skaffold/render/renderer/kubectl/kubectl.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2022 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"context"
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/generate"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer/util"
+	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
+)
+
+type Kubectl struct {
+	generate.Generator
+	hydrationDir string
+	labels       map[string]string
+}
+
+func New(config *latestV2.RenderConfig, workingDir, hydrationDir string,
+	labels map[string]string) (Kubectl, error) {
+	generator := generate.NewGenerator(workingDir, config.Generate, hydrationDir)
+	return Kubectl{Generator: generator, hydrationDir: hydrationDir, labels: labels}, nil
+}
+
+func (r Kubectl) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, _ bool, _ string) error {
+	return util.GenerateHydratedManifests(ctx, out, builds, r.Generator, r.hydrationDir, r.labels)
+}

--- a/pkg/skaffold/render/renderer/kubectl/kubectl_test.go
+++ b/pkg/skaffold/render/renderer/kubectl/kubectl_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2021 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package kubectl
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/constants"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	rUtil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer/util"
+	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+const (
+	// Raw manifests
+	podYaml = `apiVersion: v1
+kind: Pod
+metadata:
+  name: leeroy-web
+spec:
+  containers:
+  - image: leeroy-web
+    name: leeroy-web
+`
+	// manifests with image tags and label
+	labeledPodYaml = `apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run.id: test
+  name: leeroy-web
+spec:
+  containers:
+  - image: leeroy-web:v1
+    name: leeroy-web
+`
+	// manifests with image tags
+	taggedPodYaml = `apiVersion: v1
+kind: Pod
+metadata:
+  name: leeroy-web
+spec:
+  containers:
+  - image: leeroy-web:v1
+    name: leeroy-web
+`
+)
+
+func TestRender(t *testing.T) {
+	tests := []struct {
+		description  string
+		renderConfig *latestV2.RenderConfig
+		labels       map[string]string
+		expected     string
+	}{
+		{
+			description: "single manifest with no labels",
+			renderConfig: &latestV2.RenderConfig{
+				Generate: latestV2.Generate{RawK8s: []string{"pod.yaml"}},
+			},
+			expected: taggedPodYaml,
+		},
+		{
+			description: "single manifest with labels",
+			renderConfig: &latestV2.RenderConfig{
+				Generate: latestV2.Generate{RawK8s: []string{"pod.yaml"}},
+			},
+			labels:   map[string]string{"run.id": "test"},
+			expected: labeledPodYaml,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			tmpDirObj := t.NewTempDir()
+			tmpDirObj.Write("pod.yaml", podYaml).
+				Touch("empty.ignored").
+				Chdir()
+			r, err := New(test.renderConfig, tmpDirObj.Root(),
+				filepath.Join(tmpDirObj.Root(), constants.DefaultHydrationDir), test.labels)
+			t.CheckNoError(err)
+			var b bytes.Buffer
+			err = r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}},
+				true, "")
+			t.CheckNoError(err)
+			t.CheckFileExistAndContent(filepath.Join(tmpDirObj.Root(), constants.DefaultHydrationDir, rUtil.DryFileName), []byte(test.expected))
+		})
+	}
+}

--- a/pkg/skaffold/render/renderer/renderer.go
+++ b/pkg/skaffold/render/renderer/renderer.go
@@ -13,34 +13,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package renderer
 
 import (
 	"context"
-	"fmt"
 	"io"
-	"io/ioutil"
-	"os"
-	"os/exec"
-	"path/filepath"
 
-	sErrors "github.com/GoogleContainerTools/skaffold/pkg/skaffold/errors"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/errors"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/generate"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/kptfile"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/transform"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/validate"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer/kpt"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer/kubectl"
 	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
-	"github.com/GoogleContainerTools/skaffold/proto/v1"
-)
-
-const (
-	dryFileName = "manifests.yaml"
 )
 
 type Renderer interface {
@@ -50,163 +33,11 @@ type Renderer interface {
 	ManifestDeps() ([]string, error)
 }
 
-// NewSkaffoldRenderer creates a new Renderer object from the latestV2 API schema.
-func NewSkaffoldRenderer(config *latestV2.RenderConfig, workingDir, hydrationDir string,
+// New creates a new Renderer object from the latestV2 API schema.
+func New(config *latestV2.RenderConfig, workingDir, hydrationDir string,
 	labels map[string]string) (Renderer, error) {
-	generator := generate.NewGenerator(workingDir, config.Generate, hydrationDir)
-	var validator validate.Validator
-	if config.Validate != nil {
-		var err error
-		validator, err = validate.NewValidator(*config.Validate)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		validator, _ = validate.NewValidator([]latestV2.Validator{})
+	if config.Validate == nil && config.Transform == nil && config.Kpt == nil {
+		return kubectl.New(config, workingDir, hydrationDir, labels)
 	}
-
-	var transformer transform.Transformer
-	if config.Transform != nil {
-		var err error
-		transformer, err = transform.NewTransformer(*config.Transform)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		transformer, _ = transform.NewTransformer([]latestV2.Transformer{})
-	}
-	return &SkaffoldRenderer{Generator: generator, Validator: validator, Transformer: transformer,
-		hydrationDir: hydrationDir, labels: labels}, nil
-}
-
-type SkaffoldRenderer struct {
-	generate.Generator
-	validate.Validator
-	transform.Transformer
-	hydrationDir string
-	labels       map[string]string
-}
-
-func (r *SkaffoldRenderer) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, _ bool, output string) error {
-	kptfilePath := filepath.Join(r.hydrationDir, kptfile.KptFileName)
-	kfConfig := &kptfile.KptFile{}
-
-	// Initialize the kpt hydration directory.
-	// This directory is used to cache DRY config and hydrates the DRY config to WET config in-place.
-	// This is needed because kpt v1 only supports in-place config while users may not want to have their config be
-	// hydrated in place.
-	// Once Kptfile is initialized, its "pipeline" field will be updated in each skaffold render, and its "inventory"
-	// will keep the same to guarantee accurate `kpt live apply`.
-	_, endTrace := instrumentation.StartTrace(ctx, "Render_initKptfile")
-	if _, err := os.Stat(kptfilePath); os.IsNotExist(err) {
-		if err := os.MkdirAll(r.hydrationDir, os.ModePerm); err != nil {
-			endTrace(instrumentation.TraceEndError(fmt.Errorf("create hydration dir %v:%w", r.hydrationDir, err)))
-			return err
-		}
-		cmd := exec.CommandContext(ctx, "kpt", "pkg", "init", r.hydrationDir)
-		if _, err := util.RunCmdOut(ctx, cmd); err != nil {
-			return sErrors.NewError(err,
-				&proto.ActionableErr{
-					Message: fmt.Sprintf("unable to initialize Kptfile in %v", r.hydrationDir),
-					ErrCode: proto.StatusCode_RENDER_KPTFILE_INIT_ERR,
-					Suggestions: []*proto.Suggestion{
-						{
-							SuggestionCode: proto.SuggestionCode_KPTFILE_MANUAL_INIT,
-							Action:         fmt.Sprintf("please manually run `kpt pkg init %v`", r.hydrationDir),
-						},
-					},
-				})
-		}
-	}
-	endTrace()
-	_, endTrace = instrumentation.StartTrace(ctx, "Render_readKptfile")
-	kptfileBytes, err := ioutil.ReadFile(kptfilePath)
-	if err != nil {
-		endTrace(instrumentation.TraceEndError(fmt.Errorf("read Kptfile from %v: %w",
-			filepath.Dir(kptfilePath), err)))
-		return err
-	}
-	if err := yaml.UnmarshalStrict(kptfileBytes, &kfConfig); err != nil {
-		return errors.ParseKptfileError(err, r.hydrationDir)
-	}
-	if err := os.RemoveAll(r.hydrationDir); err != nil {
-		return errors.DeleteKptfileError(err, r.hydrationDir)
-	}
-	if err := os.MkdirAll(r.hydrationDir, os.ModePerm); err != nil {
-		return err
-	}
-	endTrace()
-
-	// Generate manifests.
-	rCtx, endTrace := instrumentation.StartTrace(ctx, "Render_generateManifest")
-	manifests, err := r.Generate(rCtx, out)
-	if err != nil {
-		return err
-	}
-	endTrace()
-
-	// Update image labels.renderer_test.go
-	rCtx, endTrace = instrumentation.StartTrace(ctx, "Render_setSkaffoldLabels")
-	manifests, err = manifests.ReplaceImages(rCtx, builds)
-	if err != nil {
-		return err
-	}
-	if manifests, err = manifests.SetLabels(r.labels); err != nil {
-		return err
-	}
-	endTrace()
-
-	// Cache the dry manifests to the hydration directory.
-	_, endTrace = instrumentation.StartTrace(ctx, "Render_cacheDryConfig")
-	dryConfigPath := filepath.Join(r.hydrationDir, dryFileName)
-	if err := manifest.Write(manifests.String(), dryConfigPath, out); err != nil {
-		return err
-	}
-	endTrace()
-
-	if kfConfig.Pipeline == nil {
-		kfConfig.Pipeline = &kptfile.Pipeline{}
-	}
-	kfConfig.Pipeline.Validators = r.GetDeclarativeValidators()
-	kfConfig.Pipeline.Mutators, err = r.GetDeclarativeTransformers()
-	if err != nil {
-		return err
-	}
-	configByte, err := yaml.Marshal(kfConfig)
-	if err != nil {
-		return err
-	}
-	if err = ioutil.WriteFile(kptfilePath, configByte, 0644); err != nil {
-		return err
-	}
-	endTrace()
-
-	rCtx, endTrace = instrumentation.StartTrace(ctx, "Render_kptRenderCommand")
-	cmd := exec.CommandContext(rCtx, "kpt", "fn", "render", r.hydrationDir)
-	cmd.Stdout = out
-	cmd.Stderr = out
-	if err := util.RunCmd(ctx, cmd); err != nil {
-		endTrace(instrumentation.TraceEndError(err))
-		// TODO(yuwenma): How to guide users when they face kpt error (may due to bad user config)?
-		return err
-	}
-
-	if output != "" {
-		r.writeManifestsToFile(ctx, out, output)
-	}
-	return nil
-}
-
-// writeManifestsToFile converts the structured manifest to a flatten format and store them in the given `output` file.
-func (r *SkaffoldRenderer) writeManifestsToFile(ctx context.Context, out io.Writer, output string) error {
-	rCtx, endTrace := instrumentation.StartTrace(ctx, "Render_outputManifests")
-	cmd := exec.CommandContext(rCtx, "kpt", "fn", "source", r.hydrationDir, "-o", "unwrap")
-	var buf []byte
-	cmd.Stderr = out
-	buf, err := util.RunCmdOut(ctx, cmd)
-	if err != nil {
-		endTrace(instrumentation.TraceEndError(err))
-		return err
-	}
-	return ioutil.WriteFile(output, buf, os.ModePerm)
+	return kpt.New(config, workingDir, hydrationDir, labels)
 }

--- a/pkg/skaffold/render/renderer/util/util.go
+++ b/pkg/skaffold/render/renderer/util/util.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/generate"
+)
+
+const (
+	DryFileName = "manifests.yaml"
+)
+
+func GenerateHydratedManifests(ctx context.Context, out io.Writer, builds []graph.Artifact, g generate.Generator, hydrationDir string, labels map[string]string) error {
+	// Generate manifests.
+	rCtx, endTrace := instrumentation.StartTrace(ctx, "Render_generateManifest")
+	if err := os.MkdirAll(hydrationDir, os.ModePerm); err != nil {
+		return err
+	}
+	manifests, err := g.Generate(rCtx, out)
+	if err != nil {
+		return err
+	}
+	endTrace()
+
+	// Update image labels.renderer_test.go
+	rCtx, endTrace = instrumentation.StartTrace(ctx, "Render_setSkaffoldLabels")
+	manifests, err = manifests.ReplaceImages(rCtx, builds)
+	if err != nil {
+		return err
+	}
+	if manifests, err = manifests.SetLabels(labels); err != nil {
+		return err
+	}
+	endTrace()
+
+	// Cache the dry manifests to the hydration directory.
+	_, endTrace = instrumentation.StartTrace(ctx, "Render_cacheDryConfig")
+	dryConfigPath := filepath.Join(hydrationDir, DryFileName)
+	if err := manifest.Write(manifests.String(), dryConfigPath, out); err != nil {
+		return err
+	}
+	endTrace()
+	return nil
+}

--- a/pkg/skaffold/render/transform/transform.go
+++ b/pkg/skaffold/render/transform/transform.go
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package transform
 
 import (

--- a/pkg/skaffold/runner/v2/new.go
+++ b/pkg/skaffold/runner/v2/new.go
@@ -81,7 +81,7 @@ func NewForConfig(ctx context.Context, runCtx *runcontext.RunContext) (*Skaffold
 		return nil, fmt.Errorf("getting render output path: %w", err)
 	}
 
-	renderer, err := renderer.NewSkaffoldRenderer(
+	renderer, err := renderer.New(
 		runCtx.GetRenderConfig(), runCtx.GetWorkingDir(), hydrationDir, labeller.Labels())
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(err))

--- a/pkg/skaffold/runner/v2/runner_test.go
+++ b/pkg/skaffold/runner/v2/runner_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer"
 	"github.com/blang/semver"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -40,7 +41,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/platform"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/generate"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer"
+	kRenderer "github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	v2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v2"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/defaults"
@@ -368,7 +369,7 @@ func TestNewForConfig(t *testing.T) {
 				},
 			},
 			expectedTester:   &test.FullTester{},
-			expectedRenderer: &renderer.SkaffoldRenderer{},
+			expectedRenderer: &kRenderer.Kubectl{},
 			expectedDeployer: &kubectl.Deployer{},
 		},
 		{
@@ -387,7 +388,7 @@ func TestNewForConfig(t *testing.T) {
 				},
 			},
 			expectedTester:   &test.FullTester{},
-			expectedRenderer: &renderer.SkaffoldRenderer{},
+			expectedRenderer: &kRenderer.Kubectl{},
 			expectedDeployer: &kubectl.Deployer{},
 		},
 		{
@@ -406,7 +407,7 @@ func TestNewForConfig(t *testing.T) {
 				},
 			},
 			expectedTester:   &test.FullTester{},
-			expectedRenderer: &renderer.SkaffoldRenderer{},
+			expectedRenderer: &kRenderer.Kubectl{},
 			expectedDeployer: &kubectl.Deployer{},
 		},
 		{
@@ -431,7 +432,7 @@ func TestNewForConfig(t *testing.T) {
 			pipeline:         latestV2.Pipeline{},
 			shouldErr:        true,
 			expectedTester:   &test.FullTester{},
-			expectedRenderer: &renderer.SkaffoldRenderer{},
+			expectedRenderer: &kRenderer.Kubectl{},
 			expectedDeployer: &kubectl.Deployer{},
 		},
 		{
@@ -450,7 +451,7 @@ func TestNewForConfig(t *testing.T) {
 				},
 			},
 			expectedTester:   &test.FullTester{},
-			expectedRenderer: &renderer.SkaffoldRenderer{},
+			expectedRenderer: &kRenderer.Kubectl{},
 			expectedDeployer: &kubectl.Deployer{},
 			cacheArtifacts:   true,
 		},
@@ -473,7 +474,7 @@ func TestNewForConfig(t *testing.T) {
 				},
 			},
 			expectedTester: &test.FullTester{},
-			expectedRenderer: &renderer.SkaffoldRenderer{
+			expectedRenderer: &kRenderer.Kubectl{
 				Generator: generate.Generator{},
 			},
 			expectedDeployer: &kubectl.Deployer{},

--- a/pkg/skaffold/runner/v2/runner_test.go
+++ b/pkg/skaffold/runner/v2/runner_test.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"testing"
 
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer"
 	"github.com/blang/semver"
 	"k8s.io/client-go/tools/clientcmd/api"
 
@@ -41,6 +40,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/platform"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/generate"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer"
 	kRenderer "github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	v2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext/v2"


### PR DESCRIPTION
In PR, we are adding a kubectl renderer so user's just relying on kubectl or helm don't have to depend on kpt. 

The kubectl renderer is invoked when
1) there is no validator is defined
2) no kpt config defined and
3) No transformer defined.
```
if config.Validate == nil && config.Transform == nil && config.Kpt == nil {
		return kubectl.New(config, workingDir, hydrationDir, labels)
	}
```


### *Description of changes*
1) Move skaffold/render/renderer/renderer.go  → pkg/skaffold/render/renderer/kpt/kpt.go  and rename `renderer.SkaffoldRenderer` to `renderer.kpt.Kpt`  
2) Move  skaffold/render/renderer/renderer_test.go → pkg/skaffold/render/renderer/kpt/kpt_test.go
3) Add `renderer.kubectl.Kubectl` in `pkg/skaffold/render/renderer/kubectl/kubectl.go` which uses the already implemented `generated.Generator` to read k8s manifests, add labels to these manifests and write them to a hydration dir
4) Create a render util `GenerateHydratedManifests` which calls `generated.Generator.Generate` to read k8s manifests, add labels to these manifests and write them to a hydration dir. This method is used in both Kpt and Kubectl renderer.

Things to do next
- [ ] Remove `Render` from deployer.Deploy interface
- [ ] Remove `--skip-render` flag as rendering will always happen
- [ ] Remove `manifests` from `v1.KubectlDeploy` section.
- [ ] Support helm rendering i.e #6720 


