### PR TITLE
chore: update go version in actions that weren't specifying go 1.17

### DIFF
--- a/.github/workflows/linters-checks-and-unit-tests-linux.yml
+++ b/.github/workflows/linters-checks-and-unit-tests-linux.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.14
+        go-version: 1.17.*
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/performance-comparison.yml
+++ b/.github/workflows/performance-comparison.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.14
+        go-version: 1.17.*
       id: go
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
**Description**
Specifies go version 1.17 in Github actions that had loose version specification
