### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,11 @@
-# Global owners
-
-* @GoogleContainerTools/skaffold-team
-
 # JIB owners
-
 **/**jib** @GoogleContainerTools/skaffold-team @chanseokoh
 
 # kpt owners
 pkg/skaffold/deploy/**kpt** @GoogleContainerTools/skaffold-team @yuwenma
 
 # Debug owners
-
-pkg/skaffold/debug/** @GoogleContainerTools/skaffold-team @quoctruong
-docs/content/en/docs/how-tos/debug/** @GoogleContainerTools/skaffold-team @quoctruong
-integration/test-data/debug/** @GoogleContainerTools/skaffold-team @quoctruong
-integration/debug_test.go @GoogleContainerTools/skaffold-team @quoctruong
+pkg/skaffold/debug/** @GoogleContainerTools/skaffold-team
+docs/content/en/docs/how-tos/debug/** @GoogleContainerTools/skaffold-team
+integration/test-data/debug/** @GoogleContainerTools/skaffold-team
+integration/debug_test.go @GoogleContainerTools/skaffold-team


### PR DESCRIPTION
Update with recent team changes.  I don't think we need a global owner since `skaffold-team` already owns this code.  I *think* that should address `skaffold-team` being requested on all reviews and let us benefit from GitHub's round-robin assignments.