### PR TITLE
fix: `make install` works for Mac M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ endif
 .PHONY: install
 install: $(BUILD_DIR)/$(PROJECT)
 	mkdir -p $(GOPATH)/bin
+	rm -f $(GOBIN)/$(PROJECT)
 	cp $(BUILD_DIR)/$(PROJECT) $(GOBIN)/$(PROJECT)
 
 .PRECIOUS: $(foreach platform, $(SUPPORTED_PLATFORMS), $(BUILD_DIR)/$(PROJECT)-$(platform))


### PR DESCRIPTION
`make install` on Mac M1 runs into [this](https://stackoverflow.com/questions/67378106/mac-m1-cping-binary-over-another-results-in-crash) issue. Deleting the binary before copying over fixes it.