### PR TITLE
fix: running skaffold from a directory other than repository root

### DIFF
--- a/pkg/skaffold/build/bazel/build.go
+++ b/pkg/skaffold/build/bazel/build.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/docker"
@@ -84,7 +85,7 @@ func (b *Builder) buildTar(ctx context.Context, out io.Writer, workspace string,
 		return "", fmt.Errorf("getting bazel tar path: %w", err)
 	}
 
-	return tarPath, nil
+	return filepath.Join(workspace, tarPath), nil
 }
 
 func (b *Builder) loadImage(ctx context.Context, out io.Writer, tarPath string, a *latest.BazelArtifact, tag string) (string, error) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7281
**Related**: #7251

**Description**

1. The `bazel cquery` runs in the directory corresponding to the context and returns the tar path relative to that path. 
2. The `docker.Push()` function is invoked with the same working directory as the current working directory of the process.

Prior to #7251, the path returned by `bazel cquery` was appended with an absolute path returned by `bazel info bazel-bin`, so it ended up being an absolute path. With #7251 merged, this no longer happens, so `docker.Push()` receives a relative path returned by `bazel cquery`.

If `skaffold build` is executed in a directory different from the repository root, `docker.Push()` will receive a relative path against the repository root and won't find the file.

Take the following example. There is a `skaffold.yaml` file in `projects/acme/some-project`:
```yaml
apiVersion: skaffold/v2beta26
kind: Config
build:
  artifacts:
  - image: quay.io/acme/some-project
    context: ../../..
...
```
If one does:
```
cd projects/acme/some-projects && skaffold build
```
It will no longer work. It will fail with an error like:
> build [quay.io/acme/some-project] failed: reading image "bazel-out/darwin-fastbuild-ST-4a519fd6d3e4/bin/projects/some-project/docker.tar": open bazel-out/darwin-fastbuild-ST-4a519fd6d3e4/bin/projects/some-project/docker.tar: no such file or directory

This error may be confusing because the path does exist relative to the repository root. It does not exist relative to the current working directory though.