### PR TITLE
feat: allow using env vars within deploy.helm.releases[].repo field

### DIFF
--- a/docs/content/en/docs/environment/templating.md
+++ b/docs/content/en/docs/environment/templating.md
@@ -21,6 +21,7 @@ List of fields that support templating:
 * `deploy.helm.releases.setValueTemplates` (see [Deploying with helm]({{< relref "/docs/pipeline-stages/deployers#deploying-with-helm)" >}}))
 * `deploy.helm.releases.name` (see [Deploying with helm]({{< relref "/docs/pipeline-stages/deployers#deploying-with-helm)" >}}))
 * `deploy.helm.releases.namespace` (see [Deploying with helm]({{< relref "/docs/pipeline-stages/deployers#deploying-with-helm)" >}}))
+* `deploy.helm.releases[].repo` (see [Deploying with helm]({{< relref "/docs/pipeline-stages/deployers#deploying-with-helm)" >}}))
 * `deploy.helm.releases.version` (see [Deploying with helm]({{< relref "/docs/pipeline-stages/deployers#deploying-with-helm)" >}}))
 * `deploy.kubectl.defaultNamespace`
 * `deploy.kustomize.defaultNamespace`


### PR DESCRIPTION
Signed-off-by: Pablo Caderno <kaderno@gmail.com>


<!-- Include if applicable: -->
Fixes: #5716

**Description**
Allow using environment variables within deploy.helm.releases[].repo field



**Follow-up Work (remove if N/A)**
Adding a couple lines of documentation about this feature could be useful.


