### PR TITLE
fix: warn instead of fail for multi-arch builds

### DIFF
--- a/pkg/skaffold/build/bazel/build.go
+++ b/pkg/skaffold/build/bazel/build.go
@@ -38,7 +38,7 @@ import (
 func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latestV1.Artifact, tag string, matcher platform.Matcher) (string, error) {
 	// TODO: Implement building multi-platform images
 	if matcher.IsMultiPlatform() {
-		log.Entry(ctx).Println("skaffold doesn't yet support multi platform builds for the bazel builder")
+		log.Entry(ctx).Warnf("multiple target platforms %q found for artifact %q. Skaffold doesn't yet support multi-platform builds for the bazel builder. Consider specifying a single target platform explicitly. See https://skaffold.dev/docs/pipeline-stages/builders/#cross-platform-build-support", matcher.String(), artifact.ImageName)
 	}
 
 	a := artifact.ArtifactType.BazelArtifact

--- a/pkg/skaffold/build/buildpacks/build.go
+++ b/pkg/skaffold/build/buildpacks/build.go
@@ -33,7 +33,7 @@ import (
 func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latestV1.Artifact, tag string, matcher platform.Matcher) (string, error) {
 	if matcher.IsMultiPlatform() {
 		// TODO: Implement building multiplatform images
-		log.Entry(ctx).Println("skaffold doesn't yet support multi platform builds for the buildpacks builder")
+		log.Entry(ctx).Warnf("multiple target platforms %q found for artifact %q. Skaffold doesn't yet support multi-platform builds for the buildpacks builder. Consider specifying a single target platform explicitly. See https://skaffold.dev/docs/pipeline-stages/builders/#cross-platform-build-support", matcher.String(), artifact.ImageName)
 	}
 
 	built, err := b.build(ctx, out, artifact, tag)

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -41,7 +41,7 @@ const initContainer = "kaniko-init-container"
 func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace string, artifactName string, artifact *latestV1.KanikoArtifact, tag string, requiredImages map[string]*string, platforms platform.Matcher) (string, error) {
 	// TODO: Implement building multi-platform images for cluster builder
 	if platforms.IsMultiPlatform() {
-		log.Entry(ctx).Warnf("Multiple target platforms %q found for artifact %q. Skaffold doesn't yet support multi-platform builds for the cluster builder.", platforms.String(), artifactName)
+		log.Entry(ctx).Warnf("multiple target platforms %q found for artifact %q. Skaffold doesn't yet support multi-platform builds for the docker builder. Consider specifying a single target platform explicitly. See https://skaffold.dev/docs/pipeline-stages/builders/#cross-platform-build-support", platforms.String(), artifactName)
 	}
 
 	generatedEnvs, err := generateEnvFromImage(tag)

--- a/pkg/skaffold/build/docker/docker.go
+++ b/pkg/skaffold/build/docker/docker.go
@@ -18,7 +18,6 @@ package docker
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,6 +26,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/platform"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
@@ -66,7 +66,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, a *latestV1.Artifact
 	// we might consider a different approach in the future.
 	// use CLI for cross-platform builds
 	if b.useCLI || (b.useBuildKit != nil && *b.useBuildKit) || len(a.DockerArtifact.CliFlags) > 0 || matcher.IsNotEmpty() {
-		imageID, err = b.dockerCLIBuild(ctx, output.GetUnderlyingWriter(out), a.Workspace, dockerfile, a.ArtifactType.DockerArtifact, opts, matcher)
+		imageID, err = b.dockerCLIBuild(ctx, output.GetUnderlyingWriter(out), a.ImageName, a.Workspace, dockerfile, a.ArtifactType.DockerArtifact, opts, matcher)
 	} else {
 		imageID, err = b.localDocker.Build(ctx, out, a.Workspace, a.ImageName, a.ArtifactType.DockerArtifact, opts)
 	}
@@ -84,10 +84,10 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, a *latestV1.Artifact
 	return imageID, nil
 }
 
-func (b *Builder) dockerCLIBuild(ctx context.Context, out io.Writer, workspace string, dockerfilePath string, a *latestV1.DockerArtifact, opts docker.BuildOptions, matcher platform.Matcher) (string, error) {
+func (b *Builder) dockerCLIBuild(ctx context.Context, out io.Writer, name string, workspace string, dockerfilePath string, a *latestV1.DockerArtifact, opts docker.BuildOptions, matcher platform.Matcher) (string, error) {
 	if matcher.IsMultiPlatform() {
 		// TODO: implement multi platform build
-		return "", errors.New("skaffold doesn't yet support multi platform builds for the docker builder")
+		log.Entry(ctx).Warnf("multiple target platforms %q found for artifact %q. Skaffold doesn't yet support multi-platform builds for the docker builder. Consider specifying a single target platform explicitly. See https://skaffold.dev/docs/pipeline-stages/builders/#cross-platform-build-support", matcher.String(), name)
 	}
 
 	args := []string{"build", workspace, "--file", dockerfilePath, "-t", opts.Tag}
@@ -105,7 +105,7 @@ func (b *Builder) dockerCLIBuild(ctx context.Context, out io.Writer, workspace s
 		args = append(args, "--force-rm")
 	}
 
-	if matcher.IsNotEmpty() {
+	if len(matcher.Platforms) == 1 {
 		args = append(args, "--platform", platform.Format(matcher.Platforms[0]))
 	}
 
@@ -117,7 +117,8 @@ func (b *Builder) dockerCLIBuild(ctx context.Context, out io.Writer, workspace s
 		} else {
 			cmd.Env = append(cmd.Env, "DOCKER_BUILDKIT=0")
 		}
-	} else if matcher.IsNotEmpty() { // cross-platform builds require buildkit
+	} else if len(matcher.Platforms) == 1 { // cross-platform builds require buildkit
+		log.Entry(ctx).Debugf("setting DOCKER_BUILDKIT=1 for docker build for artifact %q since it targets platform %q", name, matcher.Platforms[0])
 		cmd.Env = append(cmd.Env, "DOCKER_BUILDKIT=1")
 	}
 	cmd.Stdout = out


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7132 <!-- tracking issues that this PR will close -->
**Related**: 6120

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
For mixed platform kubernetes clusters, skaffold was attempting to build multi-arch images. Since this feature isn't implemented yet, it was throwing an error for docker builder. This effectively breaks backwards compatibility for users of previous skaffold versions that were using mixed platform clusters. 

This PR reduces these errors to warning messages asking the user to explicitly set the target platform, but continuing on with the run as before.
**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->
Get a warning message like:
```
Starting build...
Building [skaffold-example]...
Target platforms: [linux/amd64,linux/arm64]
WARN[0001] multiple target platforms "linux/amd64,linux/arm64" found for artifact "skaffold-example". Skaffold doesn't yet support multi-platform builds for the docker builder. Consider specifying a single target platform explicitly. See https://skaffold.dev/docs/pipeline-stages/builders/#cross-platform-build-support  subtask=skaffold-example task=Build
[+] Building 0.1s (11/11) FINISHED
...                                                                                            
Starting deploy...
 - pod/getting-started created
Waiting for deployments to stabilize...
 - pods: creating container getting-started
    - pod/getting-started: creating container getting-started
 - pods is ready.
Deployments stabilized in 34.975 seconds
```