### PR TITLE
feat: support the contextSubPath param in the Kaniko Artifact

### DIFF
--- a/pkg/skaffold/build/cache/hash.go
+++ b/pkg/skaffold/build/cache/hash.go
@@ -28,6 +28,7 @@ import (
 	"sort"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/config"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/graph"
@@ -191,7 +192,7 @@ func hashBuildArgs(artifact *latest.Artifact, mode config.RunMode) ([]string, er
 	case artifact.DockerArtifact != nil:
 		args, err = docker.EvalBuildArgs(mode, artifact.Workspace, artifact.DockerArtifact.DockerfilePath, artifact.DockerArtifact.BuildArgs, nil)
 	case artifact.KanikoArtifact != nil:
-		args, err = docker.EvalBuildArgs(mode, artifact.Workspace, artifact.KanikoArtifact.DockerfilePath, artifact.KanikoArtifact.BuildArgs, nil)
+		args, err = docker.EvalBuildArgs(mode, kaniko.GetContext(artifact.KanikoArtifact, artifact.Workspace), artifact.KanikoArtifact.DockerfilePath, artifact.KanikoArtifact.BuildArgs, nil)
 	case artifact.BuildpackArtifact != nil:
 		env, err = buildpacks.GetEnv(artifact, mode)
 	case artifact.CustomArtifact != nil && artifact.CustomArtifact.Dependencies.Dockerfile != nil:

--- a/pkg/skaffold/build/cluster/kaniko.go
+++ b/pkg/skaffold/build/cluster/kaniko.go
@@ -54,7 +54,7 @@ func (b *Builder) buildWithKaniko(ctx context.Context, out io.Writer, workspace 
 	}
 	artifact.Env = env
 
-	buildArgs, err := docker.EvalBuildArgsWithEnv(b.cfg.Mode(), workspace, artifact.DockerfilePath, artifact.BuildArgs, requiredImages, envMapFromVars(artifact.Env))
+	buildArgs, err := docker.EvalBuildArgsWithEnv(b.cfg.Mode(), kaniko.GetContext(artifact, workspace), artifact.DockerfilePath, artifact.BuildArgs, requiredImages, envMapFromVars(artifact.Env))
 	if err != nil {
 		return "", fmt.Errorf("unable to evaluate build args: %w", err)
 	}
@@ -112,7 +112,7 @@ func (b *Builder) copyKanikoBuildContext(ctx context.Context, workspace string, 
 	buildCtx, buildCtxWriter := io.Pipe()
 	go func() {
 		err := docker.CreateDockerTarContext(ctx, buildCtxWriter, docker.NewBuildConfig(
-			workspace, artifactName, artifact.DockerfilePath, artifact.BuildArgs), b.cfg)
+			kaniko.GetContext(artifact, workspace), artifactName, artifact.DockerfilePath, artifact.BuildArgs), b.cfg)
 		if err != nil {
 			buildCtxWriter.CloseWithError(fmt.Errorf("creating docker context: %w", err))
 			errs <- err

--- a/pkg/skaffold/build/gcb/kaniko.go
+++ b/pkg/skaffold/build/gcb/kaniko.go
@@ -32,7 +32,7 @@ func (b *Builder) kanikoBuildSpec(a *latest.Artifact, tag string) (cloudbuild.Bu
 	k := a.KanikoArtifact
 	requiredImages := docker.ResolveDependencyImages(a.Dependencies, b.artifactStore, true)
 	// add required artifacts as build args
-	buildArgs, err := docker.EvalBuildArgs(b.cfg.Mode(), a.Workspace, k.DockerfilePath, k.BuildArgs, requiredImages)
+	buildArgs, err := docker.EvalBuildArgs(b.cfg.Mode(), kaniko.GetContext(a.KanikoArtifact, a.Workspace), k.DockerfilePath, k.BuildArgs, requiredImages)
 	if err != nil {
 		return cloudbuild.Build{}, fmt.Errorf("unable to evaluate build args: %w", err)
 	}

--- a/pkg/skaffold/build/kaniko/args.go
+++ b/pkg/skaffold/build/kaniko/args.go
@@ -18,6 +18,7 @@ package kaniko
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/name"
 
@@ -29,7 +30,7 @@ import (
 func Args(artifact *latest.KanikoArtifact, tag, context string) ([]string, error) {
 	args := []string{
 		"--destination", tag,
-		"--dockerfile", artifact.DockerfilePath,
+		"--dockerfile", filepath.ToSlash(filepath.Join(artifact.ContextSubPath, artifact.DockerfilePath)),
 	}
 
 	if context != "" {

--- a/pkg/skaffold/build/kaniko/args_test.go
+++ b/pkg/skaffold/build/kaniko/args_test.go
@@ -34,7 +34,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "simple build",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 			},
 			expectedArgs: []string{},
 			wantErr:      false,
@@ -42,7 +42,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with BuildArgs",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				BuildArgs: map[string]*string{
 					"arg1": util.StringPtr("value1"),
 					"arg2": nil,
@@ -57,7 +57,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with Cache",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				Cache:          &latest.KanikoCache{},
 			},
 			expectedArgs: []string{
@@ -68,7 +68,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with Cache Options",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				Cache: &latest.KanikoCache{
 					Repo:     "gcr.io/ngnix",
 					HostPath: "/cache",
@@ -86,7 +86,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with Cleanup",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				Cleanup:        true,
 			},
 			expectedArgs: []string{
@@ -97,7 +97,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with DigestFile",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				DigestFile:     "/tmp/digest",
 			},
 			expectedArgs: []string{
@@ -108,7 +108,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with Force",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				Force:          true,
 			},
 			expectedArgs: []string{
@@ -119,7 +119,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with ImageNameWithDigestFile",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath:          "Dockerfile",
+				DockerfilePath:          "dir/Dockerfile",
 				ImageNameWithDigestFile: "/tmp/imageName",
 			},
 			expectedArgs: []string{
@@ -130,7 +130,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with Insecure",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				Insecure:       true,
 			},
 			expectedArgs: []string{
@@ -141,7 +141,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with InsecurePull",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				InsecurePull:   true,
 			},
 			expectedArgs: []string{
@@ -152,7 +152,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with InsecureRegistry",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				InsecureRegistry: []string{
 					"s1.registry.url:5000",
 					"s2.registry.url:5000",
@@ -167,7 +167,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with LogFormat",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				LogFormat:      "json",
 			},
 			expectedArgs: []string{
@@ -178,7 +178,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with LogTimestamp",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				LogTimestamp:   true,
 			},
 			expectedArgs: []string{
@@ -189,7 +189,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with NoPush",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				NoPush:         true,
 			},
 			expectedArgs: []string{
@@ -200,7 +200,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with OCILayoutPath",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				OCILayoutPath:  "/tmp/builtImage",
 			},
 			expectedArgs: []string{
@@ -211,7 +211,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with RegistryCertificate",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				RegistryCertificate: map[string]*string{
 					"s1.registry.url": util.StringPtr("/etc/certs/certificate1.cert"),
 					"s2.registry.url": util.StringPtr("/etc/certs/certificate2.cert"),
@@ -226,7 +226,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with RegistryMirror",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				RegistryMirror: "mirror.gcr.io",
 			},
 			expectedArgs: []string{
@@ -237,7 +237,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with Reproducible",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				Reproducible:   true,
 			},
 			expectedArgs: []string{
@@ -248,7 +248,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with SingleSnapshot",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				SingleSnapshot: true,
 			},
 			expectedArgs: []string{
@@ -259,7 +259,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with SkipTLS",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				SkipTLS:        true,
 			},
 			expectedArgs: []string{
@@ -271,7 +271,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with SkipTLSVerifyPull",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath:    "Dockerfile",
+				DockerfilePath:    "dir/Dockerfile",
 				SkipTLSVerifyPull: true,
 			},
 			expectedArgs: []string{
@@ -282,7 +282,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with SkipTLSVerifyRegistry",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				SkipTLSVerifyRegistry: []string{
 					"s1.registry.url:443",
 					"s2.registry.url:443",
@@ -297,7 +297,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with SkipUnusedStages",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath:   "Dockerfile",
+				DockerfilePath:   "dir/Dockerfile",
 				SkipUnusedStages: true,
 			},
 			expectedArgs: []string{
@@ -308,7 +308,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with Target",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				Target:         "builder",
 			},
 			expectedArgs: []string{
@@ -319,7 +319,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with SnapshotMode",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				SnapshotMode:   "redo",
 			},
 			expectedArgs: []string{
@@ -330,7 +330,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with TarPath",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				TarPath:        "/workspace/tars",
 			},
 			expectedArgs: []string{
@@ -341,7 +341,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with UseNewRun",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				UseNewRun:      true,
 			},
 			expectedArgs: []string{
@@ -352,7 +352,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with Verbosity",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath: "Dockerfile",
+				DockerfilePath: "dir/Dockerfile",
 				Verbosity:      "trace",
 			},
 			expectedArgs: []string{
@@ -363,7 +363,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with WhitelistVarRun",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath:  "Dockerfile",
+				DockerfilePath:  "dir/Dockerfile",
 				WhitelistVarRun: true,
 			},
 			expectedArgs: []string{
@@ -374,7 +374,7 @@ func TestArgs(t *testing.T) {
 		{
 			description: "with WhitelistVarRun",
 			artifact: &latest.KanikoArtifact{
-				DockerfilePath:  "Dockerfile",
+				DockerfilePath:  "dir/Dockerfile",
 				WhitelistVarRun: true,
 			},
 			expectedArgs: []string{
@@ -383,9 +383,18 @@ func TestArgs(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			description: "with Labels",
+			description: "with ContextSubPath",
 			artifact: &latest.KanikoArtifact{
 				DockerfilePath: "Dockerfile",
+				ContextSubPath: "dir/",
+			},
+			expectedArgs: []string{},
+			wantErr:      false,
+		},
+		{
+			description: "with Labels",
+			artifact: &latest.KanikoArtifact{
+				DockerfilePath: "dir/Dockerfile",
 				Label: map[string]*string{
 					"label1": util.StringPtr("value1"),
 					"label2": nil,
@@ -401,7 +410,7 @@ func TestArgs(t *testing.T) {
 
 	defaultExpectedArgs := []string{
 		"--destination", "gcr.io/nginx",
-		"--dockerfile", "Dockerfile",
+		"--dockerfile", "dir/Dockerfile",
 		"--context", fmt.Sprintf("dir://%s", DefaultEmptyDirMountPath),
 	}
 

--- a/pkg/skaffold/build/kaniko/utils.go
+++ b/pkg/skaffold/build/kaniko/utils.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2022 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kaniko
+
+import (
+	"path/filepath"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+)
+
+// GetContext returns the context containing context sub path
+func GetContext(artifact *latest.KanikoArtifact, context string) string {
+	return filepath.Join(context, artifact.ContextSubPath)
+}

--- a/pkg/skaffold/build/kaniko/utils_test.go
+++ b/pkg/skaffold/build/kaniko/utils_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2022 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kaniko
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestGetContext(t *testing.T) {
+	tests := []struct {
+		description string
+		context     string
+		artifact    *latest.KanikoArtifact
+		expected    string
+	}{
+		{
+			description: "with ContextSubPath",
+			context:     "dir/",
+			artifact: &latest.KanikoArtifact{
+				ContextSubPath: "sub/",
+			},
+			expected: filepath.FromSlash("dir/sub"),
+		},
+		{
+			description: "without ContextSubPath",
+			context:     "dir/",
+			artifact:    &latest.KanikoArtifact{},
+			expected:    filepath.FromSlash("dir"),
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			got := GetContext(test.artifact, test.context)
+			t.CheckDeepEqual(got, test.expected)
+		})
+	}
+}

--- a/pkg/skaffold/docker/build_args.go
+++ b/pkg/skaffold/docker/build_args.go
@@ -65,7 +65,6 @@ func evalBuildArgs(mode config.RunMode, workspace string, dockerfilePath string,
 	for k, v := range extra {
 		result[k] = v
 	}
-
 	absDockerfilePath, err := NormalizeDockerfilePath(workspace, dockerfilePath)
 	if err != nil {
 		return nil, fmt.Errorf("normalizing dockerfile path: %w", err)

--- a/pkg/skaffold/graph/dependencies.go
+++ b/pkg/skaffold/graph/dependencies.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/buildpacks"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/custom"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/jib"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/kaniko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/ko"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/build/misc"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
@@ -126,11 +127,11 @@ func sourceDependenciesForArtifact(ctx context.Context, a *latest.Artifact, cfg 
 
 	case a.KanikoArtifact != nil:
 		deps := docker.ResolveDependencyImages(a.Dependencies, r, false)
-		args, evalErr := docker.EvalBuildArgs(cfg.Mode(), a.Workspace, a.KanikoArtifact.DockerfilePath, a.KanikoArtifact.BuildArgs, deps)
+		args, evalErr := docker.EvalBuildArgs(cfg.Mode(), kaniko.GetContext(a.KanikoArtifact, a.Workspace), a.KanikoArtifact.DockerfilePath, a.KanikoArtifact.BuildArgs, deps)
 		if evalErr != nil {
 			return nil, fmt.Errorf("unable to evaluate build args: %w", evalErr)
 		}
-		paths, err = docker.GetDependencies(ctx, docker.NewBuildConfig(a.Workspace, a.ImageName, a.KanikoArtifact.DockerfilePath, args), cfg)
+		paths, err = docker.GetDependencies(ctx, docker.NewBuildConfig(kaniko.GetContext(a.KanikoArtifact, a.Workspace), a.ImageName, a.KanikoArtifact.DockerfilePath, args), cfg)
 
 	case a.BazelArtifact != nil:
 		paths, err = bazel.GetDependencies(ctx, a.Workspace, a.BazelArtifact)

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -1279,6 +1279,9 @@ type KanikoArtifact struct {
 
 	// VolumeMounts are volume mounts passed to kaniko pod.
 	VolumeMounts []v1.VolumeMount `yaml:"volumeMounts,omitempty"`
+
+	// ContextSubPath is to specify a sub path within the context.
+	ContextSubPath string `yaml:"contextSubPath,omitempty" skaffold:"filepath"`
 }
 
 // DockerArtifact describes an artifact built from a Dockerfile,


### PR DESCRIPTION
Fixes: #7302 

**Description**
Support the `contextSubPath` param in the Kaniko Artifact.

**Implementation Strategy**

Before I implement this feature, I was going to add `--context-sub-path` param in Kaniko executor.
But when creating `tar` file, the file path of the dependencies turns relative path from context.

https://github.com/GoogleContainerTools/skaffold/blob/8ff6917f61f08795b1ed6a84010190521d63e0cd/pkg/skaffold/util/tar.go#L139

By the above effect, the dependencies is decompressed in Kaniko root context as `dir:///kaniko/buildcontext`.

For example,

* dir structure
```
environments/my-api/app/
├── docker
│   └── Dockerfile
└── skaffold.yaml
my-api/
└── src/ (source code for my-api)
```

* skaffold.yaml
```
apiVersion: skaffold/v3alpha1
kind: Config
metadata:
  name: my-api
build:
  artifacts:
    - image: my-registory/my-api
      context: ../../../
      kaniko:
        dockerfile: ../environments/my-api/app/docker/Dockerfile
        contextSubPath: my-api/
...
```

* dir structure in Kaniko executor pod after decompressing `tar` of dependencies.
```
# ls /kaniko/buildcontext
src/
environments/
```

In case of this example if I add `--context-sub-path my-api/` to Kaniko executor it fails to find context because `my-api/` dir doesn't exist in `/kaniko/buildcontext`.

So I implemented this feature by combining `contextSubPath` and `dockerfile` path like following.

* pkg/skaffold/build/kaniko/args.go
```
"--dockerfile", filepath.Join(artifact.ContextSubPath, artifact.DockerfilePath),
```

Please review and thanks a lot in advance.
