### PR TITLE
fix: update pkg/webhook to support previewing v2 docs site from github label

### DIFF
--- a/deploy/docs-v2/cloudbuild-release.yaml
+++ b/deploy/docs-v2/cloudbuild-release.yaml
@@ -6,22 +6,22 @@ steps:
   args:
   - '-c'
   - |
-    docker pull gcr.io/$PROJECT_ID/docs-controller:latest || exit 0
+    docker pull gcr.io/$PROJECT_ID/docs-controller-v2:latest || exit 0
   # until https://github.com/GoogleCloudPlatform/cloud-builders/issues/253 is fixed
 
-# Build and push latest version of the docs-controller image
+# Build and push latest version of the docs-controller-v2 image
 - name: gcr.io/cloud-builders/docker
   args:
   - 'build'
   - '-t'
-  - 'gcr.io/$PROJECT_ID/docs-controller:latest'
+  - 'gcr.io/$PROJECT_ID/docs-controller-v2:latest'
   - '--cache-from'
-  - 'gcr.io/$PROJECT_ID/docs-controller:latest'
+  - 'gcr.io/$PROJECT_ID/docs-controller-v2:latest'
   - '--target'
   - 'runtime_deps'
   - 'deploy/webhook-v2'
 
-- name: gcr.io/$PROJECT_ID/docs-controller:latest
+- name: gcr.io/$PROJECT_ID/docs-controller-v2:latest
   env:
     - 'HUGO_ENV=production'
   args:
@@ -31,5 +31,5 @@ steps:
     deploy/docs-v2/build.sh https://skaffold-v2.firebaseapp.com && cd docs-v2 && firebase deploy --only hosting:release --project $PROJECT_ID
 
 images: [
-  'gcr.io/$PROJECT_ID/docs-controller:latest'
+  'gcr.io/$PROJECT_ID/docs-controller-v2:latest'
 ]

--- a/deploy/docs-v2/cloudbuild.yaml
+++ b/deploy/docs-v2/cloudbuild.yaml
@@ -1,27 +1,27 @@
 steps:
 
-# Download the latest version of the docs-controller image
+# Download the latest version of the docs-controller-v2 image
 - name: gcr.io/cloud-builders/docker
   entrypoint: 'bash'
   args:
   - '-c'
   - |
-    docker pull gcr.io/$PROJECT_ID/docs-controller:latest || exit 0
+    docker pull gcr.io/$PROJECT_ID/docs-controller-v2:latest || exit 0
   # until https://github.com/GoogleCloudPlatform/cloud-builders/issues/253 is fixed
 
-# Build and push latest version of the docs-controller image
+# Build and push latest version of the docs-controller-v2 image
 - name: gcr.io/cloud-builders/docker
   args:
   - 'build'
   - '-t'
-  - 'gcr.io/$PROJECT_ID/docs-controller:latest'
+  - 'gcr.io/$PROJECT_ID/docs-controller-v2:latest'
   - '--cache-from'
-  - 'gcr.io/$PROJECT_ID/docs-controller:latest'
+  - 'gcr.io/$PROJECT_ID/docs-controller-v2:latest'
   - '--target'
   - 'runtime_deps'
   - 'deploy/webhook-v2'
 
-- name: gcr.io/$PROJECT_ID/docs-controller:latest
+- name: gcr.io/$PROJECT_ID/docs-controller-v2:latest
   env:
     - 'HUGO_ENV=production'
   args:
@@ -31,4 +31,4 @@ steps:
     deploy/docs-v2/build.sh https://skaffold-v2-latest.firebaseapp.com && cd docs-v2 && firebase deploy --only hosting:head --project $PROJECT_ID
 
 images:
-- 'gcr.io/$PROJECT_ID/docs-controller:latest'
+- 'gcr.io/$PROJECT_ID/docs-controller-v2:latest'

--- a/deploy/webhook-v2/Dockerfile
+++ b/deploy/webhook-v2/Dockerfile
@@ -49,7 +49,8 @@ COPY --from=download-kubectl /kubectl /usr/local/bin/
 FROM golang:1.17 as webhook
 WORKDIR /skaffold
 COPY . .
-RUN go build -o /webhook webhook/webhook.go
+# TODO(aaron-prindle) pass ldflags for -v2
+RUN go build -o /webhook -ldflags="-X 'github.com/GoogleContainerTools/skaffold/pkg/webhook/constants.DocsVersion=-v2'" webhook/webhook.go
 
 FROM runtime_deps
 COPY --from=webhook /webhook /webhook

--- a/deploy/webhook-v2/cloudbuild.yaml
+++ b/deploy/webhook-v2/cloudbuild.yaml
@@ -1,11 +1,11 @@
 steps:
-# Download the latest version of the docs-controller image
+# Download the latest version of the docs-controller-v2 image
 - name: gcr.io/cloud-builders/docker
   entrypoint: 'bash'
   args:
     - '-c'
     - |
-      docker pull gcr.io/$PROJECT_ID/docs-controller:latest || exit 0
+      docker pull gcr.io/$PROJECT_ID/docs-controller-v2:latest || exit 0
   # until https://github.com/GoogleCloudPlatform/cloud-builders/issues/253 is fixed
 
   # Get cluster credentials

--- a/deploy/webhook-v2/deployment.yaml
+++ b/deploy/webhook-v2/deployment.yaml
@@ -20,7 +20,7 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: docs-controller
+  name: docs-controller-v2
   labels:
     run: docs
 spec:
@@ -34,8 +34,8 @@ spec:
     spec:
       serviceAccountName: admin-serviceaccount
       containers:
-      - name: docs-controller
-        image: gcr.io/k8s-skaffold/docs-controller:latest
+      - name: docs-controller-v2
+        image: gcr.io/k8s-skaffold/docs-controller-v2:latest
         args: ["/webhook"]
         volumeMounts:
         - name: webhook

--- a/deploy/webhook-v2/skaffold.yaml
+++ b/deploy/webhook-v2/skaffold.yaml
@@ -2,11 +2,11 @@ apiVersion: skaffold/v1alpha5
 kind: Config
 build:
     artifacts:
-    - image: gcr.io/k8s-skaffold/docs-controller
+    - image: gcr.io/k8s-skaffold/docs-controller-v2
       docker:
         dockerfile: deploy/webhook-v2/Dockerfile
         cacheFrom:
-          - gcr.io/k8s-skaffold/docs-controller
+          - gcr.io/k8s-skaffold/docs-controller-v2
 deploy:
   kubectl:
     manifests:

--- a/pkg/webhook/constants/constants.go
+++ b/pkg/webhook/constants/constants.go
@@ -16,6 +16,15 @@ limitations under the License.
 
 package constants
 
+import "fmt"
+
+// DocsVersion defines the version of the docs currently ""(for v1) and "-v2"(for v2)
+// This variable is injected at build time based on what version of the controller is being built
+var DocsVersion string
+
+// DocsLabel kicks off the controller when added to a PR
+var DocsLabel = fmt.Sprintf("docs-modifications%s", DocsVersion)
+
 const (
 	// GithubAccessToken is the env variable auth for container-tools-bot is stored in
 	GithubAccessToken = "GITHUB_ACCESS_TOKEN"
@@ -34,9 +43,6 @@ const (
 	ClosedAction = "closed"
 	// when a PR is labeled
 	LabeledAction = "labeled"
-
-	// DocsLabel kicks off the controller when added to a PR
-	DocsLabel = "docs-modifications"
 
 	// Namespace is the namespace deployments and services will be created in
 	Namespace = "default"

--- a/pkg/webhook/kubernetes/deployment.go
+++ b/pkg/webhook/kubernetes/deployment.go
@@ -93,7 +93,7 @@ func CreateDeployment(pr *github.PullRequestEvent, svc *v1.Service, externalIP s
 						{
 							Name:       "server",
 							Image:      constants.DeploymentImage,
-							Args:       []string{"deploy/docs/preview.sh", BaseURL(externalIP)},
+							Args:       []string{fmt.Sprintf("deploy/docs%s/preview.sh", constants.DocsVersion), BaseURL(externalIP)},
 							WorkingDir: repoPath,
 							VolumeMounts: []v1.VolumeMount{
 								{

--- a/webhook/webhook.go
+++ b/webhook/webhook.go
@@ -42,7 +42,7 @@ func main() {
 	http.HandleFunc("/receive", handleGithubEvent)
 	flag.Parse()
 	// Start the server
-	log.Println("Listening...")
+	log.Printf("Listening%s...\n", constants.DocsVersion)
 	log.Fatal(http.ListenAndServe(port, nil))
 }
 


### PR DESCRIPTION
Initially I ported over the webhook to a  new cluster `docs-v2` but the webhook did not actually generate a preview site for the v2 docs and was still designed for v1.  This PR updates the webhook-v2 container and cluster to work for a new label `docs-modifications-v2` and generate a preview for v2 docs