### PR TITLE
site: support nested tabs

### DIFF
--- a/docs/static/javascripts/tabs.js
+++ b/docs/static/javascripts/tabs.js
@@ -1,6 +1,6 @@
 function initTabs() {
-    $('.tab-content').find('.tab-pane').each(function(idx, item) {
-      var navTabs = $(this).closest('.code-tabs').find('.nav-tabs'),
+    $('.tab-content').children('.tab-pane').each(function(idx, item) {
+      var navTabs = $(this).closest('.code-tabs').children('.nav-tabs'),
           title = $(this).attr('title');
       navTabs.append('<li class="nav-tab"><a href="#" class="nav-tab">'+title+'</a></li');
     });
@@ -18,8 +18,9 @@ function initTabs() {
       var tab = $(this).parent(),
           tabIndex = tab.index(),
           tabPanel = $(this).closest('.code-tabs'),
-          tabPane = tabPanel.find('.tab-pane').eq(tabIndex);
-      tabPanel.find('.active').removeClass('active');
+          tabPane = tabPanel.find('.tab-content:first').children('.tab-pane').eq(tabIndex);
+      tab.siblings().removeClass('active');
+      tabPane.siblings().removeClass('active');
       tab.addClass('active');
       tabPane.addClass('active');
     });


### PR DESCRIPTION
**Description**
Same as https://github.com/kubernetes/minikube/pull/13790

The `find`s are too general to support nested tabs, so replaced with `children` to not touch nested tabs.

**Before:**
![Screen Shot 2022-03-15 at 12 08 03 PM](https://user-images.githubusercontent.com/44844360/158453032-b15cd6f7-a323-4c28-817f-5caff63ab7d3.png)


**After:**
![Screen Shot 2022-03-15 at 12 07 03 PM](https://user-images.githubusercontent.com/44844360/158453052-c760842a-eb36-4f92-9e1c-f6894805e277.png)

Incase you have a need for nested tabs in the future