### PR TITLE
feat: add metrics related to cross-platform build

### DIFF
--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -271,11 +271,30 @@ func builderMetrics(ctx context.Context, meter skaffoldMeter, m metric.Meter, la
 	builderCounter := metric.Must(m).NewInt64ValueRecorder("builders", metric.WithDescription("Builders used"))
 	artifactCounter := metric.Must(m).NewInt64ValueRecorder("artifacts", metric.WithDescription("Number of artifacts used"))
 	dependenciesCounter := metric.Must(m).NewInt64ValueRecorder("artifact-dependencies", metric.WithDescription("Number of artifacts with dependencies"))
+	platformsCounter := metric.Must(m).NewInt64ValueRecorder("artifact-with-platforms", metric.WithDescription("Number of artifacts with target platforms specified"))
 	for builder, count := range meter.Builders {
 		bLabel := attribute.String("builder", builder)
 		builderCounter.Record(ctx, 1, append(labels, bLabel)...)
 		artifactCounter.Record(ctx, int64(count), append(labels, bLabel)...)
 		dependenciesCounter.Record(ctx, int64(meter.BuildDependencies[builder]), append(labels, bLabel)...)
+		platformsCounter.Record(ctx, int64(meter.BuildWithPlatforms[builder]), append(labels, bLabel)...)
+	}
+
+	if len(meter.ResolvedBuildTargetPlatforms) > 0 {
+		platforms := metric.Must(m).NewInt64ValueRecorder("build-platforms", metric.WithDescription("The resolved build target platforms for each run"))
+		for _, buildPlatform := range meter.ResolvedBuildTargetPlatforms {
+			platforms.Record(ctx, 1, append(labels, attribute.String("os_arch", buildPlatform))...)
+		}
+	}
+
+	if len(meter.CliBuildTargetPlatforms) > 0 {
+		platforms := metric.Must(m).NewInt64ValueRecorder("cli-platforms", metric.WithDescription("The build target platforms specified via CLI flag --platform"))
+		platforms.Record(ctx, 1, append(labels, attribute.String("os_arch", meter.CliBuildTargetPlatforms))...)
+	}
+
+	if len(meter.DeployNodePlatforms) > 0 {
+		platforms := metric.Must(m).NewInt64ValueRecorder("node-platforms", metric.WithDescription("The kubernetes cluster node platforms"))
+		platforms.Record(ctx, 1, append(labels, attribute.String("os_arch", meter.DeployNodePlatforms))...)
 	}
 }
 

--- a/pkg/skaffold/instrumentation/types.go
+++ b/pkg/skaffold/instrumentation/types.go
@@ -64,6 +64,9 @@ type skaffoldMeter struct {
 	// Builders Enum values for all the builders used to build the artifacts built.
 	Builders map[string]int
 
+	// BuildWithPlatforms Enum values for all the builders with target platform constraints.
+	BuildWithPlatforms map[string]int
+
 	// BuildDependencies Enum values for all the builders using build dependencies.
 	BuildDependencies map[string]int
 
@@ -92,6 +95,15 @@ type skaffoldMeter struct {
 
 	// ClusterType reports if user cluster is a GKE cluster or not.
 	ClusterType string
+
+	// ResolvedBuildTargetPlatforms represents the set of resolved build target platforms for each pipeline
+	ResolvedBuildTargetPlatforms []string
+
+	// CliBuildTargetPlatforms represents the build target platforms specified via command line flag `--platform`
+	CliBuildTargetPlatforms string
+
+	// DeployNodePlatforms represents the set of kubernetes cluster node platforms
+	DeployNodePlatforms string
 }
 
 // devIteration describes how an iteration and started and if an error happened.

--- a/pkg/skaffold/platform/resolver.go
+++ b/pkg/skaffold/platform/resolver.go
@@ -25,6 +25,7 @@ import (
 	coreV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/instrumentation"
 	kubernetesclient "github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/client"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 	latestV1 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v1"
@@ -58,6 +59,7 @@ func NewResolver(ctx context.Context, pipelines []latestV1.Pipeline, cliPlatform
 		return r, fmt.Errorf("failed to parse platforms: %w", err)
 	}
 	log.Entry(ctx).Debugf("CLI platforms provided: %q", fromCli)
+	instrumentation.AddCliBuildTargetPlatforms(fromCli.String())
 
 	if runMode == config.RunModes.Dev || runMode == config.RunModes.Debug || runMode == config.RunModes.Run {
 		fromClusterNodes, err = getClusterPlatforms(ctx, kubeContext, runMode == config.RunModes.Dev || runMode == config.RunModes.Debug)
@@ -67,7 +69,7 @@ func NewResolver(ctx context.Context, pipelines []latestV1.Pipeline, cliPlatform
 		}
 	}
 	log.Entry(ctx).Debugf("platforms detected from active kubernetes cluster nodes: %q", fromClusterNodes)
-
+	instrumentation.AddDeployNodePlatforms(fromClusterNodes.String())
 	for _, pipeline := range pipelines {
 		platforms := fromCli
 		if platforms.IsEmpty() {
@@ -85,6 +87,7 @@ func NewResolver(ctx context.Context, pipelines []latestV1.Pipeline, cliPlatform
 				return r, fmt.Errorf("build target platforms %q do not match active kubernetes cluster node platforms %q", platforms, fromClusterNodes)
 			}
 		}
+		instrumentation.AddResolvedBuildTargetPlatforms(platforms.String())
 		for _, artifact := range pipeline.Build.Artifacts {
 			pl := platforms
 			constraints, err := Parse(artifact.Platforms)


### PR DESCRIPTION
Add metrics related to cross-platform builds:
- Count of artifacts defining target platforms.
- Platforms specified via CLI flag `--platform`.
- Resolved build target platforms.
- Platform kind for the kubernetes cluster nodes.