### PR TITLE
chore: [v1] cherry pick the fix to collect cluster type on v1 branch

### DIFF
--- a/hack/versions/pkg/schema/check.go
+++ b/hack/versions/pkg/schema/check.go
@@ -28,7 +28,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/hack/versions/pkg/diff"
 )
 
-const baseRef = "origin/main"
+const baseRef = "origin/v1"
 
 func RunSchemaCheckOnChangedFiles() error {
 	git, err := newGit(baseRef)

--- a/pkg/skaffold/instrumentation/export.go
+++ b/pkg/skaffold/instrumentation/export.go
@@ -178,6 +178,7 @@ func createMetrics(ctx context.Context, meter skaffoldMeter) {
 		attribute.String("error", meter.ErrorCode.String()),
 		attribute.String("platform_type", meter.PlatformType),
 		attribute.String("config_count", strconv.Itoa(meter.ConfigCount)),
+		attribute.String("cluster_type", meter.ClusterType),
 	}
 	sharedLabels := []attribute.KeyValue{
 		randLabel,


### PR DESCRIPTION
This PR was created using

1) `git cherry-pick 97f2bdc9b3c1ef7ad1f5dec2e2e169732712f0a0`
2) `git commit -am chore: fix the hack/schema-changes.sh on main`