### PR TITLE
chore: fix integration/test_debug/helm test

### DIFF
--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -63,12 +63,12 @@ func TestDebug(t *testing.T) {
 			deployments: []string{"java"},
 			pods:        []string{"nodejs", "npm" /*, "python3"*/, "go" /*, "netcore"*/},
 		},
-		//  {
-		//	description:   "helm",
-		//	dir:           "examples/helm-deployment",
-		//	deployments:   []string{"skaffold-helm"},
-		//	ignoreWorkdir: true, // dockerfile doesn't have a workdir
-		// }, fix in https://github.com/GoogleContainerTools/skaffold/issues/7419
+		{
+			description:   "helm",
+			dir:           "examples/helm-deployment",
+			deployments:   []string{"skaffold-helm"},
+			ignoreWorkdir: true, // dockerfile doesn't have a workdir
+		},
 		{
 			description:   "modules",
 			dir:           "examples/multi-config-microservices",

--- a/integration/skaffold/helper.go
+++ b/integration/skaffold/helper.go
@@ -346,7 +346,6 @@ func (b *RunBuilder) cmd(ctx context.Context) *exec.Cmd {
 	if value, found := os.LookupEnv("SKAFFOLD_BINARY"); found {
 		skaffoldBinary = value
 	}
-	b.env = append(b.env, "SKAFFOLD_INT_TEST=true")
 	cmd := exec.CommandContext(ctx, skaffoldBinary, args...)
 	cmd.Env = append(removeSkaffoldEnvVariables(util.OSEnviron()), b.env...)
 	if b.stdin != nil {

--- a/pkg/skaffold/config/options.go
+++ b/pkg/skaffold/config/options.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"os"
 	"strings"
 	"time"
 
@@ -114,7 +113,6 @@ var RunModes = struct {
 	Render   RunMode
 	Delete   RunMode
 	Diagnose RunMode
-	IntTest  RunMode
 }{
 	Build:    "build",
 	Dev:      "dev",
@@ -124,7 +122,6 @@ var RunModes = struct {
 	Render:   "render",
 	Delete:   "delete",
 	Diagnose: "diagnose",
-	IntTest:  "testing",
 }
 
 // Prune returns true iff the user did NOT specify the --no-prune flag,
@@ -134,9 +131,6 @@ func (opts *SkaffoldOptions) Prune() bool {
 }
 
 func (opts *SkaffoldOptions) Mode() RunMode {
-	if _, ok := os.LookupEnv("SKAFFOLD_INT_TEST"); ok {
-		return RunModes.IntTest
-	}
 	return RunMode(opts.Command)
 }
 


### PR DESCRIPTION
Fixes: #7419 

**Related** 
 - #7397 introduced testing mode which causes integration test_debug helm test failure 
 - we had a discussion about adding testing mode in #7401 , but the conclusion was not to add testing mode, not sure #7497 added testing mode on purpose, if it's accidentally added then we can remove it and this pr is not necessary. 


**Description**
 -  The test failed due to running with testing run mode while helm deployer relies on debug RunMode to determine if it adds --debugging filter
 - this change add a flag to bypass testing mode in integration test

