### PR TITLE
doc: remove image build from the render command decription

### DIFF
--- a/cmd/skaffold/app/cmd/render.go
+++ b/cmd/skaffold/app/cmd/render.go
@@ -38,7 +38,7 @@ var (
 // NewCmdRender describes the CLI command to build artifacts render Kubernetes manifests.
 func NewCmdRender() *cobra.Command {
 	return NewCmd("render").
-		WithDescription("Perform all image builds, and output rendered Kubernetes manifests").
+		WithDescription("Generate rendered Kubernetes manifests").
 		WithExample("Hydrate Kubernetes manifests without building the images, using digest resolved from tag in remote registry ", "render --digest-source=remote").
 		WithCommonFlags().
 		WithFlags([]*Flag{

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -935,7 +935,7 @@ The following options can be passed to any command:
 
 ### skaffold render
 
-Perform all image builds, and output rendered Kubernetes manifests
+Output rendered Kubernetes manifests
 
 ```
 

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -935,7 +935,7 @@ The following options can be passed to any command:
 
 ### skaffold render
 
-Generate rendered Kubernetes manifests
+Perform all image builds, and output rendered Kubernetes manifests
 
 ```
 

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -935,7 +935,7 @@ The following options can be passed to any command:
 
 ### skaffold render
 
-Output rendered Kubernetes manifests
+Generate rendered Kubernetes manifests
 
 ```
 

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -935,7 +935,7 @@ The following options can be passed to any command:
 
 ### skaffold render
 
-Perform all image builds, and output rendered Kubernetes manifests
+Generate rendered Kubernetes manifests
 
 ```
 

--- a/docs/content/en/docs/references/cli/_index.md
+++ b/docs/content/en/docs/references/cli/_index.md
@@ -77,7 +77,7 @@ Pipeline Building Blocks:
   test              Run tests against your built application images
   deploy            Deploy pre-built artifacts
   delete            Delete any resources deployed by Skaffold
-  render            Perform all image builds, and output rendered Kubernetes manifests
+  render            Generate rendered Kubernetes manifests
   apply             Apply hydrated manifests to a cluster
   verify            Run verification tests against skaffold deployments
 


### PR DESCRIPTION
Fixes:
**Related**:  N/A
**Merge before/after**:  N/A

**Description**
- The public docs for the `skaffold render` command talks about *building images*
- However, the build step has been decoupled from the render command
- Thus, we must remove the information on `image builds` from the description to the `render` command
