### PR TITLE
ci: reenable `TestRunTail` integration test

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -178,8 +178,6 @@ func TestRun(t *testing.T) {
 }
 
 func TestRunTail(t *testing.T) {
-	// TODO: Fix https://github.com/GoogleContainerTools/skaffold/issues/7287
-	t.Skipf("fix https://github.com/GoogleContainerTools/skaffold/issues/7287")
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes: https://github.com/GoogleContainerTools/skaffold/issues/7287

**Description**
Reenable `TestRunTail`, which has been fixed on main