### PR TITLE
feat: add better support and messaging around using helm with skaffold apply

### DIFF
--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -66,11 +66,43 @@ func (d *deployerCtx) JSONParseConfig() v1.JSONParseConfig {
 
 // GetDeployer creates a deployer from a given RunContext and deploy pipeline definitions.
 func GetDeployer(ctx context.Context, runCtx *runcontext.RunContext, labeller *label.DefaultLabeller) (deploy.Deployer, error) {
+	deployerCfg := runCtx.Deployers()
+
 	if runCtx.Opts.Apply {
+		helmNamespaces := make(map[string]bool)
+		nonHelmDeployFound := false
+
+		for _, d := range deployerCfg {
+			if d.DockerDeploy != nil || d.KptDeploy != nil || d.KubectlDeploy != nil || d.KustomizeDeploy != nil {
+				nonHelmDeployFound = true
+			}
+
+			if d.HelmDeploy != nil {
+				for _, release := range d.HelmDeploy.Releases {
+					if release.Namespace != "" {
+						helmNamespaces[release.Namespace] = true
+					}
+				}
+			}
+		}
+
+		if len(helmNamespaces) > 1 || (nonHelmDeployFound && len(helmNamespaces) == 1) {
+			return nil, errors.New("skaffold apply called with conflicting namespaces set via skaffold.yaml. This is likely due to the use of the 'deploy.helm.releases.*.namespace' field which is not supported in apply.  Remove the 'deploy.helm.releases.*.namespace' field(s) and run skaffold apply again")
+		}
+
+		if len(helmNamespaces) == 1 && !nonHelmDeployFound {
+			if runCtx.Opts.Namespace == "" {
+				// if skaffold --namespace flag not set, use the helm namespace value
+				for k := range helmNamespaces {
+					// map only has 1 (k,v) from length check in if condition
+					runCtx.Opts.Namespace = k
+				}
+			}
+		}
+
 		return getDefaultDeployer(runCtx, labeller)
 	}
 
-	deployerCfg := runCtx.Deployers()
 	localDeploy := false
 	remoteDeploy := false
 


### PR DESCRIPTION
fixes #7101 

This PR makes it so that if a single helm release is specified with a namespace option and that release is the only deployment, skaffold will set the kubectl namespace to that namespace.  In the case that a helm release is specified with a namespace option and another deployment exists (eg: helm + kubectl deployments) or the case that multiple helm releases with namespaces are specified, `skaffold apply` will error stating:
```
skaffold apply called with 'deploy.helm.releases.*.namespace' field set which is not supported.  Remove the 'deploy.helm.releases.*.namespace' field(s) and run skaffold apply again
```

NOTE: for this to work properly, the apply call must also specify the profile used in the render call
`skaffold apply -p dev --filename=skaffold.yaml manifest.yaml`

^^ This is because render does not store anywhere (skaffold state, manifest files, etc) which profile was used to generate the manifests so it needs to be passed in both places