### PR TITLE
fix: `make preview-docs` should run for Mac M1

### DIFF
--- a/deploy/docs/local-preview.sh
+++ b/deploy/docs/local-preview.sh
@@ -26,5 +26,5 @@ for dir in $(find ${DOCS_DIR} -mindepth 1 -maxdepth 1 -type d | grep -v themes |
     MOUNTS="${MOUNTS} -v $dir:/app/docs/$(basename $dir):ro"
 done
 
-docker build -t skaffold-docs-previewer --target runtime_deps deploy/webhook
-docker run --rm -ti -p 1313:1313 ${MOUNTS} skaffold-docs-previewer $@
+docker build --platform linux/amd64 -t skaffold-docs-previewer --target runtime_deps deploy/webhook
+docker run --platform linux/amd64 --rm -ti -p 1313:1313 ${MOUNTS} skaffold-docs-previewer $@


### PR DESCRIPTION
`skaffold-docs-previewer` image should be built for `linux/amd64` explicitly for it to work on Mac M1.
Otherwise it builds for the host architecture and for `linux/arm64` we get this error:
```
❯ make preview-docs
./deploy/docs/local-preview.sh hugo serve -D --bind=0.0.0.0 --ignoreCache
[+] Building 191.9s (21/21) FINISHED                                                                                               0.0s
...
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them
qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
make: *** [preview-docs] Error 255
```