### PR TITLE
docs: Add Docker port-forwarding note

### DIFF
--- a/docs/content/en/docs/pipeline-stages/port-forwarding.md
+++ b/docs/content/en/docs/pipeline-stages/port-forwarding.md
@@ -68,13 +68,17 @@ Skaffold will request matching local ports only when the remote port is `> 1023`
 User-defined port-forwards in the `skaffold.yaml` are unaffected and can bind to system ports.
 {{< /alert >}}
 
+{{< alert title="Note about user-defined port-forwarding for Docker deployments" >}}
+When [deploying to Docker]({{< relref "/pipeline-stages/deployers/docker" >}}) with a user-defined port-forward in the `skaffold.yaml`, the `resourceType` of `portForward` must be set to `container`. Otherwise, Skaffold will not tell the Docker daemon to expose that port.
+{{< /alert >}}
+
 Skaffold will run `kubectl port-forward` on each of these resources in addition to the automatic port forwarding described above.
 Acceptable resource types include: `Service`, `Pod` and Controller resource type that has a pod spec: `ReplicaSet`, `ReplicationController`, `Deployment`, `StatefulSet`, `DaemonSet`, `Job`, `CronJob`. 
 
 
 | Field        | Values           | Mandatory  |
 | ------------- |-------------| -----|
-| resourceType     | `pod`, `service`, `deployment`, `replicaset`, `statefulset`, `replicationcontroller`, `daemonset`, `job`, `cronjob` | Yes | 
+| resourceType     | `pod`, `service`, `deployment`, `replicaset`, `statefulset`, `replicationcontroller`, `daemonset`, `job`, `cronjob`, `container` | Yes | 
 | resourceName     | Name of the resource to forward.     | Yes | 
 | namespace  | The namespace of the resource to port forward.     | No. Defaults to current namespace, or `default` if no current namespace is defined | 
 | port | Port is the resource port that will be forwarded. | Yes |


### PR DESCRIPTION
This change documents the settings necessary for port forwarding when deploying to Docker.

Skaffold [does not publish](https://github.com/nkubala/skaffold/blob/16b931d138b6f10c18dfc04a4f8ca5057d612fe6/pkg/skaffold/deploy/docker/port.go#L94) user-defined port forwards to the Docker daemon unless `resourceType` is set to `container`.

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7175  <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
Docker port forwarding is currently undocumented, and required a little code reading to get working properly. This change documents a new `resourceType`, `container`, which the Docker deploy code checks for.
