### PR TITLE
chore: fix flaky test -TestDevAutoSyncAPITrigger

### DIFF
--- a/pkg/skaffold/event/event.go
+++ b/pkg/skaffold/event/event.go
@@ -654,6 +654,9 @@ func (ev *eventHandler) handleExec(f firedEvent) {
 		rse := e.ResourceStatusCheckEvent
 		rseName := rse.Resource
 		ev.stateLock.Lock()
+		if ev.state.StatusCheckState.Resources == nil {
+			ev.state.StatusCheckState.Resources = map[string]string{}
+		}
 		ev.state.StatusCheckState.Resources[rseName] = rse.Status
 		ev.stateLock.Unlock()
 		switch rse.Status {

--- a/pkg/skaffold/event/event_test.go
+++ b/pkg/skaffold/event/event_test.go
@@ -237,6 +237,21 @@ func TestPortForwarded_handleNil(t *testing.T) {
 	wait(t, func() bool { return handler.getState().ForwardedPorts[8080] != nil })
 }
 
+func TestResourceCheckEvent_handleNil(t *testing.T) {
+	defer func() { handler = newHandler() }()
+
+	handler = newHandler()
+	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
+	handler.setState(handler.getState())
+
+	if handler.state.StatusCheckState.Resources != nil {
+		t.Error("Resources should be a nil map")
+	}
+	resourceStatusCheckEventSucceeded("pods")
+	// Resources will be reset to map[string]string{} in handleExec
+	wait(t, func() bool { return handler.state.StatusCheckState.Resources != nil })
+}
+
 func TestStatusCheckEventStarted(t *testing.T) {
 	defer func() { handler = newHandler() }()
 

--- a/pkg/skaffold/event/event_test.go
+++ b/pkg/skaffold/event/event_test.go
@@ -244,12 +244,15 @@ func TestResourceCheckEvent_handleNil(t *testing.T) {
 	handler.state = emptyState(mockCfg([]latest.Pipeline{{}}, "test"))
 	handler.setState(handler.getState())
 
-	if handler.state.StatusCheckState.Resources != nil {
+	if handler.getState().StatusCheckState.Resources != nil {
 		t.Error("Resources should be a nil map")
 	}
 	resourceStatusCheckEventSucceeded("pods")
 	// Resources will be reset to map[string]string{} in handleExec
-	wait(t, func() bool { return handler.state.StatusCheckState.Resources != nil })
+	wait(t, func() bool {
+		_, ok := handler.getState().StatusCheckState.Resources["pods"]
+		return ok
+	})
 }
 
 func TestStatusCheckEventStarted(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7551  <!-- tracking issues that this PR will close -->
**Related**:  
 - The same issue as #5615

**Test Flakyness Reason**
 - rpc.ClientAutoSync will invoke /proto.SkaffoldService/AutoSync method which calls [UpdateStateAutoSyncTrigger](https://github.com/ericzzzzzzz/skaffold/blob/TestDevAutoSyncAPITrigger/pkg/skaffold/event/event.go#L765-L769) method, this does deepCopy for handler.state but state.StatusCheckState.Resource will be set to nil if the original Resource is an empty map. 
 - [pollResourceStatus](https://github.com/ericzzzzzzz/skaffold/blob/TestDevAutoSyncAPITrigger/pkg/skaffold/kubernetes/status/status_check.go#L235) emits Event_ResourceStatusCheckEvent, if ``UpdateStateAutoSyncTrigger`` happens first then Resources map will become nil from empty map , so when event handler processes the event it will fail. If Event_ResourceStatusCheckEvent happen first, then things are ok. 

**Description**
 - assign a new map to ev.state.StatusCheckState.Resources if nil when handling Event_ResourceStatusCheckEvent 

