### PR TITLE
fix: fix skaffold label setter to work properly for cnrm resources

### DIFF
--- a/pkg/skaffold/kubernetes/manifest/labels.go
+++ b/pkg/skaffold/kubernetes/manifest/labels.go
@@ -61,6 +61,9 @@ func (rsi *ResourceSelectorLabels) allowByGroupKind(gk apimachinery.GroupKind) b
 func (rsi *ResourceSelectorLabels) allowByNavpath(gk apimachinery.GroupKind, navpath string, k string) (string, bool) {
 	for _, w := range ConfigConnectorResourceSelector {
 		if w.Matches(gk.Group, gk.Kind) {
+			if k != metadataField {
+				return "", false
+			}
 			return "labels", true
 		}
 	}
@@ -85,7 +88,7 @@ func (rsi *ResourceSelectorLabels) allowByNavpath(gk apimachinery.GroupKind, nav
 	if rf, ok := rsi.allowlist[gk]; ok {
 		for _, allowpath := range rf.Labels {
 			if allowpath == ".*" {
-				if k != "metadata" {
+				if k != metadataField {
 					return "", false
 				}
 				return "labels", true

--- a/pkg/skaffold/kubernetes/manifest/namespaces.go
+++ b/pkg/skaffold/kubernetes/manifest/namespaces.go
@@ -55,7 +55,7 @@ func newNamespaceCollector() *namespaceCollector {
 }
 
 func (r *namespaceCollector) Visit(gk schema.GroupKind, navpath string, o map[string]interface{}, k string, v interface{}, rs ResourceSelector) bool {
-	if k != "metadata" {
+	if k != metadataField {
 		return true
 	}
 

--- a/pkg/skaffold/kubernetes/manifest/visitor.go
+++ b/pkg/skaffold/kubernetes/manifest/visitor.go
@@ -25,6 +25,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/yaml"
 )
 
+const metadataField = "metadata"
+
 type ResourceSelector interface {
 	allowByGroupKind(apimachinery.GroupKind) bool
 	allowByNavpath(apimachinery.GroupKind, string, string) (string, bool)


### PR DESCRIPTION
fixes #7219 

#7056 added an issue where currently cnrm objects have a spec.labels field created which should not be the case (should only have their *.metadata.labels field modified which is still occuring correctly).  This can cause previously successful CNRM deploys (from skaffold v1.36.0, etc.) to break for some resources now as there is a field added which is not in the schema. This change fixes that issue.

Tested manually using `compute.cnrm.cloud.google.com/v1beta1` which had the issue and it deploys successfully now

NOTE: s/metadata/metadataField was required to get linting to pass, was seeing
```
string `metadata` has 3 occurrences, make it a constant (goconst)
```