### PR TITLE
chore: Add cluster type to exported metrics.

### DIFF
--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -178,6 +178,7 @@ func createMetrics(ctx context.Context, meter skaffoldMeter) {
 		attribute.String("error", meter.ErrorCode.String()),
 		attribute.String("platform_type", meter.PlatformType),
 		attribute.String("config_count", strconv.Itoa(meter.ConfigCount)),
+		attribute.String("cluster_type", meter.ClusterType),
 	}
 	sharedLabels := []attribute.KeyValue{
 		randLabel,


### PR DESCRIPTION
While investigating on on how many CLI users deploy to GKE, I found out we were not exporting the detected metric.

Adding this to the launch metric