### PR TITLE
fix: integration/sync_file tests

### DIFF
--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -55,8 +55,6 @@ var syncTests = []struct {
 }
 
 func TestDevSync(t *testing.T) {
-	// TODO: This test shall pass once render v2 is completed.
-	t.SkipNow()
 
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 
@@ -84,8 +82,6 @@ func TestDevSync(t *testing.T) {
 }
 
 func TestDevSyncDefaultNamespace(t *testing.T) {
-	// TODO: fix https://github.com/GoogleContainerTools/skaffold/issues/7286
-	t.Skipf("Fix https://github.com/GoogleContainerTools/skaffold/issues/7286")
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 
 	for _, test := range syncTests {
@@ -113,8 +109,6 @@ func TestDevSyncDefaultNamespace(t *testing.T) {
 }
 
 func TestDevAutoSync(t *testing.T) {
-	// TODO: This test shall pass once render v2 is completed.
-	t.SkipNow()
 
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -55,7 +55,6 @@ var syncTests = []struct {
 }
 
 func TestDevSync(t *testing.T) {
-
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 
 	for _, test := range syncTests {
@@ -109,7 +108,6 @@ func TestDevSyncDefaultNamespace(t *testing.T) {
 }
 
 func TestDevAutoSync(t *testing.T) {
-
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 
 	dir := "examples/jib-sync/"

--- a/integration/testdata/file-sync/skaffold-infer.yaml
+++ b/integration/testdata/file-sync/skaffold-infer.yaml
@@ -10,5 +10,5 @@ build:
       infer:
       - '**/foo*'
 manifests:
-  rarYaml:
+  rawYaml:
     - pod.yaml

--- a/integration/testdata/file-sync/skaffold-infer.yaml
+++ b/integration/testdata/file-sync/skaffold-infer.yaml
@@ -9,7 +9,6 @@ build:
     sync:
       infer:
       - '**/foo*'
-deploy:
- kubectl:
-   manifests:
-   - pod.yaml
+manifests:
+  rarYaml:
+    - pod.yaml

--- a/integration/testdata/file-sync/skaffold-manual.yaml
+++ b/integration/testdata/file-sync/skaffold-manual.yaml
@@ -10,7 +10,6 @@ build:
       manual:
       - src: '**/foo*'
         dest: /
-deploy:
- kubectl:
-   manifests:
+manifests:
+  rarYaml:
    - pod.yaml

--- a/integration/testdata/file-sync/skaffold-manual.yaml
+++ b/integration/testdata/file-sync/skaffold-manual.yaml
@@ -11,5 +11,5 @@ build:
       - src: '**/foo*'
         dest: /
 manifests:
-  rarYaml:
+  rawYaml:
    - pod.yaml


### PR DESCRIPTION
Fixes: #7286 


**Description**
 - update integration/testdata/sync_file skaffold.yaml to use the new style for manifests to fix sync_file tests
 - remove skip statements for tests in sync_file test



**Follow-up Work (remove if N/A)**
 - update all skaffold.yaml files in testdata to use the new style for manifests. 



