### PR TITLE
fix: change error to warning for build platform mismatch with cluster node platform

### DIFF
--- a/pkg/skaffold/platform/resolver.go
+++ b/pkg/skaffold/platform/resolver.go
@@ -84,7 +84,7 @@ func NewResolver(ctx context.Context, pipelines []latest.Pipeline, cliPlatformsS
 			} else if p := platforms.Intersect(fromClusterNodes); p.IsNotEmpty() {
 				platforms = p
 			} else {
-				return r, fmt.Errorf("build target platforms %q do not match active kubernetes cluster node platforms %q", platforms, fromClusterNodes)
+				log.Entry(ctx).Warnf("build target platforms %q do not match active kubernetes cluster node platforms %q", platforms, fromClusterNodes)
 			}
 		}
 		instrumentation.AddResolvedBuildTargetPlatforms(platforms.String())

--- a/pkg/skaffold/platform/resolver_test.go
+++ b/pkg/skaffold/platform/resolver_test.go
@@ -67,8 +67,11 @@ func TestResolver(t *testing.T) {
 			pipelines: []latest.Pipeline{{Build: latest.BuildConfig{
 				Platforms: []string{"windows/amd64"},
 				Artifacts: []*latest.Artifact{{ImageName: "img1"}, {ImageName: "img2"}}}}},
-			runMode:   config.RunModes.Dev,
-			shouldErr: true,
+			runMode: config.RunModes.Dev,
+			expected: map[string]Matcher{
+				"img1": {Platforms: []v1.Platform{{OS: "linux", Architecture: "amd64"}, {OS: "linux", Architecture: "386"}}},
+				"img2": {Platforms: []v1.Platform{{OS: "linux", Architecture: "amd64"}, {OS: "linux", Architecture: "386"}}},
+			},
 		},
 		{
 			description:      "cluster platform selected for `dev` mode",


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7355 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
`minikube` and `docker-desktop` on Apple M1 report their cluster node types as `linux/arm64` but they can run `linux/amd64` images using qemu binfmt_misc extensions. So we change this error condition to a warning message instead.
**User facing changes (remove if N/A)**
<!-- Describe any user facing changes this PR introduces. -->
Users can force build for specific platforms using `--platform` flag even if it doesn't match the kubernetes cluster node types.

**Follow up Work**

Cherrypick this to `v1` branch before v1.39.0 release.