### PR TITLE
feat(v2): allow using legacy helm deployer

### DIFF
--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -423,7 +423,7 @@ spec:
 				}}),
 			}, &label.DefaultLabeller{}, &latestV2.HelmDeploy{
 				Releases: test.helmReleases,
-			})
+			}, nil)
 			t.RequireNoError(err)
 			var b bytes.Buffer
 			err = deployer.Render(context.Background(), &b, test.builds, true, "")

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -415,13 +415,13 @@ spec:
 				Pipelines: v2.NewPipelines([]latestV2.Pipeline{{
 					Deploy: latestV2.DeployConfig{
 						DeployType: latestV2.DeployType{
-							HelmDeploy: &latestV2.HelmDeploy{
+							LegacyHelmDeploy: &latestV2.LegacyHelmDeploy{
 								Releases: test.helmReleases,
 							},
 						},
 					},
 				}}),
-			}, &label.DefaultLabeller{}, &latestV2.HelmDeploy{
+			}, &label.DefaultLabeller{}, &latestV2.LegacyHelmDeploy{
 				Releases: test.helmReleases,
 			}, nil)
 			t.RequireNoError(err)

--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -87,7 +87,7 @@ var writeBuildArtifactsFunc = writeBuildArtifacts
 
 // Deployer deploys workflows using the helm CLI
 type Deployer struct {
-	*latestV2.HelmDeploy
+	*latestV2.LegacyHelmDeploy
 
 	accessor      access.Accessor
 	debugger      debug.Debugger
@@ -130,7 +130,7 @@ type Config interface {
 }
 
 // NewDeployer returns a configured Deployer.  Returns an error if current version of helm is less than 3.1.0.
-func NewDeployer(ctx context.Context, cfg Config, labeller *label.DefaultLabeller, h *latestV2.HelmDeploy, artifacts []*latestV2.Artifact) (*Deployer, error) {
+func NewDeployer(ctx context.Context, cfg Config, labeller *label.DefaultLabeller, h *latestV2.LegacyHelmDeploy, artifacts []*latestV2.Artifact) (*Deployer, error) {
 	hv, err := binVer(ctx)
 	if err != nil {
 		return nil, versionGetErr(err)
@@ -154,26 +154,26 @@ func NewDeployer(ctx context.Context, cfg Config, labeller *label.DefaultLabelle
 		})
 	}
 	return &Deployer{
-		HelmDeploy:     h,
-		podSelector:    podSelector,
-		namespaces:     &namespaces,
-		accessor:       component.NewAccessor(cfg, cfg.GetKubeContext(), kubectl, podSelector, labeller, &namespaces),
-		debugger:       component.NewDebugger(cfg.Mode(), podSelector, &namespaces, cfg.GetKubeContext()),
-		imageLoader:    component.NewImageLoader(cfg, kubectl),
-		logger:         logger,
-		statusMonitor:  component.NewMonitor(cfg, cfg.GetKubeContext(), labeller, &namespaces),
-		syncer:         component.NewSyncer(kubectl, &namespaces, logger.GetFormatter()),
-		hookRunner:     hooks.NewDeployRunner(kubectl, h.LifecycleHooks, &namespaces, logger.GetFormatter(), hooks.NewDeployEnvOpts(labeller.GetRunID(), kubectl.KubeContext, namespaces)),
-		originalImages: ogImages,
-		kubeContext:    cfg.GetKubeContext(),
-		kubeConfig:     cfg.GetKubeConfig(),
-		namespace:      cfg.GetKubeNamespace(),
-		forceDeploy:    cfg.ForceDeploy(),
-		configFile:     cfg.ConfigurationFile(),
-		labels:         labeller.Labels(),
-		bV:             hv,
-		enableDebug:    cfg.Mode() == config.RunModes.Debug,
-		isMultiConfig:  cfg.IsMultiConfig(),
+		LegacyHelmDeploy: h,
+		podSelector:      podSelector,
+		namespaces:       &namespaces,
+		accessor:         component.NewAccessor(cfg, cfg.GetKubeContext(), kubectl, podSelector, labeller, &namespaces),
+		debugger:         component.NewDebugger(cfg.Mode(), podSelector, &namespaces, cfg.GetKubeContext()),
+		imageLoader:      component.NewImageLoader(cfg, kubectl),
+		logger:           logger,
+		statusMonitor:    component.NewMonitor(cfg, cfg.GetKubeContext(), labeller, &namespaces),
+		syncer:           component.NewSyncer(kubectl, &namespaces, logger.GetFormatter()),
+		hookRunner:       hooks.NewDeployRunner(kubectl, h.LifecycleHooks, &namespaces, logger.GetFormatter(), hooks.NewDeployEnvOpts(labeller.GetRunID(), kubectl.KubeContext, namespaces)),
+		originalImages:   ogImages,
+		kubeContext:      cfg.GetKubeContext(),
+		kubeConfig:       cfg.GetKubeConfig(),
+		namespace:        cfg.GetKubeNamespace(),
+		forceDeploy:      cfg.ForceDeploy(),
+		configFile:       cfg.ConfigurationFile(),
+		labels:           labeller.Labels(),
+		bV:               hv,
+		enableDebug:      cfg.Mode() == config.RunModes.Debug,
+		isMultiConfig:    cfg.IsMultiConfig(),
 	}, nil
 }
 
@@ -437,7 +437,7 @@ func (h *Deployer) Render(ctx context.Context, out io.Writer, builds []graph.Art
 }
 
 func (h *Deployer) HasRunnableHooks() bool {
-	return len(h.HelmDeploy.LifecycleHooks.PreHooks) > 0 || len(h.HelmDeploy.LifecycleHooks.PostHooks) > 0
+	return len(h.LegacyHelmDeploy.LifecycleHooks.PreHooks) > 0 || len(h.LegacyHelmDeploy.LifecycleHooks.PostHooks) > 0
 }
 
 func (h *Deployer) PreDeployHooks(ctx context.Context, out io.Writer) error {

--- a/pkg/skaffold/deploy/helm/helm.go
+++ b/pkg/skaffold/deploy/helm/helm.go
@@ -97,9 +97,9 @@ type Deployer struct {
 	syncer        sync.Syncer
 	hookRunner    hooks.Runner
 
-	podSelector *kubernetes.ImageList
+	podSelector    *kubernetes.ImageList
 	originalImages []graph.Artifact // the set of images defined in ArtifactOverrides
-	localImages []graph.Artifact // the set of images marked as "local" by the Runner
+	localImages    []graph.Artifact // the set of images marked as "local" by the Runner
 
 	kubeContext string
 	kubeConfig  string
@@ -154,26 +154,26 @@ func NewDeployer(ctx context.Context, cfg Config, labeller *label.DefaultLabelle
 		})
 	}
 	return &Deployer{
-		HelmDeploy:    h,
-		podSelector:   podSelector,
-		namespaces:    &namespaces,
-		accessor:      component.NewAccessor(cfg, cfg.GetKubeContext(), kubectl, podSelector, labeller, &namespaces),
-		debugger:      component.NewDebugger(cfg.Mode(), podSelector, &namespaces, cfg.GetKubeContext()),
-		imageLoader:   component.NewImageLoader(cfg, kubectl),
-		logger:        logger,
-		statusMonitor: component.NewMonitor(cfg, cfg.GetKubeContext(), labeller, &namespaces),
-		syncer:        component.NewSyncer(kubectl, &namespaces, logger.GetFormatter()),
-		hookRunner:    hooks.NewDeployRunner(kubectl, h.LifecycleHooks, &namespaces, logger.GetFormatter(), hooks.NewDeployEnvOpts(labeller.GetRunID(), kubectl.KubeContext, namespaces)),
+		HelmDeploy:     h,
+		podSelector:    podSelector,
+		namespaces:     &namespaces,
+		accessor:       component.NewAccessor(cfg, cfg.GetKubeContext(), kubectl, podSelector, labeller, &namespaces),
+		debugger:       component.NewDebugger(cfg.Mode(), podSelector, &namespaces, cfg.GetKubeContext()),
+		imageLoader:    component.NewImageLoader(cfg, kubectl),
+		logger:         logger,
+		statusMonitor:  component.NewMonitor(cfg, cfg.GetKubeContext(), labeller, &namespaces),
+		syncer:         component.NewSyncer(kubectl, &namespaces, logger.GetFormatter()),
+		hookRunner:     hooks.NewDeployRunner(kubectl, h.LifecycleHooks, &namespaces, logger.GetFormatter(), hooks.NewDeployEnvOpts(labeller.GetRunID(), kubectl.KubeContext, namespaces)),
 		originalImages: ogImages,
-		kubeContext:   cfg.GetKubeContext(),
-		kubeConfig:    cfg.GetKubeConfig(),
-		namespace:     cfg.GetKubeNamespace(),
-		forceDeploy:   cfg.ForceDeploy(),
-		configFile:    cfg.ConfigurationFile(),
-		labels:        labeller.Labels(),
-		bV:            hv,
-		enableDebug:   cfg.Mode() == config.RunModes.Debug,
-		isMultiConfig: cfg.IsMultiConfig(),
+		kubeContext:    cfg.GetKubeContext(),
+		kubeConfig:     cfg.GetKubeConfig(),
+		namespace:      cfg.GetKubeNamespace(),
+		forceDeploy:    cfg.ForceDeploy(),
+		configFile:     cfg.ConfigurationFile(),
+		labels:         labeller.Labels(),
+		bV:             hv,
+		enableDebug:    cfg.Mode() == config.RunModes.Debug,
+		isMultiConfig:  cfg.IsMultiConfig(),
 	}, nil
 }
 

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -386,7 +386,7 @@ func TestNewDeployer(t *testing.T) {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", test.helmVersion))
 
-			_, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig)
+			_, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig, nil)
 			t.CheckError(test.shouldErr, err)
 		})
 	}
@@ -940,7 +940,7 @@ func TestHelmDeploy(t *testing.T) {
 				namespace:  test.namespace,
 				force:      test.force,
 				configFile: "test.yaml",
-			}, &label.DefaultLabeller{}, &test.helm)
+			}, &label.DefaultLabeller{}, &test.helm, nil)
 			t.RequireNoError(err)
 
 			if test.configure != nil {
@@ -1027,7 +1027,7 @@ func TestHelmCleanup(t *testing.T) {
 
 			deployer, err := NewDeployer(context.Background(), &helmConfig{
 				namespace: test.namespace,
-			}, &label.DefaultLabeller{}, &test.helm)
+			}, &label.DefaultLabeller{}, &test.helm, nil)
 			t.RequireNoError(err)
 
 			deployer.Cleanup(context.Background(), ioutil.Discard, test.dryRun)
@@ -1140,7 +1140,7 @@ func TestHelmDependencies(t *testing.T) {
 					SetValues:             map[string]string{"some.key": "somevalue"},
 					SkipBuildDependencies: test.skipBuildDependencies,
 				}},
-			})
+			}, nil)
 			t.RequireNoError(err)
 			deps, err := deployer.Dependencies()
 
@@ -1395,7 +1395,7 @@ func TestHelmRender(t *testing.T) {
 			t.Override(&util.DefaultExecCommand, test.commands)
 			deployer, err := NewDeployer(context.Background(), &helmConfig{
 				namespace: test.namespace,
-			}, &label.DefaultLabeller{}, &test.helm)
+			}, &label.DefaultLabeller{}, &test.helm, nil)
 			t.RequireNoError(err)
 			err = deployer.Render(context.Background(), ioutil.Discard, test.builds, true, file)
 			t.CheckError(test.shouldErr, err)
@@ -1470,7 +1470,7 @@ func TestGenerateSkaffoldFilter(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", version31))
-			h, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig)
+			h, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig, nil)
 			h.enableDebug = test.enableDebug
 			t.RequireNoError(err)
 			result := h.generateSkaffoldFilter(test.buildFile)
@@ -1516,7 +1516,7 @@ func TestHelmHooks(t *testing.T) {
 				return test.runner
 			})
 
-			k, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig)
+			k, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &testDeployConfig, nil)
 			t.RequireNoError(err)
 			err = k.PreDeployHooks(context.Background(), ioutil.Discard)
 			t.CheckError(test.shouldErr, err)
@@ -1568,7 +1568,7 @@ func TestHasRunnableHooks(t *testing.T) {
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
 			t.Override(&util.DefaultExecCommand, testutil.CmdRunWithOutput("helm version --client", version31))
-			k, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &test.cfg)
+			k, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &test.cfg, nil)
 			t.RequireNoError(err)
 			actual := k.HasRunnableHooks()
 			t.CheckDeepEqual(test.expected, actual)

--- a/pkg/skaffold/deploy/helm/helm_test.go
+++ b/pkg/skaffold/deploy/helm/helm_test.go
@@ -51,7 +51,7 @@ var testBuilds = []graph.Artifact{{
 	Tag:       "docker.io:5000/skaffold-helm:3605e7bc17cf46e53f4d81c4cbc24e5b4c495184",
 }}
 
-var testDeployConfig = latestV2.HelmDeploy{
+var testDeployConfig = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
@@ -62,7 +62,7 @@ var testDeployConfig = latestV2.HelmDeploy{
 	}},
 }
 
-var testDeployNamespacedConfig = latestV2.HelmDeploy{
+var testDeployNamespacedConfig = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
@@ -74,7 +74,7 @@ var testDeployNamespacedConfig = latestV2.HelmDeploy{
 	}},
 }
 
-var testDeployEnvTemplateNamespacedConfig = latestV2.HelmDeploy{
+var testDeployEnvTemplateNamespacedConfig = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
@@ -86,7 +86,7 @@ var testDeployEnvTemplateNamespacedConfig = latestV2.HelmDeploy{
 	}},
 }
 
-var testDeployConfigRemoteRepo = latestV2.HelmDeploy{
+var testDeployConfigRemoteRepo = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
@@ -98,7 +98,7 @@ var testDeployConfigRemoteRepo = latestV2.HelmDeploy{
 	}},
 }
 
-var testDeployConfigTemplated = latestV2.HelmDeploy{
+var testDeployConfigTemplated = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
@@ -114,7 +114,7 @@ var testDeployConfigTemplated = latestV2.HelmDeploy{
 	}},
 }
 
-var testDeployConfigValuesFilesTemplated = latestV2.HelmDeploy{
+var testDeployConfigValuesFilesTemplated = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
@@ -125,7 +125,7 @@ var testDeployConfigValuesFilesTemplated = latestV2.HelmDeploy{
 	}},
 }
 
-var testDeployConfigVersionTemplated = latestV2.HelmDeploy{
+var testDeployConfigVersionTemplated = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
@@ -133,7 +133,7 @@ var testDeployConfigVersionTemplated = latestV2.HelmDeploy{
 	}},
 }
 
-var testDeployConfigSetFiles = latestV2.HelmDeploy{
+var testDeployConfigSetFiles = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
@@ -145,7 +145,7 @@ var testDeployConfigSetFiles = latestV2.HelmDeploy{
 	}},
 }
 
-var testDeployRecreatePodsConfig = latestV2.HelmDeploy{
+var testDeployRecreatePodsConfig = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
@@ -157,7 +157,7 @@ var testDeployRecreatePodsConfig = latestV2.HelmDeploy{
 	}},
 }
 
-var testDeploySkipBuildDependenciesConfig = latestV2.HelmDeploy{
+var testDeploySkipBuildDependenciesConfig = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
@@ -169,7 +169,7 @@ var testDeploySkipBuildDependenciesConfig = latestV2.HelmDeploy{
 	}},
 }
 
-var testDeployWithPackaged = latestV2.HelmDeploy{
+var testDeployWithPackaged = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "testdata/skaffold-helm",
@@ -180,7 +180,7 @@ var testDeployWithPackaged = latestV2.HelmDeploy{
 	}},
 }
 
-var testDeployWithTemplatedName = latestV2.HelmDeploy{
+var testDeployWithTemplatedName = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:      "{{.USER}}-skaffold-helm",
 		ChartPath: "examples/test",
@@ -191,7 +191,7 @@ var testDeployWithTemplatedName = latestV2.HelmDeploy{
 	},
 }
 
-var testDeploySkipBuildDependencies = latestV2.HelmDeploy{
+var testDeploySkipBuildDependencies = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:                  "skaffold-helm",
 		ChartPath:             "stable/chartmuseum",
@@ -199,7 +199,7 @@ var testDeploySkipBuildDependencies = latestV2.HelmDeploy{
 	}},
 }
 
-var testDeployRemoteChart = latestV2.HelmDeploy{
+var testDeployRemoteChart = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:        "skaffold-helm-remote",
 		RemoteChart: "stable/chartmuseum",
@@ -207,7 +207,7 @@ var testDeployRemoteChart = latestV2.HelmDeploy{
 	}},
 }
 
-var testDeployRemoteChartVersion = latestV2.HelmDeploy{
+var testDeployRemoteChartVersion = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:        "skaffold-helm-remote",
 		RemoteChart: "stable/chartmuseum",
@@ -217,7 +217,7 @@ var testDeployRemoteChartVersion = latestV2.HelmDeploy{
 }
 
 var upgradeOnChangeFalse = false
-var testDeployUpgradeOnChange = latestV2.HelmDeploy{
+var testDeployUpgradeOnChange = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:            "skaffold-helm-upgradeOnChange",
 		ChartPath:       "examples/test",
@@ -225,7 +225,7 @@ var testDeployUpgradeOnChange = latestV2.HelmDeploy{
 	}},
 }
 
-var testTwoReleases = latestV2.HelmDeploy{
+var testTwoReleases = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:      "other",
 		ChartPath: "examples/test",
@@ -236,7 +236,7 @@ var testTwoReleases = latestV2.HelmDeploy{
 }
 
 var createNamespaceFlag = true
-var testDeployCreateNamespaceConfig = latestV2.HelmDeploy{
+var testDeployCreateNamespaceConfig = latestV2.LegacyHelmDeploy{
 	Releases: []latestV2.HelmRelease{{
 		Name:      "skaffold-helm",
 		ChartPath: "examples/test",
@@ -406,7 +406,7 @@ func TestHelmDeploy(t *testing.T) {
 		description        string
 		commands           util.Command
 		env                []string
-		helm               latestV2.HelmDeploy
+		helm               latestV2.LegacyHelmDeploy
 		namespace          string
 		configure          func(*Deployer)
 		builds             []graph.Artifact
@@ -960,7 +960,7 @@ func TestHelmCleanup(t *testing.T) {
 	tests := []struct {
 		description      string
 		commands         util.Command
-		helm             latestV2.HelmDeploy
+		helm             latestV2.LegacyHelmDeploy
 		namespace        string
 		builds           []graph.Artifact
 		expectedWarnings []string
@@ -1130,7 +1130,7 @@ func TestHelmDependencies(t *testing.T) {
 				local = tmpDir.Root()
 			}
 
-			deployer, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &latestV2.HelmDeploy{
+			deployer, err := NewDeployer(context.Background(), &helmConfig{}, &label.DefaultLabeller{}, &latestV2.LegacyHelmDeploy{
 				Releases: []latestV2.HelmRelease{{
 					Name:                  "skaffold-helm",
 					ChartPath:             local,
@@ -1226,7 +1226,7 @@ func TestHelmRender(t *testing.T) {
 		description string
 		shouldErr   bool
 		commands    util.Command
-		helm        latestV2.HelmDeploy
+		helm        latestV2.LegacyHelmDeploy
 		env         []string
 		outputFile  string
 		expected    string
@@ -1543,23 +1543,23 @@ func (c *helmConfig) PortForwardResources() []*latestV2.PortForwardResource { re
 func TestHasRunnableHooks(t *testing.T) {
 	tests := []struct {
 		description string
-		cfg         latestV2.HelmDeploy
+		cfg         latestV2.LegacyHelmDeploy
 		expected    bool
 	}{
 		{
 			description: "no hooks defined",
-			cfg:         latestV2.HelmDeploy{},
+			cfg:         latestV2.LegacyHelmDeploy{},
 		},
 		{
 			description: "has pre-deploy hook defined",
-			cfg: latestV2.HelmDeploy{
+			cfg: latestV2.LegacyHelmDeploy{
 				LifecycleHooks: latestV2.DeployHooks{PreHooks: []latestV2.DeployHookItem{{}}},
 			},
 			expected: true,
 		},
 		{
 			description: "has post-deploy hook defined",
-			cfg: latestV2.HelmDeploy{
+			cfg: latestV2.LegacyHelmDeploy{
 				LifecycleHooks: latestV2.DeployHooks{PostHooks: []latestV2.DeployHookItem{{}}},
 			},
 			expected: true,

--- a/pkg/skaffold/deploy/util/namespaces.go
+++ b/pkg/skaffold/deploy/util/namespaces.go
@@ -71,8 +71,8 @@ func GetAllPodNamespaces(configNamespace string, pipelines []latestV2.Pipeline) 
 func collectHelmReleasesNamespaces(pipelines []latestV2.Pipeline) ([]string, error) {
 	var namespaces []string
 	for _, cfg := range pipelines {
-		if cfg.Deploy.HelmDeploy != nil {
-			for _, release := range cfg.Deploy.HelmDeploy.Releases {
+		if cfg.Deploy.LegacyHelmDeploy != nil {
+			for _, release := range cfg.Deploy.LegacyHelmDeploy.Releases {
 				if release.Namespace != "" {
 					templatedNamespace, err := util.ExpandEnvTemplateOrFail(release.Namespace, nil)
 					if err != nil {

--- a/pkg/skaffold/deploy/util/namespaces_test.go
+++ b/pkg/skaffold/deploy/util/namespaces_test.go
@@ -80,7 +80,7 @@ func TestCollectHelmReleasesNamespaces(t *testing.T) {
 				{
 					Deploy: latestV2.DeployConfig{
 						DeployType: latestV2.DeployType{
-							HelmDeploy: &latestV2.HelmDeploy{
+							LegacyHelmDeploy: &latestV2.LegacyHelmDeploy{
 								Releases: test.helmReleases,
 							},
 						},

--- a/pkg/skaffold/deploy/util/util.go
+++ b/pkg/skaffold/deploy/util/util.go
@@ -67,11 +67,14 @@ func ApplyDefaultRepo(globalConfig string, defaultRepo *string, tag string) (str
 func AddTagsToPodSelector(artifacts []graph.Artifact, deployerArtifacts []graph.Artifact, podSelector *kubernetes.ImageList) {
 	m := map[string]bool{}
 	for _, a := range deployerArtifacts {
+		log.Entry(context.TODO()).Infof("Adding deployer artifact: %s", a.ImageName)
 		m[a.ImageName] = true
 	}
 	for _, artifact := range artifacts {
 		imageName := docker.SanitizeImageName(artifact.ImageName)
+		log.Entry(context.TODO()).Infof("Checking build image name %s", imageName)
 		if _, ok := m[imageName]; ok {
+			log.Entry(context.TODO()).Infof("matched %s, %s", artifact.ImageName, artifact.Tag)
 			podSelector.Add(artifact.Tag)
 		}
 	}

--- a/pkg/skaffold/event/util.go
+++ b/pkg/skaffold/event/util.go
@@ -101,8 +101,8 @@ func getBuilders(b latestV2.BuildConfig) []*proto.BuildMetadata_ImageBuilder {
 func getDeploy(d latestV2.DeployConfig) []*proto.DeployMetadata_Deployer {
 	var deployers []*proto.DeployMetadata_Deployer
 
-	if d.HelmDeploy != nil {
-		deployers = append(deployers, &proto.DeployMetadata_Deployer{Type: proto.DeployerType_HELM, Count: int32(len(d.HelmDeploy.Releases))})
+	if d.LegacyHelmDeploy != nil {
+		deployers = append(deployers, &proto.DeployMetadata_Deployer{Type: proto.DeployerType_HELM, Count: int32(len(d.LegacyHelmDeploy.Releases))})
 	}
 	if d.KubectlDeploy != nil {
 		deployers = append(deployers, &proto.DeployMetadata_Deployer{Type: proto.DeployerType_KUBECTL, Count: 1})

--- a/pkg/skaffold/event/util_test.go
+++ b/pkg/skaffold/event/util_test.go
@@ -43,8 +43,8 @@ func TestEmptyState(t *testing.T) {
 				},
 				Deploy: latestV2.DeployConfig{
 					DeployType: latestV2.DeployType{
-						KubectlDeploy: &latestV2.KubectlDeploy{},
-						HelmDeploy:    &latestV2.HelmDeploy{Releases: []latestV2.HelmRelease{{Name: "first"}, {Name: "second"}}},
+						KubectlDeploy:    &latestV2.KubectlDeploy{},
+						LegacyHelmDeploy: &latestV2.LegacyHelmDeploy{Releases: []latestV2.HelmRelease{{Name: "first"}, {Name: "second"}}},
 					},
 				},
 			},

--- a/pkg/skaffold/event/v2/metadata.go
+++ b/pkg/skaffold/event/v2/metadata.go
@@ -115,8 +115,8 @@ func getArtifacts(b latestV2.BuildConfig) []*proto.BuildMetadata_Artifact {
 func getDeploy(d latestV2.DeployConfig) []*proto.DeployMetadata_Deployer {
 	var deployers []*proto.DeployMetadata_Deployer
 
-	if d.HelmDeploy != nil {
-		deployers = append(deployers, &proto.DeployMetadata_Deployer{Type: proto.DeployerType_HELM, Count: int32(len(d.HelmDeploy.Releases))})
+	if d.LegacyHelmDeploy != nil {
+		deployers = append(deployers, &proto.DeployMetadata_Deployer{Type: proto.DeployerType_HELM, Count: int32(len(d.LegacyHelmDeploy.Releases))})
 	}
 	if d.KubectlDeploy != nil {
 		deployers = append(deployers, &proto.DeployMetadata_Deployer{Type: proto.DeployerType_KUBECTL, Count: 1})

--- a/pkg/skaffold/event/v2/metadata_test.go
+++ b/pkg/skaffold/event/v2/metadata_test.go
@@ -43,8 +43,8 @@ func TestEmptyState(t *testing.T) {
 				},
 				Deploy: latestV2.DeployConfig{
 					DeployType: latestV2.DeployType{
-						KubectlDeploy: &latestV2.KubectlDeploy{},
-						HelmDeploy:    &latestV2.HelmDeploy{Releases: []latestV2.HelmRelease{{Name: "first"}, {Name: "second"}}},
+						KubectlDeploy:    &latestV2.KubectlDeploy{},
+						LegacyHelmDeploy: &latestV2.LegacyHelmDeploy{Releases: []latestV2.HelmRelease{{Name: "first"}, {Name: "second"}}},
 					},
 				},
 			},

--- a/pkg/skaffold/generate_pipeline/tasks.go
+++ b/pkg/skaffold/generate_pipeline/tasks.go
@@ -135,7 +135,7 @@ func generateDeployTasks(namespace string, configFiles []*ConfigFile) ([]*tekton
 
 func generateDeployTask(configFile *ConfigFile) (*tekton.Task, error) {
 	deployConfig := configFile.Config.Deploy
-	if deployConfig.HelmDeploy == nil && deployConfig.KubectlDeploy == nil && deployConfig.KustomizeDeploy == nil {
+	if deployConfig.LegacyHelmDeploy == nil && deployConfig.KubectlDeploy == nil && deployConfig.KustomizeDeploy == nil {
 		return nil, errors.New("no Helm/Kubectl/Kustomize deploy config")
 	}
 

--- a/pkg/skaffold/generate_pipeline/tasks_test.go
+++ b/pkg/skaffold/generate_pipeline/tasks_test.go
@@ -224,7 +224,7 @@ func TestGenerateDeployTasks(t *testing.T) {
 						Pipeline: latestV2.Pipeline{
 							Deploy: latestV2.DeployConfig{
 								DeployType: latestV2.DeployType{
-									HelmDeploy: &latestV2.HelmDeploy{},
+									LegacyHelmDeploy: &latestV2.LegacyHelmDeploy{},
 								},
 							},
 						},
@@ -236,7 +236,7 @@ func TestGenerateDeployTasks(t *testing.T) {
 						Pipeline: latestV2.Pipeline{
 							Deploy: latestV2.DeployConfig{
 								DeployType: latestV2.DeployType{
-									HelmDeploy: &latestV2.HelmDeploy{},
+									LegacyHelmDeploy: &latestV2.LegacyHelmDeploy{},
 								},
 							},
 						},
@@ -289,7 +289,7 @@ func TestGenerateDeployTasks(t *testing.T) {
 						Pipeline: latestV2.Pipeline{
 							Deploy: latestV2.DeployConfig{
 								DeployType: latestV2.DeployType{
-									HelmDeploy: &latestV2.HelmDeploy{},
+									LegacyHelmDeploy: &latestV2.LegacyHelmDeploy{},
 								},
 							},
 						},
@@ -344,7 +344,7 @@ func TestGenerateDeployTask(t *testing.T) {
 			description: "successfully generate deploy task",
 			deployConfig: latestV2.DeployConfig{
 				DeployType: latestV2.DeployType{
-					HelmDeploy: &latestV2.HelmDeploy{},
+					LegacyHelmDeploy: &latestV2.LegacyHelmDeploy{},
 				},
 			},
 			shouldErr: false,
@@ -353,9 +353,9 @@ func TestGenerateDeployTask(t *testing.T) {
 			description: "fail generating deploy task",
 			deployConfig: latestV2.DeployConfig{
 				DeployType: latestV2.DeployType{
-					HelmDeploy:      nil,
-					KubectlDeploy:   nil,
-					KustomizeDeploy: nil,
+					LegacyHelmDeploy: nil,
+					KubectlDeploy:    nil,
+					KustomizeDeploy:  nil,
 				},
 			},
 			shouldErr: true,

--- a/pkg/skaffold/initializer/util/util_test.go
+++ b/pkg/skaffold/initializer/util/util_test.go
@@ -87,8 +87,8 @@ func TestListDeployers(t *testing.T) {
 			description: "multiple deployers config",
 			deploy: &latestV2.DeployConfig{
 				DeployType: latestV2.DeployType{
-					HelmDeploy:    &latestV2.HelmDeploy{},
-					KubectlDeploy: &latestV2.KubectlDeploy{},
+					LegacyHelmDeploy: &latestV2.LegacyHelmDeploy{},
+					KubectlDeploy:    &latestV2.KubectlDeploy{},
 				},
 			},
 			expected: []string{"helm", "kubectl"},

--- a/pkg/skaffold/instrumentation/meter.go
+++ b/pkg/skaffold/instrumentation/meter.go
@@ -103,7 +103,7 @@ func InitMeterFromConfig(configs []*latestV2.SkaffoldConfig, user, deployCtx str
 			}
 		}
 		meter.Deployers = append(meter.Deployers, yamltags.GetYamlKeys(config.Deploy.DeployType)...)
-		if h := config.Deploy.HelmDeploy; h != nil {
+		if h := config.Deploy.LegacyHelmDeploy; h != nil {
 			meter.HelmReleasesCount = len(h.Releases)
 		}
 		if k := config.Deploy.KubectlDeploy; k != nil {

--- a/pkg/skaffold/render/renderer/noop/noop.go
+++ b/pkg/skaffold/render/renderer/noop/noop.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package noop
+
+import (
+	"context"
+	"io"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
+)
+
+type Noop struct {}
+
+func New(config *latestV2.RenderConfig, workingDir, hydrationDir string, labels map[string]string) (Noop, error) {
+	//generator := generate.NewGenerator(workingDir, config.Generate, hydrationDir)
+	return Noop{}, nil
+}
+
+func (r Noop) Render(_ context.Context, _ io.Writer, _ []graph.Artifact, _ bool, _ string) error {
+	return nil
+}
+
+func (r Noop) ManifestDeps() ([]string, error) {
+	return nil, nil
+}

--- a/pkg/skaffold/render/renderer/noop/noop.go
+++ b/pkg/skaffold/render/renderer/noop/noop.go
@@ -24,10 +24,9 @@ import (
 	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
 )
 
-type Noop struct {}
+type Noop struct{}
 
-func New(config *latestV2.RenderConfig, workingDir, hydrationDir string, labels map[string]string) (Noop, error) {
-	//generator := generate.NewGenerator(workingDir, config.Generate, hydrationDir)
+func New(_ *latestV2.RenderConfig, _, _ string, _ map[string]string) (Noop, error) {
 	return Noop{}, nil
 }
 

--- a/pkg/skaffold/render/renderer/renderer.go
+++ b/pkg/skaffold/render/renderer/renderer.go
@@ -35,8 +35,8 @@ type Renderer interface {
 }
 
 // New creates a new Renderer object from the latestV2 API schema.
-func New(config *latestV2.RenderConfig, workingDir, hydrationDir string, labels map[string]string, usingHelmDeploy bool) (Renderer, error) {
-	if usingHelmDeploy {
+func New(config *latestV2.RenderConfig, workingDir, hydrationDir string, labels map[string]string, usingLegacyHelmDeploy bool) (Renderer, error) {
+	if usingLegacyHelmDeploy {
 		return noop.New(config, workingDir, hydrationDir, labels)
 	}
 	if config.Validate == nil && config.Transform == nil && config.Kpt == nil {

--- a/pkg/skaffold/render/renderer/renderer.go
+++ b/pkg/skaffold/render/renderer/renderer.go
@@ -23,19 +23,22 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer/kpt"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer/kubectl"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/render/renderer/noop"
 	latestV2 "github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest/v2"
 )
 
 type Renderer interface {
 	Render(ctx context.Context, out io.Writer, artifacts []graph.Artifact, offline bool, output string) error
-	// ManifestDeps returns the user kubenertes manifests to file watcher. In dev mode, a "redeploy" will be triggered
+	// ManifestDeps returns the user kubernetes manifests to file watcher. In dev mode, a "redeploy" will be triggered
 	// if any of the "Dependencies" manifest is changed.
 	ManifestDeps() ([]string, error)
 }
 
 // New creates a new Renderer object from the latestV2 API schema.
-func New(config *latestV2.RenderConfig, workingDir, hydrationDir string,
-	labels map[string]string) (Renderer, error) {
+func New(config *latestV2.RenderConfig, workingDir, hydrationDir string, labels map[string]string, usingHelmDeploy bool) (Renderer, error) {
+	if usingHelmDeploy {
+		return noop.New(config, workingDir, hydrationDir, labels)
+	}
 	if config.Validate == nil && config.Transform == nil && config.Kpt == nil {
 		return kubectl.New(config, workingDir, hydrationDir, labels)
 	}

--- a/pkg/skaffold/render/renderer/renderer.go
+++ b/pkg/skaffold/render/renderer/renderer.go
@@ -39,5 +39,6 @@ func New(config *latestV2.RenderConfig, workingDir, hydrationDir string,
 	if config.Validate == nil && config.Transform == nil && config.Kpt == nil {
 		return kubectl.New(config, workingDir, hydrationDir, labels)
 	}
+
 	return kpt.New(config, workingDir, hydrationDir, labels)
 }

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -79,7 +79,7 @@ func GetDeployer(ctx context.Context, runCtx *v2.RunContext, labeller *label.Def
 	for _, p := range pipelines {
 		if p.Render.Generate.Helm != nil {
 			dCtx := &deployerCtx{runCtx, p.Deploy}
-			h, err := helm.NewDeployer(ctx, dCtx, labeller, &latestV2.HelmDeploy{
+			h, err := helm.NewDeployer(ctx, dCtx, labeller, &latestV2.LegacyHelmDeploy{
 				Flags: p.Render.Generate.Helm.Flags,
 			}, runCtx.Artifacts())
 			if err != nil {
@@ -115,8 +115,8 @@ func GetDeployer(ctx context.Context, runCtx *v2.RunContext, labeller *label.Def
 		}
 
 		// TODO(nkubala)[v2-merge]: add d.LegacyHelmDeploy (or something similar)
-		if d.HelmDeploy != nil {
-			h, err := helm.NewDeployer(ctx, dCtx, labeller, d.HelmDeploy, runCtx.Artifacts())
+		if d.LegacyHelmDeploy != nil {
+			h, err := helm.NewDeployer(ctx, dCtx, labeller, d.LegacyHelmDeploy, runCtx.Artifacts())
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/skaffold/runner/deployer.go
+++ b/pkg/skaffold/runner/deployer.go
@@ -81,7 +81,7 @@ func GetDeployer(ctx context.Context, runCtx *v2.RunContext, labeller *label.Def
 			dCtx := &deployerCtx{runCtx, p.Deploy}
 			h, err := helm.NewDeployer(ctx, dCtx, labeller, &latestV2.HelmDeploy{
 				Flags: p.Render.Generate.Helm.Flags,
-			})
+			}, runCtx.Artifacts())
 			if err != nil {
 				return nil, err
 			}
@@ -91,7 +91,6 @@ func GetDeployer(ctx context.Context, runCtx *v2.RunContext, labeller *label.Def
 			deployers = append(deployers, h)
 		}
 	}
-
 	deployerCfg := runCtx.Deployers()
 	localDeploy := false
 	remoteDeploy := false
@@ -116,14 +115,13 @@ func GetDeployer(ctx context.Context, runCtx *v2.RunContext, labeller *label.Def
 		}
 
 		// TODO(nkubala)[v2-merge]: add d.LegacyHelmDeploy (or something similar)
-
-		// if d.HelmDeploy != nil {
-		// 	h, err := helm.NewDeployer(dCtx, labeller, d.HelmDeploy)
-		// 	if err != nil {
-		// 		return nil, err
-		// 	}
-		// 	deployers = append(deployers, h)
-		// }
+		if d.HelmDeploy != nil {
+			h, err := helm.NewDeployer(ctx, dCtx, labeller, d.HelmDeploy, runCtx.Artifacts())
+			if err != nil {
+				return nil, err
+			}
+			deployers = append(deployers, h)
+		}
 
 		if d.KubectlDeploy != nil {
 			deployer, err := kubectl.NewDeployer(dCtx, labeller, d.KubectlDeploy, hydrationDir)

--- a/pkg/skaffold/runner/deployer_test.go
+++ b/pkg/skaffold/runner/deployer_test.go
@@ -269,7 +269,7 @@ func TestGetDefaultDeployer(tOuter *testing.T) {
 			{
 				name: "one config with helm deploy",
 				cfgs: []latestV2.DeployType{{
-					HelmDeploy: &latestV2.HelmDeploy{},
+					LegacyHelmDeploy: &latestV2.LegacyHelmDeploy{},
 				}},
 				expected: t.RequireNonNilResult(kubectl.NewDeployer(&v2.RunContext{
 					Pipelines: v2.NewPipelines([]latestV2.Pipeline{{}}),

--- a/pkg/skaffold/runner/runcontext/v2/context.go
+++ b/pkg/skaffold/runner/runcontext/v2/context.go
@@ -178,9 +178,9 @@ func (rc *RunContext) AddSkaffoldLabels() bool {
 	return rc.Opts.Mode() != config.RunModes.Render
 }
 
-func (rc *RunContext) UsingHelmDeploy() bool {
+func (rc *RunContext) UsingLegacyHelmDeploy() bool {
 	for _, config := range rc.DeployConfigs() {
-		if config.HelmDeploy != nil {
+		if config.LegacyHelmDeploy != nil {
 			return true
 		}
 	}

--- a/pkg/skaffold/runner/runcontext/v2/context.go
+++ b/pkg/skaffold/runner/runcontext/v2/context.go
@@ -178,6 +178,16 @@ func (rc *RunContext) AddSkaffoldLabels() bool {
 	return rc.Opts.Mode() != config.RunModes.Render
 }
 
+func (rc *RunContext) UsingHelmDeploy() bool {
+	for _, config := range rc.DeployConfigs() {
+		if config.HelmDeploy != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (rc *RunContext) DefaultPipeline() latestV2.Pipeline            { return rc.Pipelines.Head() }
 func (rc *RunContext) GetKubeContext() string                        { return rc.KubeContext }
 func (rc *RunContext) GetNamespaces() []string                       { return rc.Namespaces }

--- a/pkg/skaffold/runner/v2/new.go
+++ b/pkg/skaffold/runner/v2/new.go
@@ -82,7 +82,7 @@ func NewForConfig(ctx context.Context, runCtx *runcontext.RunContext) (*Skaffold
 	}
 
 	renderer, err := renderer.New(
-		runCtx.GetRenderConfig(), runCtx.GetWorkingDir(), hydrationDir, labeller.Labels(), runCtx.UsingHelmDeploy())
+		runCtx.GetRenderConfig(), runCtx.GetWorkingDir(), hydrationDir, labeller.Labels(), runCtx.UsingLegacyHelmDeploy())
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(err))
 		return nil, fmt.Errorf("creating renderer: %w", err)

--- a/pkg/skaffold/runner/v2/new.go
+++ b/pkg/skaffold/runner/v2/new.go
@@ -82,7 +82,7 @@ func NewForConfig(ctx context.Context, runCtx *runcontext.RunContext) (*Skaffold
 	}
 
 	renderer, err := renderer.New(
-		runCtx.GetRenderConfig(), runCtx.GetWorkingDir(), hydrationDir, labeller.Labels())
+		runCtx.GetRenderConfig(), runCtx.GetWorkingDir(), hydrationDir, labeller.Labels(), runCtx.UsingHelmDeploy())
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(err))
 		return nil, fmt.Errorf("creating renderer: %w", err)

--- a/pkg/skaffold/runner/v2/runner_test.go
+++ b/pkg/skaffold/runner/v2/runner_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/debug"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/helm"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kubectl"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/kustomize"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/filemon"
@@ -514,13 +513,11 @@ func TestNewForConfig(t *testing.T) {
 					DeployType: latestV2.DeployType{
 						KubectlDeploy:   &latestV2.KubectlDeploy{},
 						KustomizeDeploy: &latestV2.KustomizeDeploy{},
-						HelmDeploy:      &latestV2.HelmDeploy{},
 					},
 				},
 			},
 			expectedTester: &test.FullTester{},
 			expectedDeployer: deploy.NewDeployerMux([]deploy.Deployer{
-				&helm.Deployer{},
 				&kubectl.Deployer{},
 				&kustomize.Deployer{},
 			}, false),

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -124,7 +124,10 @@ func SetDefaultRenderer(c *latestV2.SkaffoldConfig) {
 	if len(c.Render.Generate.Kustomize) > 0 {
 		return
 	}
-	if c.Render.Generate.Helm != nil || c.Deploy.HelmDeploy != nil {
+	if c.Render.Generate.Helm != nil {
+		return
+	}
+	if c.Deploy.HelmDeploy != nil {
 		return
 	}
 	// Set default manifests to "k8s/*.yaml", same as v1.

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -124,7 +124,7 @@ func SetDefaultRenderer(c *latestV2.SkaffoldConfig) {
 	if len(c.Render.Generate.Kustomize) > 0 {
 		return
 	}
-	if c.Render.Generate.Helm != nil {
+	if c.Render.Generate.Helm != nil || c.Deploy.HelmDeploy != nil {
 		return
 	}
 	// Set default manifests to "k8s/*.yaml", same as v1.

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -127,7 +127,7 @@ func SetDefaultRenderer(c *latestV2.SkaffoldConfig) {
 	if c.Render.Generate.Helm != nil {
 		return
 	}
-	if c.Deploy.HelmDeploy != nil {
+	if c.Deploy.LegacyHelmDeploy != nil {
 		return
 	}
 	// Set default manifests to "k8s/*.yaml", same as v1.

--- a/pkg/skaffold/schema/latest/v2/config.go
+++ b/pkg/skaffold/schema/latest/v2/config.go
@@ -629,8 +629,8 @@ type DeployType struct {
 	// DockerDeploy *alpha* uses the `docker` CLI to create application containers in Docker.
 	DockerDeploy *DockerDeploy `yaml:"-,omitempty"`
 
-	// HelmDeploy *beta* uses the `helm` CLI to apply the charts to the cluster.
-	HelmDeploy *HelmDeploy `yaml:"helm,omitempty"`
+	// LegacyHelmDeploy *beta* uses the `helm` CLI to apply the charts to the cluster.
+	LegacyHelmDeploy *LegacyHelmDeploy `yaml:"helm,omitempty"`
 
 	// KubectlDeploy *beta* uses a client side `kubectl apply` to deploy manifests.
 	// You'll need a `kubectl` CLI version installed that's compatible with your cluster.
@@ -1625,10 +1625,10 @@ func (ka *KanikoArtifact) MarshalYAML() (interface{}, error) {
 	return m, err
 }
 
-// TODO (yuwenma): HelmDeploy and KustomizeDeploy shall be deprecated.
+// TODO (yuwenma): LegacyHelmDeploy and KustomizeDeploy shall be deprecated.
 
-// HelmDeploy *beta* uses the `helm` CLI to apply the charts to the cluster.
-type HelmDeploy struct {
+// LegacyHelmDeploy *beta* uses the `helm` CLI to apply the charts to the cluster.
+type LegacyHelmDeploy struct {
 	// Releases is a list of Helm releases.
 	Releases []HelmRelease `yaml:"releases,omitempty" yamltags:"required"`
 

--- a/pkg/skaffold/schema/profiles_test.go
+++ b/pkg/skaffold/schema/profiles_test.go
@@ -230,7 +230,7 @@ func TestApplyProfiles(t *testing.T) {
 					Pipeline: latestV2.Pipeline{
 						Deploy: latestV2.DeployConfig{
 							DeployType: latestV2.DeployType{
-								HelmDeploy: &latestV2.HelmDeploy{},
+								LegacyHelmDeploy: &latestV2.LegacyHelmDeploy{},
 							},
 						},
 					},

--- a/pkg/skaffold/schema/v3alpha1/config.go
+++ b/pkg/skaffold/schema/v3alpha1/config.go
@@ -1485,7 +1485,7 @@ func (ka *KanikoArtifact) MarshalYAML() (interface{}, error) {
 	return m, err
 }
 
-// TODO (yuwenma): HelmDeploy and KustomizeDeploy shall be deprecated.
+// TODO (yuwenma): LegacyHelmDeploy and KustomizeDeploy shall be deprecated.
 
 // HelmDeploy *beta* uses the `helm` CLI to apply the charts to the cluster.
 type HelmDeploy struct {

--- a/pkg/skaffold/schema/validation/validation_test.go
+++ b/pkg/skaffold/schema/validation/validation_test.go
@@ -58,8 +58,8 @@ var (
 			},
 			Deploy: latestV2.DeployConfig{
 				DeployType: latestV2.DeployType{
-					HelmDeploy:    &latestV2.HelmDeploy{},
-					KubectlDeploy: &latestV2.KubectlDeploy{},
+					LegacyHelmDeploy: &latestV2.LegacyHelmDeploy{},
+					KubectlDeploy:    &latestV2.KubectlDeploy{},
 				},
 			},
 		},

--- a/pkg/skaffold/schema/versions_test.go
+++ b/pkg/skaffold/schema/versions_test.go
@@ -564,7 +564,7 @@ func withKubeContext(kubeContext string) func(*latestV2.SkaffoldConfig) {
 
 func withHelmDeploy() func(*latestV2.SkaffoldConfig) {
 	return func(cfg *latestV2.SkaffoldConfig) {
-		cfg.Deploy.DeployType.HelmDeploy = &latestV2.HelmDeploy{}
+		cfg.Deploy.DeployType.LegacyHelmDeploy = &latestV2.LegacyHelmDeploy{}
 	}
 }
 

--- a/pkg/skaffold/yamltags/tags.go
+++ b/pkg/skaffold/yamltags/tags.go
@@ -76,7 +76,7 @@ func GetYamlTag(value interface{}) string {
 }
 
 // GetYamlKeys returns the yaml key for each non-nested field of the given non-nil config parameter
-// For example if config is `latestV2.DeployType{HelmDeploy: &HelmDeploy{...}, KustomizeDeploy: &KustomizeDeploy{...}}`
+// For example if config is `latestV2.DeployType{LegacyHelmDeploy: &LegacyHelmDeploy{...}, KustomizeDeploy: &KustomizeDeploy{...}}`
 // then it returns `["helm", "kustomize"]`
 func GetYamlKeys(config interface{}) []string {
 	var tags []string


### PR DESCRIPTION
**Description**
This change allows use of the legacy helm deployer. Most necessary code is from v1, but the way that we track images has been changed. 

I've also introduced a noop renderer to essentially skip the render phase when using this deployer.