### PR TITLE
fix:  skaffold's assumption for image tag when building via buildkit and custom output

### DIFF
--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -540,6 +540,10 @@ func (l *localDaemon) TagWithImageID(ctx context.Context, ref string, imageID st
 		return "", err
 	}
 
+	if imageID == "" {
+		log.Entry(ctx).Debugf("generating tag for %s: empty image id\n", ref)
+		return "", nil
+	}
 	uniqueTag := parsed.BaseName + ":" + strings.TrimPrefix(imageID, "sha256:")
 	if err := l.Tag(ctx, imageID, uniqueTag); err != nil {
 		return "", err

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -537,6 +537,10 @@ func TestTagWithImageID(t *testing.T) {
 			imageName:   "!!invalid!!",
 			shouldErr:   true,
 		},
+		{
+			description: "empty image id",
+			imageName:   "ref",
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7024 <!-- tracking issues that this PR will close -->


**Description**
The original issue is about using local docker buildkit build. When building with buildkit and custom output, image is not tagged by default. Empty image id is passed to `ImageAPIClient.ImageTag` from the docker package, which fails.

This [line](https://github.com/GoogleContainerTools/skaffold/blob/55bea853ef2e81e4fc5b15322d6a04997176d1d0/pkg/skaffold/docker/image.go#L555) suggests that an empty image id is a valid use case in some circumstances. 

I simply added a new condition to the method - if image id is empty, docker `ImageTag` is not called and simply returns empty string instead. 
Unit test included. 

**User facing changes (remove if N/A)**
**Before**
When using buildkit and custom output, skaffold returned the following error
`Error parsing reference: "" is not a valid repository/tag: invalid reference format`
**After**
When using buildkit and custom output, skaffold successfully completes build. 

Custom output is produced in both cases, as it's exported by the docker cli, not by skaffold