### PR TITLE
chore: fix-TestRunRenderOnly test

### DIFF
--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/GoogleContainerTools/skaffold/cmd/skaffold/app/tips"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/kubernetes/manifest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/runner"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/util"
 )
@@ -57,7 +58,10 @@ func doRun(ctx context.Context, out io.Writer) error {
 		// Render
 		manifestList, err := r.Render(ctx, out, bRes, true)
 		if err != nil {
-			return err
+			return fmt.Errorf("rendering manifests: %w", err)
+		}
+		if opts.RenderOnly {
+			return manifest.Write(manifestList.String(), opts.RenderOutput, out)
 		}
 
 		err = r.DeployAndLog(ctx, out, bRes, manifestList)

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -217,9 +217,6 @@ func TestRunTailDefaultNamespace(t *testing.T) {
 }
 
 func TestRunRenderOnly(t *testing.T) {
-	// TODO: This test shall pass once render v2 is completed.
-	t.SkipNow()
-
 	MarkIntegrationTest(t, CanRunWithoutGcp)
 
 	testutil.Run(t, "write rendered manifest to provided filepath", func(tu *testutil.T) {


### PR DESCRIPTION


**Description**
 - Fixes: #7473
 - add write manifests when render--only flag is passed to run-command
 - re-enable TestRunRenderOnly test
 
