### PR TITLE
fix: Update skaffold-kustomize-args.yaml

### DIFF
--- a/examples/kustomize/skaffold-kustomize-args.yaml
+++ b/examples/kustomize/skaffold-kustomize-args.yaml
@@ -3,4 +3,4 @@ kind: Config
 deploy:
   kustomize:
     buildArgs:
-      - "--load_restrictor none"
+      - "--load-restrictor LoadRestrictionsNone"

--- a/integration/examples/kustomize/skaffold-kustomize-args.yaml
+++ b/integration/examples/kustomize/skaffold-kustomize-args.yaml
@@ -3,4 +3,4 @@ kind: Config
 deploy:
   kustomize:
     buildArgs:
-      - "--load_restrictor none"
+      - "--load-restrictor LoadRestrictionsNone"


### PR DESCRIPTION
Modified Kustomize load-restrictor argument and syntax to follow changes implemented in Kustomize v4+ and make the example work in Cloud Shell.

Fixes:  [#7331](https://github.com/GoogleContainerTools/skaffold/issues/7331)

**Description**
This example is designed to work with <4 versions of Kustomize. The `load_restrictor` argument syntax has been changed by `--load-restrictor` and the value should now be `LoadRestrictionsNone` instead of `none`.

**Follow-up Work (remove if N/A)**
[Outdated Kustomize build flags in Examples #7331
](https://github.com/GoogleContainerTools/skaffold/issues/7331)
