### PR TITLE
feat: skaffold Init with v2 skaffold config

### DIFF
--- a/pkg/skaffold/initializer/config.go
+++ b/pkg/skaffold/initializer/config.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/build"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/deploy"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/render"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/warnings"
@@ -35,7 +36,7 @@ var (
 	getWd = os.Getwd
 )
 
-func generateSkaffoldConfig(b build.Initializer, d deploy.Initializer) *latest.SkaffoldConfig {
+func generateSkaffoldConfig(b build.Initializer, r render.Initializer, d deploy.Initializer) *latest.SkaffoldConfig {
 	// if we're here, the user has no skaffold yaml so we need to generate one
 	// if the user doesn't have any k8s yamls, generate one for each dockerfile
 	log.Entry(context.TODO()).Info("generating skaffold config")
@@ -45,8 +46,9 @@ func generateSkaffoldConfig(b build.Initializer, d deploy.Initializer) *latest.S
 		warnings.Printf("Couldn't generate default config name: %s", err.Error())
 	}
 
-	deploy, profiles := d.DeployConfig()
-	build, portForward := b.BuildConfig()
+	renderConfig, profiles := r.RenderConfig()
+	deployConfig := d.DeployConfig()
+	buildConfig, portForward := b.BuildConfig()
 
 	return &latest.SkaffoldConfig{
 		APIVersion: latest.Version,
@@ -55,8 +57,9 @@ func generateSkaffoldConfig(b build.Initializer, d deploy.Initializer) *latest.S
 			Name: name,
 		},
 		Pipeline: latest.Pipeline{
-			Build:       build,
-			Deploy:      deploy,
+			Build:       buildConfig,
+			Render:      renderConfig,
+			Deploy:      deployConfig,
 			PortForward: portForward,
 		},
 		Profiles: profiles,

--- a/pkg/skaffold/initializer/deploy/helm_test.go
+++ b/pkg/skaffold/initializer/deploy/helm_test.go
@@ -17,15 +17,9 @@ limitations under the License.
 package deploy
 
 import (
-	"errors"
-	"fmt"
 	"testing"
 
-	logrustest "github.com/sirupsen/logrus/hooks/test"
-
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
-	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 	"github.com/GoogleContainerTools/skaffold/testutil"
 )
 
@@ -79,118 +73,8 @@ func TestDeployConfig(t *testing.T) {
 				return []byte{}, nil
 			})
 			h := newHelmInitializer(test.input)
-			d, _ := h.DeployConfig()
+			d := h.DeployConfig()
 			CheckHelmInitStruct(t, test.expected, d.LegacyHelmDeploy.Releases)
 		})
 	}
 }
-
-func TestGetImages(t *testing.T) {
-	tests := []struct {
-		description string
-		values      []string
-		templates   []string
-		cmd         string
-		err         error
-		shouldMatch string
-		expected    []string
-	}{
-		{
-			description: "helm templates multiple value files",
-			templates:   []string{backendTemp},
-			values:      []string{"backend/val.yml", "backend/values.yaml"},
-			cmd:         "helm template backend -f backend/val.yml -f backend/values.yaml",
-			expected:    []string{"go-guestbook-backend"},
-		},
-		{
-			description: "no values files",
-			values:      []string{},
-			cmd:         "helm template backend",
-			templates:   []string{backendTemp},
-			expected:    []string{"go-guestbook-backend"},
-		},
-		{
-			description: "err parsing template",
-			values:      []string{"backend/values.yaml"},
-			cmd:         "helm template backend -f backend/values.yaml",
-			templates:   []string{"invalid"},
-			shouldMatch: "reading Kubernetes YAML: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `invalid` into kubernetes.yamlObject",
-		},
-		{
-			description: "err when running helm template",
-			values:      []string{"backend/values.yaml"},
-			cmd:         "helm template backend -f backend/values.yaml",
-			err:         errors.New("invalid"),
-			shouldMatch: "encountered error: invalid",
-			expected:    []string{},
-		},
-	}
-	for _, test := range tests {
-		testutil.Run(t, test.description, func(t *testutil.T) {
-			t.Override(&readFile, func(_ string) ([]byte, error) {
-				return []byte{}, nil
-			})
-			h := newHelmInitializer(map[string][]string{"backend": test.values})
-			hook := &logrustest.Hook{}
-			log.AddHook(hook)
-			tmpDir := t.NewTempDir()
-			for i, contents := range test.templates {
-				tmpDir.Write(fmt.Sprintf("template/template_%d.yaml", i), contents)
-			}
-			cmd := fmt.Sprintf("%s --output-dir %s", test.cmd, tmpDir.Path("template"))
-			t.Override(&util.DefaultExecCommand, testutil.CmdRunErr(cmd, test.err))
-			t.Override(&tempDir, func(dir, pattern string) (name string, err error) {
-				return tmpDir.Path("template"), nil
-			})
-			images := h.GetImages()
-			t.CheckElementsMatch(test.expected, images)
-			t.CheckMatches(test.shouldMatch, lastEntryHook(hook))
-		})
-	}
-}
-
-func lastEntryHook(hook *logrustest.Hook) string {
-	for _, entry := range hook.AllEntries() {
-		return entry.Message
-	}
-	return ""
-}
-
-var backendTemp = `---
-# Source: backend/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: backend
-  labels:
-    app: backend
-    tier: backend
-spec:
-  type: ClusterIP
-  selector:
-    app: backend
-    tier: backend
-  ports:
-  - port: 8080
-    targetPort: http-server
----
-# Source: backend/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: backend
-  labels:
-    app: backend
-spec:
-  selector:
-    matchLabels:
-      app: backend
-  replicas: 2
-  template:
-    metadata:
-      labels:
-        app: backend
-    spec:
-      containers:
-      - name: backend
-        image: go-guestbook-backend`

--- a/pkg/skaffold/initializer/helm_test.go
+++ b/pkg/skaffold/initializer/helm_test.go
@@ -109,8 +109,8 @@ spec:
 			a := analyze.NewAnalyzer(config)
 			err := a.Analyze(".")
 			t.CheckError(test.shouldErr, err)
-			d := deploy.NewInitializer(a.Manifests(), a.KustomizeBases(), a.KustomizePaths(), a.HelmChartInfo(), config)
-			dc, _ := d.DeployConfig()
+			d := deploy.NewInitializer(a.HelmChartInfo(), config)
+			dc := d.DeployConfig()
 			deploy.CheckHelmInitStruct(t, test.expected, dc.LegacyHelmDeploy.Releases)
 		})
 	}

--- a/pkg/skaffold/initializer/render/helm_test.go
+++ b/pkg/skaffold/initializer/render/helm_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2022 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package render
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/output/log"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+	"github.com/GoogleContainerTools/skaffold/testutil"
+)
+
+func TestGetImages(t *testing.T) {
+	tests := []struct {
+		description string
+		values      []string
+		templates   []string
+		cmd         string
+		err         error
+		shouldMatch string
+		expected    []string
+	}{
+		{
+			description: "helm templates multiple value files",
+			templates:   []string{backendTemp},
+			values:      []string{"backend/val.yml", "backend/values.yaml"},
+			cmd:         "helm template backend -f backend/val.yml -f backend/values.yaml",
+			expected:    []string{"go-guestbook-backend"},
+		},
+		{
+			description: "no values files",
+			values:      []string{},
+			cmd:         "helm template backend",
+			templates:   []string{backendTemp},
+			expected:    []string{"go-guestbook-backend"},
+		},
+		{
+			description: "err parsing template",
+			values:      []string{"backend/values.yaml"},
+			cmd:         "helm template backend -f backend/values.yaml",
+			templates:   []string{"invalid"},
+			shouldMatch: "reading Kubernetes YAML: yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `invalid` into kubernetes.yamlObject",
+		},
+		{
+			description: "err when running helm template",
+			values:      []string{"backend/values.yaml"},
+			cmd:         "helm template backend -f backend/values.yaml",
+			err:         errors.New("invalid"),
+			shouldMatch: "encountered error: invalid",
+			expected:    []string{},
+		},
+	}
+	for _, test := range tests {
+		testutil.Run(t, test.description, func(t *testutil.T) {
+			t.Override(&readFile, func(_ string) ([]byte, error) {
+				return []byte{}, nil
+			})
+			h := newHelmInitializer(map[string][]string{"backend": test.values})
+			hook := &logrustest.Hook{}
+			log.AddHook(hook)
+			tmpDir := t.NewTempDir()
+			for i, contents := range test.templates {
+				tmpDir.Write(fmt.Sprintf("template/template_%d.yaml", i), contents)
+			}
+			cmd := fmt.Sprintf("%s --output-dir %s", test.cmd, tmpDir.Path("template"))
+			t.Override(&util.DefaultExecCommand, testutil.CmdRunErr(cmd, test.err))
+			t.Override(&tempDir, func(dir, pattern string) (name string, err error) {
+				return tmpDir.Path("template"), nil
+			})
+			images := h.GetImages()
+			t.CheckElementsMatch(test.expected, images)
+			t.CheckMatches(test.shouldMatch, lastEntryHook(hook))
+		})
+	}
+}
+
+func lastEntryHook(hook *logrustest.Hook) string {
+	for _, entry := range hook.AllEntries() {
+		return entry.Message
+	}
+	return ""
+}
+
+var backendTemp = `---
+# Source: backend/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend
+  labels:
+    app: backend
+    tier: backend
+spec:
+  type: ClusterIP
+  selector:
+    app: backend
+    tier: backend
+  ports:
+  - port: 8080
+    targetPort: http-server
+---
+# Source: backend/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend
+  labels:
+    app: backend
+spec:
+  selector:
+    matchLabels:
+      app: backend
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+      - name: backend
+        image: go-guestbook-backend`

--- a/pkg/skaffold/initializer/render/init.go
+++ b/pkg/skaffold/initializer/render/init.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2022 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package render
+
+import (
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/analyze"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/config"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
+)
+
+// Initializer detects a deployment type and is able to extract image names from it
+type Initializer interface {
+	// renderConfig generates Render Config for skaffold configuration.
+	RenderConfig() (latest.RenderConfig, []latest.Profile)
+	// GetImages fetches all the images defined in the manifest files.
+	GetImages() []string
+	// Validate ensures preconditions are met before generating a skaffold config
+	Validate() error
+	// AddManifestForImage adds a provided manifest for a given image to the initializer
+	AddManifestForImage(string, string)
+}
+
+type cliManifestsInit struct {
+	cliKubernetesManifests []string
+}
+
+func (c *cliManifestsInit) RenderConfig() (latest.RenderConfig, []latest.Profile) {
+	return latest.RenderConfig{
+		Generate: latest.Generate{RawK8s: c.cliKubernetesManifests},
+	}, nil
+}
+
+func (c *cliManifestsInit) GetImages() []string {
+	return nil
+}
+
+func (c *cliManifestsInit) Validate() error {
+	if len(c.cliKubernetesManifests) == 0 {
+		return errors.NoManifestErr{}
+	}
+	return nil
+}
+
+func (c *cliManifestsInit) AddManifestForImage(string, string) {}
+
+// if any CLI manifests are provided, we always use those as part of a kubectl render first
+// if not, then if a kustomization yaml is found, we use that next
+// otherwise, default to a kubectl render.
+func NewInitializer(manifests, bases, kustomizations []string, h analyze.HelmChartInfo, c config.Config) Initializer {
+	switch {
+	case len(c.CliKubernetesManifests) > 0:
+		return &cliManifestsInit{c.CliKubernetesManifests}
+	case len(kustomizations) > 0:
+		return newKustomizeInitializer(c.DefaultKustomization, bases, kustomizations, manifests)
+	case len(h.Charts()) > 0:
+		return newHelmInitializer(h.Charts())
+	default:
+		return newKubectlInitializer(manifests)
+	}
+}

--- a/pkg/skaffold/initializer/render/kubectl.go
+++ b/pkg/skaffold/initializer/render/kubectl.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2022 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deploy
+package render
 
 import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/initializer/errors"
@@ -22,7 +22,7 @@ import (
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/schema/latest"
 )
 
-// kubectl implements deploymentInitializer for the kubectl deployer.
+// kubectl implements render Initializer for the kubectl renderer.
 type kubectl struct {
 	configs []string // the k8s manifest files present in the project
 	images  []string // the images parsed from the k8s manifest files
@@ -44,14 +44,12 @@ func newKubectlInitializer(potentialConfigs []string) *kubectl {
 	}
 }
 
-// deployConfig implements the Initializer interface and generates
-// skaffold kubectl deployment config.
-func (k *kubectl) DeployConfig() (latest.DeployConfig, []latest.Profile) {
-	return latest.DeployConfig{
-		DeployType: latest.DeployType{
-			KubectlDeploy: &latest.KubectlDeploy{
-				Manifests: k.configs,
-			},
+// RenderConfig implements the Initializer interface and generates
+// skaffold kubectl render config.
+func (k *kubectl) RenderConfig() (latest.RenderConfig, []latest.Profile) {
+	return latest.RenderConfig{
+		Generate: latest.Generate{
+			RawK8s: k.configs,
 		},
 	}, nil
 }

--- a/pkg/skaffold/initializer/render/kubectl_test.go
+++ b/pkg/skaffold/initializer/render/kubectl_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Skaffold Authors
+Copyright 2022 The Skaffold Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deploy
+package render
 
 import (
 	"testing"
@@ -40,15 +40,13 @@ spec:
 
 	k := newKubectlInitializer([]string{filename})
 
-	expectedConfig := latest.DeployConfig{
-		DeployType: latest.DeployType{
-			KubectlDeploy: &latest.KubectlDeploy{
-				Manifests: []string{filename},
-			},
+	expectedConfig := latest.RenderConfig{
+		Generate: latest.Generate{
+			RawK8s: []string{filename},
 		},
 	}
-	deployConfig, profiles := k.DeployConfig()
-	testutil.CheckDeepEqual(t, expectedConfig, deployConfig)
+	renderConfig, profiles := k.RenderConfig()
+	testutil.CheckDeepEqual(t, expectedConfig, renderConfig)
 	if profiles != nil {
 		t.Errorf("generated profiles should be nil, but got: %+v\n", profiles)
 	}

--- a/pkg/skaffold/initializer/render/kustomize_test.go
+++ b/pkg/skaffold/initializer/render/kustomize_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deploy
+package render
 
 import (
 	"path/filepath"
@@ -80,10 +80,10 @@ func TestGenerateKustomizePipeline(t *testing.T) {
 			overlays:          []overlay{{"dev", overlayDeployment, overlayKustomization}},
 			expectedConfig: latest.SkaffoldConfig{
 				Pipeline: latest.Pipeline{
-					Deploy: latest.DeployConfig{
-						DeployType: latest.DeployType{
-							KustomizeDeploy: &latest.KustomizeDeploy{
-								KustomizePaths: []string{filepath.Join("overlays", "dev")},
+					Render: latest.RenderConfig{
+						Generate: latest.Generate{
+							Kustomize: &latest.Kustomize{
+								Paths: []string{filepath.Join("overlays", "dev")},
 							},
 						},
 					},
@@ -101,10 +101,10 @@ func TestGenerateKustomizePipeline(t *testing.T) {
 			},
 			expectedConfig: latest.SkaffoldConfig{
 				Pipeline: latest.Pipeline{
-					Deploy: latest.DeployConfig{
-						DeployType: latest.DeployType{
-							KustomizeDeploy: &latest.KustomizeDeploy{
-								KustomizePaths: []string{filepath.Join("overlays", "foo")},
+					Render: latest.RenderConfig{
+						Generate: latest.Generate{
+							Kustomize: &latest.Kustomize{
+								Paths: []string{filepath.Join("overlays", "foo")},
 							},
 						},
 					},
@@ -113,10 +113,10 @@ func TestGenerateKustomizePipeline(t *testing.T) {
 					{
 						Name: "bar",
 						Pipeline: latest.Pipeline{
-							Deploy: latest.DeployConfig{
-								DeployType: latest.DeployType{
-									KustomizeDeploy: &latest.KustomizeDeploy{
-										KustomizePaths: []string{filepath.Join("overlays", "bar")},
+							Render: latest.RenderConfig{
+								Generate: latest.Generate{
+									Kustomize: &latest.Kustomize{
+										Paths: []string{filepath.Join("overlays", "bar")},
 									},
 								},
 							},
@@ -125,10 +125,10 @@ func TestGenerateKustomizePipeline(t *testing.T) {
 					{
 						Name: "baz",
 						Pipeline: latest.Pipeline{
-							Deploy: latest.DeployConfig{
-								DeployType: latest.DeployType{
-									KustomizeDeploy: &latest.KustomizeDeploy{
-										KustomizePaths: []string{filepath.Join("overlays", "baz")},
+							Render: latest.RenderConfig{
+								Generate: latest.Generate{
+									Kustomize: &latest.Kustomize{
+										Paths: []string{filepath.Join("overlays", "baz")},
 									},
 								},
 							},
@@ -157,8 +157,8 @@ func TestGenerateKustomizePipeline(t *testing.T) {
 
 			k := newKustomizeInitializer("", []string{test.base}, overlays, manifests)
 
-			deployConfig, profiles := k.DeployConfig()
-			testutil.CheckDeepEqual(t, test.expectedConfig.Pipeline.Deploy, deployConfig)
+			renderConfig, profiles := k.RenderConfig()
+			testutil.CheckDeepEqual(t, test.expectedConfig.Pipeline.Render, renderConfig)
 			testutil.CheckDeepEqual(t, test.expectedConfig.Profiles, profiles)
 		})
 	}

--- a/pkg/skaffold/initializer/testdata/init/allcli/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/allcli/skaffold.yaml
@@ -7,8 +7,7 @@ build:
     - image: passed-in-artifact
       docker:
         dockerfile: Dockerfile
-deploy:
-  kubectl:
-    manifests:
-      - manifest-placeholder1.yaml
-      - manifest-placeholder2.yaml
+manifests:
+  rawYaml:
+    - manifest-placeholder1.yaml
+    - manifest-placeholder2.yaml

--- a/pkg/skaffold/initializer/testdata/init/getting-started-kustomize/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/getting-started-kustomize/skaffold.yaml
@@ -7,5 +7,8 @@ build:
   - image: hello-world
     docker:
       dockerfile: Dockerfile
-deploy:
-  kustomize: {}
+manifests:
+  kustomize:
+    paths:
+      - "."
+

--- a/pkg/skaffold/initializer/testdata/init/hello/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/hello/skaffold.yaml
@@ -7,7 +7,6 @@ build:
   - image: skaffold-example
     docker:
       dockerfile: Dockerfile
-deploy:
-  kubectl:
-    manifests:
-    - k8s-pod.yaml
+manifests:
+  rawYaml:
+  - k8s-pod.yaml

--- a/pkg/skaffold/initializer/testdata/init/ignore-tags/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/ignore-tags/skaffold.yaml
@@ -7,7 +7,6 @@ build:
   - image: gcr.io/k8s-skaffold/skaffold-example
     docker:
       dockerfile: Dockerfile
-deploy:
-  kubectl:
-    manifests:
+manifests:
+  rawYaml:
     - k8s-pod.yaml

--- a/pkg/skaffold/initializer/testdata/init/microservices/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/microservices/skaffold.yaml
@@ -12,8 +12,7 @@ build:
     context: leeroy-web
     docker:
       dockerfile: Dockerfile
-deploy:
-  kubectl:
-    manifests:
+manifests:
+  rawYaml:
     - leeroy-app/kubernetes/deployment.yaml
     - leeroy-web/kubernetes/deployment.yaml

--- a/pkg/skaffold/initializer/testdata/init/windows/skaffold.yaml
+++ b/pkg/skaffold/initializer/testdata/init/windows/skaffold.yaml
@@ -8,7 +8,6 @@ build:
     context: apps/web
     docker:
       dockerfile: build/Dockerfile
-deploy:
-  kubectl:
-    manifests:
+manifests:
+  rawYaml:
     - apps/web/deployment.yaml


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #6722 <!-- tracking issues that this PR will close -->


**Description**
 - create renderInitializer to take over GetImage, Validate, AddManifestsForImage from deployInitializer
 - If kustomize, raw manifests detected or cli provide manifests, generated skaffold config will have render config without deploy config
 - If helm charts are detected, generated skaffold ocnfig will have deploy config for helm without render config
  

**User facing changes (remove if N/A)**
 - skaffold init will generate v2 skaffold config 

**Future Work**
 - #7554