### PR TITLE
feat: handle minikube exit code 89

### DIFF
--- a/pkg/skaffold/docker/client.go
+++ b/pkg/skaffold/docker/client.go
@@ -38,6 +38,7 @@ import (
 
 // minikube 1.13.0 renumbered exit codes
 const minikubeDriverConfictExitCode = 51
+const minikubeExGuestUnavailable = 89
 const oldMinikubeBadUsageExitCode = 64
 
 // For testing
@@ -113,7 +114,7 @@ func newMinikubeAPIClient(ctx context.Context, minikubeProfile string) ([]string
 		// code 51 (>= 1.13.0) or 64 (< 1.13.0).  Note that exit code 51 was unused prior to 1.13.0
 		// so it is safe to check here without knowing the minikube version.
 		var exitError ExitCoder
-		if errors.As(err, &exitError) && (exitError.ExitCode() == minikubeDriverConfictExitCode || exitError.ExitCode() == oldMinikubeBadUsageExitCode) {
+		if errors.As(err, &exitError) && (exitError.ExitCode() == minikubeDriverConfictExitCode || exitError.ExitCode() == oldMinikubeBadUsageExitCode || exitError.ExitCode() == minikubeExGuestUnavailable) {
 			// Let's ignore the error and fall back to local docker daemon.
 			log.Entry(context.TODO()).Warnf("Could not get minikube docker env, falling back to local docker daemon: %s", err)
 			return newEnvAPIClient()

--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -144,6 +144,10 @@ DOCKER_HOST`),
 			description: "minikube exit code 51 (minikube >= 1.13.0) - fallback to host docker",
 			command:     testutil.CmdRunOutErr("minikube docker-env --shell none -p minikube", "", fmt.Errorf("fail: %w", &driverConflictErr{})),
 		},
+		{
+			description: "minikube exit code 89 - fallback to host docker",
+			command:     testutil.CmdRunOutErr("minikube docker-env --shell none -p minikube", "", fmt.Errorf("fail: %w", &exGuestUnavailable{})),
+		},
 	}
 	for _, test := range tests {
 		testutil.Run(t, test.description, func(t *testutil.T) {
@@ -168,6 +172,11 @@ type driverConflictErr struct{}
 
 func (e *driverConflictErr) Error() string { return "driver conflict" }
 func (e *driverConflictErr) ExitCode() int { return 51 }
+
+type exGuestUnavailable struct{}
+
+func (e *exGuestUnavailable) Error() string { return "minikube not available" }
+func (e *exGuestUnavailable) ExitCode() int { return 89 }
 
 type fakeMinikubeClient struct{}
 


### PR DESCRIPTION
Fixes #7406

**Description**
Before
```
examples/profiles$ skaffold dev
invalid skaffold config: getting minikube env: running [/usr/local/bin/minikube docker-env --shell none -p minikube --user=skaffold]
 - stdout: "false exit code 89\n"
 - stderr: ""
 - cause: exit status 89

```
After
```
$ cd examples/profiles/
examples/profiles$ ../../out/skaffold dev
WARN[0003] Could not get minikube docker env, falling back to local docker daemon: getting minikube env: running [/usr/local/bin/minikube docker-env --shell none -p minikube --user=skaffold]
 - stdout: "false exit code 89\n"
 - stderr: ""
 - cause: exit status 89  subtask=-1 task=DevLoop
WARN[0006] failed to detect active kubernetes cluster node platform. Specify the correct build platform in the `skaffold.yaml` file or using the `--platform` flag  subtask=-1 task=DevLoop
Listing files to watch...
 - skaffold-hello
Generating tags...
 - skaffold-hello -> skaffold-hello:v1.38.0-78-g691b4dd7c
Checking cache...
 - skaffold-hello: Not found. Building
Starting build...
Found [minikube] context, using local docker daemon.
Building [skaffold-hello]...
^C
```