### PR TITLE
fix: make TestDevPortForwardDefaultNamespace pass

### DIFF
--- a/integration/dev_test.go
+++ b/integration/dev_test.go
@@ -311,8 +311,6 @@ func TestDevPortForward(t *testing.T) {
 
 func TestDevPortForwardDefaultNamespace(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
-	// TODO: fix https://github.com/GoogleContainerTools/skaffold/issues/7032
-	t.Skipf("Fix todo https://github.com/GoogleContainerTools/skaffold/issues/7032")
 
 	// Run skaffold build first to fail quickly on a build failure
 	skaffold.Build().InDir("examples/microservices").RunOrFail(t)

--- a/integration/examples/microservices/skaffold.yaml
+++ b/integration/examples/microservices/skaffold.yaml
@@ -14,11 +14,10 @@ build:
           alias: BASE
     - image: base
       context: base
-deploy:
-  kubectl:
-    manifests:
-      - leeroy-web/kubernetes/*
-      - leeroy-app/kubernetes/*
+manifests:
+  rawYaml:
+    - leeroy-web/kubernetes/*
+    - leeroy-app/kubernetes/*
 portForward:
   - resourceType: deployment
     resourceName: leeroy-web


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/7032

**Description**
This PR fixes the mentioned integration test by making a block of code behave as it did on the v1 branch. The digest source code only ran when doing render only behavior, so that has been brought over to v2.

**Follow Up Work**
This may have inadvertently fixed other tests as well if they were blocked on the same remote digest issue. We'll have to investigate and see.
