### PR TITLE
fix: choose cli default-repo over config file

### DIFF
--- a/pkg/skaffold/config/util.go
+++ b/pkg/skaffold/config/util.go
@@ -257,10 +257,6 @@ func GetCluster(ctx context.Context, opts GetClusterOpts) (Cluster, error) {
 
 	var defaultRepo = opts.DefaultRepo
 
-	if defaultRepo.Value() != nil && cfg.DefaultRepo != "" {
-		defaultRepo = NewStringOrUndefined(&cfg.DefaultRepo)
-	}
-
 	if local && defaultRepo.Value() == nil {
 		registry, err := DiscoverLocalRegistry(ctx, kubeContext)
 		switch {

--- a/pkg/skaffold/config/util_test.go
+++ b/pkg/skaffold/config/util_test.go
@@ -391,6 +391,12 @@ func TestGetCluster(t *testing.T) {
 			cfg:         &ContextConfig{Kubecontext: "not-k3d"},
 			expected:    Cluster{Local: false, LoadImages: false, PushImages: true},
 		},
+		{
+			description: "generic cluster, default repo already defined",
+			cfg:         &ContextConfig{Kubecontext: "anything-else", DefaultRepo: "myrepo"},
+			defaultRepo: NewStringOrUndefined(&defaultRepo),
+			expected:    Cluster{Local: false, LoadImages: false, PushImages: true, DefaultRepo: NewStringOrUndefined(&defaultRepo)},
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {


### PR DESCRIPTION
Fixes:  #7125

**Description**
Fixes error introducing in pr #6985. Logic was introduced there to give precedence to config value instead of cli.