### PR TITLE
fix: do not replace every string matching image names

### DIFF
--- a/pkg/skaffold/kubernetes/manifest/images.go
+++ b/pkg/skaffold/kubernetes/manifest/images.go
@@ -29,6 +29,8 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
+const imageField = "image"
+
 type ResourceSelectorImages struct {
 	allowlist map[apimachinery.GroupKind]latest.ResourceFilter
 	denylist  map[apimachinery.GroupKind]latest.ResourceFilter
@@ -62,9 +64,12 @@ func (rsi *ResourceSelectorImages) allowByGroupKind(gk apimachinery.GroupKind) b
 }
 
 func (rsi *ResourceSelectorImages) allowByNavpath(gk apimachinery.GroupKind, navpath string, k string) (string, bool) {
+	matchedConfigConnectorImage := false
+
 	for _, w := range ConfigConnectorResourceSelector {
-		if w.Matches(gk.Group, gk.Kind) {
-			return "", true
+		if k == imageField && w.Matches(gk.Group, gk.Kind) {
+			matchedConfigConnectorImage = true
+			break
 		}
 	}
 
@@ -80,11 +85,10 @@ func (rsi *ResourceSelectorImages) allowByNavpath(gk apimachinery.GroupKind, nav
 	}
 
 	if rf, ok := rsi.allowlist[gk]; ok {
+		matchedConfigConnectorImage = false
+
 		for _, allowpath := range rf.Image {
-			if allowpath == ".*" {
-				if k != "image" {
-					return "", false
-				}
+			if allowpath == ".*" && k == imageField {
 				return "", true
 			}
 			if navpath == allowpath {
@@ -92,7 +96,7 @@ func (rsi *ResourceSelectorImages) allowByNavpath(gk apimachinery.GroupKind, nav
 			}
 		}
 	}
-	return "", false
+	return "", matchedConfigConnectorImage
 }
 
 // GetImages gathers a map of base image names to the image with its tag
@@ -107,7 +111,7 @@ type imageSaver struct {
 }
 
 func (is *imageSaver) Visit(gk apimachinery.GroupKind, navpath string, o map[string]interface{}, k string, v interface{}, rs ResourceSelector) bool {
-	if k != "image" {
+	if k != imageField {
 		return true
 	}
 


### PR DESCRIPTION
Skaffold does not behave consistently when transforming manifests. It will always replace fields inside Config Connector manifests that match some image name in the build. See the example below.

```yaml
image: image-name
something: image-name
image: do-no-match
```

Skaffold will produce the following output:

```yaml
image: <REPLACED>
something: <REPLACED>
image: do-no-match
```

However, the expected result would be:

```yaml
image: <REPLACED>
something: image-name
image: do-no-match
```

This bug only exists for Config Connector resources due to [this line](https://github.com/GoogleContainerTools/skaffold/compare/main...barata:main#diff-8e1e726f52eed31819c51b1de64e9c24bc22cbbc63b022edd299d9970b73ad60L67).

The fix will make the behavior consistent with other kinds of resources and only replace `image` fields, unless some rule inside `TransformAllowlist` tell otherwise. Many tests were added to illustrate the expected behavior.

Another minor bug in [this block](https://github.com/GoogleContainerTools/skaffold/pull/7282/files#diff-8e1e726f52eed31819c51b1de64e9c24bc22cbbc63b022edd299d9970b73ad60L84-L87) was fixed. The problem happens when there is a wildcard `.*` and some other field inside the same `image` definition. The previous code will just stop the loop when it finds a wildcard, which is not the desired state. See the example below.

```yaml
image: image-name
something: image-name
```

In case `Image: [".*", ".something"]` exists, Skaffold will not replace the field `something` because a wildcard is found first inside the loop. Tests were also added to cover this case.