### PR TITLE
feat: Add region configuration for gcb

### DIFF
--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -268,6 +268,11 @@ func TestRunGCPOnly(t *testing.T) {
 			pods:        []string{"getting-started"},
 		},
 		{
+			description: "Google Cloud Build with location",
+			dir:         "testdata/gcb-with-location",
+			pods:        []string{"getting-started"},
+		},
+		{
 			description: "Google Cloud Build with source artifact dependencies",
 			dir:         "examples/microservices",
 			args:        []string{"-p", "gcb"},

--- a/integration/testdata/gcp-with-location/Dockerfile
+++ b/integration/testdata/gcp-with-location/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.18 as builder
+WORKDIR /code
+COPY main.go .
+COPY go.mod .
+# `skaffold debug` sets SKAFFOLD_GO_GCFLAGS to disable compiler optimizations
+ARG SKAFFOLD_GO_GCFLAGS
+RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -trimpath -o /app main.go
+
+FROM alpine:3
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+CMD ["./app"]
+COPY --from=builder /app .

--- a/integration/testdata/gcp-with-location/README.md
+++ b/integration/testdata/gcp-with-location/README.md
@@ -1,0 +1,9 @@
+### Example: Getting started with a simple go app
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleContainerTools/skaffold&cloudshell_open_in_editor=README.md&cloudshell_workspace=examples/google-cloud-build)
+
+This is a simple example based on:
+
+* **building** a single Go file app and with a multistage `Dockerfile` using Google Cloud Build
+* **tagging** using the default tagPolicy (`gitCommit`)
+* **deploying** a single container pod using `kubectl`

--- a/integration/testdata/gcp-with-location/go.mod
+++ b/integration/testdata/gcp-with-location/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleContainerTools/skaffold/examples/google-cloud-build
+
+go 1.18

--- a/integration/testdata/gcp-with-location/k8s-pod.yaml
+++ b/integration/testdata/gcp-with-location/k8s-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+  - name: getting-started
+    image: skaffold-example-with-location

--- a/integration/testdata/gcp-with-location/main.go
+++ b/integration/testdata/gcp-with-location/main.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/integration/testdata/gcp-with-location/skaffold.yaml
+++ b/integration/testdata/gcp-with-location/skaffold.yaml
@@ -1,0 +1,12 @@
+apiVersion: skaffold/v3alpha1
+kind: Config
+build:
+  googleCloudBuild:
+    projectId: k8s-skaffold
+    region: asia-east1
+  artifacts:
+  - image: gcr.io/k8s-skaffold/skaffold-example-with-location
+deploy:
+  kubectl:
+    manifests:
+      - k8s-*

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -394,6 +394,7 @@ type GoogleCloudBuild struct {
 	// Region configures the region to run the build. If WorkerPool is configured, the region will
 	// be deduced from the WorkerPool configuration. If neither WorkerPool nor Region is configured,
 	// the build will be run in global(non-regional).
+	// See [Cloud Build locations](https://cloud.google.com/build/docs/locations)
 	Region string `yaml:"region,omitempty"`
 }
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -393,7 +393,7 @@ type GoogleCloudBuild struct {
 
 	// Region configures the region to run the build. If WorkerPool is configured, the region will
 	// be deduced from the WorkerPool configuration. If neither WorkerPool nor Region is configured,
-	// the build will be run in global(non-region).
+	// the build will be run in global(non-regional).
 	Region string `yaml:"region,omitempty"`
 }
 

--- a/pkg/skaffold/schema/latest/config.go
+++ b/pkg/skaffold/schema/latest/config.go
@@ -390,6 +390,11 @@ type GoogleCloudBuild struct {
 
 	// WorkerPool configures a pool of workers to run the build.
 	WorkerPool string `yaml:"workerPool,omitempty"`
+
+	// Region configures the region to run the build. If WorkerPool is configured, the region will
+	// be deduced from the WorkerPool configuration. If neither WorkerPool nor Region is configured,
+	// the build will be run in global(non-region).
+	Region string `yaml:"region,omitempty"`
 }
 
 // KanikoCache configures Kaniko caching. If a cache is specified, Kaniko will


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7342

**Description**
 - add region configuration in googleCouldBuild
 - implement change to support configure the region, if workerPool is configured, build location is still deduced from workerPool. If not and region is configured, region in the configuration will be used as build location. 

**User facing changes (remove if N/A)**
 -  Add region configuration for gcb, so users are able to configure region to run gcb

**Follow-up Work (remove if N/A)**
may need to cherry-pick this change on v1

**Test Plan**
 use the following configuration to run ``skaffold build``

```yaml
apiVersion: skaffold/v3alpha1
kind: Config
build:
  googleCloudBuild:
    # Change `ericz-skaffold` with your PROJECT_ID
    projectId: ericz-skaffold
   # Change us-central1 to where you want to run the build
    region: us-central1
  artifacts:
  # Your artifact registry
  - image: us-west2-docker.pkg.dev/ericz-skaffold/quickstart-docker-repo/skaffold-example
deploy:
  kubectl:
    manifests:
      - k8s-*
```

check google cloud build console, and selected the region configured in skaffold.yaml, should see the build in the histroy. 

