### PR TITLE
feat: adding support for supplying manifests with url

### DIFF
--- a/pkg/skaffold/deploy/kubectl/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl/kubectl_test.go
@@ -158,20 +158,6 @@ func TestKubectlV1RenderDeploy(t *testing.T) {
 			},
 		},
 		{
-			description: "http manifest",
-			generate: latest.Generate{
-				RawK8s: []string{"deployment.yaml", "http://remote.yaml"},
-			},
-			commands: testutil.
-				CmdRunOut("kubectl --context kubecontext --namespace testNamespace get -f - --ignore-not-found -ojson", "").
-				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f -"),
-			builds: []graph.Artifact{{
-				ImageName: "leeroy-web",
-				Tag:       "leeroy-web:v1",
-			}},
-			waitForDeletions: true,
-		},
-		{
 			description: "deploy command error",
 			generate: latest.Generate{
 				RawK8s: []string{"deployment.yaml"},
@@ -609,7 +595,7 @@ func TestGCSManifests(t *testing.T) {
 				RawK8s: []string{"gs://dev/deployment.yaml"},
 			},
 			commands: testutil.
-				CmdRunOut(fmt.Sprintf("gsutil cp -r %s %s", "gs://dev/deployment.yaml", manifest.ManifestTmpDir), "log").
+				CmdRunOut(fmt.Sprintf("gsutil cp -r %s %s", "gs://dev/deployment.yaml", filepath.Join(manifest.ManifestTmpDir, manifest.ManifestsFromGCS)), "log").
 				AndRun("kubectl --context kubecontext --namespace testNamespace apply -f -"),
 		}}
 	for _, test := range tests {

--- a/pkg/skaffold/kubernetes/manifest/gcs.go
+++ b/pkg/skaffold/kubernetes/manifest/gcs.go
@@ -20,15 +20,19 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
 )
 
+var ManifestsFromGCS = "manifests_from_gcs"
+
 // DownloadFromGCS downloads all provided manifests from a remote GCS bucket,
 // and returns a relative path pointing to the GCS temp dir.
 func DownloadFromGCS(manifests []string) (string, error) {
-	if err := os.MkdirAll(ManifestTmpDir, os.ModePerm); err != nil {
+	dir := filepath.Join(ManifestTmpDir, ManifestsFromGCS)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		return "", fmt.Errorf("failed to create the tmp directory: %w", err)
 	}
 	for _, manifest := range manifests {
@@ -36,7 +40,7 @@ func DownloadFromGCS(manifests []string) (string, error) {
 			return "", fmt.Errorf("%v is not a valid GCS path", manifest)
 		}
 		gcs := util.Gsutil{}
-		if err := gcs.Copy(context.Background(), manifest, ManifestTmpDir, true); err != nil {
+		if err := gcs.Copy(context.Background(), manifest, dir, true); err != nil {
 			return "", fmt.Errorf("failed to download manifests fom GCS: %w", err)
 		}
 	}

--- a/pkg/skaffold/kubernetes/manifest/url.go
+++ b/pkg/skaffold/kubernetes/manifest/url.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 The Skaffold Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifest
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/GoogleContainerTools/skaffold/pkg/skaffold/util"
+)
+
+var ManifestsFromURL = "manifests_from_url"
+
+// DownloadFromURL downloads the provided manifests from their URLs,
+// and returns a slice containing downloaded file destinations.
+func DownloadFromURL(manifests []string) ([]string, error) {
+	dir := filepath.Join(ManifestTmpDir, ManifestsFromURL)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return nil, fmt.Errorf("failed to create the tmp directory: %w", err)
+	}
+	var paths []string
+	for _, manifest := range manifests {
+		out, err := downloadFromURL(dir, manifest)
+
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, out)
+	}
+	return paths, nil
+}
+
+func downloadFromURL(destDir string, manifest string) (string, error) {
+	if manifest == "" || !util.IsURL(manifest) {
+		return "", fmt.Errorf("%s is not a valid URL", manifest)
+	}
+
+	resp, err := http.Get(manifest)
+	if err != nil {
+		return "", fmt.Errorf("failed to download manifest from %s, err : %w", manifest, err)
+	}
+	defer resp.Body.Close()
+
+	f, err := os.CreateTemp(destDir, "*.yaml")
+	if err != nil {
+		return "", fmt.Errorf("failed to create manifest file: %w", err)
+	}
+	defer f.Close()
+	_, err = io.Copy(f, resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to write manifest to file, err: %w", err)
+	}
+
+	return f.Name(), nil
+}

--- a/pkg/skaffold/render/generate/generate.go
+++ b/pkg/skaffold/render/generate/generate.go
@@ -57,9 +57,11 @@ type Generator struct {
 func resolveRemoteAndLocal(paths []string, workdir string) ([]string, error) {
 	var localPaths []string
 	var gcsManifests []string
+	var urlManifests []string
 	for _, path := range paths {
 		switch {
 		case util.IsURL(path):
+			urlManifests = append(urlManifests, path)
 		case strings.HasPrefix(path, "gs://"):
 			gcsManifests = append(gcsManifests, path)
 		default:
@@ -81,6 +83,13 @@ func resolveRemoteAndLocal(paths []string, workdir string) ([]string, error) {
 			return nil, fmt.Errorf("expanding kubectl manifest paths: %w", err)
 		}
 		list = append(list, l...)
+	}
+	if len(urlManifests) != 0 {
+		paths, err := manifest.DownloadFromURL(urlManifests)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, paths...)
 	}
 	return list, nil
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Include if applicable: -->
Fixes: #7442  <!-- tracking issues that this PR will close -->
**Related**: _Relevant tracking issues, for context_
**Merge before/after**: _Dependent or prerequisite PRs_

**Description**
 - add support for supplying manifests with url
 - split tmp gcs/url manifests destination to different folders
 - add tests.
 - remove http test from deploy/kubectl as it is not necessary

**User facing changes (remove if N/A)**
 - users should be able to specify manifests with url in manifests.rawYaml

**Follow-up Work (remove if N/A)**
 - supply manifests with url from sub-configs are not working in v1, v2 we should fix it, link issues later


