### PR TITLE
chore: reenable-build_gcb_test

### DIFF
--- a/integration/build_gcb_test.go
+++ b/integration/build_gcb_test.go
@@ -23,9 +23,6 @@ import (
 )
 
 func TestBuildGCBWithExplicitRepo(t *testing.T) {
-	// TODO: This test shall pass once render v2 is completed.
-	t.SkipNow()
-
 	MarkIntegrationTest(t, NeedsGcp)
 
 	// Other integration tests run with the --default-repo option.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->


Fixes: #7491  <!-- tracking issues that this PR will close -->


**Description**
 - the original test shouldn't have been marked as skipped since it's unrelated to render
 - test should pass when manually change needsGCP to CanRunWithoutGcp 

