### PR TITLE
fix: Do not ignore supplied platform when retagging an image

### DIFF
--- a/pkg/skaffold/build/bazel/build.go
+++ b/pkg/skaffold/build/bazel/build.go
@@ -48,7 +48,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest.Art
 	}
 
 	if b.pushImages {
-		return docker.Push(tarPath, tag, b.cfg)
+		return docker.Push(tarPath, tag, b.cfg, nil)
 	}
 	return b.loadImage(ctx, out, tarPath, a, tag)
 }

--- a/pkg/skaffold/build/cache/lookup.go
+++ b/pkg/skaffold/build/cache/lookup.go
@@ -108,7 +108,7 @@ func (c *cache) lookupLocal(ctx context.Context, hash, tag string, entry ImageDe
 }
 
 func (c *cache) lookupRemote(ctx context.Context, hash, tag string, entry ImageDetails) cacheDetails {
-	if remoteDigest, err := docker.RemoteDigest(tag, c.cfg); err == nil {
+	if remoteDigest, err := docker.RemoteDigest(tag, c.cfg, nil); err == nil {
 		// Image exists remotely with the same tag and digest
 		if remoteDigest == entry.Digest {
 			return found{hash: hash}
@@ -117,7 +117,7 @@ func (c *cache) lookupRemote(ctx context.Context, hash, tag string, entry ImageD
 
 	// Image exists remotely with a different tag
 	fqn := tag + "@" + entry.Digest // Actual tag will be ignored but we need the registry and the digest part of it.
-	if remoteDigest, err := docker.RemoteDigest(fqn, c.cfg); err == nil {
+	if remoteDigest, err := docker.RemoteDigest(fqn, c.cfg, nil); err == nil {
 		if remoteDigest == entry.Digest {
 			return needsRemoteTagging{hash: hash, tag: tag, digest: entry.Digest}
 		}
@@ -159,7 +159,7 @@ func (c *cache) tryImport(ctx context.Context, a *latest.Artifact, tag string, h
 		entry.ID = imageID
 	}
 
-	if digest, err := docker.RemoteDigest(tag, c.cfg); err == nil {
+	if digest, err := docker.RemoteDigest(tag, c.cfg, nil); err == nil {
 		log.Entry(ctx).Debugf("Added digest for %s to cache entry", tag)
 		entry.Digest = digest
 	}

--- a/pkg/skaffold/build/cache/retrieve.go
+++ b/pkg/skaffold/build/cache/retrieve.go
@@ -82,7 +82,7 @@ func (c *cache) Build(ctx context.Context, out io.Writer, tags tag.ImageTags, ar
 		case needsTagging:
 			eventV2.CacheCheckHit(artifact.ImageName)
 			output.Green.Fprintln(out, "Found. Tagging")
-			if err := result.Tag(ctx, c); err != nil {
+			if err := result.Tag(ctx, c, platforms); err != nil {
 				endTrace(instrumentation.TraceEndError(err))
 				return nil, fmt.Errorf("tagging image: %w", err)
 			}

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -97,7 +97,7 @@ func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace 
 
 	waitForLogs()
 
-	return docker.RemoteDigest(tag, b.cfg)
+	return docker.RemoteDigest(tag, b.cfg, nil)
 }
 
 // first copy over the buildcontext tarball into the init container tmp dir via kubectl cp

--- a/pkg/skaffold/build/custom/build.go
+++ b/pkg/skaffold/build/custom/build.go
@@ -39,7 +39,7 @@ func (b *Builder) Build(ctx context.Context, out io.Writer, artifact *latest.Art
 	}
 
 	if b.pushImages {
-		return docker.RemoteDigest(tag, b.cfg)
+		return docker.RemoteDigest(tag, b.cfg, nil)
 	}
 
 	imageID, err := b.localDocker.ImageID(ctx, tag)

--- a/pkg/skaffold/build/gcb/cloud_build.go
+++ b/pkg/skaffold/build/gcb/cloud_build.go
@@ -240,7 +240,7 @@ watch:
 		switch cb.Status {
 		case StatusQueued, StatusWorking, StatusUnknown:
 		case StatusSuccess:
-			digest, err = b.getDigest(cb, tag)
+			digest, err = b.getDigest(cb, tag, platform)
 			if err != nil {
 				return "", sErrors.NewErrorWithStatusCode(&proto.ActionableErr{
 					ErrCode: proto.StatusCode_BUILD_GCB_GET_BUILT_IMAGE_ERR,
@@ -301,7 +301,7 @@ func getBuildID(op *cloudbuild.Operation) (string, error) {
 	return buildMeta.Build.Id, nil
 }
 
-func (b *Builder) getDigest(cb *cloudbuild.Build, defaultToTag string) (string, error) {
+func (b *Builder) getDigest(cb *cloudbuild.Build, defaultToTag string, platforms platform.Matcher) (string, error) {
 	if cb.Results != nil && len(cb.Results.Images) == 1 {
 		return cb.Results.Images[0].Digest, nil
 	}
@@ -309,7 +309,7 @@ func (b *Builder) getDigest(cb *cloudbuild.Build, defaultToTag string) (string, 
 	// The build steps pushed the image directly like when we use Jib.
 	// Retrieve the digest for that tag.
 	// TODO(dgageot): I don't think GCB can push to an insecure registry.
-	return docker.RemoteDigest(defaultToTag, b.cfg)
+	return docker.RemoteDigest(defaultToTag, b.cfg, util.ConvertToV1Platform(platforms.Platforms[0]))
 }
 
 func (b *Builder) getLogs(ctx context.Context, c *cstorage.Client, offset int64, bucket, objectName string) (io.ReadCloser, error) {

--- a/pkg/skaffold/build/jib/gradle.go
+++ b/pkg/skaffold/build/jib/gradle.go
@@ -59,7 +59,7 @@ func (b *Builder) buildJibGradleToRegistry(ctx context.Context, out io.Writer, w
 		return "", jibToolErr(err)
 	}
 
-	return docker.RemoteDigest(tag, b.cfg)
+	return docker.RemoteDigest(tag, b.cfg, nil)
 }
 
 func (b *Builder) runGradleCommand(ctx context.Context, out io.Writer, workspace string, args []string) error {

--- a/pkg/skaffold/build/jib/maven.go
+++ b/pkg/skaffold/build/jib/maven.go
@@ -59,7 +59,7 @@ func (b *Builder) buildJibMavenToRegistry(ctx context.Context, out io.Writer, wo
 		return "", jibToolErr(err)
 	}
 
-	return docker.RemoteDigest(tag, b.cfg)
+	return docker.RemoteDigest(tag, b.cfg, nil)
 }
 
 func (b *Builder) runMavenCommand(ctx context.Context, out io.Writer, workspace string, args []string) error {

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -284,7 +284,7 @@ func (l *localDaemon) ConfigFile(ctx context.Context, image string) (*v1.ConfigF
 			return nil, err
 		}
 	} else {
-		cfg, err = RetrieveRemoteConfig(image, l.cfg)
+		cfg, err = RetrieveRemoteConfig(image, l.cfg, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -431,7 +431,7 @@ func (l *localDaemon) Push(ctx context.Context, out io.Writer, ref string) (stri
 	if digest == "" {
 		// Maybe this version of Docker doesn't return the digest of the image
 		// that has been pushed.
-		digest, err = RemoteDigest(ref, l.cfg)
+		digest, err = RemoteDigest(ref, l.cfg, nil)
 		if err != nil {
 			return "", fmt.Errorf("getting digest: %w", err)
 		}

--- a/pkg/skaffold/docker/image_util.go
+++ b/pkg/skaffold/docker/image_util.go
@@ -40,7 +40,7 @@ func RetrieveConfigFile(ctx context.Context, tagged string, cfg Config) (*v1.Con
 	}
 	if err != nil {
 		// No local Docker is available
-		cf, err = RetrieveRemoteConfig(tagged, cfg)
+		cf, err = RetrieveRemoteConfig(tagged, cfg, nil)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("retrieving image config: %w", err)

--- a/pkg/skaffold/runner/v1/render.go
+++ b/pkg/skaffold/runner/v1/render.go
@@ -32,7 +32,8 @@ func (r *SkaffoldRunner) Render(ctx context.Context, out io.Writer, builds []gra
 	// Fetch the digest and append it to the tag with the format of "tag@digest"
 	if r.runCtx.DigestSource() == runner.RemoteDigestSource {
 		for i, a := range builds {
-			digest, err := docker.RemoteDigest(a.Tag, r.runCtx)
+			// remote digest to platform dependant build not supported
+			digest, err := docker.RemoteDigest(a.Tag, r.runCtx, nil)
 			if err != nil {
 				return fmt.Errorf("failed to resolve the digest of %s: does the image exist remotely?", a.Tag)
 			}

--- a/pkg/skaffold/util/platform.go
+++ b/pkg/skaffold/util/platform.go
@@ -1,0 +1,10 @@
+package util
+
+import (
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func ConvertToV1Platform(platform specs.Platform) *v1.Platform {
+	return &v1.Platform{Architecture: platform.Architecture, OS: platform.OS, OSVersion: platform.OSVersion, OSFeatures: platform.OSFeatures, Variant: platform.Variant}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

When building image using the --platform flag, if platform is not equal to the platform of the built image and skaffold decides it only needs to retag the image, the operation will fails because the platform do not match and will fail with 
```
getting image: no child with platform {Architecture:amd64 OS:linux OSVersion: OSFeatures:[] Variant: Features:[]} in index <image tag>
```

this PR tries to fix this issue.