### PR TITLE
fix: render v2 for multi-config projects

### DIFF
--- a/cmd/skaffold/app/cmd/runner.go
+++ b/cmd/skaffold/app/cmd/runner.go
@@ -83,6 +83,7 @@ func runContext(ctx context.Context, out io.Writer, opts config.SkaffoldOptions)
 	if err != nil {
 		return nil, nil, err
 	}
+	setDefaultRendererAndDeployer(cfgSet)
 
 	if err := validation.Process(cfgSet, validation.GetValidationOpts(opts)); err != nil {
 		return nil, nil, fmt.Errorf("invalid skaffold config: %w", err)
@@ -148,4 +149,14 @@ func warnIfUpdateIsAvailable() {
 	if warning != "" {
 		log.Entry(context.TODO()).Warn(warning)
 	}
+}
+
+func setDefaultRendererAndDeployer(configs parser.SkaffoldConfigSet) {
+	// do not set a default deployer or renderer in a multi-config application.
+	if len(configs) > 1 {
+		return
+	}
+	// there always exists at least one config
+	defaults.SetDefaultRenderer(configs[0].SkaffoldConfig)
+	defaults.SetDefaultDeployer(configs[0].SkaffoldConfig)
 }

--- a/integration/examples/multi-config-microservices/leeroy-app/skaffold.yaml
+++ b/integration/examples/multi-config-microservices/leeroy-app/skaffold.yaml
@@ -13,6 +13,8 @@ build:
 manifests:
   rawYaml:
     - kubernetes/*
+deploy:
+  kubectl: {}
 portForward:
 - resourceType: deployment
   resourceName: leeroy-app

--- a/integration/examples/multi-config-microservices/leeroy-web/skaffold.yaml
+++ b/integration/examples/multi-config-microservices/leeroy-web/skaffold.yaml
@@ -13,6 +13,8 @@ build:
 manifests:
   rawYaml:
     - kubernetes/*
+deploy:
+  kubectl: {}
 portForward:
 - resourceType: deployment
   resourceName: leeroy-web

--- a/integration/examples/multi-config-microservices/leeroy-web/skaffold.yaml
+++ b/integration/examples/multi-config-microservices/leeroy-web/skaffold.yaml
@@ -11,8 +11,8 @@ build:
     - image: base
       alias: BASE
 manifests:
-    rawYaml:
-      - kubernetes/*
+  rawYaml:
+    - kubernetes/*
 portForward:
 - resourceType: deployment
   resourceName: leeroy-web

--- a/integration/testdata/modules/app1/skaffold.yaml
+++ b/integration/testdata/modules/app1/skaffold.yaml
@@ -19,3 +19,6 @@ build:
 manifests:
   rawYaml:
   - 'k8s.yaml'
+
+deploy:
+  kubectl: {}

--- a/integration/testdata/modules/app2/skaffold.yaml
+++ b/integration/testdata/modules/app2/skaffold.yaml
@@ -20,3 +20,6 @@ build:
 manifests:
   rawYaml:
   - 'k8s.yaml'
+
+deploy:
+  kubectl: {}

--- a/integration/testdata/modules/app3/skaffold.yaml
+++ b/integration/testdata/modules/app3/skaffold.yaml
@@ -15,3 +15,6 @@ build:
 manifests:
   rawYaml:
   - 'k8s.yaml'
+
+deploy:
+  kubectl: {}

--- a/pkg/skaffold/schema/defaults/defaults.go
+++ b/pkg/skaffold/schema/defaults/defaults.go
@@ -108,8 +108,6 @@ func Set(c *latest.SkaffoldConfig) error {
 	}
 
 	setDefaultTestWorkspace(c)
-	SetDefaultRenderer(c)
-	SetDefaultDeployer(c)
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7417 <!-- tracking issues that this PR will close -->

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->

[This](https://github.com/GoogleContainerTools/skaffold/blob/a345baba07b8be6c0c021194a1186338cd6d4d67/cmd/skaffold/app/cmd/runner.go#L86) behavior exists on `v1` branch and was lost on merging `v2`. It ensures that we create the default renderer and deployer only for single config skaffold.yaml files, as was the behavior with `v1`.