### PR TITLE
fix: use http://json-schema.org/draft-07/schema# in JSONSchema v7 as value for $schema key

### DIFF
--- a/docs-v2/content/en/schemas/v1.json
+++ b/docs-v2/content/en/schemas/v1.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1alpha1.json
+++ b/docs-v2/content/en/schemas/v1alpha1.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1alpha2.json
+++ b/docs-v2/content/en/schemas/v1alpha2.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "type": "object",

--- a/docs-v2/content/en/schemas/v1alpha3.json
+++ b/docs-v2/content/en/schemas/v1alpha3.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "type": "object",

--- a/docs-v2/content/en/schemas/v1alpha4.json
+++ b/docs-v2/content/en/schemas/v1alpha4.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "type": "object",

--- a/docs-v2/content/en/schemas/v1alpha5.json
+++ b/docs-v2/content/en/schemas/v1alpha5.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "type": "object",

--- a/docs-v2/content/en/schemas/v1beta1.json
+++ b/docs-v2/content/en/schemas/v1beta1.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "type": "object",

--- a/docs-v2/content/en/schemas/v1beta10.json
+++ b/docs-v2/content/en/schemas/v1beta10.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1beta11.json
+++ b/docs-v2/content/en/schemas/v1beta11.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1beta12.json
+++ b/docs-v2/content/en/schemas/v1beta12.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1beta13.json
+++ b/docs-v2/content/en/schemas/v1beta13.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1beta14.json
+++ b/docs-v2/content/en/schemas/v1beta14.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1beta15.json
+++ b/docs-v2/content/en/schemas/v1beta15.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1beta16.json
+++ b/docs-v2/content/en/schemas/v1beta16.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1beta17.json
+++ b/docs-v2/content/en/schemas/v1beta17.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1beta2.json
+++ b/docs-v2/content/en/schemas/v1beta2.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "type": "object",

--- a/docs-v2/content/en/schemas/v1beta3.json
+++ b/docs-v2/content/en/schemas/v1beta3.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "type": "object",

--- a/docs-v2/content/en/schemas/v1beta4.json
+++ b/docs-v2/content/en/schemas/v1beta4.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1beta5.json
+++ b/docs-v2/content/en/schemas/v1beta5.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1beta6.json
+++ b/docs-v2/content/en/schemas/v1beta6.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1beta7.json
+++ b/docs-v2/content/en/schemas/v1beta7.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1beta8.json
+++ b/docs-v2/content/en/schemas/v1beta8.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v1beta9.json
+++ b/docs-v2/content/en/schemas/v1beta9.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2alpha1.json
+++ b/docs-v2/content/en/schemas/v2alpha1.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2alpha2.json
+++ b/docs-v2/content/en/schemas/v2alpha2.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2alpha3.json
+++ b/docs-v2/content/en/schemas/v2alpha3.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2alpha4.json
+++ b/docs-v2/content/en/schemas/v2alpha4.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta1.json
+++ b/docs-v2/content/en/schemas/v2beta1.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta10.json
+++ b/docs-v2/content/en/schemas/v2beta10.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta11.json
+++ b/docs-v2/content/en/schemas/v2beta11.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta12.json
+++ b/docs-v2/content/en/schemas/v2beta12.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta13.json
+++ b/docs-v2/content/en/schemas/v2beta13.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta14.json
+++ b/docs-v2/content/en/schemas/v2beta14.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta15.json
+++ b/docs-v2/content/en/schemas/v2beta15.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta16.json
+++ b/docs-v2/content/en/schemas/v2beta16.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta17.json
+++ b/docs-v2/content/en/schemas/v2beta17.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta18.json
+++ b/docs-v2/content/en/schemas/v2beta18.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta19.json
+++ b/docs-v2/content/en/schemas/v2beta19.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta2.json
+++ b/docs-v2/content/en/schemas/v2beta2.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta20.json
+++ b/docs-v2/content/en/schemas/v2beta20.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta21.json
+++ b/docs-v2/content/en/schemas/v2beta21.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta22.json
+++ b/docs-v2/content/en/schemas/v2beta22.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta23.json
+++ b/docs-v2/content/en/schemas/v2beta23.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta24.json
+++ b/docs-v2/content/en/schemas/v2beta24.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta25.json
+++ b/docs-v2/content/en/schemas/v2beta25.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta26.json
+++ b/docs-v2/content/en/schemas/v2beta26.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta27.json
+++ b/docs-v2/content/en/schemas/v2beta27.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta28.json
+++ b/docs-v2/content/en/schemas/v2beta28.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta3.json
+++ b/docs-v2/content/en/schemas/v2beta3.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta4.json
+++ b/docs-v2/content/en/schemas/v2beta4.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta5.json
+++ b/docs-v2/content/en/schemas/v2beta5.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta6.json
+++ b/docs-v2/content/en/schemas/v2beta6.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta7.json
+++ b/docs-v2/content/en/schemas/v2beta7.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta8.json
+++ b/docs-v2/content/en/schemas/v2beta8.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs-v2/content/en/schemas/v2beta9.json
+++ b/docs-v2/content/en/schemas/v2beta9.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1.json
+++ b/docs/content/en/schemas/v1.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1alpha1.json
+++ b/docs/content/en/schemas/v1alpha1.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "properties": {

--- a/docs/content/en/schemas/v1alpha2.json
+++ b/docs/content/en/schemas/v1alpha2.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "type": "object",

--- a/docs/content/en/schemas/v1alpha3.json
+++ b/docs/content/en/schemas/v1alpha3.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "type": "object",

--- a/docs/content/en/schemas/v1alpha4.json
+++ b/docs/content/en/schemas/v1alpha4.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "type": "object",

--- a/docs/content/en/schemas/v1alpha5.json
+++ b/docs/content/en/schemas/v1alpha5.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "type": "object",

--- a/docs/content/en/schemas/v1beta1.json
+++ b/docs/content/en/schemas/v1beta1.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "type": "object",

--- a/docs/content/en/schemas/v1beta10.json
+++ b/docs/content/en/schemas/v1beta10.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1beta11.json
+++ b/docs/content/en/schemas/v1beta11.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1beta12.json
+++ b/docs/content/en/schemas/v1beta12.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1beta13.json
+++ b/docs/content/en/schemas/v1beta13.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1beta14.json
+++ b/docs/content/en/schemas/v1beta14.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1beta15.json
+++ b/docs/content/en/schemas/v1beta15.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1beta16.json
+++ b/docs/content/en/schemas/v1beta16.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1beta17.json
+++ b/docs/content/en/schemas/v1beta17.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1beta2.json
+++ b/docs/content/en/schemas/v1beta2.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "type": "object",

--- a/docs/content/en/schemas/v1beta3.json
+++ b/docs/content/en/schemas/v1beta3.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Artifact": {
       "type": "object",

--- a/docs/content/en/schemas/v1beta4.json
+++ b/docs/content/en/schemas/v1beta4.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1beta5.json
+++ b/docs/content/en/schemas/v1beta5.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1beta6.json
+++ b/docs/content/en/schemas/v1beta6.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1beta7.json
+++ b/docs/content/en/schemas/v1beta7.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1beta8.json
+++ b/docs/content/en/schemas/v1beta8.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v1beta9.json
+++ b/docs/content/en/schemas/v1beta9.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2alpha1.json
+++ b/docs/content/en/schemas/v2alpha1.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2alpha2.json
+++ b/docs/content/en/schemas/v2alpha2.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2alpha3.json
+++ b/docs/content/en/schemas/v2alpha3.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2alpha4.json
+++ b/docs/content/en/schemas/v2alpha4.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta1.json
+++ b/docs/content/en/schemas/v2beta1.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta10.json
+++ b/docs/content/en/schemas/v2beta10.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta11.json
+++ b/docs/content/en/schemas/v2beta11.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta12.json
+++ b/docs/content/en/schemas/v2beta12.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta13.json
+++ b/docs/content/en/schemas/v2beta13.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta14.json
+++ b/docs/content/en/schemas/v2beta14.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta15.json
+++ b/docs/content/en/schemas/v2beta15.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta16.json
+++ b/docs/content/en/schemas/v2beta16.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta17.json
+++ b/docs/content/en/schemas/v2beta17.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta18.json
+++ b/docs/content/en/schemas/v2beta18.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta19.json
+++ b/docs/content/en/schemas/v2beta19.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta2.json
+++ b/docs/content/en/schemas/v2beta2.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta20.json
+++ b/docs/content/en/schemas/v2beta20.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta21.json
+++ b/docs/content/en/schemas/v2beta21.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta22.json
+++ b/docs/content/en/schemas/v2beta22.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta23.json
+++ b/docs/content/en/schemas/v2beta23.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta24.json
+++ b/docs/content/en/schemas/v2beta24.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta25.json
+++ b/docs/content/en/schemas/v2beta25.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta26.json
+++ b/docs/content/en/schemas/v2beta26.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta27.json
+++ b/docs/content/en/schemas/v2beta27.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta28.json
+++ b/docs/content/en/schemas/v2beta28.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta3.json
+++ b/docs/content/en/schemas/v2beta3.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta4.json
+++ b/docs/content/en/schemas/v2beta4.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta5.json
+++ b/docs/content/en/schemas/v2beta5.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta6.json
+++ b/docs/content/en/schemas/v2beta6.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta7.json
+++ b/docs/content/en/schemas/v2beta7.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta8.json
+++ b/docs/content/en/schemas/v2beta8.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/docs/content/en/schemas/v2beta9.json
+++ b/docs/content/en/schemas/v2beta9.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/SkaffoldConfig"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "Activation": {
       "properties": {

--- a/hack/schemas/main.go
+++ b/hack/schemas/main.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	version7  = "http://json-schema-org/draft-07/schema#"
+	version7  = "http://json-schema.org/draft-07/schema#"
 	defPrefix = "#/definitions/"
 )
 

--- a/hack/schemas/testdata/inline-anyof/output.json
+++ b/hack/schemas/testdata/inline-anyof/output.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/TestStruct"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "TestStruct": {
       "required": [

--- a/hack/schemas/testdata/inline-hybrid/output.json
+++ b/hack/schemas/testdata/inline-hybrid/output.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/TestStruct"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "TestStruct": {
       "required": [

--- a/hack/schemas/testdata/inline-skiptrim/output.json
+++ b/hack/schemas/testdata/inline-skiptrim/output.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/TestStruct"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "AnotherTestStruct": {
       "properties": {

--- a/hack/schemas/testdata/inline/output.json
+++ b/hack/schemas/testdata/inline/output.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/TestStruct"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "TestStruct": {
       "required": [

--- a/hack/schemas/testdata/integer/output.json
+++ b/hack/schemas/testdata/integer/output.json
@@ -5,7 +5,7 @@
       "$ref": "#/definitions/TestStruct"
     }
   ],
-  "$schema": "http://json-schema-org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "TestStruct": {
       "properties": {


### PR DESCRIPTION
skaffold json schemas were using a non-standard value for the $schema field, resulting in issues with ajv. 

<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7298 
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
I made a project wide search and replace for `http://json-schema-org/draft-07/schema#` and replaced it with `http://json-schema.org/draft-07/schema#`. 

**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
<!-- "Before" and "After" sections work great - bonus points for screenshots! -->
<!-- Be sure all docs have been updated as well! -->

**Follow-up Work (remove if N/A)**
<!-- Mention any related follow up work to this PR. -->


<!--
Please be sure your PR includes unit tests - we don't merge code that brings down test coverage! 
Integration tests are sometimes an appropriate substitute. 
-->
