### PR TITLE
chore: v1: add `--transform` to v1 filter command.

### DIFF
--- a/cmd/skaffold/app/cmd/filter.go
+++ b/cmd/skaffold/app/cmd/filter.go
@@ -23,15 +23,18 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	apim "k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/flags"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	deployutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/deploy/util"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/debugging"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
+	pkgutil "github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
 // for tests
@@ -39,7 +42,7 @@ var doFilter = runFilter
 
 // NewCmdFilter describes the CLI command to filter and transform a set of Kubernetes manifests.
 func NewCmdFilter() *cobra.Command {
-	var debuggingFilters bool
+	var debuggingFilters, transform bool
 	var renderFromBuildOutputFile flags.BuildOutputFileFlag
 
 	return NewCmd("filter").
@@ -50,20 +53,35 @@ func NewCmdFilter() *cobra.Command {
 		WithFlags([]*Flag{
 			{Value: &renderFromBuildOutputFile, Name: "build-artifacts", Shorthand: "a", Usage: "File containing build result from a previous 'skaffold build --file-output'"},
 			{Value: &debuggingFilters, Name: "debugging", DefValue: false, Usage: `Apply debug transforms similar to "skaffold debug"`, IsEnum: true},
+			{Value: &transform, Name: "transform", DefValue: false, Usage: `(experimental) Replace images in manifest and set labels`, IsEnum: true},
 		}).
 		NoArgs(func(ctx context.Context, out io.Writer) error {
-			return doFilter(ctx, out, debuggingFilters, renderFromBuildOutputFile.BuildArtifacts())
+			return doFilter(ctx, out, debuggingFilters, renderFromBuildOutputFile.BuildArtifacts(), transform)
 		})
 }
 
 // runFilter loads the Kubernetes manifests from stdin and applies the debug transformations.
 // Unlike `skaffold debug`, this filtering affects all images and not just the built artifacts.
-func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildArtifacts []graph.Artifact) error {
+func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildArtifacts []graph.Artifact, transform bool) error {
 	return withRunner(ctx, out, func(r runner.Runner, configs []util.VersionedConfig) error {
 		manifestList, err := manifest.Load(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("loading manifests: %w", err)
 		}
+
+		allow, deny := getTransformList(configs)
+		if transform {
+			manifestList, err = manifestList.SetLabels(pkgutil.EnvSliceToMap(opts.CustomLabels, "="),
+				manifest.NewResourceSelectorLabels(allow, deny))
+			if err != nil {
+				return err
+			}
+			manifestList, err = manifestList.ReplaceImages(ctx, buildArtifacts, manifest.NewResourceSelectorImages(allow, deny))
+			if err != nil {
+				return err
+			}
+		}
+
 		if debuggingFilters {
 			// TODO(bdealwis): refactor this code
 			debugHelpersRegistry, err := config.GetDebugHelpersRegistry(opts.GlobalConfig)
@@ -86,6 +104,36 @@ func runFilter(ctx context.Context, out io.Writer, debuggingFilters bool, buildA
 		out.Write([]byte(manifestList.String()))
 		return nil
 	})
+}
+
+func getTransformList(configs []util.VersionedConfig) (map[apim.GroupKind]latest.ResourceFilter, map[apim.GroupKind]latest.ResourceFilter) {
+	// TODO: remove code duplication by adding a new Filter method to the runner.
+	// and reuse renderer/util.ConsolidateTransformConfiguration
+
+	allow := manifest.TransformAllowlist
+	deny := manifest.TransformDenylist
+
+	// add default values
+	for _, rf := range manifest.TransformAllowlist {
+		groupKind := apim.ParseGroupKind(rf.GroupKind)
+		allow[groupKind] = deployutil.ConvertJSONPathIndex(rf)
+	}
+	for _, rf := range manifest.TransformDenylist {
+		groupKind := apim.ParseGroupKind(rf.GroupKind)
+		allow[groupKind] = deployutil.ConvertJSONPathIndex(rf)
+	}
+
+	for _, cfg := range configs {
+		for _, rf := range cfg.(*latest.SkaffoldConfig).ResourceSelector.Allow {
+			groupKind := apim.ParseGroupKind(rf.GroupKind)
+			allow[groupKind] = deployutil.ConvertJSONPathIndex(rf)
+		}
+		for _, rf := range cfg.(*latest.SkaffoldConfig).ResourceSelector.Deny {
+			groupKind := apim.ParseGroupKind(rf.GroupKind)
+			deny[groupKind] = deployutil.ConvertJSONPathIndex(rf)
+		}
+	}
+	return allow, deny
 }
 
 func getInsecureRegistries(opts config.SkaffoldOptions, configs []util.VersionedConfig) (map[string]bool, error) {

--- a/cmd/skaffold/app/cmd/filter_test.go
+++ b/cmd/skaffold/app/cmd/filter_test.go
@@ -17,9 +17,17 @@ limitations under the License.
 package cmd
 
 import (
+	"bytes"
+	"context"
+	"io"
 	"testing"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner/runcontext"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -32,4 +40,76 @@ func TestFilterIsHidden(t *testing.T) {
 
 		t.CheckDeepEqual(true, cmd.Hidden)
 	})
+}
+
+func TestFilterTransform(t *testing.T) {
+	manifest := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chartName
+  labels:
+    app: chartName
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: chartName
+        image: image1`
+	tests := []struct {
+		description    string
+		manifestsStr   string
+		buildArtifacts []graph.Artifact
+		labels         []string
+		expected       string
+		transform      bool
+	}{
+		{
+			description:  "manifests with images",
+			manifestsStr: manifest,
+			buildArtifacts: []graph.Artifact{
+				{ImageName: "image1", Tag: "image1:tag1"},
+				{ImageName: "image2", Tag: "image2:tag2"}},
+			labels:    []string{"label1=foo", "run.id=random"},
+			transform: true,
+			expected: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: chartName
+    label1: foo
+    run.id: random
+  name: chartName
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - image: image1:tag1
+        name: chartName`,
+		},
+		{
+			description:  "no transform",
+			manifestsStr: manifest,
+			buildArtifacts: []graph.Artifact{
+				{ImageName: "image1", Tag: "image1:tag1"},
+				{ImageName: "image2", Tag: "image2:tag2"}},
+			labels:   []string{"label1=foo", "run.id=random"},
+			expected: manifest,
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&opts, config.SkaffoldOptions{CustomLabels: test.labels})
+			mockRunner := &mockDevRunner{}
+			t.Override(&createRunner, func(context.Context, io.Writer, config.SkaffoldOptions) (runner.Runner, []util.VersionedConfig, *runcontext.RunContext, error) {
+				return mockRunner, []util.VersionedConfig{&latest.SkaffoldConfig{}}, nil, nil
+			})
+			t.SetStdin([]byte(test.manifestsStr))
+			var b bytes.Buffer
+			err := runFilter(context.TODO(), &b, false, test.buildArtifacts, test.transform)
+			t.CheckNoError(err)
+			t.CheckDeepEqual(test.expected, b.String())
+		})
+	}
 }

--- a/cmd/skaffold/app/cmd/flags.go
+++ b/cmd/skaffold/app/cmd/flags.go
@@ -229,7 +229,7 @@ var flagRegistry = []Flag{
 		Value:         &opts.CustomLabels,
 		DefValue:      []string{},
 		FlagAddMethod: "StringSliceVar",
-		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render"},
+		DefinedOn:     []string{"dev", "run", "debug", "deploy", "render", "filter"},
 	},
 	{
 		Name:          "toot",

--- a/pkg/skaffold/deploy/util/util.go
+++ b/pkg/skaffold/deploy/util/util.go
@@ -115,24 +115,24 @@ func ConsolidateTransformConfiguration(cfg types.Config) (map[schema.GroupKind]l
 	// add default values
 	for _, rf := range manifest.TransformAllowlist {
 		groupKind := schema.ParseGroupKind(rf.GroupKind)
-		transformableAllowlist[groupKind] = convertJSONPathIndex(rf)
+		transformableAllowlist[groupKind] = ConvertJSONPathIndex(rf)
 	}
 	for _, rf := range manifest.TransformDenylist {
 		groupKind := schema.ParseGroupKind(rf.GroupKind)
-		transformableDenylist[groupKind] = convertJSONPathIndex(rf)
+		transformableDenylist[groupKind] = ConvertJSONPathIndex(rf)
 	}
 
 	// add user schema values, override defaults
 	for _, rf := range cfg.TransformAllowList() {
 		instrumentation.AddResourceFilter("schema", "allow")
 		groupKind := schema.ParseGroupKind(rf.GroupKind)
-		transformableAllowlist[groupKind] = convertJSONPathIndex(rf)
+		transformableAllowlist[groupKind] = ConvertJSONPathIndex(rf)
 		delete(transformableDenylist, groupKind)
 	}
 	for _, rf := range cfg.TransformDenyList() {
 		instrumentation.AddResourceFilter("schema", "deny")
 		groupKind := schema.ParseGroupKind(rf.GroupKind)
-		transformableDenylist[groupKind] = convertJSONPathIndex(rf)
+		transformableDenylist[groupKind] = ConvertJSONPathIndex(rf)
 		delete(transformableAllowlist, groupKind)
 	}
 
@@ -151,14 +151,14 @@ func ConsolidateTransformConfiguration(cfg types.Config) (map[schema.GroupKind]l
 		for _, rf := range rsc.Allow {
 			instrumentation.AddResourceFilter("cli-flag", "allow")
 			groupKind := schema.ParseGroupKind(rf.GroupKind)
-			transformableAllowlist[groupKind] = convertJSONPathIndex(rf)
+			transformableAllowlist[groupKind] = ConvertJSONPathIndex(rf)
 			delete(transformableDenylist, groupKind)
 		}
 
 		for _, rf := range rsc.Deny {
 			instrumentation.AddResourceFilter("cli-flag", "deny")
 			groupKind := schema.ParseGroupKind(rf.GroupKind)
-			transformableDenylist[groupKind] = convertJSONPathIndex(rf)
+			transformableDenylist[groupKind] = ConvertJSONPathIndex(rf)
 			delete(transformableAllowlist, groupKind)
 		}
 	}
@@ -166,7 +166,7 @@ func ConsolidateTransformConfiguration(cfg types.Config) (map[schema.GroupKind]l
 	return transformableAllowlist, transformableDenylist, nil
 }
 
-func convertJSONPathIndex(rf latest.ResourceFilter) latest.ResourceFilter {
+func ConvertJSONPathIndex(rf latest.ResourceFilter) latest.ResourceFilter {
 	nrf := latest.ResourceFilter{}
 	nrf.GroupKind = rf.GroupKind
 


### PR DESCRIPTION
This is related to #6683 but for V1 branch

For v1 branch
1) Adding `--tranform` flag to the filter command.  This command will be used in `helmv3.1Deployer` to use helm post renderer functionality for performing image replacements.