### PR TITLE
chore: include `fs/assets/check.txt` in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ docs/themes
 docs/package-lock.json
 pkg/skaffold/output/debug.test
 fs/assets/*_generated
+fs/assets/check.txt
 secrets/keys.json


### PR DESCRIPTION
**Description**
This PR simple includes a file that shows up when building skaffold in the gitignore, since we don't want to check in this file. 
