### PR TITLE
fix: set build concurrency correctly for multi-config projects

### DIFF
--- a/pkg/skaffold/build/builder_mux.go
+++ b/pkg/skaffold/build/builder_mux.go
@@ -150,10 +150,11 @@ func getConcurrency(pbs []PipelineBuilder, cliConcurrency int) int {
 	}
 	minConcurrency := -1
 	for i, b := range pbs {
-		concurrency := 1
-		if b.Concurrency() != nil {
-			concurrency = *b.Concurrency()
+		if b.Concurrency() == nil {
+			continue
 		}
+		concurrency := *b.Concurrency()
+
 		// set mux concurrency to be the minimum of all builders' concurrency. (concurrency = 0 means unlimited)
 		switch {
 		case minConcurrency < 0:

--- a/pkg/skaffold/build/builder_mux_test.go
+++ b/pkg/skaffold/build/builder_mux_test.go
@@ -123,12 +123,10 @@ func TestGetConcurrency(t *testing.T) {
 			pbs: []PipelineBuilder{
 				&mockPipelineBuilder{concurrency: util.IntPtr(2), builderType: "local"},
 				&mockPipelineBuilder{concurrency: util.IntPtr(2), builderType: "local"},
-				// As per docs https://github.com/GoogleContainerTools/skaffold/blob/dbd18994955f5805e80c6354ed0fd424ec4d987b/pkg/skaffold/schema/v2beta26/config.go#L287
-				// nil concurrency defaults to 1
 				&mockPipelineBuilder{concurrency: nil, builderType: "local"},
 			},
 			cliConcurrency:      -1,
-			expectedConcurrency: 1,
+			expectedConcurrency: 2,
 		},
 		{
 			description: "builder concurrency set to 0 and cli concurrency set to 1",
@@ -149,6 +147,18 @@ func TestGetConcurrency(t *testing.T) {
 			},
 			cliConcurrency:      -1,
 			expectedConcurrency: 0,
+		},
+		{
+			description: "concurrency set in a different pipeline than the builder",
+			pbs: []PipelineBuilder{
+				// build all in parallel
+				&mockPipelineBuilder{builderType: "local"},
+				&mockPipelineBuilder{builderType: "local"},
+				&mockPipelineBuilder{builderType: "local"},
+				&mockPipelineBuilder{concurrency: util.IntPtr(3), builderType: "local"},
+			},
+			cliConcurrency:      -1,
+			expectedConcurrency: 3,
 		},
 		{
 			description: "builder concurrency set to default 0 for gcb",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7310 <!-- tracking issues that this PR will close -->
**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
This was earlier fixed in https://github.com/GoogleContainerTools/skaffold/pull/7182 but regressed due to a bad subsequent [commit](https://github.com/GoogleContainerTools/skaffold/pull/7182/commits/f8904bd6575a22bca86fa7bb4c078fe13d9ea3b2) and missing test case. Fixed here and added the test case.