### PR TITLE
fix: add default value for status-check flag when no value is specified

### DIFF
--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -320,6 +320,7 @@ var flagRegistry = []Flag{
 		FlagAddMethod: "Var",
 		DefinedOn:     []string{"dev", "debug", "deploy", "run", "apply"},
 		IsEnum:        true,
+		NoOptDefVal:   "true",
 	},
 	{
 		Name:          "iterative-status-check",

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -458,3 +458,34 @@ func TestRunTest(t *testing.T) {
 		})
 	}
 }
+
+// TestRunNoOptFlags tests to ensure that flags that don't require a value to be passed work when no value is passed
+func TestRunNoOptFlags(t *testing.T) {
+	test := struct {
+		description string
+		dir         string
+		targetLog   string
+		pods        []string
+		args        []string
+	}{
+		description: "getting-started",
+		dir:         "testdata/getting-started",
+		pods:        []string{"getting-started"},
+		targetLog:   "Hello world!",
+		args: []string{
+			"--port-forward",
+			"--status-check",
+		},
+	}
+
+	MarkIntegrationTest(t, CanRunWithoutGcp)
+	t.Run(test.description, func(t *testing.T) {
+		ns, _ := SetupNamespace(t)
+
+		args := append(test.args, "--tail")
+		out := skaffold.Run(args...).InDir(test.dir).InNs(ns.Name).RunLive(t)
+		defer skaffold.Delete().InDir(test.dir).InNs(ns.Name).RunOrFail(t)
+
+		WaitForLogs(t, out, test.targetLog)
+	})
+}


### PR DESCRIPTION
Fixes problem addressed here: https://github.com/GoogleContainerTools/skaffold/pull/7089/files#r845391034

`--status-check` can now be used without specifying `={true|false}`