### PR TITLE
fix (partial): [V2] TestDockerDebug failing #7170

### DIFF
--- a/integration/testdata/debug/skaffold.yaml
+++ b/integration/testdata/debug/skaffold.yaml
@@ -59,7 +59,20 @@ profiles:
       context: go
       buildpacks:
         builder: "gcr.io/buildpacks/builder:v1"
+        env:
+        - GOOGLE_RUNTIME_VERSION=1.16 # temporarily pin due to issue#6450
     #- image: skaffold-debug-netcore
     #  context: netcore
     #  buildpacks:
     #    builder: "gcr.io/buildpacks/builder:v1"
+- name: docker
+  patches:
+  - op: remove
+    path: /deploy/kubectl
+  build:
+    artifacts:
+    - image: skaffold-debug-nodejs
+      context: nodejs
+  deploy:
+    docker:
+      images: [skaffold-debug-nodejs]

--- a/integration/testdata/debug/skaffold.yaml
+++ b/integration/testdata/debug/skaffold.yaml
@@ -59,8 +59,6 @@ profiles:
       context: go
       buildpacks:
         builder: "gcr.io/buildpacks/builder:v1"
-        env:
-        - GOOGLE_RUNTIME_VERSION=1.16 # temporarily pin due to issue#6450
     #- image: skaffold-debug-netcore
     #  context: netcore
     #  buildpacks:

--- a/pkg/skaffold/schema/latest/v2/config.go
+++ b/pkg/skaffold/schema/latest/v2/config.go
@@ -627,7 +627,7 @@ type DeployConfig struct {
 // time for hybrid workflows.
 type DeployType struct {
 	// DockerDeploy *alpha* uses the `docker` CLI to create application containers in Docker.
-	DockerDeploy *DockerDeploy `yaml:"-,omitempty"`
+	DockerDeploy *DockerDeploy `yaml:"docker,omitempty"`
 
 	// HelmDeploy *beta* uses the `helm` CLI to apply the charts to the cluster.
 	HelmDeploy *HelmDeploy `yaml:"helm,omitempty"`


### PR DESCRIPTION
**Partially Fixes:** https://github.com/GoogleContainerTools/skaffold/issues/7030

**Description:**

Adds back some missing integration test code and adds Docker Deployer to the schema. These changes seem to be missing from large Docker Debugger PR: https://github.com/GoogleContainerTools/skaffold/pull/6528

**Follow Up:**

While this may fully fix the bug as intended, the integration is either not fully passing or is passing in error. `skaffold debug` while running locally or in minikube is still blocked by: https://github.com/GoogleContainerTools/skaffold/issues/7104

This PR unblocks the `skaffold build` part of the test:
https://github.com/GoogleContainerTools/skaffold/blob/aa2d9b9cdd3223d9349fa3f448d2f08fbb51c4c5/integration/debug_test.go#L127

The `skaffold debug` part of the test is still blocked.

https://github.com/GoogleContainerTools/skaffold/blob/aa2d9b9cdd3223d9349fa3f448d2f08fbb51c4c5/integration/debug_test.go#L129

However, I am able to run the test locally and it passes, even though it appears to not deploy anything and has the expected "failed to resolve digest" error:

```bash
=== RUN   TestDockerDebug
=== RUN   TestDockerDebug/debug_docker_deployment
time="2022-03-14T15:10:57-04:00" level=info msg="Running [skaffold build --default-repo gcr.io/k8s-skaffold -p docker] in testdata/debug"
time="2022-03-14T15:10:59-04:00" level=info msg="Ran [skaffold build --default-repo gcr.io/k8s-skaffold -p docker] in 1.788 second"
time="2022-03-14T15:10:59-04:00" level=info msg="Running [skaffold debug --default-repo gcr.io/k8s-skaffold -p docker] in testdata/debug"
time="2022-03-14T15:10:59-04:00" level=warning msg="failed to detect active kubernetes cluter node platform. Specify the correct build platform in the `skaffold.yaml` file or using the `--platform` flag" subtask=-1 task=DevLoop
time="2022-03-14T15:10:59-04:00" level=warning msg="k8s/*.yaml did not match any file" subtask=-1 task=DevLoop
failed to resolve the digest of skaffold-debug-nodejs:07ae88f3209c4648d7cb9f9b8b87e0813c061525d1c6102980b56999730f4fd3: does the image exist remotely?
time="2022-03-14T15:11:01-04:00" level=info msg="Ran [skaffold debug --default-repo gcr.io/k8s-skaffold -p docker] in 1.804 second"
time="2022-03-14T15:11:01-04:00" level=info msg="Running [skaffold delete --default-repo gcr.io/k8s-skaffold -p docker] in testdata/debug"
time="2022-03-14T15:11:01-04:00" level=info msg="Ran [skaffold delete --default-repo gcr.io/k8s-skaffold -p docker] in 6.569188ms"
--- PASS: TestDockerDebug (3.94s)
    --- PASS: TestDockerDebug/debug_docker_deployment (3.94s)
PASS
ok      github.com/GoogleContainerTools/skaffold/integration    (cached)
```