### PR TITLE
fix: Fix broken markdown

### DIFF
--- a/docs/content/en/docs/workflows/debug.md
+++ b/docs/content/en/docs/workflows/debug.md
@@ -16,7 +16,7 @@ Debugging is currently supported for five language runtimes.
   - Python 3.5+ (runtime ID: `python`) using `debugpy` (Debug Adapter Protocol) or `pydevd`
   - .NET Core (runtime ID: `netcore`) using `vsdbg` (only for VS Code)
 
-Skaffold can usually detect the correct language runtime if present. However if you encounter difficulties then checkout the [Supported Language Runtimes]({{< relref "#supported-language-runtimes">}}) section for the exact heuristics that Skaffold uses and you can modify your application accordingly, or read about [manually configuring your container for debugging]({{<relref "#manually-configuring-your-container-for-debugging">}}).
+Skaffold can usually detect the correct language runtime if present. However if you encounter difficulties then checkout the [Supported Language Runtimes]({{< relref "#supported-language-runtimes">}}) section for the exact heuristics that Skaffold uses and you can modify your application accordingly, or read about [manually configuring your container for debugging]({{< relref "#manually-configuring-your-container-for-debugging">}}).
 
 ## (Recommended) Debugging using Cloud Code
 


### PR DESCRIPTION
Adding the required space before the `relref`.

Fixes: #7462 