### PR TITLE
fix(examples/typescript): use tsc-watch --noClear to keep previous logs

### DIFF
--- a/examples/typescript/backend/package.json
+++ b/examples/typescript/backend/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "production": "node src/index.js",
-    "development": "tsc-watch --onSuccess 'node ./src/index.js'"
+    "development": "tsc-watch --noClear --onSuccess 'node ./src/index.js'"
   },
   "dependencies": {
     "express": "^4.16.4"

--- a/integration/examples/typescript/backend/package.json
+++ b/integration/examples/typescript/backend/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "production": "node src/index.js",
-    "development": "tsc-watch --onSuccess 'node ./src/index.js'"
+    "development": "tsc-watch --noClear --onSuccess 'node ./src/index.js'"
   },
   "dependencies": {
     "express": "^4.16.4"


### PR DESCRIPTION
@sh3lld00m noticed that the `examples/typescript` demo clears the screen on start, causing valuable logging information to be lost.  This PR uses `tsc-watch --noClear` to avoid the clear-screen.