### PR TITLE
release: v1.37.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+# v1.37.2 Release - 04/29/2022
+**Linux amd64**
+`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.37.2/skaffold-linux-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
+
+**Linux arm64**
+`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.37.2/skaffold-linux-arm64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
+
+**macOS amd64**
+`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.37.2/skaffold-darwin-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
+
+**macOS arm64**
+`curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.37.2/skaffold-darwin-arm64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`
+
+**Windows**
+https://storage.googleapis.com/skaffold/releases/v1.37.2/skaffold-windows-amd64.exe
+
+**Docker image**
+`gcr.io/k8s-skaffold/skaffold:v1.37.2`
+
+Fixes:
+* fix: cloud build cannot find private workerpool issue [#7356](https://github.com/GoogleContainerTools/skaffold/pull/7356)
+* fix: properly update 'label' field for helm + render w/ -l flag [#7349](https://github.com/GoogleContainerTools/skaffold/pull/7349)
+
 # v1.38.0 Release - 04/06/2022
 **Linux amd64**
 `curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/v1.38.0/skaffold-linux-amd64 && chmod +x skaffold && sudo mv skaffold /usr/local/bin`


### PR DESCRIPTION
release v1.37.2

v1.37.2 binaries are already released, this PR just is just them to the CHANGELOG.md.  Once this is merged I will update the release page

You can see all tests for v1.37.2 are passing here - https://github.com/GoogleContainerTools/skaffold/pull/7358