### PR TITLE
WIP: feat: allow use of URL manifests

### DIFF
--- a/pkg/skaffold/kubernetes/manifest/url.go
+++ b/pkg/skaffold/kubernetes/manifest/url.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifest
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+// DownloadFromURL downloads the provided manifests from their URLs,
+// and returns a relative path pointing to the URL temp dir.
+func DownloadFromURL(manifests []string) (string, error) {
+	if err := os.MkdirAll(ManifestTmpDir, os.ModePerm); err != nil {
+		return "", fmt.Errorf("failed to create the tmp directory: %w", err)
+	}
+	for _, manifest := range manifests {
+		if manifest == "" || !util.IsURL(manifest) {
+			return "", fmt.Errorf("%v is not a valid URL", manifest)
+		}
+		resp, err := http.Get(manifest)
+		if err != nil {
+			return "", fmt.Errorf("failed to download manifest fom URL: %w", err)
+		}
+		defer resp.Body.Close()
+		// TODO discuss about file names and deletion
+		// fileName := path.Base(manifest)
+
+		// destinationPath := path.Join(ManifestTmpDir, fileName)
+		// f, err := os.Create(destinationPath)
+		f, err := os.CreateTemp(ManifestTmpDir, "url-manifest-")
+		if err != nil {
+			return "", fmt.Errorf("failed to create manifest file: %w", err)
+		}
+		defer f.Close()
+
+		_, err = io.Copy(f, resp.Body)
+		if err != nil {
+			return "", fmt.Errorf("copying manifest file failed: %w", err)
+		}
+	}
+	return ManifestTmpDir, nil
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7442  

**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
This change allows using remote manifests as in:
```
apiVersion: skaffold/v2beta28
kind: Config
build:
  artifacts:
  - image: skaffold-example
deploy:
  kubectl:
    manifests:
      - https://raw.githubusercontent.com/GoogleContainerTools/skaffold/main/examples/getting-started/k8s-pod.yaml

```

**Follow-up Work**
 - This feature should be documented
 - Also I have a couple questions about temporary files/dirs, hence the WIP. Should I try to maintain the original filename if possible? (that was my initial approach and I've left some commented out code on purpose), although then I thought it is easier using tmp files. How does skaffold  deal with cleaning up the `ManifestTmpDir`? The first time I run this new code it was failing because there was already some file within that directory. So it might be useful having an additional subdirectory for the downloaded manifests (gcs and urls) and perform a cleanup before downloading anything. Opinions?
