### PR TITLE
feat: add warning message when no pods are matched for an image doing sync

### DIFF
--- a/pkg/skaffold/sync/sync.go
+++ b/pkg/skaffold/sync/sync.go
@@ -351,6 +351,7 @@ func Perform(ctx context.Context, image string, files syncMap, cmdFn func(contex
 	}
 
 	if numSynced == 0 {
+		log.Entry(ctx).Warnf("sync failed for artifact %q", image)
 		return errors.New("didn't sync any files")
 	}
 	return nil


### PR DESCRIPTION
Fixes: #7240

**Follow-up Work**
- With this change, the warning message could appear multiple times in one dev loop, for a single file. [This issue](https://github.com/GoogleContainerTools/skaffold/issues/7447) was created to follow-up on the work needed to check that behavior.