### PR TITLE
ci: reenable TestDeployTailDefaultNamespace

### DIFF
--- a/integration/deploy_test.go
+++ b/integration/deploy_test.go
@@ -147,8 +147,7 @@ func TestDeployTail(t *testing.T) {
 
 func TestDeployTailDefaultNamespace(t *testing.T) {
 	MarkIntegrationTest(t, CanRunWithoutGcp)
-	// TODO: https://github.com/GoogleContainerTools/skaffold/issues/7054
-	t.Skipf("fix https://github.com/GoogleContainerTools/skaffold/issues/7054")
+
 	// `--default-repo=` is used to cancel the default repo that is set by default.
 	out := skaffold.Deploy("--tail", "--images", "busybox:latest", "--default-repo=").InDir("testdata/deploy-hello-tail").RunLive(t)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/7031

**Description**

