### PR TITLE
chore: add caching for tests

### DIFF
--- a/integration/skaffold/helper.go
+++ b/integration/skaffold/helper.go
@@ -346,6 +346,7 @@ func (b *RunBuilder) cmd(ctx context.Context) *exec.Cmd {
 	if value, found := os.LookupEnv("SKAFFOLD_BINARY"); found {
 		skaffoldBinary = value
 	}
+	b.env = append(b.env, "SKAFFOLD_INT_TEST=true")
 	cmd := exec.CommandContext(ctx, skaffoldBinary, args...)
 	cmd.Env = append(removeSkaffoldEnvVariables(util.OSEnviron()), b.env...)
 	if b.stdin != nil {

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"os"
 	"strings"
 	"time"
 
@@ -113,6 +114,7 @@ var RunModes = struct {
 	Render   RunMode
 	Delete   RunMode
 	Diagnose RunMode
+	IntTest  RunMode
 }{
 	Build:    "build",
 	Dev:      "dev",
@@ -122,6 +124,7 @@ var RunModes = struct {
 	Render:   "render",
 	Delete:   "delete",
 	Diagnose: "diagnose",
+	IntTest:  "testing",
 }
 
 // Prune returns true iff the user did NOT specify the --no-prune flag,
@@ -131,6 +134,9 @@ func (opts *SkaffoldOptions) Prune() bool {
 }
 
 func (opts *SkaffoldOptions) Mode() RunMode {
+	if _, ok := os.LookupEnv("SKAFFOLD_INT_TEST"); ok {
+		return RunModes.IntTest
+	}
 	return RunMode(opts.Command)
 }
 


### PR DESCRIPTION
All our integration tests first run `skaffold build` to fail fast and then run the command to be tested. 

Before including run mode (some time before #4893) in the artifact hash,  the artifact hash for skaffold build and skaffold dev were same. 
The tests could rely on the built image from the previous build command. 
There was reason for adding RunModes in the artifact hash. 

I am adding a new RunMode `testing` which can be used in the testing. This will reduce the test times and subsequent skaffold commands will use the built artifact from the previous skaffold built.

Time reduced : [16 mins](https://github.com/GoogleContainerTools/skaffold/actions/workflows/integration-linux.yml?query=actor%3AMarlonGamez) to  < 9 min(https://github.com/GoogleContainerTools/skaffold/runs/6415058294?check_suite_focus=true)