### PR TITLE
fix: correct render output;  render func parameters

### DIFF
--- a/cmd/skaffold/app/cmd/deploy.go
+++ b/cmd/skaffold/app/cmd/deploy.go
@@ -56,7 +56,7 @@ func doDeploy(ctx context.Context, out io.Writer) error {
 			return err
 		}
 		// Render
-		manifests, errR := r.Render(ctx, out, buildArtifacts, true, opts.RenderOutput)
+		manifests, errR := r.Render(ctx, out, buildArtifacts, true)
 		if errR != nil {
 			return errR
 		}

--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -75,11 +75,10 @@ func doRender(ctx context.Context, out io.Writer) error {
 			}
 		}
 
-		manifests, errR := r.Render(ctx, out, bRes, offline, opts.RenderOutput)
-		if errR != nil {
-			return fmt.Errorf("rendering manifests: %w", errR)
+		manifests, err := r.Render(ctx, out, bRes, offline)
+		if err != nil {
+			return fmt.Errorf("rendering manifests: %w", err)
 		}
-		manifest.Write(manifests.String(), opts.RenderOutput, out)
-		return nil
+		return manifest.Write(manifests.String(), opts.RenderOutput, out)
 	})
 }

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -55,7 +55,7 @@ func doRun(ctx context.Context, out io.Writer) error {
 		}
 
 		// Render
-		manifestList, err := r.Render(ctx, out, bRes, true, opts.RenderOutput)
+		manifestList, err := r.Render(ctx, out, bRes, true)
 		if err != nil {
 			return err
 		}

--- a/cmd/skaffold/app/cmd/run_test.go
+++ b/cmd/skaffold/app/cmd/run_test.go
@@ -78,7 +78,7 @@ func (r *mockRunRunner) DeployAndLog(context.Context, io.Writer, []graph.Artifac
 	return nil
 }
 
-func (r *mockRunRunner) Render(context.Context, io.Writer, []graph.Artifact, bool, string) (manifest.ManifestList, error) {
+func (r *mockRunRunner) Render(context.Context, io.Writer, []graph.Artifact, bool) (manifest.ManifestList, error) {
 	r.renderRan = true
 	return manifest.ManifestList{}, nil
 }

--- a/integration/examples/getting-started/artifacts.json
+++ b/integration/examples/getting-started/artifacts.json
@@ -1,1 +1,0 @@
-{"builds":null}

--- a/integration/examples/getting-started/images.json
+++ b/integration/examples/getting-started/images.json
@@ -1,1 +1,0 @@
-{"builds":null}

--- a/integration/examples/getting-started/skaffold.yaml
+++ b/integration/examples/getting-started/skaffold.yaml
@@ -5,4 +5,4 @@ build:
   - image: skaffold-example
 manifests:
   rawYaml:
-  - k8s-*
+  - k8s-pod.yaml

--- a/integration/render_test.go
+++ b/integration/render_test.go
@@ -43,7 +43,6 @@ func TestKubectlRenderOutput(t *testing.T) {
 	test := struct {
 		description string
 		builds      []graph.Artifact
-		renderPath  string
 		input       string
 		expectedOut string
 	}{
@@ -54,7 +53,6 @@ func TestKubectlRenderOutput(t *testing.T) {
 				Tag:       "gcr.io/k8s-skaffold/skaffold:test",
 			},
 		},
-		renderPath: "./test-output",
 		input: `apiVersion: v1
 kind: Pod
 spec:
@@ -81,7 +79,7 @@ spec:
 		r, err := kubectl.New(mockCfg, rc, map[string]string{})
 		t.RequireNoError(err)
 		var b bytes.Buffer
-		l, err := r.Render(context.Background(), &b, test.builds, false, test.renderPath)
+		l, err := r.Render(context.Background(), &b, test.builds, false)
 
 		t.CheckNoError(err)
 
@@ -220,7 +218,7 @@ spec:
 			r, err := kubectl.New(mockCfg, rc, map[string]string{})
 			t.RequireNoError(err)
 			var b bytes.Buffer
-			l, err := r.Render(context.Background(), &b, test.builds, false, "")
+			l, err := r.Render(context.Background(), &b, test.builds, false)
 
 			t.CheckNoError(err)
 			t.CheckDeepEqual(test.expectedOut, l.String())

--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -250,7 +250,7 @@ func TestKubectlV1RenderDeploy(t *testing.T) {
 			t.CheckNoError(err)
 			var b bytes.Buffer
 			m, errR := r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}},
-				true, "")
+				true)
 			t.CheckNoError(errR)
 			err = k.Deploy(context.Background(), ioutil.Discard, test.builds, m)
 
@@ -341,7 +341,7 @@ func TestKubectlCleanup(t *testing.T) {
 			t.CheckNoError(err)
 			var b bytes.Buffer
 			m, errR := r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}},
-				true, "")
+				true)
 			t.CheckNoError(errR)
 
 			err = k.Cleanup(context.Background(), ioutil.Discard, test.dryRun, m)
@@ -638,7 +638,7 @@ func TestGCSManifests(t *testing.T) {
 			t.CheckNoError(err)
 			var b bytes.Buffer
 			m, errR := r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}},
-				true, "")
+				true)
 			t.CheckNoError(errR)
 
 			k, err := NewDeployer(&kubectlConfig{

--- a/pkg/skaffold/render/renderer/kpt/kpt.go
+++ b/pkg/skaffold/render/renderer/kpt/kpt.go
@@ -97,7 +97,7 @@ func New(cfg render.Config, rCfg latest.RenderConfig, hydrationDir string, label
 	}, nil
 }
 
-func (r *Kpt) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, _ bool, output string) (manifest.ManifestList, error) {
+func (r *Kpt) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, _ bool) (manifest.ManifestList, error) {
 	kptfilePath := filepath.Join(r.hydrationDir, kptfile.KptFileName)
 	kfConfig := &kptfile.KptFile{}
 
@@ -153,7 +153,7 @@ func (r *Kpt) Render(ctx context.Context, out io.Writer, builds []graph.Artifact
 	if err := os.MkdirAll(r.hydrationDir, os.ModePerm); err != nil {
 		return nil, err
 	}
-	if err := manifest.Write(manifests.String(), dryConfigPath, out); err != nil {
+	if err := manifest.Write(manifests.String(), dryConfigPath, io.Discard); err != nil {
 		return nil, err
 	}
 	endTrace()
@@ -183,15 +183,12 @@ func (r *Kpt) Render(ctx context.Context, out io.Writer, builds []graph.Artifact
 		// TODO(yuwenma): How to guide users when they face kpt error (may due to bad user config)?
 		return nil, err
 	}
-
-	if output != "" {
-		r.writeManifestsToFile(ctx, out, output)
-	}
-	return manifests, nil
+	return r.unwrapManifests(ctx, out)
 }
 
-// writeManifestsToFile converts the structured manifest to a flatten format and store them in the given `output` file.
-func (r *Kpt) writeManifestsToFile(ctx context.Context, out io.Writer, output string) error {
+// unwrapManifests converts the structured manifest to a flatten format
+func (r *Kpt) unwrapManifests(ctx context.Context, out io.Writer) (manifest.ManifestList, error) {
+	var m manifest.ManifestList
 	rCtx, endTrace := instrumentation.StartTrace(ctx, "Render_outputManifests")
 	cmd := exec.CommandContext(rCtx, "kpt", "fn", "source", r.hydrationDir, "-o", "unwrap")
 	var buf []byte
@@ -199,7 +196,8 @@ func (r *Kpt) writeManifestsToFile(ctx context.Context, out io.Writer, output st
 	buf, err := util.RunCmdOut(ctx, cmd)
 	if err != nil {
 		endTrace(instrumentation.TraceEndError(err))
-		return err
+		return m, err
 	}
-	return ioutil.WriteFile(output, buf, os.ModePerm)
+	m = append(m, buf)
+	return m, nil
 }

--- a/pkg/skaffold/render/renderer/kpt/kpt_test.go
+++ b/pkg/skaffold/render/renderer/kpt/kpt_test.go
@@ -177,7 +177,9 @@ pipeline:
 			t.CheckNoError(err)
 			t.Override(&util.DefaultExecCommand,
 				testutil.CmdRun(fmt.Sprintf("kpt fn render %v",
-					filepath.Join(tmpDirObj.Root(), ".kpt-pipeline"))))
+					filepath.Join(tmpDirObj.Root(), ".kpt-pipeline"))).
+					AndRunOut(fmt.Sprintf("kpt fn source %v -o unwrap",
+						filepath.Join(tmpDirObj.Root(), ".kpt-pipeline")), ""))
 			var b bytes.Buffer
 			_, err = r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}},
 				true)
@@ -246,7 +248,9 @@ inventory:
 			t.CheckNoError(err)
 			t.Override(&util.DefaultExecCommand,
 				testutil.CmdRun(fmt.Sprintf("kpt fn render %v",
-					filepath.Join(tmpDirObj.Root(), ".kpt-pipeline"))))
+					filepath.Join(tmpDirObj.Root(), ".kpt-pipeline"))).
+					AndRunOut(fmt.Sprintf("kpt fn source %v -o unwrap",
+						filepath.Join(tmpDirObj.Root(), ".kpt-pipeline")), ""))
 			var b bytes.Buffer
 			_, err = r.Render(context.Background(), &b, []graph.Artifact{},
 				true)

--- a/pkg/skaffold/render/renderer/kpt/kpt_test.go
+++ b/pkg/skaffold/render/renderer/kpt/kpt_test.go
@@ -180,7 +180,7 @@ pipeline:
 					filepath.Join(tmpDirObj.Root(), ".kpt-pipeline"))))
 			var b bytes.Buffer
 			_, err = r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}},
-				true, "")
+				true)
 			t.CheckNoError(err)
 			t.CheckFileExistAndContent(filepath.Join(tmpDirObj.Root(), constants.DefaultHydrationDir, DryFileName), []byte(labeledPodYaml))
 			t.CheckFileExistAndContent(filepath.Join(tmpDirObj.Root(), constants.DefaultHydrationDir, kptfile.KptFileName), []byte(test.updatedKptfile))
@@ -249,7 +249,7 @@ inventory:
 					filepath.Join(tmpDirObj.Root(), ".kpt-pipeline"))))
 			var b bytes.Buffer
 			_, err = r.Render(context.Background(), &b, []graph.Artifact{},
-				true, "")
+				true)
 			t.CheckNoError(err)
 			t.CheckFileExistAndContent(filepath.Join(tmpDirObj.Root(), constants.DefaultHydrationDir, kptfile.KptFileName),
 				[]byte(test.updatedKptfile))

--- a/pkg/skaffold/render/renderer/kubectl/kubectl.go
+++ b/pkg/skaffold/render/renderer/kubectl/kubectl.go
@@ -55,7 +55,7 @@ func New(cfg render.Config, rCfg latest.RenderConfig, labels map[string]string) 
 	}, nil
 }
 
-func (r Kubectl) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, _ bool, _ string) (manifest.ManifestList, error) {
+func (r Kubectl) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, _ bool) (manifest.ManifestList, error) {
 	_, endTrace := instrumentation.StartTrace(ctx, "Render_KubectlManifests")
 	log.Entry(ctx).Infof("rendering using kubectl")
 	instrumentation.AddAttributesToCurrentSpanFromContext(ctx, map[string]string{

--- a/pkg/skaffold/render/renderer/kubectl/kubectl_test.go
+++ b/pkg/skaffold/render/renderer/kubectl/kubectl_test.go
@@ -91,7 +91,7 @@ func TestRender(t *testing.T) {
 			t.CheckNoError(err)
 			var b bytes.Buffer
 			manifestList, errR := r.Render(context.Background(), &b, []graph.Artifact{{ImageName: "leeroy-web", Tag: "leeroy-web:v1"}},
-				true, "")
+				true)
 			t.CheckNoError(errR)
 			t.CheckDeepEqual(test.expected, manifestList.String())
 		})

--- a/pkg/skaffold/render/renderer/noop/noop.go
+++ b/pkg/skaffold/render/renderer/noop/noop.go
@@ -34,7 +34,7 @@ func New(_ latest.RenderConfig, _, _ string, _ map[string]string) (Noop, error) 
 	return Noop{}, nil
 }
 
-func (r Noop) Render(_ context.Context, _ io.Writer, _ []graph.Artifact, _ bool, _ string) (manifest.ManifestList, error) {
+func (r Noop) Render(_ context.Context, _ io.Writer, _ []graph.Artifact, _ bool) (manifest.ManifestList, error) {
 	return manifest.ManifestList{}, nil
 }
 

--- a/pkg/skaffold/render/renderer/render_mux.go
+++ b/pkg/skaffold/render/renderer/render_mux.go
@@ -41,13 +41,13 @@ func NewRenderMux(renderers []Renderer) Renderer {
 	return RenderMux{renderers: renderers}
 }
 
-func (r RenderMux) Render(ctx context.Context, out io.Writer, artifacts []graph.Artifact, offline bool, outputPath string) (manifest.ManifestList, error) {
+func (r RenderMux) Render(ctx context.Context, out io.Writer, artifacts []graph.Artifact, offline bool) (manifest.ManifestList, error) {
 	allManifests := manifest.ManifestList{}
 	for i, renderer := range r.renderers {
 		eventV2.RendererInProgress(i)
 		w, ctx := output.WithEventContext(ctx, out, constants.Render, strconv.Itoa(i))
 		ctx, endTrace := instrumentation.StartTrace(ctx, "Render")
-		ms, err := renderer.Render(ctx, w, artifacts, offline, "" /* never write to files */)
+		ms, err := renderer.Render(ctx, w, artifacts, offline)
 		if err != nil {
 			eventV2.RendererFailed(i, err)
 			endTrace(instrumentation.TraceEndError(err))

--- a/pkg/skaffold/render/renderer/render_mux_test.go
+++ b/pkg/skaffold/render/renderer/render_mux_test.go
@@ -74,7 +74,7 @@ func TestRenderMux_Render(t *testing.T) {
 				}}})
 			mux := NewRenderMux(tc.renderers)
 			buf := &bytes.Buffer{}
-			actual, err := mux.Render(context.Background(), buf, nil, true, "")
+			actual, err := mux.Render(context.Background(), buf, nil, true)
 			t.CheckErrorAndDeepEqual(tc.shouldErr, err, tc.expected, actual.String())
 			actualDeps, errD := mux.ManifestDeps()
 			t.CheckNoError(errD)
@@ -93,7 +93,7 @@ func (m mock) ManifestDeps() ([]string, error) {
 	return m.deps, nil
 }
 
-func (m mock) Render(context.Context, io.Writer, []graph.Artifact, bool, string) (manifest.ManifestList, error) {
+func (m mock) Render(context.Context, io.Writer, []graph.Artifact, bool) (manifest.ManifestList, error) {
 	if m.shouldErr {
 		return nil, fmt.Errorf("render error")
 	}

--- a/pkg/skaffold/render/renderer/renderer.go
+++ b/pkg/skaffold/render/renderer/renderer.go
@@ -31,7 +31,7 @@ import (
 )
 
 type Renderer interface {
-	Render(ctx context.Context, out io.Writer, artifacts []graph.Artifact, offline bool, output string) (manifest.ManifestList, error)
+	Render(ctx context.Context, out io.Writer, artifacts []graph.Artifact, offline bool) (manifest.ManifestList, error)
 	// ManifestDeps returns the user kubernetes manifests to file watcher. In dev mode, a "redeploy" will be triggered
 	// if any of the "Dependencies" manifest is changed.
 	ManifestDeps() ([]string, error)

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -45,8 +45,7 @@ type Runner interface {
 	HasDeployed() bool
 	Prune(context.Context, io.Writer) error
 
-	// "output" arg is only used in Render v1.
-	Render(ctx context.Context, out io.Writer, builds []graph.Artifact, offline bool, output string) (manifest.ManifestList, error)
+	Render(ctx context.Context, out io.Writer, builds []graph.Artifact, offline bool) (manifest.ManifestList, error)
 	Test(context.Context, io.Writer, []graph.Artifact) error
 	Verify(context.Context, io.Writer, []graph.Artifact) error
 	VerifyAndLog(context.Context, io.Writer, []graph.Artifact) error

--- a/pkg/skaffold/runner/timings.go
+++ b/pkg/skaffold/runner/timings.go
@@ -83,11 +83,11 @@ func (w withTimings) Test(ctx context.Context, out io.Writer, builds []graph.Art
 	return nil
 }
 
-func (w withTimings) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, offline bool, filepath string) (manifest.ManifestList, error) {
+func (w withTimings) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, offline bool) (manifest.ManifestList, error) {
 	start := time.Now()
 	log.Entry(ctx).Infoln("Starting render...")
 
-	manifestsLists, err := w.Renderer.Render(ctx, out, builds, offline, filepath)
+	manifestsLists, err := w.Renderer.Render(ctx, out, builds, offline)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/skaffold/runner/timings_test.go
+++ b/pkg/skaffold/runner/timings_test.go
@@ -74,7 +74,7 @@ type mockRenderer struct {
 	err bool
 }
 
-func (m *mockRenderer) Render(context.Context, io.Writer, []graph.Artifact, bool, string) (manifest.ManifestList, error) {
+func (m *mockRenderer) Render(context.Context, io.Writer, []graph.Artifact, bool) (manifest.ManifestList, error) {
 	if m.err {
 		return nil, errors.New("Unable to render")
 	}
@@ -246,7 +246,7 @@ func TestTimingsRender(t *testing.T) {
 			_, _, render, _ := WithTimings(nil, nil, r, nil, false)
 
 			var out bytes.Buffer
-			_, err := render.Render(context.Background(), &out, nil, false, "")
+			_, err := render.Render(context.Background(), &out, nil, false)
 
 			t.CheckError(test.shouldErr, err)
 			t.CheckMatches(test.shouldOutput, out.String())

--- a/pkg/skaffold/runner/v2/dev.go
+++ b/pkg/skaffold/runner/v2/dev.go
@@ -178,7 +178,7 @@ func (r *SkaffoldRunner) doDev(ctx context.Context, out io.Writer) error {
 		if !meterUpdated {
 			instrumentation.AddDevIteration("deploy")
 		}
-		manifests, err := r.Render(childCtx, out, r.Builds, false, "")
+		manifests, err := r.Render(childCtx, out, r.Builds, false)
 		if err != nil {
 			log.Entry(ctx).Warn("Skipping render due to error:", err)
 			event.DevLoopFailedInPhase(r.devIteration, constants.Render, err)
@@ -347,7 +347,7 @@ func (r *SkaffoldRunner) Dev(ctx context.Context, out io.Writer, artifacts []*la
 	r.deployer.GetLogger().SetSince(time.Now())
 
 	// First render
-	manifests, err := r.Render(ctx, out, r.Builds, true, "")
+	manifests, err := r.Render(ctx, out, r.Builds, true)
 	if err != nil {
 		event.DevLoopFailedInPhase(r.devIteration, constants.Render, err)
 		eventV2.TaskFailed(constants.DevLoop, err)

--- a/pkg/skaffold/runner/v2/render.go
+++ b/pkg/skaffold/runner/v2/render.go
@@ -29,7 +29,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output"
 )
 
-func (r *SkaffoldRunner) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, offline bool, renderOutputFile string) (manifest.ManifestList, error) {
+func (r *SkaffoldRunner) Render(ctx context.Context, out io.Writer, builds []graph.Artifact, offline bool) (manifest.ManifestList, error) {
 	if r.runCtx.RenderOnly() {
 		// Fetch the digest and append it to the tag with the format of "tag@digest"
 		if r.runCtx.DigestSource() == constants.RemoteDigestSource {
@@ -48,11 +48,12 @@ func (r *SkaffoldRunner) Render(ctx context.Context, out io.Writer, builds []gra
 	}
 
 	ctx, endTrace := instrumentation.StartTrace(ctx, "Render")
-	manifestList, errR := r.renderer.Render(ctx, out, builds, offline, renderOutputFile)
-	if errR != nil {
-		endTrace(instrumentation.TraceEndError(errR))
-		return nil, errR
+	manifestList, err := r.renderer.Render(ctx, out, builds, offline)
+	if err != nil {
+		endTrace(instrumentation.TraceEndError(err))
+		return nil, err
 	}
+
 	endTrace()
 	return manifestList, nil
 }

--- a/pkg/skaffold/runner/v2/runner_test.go
+++ b/pkg/skaffold/runner/v2/runner_test.go
@@ -215,7 +215,7 @@ func (t *TestBench) Deploy(_ context.Context, _ io.Writer, artifacts []graph.Art
 	return nil
 }
 
-func (t *TestBench) Render(_ context.Context, _ io.Writer, artifacts []graph.Artifact, _ bool, _ string) (manifest.ManifestList, error) {
+func (t *TestBench) Render(_ context.Context, _ io.Writer, artifacts []graph.Artifact, _ bool) (manifest.ManifestList, error) {
 	if len(t.renderErrors) > 0 {
 		err := t.renderErrors[0]
 		t.renderErrors = t.renderErrors[1:]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7413, #7103 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This PR comprehensively fixes render phase output generation. It removes `filepath` as a function parameter to the various render package functions.